### PR TITLE
Fix reset catalog-domain preservation

### DIFF
--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -2007,9 +2007,11 @@ static int resetStageNamedPaths(
   int nPaths
 ){
   struct TableEntry *aHead = 0, *aStaged = 0;
-  int nHead = 0, nStaged = 0;
+  SchemaEntry *aHeadSchema = 0;
+  int nHead = 0, nStaged = 0, nHeadSchema = 0;
   ProllyHash headCatHash, stagedHash;
-  int p;
+  Pgno iNextFree = 2;
+  int p, k;
   int rc;
 
   rc = doltliteGetHeadCatalogHash(db, &headCatHash);
@@ -2017,15 +2019,22 @@ static int resetStageNamedPaths(
   if( !prollyHashIsEmpty(&headCatHash) ){
     rc = doltliteLoadCatalog(db, &headCatHash, &aHead, &nHead, 0);
     if( rc!=SQLITE_OK ) return rc;
+    rc = loadSchemaFromCatalog(db, cs, doltliteGetCache(db), &headCatHash,
+                               &aHeadSchema, &nHeadSchema);
+    if( rc!=SQLITE_OK ){
+      doltliteFreeCatalog(aHead, nHead);
+      return rc;
+    }
   }
 
   doltliteGetSessionStaged(db, &stagedHash);
   if( !prollyHashIsEmpty(&stagedHash) ){
     rc = doltliteLoadCatalog(db, &stagedHash, &aStaged, &nStaged, 0);
-    if( rc!=SQLITE_OK ){
-      doltliteFreeCatalog(aHead, nHead);
-      return rc;
-    }
+    if( rc!=SQLITE_OK ) goto done;
+  }
+
+  for(k=0; k<nStaged; k++){
+    if( aStaged[k].iTable >= iNextFree ) iNextFree = aStaged[k].iTable + 1;
   }
 
   for(p=0; p<nPaths; p++){
@@ -2045,6 +2054,10 @@ static int resetStageNamedPaths(
       }
       nStaged--;
     }else if( iS<0 ){
+      /* Restoring a staged-dropped table: the HEAD entry is numbered in
+      ** HEAD's domain and its schema row is absent from the staged master
+      ** (and from the live schema -- the table is dropped there), so it
+      ** gets a fresh number and its row comes from the HEAD fallback. */
       struct TableEntry *aNew = sqlite3_realloc(aStaged,
           (nStaged+1)*(int)sizeof(struct TableEntry));
       if( !aNew ){
@@ -2059,8 +2072,12 @@ static int resetStageNamedPaths(
       }
       aStaged[nStaged] = aHead[iH];
       aStaged[nStaged].zName = zDup;
+      aStaged[nStaged].iTable = iNextFree++;
       nStaged++;
     }else{
+      /* Take HEAD's content under the STAGED entry's number so the entry
+      ** keeps pairing with the staged catalog's schema row. */
+      Pgno iKeep = aStaged[iS].iTable;
       zDup = aHead[iH].zName ? sqlite3_mprintf("%s", aHead[iH].zName) : 0;
       if( aHead[iH].zName && !zDup ){
         rc = SQLITE_NOMEM;
@@ -2069,6 +2086,7 @@ static int resetStageNamedPaths(
       sqlite3_free(aStaged[iS].zName);
       aStaged[iS] = aHead[iH];
       aStaged[iS].zName = zDup;
+      aStaged[iS].iTable = iKeep;
     }
   }
 
@@ -2076,7 +2094,8 @@ static int resetStageNamedPaths(
     u8 *buf = 0;
     int nBuf = 0;
     ProllyHash newStagedHash;
-    rc = doltliteSerializeCatalogEntries(db, aStaged, nStaged, &buf, &nBuf);
+    rc = doltliteSerializeCatalogEntriesWithFallbackSchema(
+        db, aStaged, nStaged, aHeadSchema, nHeadSchema, &buf, &nBuf);
     if( rc==SQLITE_OK ){
       rc = chunkStorePut(cs, buf, nBuf, &newStagedHash);
     }
@@ -2089,6 +2108,10 @@ static int resetStageNamedPaths(
 done:
   doltliteFreeCatalog(aHead, nHead);
   doltliteFreeCatalog(aStaged, nStaged);
+  if( aHeadSchema ){
+    for(k=0; k<nHeadSchema; k++) clearSchemaEntry(&aHeadSchema[k]);
+    sqlite3_free(aHeadSchema);
+  }
   return rc;
 }
 
@@ -2226,10 +2249,35 @@ static int doltlitePreserveUntrackedTablesOnHardReset(
     pStmt = 0;
   }
 
+  /* An untracked table's indexes carry their own catalog entries. */
+  if( rc==SQLITE_OK && nUntracked>0 ){
+    rc = sqlite3_prepare_v2(db,
+        "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name=?",
+        -1, &pStmt, 0);
+    for(j=0; rc==SQLITE_OK && j<nUntracked; j++){
+      sqlite3_bind_text(pStmt, 1, azUntracked[j], -1, SQLITE_STATIC);
+      while( sqlite3_step(pStmt)==SQLITE_ROW ){
+        const char *zIdx = (const char*)sqlite3_column_text(pStmt, 0);
+        char **aNew;
+        if( !zIdx ) continue;
+        aNew = sqlite3_realloc(azUntracked,
+            (nUntracked+1)*(int)sizeof(char*));
+        if( !aNew ){ rc = SQLITE_NOMEM; break; }
+        azUntracked = aNew;
+        azUntracked[nUntracked++] = sqlite3_mprintf("%s", zIdx);
+      }
+      sqlite3_reset(pStmt);
+    }
+    sqlite3_finalize(pStmt);
+    pStmt = 0;
+  }
+
   if( rc==SQLITE_OK && nUntracked>0 ){
     ProllyHash workingHash;
     struct TableEntry *aWorking = 0, *aTarget = 0;
-    int nWorking = 0, nTarget = 0;
+    SchemaEntry *aWorkSchema = 0;
+    int nWorking = 0, nTarget = 0, nWorkSchema = 0;
+    Pgno iNextFree = 2;
 
     rc = doltliteFlushCatalogToHash(db, &workingHash);
     if( rc==SQLITE_OK ){
@@ -2239,34 +2287,56 @@ static int doltlitePreserveUntrackedTablesOnHardReset(
       rc = doltliteLoadCatalog(db, pTargetCatHash, &aTarget, &nTarget, 0);
     }
     if( rc==SQLITE_OK ){
-      for(j=0; j<nWorking; j++){
-        int tgtIdx = -1;
-        if( aWorking[j].iTable==1 ) continue;
-        for(k=0; k<nTarget; k++){
-          if( aTarget[k].zName && aWorking[j].zName
-           && strcmp(aTarget[k].zName, aWorking[j].zName)==0 ){
-            tgtIdx = k;
+      rc = loadSchemaFromCatalog(db, cs, doltliteGetCache(db), &workingHash,
+                                 &aWorkSchema, &nWorkSchema);
+    }
+    /* Build FROM the target so every tracked table -- including ones
+    ** dropped in the working tree -- is restored, then append the
+    ** untracked entries renumbered past the target range (working numbers
+    ** can collide with target numbers for different tables). Loaded index
+    ** entries carry no name, so each untracked object is located through
+    ** the working schema rows (name -> working number -> entry); its
+    ** schema row reaches the blob via the fallback list, which pairs by
+    ** name and stamps the appended number. */
+    if( rc==SQLITE_OK ){
+      for(k=0; k<nTarget; k++){
+        if( aTarget[k].iTable >= iNextFree ) iNextFree = aTarget[k].iTable + 1;
+      }
+      for(j=0; j<nUntracked && rc==SQLITE_OK; j++){
+        SchemaEntry *pSe = findSchemaEntry(aWorkSchema, nWorkSchema,
+                                           azUntracked[j]);
+        struct TableEntry *pWork = 0;
+        struct TableEntry *aNew;
+        char *zDup;
+        if( !pSe || pSe->iRootpage<=1 ) continue;
+        for(k=0; k<nWorking; k++){
+          if( aWorking[k].iTable==pSe->iRootpage ){
+            pWork = &aWorking[k];
             break;
           }
         }
-        if( tgtIdx>=0 ){
-          char *zDup = aTarget[tgtIdx].zName
-                         ? sqlite3_mprintf("%s", aTarget[tgtIdx].zName) : 0;
-          if( aTarget[tgtIdx].zName && !zDup ){
-            rc = SQLITE_NOMEM;
-            break;
-          }
-          sqlite3_free(aWorking[j].zName);
-          aWorking[j] = aTarget[tgtIdx];
-          aWorking[j].zName = zDup;
+        if( !pWork ) continue;
+        zDup = sqlite3_mprintf("%s", azUntracked[j]);
+        aNew = zDup ? sqlite3_realloc(aTarget,
+                        (nTarget+1)*(int)sizeof(struct TableEntry)) : 0;
+        if( !aNew ){
+          sqlite3_free(zDup);
+          rc = SQLITE_NOMEM;
+          break;
         }
+        aTarget = aNew;
+        aTarget[nTarget] = *pWork;
+        aTarget[nTarget].zName = zDup;
+        aTarget[nTarget].iTable = iNextFree++;
+        nTarget++;
       }
     }
     if( rc==SQLITE_OK ){
       u8 *buf = 0;
       int nBuf = 0;
       ProllyHash mergedHash;
-      rc = doltliteSerializeCatalogEntries(db, aWorking, nWorking, &buf, &nBuf);
+      rc = doltliteSerializeCatalogEntriesForeignDomain(
+          db, aTarget, nTarget, aWorkSchema, nWorkSchema, &buf, &nBuf);
       if( rc==SQLITE_OK ){
         rc = chunkStorePut(cs, buf, nBuf, &mergedHash);
       }
@@ -2277,6 +2347,10 @@ static int doltlitePreserveUntrackedTablesOnHardReset(
     }
     doltliteFreeCatalog(aWorking, nWorking);
     doltliteFreeCatalog(aTarget, nTarget);
+    if( aWorkSchema ){
+      for(j=0; j<nWorkSchema; j++) clearSchemaEntry(&aWorkSchema[j]);
+      sqlite3_free(aWorkSchema);
+    }
   }
 
   if( pStmt ) sqlite3_finalize(pStmt);

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -744,6 +744,10 @@ int doltliteSerializeCatalogEntriesWithFallbackSchema(
     sqlite3 *db, struct TableEntry *aTables, int nTables,
     SchemaEntry *aFallbackSchema, int nFallbackSchema,
     u8 **ppOut, int *pnOut);
+int doltliteSerializeCatalogEntriesForeignDomain(
+    sqlite3 *db, struct TableEntry *aTables, int nTables,
+    SchemaEntry *aFallbackSchema, int nFallbackSchema,
+    u8 **ppOut, int *pnOut);
 int doltliteGetHeadCatalogHash(sqlite3 *db, ProllyHash *pCatHash);
 int doltliteFlushAndSerializeCatalog(sqlite3 *db, u8 **ppOut, int *pnOut);
 int doltliteDeserializeCatalogForTest(sqlite3 *db, const u8 *data, int nData);

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -2063,6 +2063,54 @@ static int appendFallbackSchemaCatalogRows(
     nRows++;
   }
 
+  for(i=0; i<nFallback; i++){
+    SchemaEntry *pSe = &aFallback[i];
+    SchemaCatalogRow *pRow;
+    int exists = 0;
+    if( !pSe->zName || !pSe->zType ) continue;
+    if( strcmp(pSe->zType, "table")==0 || strcmp(pSe->zType, "index")==0 ){
+      continue;
+    }
+    for(j=0; j<nRows; j++){
+      if( aRows[j].zType && aRows[j].zName
+       && strcmp(aRows[j].zType, pSe->zType)==0
+       && strcmp(aRows[j].zName, pSe->zName)==0 ){
+        exists = 1;
+        break;
+      }
+    }
+    if( exists ) continue;
+    if( nRows>=nAlloc ){
+      i64 nNew = nAlloc ? (i64)nAlloc * 2 : (i64)16;
+      SchemaCatalogRow *aNew;
+      if( nNew > (i64)0x7fffffff/(i64)sizeof(SchemaCatalogRow) ){
+        freeSchemaCatalogRows(aRows, nRows);
+        return SQLITE_NOMEM;
+      }
+      aNew = sqlite3_realloc(aRows,
+                             (int)(nNew * (i64)sizeof(SchemaCatalogRow)));
+      if( !aNew ){
+        freeSchemaCatalogRows(aRows, nRows);
+        return SQLITE_NOMEM;
+      }
+      aRows = aNew;
+      nAlloc = (int)nNew;
+    }
+    pRow = &aRows[nRows];
+    memset(pRow, 0, sizeof(*pRow));
+    pRow->iRowid = iNextRowid++;
+    pRow->oldPg = pSe->iRootpage;
+    pRow->zType = sqlite3_mprintf("%s", pSe->zType ? pSe->zType : "");
+    pRow->zName = sqlite3_mprintf("%s", pSe->zName ? pSe->zName : "");
+    pRow->zTblName = sqlite3_mprintf("%s", pSe->zTblName ? pSe->zTblName : "");
+    pRow->zSql = pSe->zSql ? sqlite3_mprintf("%s", pSe->zSql) : 0;
+    if( !pRow->zType || !pRow->zName || !pRow->zTblName || (pSe->zSql && !pRow->zSql) ){
+      freeSchemaCatalogRows(aRows, nRows+1);
+      return SQLITE_NOMEM;
+    }
+    nRows++;
+  }
+
   *paRows = aRows;
   *pnRows = nRows;
   return SQLITE_OK;
@@ -2085,6 +2133,7 @@ static int doltliteSerializeCatalogEntriesForBtreeImpl(
   int nTables,
   SchemaEntry *aFallbackSchema,
   int nFallbackSchema,
+  int bForeignDomain,
   u8 **ppOut,
   int *pnOut
 ){
@@ -2110,9 +2159,15 @@ static int doltliteSerializeCatalogEntriesForBtreeImpl(
     return rc;
   }
   filterSchemaCatalogRows(aRows, &nRows, aTables, nTables);
-  rc = appendMissingSchemaCatalogRows(db, btreeSchemaName(pBtree),
-                                      &aRows, &nRows, aMeta, nMeta,
-                                      aTables, nTables);
+  /* Live-schema supplementation keys rows by the CONNECTION's table
+  ** numbers. Arrays numbered in a foreign domain (a reset target catalog)
+  ** must not use it -- a live number there can belong to a different table
+  ** entirely, and their missing rows come from the fallback schema. */
+  if( !bForeignDomain ){
+    rc = appendMissingSchemaCatalogRows(db, btreeSchemaName(pBtree),
+                                        &aRows, &nRows, aMeta, nMeta,
+                                        aTables, nTables);
+  }
   if( rc==SQLITE_OK ){
     rc = appendFallbackSchemaCatalogRows(&aRows, &nRows, aTables, nTables,
                                          aFallbackSchema, nFallbackSchema);
@@ -2243,13 +2298,25 @@ static int doltliteSerializeCatalogEntriesForBtreeImpl(
         aSorted[i].zTblName = "";
         continue;
       }
-      /* The table number is the entry's identity; match it first. Cached
-      ** entry names go stale across RENAME, so a name match is only a
-      ** fallback for entries whose number has no schema row. */
-      for(j=0; j<nRows; j++){
-        if( aRows[j].oldPg==aTables[i].iTable ){
-          pRow = &aRows[j];
-          break;
+      /* The table number is the entry's identity; match it first. For the
+      ** LIVE catalog that match is unconditional -- cached entry names go
+      ** stale across RENAME, so a name match is only a fallback for entries
+      ** whose number has no schema row. Constructed arrays (staging, merge,
+      ** reset) carry authoritative loaded names but may mix entries from
+      ** two numbering domains, so a number match that disagrees on name is
+      ** a cross-domain collision and must be rejected. */
+      {
+        int bLiveCatalog = (aTables==pBtree->cat.a);
+        for(j=0; j<nRows; j++){
+          if( aRows[j].oldPg==aTables[i].iTable ){
+            if( !bLiveCatalog
+             && aTables[i].zName && aRows[j].zName
+             && strcmp(aRows[j].zName, aTables[i].zName)!=0 ){
+              continue;
+            }
+            pRow = &aRows[j];
+            break;
+          }
         }
       }
       if( !pRow && aTables[i].zName ){
@@ -2359,7 +2426,23 @@ int doltliteSerializeCatalogEntriesWithFallbackSchema(
   if( db->nDb<=0 || !db->aDb[0].pBt ) return SQLITE_ERROR;
   return doltliteSerializeCatalogEntriesForBtreeImpl(
       db->aDb[0].pBt, aTables, nTables,
-      aFallbackSchema, nFallbackSchema, ppOut, pnOut);
+      aFallbackSchema, nFallbackSchema, 0, ppOut, pnOut);
+}
+
+int doltliteSerializeCatalogEntriesForeignDomain(
+  sqlite3 *db,
+  struct TableEntry *aTables,
+  int nTables,
+  SchemaEntry *aFallbackSchema,
+  int nFallbackSchema,
+  u8 **ppOut,
+  int *pnOut
+){
+  if( !db ) return SQLITE_MISUSE;
+  if( db->nDb<=0 || !db->aDb[0].pBt ) return SQLITE_ERROR;
+  return doltliteSerializeCatalogEntriesForBtreeImpl(
+      db->aDb[0].pBt, aTables, nTables,
+      aFallbackSchema, nFallbackSchema, 1, ppOut, pnOut);
 }
 
 static int serializeCatalogPatchRoots(Btree *pBtree, u8 **ppOut, int *pnOut){
@@ -2470,7 +2553,7 @@ static int serializeCatalogPatchRoots(Btree *pBtree, u8 **ppOut, int *pnOut){
 
 static int serializeCatalog(Btree *pBtree, u8 **ppOut, int *pnOut){
   return doltliteSerializeCatalogEntriesForBtreeImpl(
-      pBtree, pBtree->cat.a, pBtree->cat.n, 0, 0, ppOut, pnOut);
+      pBtree, pBtree->cat.a, pBtree->cat.n, 0, 0, 0, ppOut, pnOut);
 }
 
 static int serializeCatalogForCommit(Btree *pBtree, u8 **ppOut, int *pnOut){

--- a/test/vc_oracle_reset_test.sh
+++ b/test/vc_oracle_reset_test.sh
@@ -541,6 +541,150 @@ CALL dolt_reset('a');
 SELECT concat('Q|', count(*)) FROM dolt_status
       WHERE table_name='a' AND staged=false AND status='modified';"
 
+oracle_same_session "reset_path_staged_dropped_indexed_table_unstages_drop" "
+CREATE TABLE a(id INTEGER PRIMARY KEY, s TEXT CHECK (length(s) > 0));
+CREATE UNIQUE INDEX a_s_idx ON a(s);
+INSERT INTO a VALUES (1, 'base');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+DROP TABLE a;
+SELECT dolt_add('-A');
+SELECT dolt_reset('a');
+" "SELECT 'Q|unstaged|' || count(*) FROM dolt_status
+      WHERE table_name='a' AND staged=0 AND status='deleted';
+SELECT 'Q|staged|' || count(*) FROM dolt_status
+      WHERE table_name='a' AND staged=1;" \
+"CREATE TABLE a(id INTEGER PRIMARY KEY, s TEXT CHECK (length(s) > 0));
+CREATE UNIQUE INDEX a_s_idx ON a(s);
+INSERT INTO a VALUES (1, 'base');
+CALL dolt_add('-A');
+CALL dolt_commit('-m', 'c1');
+DROP TABLE a;
+CALL dolt_add('-A');
+CALL dolt_reset('a');
+" "SELECT concat('Q|unstaged|', count(*)) FROM dolt_status
+      WHERE table_name='a' AND staged=false AND status='deleted';
+SELECT concat('Q|staged|', count(*)) FROM dolt_status
+      WHERE table_name='a' AND staged=true;"
+
+oracle_same_session "reset_path_staged_dropped_fk_table_unstages_drop" "
+CREATE TABLE p(id INTEGER PRIMARY KEY);
+CREATE TABLE c(id INTEGER PRIMARY KEY, p_id INTEGER REFERENCES p(id));
+INSERT INTO p VALUES (1);
+INSERT INTO c VALUES (10, 1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+DROP TABLE c;
+SELECT dolt_add('-A');
+SELECT dolt_reset('c');
+" "SELECT 'Q|unstaged|' || count(*) FROM dolt_status
+      WHERE table_name='c' AND staged=0 AND status='deleted';
+SELECT 'Q|staged|' || count(*) FROM dolt_status
+      WHERE table_name='c' AND staged=1;
+SELECT 'Q|parent|' || count(*) FROM p;" \
+"CREATE TABLE p(id INTEGER PRIMARY KEY);
+CREATE TABLE c(id INTEGER PRIMARY KEY, p_id INTEGER REFERENCES p(id));
+INSERT INTO p VALUES (1);
+INSERT INTO c VALUES (10, 1);
+CALL dolt_add('-A');
+CALL dolt_commit('-m', 'c1');
+DROP TABLE c;
+CALL dolt_add('-A');
+CALL dolt_reset('c');
+" "SELECT concat('Q|unstaged|', count(*)) FROM dolt_status
+      WHERE table_name='c' AND staged=false AND status='deleted';
+SELECT concat('Q|staged|', count(*)) FROM dolt_status
+      WHERE table_name='c' AND staged=true;
+SELECT concat('Q|parent|', count(*)) FROM p;"
+
+echo "--- hard reset preserves untracked schema objects ---"
+
+oracle_same_session "reset_hard_preserves_untracked_index_view_trigger" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1, 'base');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+UPDATE t SET v='dirty' WHERE id=1;
+CREATE TABLE u(id INTEGER PRIMARY KEY, v TEXT CHECK (length(v) > 0));
+CREATE UNIQUE INDEX u_v_idx ON u(v);
+CREATE TABLE audit(id INTEGER PRIMARY KEY);
+CREATE TRIGGER u_ai AFTER INSERT ON u BEGIN INSERT INTO audit VALUES (NEW.id); END;
+CREATE VIEW uv AS SELECT id, v FROM u;
+INSERT INTO u VALUES (1, 'one');
+SELECT dolt_reset('--hard');
+INSERT INTO u VALUES (2, 'two');
+" "SELECT 'Q|tracked|' || v FROM t;
+SELECT 'Q|u|' || id || '|' || v FROM u ORDER BY id;
+SELECT 'Q|idx|' || count(*) FROM pragma_index_list('u') WHERE name='u_v_idx';
+SELECT 'Q|view|' || count(*) FROM uv;
+SELECT 'Q|audit|' || count(*) FROM audit;" \
+"CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1, 'base');
+CALL dolt_add('-A');
+CALL dolt_commit('-m', 'c1');
+UPDATE t SET v='dirty' WHERE id=1;
+CREATE TABLE u(id INTEGER PRIMARY KEY, v TEXT CHECK (length(v) > 0));
+CREATE UNIQUE INDEX u_v_idx ON u(v);
+CREATE TABLE audit(id INTEGER PRIMARY KEY);
+CREATE TRIGGER u_ai AFTER INSERT ON u FOR EACH ROW INSERT INTO audit VALUES (NEW.id);
+CREATE VIEW uv AS SELECT id, v FROM u;
+INSERT INTO u VALUES (1, 'one');
+CALL dolt_reset('--hard');
+INSERT INTO u VALUES (2, 'two');
+" "SELECT concat('Q|tracked|', v) FROM t;
+SELECT concat('Q|u|', id, '|', v) FROM u ORDER BY id;
+SELECT concat('Q|idx|', count(*)) FROM information_schema.statistics
+      WHERE table_name='u' AND index_name='u_v_idx';
+SELECT concat('Q|view|', count(*)) FROM uv;
+SELECT concat('Q|audit|', count(*)) FROM audit;"
+
+oracle_same_session "reset_hard_preserves_untracked_tables_after_target_recreate" "
+CREATE TABLE a(id INTEGER PRIMARY KEY, v TEXT);
+CREATE TABLE b(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO a VALUES (1, 'a1');
+INSERT INTO b VALUES (1, 'b1');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+DROP TABLE a;
+CREATE TABLE a(k INTEGER PRIMARY KEY, n INTEGER);
+INSERT INTO a VALUES (7, 70);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'recreate-a');
+CREATE TABLE u1(id INTEGER PRIMARY KEY, v TEXT);
+CREATE TABLE u2(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO u1 VALUES (11, 'u1');
+INSERT INTO u2 VALUES (22, 'u2');
+SELECT dolt_reset('--hard', 'HEAD~1');
+" "SELECT 'Q|a_cols|' || group_concat(name || ':' || replace(lower(type), 'integer', 'int'), '|')
+       FROM pragma_table_info('a');
+SELECT 'Q|a|' || id || '|' || v FROM a;
+SELECT 'Q|b|' || count(*) FROM b;
+SELECT 'Q|u1|' || id || '|' || v FROM u1;
+SELECT 'Q|u2|' || id || '|' || v FROM u2;" \
+"CREATE TABLE a(id INTEGER PRIMARY KEY, v TEXT);
+CREATE TABLE b(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO a VALUES (1, 'a1');
+INSERT INTO b VALUES (1, 'b1');
+CALL dolt_add('-A');
+CALL dolt_commit('-m', 'c1');
+DROP TABLE a;
+CREATE TABLE a(k INTEGER PRIMARY KEY, n INTEGER);
+INSERT INTO a VALUES (7, 70);
+CALL dolt_add('-A');
+CALL dolt_commit('-m', 'recreate-a');
+CREATE TABLE u1(id INTEGER PRIMARY KEY, v TEXT);
+CREATE TABLE u2(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO u1 VALUES (11, 'u1');
+INSERT INTO u2 VALUES (22, 'u2');
+CALL dolt_reset('--hard', 'HEAD~1');
+" "SELECT concat('Q|a_cols|', group_concat(concat(column_name, ':', replace(lower(column_type), 'integer', 'int')) ORDER BY ordinal_position SEPARATOR '|'))
+       FROM information_schema.columns
+      WHERE table_schema = database() AND table_name = 'a';
+SELECT concat('Q|a|', id, '|', v) FROM a;
+SELECT concat('Q|b|', count(*)) FROM b;
+SELECT concat('Q|u1|', id, '|', v) FROM u1;
+SELECT concat('Q|u2|', id, '|', v) FROM u2;"
+
 echo "--- error paths ---"
 
 oracle_error "reset_to_nonexistent_ref" "


### PR DESCRIPTION
Fixes reset catalog serialization when HEAD, staged, working, and target catalogs use different table-number domains.\n\nThis covers:\n- unstaging staged drops for indexed/FK tables\n- hard-reset preserving untracked indexed tables\n- hard-reset preserving untracked views/triggers\n- hard-reset restoring target tracked tables when working table numbers collide\n\nVerification:\n- make -C build doltlite\n- bash test/vc_oracle_reset_test.sh build/doltlite dolt\n- bash test/doltlite_reset.sh build/doltlite