### PR TITLE
Restore plaintext HTTP remotes in amalgamation

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -382,6 +382,15 @@ jobs:
       run: cd build && bash ../test/remote_https_auth_test.sh ./doltlite ./doltlite-remotesrv
       timeout-minutes: 5
 
+    - name: Amalgamation plaintext HTTP remote test
+      if: matrix.platform != 'windows'
+      run: |
+        cd build
+        rm -f sqlite3.c .target_source
+        make DOLTLITE_PROLLY=1 DOLTLITE_PROLLY_CHECK=1 sqlite3.c sqlite3.h
+        bash ../test/amalgamation_http_remote_test.sh .
+      timeout-minutes: 5
+
     # -- C/Python/Go integration tests -----------------------
 
     - name: C integration tests

--- a/main.mk
+++ b/main.mk
@@ -629,7 +629,7 @@ ifeq ($(DOLTLITE_PROLLY),1)
     $(TOP)/src/doltlite_commit.h $(TOP)/src/doltlite_constraint_violations.h \
     $(TOP)/src/doltlite_ignore.h $(TOP)/src/doltlite_internal.h \
     $(TOP)/src/doltlite_record.h $(TOP)/src/doltlite_remote.h $(TOP)/src/doltlite_remotesrv.h \
-    $(TOP)/src/doltlite_creds.h $(TOP)/src/doltlite_tls.h \
+    $(TOP)/src/doltlite_creds.h $(TOP)/src/doltlite_net.h $(TOP)/src/doltlite_tls.h \
     $(TOP)/src/doltlite_vtab_util.h \
     $(TOP)/src/btree_orig_prefix.h $(TOP)/src/btree_orig_api.h $(TOP)/src/btree_orig_api.c \
     $(TOP)/ext/blake3/blake3.c $(TOP)/ext/blake3/blake3_portable.c \

--- a/src/doltlite_http_remote.c
+++ b/src/doltlite_http_remote.c
@@ -6,18 +6,15 @@
 #include "chunk_store.h"
 #include "doltlite_remote.h"
 #include "doltlite_commit.h"
-#include "doltlite_tls.h"
 #include "doltlite_creds.h"
+#include "doltlite_net.h"
+#ifdef DOLTLITE_HAVE_AUTH
+#include "doltlite_tls.h"
+#endif
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <errno.h>
-
-#ifndef DOLTLITE_HAVE_AUTH
-
-DoltliteRemote *doltliteHttpRemoteOpen(const char *zUrl){ (void)zUrl; return 0; }
-#else
-#include "doltlite_net.h"
 
 typedef struct HttpRemote HttpRemote;
 struct HttpRemote {
@@ -27,8 +24,10 @@ struct HttpRemote {
   int useTls;
   char *zBasePath;
 
+#ifdef DOLTLITE_HAVE_AUTH
   DoltliteCreds *cred;  /* NULL when unauthenticated */
   char *zAudience;      /* JWT audience: remote host or override */
+#endif
 
   u8 *pUploadBuf;
   i64 nUploadBuf;
@@ -42,14 +41,84 @@ struct HttpRemote {
 
 #define HTTP_RESP_MAX_BYTES ((i64)128 * 1024 * 1024)
 
-static int readUntilEof(DoltliteConn *conn, u8 **ppOut, int *pnOut){
+#ifdef DOLTLITE_HAVE_AUTH
+typedef DoltliteConn HttpConn;
+#define httpConnOpen(H,P,T) doltliteConnOpen((H),(P),(T))
+#define httpConnWriteAll(C,B,N) doltliteConnWriteAll((C),(B),(N))
+#define httpConnRead(C,B,N) doltliteConnRead((C),(B),(N))
+#define httpConnClose(C) doltliteConnClose((C))
+#else
+typedef struct HttpConn HttpConn;
+struct HttpConn {
+  int fd;
+};
+
+static HttpConn *httpConnOpen(const char *zHost, int port, int useTls){
+  struct addrinfo hints;
+  struct addrinfo *pRes = 0;
+  struct addrinfo *pAi;
+  char zPort[16];
+  int fd = -1;
+  HttpConn *pConn;
+
+  if( useTls ) return 0;
+  if( doltliteNetInit()!=0 ) return 0;
+  sqlite3_snprintf(sizeof(zPort), zPort, "%d", port);
+  memset(&hints, 0, sizeof(hints));
+  hints.ai_family = AF_UNSPEC;
+  hints.ai_socktype = SOCK_STREAM;
+  if( getaddrinfo(zHost, zPort, &hints, &pRes)!=0 ) return 0;
+
+  for(pAi=pRes; pAi; pAi=pAi->ai_next){
+    fd = (int)socket(pAi->ai_family, pAi->ai_socktype, pAi->ai_protocol);
+    if( fd<0 ) continue;
+    if( connect(fd, pAi->ai_addr, (int)pAi->ai_addrlen)==0 ) break;
+    doltliteCloseSocket(fd);
+    fd = -1;
+  }
+  freeaddrinfo(pRes);
+  if( fd<0 ) return 0;
+
+  pConn = sqlite3_malloc(sizeof(HttpConn));
+  if( !pConn ){
+    doltliteCloseSocket(fd);
+    return 0;
+  }
+  pConn->fd = fd;
+  return pConn;
+}
+
+static int httpConnWriteAll(HttpConn *pConn, const void *pBuf, int nBuf){
+  const char *z = (const char*)pBuf;
+  int nSent = 0;
+  while( nSent<nBuf ){
+    int n = send(pConn->fd, z+nSent, nBuf-nSent, 0);
+    if( n<=0 ) return 1;
+    nSent += n;
+  }
+  return 0;
+}
+
+static int httpConnRead(HttpConn *pConn, void *pBuf, int nBuf){
+  return recv(pConn->fd, (char*)pBuf, nBuf, 0);
+}
+
+static void httpConnClose(HttpConn *pConn){
+  if( pConn ){
+    doltliteCloseSocket(pConn->fd);
+    sqlite3_free(pConn);
+  }
+}
+#endif
+
+static int readUntilEof(HttpConn *conn, u8 **ppOut, int *pnOut){
   i64 nAlloc = 4096;
   i64 nUsed = 0;
   u8 *pBuf = sqlite3_malloc64(nAlloc);
   if( !pBuf ) return SQLITE_NOMEM;
 
   for(;;){
-    ssize_t n;
+    int n;
     if( nUsed + 1024 > nAlloc ){
       u8 *pNew;
       i64 nNew = nAlloc * 2;
@@ -66,7 +135,7 @@ static int readUntilEof(DoltliteConn *conn, u8 **ppOut, int *pnOut){
       pBuf = pNew;
       nAlloc = nNew;
     }
-    n = doltliteConnRead(conn, pBuf + nUsed, (int)(nAlloc - nUsed));
+    n = httpConnRead(conn, pBuf + nUsed, (int)(nAlloc - nUsed));
     if( n < 0 ){
       sqlite3_free(pBuf);
       return SQLITE_IOERR;
@@ -88,7 +157,7 @@ static int httpRequest(
   int *pStatus,
   u8 **ppResp, int *pnResp
 ){
-  DoltliteConn *conn;
+  HttpConn *conn;
   char *zAuth = 0;
   char *zHdr;
   u8 *pRaw = 0;
@@ -99,9 +168,10 @@ static int httpRequest(
   *ppResp = 0;
   *pnResp = 0;
 
-  conn = doltliteConnOpen(p->zHost, p->port, p->useTls);
+  conn = httpConnOpen(p->zHost, p->port, p->useTls);
   if( !conn ) return SQLITE_ERROR;
 
+#ifdef DOLTLITE_HAVE_AUTH
   if( p->useTls && p->cred ){
     char *jwt = 0;
     if( doltliteCredsBearerToken(p->cred, p->zAudience, &jwt)==0 && jwt ){
@@ -109,6 +179,7 @@ static int httpRequest(
     }
     if( jwt ) free(jwt);
   }
+#endif
 
   if( pBody && nBody > 0 ){
     zHdr = sqlite3_mprintf(
@@ -130,20 +201,20 @@ static int httpRequest(
       zMethod, zPath, p->zHost, zAuth ? zAuth : "");
   }
   sqlite3_free(zAuth);
-  if( !zHdr ){ doltliteConnClose(conn); return SQLITE_NOMEM; }
+  if( !zHdr ){ httpConnClose(conn); return SQLITE_NOMEM; }
 
-  rc = doltliteConnWriteAll(conn, zHdr, (int)strlen(zHdr)) ? SQLITE_IOERR : SQLITE_OK;
+  rc = httpConnWriteAll(conn, zHdr, (int)strlen(zHdr)) ? SQLITE_IOERR : SQLITE_OK;
   sqlite3_free(zHdr);
-  if( rc != SQLITE_OK ){ doltliteConnClose(conn); return rc; }
+  if( rc != SQLITE_OK ){ httpConnClose(conn); return rc; }
   if( pBody && nBody > 0 ){
-    if( doltliteConnWriteAll(conn, pBody, nBody) ){
-      doltliteConnClose(conn);
+    if( httpConnWriteAll(conn, pBody, nBody) ){
+      httpConnClose(conn);
       return SQLITE_IOERR;
     }
   }
 
   rc = readUntilEof(conn, &pRaw, &nRaw);
-  doltliteConnClose(conn);
+  httpConnClose(conn);
   if( rc != SQLITE_OK ) return rc;
 
   {
@@ -555,8 +626,10 @@ static int httpCommit(DoltliteRemote *pRemote){
 
 static void httpClose(DoltliteRemote *pRemote){
   HttpRemote *p = (HttpRemote*)pRemote;
+#ifdef DOLTLITE_HAVE_AUTH
   doltliteCredsFree(p->cred);
   sqlite3_free(p->zAudience);
+#endif
   sqlite3_free(p->zHost);
   sqlite3_free(p->zBasePath);
   sqlite3_free(p->pUploadBuf);
@@ -564,6 +637,7 @@ static void httpClose(DoltliteRemote *pRemote){
   sqlite3_free(p);
 }
 
+#ifdef DOLTLITE_HAVE_AUTH
 static void httpResolveCreds(HttpRemote *p){
   char *dir = doltliteCredsDir();
   const char *kid = getenv("DOLTLITE_CREDS_KID");
@@ -587,6 +661,7 @@ static void httpResolveCreds(HttpRemote *p){
     }
   }
 }
+#endif
 
 DoltliteRemote *doltliteHttpRemoteOpen(const char *zUrl){
   HttpRemote *p;
@@ -603,9 +678,13 @@ DoltliteRemote *doltliteHttpRemoteOpen(const char *zUrl){
   if( !zUrl ) return 0;
 
   if( strncmp(zUrl, "https://", 8) == 0 ){
+#ifndef DOLTLITE_HAVE_AUTH
+    return 0;
+#else
     useTls = 1;
     port = 443;
     zAfterScheme = zUrl + 8;
+#endif
   }else if( strncmp(zUrl, "http://", 7) == 0 ){
     useTls = 0;
     port = 80;
@@ -675,9 +754,11 @@ DoltliteRemote *doltliteHttpRemoteOpen(const char *zUrl){
   p->zBasePath[nBasePath] = '\0';
 
   p->useTls = useTls;
+#ifdef DOLTLITE_HAVE_AUTH
   if( useTls ){
     httpResolveCreds(p);
   }
+#endif
 
   p->base.xGetChunk = httpGetChunk;
   p->base.xPutChunk = httpPutChunk;
@@ -692,5 +773,4 @@ DoltliteRemote *doltliteHttpRemoteOpen(const char *zUrl){
   return &p->base;
 }
 
-#endif
 #endif

--- a/test/amalgamation_http_remote_test.sh
+++ b/test/amalgamation_http_remote_test.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+build_dir="${1:-.}"
+cd "$build_dir"
+
+cc_bin="${CC:-cc}"
+remotesrv="${REMOTESRV:-./doltlite-remotesrv}"
+if [ ! -f ./sqlite3.c ] || [ ! -f ./sqlite3.h ]; then
+  echo "SKIP: sqlite3.c/sqlite3.h not found in $PWD"
+  exit 0
+fi
+if [ ! -x "$remotesrv" ]; then
+  echo "SKIP: doltlite-remotesrv not found at $remotesrv"
+  exit 0
+fi
+
+tmp="$(mktemp -d "${TMPDIR:-/tmp}/doltlite-amalg-http.XXXXXX")"
+srv_pid=""
+cleanup() {
+  [ -n "$srv_pid" ] && kill "$srv_pid" 2>/dev/null || true
+  rm -rf "$tmp"
+}
+trap cleanup EXIT
+
+probe_libs=(-lz -lpthread -lm)
+case "$(uname -s)" in
+  Linux*) probe_libs+=(-ldl) ;;
+  MINGW*|MSYS*|CYGWIN*) probe_libs+=(-lws2_32 -lbcrypt -lcrypt32) ;;
+esac
+
+probe_c="$tmp/amalg_http_probe.c"
+cat >"$probe_c" <<'EOF'
+#include "sqlite3.h"
+#include <stdio.h>
+#include <stdlib.h>
+
+extern int doltliteInstallAutoExt(void);
+
+static int exec_sql(sqlite3 *db, const char *zSql){
+  char *zErr = 0;
+  int rc = sqlite3_exec(db, zSql, 0, 0, &zErr);
+  if( rc!=SQLITE_OK ){
+    fprintf(stderr, "%s\n", zErr ? zErr : sqlite3_errmsg(db));
+    sqlite3_free(zErr);
+    return 1;
+  }
+  return 0;
+}
+
+static int scalar_int(sqlite3 *db, const char *zSql, int *pVal){
+  sqlite3_stmt *pStmt = 0;
+  int rc = sqlite3_prepare_v2(db, zSql, -1, &pStmt, 0);
+  if( rc!=SQLITE_OK ){
+    fprintf(stderr, "%s\n", sqlite3_errmsg(db));
+    return 1;
+  }
+  rc = sqlite3_step(pStmt);
+  if( rc!=SQLITE_ROW ){
+    fprintf(stderr, "expected row, got rc=%d\n", rc);
+    sqlite3_finalize(pStmt);
+    return 1;
+  }
+  *pVal = sqlite3_column_int(pStmt, 0);
+  sqlite3_finalize(pStmt);
+  return 0;
+}
+
+int main(int argc, char **argv){
+  sqlite3 *db = 0;
+  int n = 0;
+  char *zSql;
+  const char *zSrc;
+  const char *zClone;
+  const char *zUrl;
+
+  if( argc!=4 ){
+    fprintf(stderr, "usage: %s SRC_DB CLONE_DB HTTP_URL\n", argv[0]);
+    return 1;
+  }
+  zSrc = argv[1];
+  zClone = argv[2];
+  zUrl = argv[3];
+
+  if( doltliteInstallAutoExt()!=SQLITE_OK ){
+    fprintf(stderr, "doltliteInstallAutoExt failed\n");
+    return 1;
+  }
+
+  if( sqlite3_open(zSrc, &db)!=SQLITE_OK ){
+    fprintf(stderr, "%s\n", db ? sqlite3_errmsg(db) : "sqlite3_open failed");
+    return 1;
+  }
+  if( exec_sql(db,
+        "CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT);"
+        "INSERT INTO users VALUES(1,'alice'),(2,'bob'),(3,'charlie');"
+        "SELECT dolt_add('-A');"
+        "SELECT dolt_commit('-m','initial');") ){
+    sqlite3_close(db);
+    return 1;
+  }
+  zSql = sqlite3_mprintf(
+      "SELECT dolt_remote('add','origin',%Q);"
+      "SELECT dolt_push('origin','main');", zUrl);
+  if( !zSql || exec_sql(db, zSql) ){
+    sqlite3_free(zSql);
+    sqlite3_close(db);
+    return 1;
+  }
+  sqlite3_free(zSql);
+  sqlite3_close(db);
+
+  if( sqlite3_open(zClone, &db)!=SQLITE_OK ){
+    fprintf(stderr, "%s\n", db ? sqlite3_errmsg(db) : "sqlite3_open failed");
+    return 1;
+  }
+  zSql = sqlite3_mprintf("SELECT dolt_clone(%Q);", zUrl);
+  if( !zSql || exec_sql(db, zSql) ){
+    sqlite3_free(zSql);
+    sqlite3_close(db);
+    return 1;
+  }
+  sqlite3_free(zSql);
+  if( scalar_int(db, "SELECT count(*) FROM users;", &n) ){
+    sqlite3_close(db);
+    return 1;
+  }
+  sqlite3_close(db);
+
+  if( n!=3 ){
+    fprintf(stderr, "expected 3 cloned users, got %d\n", n);
+    return 1;
+  }
+  return 0;
+}
+EOF
+
+"$cc_bin" -w -I. "$probe_c" ./sqlite3.c "${probe_libs[@]}" -o "$tmp/amalg_http_probe"
+
+mkdir -p "$tmp/srv"
+"$remotesrv" -p 0 --bind 127.0.0.1 "$tmp/srv" >"$tmp/srv.log" 2>&1 &
+srv_pid=$!
+
+port=""
+for _ in $(seq 1 50); do
+  port="$(sed -n 's#.*://127.0.0.1:\([0-9][0-9]*\).*#\1#p' "$tmp/srv.log" | head -1)"
+  [ -n "$port" ] && break
+  sleep 0.1
+done
+if [ -z "$port" ]; then
+  echo "FAIL: server did not start"
+  cat "$tmp/srv.log"
+  exit 1
+fi
+
+"$tmp/amalg_http_probe" "$tmp/src.db" "$tmp/clone.db" "http://127.0.0.1:$port/repo.db"
+echo "amalgamation plaintext HTTP remote: PASS"

--- a/tool/mksqlite3c.tcl
+++ b/tool/mksqlite3c.tcl
@@ -239,7 +239,7 @@ if {$doltlite} {
     doltlite_ancestor.h doltlite_chunk_walk.h doltlite_commit.h
     doltlite_constraint_violations.h doltlite_ignore.h doltlite_internal.h
     doltlite_record.h doltlite_remote.h doltlite_remotesrv.h doltlite_vtab_util.h
-    doltlite_creds.h doltlite_tls.h
+    doltlite_creds.h doltlite_net.h doltlite_tls.h
   } {
     set available_hdr($hdr) 1
   }


### PR DESCRIPTION
Fixes #1625.

## Summary
- keep the HTTP remote client compiled in no-auth amalgamation builds
- add a small plaintext socket transport for no-auth builds while leaving HTTPS/auth disabled without the credential/TLS stack
- include doltlite_net.h in the DoltLite amalgamation inputs
- add a CI regression that compiles sqlite3.c into a client and verifies push+clone over plaintext HTTP against doltlite-remotesrv

## Tests
- PASS: make -C build DOLTLITE_PROLLY_CHECK=1 doltlite doltlite-remotesrv sqlite3.c sqlite3.h
- PASS: bash test/amalgamation_http_remote_test.sh build
- PASS: DOLTLITE_CHECK_CLI=0 DOLTLITE_CHECK_STATIC=0 DOLTLITE_CHECK_SHARED=0 bash test/assert_doltlite_artifacts.sh build
- NOTE: bash test/remote_https_auth_test.sh build/doltlite build/doltlite-remotesrv passes the existing auth/TLS/plaintext sections but fails locally in the pre-existing large HTTPS push section with "push failed (not a fast-forward?)"; an isolated fresh large HTTPS push succeeds.
- NOTE: make -C build devtest fails locally in debug amalgamation builds on existing btree symbol/prototype errors, before Tcl tests run.