### PR TITLE
Load the schema before the reserved shadow-name check in StartTable

### DIFF
--- a/src/build.c
+++ b/src/build.c
@@ -1260,6 +1260,11 @@ void sqlite3StartTable(
   }
   pParse->sNameToken = *pName;
   if( zName==0 ) return;
+  /* The reserved shadow-name check resolves the owning virtual table
+  ** through the schema, so the schema must be loaded before it runs. */
+  if( !IN_SPECIAL_PARSE && SQLITE_OK!=sqlite3ReadSchema(pParse) ){
+    goto begin_table_error;
+  }
   if( sqlite3CheckObjectName(pParse, zName, isView?"view":"table", zName) ){
     goto begin_table_error;
   }

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -64,9 +64,6 @@ altercons2 altercons2-6.2  # canonical adoption: canonicalized SQL text after sc
 altercons2 altercons2-9.1  # canonical adoption: canonicalized SQL text after schema commit
 alterqf alterqf-2.1  # canonical adoption: canonicalized SQL text after schema commit
 altertab altertab-1.4  # canonical adoption: canonicalized SQL text after schema commit
-altertab altertab-16.23  # REAL BUG pinned: defensive-mode reserved shadow-name check misses after a shadow-table RENAME; the check consults a partially reloaded schema during the adoption reparse window
-altertab altertab-16.24  # cascade of altertab-16.23: the wrongly-created table trips later already-exists errors
-altertab altertab-16.25  # cascade of altertab-16.23: the wrongly-created table trips later already-exists errors
 altertab altertab-17.0  # canonical adoption: canonicalized SQL text after schema commit
 altertab altertab-18.1.2  # canonical adoption: canonicalized SQL text after schema commit
 altertab altertab-18.2.2  # canonical adoption: canonicalized SQL text after schema commit


### PR DESCRIPTION
Fixes #1627.

`sqlite3CheckObjectName`'s reserved shadow-name check resolves the prefix (`y1_segments` → `y1`) to its owning virtual table via `sqlite3FindTable`, but `sqlite3StartTable` invoked it **before** `sqlite3ReadSchema`. Stock gets away with the ordering because it never unloads the schema across in-session DDL. doltlite expires all connection schemas when a schema commit adopts the canonical catalog, so the first `CREATE TABLE`/`CREATE VIEW` after a shadow-table `RENAME` ran the check against an empty schema and missed the reservation — a defensive-mode connection could claim `y1_segments` (altertab-16.23; 16.24/16.25 are cascades of the wrongly-created table).

The fix hoists the schema load above the check, preserving the `IN_SPECIAL_PARSE` exemption so `sqlite3_declare_vtab` parses don't trigger schema init (`sqlite3ReadSchema` already no-ops during `init.busy`).

**Fail-before/pass-after**: on master, altertab fails 16.23 (`got: 0 {}` vs expected reserved-name error), 16.24, 16.25; with the fix all three pass. The three divergence-list entries are removed, so the strict runner now gates this — it fails on unfixed code and passes with the fix.

Validation:
- Strict runner green on altertab, altertab2, altertab3, alter, alter2, alter3, alter4, altercol, vtab_shared, fts3ao, table, temptable, trigger1, view, e_createtable, createtab, fts4content, vtab1, vtabE (1,844 passing, 0 unexpected)
- Shell battery: 87/87 suites
- C regression with `DOLTLITE_PROLLY_CHECK=1`: 309,830/309,830

Note: PR #1628 relabels the same three divergence lines this PR deletes — whichever merges second needs a trivial conflict resolution (the entries are gone either way).

🤖 Generated with [Claude Code](https://claude.com/claude-code)