### PR TITLE
Honor the binary argument in suites that hardcoded ./doltlite

### DIFF
--- a/test/doltlite_arm_correctness.sh
+++ b/test/doltlite_arm_correctness.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-DOLTLITE=./doltlite
+DOLTLITE="${1:-./doltlite}"
 PASS=0; FAIL=0; ERRORS=""
 
 run_test() {

--- a/test/doltlite_commit.sh
+++ b/test/doltlite_commit.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-DOLTLITE=./doltlite
+DOLTLITE="${1:-./doltlite}"
 PASS=0
 FAIL=0
 ERRORS=""

--- a/test/doltlite_comparison.sh
+++ b/test/doltlite_comparison.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-DOLTLITE=./doltlite
+DOLTLITE="${1:-./doltlite}"
 PASS=0; FAIL=0; ERRORS=""
 
 run_test() {

--- a/test/doltlite_count_perf.sh
+++ b/test/doltlite_count_perf.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-DOLTLITE=./doltlite
+DOLTLITE="${1:-./doltlite}"
 PASS=0; FAIL=0; ERRORS=""
 
 echo "=== Doltlite COUNT(*) Performance Tests ==="

--- a/test/doltlite_dbpage.sh
+++ b/test/doltlite_dbpage.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-DOLTLITE=./doltlite
+DOLTLITE="${1:-./doltlite}"
 PASS=0; FAIL=0; ERRORS=""
 
 run_test() {

--- a/test/doltlite_merge_ignore_corners.sh
+++ b/test/doltlite_merge_ignore_corners.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-DOLTLITE=./doltlite
+DOLTLITE="${1:-./doltlite}"
 PASS=0; FAIL=0; ERRORS=""
 
 run_test_eq() {

--- a/test/doltlite_parity.sh
+++ b/test/doltlite_parity.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-DOLTLITE=./doltlite
+DOLTLITE="${1:-./doltlite}"
 SQLITE3=./sqlite3
 PASS=0; FAIL=0; ERRORS=""
 

--- a/test/doltlite_perf.sh
+++ b/test/doltlite_perf.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-DOLTLITE=./doltlite
+DOLTLITE="${1:-./doltlite}"
 PASS=0; FAIL=0; ERRORS=""
 
 echo "=== Doltlite Performance Tests ==="

--- a/test/doltlite_pragma_auto_vacuum.sh
+++ b/test/doltlite_pragma_auto_vacuum.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-DOLTLITE=./doltlite
+DOLTLITE="${1:-./doltlite}"
 SQLITE3=$(command -v sqlite3 2>/dev/null || echo /usr/bin/sqlite3)
 PASS=0; FAIL=0; ERRORS=""
 

--- a/test/doltlite_pragma_journal_mode.sh
+++ b/test/doltlite_pragma_journal_mode.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-DOLTLITE=./doltlite
+DOLTLITE="${1:-./doltlite}"
 SQLITE3=$(command -v sqlite3 2>/dev/null || echo /usr/bin/sqlite3)
 PASS=0; FAIL=0; ERRORS=""
 

--- a/test/doltlite_pragma_memory_journal_mode.sh
+++ b/test/doltlite_pragma_memory_journal_mode.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-DOLTLITE=./doltlite
+DOLTLITE="${1:-./doltlite}"
 PASS=0; FAIL=0; ERRORS=""
 
 run_test_eq() {

--- a/test/doltlite_pragma_page_count.sh
+++ b/test/doltlite_pragma_page_count.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-DOLTLITE=./doltlite
+DOLTLITE="${1:-./doltlite}"
 PASS=0; FAIL=0; ERRORS=""
 
 run_test_int_ge() {

--- a/test/doltlite_pragma_wal_checkpoint.sh
+++ b/test/doltlite_pragma_wal_checkpoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-DOLTLITE=./doltlite
+DOLTLITE="${1:-./doltlite}"
 SQLITE3=$(command -v sqlite3 2>/dev/null || echo /usr/bin/sqlite3)
 PASS=0; FAIL=0; ERRORS=""
 

--- a/test/doltlite_record_format.sh
+++ b/test/doltlite_record_format.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-DOLTLITE=./doltlite
+DOLTLITE="${1:-./doltlite}"
 PASS=0; FAIL=0; ERRORS=""
 
 run_test() {

--- a/test/doltlite_row_count_estimate.sh
+++ b/test/doltlite_row_count_estimate.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-DOLTLITE=./doltlite
+DOLTLITE="${1:-./doltlite}"
 PASS=0; FAIL=0; ERRORS=""
 
 if [ ! -x "$DOLTLITE" ]; then

--- a/test/doltlite_savepoint.sh
+++ b/test/doltlite_savepoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-DOLTLITE=./doltlite
+DOLTLITE="${1:-./doltlite}"
 PASS=0; FAIL=0; ERRORS=""
 
 run_test() {

--- a/test/doltlite_schema_cookie.sh
+++ b/test/doltlite_schema_cookie.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-DOLTLITE=./doltlite
+DOLTLITE="${1:-./doltlite}"
 PASS=0; FAIL=0; ERRORS=""
 
 run_test() {

--- a/test/doltlite_snapshot_isolation.sh
+++ b/test/doltlite_snapshot_isolation.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-DOLTLITE=./doltlite
+DOLTLITE="${1:-./doltlite}"
 PASS=0; FAIL=0; ERRORS=""
 
 run_test() {

--- a/test/doltlite_storage_locking.sh
+++ b/test/doltlite_storage_locking.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-DOLTLITE=./doltlite
+DOLTLITE="${1:-./doltlite}"
 PASS=0; FAIL=0; ERRORS=""
 
 run_test() {

--- a/test/doltlite_structural.sh
+++ b/test/doltlite_structural.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-DOLTLITE=./doltlite
+DOLTLITE="${1:-./doltlite}"
 PASS=0; FAIL=0; ERRORS=""
 
 echo "=== Structural Sharing & GC Tests ==="

--- a/test/doltlite_unknown_table_cursor.sh
+++ b/test/doltlite_unknown_table_cursor.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-DOLTLITE=./doltlite
+DOLTLITE="${1:-./doltlite}"
 PASS=0; FAIL=0; ERRORS=""
 
 run_test() {

--- a/test/review_regression_test.sh
+++ b/test/review_regression_test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-DOLTLITE=./doltlite
+DOLTLITE="${1:-./doltlite}"
 PASS=0; FAIL=0; ERRORS=""
 run_test() {
   local n="$1" s="$2" e="$3" d="$4"


### PR DESCRIPTION
Found while writing the #1638 gating tests: `doltlite_commit.sh` (and 21 sibling suites) hardcode `DOLTLITE=./doltlite`, silently ignoring a binary path passed as `$1`. Invoking such a suite directly — `bash test/doltlite_commit.sh build/doltlite` — looked green while actually testing whatever stale `./doltlite` sat in the cwd. That cost twenty minutes of chasing a phantom in-suite-only failure that was really a months-old binary.

One-line change per suite: `DOLTLITE="${1:-./doltlite}"`. The battery runner is unaffected — it cd's into the build dir and invokes suites with no arguments, so the default resolves exactly as before (verified: full battery 87/87). Direct invocation with a path now tests that binary (verified both modes on doltlite_commit.sh and doltlite_savepoint.sh).

🤖 Generated with [Claude Code](https://claude.com/claude-code)