### PR TITLE
Index x VC matrix suite, catalog write guardrail, and two merge fixes

### DIFF
--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -3044,9 +3044,12 @@ static void doltliteMergeFunc(
     char *zMergeErr = 0;
     SchemaMergeAction *aSchemaActions = 0;
     int nSchemaActions = 0;
+    char **azReindex = 0;
+    int nReindex = 0;
     rc = doltliteMergeCatalogs(db, &ancCatHash, &ourCatHash, &theirCatHash,
                                 &mergedCatHash, &nMergeConflicts, &zMergeErr,
-                                &aSchemaActions, &nSchemaActions, 0);
+                                &aSchemaActions, &nSchemaActions, 0,
+                                &azReindex, &nReindex);
     if( rc!=SQLITE_OK ){
       doltliteCommitClear(&ourCommit);
       doltliteCommitClear(&theirCommit);
@@ -3058,6 +3061,7 @@ static void doltliteMergeFunc(
       }
       doltliteTxnStateClear(&savedState);
       freeSchemaMergeActions(aSchemaActions, nSchemaActions);
+      doltliteFreeNameList(azReindex, nReindex);
       return;
     }
     sqlite3_free(zMergeErr);
@@ -3068,6 +3072,7 @@ static void doltliteMergeFunc(
       doltliteCommitClear(&ourCommit);
       doltliteCommitClear(&theirCommit);
       freeSchemaMergeActions(aSchemaActions, nSchemaActions);
+      doltliteFreeNameList(azReindex, nReindex);
       sqlite3_result_error(context,
         "merge conflict: another connection committed to this branch. Please retry your transaction.",
         -1);
@@ -3078,6 +3083,7 @@ static void doltliteMergeFunc(
       doltliteCommitClear(&ourCommit);
       doltliteCommitClear(&theirCommit);
       freeSchemaMergeActions(aSchemaActions, nSchemaActions);
+      doltliteFreeNameList(azReindex, nReindex);
       sqlite3_result_error_code(context, rc);
       return;
     }
@@ -3086,6 +3092,27 @@ static void doltliteMergeFunc(
     rc = doltliteSwitchCatalog(db, &mergedCatHash);
     doltliteCommitClear(&ourCommit);
     doltliteCommitClear(&theirCommit);
+    if( rc!=SQLITE_OK ){
+      if( graphLocked ){
+        chunkStoreUnlock(cs);
+        graphLocked = 0;
+      }
+      freeSchemaMergeActions(aSchemaActions, nSchemaActions);
+      doltliteFreeNameList(azReindex, nReindex);
+      sqlite3_result_error_code(context,
+          doltliteRestoreTxnStateOnFailure(db, &savedState, rc));
+      return;
+    }
+
+    /* Indexes adopted from the other branch carry only that branch's
+    ** rows; rebuild them over the merged tables while the merged catalog
+    ** is live so the flush below captures correct roots. */
+    if( nReindex>0 ){
+      rc = doltliteReindexNamedIndexes(db, azReindex, nReindex);
+    }
+    doltliteFreeNameList(azReindex, nReindex);
+    azReindex = 0;
+    nReindex = 0;
     if( rc!=SQLITE_OK ){
       if( graphLocked ){
         chunkStoreUnlock(cs);
@@ -3427,28 +3454,38 @@ static int applyMergedCatalogAndCommit(
   rc = doltliteSaveTxnState(db, &savedState);
   if( rc!=SQLITE_OK ) return rc;
 
-  rc = doltliteMergeCatalogs(db, ancCatHash, ourCatHash, theirCatHash,
-                              &mergedCatHash, pnConflicts, &zMergeErr, 0, 0,
-                              bPreferOurMaster);
-  if( rc!=SQLITE_OK ){
+  {
+    char **azReindex = 0;
+    int nReindex = 0;
+    rc = doltliteMergeCatalogs(db, ancCatHash, ourCatHash, theirCatHash,
+                                &mergedCatHash, pnConflicts, &zMergeErr, 0, 0,
+                                bPreferOurMaster, &azReindex, &nReindex);
+    if( rc!=SQLITE_OK ){
+      sqlite3_free(zMergeErr);
+      doltliteTxnStateClear(&savedState);
+      doltliteFreeNameList(azReindex, nReindex);
+      return rc;
+    }
     sqlite3_free(zMergeErr);
-    doltliteTxnStateClear(&savedState);
-    return rc;
+
+    rc = doltliteRefreshAndConfirmHead(db, cs, ourHead);
+    if( rc!=SQLITE_OK ){
+      doltliteTxnStateClear(&savedState);
+      doltliteFreeNameList(azReindex, nReindex);
+      return rc;
+    }
+    graphLocked = 1;
+
+    rc = doltliteSwitchCatalog(db, &mergedCatHash);
+    if( rc==SQLITE_OK ){
+      rc = doltlitePrimeSchemaCache(db);
+    }
+    if( rc==SQLITE_OK && nReindex>0 ){
+      rc = doltliteReindexNamedIndexes(db, azReindex, nReindex);
+    }
+    doltliteFreeNameList(azReindex, nReindex);
+    if( rc!=SQLITE_OK ) goto apply_rollback;
   }
-  sqlite3_free(zMergeErr);
-
-  rc = doltliteRefreshAndConfirmHead(db, cs, ourHead);
-  if( rc!=SQLITE_OK ){
-    doltliteTxnStateClear(&savedState);
-    return rc;
-  }
-  graphLocked = 1;
-
-  rc = doltliteSwitchCatalog(db, &mergedCatHash);
-  if( rc!=SQLITE_OK ) goto apply_rollback;
-
-  rc = doltlitePrimeSchemaCache(db);
-  if( rc!=SQLITE_OK ) goto apply_rollback;
 
   rc = doltliteFlushCatalogToHash(db, &liveMergedCatHash);
   if( rc==SQLITE_OK ){
@@ -4550,11 +4587,22 @@ static int rebaseApplyPlanRowCatalog(
     return rc;
   }
 
-  rc = doltliteMergeCatalogs(db, &parentC.catalogHash, pCurCat,
-                             &replayC.catalogHash, pMergedCat,
-                             &nConflicts, 0, 0, 0, 0);
-  if( rc==SQLITE_OK && nConflicts==0 ){
-    rc = doltliteSwitchCatalog(db, pMergedCat);
+  {
+    char **azReindex = 0;
+    int nReindex = 0;
+    rc = doltliteMergeCatalogs(db, &parentC.catalogHash, pCurCat,
+                               &replayC.catalogHash, pMergedCat,
+                               &nConflicts, 0, 0, 0, 0,
+                               &azReindex, &nReindex);
+    if( rc==SQLITE_OK && nConflicts==0 ){
+      rc = doltliteSwitchCatalog(db, pMergedCat);
+    }
+    if( rc==SQLITE_OK && nConflicts==0 && nReindex>0 ){
+      rc = doltliteReindexNamedIndexes(db, azReindex, nReindex);
+      if( rc==SQLITE_OK ) rc = doltliteFlushCatalogToHash(db, pMergedCat);
+      if( rc==SQLITE_OK ) rc = doltliteSwitchCatalog(db, pMergedCat);
+    }
+    doltliteFreeNameList(azReindex, nReindex);
   }
   if( rc==SQLITE_OK && nConflicts==0 && !bSkipConstraintDetect ){
     rc = doltliteDetectPostMergeConstraintViolations(db,

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -919,7 +919,10 @@ int doltliteMergeCatalogs(sqlite3 *db,
     const ProllyHash *theirs, ProllyHash *pMergedHash,
     int *pnConflicts, char **pzErrMsg,
     SchemaMergeAction **ppActions, int *pnActions,
-    int bPreferOurMaster);
+    int bPreferOurMaster,
+    char ***pazReindex, int *pnReindex);
+void doltliteFreeNameList(char **az, int n);
+int doltliteReindexNamedIndexes(sqlite3 *db, char **az, int n);
 
 struct ProllyDiffChange;
 

--- a/src/doltlite_merge.c
+++ b/src/doltlite_merge.c
@@ -1874,10 +1874,23 @@ do_merge_entry:
       if( !theirsEntry ){
 
         if( oursChanged ){
+          /* An index root moves whenever its table's data changes, so a
+          ** changed root alone does not make an index "modified". If its
+          ** definition matches the ancestor, the other branch's DROP wins
+          ** and the entry goes away; redefined-versus-dropped stays a real
+          ** conflict. */
+          if( !zName && zSchemaMergeName && zSchemaMergeName[0]
+           && !schemaEntryChangedByName(aAncSchema, nAncSchema,
+                                        aOursSchema, nOursSchema,
+                                        zSchemaMergeName) ){
+            continue;
+          }
           if( pzErrMsg ){
             *pzErrMsg = sqlite3_mprintf(
-              "schema conflict: table '%s' modified on one branch "
-              "and deleted on the other", zLogicalName ? zLogicalName : "");
+              "schema conflict: %s '%s' modified on one branch "
+              "and deleted on the other",
+              zName ? "table" : "index",
+              zLogicalName ? zLogicalName : "");
           }
           return SQLITE_ERROR;
         }
@@ -2166,7 +2179,9 @@ static int mergeCatalogPass2(
   Pgno *piNextMerged,
   int bDisjointSchemaChanges,
   SchemaRootpageRemap **ppaRemap,
-  int *pnRemap
+  int *pnRemap,
+  char ***pazReindex,
+  int *pnReindex
 ){
   int i;
 
@@ -2215,6 +2230,19 @@ static int mergeCatalogPass2(
             }
             if( newEntry.iTable >= *piNextMerged ) *piNextMerged = newEntry.iTable + 1;
             aMerged[(*pnMerged)++] = newEntry;
+            /* The adopted tree covers only theirs' rows; ours' row changes
+            ** never touched it. Record the index for a rebuild over the
+            ** merged table once the merged catalog is live. */
+            if( pazReindex ){
+              char **azNew = sqlite3_realloc(*pazReindex,
+                  (*pnReindex+1)*(int)sizeof(char*));
+              char *zDup;
+              if( !azNew ) return SQLITE_NOMEM;
+              *pazReindex = azNew;
+              zDup = sqlite3_mprintf("%s", pTheirSe->zName);
+              if( !zDup ) return SQLITE_NOMEM;
+              (*pazReindex)[(*pnReindex)++] = zDup;
+            }
           }else{
             /* Honor our explicit DROP; theirs may only have auto-updated it. */
           }
@@ -2377,7 +2405,9 @@ int doltliteMergeCatalogs(
   char **pzErrMsg,
   SchemaMergeAction **ppActions,
   int *pnActions,
-  int bPreferOurMaster
+  int bPreferOurMaster,
+  char ***pazReindex,
+  int *pnReindex
 ){
   struct TableEntry *aAnc = 0, *aOurs = 0, *aTheirs = 0;
   int nAnc = 0, nOurs = 0, nTheirs = 0;
@@ -2451,7 +2481,8 @@ int doltliteMergeCatalogs(
                           aTheirsSchema, nTheirsSchema,
                           aMerged, &nMerged, &iNextMerged,
                           bDisjointSchemaChanges,
-                          &aRemap, &nRemap);
+                          &aRemap, &nRemap,
+                          pazReindex, pnReindex);
   if( rc!=SQLITE_OK ) goto merge_cleanup;
 
   rc = rebuildDisjointSchemaRows(db, aMerged, nMerged,
@@ -2483,3 +2514,20 @@ merge_cleanup:
 }
 
 #endif
+
+void doltliteFreeNameList(char **az, int n){
+  int i;
+  for(i=0; i<n; i++) sqlite3_free(az[i]);
+  sqlite3_free(az);
+}
+
+int doltliteReindexNamedIndexes(sqlite3 *db, char **az, int n){
+  int i, rc = SQLITE_OK;
+  for(i=0; i<n && rc==SQLITE_OK; i++){
+    char *zSql = sqlite3_mprintf("REINDEX \"%w\"", az[i]);
+    if( !zSql ) return SQLITE_NOMEM;
+    rc = sqlite3_exec(db, zSql, 0, 0, 0);
+    sqlite3_free(zSql);
+  }
+  return rc;
+}

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -2351,6 +2351,46 @@ static int doltliteSerializeCatalogEntriesForBtreeImpl(
     qsort(aSorted, nTables, sizeof(CatalogSerializeEntry), catalogSerializeEntryCmp);
   }
 
+#ifdef DOLTLITE_PROLLY_CHECK
+  /* Two structural failures are detectable at write time regardless of
+  ** intent: an entry that pairs with no schema row and no live meta has
+  ** lost its identity crossing catalog numbering domains, and two entries
+  ** sharing a number would make the serialized catalog ambiguous. Both
+  ** are write-time signatures of the unnamed-entry overlay bug class —
+  ** fail fast instead of publishing the catalog. (A missing entry for an
+  ** emitted row cannot be checked here: the row filter intentionally
+  ** expresses subset catalogs, so absence is indistinguishable from a
+  ** staged drop.) */
+  for(i=0; i<nTables; i++){
+    if( aSorted[i].iTable<=1 ) continue;
+    if( aSorted[i].zType && strcmp(aSorted[i].zType, "unknown")==0 ){
+      fprintf(stderr,
+        "doltlite: catalog invariant violated: entry %u (%s) pairs with no "
+        "schema row or live meta\n",
+        (unsigned)aSorted[i].iTable,
+        aSorted[i].zName && aSorted[i].zName[0] ? aSorted[i].zName : "unnamed");
+      sqlite3_log(SQLITE_CORRUPT,
+        "catalog entry invariant violated: unpairable entry %u",
+        (unsigned)aSorted[i].iTable);
+      abort();
+    }
+    for(j=i+1; j<nTables; j++){
+      if( aSorted[j].iTable==aSorted[i].iTable ){
+        fprintf(stderr,
+          "doltlite: catalog invariant violated: duplicate entry number %u "
+          "(%s / %s)\n",
+          (unsigned)aSorted[i].iTable,
+          aSorted[i].zName ? aSorted[i].zName : "unnamed",
+          aSorted[j].zName ? aSorted[j].zName : "unnamed");
+        sqlite3_log(SQLITE_CORRUPT,
+          "catalog entry invariant violated: duplicate entry %u",
+          (unsigned)aSorted[i].iTable);
+        abort();
+      }
+    }
+  }
+#endif
+
   for(i=0; i<nTables; i++){
     int nType = aSorted[i].zType ? (int)strlen(aSorted[i].zType) : 0;
     int nName = aSorted[i].zName ? (int)strlen(aSorted[i].zName) : 0;

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -2357,11 +2357,15 @@ static int doltliteSerializeCatalogEntriesForBtreeImpl(
   ** lost its identity crossing catalog numbering domains, and two entries
   ** sharing a number would make the serialized catalog ambiguous. Both
   ** are write-time signatures of the unnamed-entry overlay bug class —
-  ** fail fast instead of publishing the catalog. (A missing entry for an
-  ** emitted row cannot be checked here: the row filter intentionally
-  ** expresses subset catalogs, so absence is indistinguishable from a
-  ** staged drop.) */
-  for(i=0; i<nTables; i++){
+  ** fail fast instead of publishing the catalog. Only CONSTRUCTED arrays
+  ** (staging, merge, reset) are checked: that is where the overlay bugs
+  ** live, while the LIVE catalog can legitimately reach these states
+  ** through writable_schema vandalism that stock tolerates (deleted or
+  ** rootpage-aliased schema rows). A missing entry for an emitted row
+  ** cannot be checked at all: the row filter intentionally expresses
+  ** subset catalogs, so absence is indistinguishable from a staged
+  ** drop. */
+  for(i=0; aTables!=pBtree->cat.a && i<nTables; i++){
     if( aSorted[i].iTable<=1 ) continue;
     if( aSorted[i].zType && strcmp(aSorted[i].zType, "unknown")==0 ){
       fprintf(stderr,

--- a/test/doltlite_index_vc_matrix.sh
+++ b/test/doltlite_index_vc_matrix.sh
@@ -1,0 +1,264 @@
+#!/bin/bash
+# Index x version-control matrix: every VC surface against every index
+# flavor, verifying after each step that (a) integrity_check passes and
+# (b) index-planned queries agree with table scans. Index entries are
+# unnamed in catalogs and by-name catalog overlays are structurally blind
+# to them; this suite is the intent-level oracle for that bug class.
+DOLTLITE="${1:-./doltlite}"
+PASS=0
+FAIL=0
+ERRORS=""
+
+run_sql() {
+  echo "$1" | perl -e 'alarm(20); exec @ARGV' $DOLTLITE "$2" 2>&1
+}
+
+note_fail() {
+  FAIL=$((FAIL+1))
+  ERRORS="$ERRORS\nFAIL: $1\n  $2"
+  echo "  FAIL: $1"
+}
+
+check() {
+  local name="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    PASS=$((PASS+1))
+  else
+    note_fail "$name" "expected |$expected| got |$actual|"
+  fi
+}
+
+# The fixture covers every index flavor: secondary, UNIQUE, partial,
+# expression, PK/UNIQUE autoindexes, WITHOUT ROWID, and NOCASE.
+FIXTURE="CREATE TABLE t(id INTEGER PRIMARY KEY, v INTEGER, s TEXT, e INTEGER);
+CREATE INDEX iv ON t(v);
+CREATE UNIQUE INDEX us ON t(s);
+CREATE INDEX pv ON t(v) WHERE v > 100;
+CREATE INDEX ev ON t(abs(e));
+CREATE TABLE u(a TEXT PRIMARY KEY, b INTEGER UNIQUE);
+CREATE TABLE w(k TEXT PRIMARY KEY, x INTEGER) WITHOUT ROWID;
+CREATE TABLE nc(z TEXT COLLATE NOCASE, y INTEGER);
+CREATE INDEX ncz ON nc(z);
+INSERT INTO t VALUES(1,50,'a',-1),(2,150,'b',2),(3,250,'c',-3),(4,60,'d',4);
+INSERT INTO u VALUES('k1',10),('k2',20);
+INSERT INTO w VALUES('w1',7),('w2',8);
+INSERT INTO nc VALUES('Ab',1),('aB',2),('cd',3);"
+
+# Every index-touching mutation class: key updates that move index
+# membership (incl. partial-index boundary), unique-key rewrites,
+# expression inputs, inserts and deletes on every table.
+MUTATE="UPDATE t SET v=v+100 WHERE id IN (1,2);
+UPDATE t SET s=s||'x' WHERE id IN (2,3);
+UPDATE t SET e=-e WHERE id IN (1,4);
+DELETE FROM t WHERE id=4;
+INSERT INTO t VALUES(5,75,'e',5);
+UPDATE u SET b=b+1 WHERE a='k1';
+INSERT INTO u VALUES('k3',30);
+UPDATE w SET x=x*10 WHERE k='w1';
+DELETE FROM nc WHERE z='cd';
+INSERT INTO nc VALUES('CD',4);"
+
+# One line per index: "<name>|<index-planned>|<table-scan>"; the two
+# projections must agree, and integrity_check must be clean.
+VERIFY_SQL="SELECT 'ic|'||(SELECT count(*) FROM pragma_integrity_check WHERE integrity_check='ok')||'|'||(SELECT count(*) FROM pragma_integrity_check);
+SELECT 'iv|'||(SELECT count(*)||','||coalesce(sum(v),0) FROM t INDEXED BY iv)||'|'||(SELECT count(*)||','||coalesce(sum(v),0) FROM t NOT INDEXED);
+SELECT 'us|'||(SELECT count(*)||','||coalesce(min(s),'-')||','||coalesce(max(s),'-') FROM t INDEXED BY us)||'|'||(SELECT count(*)||','||coalesce(min(s),'-')||','||coalesce(max(s),'-') FROM t NOT INDEXED);
+SELECT 'pv|'||(SELECT count(*)||','||coalesce(sum(v),0) FROM t INDEXED BY pv WHERE v>100)||'|'||(SELECT count(*)||','||coalesce(sum(v),0) FROM t NOT INDEXED WHERE v>100);
+SELECT 'ev|'||(SELECT count(*) FROM t INDEXED BY ev WHERE abs(e)>=1)||'|'||(SELECT count(*) FROM t NOT INDEXED WHERE abs(e)>=1);
+SELECT 'ua|'||(SELECT count(*)||','||coalesce(min(a),'-') FROM u INDEXED BY sqlite_autoindex_u_1)||'|'||(SELECT count(*)||','||coalesce(min(a),'-') FROM u NOT INDEXED);
+SELECT 'ub|'||(SELECT count(*)||','||coalesce(sum(b),0) FROM u INDEXED BY sqlite_autoindex_u_2)||'|'||(SELECT count(*)||','||coalesce(sum(b),0) FROM u NOT INDEXED);
+SELECT 'w|'||(SELECT count(*)||','||coalesce(sum(x),0) FROM w)||'|'||(SELECT coalesce(count(k),0)||','||coalesce(sum(x),0) FROM w NOT INDEXED);
+SELECT 'ncz|'||(SELECT count(*) FROM nc INDEXED BY ncz WHERE z='ab')||'|'||(SELECT count(*) FROM nc NOT INDEXED WHERE z='ab');"
+
+# verify <label> <db>: same-session and fresh-session agreement
+verify() {
+  local label="$1" db="$2" line lhs rhs name bad=""
+  local out
+  out=$(run_sql "$VERIFY_SQL" "$db")
+  while IFS='|' read -r name lhs rhs; do
+    [ -z "$name" ] && continue
+    if [ "$lhs" != "$rhs" ]; then bad="$bad [$name: $lhs != $rhs]"; fi
+  done <<EOF
+$out
+EOF
+  if echo "$out" | grep -qE "Parse error|Runtime error|no such"; then
+    bad="$bad [error: $(echo "$out" | grep -aE 'error|no such' | head -1)]"
+  fi
+  if [ -z "$bad" ]; then
+    PASS=$((PASS+1))
+  else
+    note_fail "$label" "$bad"
+  fi
+}
+
+# verify_commit <label> <db>: materialize HEAD on a copy and verify it,
+# so committed catalogs are checked independently of live session state.
+verify_commit() {
+  local label="$1" db="$2"
+  cp "$db" "$db.headcopy"
+  run_sql "SELECT dolt_reset('--hard');" "$db.headcopy" > /dev/null
+  verify "$label" "$db.headcopy"
+  rm -f "$db.headcopy"
+}
+
+TDIR=$(mktemp -d /tmp/idxvc.XXXXXX)
+trap 'rm -rf "$TDIR"' EXIT
+N=0
+newdb() { N=$((N+1)); DB="$TDIR/m$N.db"; }
+
+scenario() { echo "--- $1 ---"; }
+
+# ── staging surfaces ──────────────────────────────────────────────
+scenario "add -A + commit"
+newdb
+run_sql "$FIXTURE SELECT dolt_add('-A'); SELECT dolt_commit('-m','base');" "$DB" > /dev/null
+run_sql "$MUTATE SELECT dolt_add('-A'); SELECT dolt_commit('-m','mut');" "$DB" > /dev/null
+verify "addA_live" "$DB"; verify_commit "addA_commit" "$DB"
+
+scenario "named add per table + commit"
+newdb
+run_sql "$FIXTURE SELECT dolt_add('-A'); SELECT dolt_commit('-m','base');" "$DB" > /dev/null
+run_sql "$MUTATE SELECT dolt_add('t'); SELECT dolt_add('u'); SELECT dolt_add('w'); SELECT dolt_add('nc'); SELECT dolt_commit('-m','mut');" "$DB" > /dev/null
+verify "namedadd_live" "$DB"; verify_commit "namedadd_commit" "$DB"
+
+scenario "commit -am"
+newdb
+run_sql "$FIXTURE SELECT dolt_commit('-Am','base');" "$DB" > /dev/null
+run_sql "$MUTATE SELECT dolt_commit('-am','mut');" "$DB" > /dev/null
+verify "am_live" "$DB"; verify_commit "am_commit" "$DB"
+
+scenario "partial staging then -am"
+newdb
+run_sql "$FIXTURE SELECT dolt_commit('-Am','base');" "$DB" > /dev/null
+run_sql "UPDATE t SET v=v+100 WHERE id=1; SELECT dolt_add('t');
+$MUTATE SELECT dolt_commit('-am','mix');" "$DB" > /dev/null
+verify "partial_am_live" "$DB"; verify_commit "partial_am_commit" "$DB"
+
+scenario "unstage all then recommit"
+newdb
+run_sql "$FIXTURE SELECT dolt_commit('-Am','base');" "$DB" > /dev/null
+run_sql "$MUTATE SELECT dolt_add('-A'); SELECT dolt_reset(); SELECT dolt_add('-A'); SELECT dolt_commit('-m','mut');" "$DB" > /dev/null
+verify "unstage_all_live" "$DB"; verify_commit "unstage_all_commit" "$DB"
+
+scenario "named unstage then recommit"
+newdb
+run_sql "$FIXTURE SELECT dolt_commit('-Am','base');" "$DB" > /dev/null
+run_sql "$MUTATE SELECT dolt_add('-A'); SELECT dolt_reset('t'); SELECT dolt_add('t'); SELECT dolt_commit('-m','mut');" "$DB" > /dev/null
+verify "unstage_named_live" "$DB"; verify_commit "unstage_named_commit" "$DB"
+
+# ── reset surfaces ────────────────────────────────────────────────
+scenario "reset --hard discards index-touching mutations"
+newdb
+run_sql "$FIXTURE SELECT dolt_add('-A'); SELECT dolt_commit('-m','base');" "$DB" > /dev/null
+run_sql "$MUTATE SELECT dolt_reset('--hard');" "$DB" > /dev/null
+verify "reset_hard_live" "$DB"
+result=$(run_sql "SELECT count(*) FROM t; SELECT count(*) FROM dolt_status;" "$DB")
+check "reset_hard_restores_baseline" "4
+0" "$result"
+
+scenario "reset --soft one commit back, recommit"
+newdb
+run_sql "$FIXTURE SELECT dolt_commit('-Am','base');" "$DB" > /dev/null
+run_sql "$MUTATE SELECT dolt_commit('-am','mut');" "$DB" > /dev/null
+run_sql "SELECT dolt_reset('--soft','HEAD~1'); SELECT dolt_commit('-am','recommit');" "$DB" > /dev/null
+verify "reset_soft_live" "$DB"; verify_commit "reset_soft_commit" "$DB"
+
+# ── branch / checkout / merge ─────────────────────────────────────
+scenario "branch checkout roundtrip"
+newdb
+run_sql "$FIXTURE SELECT dolt_commit('-Am','base');" "$DB" > /dev/null
+run_sql "$MUTATE SELECT dolt_commit('-am','mut');" "$DB" > /dev/null
+run_sql "SELECT dolt_checkout('-b','side','HEAD~1'); SELECT dolt_checkout('main');" "$DB" > /dev/null
+verify "checkout_roundtrip_live" "$DB"
+BRANCH_VERIFY="SELECT dolt_checkout('side');
+$VERIFY_SQL"
+out=$(run_sql "$BRANCH_VERIFY" "$DB")
+if echo "$out" | grep -qE "Parse error|Runtime error|no such"; then
+  note_fail "checkout_old_branch" "$(echo "$out" | grep -aE 'error|no such' | head -1)"
+else
+  PASS=$((PASS+1))
+fi
+
+scenario "divergent merge, disjoint index-touching edits"
+newdb
+run_sql "$FIXTURE SELECT dolt_commit('-Am','base'); SELECT dolt_branch('side');" "$DB" > /dev/null
+run_sql "UPDATE t SET v=v+100 WHERE id=1; INSERT INTO t VALUES(6,300,'f',6); SELECT dolt_commit('-am','main-side');" "$DB" > /dev/null
+run_sql "SELECT dolt_checkout('side'); UPDATE t SET s=s||'y' WHERE id=3; INSERT INTO u VALUES('k9',90); SELECT dolt_commit('-am','side-side'); SELECT dolt_checkout('main');" "$DB" > /dev/null
+run_sql "SELECT dolt_merge('side');" "$DB" > /dev/null
+verify "merge_live" "$DB"; verify_commit "merge_commit" "$DB"
+
+scenario "merge carrying index schema changes"
+newdb
+run_sql "$FIXTURE SELECT dolt_commit('-Am','base'); SELECT dolt_branch('side');" "$DB" > /dev/null
+run_sql "SELECT dolt_checkout('side'); CREATE INDEX ie ON t(e); DROP INDEX iv; SELECT dolt_add('-A'); SELECT dolt_commit('-m','idx-schema'); SELECT dolt_checkout('main');" "$DB" > /dev/null
+run_sql "INSERT INTO t VALUES(7,80,'g',7); SELECT dolt_commit('-am','row'); SELECT dolt_merge('side');" "$DB" > /dev/null
+result=$(run_sql "SELECT count(*) FROM t INDEXED BY ie WHERE e>=0; PRAGMA integrity_check;" "$DB")
+check "merge_index_schema" "3
+ok" "$result"
+
+# ── cherry-pick / revert ──────────────────────────────────────────
+scenario "cherry-pick an index-touching commit"
+newdb
+run_sql "$FIXTURE SELECT dolt_commit('-Am','base'); SELECT dolt_branch('side');" "$DB" > /dev/null
+run_sql "SELECT dolt_checkout('side'); $MUTATE SELECT dolt_commit('-am','muts'); SELECT dolt_checkout('main');" "$DB" > /dev/null
+CP=$(run_sql "SELECT commit_hash FROM dolt_log('side') LIMIT 1;" "$DB" | tail -1)
+run_sql "SELECT dolt_cherry_pick('$CP');" "$DB" > /dev/null
+verify "cherry_pick_live" "$DB"; verify_commit "cherry_pick_commit" "$DB"
+
+scenario "revert an index-touching commit"
+newdb
+run_sql "$FIXTURE SELECT dolt_commit('-Am','base');" "$DB" > /dev/null
+run_sql "$MUTATE SELECT dolt_commit('-am','mut');" "$DB" > /dev/null
+run_sql "SELECT dolt_revert('HEAD');" "$DB" > /dev/null
+verify "revert_live" "$DB"; verify_commit "revert_commit" "$DB"
+result=$(run_sql "SELECT count(*) FROM t;" "$DB")
+check "revert_restores_rows" "4" "$result"
+
+# ── index DDL through VC ──────────────────────────────────────────
+scenario "CREATE INDEX / DROP INDEX through commit and checkout"
+newdb
+run_sql "$FIXTURE SELECT dolt_commit('-Am','base');" "$DB" > /dev/null
+run_sql "CREATE INDEX i2 ON t(e); DROP INDEX iv; SELECT dolt_commit('-Am','ddl');" "$DB" > /dev/null
+result=$(run_sql "SELECT dolt_reset('--hard'); SELECT count(*) FROM t INDEXED BY i2 WHERE e>=-99; SELECT name FROM sqlite_master WHERE name='iv'; PRAGMA integrity_check;" "$DB")
+check "index_ddl_commit" "0
+4
+ok" "$result"
+result=$(run_sql "SELECT dolt_checkout('-b','old','HEAD~1'); SELECT count(*) FROM t INDEXED BY iv; SELECT name FROM sqlite_master WHERE name='i2'; PRAGMA integrity_check;" "$DB")
+check "index_ddl_old_branch" "0
+4
+ok" "$result"
+
+scenario "ALTER TABLE RENAME carries indexes"
+newdb
+run_sql "$FIXTURE SELECT dolt_commit('-Am','base');" "$DB" > /dev/null
+run_sql "ALTER TABLE t RENAME TO t2; SELECT dolt_commit('-Am','rename');" "$DB" > /dev/null
+result=$(run_sql "SELECT dolt_reset('--hard'); SELECT count(*) FROM t2 INDEXED BY iv; PRAGMA integrity_check;" "$DB")
+check "rename_carries_indexes" "0
+4
+ok" "$result"
+
+# ── remotes and gc ────────────────────────────────────────────────
+scenario "clone/push/pull roundtrip preserves indexes"
+newdb
+REMOTE="file://$TDIR/rem$N.db"
+run_sql "$FIXTURE SELECT dolt_commit('-Am','base'); SELECT dolt_remote('add','origin','$REMOTE'); SELECT dolt_push('origin','main');" "$DB" > /dev/null
+CLONE="$TDIR/clone$N.db"
+run_sql "SELECT dolt_clone('$REMOTE');" "$CLONE" > /dev/null
+verify "clone_indexes" "$CLONE"
+run_sql "$MUTATE SELECT dolt_commit('-am','mut'); SELECT dolt_push('origin','main');" "$DB" > /dev/null
+run_sql "SELECT dolt_pull('origin','main');" "$CLONE" > /dev/null
+verify "pull_indexes" "$CLONE"
+
+scenario "gc preserves index chunks"
+newdb
+run_sql "$FIXTURE SELECT dolt_commit('-Am','base');" "$DB" > /dev/null
+run_sql "$MUTATE SELECT dolt_commit('-am','mut'); SELECT dolt_gc();" "$DB" > /dev/null
+verify "gc_live" "$DB"; verify_commit "gc_commit" "$DB"
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"
+if [ $FAIL -gt 0 ]; then
+  echo -e "$ERRORS"
+  exit 1
+fi
+exit 0

--- a/test/lib/doltlite_suite_manifest.sh
+++ b/test/lib/doltlite_suite_manifest.sh
@@ -14,6 +14,7 @@ doltlite_connect_branch.sh
 doltlite_tag.sh
 doltlite_merge.sh
 doltlite_merge_index_conflict.sh
+doltlite_index_vc_matrix.sh
 doltlite_stats_merge.sh
 large_merge_test.sh
 doltlite_conflicts.sh


### PR DESCRIPTION
The exhaustive coverage pass over indexes x version control. The recent finds (#1637, #1638, the reset-era residuals) share one structural root: **index entries are unnamed in catalogs, and every by-name catalog overlay is blind to them**. This PR attacks the class three ways:

**1. `test/doltlite_index_vc_matrix.sh`** (in the battery, 33 checks): every VC surface — add `-A`/named/partial, commit `-m`/`-am`/`-Am`, unstage all/named, reset soft/hard, branch checkout (incl. start-point), divergent merge, index-schema merge, cherry-pick, revert, CREATE/DROP INDEX through commits and old branches, ALTER RENAME, clone/push/pull, gc — against a fixture with every index flavor (secondary, UNIQUE, partial, expression, PK/UNIQUE autoindexes, WITHOUT ROWID, NOCASE). After every step: `integrity_check` plus index-planned vs table-scan agreement, verified on live state *and* on materialized commits (`reset --hard` on a copy).

**2. A write-time guardrail** (checked builds, in the canonical serializer): fails fast on the two structural violations detectable regardless of intent — an entry that pairs with no schema row or live meta (identity lost crossing numbering domains) and duplicate entry numbers. Zero fires across the entire battery, so it's a pure tripwire for future regressions of the class.

**3. Two real merge bugs the suite found on first runs, fixed here:**
- **False schema conflict**: DROP INDEX on one branch + table *data* changes on the other refused to merge ("table 'iv' modified on one branch and deleted on the other") — index roots move with table data, so root movement alone isn't modification. Definition-unchanged + dropped → the DROP wins; redefined + dropped stays a genuine conflict (and the message now says "index").
- **Silently stale adopted index**: an index created on one branch merged in with only that branch's rows — the other branch's inserts/updates were invisible to index-planned queries on the merged result (integrity_check: "row N missing from index"). Merge flows (merge, cherry-pick/revert, rebase replay) now rebuild adopted indexes over the merged tables before flushing the merged catalog.

Fail-before/pass-after: master fails `merge_index_schema` (both merge bugs), branch passes 33/33.

Validation: battery 88/88 (matrix included), C regression 309,830/309,830 with the guardrail active, http lifecycle 28/28, oracles vs real Dolt: merge 48/48, commit 37/37, reset 43/43.

Known residual in the class, documented rather than fixed here: unstage moves table entries but the matrix's unstage scenarios pass because staged catalogs re-derive indexes on the next add — the deeper unstage-index bookkeeping stays on the follow-up list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)