### PR TITLE
Add HTTP remote partial failure tests

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -397,6 +397,11 @@ jobs:
       run: cd build && bash ../test/remotesrv_http_concurrency_test.sh ./doltlite ./doltlite-remotesrv
       timeout-minutes: 5
 
+    - name: HTTP remote partial failure tests
+      if: matrix.platform != 'windows'
+      run: cd build && bash ../test/remotesrv_http_partial_failure_test.sh ./doltlite ./doltlite-remotesrv
+      timeout-minutes: 5
+
     - name: Amalgamation plaintext HTTP remote test
       if: matrix.platform != 'windows'
       run: |

--- a/test/remotesrv_http_partial_failure_test.sh
+++ b/test/remotesrv_http_partial_failure_test.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+DOLTLITE="${1:-$(dirname "$0")/../build/doltlite}"
+REMOTESRV="${2:-$(dirname "$0")/../build/doltlite-remotesrv}"
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "SKIP: python3 not available"
+  exit 0
+fi
+if [ ! -x "$DOLTLITE" ] || [ ! -x "$REMOTESRV" ]; then
+  echo "SKIP: doltlite/doltlite-remotesrv binaries not found ($DOLTLITE, $REMOTESRV)"
+  exit 0
+fi
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/doltlite-http-partial.XXXXXX")"
+SRV_PID=""
+PROXY_PID=""
+cleanup() {
+  [ -n "$PROXY_PID" ] && { kill "$PROXY_PID" 2>/dev/null || true; wait "$PROXY_PID" 2>/dev/null || true; }
+  [ -n "$SRV_PID" ] && { kill "$SRV_PID" 2>/dev/null || true; wait "$SRV_PID" 2>/dev/null || true; }
+  rm -rf "$TMP"
+}
+trap cleanup EXIT
+
+pass=0
+fail=0
+check() {
+  local desc="$1" expected="${2//$'\r'/}" actual="${3//$'\r'/}"
+  if [ "$expected" = "$actual" ]; then
+    echo "  PASS: $desc"; pass=$((pass+1))
+  else
+    echo "  FAIL: $desc"
+    echo "    expected: |$(echo "$expected" | head -5)|"
+    echo "    actual:   |$(echo "$actual" | head -5)|"
+    fail=$((fail+1))
+  fi
+}
+check_match() {
+  local desc="$1" pattern="$2" actual="${3//$'\r'/}"
+  if echo "$actual" | grep -qE "$pattern"; then
+    echo "  PASS: $desc"; pass=$((pass+1))
+  else
+    echo "  FAIL: $desc"
+    echo "    pattern: |$pattern|"
+    echo "    actual:  |$(echo "$actual" | head -5)|"
+    fail=$((fail+1))
+  fi
+}
+
+mkdir -p "$TMP/srv"
+"$REMOTESRV" -p 0 --bind 127.0.0.1 "$TMP/srv" >"$TMP/srv.log" 2>&1 &
+SRV_PID=$!
+SRV_PORT=""
+for _ in $(seq 1 50); do
+  SRV_PORT="$(sed -n 's#.*://127.0.0.1:\([0-9][0-9]*\).*#\1#p' "$TMP/srv.log" | head -1)"
+  [ -n "$SRV_PORT" ] && break
+  sleep 0.1
+done
+if [ -z "$SRV_PORT" ]; then
+  echo "FAIL: server did not start"; cat "$TMP/srv.log"; exit 1
+fi
+
+cat >"$TMP/proxy.py" <<'PY'
+import socket
+import socketserver
+import sys
+
+upstream_port = int(sys.argv[1])
+fail_path_file = sys.argv[2]
+
+def current_fail_path():
+    try:
+        with open(fail_path_file, "r") as f:
+            return f.read().strip()
+    except OSError:
+        return ""
+
+class Handler(socketserver.BaseRequestHandler):
+    def handle(self):
+        data = b""
+        while b"\r\n\r\n" not in data:
+            chunk = self.request.recv(4096)
+            if not chunk:
+                return
+            data += chunk
+            if len(data) > 1 << 20:
+                return
+        head, rest = data.split(b"\r\n\r\n", 1)
+        lines = head.decode("iso-8859-1").split("\r\n")
+        parts = lines[0].split(" ", 2)
+        if len(parts) < 2:
+            return
+        method, path = parts[0], parts[1]
+        headers = {}
+        for line in lines[1:]:
+            if ":" in line:
+                k, v = line.split(":", 1)
+                headers[k.strip().lower()] = v.strip()
+        nbody = int(headers.get("content-length", "0"))
+        body = rest
+        while len(body) < nbody:
+            chunk = self.request.recv(min(65536, nbody - len(body)))
+            if not chunk:
+                return
+            body += chunk
+
+        fail_path = current_fail_path()
+        if fail_path and path.endswith(fail_path):
+            self.request.sendall(
+                b"HTTP/1.1 503 Service Unavailable\r\n"
+                b"Content-Length: 0\r\nConnection: close\r\n\r\n"
+            )
+            return
+
+        with socket.create_connection(("127.0.0.1", upstream_port), timeout=10) as s:
+            s.sendall(head + b"\r\n\r\n" + body)
+            s.shutdown(socket.SHUT_WR)
+            while True:
+                chunk = s.recv(65536)
+                if not chunk:
+                    break
+                self.request.sendall(chunk)
+
+class Server(socketserver.ThreadingTCPServer):
+    allow_reuse_address = True
+    daemon_threads = True
+
+with Server(("127.0.0.1", 0), Handler) as srv:
+    print(srv.server_address[1], flush=True)
+    srv.serve_forever()
+PY
+
+: >"$TMP/fail_path"
+python3 "$TMP/proxy.py" "$SRV_PORT" "$TMP/fail_path" >"$TMP/proxy.log" 2>"$TMP/proxy.err" &
+PROXY_PID=$!
+PROXY_PORT=""
+for _ in $(seq 1 50); do
+  PROXY_PORT="$(head -1 "$TMP/proxy.log" 2>/dev/null || true)"
+  [ -n "$PROXY_PORT" ] && break
+  sleep 0.1
+done
+if [ -z "$PROXY_PORT" ]; then
+  echo "FAIL: proxy did not start"; cat "$TMP/proxy.err" 2>/dev/null || true; exit 1
+fi
+
+DB="$DOLTLITE"
+URL="http://127.0.0.1:$PROXY_PORT/repo.db"
+A="$TMP/a.db"
+
+echo "=== seed remote ==="
+"$DB" "$A" <<SQL >/dev/null
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT, payload BLOB);
+INSERT INTO t VALUES(1,'base',randomblob(512));
+SELECT dolt_commit('-A','-m','base');
+SELECT dolt_remote('add','origin','$URL');
+SQL
+result=$("$DB" "$A" "SELECT dolt_push('origin','main');" 2>&1)
+check "initial push succeeds" "0" "$result"
+base_head=$("$DB" "$A" "SELECT commit_hash FROM dolt_log LIMIT 1;")
+
+echo "=== fail after chunk upload, before refs update ==="
+"$DB" "$A" <<'SQL' >/dev/null
+INSERT INTO t VALUES(2,'refs-if-fails',randomblob(1048576));
+SELECT dolt_commit('-A','-m','refs-if-fails');
+SQL
+printf '/refs-if\n' >"$TMP/fail_path"
+result=$("$DB" "$A" "SELECT dolt_push('origin','main');" 2>&1)
+check_match "push reports refs-if failure" "ERROR|Error|error|failed" "$result"
+printf '\n' >"$TMP/fail_path"
+result=$("$DB" "$TMP/clone_after_refs_if_fail.db" "SELECT dolt_clone('$URL'); SELECT commit_hash FROM dolt_log LIMIT 1; SELECT count(*) FROM t;" 2>&1)
+check "remote head unchanged after refs-if failure" "0
+$base_head
+1" "$result"
+result=$("$DB" "$A" "SELECT dolt_push('origin','main');" 2>&1)
+check "retry after refs-if failure succeeds" "0" "$result"
+retry_head=$("$DB" "$A" "SELECT commit_hash FROM dolt_log LIMIT 1;")
+result=$("$DB" "$TMP/clone_after_refs_if_retry.db" "SELECT dolt_clone('$URL'); SELECT commit_hash FROM dolt_log LIMIT 1; SELECT count(*) FROM t;" 2>&1)
+check "remote publishes retried refs-if push" "0
+$retry_head
+2" "$result"
+
+echo "=== fail after refs update, before commit ==="
+"$DB" "$A" <<'SQL' >/dev/null
+INSERT INTO t VALUES(3,'commit-fails',randomblob(1048576));
+SELECT dolt_commit('-A','-m','commit-fails');
+SQL
+printf '/commit\n' >"$TMP/fail_path"
+result=$("$DB" "$A" "SELECT dolt_push('origin','main');" 2>&1)
+check_match "push reports commit failure" "ERROR|Error|error|failed" "$result"
+printf '\n' >"$TMP/fail_path"
+commit_fail_head=$("$DB" "$A" "SELECT commit_hash FROM dolt_log LIMIT 1;")
+result=$("$DB" "$TMP/clone_after_commit_fail.db" "SELECT dolt_clone('$URL'); SELECT commit_hash FROM dolt_log LIMIT 1; SELECT count(*) FROM t;" 2>&1)
+check "remote remains readable with refs published after commit failure" "0
+$commit_fail_head
+3" "$result"
+result=$("$DB" "$A" "SELECT dolt_push('origin','main');" 2>&1)
+check "retry after commit failure succeeds" "0" "$result"
+result=$("$DB" "$TMP/clone_after_commit_retry.db" "SELECT dolt_clone('$URL'); SELECT commit_hash FROM dolt_log LIMIT 1; SELECT count(*) FROM t;" 2>&1)
+check "remote publishes retried commit push" "0
+$commit_fail_head
+3" "$result"
+
+echo ""
+echo "======================================="
+echo "Results: $pass passed, $fail failed"
+echo "======================================="
+[ "$fail" -eq 0 ] && exit 0 || exit 1


### PR DESCRIPTION
## Summary
- add an HTTP remotesrv test for failures after chunk upload but before refs publish
- assert retries work and the remote remains readable across failed refs-if and commit phases
- run the new test in non-Windows CI with the other HTTP remotesrv tests

## Test
- make -C build -j$(sysctl -n hw.ncpu 2>/dev/null || nproc) DOLTLITE_PROLLY_CHECK=1 doltlite doltlite-remotesrv
- bash test/remotesrv_http_partial_failure_test.sh build/doltlite build/doltlite-remotesrv
- bash test/remotesrv_http_test.sh build/doltlite build/doltlite-remotesrv
- bash test/remotesrv_http_concurrency_test.sh build/doltlite build/doltlite-remotesrv