### PR TITLE
Keep unstaged views and triggers out of named-add commits

### DIFF
--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -1505,12 +1505,31 @@ static int addStageNamedTables(
     struct TableEntry *pWorkingMaster = doltliteFindTableByNumber(aWorking, nWorking, 1);
     struct TableEntry *pStagedMaster = doltliteFindTableByNumber(aStaged, nStaged, 1);
     if( pWorkingMaster ){
+      /* The staged master must share the working numbering domain, but a
+      ** wholesale adoption would carry unstaged view and trigger changes
+      ** into the commit (Dolt keeps them out of a named add). Compose the
+      ** master: table and index rows from working, view and trigger rows
+      ** from the previously staged state. */
+      ProllyHash composedRoot;
+      rc = doltliteBuildNamedStageMasterRoot(db,
+              &pWorkingMaster->root, pWorkingMaster->flags,
+              pStagedMaster ? &pStagedMaster->root : 0,
+              pStagedMaster ? pStagedMaster->flags : 0,
+              &composedRoot);
+      if( rc!=SQLITE_OK ){
+        ADDNAMED_FREE_ALL();
+        sqlite3_result_error_code(context, rc);
+        return rc;
+      }
       if( pStagedMaster ){
-        pStagedMaster->root = pWorkingMaster->root;
+        pStagedMaster->root = composedRoot;
         pStagedMaster->schemaHash = pWorkingMaster->schemaHash;
         pStagedMaster->flags = pWorkingMaster->flags;
       }else{
-        rc = addAppendTableEntry(context, &aStaged, &nStaged, pWorkingMaster);
+        struct TableEntry composed = *pWorkingMaster;
+        composed.zName = 0;
+        composed.root = composedRoot;
+        rc = addAppendTableEntry(context, &aStaged, &nStaged, &composed);
         if( rc!=SQLITE_OK ){
           ADDNAMED_FREE_ALL();
           return rc;

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -922,6 +922,10 @@ int doltliteMergeCatalogs(sqlite3 *db,
     int bPreferOurMaster,
     char ***pazReindex, int *pnReindex);
 void doltliteFreeNameList(char **az, int n);
+int doltliteBuildNamedStageMasterRoot(sqlite3 *db,
+    const ProllyHash *pWorkingMaster, u8 workingFlags,
+    const ProllyHash *pOldMaster, u8 oldFlags,
+    ProllyHash *pNewRoot);
 int doltliteReindexNamedIndexes(sqlite3 *db, char **az, int n);
 
 struct ProllyDiffChange;

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -2127,6 +2127,91 @@ int doltliteSerializeCatalogEntries(
       db, aTables, nTables, 0, 0, ppOut, pnOut);
 }
 
+/* Build a master root for a NAMED staging operation. Table and index rows
+** (including virtual tables and their shadows) come from the working
+** master so the staged entries share its numbering domain; view and
+** trigger rows keep the previously staged state, because named add stages
+** tables and never entry-less schema objects — an unstaged view must not
+** ride into the commit on the back of the master adoption. */
+int doltliteBuildNamedStageMasterRoot(
+  sqlite3 *db,
+  const ProllyHash *pWorkingMaster, u8 workingFlags,
+  const ProllyHash *pOldMaster, u8 oldFlags,
+  ProllyHash *pNewRoot
+){
+  Btree *pBtree;
+  struct TableEntry m;
+  SchemaCatalogRow *aWork = 0, *aOld = 0;
+  int nWork = 0, nOld = 0;
+  ProllyHash ignoreRoot;
+  u8 ignoreFlags;
+  ProllyMutMap mm;
+  struct TableEntry masterEntry;
+  i64 iRowid = 1;
+  int i, rc;
+
+  if( !db || db->nDb<=0 || !db->aDb[0].pBt ) return SQLITE_ERROR;
+  pBtree = db->aDb[0].pBt;
+  memset(pNewRoot, 0, sizeof(*pNewRoot));
+
+  memset(&m, 0, sizeof(m));
+  m.iTable = 1;
+  m.root = *pWorkingMaster;
+  m.flags = workingFlags;
+  rc = loadSchemaCatalogRows(pBtree, &m, 1, &aWork, &nWork,
+                             &ignoreRoot, &ignoreFlags);
+  if( rc!=SQLITE_OK ) return rc;
+  if( pOldMaster && !prollyHashIsEmpty(pOldMaster) ){
+    m.root = *pOldMaster;
+    m.flags = oldFlags;
+    rc = loadSchemaCatalogRows(pBtree, &m, 1, &aOld, &nOld,
+                               &ignoreRoot, &ignoreFlags);
+    if( rc!=SQLITE_OK ){
+      freeSchemaCatalogRows(aWork, nWork);
+      return rc;
+    }
+  }
+
+  memset(&mm, 0, sizeof(mm));
+  rc = prollyMutMapInit(&mm, 1);
+  if( rc!=SQLITE_OK ){
+    freeSchemaCatalogRows(aWork, nWork);
+    freeSchemaCatalogRows(aOld, nOld);
+    return rc;
+  }
+  for(i=0; i<nWork+nOld && rc==SQLITE_OK; i++){
+    SchemaCatalogRow *pRow = i<nWork ? &aWork[i] : &aOld[i-nWork];
+    int isEntryless = pRow->zType
+      && (strcmp(pRow->zType, "view")==0 || strcmp(pRow->zType, "trigger")==0);
+    u8 *pRec;
+    int nRec = 0;
+    if( i<nWork ? isEntryless : !isEntryless ) continue;
+    pRec = buildSchemaCatalogRecord(pRow->zType, pRow->zName,
+                                    pRow->zTblName, pRow->oldPg,
+                                    pRow->zSql, &nRec);
+    if( !pRec ){
+      rc = SQLITE_NOMEM;
+      break;
+    }
+    rc = prollyMutMapInsert(&mm, 0, 0, iRowid++, pRec, nRec);
+    sqlite3_free(pRec);
+  }
+  freeSchemaCatalogRows(aWork, nWork);
+  freeSchemaCatalogRows(aOld, nOld);
+  if( rc!=SQLITE_OK ){
+    prollyMutMapFree(&mm);
+    return rc;
+  }
+
+  memset(&masterEntry, 0, sizeof(masterEntry));
+  masterEntry.iTable = 1;
+  masterEntry.flags = workingFlags;
+  rc = applyMutMapToTableRoot(pBtree->pBt, &masterEntry, &mm);
+  prollyMutMapFree(&mm);
+  if( rc==SQLITE_OK ) *pNewRoot = masterEntry.root;
+  return rc;
+}
+
 static int doltliteSerializeCatalogEntriesForBtreeImpl(
   Btree *pBtree,
   struct TableEntry *aTables,

--- a/test/doltlite_commit.sh
+++ b/test/doltlite_commit.sh
@@ -341,7 +341,36 @@ PRAGMA integrity_check;"   "0
 0
 ok" "$DB10"
 
-rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8" "$DB9" "$DB10"
+# Named add stages tables, never entry-less schema objects: an unstaged
+# view or trigger must not ride into the commit on the master adoption,
+# while -A and -am legitimately carry them.
+DB11=/tmp/test_dolt_viewstage_$$.db; rm -f "$DB11"
+
+run_test_match "view_stage_setup"   "CREATE TABLE t(a INTEGER PRIMARY KEY);
+SELECT dolt_commit('-Am','base');"   "^[0-9a-f]{40}$" "$DB11"
+
+run_test_match "view_stage_named_commit"   "ALTER TABLE t ADD COLUMN c INTEGER;
+CREATE VIEW vv AS SELECT a FROM t;
+CREATE TRIGGER trg AFTER INSERT ON t BEGIN SELECT 1; END;
+SELECT dolt_add('t');
+SELECT dolt_commit('-m','only t');"   "^[0-9a-f]{40}$" "$DB11"
+
+run_test "view_stays_out_of_named_commit"   "SELECT count(*) FROM sqlite_master WHERE type IN ('view','trigger');
+SELECT dolt_reset('--hard');
+SELECT count(*) FROM sqlite_master WHERE type IN ('view','trigger');
+SELECT count(*) FROM pragma_table_info('t');"   "2
+0
+0
+2" "$DB11"
+
+run_test_match "view_rides_with_am"   "CREATE VIEW v2 AS SELECT a FROM t; INSERT INTO t(a) VALUES(1);
+SELECT dolt_commit('-am','am');"   "^[0-9a-f]{40}$" "$DB11"
+
+run_test "view_in_am_commit"   "SELECT dolt_reset('--hard');
+SELECT name FROM sqlite_master WHERE type='view';"   "0
+v2" "$DB11"
+
+rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8" "$DB9" "$DB10" "$DB11"
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"


### PR DESCRIPTION
Fixes #1648, the last open item from the schema-object staging survey.

Views and triggers are entry-less (schema rows only) and the row filter marks them always-wanted, so commit inclusion was decided entirely by which master root the staged catalog carried — a named `dolt_add('t')` with a schema change on `t` adopted the working master wholesale and dragged never-staged views/triggers into the commit; without the schema change they stayed out. Inconsistent, and contrary to Dolt (verified against real Dolt: named adds keep unstaged schema objects out; `-a` carries them when dolt_schemas is tracked).

The fix composes the staged master instead of adopting it (`doltliteBuildNamedStageMasterRoot`): table/index rows — including vtabs and shadows — come from the working master so the staged entries keep its numbering domain (the #1616 constraint that forced wholesale adoption in the first place), while view and trigger rows keep the previously staged state.

Verified semantics: the #1648 repro commits the table's schema change without the view/trigger; `add -A` and `commit -am` still carry views (Dolt's tracked-dolt_schemas analog); previously staged views survive later named adds; the working state keeps its uncommitted view after the commit; vtab shadow staging (#1647) unaffected.

Gating tests in `doltlite_commit.sh` fail on master (54/56) and pass with the fix (56/56).

Also split out while verifying: #1651 — `dolt_status` is blind to view/trigger-only changes (pre-existing; more visible now that named adds correctly exclude them).

Validation: battery 88/88, C regression 309,830/309,830, index×VC matrix 38/38, oracles vs real Dolt: add 27/27, commit 37/37, reset 43/43.

🤖 Generated with [Claude Code](https://claude.com/claude-code)