### PR TITLE
Show view and trigger schema changes in dolt_status

### DIFF
--- a/src/doltlite_status.c
+++ b/src/doltlite_status.c
@@ -4,10 +4,13 @@
 #include "sqliteInt.h"
 #include "prolly_hash.h"
 #include "prolly_cursor.h"
+#include "prolly_diff.h"
+#include "prolly_cache.h"
 #include "chunk_store.h"
 #include "doltlite_commit.h"
 #include "doltlite_internal.h"
 #include "doltlite_ignore.h"
+#include "doltlite_record.h"
 #include "prolly_cursor.h"
 
 #define STATUS_IDX_STAGED_EQ 0x01
@@ -224,6 +227,124 @@ static int addRow(DoltliteStatusCursor *pCur, const char *zName,
   return SQLITE_OK;
 }
 
+static int statusSchemaRecordIsViewOrTrigger(const u8 *pRec, int nRec){
+  DoltliteRecordInfo ri;
+  int st, off, len;
+  const u8 *pBody;
+  if( !pRec || nRec<=0 ) return 0;
+  doltliteParseRecord(pRec, nRec, &ri);
+  if( ri.nField < 1 ) return 0;
+  st = ri.aType[0];
+  off = ri.aOffset[0];
+  if( st < 13 || (st & 1)==0 ) return 0;
+  len = (st - 13) / 2;
+  if( off < 0 || off + len > nRec ) return 0;
+  pBody = pRec + off;
+  if( len==4 && memcmp(pBody, "view", 4)==0 ) return 1;
+  if( len==7 && memcmp(pBody, "trigger", 7)==0 ) return 1;
+  return 0;
+}
+
+static int statusSchemaHasViewOrTrigger(sqlite3 *db,
+                                        const ProllyHash *pRoot,
+                                        u8 flags){
+  ChunkStore *cs = doltliteGetChunkStore(db);
+  ProllyCache *pCache = doltliteGetCache(db);
+  ProllyCursor cur;
+  int rc, res;
+  int found = 0;
+  if( !cs || !pCache ) return 0;
+  if( prollyHashIsEmpty(pRoot) ) return 0;
+  prollyCursorInit(&cur, cs, pCache, pRoot, flags);
+  rc = prollyCursorFirst(&cur, &res);
+  if( rc!=SQLITE_OK || res ){
+    prollyCursorClose(&cur);
+    return 0;
+  }
+  while( prollyCursorIsValid(&cur) ){
+    const u8 *pVal;
+    int nVal;
+    prollyCursorValue(&cur, &pVal, &nVal);
+    if( statusSchemaRecordIsViewOrTrigger(pVal, nVal) ){
+      found = 1;
+      break;
+    }
+    if( prollyCursorNext(&cur)!=SQLITE_OK ) break;
+  }
+  prollyCursorClose(&cur);
+  return found;
+}
+
+static int statusSchemaHasViewOrTriggerDiff(sqlite3 *db,
+                                            const ProllyHash *pOldRoot,
+                                            const ProllyHash *pNewRoot,
+                                            u8 flags){
+  ChunkStore *cs = doltliteGetChunkStore(db);
+  ProllyCache *pCache = doltliteGetCache(db);
+  ProllyDiffIter iter;
+  ProllyDiffChange *pChange = 0;
+  int rc;
+  int found = 0;
+  if( !cs || !pCache ) return 0;
+  if( prollyHashCompare(pOldRoot, pNewRoot)==0 ) return 0;
+  rc = prollyDiffIterOpen(&iter, cs, pCache, pOldRoot, pNewRoot, flags);
+  if( rc!=SQLITE_OK ) return 0;
+  while( (rc = prollyDiffIterStep(&iter, &pChange))==SQLITE_ROW && pChange ){
+    if( statusSchemaRecordIsViewOrTrigger(pChange->pNewVal, pChange->nNewVal)
+     || statusSchemaRecordIsViewOrTrigger(pChange->pOldVal, pChange->nOldVal) ){
+      found = 1;
+      break;
+    }
+  }
+  prollyDiffIterClose(&iter);
+  return found;
+}
+
+static int statusCompareDoltSchemas(
+  DoltliteStatusCursor *pCur,
+  sqlite3 *db,
+  struct TableEntry *aFrom,
+  int nFrom,
+  struct TableEntry *aTo,
+  int nTo,
+  int staged,
+  const char *zFilter
+){
+  ProllyHash emptyRoot;
+  const ProllyHash *pOldRoot;
+  const ProllyHash *pNewRoot;
+  struct TableEntry *pOldMaster;
+  struct TableEntry *pNewMaster;
+  u8 flags;
+  int oldHas;
+  int newHas;
+
+  if( zFilter && strcmp(zFilter, "dolt_schemas")!=0 ) return SQLITE_OK;
+
+  memset(&emptyRoot, 0, sizeof(emptyRoot));
+  pOldMaster = doltliteFindTableByNumber(aFrom, nFrom, 1);
+  pNewMaster = doltliteFindTableByNumber(aTo, nTo, 1);
+  if( !pOldMaster && !pNewMaster ) return SQLITE_OK;
+
+  pOldRoot = pOldMaster ? &pOldMaster->root : &emptyRoot;
+  pNewRoot = pNewMaster ? &pNewMaster->root : &emptyRoot;
+  flags = pNewMaster ? pNewMaster->flags : pOldMaster->flags;
+
+  if( !statusSchemaHasViewOrTriggerDiff(db, pOldRoot, pNewRoot, flags) ){
+    return SQLITE_OK;
+  }
+
+  oldHas = statusSchemaHasViewOrTrigger(db, pOldRoot, flags);
+  newHas = statusSchemaHasViewOrTrigger(db, pNewRoot, flags);
+  if( !oldHas && newHas ){
+    return addRow(pCur, "dolt_schemas", staged, "new table");
+  }
+  if( oldHas && !newHas ){
+    return addRow(pCur, "dolt_schemas", staged, "deleted");
+  }
+  return addRow(pCur, "dolt_schemas", staged, "modified");
+}
+
 static int statusLoadLiveTableSql(
   sqlite3 *db,
   const char *zName,
@@ -414,6 +535,10 @@ static int compareCatalogs(
     }
   }
 
+  rc = statusCompareDoltSchemas(pCur, db, aFrom, nFrom, aTo, nTo,
+                                staged, 0);
+  if( rc!=SQLITE_OK ) goto compare_done;
+
   for(i=0; i<nTo; i++){
     struct TableEntry *pFrom;
     char *zName;
@@ -557,6 +682,11 @@ static int compareCatalogsFiltered(
   useRename = (nFrom <= DOLT_STATUS_RENAME_CAP && nTo <= DOLT_STATUS_RENAME_CAP);
 
   if( !zFilter ) return compareCatalogs(pCur, db, aFrom, nFrom, aTo, nTo, staged);
+
+  if( strcmp(zFilter, "dolt_schemas")==0 ){
+    return statusCompareDoltSchemas(pCur, db, aFrom, nFrom, aTo, nTo,
+                                    staged, zFilter);
+  }
 
   if( statusHasUnnamedUserTable(aFrom, nFrom)
    || statusHasUnnamedUserTable(aTo, nTo) ){

--- a/test/vc_oracle_status_test.sh
+++ b/test/vc_oracle_status_test.sh
@@ -47,6 +47,38 @@ oracle() {
   fi
 }
 
+oracle_dual() {
+  local name="$1" dl_setup="$2" dt_setup="$3" allow_empty="${4:-}"
+  local dir="$TMPROOT/$name"
+  mkdir -p "$dir/dl" "$dir/dt"
+
+  local dl_out
+  dl_out=$(printf "%s\n.headers off\n.mode list\n.separator '\t'\nSELECT table_name || char(9) || staged || char(9) || status FROM dolt_status ORDER BY table_name, staged, status;\n" "$dl_setup" \
+           | "$DOLTLITE" "$dir/dl/db" 2>"$dir/dl.err" \
+           | grep -v '^[0-9]*$' \
+           | grep -v '^[0-9a-f]\{40\}$' \
+           | normalize)
+
+  local dolt_setup
+  dolt_setup=$(vc_oracle_translate_for_dolt "$dt_setup")
+
+  (
+    cd "$dir/dt" || exit 1
+    vc_oracle_init_repo
+    echo "$dolt_setup" | "$DOLT" sql -c >/dev/null 2>"$dir/dt.err"
+    "$DOLT" sql -r csv -q "SELECT concat(table_name, char(9), staged, char(9), status) FROM dolt_status ORDER BY table_name, staged, status;" 2>>"$dir/dt.err"
+  ) > "$dir/dt.raw"
+
+  local dt_out
+  dt_out=$(vc_oracle_tail_csv_body "$dir/dt.raw" | normalize)
+
+  if [ "$allow_empty" = "EXPECT_EMPTY" ]; then
+    vc_oracle_assert_match_allow_empty "$name" "$dl_out" "$dt_out"
+  else
+    vc_oracle_assert_match "$name" "$dl_out" "$dt_out"
+  fi
+}
+
 status_filter_pushdown() {
   local name="$1" setup="$2" filter="$3" expected_idx="$4"
   local dir="$TMPROOT/${name}_pushdown"
@@ -186,6 +218,114 @@ CREATE TABLE a(k INTEGER PRIMARY KEY, n INTEGER);
 INSERT INTO a VALUES (7, 70);
 "
 
+echo "--- view and trigger schema rows ---"
+
+oracle "view_create_unstaged" "
+CREATE TABLE t(a INTEGER PRIMARY KEY);
+SELECT dolt_commit('-Am','base');
+CREATE VIEW v1 AS SELECT a FROM t;
+"
+
+oracle "view_create_staged" "
+CREATE TABLE t(a INTEGER PRIMARY KEY);
+SELECT dolt_commit('-Am','base');
+CREATE VIEW v1 AS SELECT a FROM t;
+SELECT dolt_add('-A');
+"
+
+oracle "view_create_named_add_table_stays_unstaged" "
+CREATE TABLE t(a INTEGER PRIMARY KEY);
+SELECT dolt_commit('-Am','base');
+CREATE VIEW v1 AS SELECT a FROM t;
+SELECT dolt_add('t');
+"
+
+oracle "view_modify_unstaged" "
+CREATE TABLE t(a INTEGER PRIMARY KEY);
+CREATE VIEW v1 AS SELECT a FROM t;
+SELECT dolt_commit('-Am','base');
+DROP VIEW v1;
+CREATE VIEW v1 AS SELECT a + 1 AS a FROM t;
+"
+
+oracle "view_drop_unstaged" "
+CREATE TABLE t(a INTEGER PRIMARY KEY);
+CREATE VIEW v1 AS SELECT a FROM t;
+SELECT dolt_commit('-Am','base');
+DROP VIEW v1;
+"
+
+oracle "second_view_create_is_schema_modified" "
+CREATE TABLE t(a INTEGER PRIMARY KEY);
+CREATE VIEW v1 AS SELECT a FROM t;
+SELECT dolt_commit('-Am','base');
+CREATE VIEW v2 AS SELECT a FROM t WHERE a > 10;
+"
+
+oracle "view_and_table_data_mixed_status" "
+CREATE TABLE t(a INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1, 'base');
+SELECT dolt_commit('-Am','base');
+CREATE VIEW v1 AS SELECT a FROM t;
+INSERT INTO t VALUES (2, 'new');
+"
+
+oracle_dual "trigger_create_unstaged" "
+CREATE TABLE t(a INTEGER PRIMARY KEY);
+CREATE TABLE log(msg TEXT);
+SELECT dolt_commit('-Am','base');
+CREATE TRIGGER tr AFTER INSERT ON t BEGIN INSERT INTO log VALUES('i'); END;
+" "
+CREATE TABLE t(a INTEGER PRIMARY KEY);
+CREATE TABLE log(msg TEXT);
+SELECT dolt_commit('-Am','base');
+CREATE TRIGGER tr AFTER INSERT ON t FOR EACH ROW INSERT INTO log VALUES('i');
+"
+
+oracle_dual "trigger_create_staged" "
+CREATE TABLE t(a INTEGER PRIMARY KEY);
+CREATE TABLE log(msg TEXT);
+SELECT dolt_commit('-Am','base');
+CREATE TRIGGER tr AFTER INSERT ON t BEGIN INSERT INTO log VALUES('i'); END;
+SELECT dolt_add('-A');
+" "
+CREATE TABLE t(a INTEGER PRIMARY KEY);
+CREATE TABLE log(msg TEXT);
+SELECT dolt_commit('-Am','base');
+CREATE TRIGGER tr AFTER INSERT ON t FOR EACH ROW INSERT INTO log VALUES('i');
+SELECT dolt_add('-A');
+"
+
+oracle_dual "trigger_modify_unstaged" "
+CREATE TABLE t(a INTEGER PRIMARY KEY);
+CREATE TABLE log(msg TEXT);
+CREATE TRIGGER tr AFTER INSERT ON t BEGIN INSERT INTO log VALUES('i'); END;
+SELECT dolt_commit('-Am','base');
+DROP TRIGGER tr;
+CREATE TRIGGER tr AFTER INSERT ON t BEGIN INSERT INTO log VALUES('j'); END;
+" "
+CREATE TABLE t(a INTEGER PRIMARY KEY);
+CREATE TABLE log(msg TEXT);
+CREATE TRIGGER tr AFTER INSERT ON t FOR EACH ROW INSERT INTO log VALUES('i');
+SELECT dolt_commit('-Am','base');
+DROP TRIGGER tr;
+CREATE TRIGGER tr AFTER INSERT ON t FOR EACH ROW INSERT INTO log VALUES('j');
+"
+
+oracle_dual "trigger_drop_unstaged" "
+CREATE TABLE t(a INTEGER PRIMARY KEY);
+CREATE TABLE log(msg TEXT);
+CREATE TRIGGER tr AFTER INSERT ON t BEGIN INSERT INTO log VALUES('i'); END;
+SELECT dolt_commit('-Am','base');
+DROP TRIGGER tr;
+" "
+CREATE TABLE t(a INTEGER PRIMARY KEY);
+CREATE TABLE log(msg TEXT);
+CREATE TRIGGER tr AFTER INSERT ON t FOR EACH ROW INSERT INTO log VALUES('i');
+SELECT dolt_commit('-Am','base');
+DROP TRIGGER tr;
+"
+
 echo "--- deletions ---"
 
 oracle "deleted_unstaged" "
@@ -313,6 +453,19 @@ SELECT dolt_add('a');
 SELECT dolt_commit('-m', 'seed');
 ALTER TABLE a RENAME TO b;
 " "table_name='a -> b'" "2"
+
+status_filter_pushdown "filtered_dolt_schemas_matches_unfiltered" "
+CREATE TABLE t(a INTEGER PRIMARY KEY);
+SELECT dolt_commit('-Am','base');
+CREATE VIEW v1 AS SELECT a FROM t;
+" "table_name='dolt_schemas'" "2"
+
+status_filter_pushdown "filtered_dolt_schemas_staged_matches_unfiltered" "
+CREATE TABLE t(a INTEGER PRIMARY KEY);
+SELECT dolt_commit('-Am','base');
+CREATE VIEW v1 AS SELECT a FROM t;
+SELECT dolt_add('-A');
+" "staged=1 AND table_name='dolt_schemas'" "3"
 
 echo "--- multi-table ---"
 


### PR DESCRIPTION
Fixes #1651

This updates dolt_status to report dolt_schemas when view or trigger schema rows change without a corresponding table catalog entry. It handles unstaged and staged changes, create/modify/drop transitions, and filtered scans against dolt_schemas.

Tests:
- make -C build -j$(sysctl -n hw.ncpu 2>/dev/null || nproc) DOLTLITE_PROLLY_CHECK=1 doltlite
- bash test/vc_oracle_status_test.sh build/doltlite dolt
- bash test/vc_oracle_schemas_test.sh build/doltlite dolt
- bash test/vc_oracle_commit_test.sh build/doltlite dolt
- bash test/vc_oracle_diff_test.sh build/doltlite dolt