### PR TITLE
Add schema object dolt_status oracle coverage

### DIFF
--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -788,7 +788,7 @@ static int addAppendTableEntry(
   if( pEntry->zName ){
     zDup = sqlite3_mprintf("%s", pEntry->zName);
     if( !zDup ){
-      sqlite3_result_error_nomem(context);
+      if( context ) sqlite3_result_error_nomem(context);
       return SQLITE_NOMEM;
     }
   }
@@ -796,7 +796,7 @@ static int addAppendTableEntry(
       *paEntries, (*pnEntries + 1) * (int)sizeof(struct TableEntry));
   if( !aNew ){
     sqlite3_free(zDup);
-    sqlite3_result_error_nomem(context);
+    if( context ) sqlite3_result_error_nomem(context);
     return SQLITE_NOMEM;
   }
   *paEntries = aNew;
@@ -1443,9 +1443,17 @@ static int addStageNamedTables(
         int k;
         int updated = 0;
         for(k=0; k<nStaged; k++){
-          if( aStaged[k].iTable==iTable
-           || (aStaged[k].zName && aWorking[j].zName
-               && strcmp(aStaged[k].zName, aWorking[j].zName)==0) ){
+          int nameMatch = aStaged[k].zName && aWorking[j].zName
+            && strcmp(aStaged[k].zName, aWorking[j].zName)==0;
+          int rootMatch = aStaged[k].iTable==iTable;
+          int unnamedRootMatch = rootMatch
+            && (!aStaged[k].zName || !aWorking[j].zName);
+          int renameRootMatch = rootMatch
+            && aStaged[k].zName && aWorking[j].zName
+            && strcmp(aStaged[k].zName, aWorking[j].zName)!=0
+            && !addFindEntryByName(aWorking, nWorking, aStaged[k].zName)
+            && !addFindEntryByName(aStaged, nStaged, aWorking[j].zName);
+          if( nameMatch || unnamedRootMatch || renameRootMatch ){
             int schemaChanged =
               prollyHashCompare(&aStaged[k].schemaHash, &aWorking[j].schemaHash)!=0;
             int nameChanged =
@@ -2475,6 +2483,8 @@ static int resetStageNamedPaths(
         goto done;
       }
       aStaged = aNew;
+      addRemoveIndexEntriesOfTable(aStaged, &nStaged,
+                                   aHeadSchema, nHeadSchema, zTable);
       zDup = aHead[iH].zName ? sqlite3_mprintf("%s", aHead[iH].zName) : 0;
       if( aHead[iH].zName && !zDup ){
         rc = SQLITE_NOMEM;
@@ -2484,6 +2494,11 @@ static int resetStageNamedPaths(
       aStaged[nStaged].zName = zDup;
       aStaged[nStaged].iTable = iNextFree++;
       nStaged++;
+      rc = addAppendIndexEntriesOfTable(0, &aStaged, &nStaged,
+                                        aHead, nHead,
+                                        aHeadSchema, nHeadSchema,
+                                        zTable);
+      if( rc!=SQLITE_OK ) goto done;
     }else{
       /* Take HEAD's content under the STAGED entry's number so the entry
       ** keeps pairing with the staged catalog's schema row. */

--- a/src/doltlite_status.c
+++ b/src/doltlite_status.c
@@ -345,6 +345,101 @@ static int statusCompareDoltSchemas(
   return addRow(pCur, "dolt_schemas", staged, "modified");
 }
 
+static int statusRowExists(
+  DoltliteStatusCursor *pCur,
+  const char *zName,
+  int staged
+){
+  int i;
+  for(i=0; i<pCur->nRows; i++){
+    if( pCur->aRows[i].staged==staged
+     && pCur->aRows[i].zName
+     && strcmp(pCur->aRows[i].zName, zName)==0 ){
+      return 1;
+    }
+  }
+  return 0;
+}
+
+static int statusSchemaSqlChanged(const SchemaEntry *pA, const SchemaEntry *pB){
+  const char *zA;
+  const char *zB;
+  if( !pA || !pB ) return 1;
+  zA = pA->zSql ? pA->zSql : "";
+  zB = pB->zSql ? pB->zSql : "";
+  return strcmp(zA, zB)!=0;
+}
+
+static int statusMaybeAddParentSchemaChange(
+  DoltliteStatusCursor *pCur,
+  const char *zParent,
+  int staged,
+  const char *zFilter
+){
+  if( !zParent ) return SQLITE_OK;
+  if( zFilter && strcmp(zFilter, zParent)!=0 ) return SQLITE_OK;
+  if( statusRowExists(pCur, zParent, staged) ) return SQLITE_OK;
+  return addRow(pCur, zParent, staged, "modified");
+}
+
+static int statusCompareIndexSchemaObjects(
+  DoltliteStatusCursor *pCur,
+  sqlite3 *db,
+  const ProllyHash *pFromCat,
+  const ProllyHash *pToCat,
+  int staged,
+  const char *zFilter
+){
+  ChunkStore *cs = doltliteGetChunkStore(db);
+  ProllyCache *pCache = doltliteGetCache(db);
+  SchemaEntry *aFrom = 0;
+  SchemaEntry *aTo = 0;
+  int nFrom = 0;
+  int nTo = 0;
+  int i;
+  int rc;
+
+  if( !cs || !pCache ) return SQLITE_OK;
+  rc = loadSchemaFromCatalog(db, cs, pCache, pFromCat, &aFrom, &nFrom);
+  if( rc!=SQLITE_OK ) goto index_schema_done;
+  rc = loadSchemaFromCatalog(db, cs, pCache, pToCat, &aTo, &nTo);
+  if( rc!=SQLITE_OK ) goto index_schema_done;
+
+  for(i=0; i<nTo; i++){
+    SchemaEntry *pOld;
+    if( !aTo[i].zType || strcmp(aTo[i].zType, "index")!=0 ) continue;
+    if( !aTo[i].zName || !aTo[i].zTblName ) continue;
+    pOld = findSchemaEntry(aFrom, nFrom, aTo[i].zName);
+    if( !pOld
+     || !pOld->zType
+     || strcmp(pOld->zType, "index")!=0
+     || !pOld->zTblName
+     || strcmp(pOld->zTblName, aTo[i].zTblName)!=0
+     || statusSchemaSqlChanged(pOld, &aTo[i]) ){
+      rc = statusMaybeAddParentSchemaChange(pCur, aTo[i].zTblName,
+                                            staged, zFilter);
+      if( rc!=SQLITE_OK ) goto index_schema_done;
+    }
+  }
+
+  for(i=0; i<nFrom; i++){
+    SchemaEntry *pNew;
+    if( !aFrom[i].zType || strcmp(aFrom[i].zType, "index")!=0 ) continue;
+    if( !aFrom[i].zName || !aFrom[i].zTblName ) continue;
+    pNew = findSchemaEntry(aTo, nTo, aFrom[i].zName);
+    if( !pNew || !pNew->zType || strcmp(pNew->zType, "index")!=0 ){
+      rc = statusMaybeAddParentSchemaChange(pCur, aFrom[i].zTblName,
+                                            staged, zFilter);
+      if( rc!=SQLITE_OK ) goto index_schema_done;
+    }
+  }
+
+index_schema_done:
+  freeSchemaEntries(aFrom, nFrom);
+  freeSchemaEntries(aTo, nTo);
+  return rc;
+}
+
 static int statusLoadLiveTableSql(
   sqlite3 *db,
   const char *zName,
@@ -494,6 +589,7 @@ rename_done:
 
 static int compareCatalogs(
   DoltliteStatusCursor *pCur, sqlite3 *db,
+  const ProllyHash *pFromCat, const ProllyHash *pToCat,
   struct TableEntry *aFrom, int nFrom,
   struct TableEntry *aTo, int nTo,
   int staged
@@ -602,7 +698,8 @@ static int compareCatalogs(
       if( rc!=SQLITE_OK ) goto compare_done;
     }
   }
-  rc = SQLITE_OK;
+  rc = statusCompareIndexSchemaObjects(pCur, db, pFromCat, pToCat,
+                                       staged, 0);
 
 compare_done:
   statusCatalogIndexFree(&fromIdx);
@@ -665,6 +762,7 @@ static int statusInitPairIndexes(
 
 static int compareCatalogsFiltered(
   DoltliteStatusCursor *pCur, sqlite3 *db,
+  const ProllyHash *pFromCat, const ProllyHash *pToCat,
   struct TableEntry *aFrom, int nFrom,
   struct TableEntry *aTo, int nTo,
   int staged,
@@ -681,7 +779,10 @@ static int compareCatalogsFiltered(
   #define DOLT_STATUS_RENAME_CAP 4096
   useRename = (nFrom <= DOLT_STATUS_RENAME_CAP && nTo <= DOLT_STATUS_RENAME_CAP);
 
-  if( !zFilter ) return compareCatalogs(pCur, db, aFrom, nFrom, aTo, nTo, staged);
+  if( !zFilter ){
+    return compareCatalogs(pCur, db, pFromCat, pToCat,
+                           aFrom, nFrom, aTo, nTo, staged);
+  }
 
   if( strcmp(zFilter, "dolt_schemas")==0 ){
     return statusCompareDoltSchemas(pCur, db, aFrom, nFrom, aTo, nTo,
@@ -691,7 +792,8 @@ static int compareCatalogsFiltered(
   if( statusHasUnnamedUserTable(aFrom, nFrom)
    || statusHasUnnamedUserTable(aTo, nTo) ){
     int nStart = pCur->nRows;
-    rc = compareCatalogs(pCur, db, aFrom, nFrom, aTo, nTo, staged);
+    rc = compareCatalogs(pCur, db, pFromCat, pToCat,
+                         aFrom, nFrom, aTo, nTo, staged);
     if( rc==SQLITE_OK ){
       int i, j = nStart;
       for(i=nStart; i<pCur->nRows; i++){
@@ -805,7 +907,8 @@ check_deleted:
       if( rc!=SQLITE_OK ) goto filtered_done;
     }
   }
-  rc = SQLITE_OK;
+  rc = statusCompareIndexSchemaObjects(pCur, db, pFromCat, pToCat,
+                                       staged, zFilter);
 
 filtered_done:
   if( idxInit ){
@@ -911,7 +1014,8 @@ static int statusFilter(sqlite3_vtab_cursor *pCursor,
     rc = doltliteLoadCatalog(db, &stagedCatHash, &aStaged, &nStaged, 0);
     if( rc != SQLITE_OK ) goto status_done;
     stagedLoaded = 1;
-    rc = compareCatalogsFiltered(pCur, db, aHead, nHead, aStaged, nStaged,
+    rc = compareCatalogsFiltered(pCur, db, &headCatHash, &stagedCatHash,
+                                 aHead, nHead, aStaged, nStaged,
                                  1, zTableFilter);
     if( rc != SQLITE_OK ) goto status_done;
   }
@@ -942,8 +1046,9 @@ static int statusFilter(sqlite3_vtab_cursor *pCursor,
       rc = doltliteLoadCatalog(db, &workingCatHash, &aWorking, &nWorking, 0);
       if( rc != SQLITE_OK ) goto status_done;
       workingLoaded = 1;
-      rc = compareCatalogsFiltered(pCur, db, aBase, nBase,
-                                   aWorking, nWorking, 0, zTableFilter);
+      rc = compareCatalogsFiltered(pCur, db, &baseCatHash, &workingCatHash,
+                                   aBase, nBase, aWorking, nWorking,
+                                   0, zTableFilter);
       if( rc != SQLITE_OK ) goto status_done;
     }
   }

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -2023,11 +2023,16 @@ static int appendFallbackSchemaCatalogRows(
   for(i=0; i<nTables; i++){
     SchemaEntry *pSe = 0;
     SchemaCatalogRow *pRow;
-    if( aTables[i].iTable<=1 || !aTables[i].zName ) continue;
+    if( aTables[i].iTable<=1 ) continue;
     if( schemaCatalogHasPgno(aRows, nRows, aTables[i].iTable) ) continue;
     for(j=0; j<nFallback; j++){
       if( !aFallback[j].zName || !aFallback[j].zType ) continue;
-      if( strcmp(aFallback[j].zName, aTables[i].zName)!=0 ) continue;
+      if( aTables[i].zName ){
+        if( strcmp(aFallback[j].zName, aTables[i].zName)!=0 ) continue;
+      }else{
+        if( strcmp(aFallback[j].zType, "index")!=0 ) continue;
+        if( aFallback[j].iRootpage!=aTables[i].iTable ) continue;
+      }
       pSe = &aFallback[j];
       break;
     }

--- a/test/vc_oracle_status_schema_objects_test.sh
+++ b/test/vc_oracle_status_schema_objects_test.sh
@@ -1,0 +1,303 @@
+#!/bin/bash
+
+set -u
+set -o pipefail
+
+DOLTLITE="${1:-./doltlite}"
+DOLT="${2:-dolt}"
+TMPROOT=$(mktemp -d)
+trap "rm -rf $TMPROOT" EXIT
+pass=0; fail=0
+FAILED_NAMES=""
+source "$(dirname "$0")/lib/vc_oracle_common.sh"
+
+normalize() {
+  tr -d '\r'
+}
+
+oracle_status() {
+  local name="$1" setup="$2" allow_empty="${3:-}"
+  local dir="$TMPROOT/$name"
+  mkdir -p "$dir/dl" "$dir/dt"
+
+  local dl_out
+  dl_out=$(printf "%s\n.headers off\n.mode list\n.separator '\t'\nSELECT table_name || char(9) || staged || char(9) || status FROM dolt_status ORDER BY table_name, staged, status;\n" "$setup" \
+           | "$DOLTLITE" "$dir/dl/db" 2>"$dir/dl.err" \
+           | grep -v '^[0-9]*$' \
+           | grep -v '^[0-9a-f]\{40\}$' \
+           | normalize)
+
+  local dolt_setup
+  dolt_setup=$(vc_oracle_translate_for_dolt "$setup")
+
+  (
+    cd "$dir/dt" || exit 1
+    vc_oracle_init_repo
+    echo "$dolt_setup" | "$DOLT" sql -c >/dev/null 2>"$dir/dt.err"
+    "$DOLT" sql -r csv -q "SELECT concat(table_name, char(9), staged, char(9), status) FROM dolt_status ORDER BY table_name, staged, status;" 2>>"$dir/dt.err"
+  ) > "$dir/dt.raw"
+
+  local dt_out
+  dt_out=$(vc_oracle_tail_csv_body "$dir/dt.raw" | normalize)
+
+  if [ "$allow_empty" = "EXPECT_EMPTY" ]; then
+    vc_oracle_assert_match_allow_empty "$name" "$dl_out" "$dt_out"
+  else
+    vc_oracle_assert_match "$name" "$dl_out" "$dt_out"
+  fi
+}
+
+oracle_status_dual() {
+  local name="$1" dl_setup="$2" dt_setup="$3" allow_empty="${4:-}"
+  local dir="$TMPROOT/$name"
+  mkdir -p "$dir/dl" "$dir/dt"
+
+  local dl_out
+  dl_out=$(printf "%s\n.headers off\n.mode list\n.separator '\t'\nSELECT table_name || char(9) || staged || char(9) || status FROM dolt_status ORDER BY table_name, staged, status;\n" "$dl_setup" \
+           | "$DOLTLITE" "$dir/dl/db" 2>"$dir/dl.err" \
+           | grep -v '^[0-9]*$' \
+           | grep -v '^[0-9a-f]\{40\}$' \
+           | normalize)
+
+  local dolt_setup
+  dolt_setup=$(vc_oracle_translate_for_dolt "$dt_setup")
+
+  (
+    cd "$dir/dt" || exit 1
+    vc_oracle_init_repo
+    echo "$dolt_setup" | "$DOLT" sql -c >/dev/null 2>"$dir/dt.err"
+    "$DOLT" sql -r csv -q "SELECT concat(table_name, char(9), staged, char(9), status) FROM dolt_status ORDER BY table_name, staged, status;" 2>>"$dir/dt.err"
+  ) > "$dir/dt.raw"
+
+  local dt_out
+  dt_out=$(vc_oracle_tail_csv_body "$dir/dt.raw" | normalize)
+
+  if [ "$allow_empty" = "EXPECT_EMPTY" ]; then
+    vc_oracle_assert_match_allow_empty "$name" "$dl_out" "$dt_out"
+  else
+    vc_oracle_assert_match "$name" "$dl_out" "$dt_out"
+  fi
+}
+
+status_filter_pushdown() {
+  local name="$1" setup="$2" filter="$3" expected_idx="$4"
+  local dir="$TMPROOT/${name}_pushdown"
+  mkdir -p "$dir"
+
+  local script
+  script="$setup
+.headers off
+.mode list
+.separator '	'
+CREATE TEMP TABLE expected_status AS
+  SELECT table_name, staged, status FROM dolt_status;
+SELECT 'A|' || table_name || '|' || staged || '|' || status
+  FROM expected_status
+ WHERE $filter
+ ORDER BY table_name, staged, status;
+SELECT 'B|' || table_name || '|' || staged || '|' || status
+  FROM dolt_status
+ WHERE $filter
+ ORDER BY table_name, staged, status;
+EXPLAIN QUERY PLAN SELECT * FROM dolt_status WHERE $filter;"
+
+  local out actual expected plan
+  out=$(printf "%s\n" "$script" \
+        | "$DOLTLITE" "$dir/db" 2>"$dir/err" \
+        | tr -d '\r')
+  expected=$(printf "%s\n" "$out" | grep '^A|' | sed 's/^A|//')
+  actual=$(printf "%s\n" "$out" | grep '^B|' | sed 's/^B|//')
+  plan=$(printf "%s\n" "$out" | grep "VIRTUAL TABLE INDEX $expected_idx")
+
+  if [ "$actual" = "$expected" ] && [ -n "$plan" ]; then
+    pass=$((pass+1))
+  else
+    fail=$((fail+1))
+    FAILED_NAMES="$FAILED_NAMES $name"
+    echo "  FAIL: $name"
+    echo "    expected:"; echo "$expected" | sed 's/^/      /'
+    echo "    actual:";   echo "$actual" | sed 's/^/      /'
+    echo "    plan:";     printf "%s\n" "$out" | grep "dolt_status" | sed 's/^/      /'
+    echo "    stderr:";   sed 's/^/      /' "$dir/err"
+  fi
+}
+
+echo "=== Version Control Oracle Tests: dolt_status schema objects ==="
+echo ""
+
+echo "--- indexes ---"
+
+oracle_status "create_index_unstaged" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 10);
+SELECT dolt_commit('-Am', 'base');
+CREATE INDEX idx_t_v ON t(v);
+"
+
+oracle_status "create_index_staged" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 10);
+SELECT dolt_commit('-Am', 'base');
+CREATE INDEX idx_t_v ON t(v);
+SELECT dolt_add('t');
+"
+
+oracle_status "create_index_staged_then_data_unstaged" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 10);
+SELECT dolt_commit('-Am', 'base');
+CREATE INDEX idx_t_v ON t(v);
+SELECT dolt_add('t');
+INSERT INTO t VALUES (2, 20);
+"
+
+oracle_status_dual "drop_index_unstaged" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+CREATE INDEX idx_t_v ON t(v);
+INSERT INTO t VALUES (1, 10);
+SELECT dolt_commit('-Am', 'base');
+DROP INDEX idx_t_v;
+" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+CREATE INDEX idx_t_v ON t(v);
+INSERT INTO t VALUES (1, 10);
+SELECT dolt_commit('-Am', 'base');
+DROP INDEX idx_t_v ON t;
+"
+
+oracle_status_dual "replace_index_unstaged" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT, w INT);
+CREATE INDEX idx_t_v ON t(v);
+INSERT INTO t VALUES (1, 10, 100);
+SELECT dolt_commit('-Am', 'base');
+DROP INDEX idx_t_v;
+CREATE INDEX idx_t_w ON t(w);
+" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT, w INT);
+CREATE INDEX idx_t_v ON t(v);
+INSERT INTO t VALUES (1, 10, 100);
+SELECT dolt_commit('-Am', 'base');
+DROP INDEX idx_t_v ON t;
+CREATE INDEX idx_t_w ON t(w);
+"
+
+oracle_status "unique_index_unstaged" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 10);
+SELECT dolt_commit('-Am', 'base');
+CREATE UNIQUE INDEX idx_t_v_unique ON t(v);
+"
+
+oracle_status "composite_index_unstaged" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT, w INT);
+INSERT INTO t VALUES (1, 10, 100);
+SELECT dolt_commit('-Am', 'base');
+CREATE INDEX idx_t_v_w ON t(v, w);
+"
+
+echo "--- columns and table constraints ---"
+
+oracle_status "add_column_unstaged" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 10);
+SELECT dolt_commit('-Am', 'base');
+ALTER TABLE t ADD COLUMN note TEXT;
+"
+
+oracle_status "add_column_default_staged" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 10);
+SELECT dolt_commit('-Am', 'base');
+ALTER TABLE t ADD COLUMN flag INT DEFAULT 0;
+SELECT dolt_add('t');
+"
+
+oracle_status "add_column_staged_then_data_unstaged" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 10);
+SELECT dolt_commit('-Am', 'base');
+ALTER TABLE t ADD COLUMN flag INT DEFAULT 0;
+SELECT dolt_add('t');
+INSERT INTO t(id, v, flag) VALUES (2, 20, 1);
+"
+
+oracle_status "create_check_table_unstaged" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT CHECK (v > 0));
+INSERT INTO t VALUES (1, 10);
+"
+
+oracle_status "create_unique_table_unstaged" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, email TEXT UNIQUE);
+INSERT INTO t VALUES (1, 'a@example.com');
+"
+
+echo "--- foreign keys ---"
+
+oracle_status "create_fk_child_unstaged" "
+CREATE TABLE parent(id INTEGER PRIMARY KEY);
+INSERT INTO parent VALUES (1);
+SELECT dolt_commit('-Am', 'parent');
+CREATE TABLE child(id INTEGER PRIMARY KEY, parent_id INTEGER, FOREIGN KEY(parent_id) REFERENCES parent(id));
+INSERT INTO child VALUES (1, 1);
+"
+
+oracle_status "create_fk_child_staged" "
+CREATE TABLE parent(id INTEGER PRIMARY KEY);
+INSERT INTO parent VALUES (1);
+SELECT dolt_commit('-Am', 'parent');
+CREATE TABLE child(id INTEGER PRIMARY KEY, parent_id INTEGER, FOREIGN KEY(parent_id) REFERENCES parent(id));
+INSERT INTO child VALUES (1, 1);
+SELECT dolt_add('child');
+"
+
+echo "--- mixed schema objects ---"
+
+oracle_status "two_tables_one_schema_object_staged" "
+CREATE TABLE a(id INTEGER PRIMARY KEY, v INT);
+CREATE TABLE b(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO a VALUES (1, 10);
+INSERT INTO b VALUES (1, 10);
+SELECT dolt_commit('-Am', 'base');
+CREATE INDEX idx_a_v ON a(v);
+CREATE INDEX idx_b_v ON b(v);
+SELECT dolt_add('a');
+"
+
+oracle_status "schema_object_and_table_create_mix" "
+CREATE TABLE a(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO a VALUES (1, 10);
+SELECT dolt_commit('-Am', 'base');
+CREATE INDEX idx_a_v ON a(v);
+CREATE TABLE b(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO b VALUES (1, 10);
+"
+
+echo "--- filtered scans ---"
+
+status_filter_pushdown "filtered_index_change_matches_unfiltered" "
+CREATE TABLE a(id INTEGER PRIMARY KEY, v INT);
+CREATE TABLE b(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO a VALUES (1, 10);
+INSERT INTO b VALUES (1, 10);
+SELECT dolt_commit('-Am', 'base');
+CREATE INDEX idx_a_v ON a(v);
+CREATE INDEX idx_b_v ON b(v);
+" "table_name='a'" "2"
+
+status_filter_pushdown "filtered_staged_index_change_matches_unfiltered" "
+CREATE TABLE a(id INTEGER PRIMARY KEY, v INT);
+CREATE TABLE b(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO a VALUES (1, 10);
+INSERT INTO b VALUES (1, 10);
+SELECT dolt_commit('-Am', 'base');
+CREATE INDEX idx_a_v ON a(v);
+CREATE INDEX idx_b_v ON b(v);
+SELECT dolt_add('a');
+" "staged=1 AND table_name='a'" "3"
+
+echo ""
+echo "=== Results: $pass passed, $fail failed ==="
+if [ $fail -gt 0 ]; then
+  echo "Failed:$FAILED_NAMES"
+  exit 1
+fi


### PR DESCRIPTION
This adds a dedicated Dolt oracle suite for dolt_status schema-object behavior: index create/drop/replace, unique and composite indexes, column/schema changes, CHECK/UNIQUE/FK table definitions, mixed table/schema-object states, and filtered scans.

The new oracle exposed and this PR fixes:
- index-only schema changes were missing from dolt_status
- staging a named table could overwrite a different named staged entry when SQLite reused rootpages under FK DDL
- path reset of a staged dropped indexed table restored the table without its index entries
- fallback catalog serialization could not recover schema rows for unnamed index entries

Tests:
- make -C build -j$(sysctl -n hw.ncpu 2>/dev/null || nproc) DOLTLITE_PROLLY_CHECK=1 doltlite
- bash test/vc_oracle_status_schema_objects_test.sh build/doltlite dolt
- bash test/vc_oracle_status_test.sh build/doltlite dolt
- bash test/vc_oracle_add_test.sh build/doltlite dolt
- bash test/vc_oracle_reset_test.sh build/doltlite dolt
- bash test/vc_oracle_checkout_test.sh build/doltlite dolt
- bash test/vc_oracle_schemas_test.sh build/doltlite dolt
- bash test/vc_oracle_schema_diff_test.sh build/doltlite dolt
- bash test/vc_oracle_commit_test.sh build/doltlite dolt
- bash test/vc_oracle_diff_test.sh build/doltlite dolt

Fixes #1655
