### PR TITLE
Attribute index changes to their table in the dolt_diff summary

### DIFF
--- a/src/doltlite_diff.c
+++ b/src/doltlite_diff.c
@@ -282,6 +282,59 @@ static int batchAppend(DoltliteDiffCursor *pCur,
   return SQLITE_OK;
 }
 
+/* Index changes carry no named entry of their own: attribute them to the
+** parent table by comparing each catalog's index schema rows (name + sql),
+** so an index-only commit reports the table with schema_change=1 the way
+** Dolt does. */
+static int indexRowsDifferForTable(
+  SchemaEntry *aA, int nA,
+  SchemaEntry *aB, int nB,
+  const char *zTable
+){
+  int i, j, nMatchA = 0, nB4T = 0;
+  for(i=0; i<nA; i++){
+    int found = 0;
+    if( !aA[i].zType || strcmp(aA[i].zType, "index")!=0
+     || !aA[i].zTblName || strcmp(aA[i].zTblName, zTable)!=0 ){
+      continue;
+    }
+    for(j=0; j<nB; j++){
+      if( aB[j].zType && strcmp(aB[j].zType, "index")==0
+       && aB[j].zTblName && strcmp(aB[j].zTblName, zTable)==0
+       && aB[j].zName && aA[i].zName
+       && strcmp(aB[j].zName, aA[i].zName)==0
+       && ((aB[j].zSql==0)==(aA[i].zSql==0))
+       && (aB[j].zSql==0 || strcmp(aB[j].zSql, aA[i].zSql)==0) ){
+        found = 1;
+        break;
+      }
+    }
+    if( !found ) return 1;
+    nMatchA++;
+  }
+  for(j=0; j<nB; j++){
+    if( aB[j].zType && strcmp(aB[j].zType, "index")==0
+     && aB[j].zTblName && strcmp(aB[j].zTblName, zTable)==0 ){
+      nB4T++;
+    }
+  }
+  return nMatchA!=nB4T;
+}
+
+static int loadIndexSchemaRows(
+  sqlite3 *db,
+  const ProllyHash *pCatHash,
+  SchemaEntry **ppRows,
+  int *pnRows
+){
+  ChunkStore *cs = doltliteGetChunkStore(db);
+  *ppRows = 0;
+  *pnRows = 0;
+  if( !cs || !pCatHash || prollyHashIsEmpty(pCatHash) ) return SQLITE_OK;
+  return loadSchemaFromCatalog(db, cs, doltliteGetCache(db), pCatHash,
+                               ppRows, pnRows);
+}
+
 static int diffFilteredTableRoots(
   DoltliteDiffCursor *pCur,
   sqlite3 *db,
@@ -324,13 +377,30 @@ static int diffFilteredTableRoots(
   if( !childFound || !parentFound ){
     return batchAppend(pCur, zHex, pCur->zFilterTable, pCommit, 1, 1);
   }
-  if( prollyHashCompare(&childRoot, &parentRoot)==0
-   && prollyHashCompare(&childSchema, &parentSchema)==0 ){
-    return SQLITE_OK;
+  {
+    u8 dataChange = prollyHashCompare(&childRoot, &parentRoot)!=0;
+    u8 schemaChange = prollyHashCompare(&childSchema, &parentSchema)!=0;
+    if( !schemaChange ){
+      SchemaEntry *aChildRows = 0, *aParentRows = 0;
+      int nChildRows = 0, nParentRows = 0;
+      rc = loadIndexSchemaRows(db, pChildCat, &aChildRows, &nChildRows);
+      if( rc==SQLITE_OK ){
+        rc = loadIndexSchemaRows(db, pParentCat, &aParentRows, &nParentRows);
+      }
+      if( rc==SQLITE_OK
+       && indexRowsDifferForTable(aChildRows, nChildRows,
+                                  aParentRows, nParentRows,
+                                  pCur->zFilterTable) ){
+        schemaChange = 1;
+      }
+      freeSchemaEntries(aChildRows, nChildRows);
+      freeSchemaEntries(aParentRows, nParentRows);
+      if( rc!=SQLITE_OK ) return rc;
+    }
+    if( !dataChange && !schemaChange ) return SQLITE_OK;
+    return batchAppend(pCur, zHex, pCur->zFilterTable, pCommit,
+                       dataChange, schemaChange);
   }
-  return batchAppend(pCur, zHex, pCur->zFilterTable, pCommit,
-                     prollyHashCompare(&childRoot, &parentRoot)!=0,
-                     prollyHashCompare(&childSchema, &parentSchema)!=0);
 }
 
 /* Fast path for table_name constrained scans. */
@@ -394,6 +464,8 @@ static int diffCatalogPair(
   DoltliteDiffCursor *pCur, sqlite3 *db,
   struct TableEntry *aChild, int nChild,
   struct TableEntry *aParent, int nParent,
+  SchemaEntry *aChildRows, int nChildRows,
+  SchemaEntry *aParentRows, int nParentRows,
   const char *zHex, const DoltliteCommit *pCommit
 ){
   int rc = SQLITE_OK, i;
@@ -420,6 +492,9 @@ static int diffCatalogPair(
       ProllyHash emptyRoot;
       const ProllyHash *pOldRoot;
       struct TableEntry *pOldMaster;
+      /* Only the master entry carries schema rows; unnamed index entries
+      ** are attributed to their tables through the row comparison below. */
+      if( e->iTable!=1 ) continue;
       memset(&emptyRoot, 0, sizeof(emptyRoot));
       pOldMaster = doltliteFindTableByNumber(aParent, nParent, 1);
       pOldRoot = pOldMaster ? &pOldMaster->root : &emptyRoot;
@@ -439,6 +514,11 @@ static int diffCatalogPair(
     }else{
       dataChange   = (prollyHashCompare(&e->root, &p->root) != 0) ? 1 : 0;
       schemaChange = (prollyHashCompare(&e->schemaHash, &p->schemaHash) != 0) ? 1 : 0;
+      if( !schemaChange
+       && indexRowsDifferForTable(aChildRows, nChildRows,
+                                  aParentRows, nParentRows, e->zName) ){
+        schemaChange = 1;
+      }
       if( !dataChange && !schemaChange ) continue;
     }
     rc = batchAppend(pCur, zHex, e->zName, pCommit, dataChange, schemaChange);
@@ -492,7 +572,21 @@ static int computeWorkingBatch(DoltliteDiffCursor *pCur, sqlite3 *db){
   memset(zHexBuf, 0, sizeof(zHexBuf));
   memcpy(zHexBuf, zWorkingHex, sizeof(zWorkingHex));
 
-  rc = diffCatalogPair(pCur, db, aWork, nWork, aHead, nHead, zHexBuf, 0);
+  {
+    SchemaEntry *aWorkRows = 0, *aHeadRows = 0;
+    int nWorkRows = 0, nHeadRows = 0;
+    rc = loadIndexSchemaRows(db, &workCat, &aWorkRows, &nWorkRows);
+    if( rc==SQLITE_OK ){
+      rc = loadIndexSchemaRows(db, &headCat, &aHeadRows, &nHeadRows);
+    }
+    if( rc==SQLITE_OK ){
+      rc = diffCatalogPair(pCur, db, aWork, nWork, aHead, nHead,
+                           aWorkRows, nWorkRows, aHeadRows, nHeadRows,
+                           zHexBuf, 0);
+    }
+    freeSchemaEntries(aWorkRows, nWorkRows);
+    freeSchemaEntries(aHeadRows, nHeadRows);
+  }
 
   doltliteFreeCatalog(aHead, nHead);
   doltliteFreeCatalog(aWork, nWork);
@@ -534,8 +628,32 @@ static int computeCommitBatch(DoltliteDiffCursor *pCur, sqlite3 *db,
     }
   }
 
-  rc = diffCatalogPair(pCur, db, aChild, nChild, aParent, nParent,
-                       zCommitHex, pCommit);
+  {
+    SchemaEntry *aChildRows = 0, *aParentRows = 0;
+    int nChildRows = 0, nParentRows = 0;
+    ProllyHash parentCat;
+    memset(&parentCat, 0, sizeof(parentCat));
+    if( hasParent ){
+      rc = doltliteCommitCatalogHash(db, pParentHash, &parentCat);
+      if( rc!=SQLITE_OK ){
+        doltliteFreeCatalog(aChild, nChild);
+        doltliteFreeCatalog(aParent, nParent);
+        return rc;
+      }
+    }
+    rc = loadIndexSchemaRows(db, &pCommit->catalogHash,
+                             &aChildRows, &nChildRows);
+    if( rc==SQLITE_OK && hasParent ){
+      rc = loadIndexSchemaRows(db, &parentCat, &aParentRows, &nParentRows);
+    }
+    if( rc==SQLITE_OK ){
+      rc = diffCatalogPair(pCur, db, aChild, nChild, aParent, nParent,
+                           aChildRows, nChildRows, aParentRows, nParentRows,
+                           zCommitHex, pCommit);
+    }
+    freeSchemaEntries(aChildRows, nChildRows);
+    freeSchemaEntries(aParentRows, nParentRows);
+  }
 
   doltliteFreeCatalog(aChild, nChild);
   doltliteFreeCatalog(aParent, nParent);

--- a/test/vc_oracle_diff_test.sh
+++ b/test/vc_oracle_diff_test.sh
@@ -122,6 +122,37 @@ oracle_summary() {
   vc_oracle_assert_match "$name" "$dl_out" "$dt_out"
 }
 
+# Same comparison as oracle_summary, with separate setup scripts for the
+# statements whose syntax diverges between engines (DROP INDEX, triggers).
+oracle_summary_dual() {
+  local name="$1" dl_setup="$2" dt_setup="$3"
+  local dir="$TMPROOT/${name}_summary"
+  mkdir -p "$dir/dl" "$dir/dt"
+
+  local q="SELECT 'S' || char(9) || dd.table_name || char(9) || coalesce(dl.message, dd.commit_hash) || char(9) || dd.data_change || char(9) || dd.schema_change FROM dolt_diff dd LEFT JOIN dolt_log dl ON dl.commit_hash = dd.commit_hash"
+  local q_dolt="SELECT concat('S', char(9), dd.table_name, char(9), coalesce(dl.message, dd.commit_hash), char(9), dd.data_change, char(9), dd.schema_change) FROM dolt_diff dd LEFT JOIN dolt_log dl ON dl.commit_hash = dd.commit_hash"
+
+  local dl_out
+  dl_out=$(printf "%s\n.headers off\n.mode list\n.separator '\t'\n%s;\n" "$dl_setup" "$q" \
+           | "$DOLTLITE" "$dir/dl/db" 2>"$dir/dl.err" \
+           | normalize_summary)
+
+  local dolt_setup
+  dolt_setup=$(echo "$dt_setup" | sed -E 's/SELECT[[:space:]]+(dolt_[a-z_]+\()/CALL \1/g')
+
+  local dt_out
+  dt_out=$(
+    cd "$dir/dt" || exit 1
+    "$DOLT" init --name oracle --email oracle@test >/dev/null 2>&1
+    {
+      printf '%s\n' "$dolt_setup"
+      printf '%s;\n' "$q_dolt"
+    } | "$DOLT" sql -c -r csv 2>"$dir/dt.err" | tr -d '"' | normalize_summary
+  )
+
+  vc_oracle_assert_match "$name" "$dl_out" "$dt_out"
+}
+
 oracle_summary_filter_name() {
   local name="$1" setup="$2" target="$3" allow_empty="${4:-}"
   local dir="$TMPROOT/${name}_filter"
@@ -855,6 +886,131 @@ DROP TABLE x;
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'drop_x');
 " "x"
+
+
+# ── schema objects through the diff summary ──────────────────────
+# Index changes carry no entry of their own; the summary must attribute
+# them to the parent table (schema_change=1), matching Dolt.
+
+oracle_summary "summary_index_only_commit" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 10);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'init');
+CREATE INDEX iv ON t(v);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'add_index');
+"
+
+oracle_summary_dual "summary_drop_index_commit" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 10);
+CREATE INDEX iv ON t(v);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'init');
+DROP INDEX iv;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'drop_index');
+" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 10);
+CREATE INDEX iv ON t(v);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'init');
+DROP INDEX iv ON t;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'drop_index');
+"
+
+oracle_summary "summary_index_plus_data_commit" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 10);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'init');
+INSERT INTO t VALUES (2, 20);
+CREATE INDEX iv ON t(v);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'both');
+"
+
+oracle_summary_dual "summary_index_change_working" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 10);
+CREATE INDEX iv ON t(v);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'init');
+DROP INDEX iv;
+" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 10);
+CREATE INDEX iv ON t(v);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'init');
+DROP INDEX iv ON t;
+"
+
+oracle_summary "summary_index_untouched_sibling" "
+CREATE TABLE x(a INTEGER PRIMARY KEY);
+CREATE TABLE y(b INTEGER PRIMARY KEY);
+INSERT INTO x VALUES (1);
+INSERT INTO y VALUES (1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'init');
+CREATE INDEX ix ON x(a);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'ix_only');
+"
+
+oracle_summary_filter_name "summary_filter_index_only_commit" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 10);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'init');
+CREATE INDEX iv ON t(v);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'add_index');
+" "t"
+
+oracle_summary "summary_view_only_commit" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 10);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'init');
+CREATE VIEW vv AS SELECT id FROM t;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'add_view');
+"
+
+oracle_summary_dual "summary_trigger_only_commit" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 10);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'init');
+CREATE TRIGGER trg AFTER INSERT ON t BEGIN SELECT 1; END;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'add_trigger');
+" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 10);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'init');
+CREATE TRIGGER trg AFTER INSERT ON t FOR EACH ROW SET @x = 1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'add_trigger');
+"
+
+oracle "index_only_commit_no_row_diffs" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 10);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'init');
+CREATE INDEX iv ON t(v);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'add_index');
+INSERT INTO t VALUES (2, 20);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'data');
+" "t"
 
 echo ""
 echo "=== Results: $pass passed, $fail failed ==="


### PR DESCRIPTION
From the schema-objects-through-add/diff oracle gap survey: the add oracle (516 lines) had **zero** schema-object coverage and the diff oracle (864 lines) nearly none. Probing the gaps immediately found that the `dolt_diff` summary is blind to index changes — an index-only commit produces no row at all, where Dolt reports `t | 0 | 1`:

- CREATE INDEX and DROP INDEX, committed and working-set, full scans and `table_name`-filtered scans — all silent
- view/trigger commits were already correct (`dolt_schemas | 1 | 1`) — now locked by oracle scenarios

**Fix**: the summary compares each catalog's index schema rows (name + sql) per table and sets `schema_change=1` on the parent when they differ — index changes have no named entry, so attribution must go through schema rows, the same lesson as the staging fixes. Also guards the full scan's unnamed-entry branch to the master entry (index entries were previously taking the dolt_schemas comparison path against non-master roots).

**Coverage**: nine new scenarios in `vc_oracle_diff_test.sh` verified against real Dolt, including a dual-setup helper for statements whose syntax diverges (`DROP INDEX … ON t`, MySQL trigger bodies). Fail-before: master fails exactly the six index scenarios (57/63); fixed: 63/63.

Filed alongside: #1655 — `dolt_status` has the same index blindness (sibling of #1651); its fix targets `doltlite_status.c` and is sequenced after #1653 to avoid conflicts, and the dolt_add oracle scenarios for schema objects (which project dolt_status) queue behind both.

Validation: diff oracle 63/63, diff-stat 49/49, diff-tvf 8/8, status 27/27 vs real Dolt; battery 88/88; matrix 38/38; C regression 309,830/309,830.

🤖 Generated with [Claude Code](https://claude.com/claude-code)