### PR TITLE
Compose the named-stage master per object; harden cross-domain catalog pairing

### DIFF
--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -991,6 +991,45 @@ static int addWriteStagedCatalog(
   return rc;
 }
 
+/* True when the two catalogs' index schema rows for zTable differ: any
+** index added, dropped, re-targeted, or redefined. Index changes carry no
+** named catalog entry, so every surface that reports per-table change
+** (status, the diff summary) attributes them through this comparison. */
+int doltliteIndexSchemaRowsDifferForTable(
+  SchemaEntry *aA, int nA,
+  SchemaEntry *aB, int nB,
+  const char *zTable
+){
+  int i, j, nMatchA = 0, nBForTable = 0;
+  for(i=0; i<nA; i++){
+    int found = 0;
+    if( !aA[i].zType || strcmp(aA[i].zType, "index")!=0
+     || !aA[i].zTblName || strcmp(aA[i].zTblName, zTable)!=0 ){
+      continue;
+    }
+    for(j=0; j<nB; j++){
+      if( aB[j].zType && strcmp(aB[j].zType, "index")==0
+       && aB[j].zTblName && strcmp(aB[j].zTblName, zTable)==0
+       && aB[j].zName && aA[i].zName
+       && strcmp(aB[j].zName, aA[i].zName)==0
+       && ((aB[j].zSql==0)==(aA[i].zSql==0))
+       && (aB[j].zSql==0 || strcmp(aB[j].zSql, aA[i].zSql)==0) ){
+        found = 1;
+        break;
+      }
+    }
+    if( !found ) return 1;
+    nMatchA++;
+  }
+  for(j=0; j<nB; j++){
+    if( aB[j].zType && strcmp(aB[j].zType, "index")==0
+     && aB[j].zTblName && strcmp(aB[j].zTblName, zTable)==0 ){
+      nBForTable++;
+    }
+  }
+  return nMatchA!=nBForTable;
+}
+
 /* True when the final staged entry list contains a table entry named
 ** zTbl. Index entries follow their parent table through -a staging, and
 ** the parent's presence decides whether an index entry belongs at all. */
@@ -1311,12 +1350,33 @@ static int addStageNamedTables(
   SchemaEntry *aStagedSchema = 0;
   int nWorkSchema = 0;
   int nStagedSchema = 0;
+  /* Objects whose master rows follow WORKING in this operation: the named
+  ** tables (adds and staged drops) plus a staged vtab's shadows. Names are
+  ** borrowed from the argv values and schema arrays, which outlive use. */
+  char **azTouched = 0;
+  int nTouched = 0;
 
   #define ADDNAMED_FREE_ALL() do { \
+    int ft_; \
+    for(ft_=0; ft_<nTouched; ft_++) sqlite3_free(azTouched[ft_]); \
+    sqlite3_free((void*)azTouched); \
     freeSchemaEntries(aWorkSchema, nWorkSchema); \
     freeSchemaEntries(aStagedSchema, nStagedSchema); \
     doltliteFreeCatalog(aWorking, nWorking); \
     doltliteFreeCatalog(aStaged, nStaged); \
+  } while(0)
+
+  #define ADDNAMED_TOUCH(zN) do { \
+    char **azNew = sqlite3_realloc((void*)azTouched, \
+        (nTouched+1)*(int)sizeof(char*)); \
+    char *zOwn_ = azNew ? sqlite3_mprintf("%s", (zN)) : 0; \
+    if( azNew ) azTouched = azNew; \
+    if( !azNew || !zOwn_ ){ \
+      ADDNAMED_FREE_ALL(); \
+      sqlite3_result_error_nomem(context); \
+      return SQLITE_NOMEM; \
+    } \
+    azTouched[nTouched++] = zOwn_; \
   } while(0)
 
   rc = addLoadWorkingAndStagedCatalogs(db, pWorkingHash,
@@ -1369,6 +1429,7 @@ static int addStageNamedTables(
     {
       Table *pLive = sqlite3FindTable(db, zTable, "main");
       if( pLive && IsVirtual(pLive) ){
+        int w;
         rc = addStageShadowTablesOf(db, context, &aStaged, &nStaged,
                                     aWorking, nWorking,
                                     aWorkSchema, nWorkSchema,
@@ -1376,6 +1437,16 @@ static int addStageNamedTables(
         if( rc!=SQLITE_OK ){
           ADDNAMED_FREE_ALL();
           return rc;
+        }
+        ADDNAMED_TOUCH(zTable);
+        for(w=0; w<nWorkSchema; w++){
+          if( aWorkSchema[w].zType
+           && strcmp(aWorkSchema[w].zType, "table")==0
+           && aWorkSchema[w].zName
+           && strcmp(aWorkSchema[w].zName, zTable)!=0
+           && sqlite3IsShadowTableOf(db, pLive, aWorkSchema[w].zName) ){
+            ADDNAMED_TOUCH(aWorkSchema[w].zName);
+          }
         }
         updateMaster = 1;
         continue;
@@ -1422,6 +1493,7 @@ static int addStageNamedTables(
         addRemoveShadowEntriesOfDroppedVtab(aStaged, &nStaged,
                                             aStagedSchema, nStagedSchema,
                                             aWorking, nWorking, zTable);
+        ADDNAMED_TOUCH(zTable);
         updateMaster = 1;
       }
       if( !found ){
@@ -1446,13 +1518,29 @@ static int addStageNamedTables(
           int nameMatch = aStaged[k].zName && aWorking[j].zName
             && strcmp(aStaged[k].zName, aWorking[j].zName)==0;
           int rootMatch = aStaged[k].iTable==iTable;
-          int unnamedRootMatch = rootMatch
-            && (!aStaged[k].zName || !aWorking[j].zName);
+          /* An unnamed staged entry on a bare number match can be a
+          ** cross-domain collision with an index entry; pair only when
+          ** the staged catalog's own schema rows say the entry at this
+          ** number is this very table. */
+          int unnamedRootMatch = 0;
           int renameRootMatch = rootMatch
             && aStaged[k].zName && aWorking[j].zName
             && strcmp(aStaged[k].zName, aWorking[j].zName)!=0
             && !addFindEntryByName(aWorking, nWorking, aStaged[k].zName)
             && !addFindEntryByName(aStaged, nStaged, aWorking[j].zName);
+          if( rootMatch && !aStaged[k].zName && aWorking[j].zName ){
+            int r;
+            for(r=0; r<nStagedSchema; r++){
+              if( aStagedSchema[r].iRootpage==aStaged[k].iTable
+               && aStagedSchema[r].zType
+               && strcmp(aStagedSchema[r].zType, "table")==0
+               && aStagedSchema[r].zName
+               && strcmp(aStagedSchema[r].zName, aWorking[j].zName)==0 ){
+                unnamedRootMatch = 1;
+                break;
+              }
+            }
+          }
           if( nameMatch || unnamedRootMatch || renameRootMatch ){
             int schemaChanged =
               prollyHashCompare(&aStaged[k].schemaHash, &aWorking[j].schemaHash)!=0;
@@ -1460,7 +1548,14 @@ static int addStageNamedTables(
               (!aStaged[k].zName) != (!aWorking[j].zName)
               || (aStaged[k].zName && aWorking[j].zName
                   && strcmp(aStaged[k].zName, aWorking[j].zName)!=0);
-            char *zDup = aWorking[j].zName
+            char *zDup;
+            /* A rename retires the old name: its rows (and its indexes'
+            ** rows, keyed by the old tbl_name) must follow WORKING too,
+            ** where they no longer exist. */
+            if( nameChanged && aStaged[k].zName ){
+              ADDNAMED_TOUCH(aStaged[k].zName);
+            }
+            zDup = aWorking[j].zName
                            ? sqlite3_mprintf("%s", aWorking[j].zName) : 0;
             if( aWorking[j].zName && !zDup ){
               ADDNAMED_FREE_ALL();
@@ -1504,6 +1599,7 @@ static int addStageNamedTables(
           ADDNAMED_FREE_ALL();
           return rc;
         }
+        ADDNAMED_TOUCH(zTable);
         break;
       }
     }
@@ -1523,6 +1619,7 @@ static int addStageNamedTables(
               &pWorkingMaster->root, pWorkingMaster->flags,
               pStagedMaster ? &pStagedMaster->root : 0,
               pStagedMaster ? pStagedMaster->flags : 0,
+              (const char**)azTouched, nTouched,
               &composedRoot);
       if( rc!=SQLITE_OK ){
         ADDNAMED_FREE_ALL();
@@ -1549,6 +1646,7 @@ static int addStageNamedTables(
   addAlignStagedEntriesToWorking(aWorking, nWorking, aStaged, nStaged);
   rc = addWriteStagedCatalog(db, cs, aStaged, nStaged);
   ADDNAMED_FREE_ALL();
+  #undef ADDNAMED_TOUCH
   #undef ADDNAMED_FREE_ALL
   if( rc!=SQLITE_OK ){
     sqlite3_result_error_code(context, rc);

--- a/src/doltlite_diff.c
+++ b/src/doltlite_diff.c
@@ -282,45 +282,6 @@ static int batchAppend(DoltliteDiffCursor *pCur,
   return SQLITE_OK;
 }
 
-/* Index changes carry no named entry of their own: attribute them to the
-** parent table by comparing each catalog's index schema rows (name + sql),
-** so an index-only commit reports the table with schema_change=1 the way
-** Dolt does. */
-static int indexRowsDifferForTable(
-  SchemaEntry *aA, int nA,
-  SchemaEntry *aB, int nB,
-  const char *zTable
-){
-  int i, j, nMatchA = 0, nB4T = 0;
-  for(i=0; i<nA; i++){
-    int found = 0;
-    if( !aA[i].zType || strcmp(aA[i].zType, "index")!=0
-     || !aA[i].zTblName || strcmp(aA[i].zTblName, zTable)!=0 ){
-      continue;
-    }
-    for(j=0; j<nB; j++){
-      if( aB[j].zType && strcmp(aB[j].zType, "index")==0
-       && aB[j].zTblName && strcmp(aB[j].zTblName, zTable)==0
-       && aB[j].zName && aA[i].zName
-       && strcmp(aB[j].zName, aA[i].zName)==0
-       && ((aB[j].zSql==0)==(aA[i].zSql==0))
-       && (aB[j].zSql==0 || strcmp(aB[j].zSql, aA[i].zSql)==0) ){
-        found = 1;
-        break;
-      }
-    }
-    if( !found ) return 1;
-    nMatchA++;
-  }
-  for(j=0; j<nB; j++){
-    if( aB[j].zType && strcmp(aB[j].zType, "index")==0
-     && aB[j].zTblName && strcmp(aB[j].zTblName, zTable)==0 ){
-      nB4T++;
-    }
-  }
-  return nMatchA!=nB4T;
-}
-
 static int loadIndexSchemaRows(
   sqlite3 *db,
   const ProllyHash *pCatHash,
@@ -388,7 +349,7 @@ static int diffFilteredTableRoots(
         rc = loadIndexSchemaRows(db, pParentCat, &aParentRows, &nParentRows);
       }
       if( rc==SQLITE_OK
-       && indexRowsDifferForTable(aChildRows, nChildRows,
+       && doltliteIndexSchemaRowsDifferForTable(aChildRows, nChildRows,
                                   aParentRows, nParentRows,
                                   pCur->zFilterTable) ){
         schemaChange = 1;
@@ -515,7 +476,7 @@ static int diffCatalogPair(
       dataChange   = (prollyHashCompare(&e->root, &p->root) != 0) ? 1 : 0;
       schemaChange = (prollyHashCompare(&e->schemaHash, &p->schemaHash) != 0) ? 1 : 0;
       if( !schemaChange
-       && indexRowsDifferForTable(aChildRows, nChildRows,
+       && doltliteIndexSchemaRowsDifferForTable(aChildRows, nChildRows,
                                   aParentRows, nParentRows, e->zName) ){
         schemaChange = 1;
       }

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -922,9 +922,12 @@ int doltliteMergeCatalogs(sqlite3 *db,
     int bPreferOurMaster,
     char ***pazReindex, int *pnReindex);
 void doltliteFreeNameList(char **az, int n);
+int doltliteIndexSchemaRowsDifferForTable(SchemaEntry *aA, int nA,
+    SchemaEntry *aB, int nB, const char *zTable);
 int doltliteBuildNamedStageMasterRoot(sqlite3 *db,
     const ProllyHash *pWorkingMaster, u8 workingFlags,
     const ProllyHash *pOldMaster, u8 oldFlags,
+    const char **azTouched, int nTouched,
     ProllyHash *pNewRoot);
 int doltliteReindexNamedIndexes(sqlite3 *db, char **az, int n);
 

--- a/src/doltlite_status.c
+++ b/src/doltlite_status.c
@@ -361,15 +361,6 @@ static int statusRowExists(
   return 0;
 }
 
-static int statusSchemaSqlChanged(const SchemaEntry *pA, const SchemaEntry *pB){
-  const char *zA;
-  const char *zB;
-  if( !pA || !pB ) return 1;
-  zA = pA->zSql ? pA->zSql : "";
-  zB = pB->zSql ? pB->zSql : "";
-  return strcmp(zA, zB)!=0;
-}
-
 static int statusMaybeAddParentSchemaChange(
   DoltliteStatusCursor *pCur,
   const char *zParent,
@@ -396,7 +387,7 @@ static int statusCompareIndexSchemaObjects(
   SchemaEntry *aTo = 0;
   int nFrom = 0;
   int nTo = 0;
-  int i;
+  int i, j;
   int rc;
 
   if( !cs || !pCache ) return SQLITE_OK;
@@ -405,30 +396,28 @@ static int statusCompareIndexSchemaObjects(
   rc = loadSchemaFromCatalog(db, cs, pCache, pToCat, &aTo, &nTo);
   if( rc!=SQLITE_OK ) goto index_schema_done;
 
-  for(i=0; i<nTo; i++){
-    SchemaEntry *pOld;
-    if( !aTo[i].zType || strcmp(aTo[i].zType, "index")!=0 ) continue;
-    if( !aTo[i].zName || !aTo[i].zTblName ) continue;
-    pOld = findSchemaEntry(aFrom, nFrom, aTo[i].zName);
-    if( !pOld
-     || !pOld->zType
-     || strcmp(pOld->zType, "index")!=0
-     || !pOld->zTblName
-     || strcmp(pOld->zTblName, aTo[i].zTblName)!=0
-     || statusSchemaSqlChanged(pOld, &aTo[i]) ){
-      rc = statusMaybeAddParentSchemaChange(pCur, aTo[i].zTblName,
-                                            staged, zFilter);
-      if( rc!=SQLITE_OK ) goto index_schema_done;
+  /* One comparison per distinct parent table across both row sets; the
+  ** shared comparator decides whether that table's index set changed. */
+  for(i=0; i<nFrom+nTo; i++){
+    SchemaEntry *pRow = i<nFrom ? &aFrom[i] : &aTo[i-nFrom];
+    int seen = 0;
+    if( !pRow->zType || strcmp(pRow->zType, "index")!=0
+     || !pRow->zTblName ){
+      continue;
     }
-  }
-
-  for(i=0; i<nFrom; i++){
-    SchemaEntry *pNew;
-    if( !aFrom[i].zType || strcmp(aFrom[i].zType, "index")!=0 ) continue;
-    if( !aFrom[i].zName || !aFrom[i].zTblName ) continue;
-    pNew = findSchemaEntry(aTo, nTo, aFrom[i].zName);
-    if( !pNew || !pNew->zType || strcmp(pNew->zType, "index")!=0 ){
-      rc = statusMaybeAddParentSchemaChange(pCur, aFrom[i].zTblName,
+    for(j=0; j<i; j++){
+      SchemaEntry *pPrev = j<nFrom ? &aFrom[j] : &aTo[j-nFrom];
+      if( pPrev->zType && strcmp(pPrev->zType, "index")==0
+       && pPrev->zTblName
+       && strcmp(pPrev->zTblName, pRow->zTblName)==0 ){
+        seen = 1;
+        break;
+      }
+    }
+    if( seen ) continue;
+    if( doltliteIndexSchemaRowsDifferForTable(aFrom, nFrom, aTo, nTo,
+                                              pRow->zTblName) ){
+      rc = statusMaybeAddParentSchemaChange(pCur, pRow->zTblName,
                                             staged, zFilter);
       if( rc!=SQLITE_OK ) goto index_schema_done;
     }

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -2132,16 +2132,21 @@ int doltliteSerializeCatalogEntries(
       db, aTables, nTables, 0, 0, ppOut, pnOut);
 }
 
-/* Build a master root for a NAMED staging operation. Table and index rows
-** (including virtual tables and their shadows) come from the working
-** master so the staged entries share its numbering domain; view and
-** trigger rows keep the previously staged state, because named add stages
-** tables and never entry-less schema objects — an unstaged view must not
-** ride into the commit on the back of the master adoption. */
+/* Build a master root for a NAMED staging operation. Rows follow the
+** source of their object's staging: table and index rows for objects
+** named in this operation (azTouched — the staged tables, staged drops,
+** and a staged vtab's shadows) come from the working master, everything
+** else — other tables' rows, view and trigger rows — keeps the
+** previously staged state. Wholesale working adoption leaked unstaged
+** schema changes of untouched objects into the commit; taking only the
+** touched objects' rows keeps the numbering domain of the freshly staged
+** entries while leaving the rest of the staged picture alone. A touched
+** name with no working rows is a staged drop: its old rows simply vanish. */
 int doltliteBuildNamedStageMasterRoot(
   sqlite3 *db,
   const ProllyHash *pWorkingMaster, u8 workingFlags,
   const ProllyHash *pOldMaster, u8 oldFlags,
+  const char **azTouched, int nTouched,
   ProllyHash *pNewRoot
 ){
   Btree *pBtree;
@@ -2153,7 +2158,7 @@ int doltliteBuildNamedStageMasterRoot(
   ProllyMutMap mm;
   struct TableEntry masterEntry;
   i64 iRowid = 1;
-  int i, rc;
+  int i, t, rc;
 
   if( !db || db->nDb<=0 || !db->aDb[0].pBt ) return SQLITE_ERROR;
   pBtree = db->aDb[0].pBt;
@@ -2186,13 +2191,48 @@ int doltliteBuildNamedStageMasterRoot(
   }
   for(i=0; i<nWork+nOld && rc==SQLITE_OK; i++){
     SchemaCatalogRow *pRow = i<nWork ? &aWork[i] : &aOld[i-nWork];
-    int isEntryless = pRow->zType
-      && (strcmp(pRow->zType, "view")==0 || strcmp(pRow->zType, "trigger")==0);
+    int fromWorking = i<nWork;
+    int isEntryless;
+    int touched = 0;
+    const char *zParent;
+    Pgno iPg;
     u8 *pRec;
     int nRec = 0;
-    if( i<nWork ? isEntryless : !isEntryless ) continue;
+
+    if( !pRow->zType ) continue;
+    isEntryless = strcmp(pRow->zType, "view")==0
+               || strcmp(pRow->zType, "trigger")==0;
+    if( isEntryless ){
+      if( fromWorking ) continue;      /* views/triggers keep staged state */
+    }else{
+      zParent = strcmp(pRow->zType, "index")==0
+                  ? pRow->zTblName : pRow->zName;
+      for(t=0; t<nTouched; t++){
+        if( zParent && azTouched[t]
+         && strcmp(zParent, azTouched[t])==0 ){
+          touched = 1;
+          break;
+        }
+      }
+      if( fromWorking != touched ) continue;
+    }
+    /* Staged entries whose name exists in working are aligned to the
+    ** working table number, so old-sourced table rows must carry that
+    ** number too, or the composed rows collide across numbering domains
+    ** and no longer pair with their entries. Index entries are unnamed
+    ** and never aligned; their rows keep the old number. */
+    iPg = pRow->oldPg;
+    if( !fromWorking && strcmp(pRow->zType, "table")==0 && pRow->zName ){
+      for(t=0; t<nWork; t++){
+        if( aWork[t].zType && strcmp(aWork[t].zType, "table")==0
+         && aWork[t].zName && strcmp(aWork[t].zName, pRow->zName)==0 ){
+          iPg = aWork[t].oldPg;
+          break;
+        }
+      }
+    }
     pRec = buildSchemaCatalogRecord(pRow->zType, pRow->zName,
-                                    pRow->zTblName, pRow->oldPg,
+                                    pRow->zTblName, iPg,
                                     pRow->zSql, &nRec);
     if( !pRec ){
       rc = SQLITE_NOMEM;
@@ -2402,6 +2442,15 @@ static int doltliteSerializeCatalogEntriesForBtreeImpl(
             if( !bLiveCatalog
              && aTables[i].zName && aRows[j].zName
              && strcmp(aRows[j].zName, aTables[i].zName)!=0 ){
+              continue;
+            }
+            /* Constructed arrays can mix numbering domains, and an
+            ** unnamed entry is always an index: a bare number match
+            ** against a table row is a cross-domain collision, not a
+            ** pairing. */
+            if( !bLiveCatalog
+             && !aTables[i].zName
+             && aRows[j].zType && strcmp(aRows[j].zType, "index")!=0 ){
               continue;
             }
             pRow = &aRows[j];

--- a/test/doltlite_commit.sh
+++ b/test/doltlite_commit.sh
@@ -370,7 +370,52 @@ run_test "view_in_am_commit"   "SELECT dolt_reset('--hard');
 SELECT name FROM sqlite_master WHERE type='view';"   "0
 v2" "$DB11"
 
-rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8" "$DB9" "$DB10" "$DB11"
+# A named add stages exactly the named objects: unstaged schema changes of
+# OTHER tables must not ride into the commit on the master adoption, and
+# previously staged state (including index roots) must survive unstaged
+# working changes and cross-domain entry-number collisions.
+DB12=/tmp/test_dolt_namedscope_$$.db; rm -f "$DB12"
+
+run_test_match "named_scope_setup"   "CREATE TABLE p(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO p VALUES(1,1);
+SELECT dolt_commit('-Am','base');"   "^[0-9a-f]{40}$" "$DB12"
+
+run_test_match "named_scope_commit"   "ALTER TABLE p ADD COLUMN c INT;
+CREATE TABLE q(id INTEGER PRIMARY KEY);
+SELECT dolt_add('q');
+SELECT dolt_commit('-m','only q');"   "^[0-9a-f]{40}$" "$DB12"
+
+run_test "unstaged_alter_stays_out"   "SELECT dolt_reset('--hard');
+SELECT count(*) FROM pragma_table_info('p');
+SELECT count(*) FROM q;
+PRAGMA integrity_check;"   "0
+2
+0
+ok" "$DB12"
+
+DB13=/tmp/test_dolt_stagedidx_$$.db; rm -f "$DB13"
+
+run_test_match "staged_index_collision_setup"   "CREATE TABLE p(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO p VALUES(1,1);
+CREATE INDEX ip ON p(v);
+SELECT dolt_commit('-Am','base');"   "^[0-9a-f]{40}$" "$DB13"
+
+run_test_match "staged_index_collision_commit"   "UPDATE p SET v=2;
+SELECT dolt_add('-A');
+DROP INDEX ip;
+CREATE TABLE q(id INTEGER PRIMARY KEY);
+SELECT dolt_add('q');
+SELECT dolt_commit('-m','mix');"   "^[0-9a-f]{40}$" "$DB13"
+
+run_test "staged_index_survives_unstaged_drop"   "SELECT dolt_reset('--hard');
+SELECT v FROM p INDEXED BY ip;
+SELECT count(*) FROM q;
+PRAGMA integrity_check;"   "0
+2
+0
+ok" "$DB13"
+
+rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8" "$DB9" "$DB10" "$DB11" "$DB12" "$DB13"
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"


### PR DESCRIPTION
Follow-ups to #1654/#1656 on named staging with schema objects.

## Bugs fixed

1. **Unstaged schema changes leaked into named-add commits.** A named `dolt_add` adopted the entire working master root as the staged master, so an unstaged `ALTER TABLE p ADD COLUMN` on an *untouched* table rode into the commit, and an unstaged `DROP INDEX` destroyed a *staged* index. Dolt keeps both out. The staged master is now composed per object: rows for the named objects (adds, staged drops, vtab shadows, retired rename names) come from working; every other table/index row keeps the previously staged state; views and triggers always keep staged state.

2. **Cross-domain numbering collisions in the composed master.** Composed rows span two catalog numbering domains. Old-sourced table rows are renumbered to the working number their aligned entries carry (mirroring `addAlignStagedEntriesToWorking`), otherwise a staged FK child scenario collided numbers, `appendMissingSchemaCatalogRows` appended a duplicate row with an empty tbl_name, and the committed catalog was malformed (`create_fk_child_staged` caught this).

3. **Serializer pairing hardening for constructed arrays**: an unnamed entry (always an index) never pairs with a table row on a bare number match, and a named working table only pairs with an unnamed staged entry when the staged catalog's own schema rows identify that entry as the same table.

Also consolidates the index schema-row comparison shared by status and diff summary into one helper.

## Tests

- `test/doltlite_commit.sh` +2 gating tests (`unstaged_alter_stays_out`, `staged_index_survives_unstaged_drop`) — both fail before this change and pass after.
- Full local regression green: shell battery 88/88 suites, C corpus 309,830/309,830, staging 31/31, commit 62/62, index×VC matrix 38/38, oracles: status-schema 18/18, status 40/40, add 34/34, diff 63/63, commit 37/37, reset 43/43.

🤖 Generated with [Claude Code](https://claude.com/claude-code)