### PR TITLE
Use sqlite3_strnicmp in CHECK constraint parsing

### DIFF
--- a/src/doltlite_merge_constraints.c
+++ b/src/doltlite_merge_constraints.c
@@ -1188,7 +1188,7 @@ static int nextCheckClause(
 
   while( *p ){
     if( (p[0]=='C' || p[0]=='c')
-     && strncasecmp(p, "CONSTRAINT", 10)==0
+     && sqlite3_strnicmp(p, "CONSTRAINT", 10)==0
      && (p[10]==' ' || p[10]=='\t' || p[10]=='\n') ){
       int i = 0;
       p += 10;
@@ -1200,7 +1200,7 @@ static int nextCheckClause(
       continue;
     }
     if( (p[0]=='C' || p[0]=='c')
-     && strncasecmp(p, "CHECK", 5)==0
+     && sqlite3_strnicmp(p, "CHECK", 5)==0
      && (p[5]==' ' || p[5]=='\t' || p[5]=='(' || p[5]=='\n') ){
       p += 5;
       while( *p==' ' || *p=='\t' || *p=='\n' ) p++;


### PR DESCRIPTION
Fixes #1658

Replaces the non-portable strncasecmp calls in nextCheckClause with SQLite's sqlite3_strnicmp so MSVC builds do not fail on that POSIX-only symbol.

Tests:
- rg -n "strncasecmp\(|strcasecmp\(" src ext test
- make -C build -j$(sysctl -n hw.ncpu 2>/dev/null || nproc) DOLTLITE_PROLLY_CHECK=1 doltlite
- bash test/vc_oracle_fk_merge_test.sh build/doltlite dolt
- bash test/vc_oracle_schema_merge_test.sh build/doltlite dolt
- bash test/vc_oracle_constraints_triggers_replay_test.sh build/doltlite dolt