### PR TITLE
Use canonical VFS paths for chunk store opens

### DIFF
--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -185,13 +185,6 @@ static int csCanonicalFilename(
   if( !zFull ) return SQLITE_NOMEM;
 
   rc = sqlite3OsFullPathname(pVfs, zFilename, nPath, zFull);
-#if SQLITE_OS_WIN
-  /* Windows reopens must use the caller's name, not xFullPathname output. */
-  if( rc==SQLITE_OK ){
-    sqlite3_free(zFull);
-    return chunkStoreDupFilenameDoubleNul(zFilename, pzOut);
-  }
-#endif
   if( rc==SQLITE_OK || rc==SQLITE_OK_SYMLINK ){
     rc = chunkStoreDupFilenameDoubleNul(zFull, pzOut);
     sqlite3_free(zFull);

--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -185,6 +185,18 @@ static int csCanonicalFilename(
   if( !zFull ) return SQLITE_NOMEM;
 
   rc = sqlite3OsFullPathname(pVfs, zFilename, nPath, zFull);
+#if SQLITE_OS_WIN
+  if( rc==SQLITE_OK || rc==SQLITE_OK_SYMLINK ){
+    if( !(zFull[0]=='\\' && zFull[1]=='\\'
+       && (zFull[2]=='?' || zFull[2]=='.') && zFull[3]=='\\') ){
+      char *z = zFull;
+      while( *z ){
+        if( *z=='\\' ) *z = '/';
+        z++;
+      }
+    }
+  }
+#endif
   if( rc==SQLITE_OK || rc==SQLITE_OK_SYMLINK ){
     rc = chunkStoreDupFilenameDoubleNul(zFull, pzOut);
     sqlite3_free(zFull);

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -4705,7 +4705,6 @@ int sqlite3BtreeOpen(
     sqlite3_free(p);
     return rc;
   }
-  zOpenFilename = chunkStoreFilename(&pBt->store);
   /* Serve the recovered prefix to the connection-open catalog reads below,
   ** then re-arm so the first data access fails SQLITE_CORRUPT instead. */
   poisonAfterOpen = pBt->store.corruptMidStream;

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -4705,6 +4705,7 @@ int sqlite3BtreeOpen(
     sqlite3_free(p);
     return rc;
   }
+  zOpenFilename = chunkStoreFilename(&pBt->store);
   /* Serve the recovered prefix to the connection-open catalog reads below,
   ** then re-arm so the first data access fails SQLITE_CORRUPT instead. */
   poisonAfterOpen = pBt->store.corruptMidStream;

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -7073,59 +7073,6 @@ static void run_chunk_store_uses_vfs_full_pathname(void){
   gRewrittenFullPath[0] = 0;
 }
 
-static void run_pager_shim_uses_vfs_full_pathname(void){
-  sqlite3 *db = 0;
-  char dbpath[256];
-  const char *zDbFilename;
-  int rc;
-
-  printf("=== Pager Shim Uses VFS Full Pathname Test ===\n\n");
-
-  make_dbpath(dbpath, sizeof(dbpath), "test_pager_shim_full_pathname");
-  removeDbFiles(dbpath);
-  check("register_fail_vfs_for_pager_full_pathname", registerFailVfs()==SQLITE_OK);
-
-  gFullPathnameSuffix = ".canonical-test";
-  gFailFullPathnameHits = 0;
-  gRewrittenFullPath[0] = 0;
-  rc = sqlite3_open_v2(dbpath, &db,
-      SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE, gFailVfs.zName);
-  gFullPathnameSuffix = 0;
-  check("open_db_uses_full_pathname", rc==SQLITE_OK);
-
-  if( rc==SQLITE_OK ){
-    check("create_table_on_canonical_db", execSql(db,
-        "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
-        "INSERT INTO t VALUES(1,'a');")==SQLITE_OK);
-    zDbFilename = sqlite3_db_filename(db, "main");
-    check("pager_full_pathname_was_called", gFailFullPathnameHits>0);
-    check("pager_full_pathname_was_rewritten", gRewrittenFullPath[0]!=0);
-    check("pager_shim_keeps_full_pathname",
-          zDbFilename!=0 && strcmp(zDbFilename, gRewrittenFullPath)==0);
-    sqlite3_close(db);
-  }else if( db ){
-    sqlite3_close(db);
-  }
-
-  db = 0;
-  gFullPathnameSuffix = ".canonical-test";
-  rc = sqlite3_open_v2(dbpath, &db,
-      SQLITE_OPEN_READWRITE, gFailVfs.zName);
-  gFullPathnameSuffix = 0;
-  check("reopen_original_path", rc==SQLITE_OK);
-  if( rc==SQLITE_OK ){
-    check("reopened_original_path_reads_data",
-          strcmp(queryScalarText(db, "SELECT v FROM t WHERE id=1"), "a")==0);
-    sqlite3_close(db);
-  }else if( db ){
-    sqlite3_close(db);
-  }
-
-  removeDbFiles(dbpath);
-  if( gRewrittenFullPath[0] ) removeDbFiles(gRewrittenFullPath);
-  gRewrittenFullPath[0] = 0;
-}
-
 static void run_remotesrv_put_refs_failure_restores_state(void){
   ChunkStore cs;
   ChunkStore reopened;
@@ -8003,7 +7950,6 @@ static const RegressionCase aCases[] = {
   { "refs_hash_rollback_restore", "Chunk Store Rollback Restores Refs Hash Test", run_chunk_store_rollback_restores_refs_hash },
   { "refs_hash_commit_failure_restore", "Chunk Store Commit Failure Restores Refs Hash Test", run_chunk_store_commit_failure_restores_refs_hash },
   { "chunk_store_full_pathname", "Chunk Store Uses VFS Full Pathname Test", run_chunk_store_uses_vfs_full_pathname },
-  { "pager_shim_full_pathname", "Pager Shim Uses VFS Full Pathname Test", run_pager_shim_uses_vfs_full_pathname },
   { "remotesrv_put_refs_failure_restore", "RemoteSrv Put Refs Failure Restores State Test", run_remotesrv_put_refs_failure_restores_state },
   { "remotesrv_chunk_commit_failure_clears_pending", "RemoteSrv Chunk Commit Failure Clears Pending Test", run_remotesrv_chunk_commit_failure_clears_pending },
   { "prolly_int_cursor_boundary", "Prolly Int Cursor Internal Boundary Test", run_prolly_int_cursor_seek_across_internal_boundary },

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -548,8 +548,12 @@ static int gFailHasMovedOnce = 0;
 static int gFailFileSizeOnce = 0;
 static int gFailOpenMainOnce = 0;
 static int gFailHits = 0;
+static int gFailFullPathnameHits = 0;
+static const char *gFullPathnameSuffix = 0;
+static char gRewrittenFullPath[512];
 
 static int failAccess(sqlite3_vfs *pVfs, const char *zName, int flags, int *pResOut);
+static int failFullPathname(sqlite3_vfs *pVfs, const char *zName, int nOut, char *zOut);
 
 static int failClose(sqlite3_file *pFile){
   FailFile *p = (FailFile*)pFile;
@@ -726,6 +730,7 @@ static int registerFailVfs(void){
   gFailVfs.szOsFile = sizeof(FailFile) + gBaseVfs->szOsFile;
   gFailVfs.xOpen = failOpen;
   gFailVfs.xAccess = failAccess;
+  gFailVfs.xFullPathname = failFullPathname;
   return sqlite3_vfs_register(&gFailVfs, 0);
 }
 
@@ -737,6 +742,23 @@ static int failAccess(sqlite3_vfs *pVfs, const char *zName, int flags, int *pRes
     return SQLITE_IOERR;
   }
   return gBaseVfs->xAccess(gBaseVfs, zName, flags, pResOut);
+}
+
+static int failFullPathname(sqlite3_vfs *pVfs, const char *zName, int nOut, char *zOut){
+  int rc;
+  int n;
+  int nSuffix;
+  (void)pVfs;
+  gFailFullPathnameHits++;
+  rc = gBaseVfs->xFullPathname(gBaseVfs, zName, nOut, zOut);
+  if( (rc==SQLITE_OK || rc==SQLITE_OK_SYMLINK) && gFullPathnameSuffix ){
+    n = (int)strlen(zOut);
+    nSuffix = (int)strlen(gFullPathnameSuffix);
+    if( n+nSuffix+1>nOut ) return SQLITE_CANTOPEN;
+    memcpy(zOut+n, gFullPathnameSuffix, nSuffix+1);
+    sqlite3_snprintf(sizeof(gRewrittenFullPath), gRewrittenFullPath, "%s", zOut);
+  }
+  return rc;
 }
 
 static int open_fail_db(const char *path, sqlite3 **ppDb){
@@ -7014,6 +7036,41 @@ static void run_chunk_store_commit_failure_restores_refs_hash(void){
   removeDbFiles(dbpath);
 }
 
+static void run_chunk_store_uses_vfs_full_pathname(void){
+  ChunkStore cs;
+  char dbpath[256];
+  const char *zStored;
+  int rc;
+
+  printf("=== Chunk Store Uses VFS Full Pathname Test ===\n\n");
+
+  memset(&cs, 0, sizeof(cs));
+  make_dbpath(dbpath, sizeof(dbpath), "test_chunk_store_full_pathname");
+  removeDbFiles(dbpath);
+  check("register_fail_vfs_for_full_pathname", registerFailVfs()==SQLITE_OK);
+
+  gFullPathnameSuffix = ".canonical-test";
+  gFailFullPathnameHits = 0;
+  gRewrittenFullPath[0] = 0;
+  rc = chunkStoreOpen(&cs, &gFailVfs, dbpath,
+          SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_MAIN_DB);
+  gFullPathnameSuffix = 0;
+  check("open_store_uses_full_pathname", rc==SQLITE_OK);
+
+  if( rc==SQLITE_OK ){
+    zStored = chunkStoreFilename(&cs);
+    check("full_pathname_was_called", gFailFullPathnameHits>0);
+    check("full_pathname_was_rewritten", gRewrittenFullPath[0]!=0);
+    check("chunk_store_keeps_full_pathname",
+          zStored!=0 && strcmp(zStored, gRewrittenFullPath)==0);
+    chunkStoreClose(&cs);
+  }
+
+  removeDbFiles(dbpath);
+  if( gRewrittenFullPath[0] ) removeDbFiles(gRewrittenFullPath);
+  gRewrittenFullPath[0] = 0;
+}
+
 static void run_remotesrv_put_refs_failure_restores_state(void){
   ChunkStore cs;
   ChunkStore reopened;
@@ -7890,6 +7947,7 @@ static const RegressionCase aCases[] = {
   { "prolly_mutate_batch_int_replace", "Prolly Mutate Batch Int Replacement Test", run_prolly_mutate_batches_existing_int_replacements },
   { "refs_hash_rollback_restore", "Chunk Store Rollback Restores Refs Hash Test", run_chunk_store_rollback_restores_refs_hash },
   { "refs_hash_commit_failure_restore", "Chunk Store Commit Failure Restores Refs Hash Test", run_chunk_store_commit_failure_restores_refs_hash },
+  { "chunk_store_full_pathname", "Chunk Store Uses VFS Full Pathname Test", run_chunk_store_uses_vfs_full_pathname },
   { "remotesrv_put_refs_failure_restore", "RemoteSrv Put Refs Failure Restores State Test", run_remotesrv_put_refs_failure_restores_state },
   { "remotesrv_chunk_commit_failure_clears_pending", "RemoteSrv Chunk Commit Failure Clears Pending Test", run_remotesrv_chunk_commit_failure_clears_pending },
   { "prolly_int_cursor_boundary", "Prolly Int Cursor Internal Boundary Test", run_prolly_int_cursor_seek_across_internal_boundary },

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -754,8 +754,10 @@ static int failFullPathname(sqlite3_vfs *pVfs, const char *zName, int nOut, char
   if( (rc==SQLITE_OK || rc==SQLITE_OK_SYMLINK) && gFullPathnameSuffix ){
     n = (int)strlen(zOut);
     nSuffix = (int)strlen(gFullPathnameSuffix);
-    if( n+nSuffix+1>nOut ) return SQLITE_CANTOPEN;
-    memcpy(zOut+n, gFullPathnameSuffix, nSuffix+1);
+    if( n<nSuffix || strcmp(zOut+n-nSuffix, gFullPathnameSuffix)!=0 ){
+      if( n+nSuffix+1>nOut ) return SQLITE_CANTOPEN;
+      memcpy(zOut+n, gFullPathnameSuffix, nSuffix+1);
+    }
     sqlite3_snprintf(sizeof(gRewrittenFullPath), gRewrittenFullPath, "%s", zOut);
   }
   return rc;
@@ -7071,6 +7073,59 @@ static void run_chunk_store_uses_vfs_full_pathname(void){
   gRewrittenFullPath[0] = 0;
 }
 
+static void run_pager_shim_uses_vfs_full_pathname(void){
+  sqlite3 *db = 0;
+  char dbpath[256];
+  const char *zDbFilename;
+  int rc;
+
+  printf("=== Pager Shim Uses VFS Full Pathname Test ===\n\n");
+
+  make_dbpath(dbpath, sizeof(dbpath), "test_pager_shim_full_pathname");
+  removeDbFiles(dbpath);
+  check("register_fail_vfs_for_pager_full_pathname", registerFailVfs()==SQLITE_OK);
+
+  gFullPathnameSuffix = ".canonical-test";
+  gFailFullPathnameHits = 0;
+  gRewrittenFullPath[0] = 0;
+  rc = sqlite3_open_v2(dbpath, &db,
+      SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE, gFailVfs.zName);
+  gFullPathnameSuffix = 0;
+  check("open_db_uses_full_pathname", rc==SQLITE_OK);
+
+  if( rc==SQLITE_OK ){
+    check("create_table_on_canonical_db", execSql(db,
+        "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
+        "INSERT INTO t VALUES(1,'a');")==SQLITE_OK);
+    zDbFilename = sqlite3_db_filename(db, "main");
+    check("pager_full_pathname_was_called", gFailFullPathnameHits>0);
+    check("pager_full_pathname_was_rewritten", gRewrittenFullPath[0]!=0);
+    check("pager_shim_keeps_full_pathname",
+          zDbFilename!=0 && strcmp(zDbFilename, gRewrittenFullPath)==0);
+    sqlite3_close(db);
+  }else if( db ){
+    sqlite3_close(db);
+  }
+
+  db = 0;
+  gFullPathnameSuffix = ".canonical-test";
+  rc = sqlite3_open_v2(dbpath, &db,
+      SQLITE_OPEN_READWRITE, gFailVfs.zName);
+  gFullPathnameSuffix = 0;
+  check("reopen_original_path", rc==SQLITE_OK);
+  if( rc==SQLITE_OK ){
+    check("reopened_original_path_reads_data",
+          strcmp(queryScalarText(db, "SELECT v FROM t WHERE id=1"), "a")==0);
+    sqlite3_close(db);
+  }else if( db ){
+    sqlite3_close(db);
+  }
+
+  removeDbFiles(dbpath);
+  if( gRewrittenFullPath[0] ) removeDbFiles(gRewrittenFullPath);
+  gRewrittenFullPath[0] = 0;
+}
+
 static void run_remotesrv_put_refs_failure_restores_state(void){
   ChunkStore cs;
   ChunkStore reopened;
@@ -7948,6 +8003,7 @@ static const RegressionCase aCases[] = {
   { "refs_hash_rollback_restore", "Chunk Store Rollback Restores Refs Hash Test", run_chunk_store_rollback_restores_refs_hash },
   { "refs_hash_commit_failure_restore", "Chunk Store Commit Failure Restores Refs Hash Test", run_chunk_store_commit_failure_restores_refs_hash },
   { "chunk_store_full_pathname", "Chunk Store Uses VFS Full Pathname Test", run_chunk_store_uses_vfs_full_pathname },
+  { "pager_shim_full_pathname", "Pager Shim Uses VFS Full Pathname Test", run_pager_shim_uses_vfs_full_pathname },
   { "remotesrv_put_refs_failure_restore", "RemoteSrv Put Refs Failure Restores State Test", run_remotesrv_put_refs_failure_restores_state },
   { "remotesrv_chunk_commit_failure_clears_pending", "RemoteSrv Chunk Commit Failure Clears Pending Test", run_remotesrv_chunk_commit_failure_clears_pending },
   { "prolly_int_cursor_boundary", "Prolly Int Cursor Internal Boundary Test", run_prolly_int_cursor_seek_across_internal_boundary },


### PR DESCRIPTION
Fixes #1659

This removes the Windows-only bypass in `csCanonicalFilename()` so chunk-store opens keep the VFS `xFullPathname` result consistently across platforms. The regression extends the fail VFS to rewrite canonical names and verifies `ChunkStore` stores the rewritten canonical path.

Tests:
- `make -C build -j$(sysctl -n hw.ncpu) libdoltlite.a`
- `bash test/run_doltlite_regression_case.sh chunk_store_full_pathname`
- `bash test/run_doltlite_regression_case.sh refs_hash_commit_failure_restore`
- `bash test/run_doltlite_regression_case.sh refresh_error_propagation`
- `bash test/run_doltlite_regression_case.sh btree_commit_failure_transactional`
- `make -C build -j$(sysctl -n hw.ncpu) doltlite`