### PR TITLE
Checkout oracle coverage for schema objects; fix table-restore index reconciliation

### DIFF
--- a/src/doltlite_branch.c
+++ b/src/doltlite_branch.c
@@ -848,6 +848,130 @@ int doltliteCheckoutBranchForRebase(sqlite3 *db, const char *zBranch){
   return rc;
 }
 
+/* A restored table's indexes must follow it: named indexes present only in
+** the working schema are dropped, the source's named indexes are (re)created,
+** and differing definitions are replaced. Entry roots are reconciled
+** separately after the catalog flush. */
+static int checkoutReconcileTableIndexes(
+  sqlite3 *db,
+  SchemaEntry *aSourceSchema,
+  int nSourceSchema,
+  const char *zTable
+){
+  sqlite3_stmt *pStmt = 0;
+  char **azDrop = 0;
+  int nDrop = 0;
+  int i, j, rc;
+
+  rc = sqlite3_prepare_v2(db,
+      "SELECT name, sql FROM sqlite_master"
+      " WHERE type='index' AND tbl_name=?1 AND sql IS NOT NULL",
+      -1, &pStmt, 0);
+  if( rc!=SQLITE_OK ) return rc;
+  sqlite3_bind_text(pStmt, 1, zTable, -1, SQLITE_STATIC);
+  while( sqlite3_step(pStmt)==SQLITE_ROW ){
+    const char *zName = (const char*)sqlite3_column_text(pStmt, 0);
+    const char *zSql = (const char*)sqlite3_column_text(pStmt, 1);
+    int keep = 0;
+    if( !zName ) continue;
+    for(j=0; j<nSourceSchema; j++){
+      if( aSourceSchema[j].zType && strcmp(aSourceSchema[j].zType, "index")==0
+       && aSourceSchema[j].zTblName && strcmp(aSourceSchema[j].zTblName, zTable)==0
+       && aSourceSchema[j].zName && strcmp(aSourceSchema[j].zName, zName)==0
+       && aSourceSchema[j].zSql ){
+        char *zLiveCanon = doltliteCanonicalizeSchemaSql(zSql ? zSql : "", zName);
+        char *zSrcCanon = doltliteCanonicalizeSchemaSql(aSourceSchema[j].zSql, zName);
+        keep = zLiveCanon && zSrcCanon && strcmp(zLiveCanon, zSrcCanon)==0;
+        sqlite3_free(zLiveCanon);
+        sqlite3_free(zSrcCanon);
+        break;
+      }
+    }
+    if( !keep ){
+      char **azNew = sqlite3_realloc((void*)azDrop, (nDrop+1)*(int)sizeof(char*));
+      char *zOwn = azNew ? sqlite3_mprintf("%s", zName) : 0;
+      if( azNew ) azDrop = azNew;
+      if( !azNew || !zOwn ){
+        sqlite3_finalize(pStmt);
+        doltliteFreeNameList(azDrop, nDrop);
+        return SQLITE_NOMEM;
+      }
+      azDrop[nDrop++] = zOwn;
+    }
+  }
+  rc = sqlite3_finalize(pStmt);
+  if( rc!=SQLITE_OK ){
+    doltliteFreeNameList(azDrop, nDrop);
+    return rc;
+  }
+
+  for(i=0; i<nDrop && rc==SQLITE_OK; i++){
+    char *zSql = sqlite3_mprintf("DROP INDEX \"%w\"", azDrop[i]);
+    if( !zSql ){ rc = SQLITE_NOMEM; break; }
+    rc = sqlite3_exec(db, zSql, 0, 0, 0);
+    sqlite3_free(zSql);
+  }
+  doltliteFreeNameList(azDrop, nDrop);
+  if( rc!=SQLITE_OK ) return rc;
+
+  for(j=0; j<nSourceSchema; j++){
+    int exists;
+    sqlite3_stmt *pChk = 0;
+    if( !aSourceSchema[j].zType || strcmp(aSourceSchema[j].zType, "index")!=0 ) continue;
+    if( !aSourceSchema[j].zTblName || strcmp(aSourceSchema[j].zTblName, zTable)!=0 ) continue;
+    if( !aSourceSchema[j].zName || !aSourceSchema[j].zSql ) continue;
+    rc = sqlite3_prepare_v2(db,
+        "SELECT 1 FROM sqlite_master WHERE type='index' AND name=?1",
+        -1, &pChk, 0);
+    if( rc!=SQLITE_OK ) return rc;
+    sqlite3_bind_text(pChk, 1, aSourceSchema[j].zName, -1, SQLITE_STATIC);
+    exists = sqlite3_step(pChk)==SQLITE_ROW;
+    sqlite3_finalize(pChk);
+    if( !exists ){
+      rc = sqlite3_exec(db, aSourceSchema[j].zSql, 0, 0, 0);
+      if( rc!=SQLITE_OK ) return rc;
+    }
+  }
+  return SQLITE_OK;
+}
+
+/* Point the freshly flushed working catalog's index entries for zTable at
+** the source's trees. Each side is resolved through its OWN schema rows
+** (index entries are unnamed, so name-keyed overlays cannot see them), and
+** the DDL reconcile above guarantees the two row sets agree by name. */
+static void checkoutAdoptSourceIndexRoots(
+  struct TableEntry *aWorking, int nWorking,
+  SchemaEntry *aWorkSchema, int nWorkSchema,
+  struct TableEntry *aSource, int nSource,
+  SchemaEntry *aSourceSchema, int nSourceSchema,
+  const char *zTable
+){
+  int j, k;
+  for(j=0; j<nSourceSchema; j++){
+    struct TableEntry *pSrcEntry, *pWorkEntry;
+    if( !aSourceSchema[j].zType || strcmp(aSourceSchema[j].zType, "index")!=0 ) continue;
+    if( !aSourceSchema[j].zTblName || strcmp(aSourceSchema[j].zTblName, zTable)!=0 ) continue;
+    if( !aSourceSchema[j].zName ) continue;
+    pSrcEntry = doltliteFindTableByNumber(aSource, nSource,
+                                          aSourceSchema[j].iRootpage);
+    if( !pSrcEntry ) continue;
+    for(k=0; k<nWorkSchema; k++){
+      if( aWorkSchema[k].zType && strcmp(aWorkSchema[k].zType, "index")==0
+       && aWorkSchema[k].zName
+       && strcmp(aWorkSchema[k].zName, aSourceSchema[j].zName)==0 ){
+        break;
+      }
+    }
+    if( k>=nWorkSchema ) continue;
+    pWorkEntry = doltliteFindTableByNumber(aWorking, nWorking,
+                                           aWorkSchema[k].iRootpage);
+    if( !pWorkEntry || pWorkEntry->iTable<=1 ) continue;
+    pWorkEntry->root = pSrcEntry->root;
+    pWorkEntry->schemaHash = pSrcEntry->schemaHash;
+    pWorkEntry->flags = pSrcEntry->flags;
+  }
+}
+
 static int doltliteCheckoutTables(
   sqlite3 *db,
   const char *zSourceRef,
@@ -861,7 +985,9 @@ static int doltliteCheckoutTables(
   ProllyHash newWorkingHash;
   CheckoutSchemaInfo *aSchema = 0;
   struct TableEntry *aWorking = 0, *aSource = 0;
+  SchemaEntry *aSourceSchema = 0, *aWorkSchema = 0;
   int nWorking = 0, nSource = 0;
+  int nSourceSchema = 0, nWorkSchema = 0;
   int i, j;
   int rc;
 
@@ -934,6 +1060,14 @@ static int doltliteCheckoutTables(
     }
   }
 
+  rc = loadSchemaFromCatalog(db, cs, doltliteGetCache(db), &sourceCatHash,
+                             &aSourceSchema, &nSourceSchema);
+  if( rc!=SQLITE_OK ){
+    checkoutSchemaInfoClear(aSchema, nNames);
+    doltliteFreeCatalog(aSource, nSource);
+    return rc;
+  }
+
   for(i=0; i<nNames; i++){
     const char *zName = (const char*)sqlite3_value_text(argv[iFirstName + i]);
     int bSchemaChanged;
@@ -944,42 +1078,45 @@ static int doltliteCheckoutTables(
       || (aSchema[i].hasCurrent && aSchema[i].hasSource
           && strcmp(aSchema[i].zCurrentSql ? aSchema[i].zCurrentSql : "",
                     aSchema[i].zSourceSql ? aSchema[i].zSourceSql : "")!=0);
-    if( !bSchemaChanged ) continue;
-
-    if( aSchema[i].hasCurrent ){
-      zDrop = sqlite3_mprintf("DROP TABLE \"%w\"", zName);
-      if( !zDrop ){
-        checkoutSchemaInfoClear(aSchema, nNames);
-        doltliteFreeCatalog(aSource, nSource);
-        return SQLITE_NOMEM;
+    if( bSchemaChanged ){
+      if( aSchema[i].hasCurrent ){
+        zDrop = sqlite3_mprintf("DROP TABLE \"%w\"", zName);
+        if( !zDrop ){
+          rc = SQLITE_NOMEM;
+          break;
+        }
+        rc = sqlite3_exec(db, zDrop, 0, 0, 0);
+        sqlite3_free(zDrop);
+        if( rc!=SQLITE_OK ) break;
       }
-      rc = sqlite3_exec(db, zDrop, 0, 0, 0);
-      sqlite3_free(zDrop);
-      if( rc!=SQLITE_OK ){
-        checkoutSchemaInfoClear(aSchema, nNames);
-        doltliteFreeCatalog(aSource, nSource);
-        return rc;
+      if( aSchema[i].hasSource ){
+        rc = sqlite3_exec(db, aSchema[i].zSourceSql, 0, 0, 0);
+        if( rc!=SQLITE_OK ) break;
       }
+      aSchema[i].rebuilt = 1;
     }
     if( aSchema[i].hasSource ){
-      rc = sqlite3_exec(db, aSchema[i].zSourceSql, 0, 0, 0);
-      if( rc!=SQLITE_OK ){
-        checkoutSchemaInfoClear(aSchema, nNames);
-        doltliteFreeCatalog(aSource, nSource);
-        return rc;
-      }
+      rc = checkoutReconcileTableIndexes(db, aSourceSchema, nSourceSchema, zName);
+      if( rc!=SQLITE_OK ) break;
     }
-    aSchema[i].rebuilt = 1;
+  }
+  if( rc!=SQLITE_OK ){
+    freeSchemaEntries(aSourceSchema, nSourceSchema);
+    checkoutSchemaInfoClear(aSchema, nNames);
+    doltliteFreeCatalog(aSource, nSource);
+    return rc;
   }
 
   rc = doltliteFlushCatalogToHash(db, &workingHash);
   if( rc!=SQLITE_OK ){
+    freeSchemaEntries(aSourceSchema, nSourceSchema);
     checkoutSchemaInfoClear(aSchema, nNames);
     doltliteFreeCatalog(aSource, nSource);
     return rc;
   }
   rc = doltliteLoadCatalog(db, &workingHash, &aWorking, &nWorking, 0);
   if( rc!=SQLITE_OK ){
+    freeSchemaEntries(aSourceSchema, nSourceSchema);
     checkoutSchemaInfoClear(aSchema, nNames);
     doltliteFreeCatalog(aSource, nSource);
     return rc;
@@ -1006,6 +1143,7 @@ static int doltliteCheckoutTables(
       if( aSchema[i].rebuilt && !aSchema[i].hasSource ){
         continue;
       }
+      freeSchemaEntries(aSourceSchema, nSourceSchema);
       checkoutSchemaInfoClear(aSchema, nNames);
       doltliteFreeCatalog(aWorking, nWorking);
       doltliteFreeCatalog(aSource, nSource);
@@ -1024,6 +1162,7 @@ static int doltliteCheckoutTables(
       struct TableEntry *aNew = sqlite3_realloc(aWorking,
           (nWorking+1)*(int)sizeof(struct TableEntry));
       if( !aNew ){
+        freeSchemaEntries(aSourceSchema, nSourceSchema);
         checkoutSchemaInfoClear(aSchema, nNames);
         doltliteFreeCatalog(aWorking, nWorking);
         doltliteFreeCatalog(aSource, nSource);
@@ -1033,6 +1172,7 @@ static int doltliteCheckoutTables(
       zDup = aSource[srcIdx].zName
                ? sqlite3_mprintf("%s", aSource[srcIdx].zName) : 0;
       if( aSource[srcIdx].zName && !zDup ){
+        freeSchemaEntries(aSourceSchema, nSourceSchema);
         checkoutSchemaInfoClear(aSchema, nNames);
         doltliteFreeCatalog(aWorking, nWorking);
         doltliteFreeCatalog(aSource, nSource);
@@ -1045,6 +1185,7 @@ static int doltliteCheckoutTables(
       zDup = aSource[srcIdx].zName
                ? sqlite3_mprintf("%s", aSource[srcIdx].zName) : 0;
       if( aSource[srcIdx].zName && !zDup ){
+        freeSchemaEntries(aSourceSchema, nSourceSchema);
         checkoutSchemaInfoClear(aSchema, nNames);
         doltliteFreeCatalog(aWorking, nWorking);
         doltliteFreeCatalog(aSource, nSource);
@@ -1060,6 +1201,24 @@ static int doltliteCheckoutTables(
         aWorking[workIdx].zName = zDup;
       }
     }
+  }
+
+  rc = loadSchemaFromCatalog(db, cs, doltliteGetCache(db), &workingHash,
+                             &aWorkSchema, &nWorkSchema);
+  if( rc!=SQLITE_OK ){
+    freeSchemaEntries(aSourceSchema, nSourceSchema);
+    checkoutSchemaInfoClear(aSchema, nNames);
+    doltliteFreeCatalog(aWorking, nWorking);
+    doltliteFreeCatalog(aSource, nSource);
+    return rc;
+  }
+  for(i=0; i<nNames; i++){
+    const char *zName = (const char*)sqlite3_value_text(argv[iFirstName + i]);
+    if( !zName ) continue;
+    checkoutAdoptSourceIndexRoots(aWorking, nWorking,
+                                  aWorkSchema, nWorkSchema,
+                                  aSource, nSource,
+                                  aSourceSchema, nSourceSchema, zName);
   }
 
   {
@@ -1081,6 +1240,8 @@ static int doltliteCheckoutTables(
     }
   }
 
+  freeSchemaEntries(aSourceSchema, nSourceSchema);
+  freeSchemaEntries(aWorkSchema, nWorkSchema);
   checkoutSchemaInfoClear(aSchema, nNames);
   doltliteFreeCatalog(aWorking, nWorking);
   doltliteFreeCatalog(aSource, nSource);

--- a/test/vc_oracle_checkout_test.sh
+++ b/test/vc_oracle_checkout_test.sh
@@ -806,6 +806,310 @@ ROLLBACK TO sp1;
 " "SELECT concat(active_branch(), char(9), IFNULL((SELECT v FROM a WHERE id=1), ''), char(9), IFNULL((SELECT v FROM a WHERE id=2), ''), char(9), IFNULL((SELECT v FROM a WHERE id=3), ''), char(9), IFNULL((SELECT v FROM b WHERE id=1), ''), char(9), IFNULL((SELECT v FROM b WHERE id=2), ''), char(9), IFNULL((SELECT v FROM b WHERE id=3), ''), char(9), (SELECT count(*) FROM dolt_status WHERE table_name='a' AND staged=1 AND status='modified'), char(9), (SELECT count(*) FROM dolt_status WHERE table_name='b' AND staged=1 AND status='modified'));"
 
 echo ""
+echo "--- Schema objects (views, triggers, indexes) ---"
+
+# Schema-object observability diverges (sqlite_master vs dolt_schemas /
+# information_schema) and trigger bodies and DROP INDEX cannot share one
+# script across dialects, so these run per-system setups and queries and
+# compare the projected results.
+oracle_dual_poststate() {
+  local name="$1" dl_setup="$2" dt_setup="$3" dl_query="$4" dt_query="$5"
+  local dir="$TMPROOT/${name}_dual"
+  mkdir -p "$dir/dl" "$dir/dt"
+
+  # The observation runs in the SAME session as the setup: dolt_checkout is
+  # session-scoped, so a fresh session would observe the default branch.
+  # Queries tag their rows (Q|, V|, I|) and everything else is filtered out.
+  local dl_post
+  dl_post=$(printf "%s\n.headers off\n.mode list\n%s\n" "$dl_setup" "$dl_query" \
+            | "$DOLTLITE" "$dir/dl/db" 2>"$dir/dl.err" \
+            | tr -d '\r' \
+            | grep -aE '^[QVI]\|')
+
+  local dolt_setup
+  dolt_setup=$(vc_oracle_translate_for_dolt "$dt_setup")
+  local dt_post
+  dt_post=$(
+    cd "$dir/dt" || exit 1
+    vc_oracle_init_repo
+    {
+      printf '%s\n' "$dolt_setup"
+      printf '%s\n' "$dt_query"
+    } | "$DOLT" sql -c -r csv 2>"$dir/dt.err" \
+      | tr -d '"\r' \
+      | grep -aE '^[QVI]\|'
+  )
+
+  vc_oracle_assert_match "$name" "$dl_post" "$dt_post"
+}
+
+DL_VIEW_COUNT="SELECT 'V|' || count(*) FROM sqlite_master WHERE type = 'view';"
+DT_VIEW_COUNT="SELECT concat('V|', count(*)) FROM dolt_schemas WHERE type = 'view';"
+DL_IDX_COUNT="SELECT 'I|' || count(*) FROM sqlite_master WHERE name = 'idx';"
+DT_IDX_COUNT="SELECT concat('I|', count(*)) FROM information_schema.statistics WHERE table_name = 't' AND index_name = 'idx';"
+
+oracle_dual_poststate "checkout_unstaged_view_stays_behind" "
+CREATE TABLE t(a INTEGER PRIMARY KEY);
+SELECT dolt_commit('-Am', 'base');
+SELECT dolt_branch('feature');
+CREATE VIEW v AS SELECT a FROM t;
+SELECT dolt_checkout('feature');
+" "
+CREATE TABLE t(a INT PRIMARY KEY);
+SELECT dolt_commit('-Am', 'base');
+SELECT dolt_branch('feature');
+CREATE VIEW v AS SELECT a FROM t;
+SELECT dolt_checkout('feature');
+" "$DL_VIEW_COUNT" "$DT_VIEW_COUNT"
+
+oracle_dual_poststate "checkout_unstaged_view_survives_roundtrip" "
+CREATE TABLE t(a INTEGER PRIMARY KEY);
+SELECT dolt_commit('-Am', 'base');
+SELECT dolt_branch('feature');
+CREATE VIEW v AS SELECT a FROM t;
+SELECT dolt_checkout('feature');
+SELECT dolt_checkout('main');
+" "
+CREATE TABLE t(a INT PRIMARY KEY);
+SELECT dolt_commit('-Am', 'base');
+SELECT dolt_branch('feature');
+CREATE VIEW v AS SELECT a FROM t;
+SELECT dolt_checkout('feature');
+SELECT dolt_checkout('main');
+" "$DL_VIEW_COUNT" "$DT_VIEW_COUNT"
+
+oracle_dual_poststate "checkout_branch_local_view" "
+CREATE TABLE t(a INTEGER PRIMARY KEY);
+INSERT INTO t VALUES (1), (2);
+SELECT dolt_commit('-Am', 'base');
+SELECT dolt_checkout('-b', 'feature');
+CREATE VIEW v AS SELECT a FROM t;
+SELECT dolt_commit('-Am', 'feat_view');
+SELECT dolt_checkout('main');
+SELECT dolt_checkout('feature');
+" "
+CREATE TABLE t(a INT PRIMARY KEY);
+INSERT INTO t VALUES (1), (2);
+SELECT dolt_commit('-Am', 'base');
+SELECT dolt_checkout('-b', 'feature');
+CREATE VIEW v AS SELECT a FROM t;
+SELECT dolt_commit('-Am', 'feat_view');
+SELECT dolt_checkout('main');
+SELECT dolt_checkout('feature');
+" "SELECT 'Q|' || group_concat(a, ',') FROM (SELECT a FROM v ORDER BY a);" \
+"SELECT concat('Q|', group_concat(a ORDER BY a SEPARATOR ',')) FROM v;"
+
+oracle_dual_poststate "checkout_view_absent_on_main" "
+CREATE TABLE t(a INTEGER PRIMARY KEY);
+SELECT dolt_commit('-Am', 'base');
+SELECT dolt_checkout('-b', 'feature');
+CREATE VIEW v AS SELECT a FROM t;
+SELECT dolt_commit('-Am', 'feat_view');
+SELECT dolt_checkout('main');
+" "
+CREATE TABLE t(a INT PRIMARY KEY);
+SELECT dolt_commit('-Am', 'base');
+SELECT dolt_checkout('-b', 'feature');
+CREATE VIEW v AS SELECT a FROM t;
+SELECT dolt_commit('-Am', 'feat_view');
+SELECT dolt_checkout('main');
+" "$DL_VIEW_COUNT" "$DT_VIEW_COUNT"
+
+oracle_dual_poststate "checkout_dirty_view_modify_switches" "
+CREATE TABLE t(a INTEGER PRIMARY KEY, b INT);
+INSERT INTO t VALUES (1, 10);
+CREATE VIEW v AS SELECT a FROM t;
+SELECT dolt_commit('-Am', 'base');
+SELECT dolt_checkout('-b', 'feature');
+DROP VIEW v;
+CREATE VIEW v AS SELECT b FROM t;
+SELECT dolt_commit('-Am', 'feat_view');
+SELECT dolt_checkout('main');
+DROP VIEW v;
+CREATE VIEW v AS SELECT a, b FROM t;
+SELECT dolt_checkout('feature');
+" "
+CREATE TABLE t(a INT PRIMARY KEY, b INT);
+INSERT INTO t VALUES (1, 10);
+CREATE VIEW v AS SELECT a FROM t;
+SELECT dolt_commit('-Am', 'base');
+SELECT dolt_checkout('-b', 'feature');
+DROP VIEW v;
+CREATE VIEW v AS SELECT b FROM t;
+SELECT dolt_commit('-Am', 'feat_view');
+SELECT dolt_checkout('main');
+DROP VIEW v;
+CREATE VIEW v AS SELECT a, b FROM t;
+SELECT dolt_checkout('feature');
+" "SELECT 'Q|' || group_concat(b, ',') FROM (SELECT b FROM v ORDER BY b);" \
+"SELECT concat('Q|', group_concat(b ORDER BY b SEPARATOR ',')) FROM v;"
+
+oracle_error "checkout_view_by_name_errors" "
+CREATE TABLE t(a INTEGER PRIMARY KEY);
+CREATE VIEW v AS SELECT a FROM t;
+SELECT dolt_commit('-Am', 'base');
+DROP VIEW v;
+SELECT dolt_checkout('v');
+"
+
+oracle_dual_poststate "checkout_branch_local_trigger_fires" "
+CREATE TABLE t(a INTEGER PRIMARY KEY);
+CREATE TABLE audit(a INTEGER PRIMARY KEY);
+SELECT dolt_commit('-Am', 'base');
+SELECT dolt_checkout('-b', 'feature');
+CREATE TRIGGER trg AFTER INSERT ON t BEGIN INSERT INTO audit VALUES (NEW.a); END;
+SELECT dolt_commit('-Am', 'feat_trigger');
+SELECT dolt_checkout('main');
+SELECT dolt_checkout('feature');
+INSERT INTO t VALUES (5);
+" "
+CREATE TABLE t(a INT PRIMARY KEY);
+CREATE TABLE audit(a INT PRIMARY KEY);
+SELECT dolt_commit('-Am', 'base');
+SELECT dolt_checkout('-b', 'feature');
+CREATE TRIGGER trg AFTER INSERT ON t FOR EACH ROW INSERT INTO audit VALUES (NEW.a);
+SELECT dolt_commit('-Am', 'feat_trigger');
+SELECT dolt_checkout('main');
+SELECT dolt_checkout('feature');
+INSERT INTO t VALUES (5);
+" "SELECT 'Q|' || count(*) || '|' || coalesce((SELECT a FROM audit), '~') FROM audit;" \
+"SELECT concat('Q|', count(*), '|', coalesce((SELECT a FROM audit), '~')) FROM audit;"
+
+oracle_dual_poststate "checkout_trigger_inert_on_main" "
+CREATE TABLE t(a INTEGER PRIMARY KEY);
+CREATE TABLE audit(a INTEGER PRIMARY KEY);
+SELECT dolt_commit('-Am', 'base');
+SELECT dolt_checkout('-b', 'feature');
+CREATE TRIGGER trg AFTER INSERT ON t BEGIN INSERT INTO audit VALUES (NEW.a); END;
+SELECT dolt_commit('-Am', 'feat_trigger');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES (5);
+" "
+CREATE TABLE t(a INT PRIMARY KEY);
+CREATE TABLE audit(a INT PRIMARY KEY);
+SELECT dolt_commit('-Am', 'base');
+SELECT dolt_checkout('-b', 'feature');
+CREATE TRIGGER trg AFTER INSERT ON t FOR EACH ROW INSERT INTO audit VALUES (NEW.a);
+SELECT dolt_commit('-Am', 'feat_trigger');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES (5);
+" "SELECT 'Q|' || count(*) FROM audit;" \
+"SELECT concat('Q|', count(*)) FROM audit;"
+
+oracle_dual_poststate "checkout_unstaged_index_stays_behind" "
+CREATE TABLE t(a INTEGER PRIMARY KEY, b INT);
+SELECT dolt_commit('-Am', 'base');
+SELECT dolt_branch('feature');
+CREATE INDEX idx ON t(b);
+SELECT dolt_checkout('feature');
+" "
+CREATE TABLE t(a INT PRIMARY KEY, b INT);
+SELECT dolt_commit('-Am', 'base');
+SELECT dolt_branch('feature');
+CREATE INDEX idx ON t(b);
+SELECT dolt_checkout('feature');
+" "$DL_IDX_COUNT" "$DT_IDX_COUNT"
+
+oracle_dual_poststate "checkout_branch_local_index" "
+CREATE TABLE t(a INTEGER PRIMARY KEY, b INT);
+INSERT INTO t VALUES (1, 10), (2, 10);
+SELECT dolt_commit('-Am', 'base');
+SELECT dolt_checkout('-b', 'feature');
+CREATE INDEX idx ON t(b);
+SELECT dolt_commit('-Am', 'feat_index');
+SELECT dolt_checkout('main');
+SELECT dolt_checkout('feature');
+" "
+CREATE TABLE t(a INT PRIMARY KEY, b INT);
+INSERT INTO t VALUES (1, 10), (2, 10);
+SELECT dolt_commit('-Am', 'base');
+SELECT dolt_checkout('-b', 'feature');
+CREATE INDEX idx ON t(b);
+SELECT dolt_commit('-Am', 'feat_index');
+SELECT dolt_checkout('main');
+SELECT dolt_checkout('feature');
+" "SELECT 'Q|' || (SELECT count(*) FROM sqlite_master WHERE name = 'idx') || '|' || (SELECT group_concat(a, ',') FROM (SELECT a FROM t WHERE b = 10 ORDER BY a));" \
+"SELECT concat('Q|', (SELECT count(*) FROM information_schema.statistics WHERE table_name = 't' AND index_name = 'idx'), '|', (SELECT group_concat(a ORDER BY a SEPARATOR ',') FROM t WHERE b = 10));"
+
+oracle_dual_poststate "checkout_table_restores_dropped_index" "
+CREATE TABLE t(a INTEGER PRIMARY KEY, b INT);
+CREATE INDEX idx ON t(b);
+INSERT INTO t VALUES (1, 10);
+SELECT dolt_commit('-Am', 'base');
+DROP INDEX idx;
+UPDATE t SET b = 99;
+SELECT dolt_checkout('t');
+" "
+CREATE TABLE t(a INT PRIMARY KEY, b INT);
+CREATE INDEX idx ON t(b);
+INSERT INTO t VALUES (1, 10);
+SELECT dolt_commit('-Am', 'base');
+ALTER TABLE t DROP INDEX idx;
+UPDATE t SET b = 99;
+SELECT dolt_checkout('t');
+" "SELECT 'Q|' || (SELECT count(*) FROM sqlite_master WHERE name = 'idx') || '|' || (SELECT b FROM t WHERE a = 1);" \
+"SELECT concat('Q|', (SELECT count(*) FROM information_schema.statistics WHERE table_name = 't' AND index_name = 'idx'), '|', (SELECT b FROM t WHERE a = 1));"
+
+oracle_dual_poststate "checkout_table_removes_added_index" "
+CREATE TABLE t(a INTEGER PRIMARY KEY, b INT);
+INSERT INTO t VALUES (1, 10);
+SELECT dolt_commit('-Am', 'base');
+CREATE INDEX idx ON t(b);
+UPDATE t SET b = 99;
+SELECT dolt_checkout('t');
+" "
+CREATE TABLE t(a INT PRIMARY KEY, b INT);
+INSERT INTO t VALUES (1, 10);
+SELECT dolt_commit('-Am', 'base');
+CREATE INDEX idx ON t(b);
+UPDATE t SET b = 99;
+SELECT dolt_checkout('t');
+" "SELECT 'Q|' || (SELECT count(*) FROM sqlite_master WHERE name = 'idx') || '|' || (SELECT b FROM t WHERE a = 1);" \
+"SELECT concat('Q|', (SELECT count(*) FROM information_schema.statistics WHERE table_name = 't' AND index_name = 'idx'), '|', (SELECT b FROM t WHERE a = 1));"
+
+oracle_dual_poststate "checkout_table_restores_index_definition" "
+CREATE TABLE t(a INTEGER PRIMARY KEY, b INT, c INT);
+CREATE INDEX idx ON t(b);
+INSERT INTO t VALUES (1, 10, 100);
+SELECT dolt_commit('-Am', 'base');
+DROP INDEX idx;
+CREATE INDEX idx ON t(c);
+SELECT dolt_checkout('t');
+" "
+CREATE TABLE t(a INT PRIMARY KEY, b INT, c INT);
+CREATE INDEX idx ON t(b);
+INSERT INTO t VALUES (1, 10, 100);
+SELECT dolt_commit('-Am', 'base');
+ALTER TABLE t DROP INDEX idx;
+CREATE INDEX idx ON t(c);
+SELECT dolt_checkout('t');
+" "SELECT 'Q|' || (SELECT count(*) FROM sqlite_master WHERE name = 'idx' AND sql LIKE '%(b)') || '|' || (SELECT b FROM t WHERE a = 1);" \
+"SELECT concat('Q|', (SELECT count(*) FROM information_schema.statistics WHERE table_name = 't' AND index_name = 'idx' AND column_name = 'b'), '|', (SELECT b FROM t WHERE a = 1));"
+
+oracle_dual_poststate "checkout_cross_branch_table_with_index" "
+CREATE TABLE t(a INTEGER PRIMARY KEY, b INT);
+CREATE INDEX idx ON t(b);
+INSERT INTO t VALUES (1, 10);
+SELECT dolt_commit('-Am', 'base');
+SELECT dolt_checkout('-b', 'feature');
+DROP INDEX idx;
+UPDATE t SET b = 77;
+SELECT dolt_commit('-Am', 'feat_change');
+SELECT dolt_checkout('main', 't');
+" "
+CREATE TABLE t(a INT PRIMARY KEY, b INT);
+CREATE INDEX idx ON t(b);
+INSERT INTO t VALUES (1, 10);
+SELECT dolt_commit('-Am', 'base');
+SELECT dolt_checkout('-b', 'feature');
+ALTER TABLE t DROP INDEX idx;
+UPDATE t SET b = 77;
+SELECT dolt_commit('-Am', 'feat_change');
+SELECT dolt_checkout('main', 't');
+" "SELECT 'Q|' || (SELECT count(*) FROM sqlite_master WHERE name = 'idx') || '|' || (SELECT b FROM t WHERE a = 1);" \
+"SELECT concat('Q|', (SELECT count(*) FROM information_schema.statistics WHERE table_name = 't' AND index_name = 'idx'), '|', (SELECT b FROM t WHERE a = 1));"
+
+echo ""
 echo "=== Results: $pass passed, $fail failed ==="
 if [ $fail -gt 0 ]; then
   echo "Failed:$FAILED_NAMES"


### PR DESCRIPTION
Continues the schema-objects × VC oracle campaign (#1657 add, #1663 merge). Fills the checkout gap.

## Coverage added (14 scenarios, live-Dolt comparison)

- **Views**: unstaged views stay behind on their branch (and survive the round trip), committed views are branch-local, dirty modifies switch cleanly, and `dolt_checkout('<view name>')` errors on both systems.
- **Triggers**: branch-local trigger fires after checkout, and is inert on branches that don't have it (dual per-dialect setups for trigger bodies).
- **Indexes**: unstaged indexes stay behind, committed indexes are branch-local and usable, and **every table-restore form crossed with index deltas** (below).
- Observation queries run in the same session as setup — `dolt_checkout` is session-scoped, so a fresh session would observe the default branch.

## Bug found and fixed

`dolt_checkout('<table>')` reconciled only the table's own DDL and data root. Two consequences, both caught by the new scenarios:

- A working-set `DROP INDEX` survived the restore — Dolt brings the index back.
- Worse: a working-set `CREATE INDEX` survived with its **old tree intact**, so `INDEXED BY` scans returned rows the restored table no longer contains (probe: table says `b=10`, index scan says `b=99`).

The restore now reconciles named-index DDL against the source catalog before the flush (drop extras, recreate differing/missing definitions) and points the flushed catalog's index entries at the source's trees — each side resolved through its own schema rows, since index entries are unnamed (the established unnamed-entry protocol). Covers restore-from-HEAD, restore-from-staged, and cross-branch `dolt_checkout('branch', 'table')`.

## Tests

The four table-restore × index scenarios fail before the fix and pass after. Full local regression green: battery 88/88 suites, C corpus 309,835/309,835, checkout oracle 64/64, branch suite 62/62, branch edge 76/76, index×VC matrix 38/38, state transitions 19/19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)