### PR TITLE
Define SEH WAL errno pager shim

### DIFF
--- a/src/pager_shim.c
+++ b/src/pager_shim.c
@@ -72,6 +72,9 @@ extern sqlite3_backup *orig_sqlite3_backup_init(sqlite3*,const char*,
 extern void orig_sqlite3PagerPagecount(Pager*, int*);
 extern int orig_sqlite3PagerCommitPhaseOne(Pager*, const char*, int);
 extern int orig_sqlite3PagerCommitPhaseTwo(Pager*);
+#if defined(SQLITE_USE_SEH) && !defined(SQLITE_OMIT_WAL)
+extern int orig_sqlite3PagerWalSystemErrno(Pager*);
+#endif
 
 struct PagerOps {
   sqlite3_file *(*xFile)(Pager*);
@@ -506,6 +509,13 @@ static inline const PagerOps *getPagerOps(const Pager *p){
 int pagerShimIsShim(const Pager *p){
   return p && ((const PagerShim*)p)->magic == PAGER_SHIM_MAGIC;
 }
+
+#if defined(SQLITE_USE_SEH) && !defined(SQLITE_OMIT_WAL)
+int sqlite3PagerWalSystemErrno(Pager *pPager){
+  if( pagerShimIsShim(pPager) ) return 0;
+  return orig_sqlite3PagerWalSystemErrno(pPager);
+}
+#endif
 
 PagerShim *pagerShimCreate(
   sqlite3_vfs *pVfs,

--- a/src/pager_shim.h
+++ b/src/pager_shim.h
@@ -59,4 +59,8 @@ void sqlite3PagerCacheStat(Pager*, int, int, u64*);
 int sqlite3PagerIsMemdb(Pager*);
 int sqlite3PagerLockingMode(Pager*, int);
 
+#if defined(SQLITE_USE_SEH) && !defined(SQLITE_OMIT_WAL)
+int sqlite3PagerWalSystemErrno(Pager*);
+#endif
+
 #endif


### PR DESCRIPTION
Fixes #1669.

### Summary
- Defines `sqlite3PagerWalSystemErrno()` for DoltLite pager shim builds when Windows SEH support is enabled.
- For real SQLite pagers, forwards to `orig_sqlite3PagerWalSystemErrno()`.
- For DoltLite shim pagers, returns `0` because there is no SQLite WAL object backing the shim.

### Testing
- `make -j8 doltlite`
- `make -j8 sqlite3.c`
- `cc -c sqlite3.c -o /tmp/doltlite_sqlite3_amalgam.o -DSQLITE_THREADSAFE=1 -DSQLITE_ENABLE_FTS5 -DSQLITE_ENABLE_RTREE -DSQLITE_HAVE_ZLIB=1 -DDOLTLITE_PROLLY=1 -I. -I src`
- `make -j8 DOLTLITE_PROLLY_CHECK=1 doltlite doltlite-remotesrv doltlite-lib`

`make devtest` was attempted, but this local environment fails before tests run in alternate testfixture builds due existing local build issues, including missing `tommath` during testfixture link and existing amalgamation debug-build errors unrelated to this change.