### PR TITLE
Align diff revision ranges with Dolt

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,13 +366,23 @@ SELECT diff_type, to_name, to_email, to_commit
 
 SELECT * FROM dolt_diff_users WHERE to_commit = 'WORKING';  -- staged+working
 
--- TVF form: slice between two refs without filtering. Equivalent to
+-- TVF form: compare the table snapshots at two refs. Equivalent to
 -- Dolt's dolt_diff(from_ref, to_ref, table) TVF — the table name
 -- rides in the module name (SQLite TVFs declare a static schema at
 -- xConnect, so the per-table column list can't move into the
 -- argument list) and the two refs come through as positional args.
 SELECT * FROM dolt_diff_users('HEAD~1', 'HEAD');
 SELECT * FROM dolt_diff_users('v1.0', 'WORKING');
+
+-- Two dots also compare the endpoint snapshots. Three dots compare the
+-- merge base to the right endpoint.
+SELECT * FROM dolt_diff_users('main..feature');
+SELECT * FROM dolt_diff_users('main...feature');
+
+-- Restrict the commit-attributed system table to a history range.
+SELECT d.*
+  FROM dolt_diff_users AS d
+  JOIN dolt_log('v1.0..HEAD') AS l ON l.commit_hash = d.to_commit;
 ```
 
 #### Log and History
@@ -380,6 +390,8 @@ SELECT * FROM dolt_diff_users('v1.0', 'WORKING');
 ```sql
 -- Commit history
 SELECT * FROM dolt_log;
+SELECT * FROM dolt_log('feature');
+SELECT * FROM dolt_log('main..feature');
 -- commit_hash | committer | email | date | message
 ```
 

--- a/src/doltlite_diff_table.c
+++ b/src/doltlite_diff_table.c
@@ -102,6 +102,7 @@ struct DiffTblCursor {
 
 #define DT_IDX_TO_COMMIT_EQ  0x01
 #define DT_IDX_SLICE         0x02
+#define DT_IDX_RANGE_SPEC    0x04
 
 static void clearAuditRow(AuditRow *r){
   sqlite3_free(r->pKeyRec);
@@ -610,171 +611,124 @@ static int buildCommitDiffPair(
   return rc;
 }
 
-/* Add pHash and all of its ancestors (its reachable set) to pSet. Used to
-** identify from_ref's history so a range walk can tell in-range commits (which
-** get attributed) from the out-of-range parents that only supply the "from"
-** side of a boundary change. */
-static int addReachableToSet(
-  sqlite3 *db,
-  ProllyHashSet *pSet,
-  const ProllyHash *pHash
-){
-  DoltliteCommitQueue q;
-  int rc;
-
-  memset(&q, 0, sizeof(q));
-  rc = doltliteCommitQueueInit(&q, pHash);
-  if( rc!=SQLITE_OK ) return rc;
-
-  while( rc==SQLITE_OK ){
-    ProllyHash cur;
-    DoltliteCommit c;
-    int has = 0;
-    rc = doltliteCommitQueueNext(&q, &cur, &has);
-    if( rc!=SQLITE_OK || !has ) break;
-    rc = prollyHashSetAdd(pSet, &cur);
-    if( rc!=SQLITE_OK ) break;
-    memset(&c, 0, sizeof(c));
-    rc = doltliteLoadCommit(db, &cur, &c);
-    if( rc!=SQLITE_OK ) break;
-    rc = doltliteCommitQueueEnqueueParents(&q, &c);
-    doltliteCommitClear(&c);
-  }
-
-  doltliteCommitQueueClear(&q);
-  return rc;
-}
-
-/* Range diff: emit, for every commit in from_ref..to_ref (reachable from
-** to_ref but not from from_ref), the change it introduced against its parent,
-** attributed to that commit -- the same per-commit walk as the unfiltered
-** dolt_diff_<table>, restricted to the range. Equivalent to the unfiltered
-** system table filtered by "to_commit IN (commits of from_ref..to_ref)". The
-** walk starts at to_ref and descends parent-ward, but only expands a commit's
-** parents when the commit is itself in range; an out-of-range parent is still
-** visited once to supply the "from" side of the boundary change (so a merge
-** parent's own history is attributed correctly). to_ref may be WORKING, in
-** which case the HEAD->working change is included and attributed to WORKING.
-** The net two-dot diff between two refs lives in the dolt_diff() function.
-**
-** Cost is O(history reachable from to_ref) plus from_ref's reachable set, the
-** same order as the unfiltered table; a range near the tip does not shortcut
-** the reachability computation. */
-static int buildRangeDiffPairs(
+static int buildSliceDiffPair(
   DiffTblCursor *pCur,
   sqlite3 *db,
   const char *zTableName,
   const char *zFromRef,
   const char *zToRef
 ){
-  ChunkStore *cs = doltliteGetChunkStore(db);
-  ProllyHash fromHash;
-  CmTblMap map;
-  ProllyHash *aStack = 0;
-  int nStack = 0, nStackAlloc = 0;
-  ProllyHashSet seen;
-  ProllyHashSet reachFrom;
-  int seenInit = 0;
-  int reachInit = 0;
-  int currInited = 0;
-  ProllyHash curr;
-  int rc = SQLITE_OK;
+  ProllyHash fromHash, toHash;
+  ProllyHash fromTblRoot, toTblRoot;
+  ProllyHash fromCatHash, toCatHash;
+  ProllyHash fromSchemaHash, toSchemaHash;
+  DoltliteCommit fromCommit;
+  u8 fromFlags = 0;
+  u8 toFlags = 0;
+  i64 fromDate = 0;
+  i64 toDate = 0;
+  int toIsWorking = 0;
+  char zToLabel[PROLLY_HASH_SIZE*2+1];
+  int rc;
 
-  if( !cs ) return SQLITE_OK;
-  if( !zFromRef || !zToRef ) return SQLITE_OK;
-  memset(&map, 0, sizeof(map));
   memset(&fromHash, 0, sizeof(fromHash));
+  memset(&toHash, 0, sizeof(toHash));
+  memset(&fromTblRoot, 0, sizeof(fromTblRoot));
+  memset(&toTblRoot, 0, sizeof(toTblRoot));
+  memset(&fromCatHash, 0, sizeof(fromCatHash));
+  memset(&toCatHash, 0, sizeof(toCatHash));
+  memset(&fromSchemaHash, 0, sizeof(fromSchemaHash));
+  memset(&toSchemaHash, 0, sizeof(toSchemaHash));
+  memset(&fromCommit, 0, sizeof(fromCommit));
+  memset(zToLabel, 0, sizeof(zToLabel));
 
-  /* An unresolvable from_ref leaves the range unbounded below; treat it as an
-  ** empty result rather than an error, matching the vtable's other ref paths. */
+  if( !zFromRef || !zToRef ) return SQLITE_OK;
+
   rc = doltliteResolveRef(db, zFromRef, &fromHash);
   if( rc!=SQLITE_OK ) return SQLITE_OK;
-
-  rc = prollyHashSetInit(&seen, 64);
+  rc = doltliteLoadCommit(db, &fromHash, &fromCommit);
   if( rc!=SQLITE_OK ) return rc;
-  seenInit = 1;
-  rc = prollyHashSetInit(&reachFrom, 64);
-  if( rc!=SQLITE_OK ) goto walk_done;
-  reachInit = 1;
+  memcpy(&fromCatHash, &fromCommit.catalogHash, sizeof(ProllyHash));
+  fromDate = fromCommit.timestamp;
+  doltliteCommitClear(&fromCommit);
 
-  /* from_ref and everything behind it are out of range (a commit is in range
-  ** iff reachable from to_ref and NOT in this set). */
-  rc = addReachableToSet(db, &reachFrom, &fromHash);
-  if( rc!=SQLITE_OK ) goto walk_done;
+  rc = doltliteLoadTableRootByName(db, &fromCatHash, zTableName,
+                                   &fromTblRoot, &fromFlags, &fromSchemaHash);
+  if( rc!=SQLITE_OK && rc!=SQLITE_NOTFOUND ) return rc;
 
   if( sqlite3_stricmp(zToRef, "WORKING")==0 ){
-    ProllyHash headHash;
-    doltliteGetSessionHead(db, &headHash);
-    if( prollyHashIsEmpty(&headHash) ) goto walk_done;
-    rc = seedWorkingChildInfo(db, &headHash, zTableName, &map);
-    if( rc!=SQLITE_OK ) goto walk_done;
-    rc = stackPushUnique(&seen, &aStack, &nStack, &nStackAlloc, &headHash);
-    if( rc!=SQLITE_OK ) goto walk_done;
+    toIsWorking = 1;
+    rc = doltliteGetWorkingTableState(db, zTableName,
+                                      &toTblRoot, &toFlags,
+                                      &toSchemaHash);
+    if( rc==SQLITE_NOTFOUND ) rc = SQLITE_OK;
+    if( rc!=SQLITE_OK ) return rc;
+    rc = doltliteFlushCatalogToHash(db, &toCatHash);
+    if( rc!=SQLITE_OK ) return rc;
+    memcpy(zToLabel, "WORKING", 7);
   }else{
-    ProllyHash toHash;
-    memset(&toHash, 0, sizeof(toHash));
+    DoltliteCommit toCommit;
+    memset(&toCommit, 0, sizeof(toCommit));
     rc = doltliteResolveRef(db, zToRef, &toHash);
-    if( rc!=SQLITE_OK ){ rc = SQLITE_OK; goto walk_done; }
-    /* to_ref is visited but never seeded with a child, so it emits no change
-    ** of its own; visiting it registers parent(to_ref)->to_ref. */
-    rc = stackPushUnique(&seen, &aStack, &nStack, &nStackAlloc, &toHash);
-    if( rc!=SQLITE_OK ) goto walk_done;
+    if( rc!=SQLITE_OK ) return SQLITE_OK;
+    rc = doltliteLoadCommit(db, &toHash, &toCommit);
+    if( rc!=SQLITE_OK ) return rc;
+    memcpy(&toCatHash, &toCommit.catalogHash, sizeof(ProllyHash));
+    toDate = toCommit.timestamp;
+    doltliteCommitClear(&toCommit);
+    rc = doltliteLoadTableRootByName(db, &toCatHash, zTableName,
+                                     &toTblRoot, &toFlags, &toSchemaHash);
+    if( rc!=SQLITE_OK && rc!=SQLITE_NOTFOUND ) return rc;
+    doltliteHashToHex(&toHash, zToLabel);
   }
 
-  if( nStack>0 ){
-    curr = aStack[--nStack];
-    currInited = 1;
+  if( !toIsWorking && prollyHashCompare(&fromHash, &toHash)==0 ){
+    return SQLITE_OK;
+  }
+  if( prollyHashCompare(&fromTblRoot, &toTblRoot)==0
+   && prollyHashCompare(&fromSchemaHash, &toSchemaHash)==0 ){
+    return SQLITE_OK;
   }
 
-  while( currInited ){
-    DoltliteCommit commit;
-    ProllyHash curTblRoot;
-    ProllyHash curSchemaHash;
-    u8 curFlags = 0;
-    char curHex[PROLLY_HASH_SIZE*2+1];
+  if( !fromFlags ) fromFlags = toFlags;
+  if( !toFlags ) toFlags = fromFlags;
+  return pairsAppend(pCur, &fromHash, &fromTblRoot, &fromCatHash,
+                     &fromSchemaHash, fromFlags, fromDate,
+                     zToLabel, &toTblRoot, &toCatHash, &toSchemaHash,
+                     toFlags, toDate);
+}
 
-    memset(&commit, 0, sizeof(commit));
-    memset(&curTblRoot, 0, sizeof(curTblRoot));
-    memset(&curSchemaHash, 0, sizeof(curSchemaHash));
+static int buildRangeSpecDiffPair(
+  DiffTblCursor *pCur,
+  sqlite3 *db,
+  const char *zTableName,
+  const char *zSpec
+){
+  char *zLeft = 0;
+  char *zRight = 0;
+  int rangeType = DOLTLITE_RANGE_NONE;
+  int rc;
 
-    rc = doltliteLoadCommit(db, &curr, &commit);
-    if( rc!=SQLITE_OK ) break;
-
-    rc = doltliteLoadTableRootByNameOrEmpty(db, &commit.catalogHash,
-                                            zTableName, &curTblRoot,
-                                            &curFlags, &curSchemaHash);
-    if( rc!=SQLITE_OK ){
-      doltliteCommitClear(&commit);
-      break;
+  rc = doltliteSplitRevisionRange(zSpec, &zLeft, &zRight, &rangeType);
+  if( rc==SQLITE_NOTFOUND ) return SQLITE_MISMATCH;
+  if( rc!=SQLITE_OK ) return rc;
+  if( rangeType==DOLTLITE_RANGE_THREE_DOT ){
+    ProllyHash leftHash, rightHash, ancestor;
+    char zAncestor[PROLLY_HASH_SIZE*2+1];
+    rc = doltliteResolveRef(db, zLeft, &leftHash);
+    if( rc==SQLITE_OK ) rc = doltliteResolveRef(db, zRight, &rightHash);
+    if( rc==SQLITE_OK ){
+      rc = doltliteFindAncestor(db, &leftHash, &rightHash, &ancestor);
     }
-
-    doltliteHashToHex(&curr, curHex);
-    /* Emit curr -> its registered child (only in-range commits ever get
-    ** registered as a child, so any emitted pair is attributed in-range). */
-    rc = appendCurrentDiffPair(pCur, &curr, &commit, &curTblRoot,
-                               &curSchemaHash, curFlags, &map);
-    /* Expand parents only for in-range commits; an out-of-range parent is a
-    ** boundary from-side and must not drag its own history into the range. */
-    if( rc==SQLITE_OK && !prollyHashSetContains(&reachFrom, &curr) ){
-      rc = registerCommitParents(&map, &seen, &aStack, &nStack, &nStackAlloc,
-                                 &commit, &curTblRoot,
-                                 &curSchemaHash, curFlags, curHex);
+    if( rc==SQLITE_OK ){
+      doltliteHashToHex(&ancestor, zAncestor);
+      rc = buildSliceDiffPair(pCur, db, zTableName, zAncestor, zRight);
     }
-    doltliteCommitClear(&commit);
-    if( rc!=SQLITE_OK ) break;
-
-    if( nStack==0 ){
-      currInited = 0;
-    }else{
-      curr = aStack[--nStack];
-    }
+  }else{
+    rc = buildSliceDiffPair(pCur, db, zTableName, zLeft, zRight);
   }
-
-walk_done:
-  cmMapFree(&map);
-  sqlite3_free(aStack);
-  if( seenInit ) prollyHashSetFree(&seen);
-  if( reachInit ) prollyHashSetFree(&reachFrom);
+  sqlite3_free(zLeft);
+  sqlite3_free(zRight);
   return rc;
 }
 
@@ -1044,6 +998,11 @@ static int dtBestIndex(sqlite3_vtab *pVtab, sqlite3_index_info *pInfo){
     pInfo->aConstraintUsage[iToRefEq].argvIndex = 2;
     pInfo->aConstraintUsage[iToRefEq].omit = 1;
     pInfo->estimatedCost = 10.0;
+  }else if( iFromRefEq>=0 ){
+    pInfo->idxNum = DT_IDX_RANGE_SPEC;
+    pInfo->aConstraintUsage[iFromRefEq].argvIndex = 1;
+    pInfo->aConstraintUsage[iFromRefEq].omit = 1;
+    pInfo->estimatedCost = 10.0;
   }else if( iToCommitEq>=0 ){
     pInfo->idxNum = DT_IDX_TO_COMMIT_EQ;
     pInfo->aConstraintUsage[iToCommitEq].argvIndex = 1;
@@ -1102,7 +1061,16 @@ static int dtFilter(sqlite3_vtab_cursor *cur,
   if( (idxNum & DT_IDX_SLICE)!=0 && argc>=2 ){
     const char *zFromRef = (const char*)sqlite3_value_text(argv[0]);
     const char *zToRef = (const char*)sqlite3_value_text(argv[1]);
-    rc = buildRangeDiffPairs(c, db, pVtab->zTableName, zFromRef, zToRef);
+    rc = buildSliceDiffPair(c, db, pVtab->zTableName, zFromRef, zToRef);
+  }else if( (idxNum & DT_IDX_RANGE_SPEC)!=0 && argc>=1 ){
+    const char *zSpec = (const char*)sqlite3_value_text(argv[0]);
+    rc = buildRangeSpecDiffPair(c, db, pVtab->zTableName, zSpec);
+    if( rc==SQLITE_MISMATCH ){
+      sqlite3_free(pVtab->base.zErrMsg);
+      pVtab->base.zErrMsg = sqlite3_mprintf(
+          "dolt_diff_%s requires a '..' or '...' revision range",
+          pVtab->zTableName);
+    }
   }else if( (idxNum & DT_IDX_TO_COMMIT_EQ)!=0 && argc>=1 ){
     const char *zToCommit = (const char*)sqlite3_value_text(argv[0]);
     if( zToCommit && sqlite3_stricmp(zToCommit, "WORKING")==0 ){

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -17,6 +17,50 @@ typedef struct DoltliteTxnState DoltliteTxnState;
 typedef struct DoltlitePkRange DoltlitePkRange;
 typedef struct DoltliteCommitQueue DoltliteCommitQueue;
 
+#define DOLTLITE_RANGE_NONE      0
+#define DOLTLITE_RANGE_TWO_DOT   2
+#define DOLTLITE_RANGE_THREE_DOT 3
+
+static SQLITE_INLINE int doltliteSplitRevisionRange(
+  const char *zSpec,
+  char **pzLeft,
+  char **pzRight,
+  int *pRangeType
+){
+  const char *zSep;
+  int nLeft;
+  int nSep;
+
+  *pzLeft = 0;
+  *pzRight = 0;
+  *pRangeType = DOLTLITE_RANGE_NONE;
+  if( !zSpec ) return SQLITE_MISMATCH;
+
+  zSep = strstr(zSpec, "...");
+  nSep = 3;
+  if( !zSep ){
+    zSep = strstr(zSpec, "..");
+    nSep = 2;
+  }
+  if( !zSep ) return SQLITE_NOTFOUND;
+  if( strstr(zSep + nSep, "..") ) return SQLITE_ERROR;
+
+  nLeft = (int)(zSep - zSpec);
+  *pzLeft = nLeft ? sqlite3_mprintf("%.*s", nLeft, zSpec)
+                  : sqlite3_mprintf("HEAD");
+  *pzRight = zSep[nSep] ? sqlite3_mprintf("%s", zSep + nSep)
+                        : sqlite3_mprintf("HEAD");
+  if( !*pzLeft || !*pzRight ){
+    sqlite3_free(*pzLeft);
+    sqlite3_free(*pzRight);
+    *pzLeft = 0;
+    *pzRight = 0;
+    return SQLITE_NOMEM;
+  }
+  *pRangeType = nSep;
+  return SQLITE_OK;
+}
+
 struct DoltlitePkRange {
   i64 pkLo;
   i64 pkHi;
@@ -773,6 +817,9 @@ int doltliteSaveTxnState(sqlite3 *db, DoltliteTxnState *p);
 int doltliteRestoreTxnState(sqlite3 *db, DoltliteTxnState *p);
 
 int doltliteResolveRef(sqlite3 *db, const char *zRef, ProllyHash *pCommit);
+int doltliteFindAncestor(sqlite3 *db, const ProllyHash *pCommit1,
+                         const ProllyHash *pCommit2,
+                         ProllyHash *pAncestor);
 
 typedef struct DoltliteCommit DoltliteCommit;
 int doltliteLoadCommit(sqlite3 *db, const ProllyHash *pHash,

--- a/src/doltlite_log.c
+++ b/src/doltlite_log.c
@@ -11,6 +11,7 @@
 #include <time.h>
 
 #define LOG_IDX_HASH_EQ 0x01
+#define LOG_IDX_REVISION 0x02
 
 typedef struct DoltliteLogVtab DoltliteLogVtab;
 struct DoltliteLogVtab {
@@ -22,6 +23,8 @@ typedef struct DoltliteLogCursor DoltliteLogCursor;
 struct DoltliteLogCursor {
   sqlite3_vtab_cursor base;
   DoltliteCommitQueue queue;
+  ProllyHashSet excluded;
+  int excludedInit;
   char zHex[PROLLY_HASH_SIZE*2+1];
   DoltliteCommit curCommit;
   int hasRow;
@@ -35,7 +38,8 @@ static const char *doltliteLogSchema =
   "  committer TEXT,"
   "  email TEXT,"
   "  date TEXT,"
-  "  message TEXT"
+  "  message TEXT,"
+  "  revision TEXT HIDDEN"
   ")";
 
 static int doltliteLogConnect(
@@ -64,8 +68,13 @@ static void logCursorReset(DoltliteLogCursor *pCur){
   doltliteCommitClear(&pCur->curCommit);
   memset(&pCur->curCommit, 0, sizeof(pCur->curCommit));
   doltliteCommitQueueClear(&pCur->queue);
+  if( pCur->excludedInit ){
+    prollyHashSetFree(&pCur->excluded);
+    pCur->excludedInit = 0;
+  }
   pCur->hasRow = 0;
   pCur->iRowid = 0;
+  pCur->singleCommit = 0;
 }
 
 static int doltliteLogClose(sqlite3_vtab_cursor *pCursor){
@@ -87,6 +96,10 @@ static int logAdvance(DoltliteLogCursor *pCur, sqlite3 *db){
     rc = doltliteCommitQueueNext(&pCur->queue, &cur, &hasHash);
     if( rc!=SQLITE_OK ) return rc;
     if( !hasHash ) break;
+    if( pCur->excludedInit
+     && prollyHashSetContains(&pCur->excluded, &cur) ){
+      continue;
+    }
 
     rc = doltliteLoadCommit(db, &cur, &pCur->curCommit);
     if( rc!=SQLITE_OK ){
@@ -110,6 +123,35 @@ static int logAdvance(DoltliteLogCursor *pCur, sqlite3 *db){
   return SQLITE_OK;
 }
 
+static int logAddReachable(
+  sqlite3 *db,
+  ProllyHashSet *pSet,
+  const ProllyHash *pHead
+){
+  DoltliteCommitQueue queue;
+  int rc;
+
+  memset(&queue, 0, sizeof(queue));
+  rc = doltliteCommitQueueInit(&queue, pHead);
+  while( rc==SQLITE_OK ){
+    ProllyHash hash;
+    DoltliteCommit commit;
+    int hasHash = 0;
+    rc = doltliteCommitQueueNext(&queue, &hash, &hasHash);
+    if( rc!=SQLITE_OK || !hasHash ) break;
+    rc = prollyHashSetAdd(pSet, &hash);
+    if( rc!=SQLITE_OK ) break;
+    memset(&commit, 0, sizeof(commit));
+    rc = doltliteLoadCommit(db, &hash, &commit);
+    if( rc==SQLITE_OK ){
+      rc = doltliteCommitQueueEnqueueParents(&queue, &commit);
+    }
+    doltliteCommitClear(&commit);
+  }
+  doltliteCommitQueueClear(&queue);
+  return rc;
+}
+
 static int doltliteLogNext(sqlite3_vtab_cursor *pCursor){
   DoltliteLogCursor *pCur = (DoltliteLogCursor*)pCursor;
   DoltliteLogVtab *pVtab = (DoltliteLogVtab*)pCursor->pVtab;
@@ -125,24 +167,16 @@ static int doltliteLogFilter(
   DoltliteLogCursor *pCur = (DoltliteLogCursor*)pCursor;
   DoltliteLogVtab *pVtab = (DoltliteLogVtab*)pCursor->pVtab;
   ProllyHash head;
+  ProllyHash secondHead;
   ProllyHash startHash;
   ChunkStore *cs;
   int rc;
   int useStart = 0;
+  int useSecondHead = 0;
   (void)idxStr;
 
   logCursorReset(pCur);
   memset(&startHash, 0, sizeof(startHash));
-
-  if( (idxNum & LOG_IDX_HASH_EQ) && argc>0 ){
-    const char *z = (const char*)sqlite3_value_text(argv[0]);
-    if( z && doltliteHexToHash(z, &startHash)==SQLITE_OK
-        && !prollyHashIsEmpty(&startHash) ){
-      useStart = 1;
-    }else{
-      return SQLITE_OK;
-    }
-  }
 
   cs = doltliteGetChunkStore(pVtab->db);
   if( !cs ){
@@ -154,17 +188,68 @@ static int doltliteLogFilter(
     return SQLITE_OK;
   }
 
-  if( useStart ){
+  if( (idxNum & LOG_IDX_HASH_EQ) && argc>0 ){
+    const char *z = (const char*)sqlite3_value_text(argv[0]);
+    if( z && doltliteHexToHash(z, &startHash)==SQLITE_OK
+        && !prollyHashIsEmpty(&startHash) ){
+      useStart = 1;
+    }else{
+      return SQLITE_OK;
+    }
+  }else if( (idxNum & LOG_IDX_REVISION) && argc>0 ){
+    const char *zSpec = (const char*)sqlite3_value_text(argv[0]);
+    char *zLeft = 0;
+    char *zRight = 0;
+    int rangeType = DOLTLITE_RANGE_NONE;
+
+    rc = doltliteSplitRevisionRange(zSpec, &zLeft, &zRight, &rangeType);
+    if( rc==SQLITE_NOTFOUND ){
+      rc = doltliteResolveRef(pVtab->db, zSpec, &head);
+    }else if( rc==SQLITE_OK ){
+      ProllyHash leftHash;
+      rc = doltliteResolveRef(pVtab->db, zLeft, &leftHash);
+      if( rc==SQLITE_OK ) rc = doltliteResolveRef(pVtab->db, zRight, &head);
+      if( rc==SQLITE_OK ){
+        rc = prollyHashSetInit(&pCur->excluded, 64);
+        if( rc==SQLITE_OK ) pCur->excludedInit = 1;
+      }
+      if( rc==SQLITE_OK && rangeType==DOLTLITE_RANGE_THREE_DOT ){
+        ProllyHash ancestor;
+        secondHead = leftHash;
+        useSecondHead = 1;
+        rc = doltliteFindAncestor(pVtab->db, &leftHash, &head, &ancestor);
+        if( rc==SQLITE_OK ){
+          rc = logAddReachable(pVtab->db, &pCur->excluded, &ancestor);
+        }
+      }else if( rc==SQLITE_OK ){
+        rc = logAddReachable(pVtab->db, &pCur->excluded, &leftHash);
+      }
+    }
+    sqlite3_free(zLeft);
+    sqlite3_free(zRight);
+    if( rc!=SQLITE_OK ){
+      sqlite3_free(pCursor->pVtab->zErrMsg);
+      pCursor->pVtab->zErrMsg = sqlite3_mprintf(
+          "invalid dolt_log revision: %s", zSpec ? zSpec : "");
+      return pCursor->pVtab->zErrMsg ? SQLITE_ERROR : SQLITE_NOMEM;
+    }
+    useStart = 2;
+  }
+
+  if( useStart==1 ){
     head = startHash;
     pCur->singleCommit = 1;
-  }else{
+  }else if( useStart==0 ){
     doltliteGetSessionHead(pVtab->db, &head);
     if( prollyHashIsEmpty(&head) ) return SQLITE_OK;
-    pCur->singleCommit = 0;
   }
 
   rc = doltliteCommitQueueInit(&pCur->queue, &head);
   if( rc!=SQLITE_OK ) return rc;
+  if( useSecondHead ){
+    rc = doltliteCommitQueueEnqueue(&pCur->queue, &secondHead);
+    if( rc!=SQLITE_OK ) return rc;
+  }
 
   return logAdvance(pCur, pVtab->db);
 }
@@ -215,7 +300,7 @@ static int doltliteLogRowid(sqlite3_vtab_cursor *pCursor, sqlite3_int64 *pRowid)
 }
 
 static int doltliteLogBestIndex(sqlite3_vtab *pVtab, sqlite3_index_info *pInfo){
-  int i, iHashEq = -1;
+  int i, iHashEq = -1, iRevisionEq = -1;
   int idxNum = 0;
   (void)pVtab;
 
@@ -225,10 +310,18 @@ static int doltliteLogBestIndex(sqlite3_vtab *pVtab, sqlite3_index_info *pInfo){
     if( pC->op != SQLITE_INDEX_CONSTRAINT_EQ ) continue;
     if( pC->iColumn == 0 && iHashEq < 0 ){
       iHashEq = i;
+    }else if( pC->iColumn == 5 && iRevisionEq < 0 ){
+      iRevisionEq = i;
     }
   }
 
-  if( iHashEq >= 0 ){
+  if( iRevisionEq >= 0 ){
+    pInfo->aConstraintUsage[iRevisionEq].argvIndex = 1;
+    pInfo->aConstraintUsage[iRevisionEq].omit = 1;
+    idxNum |= LOG_IDX_REVISION;
+    pInfo->estimatedCost = 100.0;
+    pInfo->estimatedRows = 10;
+  }else if( iHashEq >= 0 ){
     pInfo->aConstraintUsage[iHashEq].argvIndex = 1;
     pInfo->aConstraintUsage[iHashEq].omit = 1;
     idxNum |= LOG_IDX_HASH_EQ;

--- a/test/doltlite_diff_table_range.sh
+++ b/test/doltlite_diff_table_range.sh
@@ -1,19 +1,70 @@
 #!/bin/bash
 . "$(dirname "$0")/lib/doltlite_test_common.sh"
 
-# dolt_diff_<table>(from_ref, to_ref) must attribute each changed row to the
-# commit inside the range that actually made the change -- the same per-commit
-# audit the unfiltered dolt_diff_<table> gives -- rather than collapsing the
-# range into a single net two-dot diff labelled with the range endpoints.
-# (The net two-dot diff lives in the dolt_diff() table function.)
-
-echo "=== Doltlite dolt_diff_<table> ranged attribution tests ==="
+echo "=== Doltlite diff revision range tests ==="
 echo ""
 
 DB=/tmp/test_dt_range_$$.db; rm -f "$DB"
 
-# c1 adds id=1; c2 adds id=2; c3 modifies id=1; c4 deletes id=2;
-# c5 modifies id=1 again (a repeated change to the same row).
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(0,'base');
+SELECT dolt_commit('-A','-m','base');
+SELECT dolt_branch('feature');
+INSERT INTO t VALUES(1,'main only');
+SELECT dolt_commit('-A','-m','main change');
+SELECT dolt_checkout('feature');
+INSERT INTO t VALUES(2,'feature only');
+SELECT dolt_commit('-A','-m','feature change');" \
+  | $DOLTLITE "$DB" > /dev/null 2>&1
+
+MAIN=$(echo "SELECT hash FROM dolt_branches WHERE name='main';" | $DOLTLITE "$DB")
+FEATURE=$(echo "SELECT hash FROM dolt_branches WHERE name='feature';" | $DOLTLITE "$DB")
+BASE=$(echo "SELECT commit_hash FROM dolt_log WHERE message='base';" | $DOLTLITE "$DB")
+
+run_test "two_ref_snapshot_diff" \
+  "SELECT group_concat(id || ':' || diff_type, ',') FROM
+     (SELECT coalesce(from_id,to_id) AS id, diff_type
+        FROM dolt_diff_t('main','feature') ORDER BY id);" \
+  "1:removed,2:added" "$DB"
+
+run_test "two_dot_snapshot_diff" \
+  "SELECT group_concat(id || ':' || diff_type, ',') FROM
+     (SELECT coalesce(from_id,to_id) AS id, diff_type
+        FROM dolt_diff_t('main..feature') ORDER BY id);" \
+  "1:removed,2:added" "$DB"
+
+run_test "two_dot_omitted_head" \
+  "SELECT count(*) FROM dolt_diff_t('..feature');" "2" "$DB"
+
+run_test "three_dot_feature" \
+  "SELECT coalesce(from_id,to_id) || ':' || diff_type
+     FROM dolt_diff_t('main...feature');" "2:added" "$DB"
+
+run_test "three_dot_main" \
+  "SELECT coalesce(from_id,to_id) || ':' || diff_type
+     FROM dolt_diff_t('feature...main');" "1:added" "$DB"
+
+run_test "three_dot_uses_merge_base" \
+  "SELECT from_commit || '|' || to_commit
+     FROM dolt_diff_t('main...feature');" "$BASE|$FEATURE" "$DB"
+
+run_test "hash_snapshot_diff" \
+  "SELECT count(*) FROM dolt_diff_t('$MAIN','$FEATURE');" "2" "$DB"
+
+run_test "log_branch_ref" \
+  "SELECT message FROM dolt_log('main') LIMIT 1;" "main change" "$DB"
+
+run_test "log_two_dot" \
+  "SELECT group_concat(message, ',') FROM
+     (SELECT message FROM dolt_log('main..feature') ORDER BY message);" \
+  "feature change" "$DB"
+
+run_test "log_three_dot" \
+  "SELECT group_concat(message, ',') FROM
+     (SELECT message FROM dolt_log('main...feature') ORDER BY message);" \
+  "feature change,main change" "$DB"
+
+HDB=/tmp/test_dt_history_$$.db; rm -f "$HDB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'a');
 SELECT dolt_commit('-A','-m','c1');
@@ -24,75 +75,33 @@ SELECT dolt_commit('-A','-m','c3');
 DELETE FROM t WHERE id=2;
 SELECT dolt_commit('-A','-m','c4');
 UPDATE t SET v='a3' WHERE id=1;
-SELECT dolt_commit('-A','-m','c5');" | $DOLTLITE "$DB" > /dev/null 2>&1
+SELECT dolt_commit('-A','-m','c5');" \
+  | $DOLTLITE "$HDB" > /dev/null 2>&1
 
-C1=$(echo "SELECT commit_hash FROM dolt_log WHERE message='c1';" | $DOLTLITE "$DB")
-C2=$(echo "SELECT commit_hash FROM dolt_log WHERE message='c2';" | $DOLTLITE "$DB")
-C3=$(echo "SELECT commit_hash FROM dolt_log WHERE message='c3';" | $DOLTLITE "$DB")
-C4=$(echo "SELECT commit_hash FROM dolt_log WHERE message='c4';" | $DOLTLITE "$DB")
-C5=$(echo "SELECT commit_hash FROM dolt_log WHERE message='c5';" | $DOLTLITE "$DB")
+C2=$(echo "SELECT commit_hash FROM dolt_log WHERE message='c2';" | $DOLTLITE "$HDB")
+C5=$(echo "SELECT commit_hash FROM dolt_log WHERE message='c5';" | $DOLTLITE "$HDB")
 
-# Range c2..c5 = commits c3 (modify id1), c4 (delete id2), c5 (modify id1).
-# c2's own change (adding id=2) is the lower boundary and excluded.
-run_test "range_count" \
-  "SELECT count(*) FROM dolt_diff_t('$C2','$C5');" "3" "$DB"
+run_test "endpoint_collapses_repeated_changes" \
+  "SELECT count(*) FROM dolt_diff_t('$C2','$C5');" "2" "$HDB"
 
-# The core of the feature: three distinct attributing commits, not one.
-run_test "range_distinct_commits" \
-  "SELECT count(DISTINCT to_commit) FROM dolt_diff_t('$C2','$C5');" "3" "$DB"
+run_test "history_range_preserves_attribution" \
+  "SELECT count(*) FROM dolt_diff_t d
+     JOIN dolt_log('$C2..$C5') l ON l.commit_hash=d.to_commit;" "3" "$HDB"
 
-# Each change is attributed to the commit that made it, not the endpoint.
-run_test "range_attribution_c3" \
-  "SELECT to_v FROM dolt_diff_t('$C2','$C5') WHERE to_commit='$C3';" "a2" "$DB"
-run_test "range_attribution_c5" \
-  "SELECT to_v FROM dolt_diff_t('$C2','$C5') WHERE to_commit='$C5';" "a3" "$DB"
+run_test "history_range_preserves_repeated_changes" \
+  "SELECT count(*) FROM dolt_diff_t d
+     JOIN dolt_log('$C2..$C5') l ON l.commit_hash=d.to_commit
+    WHERE d.diff_type='modified' AND d.to_id=1;" "2" "$HDB"
 
-# Deletions inside the range are shown, attributed to the deleting commit.
-run_test "range_delete_shown" \
-  "SELECT diff_type || ':' || from_id FROM dolt_diff_t('$C2','$C5') WHERE to_commit='$C4';" \
-  "removed:2" "$DB"
+run_test "history_range_preserves_delete" \
+  "SELECT count(*) FROM dolt_diff_t d
+     JOIN dolt_log('$C2..$C5') l ON l.commit_hash=d.to_commit
+    WHERE d.diff_type='removed' AND d.from_id=2;" "1" "$HDB"
 
-# Repeated changes to one row appear once per commit that touched it.
-run_test "range_repeated_change" \
-  "SELECT count(*) FROM dolt_diff_t('$C2','$C5') WHERE diff_type='modified' AND to_id=1;" \
-  "2" "$DB"
+echo "UPDATE t SET v='a4' WHERE id=1;" | $DOLTLITE "$HDB" > /dev/null 2>&1
+run_test "endpoint_to_working" \
+  "SELECT to_v || ':' || diff_type FROM dolt_diff_t('$C5','WORKING');" \
+  "a4:modified" "$HDB"
 
-# Lower bound excludes from_ref's own change: adding id=2 happened at c2 and
-# must not appear in c2..c5.
-run_test "range_excludes_from_boundary" \
-  "SELECT count(*) FROM dolt_diff_t('$C2','$C5') WHERE diff_type='added';" "0" "$DB"
-
-# ...but the commit immediately after from_ref is included: c1..c3 covers c2's
-# add of id=2 and c3's modify of id=1, while c1's add of id=1 is excluded.
-run_test "range_lower_neighbor_count" \
-  "SELECT count(*) FROM dolt_diff_t('$C1','$C3');" "2" "$DB"
-run_test "range_lower_neighbor_add" \
-  "SELECT to_commit FROM dolt_diff_t('$C1','$C3') WHERE diff_type='added' AND to_id=2;" \
-  "$C2" "$DB"
-run_test "range_lower_neighbor_excludes_c1" \
-  "SELECT count(*) FROM dolt_diff_t('$C1','$C3') WHERE to_id=1 AND diff_type='added';" \
-  "0" "$DB"
-
-# A range is a subset of the full per-commit history and preserves the same
-# attribution the unfiltered table gives for those commits.
-run_test "range_matches_full_attribution" \
-  "SELECT (SELECT to_v FROM dolt_diff_t('$C2','$C5') WHERE to_commit='$C3')
-        = (SELECT to_v FROM dolt_diff_t WHERE to_commit='$C3' AND to_id=1);" \
-  "1" "$DB"
-
-# Reversed / empty range yields nothing.
-run_test "range_reversed_empty" \
-  "SELECT count(*) FROM dolt_diff_t('$C5','$C2');" "0" "$DB"
-run_test "range_identical_empty" \
-  "SELECT count(*) FROM dolt_diff_t('$C3','$C3');" "0" "$DB"
-
-# to_ref = WORKING bounds the range at the tip and includes the working change,
-# attributed to WORKING; c5's committed change to id=1 is also in c4..WORKING.
-echo "UPDATE t SET v='a4' WHERE id=1;" | $DOLTLITE "$DB" > /dev/null 2>&1
-run_test "range_working_has_working_row" \
-  "SELECT to_v FROM dolt_diff_t('$C4','WORKING') WHERE to_commit='WORKING';" "a4" "$DB"
-run_test "range_working_includes_c5" \
-  "SELECT to_v FROM dolt_diff_t('$C4','WORKING') WHERE to_commit='$C5';" "a3" "$DB"
-
-rm -f "$DB"
+rm -f "$DB" "$HDB"
 dltest_finish

--- a/test/vc_oracle_diff_multi_pk_test.sh
+++ b/test/vc_oracle_diff_multi_pk_test.sh
@@ -10,18 +10,13 @@ pass=0; fail=0
 FAILED_NAMES=""
 source "$(dirname "$0")/lib/vc_oracle_common.sh"
 
-# doltlite's dolt_diff_<tbl>(from, to) is a ranged, per-commit-attributed diff;
-# Dolt's equivalent is the dolt_diff_<tbl> system table filtered to the commits
-# in the from..to range. dolt_diff_stat/summary stay net-range functions and are
-# shielded from the row-diff rewrite.
 translate_for_dolt() {
-  sed -E "
+  sed -E '
     s/SELECT[[:space:]]+(dolt_[a-z_]+\()/CALL \1/g
     s/dolt_diff_(stat|summary)([^a-zA-Z0-9_])/@@DOLT_DIFF_\1@@\2/g
-    s/dolt_diff_([a-zA-Z0-9_]+)\('([^']*)', *'WORKING'\)/dolt_diff_\1 WHERE to_commit = 'WORKING' OR to_commit IN (SELECT commit_hash FROM dolt_log('\2..HEAD'))/g
-    s/dolt_diff_([a-zA-Z0-9_]+)\('([^']*)', *'([^']*)'\)/dolt_diff_\1 WHERE to_commit IN (SELECT commit_hash FROM dolt_log('\2..\3'))/g
+    s/dolt_diff_([a-zA-Z0-9_]+)\(([^)]*)\)/dolt_diff(\2, "\1")/g
     s/@@DOLT_DIFF_(stat|summary)@@/dolt_diff_\1/g
-  "
+  '
 }
 
 oracle() {

--- a/test/vc_oracle_diff_tvf_test.sh
+++ b/test/vc_oracle_diff_tvf_test.sh
@@ -10,17 +10,11 @@ pass=0; fail=0
 FAILED_NAMES=""
 source "$(dirname "$0")/lib/vc_oracle_common.sh"
 
-# doltlite's dolt_diff_<tbl>(from, to) is a ranged, per-commit-attributed diff
-# (each changed row tagged with the commit inside from..to that made it). Dolt
-# has no arg form of the dolt_diff_<tbl> system table; its equivalent is that
-# same system table filtered to the commits in the from..to range, so that is
-# what we compare against. to=WORKING additionally includes the working-set row.
 translate_for_dolt() {
-  sed -E "
+  sed -E '
     s/SELECT[[:space:]]+(dolt_[a-z_]+\()/CALL \1/g
-    s/dolt_diff_([a-zA-Z0-9_]+)\('([^']*)', *'WORKING'\)/dolt_diff_\1 WHERE to_commit = 'WORKING' OR to_commit IN (SELECT commit_hash FROM dolt_log('\2..HEAD'))/g
-    s/dolt_diff_([a-zA-Z0-9_]+)\('([^']*)', *'([^']*)'\)/dolt_diff_\1 WHERE to_commit IN (SELECT commit_hash FROM dolt_log('\2..\3'))/g
-  "
+    s/dolt_diff_([a-zA-Z0-9_]+)\(([^)]*)\)/dolt_diff(\2, "\1")/g
+  '
 }
 
 oracle() {
@@ -115,6 +109,38 @@ echo "--- no diff (same ref both sides) ---"
 oracle "slice_no_change" "$SETUP_LINEAR" \
   "SELECT CONCAT('R|', IFNULL(to_id,''), '|', IFNULL(to_v,''), '|', IFNULL(from_id,''), '|', IFNULL(from_v,''), '|', diff_type) FROM dolt_diff_t('HEAD', 'HEAD');" \
   "EXPECT_EMPTY"
+
+echo "--- divergent history ---"
+
+SETUP_DIVERGENT="
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(0, 'base');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'base');
+SELECT dolt_branch('feature');
+INSERT INTO t VALUES(1, 'main only');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'main change');
+SELECT dolt_checkout('feature');
+INSERT INTO t VALUES(2, 'feature only');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'feature change');
+"
+
+oracle "divergent_two_ref" "$SETUP_DIVERGENT" \
+  "SELECT CONCAT('R|', IFNULL(from_id,to_id), '|', diff_type) FROM dolt_diff_t('main', 'feature');"
+
+oracle "divergent_two_dot" "$SETUP_DIVERGENT" \
+  "SELECT CONCAT('R|', IFNULL(from_id,to_id), '|', diff_type) FROM dolt_diff_t('main..feature');"
+
+oracle "divergent_three_dot_feature" "$SETUP_DIVERGENT" \
+  "SELECT CONCAT('R|', IFNULL(from_id,to_id), '|', diff_type) FROM dolt_diff_t('main...feature');"
+
+oracle "divergent_three_dot_main" "$SETUP_DIVERGENT" \
+  "SELECT CONCAT('R|', IFNULL(from_id,to_id), '|', diff_type) FROM dolt_diff_t('feature...main');"
+
+oracle "log_two_dot" "$SETUP_DIVERGENT" \
+  "SELECT CONCAT('R|', message) FROM dolt_log('main..feature');"
+
+oracle "log_three_dot" "$SETUP_DIVERGENT" \
+  "SELECT CONCAT('R|', message) FROM dolt_log('main...feature');"
 
 echo "--- multi-column table ---"
 

--- a/test/vc_oracle_pk_edge_values_test.sh
+++ b/test/vc_oracle_pk_edge_values_test.sh
@@ -16,15 +16,13 @@ pass=0; fail=0
 FAILED_NAMES=""
 source "$(dirname "$0")/lib/vc_oracle_common.sh"
 
-# doltlite's dolt_diff_<tbl>(from, to) maps to Dolt's dolt_diff_<tbl> system
-# table filtered to the commits in the range (same as the multi-pk diff test).
 translate_for_dolt() {
-  sed -E "
+  sed -E '
     s/SELECT[[:space:]]+(dolt_[a-z_]+\()/CALL \1/g
     s/dolt_diff_(stat|summary)([^a-zA-Z0-9_])/@@DOLT_DIFF_\1@@\2/g
-    s/dolt_diff_([a-zA-Z0-9_]+)\('([^']*)', *'([^']*)'\)/dolt_diff_\1 WHERE to_commit IN (SELECT commit_hash FROM dolt_log('\2..\3'))/g
+    s/dolt_diff_([a-zA-Z0-9_]+)\(([^)]*)\)/dolt_diff(\2, "\1")/g
     s/@@DOLT_DIFF_(stat|summary)@@/dolt_diff_\1/g
-  "
+  '
 }
 
 oracle() {

--- a/test/vc_oracle_pk_only_tables_test.sh
+++ b/test/vc_oracle_pk_only_tables_test.sh
@@ -18,10 +18,10 @@ FAILED_NAMES=""
 source "$(dirname "$0")/lib/vc_oracle_common.sh"
 
 translate_for_dolt() {
-  sed -E "
+  sed -E '
     s/SELECT[[:space:]]+(dolt_[a-z_]+\()/CALL \1/g
-    s/dolt_diff_([a-zA-Z0-9_]+)\('([^']*)', *'([^']*)'\)/dolt_diff_\1 WHERE to_commit IN (SELECT commit_hash FROM dolt_log('\2..\3'))/g
-  "
+    s/dolt_diff_([a-zA-Z0-9_]+)\(([^)]*)\)/dolt_diff(\2, "\1")/g
+  '
 }
 
 oracle() {

--- a/test/vc_oracle_pk_shapes_scale_test.sh
+++ b/test/vc_oracle_pk_shapes_scale_test.sh
@@ -17,12 +17,12 @@ FAILED_NAMES=""
 source "$(dirname "$0")/lib/vc_oracle_common.sh"
 
 translate_for_dolt() {
-  sed -E "
+  sed -E '
     s/SELECT[[:space:]]+(dolt_[a-z_]+\()/CALL \1/g
     s/dolt_diff_(stat|summary)([^a-zA-Z0-9_])/@@DOLT_DIFF_\1@@\2/g
-    s/dolt_diff_([a-zA-Z0-9_]+)\('([^']*)', *'([^']*)'\)/dolt_diff_\1 WHERE to_commit IN (SELECT commit_hash FROM dolt_log('\2..\3'))/g
+    s/dolt_diff_([a-zA-Z0-9_]+)\(([^)]*)\)/dolt_diff(\2, "\1")/g
     s/@@DOLT_DIFF_(stat|summary)@@/dolt_diff_\1/g
-  "
+  '
 }
 
 oracle() {

--- a/test/vc_oracle_pk_shapes_table_ops_test.sh
+++ b/test/vc_oracle_pk_shapes_table_ops_test.sh
@@ -17,12 +17,12 @@ FAILED_NAMES=""
 source "$(dirname "$0")/lib/vc_oracle_common.sh"
 
 translate_for_dolt() {
-  sed -E "
+  sed -E '
     s/SELECT[[:space:]]+(dolt_[a-z_]+\()/CALL \1/g
     s/dolt_diff_(stat|summary)([^a-zA-Z0-9_])/@@DOLT_DIFF_\1@@\2/g
-    s/dolt_diff_([a-zA-Z0-9_]+)\('([^']*)', *'([^']*)'\)/dolt_diff_\1 WHERE to_commit IN (SELECT commit_hash FROM dolt_log('\2..\3'))/g
+    s/dolt_diff_([a-zA-Z0-9_]+)\(([^)]*)\)/dolt_diff(\2, "\1")/g
     s/@@DOLT_DIFF_(stat|summary)@@/dolt_diff_\1/g
-  "
+  '
 }
 
 oracle() {


### PR DESCRIPTION
## Summary
- restore endpoint snapshot semantics for `dolt_diff_<table>(from_ref, to_ref)`
- support Dolt-compatible `A..B` endpoint diffs and `A...B` merge-base diffs
- add branch and range arguments to `dolt_log` so callers can still select commit-attributed history
- document both behaviors and compare divergent histories against Dolt

Fixes #1671

## Testing
- `test/doltlite_diff_table_range.sh`
- `test/vc_oracle_diff_tvf_test.sh`
- diff, workspace, correctness, and primary-key oracle suites (245 assertions total)
- `make devtest` reaches the generated amalgamation build, then fails in the existing `btree_orig` compatibility layer; the same 9 build failures reproduce from an untouched `origin/master` worktree