### PR TITLE
Reject credential KID path traversal

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -367,6 +367,7 @@ jobs:
       run: |
         cd build
         bash ../test/creds_kat_test.sh
+        bash ../test/creds_path_test.sh "$DOLTLITE"
         bash ../test/tls_test.sh
         bash ../test/creds_verify_test.sh
         bash ../test/remote_test.sh ./doltlite
@@ -394,7 +395,10 @@ jobs:
 
     - name: Credential verify known-answer test
       if: matrix.platform != 'windows'
-      run: cd build && bash ../test/creds_verify_test.sh
+      run: |
+        cd build
+        bash ../test/creds_verify_test.sh
+        bash ../test/creds_path_test.sh ./doltlite
       timeout-minutes: 5
 
     - name: Remote HTTPS + credential auth tests

--- a/src/doltlite_creds.c
+++ b/src/doltlite_creds.c
@@ -456,9 +456,26 @@ static int mkdirp(const char *path) {
   return 0;
 }
 
+static int credsKidValid(const char *kid) {
+  const size_t nKid = (DOLTLITE_KID_RAW_LEN * 8 + 4) / 5;
+  size_t i;
+  if (!kid) return 0;
+  for (i = 0; i < nKid; i++) {
+    const char *p;
+    if (!kid[i]) return 0;
+    p = strchr(B32_ALPHABET, kid[i]);
+    if (!p) return 0;
+    if (i == nKid - 1 && ((p - B32_ALPHABET) & 1) != 0) return 0;
+  }
+  return kid[nKid] == '\0';
+}
+
 static char *credsFilePath(const char *dir, const char *kid) {
-  size_t n = strlen(dir) + 1 + strlen(kid) + strlen(".jwk") + 1;
-  char *path = (char *)malloc(n);
+  size_t n;
+  char *path;
+  if (!credsKidValid(kid)) return NULL;
+  n = strlen(dir) + 1 + strlen(kid) + strlen(".jwk") + 1;
+  path = (char *)malloc(n);
   if (!path) return NULL;
   snprintf(path, n, "%s/%s.jwk", dir, kid);
   return path;
@@ -630,13 +647,19 @@ int doltliteCredsLoadDefault(const char *dir, DoltliteCreds **out) {
   while ((name = dirNext(&it)) != NULL) {
     size_t n = strlen(name);
     if (n > 4 && strcmp(name + n - 4, ".jwk") == 0) {
+      char *candidate = (char *)malloc(n - 4 + 1);
+      if (!candidate) continue;
+      memcpy(candidate, name, n - 4);
+      candidate[n - 4] = '\0';
+      if (!credsKidValid(candidate)) {
+        free(candidate);
+        continue;
+      }
       count++;
       if (count == 1) {
-        kid = (char *)malloc(n - 4 + 1);
-        if (kid) {
-          memcpy(kid, name, n - 4);
-          kid[n - 4] = '\0';
-        }
+        kid = candidate;
+      } else {
+        free(candidate);
       }
     }
   }
@@ -673,17 +696,24 @@ int doltliteCredsList(const char *dir, char ***out, int *n) {
     size_t ln = strlen(name);
     char *kid;
     if (!(ln > 4 && strcmp(name + ln - 4, ".jwk") == 0)) continue;
-    if (cnt == cap) {
-      int nc = cap ? cap * 2 : 8;
-      char **na = (char **)realloc(arr, (size_t)nc * sizeof(char *));
-      if (!na) goto oom;
-      arr = na;
-      cap = nc;
-    }
     kid = (char *)malloc(ln - 4 + 1);
     if (!kid) goto oom;
     memcpy(kid, name, ln - 4);
     kid[ln - 4] = '\0';
+    if (!credsKidValid(kid)) {
+      free(kid);
+      continue;
+    }
+    if (cnt == cap) {
+      int nc = cap ? cap * 2 : 8;
+      char **na = (char **)realloc(arr, (size_t)nc * sizeof(char *));
+      if (!na) {
+        free(kid);
+        goto oom;
+      }
+      arr = na;
+      cap = nc;
+    }
     arr[cnt++] = kid;
   }
   dirClose(&it);

--- a/test/creds_path_test.sh
+++ b/test/creds_path_test.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+set -u
+set -o pipefail
+
+DOLTLITE="${1:-./doltlite}"
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+mkdir -p "$TMP/creds"
+pass=0
+fail=0
+
+check() {
+  local name="$1"
+  shift
+  if "$@"; then
+    echo "  PASS  $name"
+    pass=$((pass + 1))
+  else
+    echo "  FAIL  $name"
+    fail=$((fail + 1))
+  fi
+}
+
+reject_remove() {
+  local kid="$1"
+  ! DOLTLITE_CREDS_DIR="$TMP/creds" "$DOLTLITE" :memory: \
+    "SELECT dolt_creds('rm','$kid');" >/dev/null 2>&1
+}
+
+echo "=== doltlite credential path tests ==="
+printf '{}' > "$TMP/victim.jwk"
+check "parent traversal removal rejected" reject_remove "../victim"
+check "outside file preserved" test -f "$TMP/victim.jwk"
+check "Windows separator traversal rejected" reject_remove '..\victim'
+check "Windows drive-relative KID rejected" reject_remove 'C:victim'
+check "absolute KID rejected" reject_remove '/tmp/victim'
+
+created=$(DOLTLITE_CREDS_DIR="$TMP/creds" "$DOLTLITE" :memory: \
+  "SELECT dolt_creds_new();" 2>/dev/null)
+created=${created//$'\r'/}
+kid=$(printf '%s\n' "$created" | sed -n \
+  's/^Created credential \([0-9a-v][0-9a-v]*\)$/\1/p' | head -1)
+check "canonical credential created" test "${#kid}" -eq 45
+check "canonical credential stored" test -f "$TMP/creds/$kid.jwk"
+check "canonical credential removal succeeds" env \
+  DOLTLITE_CREDS_DIR="$TMP/creds" "$DOLTLITE" :memory: \
+  "SELECT dolt_creds('rm','$kid');"
+check "canonical credential removed" test ! -e "$TMP/creds/$kid.jwk"
+
+echo ""
+echo "Results: $pass passed, $fail failed"
+test "$fail" -eq 0

--- a/test/creds_verify_kat.c
+++ b/test/creds_verify_kat.c
@@ -21,9 +21,63 @@ static void check(const char *name, int ok) {
 #define MID 1700000015L
 #define LATE 1700001000L
 
+static char *encodeRaw(const unsigned char *p, size_t n) {
+  char *z = doltliteBase64UrlEncode(p, n);
+  size_t len;
+  if (!z) return NULL;
+  len = strlen(z);
+  while (len > 0 && z[len - 1] == '=') z[--len] = '\0';
+  return z;
+}
+
+static char *tokenForKid(const DoltliteCreds *c, const char *kid) {
+  char *header = NULL, *claims = NULL, *h64 = NULL, *c64 = NULL;
+  char *input = NULL, *s64 = NULL, *token = NULL;
+  unsigned char sig[DOLTLITE_SIG_LEN];
+  size_t n;
+
+  n = strlen(kid) + 96;
+  header = (char *)malloc(n);
+  if (!header) goto done;
+  snprintf(header, n,
+           "{\"alg\":\"EdDSA\",\"kid\":\"%s\",\"dolt_token_version\":\"2023.01\"}",
+           kid);
+  n = strlen(kid) * 2 + strlen(AUD) + 160;
+  claims = (char *)malloc(n);
+  if (!claims) goto done;
+  snprintf(claims, n,
+           "{\"iss\":\"dolt-client.dolthub.com\","
+           "\"sub\":\"doltClientCredentials/%s\",\"aud\":\"%s\","
+           "\"iat\":%ld,\"exp\":%ld}",
+           kid, AUD, IAT, IAT + 30);
+  h64 = encodeRaw((const unsigned char *)header, strlen(header));
+  c64 = encodeRaw((const unsigned char *)claims, strlen(claims));
+  if (!h64 || !c64) goto done;
+  n = strlen(h64) + strlen(c64) + 2;
+  input = (char *)malloc(n);
+  if (!input) goto done;
+  snprintf(input, n, "%s.%s", h64, c64);
+  doltliteCredsSign(c, (const unsigned char *)input, strlen(input), sig);
+  s64 = encodeRaw(sig, sizeof(sig));
+  if (!s64) goto done;
+  n = strlen(input) + strlen(s64) + 2;
+  token = (char *)malloc(n);
+  if (token) snprintf(token, n, "%s.%s", input, s64);
+
+done:
+  free(header);
+  free(claims);
+  free(h64);
+  free(c64);
+  free(input);
+  free(s64);
+  return token;
+}
+
 int main(int argc, char **argv) {
   const char *authDir = argc > 1 ? argv[1] : ".";
   const char *emptyDir = argc > 2 ? argv[2] : ".";
+  const char *outsideDir = argc > 3 ? argv[3] : ".";
   unsigned char seed[32];
   DoltliteCreds *c = NULL;
   char *jwt = NULL, *kid = NULL, *kidOut = NULL;
@@ -79,6 +133,22 @@ int main(int argc, char **argv) {
   }
   check("tampered signature rejected",
         doltliteCredsVerifyBearer(tampered, AUD, authDir, MID, NULL) != 0);
+
+  {
+    char *traversalKid;
+    char *traversalJwt;
+    size_t n = strlen(kid) + strlen("../outside/") + 1;
+    check("save key outside authorized directory",
+          doltliteCredsSave(c, outsideDir) == 0);
+    traversalKid = (char *)malloc(n);
+    snprintf(traversalKid, n, "../outside/%s", kid);
+    traversalJwt = tokenForKid(c, traversalKid);
+    check("signed token cannot traverse auth-key directory",
+          traversalJwt &&
+              doltliteCredsVerifyBearer(traversalJwt, AUD, authDir, MID, NULL) != 0);
+    free(traversalKid);
+    free(traversalJwt);
+  }
 
   free(jwt);
   free(kid);

--- a/test/creds_verify_test.sh
+++ b/test/creds_verify_test.sh
@@ -10,7 +10,7 @@ TMP=$(mktemp -d)
 trap 'rm -rf "$TMP"' EXIT
 
 BIN="$TMP/creds_verify_kat"
-mkdir -p "$TMP/authkeys" "$TMP/empty"
+mkdir -p "$TMP/authkeys" "$TMP/empty" "$TMP/outside"
 
 echo "=== doltlite credential-verify KAT ==="
 "$CC" -O2 -Wall \
@@ -32,4 +32,4 @@ echo "=== doltlite credential-verify KAT ==="
   exit 1
 }
 
-"$BIN" "$TMP/authkeys" "$TMP/empty"
+"$BIN" "$TMP/authkeys" "$TMP/empty" "$TMP/outside"

--- a/test/doltlite_creds_kat.c
+++ b/test/doltlite_creds_kat.c
@@ -56,6 +56,13 @@ static void check_bool(const char *name, int cond) {
   }
 }
 
+static int fileExists(const char *path) {
+  FILE *f = fopen(path, "rb");
+  if (!f) return 0;
+  fclose(f);
+  return 1;
+}
+
 static char *decodeSegZ(const char *seg, size_t seglen, size_t *outlen) {
   char *z = (char *)malloc(seglen + 1);
   unsigned char *raw = NULL;
@@ -242,9 +249,65 @@ int main(int argc, char **argv) {
 
   {
     const char *dir = (argc > 1) ? argv[1] : NULL;
+    const struct {
+      const char *name;
+      const char *kid;
+    } invalid[] = {
+        {"parent traversal KID rejected", "../victim"},
+        {"Windows traversal KID rejected", "..\\victim"},
+        {"dot KID rejected", "."},
+        {"empty KID rejected", ""},
+        {"drive-relative KID rejected", "C:credential"},
+        {"uppercase KID rejected",
+         "7ku1cgd7ujkcri5u4smmrsrpcp3ejsmgc9t7o3dkdbarS"},
+        {"non-canonical final base32 bits rejected",
+         "7ku1cgd7ujkcri5u4smmrsrpcp3ejsmgc9t7o3dkdbart"}};
+    unsigned char pub[DOLTLITE_PUBKEY_LEN];
+    DoltliteCreds *loaded = NULL;
+    char *json = doltliteCredsToJwk(c);
+    char *outside;
+    FILE *f;
+    size_t i;
+    size_t n = strlen(dir) + strlen("/../victim.jwk") + 1;
+
+    outside = (char *)malloc(n);
+    snprintf(outside, n, "%s/../victim.jwk", dir);
+    f = fopen(outside, "wb");
+    if (f && json) fwrite(json, 1, strlen(json), f);
+    if (f) fclose(f);
+
+    check_bool("creds load rejects parent traversal",
+               doltliteCredsLoad(dir, "../victim", &loaded) != 0);
+    check_bool("public-key load rejects parent traversal",
+               doltliteCredsLoadPubKey(dir, "../victim", pub) != 0);
+    check_bool("creds remove rejects parent traversal",
+               doltliteCredsRemove(dir, "../victim") != 0);
+    check_bool("traversal rejection preserves outside file", fileExists(outside));
+    for (i = 0; i < sizeof(invalid) / sizeof(invalid[0]); i++) {
+      check_bool(invalid[i].name,
+                 doltliteCredsRemove(dir, invalid[i].kid) != 0);
+    }
+
+    doltliteCredsFree(loaded);
+    free(json);
+    free(outside);
+  }
+
+  {
+    const char *dir = (argc > 1) ? argv[1] : NULL;
     char *kid = doltliteCredsKid(c);
     char **kids = NULL;
     int n = 0, i, found = 0;
+    char *invalidPath;
+    FILE *invalidFile;
+
+    invalidPath = (char *)malloc(strlen(dir) + strlen("/not-a-kid.jwk") + 1);
+    sprintf(invalidPath, "%s/not-a-kid.jwk", dir);
+    invalidFile = fopen(invalidPath, "wb");
+    if (invalidFile) {
+      fputs("{}", invalidFile);
+      fclose(invalidFile);
+    }
 
     if (doltliteCredsList(dir, &kids, &n) != 0) {
       failures++;
@@ -254,7 +317,15 @@ int main(int argc, char **argv) {
         if (kid && strcmp(kids[i], kid) == 0) found = 1;
       }
       check_bool("creds list includes the saved kid", found);
+      check_bool("creds list excludes non-canonical filenames", n == 1);
       doltliteCredsFreeList(kids, n);
+    }
+
+    {
+      DoltliteCreds *loaded = NULL;
+      check_bool("default load ignores non-canonical filenames",
+                 doltliteCredsLoadDefault(dir, &loaded) == 0);
+      doltliteCredsFree(loaded);
     }
 
     if (doltliteCredsRemove(dir, kid) != 0) {
@@ -269,8 +340,11 @@ int main(int argc, char **argv) {
         if (kid && strcmp(kids[i], kid) == 0) found = 1;
       }
       check_bool("creds remove deletes the kid", !found);
+      check_bool("creds list remains empty with invalid filenames", n == 0);
       doltliteCredsFreeList(kids, n);
     }
+    remove(invalidPath);
+    free(invalidPath);
     free(kid);
   }
 


### PR DESCRIPTION
## Summary
- require credential IDs to use DoltLite's canonical 45-character base32 format before constructing a file path
- ignore non-canonical `.jwk` filenames when listing or selecting default credentials
- cover SQL and C API removal/loading, Unix and Windows path forms, and signed JWT traversal

Closes #1675

## Testing
- clean checked build with no compiler warnings
- credential KAT: 33 passed
- bearer verification KAT: 12 passed
- credential path tests: 9 passed
- HTTPS auth integration: 13 passed
- layer lint and shell syntax checks