### PR TITLE
Make default branch ref mutations atomic

### DIFF
--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -5597,6 +5597,16 @@ static void doltliteVersionFunc(sqlite3_context *ctx, int argc, sqlite3_value **
   sqlite3_result_text(ctx, DOLTLITE_VERSION, -1, SQLITE_STATIC);
 }
 
+static int mutateDefaultBranch(sqlite3 *db, ChunkStore *cs, void *pArg){
+  const char *zName = (const char*)pArg;
+  ProllyHash unused;
+  int rc;
+  (void)db;
+  rc = chunkStoreFindBranch(cs, zName, &unused);
+  if( rc!=SQLITE_OK ) return rc;
+  return chunkStoreSetDefaultBranch(cs, zName);
+}
+
 static void doltliteDefaultBranchFunc(
   sqlite3_context *ctx, int argc, sqlite3_value **argv
 ){
@@ -5613,7 +5623,6 @@ static void doltliteDefaultBranchFunc(
   }
   if( argc==1 ){
     const char *zNew;
-    ProllyHash unused;
     int rc;
     if( sqlite3_value_type(argv[0])!=SQLITE_TEXT ){
       sqlite3_result_error(ctx,
@@ -5625,19 +5634,13 @@ static void doltliteDefaultBranchFunc(
       sqlite3_result_error(ctx, "branch name required", -1);
       return;
     }
-    if( chunkStoreFindBranch(cs, zNew, &unused)!=SQLITE_OK ){
+    rc = doltliteMutateRefs(db, mutateDefaultBranch, (void*)zNew);
+    if( rc==SQLITE_NOTFOUND ){
       char *zErr = sqlite3_mprintf("branch '%s' not found", zNew);
       sqlite3_result_error(ctx, zErr ? zErr : "branch not found", -1);
       sqlite3_free(zErr);
       return;
     }
-    rc = chunkStoreSetDefaultBranch(cs, zNew);
-    if( rc!=SQLITE_OK ){
-      sqlite3_result_error_code(ctx, rc);
-      return;
-    }
-    rc = chunkStoreSerializeRefs(cs);
-    if( rc==SQLITE_OK ) rc = chunkStoreCommit(cs);
     if( rc!=SQLITE_OK ){
       sqlite3_result_error_code(ctx, rc);
       return;

--- a/src/doltlite_branch.c
+++ b/src/doltlite_branch.c
@@ -62,7 +62,9 @@ static int mutateBranchRef(sqlite3 *db, ChunkStore *cs, void *pArg){
   BranchMutationCtx *p = (BranchMutationCtx*)pArg;
 
   if( p->isDelete ){
+    const char *zDefault = chunkStoreGetDefaultBranch(cs);
     (void)db;
+    if( zDefault && strcmp(p->zName, zDefault)==0 ) return SQLITE_CONSTRAINT;
     return chunkStoreDeleteBranch(cs, p->zName);
   }
 
@@ -105,17 +107,28 @@ struct BranchMoveCtx {
 static int mutateBranchMove(sqlite3 *db, ChunkStore *cs, void *pArg){
   BranchMoveCtx *p = (BranchMoveCtx*)pArg;
   ProllyHash srcCommit, srcWorkingSet;
+  const char *zDefault;
+  int srcIsDefault;
   int rc;
   (void)db;
 
   rc = chunkStoreFindBranch(cs, p->zSrc, &srcCommit);
   if( rc!=SQLITE_OK ) return rc;
+  zDefault = chunkStoreGetDefaultBranch(cs);
+  srcIsDefault = zDefault && strcmp(p->zSrc, zDefault)==0;
   rc = chunkStoreGetBranchWorkingSet(cs, p->zSrc, &srcWorkingSet);
   if( rc!=SQLITE_OK ) memset(&srcWorkingSet, 0, sizeof(srcWorkingSet));
   rc = chunkStoreAddBranch(cs, p->zDest, &srcCommit);
   if( rc!=SQLITE_OK ) return rc;
   if( !prollyHashIsEmpty(&srcWorkingSet) ){
     rc = chunkStoreSetBranchWorkingSet(cs, p->zDest, &srcWorkingSet);
+    if( rc!=SQLITE_OK ){
+      chunkStoreDeleteBranch(cs, p->zDest);
+      return rc;
+    }
+  }
+  if( srcIsDefault ){
+    rc = chunkStoreSetDefaultBranch(cs, p->zDest);
     if( rc!=SQLITE_OK ){
       chunkStoreDeleteBranch(cs, p->zDest);
       return rc;
@@ -354,15 +367,6 @@ static void doltBranchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv)
         branchError(ctx, hadSavepoint, "cannot delete the current branch");
         return;
       }
-      {
-        const char *zDefault = chunkStoreGetDefaultBranch(cs);
-        if( zDefault && strcmp(aPositional[0], zDefault)==0 ){
-          branchError(ctx, hadSavepoint,
-            "cannot delete the default branch; "
-            "call dolt_default_branch(<other>) first");
-          return;
-        }
-      }
       if( !force ){
         rc = chunkStoreFindBranch(cs, aPositional[0], &branchHead);
         if( rc!=SQLITE_OK ){
@@ -380,6 +384,12 @@ static void doltBranchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv)
       m.zName = aPositional[0];
       m.isDelete = 1;
       rc = doltliteMutateRefs(db, mutateBranchRef, &m);
+      if( rc==SQLITE_CONSTRAINT ){
+        branchError(ctx, hadSavepoint,
+          "cannot delete the default branch; "
+          "call dolt_default_branch(<other>) first");
+        return;
+      }
       if( rc!=SQLITE_OK ){
         branchNamedResultError(ctx, hadSavepoint, rc, "branch not found", 0);
         return;
@@ -432,26 +442,15 @@ static void doltBranchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv)
       memset(&m, 0, sizeof(m));
       m.zSrc = aPositional[0];
       m.zDest = aPositional[1];
-      {
-        const char *zDefault = chunkStoreGetDefaultBranch(cs);
-        /* Resolve "was the default?" before the mutate: doltliteMutateRefs
-        ** reloads persisted refs, freeing the buffer zDefault points into. */
-        int srcWasDefault = zDefault && strcmp(m.zSrc, zDefault)==0;
-        renamingCurrent = strcmp(m.zSrc, doltliteGetSessionBranch(db))==0;
-        rc = doltliteMutateRefs(db, mutateBranchMove, &m);
-        if( rc!=SQLITE_OK ){
-          branchNamedResultError(ctx, hadSavepoint, rc,
-            "source branch not found", "destination already exists");
-          return;
-        }
-        if( renamingCurrent ){
-          doltliteSetSessionBranch(db, m.zDest);
-        }
-        if( srcWasDefault ){
-          chunkStoreSetDefaultBranch(cs, m.zDest);
-          (void)chunkStoreSerializeRefs(cs);
-          (void)chunkStoreCommit(cs);
-        }
+      renamingCurrent = strcmp(m.zSrc, doltliteGetSessionBranch(db))==0;
+      rc = doltliteMutateRefs(db, mutateBranchMove, &m);
+      if( rc!=SQLITE_OK ){
+        branchNamedResultError(ctx, hadSavepoint, rc,
+          "source branch not found", "destination already exists");
+        return;
+      }
+      if( renamingCurrent ){
+        doltliteSetSessionBranch(db, m.zDest);
       }
       break;
     }

--- a/test/concurrent_branch_test.c
+++ b/test/concurrent_branch_test.c
@@ -32,6 +32,8 @@ static const char *queryScalarText(sqlite3 *db, const char *sql){
     if( val ){
       snprintf(result_buf, sizeof(result_buf), "%s", val);
     }
+  }else if( rc!=SQLITE_DONE ){
+    snprintf(result_buf, sizeof(result_buf), "ERROR: %s", sqlite3_errmsg(db));
   }
   sqlite3_finalize(stmt);
   return result_buf;
@@ -49,7 +51,9 @@ static int execSql(sqlite3 *db, const char *sql){
 
 int main(){
   sqlite3 *db1 = 0, *db2 = 0;
+  sqlite3 *db3 = 0;
   const char *dbpath = "/tmp/test_concurrent_branch.db";
+  const char *defaultPath = "/tmp/test_concurrent_default_branch.db";
   int rc;
 
   remove(dbpath); { char _w[256]; snprintf(_w,256,"%s-wal",dbpath); remove(_w); }
@@ -99,6 +103,73 @@ int main(){
   sqlite3_close(db1);
   sqlite3_close(db2);
   remove(dbpath); { char _w[256]; snprintf(_w,256,"%s-wal",dbpath); remove(_w); }
+
+  remove(defaultPath);
+  rc = sqlite3_open(defaultPath, &db1);
+  check("open_stale_rename_connection", rc==SQLITE_OK);
+  check("setup_default_rename_repo", execSql(db1,
+    "CREATE TABLE t(id INTEGER PRIMARY KEY);"
+    "SELECT dolt_commit('-A','-m','init');"
+    "SELECT dolt_branch('feat');")==SQLITE_OK);
+  rc = sqlite3_open(defaultPath, &db2);
+  check("open_default_setter_connection", rc==SQLITE_OK);
+  check("peer_sets_new_default",
+        strcmp(queryScalarText(db2,
+          "SELECT dolt_default_branch('feat')"), "0")==0);
+  check("stale_connection_renames_old_default",
+        strcmp(queryScalarText(db1,
+          "SELECT dolt_branch('-m','main','trunk')"), "0")==0);
+  rc = sqlite3_open(defaultPath, &db3);
+  check("open_fresh_default_reader", rc==SQLITE_OK);
+  check("stale_rename_preserves_peer_default",
+        strcmp(queryScalarText(db3,
+          "SELECT dolt_default_branch()"), "feat")==0);
+  check("stale_rename_moves_source_branch",
+        strcmp(queryScalarText(db3,
+          "SELECT count(*) FROM dolt_branches WHERE name='trunk'"), "1")==0);
+  check("stale_rename_removes_old_branch_name",
+        strcmp(queryScalarText(db3,
+          "SELECT count(*) FROM dolt_branches WHERE name='main'"), "0")==0);
+  sqlite3_close(db3);
+
+  check("peer_creates_branch_after_setter_opened",
+        strcmp(queryScalarText(db1,
+          "SELECT dolt_branch('side')"), "0")==0);
+  check("stale_default_setter_refreshes_refs",
+        strcmp(queryScalarText(db2,
+          "SELECT dolt_default_branch('trunk')"), "0")==0);
+  rc = sqlite3_open(defaultPath, &db3);
+  check("reopen_after_stale_default_setter", rc==SQLITE_OK);
+  check("stale_default_setter_preserves_peer_branch",
+        strcmp(queryScalarText(db3,
+          "SELECT count(*) FROM dolt_branches WHERE name='side'"), "1")==0);
+  check("stale_default_setter_persists_selection",
+        strcmp(queryScalarText(db3,
+          "SELECT dolt_default_branch()"), "trunk")==0);
+  sqlite3_close(db3);
+  db3 = 0;
+
+  check("peer_selects_new_default_before_delete",
+        strcmp(queryScalarText(db2,
+          "SELECT dolt_default_branch('side')"), "0")==0);
+  check("stale_connection_cannot_delete_new_default",
+        strstr(queryScalarText(db1,
+          "SELECT dolt_branch('-D','side')"),
+          "cannot delete the default branch")!=0);
+  rc = sqlite3_open(defaultPath, &db3);
+  check("reopen_after_stale_default_delete", rc==SQLITE_OK);
+  check("stale_delete_preserves_default_branch",
+        strcmp(queryScalarText(db3,
+          "SELECT dolt_default_branch()"), "side")==0);
+  check("stale_delete_preserves_default_ref",
+        strcmp(queryScalarText(db3,
+          "SELECT count(*) FROM dolt_branches WHERE name='side'"), "1")==0);
+
+  sqlite3_close(db1);
+  sqlite3_close(db2);
+  sqlite3_close(db3);
+  remove(defaultPath);
+  { char _w[256]; snprintf(_w,256,"%s-wal",defaultPath); remove(_w); }
 
   printf("\nResults: %d passed, %d failed out of %d tests\n", nPass, nFail, nPass+nFail);
   return nFail > 0 ? 1 : 0;

--- a/test/vc_ref_mutation_stress_test.c
+++ b/test/vc_ref_mutation_stress_test.c
@@ -9,6 +9,7 @@
 #define N_WORKERS 3
 #define N_ROUNDS 4
 #define N_ATTEMPTS 600
+#define DEFAULT_RENAME_ROUNDS 50
 
 static int nPass = 0;
 static int nFail = 0;
@@ -313,6 +314,126 @@ static void verifyFinalState(const char *path){
   sqlite3_close(db);
 }
 
+static int pipeSend(int fd, char value){
+  return write(fd, &value, 1)==1 ? 0 : 1;
+}
+
+static int pipeReceive(int fd, char *pValue){
+  return read(fd, pValue, 1)==1 ? 0 : 1;
+}
+
+static int setupDefaultRenameDb(const char *path){
+  sqlite3 *db = 0;
+  int rc;
+  cleanupDb(path);
+  rc = sqlite3_open(path, &db);
+  if( rc==SQLITE_OK ){
+    rc = execSql(db,
+      "CREATE TABLE t(id INTEGER PRIMARY KEY);"
+      "SELECT dolt_commit('-A','-m','init');"
+      "SELECT dolt_branch('feat')");
+  }
+  sqlite3_close(db);
+  return rc;
+}
+
+static int runDefaultSetterChild(const char *path, int readFd, int writeFd){
+  sqlite3 *db = 0;
+  char value;
+  char out[128];
+  int i;
+  int rc = sqlite3_open(path, &db);
+  if( rc!=SQLITE_OK ) return 1;
+  sqlite3_busy_timeout(db, 5000);
+  for(i=0; i<DEFAULT_RENAME_ROUNDS; i++){
+    if( pipeReceive(readFd, &value) ){
+      sqlite3_close(db);
+      return 1;
+    }
+    rc = queryTextWithRetry(db, "SELECT dolt_default_branch('feat')",
+                            out, sizeof(out));
+    value = rc==SQLITE_OK && strcmp(out, "0")==0 ? '1' : '0';
+    if( pipeSend(writeFd, value) ){
+      sqlite3_close(db);
+      return 1;
+    }
+    if( value!='1' ){
+      sqlite3_close(db);
+      return 1;
+    }
+  }
+  sqlite3_close(db);
+  return 0;
+}
+
+static void runDefaultRenameStress(void){
+  const char *path = "/tmp/test_vc_default_rename_stress.db";
+  sqlite3 *db = 0;
+  int toChild[2];
+  int fromChild[2];
+  pid_t pid;
+  int status = 0;
+  int i;
+  const char *zSrc = "main";
+  const char *zDest = "trunk";
+  char out[128];
+
+  check("default_rename_setup", setupDefaultRenameDb(path)==SQLITE_OK);
+  check("default_rename_open", sqlite3_open(path, &db)==SQLITE_OK);
+  sqlite3_busy_timeout(db, 5000);
+  check("default_rename_initial_default",
+        queryTextWithRetry(db, "SELECT dolt_default_branch()",
+                           out, sizeof(out))==SQLITE_OK
+        && strcmp(out, "main")==0);
+  check("default_rename_pipe_to_child", pipe(toChild)==0);
+  check("default_rename_pipe_from_child", pipe(fromChild)==0);
+  pid = fork();
+  check("default_rename_fork", pid>=0);
+  if( pid==0 ){
+    close(toChild[1]);
+    close(fromChild[0]);
+    _exit(runDefaultSetterChild(path, toChild[0], fromChild[1]));
+  }
+  close(toChild[0]);
+  close(fromChild[1]);
+
+  for(i=0; i<DEFAULT_RENAME_ROUNDS && pid>0; i++){
+    char value = 0;
+    char sql[256];
+    int rc;
+    check("default_rename_signal_setter", pipeSend(toChild[1], '1')==0);
+    check("default_rename_setter_completed",
+          pipeReceive(fromChild[0], &value)==0 && value=='1');
+    snprintf(sql, sizeof(sql),
+             "SELECT dolt_branch('-m','%s','%s')", zSrc, zDest);
+    rc = queryTextWithRetry(db, sql, out, sizeof(out));
+    check("default_rename_move_completed",
+          rc==SQLITE_OK && strcmp(out, "0")==0);
+    rc = queryTextWithRetry(db, "SELECT dolt_default_branch()",
+                            out, sizeof(out));
+    check("default_rename_preserves_peer_default",
+          rc==SQLITE_OK && strcmp(out, "feat")==0);
+    snprintf(sql, sizeof(sql),
+             "SELECT dolt_default_branch('%s')", zDest);
+    rc = queryTextWithRetry(db, sql, out, sizeof(out));
+    check("default_rename_prepares_next_round",
+          rc==SQLITE_OK && strcmp(out, "0")==0);
+    {
+      const char *zTmp = zSrc;
+      zSrc = zDest;
+      zDest = zTmp;
+    }
+  }
+
+  close(toChild[1]);
+  close(fromChild[0]);
+  if( pid>0 ) waitpid(pid, &status, 0);
+  check("default_rename_setter_exited_cleanly",
+        pid>0 && WIFEXITED(status) && WEXITSTATUS(status)==0);
+  sqlite3_close(db);
+  cleanupDb(path);
+}
+
 int main(void){
   const char *path = "/tmp/test_vc_ref_mutation_stress.db";
   pid_t pids[N_WORKERS];
@@ -339,6 +460,7 @@ int main(void){
 
   verifyFinalState(path);
   cleanupDb(path);
+  runDefaultRenameStress();
 
   printf("\nResults: %d passed, %d failed out of %d tests\n",
          nPass, nFail, nPass+nFail);


### PR DESCRIPTION
## Summary
- refresh refs and update the default pointer inside the same locked mutation as branch rename
- route `dolt_default_branch(name)` through the shared locked ref mutation path
- check default-branch deletion after refreshing refs, preventing stale handles from deleting a peer-selected default
- add deterministic multi-connection regressions and a 50-round multi-process handoff stress

Closes #1676

## Testing
- concurrent branch integration: 34 passed, repeated 100 times
- VC ref mutation stress: 271 passed
- default branch suite: 12 passed
- branch suite: 62 passed
- branch oracle: 33 passed
- branches oracle: 15 passed
- durable rename failure regression: 12 passed
- refs commit rollback regression: 18 passed
- clean checked out-of-tree build
- layer lint and diff checks