### PR TITLE
Prevent stalled clients from blocking remotesrv

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -382,6 +382,7 @@ jobs:
         bash ../test/http_remote_content_length_test.sh ./doltlite.exe ./doltlite-remotesrv.exe
         bash ../test/remotesrv_http_test.sh ./doltlite.exe ./doltlite-remotesrv.exe
         bash ../test/remotesrv_http_concurrency_test.sh ./doltlite.exe ./doltlite-remotesrv.exe
+        bash ../test/remotesrv_stall_test.sh ./doltlite.exe ./doltlite-remotesrv.exe
         bash ../test/remotesrv_http_partial_failure_test.sh ./doltlite.exe ./doltlite-remotesrv.exe
         bash ../test/remotesrv_http_force_push_test.sh ./doltlite.exe ./doltlite-remotesrv.exe
         make DOLTLITE_PROLLY=1 DOLTLITE_PROLLY_CHECK=1 sqlite3.c sqlite3.h
@@ -419,6 +420,11 @@ jobs:
     - name: HTTP remote concurrency tests
       if: matrix.platform != 'windows'
       run: cd build && bash ../test/remotesrv_http_concurrency_test.sh ./doltlite ./doltlite-remotesrv
+      timeout-minutes: 5
+
+    - name: HTTP remote stalled client tests
+      if: matrix.platform != 'windows'
+      run: cd build && bash ../test/remotesrv_stall_test.sh ./doltlite ./doltlite-remotesrv
       timeout-minutes: 5
 
     - name: HTTP remote partial failure tests

--- a/main.mk
+++ b/main.mk
@@ -616,6 +616,7 @@ ifeq ($(DOLTLITE_PROLLY),1)
   # Also compile original btree/pager/wal with renamed symbols for ATTACH
   LIBOBJS0 += btree_orig.o pager_orig.o wal_orig.o btmutex_orig.o backup_orig.o btree_orig_api.o
   OPT_FEATURE_FLAGS += -DDOLTLITE_PROLLY=1 -DDOLTLITE_VERSION='"$(DOLTLITE_VERSION)"'
+  OPT_FEATURE_FLAGS += -DMBEDTLS_THREADING_C -DMBEDTLS_THREADING_PTHREAD
   # Generate a real doltlite amalgamation (prolly engine + VC layer woven in).
   AMALGAMATION_GEN_FLAGS += --doltlite
   # Source headers and the portable BLAKE3 sources that aren't in $(SRC) but the

--- a/src/doltlite_net.h
+++ b/src/doltlite_net.h
@@ -14,6 +14,16 @@
 typedef WSAPOLLFD doltlite_pollfd;
 #define doltliteCloseSocket closesocket
 #define doltlitePoll(fds, n, ms) WSAPoll((fds), (n), (ms))
+#define doltliteShutdownSocket(fd) shutdown((fd), SD_BOTH)
+
+static inline int doltliteSocketSetTimeout(int fd, int timeoutMs) {
+  DWORD timeout = (DWORD)timeoutMs;
+  int rc1 = setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO,
+                       (const char *)&timeout, sizeof(timeout));
+  int rc2 = setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO,
+                       (const char *)&timeout, sizeof(timeout));
+  return rc1 == 0 && rc2 == 0 ? 0 : 1;
+}
 
 /* WSAStartup is refcounted and never torn down here; process exit reclaims
  * it. Idempotent enough for a CLI and the test server. */
@@ -33,11 +43,23 @@ static inline int doltliteNetInit(void) {
 #include <arpa/inet.h>
 #include <netdb.h>
 #include <poll.h>
+#include <sys/time.h>
 #include <unistd.h>
 
 typedef struct pollfd doltlite_pollfd;
 #define doltliteCloseSocket close
 #define doltlitePoll(fds, n, ms) poll((fds), (n), (ms))
+#define doltliteShutdownSocket(fd) shutdown((fd), SHUT_RDWR)
+
+static inline int doltliteSocketSetTimeout(int fd, int timeoutMs) {
+  struct timeval timeout;
+  int rc1, rc2;
+  timeout.tv_sec = timeoutMs / 1000;
+  timeout.tv_usec = (timeoutMs % 1000) * 1000;
+  rc1 = setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout));
+  rc2 = setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &timeout, sizeof(timeout));
+  return rc1 == 0 && rc2 == 0 ? 0 : 1;
+}
 
 static inline int doltliteNetInit(void) { return 0; }
 

--- a/src/doltlite_remotesrv.c
+++ b/src/doltlite_remotesrv.c
@@ -23,12 +23,36 @@ int doltliteServerPort(DoltliteServer *s){ (void)s; return 0; }
 #include <pthread.h>
 #include <errno.h>
 
+/* Bound resource use while keeping any one slow client off the accept loop. */
+#define SERVER_WORKERS 4
+#define SERVER_QUEUE_SIZE 16
+#define SERVER_DEFAULT_TIMEOUT_MS 30000
+
+typedef struct DoltliteWorkerArg DoltliteWorkerArg;
+
+struct DoltliteWorkerArg {
+  DoltliteServer *pSrv;
+  int index;
+};
+
 struct DoltliteServer {
   int listenFd;
   int port;
-  volatile int running;
+  int running;
   char *zDir;
   pthread_t thread;
+  pthread_t workers[SERVER_WORKERS];
+  DoltliteWorkerArg workerArgs[SERVER_WORKERS];
+  int nWorkers;
+  pthread_mutex_t mutex;
+  pthread_cond_t workReady;
+  int mutexInit;
+  int condInit;
+  int queue[SERVER_QUEUE_SIZE];
+  int queueHead;
+  int nQueue;
+  int activeFd[SERVER_WORKERS];
+  int timeoutMs;
 
   DoltliteTlsServer *tls;
   char *authKeysDir;
@@ -709,6 +733,101 @@ static void handleRequest(DoltliteServer *pSrv, DoltliteConn *fd){
 
 static void serverCleanup(DoltliteServer *pSrv);
 
+static void *serverWorkerEntry(void *pArg){
+  DoltliteWorkerArg *pWorker = (DoltliteWorkerArg*)pArg;
+  DoltliteServer *pSrv = pWorker->pSrv;
+
+  for(;;){
+    DoltliteConn *conn;
+    int clientFd;
+
+    pthread_mutex_lock(&pSrv->mutex);
+    while( pSrv->nQueue==0 && pSrv->running ){
+      pthread_cond_wait(&pSrv->workReady, &pSrv->mutex);
+    }
+    if( pSrv->nQueue==0 ){
+      pthread_mutex_unlock(&pSrv->mutex);
+      break;
+    }
+    clientFd = pSrv->queue[pSrv->queueHead];
+    pSrv->queueHead = (pSrv->queueHead + 1) % SERVER_QUEUE_SIZE;
+    pSrv->nQueue--;
+    pSrv->activeFd[pWorker->index] = clientFd;
+    pthread_mutex_unlock(&pSrv->mutex);
+
+    conn = pSrv->tls ? doltliteConnServerAccept(pSrv->tls, clientFd)
+                     : doltliteConnFromFd(clientFd);
+    if( conn ){
+      handleRequest(pSrv, conn);
+      doltliteConnClose(conn);
+    }
+
+    pthread_mutex_lock(&pSrv->mutex);
+    pSrv->activeFd[pWorker->index] = -1;
+    pthread_mutex_unlock(&pSrv->mutex);
+  }
+  return 0;
+}
+
+static int serverStartWorkers(DoltliteServer *pSrv){
+  int i;
+  for(i=0; i<SERVER_WORKERS; i++){
+    pSrv->workerArgs[i].pSrv = pSrv;
+    pSrv->workerArgs[i].index = i;
+    if( pthread_create(&pSrv->workers[i], 0, serverWorkerEntry,
+                       &pSrv->workerArgs[i])!=0 ){
+      pthread_mutex_lock(&pSrv->mutex);
+      pSrv->running = 0;
+      pthread_cond_broadcast(&pSrv->workReady);
+      pthread_mutex_unlock(&pSrv->mutex);
+      while( pSrv->nWorkers>0 ){
+        pthread_join(pSrv->workers[--pSrv->nWorkers], 0);
+      }
+      return SQLITE_ERROR;
+    }
+    pSrv->nWorkers++;
+  }
+  return SQLITE_OK;
+}
+
+static void serverRequestStop(DoltliteServer *pSrv){
+  int i;
+  pthread_mutex_lock(&pSrv->mutex);
+  pSrv->running = 0;
+  while( pSrv->nQueue>0 ){
+    int fd = pSrv->queue[pSrv->queueHead];
+    pSrv->queueHead = (pSrv->queueHead + 1) % SERVER_QUEUE_SIZE;
+    pSrv->nQueue--;
+    doltliteShutdownSocket(fd);
+    doltliteCloseSocket(fd);
+  }
+  /* Workers close active sockets. shutdown() wakes their blocking I/O without
+  ** risking descriptor reuse between this thread and the owning worker. */
+  for(i=0; i<pSrv->nWorkers; i++){
+    if( pSrv->activeFd[i]>=0 ){
+      doltliteShutdownSocket(pSrv->activeFd[i]);
+    }
+  }
+  pthread_cond_broadcast(&pSrv->workReady);
+  pthread_mutex_unlock(&pSrv->mutex);
+}
+
+static void serverJoinWorkers(DoltliteServer *pSrv){
+  int i;
+  for(i=0; i<pSrv->nWorkers; i++){
+    pthread_join(pSrv->workers[i], 0);
+  }
+  pSrv->nWorkers = 0;
+}
+
+static int serverIsRunning(DoltliteServer *pSrv){
+  int running;
+  pthread_mutex_lock(&pSrv->mutex);
+  running = pSrv->running;
+  pthread_mutex_unlock(&pSrv->mutex);
+  return running;
+}
+
 static char *dupStr(const char *z){
   int n;
   char *s;
@@ -724,10 +843,21 @@ static int serverInit(DoltliteServer *pSrv, const DoltliteServeOpts *o){
   socklen_t addrLen;
   struct in_addr bindIn;
   int opt = 1;
+  int i;
   const char *zBindAddr = o->zBindAddr;
 
   memset(pSrv, 0, sizeof(*pSrv));
   pSrv->listenFd = -1;
+  pSrv->timeoutMs = o->timeoutMs>0 ? o->timeoutMs
+                                   : SERVER_DEFAULT_TIMEOUT_MS;
+  for(i=0; i<SERVER_WORKERS; i++) pSrv->activeFd[i] = -1;
+  if( pthread_mutex_init(&pSrv->mutex, 0)!=0 ) return SQLITE_ERROR;
+  pSrv->mutexInit = 1;
+  if( pthread_cond_init(&pSrv->workReady, 0)!=0 ){
+    serverCleanup(pSrv);
+    return SQLITE_ERROR;
+  }
+  pSrv->condInit = 1;
 
   if( zBindAddr==0 || zBindAddr[0]=='\0' ){
     zBindAddr = "127.0.0.1";
@@ -788,30 +918,41 @@ static int serverInit(DoltliteServer *pSrv, const DoltliteServeOpts *o){
   }
 
   pSrv->running = 1;
+  if( serverStartWorkers(pSrv)!=SQLITE_OK ){
+    serverCleanup(pSrv);
+    return SQLITE_ERROR;
+  }
   return SQLITE_OK;
 }
 
 static void serverLoop(DoltliteServer *pSrv){
-  while( pSrv->running ){
+  while( serverIsRunning(pSrv) ){
     doltlite_pollfd pfd;
     int clientFd;
-    DoltliteConn *conn;
 
     pfd.fd = pSrv->listenFd;
     pfd.events = POLLIN;
     pfd.revents = 0;
 
-    if( doltlitePoll(&pfd, 1, 1000) <= 0 ) continue;
+    if( doltlitePoll(&pfd, 1, 100) <= 0 ) continue;
 
     clientFd = (int)accept(pSrv->listenFd, NULL, NULL);
     if( clientFd < 0 ) continue;
+    if( doltliteSocketSetTimeout(clientFd, pSrv->timeoutMs)!=0 ){
+      doltliteCloseSocket(clientFd);
+      continue;
+    }
 
-    conn = pSrv->tls ? doltliteConnServerAccept(pSrv->tls, clientFd)
-                     : doltliteConnFromFd(clientFd);
-    if( !conn ) continue;
-
-    handleRequest(pSrv, conn);
-    doltliteConnClose(conn);
+    pthread_mutex_lock(&pSrv->mutex);
+    if( !pSrv->running || pSrv->nQueue==SERVER_QUEUE_SIZE ){
+      pthread_mutex_unlock(&pSrv->mutex);
+      doltliteCloseSocket(clientFd);
+      continue;
+    }
+    pSrv->queue[(pSrv->queueHead + pSrv->nQueue) % SERVER_QUEUE_SIZE] = clientFd;
+    pSrv->nQueue++;
+    pthread_cond_signal(&pSrv->workReady);
+    pthread_mutex_unlock(&pSrv->mutex);
   }
 }
 
@@ -830,6 +971,14 @@ static void serverCleanup(DoltliteServer *pSrv){
   pSrv->authKeysDir = 0;
   sqlite3_free(pSrv->audience);
   pSrv->audience = 0;
+  if( pSrv->condInit ){
+    pthread_cond_destroy(&pSrv->workReady);
+    pSrv->condInit = 0;
+  }
+  if( pSrv->mutexInit ){
+    pthread_mutex_destroy(&pSrv->mutex);
+    pSrv->mutexInit = 0;
+  }
 }
 
 int doltliteServeOpts(const DoltliteServeOpts *o){
@@ -840,6 +989,8 @@ int doltliteServeOpts(const DoltliteServeOpts *o){
   if( rc!=SQLITE_OK ) return rc;
 
   serverLoop(&server);
+  serverRequestStop(&server);
+  serverJoinWorkers(&server);
   serverCleanup(&server);
   return SQLITE_OK;
 }
@@ -856,7 +1007,6 @@ int doltliteServe(const char *zDir, int port, const char *zBindAddr){
 static void *serverThreadEntry(void *pArg){
   DoltliteServer *pSrv = (DoltliteServer*)pArg;
   serverLoop(pSrv);
-  serverCleanup(pSrv);
   return 0;
 }
 
@@ -874,6 +1024,8 @@ DoltliteServer *doltliteServeAsyncOpts(const DoltliteServeOpts *o){
   }
 
   if( pthread_create(&pSrv->thread, 0, serverThreadEntry, pSrv)!=0 ){
+    serverRequestStop(pSrv);
+    serverJoinWorkers(pSrv);
     serverCleanup(pSrv);
     sqlite3_free(pSrv);
     return 0;
@@ -894,13 +1046,10 @@ DoltliteServer *doltliteServeAsync(const char *zDir, int port,
 
 void doltliteServerStop(DoltliteServer *pServer){
   if( !pServer ) return;
-  pServer->running = 0;
-
-  if( pServer->listenFd >= 0 ){
-    doltliteCloseSocket(pServer->listenFd);
-    pServer->listenFd = -1;
-  }
+  serverRequestStop(pServer);
   pthread_join(pServer->thread, 0);
+  serverJoinWorkers(pServer);
+  serverCleanup(pServer);
   sqlite3_free(pServer);
 }
 

--- a/src/doltlite_remotesrv.h
+++ b/src/doltlite_remotesrv.h
@@ -11,6 +11,7 @@ typedef struct DoltliteServeOpts {
   const char *keyFile;
   const char *authKeysDir;
   const char *audience;
+  int timeoutMs;
 } DoltliteServeOpts;
 
 int doltliteServe(const char *zDir, int port, const char *zBindAddr);

--- a/src/doltlite_tls.c
+++ b/src/doltlite_tls.c
@@ -37,6 +37,34 @@ struct DoltliteTlsServer {
   mbedtls_entropy_context entropy;
 };
 
+static void configureSocket(int fd) {
+#if !defined(_WIN32) && defined(SO_NOSIGPIPE)
+  int one = 1;
+  setsockopt(fd, SOL_SOCKET, SO_NOSIGPIPE, &one, sizeof(one));
+#else
+  (void)fd;
+#endif
+}
+
+static int connSend(void *pCtx, const unsigned char *pBuf, size_t nBuf) {
+  int fd = ((mbedtls_net_context *)pCtx)->fd;
+  int flags = 0;
+#ifdef MSG_NOSIGNAL
+  flags = MSG_NOSIGNAL;
+#endif
+#ifdef _WIN32
+  {
+    int n = send(fd, (const char *)pBuf, (int)nBuf, flags);
+    return n < 0 ? MBEDTLS_ERR_NET_SEND_FAILED : n;
+  }
+#else
+  {
+    int n = (int)send(fd, pBuf, nBuf, flags);
+    return n < 0 ? MBEDTLS_ERR_NET_SEND_FAILED : n;
+  }
+#endif
+}
+
 #ifdef _WIN32
 static int loadSystemRoots(mbedtls_x509_crt *ca) {
   HCERTSTORE store = CertOpenSystemStoreW(0, L"ROOT");
@@ -95,6 +123,7 @@ DoltliteConn *doltliteConnOpen(const char *host, int port, int useTls) {
   if (mbedtls_net_connect(&c->net, host, portstr, MBEDTLS_NET_PROTO_TCP) != 0) {
     goto fail_net;
   }
+  configureSocket(c->net.fd);
   if (!useTls) {
     return c;
   }
@@ -125,7 +154,7 @@ DoltliteConn *doltliteConnOpen(const char *host, int port, int useTls) {
   if (mbedtls_ssl_setup(&c->ssl, &c->conf) != 0) goto fail_tls;
 
   if (mbedtls_ssl_set_hostname(&c->ssl, host) != 0) goto fail_tls;
-  mbedtls_ssl_set_bio(&c->ssl, &c->net, mbedtls_net_send, mbedtls_net_recv, NULL);
+  mbedtls_ssl_set_bio(&c->ssl, &c->net, connSend, mbedtls_net_recv, NULL);
 
   do {
     ret = mbedtls_ssl_handshake(&c->ssl);
@@ -155,7 +184,7 @@ int doltliteConnWriteAll(DoltliteConn *c, const void *buf, int nbuf) {
     if (c->useTls) {
       n = mbedtls_ssl_write(&c->ssl, p + off, (size_t)(nbuf - off));
     } else {
-      n = (int)mbedtls_net_send(&c->net, p + off, (size_t)(nbuf - off));
+      n = connSend(&c->net, p + off, (size_t)(nbuf - off));
     }
     if (n == MBEDTLS_ERR_SSL_WANT_READ || n == MBEDTLS_ERR_SSL_WANT_WRITE) continue;
     if (n <= 0) return 1;
@@ -255,10 +284,11 @@ DoltliteConn *doltliteConnServerAccept(DoltliteTlsServer *s, int clientFd) {
   c->ownsConf = 0;
   mbedtls_net_init(&c->net);
   c->net.fd = clientFd;
+  configureSocket(clientFd);
   mbedtls_ssl_init(&c->ssl);
 
   if (mbedtls_ssl_setup(&c->ssl, &s->conf) != 0) goto fail;
-  mbedtls_ssl_set_bio(&c->ssl, &c->net, mbedtls_net_send, mbedtls_net_recv, NULL);
+  mbedtls_ssl_set_bio(&c->ssl, &c->net, connSend, mbedtls_net_recv, NULL);
   do {
     ret = mbedtls_ssl_handshake(&c->ssl);
   } while (ret == MBEDTLS_ERR_SSL_WANT_READ || ret == MBEDTLS_ERR_SSL_WANT_WRITE);
@@ -282,5 +312,6 @@ DoltliteConn *doltliteConnFromFd(int clientFd) {
   c->ownsConf = 0;
   mbedtls_net_init(&c->net);
   c->net.fd = clientFd;
+  configureSocket(clientFd);
   return c;
 }

--- a/src/remotesrv_main.c
+++ b/src/remotesrv_main.c
@@ -25,6 +25,7 @@ static void usage(const char *prog){
     "  --auth-keys DIR Require a bearer credential; authorized public keys are\n"
     "                  <kid>.jwk files in DIR\n"
     "  --audience AUD  Expected JWT audience (default: none)\n"
+    "  --timeout-ms MS Connection I/O timeout (default: 30000)\n"
     "  -h              Show this help\n"
     "\n"
     "Example:\n"
@@ -59,6 +60,8 @@ int main(int argc, char **argv){
       o.authKeysDir = argv[++i];
     }else if( strcmp(argv[i], "--audience")==0 && i+1<argc ){
       o.audience = argv[++i];
+    }else if( strcmp(argv[i], "--timeout-ms")==0 && i+1<argc ){
+      o.timeoutMs = atoi(argv[++i]);
     }else if( strcmp(argv[i], "-h")==0 || strcmp(argv[i], "--help")==0 ){
       usage(argv[0]);
       return 0;
@@ -78,6 +81,10 @@ int main(int argc, char **argv){
   }
   if( (o.certFile!=0) != (o.keyFile!=0) ){
     fprintf(stderr, "Error: --cert and --key must be given together\n");
+    return 1;
+  }
+  if( o.timeoutMs<0 ){
+    fprintf(stderr, "Error: --timeout-ms must not be negative\n");
     return 1;
   }
 

--- a/test/remotesrv_stall_test.sh
+++ b/test/remotesrv_stall_test.sh
@@ -68,7 +68,7 @@ PY
     echo "FAIL: server shutdown blocked on stalled client"
     exit 1
   fi
-  wait "$SRV_PID"
+  wait "$SRV_PID" 2>/dev/null || true
   SRV_PID=""
   kill "$CLIENT_PID" 2>/dev/null || true
   wait "$CLIENT_PID" 2>/dev/null || true

--- a/test/remotesrv_stall_test.sh
+++ b/test/remotesrv_stall_test.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REMOTESRV="${2:-$(dirname "$0")/../build/doltlite-remotesrv}"
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "SKIP: python3 not available"
+  exit 0
+fi
+if [ ! -x "$REMOTESRV" ]; then
+  echo "SKIP: doltlite-remotesrv binary not found ($REMOTESRV)"
+  exit 0
+fi
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/doltlite-remotesrv-stall.XXXXXX")"
+SRV_PID=""
+CLIENT_PID=""
+cleanup() {
+  [ -n "$CLIENT_PID" ] && { kill "$CLIENT_PID" 2>/dev/null || true; wait "$CLIENT_PID" 2>/dev/null || true; }
+  [ -n "$SRV_PID" ] && { kill "$SRV_PID" 2>/dev/null || true; wait "$SRV_PID" 2>/dev/null || true; }
+  rm -rf "$TMP"
+}
+trap cleanup EXIT
+
+start_server() {
+  local log="$1"
+  shift
+  mkdir -p "$TMP/srv"
+  "$REMOTESRV" --timeout-ms 2000 -p 0 --bind 127.0.0.1 "$@" \
+    "$TMP/srv" >"$log" 2>&1 &
+  SRV_PID=$!
+  PORT=""
+  for _ in $(seq 1 50); do
+    PORT="$(sed -n 's#.*://127.0.0.1:\([0-9][0-9]*\).*#\1#p' "$log" | head -1)"
+    [ -n "$PORT" ] && return
+    sleep 0.1
+  done
+  echo "FAIL: server did not start"
+  cat "$log"
+  exit 1
+}
+
+stop_server_with_stalled_clients() {
+  local port="$1"
+  python3 - "$port" <<'PY' &
+import socket
+import sys
+import time
+
+sockets = []
+for _ in range(24):
+    try:
+        s = socket.create_connection(("127.0.0.1", int(sys.argv[1])))
+        s.sendall(b"G")
+        sockets.append(s)
+    except OSError:
+        pass
+time.sleep(30)
+PY
+  CLIENT_PID=$!
+  sleep 0.2
+  kill -TERM "$SRV_PID"
+  for _ in $(seq 1 30); do
+    kill -0 "$SRV_PID" 2>/dev/null || break
+    sleep 0.1
+  done
+  if kill -0 "$SRV_PID" 2>/dev/null; then
+    echo "FAIL: server shutdown blocked on stalled client"
+    exit 1
+  fi
+  wait "$SRV_PID"
+  SRV_PID=""
+  kill "$CLIENT_PID" 2>/dev/null || true
+  wait "$CLIENT_PID" 2>/dev/null || true
+  CLIENT_PID=""
+  echo "  PASS: shutdown interrupts active and queued stalled clients"
+}
+
+echo "=== plaintext stalled clients ==="
+start_server "$TMP/plain.log"
+python3 - "$PORT" <<'PY'
+import socket
+import sys
+import time
+
+port = int(sys.argv[1])
+
+def connect(payload):
+    s = socket.create_connection(("127.0.0.1", port), timeout=2)
+    s.sendall(payload)
+    return s
+
+def healthy_request():
+    start = time.monotonic()
+    s = connect(b"GET /missing.db/root HTTP/1.1\r\nHost: localhost\r\n\r\n")
+    response = b""
+    while b"\r\n\r\n" not in response:
+        response += s.recv(4096)
+    s.close()
+    elapsed = time.monotonic() - start
+    assert response.startswith(b"HTTP/1.1 404 "), response
+    assert elapsed < 1.5, elapsed
+
+def expect_closed(s):
+    s.settimeout(4)
+    while s.recv(4096):
+        pass
+    s.close()
+
+header = connect(b"G")
+body = connect(
+    b"POST /repo.db/chunks HTTP/1.1\r\n"
+    b"Host: localhost\r\nContent-Length: 10\r\n\r\nx"
+)
+healthy_request()
+expect_closed(header)
+expect_closed(body)
+print("  PASS: partial headers and bodies do not block healthy requests")
+print("  PASS: plaintext read deadlines close stalled clients")
+PY
+stop_server_with_stalled_clients "$PORT"
+
+if ! command -v openssl >/dev/null 2>&1; then
+  echo "SKIP: openssl not available; TLS stall checks skipped"
+  exit 0
+fi
+openssl req -x509 -newkey rsa:2048 -nodes -days 1 \
+  -keyout "$TMP/key.pem" -out "$TMP/cert.pem" \
+  -subj "/CN=localhost" -addext "subjectAltName=DNS:localhost,IP:127.0.0.1" \
+  >/dev/null 2>&1 || { echo "SKIP: openssl cert generation failed"; exit 0; }
+
+echo "=== TLS stalled client ==="
+rm -rf "$TMP/srv"
+start_server "$TMP/tls.log" --cert "$TMP/cert.pem" --key "$TMP/key.pem"
+python3 - "$PORT" <<'PY'
+import socket
+import ssl
+import sys
+import time
+
+port = int(sys.argv[1])
+stalled = socket.create_connection(("127.0.0.1", port), timeout=2)
+
+start = time.monotonic()
+context = ssl._create_unverified_context()
+healthy = context.wrap_socket(
+    socket.create_connection(("127.0.0.1", port), timeout=2),
+    server_hostname="localhost",
+)
+healthy.sendall(b"GET /missing.db/root HTTP/1.1\r\nHost: localhost\r\n\r\n")
+response = b""
+while b"\r\n\r\n" not in response:
+    response += healthy.recv(4096)
+healthy.close()
+elapsed = time.monotonic() - start
+assert response.startswith(b"HTTP/1.1 404 "), response
+assert elapsed < 1.5, elapsed
+
+stalled.settimeout(4)
+while stalled.recv(4096):
+    pass
+stalled.close()
+print("  PASS: stalled TLS handshake does not block healthy requests")
+print("  PASS: TLS handshake deadline closes stalled clients")
+PY
+stop_server_with_stalled_clients "$PORT"


### PR DESCRIPTION
## Summary
- serve requests through a bounded worker pool so partial clients do not block the accept loop
- apply configurable I/O deadlines and interrupt active and queued sockets during shutdown
- make concurrent TLS 1.3 use Mbed TLS threading and suppress SIGPIPE on closed peers
- cover partial headers, partial bodies, stalled TLS handshakes, healthy concurrent requests, deadline closure, queue saturation, and shutdown on Unix and Windows CI

## Testing
- clean release build
- remotesrv_stall_test.sh (3 repeated runs)
- remotesrv_http_concurrency_test.sh (5 repeated runs)
- remotesrv_http_test.sh
- remotesrv_http_partial_failure_test.sh
- remotesrv_http_force_push_test.sh
- remote_https_auth_test.sh
- http_remote_content_length_test.sh
- amalgamation_http_remote_test.sh
- ThreadSanitizer remotesrv stall and concurrent-push runs

Closes #1677