### PR TITLE
Fix DoltLite development amalgamation builds

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -202,7 +202,7 @@ jobs:
       if: matrix.platform == 'ubuntu'
       run: |
         cd build
-        rm -f sqlite3.c
+        rm -rf sqlite3.c tsrc .target_source
         make DOLTLITE_PROLLY=1 testfixture
         ./testfixture ../test/testrunner.tcl --buildonly --jobs 1 mdevtest
 

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -104,7 +104,7 @@ jobs:
 
   development-builds:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 20
 
     steps:
     - uses: actions/checkout@v4
@@ -131,7 +131,7 @@ jobs:
   build-and-test:
     name: ${{ matrix.platform }}
     runs-on: ${{ matrix.runs-on }}
-    timeout-minutes: 45
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -198,6 +198,10 @@ jobs:
         DOLTLITE_CHECK_AMALGAMATION=0 DOLTLITE_CHECK_SHARED=0 bash ../test/assert_doltlite_artifacts.sh .
         cp -f "$(command -v sqlite3)" sqlite3
 
+    - name: Build development test configurations
+      if: matrix.platform == 'ubuntu'
+      run: cd build && ../test/testrunner.tcl --buildonly --jobs 1 mdevtest
+
     - name: Lint
       if: matrix.platform != 'windows'
       run: cd build && make lint

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -200,7 +200,10 @@ jobs:
 
     - name: Build development test configurations
       if: matrix.platform == 'ubuntu'
-      run: cd build && ../test/testrunner.tcl --buildonly --jobs 1 mdevtest
+      run: |
+        cd build
+        make testfixture
+        ./testfixture ../test/testrunner.tcl --buildonly --jobs 1 mdevtest
 
     - name: Lint
       if: matrix.platform != 'windows'

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -102,6 +102,32 @@ jobs:
           ext/wasm/jswasm/*
           ext/wasm/sqlite-wasm-*.zip
 
+  development-builds:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install dependencies
+      run: bash .github/scripts/install-apt-deps.sh tcl-dev build-essential zlib1g-dev
+
+    - name: Configure
+      run: |
+        mkdir -p build && cd build
+        TCL_CONFIG=$(find /usr -path '/usr/share/miniconda/*' -prune -o -name tclConfig.sh -print 2>/dev/null | head -1)
+        if [ -n "$TCL_CONFIG" ]; then
+          ../configure --with-tcl=$(dirname $TCL_CONFIG)
+        else
+          ../configure
+        fi
+
+    - name: Build development test configurations
+      run: |
+        cd build
+        make DOLTLITE_PROLLY=1 testfixture
+        ./testfixture ../test/testrunner.tcl --buildonly --jobs 2 mdevtest
+
   build-and-test:
     name: ${{ matrix.platform }}
     runs-on: ${{ matrix.runs-on }}
@@ -197,14 +223,6 @@ jobs:
         make -j$(nproc) DOLTLITE_PROLLY_CHECK=1 doltlite.exe doltlite-remotesrv.exe doltlite-lib
         DOLTLITE_CHECK_AMALGAMATION=0 DOLTLITE_CHECK_SHARED=0 bash ../test/assert_doltlite_artifacts.sh .
         cp -f "$(command -v sqlite3)" sqlite3
-
-    - name: Build development test configurations
-      if: matrix.platform == 'ubuntu'
-      run: |
-        cd build
-        rm -rf sqlite3.c tsrc .target_source
-        make DOLTLITE_PROLLY=1 testfixture
-        ./testfixture ../test/testrunner.tcl --buildonly --jobs 1 mdevtest
 
     - name: Lint
       if: matrix.platform != 'windows'

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -202,7 +202,8 @@ jobs:
       if: matrix.platform == 'ubuntu'
       run: |
         cd build
-        make testfixture
+        rm -f sqlite3.c
+        make DOLTLITE_PROLLY=1 testfixture
         ./testfixture ../test/testrunner.tcl --buildonly --jobs 1 mdevtest
 
     - name: Lint

--- a/src/btree_orig_api.c
+++ b/src/btree_orig_api.c
@@ -60,7 +60,14 @@ int origBtreeClearTable(void *p, int i, i64 *pn){ return orig_sqlite3BtreeClearT
 void origBtreeGetMeta(void *p, int i, u32 *pv){ orig_sqlite3BtreeGetMeta(B(p),i,pv); }
 int origBtreeUpdateMeta(void *p, int i, u32 v){ return orig_sqlite3BtreeUpdateMeta(B(p),i,v); }
 int origBtreeSchemaLocked(void *p){ return orig_sqlite3BtreeSchemaLocked(B(p)); }
-int origBtreeLockTable(void *p, int t, u8 w){ return orig_sqlite3BtreeLockTable(B(p),t,w); }
+int origBtreeLockTable(void *p, int t, u8 w){
+#ifndef SQLITE_OMIT_SHARED_CACHE
+  return orig_sqlite3BtreeLockTable(B(p),t,w);
+#else
+  (void)p; (void)t; (void)w;
+  return SQLITE_OK;
+#endif
+}
 
 Schema *origBtreeSchema(void *p, int nBytes, void(*xFree)(void*)){
   return orig_sqlite3BtreeSchema(B(p), nBytes, xFree);
@@ -140,8 +147,20 @@ int origBtreeCursorIsValidNN(void *pCur){
 int origBtreeTransferRow(void *pDest, void *pSrc, i64 iKey){
   return orig_sqlite3BtreeTransferRow(C(pDest), C(pSrc), iKey);
 }
-void origBtreeEnterAll(sqlite3 *db){ orig_sqlite3BtreeEnterAll(db); }
-void origBtreeLeaveAll(sqlite3 *db){ orig_sqlite3BtreeLeaveAll(db); }
+void origBtreeEnterAll(sqlite3 *db){
+#ifndef SQLITE_OMIT_SHARED_CACHE
+  orig_sqlite3BtreeEnterAll(db);
+#else
+  (void)db;
+#endif
+}
+void origBtreeLeaveAll(sqlite3 *db){
+#if !defined(SQLITE_OMIT_SHARED_CACHE) && SQLITE_THREADSAFE
+  orig_sqlite3BtreeLeaveAll(db);
+#else
+  (void)db;
+#endif
+}
 int origBtreeIsEmpty(void *pCur, int *pRes){
   return orig_sqlite3BtreeIsEmpty(C(pCur), pRes);
 }
@@ -157,8 +176,20 @@ void origBtreeCursorHint(void *pCur, unsigned int mask, ...){
 }
 
 int origBtreeCursorSize(void){ return orig_sqlite3BtreeCursorSize(); }
-void origBtreeEnter(void *p){ orig_sqlite3BtreeEnter(B(p)); }
-void origBtreeLeave(void *p){ orig_sqlite3BtreeLeave(B(p)); }
+void origBtreeEnter(void *p){
+#ifndef SQLITE_OMIT_SHARED_CACHE
+  orig_sqlite3BtreeEnter(B(p));
+#else
+  (void)p;
+#endif
+}
+void origBtreeLeave(void *p){
+#if !defined(SQLITE_OMIT_SHARED_CACHE) && SQLITE_THREADSAFE
+  orig_sqlite3BtreeLeave(B(p));
+#else
+  (void)p;
+#endif
+}
 void *origBtreePager(void *p){ return orig_sqlite3BtreePager(B(p)); }
 
 /* Probe failures normally mean "not a legacy sqlite file" (the chunk-store

--- a/src/pager_shim.c
+++ b/src/pager_shim.c
@@ -844,10 +844,12 @@ int sqlite3PagerCloseWal(Pager *pPager, sqlite3 *db){
 }
 #endif
 
+#ifndef SQLITE_OMIT_SHARED_CACHE
 int sqlite3_enable_shared_cache(int enable){
   (void)enable;
   return SQLITE_OK;
 }
+#endif
 
 sqlite3_file *sqlite3_database_file_object(const char *zName){
   (void)zName;

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -6842,11 +6842,11 @@ int sqlite3BtreeSchemaLocked(Btree *p){
   return p->pOps->xSchemaLocked(p);
 }
 
-#ifndef SQLITE_OMIT_SHARED_CACHE
 static int prollyBtreeLockTable(Btree *p, int iTab, u8 isWriteLock){
   (void)p; (void)iTab; (void)isWriteLock;
   return SQLITE_OK;
 }
+#ifndef SQLITE_OMIT_SHARED_CACHE
 int sqlite3BtreeLockTable(Btree *p, int iTab, u8 isWriteLock){
   if( !p ) return SQLITE_OK;
   return p->pOps->xLockTable(p, iTab, isWriteLock);
@@ -9736,8 +9736,8 @@ static int prollyBtCursorTransferRow(BtCursor *pDest, BtCursor *pSrc, i64 iKey){
   return rc;
 }
 
-#ifndef SQLITE_OMIT_SHARED_CACHE
 static void prollyBtreeEnter(Btree *p){ (void)p; }
+#ifndef SQLITE_OMIT_SHARED_CACHE
 void sqlite3BtreeEnter(Btree *p){
   if( p ) p->pOps->xEnter(p);
 }
@@ -9752,8 +9752,8 @@ void sqlite3BtreeEnterCursor(BtCursor *pCur){ (void)pCur; }
 int sqlite3BtreeConnectionCount(Btree *p){ (void)p; return 1; }
 #endif
 
-#if !defined(SQLITE_OMIT_SHARED_CACHE) && SQLITE_THREADSAFE
 static void prollyBtreeLeave(Btree *p){ (void)p; }
+#if !defined(SQLITE_OMIT_SHARED_CACHE) && SQLITE_THREADSAFE
 void sqlite3BtreeLeave(Btree *p){
   if( p ) p->pOps->xLeave(p);
 }
@@ -9772,9 +9772,6 @@ int sqlite3SchemaMutexHeld(sqlite3 *db, int iDb, Schema *pSchema){
   return 1;
 }
 #endif
-#elif !defined(SQLITE_OMIT_SHARED_CACHE)
-
-static void prollyBtreeLeave(Btree *p){ (void)p; }
 #endif
 
 int sqlite3BtreeTripAllCursors(Btree *p, int errCode, int writeOnly){

--- a/tool/mksqlite3c.tcl
+++ b/tool/mksqlite3c.tcl
@@ -456,12 +456,30 @@ proc copy_file_verbatim {filename} {
 proc emit_doltlite_storage_block {} {
   global out srcdir available_hdr skipstructs skipfns
   section_comment "doltlite: BEGIN orig_* storage engine block"
-  # Names that the prefix header renames but which are *active no-op macros* in
-  # the release build (NDEBUG, no SQLITE_TEST) — defined by btree.h/pager.h.
-  # Renaming + later #undef of these would strip the no-op macro that core code
-  # (outside this block) still needs, so leave them untouched.
-  set skiprename {disable_simulated_io_errors enable_simulated_io_errors
-                  sqlite3BtreeSeekCount}
+  # Names that are conditional functions or no-op macros in btree.h/pager.h.
+  # Emit the btree renames under the same conditions below so closing this
+  # scope does not remove a no-op macro needed by the rest of the amalgamation.
+  set conditionalrenames {
+    {defined(SQLITE_DEBUG)} {
+      sqlite3BtreeSeekCount
+    }
+    {!defined(SQLITE_OMIT_SHARED_CACHE)} {
+      sqlite3BtreeConnectionCount sqlite3BtreeEnter sqlite3BtreeEnterAll
+      sqlite3BtreeEnterCursor sqlite3BtreeSharable
+    }
+    {!defined(SQLITE_OMIT_SHARED_CACHE) && SQLITE_THREADSAFE} {
+      sqlite3BtreeHoldsAllMutexes sqlite3BtreeHoldsMutex sqlite3BtreeLeave
+      sqlite3BtreeLeaveAll sqlite3BtreeLeaveCursor sqlite3SchemaMutexHeld
+    }
+  }
+  # test1.c links sqlite3WalTrace by its public test instrumentation name.
+  set skiprename {
+    disable_simulated_io_errors enable_simulated_io_errors
+    sqlite3WalTrace
+  }
+  foreach {condition names} $conditionalrenames {
+    set skiprename [concat $skiprename $names]
+  }
   # Open the rename scope: the external renames from btree_orig_prefix.h, the
   # three btree type tags that prolly_btree.c redefines with a different layout,
   # and the two file-local statics that collide with prolly_btree.c.
@@ -476,6 +494,13 @@ proc emit_doltlite_storage_block {} {
     puts $out $line
   }
   close $pin
+  foreach {condition names} $conditionalrenames {
+    puts $out "#if $condition"
+    foreach nm $names {
+      puts $out "#define $nm orig_$nm"
+    }
+    puts $out "#endif"
+  }
   foreach nm {Btree BtShared BtCursor sqlite3SharedCacheList
               saveAllCursors saveCursorPosition} {
     puts $out "#define $nm orig_$nm"
@@ -534,6 +559,13 @@ proc emit_doltlite_storage_block {} {
   # Close the rename scope so later files bind the unprefixed names.
   foreach nm $prefixnames {
     puts $out "#undef $nm"
+  }
+  foreach {condition names} $conditionalrenames {
+    puts $out "#if $condition"
+    foreach nm $names {
+      puts $out "#undef $nm"
+    }
+    puts $out "#endif"
   }
   puts $out "#ifdef SQLITE_TEST"
   puts $out "#undef disable_simulated_io_errors"


### PR DESCRIPTION
## Summary

- preserve conditional B-tree compatibility aliases in DoltLite amalgamation builds
- guard bridge and virtual-table helpers for threadless and shared-cache-omitted builds
- add an independent `Build-Test / development-builds` check that compiles 10 targets from the `All-Debug` and `All-O0` configurations, two at a time

The new check is compile-only. It does not run the SQLite runtime corpus or add work to the existing Ubuntu job.

## Testing

- `./testfixture ../test/testrunner.tcl --buildonly --jobs 2 mdevtest` (10/10 build targets passed)
- `make -j4 DOLTLITE_PROLLY_CHECK=1 doltlite doltlite-lib c-tests`
- `DOLTLITE_CHECK_AMALGAMATION=1 bash ../test/assert_doltlite_artifacts.sh .`
- explicit `SQLITE_DEBUG`, `SQLITE_TEST`, and `SQLITE_OMIT_SHARED_CACHE` amalgamation syntax compilation

The full runtime `devtest` corpus remains outside this gate because it contains tracked DoltLite divergences and a known hang.

Closes #1679