### PR TITLE
Track coverage for excluded crash tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -307,12 +307,13 @@ jobs:
     # is the permutations suite-runner that re-sources the fts3 family
     # inline (pure double coverage of files already in the fts bucket), and
     # its inlined OOM sections fail load-sensitively.
-    - name: Check bucket lists are disjoint
+    - name: Check regression coverage manifests
       run: |
         dups=$(cat test/regression-buckets/*.txt | sort | uniq -d)
         if [ -n "$dups" ]; then
           echo "::error::files in more than one regression bucket:"; echo "$dups"; exit 1
         fi
+        bash test/check_testfixture_crash_coverage.sh
 
     - name: SQLite regression tests - ${{ matrix.bucket }}
       run: |

--- a/test/check_testfixture_crash_coverage.sh
+++ b/test/check_testfixture_crash_coverage.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+CRASH_FILE="${1:-$SCRIPT_DIR/known_testfixture_crashes.txt}"
+COVERAGE_FILE="${2:-$SCRIPT_DIR/known_testfixture_crash_coverage.txt}"
+BUCKET_DIR="${3:-$SCRIPT_DIR/regression-buckets}"
+
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+FAIL=0
+report_set() {
+  local label="$1"
+  local file="$2"
+  if [ -s "$file" ]; then
+    echo "ERROR: $label:"
+    sed 's/^/  /' "$file"
+    FAIL=1
+  fi
+}
+
+awk '
+  { sub(/#.*/, ""); if (NF) print $1 }
+' "$CRASH_FILE" | sort -u > "$TMP_DIR/crashes"
+
+awk '
+  { sub(/#.*/, ""); if (NF) print $1 }
+' "$BUCKET_DIR"/*.txt | sort -u > "$TMP_DIR/bucketed"
+
+comm -23 "$TMP_DIR/crashes" "$TMP_DIR/bucketed" > "$TMP_DIR/excluded"
+
+if ! awk '
+  {
+    sub(/#.*/, "")
+    if (NF == 0) next
+    if (NF != 3) {
+      printf "%s:%d: expected 3 fields, found %d\n", FILENAME, NR, NF
+      bad = 1
+    }
+  }
+  END { exit bad }
+' "$COVERAGE_FILE"; then
+  exit 1
+fi
+
+awk '
+  { sub(/#.*/, ""); if (NF) print $1 }
+' "$COVERAGE_FILE" | sort -u > "$TMP_DIR/mapped"
+
+comm -23 "$TMP_DIR/excluded" "$TMP_DIR/mapped" > "$TMP_DIR/missing"
+comm -13 "$TMP_DIR/excluded" "$TMP_DIR/mapped" > "$TMP_DIR/stale"
+report_set "unbucketed crash entries without replacement coverage" "$TMP_DIR/missing"
+report_set "coverage mappings for tests that are not unbucketed crashes" "$TMP_DIR/stale"
+
+awk '
+  { sub(/#.*/, ""); if (NF) print $1, $2, $3 }
+' "$COVERAGE_FILE" | sort | uniq -d > "$TMP_DIR/duplicates"
+report_set "duplicate coverage mappings" "$TMP_DIR/duplicates"
+
+while read -r source kind target; do
+  [ -n "${source:-}" ] || continue
+  case "$kind" in
+    testfixture)
+      if [ ! -f "$SCRIPT_DIR/$target.test" ]; then
+        echo "ERROR: $source maps to missing testfixture test/$target.test"
+        FAIL=1
+      elif ! grep -Fqx "$target" "$BUCKET_DIR"/*.txt; then
+        echo "ERROR: $source maps to testfixture $target, but it is not in a regression bucket"
+        FAIL=1
+      fi
+      ;;
+    c-test)
+      if [ ! -f "$SCRIPT_DIR/$target.c" ]; then
+        echo "ERROR: $source maps to missing C test test/$target.c"
+        FAIL=1
+      elif ! sed -n '/^GATING=(/,/^)/p' "$SCRIPT_DIR/run_c_tests.sh" \
+          | grep -Eq "^[[:space:]]*$target[[:space:]]*$"; then
+        echo "ERROR: $source maps to C test $target, but it is not gating"
+        FAIL=1
+      fi
+      ;;
+    workflow-script)
+      if [ ! -f "$SCRIPT_DIR/$target" ]; then
+        echo "ERROR: $source maps to missing script test/$target"
+        FAIL=1
+      elif ! grep -R -Fq "$target" "$ROOT_DIR/.github/workflows"; then
+        echo "ERROR: $source maps to script $target, but no workflow runs it"
+        FAIL=1
+      fi
+      ;;
+    *)
+      echo "ERROR: $source has unknown coverage kind: $kind"
+      FAIL=1
+      ;;
+  esac
+done < <(awk '{ sub(/#.*/, ""); if (NF) print $1, $2, $3 }' "$COVERAGE_FILE")
+
+if [ "$FAIL" -ne 0 ]; then
+  exit 1
+fi
+
+echo "OK: $(wc -l < "$TMP_DIR/excluded" | tr -d ' ') unbucketed crash tests have gated replacement coverage"

--- a/test/known_testfixture_crash_coverage.txt
+++ b/test/known_testfixture_crash_coverage.txt
@@ -1,0 +1,19 @@
+# Deterministic coverage for crash-listed testfixture files that cannot run in
+# a regression bucket. Format:
+#
+#   <excluded-test> <testfixture|c-test|workflow-script> <replacement>
+#
+# Multiple replacements may cover distinct behavior from one excluded file.
+
+backup_ioerr testfixture doltlite_recover_backup_fault # backup/restore OOM and persistent I/O errors
+corrupt4 c-test corruption_test # malformed chunk data, metadata, indexes, and truncated writes
+crash8 workflow-script crash_injection_test.sh # first and later commit crash durability
+ioerr2 testfixture doltlite_recover_shared_ioerr # persistent I/O errors preserve writer and peer state
+malloc testfixture doltlite_recover_savepointfault # OOM during savepoint rollback and release
+malloc c-test oom_dolt_fault_test # fork-isolated OOM sweeps over Dolt operations
+malloc3 testfixture doltlite_recover_postcommit_oom # OOM result agrees with durable statement state
+malloc3 c-test oom_dolt_fault_test # prepare, execute, and version-control allocation failures
+pagerfault testfixture doltlite_recover_cacheflush_oom # OOM during dirty-cache flush and merged scans
+pagerfault testfixture doltlite_recover_savepointfault # OOM while restoring transaction state
+pagerfault2 testfixture doltlite_recover_cacheflush_oom # large dirty-state OOM and rollback integrity
+pagerfault2 testfixture doltlite_recover_postcommit_oom # durable state remains consistent after OOM

--- a/test/known_testfixture_crashes.txt
+++ b/test/known_testfixture_crashes.txt
@@ -7,8 +7,10 @@
 #
 # Every file listed here is also in a regression bucket unless noted below,
 # so the gate re-verifies each expected crash on every CI run and flags the
-# entry the moment a fix makes the file complete. Files that CANNOT be
-# bucket-enforced (kept out of the buckets on purpose):
+# entry the moment a fix makes the file complete. Files that cannot be
+# bucket-enforced must have continuously gated replacement coverage in
+# known_testfixture_crash_coverage.txt. CI rejects missing or stale mappings.
+# Reasons some files cannot be bucket-enforced include:
 #   malloc, backup_ioerr -- complete at the tester error cap with a summary
 #     line, so the gate would report them as fixed crashes; their failure
 #     lists are cap-truncated and order-fragile, so they cannot be gated as


### PR DESCRIPTION
## Summary

- map every unbucketed expected-crash test to deterministic replacement coverage
- validate mappings against regression buckets, gating C tests, and workflow-run scripts
- fail SQLite regression CI for missing, stale, duplicate, or inactive mappings

## Testing

- `bash test/check_testfixture_crash_coverage.sh`
- guard rejection tests for missing, stale, and nonexistent mappings
- 488 assertions across the five mapped testfixture replacements
- `corruption_test` (81/81)
- `oom_dolt_fault_test` (3,500 fault iterations)
- `make lint`

The crash-injection replacement is validated against its existing smoke-workflow invocation. Its dedicated binary does not link locally with Homebrew Tcl 9 because upstream FTS3 test code requires a legacy Tcl symbol; CI builds it with Tcl 8.6.

Closes #1680