### PR TITLE
Cap all CI jobs at a uniform 20-minute timeout

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -105,7 +105,7 @@ jobs:
   build-and-test:
     name: ${{ matrix.platform }}
     runs-on: ${{ matrix.runs-on }}
-    timeout-minutes: 45
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   asan-ubsan:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
 
     steps:
     - uses: actions/checkout@v4
@@ -120,7 +120,7 @@ jobs:
 
   tsan:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
 
     env:
       TSAN_CFLAGS: -O1 -g -fsanitize=thread -fno-omit-frame-pointer
@@ -169,7 +169,7 @@ jobs:
 
   no-dead-code:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/sqlite-upstream-drift.yml
+++ b/.github/workflows/sqlite-upstream-drift.yml
@@ -23,6 +23,7 @@ permissions:
 jobs:
   check-drift:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Check out doltlite
         uses: actions/checkout@v4


### PR DESCRIPTION
## Why

On #1686 a Windows job hung on the "Windows HTTP remotesrv tests" step and sat for ~48 minutes — that step has no per-step timeout, so it could consume the entire **45-minute** `build-and-test` job budget before GitHub force-killed it, blocking the PR and resisting cancellation.

## Change

Every CI/PR job now has a uniform `timeout-minutes: 20`, so a hang fails fast instead of eating the full budget:

| workflow | job | before | after |
|---|---|---|---|
| build-test | build-and-test | 45 | 20 |
| sanitizers | asan-ubsan, tsan, no-dead-code | 10 | 20 |
| sqlite-upstream-drift | check-drift | none (6h default) | 20 |

All other CI jobs (test, smoke, benchmark, wasm) were already at 20 and are unchanged.

**release.yml is intentionally left alone** — its packaging, cross-build (android/swift/ruby), and publish jobs can legitimately run longer than 20 minutes, and capping them risks failing a release.

Validated: all six CI workflows parse and every job resolves to `timeout-minutes: 20`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)