### PR TITLE
Bound refs-blob counts and size allocations with a 64-bit product

### DIFF
--- a/src/chunk_refs.c
+++ b/src/chunk_refs.c
@@ -253,12 +253,16 @@ int csDeserializeRefs(ChunkStore *cs, const u8 *data, int nData){
   memcpy(cs->refs.zDefaultBranch, bufCur, defLen); cs->refs.zDefaultBranch[defLen]=0; bufCur+=defLen;
   if( bufCur+4>data+nData ) return SQLITE_CORRUPT;
   nBranches = (int)CS_READ_U32(bufCur); bufCur+=4;
-  if( nBranches<0 || nBranches>(int)(data+nData-bufCur)/4 ) return SQLITE_CORRUPT;
+  /* Bound the count by the smallest on-disk entry (4-byte name length + a
+  ** commit hash = 24 bytes) so a crafted count cannot exceed what the blob
+  ** could hold, and size the allocation with a 64-bit product so
+  ** count*sizeof(struct) cannot wrap a 32-bit int into a tiny allocation. */
+  if( nBranches<0 || nBranches>(int)(data+nData-bufCur)/(4+PROLLY_HASH_SIZE) ) return SQLITE_CORRUPT;
   csFreeBranches(cs);
   if( nBranches>0 ){
-    cs->refs.aBranches = sqlite3_malloc(nBranches*(int)sizeof(struct BranchRef));
+    cs->refs.aBranches = sqlite3_malloc64((sqlite3_int64)nBranches*(sqlite3_int64)sizeof(struct BranchRef));
     if(!cs->refs.aBranches) return SQLITE_NOMEM;
-    memset(cs->refs.aBranches, 0, nBranches*(int)sizeof(struct BranchRef));
+    memset(cs->refs.aBranches, 0, (size_t)nBranches*sizeof(struct BranchRef));
     /* Count the whole zeroed array up front (here and below): a parse
     ** failure mid-entry must leave already-allocated fields visible to
     ** csFreeBranches, or a truncated blob leaks them. */
@@ -281,11 +285,13 @@ int csDeserializeRefs(ChunkStore *cs, const u8 *data, int nData){
   csFreeTags(cs);
   if( bufCur+4<=data+nData ){
     nTags = (int)CS_READ_U32(bufCur); bufCur+=4;
-    if( nTags<0 || nTags>(int)(data+nData-bufCur)/4 ) return SQLITE_CORRUPT;
+    /* Minimum tag entry: name len + commit hash + tagger/email/message lens
+    ** + timestamp = 4 + PROLLY_HASH_SIZE + 4 + 4 + 8 + 4. */
+    if( nTags<0 || nTags>(int)(data+nData-bufCur)/(24+PROLLY_HASH_SIZE) ) return SQLITE_CORRUPT;
     if( nTags>0 ){
-      cs->refs.aTags = sqlite3_malloc(nTags*(int)sizeof(struct TagRef));
+      cs->refs.aTags = sqlite3_malloc64((sqlite3_int64)nTags*(sqlite3_int64)sizeof(struct TagRef));
       if(!cs->refs.aTags) return SQLITE_NOMEM;
-      memset(cs->refs.aTags, 0, nTags*(int)sizeof(struct TagRef));
+      memset(cs->refs.aTags, 0, (size_t)nTags*sizeof(struct TagRef));
       cs->refs.nTags = nTags;
       for(i=0;i<nTags;i++){
         int nameLen; if(bufCur+4>data+nData) return SQLITE_CORRUPT;
@@ -330,11 +336,12 @@ int csDeserializeRefs(ChunkStore *cs, const u8 *data, int nData){
   csFreeTracking(cs);
   if( bufCur+4<=data+nData ){
     int nRemotes = (int)CS_READ_U32(bufCur); bufCur+=4;
-    if( nRemotes<0 || nRemotes>(int)(data+nData-bufCur)/4 ) return SQLITE_CORRUPT;
+    /* Minimum remote entry: name len + url len = 8 bytes. */
+    if( nRemotes<0 || nRemotes>(int)(data+nData-bufCur)/8 ) return SQLITE_CORRUPT;
     if( nRemotes>0 ){
-      cs->refs.aRemotes = sqlite3_malloc(nRemotes*(int)sizeof(struct RemoteRef));
+      cs->refs.aRemotes = sqlite3_malloc64((sqlite3_int64)nRemotes*(sqlite3_int64)sizeof(struct RemoteRef));
       if(!cs->refs.aRemotes) return SQLITE_NOMEM;
-      memset(cs->refs.aRemotes, 0, nRemotes*(int)sizeof(struct RemoteRef));
+      memset(cs->refs.aRemotes, 0, (size_t)nRemotes*sizeof(struct RemoteRef));
       cs->refs.nRemotes = nRemotes;
       for(i=0;i<nRemotes;i++){
         int nameLen, urlLen;
@@ -355,11 +362,12 @@ int csDeserializeRefs(ChunkStore *cs, const u8 *data, int nData){
     }
     if( bufCur+4<=data+nData ){
       int nTracking = (int)CS_READ_U32(bufCur); bufCur+=4;
-      if( nTracking<0 || nTracking>(int)(data+nData-bufCur)/4 ) return SQLITE_CORRUPT;
+      /* Minimum tracking entry: remote len + branch len + commit hash. */
+      if( nTracking<0 || nTracking>(int)(data+nData-bufCur)/(8+PROLLY_HASH_SIZE) ) return SQLITE_CORRUPT;
       if( nTracking>0 ){
-        cs->refs.aTracking = sqlite3_malloc(nTracking*(int)sizeof(struct TrackingBranch));
+        cs->refs.aTracking = sqlite3_malloc64((sqlite3_int64)nTracking*(sqlite3_int64)sizeof(struct TrackingBranch));
         if(!cs->refs.aTracking) return SQLITE_NOMEM;
-        memset(cs->refs.aTracking, 0, nTracking*(int)sizeof(struct TrackingBranch));
+        memset(cs->refs.aTracking, 0, (size_t)nTracking*sizeof(struct TrackingBranch));
       cs->refs.nTracking = nTracking;
         for(i=0;i<nTracking;i++){
           int remoteLen, branchLen;
@@ -388,9 +396,9 @@ int csDeserializeRefs(ChunkStore *cs, const u8 *data, int nData){
         return SQLITE_CORRUPT;
       }
       if( nSequences>0 ){
-        cs->refs.aSequences = sqlite3_malloc(nSequences*(int)sizeof(SequenceRef));
+        cs->refs.aSequences = sqlite3_malloc64((sqlite3_int64)nSequences*(sqlite3_int64)sizeof(SequenceRef));
         if(!cs->refs.aSequences) return SQLITE_NOMEM;
-        memset(cs->refs.aSequences, 0, nSequences*(int)sizeof(SequenceRef));
+        memset(cs->refs.aSequences, 0, (size_t)nSequences*sizeof(SequenceRef));
       cs->refs.nSequences = nSequences;
         for(i=0;i<nSequences;i++){
           int nameLen;

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -7849,7 +7849,80 @@ static void run_incrblob_chunked_and_multihandle(void){
   removeDbFiles(dbpath);
 }
 
+/* The refs blob is untrusted (it comes from a .db file or a remote fetch).
+** Each section reads a u32 count and allocates count*sizeof(struct); the count
+** must be bounded by the smallest possible on-disk entry and the allocation
+** sized with a 64-bit product, or a crafted count wraps a 32-bit size into a
+** tiny allocation that the fill loop then overruns. This verifies a valid blob
+** round-trips and that oversized counts are rejected as corrupt rather than
+** trusted. (The wrap itself needs a >256MB input, beyond this corpus's and the
+** fuzzer's size budget, so it is prevented by construction here.) */
+static void run_refs_deserialize_overflow_guard(void){
+  printf("=== Refs Deserialize Overflow Guard Test ===\n\n");
+
+  {
+    u8 buf[128];
+    u8 *p = buf;
+    ChunkStore cs;
+    int n, rc;
+    *p++ = 7;                                 /* version */
+    CS_WRITE_U32(p, 4); p += 4;               /* default branch name length */
+    memcpy(p, "main", 4); p += 4;
+    CS_WRITE_U32(p, 1); p += 4;               /* nBranches */
+    CS_WRITE_U32(p, 4); p += 4;               /* branch name length */
+    memcpy(p, "feat", 4); p += 4;
+    memset(p, 0xAB, PROLLY_HASH_SIZE); p += PROLLY_HASH_SIZE;  /* commit hash */
+    memset(p, 0xCD, PROLLY_HASH_SIZE); p += PROLLY_HASH_SIZE;  /* working set */
+    CS_WRITE_U32(p, 0); p += 4;               /* nTags */
+    CS_WRITE_U32(p, 0); p += 4;               /* nRemotes */
+    CS_WRITE_U32(p, 0); p += 4;               /* nTracking */
+    CS_WRITE_U32(p, 0); p += 4;               /* nSequences */
+    n = (int)(p - buf);
+
+    memset(&cs, 0, sizeof(cs));
+    rc = csDeserializeRefs(&cs, buf, n);
+    check("refs_roundtrip_ok", rc==SQLITE_OK);
+    check("refs_roundtrip_default_branch",
+          cs.refs.zDefaultBranch && strcmp(cs.refs.zDefaultBranch, "main")==0);
+    check("refs_roundtrip_branch_count", cs.refs.nBranches==1);
+    check("refs_roundtrip_branch_name",
+          cs.refs.nBranches==1 && cs.refs.aBranches[0].zName
+          && strcmp(cs.refs.aBranches[0].zName, "feat")==0);
+    csFreeRefsState(&cs);
+  }
+
+  {
+    u8 buf[16];
+    u8 *p = buf;
+    ChunkStore cs;
+    int rc;
+    *p++ = 7;
+    CS_WRITE_U32(p, 0); p += 4;               /* empty default branch name */
+    CS_WRITE_U32(p, 0x10000000); p += 4;      /* 268M branches, tiny blob */
+    memset(&cs, 0, sizeof(cs));
+    rc = csDeserializeRefs(&cs, buf, (int)(p - buf));
+    check("refs_oversized_branches_rejected", rc==SQLITE_CORRUPT);
+    csFreeRefsState(&cs);
+  }
+
+  {
+    u8 buf[24];
+    u8 *p = buf;
+    ChunkStore cs;
+    int rc;
+    *p++ = 7;
+    CS_WRITE_U32(p, 0); p += 4;               /* default branch name length */
+    CS_WRITE_U32(p, 0); p += 4;               /* nBranches = 0 */
+    CS_WRITE_U32(p, 0x10000000); p += 4;      /* oversized nTags */
+    memset(&cs, 0, sizeof(cs));
+    rc = csDeserializeRefs(&cs, buf, (int)(p - buf));
+    check("refs_oversized_tags_rejected", rc==SQLITE_CORRUPT);
+    csFreeRefsState(&cs);
+  }
+}
+
 static const RegressionCase aCases[] = {
+  { "refs_deserialize_overflow_guard", "Refs Deserialize Overflow Guard Test", run_refs_deserialize_overflow_guard },
   { "backup_safety", "Backup Safety Test", run_backup_safety },
   { "integer_pk_autocommit_append_correctness", "Integer PK Autocommit Append Correctness Test", run_integer_pk_autocommit_append_correctness },
   { "create_collation_unsupported", "Create Collation Unsupported Test", run_create_collation_unsupported },


### PR DESCRIPTION
## The bug (CRITICAL — untrusted-input heap overflow)

`csDeserializeRefs` parses the refs blob, which is **untrusted** — it comes from a `.db` file or a remote fetch over clone/pull. Each section (branches, tags, remotes, tracking, sequences) reads a `u32` count and then allocated `count * (int)sizeof(struct X)`:

- the count guard was `count > (remaining bytes) / 4`, but the smallest on-disk entry is ≥24 bytes (`BranchRef` is 48, `TagRef` 64), so a crafted count far larger than the blob could hold still passed;
- `count * (int)sizeof(struct X)` is a **32-bit `int` multiply that wraps**.

A ~358 MB blob claiming ~89.5M branches makes `89478486 * 48` wrap past 2³² to **32** — `sqlite3_malloc(32)` succeeds, then the fill loop writes 48-byte entries starting at index 0, overrunning the buffer. The content hash doesn't help: an attacker crafting the blob controls both its bytes and the manifest hash.

The correct guard already exists elsewhere in the tree — `csReadIndex` (`chunk_index.c:119`) uses `n > INT_MAX/sizeof(...)` with `sqlite3_malloc64`. `csDeserializeRefs` just didn't.

## Fix

For all five sections:
- bound the count by that section's **smallest on-disk entry** (e.g. branches `4 + PROLLY_HASH_SIZE`, tags `24 + PROLLY_HASH_SIZE`, remotes `8`, tracking `8 + PROLLY_HASH_SIZE`, sequences `12`), and
- size every allocation with `sqlite3_malloc64` over a **64-bit product** so it can't wrap.

## Tests

New C-corpus case `refs_deserialize_overflow_guard`: round-trips a valid v7 blob and asserts oversized branch/tag counts are rejected as `SQLITE_CORRUPT` rather than trusted.

Coverage note: the wrap itself needs a >256 MB input, beyond both this corpus's budget and the `fuzz_deserialize_refs` harness's 1 MB cap — so the overflow is prevented by construction (64-bit product + min-size guards) rather than reproduced by a triggering input. (Raising the fuzzer cap or ASan-fuzzing the clone/pull path is a reasonable separate follow-up.)

Full local regression green: C corpus 309,841/309,841, branch 62/62, tag 19/19, remotesrv HTTP 28/28, default-branch 12/12, and a clone→pull round trip with integrity check.

Second finding from the deep code review (the one CRITICAL memory-safety item).

🤖 Generated with [Claude Code](https://claude.com/claude-code)