### PR TITLE
Fix three cold-path memory defects (merge double-free, COUNT cursor leak, uninitialized read)

### DIFF
--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -232,9 +232,9 @@ int doltliteHasUncommittedChanges(sqlite3 *db){
     if( cs ){
       rc = doltliteFlushAndSerializeCatalog(db, &wCatData, &nWCat);
       if( rc==SQLITE_OK ){
-        chunkStorePut(cs, wCatData, nWCat, &workingCatHash);
+        rc = chunkStorePut(cs, wCatData, nWCat, &workingCatHash);
         sqlite3_free(wCatData);
-        if( prollyHashCompare(&headCatHash, &workingCatHash)!=0 ){
+        if( rc==SQLITE_OK && prollyHashCompare(&headCatHash, &workingCatHash)!=0 ){
           return 1;
         }
       }

--- a/src/doltlite_merge.c
+++ b/src/doltlite_merge.c
@@ -2613,7 +2613,14 @@ int doltliteMergeCatalogs(
     for(k=0; k<nMerged; k++){
       if( aMerged[k].zName ){
         char *z = sqlite3_mprintf("%s", aMerged[k].zName);
-        if( !z ){ rc = SQLITE_NOMEM; goto merge_cleanup; }
+        if( !z ){
+          /* Entries not yet re-duped still alias aOurs; null them so cleanup
+          ** frees each aliased name once (via aOurs), never twice. */
+          int j;
+          for(j=k; j<nMerged; j++) aMerged[j].zName = 0;
+          rc = SQLITE_NOMEM;
+          goto merge_cleanup;
+        }
         aMerged[k].zName = z;
       }
     }

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -4338,7 +4338,7 @@ static int countIntKeysUpTo(
 
   prollyCursorInit(&cur, &pBt->store, &pBt->cache, pRoot, flags);
   rc = prollyCursorSeekInt(&cur, intKey, &res);
-  if( rc!=SQLITE_OK ) return rc;
+  if( rc!=SQLITE_OK ){ prollyCursorClose(&cur); return rc; }
   if( cur.eState!=PROLLY_CURSOR_VALID ){
     prollyCursorClose(&cur);
     *pCount = 0;
@@ -4457,7 +4457,7 @@ static int countBlobKeysBefore(
 
   prollyCursorInit(&cur, &pBt->store, &pBt->cache, pRoot, flags);
   rc = prollyCursorSeekBlob(&cur, pKey, nKey, &res);
-  if( rc!=SQLITE_OK ) return rc;
+  if( rc!=SQLITE_OK ){ prollyCursorClose(&cur); return rc; }
   if( cur.eState!=PROLLY_CURSOR_VALID ){
     prollyCursorClose(&cur);
     *pCount = 0;


### PR DESCRIPTION
Three memory defects on error/failure paths from the deep code review's memory-safety pass. All confirmed still present on current master.

## Fixes

1. **Merge OOM double-free** (`doltlite_merge.c`). `doltliteMergeCatalogs` builds `aMerged` by shallow-copying `aOurs` entries, so `aMerged[k].zName` aliases `aOurs`. A loop then re-`mprintf`s each name to detach it. If that `mprintf` fails mid-loop, entries `[k, nMerged)` still alias `aOurs`, and `merge_cleanup` frees both catalogs → double-free. Now nulls the un-duped tail before the jump (the same guard the pass1 error path already uses).

2. **COUNT cursor cache-pin leak** (`prolly_btree.c`). `countIntKeysUpTo` and `countBlobKeysBefore` `return rc` on a failed `prollyCursorSeek*` without `prollyCursorClose`, permanently leaking the cursor's cache-entry refcounts. This is the most *reachable* of the three — it needs only an I/O error or a corrupt/undecryptable chunk during a range `COUNT`, not OOM. Now closes before returning.

3. **Uninitialized read** (`doltlite.c`). `doltliteHasUncommittedChanges` ignored the `chunkStorePut` return, so on a put failure the uninitialized `workingCatHash` was compared against HEAD — making the "has uncommitted changes" answer depend on stack garbage (can misroute commit/checkout/merge guards). Now gates the compare on the put succeeding.

## Note on two related findings, already fixed upstream

The review also flagged an unlocked default-branch ref write in `dolt_default_branch` and the branch-rename `MODE_MOVE` path. Both now route through `doltliteMutateRefs` (the locked refresh-serialize-commit path) on current master, so they're already resolved and are **not** part of this PR.

## Testing

These are cold-path OOM / I/O-error defects with no cheap triggering input, so they're verified by inspection plus no-regression: dead-code gate PASS, battery 88/88, C corpus 309,835/309,835, merge 94/94, conflicts 40/40, merge oracle 71/71. (The clean way to exercise these is a fault-injection ASan pass over clone/pull/gc/branch — the review's item #3, a reasonable follow-up.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)