### PR TITLE
oracle_error: reject a crash as a handled error

### DIFF
--- a/test/lib/vc_oracle_common.sh
+++ b/test/lib/vc_oracle_common.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+# True only for a clean, handled non-zero exit. A status >=128 is 128+signal
+# (139 = SIGSEGV, 134 = SIGABRT, 136 = SIGFPE, ...): a crash, which must never
+# be scored the same as Dolt's orderly error rejection in an oracle_error case.
+vc_oracle_is_clean_error() {
+  [ "$1" -ne 0 ] && [ "$1" -lt 128 ]
+}
+
 vc_oracle_translate_for_dolt() {
   printf '%s\n' "$1" | sed -E 's/SELECT[[:space:]]+(dolt_[a-z_]+\()/CALL \1/g'
 }

--- a/test/vc_oracle_add_test.sh
+++ b/test/vc_oracle_add_test.sh
@@ -60,7 +60,7 @@ oracle_error() {
   vc_oracle_run_dolt_script_for_error "$dir/dt" "$dir/dt.out" "$dir/dt.err" "$dolt_setup"
   dt_rc=$?
 
-  if [ "$dl_rc" -ne 0 ] && [ "$dt_rc" -ne 0 ]; then
+  if vc_oracle_is_clean_error "$dl_rc" && vc_oracle_is_clean_error "$dt_rc"; then
     pass=$((pass+1))
   else
     fail=$((fail+1))
@@ -99,7 +99,7 @@ $dolt_call")"
   ) > "$dir/dt.raw"
   dt_out=$(tail -n +2 "$dir/dt.raw" | tr -d '"\r' | grep '^Q|')
 
-  if [ "$dl_rc" -ne 0 ] && [ "$dt_rc" -ne 0 ] && [ "$dl_out" = "$dt_out" ]; then
+  if vc_oracle_is_clean_error "$dl_rc" && vc_oracle_is_clean_error "$dt_rc" && [ "$dl_out" = "$dt_out" ]; then
     pass=$((pass+1))
   else
     fail=$((fail+1))

--- a/test/vc_oracle_ancestor_spec_test.sh
+++ b/test/vc_oracle_ancestor_spec_test.sh
@@ -89,7 +89,7 @@ oracle_both_error() {
   run_dt_query "$dir/dt" "$dl_query" "$dir/dt.out" "$dir/dt.err"
   local dt_rc=$?
 
-  if [ "$dl_rc" -ne 0 ] && [ "$dt_rc" -ne 0 ]; then
+  if vc_oracle_is_clean_error "$dl_rc" && vc_oracle_is_clean_error "$dt_rc"; then
     pass=$((pass+1))
   else
     fail=$((fail+1)); FAILED_NAMES="$FAILED_NAMES $name"

--- a/test/vc_oracle_at_test.sh
+++ b/test/vc_oracle_at_test.sh
@@ -66,7 +66,7 @@ oracle_error() {
   vc_oracle_run_dolt_script_for_error "$dir/dt" "$dir/dt.out" "$dir/dt.err" "$dt_sql"
   dt_rc=$?
 
-  if [ "$dl_rc" -ne 0 ] && [ "$dt_rc" -ne 0 ]; then
+  if vc_oracle_is_clean_error "$dl_rc" && vc_oracle_is_clean_error "$dt_rc"; then
     pass=$((pass+1))
   else
     fail=$((fail+1))

--- a/test/vc_oracle_branch_test.sh
+++ b/test/vc_oracle_branch_test.sh
@@ -70,7 +70,7 @@ oracle_error() {
   vc_oracle_run_dolt_script_for_error "$dir/dt" "$dir/dt.out" "$dir/dt.err" "$dolt_setup"
   dt_rc=$?
 
-  if [ "$dl_rc" -ne 0 ] && [ "$dt_rc" -ne 0 ]; then
+  if vc_oracle_is_clean_error "$dl_rc" && vc_oracle_is_clean_error "$dt_rc"; then
     pass=$((pass+1))
   else
     fail=$((fail+1))

--- a/test/vc_oracle_checkout_test.sh
+++ b/test/vc_oracle_checkout_test.sh
@@ -89,7 +89,7 @@ oracle_error() {
   vc_oracle_run_dolt_script_for_error "$dir/dt" "$dir/dt.out" "$dir/dt.err" "$dolt_setup"
   dt_rc=$?
 
-  if [ "$dl_rc" -ne 0 ] && [ "$dt_rc" -ne 0 ]; then
+  if vc_oracle_is_clean_error "$dl_rc" && vc_oracle_is_clean_error "$dt_rc"; then
     pass=$((pass+1))
   else
     fail=$((fail+1))
@@ -119,7 +119,7 @@ oracle_error_poststate() {
   dt_rc=$?
   dt_post=$(cd "$dir/dt" && "$DOLT" sql -r csv -q "$query" 2>>"$dir/dt.err" | tail -n +2 | tr -d '"' | tr -d '\r')
 
-  if [ "$dl_rc" -ne 0 ] && [ "$dt_rc" -ne 0 ] && [ "$dl_post" = "$dt_post" ]; then
+  if vc_oracle_is_clean_error "$dl_rc" && vc_oracle_is_clean_error "$dt_rc" && [ "$dl_post" = "$dt_post" ]; then
     pass=$((pass+1))
   else
     fail=$((fail+1))
@@ -149,7 +149,7 @@ oracle_savepoint_poststate() {
   dt_rc=$?
   dt_post=$(cd "$dir/dt" && "$DOLT" sql -r csv -q "$query" 2>>"$dir/dt.err" | tail -n +2 | tr -d '"' | tr -d '\r')
 
-  if [ "$dl_rc" -ne 0 ] && [ "$dt_rc" -ne 0 ] && [ "$dl_post" = "$dt_post" ]; then
+  if vc_oracle_is_clean_error "$dl_rc" && vc_oracle_is_clean_error "$dt_rc" && [ "$dl_post" = "$dt_post" ]; then
     pass=$((pass+1))
   else
     fail=$((fail+1))

--- a/test/vc_oracle_commit_test.sh
+++ b/test/vc_oracle_commit_test.sh
@@ -119,7 +119,7 @@ oracle_error() {
   vc_oracle_run_dolt_script_for_error "$dir/dt" "$dir/dt.out" "$dir/dt.err" "$dolt_setup"
   dt_rc=$?
 
-  if [ "$dl_rc" -ne 0 ] && [ "$dt_rc" -ne 0 ]; then
+  if vc_oracle_is_clean_error "$dl_rc" && vc_oracle_is_clean_error "$dt_rc"; then
     pass=$((pass+1))
   else
     fail=$((fail+1))

--- a/test/vc_oracle_conflicts_resolve_test.sh
+++ b/test/vc_oracle_conflicts_resolve_test.sh
@@ -65,7 +65,7 @@ SET @@dolt_allow_commit_conflicts = 1;
 $dolt_setup"
   dt_rc=$?
 
-  if [ "$dl_rc" -ne 0 ] && [ "$dt_rc" -ne 0 ]; then
+  if vc_oracle_is_clean_error "$dl_rc" && vc_oracle_is_clean_error "$dt_rc"; then
     pass=$((pass+1))
   else
     fail=$((fail+1))

--- a/test/vc_oracle_connection_branch_test.sh
+++ b/test/vc_oracle_connection_branch_test.sh
@@ -129,7 +129,7 @@ oracle_error() {
   run_dt "$dir/dt" "$branch" "$query" >/dev/null 2>>"$dir/dt.err"
   dt_rc=$?
 
-  if [ "$dl_rc" -ne 0 ] && [ "$dt_rc" -ne 0 ]; then
+  if vc_oracle_is_clean_error "$dl_rc" && vc_oracle_is_clean_error "$dt_rc"; then
     pass=$((pass+1))
   else
     fail=$((fail+1))

--- a/test/vc_oracle_hashof_errors_test.sh
+++ b/test/vc_oracle_hashof_errors_test.sh
@@ -43,7 +43,7 @@ oracle_both_error() {
   (cd "$dir/dt" && "$DOLT" sql -q "$query") >"$dir/dt.out" 2>"$dir/dt.err"
   local dt_rc=$?
 
-  if [ "$dl_rc" -ne 0 ] && [ "$dt_rc" -ne 0 ]; then
+  if vc_oracle_is_clean_error "$dl_rc" && vc_oracle_is_clean_error "$dt_rc"; then
     pass=$((pass+1))
   else
     fail=$((fail+1)); FAILED_NAMES="$FAILED_NAMES $name"

--- a/test/vc_oracle_ignore_test.sh
+++ b/test/vc_oracle_ignore_test.sh
@@ -83,7 +83,7 @@ $setup"
   vc_oracle_run_dolt_script_for_error "$dir/dt" "$dir/dt.out" "$dir/dt.err" "$dolt_setup"
   dt_rc=$?
 
-  if [ "$dl_rc" -ne 0 ] && [ "$dt_rc" -ne 0 ]; then
+  if vc_oracle_is_clean_error "$dl_rc" && vc_oracle_is_clean_error "$dt_rc"; then
     pass=$((pass+1))
   else
     fail=$((fail+1))

--- a/test/vc_oracle_log_test.sh
+++ b/test/vc_oracle_log_test.sh
@@ -147,7 +147,7 @@ oracle_commit_error_poststate() {
       | normalize_commit_relations
   )
 
-  if [ "$dl_rc" -ne 0 ] && [ "$dt_rc" -ne 0 ] && [ "$dl_out" = "$dt_out" ]; then
+  if vc_oracle_is_clean_error "$dl_rc" && vc_oracle_is_clean_error "$dt_rc" && [ "$dl_out" = "$dt_out" ]; then
     pass=$((pass+1))
   else
     fail=$((fail+1))

--- a/test/vc_oracle_merge_base_test.sh
+++ b/test/vc_oracle_merge_base_test.sh
@@ -102,7 +102,7 @@ oracle_error() {
   vc_oracle_run_dolt_script_for_error "$dir/dt" "$dir/dt.out" "$dir/dt.err" "$dolt_setup"
   dt_rc=$?
 
-  if [ "$dl_rc" -ne 0 ] && [ "$dt_rc" -ne 0 ]; then
+  if vc_oracle_is_clean_error "$dl_rc" && vc_oracle_is_clean_error "$dt_rc"; then
     pass=$((pass+1))
   else
     fail=$((fail+1))

--- a/test/vc_oracle_merge_test.sh
+++ b/test/vc_oracle_merge_test.sh
@@ -110,7 +110,7 @@ oracle_error() {
   vc_oracle_run_dolt_script_for_error "$dir/dt" "$dir/dt.out" "$dir/dt.err" "$dolt_setup"
   dt_rc=$?
 
-  if [ "$dl_rc" -ne 0 ] && [ "$dt_rc" -ne 0 ]; then
+  if vc_oracle_is_clean_error "$dl_rc" && vc_oracle_is_clean_error "$dt_rc"; then
     pass=$((pass+1))
   else
     fail=$((fail+1))
@@ -1130,7 +1130,7 @@ oracle_dual_error() {
   vc_oracle_run_dolt_script_for_error "$dir/dt" "$dir/dt.out" "$dir/dt.err" "$dolt_setup"
   dt_rc=$?
 
-  if [ "$dl_rc" -ne 0 ] && [ "$dt_rc" -ne 0 ]; then
+  if vc_oracle_is_clean_error "$dl_rc" && vc_oracle_is_clean_error "$dt_rc"; then
     pass=$((pass+1))
   else
     fail=$((fail+1))

--- a/test/vc_oracle_rebase_test.sh
+++ b/test/vc_oracle_rebase_test.sh
@@ -54,7 +54,7 @@ oracle_error() {
   vc_oracle_run_dolt_script_for_error "$dir/dt" "$dir/dt.out" "$dir/dt.err" "$dolt_setup"
   dt_rc=$?
 
-  if [ "$dl_rc" -ne 0 ] && [ "$dt_rc" -ne 0 ]; then
+  if vc_oracle_is_clean_error "$dl_rc" && vc_oracle_is_clean_error "$dt_rc"; then
     pass=$((pass+1))
   else
     fail=$((fail+1))
@@ -118,7 +118,7 @@ oracle_error_reopen() {
   ) > "$dir/dt.raw"
   dt_out=$(tr -d '"\r' < "$dir/dt.raw" | grep '^LOG|')
 
-  if [ "$dl_rc" -ne 0 ] && [ "$dt_rc" -ne 0 ] && [ "$dl_out" = "$dt_out" ]; then
+  if vc_oracle_is_clean_error "$dl_rc" && vc_oracle_is_clean_error "$dt_rc" && [ "$dl_out" = "$dt_out" ]; then
     pass=$((pass+1))
   else
     fail=$((fail+1))

--- a/test/vc_oracle_remotes_test.sh
+++ b/test/vc_oracle_remotes_test.sh
@@ -65,7 +65,7 @@ oracle_error() {
   vc_oracle_run_dolt_script_for_error "$dir/dt" "$dir/dt.out" "$dir/dt.err" "$dolt_setup"
   dt_rc=$?
 
-  if [ "$dl_rc" -ne 0 ] && [ "$dt_rc" -ne 0 ]; then
+  if vc_oracle_is_clean_error "$dl_rc" && vc_oracle_is_clean_error "$dt_rc"; then
     pass=$((pass+1))
   else
     fail=$((fail+1))
@@ -97,7 +97,7 @@ oracle_savepoint_remote_poststate() {
   dt_v=$(cd "$dir/dt" && "$DOLT" sql -r csv -q "SELECT v FROM t WHERE id=1;" 2>>"$dir/dt.err" | tail -n +2 | tr -d '"')
   dt_remotes=$(cd "$dir/dt" && "$DOLT" sql -r csv -q "SELECT coalesce(group_concat(name, ','), '') FROM dolt_remotes;" 2>>"$dir/dt.err" | tail -n +2 | tr -d '"')
 
-  if [ "$dl_rc" -ne 0 ] && [ "$dt_rc" -ne 0 ] && [ "$dl_v" = "$dt_v" ] && [ "$dl_remotes" = "$dt_remotes" ]; then
+  if vc_oracle_is_clean_error "$dl_rc" && vc_oracle_is_clean_error "$dt_rc" && [ "$dl_v" = "$dt_v" ] && [ "$dl_remotes" = "$dt_remotes" ]; then
     pass=$((pass+1))
   else
     fail=$((fail+1))
@@ -127,7 +127,7 @@ oracle_savepoint_clone_poststate() {
   dt_rc=$?
   dt_post=$(cd "$dir/dt" && "$DOLT" sql -r csv -q "$query" 2>>"$dir/dt.err" | tail -n +2 | tr -d '"\r')
 
-  if [ "$dl_rc" -ne 0 ] && [ "$dt_rc" -ne 0 ] && [ "$dl_post" = "$dt_post" ]; then
+  if vc_oracle_is_clean_error "$dl_rc" && vc_oracle_is_clean_error "$dt_rc" && [ "$dl_post" = "$dt_post" ]; then
     pass=$((pass+1))
   else
     fail=$((fail+1))

--- a/test/vc_oracle_reset_test.sh
+++ b/test/vc_oracle_reset_test.sh
@@ -89,7 +89,7 @@ oracle_error() {
   vc_oracle_run_dolt_script_for_error "$dir/dt" "$dir/dt.out" "$dir/dt.err" "$dolt_setup"
   dt_rc=$?
 
-  if [ "$dl_rc" -ne 0 ] && [ "$dt_rc" -ne 0 ]; then
+  if vc_oracle_is_clean_error "$dl_rc" && vc_oracle_is_clean_error "$dt_rc"; then
     pass=$((pass+1))
   else
     fail=$((fail+1))

--- a/test/vc_oracle_revert_cherrypick_test.sh
+++ b/test/vc_oracle_revert_cherrypick_test.sh
@@ -105,7 +105,7 @@ oracle_error() {
   vc_oracle_run_dolt_script_for_error "$dir/dt" "$dir/dt.out" "$dir/dt.err" "$dolt_setup"
   dt_rc=$?
 
-  if [ "$dl_rc" -ne 0 ] && [ "$dt_rc" -ne 0 ]; then
+  if vc_oracle_is_clean_error "$dl_rc" && vc_oracle_is_clean_error "$dt_rc"; then
     pass=$((pass+1))
   else
     fail=$((fail+1))

--- a/test/vc_oracle_schema_diff_test.sh
+++ b/test/vc_oracle_schema_diff_test.sh
@@ -75,7 +75,7 @@ oracle_error() {
   vc_oracle_run_dolt_script_for_error "$dir/dt" "$dir/dt.out" "$dir/dt.err" "$dt_sql"
   dt_rc=$?
 
-  if [ "$dl_rc" -ne 0 ] && [ "$dt_rc" -ne 0 ]; then
+  if vc_oracle_is_clean_error "$dl_rc" && vc_oracle_is_clean_error "$dt_rc"; then
     pass=$((pass+1))
   else
     fail=$((fail+1))

--- a/test/vc_oracle_tags_test.sh
+++ b/test/vc_oracle_tags_test.sh
@@ -79,7 +79,7 @@ oracle_savepoint_tag_poststate() {
   dt_v=$(cd "$dir/dt" && "$DOLT" sql -r csv -q "SELECT v FROM t WHERE id=1;" 2>>"$dir/dt.err" | tail -n +2 | tr -d '"')
   dt_tags=$(cd "$dir/dt" && "$DOLT" sql -r csv -q "SELECT coalesce(group_concat(tag_name, ','), '') FROM dolt_tags;" 2>>"$dir/dt.err" | tail -n +2 | tr -d '"')
 
-  if [ "$dl_rc" -ne 0 ] && [ "$dt_rc" -ne 0 ] && [ "$dl_v" = "$dt_v" ] && [ "$dl_tags" = "$dt_tags" ]; then
+  if vc_oracle_is_clean_error "$dl_rc" && vc_oracle_is_clean_error "$dt_rc" && [ "$dl_v" = "$dt_v" ] && [ "$dl_tags" = "$dt_tags" ]; then
     pass=$((pass+1))
   else
     fail=$((fail+1))


### PR DESCRIPTION
Second half of the review's item #3 (test-harness hardening).

## Problem

The `oracle_error` assertion — used at ~26 sites across 19 oracle suites to check that both doltlite and Dolt reject an invalid operation — passed whenever **both** exit codes were non-zero:

```sh
if [ "$dl_rc" -ne 0 ] && [ "$dt_rc" -ne 0 ]; then  # pass
```

A doltlite **crash** exits `139` (SIGSEGV) or `134` (SIGABRT) — also non-zero — so a segfault scored identical to Dolt's orderly `exit 1` rejection. The single largest correctness hole in the oracle layer, and the most-used error assertion.

## Fix

A shared helper in `vc_oracle_common.sh`:

```sh
vc_oracle_is_clean_error() { [ "$1" -ne 0 ] && [ "$1" -lt 128 ]; }
```

A status ≥128 is `128 + signal` (a crash), so it's now rejected; a handled error (`exit 1`, etc.) still passes. Applied at all 26 both-errored checks.

## Validation

- Helper unit-demonstrated: accepts 1/2/127, rejects 0/134/137/139.
- No regression: merge 71/71, branch 33/33, commit 37/37, add 34/34, checkout 64/64, remotes 34/34, conflicts_resolve 28/28, revert_cherrypick 58/58, reset 43/43, merge_base 32/32 (all clean-error cases exit 1, still accepted).

## Deferred

The review's other oracle weakness — `vc_oracle_assert_match_allow_empty` passing on empty-vs-empty — is an 88-site change across scenarios where an empty result is often legitimately correct on both engines. That's a separate audit (higher risk, lower value) and is intentionally left for a focused follow-up rather than bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)