### PR TITLE
Run ref-mutation, GC, and remote suites under ASan/UBSan

### DIFF
--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -99,6 +99,20 @@ jobs:
           bash ../test/$s.sh ./doltlite || exit 1
         done
 
+    # Ref-mutation, GC, and remote clone/pull paths deserialize the refs blob
+    # and rewrite refs/chunks — memory-management code (the refs int-overflow
+    # and the cursor-pin / merge-cleanup fixes lived here) that the oracle and
+    # read-vtab suites above never exercise under ASan. Kept to fast,
+    # self-contained suites (no server, no external Dolt) to stay in budget.
+    - name: VC ref-mutation + remote suites
+      run: |
+        cd build
+        for s in doltlite_branch doltlite_default_branch doltlite_tag \
+                 doltlite_gc remote_test; do
+          echo "=== $s ==="
+          bash ../test/$s.sh ./doltlite || exit 1
+        done
+
     # The C regression corpus (~310k checks) under ASan/UBSan with leak
     # detection — where the #1325/#1328 use-after-frees and leaks lived.
     # Reuses the objects built above; only the archive and link are new.

--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -934,7 +934,11 @@ int chunkStoreAddTagFull(
 int chunkStoreDeleteTag(ChunkStore *cs, const char *zName){
   int i = findTagIdx(cs, zName);
   if( i<0 ) return SQLITE_NOTFOUND;
+  /* Free every owned field, not just zName, before the swap-remove. */
   sqlite3_free(cs->refs.aTags[i].zName);
+  sqlite3_free(cs->refs.aTags[i].zTagger);
+  sqlite3_free(cs->refs.aTags[i].zEmail);
+  sqlite3_free(cs->refs.aTags[i].zMessage);
   cs->refs.aTags[i] = cs->refs.aTags[cs->refs.nTags-1];
   cs->refs.nTags--;
   return SQLITE_OK;


### PR DESCRIPTION
Review item #3 (remainder): extend ASan coverage to the paths that had none — and it immediately caught a real leak.

## Gap

The `asan-ubsan` job ran the SQL oracle suites, the VC read-vtab suites, and the C corpus — but **not** the clone/pull, GC, or branch/tag paths, the ref-blob deserialize and refs/chunk-rewrite code where this review's recent memory fixes lived (`csDeserializeRefs` overflow #1691; COUNT cursor-pin leak + merge-cleanup double-free #1692). That blind spot is why those went undetected.

## Change

1. Adds an ASan step running five self-contained suites under the existing ASan/UBSan build: `doltlite_branch`, `doltlite_default_branch`, `doltlite_tag`, `doltlite_gc`, `remote_test` (clone/pull/push over file remotes). No spawned server or external Dolt, to stay within the 20-minute cap.

2. **Fixes the leak the new coverage found**: `chunkStoreDeleteTag` freed only `zName` before its swap-remove, leaking the deleted tag's `zTagger`/`zEmail`/`zMessage` (LeakSanitizer, Linux-only — macOS can't detect it, which is exactly why it lived). Now frees all owned fields, matching `csFreeTags`.

## Validation

Built with the job's ASan/UBSan flags and ran all five suites: branch 62/62, default_branch 12/12, tag 19/19, gc 58/58, remote_test 97/97, clean (no UAF/overflow/UB; leak coverage is the Linux CI job's part). The tag leak fix is double-free-safe (swap-remove drops the slot) and regression-free.

## Still open from item #3

OOM/allocation-fault injection over these paths and the `vc_oracle_assert_match_allow_empty` empty-vs-empty audit remain as separate follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)