### PR TITLE
Validate record inputs before pointer arithmetic

### DIFF
--- a/src/doltlite_record.c
+++ b/src/doltlite_record.c
@@ -144,8 +144,8 @@ static int recBufAppend(RecBuf *b, const char *z, int n){
 }
 
 char *doltliteDecodeRecord(const u8 *pData, int nData){
-  const u8 *p = pData;
-  const u8 *pEnd = pData + nData;
+  const u8 *p;
+  const u8 *pEnd;
   u64 hdrSize;
   int hdrBytes;
   const u8 *pHdrEnd;
@@ -155,6 +155,8 @@ char *doltliteDecodeRecord(const u8 *pData, int nData){
   int rc = SQLITE_OK;
 
   if( !pData || nData < 1 ) return 0;
+  p = pData;
+  pEnd = pData + nData;
 
   memset(&buf, 0, sizeof(buf));
 
@@ -344,14 +346,16 @@ int doltliteParseRecordStrict(
   int nData,
   DoltliteRecordInfo *pInfo
 ){
-  const u8 *p = pData;
-  const u8 *pEnd = pData + nData;
+  const u8 *p;
+  const u8 *pEnd;
   u64 hdrSize;
   int hdrBytes, off;
   const u8 *pHdrEnd;
 
   memset(pInfo, 0, sizeof(*pInfo));
   if( !pData || nData < 1 ) return SQLITE_CORRUPT;
+  p = pData;
+  pEnd = pData + nData;
 
   hdrBytes = dlReadVarint(p, pEnd, &hdrSize);
   if( hdrBytes<=0 ) return SQLITE_CORRUPT;

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -2537,12 +2537,32 @@ static void run_record_decode_corruption(void){
   static const u8 badRecord[] = {
     0x05, 0x01
   };
+  DoltliteRecordInfo info;
   char *z;
+  int rc;
 
   printf("=== Record Decode Corruption Test ===\n\n");
   z = doltliteDecodeRecord(badRecord, (int)sizeof(badRecord));
   check("corrupt_record_decodes_to_null", z==0);
   sqlite3_free(z);
+
+  check("decode_null_record_rejected", doltliteDecodeRecord(0, 1)==0);
+  check("decode_zero_length_record_rejected",
+        doltliteDecodeRecord(badRecord, 0)==0);
+  check("decode_negative_length_record_rejected",
+        doltliteDecodeRecord(badRecord, -1)==0);
+
+  memset(&info, 0xff, sizeof(info));
+  rc = doltliteParseRecordStrict(0, 1, &info);
+  check("parse_null_record_rejected", rc==SQLITE_CORRUPT && info.nField==0);
+  memset(&info, 0xff, sizeof(info));
+  rc = doltliteParseRecordStrict(badRecord, 0, &info);
+  check("parse_zero_length_record_rejected",
+        rc==SQLITE_CORRUPT && info.nField==0);
+  memset(&info, 0xff, sizeof(info));
+  rc = doltliteParseRecordStrict(badRecord, -1, &info);
+  check("parse_negative_length_record_rejected",
+        rc==SQLITE_CORRUPT && info.nField==0);
 }
 
 static void run_sortkey_two_numeric_roundtrip(void){


### PR DESCRIPTION
## Summary

- validate record pointers and lengths before deriving end pointers
- cover null, zero-length, and negative-length inputs for both record parser entry points

## Testing

- `bash test/run_doltlite_regression_case.sh record_decode_corruption` (7/7 passed)
- targeted record regression under ASan/UBSan (7/7 passed)
- `make DOLTLITE_PROLLY=1 c-tests` (17/17 gates passed)
- `make devtest` attempted; current master hits the amalgamation build failures tracked by #1679 before completing

Closes #1681