### PR TITLE
Add positive controls for the computed-empty oracle scenarios

### DIFF
--- a/test/vc_oracle_diff_multi_pk_test.sh
+++ b/test/vc_oracle_diff_multi_pk_test.sh
@@ -385,6 +385,27 @@ SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'main_check');
 SELECT dolt_merge('feat');
 " "SELECT CONCAT('R|', a, '|', b, '|', v, '|', message) FROM dolt_history_u ORDER BY a, b, message;" "EXPECT_EMPTY"
 
+# Positive control for the empty history above: the merge must actually bring
+# table u onto main. Assert its row is present post-merge, so the empty
+# dolt_history_u is Dolt's merge-history semantics on a real table, not a
+# silently-skipped replay or a table that never arrived.
+oracle "k_merge_replay_multi_pk_data_present" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1, 'base');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'c1');
+SELECT dolt_checkout('-b', 'feat');
+CREATE TABLE u(a INTEGER, b INTEGER, v TEXT, PRIMARY KEY(a, b));
+INSERT INTO u VALUES (1, 1, 'one');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'feat_add_u');
+SELECT dolt_checkout('main');
+CREATE TABLE t_new(id INTEGER PRIMARY KEY, v TEXT CHECK (length(v) > 0));
+INSERT INTO t_new SELECT * FROM t;
+DROP TABLE t;
+ALTER TABLE t_new RENAME TO t;
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'main_check');
+SELECT dolt_merge('feat');
+" "SELECT CONCAT('R|', a, '|', b, '|', v) FROM u ORDER BY a, b;"
+
 oracle "k_cherrypick_replay_multi_pk_history" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES (1, 'base');

--- a/test/vc_oracle_schema_diff_test.sh
+++ b/test/vc_oracle_schema_diff_test.sh
@@ -287,6 +287,23 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'drop_col_again');
 " "HEAD~3" "HEAD" "" "EXPECT_EMPTY"
 
+# Positive control for the net-zero range above: the same multi-commit span,
+# stopped one commit early (before the drop), must show the column add. This
+# proves the empty full-range result is a genuine net-zero, not a range-walk
+# that silently returns nothing over spans deeper than one commit.
+oracle "net_addcol_dropcol_midrange_shows_add" "
+$SEED
+ALTER TABLE t ADD COLUMN extra TEXT;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'add_col');
+UPDATE t SET extra = 'x' WHERE id = 1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'populate');
+ALTER TABLE t DROP COLUMN extra;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'drop_col_again');
+" "HEAD~3" "HEAD~1"
+
 oracle "multiple_alters_single_commit" "
 $SEED
 ALTER TABLE t ADD COLUMN a TEXT;


### PR DESCRIPTION
Follow-up to the review's deferred `allow_empty` (empty==empty) concern. Scoped first, then implemented narrowly.

## What the audit found

The empty-tolerant path (`EXPECT_EMPTY` → `vc_oracle_assert_match_allow_empty`) only *masks* a doltlite bug when **Dolt's** side is also genuinely empty — if Dolt returns rows, `dl==dt` behaves exactly like the strict asserter and the flag is a harmless no-op. Of ~40 empty-tolerant scenarios:

- **~30 are legitimately empty** (fresh/clean/cleared state, empty input, `filter_nonexistent_*`, `self_diff`, `no_changes`, `empty_after_clean_merge`, `resolve_*_clears`, …). These are *better* written empty-tolerant, and tightening the shared asserter would false-fail all of them — so it's **left unchanged**.
- Several that looked risky are **already guarded**: the `trigger_*_log_travels_with_cherrypick` group returns non-empty in Dolt (`{1,2,3}`), so `allow_empty` is a no-op there; and the filtered-schema_diff / multi-pk-`dolt_history` vtab liveness is already proven by existing non-empty scenarios (`filter_added_table_only`, `filter_modified_table_only`, `a_history`, `b_pk_update_history`, `d_three_col_history`).

## The two genuine gaps (fixed here)

1. **schema_diff had no multi-commit-range non-empty scenario** — the net-zero `modified_net_addcol_dropcol_range` (`HEAD~3..HEAD`) was the only depth-3 range, and it's empty, so a range that silently returns nothing over spans deeper than one commit would pass. Added `net_addcol_dropcol_midrange_shows_add` (`HEAD~3..HEAD~1`, shows the column add — verified non-empty).
2. **The multi-pk merge-replay history scenario** asserts `dolt_history_u` empty (Dolt's merge-history semantics) with nothing proving the merge actually brought `u` onto main. Added `k_merge_replay_multi_pk_data_present` (asserts `u`'s row is present post-merge).

## Validation

schema_diff 60/60 (was 59), diff_multi_pk 30/30 (was 29). The midrange control is confirmed non-empty (would fail on a false-empty). No change to the shared asserter or the ~30 legitimately-empty scenarios.

🤖 Generated with [Claude Code](https://claude.com/claude-code)