### PR TITLE
Reject oversized record varints

### DIFF
--- a/src/doltlite_record.c
+++ b/src/doltlite_record.c
@@ -204,9 +204,9 @@ char *doltliteDecodeRecord(const u8 *pData, int nData){
       rc = recBufAppend(&buf, tmp, -1);
       pBody += 8;
     }else if( st>=12 && (st&1)==0 ){
-      int len = ((int)st - 12) / 2;
+      int len = dlSerialTypeLen(st);
       int i;
-      if( len<0 || pBody + len > pEnd ){ rc = SQLITE_CORRUPT; break; }
+      if( len<0 || len>(int)(pEnd-pBody) ){ rc = SQLITE_CORRUPT; break; }
       rc = recBufAppend(&buf, "x'", 2);
       for(i=0; rc==SQLITE_OK && i<len; i++){
         char hex[3];
@@ -216,8 +216,8 @@ char *doltliteDecodeRecord(const u8 *pData, int nData){
       if( rc==SQLITE_OK ) rc = recBufAppend(&buf, "'", 1);
       pBody += len;
     }else if( st>=13 && (st&1)==1 ){
-      int len = ((int)st - 13) / 2;
-      if( len<0 || pBody + len > pEnd ){ rc = SQLITE_CORRUPT; break; }
+      int len = dlSerialTypeLen(st);
+      if( len<0 || len>(int)(pEnd-pBody) ){ rc = SQLITE_CORRUPT; break; }
       rc = recBufAppend(&buf, (const char*)pBody, len);
       pBody += len;
     }else{
@@ -359,7 +359,7 @@ int doltliteParseRecordStrict(
 
   hdrBytes = dlReadVarint(p, pEnd, &hdrSize);
   if( hdrBytes<=0 ) return SQLITE_CORRUPT;
-  if( (int)hdrSize < hdrBytes || (int)hdrSize > nData ) return SQLITE_CORRUPT;
+  if( hdrSize < (u64)hdrBytes || hdrSize > (u64)nData ) return SQLITE_CORRUPT;
   p += hdrBytes;
   pHdrEnd = pData + (int)hdrSize;
   off = (int)hdrSize;
@@ -370,12 +370,12 @@ int doltliteParseRecordStrict(
     int nField;
     int nSerial;
     if( stBytes<=0 ) return SQLITE_CORRUPT;
-    if( st==10 || st==11 ) return SQLITE_CORRUPT;
+    if( st==10 || st==11 || st>(u64)INT_MAX ) return SQLITE_CORRUPT;
     nField = pInfo->nField;
     if( nField >= DOLTLITE_MAX_RECORD_FIELDS ) return SQLITE_CORRUPT;
     p += stBytes;
     nSerial = dlSerialTypeLen(st);
-    if( off > nData - nSerial ) return SQLITE_CORRUPT;
+    if( nSerial<0 || nSerial>nData-off ) return SQLITE_CORRUPT;
     pInfo->aType[nField] = (int)st;
     pInfo->aOffset[nField] = off;
     off += nSerial;

--- a/src/prolly_record.h
+++ b/src/prolly_record.h
@@ -2,6 +2,7 @@
 #ifndef SQLITE_PROLLY_RECORD_H
 #define SQLITE_PROLLY_RECORD_H
 
+#include <limits.h>
 #include "sqliteInt.h"
 
 /*
@@ -32,9 +33,14 @@ static inline int dlReadVarint(const u8 *p, const u8 *pEnd, u64 *pVal){
 
 static inline int dlSerialTypeLen(u64 st){
   static const u8 aLen[] = {0, 1, 2, 3, 4, 6, 8};
+  u64 n;
   if( st <= 6 ) return aLen[st];
   if( st == 7 ) return 8;
-  if( st >= 12 ) return (int)(st - 12) / 2;
+  if( st >= 12 ){
+    n = (st - 12) / 2;
+    if( n > (u64)INT_MAX ) return -1;
+    return (int)n;
+  }
   return 0;
 }
 

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <limits.h>
 #include <unistd.h>
 #include <sys/stat.h>
 #include "sqlite3.h"
@@ -2537,6 +2538,17 @@ static void run_record_decode_corruption(void){
   static const u8 badRecord[] = {
     0x05, 0x01
   };
+  static const u8 serialTypeOverflow[] = {
+    0x06, 0x90, 0x80, 0x80, 0x80, 0x0e, 0x00
+  };
+  static const u8 headerSizeOverflow[] = {
+    0x90, 0x80, 0x80, 0x80, 0x06, 0x08
+  };
+  static const u8 maxVarintSerialType[] = {
+    0x0a, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff
+  };
+  static const u8 validBlob[] = { 0x02, 0x0e, 0x2a };
+  static const u8 validText[] = { 0x02, 0x0f, 0x78 };
   DoltliteRecordInfo info;
   char *z;
   int rc;
@@ -2563,6 +2575,39 @@ static void run_record_decode_corruption(void){
   rc = doltliteParseRecordStrict(badRecord, -1, &info);
   check("parse_negative_length_record_rejected",
         rc==SQLITE_CORRUPT && info.nField==0);
+
+  check("oversized_serial_type_is_corrupt",
+        doltliteParseRecordStrict(serialTypeOverflow,
+          (int)sizeof(serialTypeOverflow), &info)==SQLITE_CORRUPT);
+  z = doltliteDecodeRecord(serialTypeOverflow,
+                           (int)sizeof(serialTypeOverflow));
+  check("oversized_serial_type_does_not_decode", z==0);
+  sqlite3_free(z);
+
+  check("oversized_header_size_is_corrupt",
+        doltliteParseRecordStrict(headerSizeOverflow,
+          (int)sizeof(headerSizeOverflow), &info)==SQLITE_CORRUPT);
+  z = doltliteDecodeRecord(headerSizeOverflow,
+                           (int)sizeof(headerSizeOverflow));
+  check("oversized_header_size_does_not_decode", z==0);
+  sqlite3_free(z);
+
+  check("maximum_varint_serial_type_is_corrupt",
+        doltliteParseRecordStrict(maxVarintSerialType,
+          (int)sizeof(maxVarintSerialType), &info)==SQLITE_CORRUPT);
+  check("largest_serial_payload_length_fits",
+        dlSerialTypeLen((u64)INT_MAX * 2 + 12)==INT_MAX);
+  check("oversized_serial_payload_length_is_rejected",
+        dlSerialTypeLen((u64)INT_MAX * 2 + 14)<0);
+
+  check("neighboring_blob_record_is_valid",
+        doltliteParseRecordStrict(validBlob,
+          (int)sizeof(validBlob), &info)==SQLITE_OK
+        && info.nField==1 && info.aType[0]==14 && info.aOffset[0]==2);
+  check("neighboring_text_record_is_valid",
+        doltliteParseRecordStrict(validText,
+          (int)sizeof(validText), &info)==SQLITE_OK
+        && info.nField==1 && info.aType[0]==15 && info.aOffset[0]==2);
 }
 
 static void run_sortkey_two_numeric_roundtrip(void){


### PR DESCRIPTION
## Summary

- validate record header sizes before narrowing them to `int`
- reject serial types and payload lengths that cannot fit the record parser's internal representation
- use the checked serial-length helper in the record decoder and merge parser paths
- cover oversized headers, oversized serial types, the maximum varint, boundary lengths, and valid neighboring records

Before the fix, the focused regression reported 5 failures out of 16 checks. It now passes all 16.

## Testing

- `DOLTLITE_BUILD_DIR=build bash test/run_doltlite_regression_case.sh record_decode_corruption`: 16/16
- ASan/UBSan focused regression: 16/16
- `make c-tests`: 17/17 gating executables
- `test/doltlite_merge.sh`: 94/94
- `test/doltlite_merge_index_conflict.sh`: 9/9
- `test/doltlite_record_format.sh`: 6/6
- generated amalgamation passed `srcck1`

`make devtest` was attempted. Its local runner failed after amalgamation generation because `tommath` is unavailable, fuzz databases could not be opened by `sqlite3_deserialize()`, and existing debug builds hit `cursorHoldsMutex` assertions. The failures do not reference the changed parser paths.

Closes #1697.