### PR TITLE
Mark side-effecting Dolt functions direct-only

### DIFF
--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -5660,29 +5660,38 @@ static int doltliteMaybeSeedRepo(sqlite3 *db){
 
 int doltliteRegister(sqlite3 *db){
   int rc;
-  rc = sqlite3_create_function(db, "dolt_commit", -1, SQLITE_UTF8, 0,
+  rc = sqlite3_create_function(db, "dolt_commit", -1,
+                               DOLTLITE_COMMAND_FUNC_FLAGS, 0,
                                doltliteCommitFunc, 0, 0);
-  if( rc==SQLITE_OK ) rc = sqlite3_create_function(db, "dolt_add", -1, SQLITE_UTF8, 0,
+  if( rc==SQLITE_OK ) rc = sqlite3_create_function(db, "dolt_add", -1,
+                                                   DOLTLITE_COMMAND_FUNC_FLAGS, 0,
                                                    doltliteAddFunc, 0, 0);
-  if( rc==SQLITE_OK ) rc = sqlite3_create_function(db, "dolt_reset", -1, SQLITE_UTF8, 0,
+  if( rc==SQLITE_OK ) rc = sqlite3_create_function(db, "dolt_reset", -1,
+                                                   DOLTLITE_COMMAND_FUNC_FLAGS, 0,
                                                    doltliteResetFunc, 0, 0);
-  if( rc==SQLITE_OK ) rc = sqlite3_create_function(db, "dolt_merge", -1, SQLITE_UTF8, 0,
+  if( rc==SQLITE_OK ) rc = sqlite3_create_function(db, "dolt_merge", -1,
+                                                   DOLTLITE_COMMAND_FUNC_FLAGS, 0,
                                                    doltliteMergeFunc, 0, 0);
-  if( rc==SQLITE_OK ) rc = sqlite3_create_function(db, "dolt_cherry_pick", -1, SQLITE_UTF8, 0,
+  if( rc==SQLITE_OK ) rc = sqlite3_create_function(db, "dolt_cherry_pick", -1,
+                                                   DOLTLITE_COMMAND_FUNC_FLAGS, 0,
                                                    doltliteCherryPickFunc, 0, 0);
-  if( rc==SQLITE_OK ) rc = sqlite3_create_function(db, "dolt_revert", -1, SQLITE_UTF8, 0,
+  if( rc==SQLITE_OK ) rc = sqlite3_create_function(db, "dolt_revert", -1,
+                                                   DOLTLITE_COMMAND_FUNC_FLAGS, 0,
                                                    doltliteRevertFunc, 0, 0);
-  if( rc==SQLITE_OK ) rc = sqlite3_create_function(db, "dolt_rebase", -1, SQLITE_UTF8, 0,
+  if( rc==SQLITE_OK ) rc = sqlite3_create_function(db, "dolt_rebase", -1,
+                                                   DOLTLITE_COMMAND_FUNC_FLAGS, 0,
                                                    doltliteRebaseFunc, 0, 0);
-  if( rc==SQLITE_OK ) rc = sqlite3_create_function(db, "dolt_config", -1, SQLITE_UTF8, 0,
+  if( rc==SQLITE_OK ) rc = sqlite3_create_function(db, "dolt_config", -1,
+                                                   DOLTLITE_COMMAND_FUNC_FLAGS, 0,
                                                    doltliteConfigFunc, 0, 0);
   if( rc==SQLITE_OK ) rc = sqlite3_create_function(db, "dolt_version", 0, SQLITE_UTF8, 0,
                                                    doltliteVersionFunc, 0, 0);
-  if( rc==SQLITE_OK ) rc = sqlite3_create_function(db, "dolt_default_branch", -1, SQLITE_UTF8, 0,
+  if( rc==SQLITE_OK ) rc = sqlite3_create_function(db, "dolt_default_branch", -1,
+                                                   DOLTLITE_COMMAND_FUNC_FLAGS, 0,
                                                    doltliteDefaultBranchFunc, 0, 0);
   if( rc==SQLITE_OK ) rc = sqlite3_create_function(db,
                                                    "doltlite_internal_materialize_default_column",
-                                                   3, SQLITE_UTF8, 0,
+                                                   3, DOLTLITE_COMMAND_FUNC_FLAGS, 0,
                                                    doltliteInternalMaterializeDefaultColumnFunc,
                                                    0, 0);
   if( rc!=SQLITE_OK ) return rc;

--- a/src/doltlite_branch.c
+++ b/src/doltlite_branch.c
@@ -1700,10 +1700,16 @@ static sqlite3_module brMod = {
 
 int doltliteBranchRegister(sqlite3 *db){
   int rc;
-  rc = sqlite3_create_function(db, "dolt_branch", -1, SQLITE_UTF8, 0, doltBranchFunc, 0, 0);
-  if(rc==SQLITE_OK) rc = sqlite3_create_function(db, "dolt_checkout", -1, SQLITE_UTF8, 0, doltCheckoutFunc, 0, 0);
+  rc = sqlite3_create_function(db, "dolt_branch", -1,
+                               DOLTLITE_COMMAND_FUNC_FLAGS, 0,
+                               doltBranchFunc, 0, 0);
+  if(rc==SQLITE_OK) rc = sqlite3_create_function(db, "dolt_checkout", -1,
+                                                  DOLTLITE_COMMAND_FUNC_FLAGS,
+                                                  0, doltCheckoutFunc, 0, 0);
   if(rc==SQLITE_OK) rc = sqlite3_create_function(db, "active_branch", 0, SQLITE_UTF8, 0, activeBranchFunc, 0, 0);
-  if(rc==SQLITE_OK) rc = sqlite3_create_function(db, "dolt_connect_branch", 1, SQLITE_UTF8, 0, doltConnectBranchFunc, 0, 0);
+  if(rc==SQLITE_OK) rc = sqlite3_create_function(db, "dolt_connect_branch", 1,
+                                                  DOLTLITE_COMMAND_FUNC_FLAGS,
+                                                  0, doltConnectBranchFunc, 0, 0);
   if(rc==SQLITE_OK) rc = sqlite3_create_module(db, "dolt_branches", &brMod, 0);
   return rc;
 }

--- a/src/doltlite_conflicts.c
+++ b/src/doltlite_conflicts.c
@@ -988,7 +988,8 @@ int doltliteConflictsRegister(sqlite3 *db){
   int rc;
   rc = sqlite3_create_module(db, "dolt_conflicts", &conflictsModule, 0);
   if( rc==SQLITE_OK )
-    rc = sqlite3_create_function(db, "dolt_conflicts_resolve", -1, SQLITE_UTF8, 0,
+    rc = sqlite3_create_function(db, "dolt_conflicts_resolve", -1,
+                                  DOLTLITE_COMMAND_FUNC_FLAGS, 0,
                                   conflictsResolveFunc, 0, 0);
 
   if( rc==SQLITE_OK )

--- a/src/doltlite_gc.c
+++ b/src/doltlite_gc.c
@@ -1059,7 +1059,8 @@ int doltliteGcCompact(sqlite3 *db){
 }
 
 int doltliteGcRegister(sqlite3 *db){
-  return sqlite3_create_function(db, "dolt_gc", 0, SQLITE_UTF8, 0,
+  return sqlite3_create_function(db, "dolt_gc", 0,
+                                  DOLTLITE_COMMAND_FUNC_FLAGS, 0,
                                   doltliteGcFunc, 0, 0);
 }
 

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -21,6 +21,9 @@ typedef struct DoltliteCommitQueue DoltliteCommitQueue;
 #define DOLTLITE_RANGE_TWO_DOT   2
 #define DOLTLITE_RANGE_THREE_DOT 3
 
+/* Repository commands must not execute from persistent schema objects. */
+#define DOLTLITE_COMMAND_FUNC_FLAGS (SQLITE_UTF8 | SQLITE_DIRECTONLY)
+
 static SQLITE_INLINE int doltliteSplitRevisionRange(
   const char *zSpec,
   char **pzLeft,

--- a/src/doltlite_remote_sql.c
+++ b/src/doltlite_remote_sql.c
@@ -911,20 +911,27 @@ static void doltCredsFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
 
 int doltliteRemoteSqlRegister(sqlite3 *db){
   int rc;
-  rc = sqlite3_create_function(db, "dolt_remote", -1, SQLITE_UTF8, 0,
+  rc = sqlite3_create_function(db, "dolt_remote", -1,
+                               DOLTLITE_COMMAND_FUNC_FLAGS, 0,
                                doltRemoteFunc, 0, 0);
-  if( rc==SQLITE_OK ) rc = sqlite3_create_function(db, "dolt_push", -1, SQLITE_UTF8, 0,
+  if( rc==SQLITE_OK ) rc = sqlite3_create_function(db, "dolt_push", -1,
+                                                   DOLTLITE_COMMAND_FUNC_FLAGS, 0,
                                                    doltPushFunc, 0, 0);
-  if( rc==SQLITE_OK ) rc = sqlite3_create_function(db, "dolt_fetch", -1, SQLITE_UTF8, 0,
+  if( rc==SQLITE_OK ) rc = sqlite3_create_function(db, "dolt_fetch", -1,
+                                                   DOLTLITE_COMMAND_FUNC_FLAGS, 0,
                                                    doltFetchFunc, 0, 0);
-  if( rc==SQLITE_OK ) rc = sqlite3_create_function(db, "dolt_pull", -1, SQLITE_UTF8, 0,
+  if( rc==SQLITE_OK ) rc = sqlite3_create_function(db, "dolt_pull", -1,
+                                                   DOLTLITE_COMMAND_FUNC_FLAGS, 0,
                                                    doltPullFunc, 0, 0);
-  if( rc==SQLITE_OK ) rc = sqlite3_create_function(db, "dolt_clone", -1, SQLITE_UTF8, 0,
+  if( rc==SQLITE_OK ) rc = sqlite3_create_function(db, "dolt_clone", -1,
+                                                   DOLTLITE_COMMAND_FUNC_FLAGS, 0,
                                                    doltCloneFunc, 0, 0);
 #ifdef DOLTLITE_HAVE_AUTH
-  if( rc==SQLITE_OK ) rc = sqlite3_create_function(db, "dolt_creds_new", -1, SQLITE_UTF8, 0,
+  if( rc==SQLITE_OK ) rc = sqlite3_create_function(db, "dolt_creds_new", -1,
+                                                   DOLTLITE_COMMAND_FUNC_FLAGS, 0,
                                                    doltCredsNewFunc, 0, 0);
-  if( rc==SQLITE_OK ) rc = sqlite3_create_function(db, "dolt_creds", -1, SQLITE_UTF8, 0,
+  if( rc==SQLITE_OK ) rc = sqlite3_create_function(db, "dolt_creds", -1,
+                                                   DOLTLITE_COMMAND_FUNC_FLAGS, 0,
                                                    doltCredsFunc, 0, 0);
 #endif
   if( rc==SQLITE_OK ) rc = sqlite3_create_module(db, "dolt_remotes", &remotesModule, 0);

--- a/src/doltlite_tag.c
+++ b/src/doltlite_tag.c
@@ -287,7 +287,9 @@ static sqlite3_module tagModule = {
 
 int doltliteTagRegister(sqlite3 *db){
   int rc;
-  rc = sqlite3_create_function(db, "dolt_tag", -1, SQLITE_UTF8, 0, doltTagFunc, 0, 0);
+  rc = sqlite3_create_function(db, "dolt_tag", -1,
+                               DOLTLITE_COMMAND_FUNC_FLAGS, 0,
+                               doltTagFunc, 0, 0);
   if( rc==SQLITE_OK ) rc = sqlite3_create_module(db, "dolt_tags", &tagModule, 0);
   return rc;
 }

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -7941,7 +7941,99 @@ static void run_refs_deserialize_overflow_guard(void){
   }
 }
 
+static void run_directonly_dolt_functions(void){
+  static const char *zCommandNames =
+    "'dolt_add','dolt_branch','dolt_checkout','dolt_cherry_pick',"
+    "'dolt_clone','dolt_commit','dolt_config','dolt_conflicts_resolve',"
+    "'dolt_connect_branch','dolt_creds','dolt_creds_new',"
+    "'dolt_default_branch','dolt_fetch','dolt_gc','dolt_merge','dolt_pull',"
+    "'dolt_push','dolt_rebase','dolt_remote','dolt_reset','dolt_revert',"
+    "'dolt_tag','doltlite_internal_materialize_default_column'";
+  sqlite3 *db = 0;
+  char dbpath[256];
+  char *zSql;
+  const char *zResult;
+  int rc;
+
+  printf("=== Direct-Only Dolt Functions Test ===\n\n");
+  make_dbpath(dbpath, sizeof(dbpath), "test_directonly_dolt_functions");
+  removeDbFiles(dbpath);
+  check("directonly_open", open_db(dbpath, &db)==SQLITE_OK);
+  if( !db ) return;
+
+  zSql = sqlite3_mprintf(
+    "SELECT count(*) || '|' || coalesce(sum((flags & %d)!=0),0) "
+    "FROM pragma_function_list WHERE name IN (%s)",
+    SQLITE_DIRECTONLY, zCommandNames);
+  check("directonly_flags_query_allocated", zSql!=0);
+  if( zSql ){
+    zResult = queryScalarText(db, zSql);
+    check("all_command_functions_are_directonly",
+          strcmp(zResult, "23|23")==0);
+    sqlite3_free(zSql);
+  }
+
+  zSql = sqlite3_mprintf(
+    "SELECT count(*) FROM pragma_function_list "
+    "WHERE name IN ('active_branch','dolt_version','dolt_merge_base',"
+    "'dolt_hashof','dolt_hashof_table','dolt_hashof_db',"
+    "'dolt_hashof_catalog') AND (flags & %d)!=0",
+    SQLITE_DIRECTONLY);
+  check("readonly_flags_query_allocated", zSql!=0);
+  if( zSql ){
+    zResult = queryScalarText(db, zSql);
+    check("readonly_functions_are_not_directonly", strcmp(zResult, "0")==0);
+    sqlite3_free(zSql);
+  }
+
+  rc = execSql(db,
+    "CREATE TABLE direct_t(id INTEGER PRIMARY KEY, value TEXT);"
+    "INSERT INTO direct_t VALUES(1,'one');"
+    "SELECT dolt_config('user.name','Direct Only Test');"
+    "SELECT dolt_config('user.email','direct@example.com');"
+    "SELECT dolt_commit('-A','-m','direct call');"
+    "SELECT dolt_branch('feature');"
+    "SELECT dolt_tag('v1');"
+    "SELECT dolt_remote('add','origin','file:///tmp/direct-only-unused');"
+    "SELECT dolt_remote('remove','origin');");
+  check("direct_command_calls_still_work", rc==SQLITE_OK);
+  zResult = queryScalarText(db, "SELECT dolt_gc()");
+  check("direct_gc_call_still_works", strstr(zResult, "ERROR:")==0);
+
+  rc = execSql(db,
+    "CREATE VIEW allowed_dolt_view AS "
+    "SELECT dolt_version() AS version, active_branch() AS branch;");
+  check("readonly_dolt_view_created", rc==SQLITE_OK);
+  zResult = queryScalarText(db, "SELECT branch FROM allowed_dolt_view");
+  check("readonly_dolt_view_works", strcmp(zResult, "main")==0);
+
+  rc = execSql(db, "CREATE VIEW blocked_dolt_view AS SELECT dolt_gc()");
+  check("directonly_view_created", rc==SQLITE_OK);
+  zResult = queryScalarText(db, "SELECT * FROM blocked_dolt_view");
+  check("directonly_view_rejected",
+        strstr(zResult, "unsafe use of dolt_gc()")!=0);
+
+  rc = execSql(db,
+    "CREATE TABLE trigger_t(id INTEGER PRIMARY KEY);"
+    "CREATE TRIGGER blocked_dolt_trigger AFTER INSERT ON trigger_t BEGIN "
+    "SELECT dolt_branch('trigger-branch'); END;");
+  check("directonly_trigger_created", rc==SQLITE_OK);
+  rc = execSqlSilent(db, "INSERT INTO trigger_t VALUES(1)");
+  check("directonly_trigger_rejected", rc==SQLITE_ERROR
+        && strstr(sqlite3_errmsg(db), "unsafe use of dolt_branch()")!=0);
+  check("directonly_trigger_statement_rolled_back",
+        strcmp(queryScalarText(db, "SELECT count(*) FROM trigger_t"), "0")==0);
+  check("directonly_trigger_had_no_branch_side_effect",
+        strcmp(queryScalarText(db,
+          "SELECT count(*) FROM dolt_branches WHERE name='trigger-branch'"),
+          "0")==0);
+
+  sqlite3_close(db);
+  removeDbFiles(dbpath);
+}
+
 static const RegressionCase aCases[] = {
+  { "directonly_dolt_functions", "Direct-Only Dolt Functions Test", run_directonly_dolt_functions },
   { "refs_deserialize_overflow_guard", "Refs Deserialize Overflow Guard Test", run_refs_deserialize_overflow_guard },
   { "backup_safety", "Backup Safety Test", run_backup_safety },
   { "integer_pk_autocommit_append_correctness", "Integer PK Autocommit Append Correctness Test", run_integer_pk_autocommit_append_correctness },


### PR DESCRIPTION
## Summary
- register repository-mutating, GC, remote, and credential SQL functions with `SQLITE_DIRECTONLY`
- keep read-only Dolt helpers available to views and triggers
- verify top-level calls still work and indirect calls fail without applying their statement or repository side effects

## Testing
- `DOLTLITE_BUILD_DIR=build bash test/run_doltlite_regression_case.sh directonly_dolt_functions` (15 passed)
- full C regression suite (309,862 passed)
- `make -C build c-tests` (17/17 gating programs passed)
- `bash test/doltlite_commit.sh build/doltlite` (62 passed)
- `bash test/doltlite_record_format.sh build/doltlite` (6 passed)
- ASan/UBSan focused regression (15 passed; leak detection disabled because unsupported on macOS)
- `make devtest` source checks passed; existing DoltLite fuzz/testfixture incompatibilities stopped the upstream runner

Closes #1698