### PR TITLE
Clean up remotesrv initialization failures

### DIFF
--- a/main.mk
+++ b/main.mk
@@ -2685,6 +2685,7 @@ DOLTLITE_C_TESTS = \
 	three_way_diff_test$(T.exe) \
 	sequence_reload_test$(T.exe) \
 	chunk_store_fork_lock_test$(T.exe) \
+	remotesrv_init_failure_test$(T.exe) \
 	oom_dolt_fault_test$(T.exe)
 
 ancestor_test$(T.exe): $(TOP)/test/ancestor_test.c libdoltlite$(T.lib)
@@ -2729,6 +2730,10 @@ sequence_reload_test$(T.exe): $(TOP)/test/sequence_reload_test.c libdoltlite$(T.
 
 chunk_store_fork_lock_test$(T.exe): $(TOP)/test/chunk_store_fork_lock_test.c libdoltlite$(T.lib)
 	$(T.link) -I. -I$(TOP)/src -o $@ $(TOP)/test/chunk_store_fork_lock_test.c \
+		libdoltlite$(T.lib) -lz -lpthread -lm
+
+remotesrv_init_failure_test$(T.exe): $(TOP)/test/remotesrv_init_failure_test.c libdoltlite$(T.lib)
+	$(T.link) -I. -I$(TOP)/src -o $@ $(TOP)/test/remotesrv_init_failure_test.c \
 		libdoltlite$(T.lib) -lz -lpthread -lm
 
 invariant_test$(T.exe): $(TOP)/test/invariant_test.c libdoltlite$(T.lib)

--- a/src/doltlite_remotesrv.c
+++ b/src/doltlite_remotesrv.c
@@ -863,11 +863,15 @@ static int serverInit(DoltliteServer *pSrv, const DoltliteServeOpts *o){
     zBindAddr = "127.0.0.1";
   }
   if( inet_pton(AF_INET, zBindAddr, &bindIn)!=1 ){
+    serverCleanup(pSrv);
     return SQLITE_ERROR;
   }
 
   pSrv->zDir = dupStr(o->zDir);
-  if( !pSrv->zDir ) return SQLITE_NOMEM;
+  if( !pSrv->zDir ){
+    serverCleanup(pSrv);
+    return SQLITE_NOMEM;
+  }
 
   if( o->authKeysDir && o->authKeysDir[0] ){
     pSrv->authKeysDir = dupStr(o->authKeysDir);
@@ -979,6 +983,25 @@ static void serverCleanup(DoltliteServer *pSrv){
     pthread_mutex_destroy(&pSrv->mutex);
     pSrv->mutexInit = 0;
   }
+}
+
+int doltliteRemoteSrvInitForTest(
+  const DoltliteServeOpts *o,
+  int *pMutexInit,
+  int *pCondInit
+){
+  DoltliteServer server;
+  int rc;
+
+  rc = serverInit(&server, o);
+  *pMutexInit = server.mutexInit;
+  *pCondInit = server.condInit;
+  if( rc==SQLITE_OK ){
+    serverRequestStop(&server);
+    serverJoinWorkers(&server);
+  }
+  serverCleanup(&server);
+  return rc;
 }
 
 int doltliteServeOpts(const DoltliteServeOpts *o){

--- a/test/remotesrv_init_failure_test.c
+++ b/test/remotesrv_init_failure_test.c
@@ -1,0 +1,177 @@
+#include <stdio.h>
+#include <string.h>
+#include "sqlite3.h"
+#include "doltlite_remotesrv.h"
+
+extern int doltliteRemoteSrvInitForTest(
+  const DoltliteServeOpts *o,
+  int *pMutexInit,
+  int *pCondInit
+);
+
+typedef struct FaultAllocator FaultAllocator;
+struct FaultAllocator {
+  sqlite3_mem_methods real;
+  sqlite3_int64 nOutstanding;
+  int nCall;
+  int failAt;
+  int triggered;
+};
+
+static FaultAllocator gFault;
+static int nPass;
+static int nFail;
+
+static void check(const char *zName, int condition){
+  if( condition ){
+    nPass++;
+  }else{
+    nFail++;
+    fprintf(stderr, "FAIL: %s\n", zName);
+  }
+}
+
+static int shouldFail(void){
+  gFault.nCall++;
+  if( gFault.nCall==gFault.failAt ){
+    gFault.triggered = 1;
+    return 1;
+  }
+  return 0;
+}
+
+static void *faultMalloc(int n){
+  void *p;
+  if( shouldFail() ) return 0;
+  p = gFault.real.xMalloc(n);
+  if( p ) gFault.nOutstanding++;
+  return p;
+}
+
+static void faultFree(void *p){
+  if( !p ) return;
+  gFault.nOutstanding--;
+  gFault.real.xFree(p);
+}
+
+static void *faultRealloc(void *p, int n){
+  void *pNew;
+  if( !p ) return faultMalloc(n);
+  if( shouldFail() ) return 0;
+  pNew = gFault.real.xRealloc(p, n);
+  return pNew;
+}
+
+static int faultSize(void *p){
+  return gFault.real.xSize(p);
+}
+
+static int faultRoundup(int n){
+  return gFault.real.xRoundup(n);
+}
+
+static int faultInit(void *pArg){
+  (void)pArg;
+  return gFault.real.xInit
+       ? gFault.real.xInit(gFault.real.pAppData) : SQLITE_OK;
+}
+
+static void faultShutdown(void *pArg){
+  (void)pArg;
+  if( gFault.real.xShutdown ){
+    gFault.real.xShutdown(gFault.real.pAppData);
+  }
+}
+
+static int installFaultAllocator(void){
+  sqlite3_mem_methods wrapped;
+  int rc;
+
+  sqlite3_shutdown();
+  memset(&gFault, 0, sizeof(gFault));
+  gFault.failAt = -1;
+  rc = sqlite3_config(SQLITE_CONFIG_GETMALLOC, &gFault.real);
+  if( rc!=SQLITE_OK ) return rc;
+  wrapped = gFault.real;
+  wrapped.xMalloc = faultMalloc;
+  wrapped.xFree = faultFree;
+  wrapped.xRealloc = faultRealloc;
+  wrapped.xSize = faultSize;
+  wrapped.xRoundup = faultRoundup;
+  wrapped.xInit = faultInit;
+  wrapped.xShutdown = faultShutdown;
+  wrapped.pAppData = 0;
+  rc = sqlite3_config(SQLITE_CONFIG_MALLOC, &wrapped);
+  if( rc!=SQLITE_OK ) return rc;
+  return sqlite3_initialize();
+}
+
+static void setFailure(int failAt){
+  gFault.nCall = 0;
+  gFault.failAt = failAt;
+  gFault.triggered = 0;
+}
+
+int main(void){
+  DoltliteServeOpts opts;
+  sqlite3_int64 nBaseline;
+  int mutexInit;
+  int condInit;
+  int cleanFailures = 1;
+  int rc;
+  int i;
+
+  printf("=== RemoteSrv Initialization Failure Tests ===\n\n");
+  rc = installFaultAllocator();
+  check("install_fault_allocator", rc==SQLITE_OK);
+  if( rc!=SQLITE_OK ) return 1;
+
+  memset(&opts, 0, sizeof(opts));
+  opts.zDir = ".";
+  opts.zBindAddr = "not-a-numeric-address";
+  nBaseline = gFault.nOutstanding;
+
+  setFailure(-1);
+  for(i=0; i<1000; i++){
+    rc = doltliteServeOpts(&opts);
+    if( rc!=SQLITE_ERROR ) cleanFailures = 0;
+    if( doltliteServeAsyncOpts(&opts)!=0 ) cleanFailures = 0;
+  }
+  check("repeated_invalid_address_fails", cleanFailures);
+  check("repeated_invalid_address_frees_allocations",
+        gFault.nOutstanding==nBaseline);
+
+  mutexInit = -1;
+  condInit = -1;
+  rc = doltliteRemoteSrvInitForTest(&opts, &mutexInit, &condInit);
+  check("invalid_address_init_fails", rc==SQLITE_ERROR);
+  check("invalid_address_destroys_mutex", mutexInit==0);
+  check("invalid_address_destroys_condition", condInit==0);
+
+  opts.zBindAddr = "127.0.0.1";
+  setFailure(1);
+  mutexInit = -1;
+  condInit = -1;
+  rc = doltliteRemoteSrvInitForTest(&opts, &mutexInit, &condInit);
+  check("directory_copy_oom_injected", gFault.triggered);
+  check("directory_copy_oom_reported", rc==SQLITE_NOMEM);
+  check("directory_copy_oom_destroys_mutex", mutexInit==0);
+  check("directory_copy_oom_destroys_condition", condInit==0);
+  check("directory_copy_oom_frees_allocations",
+        gFault.nOutstanding==nBaseline);
+
+  setFailure(2);
+  check("async_directory_copy_oom_returns_null",
+        doltliteServeAsyncOpts(&opts)==0);
+  check("async_directory_copy_oom_injected", gFault.triggered);
+  check("async_directory_copy_oom_frees_allocations",
+        gFault.nOutstanding==nBaseline);
+
+  setFailure(-1);
+  sqlite3_shutdown();
+  sqlite3_config(SQLITE_CONFIG_MALLOC, &gFault.real);
+
+  printf("\nResults: %d passed, %d failed out of %d tests\n",
+         nPass, nFail, nPass+nFail);
+  return nFail ? 1 : 0;
+}

--- a/test/run_c_tests.sh
+++ b/test/run_c_tests.sh
@@ -23,6 +23,7 @@ GATING=(
   catalog_serialize_determinism_test
   sequence_reload_test
   chunk_store_fork_lock_test
+  remotesrv_init_failure_test
 )
 
 run_one() {


### PR DESCRIPTION
## Summary
- clean up initialized remotesrv synchronization state when bind-address validation or repository-directory allocation fails
- add a gating C test covering repeated synchronous and asynchronous invalid-address failures
- fault-inject the directory copy and verify synchronization and SQLite allocations return to baseline

## Before/after
- before: initialization regression test failed 4 of 14 assertions
- after: 14 of 14 assertions pass

## Testing
- `make -C build c-tests` (18/18 gating programs passed)
- remotesrv HTTP lifecycle, partial-failure, concurrency, and stalled-client suites (56 passed)
- fresh ASan/UBSan `remotesrv_init_failure_test` (14 passed)
- `test/dead_code_check.sh`
- `make devtest` source checks passed; existing DoltLite fuzz/testfixture incompatibilities stopped the upstream runner

Closes #1699