### PR TITLE
Zero both diff iterators before the first fallible open

### DIFF
--- a/src/prolly_three_way_diff.c
+++ b/src/prolly_three_way_diff.c
@@ -176,6 +176,9 @@ int prollyThreeWayDiff(
   int rcL, rcR;
   int rc = SQLITE_OK;
 
+  memset(&iterL, 0, sizeof(iterL));
+  memset(&iterR, 0, sizeof(iterR));
+
   rcL = prollyDiffIterOpen(&iterL, pStore, pCache,
                            pAncestorRoot, pOursRoot, flags);
   if( rcL!=SQLITE_OK ){

--- a/test/three_way_diff_test.c
+++ b/test/three_way_diff_test.c
@@ -920,6 +920,41 @@ static void test_sorted_output(void){
   printf("  test_sorted_output passed\n");
 }
 
+static void poisonStack(void){
+  volatile u8 buf[8192];
+  memset((void*)buf, 0xEF, sizeof(buf));
+}
+
+static void test_open_failure_cleanup(void){
+  ChunkStore cs;
+  ProllyCache cache;
+  ProllyHash bogus, theirs;
+  int rc;
+  const char *path = "/tmp/test_3wd_openfail";
+
+  rc = openTestStore(&cs, &cache, path);
+  check("open_fail: open", rc==SQLITE_OK);
+
+  {
+    i64 keys[] = {1};
+    const char *vals[] = {"x"};
+    rc = buildTree(&cs, &cache, keys, vals, 1, &theirs);
+    check("open_fail: build theirs", rc==SQLITE_OK);
+  }
+
+  memset(&bogus, 0xAB, sizeof(bogus));
+
+  resetChanges();
+  poisonStack();
+  rc = prollyThreeWayDiff(&cs, &cache, &bogus, &bogus, &theirs,
+                          PROLLY_NODE_INTKEY, collectCallback, 0);
+  check("open_fail: diff returns error", rc!=SQLITE_OK);
+  check("open_fail: no changes emitted", nChanges==0);
+
+  closeTestStore(&cs, &cache, path);
+  printf("  test_open_failure_cleanup passed\n");
+}
+
 int main(void){
   sqlite3_initialize();
   printf("Three-way diff engine unit tests\n");
@@ -943,6 +978,7 @@ int main(void){
   test_conflict_add();
   test_many_rows();
   test_sorted_output();
+  test_open_failure_cleanup();
 
   printf("\n%d passed, %d failed\n", nPass, nFail);
   return nFail>0 ? 1 : 0;


### PR DESCRIPTION
## Problem

`prollyThreeWayDiff` opens `iterL`, then `iterR`, with both sharing a single `cleanup` label that closes them. `prollyDiffIterOpen` only `memset`s the iterator it is handed, and only after it is entered — so a failure opening `iterL` reached `cleanup` with `iterR` still holding uninitialized stack memory. `prollyDiffIterClose` then freed its wild `pCurOld`/`pCurNew`, corrupting the heap or crashing.

Reachable whenever the first open fails:
- a corrupt/unreadable ancestor or ours root (e.g. `dolt_merge` against a damaged merge base), or
- OOM allocating the left cursor.

## Fix

Zero both iterators up front so `cleanup` is safe regardless of how far opening got.

## Test

Adds `test_open_failure_cleanup` to `test/three_way_diff_test.c`. It induces the first-open failure with a non-empty root hash absent from the chunk store, poisoning the stack first so the uninitialized `iterR` reliably holds non-NULL garbage.

Verified by rebuilding the same binary each way (only the 2-line fix differing):
- **Unfixed:** `SIGSEGV` in `prollyCacheRelease(entry=0x…c00000001)` — a wild pointer from the poisoned stack, via `prollyDiffIterClose` on the never-initialized `iterR`.
- **Fixed:** `148 passed, 0 failed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)