### PR TITLE
Guard dolt_diff_summary against a table absent from both refs

### DIFF
--- a/src/doltlite_diff_stat.c
+++ b/src/doltlite_diff_stat.c
@@ -925,6 +925,8 @@ static int dssAppendTableChange(
   int schemaChange;
   const char *zDiffType;
 
+  if( !pFromEntry && !pToEntry ) return SQLITE_OK;
+
   if( pFromEntry && pToEntry ){
     int rootsDiffer = prollyHashCompare(&pFromEntry->root, &pToEntry->root)!=0;
     int schemasDiffer = prollyHashCompare(&pFromEntry->schemaHash,

--- a/test/doltlite_diff.sh
+++ b/test/doltlite_diff.sh
@@ -44,6 +44,10 @@ run_test "diff_summary_between_commits" \
   "SELECT data_change || '|' || schema_change FROM dolt_diff_summary((SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 1), (SELECT commit_hash FROM dolt_log LIMIT 1), 't');" \
   "1|0" "$DB"
 
+run_test "diff_summary_no_such_table" \
+  "SELECT count(*) FROM dolt_diff_summary('main','main','nonexistent');" \
+  "0" "$DB"
+
 run_test "diff_no_such_table" \
   "SELECT count(*) FROM dolt_diff WHERE table_name='nonexistent';" \
   "0" "$DB"


### PR DESCRIPTION
## Problem

`dssAppendTableChange` handled from+to (modified), to-only (added), and from-only (dropped), then fell through to `dsCountRows(db, &pFromEntry->root, ...)`. When the table filter names a table present in **neither** ref, both entries are NULL and that fall-through dereferences a NULL pointer.

`dolt_diff_summary` seeds its candidate-name list with the filter string verbatim (existence unchecked), so this crashes:

```sql
SELECT * FROM dolt_diff_summary('main','main','nonexistent');
```

The sibling `dsComputeTableStats` (backing `dolt_diff_stat`) already guards `if(!hasFrom && !hasTo) return SQLITE_OK` — the summary path simply omitted it.

## Fix

Add the both-NULL short-circuit at the top of `dssAppendTableChange`.

## Test

Adds `diff_summary_no_such_table` to `test/doltlite_diff.sh`. Verified against a rebuilt CLI both ways:
- **Unfixed:** `SIGSEGV` (exit 139) on the query above.
- **Fixed:** returns `0` rows; full suite `41 passed, 0 failed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)