### PR TITLE
Accumulate serialized record size in 64-bit width

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -2977,12 +2977,13 @@ static int serializeUnpackedRecordBuffer(
 ){
   int nField = pRec->nField;
   Mem *aMem = pRec->aMem;
-  u32 nData = 0;
+  i64 nData = 0;
   u32 aType[MAX_RECORD_FIELDS];
   u32 aLen[MAX_RECORD_FIELDS];
   int i;
   u8 *pOut;
   int nHdr, nTotal;
+  i64 nTotal64;
 
   if( nField > MAX_RECORD_FIELDS ) nField = MAX_RECORD_FIELDS;
 
@@ -2995,7 +2996,9 @@ static int serializeUnpackedRecordBuffer(
   for(i=0; i<nField; i++) nHdr += sqlite3VarintLen(aType[i]);
   if( nHdr > MAX_ONEBYTE_HEADER ) nHdr++;
 
-  nTotal = nHdr + (int)nData;
+  nTotal64 = (i64)nHdr + nData;
+  if( nTotal64 > 0x7fffffff ) return SQLITE_TOOBIG;
+  nTotal = (int)nTotal64;
   if( *pnAlloc < nTotal ){
     u8 *pNew = (u8*)sqlite3_realloc(*ppBuf, nTotal);
     if( !pNew ) return SQLITE_NOMEM;


### PR DESCRIPTION
## Summary

`serializeUnpackedRecordBuffer` accumulated per-field lengths into a `u32` and computed `nTotal` as an `int`. Its sibling serializers — `cacheCursorPayloadZeroTail` and the catalog serializer — already accumulate in `i64` and reject totals above `0x7fffffff` with `SQLITE_TOOBIG`. This brings the outlier in line.

## Reachability (defense-in-depth, not a live bug)

The overflow is **not reachable today**: `SQLITE_MAX_LENGTH` is `1e9` (`src/sqliteLimit.h:24`, no override), `sqlite3_limit` clamps to it, and every `UnpackedRecord` reaching this function has already passed `OP_MakeRecord`'s record-size gate — so `nData` stays far below the 2³¹ wrap point.

I verified this empirically: a C harness that raises `SQLITE_LIMIT_LENGTH` to the compile ceiling and attempts a 2.28 GB composite-index record returns a clean `SQLITE_TOOBIG` on the **unfixed** library — no crash, identical to the fixed build. There is intentionally **no regression test**, because no reachable input reproduces the wrap.

The value of the change is consistency with the sibling paths and safety if `SQLITE_MAX_LENGTH` is ever raised above 2³¹.

## Safety

No behavior change on any reachable input. Both call sites already check and propagate the non-OK return and free their serialize buffers. Index/sort-key suites (`doltlite_index_prefix`, `doltlite_nocase_index`, `doltlite_index_vc_matrix`) pass unchanged: 74/74.

🤖 Generated with [Claude Code](https://claude.com/claude-code)