### PR TITLE
Size chunk-count allocations in 64-bit width

### DIFF
--- a/main.mk
+++ b/main.mk
@@ -2683,6 +2683,7 @@ DOLTLITE_C_TESTS = \
 	prepared_stmt_reuse_test$(T.exe) \
 	catalog_serialize_determinism_test$(T.exe) \
 	three_way_diff_test$(T.exe) \
+	prolly_hashset_test$(T.exe) \
 	sequence_reload_test$(T.exe) \
 	chunk_store_fork_lock_test$(T.exe) \
 	remotesrv_init_failure_test$(T.exe) \
@@ -2760,6 +2761,14 @@ three_way_diff_test$(T.exe): $(TOP)/test/three_way_diff_test.c $(LIBOBJS0)
 	$(T.link) -I. -I$(TOP)/src -DDOLTLITE_PROLLY=1 -D_HAVE_SQLITE_CONFIG_H \
 		-o $@ $(TOP)/test/three_way_diff_test.c $(LIBOBJS0) \
 		-lz -lpthread -lm
+
+# prolly_hashset_test includes prolly_hashset.h (which pulls sqliteInt.h via
+# prolly_hash.h), so it needs the same defines as three_way_diff_test; the
+# hashset entry points are exported, so it links the static archive.
+prolly_hashset_test$(T.exe): $(TOP)/test/prolly_hashset_test.c libdoltlite$(T.lib)
+	$(T.link) -I. -I$(TOP)/src -DDOLTLITE_PROLLY=1 -D_HAVE_SQLITE_CONFIG_H \
+		-o $@ $(TOP)/test/prolly_hashset_test.c \
+		libdoltlite$(T.lib) -lz -lpthread -lm
 
 # oom_dolt_fault_test installs a wrapper allocator that fails the Nth
 # malloc, then sweeps N across a series of dolt_* operations. Forks

--- a/src/chunk_index.c
+++ b/src/chunk_index.c
@@ -216,16 +216,19 @@ int csMergeIndex(
   ChunkIndexEntry **ppMerged,
   int *pnMerged
 ){
-  int nTotal = cs->index.nIndex + cs->staging.nPending;
+  i64 nTotal64 = (i64)cs->index.nIndex + (i64)cs->staging.nPending;
+  int nTotal;
   ChunkIndexEntry *aMerged;
   int idxPos, pendPos, outPos;
 
   *ppMerged = 0;
   *pnMerged = 0;
-  if( nTotal == 0 ) return SQLITE_OK;
+  if( nTotal64 == 0 ) return SQLITE_OK;
+  if( nTotal64 > INT_MAX/(int)sizeof(ChunkIndexEntry) ) return SQLITE_TOOBIG;
+  nTotal = (int)nTotal64;
 
-  aMerged = (ChunkIndexEntry *)sqlite3_malloc(
-    nTotal * (int)sizeof(ChunkIndexEntry)
+  aMerged = (ChunkIndexEntry *)sqlite3_malloc64(
+    (sqlite3_uint64)nTotal * sizeof(ChunkIndexEntry)
   );
   if( aMerged == 0 ) return SQLITE_NOMEM;
 

--- a/src/chunk_staging.c
+++ b/src/chunk_staging.c
@@ -248,41 +248,46 @@ int csSearchRecent(ChunkStore *cs, const ProllyHash *pHash, int *pIdx){
 
 int csGrowPending(ChunkStore *cs){
   if( cs->staging.nPending >= cs->staging.nPendingAlloc ){
-    int nNew = cs->staging.nPendingAlloc ? cs->staging.nPendingAlloc * 2 : CS_INIT_PENDING_ALLOC;
-    ChunkIndexEntry *aNew = (ChunkIndexEntry *)sqlite3_realloc(
-      cs->staging.aPending, nNew * (int)sizeof(ChunkIndexEntry)
-    );
+    i64 nNew = cs->staging.nPendingAlloc ? (i64)cs->staging.nPendingAlloc * 2
+                                         : CS_INIT_PENDING_ALLOC;
+    ChunkIndexEntry *aNew;
     i64 *aNewZ;
+    if( nNew > (i64)0x7fffffff/(i64)sizeof(ChunkIndexEntry) ) return SQLITE_NOMEM;
+    aNew = (ChunkIndexEntry *)sqlite3_realloc64(
+      cs->staging.aPending, (sqlite3_uint64)nNew * sizeof(ChunkIndexEntry)
+    );
     if( aNew == 0 ) return SQLITE_NOMEM;
     cs->staging.aPending = aNew;
-    aNewZ = (i64 *)sqlite3_realloc(
-      cs->staging.aPendingZeroTail, nNew * (int)sizeof(i64)
+    aNewZ = (i64 *)sqlite3_realloc64(
+      cs->staging.aPendingZeroTail, (sqlite3_uint64)nNew * sizeof(i64)
     );
     if( aNewZ == 0 ) return SQLITE_NOMEM;
     cs->staging.aPendingZeroTail = aNewZ;
-    cs->staging.nPendingAlloc = nNew;
+    cs->staging.nPendingAlloc = (int)nNew;
   }
   return SQLITE_OK;
 }
 
 int csGrowRecent(ChunkStore *cs, int nAdd){
-  int nNeed = cs->staging.nRecent + nAdd;
+  i64 nNeed = (i64)cs->staging.nRecent + nAdd;
   if( nNeed > cs->staging.nRecentAlloc ){
-    int nNew = cs->staging.nRecentAlloc ? cs->staging.nRecentAlloc * 2 : CS_INIT_PENDING_ALLOC;
+    i64 nNew = cs->staging.nRecentAlloc ? (i64)cs->staging.nRecentAlloc * 2
+                                        : CS_INIT_PENDING_ALLOC;
     ChunkIndexEntry *aNew;
     i64 *aNewZ;
     while( nNew < nNeed ) nNew *= 2;
-    aNew = (ChunkIndexEntry *)sqlite3_realloc(
-      cs->staging.aRecent, nNew * (int)sizeof(ChunkIndexEntry)
+    if( nNew > (i64)0x7fffffff/(i64)sizeof(ChunkIndexEntry) ) return SQLITE_NOMEM;
+    aNew = (ChunkIndexEntry *)sqlite3_realloc64(
+      cs->staging.aRecent, (sqlite3_uint64)nNew * sizeof(ChunkIndexEntry)
     );
     if( aNew == 0 ) return SQLITE_NOMEM;
     cs->staging.aRecent = aNew;
-    aNewZ = (i64 *)sqlite3_realloc(
-      cs->staging.aRecentZeroTail, nNew * (int)sizeof(i64)
+    aNewZ = (i64 *)sqlite3_realloc64(
+      cs->staging.aRecentZeroTail, (sqlite3_uint64)nNew * sizeof(i64)
     );
     if( aNewZ == 0 ) return SQLITE_NOMEM;
     cs->staging.aRecentZeroTail = aNewZ;
-    cs->staging.nRecentAlloc = nNew;
+    cs->staging.nRecentAlloc = (int)nNew;
   }
   return SQLITE_OK;
 }

--- a/src/prolly_hashset.c
+++ b/src/prolly_hashset.c
@@ -11,17 +11,19 @@ static u32 prollyHashSetSlotIndex(const ProllyHash *h, int nSlots){
 }
 
 int prollyHashSetInit(ProllyHashSet *hs, int nCapacity){
-  int n = 256;
-  while( n < nCapacity*2 ) n *= 2;
-  hs->aSlots = sqlite3_malloc(n * sizeof(ProllyHash));
-  hs->aUsed = sqlite3_malloc(n);
+  i64 n = 256;
+  i64 want = (i64)nCapacity * 2;
+  while( n < want ) n *= 2;
+  if( n > (i64)0x7fffffff/(i64)sizeof(ProllyHash) ) return SQLITE_NOMEM;
+  hs->aSlots = sqlite3_malloc64((sqlite3_uint64)n * sizeof(ProllyHash));
+  hs->aUsed = sqlite3_malloc64((sqlite3_uint64)n);
   if( !hs->aSlots || !hs->aUsed ){
     sqlite3_free(hs->aSlots);
     sqlite3_free(hs->aUsed);
     return SQLITE_NOMEM;
   }
-  memset(hs->aUsed, 0, n);
-  hs->nSlots = n;
+  memset(hs->aUsed, 0, (size_t)n);
+  hs->nSlots = (int)n;
   hs->nUsed = 0;
   return SQLITE_OK;
 }
@@ -71,16 +73,17 @@ int prollyHashSetAdd(ProllyHashSet *hs, const ProllyHash *h){
 static int prollyHashSetGrow(ProllyHashSet *hs){
   ProllyHashSet newHs;
   int i, rc;
-  int newSize = hs->nSlots * 2;
-  newHs.aSlots = sqlite3_malloc(newSize * sizeof(ProllyHash));
-  newHs.aUsed = sqlite3_malloc(newSize);
+  i64 newSize = (i64)hs->nSlots * 2;
+  if( newSize > (i64)0x7fffffff/(i64)sizeof(ProllyHash) ) return SQLITE_NOMEM;
+  newHs.aSlots = sqlite3_malloc64((sqlite3_uint64)newSize * sizeof(ProllyHash));
+  newHs.aUsed = sqlite3_malloc64((sqlite3_uint64)newSize);
   if( !newHs.aSlots || !newHs.aUsed ){
     sqlite3_free(newHs.aSlots);
     sqlite3_free(newHs.aUsed);
     return SQLITE_NOMEM;
   }
-  memset(newHs.aUsed, 0, newSize);
-  newHs.nSlots = newSize;
+  memset(newHs.aUsed, 0, (size_t)newSize);
+  newHs.nSlots = (int)newSize;
   newHs.nUsed = 0;
   for(i=0; i<hs->nSlots; i++){
     if( hs->aUsed[i] ){

--- a/test/prolly_hashset_test.c
+++ b/test/prolly_hashset_test.c
@@ -1,0 +1,75 @@
+#include <stdio.h>
+#include <string.h>
+#include "sqliteInt.h"
+#include "prolly_hash.h"
+#include "prolly_hashset.h"
+
+static int nPass = 0;
+static int nFail = 0;
+
+static void check(const char *name, int condition){
+  if( condition ){
+    nPass++;
+  }else{
+    nFail++;
+    fprintf(stderr, "FAIL: %s\n", name);
+  }
+}
+
+static void hashFromInt(ProllyHash *h, u32 v){
+  memset(h, 0, sizeof(*h));
+  h->data[0] = (u8)(v);
+  h->data[1] = (u8)(v>>8);
+  h->data[2] = (u8)(v>>16);
+  h->data[3] = (u8)(v>>24);
+}
+
+static void test_basic(void){
+  ProllyHashSet hs;
+  ProllyHash a, b;
+  int rc, i;
+
+  rc = prollyHashSetInit(&hs, 64);
+  check("basic: init", rc==SQLITE_OK);
+
+  hashFromInt(&a, 1);
+  hashFromInt(&b, 2);
+  check("basic: absent before add", !prollyHashSetContains(&hs, &a));
+  check("basic: add a", prollyHashSetAdd(&hs, &a)==SQLITE_OK);
+  check("basic: present after add", prollyHashSetContains(&hs, &a));
+  check("basic: b still absent", !prollyHashSetContains(&hs, &b));
+  check("basic: add a again idempotent", prollyHashSetAdd(&hs, &a)==SQLITE_OK);
+
+  /* Force several grows to exercise the resize path. */
+  for(i=0; i<1000; i++){
+    ProllyHash h;
+    hashFromInt(&h, (u32)(100+i));
+    if( prollyHashSetAdd(&hs, &h)!=SQLITE_OK ){ check("basic: bulk add", 0); break; }
+  }
+  check("basic: grown member present", prollyHashSetContains(&hs, &a));
+  prollyHashSetFree(&hs);
+}
+
+/* A capacity whose rounded-up slot count times sizeof(ProllyHash) exceeds
+** INT_MAX must be rejected, not silently truncated into an undersized
+** allocation. 1e8 rounds to 2^28 slots; 2^28*20 wraps a 32-bit size. */
+static void test_capacity_overflow_rejected(void){
+  ProllyHashSet hs;
+  int rc;
+  memset(&hs, 0, sizeof(hs));
+  rc = prollyHashSetInit(&hs, 100000000);
+  check("overflow: rejected with NOMEM", rc==SQLITE_NOMEM);
+  if( rc==SQLITE_OK ) prollyHashSetFree(&hs);
+}
+
+int main(void){
+  sqlite3_initialize();
+  printf("Prolly hashset unit tests\n");
+  printf("=========================\n\n");
+
+  test_basic();
+  test_capacity_overflow_rejected();
+
+  printf("\n%d passed, %d failed\n", nPass, nFail);
+  return nFail>0 ? 1 : 0;
+}

--- a/test/run_c_tests.sh
+++ b/test/run_c_tests.sh
@@ -10,6 +10,7 @@ GATING=(
   sql_transaction_test
   invariant_test
   three_way_diff_test
+  prolly_hashset_test
   concurrent_stress_test
   vc_concurrency_test
   vc_ref_mutation_stress_test


### PR DESCRIPTION
## Summary

Several chunk-count-driven allocations sized their buffers with a 32-bit `count * (int)sizeof(...)` product (and, in the hashset, a 32-bit capacity doubling):

- `prollyHashSetInit` / `prollyHashSetGrow` (`src/prolly_hashset.c`) — capacity from the on-disk chunk count via `dolt_gc`
- `csGrowPending` / `csGrowRecent` (`src/chunk_staging.c`) — pending/recent chunks accumulated across a transaction or WAL replay
- `csMergeIndex` (`src/chunk_index.c`) — committed index + pending count

Unlike record/value sizes, these counts are **not** bounded by `SQLITE_MAX_LENGTH`. At tens of millions of chunks the product wraps: `sqlite3_malloc`'s `int` argument truncates a >2 GB size to a small positive value, under-allocating a buffer the caller then fills past its end.

## Fix

Accumulate and bound these in `i64`, reject totals above the `int` ceiling, and allocate with `sqlite3_malloc64` / `sqlite3_realloc64` — matching the existing guards in `csReadIndex` (`chunk_index.c:119`) and the `prolly_node` builders. `prollyHashSetInit` now returns `SQLITE_NOMEM` for a capacity whose slot count would overflow, instead of silently under-allocating.

## Test

Adds `test/prolly_hashset_test.c` (wired into `main.mk` + `run_c_tests.sh`):
- `overflow: rejected with NOMEM` — `prollyHashSetInit(1e8)` (rounds to 2²⁸ slots; ×20 wraps a 32-bit size). **Fails on unfixed** (returns `SQLITE_OK` with an undersized buffer), passes with the fix.
- basic add/contains + forced-grow sanity.

Verified fail-before/pass-after: unfixed `7 passed, 1 failed`; fixed `8 passed, 0 failed`. No regression across `doltlite_gc`, `doltlite_gc_scale`, `doltlite_staging`, `doltlite_conflicts`, `doltlite_merge`, `doltlite_branch_gc_stress` (270 tests) or `ancestor_test` / `three_way_diff_test` / `corruption_test`.

## Deliberately unchanged

The conflicts and constraint-violations table-array allocations (`doltlite_conflicts.c:148`, `doltlite_constraint_violations.c:172`) were flagged in review but left alone: their table count is read via `dlReadU16` (≤ 65535 × a 24-byte struct), so the product cannot overflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)