### PR TITLE
Parse remote HTTP headers exactly

### DIFF
--- a/src/doltlite_remotesrv.c
+++ b/src/doltlite_remotesrv.c
@@ -130,6 +130,40 @@ static int readExact(DoltliteConn *fd, u8 *pBuf, int nBytes){
   return 0;
 }
 
+static int headerNameEquals(
+  const char *zName,
+  int nName,
+  const char *zExpected
+){
+  int nExpected = (int)strlen(zExpected);
+  return nName==nExpected
+      && sqlite3_strnicmp(zName, zExpected, nExpected)==0;
+}
+
+static int parseContentLength(
+  const char *zValue,
+  const char *zEnd,
+  int *pnValue
+){
+  i64 nValue = 0;
+  const char *p = zValue;
+
+  while( p<zEnd && (*p==' ' || *p=='\t') ) p++;
+  while( zEnd>p && (zEnd[-1]==' ' || zEnd[-1]=='\t') ) zEnd--;
+  if( p==zEnd ) return -1;
+
+  while( p<zEnd ){
+    int digit;
+    if( *p<'0' || *p>'9' ) return -1;
+    digit = *p - '0';
+    if( nValue>(MAX_REQUEST_BYTES-digit)/10 ) return -2;
+    nValue = nValue*10 + digit;
+    p++;
+  }
+  *pnValue = (int)nValue;
+  return 0;
+}
+
 static int parseRequest(
   DoltliteConn *fd,
   char *zMethod, int nMethodMax,
@@ -141,6 +175,8 @@ static int parseRequest(
   int nBuf = 0;
   int headerEnd = 0;
   int contentLength = 0;
+  int seenContentLength = 0;
+  int seenAuthorization = 0;
   char *p;
 
   *ppBody = 0;
@@ -183,49 +219,51 @@ static int parseRequest(
     p = pSpace + 1;
   }
 
-  {
-    const char *zCL = "Content-Length:";
-    int nCL = (int)strlen(zCL);
-    char *pLine = strstr(aBuf, zCL);
-    if( !pLine ){
+  p = strstr(aBuf, "\r\n");
+  if( !p ) return -1;
+  p += 2;
+  while( p[0]!='\r' || p[1]!='\n' ){
+    char *pEnd = strstr(p, "\r\n");
+    char *pColon;
+    char *pValue;
+    char *pValueEnd;
+    int nName;
+    int i;
 
-      zCL = "content-length:";
-      pLine = strstr(aBuf, zCL);
+    if( !pEnd ) return -1;
+    pColon = (char*)memchr(p, ':', (size_t)(pEnd - p));
+    if( !pColon || pColon==p ) return -1;
+    nName = (int)(pColon - p);
+    for(i=0; i<nName; i++){
+      if( p[i]==' ' || p[i]=='\t' ) return -1;
     }
-    if( pLine ){
-      pLine += nCL;
-      while( *pLine==' ' || *pLine=='\t' ) pLine++;
-      contentLength = atoi(pLine);
-    }
-  }
+    pValue = pColon + 1;
+    pValueEnd = pEnd;
 
-  if( zAuth && nAuthMax>0 ){
-    const char *zH = "Authorization:";
-    char *pLine = strstr(aBuf, zH);
-    if( !pLine ){
-      zH = "authorization:";
-      pLine = strstr(aBuf, zH);
-    }
-    if( pLine ){
-      char *pEnd;
+    if( headerNameEquals(p, nName, "Content-Length") ){
+      int rc;
+      if( seenContentLength ) return -1;
+      seenContentLength = 1;
+      rc = parseContentLength(pValue, pValueEnd, &contentLength);
+      if( rc!=0 ) return rc;
+    }else if( headerNameEquals(p, nName, "Transfer-Encoding") ){
+      /* Chunked request bodies are not implemented. Reject the request
+      ** instead of treating its first chunk as another HTTP request. */
+      return -1;
+    }else if( zAuth && nAuthMax>0
+           && headerNameEquals(p, nName, "Authorization") ){
       int len;
-      pLine += (int)strlen("Authorization:");
-      while( *pLine==' ' || *pLine=='\t' ) pLine++;
-      pEnd = pLine;
-      while( *pEnd && *pEnd!='\r' && *pEnd!='\n' ) pEnd++;
-      len = (int)(pEnd - pLine);
+      if( seenAuthorization ) return -1;
+      seenAuthorization = 1;
+      while( pValue<pValueEnd && (*pValue==' ' || *pValue=='\t') ) pValue++;
+      while( pValueEnd>pValue
+          && (pValueEnd[-1]==' ' || pValueEnd[-1]=='\t') ) pValueEnd--;
+      len = (int)(pValueEnd - pValue);
       if( len >= nAuthMax ) len = nAuthMax - 1;
-      memcpy(zAuth, pLine, len);
+      memcpy(zAuth, pValue, len);
       zAuth[len] = '\0';
     }
-  }
-
-  /* Reject negative (e.g. integer overflow from atoi) or oversized bodies.
-  ** A hostile peer could send Content-Length: 2147483647 and OOM the host;
-  ** -2 signals the caller to return HTTP 413.
-  */
-  if( contentLength < 0 || contentLength > MAX_REQUEST_BYTES ){
-    return -2;
+    p = pEnd + 2;
   }
 
   if( contentLength > 0 ){

--- a/test/creds_token.c
+++ b/test/creds_token.c
@@ -1,0 +1,28 @@
+#include "doltlite_creds.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(int argc, char **argv) {
+  DoltliteCreds *cred = NULL;
+  char *jwt = NULL;
+
+  if (argc != 3) {
+    fprintf(stderr, "usage: %s CREDS_DIR AUDIENCE\n", argv[0]);
+    return 2;
+  }
+  if (doltliteCredsLoadDefault(argv[1], &cred) != 0 || !cred) {
+    fprintf(stderr, "failed to load credential\n");
+    return 1;
+  }
+  if (doltliteCredsBearerToken(cred, argv[2], &jwt) != 0 || !jwt) {
+    fprintf(stderr, "failed to create bearer token\n");
+    doltliteCredsFree(cred);
+    return 1;
+  }
+
+  puts(jwt);
+  free(jwt);
+  doltliteCredsFree(cred);
+  return 0;
+}

--- a/test/remote_https_auth_test.sh
+++ b/test/remote_https_auth_test.sh
@@ -3,6 +3,8 @@ set -u
 
 DOLTLITE="${1:-$(dirname "$0")/../build/doltlite}"
 REMOTESRV="${2:-$(dirname "$0")/../build/doltlite-remotesrv}"
+HERE=$(cd "$(dirname "$0")/.." && pwd)
+CC="${CC:-cc}"
 TMP=$(mktemp -d)
 SRV_PID=""
 cleanup() {
@@ -136,6 +138,45 @@ clone_rows=$(DOLTLITE_CREDS_DIR="$TMP/cc" "$DOLTLITE" "$TMP/bigclone.db" "SELECT
 check "large clone round-trips 2000 rows" "2000" "$clone_rows"
 clone_hash=$(DOLTLITE_CREDS_DIR="$TMP/cc" "$DOLTLITE" "$TMP/bigclone.db" "SELECT dolt_hashof_table('blobs');" 2>&1)
 check "clone table hash matches source (chunks intact)" "$src_hash" "$clone_hash"
+
+echo "=== 7. Authorization header names are case-insensitive and exact ==="
+DOLTLITE_EXTRA_LIBS=""
+case "$(uname -s)" in MINGW*|MSYS*|CYGWIN*) DOLTLITE_EXTRA_LIBS="-lws2_32 -lbcrypt -lcrypt32";; esac
+"$CC" -O2 -Wall \
+  -I "$HERE/src" -I "$HERE/ext/ed25519" \
+  "$HERE/test/creds_token.c" \
+  "$HERE/src/doltlite_creds.c" \
+  "$HERE/ext/ed25519/fe.c" \
+  "$HERE/ext/ed25519/ge.c" \
+  "$HERE/ext/ed25519/sc.c" \
+  "$HERE/ext/ed25519/sha512.c" \
+  "$HERE/ext/ed25519/keypair.c" \
+  "$HERE/ext/ed25519/sign.c" \
+  "$HERE/ext/ed25519/verify.c" \
+  "$HERE/ext/ed25519/add_scalar.c" \
+  $DOLTLITE_EXTRA_LIBS \
+  -o "$TMP/creds_token" 2>"$TMP/token_build.err" || {
+  echo "FAIL: bearer-token test helper did not build"
+  cat "$TMP/token_build.err"
+  exit 1
+}
+token=$("$TMP/creds_token" "$TMP/cc" localhost) || {
+  echo "FAIL: bearer-token test helper failed"
+  exit 1
+}
+
+tls_request() {
+  local header_name="$1"
+  printf 'GET /repo.db/refs HTTP/1.1\r\nHost: localhost\r\n%s: Bearer %s\r\nConnection: close\r\n\r\n' \
+    "$header_name" "$token" | \
+    openssl s_client -quiet -connect "localhost:$PORT" -servername localhost \
+      -CAfile "$TMP/cert.pem" 2>/dev/null || true
+}
+
+result=$(tls_request "aUtHoRiZaTiOn" | sed -n '1s/.* \([0-9][0-9][0-9]\) .*/\1/p')
+check "mixed-case Authorization is accepted" "200" "$result"
+result=$(tls_request "X-Authorization" | sed -n '1s/.* \([0-9][0-9][0-9]\) .*/\1/p')
+check "X-Authorization is not treated as Authorization" "401" "$result"
 
 echo ""
 echo "======================================="

--- a/test/remotesrv_http_test.sh
+++ b/test/remotesrv_http_test.sh
@@ -81,6 +81,84 @@ restart_server_same_port() {
 mkdir -p "$TMP/srv"
 start_server
 
+echo "--- 0. request header parsing ---"
+result=$(python3 - "$SRV_PORT" <<'PY'
+import socket
+import sys
+
+port = int(sys.argv[1])
+
+def exchange(request):
+    with socket.create_connection(("127.0.0.1", port), timeout=5) as sock:
+        sock.sendall(request)
+        sock.shutdown(socket.SHUT_WR)
+        response = b""
+        while True:
+            try:
+                chunk = sock.recv(4096)
+            except ConnectionResetError:
+                break
+            if not chunk:
+                break
+            response += chunk
+    head, _, body = response.partition(b"\r\n\r\n")
+    lines = head.split(b"\r\n")
+    status = lines[0].split(b" ", 2)[1].decode("ascii")
+    headers = {}
+    for line in lines[1:]:
+        if b":" in line:
+            name, value = line.split(b":", 1)
+            headers[name.strip().lower()] = value.strip()
+    return status, int(headers.get(b"content-length", b"0")), len(body)
+
+mixed = exchange(
+    b"POST /headers.db/has-chunks HTTP/1.1\r\n"
+    b"Host: localhost\r\n"
+    b"cOnTeNt-LeNgTh: 20\r\n\r\n" + b"x" * 20
+)
+prefixed = exchange(
+    b"POST /headers.db/has-chunks HTTP/1.1\r\n"
+    b"Host: localhost\r\n"
+    b"X-Content-Length: 20\r\n\r\n"
+)
+duplicate = exchange(
+    b"POST /headers.db/has-chunks HTTP/1.1\r\n"
+    b"Host: localhost\r\n"
+    b"Content-Length: 0\r\n"
+    b"content-length: 0\r\n\r\n"
+)
+malformed = exchange(
+    b"POST /headers.db/has-chunks HTTP/1.1\r\n"
+    b"Host: localhost\r\n"
+    b"Content-Length: 1x\r\n\r\n"
+)
+oversized = exchange(
+    b"POST /headers.db/has-chunks HTTP/1.1\r\n"
+    b"Host: localhost\r\n"
+    b"Content-Length: 999999999999999999999999\r\n\r\n"
+)
+chunked = exchange(
+    b"POST /headers.db/has-chunks HTTP/1.1\r\n"
+    b"Host: localhost\r\n"
+    b"Transfer-Encoding: chunked\r\n\r\n"
+)
+
+print(f"mixed={mixed[0]}|{mixed[1]}|{mixed[2]}")
+print(f"prefixed={prefixed[0]}|{prefixed[1]}|{prefixed[2]}")
+print(f"duplicate={duplicate[0]}")
+print(f"malformed={malformed[0]}")
+print(f"oversized={oversized[0]}")
+print(f"chunked={chunked[0]}")
+PY
+)
+check "header names are case-insensitive and exact" \
+"mixed=200|1|1
+prefixed=200|0|0
+duplicate=400
+malformed=400
+oversized=413
+chunked=400" "$result"
+
 cat >"$TMP/proxy.py" <<'PY'
 import re
 import socket


### PR DESCRIPTION
## Summary

- parse remote-server headers line by line with exact, case-insensitive field-name matching
- strictly validate Content-Length, reject duplicates and oversized values, and reject unsupported Transfer-Encoding
- prevent prefixed fields such as X-Content-Length and X-Authorization from being treated as protocol headers
- add raw HTTP and authenticated TLS regression coverage

## Tests

- `make -j4 doltlite doltlite-remotesrv`
- `bash ../test/remotesrv_http_test.sh ./doltlite ./doltlite-remotesrv` — 29 passed
- `bash ../test/remote_https_auth_test.sh ./doltlite ./doltlite-remotesrv` — 15 passed
- `git diff --check`