### PR TITLE
Re-confirm branch tip under lock before fast-forward pull

### DIFF
--- a/src/doltlite_remote_sql.c
+++ b/src/doltlite_remote_sql.c
@@ -541,10 +541,33 @@ static void doltPullFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
     return;
   }
 
-  rc = chunkStoreUpdateBranch(cs, zBranch, &trackingCommit);
+  /* Advance and persist the branch under the graph lock, first re-confirming
+  ** the branch's authoritative on-disk tip still matches the one the
+  ** fast-forward was computed from. Holding the lock across the confirm and
+  ** the persist keeps a peer from committing to zBranch in between, which
+  ** would otherwise be clobbered (lost update). */
+  rc = chunkStoreLockAndRefresh(cs);
   if( rc!=SQLITE_OK ){
-    remoteSqlRestoreAndReport(ctx, db, cs, &savedState, SQLITE_ERROR,
-                              "failed to update branch");
+    remoteSqlRestoreAndReport(ctx, db, cs, &savedState, rc, 0);
+    return;
+  }
+  {
+    ProllyHash diskTip;
+    int found = 0;
+    rc = chunkStoreReadDiskBranchTip(cs, zBranch, &diskTip, &found);
+    if( rc==SQLITE_OK && found && prollyHashCompare(&diskTip, &localCommit)!=0 ){
+      rc = SQLITE_BUSY;
+    }
+  }
+  if( rc==SQLITE_OK ) rc = chunkStoreUpdateBranch(cs, zBranch, &trackingCommit);
+  if( rc==SQLITE_OK ) rc = doltliteRemotePersistRefs(cs);
+  chunkStoreUnlock(cs);
+  if( rc!=SQLITE_OK ){
+    remoteSqlRestoreAndReport(ctx, db, cs, &savedState, rc,
+      rc==SQLITE_BUSY
+        ? "pull conflict: another connection committed to this branch. "
+          "Please retry."
+        : "failed to update branch");
     return;
   }
 
@@ -555,12 +578,6 @@ static void doltPullFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
                                 "failed to update working tree from branch");
       return;
     }
-  }
-
-  rc = doltliteRemotePersistRefs(cs);
-  if( rc!=SQLITE_OK ){
-    remoteSqlRestoreAndReport(ctx, db, cs, &savedState, rc, 0);
-    return;
   }
   doltliteTxnStateClear(&savedState);
   rc = doltliteVcSealBranchStyleTxn(db);


### PR DESCRIPTION
## Problem

The fast-forward path of `dolt_pull` (`doltlite_remote_sql.c`) advanced the branch (`chunkStoreUpdateBranch`) and persisted it **without re-confirming** that the branch's authoritative on-disk tip still matched the commit the fast-forward was computed from. A peer that committed to the same branch between the fetch and the advance was silently clobbered — a lost update.

This is the exact hazard the merge fast-forward path already guards against via `doltliteRefreshAndConfirmHead`, and memory note #1098 explicitly lists pull among the multi-step VC ops that must re-confirm head before advancing. (The non-fast-forward path already delegates to `dolt_merge`, which confirms.)

## Fix

Acquire the graph lock, re-read the branch's authoritative on-disk tip (`chunkStoreReadDiskBranchTip`), and CAS it against the fast-forward base before advancing. On mismatch, abort with `SQLITE_BUSY` and leave the peer's commit intact. The advance and persist run under the same continuous lock hold, so no peer can slip in between.

`doltliteRemotePersistRefs` → `chunkStoreCommit` already acquired this lock, so holding it a few lines earlier introduces no new lock interaction — it just closes the confirm→persist window. The session working-tree reset stays after the lock is released, since it rematerializes tables and must not run under the graph lock.

## Testing

No behavior change on the non-concurrent path: `remote_test` (97), `vc_oracle_fetch_pull_convergence_test` (29), `vc_oracle_remotes_test` (34), `vc_oracle_push_default_branch_test` (19), plus rebase/state suites all pass unchanged.

A deterministic regression test is not feasible from the public API: `dolt_pull` is atomic, so triggering the race requires interposing a peer commit mid-pull, which needs test hooks the project does not expose — the same reason the original #1098 merge fix relies on the concurrency stress harness (`vc_concurrency_test.c`) rather than a deterministic unit test. The fix is correct by construction, mirroring the established `mergeFastForward` CAS.

## Scope note

The review also flagged rebase finalize (`doltlite.c`) for the same pattern. That is **intentional** and left unchanged: `test/multi_process_merge_rebase_test.c` documents that "rebase is not atomic against a concurrent peer commit by design."

🤖 Generated with [Claude Code](https://claude.com/claude-code)