### PR TITLE
Propagate the underlying error code from dolt_clone

### DIFF
--- a/main.mk
+++ b/main.mk
@@ -2682,6 +2682,7 @@ DOLTLITE_C_TESTS = \
 	corruption_test$(T.exe) \
 	prepared_stmt_reuse_test$(T.exe) \
 	catalog_serialize_determinism_test$(T.exe) \
+	clone_error_code_test$(T.exe) \
 	three_way_diff_test$(T.exe) \
 	prolly_hashset_test$(T.exe) \
 	sequence_reload_test$(T.exe) \
@@ -2691,6 +2692,10 @@ DOLTLITE_C_TESTS = \
 
 ancestor_test$(T.exe): $(TOP)/test/ancestor_test.c libdoltlite$(T.lib)
 	$(T.link) -I. -I$(TOP)/src -o $@ $(TOP)/test/ancestor_test.c \
+		libdoltlite$(T.lib) -lz -lpthread -lm
+
+clone_error_code_test$(T.exe): $(TOP)/test/clone_error_code_test.c libdoltlite$(T.lib)
+	$(T.link) -I. -I$(TOP)/src -o $@ $(TOP)/test/clone_error_code_test.c \
 		libdoltlite$(T.lib) -lz -lpthread -lm
 
 sql_transaction_test$(T.exe): $(TOP)/test/sql_transaction_test.c libdoltlite$(T.lib)

--- a/src/doltlite_remote_sql.c
+++ b/src/doltlite_remote_sql.c
@@ -643,8 +643,7 @@ static void doltCloneFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   rc = doltliteClone(cs, pRemote);
   pRemote->xClose(pRemote);
   if( rc!=SQLITE_OK ){
-    remoteSqlRestoreAndReport(ctx, db, cs, &savedState, SQLITE_ERROR,
-                              "clone failed");
+    remoteSqlRestoreAndReport(ctx, db, cs, &savedState, rc, "clone failed");
     return;
   }
 

--- a/test/clone_error_code_test.c
+++ b/test/clone_error_code_test.c
@@ -1,0 +1,60 @@
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include "sqlite3.h"
+
+static int nPass = 0;
+static int nFail = 0;
+
+static void check(const char *name, int condition){
+  if( condition ){
+    nPass++;
+  }else{
+    nFail++;
+    fprintf(stderr, "FAIL: %s\n", name);
+  }
+}
+
+/* dolt_clone must surface the underlying error code from doltliteClone rather
+** than flattening every failure to SQLITE_ERROR, so an embedder can react to
+** e.g. SQLITE_AUTH. A file:// remote under a nonexistent parent directory
+** fails the open inside the clone with SQLITE_CANTOPEN. */
+static void test_clone_error_code_propagates(void){
+  sqlite3 *db = 0;
+  char *err = 0;
+  char target[256];
+  char url[256];
+  int rc;
+
+  snprintf(target, sizeof(target), "/tmp/dolt_clone_ec_target_%d.db", (int)getpid());
+  snprintf(url, sizeof(url),
+           "file:///tmp/dolt_clone_ec_nodir_%d/remote.db", (int)getpid());
+  remove(target);
+
+  rc = sqlite3_open(target, &db);
+  check("clone_ec: open target", rc==SQLITE_OK);
+
+  {
+    char sql[512];
+    snprintf(sql, sizeof(sql), "SELECT dolt_clone('%s')", url);
+    rc = sqlite3_exec(db, sql, 0, 0, &err);
+  }
+  check("clone_ec: clone fails", rc!=SQLITE_OK);
+  check("clone_ec: code is CANTOPEN, not flattened to ERROR",
+        sqlite3_extended_errcode(db)==SQLITE_CANTOPEN);
+
+  sqlite3_free(err);
+  sqlite3_close(db);
+  remove(target);
+}
+
+int main(void){
+  sqlite3_initialize();
+  printf("dolt_clone error-code propagation test\n");
+  printf("======================================\n\n");
+
+  test_clone_error_code_propagates();
+
+  printf("\n%d passed, %d failed\n", nPass, nFail);
+  return nFail>0 ? 1 : 0;
+}

--- a/test/run_c_tests.sh
+++ b/test/run_c_tests.sh
@@ -10,6 +10,7 @@ GATING=(
   sql_transaction_test
   invariant_test
   three_way_diff_test
+  clone_error_code_test
   prolly_hashset_test
   concurrent_stress_test
   vc_concurrency_test


### PR DESCRIPTION
Fixes #1711.

## Problem

`doltCloneFunc` reported every `doltliteClone` failure as `SQLITE_ERROR`, discarding the real return code:

```c
if( rc!=SQLITE_OK ){
  remoteSqlRestoreAndReport(ctx, db, cs, &savedState, SQLITE_ERROR, "clone failed");
  return;
}
```

An embedder could not distinguish an auth failure, a missing remote, etc. from a generic error.

## Fix

Pass the real `rc` through. `remoteSqlRestoreAndReport` sets the message then the code, so the "clone failed" message is unchanged while the result code now reflects the cause (e.g. `SQLITE_CANTOPEN`, `SQLITE_NOTFOUND`, `SQLITE_AUTH`).

## Test

Adds `test/clone_error_code_test.c` (wired into `main.mk` + `run_c_tests.sh`): cloning a `file://` remote under a nonexistent parent directory fails the open inside the clone, and the test asserts the surfaced `sqlite3_extended_errcode` is `SQLITE_CANTOPEN` — not the flattened `SQLITE_ERROR`.

Verified fail-before/pass-after: unfixed `2 passed, 1 failed` (code flattened to `SQLITE_ERROR`), fixed `3 passed, 0 failed`. `remote_test` (97) and `vc_oracle_fetch_pull_convergence_test` (29) pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)