### PR TITLE
Add dolt_patch table function

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,20 @@ SELECT * FROM dolt_diff_summary('v1.0', 'HEAD');
 -- Schema-level diff (tables, views, indexes)
 SELECT * FROM dolt_schema_diff('v1.0', 'v2.0');
 
+-- Turn a diff into ordered, executable SQLite statements. The result has
+-- Dolt's statement_order, from_commit_hash, to_commit_hash, table_name,
+-- diff_type, and statement columns. Schema changes that SQLite cannot express
+-- with ALTER TABLE are emitted as an ordered table rebuild.
+SELECT * FROM dolt_patch('v1.0', 'v2.0');
+SELECT * FROM dolt_patch('v1.0', 'v2.0', 'users');
+SELECT * FROM dolt_patch('v1.0..v2.0');
+SELECT * FROM dolt_patch('main...feature', 'users');
+
+-- Generate only data statements; numbering is compacted just as in Dolt.
+SELECT statement FROM dolt_patch('HEAD', 'WORKING')
+ WHERE diff_type = 'data'
+ ORDER BY statement_order;
+
 -- Row-level history for a single table: every INSERT / UPDATE / DELETE
 -- that was ever committed, with real per-column to_/from_ pairs plus
 -- commit metadata and a diff_type. One virtual table per user table,

--- a/main.mk
+++ b/main.mk
@@ -599,7 +599,7 @@ PROLLY_OBJS = $(DOLTLITE_AUTH_OBJS) \
               prolly_mutate.o prolly_check.o prolly_diff.o prolly_three_way_diff.o prolly_three_way_merge.o prolly_btree.o pager_shim.o sortkey.o \
               doltlite.o doltlite_commit.o doltlite_ref.o doltlite_log.o doltlite_commit_ancestors.o doltlite_status.o \
               doltlite_diff.o doltlite_diff_table.o doltlite_workspace.o doltlite_branch.o doltlite_tag.o doltlite_ancestor.o doltlite_merge.o doltlite_conflicts.o \
-              doltlite_gc.o doltlite_chunk_walk.o doltlite_history.o doltlite_at.o doltlite_blame.o doltlite_schema_diff.o doltlite_schemas.o doltlite_diff_stat.o doltlite_record.o \
+              doltlite_gc.o doltlite_chunk_walk.o doltlite_history.o doltlite_at.o doltlite_blame.o doltlite_schema_diff.o doltlite_patch.o doltlite_schemas.o doltlite_diff_stat.o doltlite_record.o \
               doltlite_ignore.o doltlite_hashof.o \
               doltlite_constraint_violations.o \
               doltlite_merge_constraints.o \
@@ -647,7 +647,7 @@ ifeq ($(DOLTLITE_PROLLY),1)
     $(TOP)/src/doltlite_merge.c \
     $(TOP)/src/doltlite_conflicts.c $(TOP)/src/doltlite_gc.c $(TOP)/src/doltlite_chunk_walk.c \
     $(TOP)/src/doltlite_history.c $(TOP)/src/doltlite_at.c $(TOP)/src/doltlite_blame.c \
-    $(TOP)/src/doltlite_schema_diff.c $(TOP)/src/doltlite_schemas.c \
+    $(TOP)/src/doltlite_schema_diff.c $(TOP)/src/doltlite_patch.c $(TOP)/src/doltlite_schemas.c \
     $(TOP)/src/doltlite_diff_stat.c $(TOP)/src/doltlite_record.c $(TOP)/src/doltlite_ignore.c \
     $(TOP)/src/doltlite_hashof.c $(TOP)/src/doltlite_constraint_violations.c \
     $(TOP)/src/doltlite_merge_constraints.c $(TOP)/src/doltlite_dbpage.c \
@@ -1578,6 +1578,9 @@ doltlite_blame.o:	$(TOP)/src/doltlite_blame.c $(DEPS_OBJ_COMMON)
 
 doltlite_schema_diff.o:	$(TOP)/src/doltlite_schema_diff.c $(DEPS_OBJ_COMMON)
 	$(T.cc.sqlite) -c $(TOP)/src/doltlite_schema_diff.c
+
+doltlite_patch.o:	$(TOP)/src/doltlite_patch.c $(DEPS_OBJ_COMMON)
+	$(T.cc.sqlite) -c $(TOP)/src/doltlite_patch.c
 
 doltlite_schemas.o:	$(TOP)/src/doltlite_schemas.c $(DEPS_OBJ_COMMON)
 	$(T.cc.sqlite) -c $(TOP)/src/doltlite_schemas.c

--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -80,6 +80,7 @@ extern int doltliteRegisterHistoryTables(sqlite3 *db);
 extern int doltliteRegisterBlameTables(sqlite3 *db);
 extern int doltliteRefreshConstraintViolationTables(sqlite3 *db);
 extern int doltliteSchemaDiffRegister(sqlite3 *db);
+extern int doltlitePatchRegister(sqlite3 *db);
 extern int doltliteRemoteSqlRegister(sqlite3 *db);
 
 extern int doltliteFindAncestor(sqlite3 *db, const ProllyHash *h1,
@@ -5767,6 +5768,7 @@ int doltliteRegister(sqlite3 *db){
   if( (rc = doltliteRegisterHistoryTables(db))!=SQLITE_OK ) return rc;
   if( (rc = doltliteRegisterBlameTables(db))!=SQLITE_OK ) return rc;
   if( (rc = doltliteSchemaDiffRegister(db))!=SQLITE_OK ) return rc;
+  if( (rc = doltlitePatchRegister(db))!=SQLITE_OK ) return rc;
   if( (rc = doltliteSchemasRegister(db))!=SQLITE_OK ) return rc;
   if( (rc = doltliteDiffStatRegister(db))!=SQLITE_OK ) return rc;
   if( (rc = doltliteRemoteSqlRegister(db))!=SQLITE_OK ) return rc;

--- a/src/doltlite_patch.c
+++ b/src/doltlite_patch.c
@@ -4,6 +4,7 @@
 #include "doltlite_vtab_util.h"
 #include "doltlite_internal.h"
 #include "record_codec.h"
+#include "prolly_cursor.h"
 #include "prolly_diff.h"
 #include "prolly_record.h"
 #include <math.h>
@@ -217,7 +218,65 @@ static int patchTableCmp(const void *a, const void *b){
   return strcmp(zA, zB);
 }
 
+static int patchRootsShareKey(
+  sqlite3 *db,
+  const struct TableEntry *pFrom,
+  const struct TableEntry *pTo
+){
+  ChunkStore *cs;
+  ProllyCache *cache;
+  ProllyCursor fromCur, toCur;
+  int rc, res, found = 0;
+  if( pFrom->flags!=pTo->flags
+   || prollyHashIsEmpty(&pFrom->root)
+   || prollyHashIsEmpty(&pTo->root) ) return 0;
+  cs = doltliteGetChunkStore(db);
+  cache = doltliteGetCache(db);
+  if( !cs || !cache ) return 0;
+  prollyCursorInit(&fromCur,cs,cache,&pFrom->root,pFrom->flags);
+  prollyCursorInit(&toCur,cs,cache,&pTo->root,pTo->flags);
+  rc = prollyCursorFirst(&fromCur,&res);
+  if( rc==SQLITE_OK && res!=0 ) rc = SQLITE_DONE;
+  while( rc==SQLITE_OK && prollyCursorIsValid(&fromCur) ){
+    if( pFrom->flags & BTREE_INTKEY ){
+      rc = prollyCursorSeekInt(&toCur,prollyCursorIntKey(&fromCur),&res);
+    }else{
+      const u8 *pKey = 0;
+      int nKey = 0;
+      prollyCursorKey(&fromCur,&pKey,&nKey);
+      rc = prollyCursorSeekBlob(&toCur,pKey,nKey,&res);
+    }
+    if( rc==SQLITE_OK && res==0 && prollyCursorIsValid(&toCur) ){
+      found = 1;
+      break;
+    }
+    if( rc==SQLITE_OK ) rc = prollyCursorNext(&fromCur);
+  }
+  prollyCursorClose(&fromCur);
+  prollyCursorClose(&toCur);
+  return found;
+}
+
+static int patchIsRenamePair(
+  sqlite3 *db,
+  const struct TableEntry *pFrom,
+  const struct TableEntry *pTo,
+  const SchemaEntry *pFromSchema,
+  const SchemaEntry *pToSchema
+){
+  const char *zFromBody;
+  const char *zToBody;
+  if( pFrom->iTable!=pTo->iTable ) return 0;
+  if( prollyHashCompare(&pFrom->root,&pTo->root)==0 ) return 1;
+  if( !pFromSchema || !pToSchema ) return 0;
+  zFromBody = strchr(pFromSchema->zSql,'(');
+  zToBody = strchr(pToSchema->zSql,'(');
+  if( !zFromBody || !zToBody || strcmp(zFromBody,zToBody)!=0 ) return 0;
+  return patchRootsShareKey(db,pFrom,pTo);
+}
+
 static int patchBuildTables(
+  sqlite3 *db,
   SchemaEntry *aFromSchema, int nFromSchema,
   SchemaEntry *aToSchema, int nToSchema,
   struct TableEntry *aFromTable, int nFromTable,
@@ -244,8 +303,8 @@ static int patchBuildTables(
     if( !pToSchema ) continue;
     /* Names are the durable identity for ordinary changes. Catalog page
     ** numbers can be reused when a table is added or dropped. Only use a
-    ** number to infer a rename when the old name disappeared and the table
-    ** root is unchanged, which is the same safeguard as dolt_schema_diff. */
+    ** number to infer a rename when the old name disappeared and the roots
+    ** are equal, or the schemas match and at least one key survived. */
     for(j=0; j<nFromTable; j++){
       if( aFromUsed[j] || !aFromTable[j].zName ) continue;
       if( strcmp(aFromTable[j].zName,pTo->zName)==0 ){
@@ -254,10 +313,14 @@ static int patchBuildTables(
     }
     if( !pFrom ){
       for(j=0; j<nFromTable; j++){
+        SchemaEntry *pFromSchema;
         if( aFromUsed[j] || !aFromTable[j].zName ) continue;
-        if( aFromTable[j].iTable==pTo->iTable
-         && !doltliteFindTableByName(aToTable,nToTable,aFromTable[j].zName)
-         && prollyHashCompare(&aFromTable[j].root,&pTo->root)==0 ){
+        if( doltliteFindTableByName(aToTable,nToTable,aFromTable[j].zName) ){
+          continue;
+        }
+        pFromSchema = patchFindTableSchema(aFromSchema,nFromSchema,
+                                           aFromTable[j].zName);
+        if( patchIsRenamePair(db,&aFromTable[j],pTo,pFromSchema,pToSchema) ){
           pFrom=&aFromTable[j]; jFrom=j; break;
         }
       }
@@ -361,6 +424,38 @@ static int patchColumnIndex(const PatchSchema *p, const char *zName){
   return -1;
 }
 
+static const char *patchRowidName(const PatchSchema *p){
+  static const char *const azRowid[] = {"rowid", "_rowid_", "oid"};
+  int i;
+  for(i=0; i<ArraySize(azRowid); i++){
+    if( patchColumnIndex(p,azRowid[i])<0 ) return azRowid[i];
+  }
+  return 0;
+}
+
+static int patchHasPrimaryKey(const PatchSchema *p){
+  int i;
+  for(i=0; i<p->col.nCol; i++) if( p->aPk[i]>0 ) return 1;
+  return 0;
+}
+
+static int patchPrimaryKeyChanged(
+  const PatchSchema *pFrom,
+  const PatchSchema *pTo
+){
+  int i, j, nFrom = 0, nTo = 0;
+  for(i=0; i<pFrom->col.nCol; i++) if( pFrom->aPk[i]>0 ) nFrom++;
+  for(i=0; i<pTo->col.nCol; i++) if( pTo->aPk[i]>0 ) nTo++;
+  if( nFrom!=nTo ) return 1;
+  for(i=0; i<pTo->col.nCol; i++){
+    if( pTo->aPk[i]<=0 ) continue;
+    j = patchColumnIndex(pFrom,pTo->col.azName[i]);
+    if( j<0 && pFrom->col.nCol==pTo->col.nCol ) j = i;
+    if( j<0 || pFrom->aPk[j]!=pTo->aPk[i] ) return 1;
+  }
+  return 0;
+}
+
 static int patchAppendAssociated(
   PatchCursor *pCur,
   const char *zTable,
@@ -371,8 +466,7 @@ static int patchAppendAssociated(
   for(i=0; i<nSchema; i++){
     SchemaEntry *p = &aSchema[i];
     if( !p->zTblName || strcmp(p->zTblName, zTable)!=0 || !p->zSql ) continue;
-    if( p->zType && (sqlite3_stricmp(p->zType,"index")==0
-                  || sqlite3_stricmp(p->zType,"trigger")==0) ){
+    if( p->zType && sqlite3_stricmp(p->zType,"index")==0 ){
       rc = patchAppendRow(pCur, zTable, "schema", p->zSql);
       if( rc!=SQLITE_OK ) return rc;
     }
@@ -406,7 +500,10 @@ static int patchAppendObjectDiffs(
     if( !p->zTblName || strcmp(p->zTblName,zTable)!=0 ) continue;
     if( !p->zSql ) continue;
     q = findSchemaEntry(aTo, nTo, p->zName);
-    if( !q || !q->zSql || strcmp(p->zSql,q->zSql)!=0 ){
+    /* Triggers must not run while the patch DML is replayed.  Drop every
+    ** trigger on a changed table, including triggers that are unchanged. */
+    if( (p->zType && sqlite3_stricmp(p->zType,"trigger")==0)
+     || !q || !q->zSql || strcmp(p->zSql,q->zSql)!=0 ){
       rc = patchAppendDropObject(pCur, zTable, p);
       if( rc!=SQLITE_OK ) return rc;
     }
@@ -415,13 +512,32 @@ static int patchAppendObjectDiffs(
     SchemaEntry *p = &aTo[i];
     SchemaEntry *q;
     if( !p->zTblName || strcmp(p->zTblName,zTable)!=0 || !p->zSql ) continue;
-    if( !p->zType || (sqlite3_stricmp(p->zType,"index")!=0
-                   && sqlite3_stricmp(p->zType,"trigger")!=0) ) continue;
+    if( !p->zType || sqlite3_stricmp(p->zType,"index")!=0 ) continue;
     q = findSchemaEntry(aFrom, nFrom, p->zName);
     if( !q || !q->zSql || strcmp(q->zSql,p->zSql)!=0 ){
       rc = patchAppendRow(pCur, zTable, "schema", p->zSql);
       if( rc!=SQLITE_OK ) return rc;
     }
+  }
+  return SQLITE_OK;
+}
+
+static int patchAppendTargetTriggers(
+  PatchCursor *pCur,
+  const PatchTable *pTable,
+  SchemaEntry *aTo,
+  int nTo
+){
+  int i, rc;
+  if( !pTable->pToSchema ) return SQLITE_OK;
+  for(i=0; i<nTo; i++){
+    SchemaEntry *p = &aTo[i];
+    if( !p->zTblName || strcmp(p->zTblName,pTable->zToName)!=0 || !p->zSql ){
+      continue;
+    }
+    if( !p->zType || sqlite3_stricmp(p->zType,"trigger")!=0 ) continue;
+    rc = patchAppendRow(pCur,pTable->zToName,"schema",p->zSql);
+    if( rc!=SQLITE_OK ) return rc;
   }
   return SQLITE_OK;
 }
@@ -464,7 +580,8 @@ static int patchAppendRebuild(
   int nFromSchema,
   SchemaEntry *aToSchema,
   int nToSchema,
-  int iTemp
+  int iTemp,
+  int bCopyData
 ){
   const char *zBody = strchr(pTable->pToSchema->zSql, '(');
   sqlite3_str *pStr;
@@ -490,41 +607,43 @@ static int patchAppendRebuild(
   sqlite3_free(zSql);
   if( rc!=SQLITE_OK ) goto done;
 
-  aUsed = sqlite3_malloc64((sqlite3_uint64)pFrom->col.nCol*sizeof(int));
-  if( pFrom->col.nCol && !aUsed ){ rc = SQLITE_NOMEM; goto done; }
-  memset(aUsed, 0, (size_t)pFrom->col.nCol*sizeof(int));
-  pStr = sqlite3_str_new(0);
-  sqlite3_str_appendall(pStr, "INSERT INTO ");
-  patchAppendIdent(pStr, zTemp);
-  sqlite3_str_appendchar(pStr, 1, '(');
-  for(i=0; i<pTo->col.nCol; i++){
-    j = patchColumnIndex(pFrom, pTo->col.azName[i]);
-    if( j<0 && pFrom->col.nCol==pTo->col.nCol && i<pFrom->col.nCol
-     && !aUsed[i] ) j = i;
-    if( j<0 ) continue;
-    if( nMap++ ) sqlite3_str_appendall(pStr, ",");
-    patchAppendIdent(pStr, pTo->col.azName[i]);
-    aUsed[j] = 1;
+  if( bCopyData ){
+    aUsed = sqlite3_malloc64((sqlite3_uint64)pFrom->col.nCol*sizeof(int));
+    if( pFrom->col.nCol && !aUsed ){ rc = SQLITE_NOMEM; goto done; }
+    memset(aUsed, 0, (size_t)pFrom->col.nCol*sizeof(int));
+    pStr = sqlite3_str_new(0);
+    sqlite3_str_appendall(pStr, "INSERT INTO ");
+    patchAppendIdent(pStr, zTemp);
+    sqlite3_str_appendchar(pStr, 1, '(');
+    for(i=0; i<pTo->col.nCol; i++){
+      j = patchColumnIndex(pFrom, pTo->col.azName[i]);
+      if( j<0 && pFrom->col.nCol==pTo->col.nCol && i<pFrom->col.nCol
+       && !aUsed[i] ) j = i;
+      if( j<0 ) continue;
+      if( nMap++ ) sqlite3_str_appendall(pStr, ",");
+      patchAppendIdent(pStr, pTo->col.azName[i]);
+      aUsed[j] = 1;
+    }
+    sqlite3_str_appendall(pStr, ") SELECT ");
+    nMap = 0;
+    memset(aUsed, 0, (size_t)pFrom->col.nCol*sizeof(int));
+    for(i=0; i<pTo->col.nCol; i++){
+      j = patchColumnIndex(pFrom, pTo->col.azName[i]);
+      if( j<0 && pFrom->col.nCol==pTo->col.nCol && i<pFrom->col.nCol
+       && !aUsed[i] ) j = i;
+      if( j<0 ) continue;
+      if( nMap++ ) sqlite3_str_appendall(pStr, ",");
+      patchAppendIdent(pStr, pFrom->col.azName[j]);
+      aUsed[j] = 1;
+    }
+    sqlite3_str_appendall(pStr, " FROM ");
+    patchAppendIdent(pStr, pTable->zFromName);
+    zSql = sqlite3_str_finish(pStr);
+    if( !zSql ){ rc = SQLITE_NOMEM; goto done; }
+    if( nMap>0 ) rc = patchAppendRow(pCur,pTable->zToName,"schema",zSql);
+    sqlite3_free(zSql);
+    if( rc!=SQLITE_OK ) goto done;
   }
-  sqlite3_str_appendall(pStr, ") SELECT ");
-  nMap = 0;
-  memset(aUsed, 0, (size_t)pFrom->col.nCol*sizeof(int));
-  for(i=0; i<pTo->col.nCol; i++){
-    j = patchColumnIndex(pFrom, pTo->col.azName[i]);
-    if( j<0 && pFrom->col.nCol==pTo->col.nCol && i<pFrom->col.nCol
-     && !aUsed[i] ) j = i;
-    if( j<0 ) continue;
-    if( nMap++ ) sqlite3_str_appendall(pStr, ",");
-    patchAppendIdent(pStr, pFrom->col.azName[j]);
-    aUsed[j] = 1;
-  }
-  sqlite3_str_appendall(pStr, " FROM ");
-  patchAppendIdent(pStr, pTable->zFromName);
-  zSql = sqlite3_str_finish(pStr);
-  if( !zSql ){ rc = SQLITE_NOMEM; goto done; }
-  if( nMap>0 ) rc = patchAppendRow(pCur,pTable->zToName,"schema",zSql);
-  sqlite3_free(zSql);
-  if( rc!=SQLITE_OK ) goto done;
 
   zSql = sqlite3_mprintf("DROP TABLE \"%w\"", pTable->zFromName);
   if( !zSql ){ rc = SQLITE_NOMEM; goto done; }
@@ -667,7 +786,10 @@ static void patchAppendWhere(
   sqlite3_str_appendall(pStr," WHERE ");
   for(i=0; i<pSchema->col.nCol; i++) if( pSchema->aPk[i]>0 ) nPk++;
   if( nPk==0 ){
-    sqlite3_str_appendf(pStr,"rowid=%lld",intKey);
+    const char *zRowid = patchRowidName(pSchema);
+    assert( zRowid!=0 );
+    patchAppendIdent(pStr,zRowid);
+    sqlite3_str_appendf(pStr,"=%lld",intKey);
     return;
   }
   nPk = 0;
@@ -686,20 +808,31 @@ static void patchAppendWhere(
 
 static int patchAppendInsert(PatchCursor *pCur, const char *zTable,
   const PatchSchema *pTo, const u8 *pRec, int nRec, i64 intKey){
-  sqlite3_str *pStr = sqlite3_str_new(0);
+  sqlite3_str *pStr;
   PatchValue v;
+  const char *zRowid;
   char *zSql;
-  int i, rc;
+  int i, nPk = 0, rc;
+  for(i=0; i<pTo->col.nCol; i++) if( pTo->aPk[i]>0 ) nPk++;
+  zRowid = nPk==0 ? patchRowidName(pTo) : 0;
+  if( nPk==0 && !zRowid ){
+    patchSetError(pCur->base.pVtab,
+      "dolt_patch: table '%s' shadows every rowid alias",zTable);
+    return SQLITE_ERROR;
+  }
+  pStr = sqlite3_str_new(0);
   sqlite3_str_appendall(pStr,"INSERT INTO ");
   patchAppendIdent(pStr,zTable);
   sqlite3_str_appendchar(pStr,1,'(');
+  if( zRowid ) patchAppendIdent(pStr,zRowid);
   for(i=0; i<pTo->col.nCol; i++){
-    if( i ) sqlite3_str_appendall(pStr,",");
+    if( i || zRowid ) sqlite3_str_appendall(pStr,",");
     patchAppendIdent(pStr,pTo->col.azName[i]);
   }
   sqlite3_str_appendall(pStr,") VALUES (");
+  if( zRowid ) sqlite3_str_appendf(pStr,"%lld",intKey);
   for(i=0; i<pTo->col.nCol; i++){
-    if( i ) sqlite3_str_appendall(pStr,",");
+    if( i || zRowid ) sqlite3_str_appendall(pStr,",");
     patchGetValue(pTo,pRec,nRec,intKey,i,&v);
     patchAppendValue(pStr,&v);
   }
@@ -713,9 +846,15 @@ static int patchAppendInsert(PatchCursor *pCur, const char *zTable,
 
 static int patchAppendDelete(PatchCursor *pCur, const char *zTable,
   const PatchSchema *pFrom, const u8 *pRec, int nRec, i64 intKey){
-  sqlite3_str *pStr = sqlite3_str_new(0);
+  sqlite3_str *pStr;
   char *zSql;
   int rc;
+  if( !patchHasPrimaryKey(pFrom) && !patchRowidName(pFrom) ){
+    patchSetError(pCur->base.pVtab,
+      "dolt_patch: table '%s' shadows every rowid alias",zTable);
+    return SQLITE_ERROR;
+  }
+  pStr = sqlite3_str_new(0);
   sqlite3_str_appendall(pStr,"DELETE FROM ");
   patchAppendIdent(pStr,zTable);
   patchAppendWhere(pStr,pFrom,pRec,nRec,intKey);
@@ -729,10 +868,16 @@ static int patchAppendDelete(PatchCursor *pCur, const char *zTable,
 static int patchAppendUpdate(PatchCursor *pCur, const char *zTable,
   const PatchSchema *pFrom, const PatchSchema *pTo,
   const u8 *pOld, int nOld, const u8 *pNew, int nNew, i64 intKey){
-  sqlite3_str *pStr = sqlite3_str_new(0);
+  sqlite3_str *pStr;
   PatchValue oldV, newV;
   char *zSql;
   int i, j, nSet = 0, rc;
+  if( !patchHasPrimaryKey(pFrom) && !patchRowidName(pFrom) ){
+    patchSetError(pCur->base.pVtab,
+      "dolt_patch: table '%s' shadows every rowid alias",zTable);
+    return SQLITE_ERROR;
+  }
+  pStr = sqlite3_str_new(0);
   sqlite3_str_appendall(pStr,"UPDATE ");
   patchAppendIdent(pStr,zTable);
   sqlite3_str_appendall(pStr," SET ");
@@ -804,7 +949,7 @@ static int patchAppendData(
     if( pChange->type==PROLLY_DIFF_ADD ){
       rc = patchAppendInsert(pCur,pTable->zToName,pTo,pNew,nNew,pChange->intKey);
     }else if( pChange->type==PROLLY_DIFF_DELETE ){
-      rc = patchAppendDelete(pCur,pTable->zFromName,pFrom,pOld,nOld,pChange->intKey);
+      rc = patchAppendDelete(pCur,pTable->zToName,pFrom,pOld,nOld,pChange->intKey);
     }else{
       rc = patchAppendUpdate(pCur,pTable->zToName,pFrom,pTo,pOld,nOld,pNew,nNew,
                              pChange->intKey);
@@ -818,6 +963,25 @@ data_step_done:
   return rc==SQLITE_DONE ? SQLITE_OK : rc;
 }
 
+static int patchAppendAllData(
+  PatchCursor *pCur,
+  sqlite3 *db,
+  const PatchTable *pTable,
+  const PatchSchema *pTo
+){
+  PatchTable allTo = *pTable;
+  PatchSchema empty;
+  memset(&empty,0,sizeof(empty));
+  allTo.pFromSchema = 0;
+  allTo.pFromTable = 0;
+  allTo.zFromName = 0;
+  return patchAppendData(pCur,db,&allTo,&empty,pTo);
+}
+
+static int patchTableUnchanged(
+  const PatchTable*, SchemaEntry*, int, SchemaEntry*, int
+);
+
 static int patchGenerateTable(
   PatchCursor *pCur,
   sqlite3 *db,
@@ -827,16 +991,11 @@ static int patchGenerateTable(
   int iTemp
 ){
   PatchSchema from, to;
-  int schemaChanged;
+  int schemaChanged, pkChanged = 0;
   int rc = SQLITE_OK;
   memset(&from,0,sizeof(from));
   memset(&to,0,sizeof(to));
-  if( pTable->pFromSchema && pTable->pToSchema
-   && strcmp(pTable->zFromName,pTable->zToName)==0
-   && strcmp(pTable->pFromSchema->zSql,pTable->pToSchema->zSql)==0
-   && prollyHashCompare(&pTable->pFromTable->root,
-                        &pTable->pToTable->root)==0
-   && !patchObjectsDiffer(pTable->zToName,aFromSchema,nFromSchema,
+  if( patchTableUnchanged(pTable,aFromSchema,nFromSchema,
                           aToSchema,nToSchema) ){
     return SQLITE_OK;
   }
@@ -865,17 +1024,36 @@ static int patchGenerateTable(
   schemaChanged = strcmp(pTable->zFromName,pTable->zToName)!=0
       || strcmp(pTable->pFromSchema->zSql,pTable->pToSchema->zSql)!=0;
   if( schemaChanged ){
+    pkChanged = pTable->pFromTable->flags!=pTable->pToTable->flags
+             || patchPrimaryKeyChanged(&from,&to);
     rc = patchAppendRebuild(pCur,pTable,&from,&to,aFromSchema,nFromSchema,
-                            aToSchema,nToSchema,iTemp);
+                            aToSchema,nToSchema,iTemp,!pkChanged);
   }else{
     rc = patchAppendObjectDiffs(pCur,pTable->zToName,
            aFromSchema,nFromSchema,aToSchema,nToSchema);
   }
-  if( rc==SQLITE_OK ) rc=patchAppendData(pCur,db,pTable,&from,&to);
+  if( rc==SQLITE_OK ){
+    if( pkChanged ) rc=patchAppendAllData(pCur,db,pTable,&to);
+    else rc=patchAppendData(pCur,db,pTable,&from,&to);
+  }
 done:
   patchSchemaClear(&from);
   patchSchemaClear(&to);
   return rc;
+}
+
+static int patchTableUnchanged(
+  const PatchTable *pTable,
+  SchemaEntry *aFromSchema, int nFromSchema,
+  SchemaEntry *aToSchema, int nToSchema
+){
+  return pTable->pFromSchema && pTable->pToSchema
+      && strcmp(pTable->zFromName,pTable->zToName)==0
+      && strcmp(pTable->pFromSchema->zSql,pTable->pToSchema->zSql)==0
+      && prollyHashCompare(&pTable->pFromTable->root,
+                           &pTable->pToTable->root)==0
+      && !patchObjectsDiffer(pTable->zToName,aFromSchema,nFromSchema,
+                             aToSchema,nToSchema);
 }
 
 static const char *patchSchemaSql =
@@ -979,6 +1157,20 @@ static int patchFilter(sqlite3_vtab_cursor *pCursor, int idxNum,
     patchSetError(&pVtab->base,"dolt_patch: invalid arguments%s","");
     return SQLITE_ERROR;
   }
+  {
+    const char *zDots = strstr(zArg1,"...");
+    int nDots = 3;
+    if( !zDots ){
+      zDots = strstr(zArg1,"..");
+      nDots = 2;
+    }
+    if( zDots && (zDots==zArg1 || zDots[nDots]==0) ){
+      patchSetError(&pVtab->base,
+                    "dolt_patch: range endpoints must not be empty near '%s'",
+                    zArg1);
+      return SQLITE_ERROR;
+    }
+  }
   rc=doltliteSplitRevisionRange(zArg1,&zLeft,&zRight,&rangeType);
   if( rc==SQLITE_OK ){
     zFrom=zLeft; zTo=zRight; zFilter=zArg2;
@@ -1001,16 +1193,32 @@ static int patchFilter(sqlite3_vtab_cursor *pCursor, int idxNum,
                                                &aFromSchema,&nFromSchema);
   if( rc==SQLITE_OK ) rc=loadSchemaFromCatalog(pVtab->db,cs,pCache,&toCat,
                                                &aToSchema,&nToSchema);
-  if( rc==SQLITE_OK ) rc=patchBuildTables(aFromSchema,nFromSchema,
+  if( rc==SQLITE_OK ) rc=patchBuildTables(pVtab->db,aFromSchema,nFromSchema,
       aToSchema,nToSchema,aFromTable,nFromTable,aToTable,nToTable,&aTable,&nTable);
   for(i=0; rc==SQLITE_OK && i<nTable; i++){
-    if( zFilter && (!aTable[i].zFromName || strcmp(zFilter,aTable[i].zFromName)!=0)
-                && (!aTable[i].zToName || strcmp(zFilter,aTable[i].zToName)!=0) ){
+    if( zFilter && (!aTable[i].zFromName
+                 || sqlite3_stricmp(zFilter,aTable[i].zFromName)!=0)
+                && (!aTable[i].zToName
+                 || sqlite3_stricmp(zFilter,aTable[i].zToName)!=0) ){
       continue;
     }
     found=1;
     rc=patchGenerateTable(pCur,pVtab->db,&aTable[i],aFromSchema,nFromSchema,
                           aToSchema,nToSchema,i+1);
+  }
+  /* Recreate triggers only after every table's data has reached its target
+  ** state.  Otherwise replaying an INSERT or UPDATE can run target triggers
+  ** a second time and make the patch diverge from the target commit. */
+  for(i=0; rc==SQLITE_OK && i<nTable; i++){
+    if( zFilter && (!aTable[i].zFromName
+                 || sqlite3_stricmp(zFilter,aTable[i].zFromName)!=0)
+                && (!aTable[i].zToName
+                 || sqlite3_stricmp(zFilter,aTable[i].zToName)!=0) ){
+      continue;
+    }
+    if( patchTableUnchanged(&aTable[i],aFromSchema,nFromSchema,
+                            aToSchema,nToSchema) ) continue;
+    rc=patchAppendTargetTriggers(pCur,&aTable[i],aToSchema,nToSchema);
   }
   if( rc==SQLITE_OK && zFilter && !found ){
     patchSetError(&pVtab->base,"dolt_patch: table '%s' does not exist",zFilter);

--- a/src/doltlite_patch.c
+++ b/src/doltlite_patch.c
@@ -894,8 +894,10 @@ static int patchAppendUpdate(PatchCursor *pCur, const char *zTable,
     patchAppendValue(pStr,&newV);
   }
   if( nSet==0 ){
-    sqlite3_str_reset(pStr);
-    return SQLITE_OK;
+    rc = sqlite3_str_errcode(pStr);
+    zSql = sqlite3_str_finish(pStr);
+    sqlite3_free(zSql);
+    return rc;
   }
   patchAppendWhere(pStr,pFrom,pOld,nOld,intKey);
   zSql = sqlite3_str_finish(pStr);

--- a/src/doltlite_patch.c
+++ b/src/doltlite_patch.c
@@ -1,0 +1,1076 @@
+#ifdef DOLTLITE_PROLLY
+
+#include "sqliteInt.h"
+#include "doltlite_vtab_util.h"
+#include "doltlite_internal.h"
+#include "record_codec.h"
+#include "prolly_diff.h"
+#include "prolly_record.h"
+#include <math.h>
+#include <string.h>
+
+/* dolt_patch() materializes a diff as executable SQLite statements.  Its
+** public shape and ordering mirror Dolt's table function, but the statements
+** deliberately use SQLite syntax. */
+
+typedef struct PatchRow PatchRow;
+typedef struct PatchVtab PatchVtab;
+typedef struct PatchCursor PatchCursor;
+typedef struct PatchTable PatchTable;
+typedef struct PatchSchema PatchSchema;
+typedef struct PatchValue PatchValue;
+
+struct PatchRow {
+  char *zTable;
+  char *zType;
+  char *zSql;
+};
+
+struct PatchVtab {
+  sqlite3_vtab base;
+  sqlite3 *db;
+};
+
+struct PatchCursor {
+  sqlite3_vtab_cursor base;
+  PatchRow *aRow;
+  int nRow;
+  int nAlloc;
+  int iRow;
+  char *zFrom;
+  char *zTo;
+};
+
+struct PatchTable {
+  SchemaEntry *pFromSchema;
+  SchemaEntry *pToSchema;
+  struct TableEntry *pFromTable;
+  struct TableEntry *pToTable;
+  const char *zFromName;
+  const char *zToName;
+};
+
+struct PatchSchema {
+  sqlite3 *db;
+  DoltliteColInfo col;
+  int *aPk;
+};
+
+struct PatchValue {
+  int eType;
+  i64 i;
+  double r;
+  const u8 *p;
+  int n;
+};
+
+static void patchRowsClear(PatchCursor *pCur){
+  int i;
+  for(i=0; i<pCur->nRow; i++){
+    sqlite3_free(pCur->aRow[i].zTable);
+    sqlite3_free(pCur->aRow[i].zType);
+    sqlite3_free(pCur->aRow[i].zSql);
+  }
+  sqlite3_free(pCur->aRow);
+  sqlite3_free(pCur->zFrom);
+  sqlite3_free(pCur->zTo);
+  pCur->aRow = 0;
+  pCur->nRow = 0;
+  pCur->nAlloc = 0;
+  pCur->iRow = 0;
+  pCur->zFrom = 0;
+  pCur->zTo = 0;
+}
+
+static int patchAppendRow(
+  PatchCursor *pCur,
+  const char *zTable,
+  const char *zType,
+  const char *zSql
+){
+  PatchRow *p;
+  if( !zSql || !zSql[0] ) return SQLITE_OK;
+  if( pCur->nRow>=pCur->nAlloc ){
+    int nNew = pCur->nAlloc ? pCur->nAlloc*2 : 32;
+    PatchRow *aNew = sqlite3_realloc64(pCur->aRow,
+                                      (sqlite3_uint64)nNew*sizeof(PatchRow));
+    if( !aNew ) return SQLITE_NOMEM;
+    pCur->aRow = aNew;
+    pCur->nAlloc = nNew;
+  }
+  p = &pCur->aRow[pCur->nRow];
+  memset(p, 0, sizeof(*p));
+  p->zTable = sqlite3_mprintf("%s", zTable ? zTable : "");
+  p->zType = sqlite3_mprintf("%s", zType ? zType : "");
+  p->zSql = sqlite3_mprintf("%s%s", zSql,
+      zSql[strlen(zSql)-1]==';' ? "" : ";");
+  if( !p->zTable || !p->zType || !p->zSql ){
+    sqlite3_free(p->zTable);
+    sqlite3_free(p->zType);
+    sqlite3_free(p->zSql);
+    memset(p, 0, sizeof(*p));
+    return SQLITE_NOMEM;
+  }
+  pCur->nRow++;
+  return SQLITE_OK;
+}
+
+static void patchSetError(sqlite3_vtab *pVtab, const char *zFmt,
+                          const char *zArg){
+  sqlite3_free(pVtab->zErrMsg);
+  pVtab->zErrMsg = sqlite3_mprintf(zFmt, zArg ? zArg : "");
+}
+
+static int patchResolveOne(
+  sqlite3 *db,
+  sqlite3_vtab *pVtab,
+  const char *zRef,
+  ProllyHash *pCommit,
+  ProllyHash *pCatalog,
+  char **pzLabel
+){
+  int rc;
+  memset(pCommit, 0, sizeof(*pCommit));
+  memset(pCatalog, 0, sizeof(*pCatalog));
+  *pzLabel = 0;
+  if( sqlite3_stricmp(zRef, "WORKING")==0 ){
+    rc = doltliteFlushCatalogToHash(db, pCatalog);
+    if( rc==SQLITE_OK ) *pzLabel = sqlite3_mprintf("WORKING");
+  }else if( sqlite3_stricmp(zRef, "STAGED")==0 ){
+    doltliteGetSessionStaged(db, pCatalog);
+    if( prollyHashIsEmpty(pCatalog) ){
+      rc = doltliteGetHeadCatalogHash(db, pCatalog);
+    }
+    else rc = SQLITE_OK;
+    if( rc==SQLITE_OK ) *pzLabel = sqlite3_mprintf("STAGED");
+  }else{
+    char zHex[PROLLY_HASH_SIZE*2+1];
+    rc = doltliteResolveRef(db, zRef, pCommit);
+    if( rc==SQLITE_OK ) rc = doltliteCommitCatalogHash(db, pCommit, pCatalog);
+    if( rc==SQLITE_OK ){
+      doltliteHashToHex(pCommit, zHex);
+      *pzLabel = sqlite3_mprintf("%s", zHex);
+    }
+  }
+  if( rc!=SQLITE_OK ){
+    patchSetError(pVtab, "dolt_patch: ref '%s' could not be resolved", zRef);
+    return SQLITE_ERROR;
+  }
+  return *pzLabel ? SQLITE_OK : SQLITE_NOMEM;
+}
+
+static int patchResolveArgs(
+  PatchVtab *pVtab,
+  const char *zFromArg,
+  const char *zToArg,
+  int bRange,
+  ProllyHash *pFromCat,
+  ProllyHash *pToCat,
+  char **pzFromLabel,
+  char **pzToLabel
+){
+  ProllyHash fromCommit, toCommit;
+  int rc;
+  rc = patchResolveOne(pVtab->db, &pVtab->base, zFromArg,
+                       &fromCommit, pFromCat, pzFromLabel);
+  if( rc!=SQLITE_OK ) return rc;
+  rc = patchResolveOne(pVtab->db, &pVtab->base, zToArg,
+                       &toCommit, pToCat, pzToLabel);
+  if( rc!=SQLITE_OK ) return rc;
+  if( bRange==DOLTLITE_RANGE_THREE_DOT ){
+    ProllyHash ancestor;
+    char zHex[PROLLY_HASH_SIZE*2+1];
+    if( prollyHashIsEmpty(&fromCommit) || prollyHashIsEmpty(&toCommit) ){
+      patchSetError(&pVtab->base,
+        "dolt_patch: three-dot range requires commit refs, not '%s'",
+        prollyHashIsEmpty(&fromCommit) ? zFromArg : zToArg);
+      return SQLITE_ERROR;
+    }
+    rc = doltliteFindAncestor(pVtab->db, &fromCommit, &toCommit, &ancestor);
+    if( rc!=SQLITE_OK ) return rc;
+    rc = doltliteCommitCatalogHash(pVtab->db, &ancestor, pFromCat);
+    if( rc!=SQLITE_OK ) return rc;
+    doltliteHashToHex(&ancestor, zHex);
+    sqlite3_free(*pzFromLabel);
+    *pzFromLabel = sqlite3_mprintf("%s", zHex);
+    if( !*pzFromLabel ) return SQLITE_NOMEM;
+  }
+  return SQLITE_OK;
+}
+
+static int patchIsTable(const SchemaEntry *p){
+  return p && p->zType && sqlite3_stricmp(p->zType, "table")==0
+      && p->zName && sqlite3_strnicmp(p->zName, "sqlite_", 7)!=0;
+}
+
+static SchemaEntry *patchFindTableSchema(SchemaEntry *a, int n,
+                                         const char *zName){
+  SchemaEntry *p = findSchemaEntry(a, n, zName);
+  return patchIsTable(p) ? p : 0;
+}
+
+static int patchTableCmp(const void *a, const void *b){
+  const PatchTable *pA = (const PatchTable*)a;
+  const PatchTable *pB = (const PatchTable*)b;
+  const char *zA = pA->zToName ? pA->zToName : pA->zFromName;
+  const char *zB = pB->zToName ? pB->zToName : pB->zFromName;
+  return strcmp(zA, zB);
+}
+
+static int patchBuildTables(
+  SchemaEntry *aFromSchema, int nFromSchema,
+  SchemaEntry *aToSchema, int nToSchema,
+  struct TableEntry *aFromTable, int nFromTable,
+  struct TableEntry *aToTable, int nToTable,
+  PatchTable **ppTable, int *pnTable
+){
+  PatchTable *aOut = 0;
+  u8 *aFromUsed = 0;
+  int nOut = 0;
+  int i;
+  if( nFromTable>0 ){
+    aFromUsed = sqlite3_malloc64((sqlite3_uint64)nFromTable);
+    if( !aFromUsed ) return SQLITE_NOMEM;
+    memset(aFromUsed,0,(size_t)nFromTable);
+  }
+  for(i=0; i<nToTable; i++){
+    struct TableEntry *pTo = &aToTable[i];
+    struct TableEntry *pFrom = 0;
+    SchemaEntry *pToSchema;
+    int jFrom = -1;
+    int j;
+    if( pTo->iTable<=1 || !pTo->zName ) continue;
+    pToSchema = patchFindTableSchema(aToSchema, nToSchema, pTo->zName);
+    if( !pToSchema ) continue;
+    /* Names are the durable identity for ordinary changes. Catalog page
+    ** numbers can be reused when a table is added or dropped. Only use a
+    ** number to infer a rename when the old name disappeared and the table
+    ** root is unchanged, which is the same safeguard as dolt_schema_diff. */
+    for(j=0; j<nFromTable; j++){
+      if( aFromUsed[j] || !aFromTable[j].zName ) continue;
+      if( strcmp(aFromTable[j].zName,pTo->zName)==0 ){
+        pFrom=&aFromTable[j]; jFrom=j; break;
+      }
+    }
+    if( !pFrom ){
+      for(j=0; j<nFromTable; j++){
+        if( aFromUsed[j] || !aFromTable[j].zName ) continue;
+        if( aFromTable[j].iTable==pTo->iTable
+         && !doltliteFindTableByName(aToTable,nToTable,aFromTable[j].zName)
+         && prollyHashCompare(&aFromTable[j].root,&pTo->root)==0 ){
+          pFrom=&aFromTable[j]; jFrom=j; break;
+        }
+      }
+    }
+    {
+      PatchTable *aNew = sqlite3_realloc64(
+          aOut,(sqlite3_uint64)(nOut+1)*sizeof(PatchTable));
+      if( !aNew ){
+        sqlite3_free(aFromUsed);
+        sqlite3_free(aOut);
+        return SQLITE_NOMEM;
+      }
+      aOut = aNew;
+    }
+    memset(&aOut[nOut], 0, sizeof(PatchTable));
+    aOut[nOut].pToTable = pTo;
+    aOut[nOut].pToSchema = pToSchema;
+    aOut[nOut].zToName = pTo->zName;
+    if( pFrom && pFrom->iTable>1 && pFrom->zName ){
+      aFromUsed[jFrom]=1;
+      aOut[nOut].pFromTable = pFrom;
+      aOut[nOut].zFromName = pFrom->zName;
+      aOut[nOut].pFromSchema = patchFindTableSchema(aFromSchema, nFromSchema,
+                                                    pFrom->zName);
+    }
+    nOut++;
+  }
+  for(i=0; i<nFromTable; i++){
+    struct TableEntry *pFrom = &aFromTable[i];
+    PatchTable *aNew;
+    if( aFromUsed[i] || pFrom->iTable<=1 || !pFrom->zName ) continue;
+    if( !patchFindTableSchema(aFromSchema, nFromSchema, pFrom->zName) ) continue;
+    aNew = sqlite3_realloc64(aOut, (sqlite3_uint64)(nOut+1)*sizeof(PatchTable));
+    if( !aNew ){
+      sqlite3_free(aFromUsed);
+      sqlite3_free(aOut);
+      return SQLITE_NOMEM;
+    }
+    aOut = aNew;
+    memset(&aOut[nOut], 0, sizeof(PatchTable));
+    aOut[nOut].pFromTable = pFrom;
+    aOut[nOut].pFromSchema = patchFindTableSchema(aFromSchema, nFromSchema,
+                                                  pFrom->zName);
+    aOut[nOut].zFromName = pFrom->zName;
+    nOut++;
+  }
+  qsort(aOut, (size_t)nOut, sizeof(PatchTable), patchTableCmp);
+  sqlite3_free(aFromUsed);
+  *ppTable = aOut;
+  *pnTable = nOut;
+  return SQLITE_OK;
+}
+
+static void patchSchemaClear(PatchSchema *p){
+  doltliteFreeColInfo(&p->col);
+  sqlite3_free(p->aPk);
+  if( p->db ) sqlite3_close(p->db);
+  memset(p, 0, sizeof(*p));
+}
+
+static int patchSchemaLoad(const SchemaEntry *pEntry, PatchSchema *pOut){
+  sqlite3_stmt *pStmt = 0;
+  char *zPragma = 0;
+  int rc;
+  int i = 0;
+  memset(pOut, 0, sizeof(*pOut));
+  if( !pEntry || !pEntry->zSql ) return SQLITE_NOTFOUND;
+  rc = sqlite3_open(":memory:", &pOut->db);
+  if( rc!=SQLITE_OK ) goto done;
+  rc = sqlite3_exec(pOut->db, pEntry->zSql, 0, 0, 0);
+  if( rc!=SQLITE_OK ) goto done;
+  rc = doltliteGetColumnNames(pOut->db, pEntry->zName, &pOut->col);
+  if( rc!=SQLITE_OK ) goto done;
+  pOut->aPk = sqlite3_malloc64((sqlite3_uint64)pOut->col.nCol*sizeof(int));
+  if( pOut->col.nCol && !pOut->aPk ){ rc = SQLITE_NOMEM; goto done; }
+  memset(pOut->aPk, 0, (size_t)pOut->col.nCol*sizeof(int));
+  zPragma = sqlite3_mprintf("PRAGMA main.table_info(\"%w\")", pEntry->zName);
+  if( !zPragma ){ rc = SQLITE_NOMEM; goto done; }
+  rc = sqlite3_prepare_v2(pOut->db, zPragma, -1, &pStmt, 0);
+  if( rc!=SQLITE_OK ) goto done;
+  while( (rc=sqlite3_step(pStmt))==SQLITE_ROW && i<pOut->col.nCol ){
+    pOut->aPk[i++] = sqlite3_column_int(pStmt, 5);
+  }
+  if( rc==SQLITE_DONE ) rc = SQLITE_OK;
+done:
+  sqlite3_finalize(pStmt);
+  sqlite3_free(zPragma);
+  if( rc!=SQLITE_OK ) patchSchemaClear(pOut);
+  return rc;
+}
+
+static void patchAppendIdent(sqlite3_str *pStr, const char *zName){
+  sqlite3_str_appendf(pStr, "\"%w\"", zName);
+}
+
+static int patchColumnIndex(const PatchSchema *p, const char *zName){
+  int i;
+  for(i=0; i<p->col.nCol; i++){
+    if( strcmp(p->col.azName[i], zName)==0 ) return i;
+  }
+  return -1;
+}
+
+static int patchAppendAssociated(
+  PatchCursor *pCur,
+  const char *zTable,
+  SchemaEntry *aSchema,
+  int nSchema
+){
+  int i, rc;
+  for(i=0; i<nSchema; i++){
+    SchemaEntry *p = &aSchema[i];
+    if( !p->zTblName || strcmp(p->zTblName, zTable)!=0 || !p->zSql ) continue;
+    if( p->zType && (sqlite3_stricmp(p->zType,"index")==0
+                  || sqlite3_stricmp(p->zType,"trigger")==0) ){
+      rc = patchAppendRow(pCur, zTable, "schema", p->zSql);
+      if( rc!=SQLITE_OK ) return rc;
+    }
+  }
+  return SQLITE_OK;
+}
+
+static int patchAppendDropObject(PatchCursor *pCur, const char *zTable,
+                                 const SchemaEntry *p){
+  char *zSql;
+  int rc;
+  if( !p->zType || !p->zName ) return SQLITE_OK;
+  if( sqlite3_stricmp(p->zType,"index")!=0
+   && sqlite3_stricmp(p->zType,"trigger")!=0 ) return SQLITE_OK;
+  zSql = sqlite3_mprintf("DROP %s \"%w\"", p->zType, p->zName);
+  if( !zSql ) return SQLITE_NOMEM;
+  rc = patchAppendRow(pCur, zTable, "schema", zSql);
+  sqlite3_free(zSql);
+  return rc;
+}
+
+static int patchAppendObjectDiffs(
+  PatchCursor *pCur, const char *zTable,
+  SchemaEntry *aFrom, int nFrom,
+  SchemaEntry *aTo, int nTo
+){
+  int i, rc;
+  for(i=0; i<nFrom; i++){
+    SchemaEntry *p = &aFrom[i];
+    SchemaEntry *q;
+    if( !p->zTblName || strcmp(p->zTblName,zTable)!=0 ) continue;
+    if( !p->zSql ) continue;
+    q = findSchemaEntry(aTo, nTo, p->zName);
+    if( !q || !q->zSql || strcmp(p->zSql,q->zSql)!=0 ){
+      rc = patchAppendDropObject(pCur, zTable, p);
+      if( rc!=SQLITE_OK ) return rc;
+    }
+  }
+  for(i=0; i<nTo; i++){
+    SchemaEntry *p = &aTo[i];
+    SchemaEntry *q;
+    if( !p->zTblName || strcmp(p->zTblName,zTable)!=0 || !p->zSql ) continue;
+    if( !p->zType || (sqlite3_stricmp(p->zType,"index")!=0
+                   && sqlite3_stricmp(p->zType,"trigger")!=0) ) continue;
+    q = findSchemaEntry(aFrom, nFrom, p->zName);
+    if( !q || !q->zSql || strcmp(q->zSql,p->zSql)!=0 ){
+      rc = patchAppendRow(pCur, zTable, "schema", p->zSql);
+      if( rc!=SQLITE_OK ) return rc;
+    }
+  }
+  return SQLITE_OK;
+}
+
+static int patchObjectsDiffer(
+  const char *zTable,
+  SchemaEntry *aFrom, int nFrom,
+  SchemaEntry *aTo, int nTo
+){
+  int i;
+  for(i=0; i<nFrom; i++){
+    SchemaEntry *p = &aFrom[i];
+    SchemaEntry *q;
+    if( !p->zTblName || strcmp(p->zTblName,zTable)!=0 ) continue;
+    if( !p->zSql ) continue;
+    if( !p->zType || (sqlite3_stricmp(p->zType,"index")!=0
+                   && sqlite3_stricmp(p->zType,"trigger")!=0) ) continue;
+    q = findSchemaEntry(aTo,nTo,p->zName);
+    if( !q || !q->zSql || strcmp(p->zSql,q->zSql)!=0 ) return 1;
+  }
+  for(i=0; i<nTo; i++){
+    SchemaEntry *p = &aTo[i];
+    SchemaEntry *q;
+    if( !p->zTblName || strcmp(p->zTblName,zTable)!=0 ) continue;
+    if( !p->zSql ) continue;
+    if( !p->zType || (sqlite3_stricmp(p->zType,"index")!=0
+                   && sqlite3_stricmp(p->zType,"trigger")!=0) ) continue;
+    q = findSchemaEntry(aFrom,nFrom,p->zName);
+    if( !q || !q->zSql || strcmp(p->zSql,q->zSql)!=0 ) return 1;
+  }
+  return 0;
+}
+
+static int patchAppendRebuild(
+  PatchCursor *pCur,
+  const PatchTable *pTable,
+  const PatchSchema *pFrom,
+  const PatchSchema *pTo,
+  SchemaEntry *aFromSchema,
+  int nFromSchema,
+  SchemaEntry *aToSchema,
+  int nToSchema,
+  int iTemp
+){
+  const char *zBody = strchr(pTable->pToSchema->zSql, '(');
+  sqlite3_str *pStr;
+  char *zSql;
+  char *zTemp = 0;
+  int *aUsed = 0;
+  int i, j, nMap = 0, rc = SQLITE_OK;
+  if( !zBody ) return SQLITE_CORRUPT;
+  do{
+    sqlite3_free(zTemp);
+    zTemp = sqlite3_mprintf("__doltlite_patch_%d", iTemp++);
+    if( !zTemp ) return SQLITE_NOMEM;
+  }while( findSchemaEntry(aFromSchema,nFromSchema,zTemp)
+       || findSchemaEntry(aToSchema,nToSchema,zTemp) );
+
+  pStr = sqlite3_str_new(0);
+  sqlite3_str_appendall(pStr, "CREATE TABLE ");
+  patchAppendIdent(pStr, zTemp);
+  sqlite3_str_appendall(pStr, zBody);
+  zSql = sqlite3_str_finish(pStr);
+  if( !zSql ){ rc = SQLITE_NOMEM; goto done; }
+  rc = patchAppendRow(pCur, pTable->zToName, "schema", zSql);
+  sqlite3_free(zSql);
+  if( rc!=SQLITE_OK ) goto done;
+
+  aUsed = sqlite3_malloc64((sqlite3_uint64)pFrom->col.nCol*sizeof(int));
+  if( pFrom->col.nCol && !aUsed ){ rc = SQLITE_NOMEM; goto done; }
+  memset(aUsed, 0, (size_t)pFrom->col.nCol*sizeof(int));
+  pStr = sqlite3_str_new(0);
+  sqlite3_str_appendall(pStr, "INSERT INTO ");
+  patchAppendIdent(pStr, zTemp);
+  sqlite3_str_appendchar(pStr, 1, '(');
+  for(i=0; i<pTo->col.nCol; i++){
+    j = patchColumnIndex(pFrom, pTo->col.azName[i]);
+    if( j<0 && pFrom->col.nCol==pTo->col.nCol && i<pFrom->col.nCol
+     && !aUsed[i] ) j = i;
+    if( j<0 ) continue;
+    if( nMap++ ) sqlite3_str_appendall(pStr, ",");
+    patchAppendIdent(pStr, pTo->col.azName[i]);
+    aUsed[j] = 1;
+  }
+  sqlite3_str_appendall(pStr, ") SELECT ");
+  nMap = 0;
+  memset(aUsed, 0, (size_t)pFrom->col.nCol*sizeof(int));
+  for(i=0; i<pTo->col.nCol; i++){
+    j = patchColumnIndex(pFrom, pTo->col.azName[i]);
+    if( j<0 && pFrom->col.nCol==pTo->col.nCol && i<pFrom->col.nCol
+     && !aUsed[i] ) j = i;
+    if( j<0 ) continue;
+    if( nMap++ ) sqlite3_str_appendall(pStr, ",");
+    patchAppendIdent(pStr, pFrom->col.azName[j]);
+    aUsed[j] = 1;
+  }
+  sqlite3_str_appendall(pStr, " FROM ");
+  patchAppendIdent(pStr, pTable->zFromName);
+  zSql = sqlite3_str_finish(pStr);
+  if( !zSql ){ rc = SQLITE_NOMEM; goto done; }
+  if( nMap>0 ) rc = patchAppendRow(pCur,pTable->zToName,"schema",zSql);
+  sqlite3_free(zSql);
+  if( rc!=SQLITE_OK ) goto done;
+
+  zSql = sqlite3_mprintf("DROP TABLE \"%w\"", pTable->zFromName);
+  if( !zSql ){ rc = SQLITE_NOMEM; goto done; }
+  rc = patchAppendRow(pCur,pTable->zToName,"schema",zSql);
+  sqlite3_free(zSql);
+  if( rc!=SQLITE_OK ) goto done;
+  zSql = sqlite3_mprintf("ALTER TABLE \"%w\" RENAME TO \"%w\"",
+                         zTemp, pTable->zToName);
+  if( !zSql ){ rc = SQLITE_NOMEM; goto done; }
+  rc = patchAppendRow(pCur,pTable->zToName,"schema",zSql);
+  sqlite3_free(zSql);
+  if( rc==SQLITE_OK ){
+    rc = patchAppendAssociated(pCur,pTable->zToName,aToSchema,nToSchema);
+  }
+done:
+  sqlite3_free(aUsed);
+  sqlite3_free(zTemp);
+  return rc;
+}
+
+static void patchGetValue(
+  const PatchSchema *pSchema,
+  const u8 *pRec, int nRec,
+  i64 intKey,
+  int iCol,
+  PatchValue *pOut
+){
+  DoltliteRecordInfo ri;
+  int iField, st, off, n;
+  memset(pOut, 0, sizeof(*pOut));
+  pOut->eType = SQLITE_NULL;
+  if( iCol==pSchema->col.iPkCol && iCol>=0 ){
+    pOut->eType = SQLITE_INTEGER;
+    pOut->i = intKey;
+    return;
+  }
+  if( !pRec || nRec<=0 ) return;
+  doltliteParseRecord(pRec, nRec, &ri);
+  iField = pSchema->col.aColToRec ? pSchema->col.aColToRec[iCol] : iCol;
+  if( iField<0 || iField>=ri.nField ) return;
+  st = ri.aType[iField];
+  off = ri.aOffset[iField];
+  if( st==0 ) return;
+  if( st==8 || st==9 ){
+    pOut->eType = SQLITE_INTEGER; pOut->i = st==9; return;
+  }
+  if( st>=1 && st<=6 ){
+    n = dlSerialTypeLen((u64)st);
+    if( off>=0 && off<=nRec-n ){
+      pOut->eType = SQLITE_INTEGER;
+      pOut->i = dlReadIntBytes(pRec+off, n);
+    }
+    return;
+  }
+  if( st==7 && off>=0 && off<=nRec-8 ){
+    u64 bits = 0;
+    int i;
+    for(i=0; i<8; i++) bits = (bits<<8) | pRec[off+i];
+    pOut->eType = SQLITE_FLOAT;
+    memcpy(&pOut->r, &bits, 8);
+    return;
+  }
+  if( st>=12 ){
+    n = dlSerialTypeLen((u64)st);
+    if( off>=0 && off<=nRec-n ){
+      pOut->eType = (st&1) ? SQLITE_TEXT : SQLITE_BLOB;
+      pOut->p = pRec+off;
+      pOut->n = n;
+    }
+  }
+}
+
+static void patchAppendHex(sqlite3_str *pStr, const u8 *p, int n){
+  static const char zHex[] = "0123456789ABCDEF";
+  int i;
+  for(i=0; i<n; i++){
+    char z[2];
+    z[0] = zHex[p[i]>>4];
+    z[1] = zHex[p[i]&15];
+    sqlite3_str_append(pStr, z, 2);
+  }
+}
+
+static void patchAppendValue(sqlite3_str *pStr, const PatchValue *pVal){
+  int i, hasNul = 0;
+  switch( pVal->eType ){
+    case SQLITE_INTEGER:
+      sqlite3_str_appendf(pStr, "%lld", pVal->i);
+      break;
+    case SQLITE_FLOAT:
+      if( sqlite3IsNaN(pVal->r) ) sqlite3_str_appendall(pStr, "NULL");
+      else if( isinf(pVal->r) ) sqlite3_str_appendf(pStr,
+          pVal->r<0 ? "-9.0e999" : "9.0e999");
+      else sqlite3_str_appendf(pStr, "%!.17g", pVal->r);
+      break;
+    case SQLITE_TEXT:
+      for(i=0; i<pVal->n; i++) if( pVal->p[i]==0 ){ hasNul=1; break; }
+      if( hasNul ){
+        sqlite3_str_appendall(pStr, "CAST(X'");
+        patchAppendHex(pStr,pVal->p,pVal->n);
+        sqlite3_str_appendall(pStr, "' AS TEXT)");
+      }else{
+        sqlite3_str_appendchar(pStr,1,'\'');
+        for(i=0; i<pVal->n; i++){
+          if( pVal->p[i]=='\'' ) sqlite3_str_appendchar(pStr,1,'\'');
+          sqlite3_str_appendchar(pStr,1,(char)pVal->p[i]);
+        }
+        sqlite3_str_appendchar(pStr,1,'\'');
+      }
+      break;
+    case SQLITE_BLOB:
+      sqlite3_str_appendall(pStr,"X'");
+      patchAppendHex(pStr,pVal->p,pVal->n);
+      sqlite3_str_appendchar(pStr,1,'\'');
+      break;
+    default:
+      sqlite3_str_appendall(pStr,"NULL");
+      break;
+  }
+}
+
+static int patchValuesEqual(const PatchValue *a, const PatchValue *b){
+  if( a->eType!=b->eType ) return 0;
+  switch( a->eType ){
+    case SQLITE_NULL: return 1;
+    case SQLITE_INTEGER: return a->i==b->i;
+    case SQLITE_FLOAT: return a->r==b->r;
+    default: return a->n==b->n && memcmp(a->p,b->p,(size_t)a->n)==0;
+  }
+}
+
+static void patchAppendWhere(
+  sqlite3_str *pStr,
+  const PatchSchema *pSchema,
+  const u8 *pRec, int nRec,
+  i64 intKey
+){
+  int i, nPk = 0;
+  PatchValue v;
+  sqlite3_str_appendall(pStr," WHERE ");
+  for(i=0; i<pSchema->col.nCol; i++) if( pSchema->aPk[i]>0 ) nPk++;
+  if( nPk==0 ){
+    sqlite3_str_appendf(pStr,"rowid=%lld",intKey);
+    return;
+  }
+  nPk = 0;
+  for(i=0; i<pSchema->col.nCol; i++){
+    if( pSchema->aPk[i]<=0 ) continue;
+    if( nPk++ ) sqlite3_str_appendall(pStr," AND ");
+    patchAppendIdent(pStr,pSchema->col.azName[i]);
+    patchGetValue(pSchema,pRec,nRec,intKey,i,&v);
+    if( v.eType==SQLITE_NULL ) sqlite3_str_appendall(pStr," IS NULL");
+    else{
+      sqlite3_str_appendchar(pStr,1,'=');
+      patchAppendValue(pStr,&v);
+    }
+  }
+}
+
+static int patchAppendInsert(PatchCursor *pCur, const char *zTable,
+  const PatchSchema *pTo, const u8 *pRec, int nRec, i64 intKey){
+  sqlite3_str *pStr = sqlite3_str_new(0);
+  PatchValue v;
+  char *zSql;
+  int i, rc;
+  sqlite3_str_appendall(pStr,"INSERT INTO ");
+  patchAppendIdent(pStr,zTable);
+  sqlite3_str_appendchar(pStr,1,'(');
+  for(i=0; i<pTo->col.nCol; i++){
+    if( i ) sqlite3_str_appendall(pStr,",");
+    patchAppendIdent(pStr,pTo->col.azName[i]);
+  }
+  sqlite3_str_appendall(pStr,") VALUES (");
+  for(i=0; i<pTo->col.nCol; i++){
+    if( i ) sqlite3_str_appendall(pStr,",");
+    patchGetValue(pTo,pRec,nRec,intKey,i,&v);
+    patchAppendValue(pStr,&v);
+  }
+  sqlite3_str_appendchar(pStr,1,')');
+  zSql = sqlite3_str_finish(pStr);
+  if( !zSql ) return SQLITE_NOMEM;
+  rc = patchAppendRow(pCur,zTable,"data",zSql);
+  sqlite3_free(zSql);
+  return rc;
+}
+
+static int patchAppendDelete(PatchCursor *pCur, const char *zTable,
+  const PatchSchema *pFrom, const u8 *pRec, int nRec, i64 intKey){
+  sqlite3_str *pStr = sqlite3_str_new(0);
+  char *zSql;
+  int rc;
+  sqlite3_str_appendall(pStr,"DELETE FROM ");
+  patchAppendIdent(pStr,zTable);
+  patchAppendWhere(pStr,pFrom,pRec,nRec,intKey);
+  zSql = sqlite3_str_finish(pStr);
+  if( !zSql ) return SQLITE_NOMEM;
+  rc = patchAppendRow(pCur,zTable,"data",zSql);
+  sqlite3_free(zSql);
+  return rc;
+}
+
+static int patchAppendUpdate(PatchCursor *pCur, const char *zTable,
+  const PatchSchema *pFrom, const PatchSchema *pTo,
+  const u8 *pOld, int nOld, const u8 *pNew, int nNew, i64 intKey){
+  sqlite3_str *pStr = sqlite3_str_new(0);
+  PatchValue oldV, newV;
+  char *zSql;
+  int i, j, nSet = 0, rc;
+  sqlite3_str_appendall(pStr,"UPDATE ");
+  patchAppendIdent(pStr,zTable);
+  sqlite3_str_appendall(pStr," SET ");
+  for(i=0; i<pTo->col.nCol; i++){
+    if( pTo->aPk[i]>0 ) continue;
+    j = patchColumnIndex(pFrom,pTo->col.azName[i]);
+    patchGetValue(pTo,pNew,nNew,intKey,i,&newV);
+    if( j>=0 ) patchGetValue(pFrom,pOld,nOld,intKey,j,&oldV);
+    else memset(&oldV,0,sizeof(oldV));
+    if( j>=0 && patchValuesEqual(&oldV,&newV) ) continue;
+    if( nSet++ ) sqlite3_str_appendall(pStr,",");
+    patchAppendIdent(pStr,pTo->col.azName[i]);
+    sqlite3_str_appendchar(pStr,1,'=');
+    patchAppendValue(pStr,&newV);
+  }
+  if( nSet==0 ){
+    sqlite3_str_reset(pStr);
+    return SQLITE_OK;
+  }
+  patchAppendWhere(pStr,pFrom,pOld,nOld,intKey);
+  zSql = sqlite3_str_finish(pStr);
+  if( !zSql ) return SQLITE_NOMEM;
+  rc = patchAppendRow(pCur,zTable,"data",zSql);
+  sqlite3_free(zSql);
+  return rc;
+}
+
+static int patchAppendData(
+  PatchCursor *pCur,
+  sqlite3 *db,
+  const PatchTable *pTable,
+  const PatchSchema *pFrom,
+  const PatchSchema *pTo
+){
+  ProllyDiffIter it;
+  ProllyDiffChange *pChange = 0;
+  ChunkStore *cs = doltliteGetChunkStore(db);
+  ProllyCache *pCache = doltliteGetCache(db);
+  ProllyHash oldRoot, newRoot;
+  u8 flags;
+  int rc;
+  memset(&oldRoot,0,sizeof(oldRoot));
+  memset(&newRoot,0,sizeof(newRoot));
+  if( pTable->pFromTable ) oldRoot = pTable->pFromTable->root;
+  if( pTable->pToTable ) newRoot = pTable->pToTable->root;
+  flags = pTable->pFromTable ? pTable->pFromTable->flags
+                             : pTable->pToTable->flags;
+  rc = prollyDiffIterOpen(&it,cs,pCache,&oldRoot,&newRoot,flags);
+  if( rc!=SQLITE_OK ) return rc;
+  while( (rc=prollyDiffIterStep(&it,&pChange))==SQLITE_ROW ){
+    const u8 *pOld = pChange->pOldVal;
+    const u8 *pNew = pChange->pNewVal;
+    int nOld = pChange->pOldVal ? pChange->nOldVal : 0;
+    int nNew = pChange->pNewVal ? pChange->nNewVal : 0;
+    u8 *pOldKey = 0, *pNewKey = 0;
+    int nOldKey = 0, nNewKey = 0;
+    if( pTable->pFromSchema && nOld==0 && pChange->type!=PROLLY_DIFF_ADD ){
+      rc = doltliteRecordFromClusteredKey(pFrom->db,pTable->zFromName,
+                pChange->pKey,pChange->nKey,&pOldKey,&nOldKey);
+      if( rc!=SQLITE_OK ) goto data_step_done;
+      if( pOldKey ){ pOld=pOldKey; nOld=nOldKey; }
+    }
+    if( pTable->pToSchema && nNew==0 && pChange->type!=PROLLY_DIFF_DELETE ){
+      rc = doltliteRecordFromClusteredKey(pTo->db,pTable->zToName,
+                pChange->pKey,pChange->nKey,&pNewKey,&nNewKey);
+      if( rc!=SQLITE_OK ) goto data_step_done;
+      if( pNewKey ){ pNew=pNewKey; nNew=nNewKey; }
+    }
+    if( pChange->type==PROLLY_DIFF_ADD ){
+      rc = patchAppendInsert(pCur,pTable->zToName,pTo,pNew,nNew,pChange->intKey);
+    }else if( pChange->type==PROLLY_DIFF_DELETE ){
+      rc = patchAppendDelete(pCur,pTable->zFromName,pFrom,pOld,nOld,pChange->intKey);
+    }else{
+      rc = patchAppendUpdate(pCur,pTable->zToName,pFrom,pTo,pOld,nOld,pNew,nNew,
+                             pChange->intKey);
+    }
+data_step_done:
+    sqlite3_free(pOldKey);
+    sqlite3_free(pNewKey);
+    if( rc!=SQLITE_OK ) break;
+  }
+  prollyDiffIterClose(&it);
+  return rc==SQLITE_DONE ? SQLITE_OK : rc;
+}
+
+static int patchGenerateTable(
+  PatchCursor *pCur,
+  sqlite3 *db,
+  const PatchTable *pTable,
+  SchemaEntry *aFromSchema, int nFromSchema,
+  SchemaEntry *aToSchema, int nToSchema,
+  int iTemp
+){
+  PatchSchema from, to;
+  int schemaChanged;
+  int rc = SQLITE_OK;
+  memset(&from,0,sizeof(from));
+  memset(&to,0,sizeof(to));
+  if( pTable->pFromSchema && pTable->pToSchema
+   && strcmp(pTable->zFromName,pTable->zToName)==0
+   && strcmp(pTable->pFromSchema->zSql,pTable->pToSchema->zSql)==0
+   && prollyHashCompare(&pTable->pFromTable->root,
+                        &pTable->pToTable->root)==0
+   && !patchObjectsDiffer(pTable->zToName,aFromSchema,nFromSchema,
+                          aToSchema,nToSchema) ){
+    return SQLITE_OK;
+  }
+  if( pTable->pFromSchema ){
+    rc = patchSchemaLoad(pTable->pFromSchema,&from);
+    if( rc!=SQLITE_OK ) goto done;
+  }
+  if( pTable->pToSchema ){
+    rc = patchSchemaLoad(pTable->pToSchema,&to);
+    if( rc!=SQLITE_OK ) goto done;
+  }
+  if( !pTable->pToSchema ){
+    char *zSql = sqlite3_mprintf("DROP TABLE \"%w\"",pTable->zFromName);
+    if( !zSql ){ rc=SQLITE_NOMEM; goto done; }
+    rc = patchAppendRow(pCur,pTable->zFromName,"schema",zSql);
+    sqlite3_free(zSql);
+    goto done;
+  }
+  if( !pTable->pFromSchema ){
+    rc = patchAppendRow(pCur,pTable->zToName,"schema",pTable->pToSchema->zSql);
+    if( rc==SQLITE_OK ) rc=patchAppendAssociated(pCur,pTable->zToName,
+                                                  aToSchema,nToSchema);
+    if( rc==SQLITE_OK ) rc=patchAppendData(pCur,db,pTable,&from,&to);
+    goto done;
+  }
+  schemaChanged = strcmp(pTable->zFromName,pTable->zToName)!=0
+      || strcmp(pTable->pFromSchema->zSql,pTable->pToSchema->zSql)!=0;
+  if( schemaChanged ){
+    rc = patchAppendRebuild(pCur,pTable,&from,&to,aFromSchema,nFromSchema,
+                            aToSchema,nToSchema,iTemp);
+  }else{
+    rc = patchAppendObjectDiffs(pCur,pTable->zToName,
+           aFromSchema,nFromSchema,aToSchema,nToSchema);
+  }
+  if( rc==SQLITE_OK ) rc=patchAppendData(pCur,db,pTable,&from,&to);
+done:
+  patchSchemaClear(&from);
+  patchSchemaClear(&to);
+  return rc;
+}
+
+static const char *patchSchemaSql =
+  "CREATE TABLE x("
+  "statement_order INTEGER,"
+  "from_commit_hash TEXT,"
+  "to_commit_hash TEXT,"
+  "table_name TEXT,"
+  "diff_type TEXT,"
+  "statement TEXT,"
+  "arg1 TEXT HIDDEN,"
+  "arg2 TEXT HIDDEN,"
+  "arg3 TEXT HIDDEN)";
+
+static int patchConnect(sqlite3 *db, void *pAux, int argc,
+    const char *const*argv, sqlite3_vtab **ppVtab, char **pzErr){
+  PatchVtab *p;
+  int rc;
+  (void)pAux; (void)argc; (void)argv;
+  rc = sqlite3_declare_vtab(db,patchSchemaSql);
+  if( rc!=SQLITE_OK ){ *pzErr=sqlite3_mprintf("%s",sqlite3_errmsg(db)); return rc; }
+  p = sqlite3_malloc(sizeof(*p));
+  if( !p ) return SQLITE_NOMEM;
+  memset(p,0,sizeof(*p));
+  p->db=db;
+  *ppVtab=&p->base;
+  return SQLITE_OK;
+}
+
+static int patchBestIndex(sqlite3_vtab *pVtab, sqlite3_index_info *pInfo){
+  int i, iFrom=-1, iTo=-1, iTable=-1, iType=-1, iArg=1;
+  (void)pVtab;
+  for(i=0; i<pInfo->nConstraint; i++){
+    if( !pInfo->aConstraint[i].usable
+     || pInfo->aConstraint[i].op!=SQLITE_INDEX_CONSTRAINT_EQ ) continue;
+    switch( pInfo->aConstraint[i].iColumn ){
+      case 4: iType=i; break;
+      case 6: iFrom=i; break;
+      case 7: iTo=i; break;
+      case 8: iTable=i; break;
+    }
+  }
+  if( iFrom>=0 ){
+    pInfo->aConstraintUsage[iFrom].argvIndex=iArg++;
+    pInfo->aConstraintUsage[iFrom].omit=1;
+  }
+  if( iTo>=0 ){
+    pInfo->aConstraintUsage[iTo].argvIndex=iArg++;
+    pInfo->aConstraintUsage[iTo].omit=1;
+  }
+  if( iTable>=0 ){
+    pInfo->aConstraintUsage[iTable].argvIndex=iArg++;
+    pInfo->aConstraintUsage[iTable].omit=1;
+  }
+  if( iType>=0 ){
+    pInfo->aConstraintUsage[iType].argvIndex=iArg++;
+    pInfo->aConstraintUsage[iType].omit=1;
+  }
+  pInfo->idxNum=(iFrom>=0?1:0)|(iTo>=0?2:0)|(iTable>=0?4:0)|(iType>=0?8:0);
+  pInfo->estimatedCost=1000.0;
+  return SQLITE_OK;
+}
+
+static int patchOpen(sqlite3_vtab *pVtab, sqlite3_vtab_cursor **ppCur){
+  (void)pVtab;
+  return doltliteVtabOpenCursor(ppCur,sizeof(PatchCursor));
+}
+
+static int patchClose(sqlite3_vtab_cursor *pCursor){
+  PatchCursor *pCur=(PatchCursor*)pCursor;
+  patchRowsClear(pCur);
+  sqlite3_free(pCur);
+  return SQLITE_OK;
+}
+
+static int patchFilter(sqlite3_vtab_cursor *pCursor, int idxNum,
+    const char *idxStr, int argc, sqlite3_value **argv){
+  PatchCursor *pCur=(PatchCursor*)pCursor;
+  PatchVtab *pVtab=(PatchVtab*)pCursor->pVtab;
+  const char *zArg1=0,*zArg2=0,*zArg3=0,*zFrom=0,*zTo=0,*zFilter=0;
+  const char *zTypeFilter=0;
+  char *zLeft=0,*zRight=0;
+  int rangeType=DOLTLITE_RANGE_NONE;
+  ProllyHash fromCat,toCat;
+  SchemaEntry *aFromSchema=0,*aToSchema=0;
+  struct TableEntry *aFromTable=0,*aToTable=0;
+  PatchTable *aTable=0;
+  int nFromSchema=0,nToSchema=0,nFromTable=0,nToTable=0,nTable=0;
+  int iArg=0,i,found=0,rc=SQLITE_OK;
+  int bTypeFilter=(idxNum&8)!=0;
+  ChunkStore *cs=doltliteGetChunkStore(pVtab->db);
+  ProllyCache *pCache=doltliteGetCache(pVtab->db);
+  (void)idxStr;
+  patchRowsClear(pCur);
+  if( !cs ) return SQLITE_OK;
+  if( (idxNum&1) && iArg<argc ) zArg1=(const char*)sqlite3_value_text(argv[iArg++]);
+  if( (idxNum&2) && iArg<argc ) zArg2=(const char*)sqlite3_value_text(argv[iArg++]);
+  if( (idxNum&4) && iArg<argc ) zArg3=(const char*)sqlite3_value_text(argv[iArg++]);
+  if( (idxNum&8) && iArg<argc ) zTypeFilter=(const char*)sqlite3_value_text(argv[iArg++]);
+  if( !zArg1 || ((idxNum&2) && !zArg2) || ((idxNum&4) && !zArg3) ){
+    patchSetError(&pVtab->base,"dolt_patch: invalid arguments%s","");
+    return SQLITE_ERROR;
+  }
+  rc=doltliteSplitRevisionRange(zArg1,&zLeft,&zRight,&rangeType);
+  if( rc==SQLITE_OK ){
+    zFrom=zLeft; zTo=zRight; zFilter=zArg2;
+    if( zArg3 ) rc=SQLITE_MISMATCH;
+  }else if( rc==SQLITE_NOTFOUND ){
+    rangeType=DOLTLITE_RANGE_NONE;
+    zFrom=zArg1; zTo=zArg2; zFilter=zArg3;
+    rc=zTo ? SQLITE_OK : SQLITE_MISMATCH;
+  }
+  if( rc!=SQLITE_OK ){
+    patchSetError(&pVtab->base,"dolt_patch: invalid arguments near '%s'",zArg1);
+    rc=SQLITE_ERROR; goto done;
+  }
+  rc=patchResolveArgs(pVtab,zFrom,zTo,rangeType,&fromCat,&toCat,
+                      &pCur->zFrom,&pCur->zTo);
+  if( rc!=SQLITE_OK ) goto done;
+  rc=doltliteLoadCatalog(pVtab->db,&fromCat,&aFromTable,&nFromTable,0);
+  if( rc==SQLITE_OK ) rc=doltliteLoadCatalog(pVtab->db,&toCat,&aToTable,&nToTable,0);
+  if( rc==SQLITE_OK ) rc=loadSchemaFromCatalog(pVtab->db,cs,pCache,&fromCat,
+                                               &aFromSchema,&nFromSchema);
+  if( rc==SQLITE_OK ) rc=loadSchemaFromCatalog(pVtab->db,cs,pCache,&toCat,
+                                               &aToSchema,&nToSchema);
+  if( rc==SQLITE_OK ) rc=patchBuildTables(aFromSchema,nFromSchema,
+      aToSchema,nToSchema,aFromTable,nFromTable,aToTable,nToTable,&aTable,&nTable);
+  for(i=0; rc==SQLITE_OK && i<nTable; i++){
+    if( zFilter && (!aTable[i].zFromName || strcmp(zFilter,aTable[i].zFromName)!=0)
+                && (!aTable[i].zToName || strcmp(zFilter,aTable[i].zToName)!=0) ){
+      continue;
+    }
+    found=1;
+    rc=patchGenerateTable(pCur,pVtab->db,&aTable[i],aFromSchema,nFromSchema,
+                          aToSchema,nToSchema,i+1);
+  }
+  if( rc==SQLITE_OK && zFilter && !found ){
+    patchSetError(&pVtab->base,"dolt_patch: table '%s' does not exist",zFilter);
+    rc=SQLITE_ERROR;
+  }
+  if( rc==SQLITE_OK && bTypeFilter ){
+    int iRead, iWrite=0;
+    for(iRead=0; iRead<pCur->nRow; iRead++){
+      PatchRow *pRow=&pCur->aRow[iRead];
+      if( zTypeFilter && strcmp(pRow->zType,zTypeFilter)==0 ){
+        if( iWrite!=iRead ){
+          pCur->aRow[iWrite]=*pRow;
+          memset(pRow,0,sizeof(*pRow));
+        }
+        iWrite++;
+      }else{
+        sqlite3_free(pRow->zTable);
+        sqlite3_free(pRow->zType);
+        sqlite3_free(pRow->zSql);
+        memset(pRow,0,sizeof(*pRow));
+      }
+    }
+    pCur->nRow=iWrite;
+  }
+done:
+  sqlite3_free(zLeft); sqlite3_free(zRight); sqlite3_free(aTable);
+  freeSchemaEntries(aFromSchema,nFromSchema);
+  freeSchemaEntries(aToSchema,nToSchema);
+  doltliteFreeCatalog(aFromTable,nFromTable);
+  doltliteFreeCatalog(aToTable,nToTable);
+  return rc;
+}
+
+static int patchNext(sqlite3_vtab_cursor *p){ ((PatchCursor*)p)->iRow++; return SQLITE_OK; }
+static int patchEof(sqlite3_vtab_cursor *p){ PatchCursor *c=(PatchCursor*)p; return c->iRow>=c->nRow; }
+static int patchColumn(sqlite3_vtab_cursor *p, sqlite3_context *ctx, int iCol){
+  PatchCursor *c=(PatchCursor*)p;
+  PatchRow *r=&c->aRow[c->iRow];
+  switch(iCol){
+    case 0: sqlite3_result_int64(ctx,c->iRow+1); break;
+    case 1: sqlite3_result_text(ctx,c->zFrom,-1,SQLITE_TRANSIENT); break;
+    case 2: sqlite3_result_text(ctx,c->zTo,-1,SQLITE_TRANSIENT); break;
+    case 3: sqlite3_result_text(ctx,r->zTable,-1,SQLITE_TRANSIENT); break;
+    case 4: sqlite3_result_text(ctx,r->zType,-1,SQLITE_TRANSIENT); break;
+    case 5: sqlite3_result_text(ctx,r->zSql,-1,SQLITE_TRANSIENT); break;
+  }
+  return SQLITE_OK;
+}
+static int patchRowid(sqlite3_vtab_cursor *p, sqlite3_int64 *pRowid){
+  *pRowid=((PatchCursor*)p)->iRow+1; return SQLITE_OK;
+}
+
+static sqlite3_module patchModule = {
+  0,0,patchConnect,patchBestIndex,doltliteVtabDisconnect,0,
+  patchOpen,patchClose,patchFilter,patchNext,patchEof,patchColumn,patchRowid,
+  0,0,0,0,0,0,0,0,0,0,0,0
+};
+
+int doltlitePatchRegister(sqlite3 *db){
+  return sqlite3_create_module(db,"dolt_patch",&patchModule,0);
+}
+
+#endif

--- a/test/vc_oracle_patch_test.sh
+++ b/test/vc_oracle_patch_test.sh
@@ -43,7 +43,7 @@ oracle_data() {
 }
 
 oracle_shape() {
-  local name="$1" setup="$2" args="$3" projection="$4"
+  local name="$1" setup="$2" args="$3" projection="$4" where="${5:-1}"
   local dir="$TMPROOT/$name"
   local dl_out dt_out dolt_setup
   mkdir -p "$dir/dl" "$dir/dt"
@@ -51,7 +51,7 @@ oracle_shape() {
     {
       printf '%s\n' "$setup"
       printf "%s\n" ".mode list" ".separator |" \
-        "SELECT 'P',$projection FROM dolt_patch($args);"
+        "SELECT 'P',$projection FROM dolt_patch($args) WHERE $where;"
     } | "$DOLTLITE" "$dir/dl/db" 2>"$dir/dl.err" | grep '^P|' || true
   )
   dolt_setup=$(vc_oracle_translate_for_dolt "$setup")
@@ -60,7 +60,7 @@ oracle_shape() {
     vc_oracle_init_repo
     {
       printf '%s\n' "$dolt_setup"
-      printf "%s\n" "SELECT concat('P|',concat_ws('|',$projection)) FROM dolt_patch($args);"
+      printf "%s\n" "SELECT concat('P|',concat_ws('|',$projection)) FROM dolt_patch($args) WHERE $where;"
     } | "$DOLT" sql -c -r csv 2>"$dir/dt.err" | tr -d '"' | grep '^P|' || true
   )
   vc_oracle_assert_match "$name" "$dl_out" "$dt_out"
@@ -91,6 +91,63 @@ oracle_error() {
   fi
 }
 
+# Apply both directions of a generated patch and compare a caller-supplied
+# schema+data fingerprint. setup must create tags named base and target.
+apply_bidirectional() {
+  local name="$1" setup="$2" fingerprint_sql="$3"
+  local dir="$TMPROOT/apply_$name"
+  local db="$TMPROOT/apply_$name/forward.db"
+  local reverse_db="$TMPROOT/apply_$name/reverse.db"
+  local base_fingerprint target_fingerprint actual
+  mkdir -p "$dir"
+  if ! printf '%s\n' "$setup" | "$DOLTLITE" "$db" \
+      >"$dir/setup.out" 2>"$dir/setup.err"; then
+    vc_oracle_assert_match "${name}_setup" \
+      "setup failed: $(cat "$dir/setup.err")" "setup succeeded"
+    return
+  fi
+  if ! printf '%s\n' "$setup" | "$DOLTLITE" "$reverse_db" \
+      >"$dir/reverse_setup.out" 2>"$dir/reverse_setup.err"; then
+    vc_oracle_assert_match "${name}_reverse_setup" \
+      "setup failed: $(cat "$dir/reverse_setup.err")" "setup succeeded"
+    return
+  fi
+  if ! "$DOLTLITE" "$db" \
+      "SELECT statement FROM dolt_patch('base','target');" \
+      >"$dir/forward.sql" 2>"$dir/forward.err"; then
+    vc_oracle_assert_match "${name}_forward_generation" \
+      "generation failed: $(cat "$dir/forward.err")" "generation succeeded"
+    return
+  fi
+  if ! "$DOLTLITE" "$db" \
+      "SELECT statement FROM dolt_patch('target','base');" \
+      >"$dir/reverse.sql" 2>"$dir/reverse.err"; then
+    vc_oracle_assert_match "${name}_reverse_generation" \
+      "generation failed: $(cat "$dir/reverse.err")" "generation succeeded"
+    return
+  fi
+
+  target_fingerprint=$("$DOLTLITE" "$db" "$fingerprint_sql" 2>"$dir/target.err")
+  "$DOLTLITE" "$db" "SELECT dolt_reset('--hard','base');" >/dev/null
+  base_fingerprint=$("$DOLTLITE" "$db" "$fingerprint_sql" 2>"$dir/base.err")
+
+  if "$DOLTLITE" "$db" <"$dir/forward.sql" >"$dir/forward.out" 2>"$dir/forward_apply.err"; then
+    actual=$("$DOLTLITE" "$db" "$fingerprint_sql" 2>"$dir/forward_actual.err")
+  else
+    actual="apply failed: $(cat "$dir/forward_apply.err")"
+  fi
+  vc_oracle_assert_match "${name}_forward" "$actual" "$target_fingerprint"
+
+  if "$DOLTLITE" "$reverse_db" <"$dir/reverse.sql" \
+      >"$dir/reverse.out" 2>"$dir/reverse_apply.err"; then
+    actual=$("$DOLTLITE" "$reverse_db" "$fingerprint_sql" \
+      2>"$dir/reverse_actual.err")
+  else
+    actual="apply failed: $(cat "$dir/reverse_apply.err")"
+  fi
+  vc_oracle_assert_match "${name}_reverse" "$actual" "$base_fingerprint"
+}
+
 basic_setup="
 CREATE TABLE t(pk INTEGER PRIMARY KEY, c1 TEXT, n INTEGER);
 INSERT INTO t VALUES (1,'one',10),(2,'two',20),(4,NULL,40);
@@ -105,6 +162,14 @@ oracle_data reverse_insert_update_delete "$basic_setup" "'HEAD','HEAD~1'" "diff_
 oracle_data two_dot_range "$basic_setup" "'HEAD~1..HEAD'" "diff_type='data'"
 oracle_data range_with_table "$basic_setup" "'HEAD~1..HEAD','t'" "diff_type='data'"
 oracle_data explicit_table "$basic_setup" "'HEAD~1','HEAD','t'" "diff_type='data'"
+oracle_data case_insensitive_table "$basic_setup" "'HEAD~1','HEAD','T'" \
+  "diff_type='data'"
+oracle_shape data_filter_count "$basic_setup" "'HEAD~1','HEAD'" "count(*)" \
+  "diff_type='data'"
+oracle_shape schema_filter_count "$basic_setup" "'HEAD~1','HEAD'" "count(*)" \
+  "diff_type='schema'"
+oracle_shape unknown_filter_empty "$basic_setup" "'HEAD~1','HEAD'" "count(*)" \
+  "diff_type='unknown'"
 
 oracle_data multi_table_order "
 CREATE TABLE z(pk INTEGER PRIMARY KEY, v TEXT);
@@ -171,6 +236,95 @@ UPDATE t SET v='main' WHERE pk=1;
 SELECT dolt_commit('-A','-m','main');
 " "'feature...main'" "diff_type='data'"
 
+# This matrix is ported from Dolt's "using branch refs different ways" patch
+# test. It checks explicit, two-dot, and both three-dot directions against a
+# divergent history with simultaneous schema and row changes.
+branch_matrix_setup="
+CREATE TABLE t(pk INTEGER PRIMARY KEY, c1 TEXT, c2 TEXT);
+INSERT INTO t VALUES(1,'one','two');
+SELECT dolt_commit('-A','-m','base');
+SELECT dolt_branch('branch1');
+INSERT INTO t VALUES(2,'main','row');
+SELECT dolt_commit('-A','-m','main change');
+CREATE TABLE newtable(pk INTEGER PRIMARY KEY);
+INSERT INTO newtable VALUES(1),(2);
+SELECT dolt_commit('-A','-m','main table');
+SELECT dolt_checkout('branch1');
+ALTER TABLE t DROP COLUMN c2;
+DELETE FROM t WHERE pk=1;
+INSERT INTO t VALUES(3,'branch');
+SELECT dolt_commit('-A','-m','branch change');
+"
+oracle_data branch_explicit_main_to_branch "$branch_matrix_setup" \
+  "'main','branch1'" "diff_type='data'"
+oracle_data branch_two_dot_main_to_branch "$branch_matrix_setup" \
+  "'main..branch1'" "diff_type='data'"
+oracle_data branch_explicit_reverse "$branch_matrix_setup" \
+  "'branch1','main'" "diff_type='data'"
+oracle_data branch_two_dot_reverse "$branch_matrix_setup" \
+  "'branch1..main'" "diff_type='data'"
+oracle_data branch_three_dot_to_branch "$branch_matrix_setup" \
+  "'main...branch1'" "diff_type='data'"
+oracle_data branch_three_dot_to_main "$branch_matrix_setup" \
+  "'branch1...main'" "diff_type='data'"
+
+# Dolt accepts both the old and new names as a filter for a rename, including
+# when the renamed table also receives new data in the same revision.
+rename_oracle_setup="
+CREATE TABLE t1(a INTEGER PRIMARY KEY, b INTEGER);
+INSERT INTO t1 VALUES(1,2);
+SELECT dolt_commit('-A','-m','base');
+ALTER TABLE t1 RENAME TO t2;
+INSERT INTO t2 VALUES(3,4);
+SELECT dolt_commit('-A','-m','renamed');
+"
+oracle_data rename_filter_new_name "$rename_oracle_setup" \
+  "'HEAD~1','HEAD','t2'" "diff_type='data'"
+oracle_data rename_filter_old_name "$rename_oracle_setup" \
+  "'HEAD~1..HEAD','t1'" "diff_type='data'"
+
+# HEAD/STAGED/WORKING are independently addressable in either direction.
+workspace_matrix_setup="
+CREATE TABLE t(pk INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'base');
+SELECT dolt_commit('-A','-m','base');
+UPDATE t SET v='staged' WHERE pk=1;
+SELECT dolt_add('t');
+UPDATE t SET v='working' WHERE pk=1;
+"
+oracle_data head_to_staged "$workspace_matrix_setup" \
+  "'HEAD','STAGED'" "diff_type='data'"
+oracle_data staged_to_working "$workspace_matrix_setup" \
+  "'STAGED','WORKING'" "diff_type='data'"
+oracle_data working_to_staged "$workspace_matrix_setup" \
+  "'WORKING','STAGED'" "diff_type='data'"
+oracle_shape working_to_working_empty "$workspace_matrix_setup" \
+  "'WORKING','WORKING'" "count(*)"
+oracle_shape staged_to_staged_empty "$workspace_matrix_setup" \
+  "'STAGED..STAGED'" "count(*)"
+
+# Exercise enough ordered changes to span many prolly chunks. Exact normalized
+# statements are still compared to Dolt, so this checks both diff iteration
+# across internal nodes and globally stable statement ordering.
+scale_setup="CREATE TABLE t(pk INTEGER PRIMARY KEY, v TEXT);"
+scale_values=""
+for i in $(seq 1 400); do
+  [ -n "$scale_values" ] && scale_values="$scale_values,"
+  scale_values="${scale_values}($i,'value$i')"
+done
+scale_setup="$scale_setup INSERT INTO t VALUES $scale_values;
+SELECT dolt_commit('-A','-m','base');
+UPDATE t SET v=concat('changed',pk) WHERE pk%10=0;
+DELETE FROM t WHERE pk%10=1;"
+scale_values=""
+for i in $(seq 401 450); do
+  [ -n "$scale_values" ] && scale_values="$scale_values,"
+  scale_values="${scale_values}($i,'value$i')"
+done
+scale_setup="$scale_setup INSERT INTO t VALUES $scale_values;
+SELECT dolt_commit('-A','-m','target');"
+oracle_data multi_chunk_ordering "$scale_setup" "'HEAD~1','HEAD'" "diff_type='data'"
+
 error_setup="
 CREATE TABLE t(pk INTEGER PRIMARY KEY, v TEXT);
 SELECT dolt_commit('-A','-m','base');
@@ -182,6 +336,22 @@ oracle_error one_non_range_argument "$error_setup" "SELECT * FROM dolt_patch('t'
 oracle_error bad_from_ref "$error_setup" "SELECT * FROM dolt_patch('missing-ref','HEAD','t');"
 oracle_error bad_to_ref "$error_setup" "SELECT * FROM dolt_patch('HEAD','missing-ref','t');"
 oracle_error missing_table "$error_setup" "SELECT * FROM dolt_patch('HEAD~1','HEAD','missing_table');"
+oracle_error empty_range_right "$error_setup" "SELECT * FROM dolt_patch('HEAD~1..');"
+oracle_error empty_range_left "$error_setup" "SELECT * FROM dolt_patch('..HEAD');"
+oracle_error four_arguments "$error_setup" \
+  "SELECT * FROM dolt_patch('HEAD~1','HEAD','t','extra');"
+oracle_error null_arguments "$error_setup" \
+  "SELECT * FROM dolt_patch(NULL,NULL,NULL);"
+oracle_error numeric_from_ref "$error_setup" \
+  "SELECT * FROM dolt_patch(123,'HEAD','t');"
+oracle_error numeric_to_ref "$error_setup" \
+  "SELECT * FROM dolt_patch('HEAD~1',123,'t');"
+oracle_error numeric_table "$error_setup" \
+  "SELECT * FROM dolt_patch('HEAD~1','HEAD',123);"
+oracle_error bad_range_from_ref "$error_setup" \
+  "SELECT * FROM dolt_patch('missing-ref..HEAD','t');"
+oracle_error bad_range_to_ref "$error_setup" \
+  "SELECT * FROM dolt_patch('HEAD~1..missing-ref','t');"
 
 # SQLite-specific verification: generate a schema+data patch, reset to the
 # source revision, execute every statement, and compare the target fingerprint.
@@ -294,6 +464,268 @@ else
   actual_fingerprint="apply failed: $(cat "$columns_dir/apply.err")"
 fi
 vc_oracle_assert_match apply_column_rename_drop_add "$actual_fingerprint" "$target_fingerprint"
+
+# Bidirectional application matrix. These cases target record layouts and DDL
+# interactions that simple statement comparison cannot validate.
+apply_bidirectional table_add_drop_multi_table "
+CREATE TABLE common(pk INTEGER PRIMARY KEY,v TEXT);
+CREATE TABLE old_table(pk INTEGER PRIMARY KEY,v TEXT);
+INSERT INTO common VALUES(1,'base');
+INSERT INTO old_table VALUES(1,'old-a'),(2,'old-b');
+SELECT dolt_commit('-A','-m','base');
+SELECT dolt_tag('base');
+DROP TABLE old_table;
+CREATE TABLE new_table(pk INTEGER PRIMARY KEY,v TEXT);
+INSERT INTO new_table VALUES(10,'new-a'),(20,'new-b');
+UPDATE common SET v='target' WHERE pk=1;
+SELECT dolt_commit('-A','-m','target');
+SELECT dolt_tag('target');
+" "
+SELECT group_concat(name||':'||sql,';') FROM (
+  SELECT name,sql FROM sqlite_master
+  WHERE type='table' AND name NOT LIKE 'dolt_%' AND name NOT LIKE 'sqlite_%'
+  ORDER BY name
+);
+SELECT count(*) FROM dolt_diff('base','WORKING');
+SELECT count(*) FROM dolt_diff('target','WORKING');
+"
+
+apply_bidirectional without_rowid_pk_only "
+CREATE TABLE t(a TEXT,b INTEGER,PRIMARY KEY(a,b)) WITHOUT ROWID;
+INSERT INTO t VALUES('a',1),('b',2),('c',3);
+SELECT dolt_commit('-A','-m','base');
+SELECT dolt_tag('base');
+DELETE FROM t WHERE a='b' AND b=2;
+INSERT INTO t VALUES('d',4);
+SELECT dolt_commit('-A','-m','target');
+SELECT dolt_tag('target');
+" "
+SELECT group_concat(a||':'||b,',') FROM (SELECT * FROM t ORDER BY a,b);
+SELECT sql FROM sqlite_master WHERE name='t';
+"
+
+apply_bidirectional keyless_rowid_reuse "
+CREATE TABLE t(a TEXT,b INTEGER);
+INSERT INTO t VALUES('same',1),('same',1),('keep',2);
+SELECT dolt_commit('-A','-m','base');
+SELECT dolt_tag('base');
+UPDATE t SET b=9 WHERE rowid=1;
+DELETE FROM t WHERE rowid=2;
+INSERT INTO t VALUES('new',3);
+SELECT dolt_commit('-A','-m','target');
+SELECT dolt_tag('target');
+" "
+SELECT group_concat(rowid||':'||a||':'||b,',') FROM (SELECT rowid,* FROM t ORDER BY rowid);
+SELECT sql FROM sqlite_master WHERE name='t';
+"
+
+apply_bidirectional keyless_rowid_alias_shadow "
+CREATE TABLE t(rowid TEXT,v INTEGER);
+INSERT INTO t(rowid,v) VALUES('declared-a',1),('declared-b',2);
+SELECT dolt_commit('-A','-m','base');
+SELECT dolt_tag('base');
+UPDATE t SET v=11 WHERE _rowid_=1;
+DELETE FROM t WHERE _rowid_=2;
+INSERT INTO t(rowid,v) VALUES('declared-c',3);
+SELECT dolt_commit('-A','-m','target');
+SELECT dolt_tag('target');
+" "
+SELECT group_concat(_rowid_||':'||rowid||':'||v,',') FROM (SELECT _rowid_,* FROM t ORDER BY _rowid_);
+SELECT sql FROM sqlite_master WHERE name='t';
+"
+
+apply_bidirectional blob_composite_primary_key "
+CREATE TABLE t(k BLOB,s TEXT,v BLOB,n REAL,PRIMARY KEY(k,s)) WITHOUT ROWID;
+INSERT INTO t VALUES(x'00ff','a',x'01',1.25),(x'10','b',x'02',-4.5);
+SELECT dolt_commit('-A','-m','base');
+SELECT dolt_tag('base');
+UPDATE t SET v=x'abcdef',n=3.141592653589793 WHERE k=x'00ff' AND s='a';
+DELETE FROM t WHERE k=x'10' AND s='b';
+INSERT INTO t VALUES(x'80','quote''s',x'00ff10',0.0);
+SELECT dolt_commit('-A','-m','target');
+SELECT dolt_tag('target');
+" "
+SELECT group_concat(hex(k)||':'||hex(s)||':'||hex(v)||':'||printf('%.17g',n),',')
+  FROM (SELECT * FROM t ORDER BY k,s);
+SELECT sql FROM sqlite_master WHERE name='t';
+"
+
+apply_bidirectional generated_columns "
+CREATE TABLE t(
+  pk INTEGER PRIMARY KEY,
+  a INTEGER,
+  doubled INTEGER GENERATED ALWAYS AS (a*2) VIRTUAL,
+  shifted INTEGER GENERATED ALWAYS AS (a+3) STORED
+);
+INSERT INTO t(pk,a) VALUES(1,5),(2,7);
+SELECT dolt_commit('-A','-m','base');
+SELECT dolt_tag('base');
+UPDATE t SET a=11 WHERE pk=1;
+DELETE FROM t WHERE pk=2;
+INSERT INTO t(pk,a) VALUES(3,13);
+SELECT dolt_commit('-A','-m','target');
+SELECT dolt_tag('target');
+" "
+SELECT group_concat(pk||':'||a||':'||doubled||':'||shifted,',') FROM (SELECT * FROM t ORDER BY pk);
+SELECT sql FROM sqlite_master WHERE name='t';
+"
+
+apply_bidirectional strict_schema_replacement "
+CREATE TABLE t(pk INTEGER PRIMARY KEY,v TEXT);
+INSERT INTO t VALUES(1,'one'),(2,'two');
+SELECT dolt_commit('-A','-m','base');
+SELECT dolt_tag('base');
+CREATE TABLE t_new(
+  pk INTEGER PRIMARY KEY,
+  v TEXT,
+  n INTEGER NOT NULL DEFAULT 7 CHECK(n>0)
+) STRICT;
+INSERT INTO t_new(pk,v) SELECT pk,v FROM t;
+DROP TABLE t;
+ALTER TABLE t_new RENAME TO t;
+UPDATE t SET v='uno',n=8 WHERE pk=1;
+INSERT INTO t(pk,v,n) VALUES(3,'three',9);
+SELECT dolt_commit('-A','-m','target');
+SELECT dolt_tag('target');
+" "
+SELECT dolt_hashof_table('t');
+SELECT sql FROM sqlite_master WHERE name='t';
+"
+
+apply_bidirectional primary_key_replacement "
+CREATE TABLE t(a TEXT PRIMARY KEY,b INTEGER,v TEXT);
+INSERT INTO t VALUES('a',1,'one'),('b',2,'two');
+SELECT dolt_commit('-A','-m','base');
+SELECT dolt_tag('base');
+CREATE TABLE t_new(a TEXT,b INTEGER,v TEXT,PRIMARY KEY(a,b)) WITHOUT ROWID;
+INSERT INTO t_new SELECT * FROM t;
+DROP TABLE t;
+ALTER TABLE t_new RENAME TO t;
+UPDATE t SET v='uno' WHERE a='a' AND b=1;
+DELETE FROM t WHERE a='b' AND b=2;
+INSERT INTO t VALUES('c',3,'three');
+SELECT dolt_commit('-A','-m','target');
+SELECT dolt_tag('target');
+" "
+SELECT dolt_hashof_table('t');
+SELECT sql FROM sqlite_master WHERE name='t';
+"
+
+apply_bidirectional integer_to_text_primary_key "
+CREATE TABLE t(pk INTEGER PRIMARY KEY,v TEXT);
+INSERT INTO t VALUES(1,'one'),(2,'two');
+SELECT dolt_commit('-A','-m','base');
+SELECT dolt_tag('base');
+CREATE TABLE t_new(pk TEXT PRIMARY KEY,v TEXT);
+INSERT INTO t_new SELECT CAST(pk AS TEXT),v FROM t;
+DROP TABLE t;
+ALTER TABLE t_new RENAME TO t;
+UPDATE t SET v='uno' WHERE pk='1';
+DELETE FROM t WHERE pk='2';
+INSERT INTO t VALUES('03','three');
+SELECT dolt_commit('-A','-m','target');
+SELECT dolt_tag('target');
+" "
+SELECT dolt_hashof_table('t');
+SELECT sql FROM sqlite_master WHERE name='t';
+"
+
+apply_bidirectional index_matrix "
+CREATE TABLE t(pk INTEGER PRIMARY KEY,a INTEGER,b TEXT);
+INSERT INTO t VALUES(1,10,'one'),(2,20,'two'),(3,30,'three');
+SELECT dolt_commit('-A','-m','base');
+SELECT dolt_tag('base');
+CREATE UNIQUE INDEX ux_t_a ON t(a);
+CREATE INDEX ix_t_expr ON t(lower(b));
+CREATE INDEX ix_t_partial ON t(b) WHERE a>=20;
+UPDATE t SET b='TWO' WHERE pk=2;
+SELECT dolt_commit('-A','-m','target');
+SELECT dolt_tag('target');
+" "
+SELECT group_concat(pk||':'||a||':'||b,',') FROM (SELECT * FROM t ORDER BY pk);
+SELECT group_concat(name||':'||sql,';') FROM (SELECT name,sql FROM sqlite_master WHERE type='index' AND tbl_name='t' ORDER BY name);
+"
+
+apply_bidirectional trigger_side_effects "
+CREATE TABLE audit(msg TEXT);
+CREATE TABLE t(pk INTEGER PRIMARY KEY,v INTEGER);
+INSERT INTO t VALUES(1,5);
+SELECT dolt_commit('-A','-m','base');
+SELECT dolt_tag('base');
+CREATE TRIGGER tr_t_insert AFTER INSERT ON t BEGIN
+  UPDATE t SET v=v+1 WHERE pk=new.pk;
+  INSERT INTO audit VALUES('insert:'||new.pk);
+END;
+INSERT INTO t VALUES(2,10);
+SELECT dolt_commit('-A','-m','target');
+SELECT dolt_tag('target');
+" "
+SELECT group_concat(pk||':'||v,',') FROM (SELECT * FROM t ORDER BY pk);
+SELECT group_concat(msg,',') FROM (SELECT * FROM audit ORDER BY msg);
+SELECT sql FROM sqlite_master WHERE name='tr_t_insert';
+"
+
+apply_bidirectional unchanged_trigger_side_effects "
+CREATE TABLE z_audit(msg TEXT);
+CREATE TABLE a_source(pk INTEGER PRIMARY KEY,v INTEGER);
+CREATE TRIGGER tr_source_insert AFTER INSERT ON a_source BEGIN
+  UPDATE a_source SET v=v+1 WHERE pk=new.pk;
+  INSERT INTO z_audit VALUES('insert:'||new.pk);
+END;
+INSERT INTO a_source VALUES(1,10);
+SELECT dolt_commit('-A','-m','base');
+SELECT dolt_tag('base');
+INSERT INTO a_source VALUES(2,20);
+SELECT dolt_commit('-A','-m','target');
+SELECT dolt_tag('target');
+" "
+SELECT group_concat(pk||':'||v,',') FROM (SELECT * FROM a_source ORDER BY pk);
+SELECT group_concat(msg,',') FROM (SELECT * FROM z_audit ORDER BY msg);
+SELECT sql FROM sqlite_master WHERE name='tr_source_insert';
+"
+
+apply_bidirectional foreign_key_rebuild "
+PRAGMA foreign_keys=ON;
+CREATE TABLE parent(id INTEGER PRIMARY KEY,name TEXT);
+CREATE TABLE child(id INTEGER PRIMARY KEY,parent_id INTEGER);
+INSERT INTO parent VALUES(1,'one'),(2,'two');
+INSERT INTO child VALUES(10,1),(20,2);
+SELECT dolt_commit('-A','-m','base');
+SELECT dolt_tag('base');
+CREATE TABLE child_new(
+  id INTEGER PRIMARY KEY,
+  parent_id INTEGER NOT NULL REFERENCES parent(id) ON DELETE CASCADE
+);
+INSERT INTO child_new SELECT * FROM child;
+DROP TABLE child;
+ALTER TABLE child_new RENAME TO child;
+UPDATE parent SET name='uno' WHERE id=1;
+SELECT dolt_commit('-A','-m','target');
+SELECT dolt_tag('target');
+" "
+PRAGMA foreign_keys=ON;
+SELECT group_concat(id||':'||name,',') FROM (SELECT * FROM parent ORDER BY id);
+SELECT group_concat(id||':'||parent_id,',') FROM (SELECT * FROM child ORDER BY id);
+SELECT count(*) FROM pragma_foreign_key_check;
+SELECT sql FROM sqlite_master WHERE name='child';
+"
+
+apply_bidirectional rebuild_temp_name_collision "
+CREATE TABLE __doltlite_patch_1(pk INTEGER PRIMARY KEY,v TEXT);
+CREATE TABLE t(pk INTEGER PRIMARY KEY,v TEXT);
+INSERT INTO __doltlite_patch_1 VALUES(1,'reserved');
+INSERT INTO t VALUES(1,'one');
+SELECT dolt_commit('-A','-m','base');
+SELECT dolt_tag('base');
+ALTER TABLE t ADD COLUMN n INTEGER DEFAULT 7;
+UPDATE t SET n=8 WHERE pk=1;
+SELECT dolt_commit('-A','-m','target');
+SELECT dolt_tag('target');
+" "
+SELECT group_concat(pk||':'||v,',') FROM __doltlite_patch_1;
+SELECT group_concat(pk||':'||v||':'||n,',') FROM t;
+SELECT group_concat(name,',') FROM (SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'dolt_%' ORDER BY name);
+"
 
 echo ""
 echo "=== dolt_patch oracle results: $pass passed, $fail failed ==="

--- a/test/vc_oracle_patch_test.sh
+++ b/test/vc_oracle_patch_test.sh
@@ -1,0 +1,303 @@
+#!/usr/bin/env bash
+
+set -u
+set -o pipefail
+
+DOLTLITE="${1:-./doltlite}"
+DOLT="${2:-dolt}"
+TMPROOT=$(mktemp -d)
+trap 'rm -rf "$TMPROOT"' EXIT
+pass=0
+fail=0
+FAILED_NAMES=""
+source "$(dirname "$0")/lib/vc_oracle_common.sh"
+
+# Compare the operation stream and normalized data SQL with Dolt. Identifier
+# quotes and insignificant spaces are removed before hex encoding so CSV
+# parsing cannot confuse commas inside generated statements.
+oracle_data() {
+  local name="$1" setup="$2" args="$3" where="${4:-1}"
+  local dir="$TMPROOT/$name"
+  local dl_out dt_out dolt_setup
+  mkdir -p "$dir/dl" "$dir/dt"
+
+  dl_out=$(
+    {
+      printf '%s\n' "$setup"
+      printf "%s\n" ".mode list" ".separator |" \
+        "SELECT 'P',statement_order,table_name,diff_type,lower(hex(replace(replace(statement,'\"',''),' ',''))) FROM dolt_patch($args) WHERE $where;"
+    } | "$DOLTLITE" "$dir/dl/db" 2>"$dir/dl.err" | grep '^P|' || true
+  )
+
+  dolt_setup=$(vc_oracle_translate_for_dolt "$setup")
+  dt_out=$(
+    cd "$dir/dt" || exit 1
+    vc_oracle_init_repo
+    {
+      printf '%s\n' "$dolt_setup"
+      printf "%s\n" \
+        "SELECT concat('P|',statement_order,'|',table_name,'|',diff_type,'|',lower(hex(replace(replace(statement,char(96),''),' ','')))) FROM dolt_patch($args) WHERE $where;"
+    } | "$DOLT" sql -c -r csv 2>"$dir/dt.err" | tr -d '"' | grep '^P|' || true
+  )
+  vc_oracle_assert_match "$name" "$dl_out" "$dt_out"
+}
+
+oracle_shape() {
+  local name="$1" setup="$2" args="$3" projection="$4"
+  local dir="$TMPROOT/$name"
+  local dl_out dt_out dolt_setup
+  mkdir -p "$dir/dl" "$dir/dt"
+  dl_out=$(
+    {
+      printf '%s\n' "$setup"
+      printf "%s\n" ".mode list" ".separator |" \
+        "SELECT 'P',$projection FROM dolt_patch($args);"
+    } | "$DOLTLITE" "$dir/dl/db" 2>"$dir/dl.err" | grep '^P|' || true
+  )
+  dolt_setup=$(vc_oracle_translate_for_dolt "$setup")
+  dt_out=$(
+    cd "$dir/dt" || exit 1
+    vc_oracle_init_repo
+    {
+      printf '%s\n' "$dolt_setup"
+      printf "%s\n" "SELECT concat('P|',concat_ws('|',$projection)) FROM dolt_patch($args);"
+    } | "$DOLT" sql -c -r csv 2>"$dir/dt.err" | tr -d '"' | grep '^P|' || true
+  )
+  vc_oracle_assert_match "$name" "$dl_out" "$dt_out"
+}
+
+oracle_error() {
+  local name="$1" setup="$2" query="$3"
+  local dir="$TMPROOT/$name"
+  local dl_rc dt_rc dolt_setup
+  mkdir -p "$dir/dl" "$dir/dt"
+  printf '%s\n%s\n' "$setup" "$query" | "$DOLTLITE" "$dir/dl/db" \
+    >"$dir/dl.out" 2>"$dir/dl.err"
+  dl_rc=$?
+  dolt_setup=$(vc_oracle_translate_for_dolt "$setup")
+  (
+    cd "$dir/dt" || exit 1
+    vc_oracle_init_repo
+    printf '%s\n%s\n' "$dolt_setup" "$query" | "$DOLT" sql \
+      >"$dir/dt.out" 2>"$dir/dt.err"
+  )
+  dt_rc=$?
+  if vc_oracle_is_clean_error "$dl_rc" && vc_oracle_is_clean_error "$dt_rc"; then
+    pass=$((pass+1))
+  else
+    fail=$((fail+1))
+    FAILED_NAMES="$FAILED_NAMES $name"
+    echo "  FAIL: $name (doltlite rc=$dl_rc, dolt rc=$dt_rc)"
+  fi
+}
+
+basic_setup="
+CREATE TABLE t(pk INTEGER PRIMARY KEY, c1 TEXT, n INTEGER);
+INSERT INTO t VALUES (1,'one',10),(2,'two',20),(4,NULL,40);
+SELECT dolt_commit('-A','-m','base');
+UPDATE t SET c1='uno',n=11 WHERE pk=1;
+DELETE FROM t WHERE pk=2;
+INSERT INTO t VALUES (3,'three',30);
+SELECT dolt_commit('-A','-m','next');
+"
+oracle_data basic_insert_update_delete "$basic_setup" "'HEAD~1','HEAD'" "diff_type='data'"
+oracle_data reverse_insert_update_delete "$basic_setup" "'HEAD','HEAD~1'" "diff_type='data'"
+oracle_data two_dot_range "$basic_setup" "'HEAD~1..HEAD'" "diff_type='data'"
+oracle_data range_with_table "$basic_setup" "'HEAD~1..HEAD','t'" "diff_type='data'"
+oracle_data explicit_table "$basic_setup" "'HEAD~1','HEAD','t'" "diff_type='data'"
+
+oracle_data multi_table_order "
+CREATE TABLE z(pk INTEGER PRIMARY KEY, v TEXT);
+CREATE TABLE a(pk INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO z VALUES (1,'z');
+INSERT INTO a VALUES (1,'a');
+SELECT dolt_commit('-A','-m','base');
+UPDATE z SET v='zee' WHERE pk=1;
+UPDATE a SET v='aye' WHERE pk=1;
+SELECT dolt_commit('-A','-m','next');
+" "'HEAD~1','HEAD'" "diff_type='data'"
+
+oracle_data added_table_rows "
+CREATE TABLE seed(pk INTEGER PRIMARY KEY);
+SELECT dolt_commit('-A','-m','base');
+CREATE TABLE added(pk INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO added VALUES (1,'a'),(2,'b');
+SELECT dolt_commit('-A','-m','next');
+" "'HEAD~1','HEAD'" "diff_type='data'"
+
+oracle_shape dropped_table_has_no_data "
+CREATE TABLE gone(pk INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO gone VALUES (1,'a');
+SELECT dolt_commit('-A','-m','base');
+DROP TABLE gone;
+SELECT dolt_commit('-A','-m','next');
+" "'HEAD~1','HEAD'" "table_name,diff_type"
+
+oracle_data composite_primary_key "
+CREATE TABLE t(a VARCHAR(20), b INTEGER, v TEXT, PRIMARY KEY(a,b));
+INSERT INTO t VALUES ('x',1,'old'),('x',2,'delete');
+SELECT dolt_commit('-A','-m','base');
+UPDATE t SET v='new' WHERE a='x' AND b=1;
+DELETE FROM t WHERE a='x' AND b=2;
+INSERT INTO t VALUES ('y',3,'add');
+SELECT dolt_commit('-A','-m','next');
+" "'HEAD~1','HEAD'" "diff_type='data'"
+
+oracle_shape working_label "
+CREATE TABLE t(pk INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1,'a');
+SELECT dolt_commit('-A','-m','base');
+UPDATE t SET v='working' WHERE pk=1;
+" "'HEAD','WORKING'" "table_name,diff_type,to_commit_hash"
+
+oracle_shape staged_label "
+CREATE TABLE t(pk INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1,'a');
+SELECT dolt_commit('-A','-m','base');
+UPDATE t SET v='staged' WHERE pk=1;
+SELECT dolt_add('t');
+" "'HEAD','STAGED'" "table_name,diff_type,to_commit_hash"
+
+oracle_data three_dot_merge_base "
+CREATE TABLE t(pk INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1,'base');
+SELECT dolt_commit('-A','-m','base');
+SELECT dolt_branch('feature');
+SELECT dolt_checkout('feature');
+INSERT INTO t VALUES (2,'feature');
+SELECT dolt_commit('-A','-m','feature');
+SELECT dolt_checkout('main');
+UPDATE t SET v='main' WHERE pk=1;
+SELECT dolt_commit('-A','-m','main');
+" "'feature...main'" "diff_type='data'"
+
+error_setup="
+CREATE TABLE t(pk INTEGER PRIMARY KEY, v TEXT);
+SELECT dolt_commit('-A','-m','base');
+INSERT INTO t VALUES(1,'a');
+SELECT dolt_commit('-A','-m','next');
+"
+oracle_error no_arguments "$error_setup" "SELECT * FROM dolt_patch();"
+oracle_error one_non_range_argument "$error_setup" "SELECT * FROM dolt_patch('t');"
+oracle_error bad_from_ref "$error_setup" "SELECT * FROM dolt_patch('missing-ref','HEAD','t');"
+oracle_error bad_to_ref "$error_setup" "SELECT * FROM dolt_patch('HEAD','missing-ref','t');"
+oracle_error missing_table "$error_setup" "SELECT * FROM dolt_patch('HEAD~1','HEAD','missing_table');"
+
+# SQLite-specific verification: generate a schema+data patch, reset to the
+# source revision, execute every statement, and compare the target fingerprint.
+apply_dir="$TMPROOT/apply_schema"
+mkdir -p "$apply_dir"
+apply_db="$apply_dir/db"
+{
+  printf '%s\n' \
+    "CREATE TABLE t(pk INTEGER PRIMARY KEY,c1 TEXT);" \
+    "INSERT INTO t VALUES(1,'one'),(2,'two');" \
+    "CREATE INDEX ix_t_c1 ON t(c1);" \
+    "SELECT dolt_commit('-A','-m','base');" \
+    "ALTER TABLE t ADD COLUMN n INTEGER DEFAULT 7;" \
+    "UPDATE t SET c1='uno',n=8 WHERE pk=1;" \
+    "DROP INDEX ix_t_c1;" \
+    "CREATE UNIQUE INDEX ix_t_c1 ON t(c1);" \
+    "CREATE TRIGGER tr AFTER INSERT ON t BEGIN UPDATE t SET n=9 WHERE pk=new.pk; END;" \
+    "SELECT dolt_commit('-A','-m','target');"
+} | "$DOLTLITE" "$apply_db" >/dev/null
+target_fingerprint=$("$DOLTLITE" "$apply_db" \
+  "SELECT group_concat(pk||':'||c1||':'||n,',') FROM (SELECT * FROM t ORDER BY pk);" \
+  "SELECT group_concat(type||':'||name,',') FROM (SELECT type,name FROM sqlite_master WHERE tbl_name='t' ORDER BY type,name);")
+"$DOLTLITE" "$apply_db" "SELECT statement FROM dolt_patch('HEAD~1','HEAD');" >"$apply_dir/patch.sql"
+"$DOLTLITE" "$apply_db" "SELECT dolt_reset('--hard','HEAD~1');" >/dev/null
+if "$DOLTLITE" "$apply_db" <"$apply_dir/patch.sql" >"$apply_dir/apply.out" 2>"$apply_dir/apply.err"; then
+  actual_fingerprint=$("$DOLTLITE" "$apply_db" \
+    "SELECT group_concat(pk||':'||c1||':'||n,',') FROM (SELECT * FROM t ORDER BY pk);" \
+    "SELECT group_concat(type||':'||name,',') FROM (SELECT type,name FROM sqlite_master WHERE tbl_name='t' ORDER BY type,name);")
+else
+  actual_fingerprint="apply failed: $(cat "$apply_dir/apply.err")"
+fi
+vc_oracle_assert_match apply_schema_and_data "$actual_fingerprint" "$target_fingerprint"
+
+# Literal round-trip covers quotes, embedded NUL text, blobs, reals and NULL.
+literal_dir="$TMPROOT/apply_literals"
+mkdir -p "$literal_dir"
+literal_db="$literal_dir/db"
+{
+  printf '%s\n' \
+    "CREATE TABLE t(pk INTEGER PRIMARY KEY, txt TEXT, b BLOB, r REAL, n TEXT);" \
+    "SELECT dolt_commit('-A','-m','base');" \
+    "INSERT INTO t VALUES(1,'it''s'||char(0)||'nul',x'00ff10',1.25,NULL);" \
+    "SELECT dolt_commit('-A','-m','target');"
+} | "$DOLTLITE" "$literal_db" >/dev/null
+target_fingerprint=$("$DOLTLITE" "$literal_db" \
+  "SELECT pk||'|'||hex(txt)||'|'||hex(b)||'|'||printf('%.17g',r)||'|'||(n IS NULL) FROM t;")
+"$DOLTLITE" "$literal_db" "SELECT statement FROM dolt_patch('HEAD~1','HEAD');" >"$literal_dir/patch.sql"
+"$DOLTLITE" "$literal_db" "SELECT dolt_reset('--hard','HEAD~1');" >/dev/null
+if "$DOLTLITE" "$literal_db" <"$literal_dir/patch.sql" 2>"$literal_dir/apply.err"; then
+  actual_fingerprint=$("$DOLTLITE" "$literal_db" \
+    "SELECT pk||'|'||hex(txt)||'|'||hex(b)||'|'||printf('%.17g',r)||'|'||(n IS NULL) FROM t;")
+else
+  actual_fingerprint="apply failed: $(cat "$literal_dir/apply.err")"
+fi
+vc_oracle_assert_match apply_literal_round_trip "$actual_fingerprint" "$target_fingerprint"
+
+# A pure table rename should be represented as a rebuild that remains
+# executable, including quoted identifiers and an index recreated under the
+# new table name.
+rename_dir="$TMPROOT/apply_rename"
+mkdir -p "$rename_dir"
+rename_db="$rename_dir/db"
+{
+  printf '%s\n' \
+    'CREATE TABLE "odd table"("pk col" TEXT PRIMARY KEY, "value" TEXT);' \
+    'INSERT INTO "odd table" VALUES('"'"'a'"'"','"'"'one'"'"'),('"'"'b'"'"','"'"'two'"'"');' \
+    'CREATE INDEX "odd index" ON "odd table"("value");' \
+    "SELECT dolt_commit('-A','-m','base');" \
+    'ALTER TABLE "odd table" RENAME TO "new table";' \
+    "SELECT dolt_commit('-A','-m','target');"
+} | "$DOLTLITE" "$rename_db" >/dev/null
+target_fingerprint=$("$DOLTLITE" "$rename_db" \
+  "SELECT group_concat(\"pk col\"||':'||\"value\",',') FROM (SELECT * FROM \"new table\" ORDER BY \"pk col\");" \
+  "SELECT group_concat(type||':'||name,',') FROM (SELECT type,name FROM sqlite_master WHERE tbl_name='new table' ORDER BY type,name);")
+"$DOLTLITE" "$rename_db" "SELECT statement FROM dolt_patch('HEAD~1','HEAD');" >"$rename_dir/patch.sql"
+"$DOLTLITE" "$rename_db" "SELECT dolt_reset('--hard','HEAD~1');" >/dev/null
+if "$DOLTLITE" "$rename_db" <"$rename_dir/patch.sql" 2>"$rename_dir/apply.err"; then
+  actual_fingerprint=$("$DOLTLITE" "$rename_db" \
+    "SELECT group_concat(\"pk col\"||':'||\"value\",',') FROM (SELECT * FROM \"new table\" ORDER BY \"pk col\");" \
+    "SELECT group_concat(type||':'||name,',') FROM (SELECT type,name FROM sqlite_master WHERE tbl_name='new table' ORDER BY type,name);")
+else
+  actual_fingerprint="apply failed: $(cat "$rename_dir/apply.err")"
+fi
+vc_oracle_assert_match apply_table_rename "$actual_fingerprint" "$target_fingerprint"
+
+# Ported from Dolt's WORKING/STAGED schema test: rename, drop, and add columns
+# together, then prove both forward and reverse generated patches execute.
+columns_dir="$TMPROOT/apply_columns"
+mkdir -p "$columns_dir"
+columns_db="$columns_dir/db"
+{
+  printf '%s\n' \
+    "CREATE TABLE t(pk INTEGER PRIMARY KEY,c1 INTEGER,c2 INTEGER,c3 INTEGER,c4 INTEGER,c5 INTEGER);" \
+    "INSERT INTO t VALUES(0,1,2,3,4,5),(1,1,2,3,4,5);" \
+    "SELECT dolt_commit('-A','-m','base');" \
+    "ALTER TABLE t RENAME COLUMN c1 TO c0;" \
+    "ALTER TABLE t DROP COLUMN c4;" \
+    "ALTER TABLE t ADD COLUMN c6 INTEGER;" \
+    "UPDATE t SET c6=60 WHERE pk=1;" \
+    "SELECT dolt_commit('-A','-m','target');"
+} | "$DOLTLITE" "$columns_db" >/dev/null
+target_fingerprint=$("$DOLTLITE" "$columns_db" \
+  "SELECT group_concat(pk||':'||c0||':'||c2||':'||c3||':'||c5||':'||coalesce(c6,'NULL'),',') FROM (SELECT * FROM t ORDER BY pk);")
+"$DOLTLITE" "$columns_db" "SELECT statement FROM dolt_patch('HEAD~1','HEAD');" >"$columns_dir/forward.sql"
+"$DOLTLITE" "$columns_db" "SELECT dolt_reset('--hard','HEAD~1');" >/dev/null
+if "$DOLTLITE" "$columns_db" <"$columns_dir/forward.sql" 2>"$columns_dir/apply.err"; then
+  actual_fingerprint=$("$DOLTLITE" "$columns_db" \
+    "SELECT group_concat(pk||':'||c0||':'||c2||':'||c3||':'||c5||':'||coalesce(c6,'NULL'),',') FROM (SELECT * FROM t ORDER BY pk);")
+else
+  actual_fingerprint="apply failed: $(cat "$columns_dir/apply.err")"
+fi
+vc_oracle_assert_match apply_column_rename_drop_add "$actual_fingerprint" "$target_fingerprint"
+
+echo ""
+echo "=== dolt_patch oracle results: $pass passed, $fail failed ==="
+if [ "$fail" -gt 0 ]; then
+  echo "Failed:$FAILED_NAMES"
+  exit 1
+fi

--- a/tool/mksqlite3c.tcl
+++ b/tool/mksqlite3c.tcl
@@ -607,7 +607,7 @@ proc emit_doltlite_engine_block {} {
     doltlite_workspace.c
     doltlite_branch.c doltlite_tag.c doltlite_ancestor.c doltlite_merge.c
     doltlite_conflicts.c doltlite_gc.c doltlite_chunk_walk.c
-    doltlite_history.c doltlite_at.c doltlite_blame.c doltlite_schema_diff.c
+    doltlite_history.c doltlite_at.c doltlite_blame.c doltlite_schema_diff.c doltlite_patch.c
     doltlite_schemas.c doltlite_diff_stat.c doltlite_record.c doltlite_ignore.c
     doltlite_hashof.c doltlite_constraint_violations.c doltlite_merge_constraints.c
     doltlite_dbpage.c doltlite_remote.c doltlite_remote_sql.c doltlite_http_remote.c


### PR DESCRIPTION
Closes #1705.

Adds a Dolt-compatible `dolt_patch()` eponymous table function with:

- explicit from/to refs and two-dot / three-dot range forms
- optional, case-insensitive table filtering and WORKING / STAGED support
- deterministic, dependency-safe statement ordering
- SQLite-native INSERT, UPDATE, DELETE, and schema statements
- executable table rebuild plans for schema and primary-key changes
- correct quoting for identifiers, embedded NUL text, blobs, NULLs, and numeric values
- `diff_type` pushdown with compact statement numbering matching Dolt
- amalgamation and README integration

Testing:

- expanded Dolt oracle and executable-replay suite: 76/76
  - forward/reverse DML, refs, ranges, merge bases, filters, ordering, and errors
  - multi-chunk diffs, add/drop/rename tables, composite and changing primary keys
  - keyless rowids and rowid alias shadowing
  - blobs, generated columns, STRICT tables, indexes, triggers, and foreign keys
  - exact forward and reverse application against tagged snapshots
- ASan + UBSan expanded oracle run: 76/76
- neighboring diff/schema/trigger/PK oracle suites: 185/185
- existing Dolt diff oracle suite: 63/63
- DoltLite amalgamation generation and compilation
- layer/file-I/O lint, source checks, shell syntax, and diff checks

The deeper replay matrix found and fixed keyless rowid loss, target-trigger double firing, primary-key rebuild collisions, rename-plus-data handling, and false renames caused by recycled SQLite table IDs.

`make devtest` was also run earlier. This machine still hits existing local prerequisites/baselines before the TCL corpus: missing libtommath, debug `cursorHoldsMutex` assertions in fuzz runs, and deserialize unable-to-open errors. The focused, oracle, amalgamation, and sanitizer runs above are clean.