### PR TITLE
Remove signed-shift UB when reading table numbers from the catalog

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -2683,7 +2683,7 @@ static int serializeCatalogPatchRoots(Btree *pBtree, u8 **ppOut, int *pnOut){
       return SQLITE_NOTFOUND;
     }
 
-    iTable = (Pgno)(q[0] | (q[1]<<8) | (q[2]<<16) | (q[3]<<24));
+    iTable = (Pgno)getU32LE(q);
     pTE = findTable(pBtree, iTable);
     if( !pTE ){
       sqlite3_free(buf);
@@ -2808,7 +2808,7 @@ static int deserializeCatalog(Btree *pBtree, const u8 *data, int nData){
       catFree(&catNew);
       return SQLITE_CORRUPT;
     }
-    iTable = (Pgno)(q[0] | (q[1]<<8) | (q[2]<<16) | (q[3]<<24));
+    iTable = (Pgno)getU32LE(q);
     q += 4;
     flags = *q++;
     pTE = catAdd(&catNew, iTable, flags);
@@ -6135,7 +6135,7 @@ static int restoreFromCommitted(Btree *p){
             rc = SQLITE_CORRUPT;
             break;
           }
-          iTable = (Pgno)(q[0] | (q[1]<<8) | (q[2]<<16) | (q[3]<<24));
+          iTable = (Pgno)getU32LE(q);
           pTE = &p->cat.a[i];
           if( pTE->iTable!=iTable ){
             rc = SQLITE_NOTFOUND;
@@ -11095,7 +11095,7 @@ int doltliteLoadTableRootById(
       sqlite3_free(data);
       return SQLITE_CORRUPT;
     }
-    entryTable = (Pgno)(q[0] | (q[1]<<8) | (q[2]<<16) | (q[3]<<24));
+    entryTable = (Pgno)getU32LE(q);
     q += CAT_ENTRY_ITABLE_SIZE;
     flags = *q++;
     memcpy(root.data, q, PROLLY_HASH_SIZE);


### PR DESCRIPTION
## Summary

Four catalog-deserialization sites in `prolly_btree.c` assembled a little-endian table number as `q[0] | (q[1]<<8) | (q[2]<<16) | (q[3]<<24)`. `q[i]` is a `u8` promoted to `int`, so `q[3]<<24` shifts into the sign bit of an `int` whenever the high byte's top bit is set — **undefined behavior**:

```
runtime error: left shift of 255 by 24 places cannot be represented in type 'int'
```

Replaced with the existing `getU32LE` helper (line 74), which casts each byte to `u32` before shifting. It is numerically identical for every input and is already used for the other 32-bit reads in this file.

## Impact / reachability

No behavior change on valid data: catalog bytes are content-addressed (hash-verified on read), so a high table byte only arises with an implausibly large table count. This is latent-UB hardening, not a reachable bug — but it's genuine UB that the `asan-ubsan` CI job would flag if ever exercised, so it's worth removing.

## Verification

- UBSan demonstrates the old expression trips (`left shift of 255 by 24 places…`) while `getU32LE` is clean.
- No regression: `doltlite_stable_catalog_numbers` (12), `doltlite_schema_cookie` (5), `doltlite_index_vc_matrix` (38), `doltlite_structural` (15) all pass.

## Scope note

I investigated the other storage-engine review findings and deliberately left them out — they turned out to be latent/defensive, not reachable bugs:
- `serializeUnpackedRecordBuffer`'s 256-field clamp: could not produce wrong results even with a 300-column composite NOCASE index (the fallback serializes index keys, not wide rows).
- `prollyGetVarint32`'s unbounded read: only ever fed VDBE-built (well-formed) seek keys, not untrusted bytes.
- On-disk chunk-count `(int)` truncation: the WAL manifest is hash-authenticated and the header copy is advisory/overwritten, so it's not meaningfully untrusted.
- `sqlite3_malloc(0)` on a zero-length incrblob write: real but extremely niche (zero-length blob + zero-length write).

Happy to follow up on any of those if you'd like them hardened as defense-in-depth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)