### PR TITLE
Check pipe/write/read returns in multi_process_test

### DIFF
--- a/test/multi_process_test.c
+++ b/test/multi_process_test.c
@@ -19,6 +19,18 @@ static void check(const char *name, int condition){
   }
 }
 
+/* pipe/write/read return values are attribute((warn_unused_result)) under
+** glibc fortify; a failed sync pipe means the test can't run, so abort. */
+static void mpPipe(int fd[2]){
+  if( pipe(fd)!=0 ){ perror("pipe"); _exit(1); }
+}
+static void mpWrite(int fd, const char *byte){
+  if( write(fd, byte, 1)!=1 ) _exit(1);
+}
+static void mpRead(int fd, char *buf){
+  if( read(fd, buf, 1)!=1 ) _exit(1);
+}
+
 static int execSql(sqlite3 *db, const char *sql){
   char *err = 0;
   int rc = sqlite3_exec(db, sql, 0, 0, &err);
@@ -233,7 +245,7 @@ static void test_gc_during_read(void){
     sqlite3_close(db);
   }
 
-  pipe(pipefd);
+  mpPipe(pipefd);
 
   pid = fork();
   if( pid==0 ){
@@ -244,7 +256,7 @@ static void test_gc_during_read(void){
 
     queryScalarText(db, "SELECT count(*) FROM t");
 
-    write(pipefd[1], "R", 1);
+    mpWrite(pipefd[1], "R");
     close(pipefd[1]);
 
     sleep(3);
@@ -261,7 +273,7 @@ static void test_gc_during_read(void){
     char buf;
     sqlite3 *db = 0;
     close(pipefd[1]);
-    read(pipefd[0], &buf, 1); /* Wait for child's signal */
+    mpRead(pipefd[0], &buf); /* Wait for child's signal */
     close(pipefd[0]);
 
     sqlite3_open(path, &db);
@@ -292,7 +304,7 @@ static void test_gc_blocked_by_writer(void){
   printf("--- Test 5: GC blocked by concurrent writer ---\n");
   setup_db(path);
 
-  pipe(pipefd);
+  mpPipe(pipefd);
 
   pid = fork();
   if( pid==0 ){
@@ -302,7 +314,7 @@ static void test_gc_blocked_by_writer(void){
     execSql(db, "BEGIN");
     execSql(db, "INSERT INTO t VALUES(2, 'blocking')");
 
-    write(pipefd[1], "W", 1);
+    mpWrite(pipefd[1], "W");
     close(pipefd[1]);
 
     sleep(2);
@@ -316,7 +328,7 @@ static void test_gc_blocked_by_writer(void){
     sqlite3 *db = 0;
     const char *r;
     close(pipefd[1]);
-    read(pipefd[0], &buf, 1);
+    mpRead(pipefd[0], &buf);
     close(pipefd[0]);
 
     sqlite3_open(path, &db);
@@ -354,7 +366,7 @@ static void test_cross_process_commit_conflict(void){
 
   setup_db(stalePath);
 
-  pipe(pipefd);
+  mpPipe(pipefd);
 
   pid = fork();
   if( pid==0 ){
@@ -365,7 +377,7 @@ static void test_cross_process_commit_conflict(void){
     execSql(db, "INSERT INTO t VALUES(2, 'child')");
     queryScalarText(db, "SELECT dolt_commit('-A','-m','child commit')");
 
-    write(pipefd[1], "C", 1);
+    mpWrite(pipefd[1], "C");
     close(pipefd[1]);
     sqlite3_close(db);
     _exit(0);
@@ -379,7 +391,7 @@ static void test_cross_process_commit_conflict(void){
     sqlite3_open(stalePath, &db);
 
     close(pipefd[1]);
-    read(pipefd[0], &buf, 1);
+    mpRead(pipefd[0], &buf);
     close(pipefd[0]);
     waitpid(pid, &status, 0);
 
@@ -506,8 +518,8 @@ static void test_many_process_commit_contention(void){
   }
 
   for(i=0; i<N_WORKERS; i++){
-    pipe(ready[i]);
-    pipe(go[i]);
+    mpPipe(ready[i]);
+    mpPipe(go[i]);
     pids[i] = fork();
     if( pids[i]==0 ){
       int rc;


### PR DESCRIPTION
## Problem

The `ubuntu` CI job enforces a warning-free build (`grep -E "warning:" build.log` → fail). On the updated runner image, glibc fortify now flags the ignored return values of `pipe`/`write`/`read` in `test/multi_process_test.c` (`-Wunused-result`):

```
test/multi_process_test.c:236:3: warning: ignoring return value of 'pipe' declared with attribute 'warn_unused_result'
```

These calls (and the file) predate this and aren't specific to any one change — the warnings surfaced with the runner/compiler bump, so the gate is now red on **every** open PR (e.g. #1717's ubuntu job, whose actual diff only touches `prolly_btree.c`).

## Fix

Route the fork/pipe sync calls through small `mpPipe`/`mpWrite`/`mpRead` helpers that check the return and `_exit(1)` on failure — a failed synchronization pipe means the test can't run meaningfully anyway. Consuming the return in a condition clears `warn_unused_result`.

No behavior change on success. Builds clean and still passes **49/49** locally.

## Note

Merging this first unblocks the shared `ubuntu` gate for all in-flight PRs (they'll go green on rebase).

🤖 Generated with [Claude Code](https://claude.com/claude-code)