### PR TITLE
Harden remote fetch/clone against wire and lifetime hazards

### DIFF
--- a/src/doltlite_http_remote.c
+++ b/src/doltlite_http_remote.c
@@ -144,6 +144,21 @@ static int readUntilEof(HttpConn *conn, u8 **ppOut, int *pnOut){
     nUsed += (i64)n;
   }
 
+  /* Callers scan the response as a C string (e.g. atoi on Content-Length), so
+  ** guarantee a trailing NUL. The growth loop keeps slack in practice, but a
+  ** buffer filled exactly to nAlloc would otherwise leave the parse to run off
+  ** the end. */
+  if( nUsed >= nAlloc ){
+    u8 *pNew = sqlite3_realloc64(pBuf, nUsed + 1);
+    if( !pNew ){
+      sqlite3_free(pBuf);
+      return SQLITE_NOMEM;
+    }
+    pBuf = pNew;
+    nAlloc = nUsed + 1;
+  }
+  pBuf[nUsed] = 0;
+
   *ppOut = pBuf;
   *pnOut = (int)nUsed;
   return SQLITE_OK;

--- a/src/doltlite_remote.c
+++ b/src/doltlite_remote.c
@@ -90,13 +90,19 @@ static int remoteCollectRootsFromRefsBlob(
 
   {
     int nBr, nTg;
+    i64 nAlloc64;
     const BranchRef *aBr;
     const TagRef *aTg;
     refsTableGetBranches(&refsView.refs, &nBr, &aBr);
     refsTableGetTags(&refsView.refs, &nTg, &aTg);
-    nAlloc = nBr + nTg + 1;
+    nAlloc64 = (i64)nBr + (i64)nTg + 1;
+    if( nAlloc64 > (i64)0x7fffffff/(i64)sizeof(ProllyHash) ){
+      chunkStoreClose(&refsView);
+      return SQLITE_CORRUPT;
+    }
+    nAlloc = (int)nAlloc64;
     if( nAlloc>0 ){
-      aRoots = sqlite3_malloc(nAlloc * (int)sizeof(ProllyHash));
+      aRoots = sqlite3_malloc64((sqlite3_uint64)nAlloc * sizeof(ProllyHash));
       if( !aRoots ){
         chunkStoreClose(&refsView);
         return SQLITE_NOMEM;

--- a/src/doltlite_remote_sql.c
+++ b/src/doltlite_remote_sql.c
@@ -389,6 +389,7 @@ static void doltFetchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
     char **azNames = 0;
     int nNames = 0;
     int i;
+    char *zUrlOwned;
 
     rc = parseRemoteBranchNames(pRemote, &azNames, &nNames);
     if( rc!=SQLITE_OK ){
@@ -400,10 +401,20 @@ static void doltFetchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
     pRemote->xClose(pRemote);
     pRemote = 0;
 
+    /* zUrl points into cs->refs.aRemotes; each doltliteFetch below can reload
+    ** refs and reallocate that array, so own a copy for the loop. */
+    zUrlOwned = sqlite3_mprintf("%s", zUrl);
+    if( !zUrlOwned ){
+      doltliteFreeStringArray(azNames, nNames);
+      sqlite3_result_error_nomem(ctx);
+      return;
+    }
+
     for(i=0; i<nNames; i++){
-      DoltliteRemote *pBrRemote = openRemoteByUrl(chunkFileGetVfs(&cs->file), zUrl);
+      DoltliteRemote *pBrRemote = openRemoteByUrl(chunkFileGetVfs(&cs->file), zUrlOwned);
       if( !pBrRemote ){
         doltliteFreeStringArray(azNames, nNames);
+        sqlite3_free(zUrlOwned);
         doltliteVcResultError(ctx, db, "failed to open remote (URL must start with file:// or http://)");
         return;
       }
@@ -411,12 +422,14 @@ static void doltFetchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
       pBrRemote->xClose(pBrRemote);
       if( rc!=SQLITE_OK ){
         doltliteFreeStringArray(azNames, nNames);
+        sqlite3_free(zUrlOwned);
         (void)doltliteVcSealSavepointError(db);
         remoteSqlResultError(ctx, rc, "fetch failed");
         return;
       }
     }
     doltliteFreeStringArray(azNames, nNames);
+    sqlite3_free(zUrlOwned);
   }
 
   if( pRemote ) pRemote->xClose(pRemote);


### PR DESCRIPTION
Three memory-safety fixes on the remote paths (from the deep-review backlog).

## 1. HTTP response over-read (`doltlite_http_remote.c`)

`readUntilEof` returned its buffer **not NUL-terminated** (`nUsed` can reach `nAlloc`), yet `httpRequest` parses it as a C string — `atoi((const char*)pRaw+i+15)` for `Content-Length`. `atoi` scans forward over digits, so a response whose digits run to the allocation boundary reads past the end (a crafted/truncated server, or a MITM on plain `http://`). Fixed by guaranteeing a trailing NUL before returning.

## 2. `zUrl` use-after-free in multi-branch fetch (`doltlite_remote_sql.c`)

`doltFetchFunc`'s all-branches loop reopened the remote each iteration with `zUrl`, which points into `cs->refs.aRemotes`. `doltliteFetch` can reload refs and reallocate that array, leaving `zUrl` dangling from iteration 2 on (reachable when a peer writes concurrently during the fetch). Own a copy of the URL for the loop. The single-branch path never re-dereferences `zUrl`, so it was already safe.

## 3. Clone roots array overflow guard (`doltlite_remote.c`)

`remoteCollectRootsFromRefsBlob` sized the roots array with a 32-bit `nBr+nTg+1` product from an untrusted remote refs blob. Bounded in `i64` with `sqlite3_malloc64`, matching the guard `parseRemoteBranchNames` already carries. (Defense-in-depth: `csDeserializeRefs` already bounds those counts by blob size.)

## Reachability / testing

All three are latent in normal single-connection use (which is why master's asan-ubsan is green): #1 needs a crafted response, #2 needs a concurrent peer write mid-loop, #3 needs a multi-GB refs blob. The fixes are correct by construction and low-risk. Validated by no regression across 160 remote-suite tests (`remote_test` 97, `vc_oracle_fetch_pull_convergence_test` 29, `vc_oracle_remotes_test` 34); CI's asan-ubsan job exercises the remote suites under ASan. Deterministic fail-before tests would require forced concurrency / a mock malicious server, which the harness doesn't expose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)