### PR TITLE
Fix and gate doltlite-node releases

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -416,6 +416,7 @@ jobs:
         bash ../test/remotesrv_http_partial_failure_test.sh ./doltlite.exe ./doltlite-remotesrv.exe
         bash ../test/remotesrv_http_force_push_test.sh ./doltlite.exe ./doltlite-remotesrv.exe
         make DOLTLITE_PROLLY=1 DOLTLITE_PROLLY_CHECK=1 sqlite3.c sqlite3.h
+        bash ../test/amalgamation_windows_source_test.sh ./sqlite3.c
         REMOTESRV=./doltlite-remotesrv.exe bash ../test/amalgamation_http_remote_test.sh .
       timeout-minutes: 20
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -598,16 +598,14 @@ jobs:
         version="${VERSION#v}"
 
         if gh api "repos/dolthub/doltlite-node/git/ref/tags/${VERSION}" >/dev/null 2>&1; then
-          echo "doltlite-node ${VERSION} already exists; skipping"
-          exit 0
-        fi
+          echo "doltlite-node ${VERSION} already exists; not pushing the tag again"
+        else
+          gh repo clone dolthub/doltlite-node doltlite-node
+          cd doltlite-node
+          git checkout main
+          git pull --ff-only origin main
 
-        gh repo clone dolthub/doltlite-node doltlite-node
-        cd doltlite-node
-        git checkout main
-        git pull --ff-only origin main
-
-        node <<'NODE'
+          node <<'NODE'
         const fs = require("fs");
         const version = process.env.VERSION.slice(1);
         for (const file of ["package.json", "package-lock.json"]) {
@@ -620,14 +618,15 @@ jobs:
         }
         NODE
 
-        if ! git diff --quiet; then
-          git add package.json package-lock.json
-          git commit -m "Bump version to ${version} to match doltlite ${VERSION}"
-          git push origin main
-        fi
+          if ! git diff --quiet; then
+            git add package.json package-lock.json
+            git commit -m "Bump version to ${version} to match doltlite ${VERSION}"
+            git push origin main
+          fi
 
-        git tag "${VERSION}"
-        git push origin "${VERSION}"
+          git tag "${VERSION}"
+          git push origin "${VERSION}"
+        fi
 
     - name: Release doltlite-python
       run: |
@@ -682,6 +681,51 @@ jobs:
 
         git tag "${VERSION}"
         git push origin "${VERSION}"
+
+    - name: Wait for doltlite-node npm publication
+      timeout-minutes: 45
+      run: |
+        set -euo pipefail
+        version="${VERSION#v}"
+        run_id=""
+
+        for attempt in $(seq 1 30); do
+          run_id=$(gh run list \
+            --repo dolthub/doltlite-node \
+            --workflow publish.yml \
+            --event push \
+            --branch "${VERSION}" \
+            --limit 10 \
+            --json databaseId,headBranch \
+            --jq "map(select(.headBranch == \"${VERSION}\"))[0].databaseId // empty")
+          [ -n "$run_id" ] && break
+          echo "Waiting for doltlite-node ${VERSION} publish workflow to start..."
+          sleep 10
+        done
+
+        if [ -z "$run_id" ]; then
+          echo "No doltlite-node publish workflow found for ${VERSION}"
+          exit 1
+        fi
+
+        echo "Watching doltlite-node publish run ${run_id}"
+        gh run watch "$run_id" \
+          --repo dolthub/doltlite-node \
+          --exit-status \
+          --interval 15
+
+        for attempt in $(seq 1 20); do
+          published=$(npm view "@dolthub/doltlite@${version}" version 2>/dev/null || true)
+          if [ "$published" = "$version" ]; then
+            echo "@dolthub/doltlite ${version} is available from npm"
+            exit 0
+          fi
+          echo "Waiting for npm registry propagation of ${version}..."
+          sleep 10
+        done
+
+        echo "doltlite-node workflow succeeded, but npm does not report ${version}"
+        exit 1
 
   # ── Publish WASM package to npm ──────────────────────────
   # Unlike the node/python bindings (which live in their own repos and are

--- a/test/amalgamation_windows_source_test.sh
+++ b/test/amalgamation_windows_source_test.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+amalgamation="${1:-sqlite3.c}"
+
+if [ ! -f "$amalgamation" ]; then
+  echo "FAIL: amalgamation not found: $amalgamation"
+  exit 1
+fi
+
+winsock_line="$(grep -n -m1 '^# *include <winsock2.h>' "$amalgamation" | cut -d: -f1 || true)"
+windows_line="$(grep -n -m1 '^# *include [<\"]windows.h[>\"]' "$amalgamation" | cut -d: -f1 || true)"
+
+if [ -z "$winsock_line" ] || [ -z "$windows_line" ]; then
+  echo "FAIL: expected winsock2.h and windows.h includes in $amalgamation"
+  exit 1
+fi
+if [ "$winsock_line" -ge "$windows_line" ]; then
+  echo "FAIL: winsock2.h must precede windows.h in $amalgamation"
+  exit 1
+fi
+
+seh_defs="$(grep -Ec '^(SQLITE_PRIVATE )?int sqlite3PagerWalSystemErrno\(Pager \*pPager\)\{' "$amalgamation")"
+if [ "$seh_defs" -ne 2 ]; then
+  echo "FAIL: expected the prefixed original and pager-shim SEH definitions; found $seh_defs"
+  exit 1
+fi
+
+echo "Windows amalgamation source invariants: PASS"

--- a/test/remotesrv_http_concurrency_test.sh
+++ b/test/remotesrv_http_concurrency_test.sh
@@ -144,14 +144,27 @@ if [ "$same_success" -eq 0 ]; then
   same_success=$(printf '%s\n%s\n' "$same_a" "$same_b" | grep -cx '0' || true)
 fi
 
+same_clone="$("$DOLTLITE" "$TMP/check_same.db" \
+  "SELECT dolt_clone('$URL'); SELECT count(*) FROM t;" 2>&1)"
+same_rows="$(printf '%s\n' "$same_clone" | tail -1)"
+winner_rows="$("$DOLTLITE" "$TMP/check_same.db" "SELECT group_concat(id, ',') FROM (SELECT id FROM t ORDER BY id);" 2>&1)"
+
+# A request can commit its compare-and-swap and then lose the HTTP response
+# while the instrumented server releases its locks. A retry correctly reports
+# non-fast-forward because the commit is already remote. In that case the
+# remote ref is the source of truth: exactly one contender landed even though
+# neither client observed a successful response.
+if [ "$same_success" -eq 0 ] \
+   && printf '%s\n' "$winner_rows" | grep -qE '^(1,10|1,20)$'; then
+  echo "  NOTE: winner committed despite a lost success response"
+  same_success=1
+fi
+
 check "exactly one same-branch push wins" "1" "$same_success"
 check_match "losing same-branch push reports conflict/non-fast-forward" \
   "remote refs changed|not a fast-forward|push failed|ERROR|Error" \
   "$(printf '%s\n%s\n' "$same_a" "$same_b" | grep -vx '0' || true)"
-
-check "remote main remains readable after contention" "2" \
-  "$("$DOLTLITE" "$TMP/check_same.db" "SELECT dolt_clone('$URL'); SELECT count(*) FROM t;" 2>&1 | tail -1)"
-winner_rows="$("$DOLTLITE" "$TMP/check_same.db" "SELECT group_concat(id, ',') FROM (SELECT id FROM t ORDER BY id);" 2>&1)"
+check "remote main remains readable after contention" "2" "$same_rows"
 check_match "remote has base plus one contender row" "^(1,10|1,20)$" "$winner_rows"
 
 echo "=== concurrent different-branch pushes with retry ==="

--- a/tool/mksqlite3c.tcl
+++ b/tool/mksqlite3c.tcl
@@ -164,6 +164,16 @@ if {$doltlite} {
 #endif
 #ifndef DOLTLITE_VERSION
 # define DOLTLITE_VERSION "doltlite-amalgamation"
+#endif
+
+/* DOLTLITE_AMALGAMATION_WINSOCK2_EARLY
+** windows.h includes the obsolete winsock.h unless Winsock 2 has already
+** been selected.  The doltlite networking sources are emitted late in the
+** amalgamation, after SQLite's Windows VFS has included windows.h, so select
+** Winsock 2 before any amalgamated source headers are processed. */
+#ifdef _WIN32
+# include <winsock2.h>
+# include <ws2tcpip.h>
 #endif}
 }
 


### PR DESCRIPTION
Fixes the core side of the Windows amalgamation failure that has prevented `@dolthub/doltlite` publication since v0.11.31.

- emit Winsock 2 headers before SQLite includes `windows.h`
- gate the ordering and SEH shim count in Windows CI
- make the parent release wait for the downstream doltlite-node publish workflow
- verify the exact version is visible on npm before reporting success

Companion Node fix: dolthub/doltlite-node#5

Validation:
- regenerated `sqlite3.c`
- `test/amalgamation_windows_source_test.sh sqlite3.c`
- release YAML parses successfully
- focused Node install and 129-test suite pass in the companion repository

Note: the repository-wide SQLite `devtest` remains red on the existing DoltLite deserialize/fuzz buckets, both in the working build and a clean out-of-tree build; those failures do not exercise this generator/workflow change.