### PR TITLE
Enforce push scope and fast-forward server-side when applying refs (#1721)

### DIFF
--- a/main.mk
+++ b/main.mk
@@ -2688,6 +2688,7 @@ DOLTLITE_C_TESTS = \
 	clone_error_code_test$(T.exe) \
 	three_way_diff_test$(T.exe) \
 	prolly_hashset_test$(T.exe) \
+	scoped_refs_push_test$(T.exe) \
 	sequence_reload_test$(T.exe) \
 	chunk_store_fork_lock_test$(T.exe) \
 	remotesrv_init_failure_test$(T.exe) \
@@ -2776,6 +2777,14 @@ three_way_diff_test$(T.exe): $(TOP)/test/three_way_diff_test.c $(LIBOBJS0)
 prolly_hashset_test$(T.exe): $(TOP)/test/prolly_hashset_test.c libdoltlite$(T.lib)
 	$(T.link) -I. -I$(TOP)/src -DDOLTLITE_PROLLY=1 -D_HAVE_SQLITE_CONFIG_H \
 		-o $@ $(TOP)/test/prolly_hashset_test.c \
+		libdoltlite$(T.lib) -lz -lpthread -lm
+
+# scoped_refs_push_test drives the push-scope validator directly; like the
+# other prolly-internal tests it needs the DoltLite defines and links the
+# static archive for the exported doltliteValidateScopedRefsUpdate entry point.
+scoped_refs_push_test$(T.exe): $(TOP)/test/scoped_refs_push_test.c libdoltlite$(T.lib)
+	$(T.link) -I. -I$(TOP)/src -DDOLTLITE_PROLLY=1 -D_HAVE_SQLITE_CONFIG_H \
+		-o $@ $(TOP)/test/scoped_refs_push_test.c \
 		libdoltlite$(T.lib) -lz -lpthread -lm
 
 # oom_dolt_fault_test installs a wrapper allocator that fails the Nth

--- a/src/doltlite_http_remote.c
+++ b/src/doltlite_http_remote.c
@@ -37,6 +37,8 @@ struct HttpRemote {
   int nPendingRefs;
   ProllyHash expectedRefsHash;
   u8 hasExpectedRefsHash;
+  char *zPushBranch;
+  int bPushForce;
 };
 
 #define HTTP_RESP_MAX_BYTES ((i64)128 * 1024 * 1024)
@@ -515,13 +517,18 @@ static int httpGetRefs(DoltliteRemote *pRemote, u8 **ppData, int *pnData){
   return SQLITE_OK;
 }
 
-static int httpSetRefs(DoltliteRemote *pRemote, const u8 *pData, int nData){
+static int httpSetRefs(DoltliteRemote *pRemote, const char *zBranch,
+                       int bForce, const u8 *pData, int nData){
   HttpRemote *p = (HttpRemote*)pRemote;
 
   sqlite3_free(p->pPendingRefs);
   p->pPendingRefs = 0;
   p->nPendingRefs = 0;
   p->hasExpectedRefsHash = 0;
+  sqlite3_free(p->zPushBranch);
+  p->zPushBranch = zBranch ? sqlite3_mprintf("%s", zBranch) : 0;
+  if( zBranch && !p->zPushBranch ) return SQLITE_NOMEM;
+  p->bPushForce = bForce;
 
   if( pData && nData > 0 ){
     p->pPendingRefs = sqlite3_malloc(nData);
@@ -535,11 +542,13 @@ static int httpSetRefs(DoltliteRemote *pRemote, const u8 *pData, int nData){
 static int httpSetRefsIf(
   DoltliteRemote *pRemote,
   const ProllyHash *pExpectedRefsHash,
+  const char *zBranch,
+  int bForce,
   const u8 *pData,
   int nData
 ){
   HttpRemote *p = (HttpRemote*)pRemote;
-  int rc = httpSetRefs(pRemote, pData, nData);
+  int rc = httpSetRefs(pRemote, zBranch, bForce, pData, nData);
   if( rc!=SQLITE_OK ) return rc;
   if( pExpectedRefsHash ){
     memcpy(&p->expectedRefsHash, pExpectedRefsHash, sizeof(ProllyHash));
@@ -572,27 +581,34 @@ static int httpCommit(DoltliteRemote *pRemote){
   }
 
   if( p->pPendingRefs && p->nPendingRefs > 0 ){
+    /* Body: [u16 branchLen][branch][u8 force] then, for refs-if, the expected
+    ** refs hash, then the refs blob. The prefix declares the push scope so the
+    ** server can reject changes to any other ref. */
+    int nBranch = p->zPushBranch ? (int)strlen(p->zPushBranch) : 0;
+    int nHashPart = p->hasExpectedRefsHash ? PROLLY_HASH_SIZE : 0;
+    int nReq = 2 + nBranch + 1 + nHashPart + p->nPendingRefs;
+    u8 *pReq;
+    int off = 0;
+
     pResp = 0; nResp = 0; status = 0;
     zPath = buildPath(p, p->hasExpectedRefsHash ? "/refs-if" : "/refs");
     if( !zPath ) return SQLITE_NOMEM;
-
-    if( p->hasExpectedRefsHash ){
-      u8 *pReq = sqlite3_malloc(PROLLY_HASH_SIZE + p->nPendingRefs);
-      if( !pReq ){
-        sqlite3_free(zPath);
-        return SQLITE_NOMEM;
-      }
-      memcpy(pReq, p->expectedRefsHash.data, PROLLY_HASH_SIZE);
-      memcpy(pReq + PROLLY_HASH_SIZE, p->pPendingRefs, p->nPendingRefs);
-      rc = httpRequest(p, "PUT", zPath,
-                       pReq, PROLLY_HASH_SIZE + p->nPendingRefs,
-                       &status, &pResp, &nResp);
-      sqlite3_free(pReq);
-    }else{
-      rc = httpRequest(p, "PUT", zPath,
-                       p->pPendingRefs, p->nPendingRefs,
-                       &status, &pResp, &nResp);
+    pReq = sqlite3_malloc(nReq);
+    if( !pReq ){
+      sqlite3_free(zPath);
+      return SQLITE_NOMEM;
     }
+    pReq[off++] = (u8)(nBranch & 0xff);
+    pReq[off++] = (u8)((nBranch >> 8) & 0xff);
+    if( nBranch>0 ){ memcpy(pReq+off, p->zPushBranch, nBranch); off += nBranch; }
+    pReq[off++] = (u8)(p->bPushForce ? 1 : 0);
+    if( nHashPart ){
+      memcpy(pReq+off, p->expectedRefsHash.data, PROLLY_HASH_SIZE);
+      off += PROLLY_HASH_SIZE;
+    }
+    memcpy(pReq+off, p->pPendingRefs, p->nPendingRefs);
+    rc = httpRequest(p, "PUT", zPath, pReq, nReq, &status, &pResp, &nResp);
+    sqlite3_free(pReq);
     sqlite3_free(zPath);
     sqlite3_free(pResp);
     if( rc != SQLITE_OK ) return rc;
@@ -622,6 +638,8 @@ static int httpCommit(DoltliteRemote *pRemote){
   sqlite3_free(p->pPendingRefs);
   p->pPendingRefs = 0;
   p->nPendingRefs = 0;
+  sqlite3_free(p->zPushBranch);
+  p->zPushBranch = 0;
 
   return SQLITE_OK;
 }
@@ -636,6 +654,7 @@ static void httpClose(DoltliteRemote *pRemote){
   sqlite3_free(p->zBasePath);
   sqlite3_free(p->pUploadBuf);
   sqlite3_free(p->pPendingRefs);
+  sqlite3_free(p->zPushBranch);
   sqlite3_free(p);
 }
 

--- a/src/doltlite_remote.c
+++ b/src/doltlite_remote.c
@@ -333,14 +333,20 @@ static int fsGetRefs(DoltliteRemote *pRemote, u8 **ppData, int *pnData){
   return rc;
 }
 
-static int fsSetRefs(DoltliteRemote *pRemote, const u8 *pData, int nData){
+static int fsSetRefs(DoltliteRemote *pRemote, const char *zBranch, int bForce,
+                     const u8 *pData, int nData){
   FsRemote *p = (FsRemote*)pRemote;
+  int rc = doltliteValidateScopedRefsUpdate(&p->store, pData, nData,
+                                            zBranch, bForce);
+  if( rc!=SQLITE_OK ) return rc;
   return chunkStoreInstallRefsBlob(&p->store, pData, nData);
 }
 
 static int fsSetRefsIf(
   DoltliteRemote *pRemote,
   const ProllyHash *pExpectedRefsHash,
+  const char *zBranch,
+  int bForce,
   const u8 *pData,
   int nData
 ){
@@ -360,7 +366,7 @@ static int fsSetRefsIf(
     p->lockedForCas = 0;
     return SQLITE_BUSY;
   }
-  rc = fsSetRefs(pRemote, pData, nData);
+  rc = fsSetRefs(pRemote, zBranch, bForce, pData, nData);
   if( rc!=SQLITE_OK ){
     chunkStoreUnlock(&p->store);
     p->lockedForCas = 0;
@@ -419,14 +425,20 @@ struct LocalAsRemote {
   ChunkStore *pStore;
 };
 
-static int localSetRefs(DoltliteRemote *pRemote, const u8 *pData, int nData){
+static int localSetRefs(DoltliteRemote *pRemote, const char *zBranch,
+                        int bForce, const u8 *pData, int nData){
   LocalAsRemote *p = (LocalAsRemote*)pRemote;
+  int rc = doltliteValidateScopedRefsUpdate(p->pStore, pData, nData,
+                                            zBranch, bForce);
+  if( rc!=SQLITE_OK ) return rc;
   return chunkStoreInstallRefsBlob(p->pStore, pData, nData);
 }
 
 static int localSetRefsIf(
   DoltliteRemote *pRemote,
   const ProllyHash *pExpectedRefsHash,
+  const char *zBranch,
+  int bForce,
   const u8 *pData,
   int nData
 ){
@@ -440,7 +452,7 @@ static int localSetRefsIf(
   if( prollyHashCompare(refsTableGetHash(&p->pStore->refs), &expected)!=0 ){
     return SQLITE_BUSY;
   }
-  return localSetRefs(pRemote, pData, nData);
+  return localSetRefs(pRemote, zBranch, bForce, pData, nData);
 }
 
 static int localCommit(DoltliteRemote *pRemote){
@@ -549,6 +561,98 @@ static int syncIsAncestor(
   prollyHashSetFree(&visited);
   syncQueueFree(&queue);
   return found;
+}
+
+int doltliteValidateScopedRefsUpdate(
+  ChunkStore *pStore,
+  const u8 *pBlob,
+  int nBlob,
+  const char *zBranch,
+  int bForce
+){
+  ChunkStore inc;
+  const BranchRef *aCur = 0, *aInc = 0;
+  const TagRef *aCurTag = 0, *aIncTag = 0;
+  int nCur = 0, nInc = 0, nCurTag = 0, nIncTag = 0;
+  const BranchRef *curB = 0, *incB = 0;
+  int rc;
+  int i, j;
+
+  if( !zBranch || !zBranch[0] ) return SQLITE_MISUSE;
+  memset(&inc, 0, sizeof(inc));
+  rc = csDeserializeRefsIntoTemp(&inc, pBlob, nBlob);
+  if( rc!=SQLITE_OK ){
+    csFreeRefsState(&inc);
+    return rc;
+  }
+
+  refsTableGetBranches(&pStore->refs, &nCur, &aCur);
+  refsTableGetBranches(&inc.refs, &nInc, &aInc);
+  refsTableGetTags(&pStore->refs, &nCurTag, &aCurTag);
+  refsTableGetTags(&inc.refs, &nIncTag, &aIncTag);
+
+  /* Every current branch other than the one being pushed must survive
+  ** unchanged: same name present, same commit. Blocks rewrite and delete. */
+  for(i=0; i<nCur; i++){
+    if( strcmp(aCur[i].zName, zBranch)==0 ) continue;
+    for(j=0; j<nInc; j++){
+      if( strcmp(aInc[j].zName, aCur[i].zName)==0 ) break;
+    }
+    if( j>=nInc
+     || prollyHashCompare(&aInc[j].commitHash, &aCur[i].commitHash)!=0 ){
+      rc = SQLITE_CONSTRAINT;
+      goto done;
+    }
+  }
+
+  /* The push may not introduce any branch other than the one declared. */
+  for(j=0; j<nInc; j++){
+    if( strcmp(aInc[j].zName, zBranch)==0 ) continue;
+    for(i=0; i<nCur; i++){
+      if( strcmp(aCur[i].zName, aInc[j].zName)==0 ) break;
+    }
+    if( i>=nCur ){
+      rc = SQLITE_CONSTRAINT;
+      goto done;
+    }
+  }
+
+  /* Tags are immutable over push: identical set, identical targets. */
+  if( nCurTag!=nIncTag ){
+    rc = SQLITE_CONSTRAINT;
+    goto done;
+  }
+  for(i=0; i<nCurTag; i++){
+    for(j=0; j<nIncTag; j++){
+      if( strcmp(aCurTag[i].zName, aIncTag[j].zName)==0 ) break;
+    }
+    if( j>=nIncTag
+     || prollyHashCompare(&aIncTag[j].commitHash, &aCurTag[i].commitHash)!=0 ){
+      rc = SQLITE_CONSTRAINT;
+      goto done;
+    }
+  }
+
+  /* The declared branch may be created freely, but an existing branch may only
+  ** move as a fast-forward unless the push is forced. */
+  for(i=0; i<nCur; i++){
+    if( strcmp(aCur[i].zName, zBranch)==0 ){ curB = &aCur[i]; break; }
+  }
+  for(j=0; j<nInc; j++){
+    if( strcmp(aInc[j].zName, zBranch)==0 ){ incB = &aInc[j]; break; }
+  }
+  if( !bForce && curB && incB
+   && prollyHashCompare(&curB->commitHash, &incB->commitHash)!=0 ){
+    int anc = syncIsAncestor(pStore, &curB->commitHash, &incB->commitHash);
+    if( anc<0 ){ rc = SQLITE_NOMEM; goto done; }
+    if( anc==0 ){ rc = SQLITE_CONSTRAINT; goto done; }
+  }
+
+  rc = SQLITE_OK;
+
+done:
+  csFreeRefsState(&inc);
+  return rc;
 }
 
 static int remoteSequencesWouldAdvance(
@@ -719,9 +823,10 @@ int doltlitePush(
       if( rc!=SQLITE_OK ) return rc;
 
       if( pRemote->xSetRefsIf ){
-        rc = pRemote->xSetRefsIf(pRemote, &expectedRefsHash, newRefs, nNewRefs);
+        rc = pRemote->xSetRefsIf(pRemote, &expectedRefsHash, zBranch, bForce,
+                                 newRefs, nNewRefs);
       }else{
-        rc = pRemote->xSetRefs(pRemote, newRefs, nNewRefs);
+        rc = pRemote->xSetRefs(pRemote, zBranch, bForce, newRefs, nNewRefs);
       }
       sqlite3_free(newRefs);
       if( rc!=SQLITE_OK ) return rc;

--- a/src/doltlite_remote.h
+++ b/src/doltlite_remote.h
@@ -15,8 +15,12 @@ struct DoltliteRemote {
   int (*xGetChunks)(DoltliteRemote*, const ProllyHash *aHash, int nHash,
                     u8 **apData, int *anData);
   int (*xGetRefs)(DoltliteRemote*, u8**, int*);
-  int (*xSetRefs)(DoltliteRemote*, const u8*, int);
-  int (*xSetRefsIf)(DoltliteRemote*, const ProllyHash*, const u8*, int);
+  /* zBranch/bForce declare the intended push scope so the receiver can reject
+  ** any refs change outside that branch and enforce fast-forward. */
+  int (*xSetRefs)(DoltliteRemote*, const char *zBranch, int bForce,
+                  const u8*, int);
+  int (*xSetRefsIf)(DoltliteRemote*, const ProllyHash*, const char *zBranch,
+                    int bForce, const u8*, int);
   int (*xCommit)(DoltliteRemote*);
   void (*xClose)(DoltliteRemote*);
 };
@@ -36,6 +40,14 @@ int doltliteSyncChunks(
 
 int doltlitePush(ChunkStore *pLocal, DoltliteRemote *pRemote,
                  const char *zBranch, int bForce);
+
+/* Enforce that a pushed refs blob only creates/advances zBranch (fast-forward
+** unless bForce) and leaves every other branch and tag byte-identical to
+** pStore's current refs. Returns SQLITE_OK if allowed, SQLITE_CONSTRAINT if
+** out of scope or a non-fast-forward without force. */
+int doltliteValidateScopedRefsUpdate(ChunkStore *pStore, const u8 *pBlob,
+                                     int nBlob, const char *zBranch,
+                                     int bForce);
 
 int doltliteFetch(ChunkStore *pLocal, DoltliteRemote *pRemote,
                   const char *zRemoteName, const char *zBranch);

--- a/src/doltlite_remotesrv.c
+++ b/src/doltlite_remotesrv.c
@@ -547,10 +547,16 @@ static int remoteSrvPersistRefs(ChunkStore *pStore){
   return rc;
 }
 
-static int remoteSrvApplyRefs(ChunkStore *pStore, const u8 *pBody, int nBody){
+static int remoteSrvApplyRefs(ChunkStore *pStore, const char *zBranch,
+                              int bForce, const u8 *pBody, int nBody){
   int rc;
 
   if( nBody<=0 ) return SQLITE_ERROR;
+  rc = doltliteValidateScopedRefsUpdate(pStore, pBody, nBody, zBranch, bForce);
+  if( rc!=SQLITE_OK ){
+    chunkStoreRollback(pStore);
+    return rc;
+  }
   rc = chunkStoreInstallRefsBlob(pStore, pBody, nBody);
   if( rc!=SQLITE_OK ){
     chunkStoreRollback(pStore);
@@ -562,6 +568,8 @@ static int remoteSrvApplyRefs(ChunkStore *pStore, const u8 *pBody, int nBody){
 static int remoteSrvApplyRefsIf(
   ChunkStore *pStore,
   const ProllyHash *pExpectedRefsHash,
+  const char *zBranch,
+  int bForce,
   const u8 *pBody,
   int nBody
 ){
@@ -573,21 +581,49 @@ static int remoteSrvApplyRefsIf(
     chunkStoreUnlock(pStore);
     return SQLITE_BUSY;
   }
-  rc = remoteSrvApplyRefs(pStore, pBody, nBody);
+  rc = remoteSrvApplyRefs(pStore, zBranch, bForce, pBody, nBody);
   chunkStoreUnlock(pStore);
   return rc;
 }
 
+/* Parse the [u16 branchLen][branch][u8 force] scope prefix a push prepends to
+** the refs body. On success *pzBranch is an owned string the caller frees, and
+** the rest output points at the remainder (refs blob, or expectedHash+blob). */
+static int remoteSrvParseRefsPrefix(
+  const u8 *pBody, int nBody,
+  char **pzBranch, int *pbForce, const u8 **ppRest, int *pnRest
+){
+  int nBranch;
+  *pzBranch = 0;
+  if( nBody < 3 ) return SQLITE_ERROR;
+  nBranch = pBody[0] | (pBody[1] << 8);
+  if( 2 + nBranch + 1 > nBody ) return SQLITE_ERROR;
+  *pzBranch = sqlite3_mprintf("%.*s", nBranch, (const char*)pBody + 2);
+  if( !*pzBranch ) return SQLITE_NOMEM;
+  *pbForce = pBody[2 + nBranch] ? 1 : 0;
+  *ppRest = pBody + 2 + nBranch + 1;
+  *pnRest = nBody - (2 + nBranch + 1);
+  return SQLITE_OK;
+}
+
 static void handlePutRefs(ChunkStore *pStore, DoltliteConn *fd,
                           const u8 *pBody, int nBody){
+  char *zBranch = 0;
+  int bForce = 0;
+  const u8 *pRest = 0;
+  int nRest = 0;
   int rc;
 
-  if( nBody<=0 ){
+  rc = remoteSrvParseRefsPrefix(pBody, nBody, &zBranch, &bForce,
+                                &pRest, &nRest);
+  if( rc!=SQLITE_OK || nRest<=0 ){
+    sqlite3_free(zBranch);
     sendBadRequest(fd);
     return;
   }
 
-  rc = remoteSrvApplyRefs(pStore, pBody, nBody);
+  rc = remoteSrvApplyRefs(pStore, zBranch, bForce, pRest, nRest);
+  sqlite3_free(zBranch);
   if( rc!=SQLITE_OK ){
     sendError(fd);
     return;
@@ -599,17 +635,25 @@ static void handlePutRefs(ChunkStore *pStore, DoltliteConn *fd,
 static void handlePutRefsIf(ChunkStore *pStore, DoltliteConn *fd,
                             const u8 *pBody, int nBody){
   ProllyHash expectedRefsHash;
+  char *zBranch = 0;
+  int bForce = 0;
+  const u8 *pRest = 0;
+  int nRest = 0;
   int rc;
 
-  if( nBody<=PROLLY_HASH_SIZE ){
+  rc = remoteSrvParseRefsPrefix(pBody, nBody, &zBranch, &bForce,
+                                &pRest, &nRest);
+  if( rc!=SQLITE_OK || nRest<=PROLLY_HASH_SIZE ){
+    sqlite3_free(zBranch);
     sendBadRequest(fd);
     return;
   }
-  memcpy(expectedRefsHash.data, pBody, PROLLY_HASH_SIZE);
+  memcpy(expectedRefsHash.data, pRest, PROLLY_HASH_SIZE);
 
-  rc = remoteSrvApplyRefsIf(pStore, &expectedRefsHash,
-                            pBody + PROLLY_HASH_SIZE,
-                            nBody - PROLLY_HASH_SIZE);
+  rc = remoteSrvApplyRefsIf(pStore, &expectedRefsHash, zBranch, bForce,
+                            pRest + PROLLY_HASH_SIZE,
+                            nRest - PROLLY_HASH_SIZE);
+  sqlite3_free(zBranch);
   if( rc==SQLITE_BUSY ){
     sendConflict(fd);
     return;
@@ -629,7 +673,16 @@ int doltliteRemoteSrvCommitPendingForTest(ChunkStore *pStore){
 int doltliteRemoteSrvApplyRefsForTest(
   ChunkStore *pStore, const u8 *pBody, int nBody
 ){
-  return remoteSrvApplyRefs(pStore, pBody, nBody);
+  /* Exercises the install/rollback path only; scope validation is covered
+  ** separately. */
+  int rc;
+  if( nBody<=0 ) return SQLITE_ERROR;
+  rc = chunkStoreInstallRefsBlob(pStore, pBody, nBody);
+  if( rc!=SQLITE_OK ){
+    chunkStoreRollback(pStore);
+    return rc;
+  }
+  return remoteSrvCommitPending(pStore);
 }
 
 static void handleCommit(ChunkStore *pStore, DoltliteConn *fd){

--- a/test/run_c_tests.sh
+++ b/test/run_c_tests.sh
@@ -12,6 +12,7 @@ GATING=(
   three_way_diff_test
   clone_error_code_test
   prolly_hashset_test
+  scoped_refs_push_test
   concurrent_stress_test
   vc_concurrency_test
   vc_ref_mutation_stress_test

--- a/test/scoped_refs_push_test.c
+++ b/test/scoped_refs_push_test.c
@@ -1,0 +1,148 @@
+#include <stdio.h>
+#include <string.h>
+#include "sqliteInt.h"
+#include "prolly_hash.h"
+#include "chunk_store.h"
+#include "doltlite_remote.h"
+
+static int nPass = 0;
+static int nFail = 0;
+
+static void check(const char *name, int condition){
+  if( condition ){
+    nPass++;
+  }else{
+    nFail++;
+    fprintf(stderr, "FAIL: %s\n", name);
+  }
+}
+
+static void mkhash(ProllyHash *h, u8 b){
+  memset(h, 0, sizeof(*h));
+  h->data[0] = b;
+  h->data[1] = (u8)(b ^ 0x5a);
+}
+
+static int openStore(ChunkStore *cs, const char *path){
+  char wal[512];
+  remove(path);
+  snprintf(wal, sizeof(wal), "%s-wal", path);
+  remove(wal);
+  memset(cs, 0, sizeof(*cs));
+  return chunkStoreOpen(cs, sqlite3_vfs_find(0), path,
+      SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_MAIN_DB);
+}
+
+/* Build a refs blob from a fresh store carrying main@a and foo@b, then hand
+** back that same starting blob so scenarios can mutate copies of it. */
+static u8 *seedRefs(ChunkStore *cs, const ProllyHash *a, const ProllyHash *b,
+                    int *pn){
+  u8 *blob = 0;
+  if( chunkStoreSetDefaultBranch(cs, "main")!=SQLITE_OK ) return 0;
+  if( chunkStoreAddBranch(cs, "main", a)!=SQLITE_OK ) return 0;
+  if( chunkStoreAddBranch(cs, "foo", b)!=SQLITE_OK ) return 0;
+  if( chunkStoreSerializeRefs(cs)!=SQLITE_OK ) return 0;
+  if( chunkStoreCommit(cs)!=SQLITE_OK ) return 0;
+  if( chunkStoreSerializeRefsToBlob(cs, &blob, pn)!=SQLITE_OK ) return 0;
+  return blob;
+}
+
+int main(void){
+  ChunkStore cs;
+  ProllyHash Ha, Hb, Hc, Hd, found;
+  u8 *curBlob = 0;
+  int nCur = 0;
+  int rc;
+  const char *path = "/tmp/scoped_refs_push_test.db";
+
+  sqlite3_initialize();
+  printf("Scoped refs-push authorization tests\n");
+  printf("====================================\n\n");
+
+  mkhash(&Ha, 0xA1);
+  mkhash(&Hb, 0xB2);
+  mkhash(&Hc, 0xC3);
+  mkhash(&Hd, 0xD4);
+
+  check("open store", openStore(&cs, path)==SQLITE_OK);
+  curBlob = seedRefs(&cs, &Ha, &Hb, &nCur);
+  check("seed refs (main@a, foo@b)", curBlob!=0);
+  if( !curBlob ){ printf("\n%d passed, %d failed\n", nPass, nFail); return 1; }
+
+  /* Attack: a push declaring branch foo carries a blob that also rewrites
+  ** main. The scoped validator must reject it, with or without force. */
+  {
+    ChunkStore tmp;
+    u8 *blob = 0; int n = 0;
+    memset(&tmp, 0, sizeof(tmp));
+    chunkStoreLoadRefsFromBlob(&tmp, curBlob, nCur);
+    chunkStoreUpdateBranch(&tmp, "main", &Hc);
+    chunkStoreSerializeRefsToBlob(&tmp, &blob, &n);
+    chunkStoreClose(&tmp);
+
+    rc = doltliteValidateScopedRefsUpdate(&cs, blob, n, "foo", 0);
+    check("reject rewriting main while pushing foo", rc==SQLITE_CONSTRAINT);
+    rc = doltliteValidateScopedRefsUpdate(&cs, blob, n, "foo", 1);
+    check("force does not authorize rewriting main", rc==SQLITE_CONSTRAINT);
+
+    /* Pre-fix behavior: installing the blob wholesale (what the server used to
+    ** do) silently hijacks main. This is the reported vulnerability. */
+    {
+      ChunkStore victim;
+      check("open victim", openStore(&victim, "/tmp/scoped_refs_victim.db")==SQLITE_OK);
+      chunkStoreAddBranch(&victim, "main", &Ha);
+      chunkStoreAddBranch(&victim, "foo", &Hb);
+      chunkStoreSerializeRefs(&victim);
+      chunkStoreCommit(&victim);
+      chunkStoreInstallRefsBlob(&victim, blob, n);
+      chunkStoreFindBranch(&victim, "main", &found);
+      check("pre-fix: raw install hijacks main (vuln demo)",
+            memcmp(&found, &Hc, sizeof(found))==0);
+      chunkStoreClose(&victim);
+      remove("/tmp/scoped_refs_victim.db");
+    }
+    sqlite3_free(blob);
+  }
+
+  /* Attack: delete another branch by omitting it from the blob. */
+  {
+    ChunkStore tmp;
+    u8 *blob = 0; int n = 0;
+    memset(&tmp, 0, sizeof(tmp));
+    chunkStoreSetDefaultBranch(&tmp, "foo");
+    chunkStoreAddBranch(&tmp, "foo", &Hb);
+    chunkStoreSerializeRefsToBlob(&tmp, &blob, &n);
+    chunkStoreClose(&tmp);
+    rc = doltliteValidateScopedRefsUpdate(&cs, blob, n, "foo", 1);
+    check("reject deleting main via omission", rc==SQLITE_CONSTRAINT);
+    sqlite3_free(blob);
+  }
+
+  /* Legitimate: move only foo. Non-fast-forward needs force (Hd has no commit
+  ** chunk, so it is not an ancestor of Hb). */
+  {
+    ChunkStore tmp;
+    u8 *blob = 0; int n = 0;
+    memset(&tmp, 0, sizeof(tmp));
+    chunkStoreLoadRefsFromBlob(&tmp, curBlob, nCur);
+    chunkStoreUpdateBranch(&tmp, "foo", &Hd);
+    chunkStoreSerializeRefsToBlob(&tmp, &blob, &n);
+    chunkStoreClose(&tmp);
+    rc = doltliteValidateScopedRefsUpdate(&cs, blob, n, "foo", 0);
+    check("reject non-fast-forward foo without force", rc==SQLITE_CONSTRAINT);
+    rc = doltliteValidateScopedRefsUpdate(&cs, blob, n, "foo", 1);
+    check("allow forced move of foo (scoped)", rc==SQLITE_OK);
+    sqlite3_free(blob);
+  }
+
+  /* Legitimate: an unchanged blob is always in scope. */
+  rc = doltliteValidateScopedRefsUpdate(&cs, curBlob, nCur, "foo", 0);
+  check("allow no-op refs update", rc==SQLITE_OK);
+
+  sqlite3_free(curBlob);
+  chunkStoreClose(&cs);
+  remove(path);
+
+  printf("\n%d passed, %d failed\n", nPass, nFail);
+  return nFail>0 ? 1 : 0;
+}


### PR DESCRIPTION
Fixes #1721.

## Problem

The push protocol replaced the whole refs table with a client-supplied blob, and the receiver installed it unconditionally (`chunkStoreInstallRefsBlob`). A client pushing branch `foo` could, in the same request, rewrite or delete `main` (or any branch/tag): scoping, fast-forward, and `--force` all lived in the client, so a modified client or a hand-crafted request bypassed them. The `refs-if` CAS is concurrency control, not authorization, and is bypassable by read-then-craft.

## Fix

The push now declares its scope — branch name + force — on the wire, and every ref-install site validates the incoming blob against current state before adopting it.

- **`doltliteValidateScopedRefsUpdate`** (`doltlite_remote.c`): only the declared branch may be created or advanced (fast-forward unless forced); every other branch and every tag must be byte-identical to current. Out-of-scope changes, branch deletion by omission, and non-fast-forward moves without force are rejected with `SQLITE_CONSTRAINT`.
- **Interface**: `xSetRefs`/`xSetRefsIf` carry `zBranch`/`bForce`; the fs, http, and local remotes and `doltPushFunc` thread them through. The HTTP body gains a `[u16 branchLen][branch][u8 force]` scope prefix that `remotesrv` parses.
- **Install sites**: `remoteSrvApplyRefs`, `fsSetRefs`, and `localSetRefs` all validate before install. The whole-refs-hash CAS is kept for concurrency; scope is a separate, independent check.

## Test

`test/scoped_refs_push_test.c` (new c-test) both **demonstrates the vulnerability** and **locks the fix**:
- `pre-fix: raw install hijacks main` — installing the crafted blob wholesale (what the server did) rewrites `main`.
- Rejected: rewriting `main` while pushing `foo` (with and without force), deleting `main` by omission, non-fast-forward `foo` without force.
- Allowed: forced scoped move of `foo`, no-op update.

`10 passed, 0 failed`. No regression: `remote_test` (97), `remotesrv_http_test` (29), `remotesrv_http_force_push_test` (11), `remotesrv_init_failure_test` (14), and the `remotesrv_put_refs_failure_restore` regression case all pass.

## Notes

- Wire format for `PUT /refs` and `/refs-if` changes (adds the scope prefix); client and server are updated together. Format isn't locked, so this is acceptable.
- This is authorization *scoping*, not per-user permissions: an authenticated pusher can still force-move the branch they declare, but can no longer touch any other ref. `remotesrv` remains the reference server; production branch-protection/permissions are a separate layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)