### PR TITLE
Implement Dolt-compatible merge schema conflicts

### DIFF
--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -2361,6 +2361,13 @@ static void doltliteCommitFunc(
     if( rc!=SQLITE_OK ) return;
   }
 
+  if( doltliteSessionHasSchemaConflicts(db) ){
+    sqlite3_result_error(context,
+      "cannot commit: unresolved schema conflicts. Abort the merge, align "
+      "the schemas on one side, then rerun the merge.", -1);
+    return;
+  }
+
   {
     ProllyHash cfHash;
     doltliteGetSessionConflictsCatalog(db, &cfHash);
@@ -3357,6 +3364,12 @@ static void doltliteMergeFunc(
       return;
     }
     sqlite3_free(zMergeErr);
+
+    if( nMergeConflicts>0 ){
+      ProllyHash conflictsHash;
+      doltliteGetSessionConflictsCatalog(db, &conflictsHash);
+      doltliteSetSessionMergeState(db, 1, &theirHead, &conflictsHash);
+    }
 
     rc = doltliteRefreshAndConfirmHead(db, cs, &ourHead);
     if( rc==SQLITE_BUSY ){

--- a/src/doltlite_conflicts.c
+++ b/src/doltlite_conflicts.c
@@ -10,6 +10,8 @@ struct ConflictTableInfo {
   char *zName;
   int nConflicts;
   DoltliteConflictRow *aRows;
+  char **azSchemaObjects;
+  int nSchemaObjects;
 };
 
 static void freeConflictTable(ConflictTableInfo *pTable);
@@ -161,9 +163,13 @@ static int loadAllConflicts(
       rc = SQLITE_CORRUPT; goto conflicts_cleanup;
     }
     aTables[i].nConflicts = nc;
-    aTables[i].aRows = sqlite3_malloc64((sqlite3_uint64)nc * sizeof(DoltliteConflictRow));
-    if( !aTables[i].aRows ){ rc = SQLITE_NOMEM; goto conflicts_cleanup; }
-    memset(aTables[i].aRows, 0, (sqlite3_uint64)nc * sizeof(DoltliteConflictRow));
+    if( nc>0 ){
+      aTables[i].aRows = sqlite3_malloc64(
+          (sqlite3_uint64)nc * sizeof(DoltliteConflictRow));
+      if( !aTables[i].aRows ){ rc = SQLITE_NOMEM; goto conflicts_cleanup; }
+      memset(aTables[i].aRows, 0,
+             (sqlite3_uint64)nc * sizeof(DoltliteConflictRow));
+    }
 
     for(j=0; j<nc; j++){
       DoltliteConflictRow *cr = &aTables[i].aRows[j];
@@ -182,6 +188,43 @@ static int loadAllConflicts(
 conflicts_cleanup:
   freeConflictTables(aTables, nTables);
   sqlite3_free(data);
+  return rc;
+}
+
+int doltliteSessionHasSchemaConflicts(sqlite3 *db){
+  ConflictTableInfo *aTables = 0;
+  int nTables = 0;
+  int i;
+  int rc = loadAllConflicts(db, doltliteGetChunkStore(db),
+                            &aTables, &nTables);
+  if( rc!=SQLITE_OK ) return 0;
+  for(i=0; i<nTables; i++){
+    if( aTables[i].nConflicts==0 ){
+      freeConflictTables(aTables, nTables);
+      return 1;
+    }
+  }
+  freeConflictTables(aTables, nTables);
+  return 0;
+}
+
+int doltliteForEachSchemaConflict(
+  sqlite3 *db,
+  int (*xConflict)(void*, const char*),
+  void *pCtx
+){
+  ConflictTableInfo *aTables = 0;
+  int nTables = 0;
+  int i;
+  int rc = loadAllConflicts(db, doltliteGetChunkStore(db),
+                            &aTables, &nTables);
+  if( rc!=SQLITE_OK ) return rc;
+  for(i=0; i<nTables && rc==SQLITE_OK; i++){
+    if( aTables[i].nConflicts==0 ){
+      rc = xConflict(pCtx, aTables[i].zName);
+    }
+  }
+  freeConflictTables(aTables, nTables);
   return rc;
 }
 
@@ -274,6 +317,10 @@ static void freeConflictTable(ConflictTableInfo *pTable){
   for(j=0; j<pTable->nConflicts; j++){
     freeConflictRow(&pTable->aRows[j]);
   }
+  for(j=0; j<pTable->nSchemaObjects; j++){
+    sqlite3_free(pTable->azSchemaObjects[j]);
+  }
+  sqlite3_free(pTable->azSchemaObjects);
   sqlite3_free(pTable->aRows);
   sqlite3_free(pTable->zName);
   memset(pTable, 0, sizeof(*pTable));
@@ -576,6 +623,28 @@ static int cfClose(sqlite3_vtab_cursor *cur){
   freeConflictTables(c->aTables, c->nTables);
   sqlite3_free(c); return SQLITE_OK;
 }
+
+/* Dolt lists a schema conflict in dolt_conflicts only when the conflicted
+** table exists in the working root.  A conflict whose "ours" side deleted
+** the table remains visible in dolt_schema_conflicts and dolt_status. */
+static void cfPruneDeletedSchemaConflicts(sqlite3 *db, ConflictsCur *c){
+  int i;
+  int nOut = 0;
+  for(i=0; i<c->nTables; i++){
+    ConflictTableInfo *p = &c->aTables[i];
+    if( p->nConflicts==0 && sqlite3FindTable(db, p->zName, 0)==0 ){
+      freeConflictTable(p);
+      continue;
+    }
+    if( nOut!=i ){
+      c->aTables[nOut] = c->aTables[i];
+      memset(&c->aTables[i], 0, sizeof(c->aTables[i]));
+    }
+    nOut++;
+  }
+  c->nTables = nOut;
+}
+
 static int cfFilter(sqlite3_vtab_cursor *cur, int n, const char *s, int a, sqlite3_value **v){
   ConflictsCur *c=(ConflictsCur*)cur;
   ConflictsVtab *vt=(ConflictsVtab*)cur->pVtab;
@@ -593,7 +662,8 @@ static int cfFilter(sqlite3_vtab_cursor *cur, int n, const char *s, int a, sqlit
     rc = loadConflictTable(vt->db, doltliteGetChunkStore(vt->db),
                            zTable, &table, &found);
     if( rc!=SQLITE_OK ) return rc;
-    if( found ){
+    if( found && (table.nConflicts!=0
+                  || sqlite3FindTable(vt->db, table.zName, 0)!=0) ){
       c->aTables = sqlite3_malloc(sizeof(*c->aTables));
       if( !c->aTables ){
         freeConflictTable(&table);
@@ -601,10 +671,15 @@ static int cfFilter(sqlite3_vtab_cursor *cur, int n, const char *s, int a, sqlit
       }
       c->aTables[0] = table;
       c->nTables = 1;
+    }else if( found ){
+      freeConflictTable(&table);
     }
     return SQLITE_OK;
   }
-  return loadAllConflicts(vt->db, doltliteGetChunkStore(vt->db), &c->aTables, &c->nTables);
+  rc = loadAllConflicts(vt->db, doltliteGetChunkStore(vt->db),
+                        &c->aTables, &c->nTables);
+  if( rc==SQLITE_OK ) cfPruneDeletedSchemaConflicts(vt->db, c);
+  return rc;
 }
 static int cfNext(sqlite3_vtab_cursor *cur){ ((ConflictsCur*)cur)->iRow++; return SQLITE_OK; }
 static int cfEof(sqlite3_vtab_cursor *cur){ ConflictsCur *c=(ConflictsCur*)cur; return c->iRow>=c->nTables; }
@@ -626,6 +701,346 @@ static int cfBestIndex(sqlite3_vtab *v, sqlite3_index_info *p){
 static sqlite3_module conflictsModule = {
   0,0,cfConnect,cfBestIndex,doltliteVtabDisconnect,0,cfOpen,cfClose,cfFilter,cfNext,cfEof,
   cfColumn,cfRowid,0,0,0,0,0,0,0,0,0,0,0,0
+};
+
+typedef struct SchemaConflictRow SchemaConflictRow;
+struct SchemaConflictRow {
+  char *zTable;
+  char *zBase;
+  char *zOurs;
+  char *zTheirs;
+  char *zDescription;
+};
+
+typedef struct SchemaConflictsVtab SchemaConflictsVtab;
+struct SchemaConflictsVtab { sqlite3_vtab base; sqlite3 *db; };
+
+typedef struct SchemaConflictsCur SchemaConflictsCur;
+struct SchemaConflictsCur {
+  sqlite3_vtab_cursor base;
+  SchemaConflictRow *aRows;
+  int nRows;
+  int iRow;
+};
+
+static void schemaConflictsFreeRows(SchemaConflictsCur *pCur){
+  int i;
+  for(i=0; i<pCur->nRows; i++){
+    sqlite3_free(pCur->aRows[i].zTable);
+    sqlite3_free(pCur->aRows[i].zBase);
+    sqlite3_free(pCur->aRows[i].zOurs);
+    sqlite3_free(pCur->aRows[i].zTheirs);
+    sqlite3_free(pCur->aRows[i].zDescription);
+  }
+  sqlite3_free(pCur->aRows);
+  pCur->aRows = 0;
+  pCur->nRows = 0;
+  pCur->iRow = 0;
+}
+
+static int schemaEntrySame(const SchemaEntry *pA, const SchemaEntry *pB){
+  if( !pA && !pB ) return 1;
+  if( !pA || !pB ) return 0;
+  if( sqlite3_stricmp(pA->zType ? pA->zType : "",
+                      pB->zType ? pB->zType : "")!=0 ) return 0;
+  if( sqlite3_stricmp(pA->zTblName ? pA->zTblName : "",
+                      pB->zTblName ? pB->zTblName : "")!=0 ) return 0;
+  if( (pA->zSql==0)!=(pB->zSql==0) ) return 0;
+  return !pA->zSql || strcmp(pA->zSql, pB->zSql)==0;
+}
+
+static SchemaEntry *schemaTableEntry(
+  SchemaEntry *aSchema,
+  int nSchema,
+  const char *zTable
+){
+  SchemaEntry *p = findSchemaEntry(aSchema, nSchema, zTable);
+  if( p && p->zType && strcmp(p->zType, "table")==0 ) return p;
+  return 0;
+}
+
+static char *schemaConflictSql(
+  SchemaEntry *aSchema,
+  int nSchema,
+  const char *zTable
+){
+  SchemaEntry *pTable = schemaTableEntry(aSchema, nSchema, zTable);
+  sqlite3_str *pStr = sqlite3_str_new(0);
+  int i;
+  int nAdded = 0;
+  char *z;
+
+  if( !pStr ) return 0;
+  if( pTable && pTable->zSql ){
+    sqlite3_str_appendall(pStr, pTable->zSql);
+    nAdded++;
+  }
+  for(i=0; i<nSchema; i++){
+    SchemaEntry *p = &aSchema[i];
+    if( !p->zSql || !p->zType || !p->zName ) continue;
+    if( strcmp(p->zType, "index")==0 && p->zTblName
+     && sqlite3_stricmp(p->zTblName, zTable)==0 ){
+      if( nAdded ) sqlite3_str_appendall(pStr, ";\n");
+      sqlite3_str_appendall(pStr, p->zSql);
+      nAdded++;
+    }
+  }
+  if( nAdded==0 ){
+    SchemaEntry *p = findSchemaEntry(aSchema, nSchema, zTable);
+    if( p && p->zSql ){
+      sqlite3_str_appendall(pStr, p->zSql);
+      nAdded++;
+    }
+  }
+  if( nAdded==0 ) sqlite3_str_appendall(pStr, "<deleted>");
+  z = sqlite3_str_finish(pStr);
+  return z;
+}
+
+static char *schemaConflictIndexDescription(
+  SchemaEntry *aBase, int nBase,
+  SchemaEntry *aOurs, int nOurs,
+  SchemaEntry *aTheirs, int nTheirs,
+  const char *zTable
+){
+  int side, i;
+  for(side=0; side<3; side++){
+    SchemaEntry *a = side==0 ? aBase : (side==1 ? aOurs : aTheirs);
+    int n = side==0 ? nBase : (side==1 ? nOurs : nTheirs);
+    for(i=0; i<n; i++){
+      SchemaEntry *pBase;
+      SchemaEntry *pOurs;
+      SchemaEntry *pTheirs;
+      int oursChanged;
+      int theirsChanged;
+      if( !a[i].zType || strcmp(a[i].zType, "index")!=0
+       || !a[i].zName || !a[i].zTblName
+       || sqlite3_stricmp(a[i].zTblName, zTable)!=0 ){
+        continue;
+      }
+      pBase = findSchemaEntry(aBase, nBase, a[i].zName);
+      pOurs = findSchemaEntry(aOurs, nOurs, a[i].zName);
+      pTheirs = findSchemaEntry(aTheirs, nTheirs, a[i].zName);
+      oursChanged = !schemaEntrySame(pBase, pOurs);
+      theirsChanged = !schemaEntrySame(pBase, pTheirs);
+      if( !oursChanged || !theirsChanged || schemaEntrySame(pOurs, pTheirs) ){
+        continue;
+      }
+      if( !pBase ){
+        return sqlite3_mprintf(
+            "both branches added index '%s' with different definitions",
+            a[i].zName);
+      }
+      if( !pOurs || !pTheirs ){
+        return sqlite3_mprintf(
+            "index '%s' modified on one branch and deleted on the other",
+            a[i].zName);
+      }
+      return sqlite3_mprintf(
+          "both branches modified index '%s' differently", a[i].zName);
+    }
+  }
+  return 0;
+}
+
+static char *schemaConflictDescription(
+  SchemaEntry *aBase, int nBase,
+  SchemaEntry *aOurs, int nOurs,
+  SchemaEntry *aTheirs, int nTheirs,
+  const char *zTable,
+  const char *zBase,
+  const char *zOurs,
+  const char *zTheirs
+){
+  SchemaEntry *pBase = schemaTableEntry(aBase, nBase, zTable);
+  SchemaEntry *pOurs = schemaTableEntry(aOurs, nOurs, zTable);
+  SchemaEntry *pTheirs = schemaTableEntry(aTheirs, nTheirs, zTable);
+  char *zDetail = 0;
+  int rc;
+
+  if( !pBase && pOurs && pTheirs ){
+    return sqlite3_mprintf(
+        "table '%s' added on both branches with different definitions", zTable);
+  }
+  if( pBase && (!pOurs || !pTheirs) ){
+    const char *zSurvivor = pOurs ? zOurs : zTheirs;
+    const char *zKind = strcmp(zBase, zSurvivor)==0
+        ? "data modification" : "schema modification";
+    return sqlite3_mprintf("cannot merge a table deletion with %s", zKind);
+  }
+  if( pBase && pOurs && pTheirs ){
+    rc = doltliteTableSchemaConflictDetail(pBase->zSql, pOurs->zSql,
+                                           pTheirs->zSql, &zDetail);
+    if( rc!=SQLITE_OK ){
+      sqlite3_free(zDetail);
+      return 0;
+    }
+    if( zDetail ) return zDetail;
+  }
+  zDetail = schemaConflictIndexDescription(
+      aBase, nBase, aOurs, nOurs, aTheirs, nTheirs, zTable);
+  if( zDetail ) return zDetail;
+  return sqlite3_mprintf("incompatible schema changes for table '%s'", zTable);
+}
+
+static int schemaConflictsLoadRows(SchemaConflictsCur *pCur, sqlite3 *db){
+  ConflictTableInfo *aTables = 0;
+  int nTables = 0;
+  ProllyHash ourHead, theirHead, ancestorHash;
+  DoltliteCommit ourCommit, theirCommit, ancestorCommit;
+  SchemaEntry *aBase = 0, *aOurs = 0, *aTheirs = 0;
+  int nBase = 0, nOurs = 0, nTheirs = 0;
+  ChunkStore *cs = doltliteGetChunkStore(db);
+  ProllyCache *pCache = doltliteGetCache(db);
+  u8 isMerging = 0;
+  int i, nSchemaRows = 0;
+  int rc;
+
+  memset(&ourCommit, 0, sizeof(ourCommit));
+  memset(&theirCommit, 0, sizeof(theirCommit));
+  memset(&ancestorCommit, 0, sizeof(ancestorCommit));
+  doltliteGetSessionMergeState(db, &isMerging, &theirHead, 0);
+  if( !isMerging || prollyHashIsEmpty(&theirHead) ) return SQLITE_OK;
+  rc = loadAllConflicts(db, cs, &aTables, &nTables);
+  if( rc!=SQLITE_OK ) goto done;
+  for(i=0; i<nTables; i++){
+    if( aTables[i].nConflicts==0 ) nSchemaRows++;
+  }
+  if( nSchemaRows==0 ) goto done;
+
+  doltliteGetSessionHead(db, &ourHead);
+  rc = doltliteFindAncestor(db, &ourHead, &theirHead, &ancestorHash);
+  if( rc!=SQLITE_OK ) goto done;
+  rc = doltliteLoadCommit(db, &ourHead, &ourCommit);
+  if( rc!=SQLITE_OK ) goto done;
+  rc = doltliteLoadCommit(db, &theirHead, &theirCommit);
+  if( rc!=SQLITE_OK ) goto done;
+  rc = doltliteLoadCommit(db, &ancestorHash, &ancestorCommit);
+  if( rc!=SQLITE_OK ) goto done;
+  rc = loadSchemaFromCatalog(db, cs, pCache, &ancestorCommit.catalogHash,
+                             &aBase, &nBase);
+  if( rc==SQLITE_OK ){
+    rc = loadSchemaFromCatalog(db, cs, pCache, &ourCommit.catalogHash,
+                               &aOurs, &nOurs);
+  }
+  if( rc==SQLITE_OK ){
+    rc = loadSchemaFromCatalog(db, cs, pCache, &theirCommit.catalogHash,
+                               &aTheirs, &nTheirs);
+  }
+  if( rc!=SQLITE_OK ) goto done;
+
+  pCur->aRows = sqlite3_malloc(nSchemaRows*(int)sizeof(SchemaConflictRow));
+  if( !pCur->aRows ){ rc = SQLITE_NOMEM; goto done; }
+  memset(pCur->aRows, 0, nSchemaRows*(int)sizeof(SchemaConflictRow));
+  for(i=0; i<nTables; i++){
+    SchemaConflictRow *pRow;
+    if( aTables[i].nConflicts!=0 ) continue;
+    pRow = &pCur->aRows[pCur->nRows];
+    pCur->nRows++;
+    pRow->zTable = sqlite3_mprintf("%s", aTables[i].zName);
+    pRow->zBase = schemaConflictSql(aBase, nBase, aTables[i].zName);
+    pRow->zOurs = schemaConflictSql(aOurs, nOurs, aTables[i].zName);
+    pRow->zTheirs = schemaConflictSql(aTheirs, nTheirs, aTables[i].zName);
+    if( !pRow->zTable || !pRow->zBase || !pRow->zOurs || !pRow->zTheirs ){
+      rc = SQLITE_NOMEM;
+      goto done;
+    }
+    pRow->zDescription = schemaConflictDescription(
+        aBase, nBase, aOurs, nOurs, aTheirs, nTheirs,
+        aTables[i].zName, pRow->zBase, pRow->zOurs, pRow->zTheirs);
+    if( !pRow->zDescription ){ rc = SQLITE_NOMEM; goto done; }
+  }
+
+done:
+  freeConflictTables(aTables, nTables);
+  freeSchemaEntries(aBase, nBase);
+  freeSchemaEntries(aOurs, nOurs);
+  freeSchemaEntries(aTheirs, nTheirs);
+  doltliteCommitClear(&ourCommit);
+  doltliteCommitClear(&theirCommit);
+  doltliteCommitClear(&ancestorCommit);
+  if( rc!=SQLITE_OK ) schemaConflictsFreeRows(pCur);
+  return rc;
+}
+
+static int scConnect(sqlite3 *db, void *pAux, int argc,
+    const char *const*argv, sqlite3_vtab **ppVtab, char **pzErr){
+  SchemaConflictsVtab *p;
+  int rc;
+  (void)pAux; (void)argc; (void)argv; (void)pzErr;
+  rc = doltliteVtabConnectSimple(db,
+      "CREATE TABLE x(table_name TEXT PRIMARY KEY, base_schema TEXT, "
+      "our_schema TEXT, their_schema TEXT, description TEXT)",
+      sizeof(*p), ppVtab);
+  if( rc==SQLITE_OK ){
+    p = (SchemaConflictsVtab*)*ppVtab;
+    p->db = db;
+  }
+  return rc;
+}
+
+static int scOpen(sqlite3_vtab *pVtab, sqlite3_vtab_cursor **ppCursor){
+  (void)pVtab;
+  return doltliteVtabOpenCursor(ppCursor, sizeof(SchemaConflictsCur));
+}
+
+static int scClose(sqlite3_vtab_cursor *pCursor){
+  SchemaConflictsCur *pCur = (SchemaConflictsCur*)pCursor;
+  schemaConflictsFreeRows(pCur);
+  sqlite3_free(pCur);
+  return SQLITE_OK;
+}
+
+static int scFilter(sqlite3_vtab_cursor *pCursor, int idxNum,
+    const char *idxStr, int argc, sqlite3_value **argv){
+  SchemaConflictsCur *pCur = (SchemaConflictsCur*)pCursor;
+  SchemaConflictsVtab *pVtab = (SchemaConflictsVtab*)pCursor->pVtab;
+  (void)idxNum; (void)idxStr; (void)argc; (void)argv;
+  schemaConflictsFreeRows(pCur);
+  return schemaConflictsLoadRows(pCur, pVtab->db);
+}
+
+static int scNext(sqlite3_vtab_cursor *pCursor){
+  ((SchemaConflictsCur*)pCursor)->iRow++;
+  return SQLITE_OK;
+}
+
+static int scEof(sqlite3_vtab_cursor *pCursor){
+  SchemaConflictsCur *pCur = (SchemaConflictsCur*)pCursor;
+  return pCur->iRow>=pCur->nRows;
+}
+
+static int scColumn(sqlite3_vtab_cursor *pCursor, sqlite3_context *ctx, int iCol){
+  SchemaConflictsCur *pCur = (SchemaConflictsCur*)pCursor;
+  SchemaConflictRow *pRow;
+  if( pCur->iRow>=pCur->nRows ) return SQLITE_OK;
+  pRow = &pCur->aRows[pCur->iRow];
+  switch( iCol ){
+    case 0: sqlite3_result_text(ctx, pRow->zTable, -1, SQLITE_TRANSIENT); break;
+    case 1: sqlite3_result_text(ctx, pRow->zBase, -1, SQLITE_TRANSIENT); break;
+    case 2: sqlite3_result_text(ctx, pRow->zOurs, -1, SQLITE_TRANSIENT); break;
+    case 3: sqlite3_result_text(ctx, pRow->zTheirs, -1, SQLITE_TRANSIENT); break;
+    case 4: sqlite3_result_text(ctx, pRow->zDescription, -1, SQLITE_TRANSIENT); break;
+  }
+  return SQLITE_OK;
+}
+
+static int scRowid(sqlite3_vtab_cursor *pCursor, sqlite3_int64 *pRowid){
+  *pRowid = ((SchemaConflictsCur*)pCursor)->iRow + 1;
+  return SQLITE_OK;
+}
+
+static int scBestIndex(sqlite3_vtab *pVtab, sqlite3_index_info *pInfo){
+  (void)pVtab;
+  pInfo->estimatedCost = 10.0;
+  pInfo->estimatedRows = 4;
+  return SQLITE_OK;
+}
+
+static sqlite3_module schemaConflictsModule = {
+  0,0,scConnect,scBestIndex,doltliteVtabDisconnect,0,
+  scOpen,scClose,scFilter,scNext,scEof,scColumn,scRowid,
+  0,0,0,0,0,0,0,0,0,0,0,0
 };
 
 typedef struct CfRowVtab CfRowVtab;
@@ -937,6 +1352,22 @@ static void conflictsResolveFunc(sqlite3_context *ctx, int argc, sqlite3_value *
   zTable = (const char*)sqlite3_value_text(argv[1]);
   if(!zMode||!zTable){ sqlite3_result_error(ctx,"invalid args",-1); return; }
 
+  rc = loadConflictTable(db, cs, zTable, &table, &found);
+  if( rc!=SQLITE_OK ){
+    sqlite3_result_error_code(ctx, rc);
+    return;
+  }
+  if( found && table.nConflicts==0 ){
+    freeConflictTable(&table);
+    sqlite3_result_error(ctx,
+      "Unable to automatically resolve schema conflicts since data changes "
+      "may not have been fully merged yet. Abort this merge, align the "
+      "schemas on one side, then rerun the merge.", -1);
+    return;
+  }
+  freeConflictTable(&table);
+  found = 0;
+
   if( strcmp(zMode,"--ours")==0 ){
     rc = removeConflictTableFromCatalog(db, cs, zTable, &found);
     if( rc!=SQLITE_OK ){
@@ -987,6 +1418,9 @@ static void conflictsResolveFunc(sqlite3_context *ctx, int argc, sqlite3_value *
 int doltliteConflictsRegister(sqlite3 *db){
   int rc;
   rc = sqlite3_create_module(db, "dolt_conflicts", &conflictsModule, 0);
+  if( rc==SQLITE_OK )
+    rc = sqlite3_create_module(db, "dolt_schema_conflicts",
+                               &schemaConflictsModule, 0);
   if( rc==SQLITE_OK )
     rc = sqlite3_create_function(db, "dolt_conflicts_resolve", -1,
                                   DOLTLITE_COMMAND_FUNC_FLAGS, 0,

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -980,6 +980,11 @@ int doltliteBuildNamedStageMasterRoot(sqlite3 *db,
     const char **azTouched, int nTouched,
     ProllyHash *pNewRoot);
 int doltliteReindexNamedIndexes(sqlite3 *db, char **az, int n);
+int doltliteTableSchemaConflictDetail(const char *zAncestorSql,
+    const char *zOurSql, const char *zTheirSql, char **pzDetail);
+int doltliteSessionHasSchemaConflicts(sqlite3 *db);
+int doltliteForEachSchemaConflict(sqlite3 *db,
+    int (*xConflict)(void*, const char*), void *pCtx);
 
 static SQLITE_INLINE int doltliteAppendQuotedIdent(sqlite3_str *pStr,
                                                    const char *zName){

--- a/src/doltlite_merge.c
+++ b/src/doltlite_merge.c
@@ -1097,6 +1097,27 @@ schema_merge_cleanup:
   return rc;
 }
 
+int doltliteTableSchemaConflictDetail(
+  const char *zAncestorSql,
+  const char *zOurSql,
+  const char *zTheirSql,
+  char **pzDetail
+){
+  char **azAdd = 0;
+  int nAdd = 0;
+  int useTheirSchema = 0;
+  int i, rc;
+
+  *pzDetail = 0;
+  if( !zAncestorSql || !zOurSql || !zTheirSql ) return SQLITE_OK;
+  rc = trySchemaColumnMerge(zAncestorSql, zOurSql, zTheirSql,
+                            &azAdd, &nAdd, &useTheirSchema, pzDetail);
+  for(i=0; i<nAdd; i++) sqlite3_free(azAdd[i]);
+  sqlite3_free(azAdd);
+  if( rc==SQLITE_ERROR ) return SQLITE_OK;
+  return rc;
+}
+
 /* Rewrite every record in theirs' table root from theirs' column order into
 ** the merged column order (ours' columns, then theirs' added columns), keyed
 ** by column name. A merged column absent from a their-record is emitted as
@@ -1265,6 +1286,8 @@ struct MergeConflictTable {
   char *zName;
   int nConflicts;
   DoltliteConflictRow *aRows;
+  char **azSchemaObjects;
+  int nSchemaObjects;
 };
 
 static void freeConflictRows(DoltliteConflictRow *aRows, int nRows){
@@ -1297,9 +1320,170 @@ static int appendConflictTable(
   }
   *ppConflictTables = aNew;
   aNew[*pnConflictTables].zName = sqlite3_mprintf("%s", zName);
+  if( !aNew[*pnConflictTables].zName ){
+    freeConflictRows(aConflictRows, nConflicts);
+    return SQLITE_NOMEM;
+  }
   aNew[*pnConflictTables].nConflicts = nConflicts;
   aNew[*pnConflictTables].aRows = aConflictRows;
+  aNew[*pnConflictTables].azSchemaObjects = 0;
+  aNew[*pnConflictTables].nSchemaObjects = 0;
   (*pnConflictTables)++;
+  return SQLITE_OK;
+}
+
+static int appendSchemaConflict(
+  MergeConflictTable **ppConflictTables,
+  int *pnConflictTables,
+  const char *zTable,
+  const char *zObject,
+  int *pAddedTable
+){
+  MergeConflictTable *pTable = 0;
+  char **azNew;
+  int i, rc;
+
+  *pAddedTable = 0;
+  for(i=0; i<*pnConflictTables; i++){
+    if( (*ppConflictTables)[i].zName
+     && sqlite3_stricmp((*ppConflictTables)[i].zName, zTable)==0 ){
+      pTable = &(*ppConflictTables)[i];
+      break;
+    }
+  }
+  if( !pTable ){
+    rc = appendConflictTable(ppConflictTables, pnConflictTables,
+                             zTable, 0, 0);
+    if( rc!=SQLITE_OK ) return rc;
+    pTable = &(*ppConflictTables)[*pnConflictTables-1];
+    *pAddedTable = 1;
+  }
+
+  for(i=0; i<pTable->nSchemaObjects; i++){
+    if( sqlite3_stricmp(pTable->azSchemaObjects[i], zObject)==0 ){
+      return SQLITE_OK;
+    }
+  }
+  azNew = sqlite3_realloc(pTable->azSchemaObjects,
+      (pTable->nSchemaObjects+1)*(int)sizeof(char*));
+  if( !azNew ) return SQLITE_NOMEM;
+  pTable->azSchemaObjects = azNew;
+  azNew[pTable->nSchemaObjects] = sqlite3_mprintf("%s", zObject);
+  if( !azNew[pTable->nSchemaObjects] ) return SQLITE_NOMEM;
+  pTable->nSchemaObjects++;
+  return SQLITE_OK;
+}
+
+static int hasSchemaConflictObject(
+  MergeConflictTable *aConflictTables,
+  int nConflictTables,
+  const char *zObject
+){
+  int i, j;
+  if( !zObject ) return 0;
+  for(i=0; i<nConflictTables; i++){
+    for(j=0; j<aConflictTables[i].nSchemaObjects; j++){
+      if( sqlite3_stricmp(aConflictTables[i].azSchemaObjects[j], zObject)==0 ){
+        return 1;
+      }
+    }
+  }
+  return 0;
+}
+
+static int hasSchemaConflictTable(
+  MergeConflictTable *aConflictTables,
+  int nConflictTables,
+  const char *zTable
+){
+  int i;
+  for(i=0; i<nConflictTables; i++){
+    if( aConflictTables[i].nSchemaObjects>0
+     && aConflictTables[i].zName
+     && sqlite3_stricmp(aConflictTables[i].zName, zTable)==0 ){
+      return 1;
+    }
+  }
+  return 0;
+}
+
+static int hasAnySchemaConflict(
+  MergeConflictTable *aConflictTables,
+  int nConflictTables
+){
+  int i;
+  for(i=0; i<nConflictTables; i++){
+    if( aConflictTables[i].nSchemaObjects>0 ) return 1;
+  }
+  return 0;
+}
+
+static int mergeSchemaEntriesSame(
+  const SchemaEntry *pA,
+  const SchemaEntry *pB
+){
+  if( !pA && !pB ) return 1;
+  if( !pA || !pB ) return 0;
+  if( sqlite3_stricmp(pA->zType ? pA->zType : "",
+                      pB->zType ? pB->zType : "")!=0 ) return 0;
+  if( sqlite3_stricmp(pA->zTblName ? pA->zTblName : "",
+                      pB->zTblName ? pB->zTblName : "")!=0 ) return 0;
+  if( (pA->zSql==0)!=(pB->zSql==0) ) return 0;
+  return !pA->zSql || strcmp(pA->zSql, pB->zSql)==0;
+}
+
+static int preDetectIndexSchemaConflicts(
+  SchemaEntry *aAnc, int nAnc,
+  SchemaEntry *aOurs, int nOurs,
+  SchemaEntry *aTheirs, int nTheirs,
+  MergeConflictTable **ppConflictTables,
+  int *pnConflictTables,
+  int *pTotalConflicts
+){
+  int side, i, j, rc;
+  for(side=0; side<3; side++){
+    SchemaEntry *a = side==0 ? aAnc : (side==1 ? aOurs : aTheirs);
+    int n = side==0 ? nAnc : (side==1 ? nOurs : nTheirs);
+    for(i=0; i<n; i++){
+      SchemaEntry *pAnc;
+      SchemaEntry *pOurs;
+      SchemaEntry *pTheirs;
+      const char *zTable;
+      int oursChanged;
+      int theirsChanged;
+      int seen = 0;
+      int addedSchemaTable = 0;
+      if( !a[i].zType || strcmp(a[i].zType, "index")!=0
+       || !a[i].zName || !a[i].zSql ){
+        continue;
+      }
+      for(j=0; j<i; j++){
+        if( a[j].zType && strcmp(a[j].zType, "index")==0
+         && a[j].zName
+         && sqlite3_stricmp(a[j].zName, a[i].zName)==0 ){
+          seen = 1;
+          break;
+        }
+      }
+      if( seen ) continue;
+      pAnc = findSchemaEntry(aAnc, nAnc, a[i].zName);
+      pOurs = findSchemaEntry(aOurs, nOurs, a[i].zName);
+      pTheirs = findSchemaEntry(aTheirs, nTheirs, a[i].zName);
+      oursChanged = !mergeSchemaEntriesSame(pAnc, pOurs);
+      theirsChanged = !mergeSchemaEntriesSame(pAnc, pTheirs);
+      if( !oursChanged || !theirsChanged
+       || mergeSchemaEntriesSame(pOurs, pTheirs) ){
+        continue;
+      }
+      zTable = pOurs && pOurs->zTblName ? pOurs->zTblName
+             : (pTheirs && pTheirs->zTblName ? pTheirs->zTblName
+                                             : a[i].zName);
+      rc = appendSchemaConflict(ppConflictTables, pnConflictTables,
+                                zTable, a[i].zName, &addedSchemaTable);
+      if( rc!=SQLITE_OK ) return rc;
+      if( addedSchemaTable ) (*pTotalConflicts)++;
+    }
+  }
   return SQLITE_OK;
 }
 
@@ -1558,6 +1742,7 @@ static SchemaEntry *mergedSchemaChoice(
   SchemaEntry *aAncSchema, int nAncSchema,
   SchemaEntry *aOursSchema, int nOursSchema,
   SchemaEntry *aTheirsSchema, int nTheirsSchema,
+  MergeConflictTable *aConflictTables, int nConflictTables,
   const char *zName
 ){
   SchemaEntry *pAnc = findSchemaEntry(aAncSchema, nAncSchema, zName);
@@ -1567,6 +1752,9 @@ static SchemaEntry *mergedSchemaChoice(
                                              aOursSchema, nOursSchema, zName);
   int theirsChanged = schemaEntryChangedByName(aAncSchema, nAncSchema,
                                                aTheirsSchema, nTheirsSchema, zName);
+  if( hasSchemaConflictObject(aConflictTables, nConflictTables, zName) ){
+    return pOurs;
+  }
   if( oursChanged && !theirsChanged ) return pOurs;
   if( theirsChanged && !oursChanged ) return pTheirs;
   /* Both sides dropped the object: falling back to the ancestor would
@@ -1610,6 +1798,7 @@ static int appendMergedHiddenIndexRow(
   SchemaEntry *aAncSchema, int nAncSchema,
   SchemaEntry *aOursSchema, int nOursSchema,
   SchemaEntry *aTheirsSchema, int nTheirsSchema,
+  MergeConflictTable *aConflictTables, int nConflictTables,
   SchemaRootpageRemap *aRemap, int nRemap,
   const char *zName
 ){
@@ -1620,6 +1809,7 @@ static int appendMergedHiddenIndexRow(
   pSe = mergedSchemaChoice(aAncSchema, nAncSchema,
                            aOursSchema, nOursSchema,
                            aTheirsSchema, nTheirsSchema,
+                           aConflictTables, nConflictTables,
                            zName);
   if( !pSe || !pSe->zType || !pSe->zName ) return SQLITE_OK;
   if( strcmp(pSe->zType, "index")!=0 ) return SQLITE_OK;
@@ -1640,6 +1830,7 @@ static int appendMergedAuxSchemaRow(
   SchemaEntry *aAncSchema, int nAncSchema,
   SchemaEntry *aOursSchema, int nOursSchema,
   SchemaEntry *aTheirsSchema, int nTheirsSchema,
+  MergeConflictTable *aConflictTables, int nConflictTables,
   SchemaRootpageRemap *aRemap, int nRemap,
   const char *zName
 ){
@@ -1650,6 +1841,7 @@ static int appendMergedAuxSchemaRow(
   pSe = mergedSchemaChoice(aAncSchema, nAncSchema,
                            aOursSchema, nOursSchema,
                            aTheirsSchema, nTheirsSchema,
+                           aConflictTables, nConflictTables,
                            zName);
   if( !pSe || !pSe->zType || !pSe->zName ) return SQLITE_OK;
   if( strcmp(pSe->zType, "table")==0 || strcmp(pSe->zType, "index")==0 ){
@@ -1669,6 +1861,7 @@ static int rebuildDisjointSchemaRows(
   SchemaEntry *aTheirsSchema, int nTheirsSchema,
   SchemaEntry *aAncSchema, int nAncSchema,
   SchemaEntry *aOursSchema, int nOursSchema,
+  MergeConflictTable *aConflictTables, int nConflictTables,
   SchemaRootpageRemap *aRemap, int nRemap
 ){
   struct TableEntry *pMaster = 0;
@@ -1693,6 +1886,7 @@ static int rebuildDisjointSchemaRows(
     pSe = mergedSchemaChoice(aAncSchema, nAncSchema,
                              aOursSchema, nOursSchema,
                              aTheirsSchema, nTheirsSchema,
+                             aConflictTables, nConflictTables,
                              zName);
     rc = appendMergedSchemaCatalogRecord(db, &root, pMaster->flags, iNextRowid++,
                                          pSe, aMerged[i].iTable);
@@ -1739,6 +1933,7 @@ static int rebuildDisjointSchemaRows(
                                     aAncSchema, nAncSchema,
                                     aOursSchema, nOursSchema,
                                     aTheirsSchema, nTheirsSchema,
+                                    aConflictTables, nConflictTables,
                                     aRemap, nRemap,
                                     aAncSchema[i].zName);
     if( rc!=SQLITE_OK ) return rc;
@@ -1749,6 +1944,7 @@ static int rebuildDisjointSchemaRows(
                                     aAncSchema, nAncSchema,
                                     aOursSchema, nOursSchema,
                                     aTheirsSchema, nTheirsSchema,
+                                    aConflictTables, nConflictTables,
                                     aRemap, nRemap,
                                     aOursSchema[i].zName);
     if( rc!=SQLITE_OK ) return rc;
@@ -1760,6 +1956,7 @@ static int rebuildDisjointSchemaRows(
                                     aAncSchema, nAncSchema,
                                     aOursSchema, nOursSchema,
                                     aTheirsSchema, nTheirsSchema,
+                                    aConflictTables, nConflictTables,
                                     aRemap, nRemap,
                                     aTheirsSchema[i].zName);
     if( rc!=SQLITE_OK ) return rc;
@@ -1770,6 +1967,7 @@ static int rebuildDisjointSchemaRows(
                                   aAncSchema, nAncSchema,
                                   aOursSchema, nOursSchema,
                                   aTheirsSchema, nTheirsSchema,
+                                  aConflictTables, nConflictTables,
                                   aRemap, nRemap,
                                   aAncSchema[i].zName);
     if( rc!=SQLITE_OK ) return rc;
@@ -1780,6 +1978,7 @@ static int rebuildDisjointSchemaRows(
                                   aAncSchema, nAncSchema,
                                   aOursSchema, nOursSchema,
                                   aTheirsSchema, nTheirsSchema,
+                                  aConflictTables, nConflictTables,
                                   aRemap, nRemap,
                                   aOursSchema[i].zName);
     if( rc!=SQLITE_OK ) return rc;
@@ -1791,6 +1990,7 @@ static int rebuildDisjointSchemaRows(
                                   aAncSchema, nAncSchema,
                                   aOursSchema, nOursSchema,
                                   aTheirsSchema, nTheirsSchema,
+                                  aConflictTables, nConflictTables,
                                   aRemap, nRemap,
                                   aTheirsSchema[i].zName);
     if( rc!=SQLITE_OK ) return rc;
@@ -1924,6 +2124,7 @@ static int mergeCatalogPass1(
     const char *zName = aOurs[i].zName;
     const char *zLogicalName = zName;
     const char *zSchemaMergeName = zName;
+    const char *zSchemaConflictTable = zName;
     struct TableEntry *ancEntry;
     struct TableEntry *theirsEntry;
 
@@ -1939,6 +2140,8 @@ static int mergeCatalogPass1(
        && strcmp(pOurSe->zType, "index")==0 ){
         zLogicalName = pOurSe->zName;
         zSchemaMergeName = pOurSe->zName;
+        zSchemaConflictTable = pOurSe->zTblName
+            ? pOurSe->zTblName : pOurSe->zName;
         ancEntry = findCatalogEntryBySchemaObject(
             aAnc, nAnc, aAncSchema, nAncSchema,
             pOurSe->zType, pOurSe->zName, pOurSe->zTblName);
@@ -1957,6 +2160,14 @@ static int mergeCatalogPass1(
 
 do_merge_entry:
 
+    if( hasSchemaConflictObject(*ppConflictTables, *pnConflictTables,
+                                zSchemaMergeName)
+     || (zName && hasSchemaConflictTable(*ppConflictTables,
+                                         *pnConflictTables, zName)) ){
+      aMerged[(*pnMerged)++] = aOurs[i];
+      continue;
+    }
+
     if( !ancEntry ){
 
       if( theirsEntry ){
@@ -1968,6 +2179,7 @@ do_merge_entry:
 
         if( prollyHashCompare(&aOurs[i].root, &theirsEntry->root)!=0
          || prollyHashCompare(&aOurs[i].schemaHash, &theirsEntry->schemaHash)!=0 ){
+          int addedSchemaTable = 0;
           /* Stat tables created on both sides from a no-stats ancestor
           ** have a fixed SQLite-defined schema; only the data differs.
           ** Take ours and let the post-merge ANALYZE regenerate. */
@@ -1977,23 +2189,26 @@ do_merge_entry:
             aMerged[(*pnMerged)++] = aOurs[i];
             continue;
           }
-          if( pzErrMsg ){
-            *pzErrMsg = sqlite3_mprintf(
-              "schema conflict: table '%s' added on both branches with "
-              "different definitions", zLogicalName ? zLogicalName : "");
-          }
-          return SQLITE_ERROR;
+          rc = appendSchemaConflict(ppConflictTables, pnConflictTables,
+                                    zSchemaConflictTable ? zSchemaConflictTable : "",
+                                    zSchemaMergeName ? zSchemaMergeName : "",
+                                    &addedSchemaTable);
+          if( rc!=SQLITE_OK ) return rc;
+          if( addedSchemaTable ) (*pTotalConflicts)++;
         }
 
       }
       aMerged[(*pnMerged)++] = aOurs[i];
     }else{
 
-      int oursChanged = prollyHashCompare(&aOurs[i].root, &ancEntry->root)!=0;
+      int oursChanged = prollyHashCompare(&aOurs[i].root, &ancEntry->root)!=0
+                     || prollyHashCompare(&aOurs[i].schemaHash,
+                                          &ancEntry->schemaHash)!=0;
 
       if( !theirsEntry ){
 
         if( oursChanged ){
+          int addedSchemaTable = 0;
           /* An index root moves whenever its table's data changes, so a
           ** changed root alone does not make an index "modified". If its
           ** definition matches the ancestor, the other branch's DROP wins
@@ -2005,14 +2220,14 @@ do_merge_entry:
                                         zSchemaMergeName) ){
             continue;
           }
-          if( pzErrMsg ){
-            *pzErrMsg = sqlite3_mprintf(
-              "schema conflict: %s '%s' modified on one branch "
-              "and deleted on the other",
-              zName ? "table" : "index",
-              zLogicalName ? zLogicalName : "");
-          }
-          return SQLITE_ERROR;
+          rc = appendSchemaConflict(ppConflictTables, pnConflictTables,
+                                    zSchemaConflictTable ? zSchemaConflictTable : "",
+                                    zSchemaMergeName ? zSchemaMergeName : "",
+                                    &addedSchemaTable);
+          if( rc!=SQLITE_OK ) return rc;
+          if( addedSchemaTable ) (*pTotalConflicts)++;
+          aMerged[(*pnMerged)++] = aOurs[i];
+          continue;
         }
 
       }else{
@@ -2024,6 +2239,7 @@ do_merge_entry:
         int bNamedSchemaObject = (!zName && zSchemaMergeName && zSchemaMergeName[0]);
         int skipRowMerge = 0;
         int bDualAddColMerge = 0;
+        int bSchemaConflict = 0;
         ProllyHash theirsNormRoot;
         const ProllyHash *pMergeTheirsRoot = &theirsEntry->root;
 
@@ -2041,8 +2257,23 @@ do_merge_entry:
           rc = tryResolveSchemaDivergence(
             db, zSchemaMergeName, pCatAnc, pCatOurs, pCatTheirs,
             ppSchemaActions, pnSchemaActions, &skipRowMerge, pzErrMsg);
-          if( rc!=SQLITE_OK ) return rc;
-          if( skipRowMerge && zName ){
+          if( rc==SQLITE_ERROR ){
+            int addedSchemaTable = 0;
+            sqlite3_free(pzErrMsg ? *pzErrMsg : 0);
+            if( pzErrMsg ) *pzErrMsg = 0;
+            rc = appendSchemaConflict(ppConflictTables, pnConflictTables,
+                                      zSchemaConflictTable ? zSchemaConflictTable : "",
+                                      zSchemaMergeName ? zSchemaMergeName : "",
+                                      &addedSchemaTable);
+            if( rc!=SQLITE_OK ) return rc;
+            if( addedSchemaTable ) (*pTotalConflicts)++;
+            aMerged[(*pnMerged)++] = aOurs[i];
+            skipRowMerge = 1;
+            bSchemaConflict = 1;
+          }else if( rc!=SQLITE_OK ){
+            return rc;
+          }
+          if( !bSchemaConflict && skipRowMerge && zName ){
             /* Both branches added columns compatibly. The post-merge ALTER
             ** evolves ours' schema to include theirs' columns; the rows still
             ** need a real three-way merge so theirs' deletes and edits to
@@ -2063,7 +2294,7 @@ do_merge_entry:
             }else{
               aMerged[(*pnMerged)++] = aOurs[i];
             }
-          }else if( skipRowMerge ){
+          }else if( !bSchemaConflict && skipRowMerge ){
             aMerged[(*pnMerged)++] = aOurs[i];
           }
         }
@@ -2213,13 +2444,64 @@ post_merge_table_rows:;
     }
   }
 
+  /* Find modify-versus-delete conflicts whose surviving object is on
+  ** theirs. Pass 2 adopts theirs-only entries, but the master catalog is
+  ** selected below, so record these conflicts before choosing that root. */
+  for(i=0; i<nTheirs; i++){
+    const char *zObject = aTheirs[i].zName;
+    const char *zTable = zObject;
+    struct TableEntry *pAncEntry = 0;
+    struct TableEntry *pOurEntry = 0;
+    int changed = 0;
+    int addedSchemaTable = 0;
+
+    if( aTheirs[i].iTable<=1 ) continue;
+    if( zObject ){
+      pAncEntry = doltliteFindTableByName(aAnc, nAnc, zObject);
+      pOurEntry = doltliteFindTableByName(aOurs, nOurs, zObject);
+      if( pAncEntry ){
+        changed = prollyHashCompare(&aTheirs[i].root, &pAncEntry->root)!=0
+               || prollyHashCompare(&aTheirs[i].schemaHash,
+                                    &pAncEntry->schemaHash)!=0;
+      }
+    }else{
+      SchemaEntry *pTheirSe = findSchemaEntryByRootpage(
+          aTheirsSchema, nTheirsSchema, aTheirs[i].iTable);
+      if( !pTheirSe || !pTheirSe->zName || !pTheirSe->zType
+       || strcmp(pTheirSe->zType, "index")!=0 ){
+        continue;
+      }
+      zObject = pTheirSe->zName;
+      zTable = pTheirSe->zTblName ? pTheirSe->zTblName : pTheirSe->zName;
+      pAncEntry = findCatalogEntryBySchemaObject(
+          aAnc, nAnc, aAncSchema, nAncSchema,
+          pTheirSe->zType, pTheirSe->zName, pTheirSe->zTblName);
+      pOurEntry = findCatalogEntryBySchemaObject(
+          aOurs, nOurs, aOursSchema, nOursSchema,
+          pTheirSe->zType, pTheirSe->zName, pTheirSe->zTblName);
+      if( pAncEntry ){
+        changed = schemaEntryChangedByName(aAncSchema, nAncSchema,
+                                           aTheirsSchema, nTheirsSchema,
+                                           pTheirSe->zName);
+      }
+    }
+    if( !pAncEntry || pOurEntry || !changed ) continue;
+    rc = appendSchemaConflict(ppConflictTables, pnConflictTables,
+                              zTable ? zTable : "",
+                              zObject ? zObject : "",
+                              &addedSchemaTable);
+    if( rc!=SQLITE_OK ) return rc;
+    if( addedSchemaTable ) (*pTotalConflicts)++;
+  }
+
   if( iTable1Idx >= 0 ){
     struct TableEntry *ancEntry = doltliteFindTableByNumber(aAnc, nAnc, 1);
     struct TableEntry *theirsEntry = doltliteFindTableByNumber(aTheirs, nTheirs, 1);
     int hasSchemaActions = (ppSchemaActions && pnSchemaActions && *pnSchemaActions > 0);
-    int bPreferOurMasterHere = bPreferOurMaster
+    int bPreferOurMasterHere = hasAnySchemaConflict(
+        *ppConflictTables, *pnConflictTables) || (bPreferOurMaster
         && replayDropsDisjointSchemaObject(aAncSchema, nAncSchema,
-                                           aTheirsSchema, nTheirsSchema);
+                                           aTheirsSchema, nTheirsSchema));
 
     if( !ancEntry ){
       if( theirsEntry ){
@@ -2322,6 +2604,8 @@ static int mergeCatalogPass2(
   struct TableEntry *aMerged, int *pnMerged,
   Pgno *piNextMerged,
   int bDisjointSchemaChanges,
+  MergeConflictTable *aConflictTables,
+  int nConflictTables,
   SchemaRootpageRemap **ppaRemap,
   int *pnRemap,
   char ***pazReindex,
@@ -2340,6 +2624,10 @@ static int mergeCatalogPass2(
           aTheirsSchema, nTheirsSchema, aTheirs[i].iTable);
       if( pTheirSe && pTheirSe->zName && pTheirSe->zType
        && strcmp(pTheirSe->zType, "index")==0 ){
+        if( hasSchemaConflictObject(aConflictTables, nConflictTables,
+                                    pTheirSe->zName) ){
+          continue;
+        }
         oursEntry = findCatalogEntryBySchemaObject(
             aOurs, nOurs, aOursSchema, nOursSchema,
             pTheirSe->zType, pTheirSe->zName, pTheirSe->zTblName);
@@ -2446,6 +2734,9 @@ static int mergeCatalogPass2(
       continue;
     }
 
+    if( hasSchemaConflictObject(aConflictTables, nConflictTables, zName) ){
+      continue;
+    }
     oursEntry = doltliteFindTableByName(aOurs, nOurs, zName);
     if( oursEntry ) continue;
 
@@ -2485,7 +2776,12 @@ static void mergeFreeConflictTables(
 ){
   int ci;
   for(ci=0; ci<nConflictTables; ci++){
+    int oi;
     freeConflictRows(aConflictTables[ci].aRows, aConflictTables[ci].nConflicts);
+    for(oi=0; oi<aConflictTables[ci].nSchemaObjects; oi++){
+      sqlite3_free(aConflictTables[ci].azSchemaObjects[oi]);
+    }
+    sqlite3_free(aConflictTables[ci].azSchemaObjects);
     sqlite3_free(aConflictTables[ci].zName);
   }
   sqlite3_free(aConflictTables);
@@ -2591,6 +2887,12 @@ int doltliteMergeCatalogs(
   iNextMerged = iNextOurs > iNextTheirs ? iNextOurs : iNextTheirs;
   bDisjointSchemaChanges = catalogHasDisjointSchemaChanges(db, ancestor, ours, theirs);
 
+  rc = preDetectIndexSchemaConflicts(
+      aAncSchema, nAncSchema, aOursSchema, nOursSchema,
+      aTheirsSchema, nTheirsSchema,
+      &aConflictTables, &nConflictTables, &totalConflicts);
+  if( rc!=SQLITE_OK ) goto merge_cleanup;
+
   rc = mergeCatalogPass1(db, aAnc, nAnc, aOurs, nOurs, aTheirs, nTheirs,
                           aAncSchema, nAncSchema,
                           aOursSchema, nOursSchema,
@@ -2632,6 +2934,7 @@ int doltliteMergeCatalogs(
                           aTheirsSchema, nTheirsSchema,
                           aMerged, &nMerged, &iNextMerged,
                           bDisjointSchemaChanges,
+                          aConflictTables, nConflictTables,
                           &aRemap, &nRemap,
                           pazReindex, pnReindex);
   if( rc!=SQLITE_OK ) goto merge_cleanup;
@@ -2640,6 +2943,7 @@ int doltliteMergeCatalogs(
                                  aTheirsSchema, nTheirsSchema,
                                  aAncSchema, nAncSchema,
                                  aOursSchema, nOursSchema,
+                                 aConflictTables, nConflictTables,
                                  aRemap, nRemap);
   if( rc!=SQLITE_OK ) goto merge_cleanup;
 

--- a/src/doltlite_status.c
+++ b/src/doltlite_status.c
@@ -323,6 +323,27 @@ static int statusRowExists(
   return 0;
 }
 
+typedef struct StatusSchemaConflictCtx StatusSchemaConflictCtx;
+struct StatusSchemaConflictCtx {
+  DoltliteStatusCursor *pCur;
+  const char *zFilter;
+};
+
+static int statusAddSchemaConflict(void *pArg, const char *zTable){
+  StatusSchemaConflictCtx *p = (StatusSchemaConflictCtx*)pArg;
+  int i;
+  if( p->zFilter && sqlite3_stricmp(p->zFilter, zTable)!=0 ) return SQLITE_OK;
+  for(i=0; i<p->pCur->nRows; i++){
+    if( p->pCur->aRows[i].zName
+     && sqlite3_stricmp(p->pCur->aRows[i].zName, zTable)==0 ){
+      p->pCur->aRows[i].staged = 0;
+      p->pCur->aRows[i].zStatus = "schema conflict";
+      return SQLITE_OK;
+    }
+  }
+  return addRow(p->pCur, zTable, 0, "schema conflict");
+}
+
 static int statusMaybeAddParentSchemaChange(
   DoltliteStatusCursor *pCur,
   const char *zParent,
@@ -1005,6 +1026,12 @@ static int statusFilter(sqlite3_vtab_cursor *pCursor,
   }
 
 status_done:
+  if( rc==SQLITE_OK && iStagedOnly!=1 ){
+    StatusSchemaConflictCtx ctx;
+    ctx.pCur = pCur;
+    ctx.zFilter = zTableFilter;
+    rc = doltliteForEachSchemaConflict(db, statusAddSchemaConflict, &ctx);
+  }
   if( headLoaded ) doltliteFreeCatalog(aHead, nHead);
   if( stagedLoaded ) doltliteFreeCatalog(aStaged, nStaged);
   if( workingLoaded ) doltliteFreeCatalog(aWorking, nWorking);

--- a/test/doltlite_behavior.sh
+++ b/test/doltlite_behavior.sh
@@ -261,7 +261,7 @@ SELECT dolt_commit('-A','-m','add w INTEGER');" | $DOLTLITE "$DB/b1" > /dev/null
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test_match "schema_merge_same_col_diff_type" \
   "SELECT dolt_merge('b1');" \
-  "schema conflict" "$DB"
+  "Merge conflict detected.*dolt_schema_conflicts" "$DB"
 
 rm -f "$DB"
 

--- a/test/doltlite_schema_merge.sh
+++ b/test/doltlite_schema_merge.sh
@@ -439,6 +439,54 @@ SELECT dolt_commit('-A','-m','feat adds extra TEXT');
 SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 run_test_match "schema_merge_same_col_diff_type" "SELECT dolt_merge('feat');" "schema conflict|conflict|Error" "$DB"
+run_test "schema_merge_autocommit_schema_conflicts_empty" \
+  "SELECT count(*) FROM dolt_schema_conflicts;" "0" "$DB"
+run_test "schema_merge_autocommit_conflicts_empty" \
+  "SELECT count(*) FROM dolt_conflicts;" "0" "$DB"
+rm -f "$DB"
+
+DB=/tmp/test_schema_conflicts_$$.db; rm -f "$DB"
+cat <<'EOF' | $DOLTLITE "$DB" > /dev/null 2>&1
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'a');
+SELECT dolt_commit('-Am','init');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+ALTER TABLE t ADD COLUMN extra TEXT;
+SELECT dolt_commit('-Am','feat schema');
+SELECT dolt_checkout('main');
+ALTER TABLE t ADD COLUMN extra INTEGER;
+SELECT dolt_commit('-Am','main schema');
+BEGIN;
+SELECT dolt_merge('feat');
+COMMIT;
+EOF
+
+run_test "schema_conflicts_columns" \
+  "SELECT group_concat(name, '|') FROM (SELECT name FROM pragma_table_info('dolt_schema_conflicts') ORDER BY cid);" \
+  "table_name|base_schema|our_schema|their_schema|description" "$DB"
+run_test "schema_conflicts_summary" \
+  "SELECT \"table\" || '|' || num_conflicts FROM dolt_conflicts;" \
+  "t|0" "$DB"
+run_test "schema_conflicts_status" \
+  "SELECT table_name || '|' || staged || '|' || status FROM dolt_status WHERE status='schema conflict';" \
+  "t|0|schema conflict" "$DB"
+run_test "schema_conflicts_row" \
+  "SELECT table_name || '|' || (base_schema LIKE 'CREATE TABLE t%') || '|' || (our_schema LIKE '%extra INTEGER%') || '|' || (their_schema LIKE '%extra TEXT%') || '|' || description FROM dolt_schema_conflicts;" \
+  "t|1|1|1|both branches add column 'extra' with different definitions" "$DB"
+run_test_match "schema_conflicts_resolve_refused" \
+  "SELECT dolt_conflicts_resolve('--ours','t');" \
+  "Unable to automatically resolve schema conflicts|Error" "$DB"
+run_test_match "schema_conflicts_commit_refused" \
+  "SELECT dolt_commit('-Am','must fail');" \
+  "unresolved schema conflicts|Error" "$DB"
+run_test "schema_conflicts_persist_reopen" \
+  "SELECT count(*) FROM dolt_schema_conflicts;" "1" "$DB"
+run_test_match "schema_conflicts_abort" \
+  "SELECT dolt_merge('--abort');" "^[0-9]+$" "$DB"
+run_test "schema_conflicts_abort_clears" \
+  "SELECT (SELECT count(*) FROM dolt_schema_conflicts) || '|' || (SELECT count(*) FROM dolt_conflicts) || '|' || (SELECT count(*) FROM dolt_status WHERE status='schema conflict');" \
+  "0|0|0" "$DB"
 rm -f "$DB"
 
 DB=/tmp/test_schema_merge13_$$.db; rm -f "$DB"

--- a/test/vc_oracle_merge_test.sh
+++ b/test/vc_oracle_merge_test.sh
@@ -1062,6 +1062,68 @@ ROLLBACK;
 " "SELECT (SELECT count(*) FROM dolt_conflicts) || '|' || (SELECT v FROM t WHERE id = 1)" \
 "SELECT CONCAT((SELECT COUNT(*) FROM dolt_conflicts), '|', (SELECT v FROM t WHERE id = 1))"
 
+oracle_error_poststate "merge_schema_conflict_autocommit_rollback" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+SELECT dolt_commit('-Am', 'init');
+SELECT dolt_branch('feature');
+SELECT dolt_checkout('feature');
+ALTER TABLE t ADD COLUMN c TEXT;
+SELECT dolt_commit('-Am', 'feature schema');
+SELECT dolt_checkout('main');
+ALTER TABLE t ADD COLUMN c INTEGER;
+SELECT dolt_commit('-Am', 'main schema');
+SELECT dolt_merge('feature');
+" "SELECT (SELECT count(*) FROM dolt_schema_conflicts) || '|' ||
+          (SELECT count(*) FROM dolt_conflicts) || '|' ||
+          (SELECT count(*) FROM dolt_status WHERE status = 'schema conflict')" \
+"SELECT CONCAT((SELECT COUNT(*) FROM dolt_schema_conflicts), '|', (SELECT COUNT(*) FROM dolt_conflicts), '|', (SELECT COUNT(*) FROM dolt_status WHERE status = 'schema conflict'))"
+
+oracle_same_session "merge_schema_conflict_in_session" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+SELECT dolt_commit('-Am', 'init');
+SELECT dolt_branch('feature');
+SELECT dolt_checkout('feature');
+ALTER TABLE t ADD COLUMN c TEXT;
+SELECT dolt_commit('-Am', 'feature schema');
+SELECT dolt_checkout('main');
+ALTER TABLE t ADD COLUMN c INTEGER;
+SELECT dolt_commit('-Am', 'main schema');
+BEGIN;
+SELECT dolt_merge('feature');
+" "SELECT 'Q' || char(9) ||
+          (SELECT count(*) FROM dolt_schema_conflicts) || char(9) ||
+          (SELECT count(*) FROM dolt_conflicts) || char(9) ||
+          (SELECT coalesce(sum(num_conflicts), -1) FROM dolt_conflicts) || char(9) ||
+          (SELECT count(*) FROM dolt_status WHERE status = 'schema conflict');" \
+"SELECT CONCAT('Q', char(9),
+               (SELECT COUNT(*) FROM dolt_schema_conflicts), char(9),
+               (SELECT COUNT(*) FROM dolt_conflicts), char(9),
+               (SELECT COALESCE(SUM(num_conflicts), -1) FROM dolt_conflicts), char(9),
+               (SELECT COUNT(*) FROM dolt_status WHERE status = 'schema conflict'));"
+
+oracle_same_session "merge_schema_conflict_ours_deleted" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INTEGER);
+SELECT dolt_commit('-Am', 'init');
+SELECT dolt_branch('feature');
+SELECT dolt_checkout('feature');
+ALTER TABLE t ADD COLUMN c INTEGER;
+SELECT dolt_commit('-Am', 'feature schema');
+SELECT dolt_checkout('main');
+DROP TABLE t;
+SELECT dolt_commit('-Am', 'main drop');
+BEGIN;
+SELECT dolt_merge('feature');
+" "SELECT 'Q' || char(9) ||
+          (SELECT count(*) FROM dolt_schema_conflicts) || char(9) ||
+          (SELECT count(*) FROM dolt_conflicts) || char(9) ||
+          (SELECT count(*) FROM dolt_status WHERE status = 'schema conflict') || char(9) ||
+          (SELECT our_schema FROM dolt_schema_conflicts);" \
+"SELECT CONCAT('Q', char(9),
+               (SELECT COUNT(*) FROM dolt_schema_conflicts), char(9),
+               (SELECT COUNT(*) FROM dolt_conflicts), char(9),
+               (SELECT COUNT(*) FROM dolt_status WHERE status = 'schema conflict'), char(9),
+               (SELECT our_schema FROM dolt_schema_conflicts));"
+
 oracle_error_poststate "merge_constraint_violation_txn_rollback" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, u INT UNIQUE, v TEXT);
 INSERT INTO t VALUES (1, 1, 'base1'), (2, 2, 'base2');

--- a/test/vc_oracle_schema_merge_test.sh
+++ b/test/vc_oracle_schema_merge_test.sh
@@ -101,6 +101,28 @@ CREATE TABLE newtbl(id INTEGER PRIMARY KEY, v INT);
 SELECT dolt_commit('-Am','main_add');
 SQL
 expect_merge_conflict "table_both_add_different" "$DB"
+expect_eq "schema_conflicts_columns" \
+  "table_name|base_schema|our_schema|their_schema|description" \
+  "$(dl "$DB" "SELECT group_concat(name, '|') FROM (SELECT name FROM pragma_table_info('dolt_schema_conflicts') ORDER BY cid);" "t2_columns")"
+expect_eq "schema_conflicts_autocommit_rollback" "0|0|0" \
+  "$(dl "$DB" "SELECT (SELECT count(*) FROM dolt_schema_conflicts) || '|' || (SELECT count(*) FROM dolt_conflicts) || '|' || (SELECT count(*) FROM dolt_status WHERE status='schema conflict');" "t2_autocommit")"
+cat <<'SQL' | dl_setup "$DB" "t2_transaction"
+BEGIN;
+SELECT dolt_merge('feat');
+COMMIT;
+SQL
+expect_eq "schema_conflicts_transaction_state" "1|1|0|1" \
+  "$(dl "$DB" "SELECT (SELECT count(*) FROM dolt_schema_conflicts) || '|' || (SELECT count(*) FROM dolt_conflicts) || '|' || (SELECT coalesce(sum(num_conflicts),-1) FROM dolt_conflicts) || '|' || (SELECT count(*) FROM dolt_status WHERE status='schema conflict');" "t2_state")"
+expect_eq "schema_conflicts_schema_rows" "newtbl|1|1|1" \
+  "$(dl "$DB" "SELECT table_name || '|' || (base_schema='<deleted>') || '|' || (our_schema LIKE 'CREATE TABLE newtbl%') || '|' || (their_schema LIKE 'CREATE TABLE newtbl%') FROM dolt_schema_conflicts;" "t2_rows")"
+if dl_errors "$DB" "SELECT dolt_conflicts_resolve('--ours','newtbl');" "t2_resolve"; then
+  pass_name "schema_conflicts_resolve_refused"
+else
+  fail_name "schema_conflicts_resolve_refused"
+fi
+dl "$DB" "SELECT dolt_merge('--abort');" "t2_abort" >/dev/null
+expect_eq "schema_conflicts_abort_clears" "0|0|0" \
+  "$(dl "$DB" "SELECT (SELECT count(*) FROM dolt_schema_conflicts) || '|' || (SELECT count(*) FROM dolt_conflicts) || '|' || (SELECT count(*) FROM dolt_status WHERE status='schema conflict');" "t2_cleared")"
 
 DB="$TMPROOT/t3.db"; rm -f "$DB"
 cat <<'SQL' | dl_setup "$DB" "t3"


### PR DESCRIPTION
## Summary

- preserve merge-time schema conflicts in the working set instead of returning before conflict state is recorded
- add the read-only `dolt_schema_conflicts` system table with Dolt-compatible columns, schema text, and descriptions
- surface schema conflicts through `dolt_conflicts` and `dolt_status`, block commit and automatic conflict resolution, and clear state on merge abort
- match Dolt transaction behavior, including autocommit rollback and deleted-table handling
- add local schema coverage and live Dolt merge oracle cases; cherry-pick behavior is intentionally out of scope

## Testing

- `make -j4 doltlite`
- `make -j4 sqlite3d`
- `bash test/vc_oracle_merge_test.sh ./doltlite dolt` (74 passed)
- `bash test/vc_oracle_schema_merge_test.sh ./doltlite` (43 passed)
- `bash test/doltlite_schema_merge.sh ./doltlite` (94 passed)
- `bash test/doltlite_merge.sh ./doltlite` (94 passed)
- `bash test/doltlite_conflicts.sh ./doltlite` (40 passed)
- `bash test/doltlite_merge_index_conflict.sh ./doltlite` (9 passed)
- `bash test/doltlite_savepoint.sh ./doltlite` (128 passed)
- `bash test/doltlite_working_set.sh ./doltlite` (21 passed)
- `bash test/doltlite_edge_cases.sh ./doltlite` (183 passed)

`make devtest` was also attempted. The broad harness did not complete cleanly: testfixture linking could not find `libtommath`, and generic fuzz jobs encountered deserialize/open failures and debug B-tree mutex assertions. No reported failure involved the merge/schema-conflict tests.