### PR TITLE
Extend diff_summary oracle to composite-PK and keyless shapes

### DIFF
--- a/test/vc_oracle_diff_stat_test.sh
+++ b/test/vc_oracle_diff_stat_test.sh
@@ -418,6 +418,72 @@ SELECT dolt_commit('-m', 'add_u');
 SELECT dolt_revert((SELECT commit_hash FROM dolt_log WHERE message='main_check' LIMIT 1));
 " "HEAD~1" "HEAD"
 
+echo "--- summary across pk shapes: composite and keyless ---"
+
+oracle_summary "summary_composite_pk_modify" "
+CREATE TABLE t(a INT, b INT, v INT, PRIMARY KEY(a,b));
+INSERT INTO t VALUES(1,1,10),(1,2,20);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+UPDATE t SET v=99 WHERE a=1 AND b=2;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c2');
+" "HEAD~1" "HEAD"
+
+oracle_summary "summary_composite_pk_schema_and_data" "
+CREATE TABLE t(a INT, b INT, v INT, PRIMARY KEY(a,b));
+INSERT INTO t VALUES(1,1,10);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+ALTER TABLE t ADD COLUMN w INT DEFAULT 0;
+INSERT INTO t VALUES(2,2,20,5);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c2');
+" "HEAD~1" "HEAD"
+
+oracle_summary "summary_composite_pk_filter_one_table" "
+CREATE TABLE t(a INT, b INT, v INT, PRIMARY KEY(a,b));
+CREATE TABLE s(a INT, b INT, v INT, PRIMARY KEY(a,b));
+INSERT INTO t VALUES(1,1,10);
+INSERT INTO s VALUES(1,1,10);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+UPDATE t SET v=99 WHERE a=1;
+UPDATE s SET v=88 WHERE a=1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c2');
+" "HEAD~1" "HEAD" "t"
+
+oracle_summary "summary_keyless_insert" "
+CREATE TABLE t(a INT, v INT);
+INSERT INTO t VALUES(1,10);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+INSERT INTO t VALUES(2,20);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c2');
+" "HEAD~1" "HEAD"
+
+oracle_summary "summary_keyless_delete" "
+CREATE TABLE t(a INT, v INT);
+INSERT INTO t VALUES(1,10),(2,20),(3,30);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+DELETE FROM t WHERE a=2;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c2');
+" "HEAD~1" "HEAD"
+
+oracle_summary "summary_keyless_modify" "
+CREATE TABLE t(a INT, v INT);
+INSERT INTO t VALUES(1,10),(2,20),(3,30);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+UPDATE t SET v=99 WHERE a=2;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c2');
+" "HEAD~1" "HEAD"
+
 echo ""
 echo "=== Results: $pass passed, $fail failed ==="
 if [ $fail -gt 0 ]; then


### PR DESCRIPTION
## What

Adds six `dolt_diff_summary` scenarios to `vc_oracle_diff_stat_test.sh`, oracled against Dolt:

- `summary_composite_pk_modify` — composite PK, data-only change
- `summary_composite_pk_schema_and_data` — composite PK, ADD COLUMN + insert (data_change + schema_change)
- `summary_composite_pk_filter_one_table` — composite PK, table-scoped arg
- `summary_keyless_insert` / `summary_keyless_delete` / `summary_keyless_modify` — keyless (no-PK) tables

## Why

`dolt_diff_summary` was already well-exercised in this suite (insert/delete/modify, create/drop, add-column, multi-table, ranges, branch/tag/merge-parent refs), but **every scenario used a single `INT PRIMARY KEY`**. Composite-PK and keyless tables are distinct diff code paths and were unoracled. Extends the existing per-surface suite rather than forking a new file.

## Divergences found (NOT in this PR — reported separately)

Two real doltlite/Dolt divergences surfaced while building this and are intentionally **not** encoded here (they'd fail CI); they need engine decisions:

1. **Table rename not detected** — `dolt_diff_summary` reports a rename as `dropped`+`added` (two rows); Dolt reports a single `renamed` row (from≠to). `doltlite_diff_stat.c` has no rename handling.
2. **`WORKING`/`STAGED` refs unsupported** — `dolt_diff_summary('HEAD','WORKING')` errors `unknown operation`; Dolt returns the uncommitted diff. Notably doltlite's own `dolt_diff` *does* support `WORKING`, so it's also an internal inconsistency.

Verified 55/55 pass; passes the orphan-suite linter (existing suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)