### PR TITLE
Resolve WORKING/STAGED refs across the dolt_diff surfaces

### DIFF
--- a/src/doltlite_commit.c
+++ b/src/doltlite_commit.c
@@ -157,6 +157,35 @@ int doltliteRefToCatalogHash(sqlite3 *db, const char *zRef,
   return doltliteCommitCatalogHash(db, &commitHash, pCatHash);
 }
 
+int doltliteRefIsWorking(const char *zRef){
+  return zRef && sqlite3_stricmp(zRef, "WORKING")==0;
+}
+
+int doltliteRefIsStaged(const char *zRef){
+  return zRef && sqlite3_stricmp(zRef, "STAGED")==0;
+}
+
+int doltliteResolveCatalogHashForRef(sqlite3 *db, const char *zRef,
+                                     ProllyHash *pCatHash){
+  if( !zRef ){
+    return doltliteGetHeadCatalogHash(db, pCatHash);
+  }
+  if( doltliteRefIsWorking(zRef) ){
+    if( doltliteHasUncommittedChanges(db) ){
+      return doltliteFlushCatalogToHash(db, pCatHash);
+    }
+    return doltliteGetPersistedWorkingCatalogHash(db, pCatHash);
+  }
+  if( doltliteRefIsStaged(zRef) ){
+    doltliteGetSessionStaged(db, pCatHash);
+    if( prollyHashIsEmpty(pCatHash) ){
+      return doltliteGetHeadCatalogHash(db, pCatHash);
+    }
+    return SQLITE_OK;
+  }
+  return doltliteRefToCatalogHash(db, zRef, pCatHash);
+}
+
 static const char hexchars[] = "0123456789abcdef";
 
 void doltliteHashToHex(const ProllyHash *h, char *buf){

--- a/src/doltlite_diff_stat.c
+++ b/src/doltlite_diff_stat.c
@@ -272,27 +272,6 @@ static struct TableEntry *dsNameIndexFind(
   return r<0 ? 0 : (struct TableEntry*)(pIdx->aBase + (size_t)r*pIdx->stride);
 }
 
-static int dsResolveCatHash(sqlite3 *db, const char *zRef,
-                            ProllyHash *pOut){
-  if( zRef ){
-    if( strcmp(zRef, "WORKING")==0 ){
-      if( doltliteHasUncommittedChanges(db) ){
-        return doltliteFlushCatalogToHash(db, pOut);
-      }
-      return doltliteGetPersistedWorkingCatalogHash(db, pOut);
-    }
-    if( strcmp(zRef, "STAGED")==0 ){
-      doltliteGetSessionStaged(db, pOut);
-      if( prollyHashIsEmpty(pOut) ){
-        return doltliteGetHeadCatalogHash(db, pOut);
-      }
-      return SQLITE_OK;
-    }
-    return doltliteRefToCatalogHash(db, zRef, pOut);
-  }
-  return doltliteGetHeadCatalogHash(db, pOut);
-}
-
 static int dsRequireRefs(sqlite3_vtab *pVtab, int idxNum, const char *zName){
   if( (idxNum & 3)!=3 ){
     sqlite3_free(pVtab->zErrMsg);
@@ -671,9 +650,9 @@ static int dsFilterInit(
     pCtx->zTblFilter = (const char*)sqlite3_value_text(argv[argIdx++]);
   }
 
-  rc = dsResolveCatHash(db, pCtx->zFromRef, &pCtx->fromCat);
+  rc = doltliteResolveCatalogHashForRef(db, pCtx->zFromRef, &pCtx->fromCat);
   if( rc!=SQLITE_OK ) return rc;
-  rc = dsResolveCatHash(db, pCtx->zToRef, &pCtx->toCat);
+  rc = doltliteResolveCatalogHashForRef(db, pCtx->zToRef, &pCtx->toCat);
   if( rc!=SQLITE_OK ) return rc;
   if( pCtx->zTblFilter ){
     pCtx->azNames = sqlite3_malloc((int)sizeof(char*));

--- a/src/doltlite_diff_stat.c
+++ b/src/doltlite_diff_stat.c
@@ -275,6 +275,19 @@ static struct TableEntry *dsNameIndexFind(
 static int dsResolveCatHash(sqlite3 *db, const char *zRef,
                             ProllyHash *pOut){
   if( zRef ){
+    if( strcmp(zRef, "WORKING")==0 ){
+      if( doltliteHasUncommittedChanges(db) ){
+        return doltliteFlushCatalogToHash(db, pOut);
+      }
+      return doltliteGetPersistedWorkingCatalogHash(db, pOut);
+    }
+    if( strcmp(zRef, "STAGED")==0 ){
+      doltliteGetSessionStaged(db, pOut);
+      if( prollyHashIsEmpty(pOut) ){
+        return doltliteGetHeadCatalogHash(db, pOut);
+      }
+      return SQLITE_OK;
+    }
     return doltliteRefToCatalogHash(db, zRef, pOut);
   }
   return doltliteGetHeadCatalogHash(db, pOut);

--- a/src/doltlite_diff_table.c
+++ b/src/doltlite_diff_table.c
@@ -63,7 +63,7 @@ struct DiffTblVtab {
 typedef struct DiffPair DiffPair;
 struct DiffPair {
 
-  ProllyHash fromHash;
+  char       zFromCommit[PROLLY_HASH_SIZE*2+1];
   ProllyHash fromTblRoot;
   ProllyHash fromCatHash;
   ProllyHash fromSchemaHash;
@@ -238,7 +238,7 @@ static int cmMapPut(CmTblMap *pMap, const ProllyHash *pKey,
 }
 
 static int pairsAppend(DiffTblCursor *pCur,
-                       const ProllyHash *pFromHash,
+                       const char *zFromHex,
                        const ProllyHash *pFromTblRoot,
                        const ProllyHash *pFromCatHash,
                        const ProllyHash *pFromSchemaHash,
@@ -260,7 +260,7 @@ static int pairsAppend(DiffTblCursor *pCur,
   }
   r = &pCur->aPairs[pCur->nPairs++];
   memset(r, 0, sizeof(*r));
-  r->fromHash       = *pFromHash;
+  memcpy(r->zFromCommit, zFromHex, PROLLY_HASH_SIZE*2+1);
   r->fromTblRoot    = *pFromTblRoot;
   r->fromCatHash    = *pFromCatHash;
   r->fromSchemaHash = *pFromSchemaHash;
@@ -344,10 +344,14 @@ static int appendCurrentDiffPair(
 
   fromFlags = curFlags;
   if( fromFlags==0 ) fromFlags = pInfo->flags;
-  return pairsAppend(pCur, pCurr, pCurTblRoot, &pCommit->catalogHash,
-                     pCurSchemaHash, fromFlags, pCommit->timestamp,
-                     pInfo->zHexName, &pInfo->tblRoot, &pInfo->catHash,
-                     &pInfo->schemaHash, pInfo->flags, pInfo->date);
+  {
+    char zFromHex[PROLLY_HASH_SIZE*2+1];
+    doltliteHashToHex(pCurr, zFromHex);
+    return pairsAppend(pCur, zFromHex, pCurTblRoot, &pCommit->catalogHash,
+                       pCurSchemaHash, fromFlags, pCommit->timestamp,
+                       pInfo->zHexName, &pInfo->tblRoot, &pInfo->catHash,
+                       &pInfo->schemaHash, pInfo->flags, pInfo->date);
+  }
 }
 
 static int registerCommitParents(
@@ -476,6 +480,7 @@ static int buildWorkingDiffPair(
   u8 fromFlags;
   int rc;
   char zWorking[PROLLY_HASH_SIZE*2+1];
+  char zHeadHex[PROLLY_HASH_SIZE*2+1];
 
   if( !cs ) return SQLITE_OK;
 
@@ -517,8 +522,9 @@ static int buildWorkingDiffPair(
       }else{
         memset(&workingCat, 0, sizeof(workingCat));
       }
+      doltliteHashToHex(&headHash, zHeadHex);
       fromFlags = headFlags ? headFlags : workingFlags;
-      rc = pairsAppend(pCur, &headHash, &headTblRoot, &headCommit.catalogHash,
+      rc = pairsAppend(pCur, zHeadHex, &headTblRoot, &headCommit.catalogHash,
                        &headSchemaHash, fromFlags, headCommit.timestamp,
                        zWorking, &workingTblRoot, &workingCat, &workingSchemaHash,
                        workingFlags, 0);
@@ -543,6 +549,7 @@ static int buildCommitDiffPair(
   u8 fromFlags = 0;
   u8 toFlags = 0;
   i64 fromDate = 0;
+  char zFromLabel[PROLLY_HASH_SIZE*2+1];
   char zToLabel[PROLLY_HASH_SIZE*2+1];
   const ProllyHash *pParent;
   int rc;
@@ -602,13 +609,71 @@ static int buildCommitDiffPair(
 
   if( !fromFlags ) fromFlags = toFlags;
   if( !toFlags ) toFlags = fromFlags;
+  doltliteHashToHex(&fromHash, zFromLabel);
   doltliteHashToHex(&toHash, zToLabel);
-  rc = pairsAppend(pCur, &fromHash, &fromTblRoot, &fromCatHash,
+  rc = pairsAppend(pCur, zFromLabel, &fromTblRoot, &fromCatHash,
                    &fromSchemaHash, fromFlags, fromDate,
                    zToLabel, &toTblRoot, &toCatHash, &toSchemaHash,
                    toFlags, toCommit.timestamp);
   doltliteCommitClear(&toCommit);
   return rc;
+}
+
+typedef struct DtSliceEnd DtSliceEnd;
+struct DtSliceEnd {
+  ProllyHash catHash;
+  ProllyHash tblRoot;
+  ProllyHash schemaHash;
+  u8 flags;
+  i64 date;
+  char zLabel[PROLLY_HASH_SIZE*2+1];
+};
+
+/* Resolve one endpoint of a dolt_diff_<table>(from, to) slice -- any commit
+** ref or the WORKING / STAGED pseudo-refs -- to its table root, catalog,
+** schema, commit date, and display label. Returns SQLITE_NOTFOUND for an
+** unresolvable ref so the caller can yield no rows, matching Dolt. */
+static int dtResolveSliceEnd(
+  sqlite3 *db, const char *zRef, const char *zTableName, DtSliceEnd *pEnd
+){
+  int rc;
+  memset(pEnd, 0, sizeof(*pEnd));
+
+  rc = doltliteResolveCatalogHashForRef(db, zRef, &pEnd->catHash);
+  if( rc!=SQLITE_OK ) return rc;
+
+  if( doltliteRefIsWorking(zRef) ){
+    rc = doltliteGetWorkingTableState(db, zTableName, &pEnd->tblRoot,
+                                      &pEnd->flags, &pEnd->schemaHash);
+    if( rc==SQLITE_NOTFOUND ) rc = SQLITE_OK;
+    if( rc!=SQLITE_OK ) return rc;
+    memcpy(pEnd->zLabel, "WORKING", 8);
+    return SQLITE_OK;
+  }
+
+  rc = doltliteLoadTableRootByNameOrEmpty(db, &pEnd->catHash, zTableName,
+                                          &pEnd->tblRoot, &pEnd->flags,
+                                          &pEnd->schemaHash);
+  if( rc!=SQLITE_OK && rc!=SQLITE_NOTFOUND ) return rc;
+
+  if( doltliteRefIsStaged(zRef) ){
+    memcpy(pEnd->zLabel, "STAGED", 7);
+    return SQLITE_OK;
+  }
+
+  {
+    ProllyHash commitHash;
+    DoltliteCommit commit;
+    memset(&commit, 0, sizeof(commit));
+    rc = doltliteResolveRef(db, zRef, &commitHash);
+    if( rc!=SQLITE_OK ) return rc;
+    rc = doltliteLoadCommit(db, &commitHash, &commit);
+    if( rc!=SQLITE_OK ) return rc;
+    pEnd->date = commit.timestamp;
+    doltliteCommitClear(&commit);
+    doltliteHashToHex(&commitHash, pEnd->zLabel);
+  }
+  return SQLITE_OK;
 }
 
 static int buildSliceDiffPair(
@@ -618,84 +683,29 @@ static int buildSliceDiffPair(
   const char *zFromRef,
   const char *zToRef
 ){
-  ProllyHash fromHash, toHash;
-  ProllyHash fromTblRoot, toTblRoot;
-  ProllyHash fromCatHash, toCatHash;
-  ProllyHash fromSchemaHash, toSchemaHash;
-  DoltliteCommit fromCommit;
-  u8 fromFlags = 0;
-  u8 toFlags = 0;
-  i64 fromDate = 0;
-  i64 toDate = 0;
-  int toIsWorking = 0;
-  char zToLabel[PROLLY_HASH_SIZE*2+1];
+  DtSliceEnd from, to;
   int rc;
-
-  memset(&fromHash, 0, sizeof(fromHash));
-  memset(&toHash, 0, sizeof(toHash));
-  memset(&fromTblRoot, 0, sizeof(fromTblRoot));
-  memset(&toTblRoot, 0, sizeof(toTblRoot));
-  memset(&fromCatHash, 0, sizeof(fromCatHash));
-  memset(&toCatHash, 0, sizeof(toCatHash));
-  memset(&fromSchemaHash, 0, sizeof(fromSchemaHash));
-  memset(&toSchemaHash, 0, sizeof(toSchemaHash));
-  memset(&fromCommit, 0, sizeof(fromCommit));
-  memset(zToLabel, 0, sizeof(zToLabel));
 
   if( !zFromRef || !zToRef ) return SQLITE_OK;
 
-  rc = doltliteResolveRef(db, zFromRef, &fromHash);
-  if( rc!=SQLITE_OK ) return SQLITE_OK;
-  rc = doltliteLoadCommit(db, &fromHash, &fromCommit);
+  rc = dtResolveSliceEnd(db, zFromRef, zTableName, &from);
+  if( rc==SQLITE_NOTFOUND ) return SQLITE_OK;
   if( rc!=SQLITE_OK ) return rc;
-  memcpy(&fromCatHash, &fromCommit.catalogHash, sizeof(ProllyHash));
-  fromDate = fromCommit.timestamp;
-  doltliteCommitClear(&fromCommit);
+  rc = dtResolveSliceEnd(db, zToRef, zTableName, &to);
+  if( rc==SQLITE_NOTFOUND ) return SQLITE_OK;
+  if( rc!=SQLITE_OK ) return rc;
 
-  rc = doltliteLoadTableRootByName(db, &fromCatHash, zTableName,
-                                   &fromTblRoot, &fromFlags, &fromSchemaHash);
-  if( rc!=SQLITE_OK && rc!=SQLITE_NOTFOUND ) return rc;
-
-  if( sqlite3_stricmp(zToRef, "WORKING")==0 ){
-    toIsWorking = 1;
-    rc = doltliteGetWorkingTableState(db, zTableName,
-                                      &toTblRoot, &toFlags,
-                                      &toSchemaHash);
-    if( rc==SQLITE_NOTFOUND ) rc = SQLITE_OK;
-    if( rc!=SQLITE_OK ) return rc;
-    rc = doltliteFlushCatalogToHash(db, &toCatHash);
-    if( rc!=SQLITE_OK ) return rc;
-    memcpy(zToLabel, "WORKING", 7);
-  }else{
-    DoltliteCommit toCommit;
-    memset(&toCommit, 0, sizeof(toCommit));
-    rc = doltliteResolveRef(db, zToRef, &toHash);
-    if( rc!=SQLITE_OK ) return SQLITE_OK;
-    rc = doltliteLoadCommit(db, &toHash, &toCommit);
-    if( rc!=SQLITE_OK ) return rc;
-    memcpy(&toCatHash, &toCommit.catalogHash, sizeof(ProllyHash));
-    toDate = toCommit.timestamp;
-    doltliteCommitClear(&toCommit);
-    rc = doltliteLoadTableRootByName(db, &toCatHash, zTableName,
-                                     &toTblRoot, &toFlags, &toSchemaHash);
-    if( rc!=SQLITE_OK && rc!=SQLITE_NOTFOUND ) return rc;
-    doltliteHashToHex(&toHash, zToLabel);
-  }
-
-  if( !toIsWorking && prollyHashCompare(&fromHash, &toHash)==0 ){
-    return SQLITE_OK;
-  }
-  if( prollyHashCompare(&fromTblRoot, &toTblRoot)==0
-   && prollyHashCompare(&fromSchemaHash, &toSchemaHash)==0 ){
+  if( prollyHashCompare(&from.tblRoot, &to.tblRoot)==0
+   && prollyHashCompare(&from.schemaHash, &to.schemaHash)==0 ){
     return SQLITE_OK;
   }
 
-  if( !fromFlags ) fromFlags = toFlags;
-  if( !toFlags ) toFlags = fromFlags;
-  return pairsAppend(pCur, &fromHash, &fromTblRoot, &fromCatHash,
-                     &fromSchemaHash, fromFlags, fromDate,
-                     zToLabel, &toTblRoot, &toCatHash, &toSchemaHash,
-                     toFlags, toDate);
+  if( !from.flags ) from.flags = to.flags;
+  if( !to.flags ) to.flags = from.flags;
+  return pairsAppend(pCur, from.zLabel, &from.tblRoot, &from.catHash,
+                     &from.schemaHash, from.flags, from.date,
+                     to.zLabel, &to.tblRoot, &to.catHash, &to.schemaHash,
+                     to.flags, to.date);
 }
 
 static int buildRangeSpecDiffPair(
@@ -855,7 +865,7 @@ static int openNextPairIter(DiffTblCursor *pCur, sqlite3 *db){
     u8 flags;
     p = &pCur->aPairs[pCur->iPair++];
     flags = p->fromFlags ? p->fromFlags : p->toFlags;
-    doltliteHashToHex(&p->fromHash, pCur->row.zFromCommit);
+    memcpy(pCur->row.zFromCommit, p->zFromCommit, PROLLY_HASH_SIZE*2+1);
     pCur->row.fromDate = p->fromDate;
     memcpy(pCur->row.zToCommit, p->zToCommit, PROLLY_HASH_SIZE*2+1);
     pCur->row.toDate = p->toDate;

--- a/src/doltlite_hashof.c
+++ b/src/doltlite_hashof.c
@@ -670,18 +670,10 @@ static void doltliteHashofCatalogFunc(sqlite3_context *ctx, int argc, sqlite3_va
   db = sqlite3_context_db_handle(ctx);
 
   if( argc==0 ){
-    if( doltliteHasUncommittedChanges(db) ){
-      rc = doltliteFlushCatalogToHash(db, &catHash);
-      if( rc!=SQLITE_OK ){
-        sqlite3_result_error(ctx, "dolt_hashof_catalog: catalog flush failed", -1);
-        return;
-      }
-    }else{
-      rc = doltliteGetPersistedWorkingCatalogHash(db, &catHash);
-      if( rc!=SQLITE_OK ){
-        sqlite3_result_error(ctx, "dolt_hashof_catalog: persisted catalog read failed", -1);
-        return;
-      }
+    rc = doltliteResolveCatalogHashForRef(db, "WORKING", &catHash);
+    if( rc!=SQLITE_OK ){
+      sqlite3_result_error(ctx, "dolt_hashof_catalog: working catalog read failed", -1);
+      return;
     }
   }else{
     if( hashofResolveRefCatalog(ctx, db, argv[0], "dolt_hashof_catalog", &catHash) ) return;

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -833,6 +833,16 @@ int doltliteCommitCatalogHash(sqlite3 *db, const ProllyHash *pCommit,
 int doltliteRefToCatalogHash(sqlite3 *db, const char *zRef,
                              ProllyHash *pCatHash);
 
+/* True when zRef names the working set / staged pseudo-refs. */
+int doltliteRefIsWorking(const char *zRef);
+int doltliteRefIsStaged(const char *zRef);
+
+/* Resolve any ref -- a commit/branch/tag, the WORKING or STAGED pseudo-refs,
+** or NULL for HEAD -- to its catalog hash. WORKING reflects uncommitted
+** in-session edits; STAGED falls back to HEAD when nothing is staged. */
+int doltliteResolveCatalogHashForRef(sqlite3 *db, const char *zRef,
+                                     ProllyHash *pCatHash);
+
 int doltliteForEachUserTable(sqlite3 *db, const char *zPrefix,
                              const sqlite3_module *pModule);
 

--- a/test/vc_oracle_diff_stat_test.sh
+++ b/test/vc_oracle_diff_stat_test.sh
@@ -517,6 +517,51 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'c2');
 " "HEAD~1" "HEAD"
 
+echo "--- working set / staged refs ---"
+
+WS_BASE="
+CREATE TABLE t(id INT PRIMARY KEY, v INT);
+INSERT INTO t VALUES(1, 10), (2, 20);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+"
+
+oracle_both "ws_head_working_modify" "
+$WS_BASE
+UPDATE t SET v = 99 WHERE id = 1;
+" "HEAD" "WORKING"
+
+oracle_both "ws_head_working_insert" "
+$WS_BASE
+INSERT INTO t VALUES(3, 30);
+" "HEAD" "WORKING"
+
+oracle_both "ws_head_working_delete" "
+$WS_BASE
+DELETE FROM t WHERE id = 2;
+" "HEAD" "WORKING"
+
+oracle_both "ws_head_working_add_column" "
+$WS_BASE
+ALTER TABLE t ADD COLUMN w INT;
+UPDATE t SET w = 7 WHERE id = 1;
+" "HEAD" "WORKING"
+
+oracle_both "ws_head_working_no_change" "$WS_BASE" "HEAD" "WORKING" "" "EXPECT_EMPTY"
+
+oracle_both "ws_head_staged" "
+$WS_BASE
+UPDATE t SET v = 99 WHERE id = 1;
+SELECT dolt_add('-A');
+" "HEAD" "STAGED"
+
+oracle_both "ws_staged_working_partial" "
+$WS_BASE
+UPDATE t SET v = 99 WHERE id = 1;
+SELECT dolt_add('-A');
+INSERT INTO t VALUES(3, 30);
+" "STAGED" "WORKING"
+
 echo ""
 echo "=== Results: $pass passed, $fail failed ==="
 if [ $fail -gt 0 ]; then

--- a/test/vc_oracle_diff_tvf_test.sh
+++ b/test/vc_oracle_diff_tvf_test.sh
@@ -104,6 +104,25 @@ SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'init');
 INSERT INTO t VALUES (99, 99);
 " "SELECT CONCAT('R|', IFNULL(to_id,''), '|', IFNULL(to_v,''), '|', IFNULL(from_id,''), '|', IFNULL(from_v,''), '|', diff_type) FROM dolt_diff_t('HEAD', 'WORKING');"
 
+echo "--- STAGED ref ---"
+
+oracle "slice_head_to_staged" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 1);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'init');
+UPDATE t SET v = 99 WHERE id = 1;
+SELECT dolt_add('-A');
+" "SELECT CONCAT('R|', IFNULL(to_id,''), '|', IFNULL(to_v,''), '|', IFNULL(from_id,''), '|', IFNULL(from_v,''), '|', diff_type) FROM dolt_diff_t('HEAD', 'STAGED');"
+
+oracle "slice_staged_to_working" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 1);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'init');
+UPDATE t SET v = 50 WHERE id = 1;
+SELECT dolt_add('-A');
+INSERT INTO t VALUES (2, 2);
+" "SELECT CONCAT('R|', IFNULL(to_id,''), '|', IFNULL(to_v,''), '|', IFNULL(from_id,''), '|', IFNULL(from_v,''), '|', diff_type) FROM dolt_diff_t('STAGED', 'WORKING');"
+
 echo "--- no diff (same ref both sides) ---"
 
 oracle "slice_no_change" "$SETUP_LINEAR" \


### PR DESCRIPTION
Fixes #1728.

## Problem

`WORKING`/`STAGED` ref resolution was inconsistent across the diff surfaces:

- `dolt_diff_summary` / `dolt_diff_stat` rejected both pseudo-refs (`unknown operation`).
- The `dolt_diff_<table>` slice TVF (`dolt_diff_t('from','to')`) resolved the **from** side with plain `doltliteResolveRef` (no pseudo-refs) and only special-cased `WORKING` on the **to** side — so `dolt_diff_t('HEAD','STAGED')` and `dolt_diff_t('STAGED','WORKING')` returned nothing where Dolt returns rows.
- The same WORKING logic was duplicated again in `dolt_hashof_catalog`.

The `dolt_diff_<table>` **system table** (no args) already matched Dolt — both fold staged into `WORKING` and emit no separate `STAGED` row (verified).

## Fix — one shared resolver, used everywhere

New `doltliteResolveCatalogHashForRef` (with `doltliteRefIsWorking` / `doltliteRefIsStaged`) in `doltlite_commit.c` is the single place that maps a commit ref, or the `WORKING`/`STAGED` pseudo-refs, or NULL/HEAD, to a catalog hash:
- **WORKING** — flush the in-session catalog if there are uncommitted edits, else the persisted working catalog.
- **STAGED** — the session staged catalog, falling back to HEAD when nothing is staged.

Adopted in `dolt_diff_stat`, `dolt_diff_summary`, `dolt_diff_<table>`, and `dolt_hashof_catalog` (the last a behavior-preserving dedup).

For the `dolt_diff_<table>` slice, both endpoints now go through one helper (`dtResolveSliceEnd`), so `WORKING`/`STAGED` work on either side. The diff pair's *from* side now carries a label (like the *to* side already did), letting a pseudo-ref surface as `from_commit`.

## Testing

Oracled against Dolt on both stat and summary (`vc_oracle_diff_stat_test.sh`): HEAD→WORKING modify / insert / delete / add-column / no-change, HEAD→STAGED, STAGED→WORKING. Added HEAD→STAGED and STAGED→WORKING to the row-level TVF suite (`vc_oracle_diff_tvf_test.sh`).

Fail-before / pass-after:
- diff_stat/summary working-set section: pre-fix **51/12 fail** → **63/0**.
- diff TVF STAGED cases: fail on the pre-fix binary → **16/0** with the fix.

No regressions: `vc_oracle_diff` (63), `vc_oracle_diff_tvf` (16), `vc_oracle_diff_multi_pk` (30), `vc_oracle_schema_diff` (60), `vc_oracle_hashof` (26), `vc_oracle_hashof_errors` (4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)