### PR TITLE
Match Dolt schema modify-delete merge behavior

### DIFF
--- a/src/doltlite_merge.c
+++ b/src/doltlite_merge.c
@@ -966,12 +966,186 @@ static ParsedColumn *findColumn(ParsedColumn *aCols, int nCols, const char *zNam
   return 0;
 }
 
+#define SCHEMA_MERGE_DEFAULT 0
+#define SCHEMA_MERGE_OURS    1
+#define SCHEMA_MERGE_THEIRS  2
+
+static const char *schemaSqlFindKeyword(
+  const char *zSql,
+  const char *zKeyword
+){
+  int nKeyword = (int)strlen(zKeyword);
+  const char *z = zSql;
+  while( z && *z ){
+    if( (int)strlen(z)>=nKeyword
+     && (z==zSql || (!sqlite3Isalnum((u8)z[-1]) && z[-1]!='_'))
+     && sqlite3_strnicmp(z, zKeyword, nKeyword)==0
+     && !sqlite3Isalnum((u8)z[nKeyword]) && z[nKeyword]!='_' ){
+      return z;
+    }
+    z++;
+  }
+  return 0;
+}
+
+static int schemaSqlHasKeyword(const char *zSql, const char *zKeyword){
+  return schemaSqlFindKeyword(zSql, zKeyword)!=0;
+}
+
+/* Return a column definition with CHECK(...) clauses removed. This is used
+** only to recognize Dolt's constraint-level modify-versus-delete rule; the
+** original SQL from the winning side is retained in the merged catalog. */
+static char *schemaColumnWithoutChecks(const char *zDef){
+  int n = (int)strlen(zDef);
+  char *zOut = sqlite3_malloc(n + 1);
+  const char *z = zDef;
+  char *zWrite = zOut;
+  if( !zOut ) return 0;
+  while( *z ){
+    if( (int)strlen(z)>=5
+     && (z==zDef || (!sqlite3Isalnum((u8)z[-1]) && z[-1]!='_'))
+     && sqlite3_strnicmp(z, "CHECK", 5)==0
+     && !sqlite3Isalnum((u8)z[5]) && z[5]!='_' ){
+      const char *zNext = z + 5;
+      int depth = 0;
+      while( isspace((unsigned char)*zNext) ) zNext++;
+      if( *zNext=='(' ){
+        do{
+          if( *zNext=='(' ) depth++;
+          else if( *zNext==')' ) depth--;
+          zNext++;
+        }while( *zNext && depth>0 );
+        z = zNext;
+        continue;
+      }
+    }
+    *zWrite++ = *z++;
+  }
+  while( zWrite>zOut && isspace((unsigned char)zWrite[-1]) ) zWrite--;
+  *zWrite = 0;
+  return zOut;
+}
+
+static int schemaColumnsSame(
+  const char *zLeftSql,
+  const char *zRightSql,
+  int ignoreChecks,
+  int *pSame
+){
+  ParsedColumn *aLeft = 0, *aRight = 0;
+  int nLeft = 0, nRight = 0;
+  int i, rc;
+  *pSame = 0;
+  rc = parseColumns(zLeftSql, &aLeft, &nLeft);
+  if( rc!=SQLITE_OK ) return rc;
+  rc = parseColumns(zRightSql, &aRight, &nRight);
+  if( rc!=SQLITE_OK ){
+    freeColumns(aLeft, nLeft);
+    return rc;
+  }
+  if( nLeft==nRight ){
+    *pSame = 1;
+    for(i=0; i<nLeft; i++){
+      ParsedColumn *pRight = findColumn(aRight, nRight, aLeft[i].zName);
+      if( !pRight ){
+        *pSame = 0;
+        break;
+      }
+      if( ignoreChecks ){
+        char *zLeft = schemaColumnWithoutChecks(aLeft[i].zDef);
+        char *zRight = schemaColumnWithoutChecks(pRight->zDef);
+        if( !zLeft || !zRight ){
+          sqlite3_free(zLeft);
+          sqlite3_free(zRight);
+          freeColumns(aLeft, nLeft);
+          freeColumns(aRight, nRight);
+          return SQLITE_NOMEM;
+        }
+        if( strcmp(zLeft, zRight)!=0 ) *pSame = 0;
+        sqlite3_free(zLeft);
+        sqlite3_free(zRight);
+      }else if( strcmp(aLeft[i].zDef, pRight->zDef)!=0 ){
+        *pSame = 0;
+      }
+      if( !*pSame ) break;
+    }
+  }
+  freeColumns(aLeft, nLeft);
+  freeColumns(aRight, nRight);
+  return SQLITE_OK;
+}
+
+static int schemaConstraintModifyDeleteChoice(
+  const char *zAncSql,
+  const char *zOursSql,
+  const char *zTheirsSql,
+  int *pChoice
+){
+  int ancHas, oursHas, theirsHas;
+  int sameAO = 0, sameAT = 0, sameOT = 0;
+  int survivorSame = 0;
+  int rc;
+  *pChoice = SCHEMA_MERGE_DEFAULT;
+
+  ancHas = schemaSqlHasKeyword(zAncSql, "REFERENCES");
+  oursHas = schemaSqlHasKeyword(zOursSql, "REFERENCES");
+  theirsHas = schemaSqlHasKeyword(zTheirsSql, "REFERENCES");
+  if( ancHas && oursHas!=theirsHas
+   && schemaSqlHasKeyword(zAncSql, "CHECK")
+        ==schemaSqlHasKeyword(zOursSql, "CHECK")
+   && schemaSqlHasKeyword(zAncSql, "CHECK")
+        ==schemaSqlHasKeyword(zTheirsSql, "CHECK") ){
+    rc = schemaColumnsSame(zAncSql, zOursSql, 0, &sameAO);
+    if( rc!=SQLITE_OK ) return rc;
+    rc = schemaColumnsSame(zAncSql, zTheirsSql, 0, &sameAT);
+    if( rc!=SQLITE_OK ) return rc;
+    rc = schemaColumnsSame(zOursSql, zTheirsSql, 0, &sameOT);
+    if( rc!=SQLITE_OK ) return rc;
+    if( sameAO && sameAT && sameOT ){
+      const char *zAncFk = schemaSqlFindKeyword(zAncSql, "REFERENCES");
+      const char *zSurvivorFk = schemaSqlFindKeyword(
+          oursHas ? zOursSql : zTheirsSql, "REFERENCES");
+      if( !zAncFk || !zSurvivorFk || strcmp(zAncFk, zSurvivorFk)==0 ){
+        return SQLITE_OK;
+      }
+      /* Dolt resolves a foreign-key modify-versus-delete in favor of the
+      ** deletion, independently of merge direction. */
+      *pChoice = oursHas ? SCHEMA_MERGE_THEIRS : SCHEMA_MERGE_OURS;
+      return SQLITE_OK;
+    }
+  }
+
+  ancHas = schemaSqlHasKeyword(zAncSql, "CHECK");
+  oursHas = schemaSqlHasKeyword(zOursSql, "CHECK");
+  theirsHas = schemaSqlHasKeyword(zTheirsSql, "CHECK");
+  if( ancHas && oursHas!=theirsHas
+   && schemaSqlHasKeyword(zAncSql, "REFERENCES")
+        ==schemaSqlHasKeyword(zOursSql, "REFERENCES")
+   && schemaSqlHasKeyword(zAncSql, "REFERENCES")
+        ==schemaSqlHasKeyword(zTheirsSql, "REFERENCES") ){
+    rc = schemaColumnsSame(zAncSql, zOursSql, 1, &sameAO);
+    if( rc!=SQLITE_OK ) return rc;
+    rc = schemaColumnsSame(zAncSql, zTheirsSql, 1, &sameAT);
+    if( rc!=SQLITE_OK ) return rc;
+    rc = schemaColumnsSame(zOursSql, zTheirsSql, 1, &sameOT);
+    if( rc!=SQLITE_OK ) return rc;
+    rc = schemaColumnsSame(zAncSql, oursHas ? zOursSql : zTheirsSql,
+                           0, &survivorSame);
+    if( rc!=SQLITE_OK ) return rc;
+    if( sameAO && sameAT && sameOT && !survivorSame ){
+      /* CHECK constraint modification wins over deletion in Dolt. */
+      *pChoice = oursHas ? SCHEMA_MERGE_OURS : SCHEMA_MERGE_THEIRS;
+    }
+  }
+  return SQLITE_OK;
+}
+
 static int trySchemaColumnMerge(
   const char *zAncSql,
   const char *zOursSql,
   const char *zTheirsSql,
   char ***ppAddCols, int *pnAddCols,
-  int *pUseTheirSchema,
+  int *pSchemaChoice,
   char **pzErrDetail
 ){
   ParsedColumn *aAnc=0, *aOurs=0, *aTheirs=0;
@@ -983,7 +1157,11 @@ static int trySchemaColumnMerge(
 
   *ppAddCols = 0;
   *pnAddCols = 0;
-  *pUseTheirSchema = 0;
+  *pSchemaChoice = SCHEMA_MERGE_DEFAULT;
+
+  rc = schemaConstraintModifyDeleteChoice(
+      zAncSql, zOursSql, zTheirsSql, pSchemaChoice);
+  if( rc!=SQLITE_OK || *pSchemaChoice!=SCHEMA_MERGE_DEFAULT ) return rc;
 
   rc = parseColumns(zAncSql, &aAnc, &nAnc);
   if( rc!=SQLITE_OK ) return rc;
@@ -1080,7 +1258,7 @@ static int trySchemaColumnMerge(
   }
 
   if( nAdd > 0 ){
-    *pUseTheirSchema = 0;
+    *pSchemaChoice = SCHEMA_MERGE_DEFAULT;
   }
   *ppAddCols = azAdd;
   *pnAddCols = nAdd;
@@ -1105,13 +1283,13 @@ int doltliteTableSchemaConflictDetail(
 ){
   char **azAdd = 0;
   int nAdd = 0;
-  int useTheirSchema = 0;
+  int schemaChoice = SCHEMA_MERGE_DEFAULT;
   int i, rc;
 
   *pzDetail = 0;
   if( !zAncestorSql || !zOurSql || !zTheirSql ) return SQLITE_OK;
   rc = trySchemaColumnMerge(zAncestorSql, zOurSql, zTheirSql,
-                            &azAdd, &nAdd, &useTheirSchema, pzDetail);
+                            &azAdd, &nAdd, &schemaChoice, pzDetail);
   for(i=0; i<nAdd; i++) sqlite3_free(azAdd[i]);
   sqlite3_free(azAdd);
   if( rc==SQLITE_ERROR ) return SQLITE_OK;
@@ -1475,6 +1653,9 @@ static int preDetectIndexSchemaConflicts(
        || mergeSchemaEntriesSame(pOurs, pTheirs) ){
         continue;
       }
+      /* Dolt keeps the modified index definition when the other branch
+      ** drops that index. Only competing surviving definitions conflict. */
+      if( pAnc && (!pOurs || !pTheirs) ) continue;
       zTable = pOurs && pOurs->zTblName ? pOurs->zTblName
              : (pTheirs && pTheirs->zTblName ? pTheirs->zTblName
                                              : a[i].zName);
@@ -2009,6 +2190,7 @@ static int tryResolveSchemaDivergence(
   SchemaMergeAction **ppSchemaActions,
   int *pnSchemaActions,
   int *pSkipRowMerge,
+  int *pSchemaChoice,
   char **pzErrMsg
 ){
   ChunkStore *csLocal;
@@ -2024,11 +2206,12 @@ static int tryResolveSchemaDivergence(
   SchemaEntry *theirSchEntry;
   char **azAddCols = 0;
   int nAddCols = 0;
-  int useTheirSchema = 0;
+  int schemaChoice = SCHEMA_MERGE_DEFAULT;
   char *zSchemaErr = 0;
   int rc;
 
   *pSkipRowMerge = 0;
+  *pSchemaChoice = SCHEMA_MERGE_DEFAULT;
   csLocal = doltliteGetChunkStore(db);
   cacheLocal = doltliteGetCache(db);
   loadSchemaFromCatalog(db, csLocal, cacheLocal, pCatAnc, &aAncSchema, &nAncSchema);
@@ -2044,7 +2227,7 @@ static int tryResolveSchemaDivergence(
    && theirSchEntry && theirSchEntry->zSql ){
     rc = trySchemaColumnMerge(
       ancSchEntry->zSql, ourSchEntry->zSql, theirSchEntry->zSql,
-      &azAddCols, &nAddCols, &useTheirSchema, &zSchemaErr);
+      &azAddCols, &nAddCols, &schemaChoice, &zSchemaErr);
   }else{
     rc = SQLITE_ERROR;
     zSchemaErr = sqlite3_mprintf("cannot load schemas for merge");
@@ -2071,6 +2254,17 @@ static int tryResolveSchemaDivergence(
     return SQLITE_ERROR;
   }
   sqlite3_free(zSchemaErr);
+
+  if( schemaChoice!=SCHEMA_MERGE_DEFAULT ){
+    if( ppSchemaActions && pnSchemaActions ){
+      rc = recordSchemaAddColumns(ppSchemaActions, pnSchemaActions, zName,
+                                  0, 0);
+      if( rc!=SQLITE_OK ) return rc;
+    }
+    *pSchemaChoice = schemaChoice;
+    freeAddedColumns(azAddCols, nAddCols);
+    return SQLITE_OK;
+  }
 
   if( nAddCols>0 ){
     if( ppSchemaActions && pnSchemaActions ){
@@ -2220,6 +2414,16 @@ do_merge_entry:
                                         zSchemaMergeName) ){
             continue;
           }
+          if( !zName && zSchemaMergeName && zSchemaMergeName[0] ){
+            /* A surviving redefinition beats the other branch's DROP. */
+            if( ppSchemaActions && pnSchemaActions ){
+              rc = recordSchemaAddColumns(ppSchemaActions, pnSchemaActions,
+                                          zSchemaMergeName, 0, 0);
+              if( rc!=SQLITE_OK ) return rc;
+            }
+            aMerged[(*pnMerged)++] = aOurs[i];
+            continue;
+          }
           rc = appendSchemaConflict(ppConflictTables, pnConflictTables,
                                     zSchemaConflictTable ? zSchemaConflictTable : "",
                                     zSchemaMergeName ? zSchemaMergeName : "",
@@ -2238,6 +2442,7 @@ do_merge_entry:
             &theirsEntry->schemaHash, &ancEntry->schemaHash)!=0;
         int bNamedSchemaObject = (!zName && zSchemaMergeName && zSchemaMergeName[0]);
         int skipRowMerge = 0;
+        int schemaChoice = SCHEMA_MERGE_DEFAULT;
         int bDualAddColMerge = 0;
         int bSchemaConflict = 0;
         ProllyHash theirsNormRoot;
@@ -2256,7 +2461,8 @@ do_merge_entry:
                                   &theirsEntry->schemaHash)!=0) ){
           rc = tryResolveSchemaDivergence(
             db, zSchemaMergeName, pCatAnc, pCatOurs, pCatTheirs,
-            ppSchemaActions, pnSchemaActions, &skipRowMerge, pzErrMsg);
+            ppSchemaActions, pnSchemaActions, &skipRowMerge,
+            &schemaChoice, pzErrMsg);
           if( rc==SQLITE_ERROR ){
             int addedSchemaTable = 0;
             sqlite3_free(pzErrMsg ? *pzErrMsg : 0);
@@ -2272,6 +2478,20 @@ do_merge_entry:
             bSchemaConflict = 1;
           }else if( rc!=SQLITE_OK ){
             return rc;
+          }
+          if( !bSchemaConflict && schemaChoice==SCHEMA_MERGE_THEIRS ){
+            SchemaEntry *pOurSe = findSchemaEntry(
+                aOursSchema, nOursSchema, zSchemaMergeName);
+            SchemaEntry *pTheirSe = findSchemaEntry(
+                aTheirsSchema, nTheirsSchema, zSchemaMergeName);
+            char *zSql = pTheirSe && pTheirSe->zSql
+                       ? sqlite3_mprintf("%s", pTheirSe->zSql) : 0;
+            if( !pOurSe || !zSql ){
+              sqlite3_free(zSql);
+              return pOurSe ? SQLITE_NOMEM : SQLITE_CORRUPT;
+            }
+            sqlite3_free(pOurSe->zSql);
+            pOurSe->zSql = zSql;
           }
           if( !bSchemaConflict && skipRowMerge && zName ){
             /* Both branches added columns compatibly. The post-merge ALTER
@@ -2414,8 +2634,8 @@ post_merge_table_rows:;
               struct TableEntry merged = aOurs[i];
               memcpy(&merged.root, &mergedTableRoot, sizeof(ProllyHash));
 
-              if( theirSchemaChanged
-               && !ourSchemaChanged ){
+              if( schemaChoice==SCHEMA_MERGE_THEIRS
+               || (theirSchemaChanged && !ourSchemaChanged) ){
                 memcpy(&merged.schemaHash, &theirsEntry->schemaHash,
                        sizeof(ProllyHash));
                 merged.flags = theirsEntry->flags;
@@ -2486,6 +2706,16 @@ post_merge_table_rows:;
       }
     }
     if( !pAncEntry || pOurEntry || !changed ) continue;
+    /* Standalone index modify-versus-delete is resolved in favor of the
+    ** modified definition and adopted by pass 2. */
+    if( !aTheirs[i].zName ){
+      if( ppSchemaActions && pnSchemaActions ){
+        rc = recordSchemaAddColumns(ppSchemaActions, pnSchemaActions,
+                                    zObject, 0, 0);
+        if( rc!=SQLITE_OK ) return rc;
+      }
+      continue;
+    }
     rc = appendSchemaConflict(ppConflictTables, pnConflictTables,
                               zTable ? zTable : "",
                               zObject ? zObject : "",
@@ -2675,8 +2905,47 @@ static int mergeCatalogPass2(
               if( !zDup ) return SQLITE_NOMEM;
               (*pazReindex)[(*pnReindex)++] = zDup;
             }
+          }else if( schemaEntryChangedByName(
+                        aAncSchema, nAncSchema,
+                        aTheirsSchema, nTheirsSchema,
+                        pTheirSe->zName) ){
+            struct TableEntry newEntry = aTheirs[i];
+            int j, conflict = 0;
+            Pgno oldPg = newEntry.iTable;
+            for(j=0; j<*pnMerged; j++){
+              if( aMerged[j].iTable==newEntry.iTable ){
+                conflict = 1;
+                break;
+              }
+            }
+            if( conflict ){
+              SchemaRootpageRemap *aNew;
+              int nOld = *pnRemap;
+              newEntry.iTable = (*piNextMerged)++;
+              aNew = sqlite3_realloc(*ppaRemap,
+                  (nOld+1)*(int)sizeof(SchemaRootpageRemap));
+              if( !aNew ) return SQLITE_NOMEM;
+              *ppaRemap = aNew;
+              aNew[nOld].oldPg = oldPg;
+              aNew[nOld].newPg = newEntry.iTable;
+              *pnRemap = nOld + 1;
+            }
+            if( newEntry.iTable >= *piNextMerged ){
+              *piNextMerged = newEntry.iTable + 1;
+            }
+            aMerged[(*pnMerged)++] = newEntry;
+            if( pazReindex ){
+              char **azNew = sqlite3_realloc(*pazReindex,
+                  (*pnReindex+1)*(int)sizeof(char*));
+              char *zDup;
+              if( !azNew ) return SQLITE_NOMEM;
+              *pazReindex = azNew;
+              zDup = sqlite3_mprintf("%s", pTheirSe->zName);
+              if( !zDup ) return SQLITE_NOMEM;
+              (*pazReindex)[(*pnReindex)++] = zDup;
+            }
           }else{
-            /* Honor our explicit DROP; theirs may only have auto-updated it. */
+            /* An unmodified index does not override our explicit DROP. */
           }
         }
         continue;

--- a/test/vc_oracle_schema_merge_test.sh
+++ b/test/vc_oracle_schema_merge_test.sh
@@ -3,9 +3,11 @@
 set -u
 
 DOLTLITE="${1:-./doltlite}"
+DOLT="${2:-dolt}"
 TMPROOT=$(mktemp -d)
 trap "rm -rf $TMPROOT" EXIT
 pass=0; fail=0; FAILED_NAMES=""
+source "$(dirname "$0")/lib/vc_oracle_common.sh"
 
 pass_name() { pass=$((pass+1)); echo "  PASS: $1"; }
 fail_name() {
@@ -13,49 +15,137 @@ fail_name() {
   echo "  FAIL: $1"
 }
 
-dl() {
-  local db="$1" sql="$2" tag="$3"
-  "$DOLTLITE" "$db" "$sql" 2>"$TMPROOT/$tag.err"
-}
-
 dl_setup() {
   local db="$1" tag="$2"
-  "$DOLTLITE" "$db" >"$TMPROOT/$tag.out" 2>"$TMPROOT/$tag.err"
-}
+  local sql dt_sql repo dl_rc dt_rc
+  sql=$(cat)
+  repo=$(dt_repo_for_db "$db")
+  mkdir -p "$repo"
+  if [ ! -d "$repo/.dolt" ]; then
+    (cd "$repo" && vc_oracle_init_repo)
+  fi
 
-dl_errors() {
-  local db="$1" sql="$2" tag="$3"
-  "$DOLTLITE" "$db" "$sql" >"$TMPROOT/$tag.out" 2>"$TMPROOT/$tag.err"
-  grep -qiE 'error|Error|conflict' "$TMPROOT/$tag.out" "$TMPROOT/$tag.err" 2>/dev/null
-}
+  printf '%s\n' "$sql" | "$DOLTLITE" "$db" \
+    >"$TMPROOT/$tag.out" 2>"$TMPROOT/$tag.err"
+  dl_rc=$?
+  dt_sql=$(printf '%s\n' "$sql" | schema_sql_for_dolt)
+  (cd "$repo" && printf '%s\n' "$dt_sql" | "$DOLT" sql -c) \
+    >"$TMPROOT/$tag.dt.out" 2>"$TMPROOT/$tag.dt.err"
+  dt_rc=$?
 
-expect_eq() {
-  local name="$1" want="$2" got="$3"
-  if [ "$want" = "$got" ]; then pass_name "$name"
-  else
-    fail_name "$name"
-    echo "    want: |$want|"
-    echo "    got:  |$got|"
+  if output_is_error "$dl_rc" "$TMPROOT/$tag.out" "$TMPROOT/$tag.err" \
+     || output_is_error "$dt_rc" "$TMPROOT/$tag.dt.out" "$TMPROOT/$tag.dt.err"; then
+    fail_name "${tag}_setup"
+    echo "    setup failed: doltlite rc=$dl_rc, dolt rc=$dt_rc"
+    echo "    doltlite stderr: $(head -2 "$TMPROOT/$tag.err")"
+    echo "    dolt stderr: $(head -2 "$TMPROOT/$tag.dt.err")"
   fi
 }
 
-expect_merge_ok() {
-  local name="$1" db="$2"
-  if dl_errors "$db" "SELECT dolt_merge('feat');" "$name"; then
-    fail_name "$name"
-    echo "    merge errored: $(cat $TMPROOT/$name.out $TMPROOT/$name.err 2>/dev/null | head -3)"
+dt_repo_for_db() {
+  local db="$1" base
+  base=$(basename "$db")
+  printf '%s/dolt_%s\n' "$TMPROOT" "${base%.db}"
+}
+
+schema_sql_for_dolt() {
+  local sql
+  sql=$(cat)
+  vc_oracle_translate_for_dolt "$sql" \
+    | sed -E 's/DROP INDEX ([a-zA-Z0-9_]+);/DROP INDEX \1 ON t;/g'
+}
+
+output_is_error() {
+  local rc="$1" out="$2" err="$3"
+  [ "$rc" -ne 0 ] || grep -qiE '(^|[^a-z])(error|failed)([ :]|$)' "$out" "$err" 2>/dev/null
+}
+
+run_merge_outcome() {
+  local engine="$1" db="$2" tag="$3"
+  local rc repo
+  if [ "$engine" = "doltlite" ]; then
+    "$DOLTLITE" "$db" "SELECT dolt_merge('feat');" \
+      >"$TMPROOT/$tag.dl.out" 2>"$TMPROOT/$tag.dl.err"
+    rc=$?
+    if output_is_error "$rc" "$TMPROOT/$tag.dl.out" "$TMPROOT/$tag.dl.err"; then
+      printf 'conflict\n'
+    else
+      printf 'ok\n'
+    fi
   else
-    pass_name "$name"
+    repo=$(dt_repo_for_db "$db")
+    (cd "$repo" && "$DOLT" sql -r csv -q "CALL dolt_merge('feat');") \
+      >"$TMPROOT/$tag.dt.out" 2>"$TMPROOT/$tag.dt.err"
+    rc=$?
+    if output_is_error "$rc" "$TMPROOT/$tag.dt.out" "$TMPROOT/$tag.dt.err" \
+       || tail -n +2 "$TMPROOT/$tag.dt.out" | grep -qi 'conflict'; then
+      printf 'conflict\n'
+    else
+      printf 'ok\n'
+    fi
   fi
 }
 
-expect_merge_conflict() {
-  local name="$1" db="$2"
-  if dl_errors "$db" "SELECT dolt_merge('feat');" "$name"; then
+expect_merge_outcome() {
+  local name="$1" db="$2" want="$3" dl_got dt_got
+  dl_got=$(run_merge_outcome doltlite "$db" "$name")
+  dt_got=$(run_merge_outcome dolt "$db" "$name")
+  if [ "$dl_got" = "$want" ] && [ "$dt_got" = "$want" ]; then
     pass_name "$name"
   else
     fail_name "$name"
-    echo "    merge succeeded but expected conflict"
+    echo "    expected $want; doltlite=$dl_got dolt=$dt_got"
+    echo "    doltlite: $(cat "$TMPROOT/$name.dl.out" "$TMPROOT/$name.dl.err" 2>/dev/null | head -2)"
+    echo "    dolt: $(cat "$TMPROOT/$name.dt.out" "$TMPROOT/$name.dt.err" 2>/dev/null | head -2)"
+  fi
+}
+
+expect_merge_ok() { expect_merge_outcome "$1" "$2" ok; }
+expect_merge_conflict() { expect_merge_outcome "$1" "$2" conflict; }
+
+run_dual_command_outcome() {
+  local name="$1" db="$2" dl_sql="$3" dt_sql="$4" want="$5"
+  local repo dl_rc dt_rc dl_got=ok dt_got=ok
+  repo=$(dt_repo_for_db "$db")
+  printf '%s\n' "$dl_sql" | "$DOLTLITE" "$db" \
+    >"$TMPROOT/$name.dl.out" 2>"$TMPROOT/$name.dl.err"
+  dl_rc=$?
+  (cd "$repo" && printf '%s\n' "$dt_sql" | "$DOLT" sql) \
+    >"$TMPROOT/$name.dt.out" 2>"$TMPROOT/$name.dt.err"
+  dt_rc=$?
+  if output_is_error "$dl_rc" "$TMPROOT/$name.dl.out" "$TMPROOT/$name.dl.err"; then dl_got=error; fi
+  if output_is_error "$dt_rc" "$TMPROOT/$name.dt.out" "$TMPROOT/$name.dt.err"; then dt_got=error; fi
+  if [ "$dl_got" = "$want" ] && [ "$dt_got" = "$want" ]; then
+    pass_name "$name"
+  else
+    fail_name "$name"
+    echo "    expected $want; doltlite=$dl_got dolt=$dt_got"
+  fi
+}
+
+query_doltlite_scalar() {
+  "$DOLTLITE" "$1" "$2" 2>"$TMPROOT/$3.dl.query.err" | tr -d '\r"'
+}
+
+query_dolt_scalar() {
+  local repo
+  repo=$(dt_repo_for_db "$1")
+  (cd "$repo" && "$DOLT" sql -r csv -q "$2") \
+    2>"$TMPROOT/$3.dt.query.err" | tail -n +2 | tr -d '\r"'
+}
+
+expect_dual_value() {
+  local name="$1" db="$2" want="$3" dl_sql="$4" dt_sql="$5"
+  local dl_got dt_got
+  dl_got=$(query_doltlite_scalar "$db" "$dl_sql" "$name")
+  dt_got=$(query_dolt_scalar "$db" "$dt_sql" "$name")
+  if [ "$dl_got" = "$want" ] && [ "$dt_got" = "$want" ]; then
+    pass_name "$name"
+  else
+    fail_name "$name"
+    echo "    expected: |$want|"
+    echo "    doltlite: |$dl_got|"
+    echo "    dolt:     |$dt_got|"
   fi
 }
 
@@ -101,28 +191,49 @@ CREATE TABLE newtbl(id INTEGER PRIMARY KEY, v INT);
 SELECT dolt_commit('-Am','main_add');
 SQL
 expect_merge_conflict "table_both_add_different" "$DB"
-expect_eq "schema_conflicts_columns" \
-  "table_name|base_schema|our_schema|their_schema|description" \
-  "$(dl "$DB" "SELECT group_concat(name, '|') FROM (SELECT name FROM pragma_table_info('dolt_schema_conflicts') ORDER BY cid);" "t2_columns")"
-expect_eq "schema_conflicts_autocommit_rollback" "0|0|0" \
-  "$(dl "$DB" "SELECT (SELECT count(*) FROM dolt_schema_conflicts) || '|' || (SELECT count(*) FROM dolt_conflicts) || '|' || (SELECT count(*) FROM dolt_status WHERE status='schema conflict');" "t2_autocommit")"
-cat <<'SQL' | dl_setup "$DB" "t2_transaction"
-BEGIN;
-SELECT dolt_merge('feat');
-COMMIT;
+expect_dual_value "schema_conflicts_autocommit_rollback" "$DB" "0|0|0" \
+  "SELECT (SELECT count(*) FROM dolt_schema_conflicts) || '|' || (SELECT count(*) FROM dolt_conflicts) || '|' || (SELECT count(*) FROM dolt_status WHERE status='schema conflict');" \
+  "SELECT CONCAT((SELECT count(*) FROM dolt_schema_conflicts), '|', (SELECT count(*) FROM dolt_conflicts), '|', (SELECT count(*) FROM dolt_status WHERE status='schema conflict'));"
+
+DB="$TMPROOT/sc1.db"; rm -f "$DB"
+cat <<'SQL' | dl_setup "$DB" "sc1"
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'a');
+SELECT dolt_commit('-Am','ancestor');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+ALTER TABLE t ADD COLUMN extra TEXT;
+SELECT dolt_commit('-Am','feat_schema');
+SELECT dolt_checkout('main');
+ALTER TABLE t ADD COLUMN extra INTEGER;
+SELECT dolt_commit('-Am','main_schema');
 SQL
-expect_eq "schema_conflicts_transaction_state" "1|1|0|1" \
-  "$(dl "$DB" "SELECT (SELECT count(*) FROM dolt_schema_conflicts) || '|' || (SELECT count(*) FROM dolt_conflicts) || '|' || (SELECT coalesce(sum(num_conflicts),-1) FROM dolt_conflicts) || '|' || (SELECT count(*) FROM dolt_status WHERE status='schema conflict');" "t2_state")"
-expect_eq "schema_conflicts_schema_rows" "newtbl|1|1|1" \
-  "$(dl "$DB" "SELECT table_name || '|' || (base_schema='<deleted>') || '|' || (our_schema LIKE 'CREATE TABLE newtbl%') || '|' || (their_schema LIKE 'CREATE TABLE newtbl%') FROM dolt_schema_conflicts;" "t2_rows")"
-if dl_errors "$DB" "SELECT dolt_conflicts_resolve('--ours','newtbl');" "t2_resolve"; then
-  pass_name "schema_conflicts_resolve_refused"
-else
-  fail_name "schema_conflicts_resolve_refused"
-fi
-dl "$DB" "SELECT dolt_merge('--abort');" "t2_abort" >/dev/null
-expect_eq "schema_conflicts_abort_clears" "0|0|0" \
-  "$(dl "$DB" "SELECT (SELECT count(*) FROM dolt_schema_conflicts) || '|' || (SELECT count(*) FROM dolt_conflicts) || '|' || (SELECT count(*) FROM dolt_status WHERE status='schema conflict');" "t2_cleared")"
+expect_merge_conflict "schema_conflict_existing_column_autocommit" "$DB"
+expect_dual_value "schema_conflicts_existing_autocommit_rollback" "$DB" "0|0|0" \
+  "SELECT (SELECT count(*) FROM dolt_schema_conflicts) || '|' || (SELECT count(*) FROM dolt_conflicts) || '|' || (SELECT count(*) FROM dolt_status WHERE status='schema conflict');" \
+  "SELECT CONCAT((SELECT count(*) FROM dolt_schema_conflicts), '|', (SELECT count(*) FROM dolt_conflicts), '|', (SELECT count(*) FROM dolt_status WHERE status='schema conflict'));"
+printf '%s\n' "BEGIN; SELECT dolt_merge('feat'); COMMIT;" \
+  | "$DOLTLITE" "$DB" >"$TMPROOT/schema_conflicts_persist.dl.out" \
+      2>"$TMPROOT/schema_conflicts_persist.dl.err" || true
+DT_T2=$(dt_repo_for_db "$DB")
+(cd "$DT_T2" && printf '%s\n' \
+  "SET @@dolt_allow_commit_conflicts=1; SET autocommit=0; CALL dolt_merge('feat'); COMMIT;" \
+  | "$DOLT" sql -c) >"$TMPROOT/schema_conflicts_persist.dt.out" \
+      2>"$TMPROOT/schema_conflicts_persist.dt.err" || true
+expect_dual_value "schema_conflicts_transaction_state" "$DB" "1|1|0|1" \
+  "SELECT (SELECT count(*) FROM dolt_schema_conflicts) || '|' || (SELECT count(*) FROM dolt_conflicts) || '|' || (SELECT coalesce(sum(num_conflicts),-1) FROM dolt_conflicts) || '|' || (SELECT count(*) FROM dolt_status WHERE status='schema conflict');" \
+  "SELECT CONCAT((SELECT count(*) FROM dolt_schema_conflicts), '|', (SELECT count(*) FROM dolt_conflicts), '|', (SELECT coalesce(sum(num_conflicts),-1) FROM dolt_conflicts), '|', (SELECT count(*) FROM dolt_status WHERE status='schema conflict'));"
+expect_dual_value "schema_conflicts_schema_rows" "$DB" "t|1|1|1" \
+  "SELECT table_name || '|' || (base_schema LIKE '%CREATE TABLE%') || '|' || (our_schema LIKE '%extra%') || '|' || (their_schema LIKE '%extra%') FROM dolt_schema_conflicts;" \
+  "SELECT CONCAT(table_name, '|', base_schema LIKE '%CREATE TABLE%', '|', our_schema LIKE '%extra%', '|', their_schema LIKE '%extra%') FROM dolt_schema_conflicts;"
+run_dual_command_outcome "schema_conflicts_resolve_refused" "$DB" \
+  "SELECT dolt_conflicts_resolve('--ours','t');" \
+  "CALL dolt_conflicts_resolve('--ours','t');" error
+run_dual_command_outcome "schema_conflicts_abort" "$DB" \
+  "SELECT dolt_merge('--abort');" "CALL dolt_merge('--abort');" ok
+expect_dual_value "schema_conflicts_abort_clears" "$DB" "0|0|0" \
+  "SELECT (SELECT count(*) FROM dolt_schema_conflicts) || '|' || (SELECT count(*) FROM dolt_conflicts) || '|' || (SELECT count(*) FROM dolt_status WHERE status='schema conflict');" \
+  "SELECT CONCAT((SELECT count(*) FROM dolt_schema_conflicts), '|', (SELECT count(*) FROM dolt_conflicts), '|', (SELECT count(*) FROM dolt_status WHERE status='schema conflict'));"
 
 DB="$TMPROOT/t3.db"; rm -f "$DB"
 cat <<'SQL' | dl_setup "$DB" "t3"
@@ -262,8 +373,8 @@ INSERT INTO t VALUES(2,'b');
 SELECT dolt_commit('-Am','main_insert');
 SQL
 expect_merge_ok "col_one_adds" "$DB"
-W=$(dl "$DB" "SELECT w FROM t WHERE id=2;" "c5_check")
-expect_eq "col_one_adds_default_filled" "0" "$W"
+expect_dual_value "col_one_adds_default_filled" "$DB" "0" \
+  "SELECT w FROM t WHERE id=2;" "SELECT w FROM t WHERE id=2;"
 
 echo ""
 
@@ -279,12 +390,12 @@ SELECT dolt_commit('-Am','ancestor');
 SELECT dolt_branch('feat');
 SELECT dolt_checkout('feat');
 DROP TABLE child;
-CREATE TABLE child(id INTEGER PRIMARY KEY, pid INTEGER REFERENCES parent(id));
+CREATE TABLE child(id INTEGER PRIMARY KEY, pid INTEGER, FOREIGN KEY(pid) REFERENCES parent(id));
 INSERT INTO child VALUES(1,1);
 SELECT dolt_commit('-Am','feat_add_fk');
 SELECT dolt_checkout('main');
 DROP TABLE child;
-CREATE TABLE child(id INTEGER PRIMARY KEY, pid INTEGER REFERENCES parent(id));
+CREATE TABLE child(id INTEGER PRIMARY KEY, pid INTEGER, FOREIGN KEY(pid) REFERENCES parent(id));
 INSERT INTO child VALUES(1,1);
 SELECT dolt_commit('-Am','main_add_fk');
 SQL
@@ -302,12 +413,12 @@ SELECT dolt_commit('-Am','ancestor');
 SELECT dolt_branch('feat');
 SELECT dolt_checkout('feat');
 DROP TABLE child;
-CREATE TABLE child(id INTEGER PRIMARY KEY, pid INTEGER REFERENCES parent(id));
+CREATE TABLE child(id INTEGER PRIMARY KEY, pid INTEGER, FOREIGN KEY(pid) REFERENCES parent(id));
 INSERT INTO child VALUES(1,1);
 SELECT dolt_commit('-Am','feat_add_fk_parent');
 SELECT dolt_checkout('main');
 DROP TABLE child;
-CREATE TABLE child(id INTEGER PRIMARY KEY, pid INTEGER REFERENCES parent2(id));
+CREATE TABLE child(id INTEGER PRIMARY KEY, pid INTEGER, FOREIGN KEY(pid) REFERENCES parent2(id));
 INSERT INTO child VALUES(1,1);
 SELECT dolt_commit('-Am','main_add_fk_parent2');
 SQL
@@ -319,7 +430,7 @@ echo "--- Indexes ---"
 
 DB="$TMPROOT/ix1.db"; rm -f "$DB"
 cat <<'SQL' | dl_setup "$DB" "ix1"
-CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+CREATE TABLE t(id INTEGER PRIMARY KEY, v VARCHAR(64));
 INSERT INTO t VALUES(1,'a');
 SELECT dolt_commit('-Am','ancestor');
 SELECT dolt_branch('feat');
@@ -334,7 +445,7 @@ expect_merge_ok "idx_both_add_identical" "$DB"
 
 DB="$TMPROOT/ix2.db"; rm -f "$DB"
 cat <<'SQL' | dl_setup "$DB" "ix2"
-CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT, w INT);
+CREATE TABLE t(id INTEGER PRIMARY KEY, v VARCHAR(64), w INT);
 INSERT INTO t VALUES(1,'a',10);
 SELECT dolt_commit('-Am','ancestor');
 SELECT dolt_branch('feat');
@@ -349,7 +460,7 @@ expect_merge_conflict "idx_both_add_different" "$DB"
 
 DB="$TMPROOT/ix3.db"; rm -f "$DB"
 cat <<'SQL' | dl_setup "$DB" "ix3"
-CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+CREATE TABLE t(id INTEGER PRIMARY KEY, v VARCHAR(64));
 CREATE INDEX idx_v ON t(v);
 INSERT INTO t VALUES(1,'a');
 SELECT dolt_commit('-Am','ancestor');
@@ -421,8 +532,9 @@ ALTER TABLE t ADD COLUMN x TEXT DEFAULT '';
 SELECT dolt_commit('-Am','main_add_x');
 SQL
 expect_merge_ok "table_both_add_different_columns" "$DB"
-COLS=$(dl "$DB" "PRAGMA table_info(t);" "t6_cols" | wc -l | tr -d ' ')
-expect_eq "table_both_add_different_columns_col_count" "4" "$COLS"
+expect_dual_value "table_both_add_different_columns_col_count" "$DB" "4" \
+  "SELECT count(*) FROM pragma_table_info('t');" \
+  "SELECT count(*) FROM information_schema.columns WHERE table_schema=DATABASE() AND table_name='t';"
 
 DB="$TMPROOT/t7.db"; rm -f "$DB"
 cat <<'SQL' | dl_setup "$DB" "t7"
@@ -522,7 +634,7 @@ echo "--- Foreign Keys (additional) ---"
 DB="$TMPROOT/fk3.db"; rm -f "$DB"
 cat <<'SQL' | dl_setup "$DB" "fk3"
 CREATE TABLE parent(id INTEGER PRIMARY KEY);
-CREATE TABLE child(id INTEGER PRIMARY KEY, pid INTEGER REFERENCES parent(id));
+CREATE TABLE child(id INTEGER PRIMARY KEY, pid INTEGER, FOREIGN KEY(pid) REFERENCES parent(id));
 INSERT INTO parent VALUES(1);
 INSERT INTO child VALUES(1,1);
 SELECT dolt_commit('-Am','ancestor');
@@ -543,14 +655,14 @@ expect_merge_ok "fk_both_delete" "$DB"
 DB="$TMPROOT/fk4.db"; rm -f "$DB"
 cat <<'SQL' | dl_setup "$DB" "fk4"
 CREATE TABLE parent(id INTEGER PRIMARY KEY);
-CREATE TABLE child(id INTEGER PRIMARY KEY, pid INTEGER REFERENCES parent(id));
+CREATE TABLE child(id INTEGER PRIMARY KEY, pid INTEGER, FOREIGN KEY(pid) REFERENCES parent(id));
 INSERT INTO parent VALUES(1);
 INSERT INTO child VALUES(1,1);
 SELECT dolt_commit('-Am','ancestor');
 SELECT dolt_branch('feat');
 SELECT dolt_checkout('feat');
 DROP TABLE child;
-CREATE TABLE child(id INTEGER PRIMARY KEY, pid INTEGER REFERENCES parent(id) ON DELETE CASCADE);
+CREATE TABLE child(id INTEGER PRIMARY KEY, pid INTEGER, FOREIGN KEY(pid) REFERENCES parent(id) ON DELETE CASCADE);
 INSERT INTO child VALUES(1,1);
 SELECT dolt_commit('-Am','feat_modify_fk');
 SELECT dolt_checkout('main');
@@ -559,24 +671,27 @@ CREATE TABLE child(id INTEGER PRIMARY KEY, pid INTEGER);
 INSERT INTO child VALUES(1,1);
 SELECT dolt_commit('-Am','main_drop_fk');
 SQL
-expect_merge_conflict "fk_modify_vs_delete" "$DB"
+expect_merge_ok "fk_modify_vs_delete" "$DB"
+expect_dual_value "fk_modify_vs_delete_keeps_delete" "$DB" "0" \
+  "SELECT count(*) FROM pragma_foreign_key_list('child');" \
+  "SELECT count(*) FROM information_schema.key_column_usage WHERE table_schema=database() AND table_name='child' AND referenced_table_name IS NOT NULL;"
 
 DB="$TMPROOT/fk5.db"; rm -f "$DB"
 cat <<'SQL' | dl_setup "$DB" "fk5"
 CREATE TABLE parent(id INTEGER PRIMARY KEY);
-CREATE TABLE child(id INTEGER PRIMARY KEY, pid INTEGER REFERENCES parent(id));
+CREATE TABLE child(id INTEGER PRIMARY KEY, pid INTEGER, FOREIGN KEY(pid) REFERENCES parent(id));
 INSERT INTO parent VALUES(1);
 INSERT INTO child VALUES(1,1);
 SELECT dolt_commit('-Am','ancestor');
 SELECT dolt_branch('feat');
 SELECT dolt_checkout('feat');
 DROP TABLE child;
-CREATE TABLE child(id INTEGER PRIMARY KEY, pid INTEGER REFERENCES parent(id) ON DELETE CASCADE);
+CREATE TABLE child(id INTEGER PRIMARY KEY, pid INTEGER, FOREIGN KEY(pid) REFERENCES parent(id) ON DELETE CASCADE);
 INSERT INTO child VALUES(1,1);
 SELECT dolt_commit('-Am','feat_add_cascade');
 SELECT dolt_checkout('main');
 DROP TABLE child;
-CREATE TABLE child(id INTEGER PRIMARY KEY, pid INTEGER REFERENCES parent(id) ON DELETE CASCADE);
+CREATE TABLE child(id INTEGER PRIMARY KEY, pid INTEGER, FOREIGN KEY(pid) REFERENCES parent(id) ON DELETE CASCADE);
 INSERT INTO child VALUES(1,1);
 SELECT dolt_commit('-Am','main_add_cascade');
 SQL
@@ -585,23 +700,47 @@ expect_merge_ok "fk_both_modify_identical" "$DB"
 DB="$TMPROOT/fk6.db"; rm -f "$DB"
 cat <<'SQL' | dl_setup "$DB" "fk6"
 CREATE TABLE parent(id INTEGER PRIMARY KEY);
-CREATE TABLE child(id INTEGER PRIMARY KEY, pid INTEGER REFERENCES parent(id));
+CREATE TABLE child(id INTEGER PRIMARY KEY, pid INTEGER, FOREIGN KEY(pid) REFERENCES parent(id));
 INSERT INTO parent VALUES(1);
 INSERT INTO child VALUES(1,1);
 SELECT dolt_commit('-Am','ancestor');
 SELECT dolt_branch('feat');
 SELECT dolt_checkout('feat');
 DROP TABLE child;
-CREATE TABLE child(id INTEGER PRIMARY KEY, pid INTEGER REFERENCES parent(id) ON DELETE CASCADE);
+CREATE TABLE child(id INTEGER PRIMARY KEY, pid INTEGER, FOREIGN KEY(pid) REFERENCES parent(id) ON DELETE CASCADE);
 INSERT INTO child VALUES(1,1);
 SELECT dolt_commit('-Am','feat_cascade');
 SELECT dolt_checkout('main');
 DROP TABLE child;
-CREATE TABLE child(id INTEGER PRIMARY KEY, pid INTEGER REFERENCES parent(id) ON DELETE SET NULL);
+CREATE TABLE child(id INTEGER PRIMARY KEY, pid INTEGER, FOREIGN KEY(pid) REFERENCES parent(id) ON DELETE SET NULL);
 INSERT INTO child VALUES(1,1);
 SELECT dolt_commit('-Am','main_setnull');
 SQL
 expect_merge_conflict "fk_both_modify_differently" "$DB"
+
+DB="$TMPROOT/fk7.db"; rm -f "$DB"
+cat <<'SQL' | dl_setup "$DB" "fk7"
+CREATE TABLE parent(id INTEGER PRIMARY KEY);
+CREATE TABLE child(id INTEGER PRIMARY KEY, pid INTEGER, FOREIGN KEY(pid) REFERENCES parent(id));
+INSERT INTO parent VALUES(1);
+INSERT INTO child VALUES(1,1);
+SELECT dolt_commit('-Am','ancestor');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+DROP TABLE child;
+CREATE TABLE child(id INTEGER PRIMARY KEY, pid INTEGER);
+INSERT INTO child VALUES(1,1);
+SELECT dolt_commit('-Am','feat_drop_fk');
+SELECT dolt_checkout('main');
+DROP TABLE child;
+CREATE TABLE child(id INTEGER PRIMARY KEY, pid INTEGER, FOREIGN KEY(pid) REFERENCES parent(id) ON DELETE CASCADE);
+INSERT INTO child VALUES(1,1);
+SELECT dolt_commit('-Am','main_modify_fk');
+SQL
+expect_merge_ok "fk_delete_vs_modify_reverse" "$DB"
+expect_dual_value "fk_delete_vs_modify_reverse_keeps_delete" "$DB" "0" \
+  "SELECT count(*) FROM pragma_foreign_key_list('child');" \
+  "SELECT count(*) FROM information_schema.key_column_usage WHERE table_schema=database() AND table_name='child' AND referenced_table_name IS NOT NULL;"
 
 echo ""
 
@@ -609,7 +748,7 @@ echo "--- Indexes (additional) ---"
 
 DB="$TMPROOT/ix4.db"; rm -f "$DB"
 cat <<'SQL' | dl_setup "$DB" "ix4"
-CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT, w INT);
+CREATE TABLE t(id INTEGER PRIMARY KEY, v VARCHAR(64), w INT);
 CREATE INDEX idx_v ON t(v);
 INSERT INTO t VALUES(1,'a',10);
 SELECT dolt_commit('-Am','ancestor');
@@ -622,11 +761,14 @@ SELECT dolt_checkout('main');
 DROP INDEX idx_v;
 SELECT dolt_commit('-Am','main_drop_idx');
 SQL
-expect_merge_conflict "idx_modify_vs_delete" "$DB"
+expect_merge_ok "idx_modify_vs_delete" "$DB"
+expect_dual_value "idx_modify_vs_delete_keeps_modify" "$DB" "2" \
+  "SELECT count(*) FROM pragma_index_info('idx_v');" \
+  "SELECT count(*) FROM information_schema.statistics WHERE table_schema=database() AND table_name='t' AND index_name='idx_v';"
 
 DB="$TMPROOT/ix5.db"; rm -f "$DB"
 cat <<'SQL' | dl_setup "$DB" "ix5"
-CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT, w INT);
+CREATE TABLE t(id INTEGER PRIMARY KEY, v VARCHAR(64), w INT);
 CREATE INDEX idx_v ON t(v);
 INSERT INTO t VALUES(1,'a',10);
 SELECT dolt_commit('-Am','ancestor');
@@ -644,7 +786,7 @@ expect_merge_ok "idx_both_modify_identical" "$DB"
 
 DB="$TMPROOT/ix6.db"; rm -f "$DB"
 cat <<'SQL' | dl_setup "$DB" "ix6"
-CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT, w INT);
+CREATE TABLE t(id INTEGER PRIMARY KEY, v VARCHAR(64), w INT);
 CREATE INDEX idx_v ON t(v);
 INSERT INTO t VALUES(1,'a',10);
 SELECT dolt_commit('-Am','ancestor');
@@ -659,6 +801,26 @@ CREATE INDEX idx_v ON t(w);
 SELECT dolt_commit('-Am','main_idx_w');
 SQL
 expect_merge_conflict "idx_both_modify_differently" "$DB"
+
+DB="$TMPROOT/ix7.db"; rm -f "$DB"
+cat <<'SQL' | dl_setup "$DB" "ix7"
+CREATE TABLE t(id INTEGER PRIMARY KEY, v VARCHAR(64), w INT);
+CREATE INDEX idx_v ON t(v);
+INSERT INTO t VALUES(1,'a',10);
+SELECT dolt_commit('-Am','ancestor');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+DROP INDEX idx_v;
+SELECT dolt_commit('-Am','feat_drop_idx');
+SELECT dolt_checkout('main');
+DROP INDEX idx_v;
+CREATE INDEX idx_v ON t(v, w);
+SELECT dolt_commit('-Am','main_modify_idx');
+SQL
+expect_merge_ok "idx_delete_vs_modify_reverse" "$DB"
+expect_dual_value "idx_delete_vs_modify_reverse_keeps_modify" "$DB" "2" \
+  "SELECT count(*) FROM pragma_index_info('idx_v');" \
+  "SELECT count(*) FROM information_schema.statistics WHERE table_schema=database() AND table_name='t' AND index_name='idx_v';"
 
 echo ""
 
@@ -700,7 +862,10 @@ CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
 INSERT INTO t VALUES(1,10);
 SELECT dolt_commit('-Am','main_drop_check');
 SQL
-expect_merge_conflict "check_modify_vs_delete" "$DB"
+expect_merge_ok "check_modify_vs_delete" "$DB"
+expect_dual_value "check_modify_vs_delete_keeps_modify" "$DB" "1" \
+  "SELECT count(*) FROM sqlite_master WHERE name='t' AND sql LIKE '%CHECK(v > 5)%';" \
+  "SELECT count(*) FROM information_schema.check_constraints WHERE check_clause LIKE '%> 5%';"
 
 DB="$TMPROOT/ck5.db"; rm -f "$DB"
 cat <<'SQL' | dl_setup "$DB" "ck5"
@@ -739,6 +904,28 @@ INSERT INTO t VALUES(1,10);
 SELECT dolt_commit('-Am','main_check_ge0');
 SQL
 expect_merge_conflict "check_both_modify_differently" "$DB"
+
+DB="$TMPROOT/ck7.db"; rm -f "$DB"
+cat <<'SQL' | dl_setup "$DB" "ck7"
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT CHECK(v > 0));
+INSERT INTO t VALUES(1,10);
+SELECT dolt_commit('-Am','ancestor');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+DROP TABLE t;
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES(1,10);
+SELECT dolt_commit('-Am','feat_drop_check');
+SELECT dolt_checkout('main');
+DROP TABLE t;
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT CHECK(v > 5));
+INSERT INTO t VALUES(1,10);
+SELECT dolt_commit('-Am','main_modify_check');
+SQL
+expect_merge_ok "check_delete_vs_modify_reverse" "$DB"
+expect_dual_value "check_delete_vs_modify_reverse_keeps_modify" "$DB" "1" \
+  "SELECT count(*) FROM sqlite_master WHERE name='t' AND sql LIKE '%CHECK(v > 5)%';" \
+  "SELECT count(*) FROM information_schema.check_constraints WHERE check_clause LIKE '%> 5%';"
 
 echo ""
 echo "======================================="


### PR DESCRIPTION
## Summary
- convert the schema merge oracle into a live Dolt-vs-DoltLite comparison
- match Dolt modify-versus-delete behavior for foreign keys, indexes, and check constraints
- verify the winning schema in both merge directions

## Tests
- `bash test/vc_oracle_schema_merge_test.sh ./doltlite dolt` (54 passed)
- `bash test/doltlite_schema_merge.sh ./doltlite` (94 passed)
- `bash test/vc_oracle_merge_test.sh ./doltlite dolt`
- `make devtest` attempted; local testfixture link is blocked by missing `libtommath` before tests start