### PR TITLE
Guard GC mark queue growth against integer overflow

### DIFF
--- a/src/doltlite_gc.c
+++ b/src/doltlite_gc.c
@@ -101,8 +101,6 @@ static int gcQueuePush(
 ){
   if( prollyHashIsEmpty(h) ) return SQLITE_OK;
   if( q->nItems >= q->nAlloc ){
-    /* Same overflow pattern as doltliteCommitQueueEnqueue: double in i64,
-    ** refuse if the byte size would not fit a positive int realloc. */
     i64 nNew = q->nAlloc ? (i64)q->nAlloc * 2 : (i64)256;
     GcQueueItem *aNew;
     if( nNew > (i64)0x7fffffff/(i64)sizeof(GcQueueItem) ) return SQLITE_NOMEM;

--- a/src/doltlite_gc.c
+++ b/src/doltlite_gc.c
@@ -77,7 +77,7 @@ static const char *gcChunkTypeName(DoltliteChunkType type){
 
 static int gcQueueInit(GcQueue *q){
   q->nAlloc = 256;
-  q->aItems = sqlite3_malloc(q->nAlloc * sizeof(GcQueueItem));
+  q->aItems = sqlite3_malloc(q->nAlloc * (int)sizeof(GcQueueItem));
   if( !q->aItems ) return SQLITE_NOMEM;
   q->nItems = 0;
   q->iHead = 0;
@@ -101,11 +101,17 @@ static int gcQueuePush(
 ){
   if( prollyHashIsEmpty(h) ) return SQLITE_OK;
   if( q->nItems >= q->nAlloc ){
-    int newAlloc = q->nAlloc * 2;
-    GcQueueItem *aNew = sqlite3_realloc(q->aItems, newAlloc * sizeof(GcQueueItem));
+    /* Same overflow pattern as doltliteCommitQueueEnqueue: double in i64,
+    ** refuse if the byte size would not fit a positive int realloc. */
+    i64 nNew = q->nAlloc ? (i64)q->nAlloc * 2 : (i64)256;
+    GcQueueItem *aNew;
+    if( nNew > (i64)0x7fffffff/(i64)sizeof(GcQueueItem) ) return SQLITE_NOMEM;
+    aNew = (GcQueueItem*)sqlite3_realloc(
+      q->aItems, (int)(nNew * (i64)sizeof(GcQueueItem))
+    );
     if( !aNew ) return SQLITE_NOMEM;
     q->aItems = aNew;
-    q->nAlloc = newAlloc;
+    q->nAlloc = (int)nNew;
   }
   memcpy(&q->aItems[q->nItems].hash, h, sizeof(ProllyHash));
   if( pParent ){


### PR DESCRIPTION
## Summary

Overflow-safe growth for the GC mark BFS queue (P0 from the storage review; remotesrv items deferred).

`gcQueuePush` doubled `nAlloc` in `int` and multiplied by `sizeof(GcQueueItem)` with no check, so a huge mark queue could wrap and under-allocate. It now follows the same pattern as `doltliteCommitQueueEnqueue`:

- double capacity in `i64`
- refuse with `SQLITE_NOMEM` if `nNew * sizeof(GcQueueItem)` would not fit a positive `int` realloc size
- then `sqlite3_realloc` and store `nAlloc` as `int`

## Test plan

- [x] `make doltlite`
- [x] `DOLTLITE=./build/doltlite bash test/doltlite_gc.sh` — 58 passed, 0 failed
- [x] Manual: create/commit/gc on a temp DB returns `0 chunks removed, N chunks kept` and data intact