### PR TITLE
Verify pending chunk hashes under SQLITE_DEBUG

### DIFF
--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -1279,6 +1279,16 @@ int chunkStoreGet(
 
     memcpy(pCopy, cs->staging.pWriteBuf + off + 4, (size_t)(sz - nZ));
     if( nZ>0 ) memset(pCopy + (sz - nZ), 0, (size_t)nZ);
+#ifdef SQLITE_DEBUG
+    {
+      ProllyHash h;
+      prollyHashCompute(pCopy, sz, &h);
+      if( memcmp(&h, hash, sizeof(ProllyHash))!=0 ){
+        sqlite3_free(pCopy);
+        return SQLITE_CORRUPT;
+      }
+    }
+#endif
     *ppData = pCopy;
     *pnData = sz;
     return SQLITE_OK;
@@ -1304,6 +1314,16 @@ int chunkStoreGet(
         u8 *pCopy = (u8 *)sqlite3_malloc(e->size);
         if( pCopy == 0 ) return SQLITE_NOMEM;
         memcpy(pCopy, cs->staging.pWriteBuf + e->offset + 4, e->size);
+#ifdef SQLITE_DEBUG
+        {
+          ProllyHash h;
+          prollyHashCompute(pCopy, e->size, &h);
+          if( memcmp(&h, hash, sizeof(ProllyHash))!=0 ){
+            sqlite3_free(pCopy);
+            return SQLITE_CORRUPT;
+          }
+        }
+#endif
         *ppData = pCopy;
         *pnData = e->size;
         return SQLITE_OK;
@@ -1384,6 +1404,16 @@ int chunkStoreGetSparse(
     if( nPhys>0 ){
       memcpy(pBuf, cs->staging.pWriteBuf + e->offset + 4, nPhys);
     }
+#ifdef SQLITE_DEBUG
+    {
+      ProllyHash h;
+      prollyHashComputeZeroTail(pBuf, nPhys, zeroTail, &h);
+      if( memcmp(&h, hash, sizeof(ProllyHash))!=0 ){
+        sqlite3_free(pBuf);
+        return SQLITE_CORRUPT;
+      }
+    }
+#endif
     *ppData = pBuf;
     *pnData = e->size;
     *pnDataPhys = nPhys;


### PR DESCRIPTION
## Summary

P1: pending/staging early returns in `chunkStoreGet` / `chunkStoreGetSparse` did not re-hash payloads. Disk paths already verify BLAKE3.

Under `SQLITE_DEBUG` only:
- pending full gets after materializing zero tails
- in-memory write-buffer hits
- pending sparse gets via `prollyHashComputeZeroTail`

Mismatch → free buffer, `SQLITE_CORRUPT`. Release builds unchanged.

## Test plan

- [x] `make doltlite` (release / `NDEBUG`)
- [x] One-off compile of `chunk_store.c` with `-DSQLITE_DEBUG=1`
- [x] `DOLTLITE=./build/doltlite bash test/doltlite_persistence.sh` — 66/66