### PR TITLE
Assert Prolly B-tree cursor, mutmap, lock, and catalog invariants

### DIFF
--- a/src/prolly_btree_catalog.c
+++ b/src/prolly_btree_catalog.c
@@ -116,12 +116,15 @@ int rollbackNeedsSchemaReset(Btree *pBtree){
 
 void invalidateCursors(BtShared *pBt, Pgno iTable, int errCode){
   BtCursor *p;
+  assert( pBt!=0 );
   for(p=pBt->pCursor; p; p=p->pNext){
     if( iTable==0 || p->pgnoRoot==iTable ){
       p->eState = CURSOR_FAULT;
       p->skipNext = errCode;
       p->mmActive = 0;
-
+      p->mmPhysActive = 0;
+      p->mmIdx = -1;
+      p->mmPhysIdx = -1;
       prollyCursorReleaseAll(&p->pCur);
     }
   }
@@ -146,6 +149,9 @@ void prollyInvalidateIncrblobCursors(BtShared *pBt, Pgno pgnoRoot,
     p->eState = CURSOR_FAULT;
     p->skipNext = SQLITE_ABORT;
     p->mmActive = 0;
+    p->mmPhysActive = 0;
+    p->mmIdx = -1;
+    p->mmPhysIdx = -1;
     prollyCursorReleaseAll(&p->pCur);
   }
 }

--- a/src/prolly_btree_cursor.c
+++ b/src/prolly_btree_cursor.c
@@ -31,11 +31,20 @@ static SQLITE_INLINE void cursorCurrentTreeValue(
   int *pnData
 ){
   ProllyCursor *pProllyCur = &pCur->pCur;
-  ProllyCacheEntry *pLeaf = pProllyCur->aLevel[pProllyCur->iLevel].pEntry;
-  ProllyNode *pNode = &pLeaf->node;
-  int i = pProllyCur->aLevel[pProllyCur->iLevel].idx;
-  u32 off0 = PROLLY_GET_U32((const u8*)&pNode->aValOff[i]);
-  u32 off1 = PROLLY_GET_U32((const u8*)&pNode->aValOff[i+1]);
+  ProllyCacheEntry *pLeaf;
+  ProllyNode *pNode;
+  int i;
+  u32 off0, off1;
+  assert( pCur!=0 );
+  assert( pProllyCur->eState==PROLLY_CURSOR_VALID );
+  assert( pProllyCur->iLevel>=0 && pProllyCur->iLevel<PROLLY_CURSOR_MAX_DEPTH );
+  pLeaf = pProllyCur->aLevel[pProllyCur->iLevel].pEntry;
+  assert( pLeaf!=0 );
+  pNode = &pLeaf->node;
+  i = pProllyCur->aLevel[pProllyCur->iLevel].idx;
+  assert( i>=0 && i<(int)pNode->nItems );
+  off0 = PROLLY_GET_U32((const u8*)&pNode->aValOff[i]);
+  off1 = PROLLY_GET_U32((const u8*)&pNode->aValOff[i+1]);
   *ppData = pNode->pValData + off0;
   *pnData = (int)(off1 - off0);
 }
@@ -47,9 +56,17 @@ void prollyBtreeCursorCurrentTreeValueSpan(
   int *pnAvail
 ){
   ProllyCursor *pProllyCur = &pCur->pCur;
-  ProllyCacheEntry *pLeaf = pProllyCur->aLevel[pProllyCur->iLevel].pEntry;
-  ProllyNode *pNode = &pLeaf->node;
-  int i = pProllyCur->aLevel[pProllyCur->iLevel].idx;
+  ProllyCacheEntry *pLeaf;
+  ProllyNode *pNode;
+  int i;
+  assert( pCur!=0 );
+  assert( pProllyCur->eState==PROLLY_CURSOR_VALID );
+  assert( pProllyCur->iLevel>=0 && pProllyCur->iLevel<PROLLY_CURSOR_MAX_DEPTH );
+  pLeaf = pProllyCur->aLevel[pProllyCur->iLevel].pEntry;
+  assert( pLeaf!=0 );
+  pNode = &pLeaf->node;
+  i = pProllyCur->aLevel[pProllyCur->iLevel].idx;
+  assert( i>=0 && i<(int)pNode->nItems );
   prollyNodeValueSpan(pNode, i, ppData, pnData, pnAvail);
 }
 
@@ -77,10 +94,18 @@ int prollyBtreeCursorCurrentTreeValueCopy(
 
 static SQLITE_INLINE u64 cursorCurrentTreeKeyPrefixInt(BtCursor *pCur){
   ProllyCursor *pProllyCur = &pCur->pCur;
-  ProllyCacheEntry *pLeaf = pProllyCur->aLevel[pProllyCur->iLevel].pEntry;
-  ProllyNode *pNode = &pLeaf->node;
-  int i = pProllyCur->aLevel[pProllyCur->iLevel].idx;
-  const u8 *p = pNode->pKeyData + i*8;
+  ProllyCacheEntry *pLeaf;
+  ProllyNode *pNode;
+  int i;
+  const u8 *p;
+  assert( pCur!=0 );
+  assert( pProllyCur->eState==PROLLY_CURSOR_VALID );
+  pLeaf = pProllyCur->aLevel[pProllyCur->iLevel].pEntry;
+  assert( pLeaf!=0 );
+  pNode = &pLeaf->node;
+  i = pProllyCur->aLevel[pProllyCur->iLevel].idx;
+  assert( i>=0 && i<(int)pNode->nItems );
+  p = pNode->pKeyData + i*8;
   assert( (pNode->flags & PROLLY_NODE_INTKEY)!=0 );
   return ((u64)p[0]<<56) | ((u64)p[1]<<48) | ((u64)p[2]<<40)
        | ((u64)p[3]<<32) | ((u64)p[4]<<24) | ((u64)p[5]<<16)
@@ -2223,6 +2248,8 @@ static int cursorPayloadFault(
 int getCursorPayload(BtCursor *pCur, const u8 **ppData, int *pnData){
   *ppData = 0;
   *pnData = 0;
+  assert( pCur!=0 );
+  assert( pCur->eState!=CURSOR_FAULT );
 
   if( pCur->pCachedPayload && pCur->nCachedPayload > 0 ){
     *ppData = pCur->pCachedPayload;

--- a/src/prolly_btree_mutation.c
+++ b/src/prolly_btree_mutation.c
@@ -26,6 +26,7 @@ int applyMutMapToTableRoot(
   ProllyMutator mut;
   int rc;
 
+  assert( pBt!=0 && pTE!=0 && pMap!=0 );
   memset(&mut, 0, sizeof(mut));
   mut.pStore = &pBt->store;
   mut.pCache = &pBt->cache;
@@ -329,9 +330,14 @@ void clearMergeCursorState(BtCursor *pCur){
 }
 
 ProllyMutMapEntry *currentMutMapEntry(BtCursor *pCur){
+  assert( pCur!=0 );
+  assert( pCur->mmActive );
+  assert( pCur->pMutMap!=0 );
   if( pCur->mmPhysActive ){
+    assert( pCur->mmPhysIdx>=0 && pCur->mmPhysIdx<pCur->pMutMap->nEntries );
     return &pCur->pMutMap->aEntries[pCur->mmPhysIdx];
   }
+  assert( pCur->mmIdx>=0 );
   return prollyMutMapEntryAt(pCur->pMutMap, pCur->mmIdx);
 }
 
@@ -346,7 +352,10 @@ SQLITE_INLINE ProllyMutMapEntry *orderedMutMapEntryAt(
 }
 
 void setCursorToMutMapEntryPhys(BtCursor *pCur, int physIdx){
-  ProllyMutMapEntry *pEntry = &pCur->pMutMap->aEntries[physIdx];
+  ProllyMutMapEntry *pEntry;
+  assert( pCur!=0 && pCur->pMutMap!=0 );
+  assert( physIdx>=0 && physIdx<pCur->pMutMap->nEntries );
+  pEntry = &pCur->pMutMap->aEntries[physIdx];
   CLEAR_CACHED_PAYLOAD(pCur);
   pCur->mmIdx = -1;
   pCur->mmPhysIdx = physIdx;
@@ -365,7 +374,10 @@ void setCursorToMutMapEntryPhys(BtCursor *pCur, int physIdx){
 }
 
 static void setCursorToMutMapMissingEntryPhys(BtCursor *pCur, int physIdx){
-  ProllyMutMapEntry *pEntry = &pCur->pMutMap->aEntries[physIdx];
+  ProllyMutMapEntry *pEntry;
+  assert( pCur!=0 && pCur->pMutMap!=0 );
+  assert( physIdx>=0 && physIdx<pCur->pMutMap->nEntries );
+  pEntry = &pCur->pMutMap->aEntries[physIdx];
   CLEAR_CACHED_PAYLOAD(pCur);
   pCur->mmIdx = -1;
   pCur->mmPhysIdx = physIdx;
@@ -407,6 +419,8 @@ int flushMutMap(BtCursor *pCur){
   int captured;
   int rc;
 
+  assert( pCur!=0 && pCur->pBtree!=0 && pCur->pBt!=0 );
+  assert( pCur->pBtree->inTrans==TRANS_WRITE );
   pTE = findTable(pCur->pBtree, pCur->pgnoRoot);
   if( !pTE ){
     return SQLITE_INTERNAL;
@@ -499,6 +513,7 @@ static int syncSavepoints(BtCursor *pCur){
 void refreshCursorMutMapAliases(Btree *pBtree, BtShared *pBt,
                                         Pgno iTable, ProllyMutMap *pNewMap){
   BtCursor *p;
+  assert( pBtree!=0 && pBt!=0 );
   for(p = pBt->pCursor; p; p = p->pNext){
     if( p->pBtree==pBtree && p->pgnoRoot==iTable ){
       p->pMutMap = pNewMap;
@@ -516,6 +531,8 @@ int ensureMutMap(BtCursor *pCur){
   struct TableEntry *pTE;
   ProllyMutMap *pMap;
 
+  assert( pCur!=0 && pCur->pBtree!=0 );
+  assert( pCur->curFlags & BTCF_WriteFlag );
   pTE = findTable(pCur->pBtree, pCur->pgnoRoot);
   if( !pTE ) return SQLITE_INTERNAL;
 
@@ -528,6 +545,7 @@ int ensureMutMap(BtCursor *pCur){
       pExisting->currentSavepointLevel = pCur->pBtree->nSavepoint;
     }
     pCur->pMutMap = pExisting;
+    assert( pCur->pMutMap==pTE->pPending );
     return SQLITE_OK;
   }
 
@@ -543,10 +561,12 @@ int ensureMutMap(BtCursor *pCur){
   }
   pTE->pPending = pMap;
   refreshCursorMutMapAliases(pCur->pBtree, pCur->pBt, pCur->pgnoRoot, pMap);
+  assert( pCur->pMutMap==pMap );
   return SQLITE_OK;
 }
 
 int saveCursorPosition(BtCursor *pCur){
+  assert( pCur!=0 );
   if( pCur->eState!=CURSOR_VALID && pCur->eState!=CURSOR_SKIPNEXT ){
     return SQLITE_OK;
   }
@@ -609,6 +629,7 @@ int saveCursorPosition(BtCursor *pCur){
   pCur->deferredTreeSeek = 0;
 
   pCur->eState = CURSOR_REQUIRESEEK;
+  assert( pCur->pCur.eState!=PROLLY_CURSOR_VALID );
   return SQLITE_OK;
 }
 
@@ -672,6 +693,7 @@ int restoreCursorPosition(BtCursor *pCur, int *pDifferentRow){
   int rc = SQLITE_OK;
   int res = 0;
 
+  assert( pCur!=0 );
   if( pCur->eState!=CURSOR_REQUIRESEEK ){
     if( pDifferentRow ) *pDifferentRow = 0;
     return SQLITE_OK;
@@ -1012,6 +1034,8 @@ int flushAllPending(Btree *pBtree, BtShared *pBt, Pgno iTable){
   BtCursor *p;
   int rc;
 
+  assert( pBtree!=0 && pBt!=0 );
+  assert( pBtree->inTrans==TRANS_WRITE );
   for(p = pBt->pCursor; p; p = p->pNext){
     if( p->pBtree==pBtree && (iTable==0 || p->pgnoRoot==iTable) ){
       rc = flushIfNeeded(p);

--- a/src/prolly_btree_txn.c
+++ b/src/prolly_btree_txn.c
@@ -751,6 +751,7 @@ int prollyBtreeBeginTrans(Btree *p, int wrFlag, int *pSchemaVersion){
     }
     p->inTrans = TRANS_WRITE;
     p->inTransaction = TRANS_WRITE;
+    assert( pBt->store.isMemory || pBt->store.lockDepth > 0 );
   } else {
     if( p->inTrans==TRANS_NONE ){
       p->inTrans = TRANS_READ;
@@ -800,6 +801,8 @@ int prollyBtreeCommitPhaseTwo(Btree *p, int bCleanup){
   if( pBt->inCatalogSerialize ) return SQLITE_OK;
 
   if( p->inTrans==TRANS_WRITE ){
+    assert( pBt->store.isMemory || pBt->store.pGraphLockFile!=0 );
+    assert( pBt->store.isMemory || pBt->store.lockDepth > 0 );
     rc = flushAllPending(p, pBt, 0);
     if( rc!=SQLITE_OK ){
       chunkStoreRollback(&pBt->store);
@@ -944,6 +947,8 @@ int prollyBtreeCommitPhaseTwo(Btree *p, int bCleanup){
       p->bMasterRootChangedTxn = 0;
 
       btreeTakeCatalogCache(p, &catData, nCatData, &catHash);
+      assert( p->nCatalogCache==nCatData );
+      assert( prollyHashCompare(&p->catalogCacheHash, &catHash)==0 );
       sqlite3_free(catData);
       chunkStoreUnlock(&pBt->store);
       pBt->store.snapshotPinned = 0;


### PR DESCRIPTION
## Summary

Assert campaign on the post-refactor Prolly B-tree modules (P1 #2). No narrative comments — only `assert()`s.

| Module | Focus |
|--------|--------|
| `prolly_btree_mutation.c` | `currentMutMapEntry` / phys setters bounds; `ensureMutMap` write-cursor; `flushMutMap` / `flushAllPending` write-txn; save clears tree VALID |
| `prolly_btree_cursor.c` | tree payload accessors need VALID leaf + in-range item; `getCursorPayload` not FAULT |
| `prolly_btree_txn.c` | write begin/commit hold graph `lockDepth`; catalog cache hash/size after commit seal |
| `prolly_btree_catalog.c` | `invalidateCursors` clears mutmap index state |

## Test plan

- [x] `make doltlite` (release / NDEBUG)
- [x] smoke: insert/update/delete/commit/branch/merge/index/gc
- [x] `doltlite_commit.sh` — 62/62
- [x] `doltlite_merge.sh` — 94/94