### PR TITLE
Broaden Prolly B-tree asserts across all split modules

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -270,7 +270,10 @@ const struct BtCursorOps origCursorVtOps = {
 };
 
 struct TableEntry *catFind(Catalog *cat, Pgno iTable){
-  int lo = 0, hi = cat->n - 1;
+  int lo = 0, hi;
+  assert( cat!=0 );
+  assert( cat->n==0 || cat->a!=0 );
+  hi = cat->n - 1;
   while( lo<=hi ){
     int mid = lo + (hi - lo) / 2;
     Pgno midTable = cat->a[mid].iTable;
@@ -288,6 +291,7 @@ struct TableEntry *catFind(Catalog *cat, Pgno iTable){
 struct TableEntry *catAdd(Catalog *cat, Pgno iTable, u8 flags){
   struct TableEntry *pEntry;
 
+  assert( cat!=0 );
   pEntry = catFind(cat, iTable);
   if( pEntry ){
     pEntry->flags = flags;
@@ -325,6 +329,15 @@ struct TableEntry *catAdd(Catalog *cat, Pgno iTable, u8 flags){
   pEntry->iTable = iTable;
   pEntry->flags = flags;
   cat->n++;
+  assert( cat->n<=cat->nAlloc );
+#ifndef NDEBUG
+  {
+    int i;
+    for(i=1; i<cat->n; i++){
+      assert( cat->a[i-1].iTable < cat->a[i].iTable );
+    }
+  }
+#endif
 
   return pEntry;
 }
@@ -333,6 +346,8 @@ struct TableEntry *catAdd(Catalog *cat, Pgno iTable, u8 flags){
 int saveAllCursors(Btree *pBtree, BtShared *pBt, Pgno iRoot,
                           BtCursor *pExcept){
   BtCursor *p;
+  assert( pBtree!=0 && pBt!=0 );
+  assert( pBtree->pBt==pBt );
   for(p=pBt->pCursor; p; p=p->pNext){
     if( p->pBtree==pBtree
      && p!=pExcept
@@ -340,6 +355,9 @@ int saveAllCursors(Btree *pBtree, BtShared *pBt, Pgno iRoot,
       if( p->eState==CURSOR_VALID || p->eState==CURSOR_SKIPNEXT ){
         int rc = saveCursorPosition(p);
         if( rc!=SQLITE_OK ) return rc;
+        assert( p->eState==CURSOR_REQUIRESEEK
+             || p->eState==CURSOR_INVALID
+             || p->eState==CURSOR_FAULT );
       }
     }
   }
@@ -1042,9 +1060,11 @@ int prollyBtreeCreateTable(Btree *p, Pgno *piTable, int flags){
   struct TableEntry *pTE;
   Pgno iTable;
 
+  assert( p!=0 && piTable!=0 );
   if( p->inTrans!=TRANS_WRITE ){
     return SQLITE_ERROR;
   }
+  PROLLY_ASSERT_GRAPH_LOCKED(p->pBt);
 
   {
     int rc = ensureStatementSavepointsCaptured(p);

--- a/src/prolly_btree_catalog.c
+++ b/src/prolly_btree_catalog.c
@@ -34,6 +34,7 @@ static const char *btreeSchemaName(Btree *pBtree){
 
 void catRemove(Catalog *cat, Pgno iTable){
   int i;
+  assert( cat!=0 );
   for(i=0; i<cat->n; i++){
     if( cat->a[i].iTable==iTable ){
       sqlite3_free(cat->a[i].zName);
@@ -48,6 +49,11 @@ void catRemove(Catalog *cat, Pgno iTable){
                 (cat->n-i-1)*(int)sizeof(struct TableEntry));
       }
       cat->n--;
+#ifndef NDEBUG
+      for(i=1; i<cat->n; i++){
+        assert( cat->a[i-1].iTable < cat->a[i].iTable );
+      }
+#endif
       return;
     }
   }
@@ -55,6 +61,7 @@ void catRemove(Catalog *cat, Pgno iTable){
 
 void catFree(Catalog *cat){
   int k;
+  assert( cat!=0 );
   for(k=0; k<cat->n; k++){
     sqlite3_free(cat->a[k].zName);
     if( cat->a[k].pPending ){
@@ -71,12 +78,14 @@ void catFree(Catalog *cat){
 }
 
 void invalidateSchema(Btree *pBtree){
+  assert( pBtree!=0 );
   if( pBtree->pSchema && pBtree->xFreeSchema ){
     pBtree->xFreeSchema(pBtree->pSchema);
   }
 }
 
 void resetConnectionSchema(Btree *pBtree){
+  assert( pBtree!=0 );
   invalidateSchema(pBtree);
   if( pBtree->db ){
     sqlite3ExpirePreparedStatements(pBtree->db, 0);
@@ -157,7 +166,9 @@ void prollyInvalidateIncrblobCursors(BtShared *pBt, Pgno pgnoRoot,
 }
 
 void refreshCursorRoot(BtCursor *pCur){
-  struct TableEntry *pTE = findTable(pCur->pBtree, pCur->pgnoRoot);
+  struct TableEntry *pTE;
+  PROLLY_ASSERT_CURSOR_OWNED(pCur);
+  pTE = findTable(pCur->pBtree, pCur->pgnoRoot);
   if( pTE ){
     pCur->pCur.root = pTE->root;
   }
@@ -1515,12 +1526,15 @@ static int serializeCatalogPatchRoots(Btree *pBtree, u8 **ppOut, int *pnOut){
 }
 
 int serializeCatalog(Btree *pBtree, u8 **ppOut, int *pnOut){
+  assert( pBtree!=0 && ppOut!=0 && pnOut!=0 );
   return doltliteSerializeCatalogEntriesForBtreeImpl(
       pBtree, pBtree->cat.a, pBtree->cat.n, 0, 0, 0, ppOut, pnOut);
 }
 
 int serializeCatalogForCommit(Btree *pBtree, u8 **ppOut, int *pnOut){
   int rc;
+  assert( pBtree!=0 && ppOut!=0 && pnOut!=0 );
+  PROLLY_ASSERT_WRITE_TXN(pBtree);
   rc = serializeCatalogPatchRoots(pBtree, ppOut, pnOut);
   if( rc==SQLITE_OK ) return SQLITE_OK;
   if( rc!=SQLITE_NOTFOUND ) return rc;
@@ -1528,6 +1542,7 @@ int serializeCatalogForCommit(Btree *pBtree, u8 **ppOut, int *pnOut){
 }
 
 void initDefaultMeta(Btree *pBtree){
+  assert( pBtree!=0 );
   memset(pBtree->aMeta, 0, sizeof(pBtree->aMeta));
   pBtree->aMeta[BTREE_FILE_FORMAT] = 4;
   pBtree->aMeta[BTREE_TEXT_ENCODING] = SQLITE_UTF8;
@@ -1541,6 +1556,8 @@ int deserializeCatalog(Btree *pBtree, const u8 *data, int nData){
   Catalog catNew;
   u32 aMetaNew[16];
 
+  assert( pBtree!=0 );
+  assert( data!=0 || nData==0 );
   {
     const u8 *pEntries;
     if( !catalogParseHeaderEx(data, nData, &iFormat, &nTables, &pEntries) ){
@@ -2059,6 +2076,7 @@ int doltliteSwitchCatalog(sqlite3 *db, const ProllyHash *catHash){
   int nData = 0;
   int rc;
 
+  assert( catHash!=0 );
   if( !pBt ) return SQLITE_ERROR;
   if( !db || db->nDb<=0 || !db->aDb[0].pBt ) return SQLITE_ERROR;
   pBtree = db->aDb[0].pBt;

--- a/src/prolly_btree_cursor.c
+++ b/src/prolly_btree_cursor.c
@@ -493,6 +493,8 @@ done:
 
 
 static int mergeCompare(BtCursor *pCur, ProllyMutMapEntry *e){
+  assert( pCur!=0 && e!=0 );
+  assert( pCur->pCur.eState==PROLLY_CURSOR_VALID );
   if( pCur->curIntKey ){
     u64 tk = cursorCurrentTreeKeyPrefixInt(pCur);
     u64 ek = e->keyPrefix;
@@ -511,7 +513,11 @@ static int mergeCompare(BtCursor *pCur, ProllyMutMapEntry *e){
 }
 
 static int mergeScan(BtCursor *pCur, int dir, int *pRes){
+  assert( pCur!=0 );
+  assert( pCur->pMutMap!=0 );
+  assert( dir==1 || dir==-1 );
   if( pCur->mmPhysActive ){
+    assert( pCur->mmPhysIdx>=0 && pCur->mmPhysIdx<pCur->pMutMap->nEntries );
     pCur->mmIdx = prollyMutMapOrderIndexFromEntry(
         pCur->pMutMap, &pCur->pMutMap->aEntries[pCur->mmPhysIdx]);
     pCur->mmPhysIdx = -1;
@@ -574,7 +580,10 @@ static int ensureCursorMutMapOrder(BtCursor *pCur){
 
 static int cursorNormalizeMmPhys(BtCursor *pCur){
   if( pCur->mmPhysActive ){
-    int rc = ensureCursorMutMapOrder(pCur);
+    int rc;
+    assert( pCur->pMutMap!=0 );
+    assert( pCur->mmPhysIdx>=0 && pCur->mmPhysIdx<pCur->pMutMap->nEntries );
+    rc = ensureCursorMutMapOrder(pCur);
     if( rc!=SQLITE_OK ) return rc;
     pCur->mmIdx = prollyMutMapOrderIndexFromEntry(
         pCur->pMutMap, &pCur->pMutMap->aEntries[pCur->mmPhysIdx]);
@@ -588,6 +597,8 @@ static int materializeDeferredTreeSeek(BtCursor *pCur, int dir){
   int rc;
   int res = 0;
   if( !pCur->deferredTreeSeek ) return SQLITE_OK;
+  assert( pCur->mmActive );
+  assert( pCur->pMutMap!=0 );
   pCur->deferredTreeSeek = 0;
   refreshCursorRoot(pCur);
   rc = prollyCursorCheckInterrupt(pCur);

--- a/src/prolly_btree_int.h
+++ b/src/prolly_btree_int.h
@@ -116,6 +116,20 @@ u32 prollyBtreeGetU32LE(const u8 *p);
   (pCsr)->cachedPayloadOwned = 0; \
 }while(0)
 
+#define PROLLY_ASSERT_WRITE_TXN(p) \
+  assert( (p)!=0 && (p)->inTrans==TRANS_WRITE )
+
+#define PROLLY_ASSERT_GRAPH_LOCKED(pBt) do{ \
+  assert( (pBt)!=0 ); \
+  assert( (pBt)->store.isMemory \
+       || ((pBt)->store.pGraphLockFile!=0 && (pBt)->store.lockDepth>0) ); \
+}while(0)
+
+#define PROLLY_ASSERT_CURSOR_OWNED(pCur) do{ \
+  assert( (pCur)!=0 && (pCur)->pBtree!=0 && (pCur)->pBt!=0 ); \
+  assert( (pCur)->pBtree->pBt==(pCur)->pBt ); \
+}while(0)
+
 #define CLEAR_CACHED_SEEK_KEY(pCur) do{ \
   (pCur)->nSeekSortKey = 0; \
   (pCur)->nSeekKeyField = 0; \

--- a/src/prolly_btree_mutation.c
+++ b/src/prolly_btree_mutation.c
@@ -419,8 +419,8 @@ int flushMutMap(BtCursor *pCur){
   int captured;
   int rc;
 
-  assert( pCur!=0 && pCur->pBtree!=0 && pCur->pBt!=0 );
-  assert( pCur->pBtree->inTrans==TRANS_WRITE );
+  PROLLY_ASSERT_CURSOR_OWNED(pCur);
+  PROLLY_ASSERT_WRITE_TXN(pCur->pBtree);
   pTE = findTable(pCur->pBtree, pCur->pgnoRoot);
   if( !pTE ){
     return SQLITE_INTERNAL;
@@ -462,7 +462,10 @@ int flushPendingForTable(
   int captured = 0;
   int rc;
 
+  assert( pBtree!=0 && pBt!=0 );
+  assert( pBtree->pBt==pBt );
   if( !pTE || !pTE->pPending ) return SQLITE_OK;
+  PROLLY_ASSERT_WRITE_TXN(pBtree);
   pMap = (ProllyMutMap*)pTE->pPending;
   if( prollyMutMapIsEmpty(pMap) ) return SQLITE_OK;
 
@@ -978,9 +981,11 @@ int flushIfNeeded(BtCursor *pCur){
   int rc;
   struct TableEntry *pTE;
 
+  PROLLY_ASSERT_CURSOR_OWNED(pCur);
   if( !pCur->pMutMap || prollyMutMapIsEmpty(pCur->pMutMap) ){
     return SQLITE_OK;
   }
+  PROLLY_ASSERT_WRITE_TXN(pCur->pBtree);
 
   {
     BtCursor *p;
@@ -1035,7 +1040,8 @@ int flushAllPending(Btree *pBtree, BtShared *pBt, Pgno iTable){
   int rc;
 
   assert( pBtree!=0 && pBt!=0 );
-  assert( pBtree->inTrans==TRANS_WRITE );
+  assert( pBtree->pBt==pBt );
+  PROLLY_ASSERT_WRITE_TXN(pBtree);
   for(p = pBt->pCursor; p; p = p->pNext){
     if( p->pBtree==pBtree && (iTable==0 || p->pgnoRoot==iTable) ){
       rc = flushIfNeeded(p);

--- a/src/prolly_btree_orig.c
+++ b/src/prolly_btree_orig.c
@@ -5,7 +5,9 @@
 /* Dispatch adapters for attached databases backed by SQLite's B-tree. */
 
 int origBtreeCloseVt(Btree *p){
-  int rc = origBtreeClose(p->pOrigBtree);
+  int rc;
+  assert( p!=0 && p->pOrigBtree!=0 );
+  rc = origBtreeClose(p->pOrigBtree);
   p->pOrigBtree = 0;
 
   if( p->pSchema && p->xFreeSchema ) p->xFreeSchema(p->pSchema);
@@ -13,111 +15,147 @@ int origBtreeCloseVt(Btree *p){
   return rc;
 }
 int origBtreeNewDbVt(Btree *p){
+  assert( p!=0 && p->pOrigBtree!=0 );
   return origBtreeNewDb(p->pOrigBtree);
 }
 int origBtreeSetCacheSizeVt(Btree *p, int mxPage){
+  assert( p!=0 && p->pOrigBtree!=0 );
   return origBtreeSetCacheSize(p->pOrigBtree, mxPage);
 }
 int origBtreeSetSpillSizeVt(Btree *p, int mxPage){
+  assert( p!=0 && p->pOrigBtree!=0 );
   return origBtreeSetSpillSize(p->pOrigBtree, mxPage);
 }
 int origBtreeSetMmapLimitVt(Btree *p, sqlite3_int64 szMmap){
+  assert( p!=0 && p->pOrigBtree!=0 );
   return origBtreeSetMmapLimit(p->pOrigBtree, szMmap);
 }
 int origBtreeSetPagerFlagsVt(Btree *p, unsigned pgFlags){
+  assert( p!=0 && p->pOrigBtree!=0 );
   return origBtreeSetPagerFlags(p->pOrigBtree, pgFlags);
 }
 int origBtreeSetPageSizeVt(Btree *p, int nPagesize, int nReserve, int eFix){
+  assert( p!=0 && p->pOrigBtree!=0 );
   return origBtreeSetPageSize(p->pOrigBtree, nPagesize, nReserve, eFix);
 }
 int origBtreeGetPageSizeVt(Btree *p){
+  assert( p!=0 && p->pOrigBtree!=0 );
   return origBtreeGetPageSize(p->pOrigBtree);
 }
 Pgno origBtreeMaxPageCountVt(Btree *p, Pgno mxPage){
+  assert( p!=0 && p->pOrigBtree!=0 );
   return origBtreeMaxPageCount(p->pOrigBtree, mxPage);
 }
 Pgno origBtreeLastPageVt(Btree *p){
+  assert( p!=0 && p->pOrigBtree!=0 );
   return origBtreeLastPage(p->pOrigBtree);
 }
 int origBtreeSecureDeleteVt(Btree *p, int newFlag){
+  assert( p!=0 && p->pOrigBtree!=0 );
   return origBtreeSecureDelete(p->pOrigBtree, newFlag);
 }
 int origBtreeGetRequestedReserveVt(Btree *p){
+  assert( p!=0 && p->pOrigBtree!=0 );
   return origBtreeGetRequestedReserve(p->pOrigBtree);
 }
 int origBtreeGetReserveNoMutexVt(Btree *p){
+  assert( p!=0 && p->pOrigBtree!=0 );
   return origBtreeGetReserveNoMutex(p->pOrigBtree);
 }
 int origBtreeSetAutoVacuumVt(Btree *p, int autoVacuum){
+  assert( p!=0 && p->pOrigBtree!=0 );
   return origBtreeSetAutoVacuum(p->pOrigBtree, autoVacuum);
 }
 int origBtreeGetAutoVacuumVt(Btree *p){
+  assert( p!=0 && p->pOrigBtree!=0 );
   return origBtreeGetAutoVacuum(p->pOrigBtree);
 }
 int origBtreeIncrVacuumVt(Btree *p){
+  assert( p!=0 && p->pOrigBtree!=0 );
   return origBtreeIncrVacuum(p->pOrigBtree);
 }
 const char *origBtreeGetFilenameVt(Btree *p){
+  assert( p!=0 && p->pOrigBtree!=0 );
   return origBtreeGetFilename(p->pOrigBtree);
 }
 const char *origBtreeGetJournalnameVt(Btree *p){
+  assert( p!=0 && p->pOrigBtree!=0 );
   return origBtreeGetJournalname(p->pOrigBtree);
 }
 int origBtreeIsReadonlyVt(Btree *p){
+  assert( p!=0 && p->pOrigBtree!=0 );
   return origBtreeIsReadonly(p->pOrigBtree);
 }
 int origBtreeBeginTransVt(Btree *p, int wrFlag, int *pSchemaVersion){
+  assert( p!=0 && p->pOrigBtree!=0 );
   return origBtreeBeginTrans(p->pOrigBtree, wrFlag, pSchemaVersion);
 }
 int origBtreeCommitPhaseOneVt(Btree *p, const char *zSuperJrnl){
+  assert( p!=0 && p->pOrigBtree!=0 );
   return origBtreeCommitPhaseOne(p->pOrigBtree, zSuperJrnl);
 }
 int origBtreeCommitPhaseTwoVt(Btree *p, int bCleanup){
+  assert( p!=0 && p->pOrigBtree!=0 );
   return origBtreeCommitPhaseTwo(p->pOrigBtree, bCleanup);
 }
 int origBtreeCommitVt(Btree *p){
+  assert( p!=0 && p->pOrigBtree!=0 );
   return origBtreeCommit(p->pOrigBtree);
 }
 int origBtreeRollbackVt(Btree *p, int tripCode, int writeOnly){
+  assert( p!=0 && p->pOrigBtree!=0 );
   return origBtreeRollback(p->pOrigBtree, tripCode, writeOnly);
 }
 int origBtreeBeginStmtVt(Btree *p, int iStatement){
+  assert( p!=0 && p->pOrigBtree!=0 );
   return origBtreeBeginStmt(p->pOrigBtree, iStatement);
 }
 int origBtreeSavepointVt(Btree *p, int op, int iSavepoint){
+  assert( p!=0 && p->pOrigBtree!=0 );
   return origBtreeSavepoint(p->pOrigBtree, op, iSavepoint);
 }
 int origBtreeTxnStateVt(Btree *p){
+  assert( p!=0 && p->pOrigBtree!=0 );
   return origBtreeTxnState(p->pOrigBtree);
 }
 int origBtreeCreateTableVt(Btree *p, Pgno *piTable, int flags){
+  assert( p!=0 && p->pOrigBtree!=0 );
   return origBtreeCreateTable(p->pOrigBtree, piTable, flags);
 }
 int origBtreeDropTableVt(Btree *p, int iTable, int *piMoved){
+  assert( p!=0 && p->pOrigBtree!=0 );
   return origBtreeDropTable(p->pOrigBtree, iTable, piMoved);
 }
 int origBtreeClearTableVt(Btree *p, int iTable, i64 *pnChange){
+  assert( p!=0 && p->pOrigBtree!=0 );
   return origBtreeClearTable(p->pOrigBtree, iTable, pnChange);
 }
 void origBtreeGetMetaVt(Btree *p, int idx, u32 *pValue){
+  assert( p!=0 && p->pOrigBtree!=0 );
   origBtreeGetMeta(p->pOrigBtree, idx, pValue);
 }
 int origBtreeUpdateMetaVt(Btree *p, int idx, u32 value){
+  assert( p!=0 && p->pOrigBtree!=0 );
   return origBtreeUpdateMeta(p->pOrigBtree, idx, value);
 }
 void *origBtreeSchemaVt(Btree *p, int nBytes, void (*xFree)(void*)){
+  assert( p!=0 && p->pOrigBtree!=0 );
   return (void*)origBtreeSchema(p->pOrigBtree, nBytes, xFree);
 }
 int origBtreeSchemaLockedVt(Btree *p){
+  assert( p!=0 && p->pOrigBtree!=0 );
   return origBtreeSchemaLocked(p->pOrigBtree);
 }
 int origBtreeLockTableVt(Btree *p, int iTab, u8 isWriteLock){
+  assert( p!=0 && p->pOrigBtree!=0 );
   return origBtreeLockTable(p->pOrigBtree, iTab, isWriteLock);
 }
 int origBtreeCursorVt(Btree *p, Pgno iTable, int wrFlag,
                              struct KeyInfo *pKeyInfo, BtCursor *pCur){
-  void *pOC = sqlite3_malloc(origBtreeCursorSize());
+  void *pOC;
   int rc;
+  assert( p!=0 && p->pOrigBtree!=0 && pCur!=0 );
+  pOC = sqlite3_malloc(origBtreeCursorSize());
   if( !pOC ) return SQLITE_NOMEM;
   memset(pOC, 0, origBtreeCursorSize());
   pCur->pOrigCursor = pOC;

--- a/src/prolly_btree_state.c
+++ b/src/prolly_btree_state.c
@@ -26,6 +26,7 @@ int btreeLoadWorkingSetBlob(
   int rc;
   u8 version;
 
+  assert( cs!=0 && zBranch!=0 );
   if( pWorkingCat ) memset(pWorkingCat, 0, sizeof(ProllyHash));
   if( pWorkingCommit ) memset(pWorkingCommit, 0, sizeof(ProllyHash));
   if( pStaged ) memset(pStaged, 0, sizeof(ProllyHash));
@@ -268,6 +269,7 @@ int btreeWriteWorkingState(
   u8 isRebasing = 0;
   int rc;
 
+  assert( cs!=0 && zBranch!=0 && pCatHash!=0 && pCommitHash!=0 );
   rc = btreeLoadWorkingSetBlob(cs, zBranch, 0, 0, &stagedCatalog, &isMerging,
                                &mergeCommitHash, &conflictsCatalogHash,
                                &isRebasing, &preRebaseCat, &rebaseOnto,
@@ -305,7 +307,7 @@ int btreeReloadBranchWorkingStateInto(
   int bLoadCatalog,
   ProllyHash *pLoadedCatHash
 ){
-  BtShared *pBt = p->pBt;
+  BtShared *pBt;
   ProllyHash catHash;
   ProllyHash workingCommitHash;
   ProllyHash stagedCatalog;
@@ -316,12 +318,16 @@ int btreeReloadBranchWorkingStateInto(
   ProllyHash constraintViolationsHash;
   char *zRebaseOrigBranch = 0;
   char *zRebaseReturnBranch = 0;
-  const char *zBr = p->zBranch ? p->zBranch : "main";
+  const char *zBr;
   u8 isMerging = 0;
   u8 isRebasing = 0;
-  int hadUserCatalog = p->cat.n > 1;
+  int hadUserCatalog;
   int rc;
 
+  assert( p!=0 && p->pBt!=0 );
+  pBt = p->pBt;
+  zBr = p->zBranch ? p->zBranch : "main";
+  hadUserCatalog = p->cat.n > 1;
   memset(&catHash, 0, sizeof(catHash));
   memset(&workingCommitHash, 0, sizeof(workingCommitHash));
   memset(&stagedCatalog, 0, sizeof(stagedCatalog));
@@ -407,6 +413,7 @@ int btreeReloadBranchWorkingStateInto(
 }
 
 void btreeStoreCommittedFromCurrent(Btree *p, const ProllyHash *pCatHash){
+  assert( p!=0 );
   if( pCatHash ){
     p->committedCatalogHash = *pCatHash;
   }
@@ -419,6 +426,7 @@ void btreeStoreCommittedFromCurrent(Btree *p, const ProllyHash *pCatHash){
 }
 
 void btreeBumpExternalDataVersion(Btree *p){
+  assert( p!=0 && p->pBt!=0 );
   if( p->pBt->pPagerShim ){
     p->pBt->pPagerShim->iDataVersion++;
   }else{
@@ -427,6 +435,7 @@ void btreeBumpExternalDataVersion(Btree *p){
 }
 
 void btreeBumpLocalDataVersion(Btree *p){
+  assert( p!=0 && p->pBt!=0 );
   if( p->pBt->pPagerShim ){
     p->pBt->pPagerShim->iDataVersion++;
     p->iBDataVersion--;
@@ -436,7 +445,9 @@ void btreeBumpLocalDataVersion(Btree *p){
 }
 
 void btreeMarkWorkingStateChanged(Btree *p, int bLocal){
-  BtShared *pBt = p->pBt;
+  BtShared *pBt;
+  assert( p!=0 && p->pBt!=0 );
+  pBt = p->pBt;
   pBt->iWorkingStateVersion++;
   if( pBt->iWorkingStateVersion==0 ){
     pBt->iWorkingStateVersion = 1;
@@ -447,12 +458,15 @@ void btreeMarkWorkingStateChanged(Btree *p, int bLocal){
   }else{
     btreeBumpExternalDataVersion(p);
   }
+  assert( p->iLoadedWorkingStateVersion==pBt->iWorkingStateVersion );
 }
 
 int btreeRefreshSharedWorkingState(Btree *p){
-  BtShared *pBt = p->pBt;
+  BtShared *pBt;
   ProllyHash loadedCatHash;
   int rc;
+  assert( p!=0 && p->pBt!=0 );
+  pBt = p->pBt;
   if( p->iLoadedWorkingStateVersion==pBt->iWorkingStateVersion ){
     return SQLITE_OK;
   }
@@ -467,13 +481,18 @@ int btreeRefreshSharedWorkingState(Btree *p){
 }
 
 int btreeRefreshFromDisk(Btree *p){
-  BtShared *pBt = p->pBt;
+  BtShared *pBt;
   int bChanged = 0;
-  u8 snapshotPinned = pBt->store.snapshotPinned;
-  int bAutocommitBoundary = p->inTrans==TRANS_NONE
-    && p->db && p->db->autoCommit && !p->db->pSavepoint;
+  u8 snapshotPinned;
+  int bAutocommitBoundary;
   ProllyHash loadedCatHash;
   int rc;
+
+  assert( p!=0 && p->pBt!=0 );
+  pBt = p->pBt;
+  snapshotPinned = pBt->store.snapshotPinned;
+  bAutocommitBoundary = p->inTrans==TRANS_NONE
+    && p->db && p->db->autoCommit && !p->db->pSavepoint;
 
   if( bAutocommitBoundary ){
     pBt->store.snapshotPinned = 0;
@@ -507,6 +526,7 @@ const char *doltliteGetSessionBranch(sqlite3 *db){
 void doltliteSetSessionBranch(sqlite3 *db, const char *zBranch){
   if( db && db->nDb>0 && db->aDb[0].pBt ){
     Btree *p = db->aDb[0].pBt;
+    assert( zBranch!=0 );
     sqlite3_free(p->zBranch);
     p->zBranch = sqlite3_mprintf("%s", zBranch);
   }

--- a/src/prolly_btree_txn.c
+++ b/src/prolly_btree_txn.c
@@ -217,6 +217,8 @@ static int ensureSavepointTablesCaptured(
 
 int ensureStatementSavepointsCaptured(Btree *pBtree){
   int i;
+  assert( pBtree!=0 );
+  assert( pBtree->nSavepoint==0 || pBtree->aSavepointTables!=0 );
   for(i=0; i<pBtree->nSavepoint; i++){
     struct SavepointTableState *pState = &pBtree->aSavepointTables[i];
     if( pState->bStatement && !pState->bTablesCaptured ){
@@ -229,6 +231,8 @@ int ensureStatementSavepointsCaptured(Btree *pBtree){
 
 static void pushSavepointOnMutMaps(Btree *pBtree, int level){
   int k;
+  assert( pBtree!=0 );
+  assert( level>=0 );
   for(k=0; k<pBtree->cat.n; k++){
     ProllyMutMap *pMap = (ProllyMutMap*)pBtree->cat.a[k].pPending;
     if( pMap ) prollyMutMapPushSavepoint(pMap, level);
@@ -387,6 +391,7 @@ int snapshotPendingForFlush(Btree *pBtree, Pgno iTable,
   if( !ppFlushMap ) return SQLITE_MISUSE;
   *ppFlushMap = 0;
   if( !pBtree || !ppPending || !*ppPending ) return SQLITE_OK;
+  assert( pBtree->inTrans==TRANS_WRITE );
   pPending = *ppPending;
   *ppFlushMap = pPending;
   if( pBtree->nSavepoint <= 0 ) return SQLITE_OK;
@@ -608,6 +613,8 @@ static int restoreTablesFromSavepoint(
 int pushSavepoint(Btree *pBtree, int bStatement){
   struct SavepointTableState *pState;
 
+  assert( pBtree!=0 );
+  PROLLY_ASSERT_WRITE_TXN(pBtree);
   if( pBtree->nSavepoint>=pBtree->nSavepointAlloc ){
     i64 nNew = pBtree->nSavepointAlloc
                  ? (i64)pBtree->nSavepointAlloc * 2 : (i64)8;
@@ -648,6 +655,7 @@ int pushSavepoint(Btree *pBtree, int bStatement){
 
   pBtree->nSavepoint++;
   pushSavepointOnMutMaps(pBtree, pBtree->nSavepoint);
+  assert( pBtree->nSavepoint<=pBtree->nSavepointAlloc );
   return SQLITE_OK;
 }
 
@@ -751,7 +759,7 @@ int prollyBtreeBeginTrans(Btree *p, int wrFlag, int *pSchemaVersion){
     }
     p->inTrans = TRANS_WRITE;
     p->inTransaction = TRANS_WRITE;
-    assert( pBt->store.isMemory || pBt->store.lockDepth > 0 );
+    PROLLY_ASSERT_GRAPH_LOCKED(pBt);
   } else {
     if( p->inTrans==TRANS_NONE ){
       p->inTrans = TRANS_READ;
@@ -801,8 +809,7 @@ int prollyBtreeCommitPhaseTwo(Btree *p, int bCleanup){
   if( pBt->inCatalogSerialize ) return SQLITE_OK;
 
   if( p->inTrans==TRANS_WRITE ){
-    assert( pBt->store.isMemory || pBt->store.pGraphLockFile!=0 );
-    assert( pBt->store.isMemory || pBt->store.lockDepth > 0 );
+    PROLLY_ASSERT_GRAPH_LOCKED(pBt);
     rc = flushAllPending(p, pBt, 0);
     if( rc!=SQLITE_OK ){
       chunkStoreRollback(&pBt->store);
@@ -1028,6 +1035,7 @@ int sqlite3BtreeCommit(Btree *p){
 }
 
 int restoreFromCommitted(Btree *p){
+  assert( p!=0 && p->pBt!=0 );
   if( prollyHashIsEmpty(&p->committedCatalogHash) ){
     if( p->bCatalogDropped ){
       /* A prior OOM rollback dropped the catalog. Installing the default
@@ -1154,8 +1162,7 @@ int prollyBtreeRollback(Btree *p, int tripCode, int writeOnly){
   if( pBt->inCatalogSerialize ) return SQLITE_OK;
 
   if( p->inTrans==TRANS_WRITE ){
-    assert( pBt->store.isMemory || pBt->store.pGraphLockFile!=0 );
-    assert( pBt->store.isMemory || pBt->store.lockDepth > 0 );
+    PROLLY_ASSERT_GRAPH_LOCKED(pBt);
     /* Read cursors survive write-only rollback by reseeking the restored tree.
     ** Write cursors, and all cursors after schema changes, are faulted.
     ** Either way detach the cursor's pending-edit map alias before
@@ -1356,8 +1363,7 @@ static int persistRolledBackSessionState(Btree *p, BtShared *pBt){
   const char *zBr = p->zBranch ? p->zBranch : "main";
   int rc;
 
-  assert( pBt->store.isMemory || pBt->store.pGraphLockFile!=0 );
-  assert( pBt->store.isMemory || pBt->store.lockDepth > 0 );
+  PROLLY_ASSERT_GRAPH_LOCKED(pBt);
 
   rc = serializeCatalog(p, &catData, &nCatData);
   if( rc==SQLITE_OK ){


### PR DESCRIPTION
## Summary

Second, broader assert campaign on the refactored Prolly B-tree. Shared helpers in `prolly_btree_int.h`:

- `PROLLY_ASSERT_WRITE_TXN`
- `PROLLY_ASSERT_GRAPH_LOCKED`
- `PROLLY_ASSERT_CURSOR_OWNED`

| Module | New coverage |
|--------|----------------|
| `prolly_btree_state.c` | working-set load/write args; reload ownership; version bump consistency; branch set |
| `prolly_btree_catalog.c` | cat remove/free; sorted order after remove; serialize/deserialize; switch catalog; refreshCursorRoot ownership |
| `prolly_btree_txn.c` | savepoint capture/push bounds; snapshot-for-flush write txn; graph lock via helper |
| `prolly_btree_mutation.c` | flushIfNeeded / flushPending ownership + write txn |
| `prolly_btree_cursor.c` | mergeScan dir/map; phys index normalize; deferred seek mutmap |
| `prolly_btree.c` | catFind/catAdd sortedness + capacity; saveAllCursors post-state; create table under lock |
| `prolly_btree_orig.c` | `pOrigBtree` non-null on dispatch adapters |

Rough assert density (assert + PROLLY_ASSERT_*): ~169 sites across the modules (was ~69 after skirmish #1).

## Test plan

- [x] `make doltlite`
- [x] smoke: DML, savepoints, branch, merge, index, gc
- [x] `doltlite_commit.sh` — 62/62
- [x] `doltlite_merge.sh` — 94/94
- [x] `doltlite_savepoint.sh` — 128/128