### PR TITLE
Guard GC compacted-index alloc against integer overflow

### DIFF
--- a/src/doltlite_gc.c
+++ b/src/doltlite_gc.c
@@ -493,8 +493,14 @@ static int gcBuildCompactedIndex(
     }
   }
 
-  aNewIndex = sqlite3_malloc((kept ? kept : 1) * (int)sizeof(ChunkIndexEntry));
-  if( !aNewIndex ) return SQLITE_NOMEM;
+  {
+    i64 nEntries = kept ? (i64)kept : 1;
+    if( nEntries > (i64)0x7fffffff/(i64)sizeof(ChunkIndexEntry) ){
+      return SQLITE_NOMEM;
+    }
+    aNewIndex = sqlite3_malloc((int)(nEntries * (i64)sizeof(ChunkIndexEntry)));
+    if( !aNewIndex ) return SQLITE_NOMEM;
+  }
 
   {
     int nIdx; const ChunkIndexEntry *aIdx;
@@ -631,8 +637,14 @@ static int gcRewriteFile(
   csSerializeManifest(&manifestCs, manifest);
   csManifestSeal(manifest);
 
-  aNewIndex = sqlite3_malloc((kept ? kept : 1) * (int)sizeof(ChunkIndexEntry));
-  if( !aNewIndex ) return SQLITE_NOMEM;
+  {
+    i64 nEntries = kept ? (i64)kept : 1;
+    if( nEntries > (i64)0x7fffffff/(i64)sizeof(ChunkIndexEntry) ){
+      return SQLITE_NOMEM;
+    }
+    aNewIndex = sqlite3_malloc((int)(nEntries * (i64)sizeof(ChunkIndexEntry)));
+    if( !aNewIndex ) return SQLITE_NOMEM;
+  }
 
   zRaw = sqlite3_mprintf("%s-gc-tmp", chunkFileGetFilename(&cs->file));
   if( !zRaw ){


### PR DESCRIPTION
## Summary

Overflow-safe allocation for GC compacted chunk-index arrays (sibling of #1736).

`gcBuildCompactedIndex` and `gcRewriteFile` both did:

```c
sqlite3_malloc((kept ? kept : 1) * (int)sizeof(ChunkIndexEntry));
```

with no check that the product fits a positive `int` size. A pathological `kept` count could wrap and under-allocate. Both sites now follow the same pattern as `gcQueuePush` / `chunk_staging`:

- compute entry count in `i64`
- refuse with `SQLITE_NOMEM` if `nEntries * sizeof(ChunkIndexEntry)` would not fit a positive `int` malloc size
- then `sqlite3_malloc` with the checked byte size

## Test plan

- [x] `make doltlite`
- [x] `DOLTLITE=./build/doltlite bash test/doltlite_gc.sh` — 58 passed, 0 failed