### PR TITLE
Harden merge conflict serialization

### DIFF
--- a/src/doltlite_conflicts.c
+++ b/src/doltlite_conflicts.c
@@ -5,14 +5,7 @@
 #include "doltlite_internal.h"
 #include <string.h>
 
-typedef struct ConflictTableInfo ConflictTableInfo;
-struct ConflictTableInfo {
-  char *zName;
-  int nConflicts;
-  DoltliteConflictRow *aRows;
-  char **azSchemaObjects;
-  int nSchemaObjects;
-};
+typedef DoltliteConflictTable ConflictTableInfo;
 
 static void freeConflictTable(ConflictTableInfo *pTable);
 static void freeConflictTables(ConflictTableInfo *aTables, int nTables);
@@ -39,29 +32,50 @@ static void freeConflictRow(DoltliteConflictRow *pRow){
 
 int doltliteSerializeConflicts(
   ChunkStore *cs,
-  ConflictTableInfo *aTables, int nTables,
+  DoltliteConflictTable *aTables, int nTables,
   ProllyHash *pHash
 ){
-  int sz = 4 + 2;
+  sqlite3_int64 sz = 4 + 2;
   int i, j, rc;
   u8 *buf;
   DlByteWriter w;
 
+  if( nTables<0 || nTables>0xffff ) return SQLITE_TOOBIG;
+  if( nTables>0 && !aTables ) return SQLITE_CORRUPT;
   for(i=0; i<nTables; i++){
-    int nl = aTables[i].zName ? (int)strlen(aTables[i].zName) : 0;
-    sz += 2 + nl + 4;
+    size_t nName = aTables[i].zName ? strlen(aTables[i].zName) : 0;
+    int nl;
+    if( nName>0xffff || aTables[i].nConflicts<0 ) return SQLITE_TOOBIG;
+    if( aTables[i].nConflicts>0 && !aTables[i].aRows ) return SQLITE_CORRUPT;
+    nl = (int)nName;
+    rc = dlAddSize(&sz, 2 + nl + 4);
+    if( rc!=SQLITE_OK ) return rc;
     for(j=0; j<aTables[i].nConflicts; j++){
-      sz += 4 + aTables[i].aRows[j].nKey
-              + 8
-              + 4 + aTables[i].aRows[j].nBaseVal
-              + 4 + aTables[i].aRows[j].nOurVal
-              + 4 + aTables[i].aRows[j].nTheirVal;
+      DoltliteConflictRow *cr = &aTables[i].aRows[j];
+      if( cr->nKey<0 || cr->nBaseVal<0 || cr->nOurVal<0
+       || cr->nTheirVal<0
+      ){
+        return SQLITE_CORRUPT;
+      }
+      if( (cr->nKey>0 && !cr->pKey)
+       || (cr->nBaseVal>0 && !cr->pBaseVal)
+       || (cr->nOurVal>0 && !cr->pOurVal)
+       || (cr->nTheirVal>0 && !cr->pTheirVal)
+      ){
+        return SQLITE_CORRUPT;
+      }
+      rc = dlAddSize(&sz, 24);
+      if( rc==SQLITE_OK ) rc = dlAddSize(&sz, cr->nKey);
+      if( rc==SQLITE_OK ) rc = dlAddSize(&sz, cr->nBaseVal);
+      if( rc==SQLITE_OK ) rc = dlAddSize(&sz, cr->nOurVal);
+      if( rc==SQLITE_OK ) rc = dlAddSize(&sz, cr->nTheirVal);
+      if( rc!=SQLITE_OK ) return rc;
     }
   }
 
-  buf = sqlite3_malloc(sz);
+  buf = sqlite3_malloc64((sqlite3_uint64)sz);
   if( !buf ) return SQLITE_NOMEM;
-  w.p = buf;
+  dlWriterInit(&w, buf, (int)sz);
 
   dlWriteFramedHeader(&w, DOLTLITE_CONFLICTS_MAGIC0, DOLTLITE_CONFLICTS_MAGIC1,
                       DOLTLITE_CONFLICTS_MAGIC2, DOLTLITE_CONFLICTS_VERSION, nTables);
@@ -79,7 +93,12 @@ int doltliteSerializeConflicts(
     }
   }
 
-  rc = chunkStorePut(cs, buf, (int)(w.p-buf), pHash);
+  if( w.err || w.p!=w.end ){
+    sqlite3_free(buf);
+    return SQLITE_CORRUPT;
+  }
+  rc = sqlite3FaultSim(950) ? SQLITE_IOERR
+                            : chunkStorePut(cs, buf, (int)sz, pHash);
   sqlite3_free(buf);
   return rc;
 }
@@ -401,7 +420,7 @@ static int deleteConflictRowFromCatalog(
     goto delete_conflict_done;
   }
 
-  w.p = out;
+  dlWriterInit(&w, out, nData);
   dlWriteFramedHeader(&w, DOLTLITE_CONFLICTS_MAGIC0, DOLTLITE_CONFLICTS_MAGIC1,
                       DOLTLITE_CONFLICTS_MAGIC2, DOLTLITE_CONFLICTS_VERSION, 0);
 
@@ -460,8 +479,9 @@ static int deleteConflictRowFromCatalog(
         w.p = pOutTableStart;
       }else{
         DlByteWriter cw;
-        cw.p = pCountOut;
+        dlWriterInit(&cw, pCountOut, 4);
         dlWriteU32(&cw, nKeep);
+        assert( !cw.err );
         nOutTables++;
       }
     }else{
@@ -475,21 +495,24 @@ static int deleteConflictRowFromCatalog(
       assert( !isMatch );
       {
         int nCopy = (int)(r.p - pTableStart);
-        memcpy(w.p, pTableStart, nCopy);
-        w.p += nCopy;
+        dlWriteBytes(&w, pTableStart, nCopy);
         nOutTables++;
       }
     }
     sqlite3_free(zName);
   }
 
-  if( r.err || r.p != r.end ){ rc = SQLITE_CORRUPT; goto delete_conflict_done; }
+  if( r.err || r.p != r.end || w.err ){
+    rc = SQLITE_CORRUPT;
+    goto delete_conflict_done;
+  }
   if( deleted ){
     DlByteWriter hw;
-    hw.p = out;
+    dlWriterInit(&hw, out, 6);
     dlWriteFramedHeader(&hw, DOLTLITE_CONFLICTS_MAGIC0, DOLTLITE_CONFLICTS_MAGIC1,
                         DOLTLITE_CONFLICTS_MAGIC2, DOLTLITE_CONFLICTS_VERSION,
                         nOutTables);
+    assert( !hw.err );
     rc = storeConflictBytes(db, cs, out, (int)(w.p - out), nOutTables);
   }
 
@@ -534,7 +557,7 @@ static int removeConflictTableFromCatalog(
     goto remove_conflict_done;
   }
 
-  w.p = out;
+  dlWriterInit(&w, out, nData);
   dlWriteFramedHeader(&w, DOLTLITE_CONFLICTS_MAGIC0, DOLTLITE_CONFLICTS_MAGIC1,
                       DOLTLITE_CONFLICTS_MAGIC2, DOLTLITE_CONFLICTS_VERSION, 0);
 
@@ -570,20 +593,23 @@ static int removeConflictTableFromCatalog(
       *pFound = 1;
     }else{
       int nCopy = (int)(r.p - pTableStart);
-      memcpy(w.p, pTableStart, nCopy);
-      w.p += nCopy;
+      dlWriteBytes(&w, pTableStart, nCopy);
       nOutTables++;
     }
     sqlite3_free(zName);
   }
 
-  if( r.err || r.p != r.end ){ rc = SQLITE_CORRUPT; goto remove_conflict_done; }
+  if( r.err || r.p != r.end || w.err ){
+    rc = SQLITE_CORRUPT;
+    goto remove_conflict_done;
+  }
   if( *pFound ){
     DlByteWriter hw;
-    hw.p = out;
+    dlWriterInit(&hw, out, 6);
     dlWriteFramedHeader(&hw, DOLTLITE_CONFLICTS_MAGIC0, DOLTLITE_CONFLICTS_MAGIC1,
                         DOLTLITE_CONFLICTS_MAGIC2, DOLTLITE_CONFLICTS_VERSION,
                         nOutTables);
+    assert( !hw.err );
     rc = storeConflictBytes(db, cs, out, (int)(w.p - out), nOutTables);
   }
 

--- a/src/doltlite_constraint_violations.c
+++ b/src/doltlite_constraint_violations.c
@@ -61,28 +61,40 @@ static int serializeViolations(
   ConstraintViolationTable *aTables, int nTables,
   ProllyHash *pHash
 ){
-  int sz = 4 + 2;
+  sqlite3_int64 sz = 4 + 2;
   int i, j, rc;
   u8 *buf;
   DlByteWriter w;
 
+  if( nTables<0 || nTables>0xffff ) return SQLITE_TOOBIG;
+  if( nTables>0 && !aTables ) return SQLITE_CORRUPT;
   for(i=0; i<nTables; i++){
-    int nl = aTables[i].zName ? (int)strlen(aTables[i].zName) : 0;
-    sz += 2 + nl + 4;
+    size_t nName = aTables[i].zName ? strlen(aTables[i].zName) : 0;
+    int nl;
+    if( nName>0xffff || aTables[i].nRows<0 ) return SQLITE_TOOBIG;
+    if( aTables[i].nRows>0 && !aTables[i].aRows ) return SQLITE_CORRUPT;
+    nl = (int)nName;
+    rc = dlAddSize(&sz, 2 + nl + 4);
+    if( rc!=SQLITE_OK ) return rc;
     for(j=0; j<aTables[i].nRows; j++){
-      int ni = aTables[i].aRows[j].zInfo
-             ? (int)strlen(aTables[i].aRows[j].zInfo) : 0;
-      sz += 1
-          + 4 + aTables[i].aRows[j].nKey
-          + 8
-          + 4 + aTables[i].aRows[j].nVal
-          + 4 + ni;
+      ConstraintViolationRow *r = &aTables[i].aRows[j];
+      size_t nInfo = r->zInfo ? strlen(r->zInfo) : 0;
+      if( r->nKey<0 || r->nVal<0 ) return SQLITE_CORRUPT;
+      if( (r->nKey>0 && !r->pKey) || (r->nVal>0 && !r->pVal) ){
+        return SQLITE_CORRUPT;
+      }
+      if( nInfo>INT_MAX ) return SQLITE_TOOBIG;
+      rc = dlAddSize(&sz, 21);
+      if( rc==SQLITE_OK ) rc = dlAddSize(&sz, r->nKey);
+      if( rc==SQLITE_OK ) rc = dlAddSize(&sz, r->nVal);
+      if( rc==SQLITE_OK ) rc = dlAddSize(&sz, (sqlite3_int64)nInfo);
+      if( rc!=SQLITE_OK ) return rc;
     }
   }
 
-  buf = sqlite3_malloc(sz);
+  buf = sqlite3_malloc64((sqlite3_uint64)sz);
   if( !buf ) return SQLITE_NOMEM;
-  w.p = buf;
+  dlWriterInit(&w, buf, (int)sz);
 
   dlWriteFramedHeader(&w, DCV_MAGIC0, DCV_MAGIC1, DCV_MAGIC2, DCV_VERSION, nTables);
 
@@ -101,7 +113,11 @@ static int serializeViolations(
     }
   }
 
-  rc = chunkStorePut(cs, buf, (int)(w.p-buf), pHash);
+  if( w.err || w.p!=w.end ){
+    sqlite3_free(buf);
+    return SQLITE_CORRUPT;
+  }
+  rc = chunkStorePut(cs, buf, (int)sz, pHash);
   sqlite3_free(buf);
   return rc;
 }
@@ -380,7 +396,7 @@ static int deleteViolationRowFromCatalog(
     goto delete_violation_done;
   }
 
-  w.p = out;
+  dlWriterInit(&w, out, nData);
   dlWriteFramedHeader(&w, DCV_MAGIC0, DCV_MAGIC1, DCV_MAGIC2, DCV_VERSION, 0);
 
   for(i=0; i<nTables; i++){
@@ -439,8 +455,9 @@ static int deleteViolationRowFromCatalog(
         w.p = pOutTableStart;
       }else{
         DlByteWriter cw;
-        cw.p = pCountOut;
+        dlWriterInit(&cw, pCountOut, 4);
         dlWriteU32(&cw, nKeep);
+        assert( !cw.err );
         nOutTables++;
       }
     }else{
@@ -454,20 +471,23 @@ static int deleteViolationRowFromCatalog(
       assert( !isMatch );
       {
         int nCopy = (int)(rd.p - pTableStart);
-        memcpy(w.p, pTableStart, nCopy);
-        w.p += nCopy;
+        dlWriteBytes(&w, pTableStart, nCopy);
         nOutTables++;
       }
     }
     sqlite3_free(zName);
   }
 
-  if( rd.err || rd.p != rd.end ){ rc = SQLITE_CORRUPT; goto delete_violation_done; }
+  if( rd.err || rd.p != rd.end || w.err ){
+    rc = SQLITE_CORRUPT;
+    goto delete_violation_done;
+  }
   if( deleted ){
     DlByteWriter hw;
-    hw.p = out;
+    dlWriterInit(&hw, out, 6);
     dlWriteFramedHeader(&hw, DCV_MAGIC0, DCV_MAGIC1, DCV_MAGIC2, DCV_VERSION,
                         nOutTables);
+    assert( !hw.err );
     rc = storeViolationBytes(db, cs, out, (int)(w.p - out), nOutTables);
   }
 

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -9,6 +9,7 @@
 #include "chunk_store.h"
 #include <time.h>
 #include <ctype.h>
+#include <limits.h>
 
 typedef struct BtShared BtShared;
 typedef struct ProllyCache ProllyCache;
@@ -735,29 +736,74 @@ static SQLITE_INLINE int dlReadU32Str(DlByteReader *r, char **pz){
   return SQLITE_OK;
 }
 
-typedef struct DlByteWriter { u8 *p; } DlByteWriter;
-static SQLITE_INLINE void dlWriteU8(DlByteWriter *w, u8 v){ *w->p++ = v; }
+static SQLITE_INLINE int dlAddSize(sqlite3_int64 *pnTotal, sqlite3_int64 nAdd){
+  if( nAdd<0 || nAdd>SQLITE_MAX_LENGTH
+   || *pnTotal<0 || *pnTotal>SQLITE_MAX_LENGTH-nAdd
+   || *pnTotal>INT_MAX-nAdd
+  ){
+    return SQLITE_TOOBIG;
+  }
+  *pnTotal += nAdd;
+  return SQLITE_OK;
+}
+
+typedef struct DlByteWriter {
+  u8 *p;
+  u8 *end;
+  int err;
+} DlByteWriter;
+static SQLITE_INLINE void dlWriterInit(DlByteWriter *w, u8 *p, int n){
+  w->p = p;
+  w->end = p + n;
+  w->err = 0;
+}
+static SQLITE_INLINE int dlWriterReserve(DlByteWriter *w, int n){
+  if( w->err || n<0 || (size_t)n>(size_t)(w->end-w->p) ){
+    w->err = 1;
+    return 0;
+  }
+  return 1;
+}
+static SQLITE_INLINE void dlWriteU8(DlByteWriter *w, u8 v){
+  if( dlWriterReserve(w, 1) ) *w->p++ = v;
+}
 static SQLITE_INLINE void dlWriteU16(DlByteWriter *w, int v){
-  w->p[0]=(u8)v; w->p[1]=(u8)(v>>8); w->p+=2;
+  if( dlWriterReserve(w, 2) ){
+    w->p[0]=(u8)v; w->p[1]=(u8)(v>>8); w->p+=2;
+  }
 }
 static SQLITE_INLINE void dlWriteU32(DlByteWriter *w, int v){
-  w->p[0]=(u8)v; w->p[1]=(u8)(v>>8); w->p[2]=(u8)(v>>16); w->p[3]=(u8)(v>>24);
-  w->p+=4;
+  if( dlWriterReserve(w, 4) ){
+    w->p[0]=(u8)v; w->p[1]=(u8)(v>>8); w->p[2]=(u8)(v>>16); w->p[3]=(u8)(v>>24);
+    w->p+=4;
+  }
 }
 static SQLITE_INLINE void dlWriteI64(DlByteWriter *w, i64 v){
   u64 k = (u64)v; int i;
-  for(i=0; i<8; i++) w->p[i] = (u8)(k >> (i*8));
-  w->p += 8;
+  if( dlWriterReserve(w, 8) ){
+    for(i=0; i<8; i++) w->p[i] = (u8)(k >> (i*8));
+    w->p += 8;
+  }
 }
 static SQLITE_INLINE void dlWriteU32Blob(DlByteWriter *w, const u8 *p, int n){
   dlWriteU32(w, n);
-  if( n>0 ) memcpy(w->p, p, n);
-  w->p += n;
+  if( dlWriterReserve(w, n) ){
+    if( n>0 ) memcpy(w->p, p, n);
+    w->p += n;
+  }
 }
 static SQLITE_INLINE void dlWriteU16Name(DlByteWriter *w, const char *z, int n){
   dlWriteU16(w, n);
-  if( n>0 ) memcpy(w->p, z, n);
-  w->p += n;
+  if( dlWriterReserve(w, n) ){
+    if( n>0 ) memcpy(w->p, z, n);
+    w->p += n;
+  }
+}
+static SQLITE_INLINE void dlWriteBytes(DlByteWriter *w, const u8 *p, int n){
+  if( dlWriterReserve(w, n) ){
+    if( n>0 ) memcpy(w->p, p, n);
+    w->p += n;
+  }
 }
 
 /* Magic (3 bytes) + version + a u16 table count: the framed header shared by
@@ -851,7 +897,19 @@ struct DoltliteConflictRow {
   u8 *pTheirVal; int nTheirVal;
 };
 
+typedef struct DoltliteConflictTable DoltliteConflictTable;
+struct DoltliteConflictTable {
+  char *zName;
+  int nConflicts;
+  DoltliteConflictRow *aRows;
+  char **azSchemaObjects;
+  int nSchemaObjects;
+};
+
 void doltliteConflictRowFree(DoltliteConflictRow *pRow);
+int doltliteSerializeConflicts(ChunkStore *cs,
+                               DoltliteConflictTable *aTables,
+                               int nTables, ProllyHash *pHash);
 
 /* Index key construction helpers (see doltlite_merge.c). Exposed for
 ** dolt_conflicts_resolve --theirs to maintain secondary indexes when

--- a/src/doltlite_merge.c
+++ b/src/doltlite_merge.c
@@ -18,10 +18,6 @@
 #include <string.h>
 #include <ctype.h>
 
-typedef struct ConflictTableInfo ConflictTableInfo;
-extern int doltliteSerializeConflicts(ChunkStore *cs, ConflictTableInfo *aTables,
-                                       int nTables, ProllyHash *pHash);
-
 typedef struct MergeIndexInfo MergeIndexInfo;
 struct MergeIndexInfo {
   Pgno iTable;
@@ -1281,14 +1277,7 @@ static int serializeMergedCatalog(
   return rc;
 }
 
-typedef struct MergeConflictTable MergeConflictTable;
-struct MergeConflictTable {
-  char *zName;
-  int nConflicts;
-  DoltliteConflictRow *aRows;
-  char **azSchemaObjects;
-  int nSchemaObjects;
-};
+typedef DoltliteConflictTable MergeConflictTable;
 
 static void freeConflictRows(DoltliteConflictRow *aRows, int nRows){
   int i;
@@ -2815,24 +2804,22 @@ static int allocMergedCatalogEntries(
   return *paMerged ? SQLITE_OK : SQLITE_NOMEM;
 }
 
-static void recordMergeConflicts(
+static int recordMergeConflicts(
   sqlite3 *db,
   MergeConflictTable *aConflictTables,
   int nConflictTables
 ){
   ProllyHash conflictsHash;
-  int rc2;
+  int rc;
 
-  rc2 = doltliteSerializeConflicts(
+  rc = doltliteSerializeConflicts(
       doltliteGetChunkStore(db),
-      (ConflictTableInfo*)aConflictTables, nConflictTables,
+      aConflictTables, nConflictTables,
       &conflictsHash);
-  if( rc2==SQLITE_OK ){
-    extern void doltliteSetSessionConflictsCatalog(sqlite3*, const ProllyHash*);
-    extern void doltliteSetSessionMergeState(sqlite3*, u8, const ProllyHash*, const ProllyHash*);
-    doltliteSetSessionConflictsCatalog(db, &conflictsHash);
-    doltliteSetSessionMergeState(db, 1, 0, &conflictsHash);
-  }
+  if( rc!=SQLITE_OK ) return rc;
+  doltliteSetSessionConflictsCatalog(db, &conflictsHash);
+  doltliteSetSessionMergeState(db, 1, 0, &conflictsHash);
+  return SQLITE_OK;
 }
 
 int doltliteMergeCatalogs(
@@ -2949,11 +2936,11 @@ int doltliteMergeCatalogs(
 
   rc = serializeMergedCatalog(db, ours, aMerged, nMerged, iNextMerged,
                               aTheirsSchema, nTheirsSchema, pMergedHash);
-  if( pnConflicts ) *pnConflicts = totalConflicts;
 
   if( totalConflicts>0 && nConflictTables>0 && rc==SQLITE_OK ){
-    recordMergeConflicts(db, aConflictTables, nConflictTables);
+    rc = recordMergeConflicts(db, aConflictTables, nConflictTables);
   }
+  if( pnConflicts && rc==SQLITE_OK ) *pnConflicts = totalConflicts;
 
 merge_cleanup:
   sqlite3_free(aRemap);

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -616,6 +616,16 @@ static int gFailHits = 0;
 static int gFailFullPathnameHits = 0;
 static const char *gFullPathnameSuffix = 0;
 static char gRewrittenFullPath[512];
+static int gRegressionFaultCode = 0;
+static int gRegressionFaultHits = 0;
+
+static int regressionFaultCallback(int iCode){
+  if( iCode==gRegressionFaultCode ){
+    gRegressionFaultHits++;
+    return 1;
+  }
+  return 0;
+}
 
 static int failAccess(sqlite3_vfs *pVfs, const char *zName, int flags, int *pResOut);
 static int failFullPathname(sqlite3_vfs *pVfs, const char *zName, int nOut, char *zOut);
@@ -2151,6 +2161,84 @@ static void run_merge_persist_failure(void){
 
   sqlite3_close(db);
   removeDbFiles(dbpath);
+}
+
+static void run_merge_conflict_persist_failure(void){
+  sqlite3 *db = 0;
+  char dbpath[256];
+  const char *res;
+  ProllyHash conflictHash;
+
+  printf("=== Merge Conflict Persist Failure Test ===\n\n");
+  make_dbpath(dbpath, sizeof(dbpath), "test_merge_conflict_persist_failure");
+  removeDbFiles(dbpath);
+
+  check("open_db_for_merge_conflict_persist_failure",
+        open_db(dbpath, &db)==SQLITE_OK);
+  check("setup_merge_conflict_persist_failure", execSql(db,
+    "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
+    "INSERT INTO t VALUES(1,'base');"
+    "SELECT dolt_commit('-A', '-m', 'init');"
+    "SELECT dolt_branch('feature');"
+    "UPDATE t SET v='main' WHERE id=1;"
+    "SELECT dolt_commit('-A', '-m', 'main edit');"
+    "SELECT dolt_checkout('feature');"
+    "UPDATE t SET v='feature' WHERE id=1;"
+    "SELECT dolt_commit('-A', '-m', 'feature edit');"
+    "SELECT dolt_checkout('main');")==SQLITE_OK);
+
+  gRegressionFaultCode = 950;
+  gRegressionFaultHits = 0;
+  sqlite3_test_control(SQLITE_TESTCTRL_FAULT_INSTALL, regressionFaultCallback);
+  res = queryScalarText(db, "SELECT dolt_merge('feature')");
+  sqlite3_test_control(SQLITE_TESTCTRL_FAULT_INSTALL, 0);
+  gRegressionFaultCode = 0;
+
+  check("merge_conflict_persist_failure_was_injected",
+        gRegressionFaultHits==1);
+  check("merge_conflict_persist_failure_is_propagated",
+        strcmp(res, "ERROR: merge failed")==0);
+  doltliteGetSessionConflictsCatalog(db, &conflictHash);
+  check("merge_conflict_persist_failure_does_not_publish_hash",
+        prollyHashIsEmpty(&conflictHash));
+  check("merge_conflict_persist_failure_preserves_working_row",
+        strcmp(queryScalarText(db, "SELECT v FROM t WHERE id=1"), "main")==0);
+
+  sqlite3_close(db);
+  removeDbFiles(dbpath);
+}
+
+static void run_conflict_serializer_bounds(void){
+  ChunkStore cs;
+  DoltliteConflictTable table;
+  DoltliteConflictRow row;
+  ProllyHash hash;
+  DlByteWriter w;
+  u8 aBuf[5] = {0, 0, 0, 0, 0x5a};
+  int rc;
+
+  printf("=== Conflict Serializer Bounds Test ===\n\n");
+  memset(&cs, 0, sizeof(cs));
+  memset(&table, 0, sizeof(table));
+  memset(&row, 0, sizeof(row));
+  check("open_memory_store_for_conflict_serializer_bounds",
+        chunkStoreOpen(&cs, sqlite3_vfs_find(0), ":memory:", 0)==SQLITE_OK);
+
+  table.zName = "t";
+  table.nConflicts = 1;
+  table.aRows = &row;
+  row.pKey = aBuf;
+  row.nKey = INT_MAX;
+  rc = doltliteSerializeConflicts(&cs, &table, 1, &hash);
+  check("conflict_serializer_rejects_size_overflow", rc==SQLITE_TOOBIG);
+
+  dlWriterInit(&w, aBuf, 4);
+  dlWriteU32(&w, 1);
+  dlWriteU8(&w, 2);
+  check("byte_writer_reports_overflow", w.err!=0);
+  check("byte_writer_preserves_canary", aBuf[4]==0x5a);
+
+  chunkStoreClose(&cs);
 }
 
 static void run_merge_conflict_surfaces_error_and_rollback_clears_durable_state(void){
@@ -8174,6 +8262,8 @@ static const RegressionCase aCases[] = {
   { "blame_all_parents_merge_base", "Blame All-Parents Merge Base Test", run_blame_all_parents_merge_base },
   { "blame_deep_history_scan", "Blame Deep History Scan Test", run_blame_deep_history_scan },
   { "merge_persist_failure", "Merge Persist Failure Test", run_merge_persist_failure },
+  { "merge_conflict_persist_failure", "Merge Conflict Persist Failure Test", run_merge_conflict_persist_failure },
+  { "conflict_serializer_bounds", "Conflict Serializer Bounds Test", run_conflict_serializer_bounds },
   { "merge_conflict_surfaces_error", "Merge Conflict Surfaces Error Test", run_merge_conflict_surfaces_error_and_rollback_clears_durable_state },
   { "failed_merge_reopen_preserves_working_set_state", "Failed Merge Reopen Preserves Working Set State Test", run_failed_merge_reopen_clears_ephemeral_conflict_state },
   { "cherry_pick_stale_branch", "Cherry-pick Stale Branch Test", run_cherry_pick_stale_branch },


### PR DESCRIPTION
Follow-up to #1741.

- propagate conflict-catalog serialization failures instead of publishing stale merge state
- use checked aggregate sizing and bounded writers for conflict and constraint-violation blobs
- share the conflict table transport type across merge and conflict modules
- add fault-injection and overflow regression coverage

Validation:
- 309,888 direct-library regression checks
- merge, conflict-row, and schema-merge suites
- lint, dead-code, and amalgamation artifact checks