### PR TITLE
Rebuild NOCASE/RTRIM/DESC secondary indexes on three-way row merge

### DIFF
--- a/src/doltlite_merge.c
+++ b/src/doltlite_merge.c
@@ -2492,6 +2492,38 @@ static int tryResolveSchemaDivergence(
   return SQLITE_OK;
 }
 
+static int mergeAppendReindexName(char ***paz, int *pn, const char *zName){
+  char **azNew;
+  char *zDup;
+  if( !paz ) return SQLITE_OK;
+  azNew = sqlite3_realloc(*paz, (*pn+1)*(int)sizeof(char*));
+  if( !azNew ) return SQLITE_NOMEM;
+  *paz = azNew;
+  zDup = sqlite3_mprintf("%s", zName);
+  if( !zDup ) return SQLITE_NOMEM;
+  (*paz)[(*pn)++] = zDup;
+  return SQLITE_OK;
+}
+
+/* Inline row-merge index maintenance encodes sort keys with a BINARY/ASC
+** KeyInfo. Indexes whose key columns fold case/space (NOCASE, RTRIM) or sort
+** DESC need the real collation and order, so rebuild them canonically over the
+** merged table via the post-merge REINDEX instead. */
+static int mergeIndexNeedsRebuild(Index *pIdx){
+  int k;
+  for(k=0; k<pIdx->nKeyCol; k++){
+    const char *zColl = pIdx->azColl ? pIdx->azColl[k] : 0;
+    if( zColl
+     && (sqlite3StrICmp(zColl,"NOCASE")==0 || sqlite3StrICmp(zColl,"RTRIM")==0) ){
+      return 1;
+    }
+    if( pIdx->aSortOrder && (pIdx->aSortOrder[k] & KEYINFO_ORDER_DESC) ){
+      return 1;
+    }
+  }
+  return 0;
+}
+
 static int mergeCatalogPass1(
   sqlite3 *db,
   struct TableEntry *aAnc, int nAnc,
@@ -2509,7 +2541,8 @@ static int mergeCatalogPass1(
   const ProllyHash *pCatTheirs,
   SchemaMergeAction **ppSchemaActions, int *pnSchemaActions,
   int bDisjointSchemaChanges,
-  int bPreferOurMaster
+  int bPreferOurMaster,
+  char ***pazReindex, int *pnReindex
 ){
   int i, rc = SQLITE_OK;
   int iTable1Idx = -1;
@@ -2765,6 +2798,15 @@ do_merge_entry:
                       struct TableEntry *oursIdx;
                       /* WITHOUT ROWID exposes the PK as the table root. */
                       if( pIdx->idxType==SQLITE_IDXTYPE_PRIMARYKEY ){
+                        continue;
+                      }
+                      if( mergeIndexNeedsRebuild(pIdx) ){
+                        rc = mergeAppendReindexName(pazReindex, pnReindex,
+                                                    pIdx->zName);
+                        if( rc!=SQLITE_OK ){
+                          sqlite3_free(aIdxInfo);
+                          return rc;
+                        }
                         continue;
                       }
                       oursIdx = doltliteFindTableByNumber(aOurs, nOurs, pIdx->tnum);
@@ -3047,7 +3089,7 @@ static int mergeCatalogPass2(
   char ***pazReindex,
   int *pnReindex
 ){
-  int i;
+  int i, rc = SQLITE_OK;
 
   for(i=0; i<nTheirs; i++){
     const char *zName = aTheirs[i].zName;
@@ -3101,16 +3143,8 @@ static int mergeCatalogPass2(
             /* The adopted tree covers only theirs' rows; ours' row changes
             ** never touched it. Record the index for a rebuild over the
             ** merged table once the merged catalog is live. */
-            if( pazReindex ){
-              char **azNew = sqlite3_realloc(*pazReindex,
-                  (*pnReindex+1)*(int)sizeof(char*));
-              char *zDup;
-              if( !azNew ) return SQLITE_NOMEM;
-              *pazReindex = azNew;
-              zDup = sqlite3_mprintf("%s", pTheirSe->zName);
-              if( !zDup ) return SQLITE_NOMEM;
-              (*pazReindex)[(*pnReindex)++] = zDup;
-            }
+            rc = mergeAppendReindexName(pazReindex, pnReindex, pTheirSe->zName);
+            if( rc!=SQLITE_OK ) return rc;
           }else if( schemaEntryChangedByName(
                         aAncSchema, nAncSchema,
                         aTheirsSchema, nTheirsSchema,
@@ -3140,16 +3174,8 @@ static int mergeCatalogPass2(
               *piNextMerged = newEntry.iTable + 1;
             }
             aMerged[(*pnMerged)++] = newEntry;
-            if( pazReindex ){
-              char **azNew = sqlite3_realloc(*pazReindex,
-                  (*pnReindex+1)*(int)sizeof(char*));
-              char *zDup;
-              if( !azNew ) return SQLITE_NOMEM;
-              *pazReindex = azNew;
-              zDup = sqlite3_mprintf("%s", pTheirSe->zName);
-              if( !zDup ) return SQLITE_NOMEM;
-              (*pazReindex)[(*pnReindex)++] = zDup;
-            }
+            rc = mergeAppendReindexName(pazReindex, pnReindex, pTheirSe->zName);
+            if( rc!=SQLITE_OK ) return rc;
           }else{
             /* An unmodified index does not override our explicit DROP. */
           }
@@ -3378,7 +3404,8 @@ int doltliteMergeCatalogs(
                           ancestor, ours, theirs,
                           ppActions, pnActions,
                           bDisjointSchemaChanges,
-                          bPreferOurMaster);
+                          bPreferOurMaster,
+                          pazReindex, pnReindex);
   if( rc!=SQLITE_OK ){
     int k;
     for(k=0; k<nMerged; k++) aMerged[k].zName = 0;

--- a/test/doltlite_index_vc_matrix.sh
+++ b/test/doltlite_index_vc_matrix.sh
@@ -196,6 +196,42 @@ result=$(run_sql "SELECT count(*) FROM t INDEXED BY ie WHERE e>=0; PRAGMA integr
 check "merge_index_schema" "3
 ok" "$result"
 
+# Both branches change disjoint rows of a table carrying a NOCASE and a
+# DESC secondary index, so the three-way row merge maintains those indexes
+# inline. Their sort keys must honor the real collation and sort order, or
+# theirs-applied index entries become unreachable by probe and mis-ordered
+# by scan while the table scan stays correct.
+scenario "divergent merge maintains NOCASE and DESC secondary indexes"
+newdb
+run_sql "CREATE TABLE m(id INTEGER PRIMARY KEY, tx TEXT COLLATE NOCASE, n INTEGER);
+CREATE INDEX mtx ON m(tx);
+CREATE INDEX mn ON m(n DESC);
+INSERT INTO m VALUES(1,'aaa',10),(2,'bbb',20),(3,'ccc',30),(4,'ddd',40);
+SELECT dolt_commit('-Am','base'); SELECT dolt_branch('side');" "$DB" > /dev/null
+run_sql "UPDATE m SET tx='MAIN1',n=15 WHERE id=1; UPDATE m SET tx='MAIN2',n=5 WHERE id=2; SELECT dolt_commit('-am','main-side');" "$DB" > /dev/null
+run_sql "SELECT dolt_checkout('side'); UPDATE m SET tx='SIDE3',n=35 WHERE id=3; UPDATE m SET tx='SIDE4',n=45 WHERE id=4; SELECT dolt_commit('-am','side-side'); SELECT dolt_checkout('main');" "$DB" > /dev/null
+run_sql "SELECT dolt_merge('side');" "$DB" > /dev/null
+result=$(run_sql "SELECT count(*) FROM m INDEXED BY mtx WHERE tx='side3';
+SELECT count(*) FROM m NOT INDEXED WHERE tx='side3';
+SELECT count(*) FROM m INDEXED BY mtx WHERE tx='main1';
+SELECT group_concat(n) FROM (SELECT n FROM m INDEXED BY mn ORDER BY n DESC);
+SELECT group_concat(n) FROM (SELECT n FROM m NOT INDEXED ORDER BY n DESC);
+PRAGMA integrity_check;" "$DB")
+check "merge_nocase_desc_live" "1
+1
+1
+45,35,15,5
+45,35,15,5
+ok" "$result"
+result=$(run_sql "SELECT dolt_reset('--hard');
+SELECT count(*) FROM m INDEXED BY mtx WHERE tx='side3';
+SELECT group_concat(n) FROM (SELECT n FROM m INDEXED BY mn ORDER BY n DESC);
+PRAGMA integrity_check;" "$DB")
+check "merge_nocase_desc_head" "0
+1
+45,35,15,5
+ok" "$result"
+
 # ── cherry-pick / revert ──────────────────────────────────────────
 scenario "cherry-pick an index-touching commit"
 newdb


### PR DESCRIPTION
## Problem

A code-quality sweep surfaced this: when both branches change disjoint rows of a table that carries a **NOCASE/RTRIM** or **DESC** secondary index, the merge corrupts that index.

`mergeCatalogPass1` maintained secondary indexes inline during the three-way row merge with `mi->pKeyInfo = 0`. A NULL `KeyInfo` makes the sort-key encoder fall back to `BINARY`/`ASC`, so the merge-applied ("theirs") entries were encoded differently from the entries the normal insert path produced with the real collation/order. Result:

- stale index entries never deleted (old key encoded as binary misses the normalized entry),
- merge-inserted entries unreachable by an index probe (probe uses the real collation),
- index-ordered scans mis-ordered,

while the plain table scan stayed correct — so the corruption is silent until a query uses the index.

## Fix

Route indexes whose key columns fold case/space (NOCASE, RTRIM) or sort DESC into the existing **post-merge `REINDEX`** list, so they are rebuilt canonically over the live merged table. This is the same path pass2 already uses for indexes adopted from the other branch (it runs after `doltliteSwitchCatalog` makes the merged catalog live). Rebuilding canonically also restores the covering-read payload, which a KeyInfo-only fix would still get wrong.

The fast inline path is kept for BINARY/ASC indexes — the NULL-KeyInfo encoding already handles those correctly, so there's no perf regression for the common case.

Also dedupes pass2's two identical reindex-name append blocks into a shared `mergeAppendReindexName` helper.

## Testing

- **Fail-before / pass-after**: new scenario `divergent merge maintains NOCASE and DESC secondary indexes` in `test/doltlite_index_vc_matrix.sh` (the suite whose contract is "index-planned queries agree with table scans across every VC surface"). It **fails on unfixed code** (2 checks) and **passes** with the fix — verified both on the live working set and against the materialized HEAD catalog (`dolt_reset --hard`).
- Full DoltLite VC battery: **89 suites, 0 failures**; all merge / schema-merge / index suites green.

## Interaction with #1745

Disjoint. #1745 (`refactor/split-doltlite-c`) only splits `doltlite.c`; it doesn't touch `doltlite_merge.c` (byte-identical to master) or the test file, and it preserves the `azReindex` → `doltliteReindexNamedIndexes` flow this fix relies on (relocated into `doltlite_merge_cmd.c`). Rebases cleanly in either merge order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)