### PR TITLE
Bounds-check commit deserializer length prefixes

### DIFF
--- a/main.mk
+++ b/main.mk
@@ -2752,6 +2752,7 @@ DOLTLITE_C_TESTS = \
 	sequence_reload_test$(T.exe) \
 	chunk_store_fork_lock_test$(T.exe) \
 	remotesrv_init_failure_test$(T.exe) \
+	commit_deserialize_test$(T.exe) \
 	oom_dolt_fault_test$(T.exe)
 
 ancestor_test$(T.exe): $(TOP)/test/ancestor_test.c libdoltlite$(T.lib)
@@ -2804,6 +2805,14 @@ chunk_store_fork_lock_test$(T.exe): $(TOP)/test/chunk_store_fork_lock_test.c lib
 
 remotesrv_init_failure_test$(T.exe): $(TOP)/test/remotesrv_init_failure_test.c libdoltlite$(T.lib)
 	$(T.link) -I. -I$(TOP)/src -o $@ $(TOP)/test/remotesrv_init_failure_test.c \
+		libdoltlite$(T.lib) -lz -lpthread -lm
+
+# commit_deserialize_test includes doltlite_commit.h (which pulls sqliteInt.h),
+# so it needs the DoltLite defines; the deserializer is an exported entry point,
+# so it links the static archive.
+commit_deserialize_test$(T.exe): $(TOP)/test/commit_deserialize_test.c libdoltlite$(T.lib)
+	$(T.link) -I. -I$(TOP)/src -DDOLTLITE_PROLLY=1 -D_HAVE_SQLITE_CONFIG_H \
+		-o $@ $(TOP)/test/commit_deserialize_test.c \
 		libdoltlite$(T.lib) -lz -lpthread -lm
 
 invariant_test$(T.exe): $(TOP)/test/invariant_test.c libdoltlite$(T.lib)

--- a/src/doltlite_commit.c
+++ b/src/doltlite_commit.c
@@ -112,6 +112,7 @@ int doltliteCommitDeserialize(const u8 *data, int nData, DoltliteCommit *c){
   c->zName[nName] = 0;
   p += nName;
 
+  if( p + 2 > data + nData ){ doltliteCommitClear(c); return SQLITE_CORRUPT; }
   nEmail = DLC_GET_U16(p); p += 2;
   if( p + nEmail > data + nData ){ doltliteCommitClear(c); return SQLITE_CORRUPT; }
   c->zEmail = sqlite3_malloc(nEmail + 1);
@@ -120,6 +121,7 @@ int doltliteCommitDeserialize(const u8 *data, int nData, DoltliteCommit *c){
   c->zEmail[nEmail] = 0;
   p += nEmail;
 
+  if( p + 2 > data + nData ){ doltliteCommitClear(c); return SQLITE_CORRUPT; }
   nMsg = DLC_GET_U16(p); p += 2;
   if( p + nMsg > data + nData ){ doltliteCommitClear(c); return SQLITE_CORRUPT; }
   c->zMessage = sqlite3_malloc(nMsg + 1);

--- a/test/commit_deserialize_test.c
+++ b/test/commit_deserialize_test.c
@@ -1,0 +1,125 @@
+/* Bounds checks for the commit-chunk deserializer. Commit chunks are
+** content-addressed only by hash, not by internal layout, so a corrupt or
+** crafted chunk can carry a length prefix that runs past the buffer. Each
+** case places the crafted buffer against a PROT_NONE guard page, so a read
+** past the final byte faults instead of silently over-reading: an unfixed
+** deserializer crashes here, a fixed one returns SQLITE_CORRUPT. */
+
+#ifdef DOLTLITE_PROLLY
+
+#include "doltlite_commit.h"
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+static int failures = 0;
+
+/* Return a pointer to an nData-byte region whose last byte abuts a
+** PROT_NONE page, so any access at data[nData] or beyond faults. */
+static u8 *guardedBuffer(int nData, void **ppMap, long *pMapLen){
+  long pg = sysconf(_SC_PAGESIZE);
+  long mapLen = pg * 2;
+  u8 *base = mmap(0, mapLen, PROT_READ|PROT_WRITE, MAP_ANON|MAP_PRIVATE, -1, 0);
+  if( base==MAP_FAILED ){ perror("mmap"); exit(2); }
+  if( mprotect(base+pg, pg, PROT_NONE)!=0 ){ perror("mprotect"); exit(2); }
+  *ppMap = base;
+  *pMapLen = mapLen;
+  return base + pg - nData;
+}
+
+static void expectCorrupt(const char *label, const u8 *tmpl, int nData){
+  void *pMap; long mapLen;
+  u8 *data = guardedBuffer(nData, &pMap, &mapLen);
+  DoltliteCommit c;
+  int rc;
+  memcpy(data, tmpl, nData);
+  rc = doltliteCommitDeserialize(data, nData, &c);
+  if( rc!=SQLITE_CORRUPT ){
+    fprintf(stderr, "FAIL %s: expected SQLITE_CORRUPT(%d), got %d\n",
+            label, SQLITE_CORRUPT, rc);
+    doltliteCommitClear(&c);
+    failures++;
+  }else{
+    printf("ok %s -> SQLITE_CORRUPT\n", label);
+  }
+  munmap(pMap, mapLen);
+}
+
+/* Header up to and including the timestamp for a 0-parent V2 commit; the
+** minimum size the length-prefix bounds check requires is 16+H. */
+static int fillHeader(u8 *buf){
+  int H = PROLLY_HASH_SIZE;
+  int off = 0;
+  buf[off++] = DOLTLITE_COMMIT_V2;
+  buf[off++] = 0;                    /* nParents */
+  memset(buf+off, 0xAB, H); off += H;/* catalogHash */
+  memset(buf+off, 0, 8); off += 8;   /* timestamp */
+  return off;                        /* 10+H */
+}
+
+static void testValidRoundTrip(void){
+  DoltliteCommit in, out;
+  u8 *buf = 0;
+  int n = 0, rc;
+  memset(&in, 0, sizeof(in));
+  memset(in.catalogHash.data, 0x11, PROLLY_HASH_SIZE);
+  in.timestamp = 123456789;
+  in.zName = "alice";
+  in.zEmail = "alice@example.com";
+  in.zMessage = "a commit message";
+  rc = doltliteCommitSerialize(&in, &buf, &n);
+  if( rc!=SQLITE_OK ){ fprintf(stderr,"FAIL roundtrip: serialize rc=%d\n",rc); failures++; return; }
+  rc = doltliteCommitDeserialize(buf, n, &out);
+  if( rc!=SQLITE_OK
+   || strcmp(out.zName,"alice")!=0
+   || strcmp(out.zEmail,"alice@example.com")!=0
+   || strcmp(out.zMessage,"a commit message")!=0
+   || out.timestamp!=123456789 ){
+    fprintf(stderr,"FAIL roundtrip: rc=%d name=%s email=%s msg=%s ts=%lld\n",
+            rc, out.zName?out.zName:"(null)", out.zEmail?out.zEmail:"(null)",
+            out.zMessage?out.zMessage:"(null)", (long long)out.timestamp);
+    failures++;
+  }else{
+    printf("ok valid round-trip\n");
+  }
+  doltliteCommitClear(&out);
+  sqlite3_free(buf);
+}
+
+int main(void){
+  int H = PROLLY_HASH_SIZE;
+  int nData = 16 + H;               /* minimum that clears the header check */
+  u8 *tmpl = malloc(nData);
+  int off;
+
+  testValidRoundTrip();
+
+  /* Truncated after a non-empty name: the email length prefix would be read
+  ** at data[nData]. */
+  off = fillHeader(tmpl);
+  tmpl[off++] = 4; tmpl[off++] = 0;  /* nName = 4 */
+  memset(tmpl+off, 'x', 4); off += 4;/* name body reaches exactly nData */
+  expectCorrupt("trunc_before_email_len", tmpl, nData);
+
+  /* Truncated after name+empty email: the message length prefix would be
+  ** read at data[nData]. */
+  off = fillHeader(tmpl);
+  tmpl[off++] = 2; tmpl[off++] = 0;  /* nName = 2 */
+  memset(tmpl+off, 'y', 2); off += 2;/* name body */
+  tmpl[off++] = 0; tmpl[off++] = 0;  /* nEmail = 0, reaches exactly nData */
+  expectCorrupt("trunc_before_msg_len", tmpl, nData);
+
+  free(tmpl);
+  if( failures ){
+    fprintf(stderr, "commit_deserialize_test: %d failure(s)\n", failures);
+    return 1;
+  }
+  printf("commit_deserialize_test: all passed\n");
+  return 0;
+}
+
+#else
+int main(void){ return 0; }
+#endif

--- a/test/run_c_tests.sh
+++ b/test/run_c_tests.sh
@@ -28,6 +28,7 @@ GATING=(
   sequence_reload_test
   chunk_store_fork_lock_test
   remotesrv_init_failure_test
+  commit_deserialize_test
 )
 
 run_one() {


### PR DESCRIPTION
## Problem

`doltliteCommitDeserialize` (`src/doltlite_commit.c`) validates forward space once, up front:

```c
if( p + nPar*PROLLY_HASH_SIZE + PROLLY_HASH_SIZE + 8 + 6 > data + nData ) return SQLITE_CORRUPT;
```

The `+6` reserves exactly the three u16 length prefixes (name, email, message) — but only if all three string **bodies** are empty. A non-empty name body consumes that slack, so after copying the name the pointer can sit at `data+nData`, and the **email** length read (`DLC_GET_U16(p)`) then reads 2 bytes past the buffer. The **message** length read has the same flaw once name+email consume the reservation.

Commit chunks are content-addressed by hash, not by internal layout, so a corrupt on-disk store or a crafted chunk reached via `doltliteLoadCommit` (and the other callers that deserialize by hash without the classify walk) hits this heap over-read. It's a 2-byte read-only over-read → crash-class.

## Fix

Guard each length read with a `p + 2 > data + nData` bounds check before dereferencing (two lines).

## Testing

New gating C-test `commit_deserialize_test` places each crafted buffer so its final byte abuts a `PROT_NONE` guard page, making the over-read fault deterministically — no ASAN required.

- **Fail-before**: on the unfixed deserializer the two truncation cases crash (SIGBUS/SIGSEGV via the guard page) → nonzero exit.
- **Pass-after**: both return `SQLITE_CORRUPT`, and a valid serialize→deserialize round-trip still succeeds.
- Adjacent `corruption_test` (82/82) and a commit/log/reopen smoke test on the CLI both pass.

Built on post-refactor master (#1745); independent of PR #1747 (fix #1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)