### PR TITLE
Implement DELETE on dolt_workspace_* tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,8 +306,9 @@ UPDATE dolt_workspace_ratings
 SELECT dolt_commit('-m', 'accept higher-confidence edits');
 ```
 
-`DELETE FROM dolt_workspace_<table>` and row-level staging on tables with
-secondary indexes are not implemented yet.
+`DELETE FROM dolt_workspace_<table>` discards unstaged working-set edits
+(restores the staged/HEAD side of those rows). Staged workspace rows cannot
+be deleted; unstage them first.
 
 #### Ignoring Tables (`dolt_ignore`)
 

--- a/src/doltlite_workspace.c
+++ b/src/doltlite_workspace.c
@@ -563,9 +563,29 @@ static int wsUpdate(sqlite3_vtab *pBase, int argc, sqlite3_value **argv,
   int newStaged;
   (void)pRowid;
   if( argc==1 ){
-    pBase->zErrMsg = sqlite3_mprintf(
-        "DELETE from dolt_workspace_%s is not yet supported", p->zTableName);
-    return SQLITE_CONSTRAINT;
+    const u8 *pVal;
+    int nVal;
+    r = wsFindCachedRow(p, sqlite3_value_int64(argv[0]));
+    if( !r ){
+      pBase->zErrMsg = sqlite3_mprintf("workspace row is no longer available");
+      return SQLITE_ABORT;
+    }
+    if( r->staged ){
+      pBase->zErrMsg = sqlite3_mprintf(
+          "cannot delete staged rows from workspace");
+      return SQLITE_ERROR;
+    }
+    /* Discard unstaged working edit: restore staged/HEAD side for this PK. */
+    if( r->diffType==PROLLY_DIFF_ADD ){
+      pVal = 0;
+      nVal = 0;
+    }else{
+      pVal = r->pOldVal;
+      nVal = r->nOldVal;
+    }
+    return doltliteApplyRawRowMutation(p->db, p->zTableName,
+                                       r->pKey, r->nKey, r->intKey,
+                                       pVal, nVal);
   }
   if( sqlite3_value_type(argv[0])==SQLITE_NULL ){
     pBase->zErrMsg = sqlite3_mprintf(

--- a/test/doltlite_workspace.sh
+++ b/test/doltlite_workspace.sh
@@ -91,4 +91,99 @@ else
   dltest_fail "workspace_indexed_nocase_query" "ci=[$nc_ci]"
 fi
 
+DEL_DB=/tmp/doltlite_workspace_delete_$$.db
+rm -rf "$DEL_DB"
+trap 'rm -rf "$DB"; rm -rf "$IDX_DB"; rm -rf "$NC_DB"; rm -rf "$DEL_DB"' EXIT
+
+# Discard unstaged insert
+dltest_run_sql "
+CREATE TABLE t(id INTEGER PRIMARY KEY, val INT);
+SELECT dolt_commit('-A','-m','seed empty');
+INSERT INTO t VALUES(42,42),(43,43);
+DELETE FROM dolt_workspace_t WHERE to_id=42;
+" "$DEL_DB" >/dev/null
+run_test "workspace_delete_discards_insert_data" \
+  "SELECT id || '|' || val FROM t ORDER BY id;" "43|43" "$DEL_DB"
+run_test "workspace_delete_discards_insert_ws" \
+  "SELECT count(*) || '|' || group_concat(to_id) FROM dolt_workspace_t;" \
+  "1|43" "$DEL_DB"
+
+# Discard unstaged delete (restore row)
+rm -rf "$DEL_DB"
+dltest_run_sql "
+CREATE TABLE t(id INTEGER PRIMARY KEY, val INT);
+INSERT INTO t VALUES(42,42),(43,43);
+SELECT dolt_commit('-A','-m','seed');
+DELETE FROM t;
+DELETE FROM dolt_workspace_t WHERE from_id=42;
+" "$DEL_DB" >/dev/null
+run_test "workspace_delete_restores_removed_row" \
+  "SELECT id || '|' || val FROM t ORDER BY id;" "42|42" "$DEL_DB"
+run_test "workspace_delete_restores_ws_remaining" \
+  "SELECT count(*) || '|' || group_concat(from_id) FROM dolt_workspace_t;" \
+  "1|43" "$DEL_DB"
+
+# Discard unstaged modify
+rm -rf "$DEL_DB"
+dltest_run_sql "
+CREATE TABLE t(id INTEGER PRIMARY KEY, val INT);
+INSERT INTO t VALUES(42,42),(43,43);
+SELECT dolt_commit('-A','-m','seed');
+UPDATE t SET val=val*2;
+DELETE FROM dolt_workspace_t WHERE to_id=42;
+" "$DEL_DB" >/dev/null
+run_test "workspace_delete_reverts_modify" \
+  "SELECT id || '|' || val FROM t ORDER BY id;" $'42|42\n43|86' "$DEL_DB"
+
+# Cannot delete staged rows
+rm -rf "$DEL_DB"
+dltest_run_sql "
+CREATE TABLE t(id INTEGER PRIMARY KEY, val INT);
+SELECT dolt_commit('-A','-m','seed');
+INSERT INTO t VALUES(42,42);
+SELECT dolt_add('t');
+" "$DEL_DB" >/dev/null
+if "$DOLTLITE" "$DEL_DB" "DELETE FROM dolt_workspace_t WHERE id=1;" \
+     >/tmp/doltlite_ws_del.out 2>/tmp/doltlite_ws_del.err; then
+  dltest_fail "workspace_delete_staged_rejected" "expected error, got success"
+else
+  if grep -qi 'cannot delete staged' /tmp/doltlite_ws_del.err; then
+    dltest_pass
+  else
+    dltest_fail "workspace_delete_staged_rejected" "$(cat /tmp/doltlite_ws_del.err)"
+  fi
+fi
+
+# Discard after unstage
+rm -rf "$DEL_DB"
+dltest_run_sql "
+CREATE TABLE t(id INTEGER PRIMARY KEY, val INT);
+SELECT dolt_commit('-A','-m','seed');
+INSERT INTO t VALUES(42,42),(43,43);
+SELECT dolt_add('t');
+UPDATE dolt_workspace_t SET staged=FALSE WHERE to_id=42;
+DELETE FROM dolt_workspace_t WHERE to_id=42;
+" "$DEL_DB" >/dev/null
+run_test "workspace_delete_after_unstage" \
+  "SELECT id || '|' || val FROM t ORDER BY id;" "43|43" "$DEL_DB"
+run_test "workspace_delete_after_unstage_staged_remains" \
+  "SELECT staged || '|' || to_id FROM dolt_workspace_t;" "1|43" "$DEL_DB"
+
+# Secondary indexes stay consistent when discarding a modify
+rm -rf "$DEL_DB"
+dltest_run_sql "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+CREATE INDEX idx_t_v ON t(v);
+INSERT INTO t VALUES(1,1);
+SELECT dolt_commit('-A','-m','seed');
+UPDATE t SET v=2;
+DELETE FROM dolt_workspace_t WHERE to_id=1;
+" "$DEL_DB" >/dev/null
+run_test "workspace_delete_index_integrity" \
+  "PRAGMA integrity_check;" "ok" "$DEL_DB"
+run_test "workspace_delete_index_query_old" \
+  "SELECT id FROM t WHERE v=1;" "1" "$DEL_DB"
+run_test "workspace_delete_index_query_new" \
+  "SELECT id FROM t WHERE v=2;" "" "$DEL_DB"
+
 dltest_finish

--- a/test/vc_oracle_workspace_test.sh
+++ b/test/vc_oracle_workspace_test.sh
@@ -54,6 +54,39 @@ oracle() {
   fi
 }
 
+# Both engines must reject the script with a clean non-crash error.
+oracle_error() {
+  local name="$1" setup="$2"
+  local dir="$TMPROOT/${name}_err"
+  mkdir -p "$dir/dl" "$dir/dt"
+
+  local dl_rc
+  vc_oracle_run_doltlite_script "$dir/dl/db" "$dir/dl.out" "$dir/dl.err" "$setup"
+  dl_rc=$?
+
+  local dolt_setup
+  dolt_setup=$(echo "$setup" | translate_for_dolt)
+  local dt_rc
+  vc_oracle_run_dolt_script_for_error "$dir/dt" "$dir/dt.out" "$dir/dt.err" "$dolt_setup"
+  dt_rc=$?
+
+  if vc_oracle_is_clean_error "$dl_rc" && vc_oracle_is_clean_error "$dt_rc"; then
+    pass=$((pass+1))
+  else
+    fail=$((fail+1))
+    FAILED_NAMES="$FAILED_NAMES $name"
+    echo "  FAIL: $name (expected both to error)"
+    echo "    doltlite rc: $dl_rc"
+    echo "    dolt rc:     $dt_rc"
+    if [ -s "$dir/dl.err" ]; then
+      echo "    doltlite err:"; sed 's/^/      /' "$dir/dl.err"
+    fi
+    if [ -s "$dir/dt.err" ]; then
+      echo "    dolt err:"; sed 's/^/      /' "$dir/dt.err"
+    fi
+  fi
+}
+
 echo "=== Version Control Oracle Tests: dolt_workspace tables ==="
 echo ""
 
@@ -485,6 +518,89 @@ UPDATE dolt_workspace_t SET staged=TRUE WHERE to_id IN (1,2);
 SELECT dolt_commit('-m','range');
 " "SELECT CONCAT('R|RNG|', id, '|', v) FROM t WHERE v BETWEEN 15 AND 30 ORDER BY v, id;"
 
+# --- DELETE FROM dolt_workspace_* (discard unstaged working edits) ---
+
+oracle "workspace_delete_discards_insert" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, val INT);
+SELECT dolt_commit('-A','-m','seed empty');
+INSERT INTO t VALUES(42,42),(43,43);
+DELETE FROM dolt_workspace_t WHERE to_id=42;
+" "SELECT CONCAT('R|DATA|', id, '|', val) FROM t ORDER BY id;
+SELECT CONCAT('R|WS|', staged, '|', diff_type, '|', IFNULL(to_id,''), '|', IFNULL(to_val,''))
+  FROM dolt_workspace_t ORDER BY to_id;"
+
+oracle "workspace_delete_restores_removed" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, val INT);
+INSERT INTO t VALUES(42,42),(43,43);
+SELECT dolt_commit('-A','-m','seed');
+DELETE FROM t;
+DELETE FROM dolt_workspace_t WHERE from_id=42;
+" "SELECT CONCAT('R|DATA|', id, '|', val) FROM t ORDER BY id;
+SELECT CONCAT('R|WS|', staged, '|', diff_type, '|', IFNULL(from_id,''), '|', IFNULL(from_val,''))
+  FROM dolt_workspace_t ORDER BY from_id;"
+
+oracle "workspace_delete_reverts_modify" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, val INT);
+INSERT INTO t VALUES(42,42),(43,43);
+SELECT dolt_commit('-A','-m','seed');
+UPDATE t SET val=val*2;
+DELETE FROM dolt_workspace_t WHERE to_id=42;
+" "SELECT CONCAT('R|DATA|', id, '|', val) FROM t ORDER BY id;
+SELECT CONCAT('R|WS|', staged, '|', diff_type, '|', to_id, '|', to_val, '|', from_val)
+  FROM dolt_workspace_t ORDER BY to_id;"
+
+oracle "workspace_delete_after_unstage" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, val INT);
+SELECT dolt_commit('-A','-m','seed empty');
+INSERT INTO t VALUES(42,42),(43,43);
+SELECT dolt_add('t');
+UPDATE dolt_workspace_t SET staged=FALSE WHERE to_id=42;
+DELETE FROM dolt_workspace_t WHERE to_id=42;
+" "SELECT CONCAT('R|DATA|', id, '|', val) FROM t ORDER BY id;
+SELECT CONCAT('R|WS|', staged, '|', diff_type, '|', to_id, '|', to_val)
+  FROM dolt_workspace_t ORDER BY to_id;"
+
+oracle "workspace_delete_all_unstaged_modifies" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, val INT);
+INSERT INTO t VALUES(1,10),(2,20),(3,30);
+SELECT dolt_commit('-A','-m','seed');
+UPDATE t SET val=val+1;
+DELETE FROM dolt_workspace_t;
+" "SELECT CONCAT('R|DATA|', id, '|', val) FROM t ORDER BY id;
+SELECT CONCAT('R|WS|', count(*)) FROM dolt_workspace_t;"
+
+oracle "workspace_delete_index_reverts_modify" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+CREATE INDEX idx_t_v ON t(v);
+INSERT INTO t VALUES(1,1),(2,2);
+SELECT dolt_commit('-A','-m','seed');
+UPDATE t SET v=99 WHERE id=1;
+DELETE FROM dolt_workspace_t WHERE to_id=1;
+" "SELECT CONCAT('R|DATA|', id, '|', v) FROM t ORDER BY id;
+SELECT CONCAT('R|IDX_OLD|', id, '|', v) FROM t WHERE v=1 ORDER BY id;
+SELECT CONCAT('R|IDX_NEW|', id, '|', v) FROM t WHERE v=99 ORDER BY id;
+SELECT CONCAT('R|WS|', count(*)) FROM dolt_workspace_t;"
+
+oracle "workspace_delete_mixed_keep_other_types" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, val INT);
+INSERT INTO t VALUES(1,10),(2,20),(3,30);
+SELECT dolt_commit('-A','-m','seed');
+UPDATE t SET val=200 WHERE id=2;
+DELETE FROM t WHERE id=3;
+INSERT INTO t VALUES(5,50);
+DELETE FROM dolt_workspace_t WHERE diff_type='modified';
+" "SELECT CONCAT('R|DATA|', id, '|', val) FROM t ORDER BY id;
+SELECT CONCAT('R|WS|', staged, '|', diff_type, '|', IFNULL(to_id,''), '|', IFNULL(from_id,''))
+  FROM dolt_workspace_t
+ ORDER BY diff_type, IFNULL(to_id, from_id);"
+
+oracle_error "workspace_delete_staged_rejected" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, val INT);
+SELECT dolt_commit('-A','-m','seed empty');
+INSERT INTO t VALUES(42,42);
+SELECT dolt_add('t');
+DELETE FROM dolt_workspace_t WHERE to_id=42;
+"
 
 echo ""
 echo "=== Results: $pass passed, $fail failed ==="


### PR DESCRIPTION
## Summary

Implements `DELETE FROM dolt_workspace_<table>` (P3 from the storage review).

Matches Dolt semantics:

- **Unstaged rows only** — discards the working-set edit and restores the staged/HEAD side of that PK
  - `added` → remove the new working row
  - `removed` → re-insert the deleted row
  - `modified` → write the old value back
- **Staged rows** rejected with `cannot delete staged rows from workspace` (unstage first)
- Uses `doltliteApplyRawRowMutation` so secondary indexes stay consistent

Also updates the README note that previously said DELETE was unimplemented.

## Test plan

- [x] `make doltlite`
- [x] `bash test/doltlite_workspace.sh` — 18 passed (includes discard insert/delete/modify, staged reject, unstage-then-delete, index integrity)
- [x] `bash test/vc_oracle_workspace_test.sh ./build/doltlite` — 42 passed, 0 failed