### PR TITLE
Propagate rebase read and recovery errors

### DIFF
--- a/src/doltlite_rebase.c
+++ b/src/doltlite_rebase.c
@@ -497,12 +497,18 @@ static int rebaseReadPlan(sqlite3 *db, RebasePlanRow **paPlan, int *pnPlan){
         (const char*)sqlite3_column_text(pStmt, 3));
     if( !r->zAction || !r->zCommitMessage ){
       rc = SQLITE_NOMEM;
+      sqlite3_free(r->zAction);
+      sqlite3_free(r->zCommitMessage);
       goto fail;
     }
     nPlan++;
+    if( sqlite3FaultSim(951) ){
+      rc = SQLITE_IOERR;
+      break;
+    }
   }
+  if( rc!=SQLITE_DONE ) goto fail;
   sqlite3_finalize(pStmt);
-  if( rc==SQLITE_DONE ) rc = SQLITE_OK;
 
   *paPlan = aPlan;
   *pnPlan = nPlan;
@@ -527,6 +533,7 @@ static int rebaseRestoreBranchState(sqlite3 *db, const char *zBranch){
   int rc;
 
   if( !cs || !zBranch || !zBranch[0] ) return SQLITE_ERROR;
+  if( sqlite3FaultSim(952) ) return SQLITE_IOERR;
   rc = chunkStoreFindBranch(cs, zBranch, &headHash);
   if( rc!=SQLITE_OK ) return rc;
   rc = doltliteLoadCommit(db, &headHash, &headCommit);
@@ -765,54 +772,93 @@ static int rebaseDeleteWorkingBranchRefs(sqlite3 *db, ChunkStore *cs, void *pArg
   return chunkStoreDeleteBranch(cs, zWorkingBranch);
 }
 
-static void rebaseDiscardWorkingBranch(
+static void rebaseKeepFirstError(int *pRc, int rc){
+  if( *pRc==SQLITE_OK && rc!=SQLITE_OK ) *pRc = rc;
+}
+
+static void rebaseResultRecoveryFailure(sqlite3_context *context, int rc){
+  sqlite3_result_error(context,
+    "rebase recovery failed — pre-rebase state may not have been fully restored",
+    -1);
+  sqlite3_result_error_code(context, rc);
+}
+
+static int rebaseDiscardWorkingBranch(
   sqlite3 *db,
   const char *zOrigBranch,
   const char *zWorkingBranch
 ){
   ChunkStore *cs = doltliteGetChunkStore(db);
+  int rc = SQLITE_OK;
+  int rc2;
 
-  (void)sqlite3_exec(db, "DROP TABLE IF EXISTS main.dolt_rebase", 0, 0, 0);
+  rc2 = sqlite3FaultSim(953) ? SQLITE_IOERR :
+      sqlite3_exec(db, "DROP TABLE IF EXISTS main.dolt_rebase", 0, 0, 0);
+  rebaseKeepFirstError(&rc, rc2);
   doltliteClearSessionRebaseState(db);
-  (void)doltlitePersistWorkingSet(db);
+  rc2 = doltlitePersistWorkingSet(db);
+  rebaseKeepFirstError(&rc, rc2);
 
   if( zOrigBranch && zOrigBranch[0] ){
-    if( doltliteCheckoutBranchForRebase(db, zOrigBranch)!=SQLITE_OK ){
-      (void)rebaseRestoreBranchState(db, zOrigBranch);
+    rc2 = doltliteCheckoutBranchForRebase(db, zOrigBranch);
+    if( rc2!=SQLITE_OK ){
+      rc2 = rebaseRestoreBranchState(db, zOrigBranch);
+      rebaseKeepFirstError(&rc, rc2);
     }
   }
   if( cs && zWorkingBranch && zWorkingBranch[0] ){
-    (void)chunkStoreDeleteBranch(cs, zWorkingBranch);
-    (void)chunkStoreSerializeRefs(cs);
-    (void)chunkStoreCommit(cs);
-    (void)doltlitePersistWorkingSet(db);
+    rc2 = chunkStoreDeleteBranch(cs, zWorkingBranch);
+    if( rc2==SQLITE_NOTFOUND ) rc2 = SQLITE_OK;
+    rebaseKeepFirstError(&rc, rc2);
+    rc2 = chunkStoreSerializeRefs(cs);
+    rebaseKeepFirstError(&rc, rc2);
+    if( rc2==SQLITE_OK ){
+      rc2 = chunkStoreCommit(cs);
+      rebaseKeepFirstError(&rc, rc2);
+    }
+    rc2 = doltlitePersistWorkingSet(db);
+    rebaseKeepFirstError(&rc, rc2);
   }
+  return rc;
 }
 
-static void rebaseAbortConflictedContinue(
+static int rebaseAbortConflictedContinue(
   sqlite3 *db,
   const char *zOrigBranch,
   const char *zReturnBranch,
   const char *zWorkingBranch
 ){
   ChunkStore *cs = doltliteGetChunkStore(db);
+  int rc = SQLITE_OK;
+  int rc2;
 
-  (void)sqlite3_exec(db, "DROP TABLE IF EXISTS main.dolt_rebase", 0, 0, 0);
+  rc2 = sqlite3_exec(db, "DROP TABLE IF EXISTS main.dolt_rebase", 0, 0, 0);
+  rebaseKeepFirstError(&rc, rc2);
   doltliteClearSessionRebaseState(db);
   doltliteClearSessionMergeState(db);
   if( zOrigBranch && zOrigBranch[0] ){
-    (void)rebaseRestoreBranchState(db, zOrigBranch);
+    rc2 = rebaseRestoreBranchState(db, zOrigBranch);
+    rebaseKeepFirstError(&rc, rc2);
     doltliteClearSessionRebaseState(db);
   }
   if( cs && zReturnBranch && zReturnBranch[0] ){
-    (void)rebaseRestoreReturnBranchWorkingState(db, zReturnBranch);
+    rc2 = rebaseRestoreReturnBranchWorkingState(db, zReturnBranch);
+    rebaseKeepFirstError(&rc, rc2);
   }
   if( cs && zWorkingBranch && zWorkingBranch[0] ){
-    (void)chunkStoreDeleteBranch(cs, zWorkingBranch);
-    (void)chunkStoreSerializeRefs(cs);
-    (void)chunkStoreCommit(cs);
-    (void)doltlitePersistWorkingSet(db);
+    rc2 = chunkStoreDeleteBranch(cs, zWorkingBranch);
+    if( rc2==SQLITE_NOTFOUND ) rc2 = SQLITE_OK;
+    rebaseKeepFirstError(&rc, rc2);
+    rc2 = chunkStoreSerializeRefs(cs);
+    rebaseKeepFirstError(&rc, rc2);
+    if( rc2==SQLITE_OK ){
+      rc2 = chunkStoreCommit(cs);
+      rebaseKeepFirstError(&rc, rc2);
+    }
+    rc2 = doltlitePersistWorkingSet(db);
+    rebaseKeepFirstError(&rc, rc2);
   }
+  return rc;
 }
 
 static void doltliteRebaseInteractiveStart(
@@ -954,7 +1000,11 @@ static void doltliteRebaseInteractiveStart(
 
 fail:
   if( bWorkingBranchCreated ){
-    rebaseDiscardWorkingBranch(db, zOrig, zWorking);
+    int recoveryRc = rebaseDiscardWorkingBranch(db, zOrig, zWorking);
+    if( recoveryRc!=SQLITE_OK ){
+      rc = recoveryRc;
+      zFailMsg = 0;
+    }
   }
   sqlite3_free(zOrig);
   sqlite3_free(zReturnBranch);
@@ -979,6 +1029,7 @@ static void doltliteRebaseInteractiveAbort(
   char *zOrigBranch = 0;
   char *zWorking = 0;
   int rc;
+  int rc2;
 
   doltliteGetSessionRebaseState(db, &isRebasing, 0, 0,
                                 &zOrigBranchConst, &zReturnBranchConst);
@@ -997,32 +1048,21 @@ static void doltliteRebaseInteractiveAbort(
     return;
   }
 
-  rebaseDiscardWorkingBranch(db, zOrigBranch, zWorking);
+  rc = rebaseDiscardWorkingBranch(db, zOrigBranch, zWorking);
   if( cs && zReturnBranch && zReturnBranch[0] ){
-    rc = rebaseRestoreReturnBranchWorkingState(db, zReturnBranch);
-    if( rc!=SQLITE_OK ){
-      sqlite3_free(zReturnBranch);
-      sqlite3_free(zWorking);
-      sqlite3_free(zOrigBranch);
-      sqlite3_result_error_code(context, rc);
-      return;
-    }
+    rc2 = rebaseRestoreReturnBranchWorkingState(db, zReturnBranch);
+    rebaseKeepFirstError(&rc, rc2);
   }
-  rc = doltlitePersistWorkingSet(db);
-  if( rc!=SQLITE_OK ){
-    sqlite3_free(zReturnBranch);
-    sqlite3_free(zWorking);
-    sqlite3_free(zOrigBranch);
-    sqlite3_result_error_code(context, rc);
-    return;
-  }
+  rc2 = doltlitePersistWorkingSet(db);
+  rebaseKeepFirstError(&rc, rc2);
 
-  rc = doltliteVcSealBranchStyleTxn(db);
+  rc2 = doltliteVcSealBranchStyleTxn(db);
+  rebaseKeepFirstError(&rc, rc2);
   if( rc!=SQLITE_OK ){
     sqlite3_free(zReturnBranch);
     sqlite3_free(zWorking);
     sqlite3_free(zOrigBranch);
-    sqlite3_result_error_code(context, rc);
+    rebaseResultRecoveryFailure(context, rc);
     return;
   }
 
@@ -1046,6 +1086,8 @@ static void doltliteRebaseInteractiveContinue(
   RebasePlanRow *aPlan = 0;
   int nPlan = 0;
   int rc;
+  int rc2;
+  int recoveryRc;
   int i;
   int bPlanDropped = 0;
   int bSkipConstraintDetect = (!db->autoCommit || db->pSavepoint!=0);
@@ -1169,29 +1211,47 @@ static void doltliteRebaseInteractiveContinue(
 
 abort_err_conflict:
   rebaseFreePlan(aPlan, nPlan);
-  rebaseAbortConflictedContinue(db, zOrigBranch, zReturnBranch, zWorking);
+  recoveryRc = rebaseAbortConflictedContinue(
+      db, zOrigBranch, zReturnBranch, zWorking);
   if( doltliteVcTxnMode(db)==DOLTLITE_VC_TXN_AUTOCOMMIT_LIKE ){
     (void)sqlite3_exec(db, "COMMIT", 0, 0, 0);
   }
   sqlite3_free(zOrigBranch);
   sqlite3_free(zReturnBranch);
   sqlite3_free(zWorking);
-  sqlite3_result_error(context,
-    "data conflicts from rebase — rebase has been aborted", -1);
+  if( recoveryRc!=SQLITE_OK ){
+    rebaseResultRecoveryFailure(context, recoveryRc);
+  }else{
+    sqlite3_result_error(context,
+      "data conflicts from rebase — rebase has been aborted", -1);
+  }
   return;
 
 abort_err:
   rebaseFreePlan(aPlan, nPlan);
-  if( bPlanDropped ){
-    rebaseDiscardWorkingBranch(db, zOrigBranch ? zOrigBranch : "main", zWorking);
-    if( cs && zReturnBranch && zReturnBranch[0] ){
-      (void)rebaseRestoreReturnBranchWorkingState(db, zReturnBranch);
-    }
+  if( !bPlanDropped ){
+    sqlite3_free(zOrigBranch);
+    sqlite3_free(zReturnBranch);
+    sqlite3_free(zWorking);
+    sqlite3_result_error(context, "rebase failed", -1);
+    return;
+  }
+  recoveryRc = SQLITE_OK;
+  recoveryRc = rebaseDiscardWorkingBranch(
+      db, zOrigBranch ? zOrigBranch : "main", zWorking);
+  if( cs && zReturnBranch && zReturnBranch[0] ){
+    rc2 = rebaseRestoreReturnBranchWorkingState(db, zReturnBranch);
+    rebaseKeepFirstError(&recoveryRc, rc2);
   }
   sqlite3_free(zOrigBranch);
   sqlite3_free(zReturnBranch);
   sqlite3_free(zWorking);
-  sqlite3_result_error(context, "rebase failed — branch restored to pre-rebase state", -1);
+  if( recoveryRc!=SQLITE_OK ){
+    rebaseResultRecoveryFailure(context, recoveryRc);
+  }else{
+    sqlite3_result_error(context,
+      "rebase failed — branch restored to pre-rebase state", -1);
+  }
   return;
 
 abort_err_silent:

--- a/test/doltlite_rebase.sh
+++ b/test/doltlite_rebase.sh
@@ -53,7 +53,7 @@ run_test_match "invalid_plan_continue_errors" \
   "SELECT dolt_rebase('-i', 'main');
    UPDATE dolt_rebase SET action = 'oops' WHERE commit_message = 'f1';
    SELECT dolt_rebase('--continue');" \
-  "rebase failed — branch restored to pre-rebase state|no rebase in progress" \
+  "rebase failed|no rebase in progress" \
   "$DB"
 run_test "invalid_plan_branch_preserved" \
   "SELECT active_branch();" \

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -616,6 +616,16 @@ static int gFailHits = 0;
 static int gFailFullPathnameHits = 0;
 static const char *gFullPathnameSuffix = 0;
 static char gRewrittenFullPath[512];
+static int gRebaseFaultCode = 0;
+static int gRebaseFaultHits = 0;
+
+static int rebaseFaultCallback(int iCode){
+  if( iCode==gRebaseFaultCode ){
+    gRebaseFaultHits++;
+    return 1;
+  }
+  return 0;
+}
 
 static int failAccess(sqlite3_vfs *pVfs, const char *zName, int flags, int *pResOut);
 static int failFullPathname(sqlite3_vfs *pVfs, const char *zName, int nOut, char *zOut);
@@ -5682,6 +5692,134 @@ static void run_rebase_temp_shadow_ignored(void){
   removeDbFiles(dbpath);
 }
 
+static void run_rebase_plan_read_error_is_not_partial(void){
+  sqlite3 *db = 0;
+  char dbpath[256];
+  const char *res;
+
+  printf("=== Rebase Plan Read Error Is Not Partial Test ===\n\n");
+  make_dbpath(dbpath, sizeof(dbpath), "test_rebase_plan_read_error");
+  removeDbFiles(dbpath);
+
+  check("open_db_for_rebase_plan_read_error", open_db(dbpath, &db)==SQLITE_OK);
+  check("setup_repo_for_rebase_plan_read_error", execSql(db,
+    "CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);"
+    "INSERT INTO t VALUES (1, 1);"
+    "SELECT dolt_commit('-A', '-m', 'init');"
+    "SELECT dolt_checkout('-b', 'feat');"
+    "INSERT INTO t VALUES (2, 2);"
+    "SELECT dolt_commit('-A', '-m', 'f1');"
+    "INSERT INTO t VALUES (3, 3);"
+    "SELECT dolt_commit('-A', '-m', 'f2');"
+    "SELECT dolt_checkout('main');"
+    "INSERT INTO t VALUES (10, 10);"
+    "SELECT dolt_commit('-A', '-m', 'm1');"
+    "SELECT dolt_checkout('feat');")==SQLITE_OK);
+  check("start_interactive_rebase_for_plan_read_error",
+        strstr(queryScalarText(db, "SELECT dolt_rebase('-i', 'main')"),
+               "interactive rebase started")!=0);
+
+  gRebaseFaultCode = 951;
+  gRebaseFaultHits = 0;
+  sqlite3_test_control(SQLITE_TESTCTRL_FAULT_INSTALL, rebaseFaultCallback);
+  res = queryScalarText(db, "SELECT dolt_rebase('--continue')");
+  sqlite3_test_control(SQLITE_TESTCTRL_FAULT_INSTALL, 0);
+  gRebaseFaultCode = 0;
+
+  check("rebase_plan_read_error_was_injected", gRebaseFaultHits==1);
+  check("rebase_plan_read_error_is_returned",
+        strstr(res, "ERROR: rebase failed")!=0);
+  check("rebase_plan_read_error_does_not_claim_restoration",
+        strstr(res, "branch restored to pre-rebase state")==0);
+  check("rebase_plan_read_error_keeps_working_branch",
+        strcmp(queryScalarText(db, "SELECT active_branch()"),
+               "dolt_rebase_feat")==0);
+  check("rebase_plan_read_error_keeps_full_plan",
+        strcmp(queryScalarText(db, "SELECT count(*) FROM dolt_rebase"), "2")==0);
+  check("rebase_plan_read_error_can_abort",
+        strcmp(queryScalarText(db, "SELECT dolt_rebase('--abort')"),
+               "Interactive rebase aborted")==0);
+
+  sqlite3_close(db);
+  removeDbFiles(dbpath);
+}
+
+static void run_rebase_recovery_failure_is_reported(void){
+  sqlite3 *db = 0;
+  char dbpath[256];
+  const char *res;
+
+  printf("=== Rebase Recovery Failure Is Reported Test ===\n\n");
+  make_dbpath(dbpath, sizeof(dbpath), "test_rebase_recovery_failure");
+  removeDbFiles(dbpath);
+
+  check("open_db_for_rebase_recovery_failure", open_db(dbpath, &db)==SQLITE_OK);
+  check("setup_repo_for_rebase_recovery_failure", execSql(db,
+    "CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);"
+    "INSERT INTO t VALUES (1, 1);"
+    "SELECT dolt_commit('-A', '-m', 'init');"
+    "SELECT dolt_checkout('-b', 'feat');"
+    "UPDATE t SET v=2 WHERE id=1;"
+    "SELECT dolt_commit('-A', '-m', 'f1');"
+    "SELECT dolt_checkout('main');"
+    "UPDATE t SET v=3 WHERE id=1;"
+    "SELECT dolt_commit('-A', '-m', 'm1');"
+    "SELECT dolt_checkout('feat');")==SQLITE_OK);
+  check("start_interactive_rebase_for_recovery_failure",
+        strstr(queryScalarText(db, "SELECT dolt_rebase('-i', 'main')"),
+               "interactive rebase started")!=0);
+
+  gRebaseFaultCode = 952;
+  gRebaseFaultHits = 0;
+  sqlite3_test_control(SQLITE_TESTCTRL_FAULT_INSTALL, rebaseFaultCallback);
+  res = queryScalarText(db, "SELECT dolt_rebase('--continue')");
+  sqlite3_test_control(SQLITE_TESTCTRL_FAULT_INSTALL, 0);
+  gRebaseFaultCode = 0;
+
+  check("rebase_recovery_failure_was_injected", gRebaseFaultHits==1);
+  check("rebase_recovery_failure_is_returned",
+        strstr(res, "ERROR: rebase recovery failed")!=0);
+  check("rebase_recovery_failure_does_not_claim_restoration",
+        strstr(res, "branch restored to pre-rebase state")==0);
+
+  sqlite3_close(db);
+  db = 0;
+  removeDbFiles(dbpath);
+
+  check("open_db_for_rebase_abort_recovery_failure",
+        open_db(dbpath, &db)==SQLITE_OK);
+  check("setup_repo_for_rebase_abort_recovery_failure", execSql(db,
+    "CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);"
+    "INSERT INTO t VALUES (1, 1);"
+    "SELECT dolt_commit('-A', '-m', 'init');"
+    "SELECT dolt_checkout('-b', 'feat');"
+    "INSERT INTO t VALUES (2, 2);"
+    "SELECT dolt_commit('-A', '-m', 'f1');"
+    "SELECT dolt_checkout('main');"
+    "INSERT INTO t VALUES (3, 3);"
+    "SELECT dolt_commit('-A', '-m', 'm1');"
+    "SELECT dolt_checkout('feat');")==SQLITE_OK);
+  check("start_interactive_rebase_for_abort_recovery_failure",
+        strstr(queryScalarText(db, "SELECT dolt_rebase('-i', 'main')"),
+               "interactive rebase started")!=0);
+
+  gRebaseFaultCode = 953;
+  gRebaseFaultHits = 0;
+  sqlite3_test_control(SQLITE_TESTCTRL_FAULT_INSTALL, rebaseFaultCallback);
+  res = queryScalarText(db, "SELECT dolt_rebase('--abort')");
+  sqlite3_test_control(SQLITE_TESTCTRL_FAULT_INSTALL, 0);
+  gRebaseFaultCode = 0;
+
+  check("rebase_abort_recovery_failure_was_injected", gRebaseFaultHits==1);
+  check("rebase_abort_recovery_failure_is_returned",
+        strstr(res, "ERROR: rebase recovery failed")!=0);
+  check("rebase_abort_recovery_failure_does_not_report_success",
+        strstr(res, "Interactive rebase aborted")==0);
+
+  sqlite3_close(db);
+  removeDbFiles(dbpath);
+}
+
 static void run_rebase_continue_conflict_abort_restores_durable_state(void){
   sqlite3 *db = 0;
   char dbpath[256];
@@ -8245,6 +8383,8 @@ static const RegressionCase aCases[] = {
   { "merge_abort_after_reopen_restores_durable_state", "Merge Abort After Reopen Restores Durable State Test", run_merge_abort_after_reopen_restores_durable_state },
   { "rebase_continue_without_active_preserves_durable_state", "Rebase Continue Without Active Preserves Durable State Test", run_rebase_continue_without_active_preserves_durable_state },
   { "rebase_abort_after_reopen_restores_durable_state", "Rebase Abort After Reopen Restores Durable State Test", run_rebase_abort_after_reopen_restores_durable_state },
+  { "rebase_plan_read_error_is_not_partial", "Rebase Plan Read Error Is Not Partial Test", run_rebase_plan_read_error_is_not_partial },
+  { "rebase_recovery_failure_is_reported", "Rebase Recovery Failure Is Reported Test", run_rebase_recovery_failure_is_reported },
   { "rebase_continue_conflict_abort_restores_durable_state", "Rebase Continue Conflict Abort Restores Durable State Test", run_rebase_continue_conflict_abort_restores_durable_state },
   { "rebase_main_table_schema_guard", "Rebase Main Table Schema Guard Test", run_rebase_main_table_schema_guard },
   { "rebase_temp_shadow_ignored", "Rebase Temp Shadow Ignored Test", run_rebase_temp_shadow_ignored },


### PR DESCRIPTION
## Summary
- reject interrupted or failed `dolt_rebase` plan reads instead of replaying a partial plan
- make rebase cleanup helpers retain the first restoration/persistence error while continuing best-effort cleanup
- only report that the pre-rebase branch was restored when recovery actually succeeds
- add fault-injection coverage for plan reads, conflicted-continue restoration, and explicit abort cleanup

## Tests
- `DOLTLITE_BUILD_DIR="$PWD" bash test/doltlite_regression_test_c.sh` (309,899 passed)
- `DOLTLITE=./doltlite bash test/doltlite_rebase.sh` (8 passed)
- `bash test/vc_oracle_rebase_test.sh ./doltlite dolt` (47 passed)
- `make lint`
- `bash test/dead_code_check.sh`
- `bash test/assert_doltlite_artifacts.sh .`

## Local devtest note
`make devtest` now builds all 10 configurations after correcting the local Homebrew Tcl/libtommath search path. It continues to hit existing fuzz/session `cursorHoldsMutex` / write-transaction assertions. The focused, full DoltLite regression, oracle, lint, dead-code, and artifact checks above pass.