### PR TITLE
Assert mutmap, staging, GC, and VC core invariants

### DIFF
--- a/src/chunk_index.c
+++ b/src/chunk_index.c
@@ -10,21 +10,32 @@
 #include <limits.h>
 
 void chunkIndexGetEntries(const ChunkIndex *idx, int *pn, const ChunkIndexEntry **par){
+  assert( idx!=0 && pn!=0 && par!=0 );
+  assert( idx->nIndex>=0 );
+  assert( idx->nIndex==0 || idx->aIndex!=0 );
   *pn = idx->nIndex;
   *par = idx->aIndex;
 }
 
 int chunkIndexCount(const ChunkIndex *idx){
+  assert( idx!=0 );
+  assert( idx->nIndex>=0 );
   return idx->nIndex;
 }
 
 void chunkIndexSetMetadata(ChunkIndex *idx, int nChunks, i64 iOffset, i64 nSize){
+  assert( idx!=0 );
+  assert( nChunks>=0 );
+  assert( iOffset>=0 && nSize>=0 );
   idx->nChunks = nChunks;
   idx->iIndexOffset = iOffset;
   idx->nIndexSize = nSize;
 }
 
 void chunkIndexReplaceEntries(ChunkIndex *idx, ChunkIndexEntry *aNew, int nNew){
+  assert( idx!=0 );
+  assert( nNew>=0 );
+  assert( nNew==0 || aNew!=0 );
   csReleaseIndexBuf(idx->aIndex, idx->aIndexMmapBase, idx->aIndexMmapSize);
   idx->aIndex = aNew;
   idx->nIndex = nNew;
@@ -46,6 +57,9 @@ int csSearchIndex(
 ){
   int lo = 0;
   int hi = nIdx - 1;
+  assert( pHash!=0 );
+  assert( nIdx>=0 );
+  assert( nIdx==0 || aIdx!=0 );
   while( lo <= hi ){
     int mid = lo + (hi - lo) / 2;
     int cmp = prollyHashCompare(&aIdx[mid].hash, pHash);

--- a/src/chunk_refs.c
+++ b/src/chunk_refs.c
@@ -8,6 +8,8 @@
 int csFindNamedRef(const void *aBase, int n, int stride, const char *zName){
   const char *p = (const char*)aBase;
   int i;
+  assert( n>=0 && stride>0 );
+  assert( n==0 || aBase!=0 );
   if( !zName ) return -1;
   for(i=0; i<n; i++){
     const char *zHave = *(const char *const*)(p + (size_t)i*stride);
@@ -17,7 +19,10 @@ int csFindNamedRef(const void *aBase, int n, int stride, const char *zName){
 }
 
 int csRefArrayGrow(void **paBase, int n, int stride){
-  void *aNew = sqlite3_realloc(*paBase, (n+1)*stride);
+  void *aNew;
+  assert( paBase!=0 );
+  assert( n>=0 && stride>0 );
+  aNew = sqlite3_realloc(*paBase, (n+1)*stride);
   if( !aNew ) return SQLITE_NOMEM;
   *paBase = aNew;
   memset((char*)aNew + (size_t)n*stride, 0, stride);
@@ -25,26 +30,41 @@ int csRefArrayGrow(void **paBase, int n, int stride){
 }
 
 void refsTableGetBranches(const RefsTable *rt, int *pn, const BranchRef **par){
+  assert( rt!=0 && pn!=0 && par!=0 );
+  assert( rt->nBranches>=0 );
+  assert( rt->nBranches==0 || rt->aBranches!=0 );
   *pn = rt->nBranches;
   *par = rt->aBranches;
 }
 
 void refsTableGetTags(const RefsTable *rt, int *pn, const TagRef **par){
+  assert( rt!=0 && pn!=0 && par!=0 );
+  assert( rt->nTags>=0 );
+  assert( rt->nTags==0 || rt->aTags!=0 );
   *pn = rt->nTags;
   *par = rt->aTags;
 }
 
 void refsTableGetRemotes(const RefsTable *rt, int *pn, const RemoteRef **par){
+  assert( rt!=0 && pn!=0 && par!=0 );
+  assert( rt->nRemotes>=0 );
+  assert( rt->nRemotes==0 || rt->aRemotes!=0 );
   *pn = rt->nRemotes;
   *par = rt->aRemotes;
 }
 
 void refsTableGetTracking(const RefsTable *rt, int *pn, const TrackingBranch **par){
+  assert( rt!=0 && pn!=0 && par!=0 );
+  assert( rt->nTracking>=0 );
+  assert( rt->nTracking==0 || rt->aTracking!=0 );
   *pn = rt->nTracking;
   *par = rt->aTracking;
 }
 
 void refsTableGetSequences(const RefsTable *rt, int *pn, const SequenceRef **par){
+  assert( rt!=0 && pn!=0 && par!=0 );
+  assert( rt->nSequences>=0 );
+  assert( rt->nSequences==0 || rt->aSequences!=0 );
   *pn = rt->nSequences;
   *par = rt->aSequences;
 }
@@ -72,6 +92,7 @@ int refsTableRemoteCount(const RefsTable *rt){
 }
 
 void refsTableSetHash(RefsTable *rt, const ProllyHash *h){
+  assert( rt!=0 && h!=0 );
   memcpy(&rt->refsHash, h, sizeof(ProllyHash));
 }
 

--- a/src/chunk_staging.c
+++ b/src/chunk_staging.c
@@ -13,11 +13,16 @@
 #define CS_RECENT_HT_MIN_COUNT 64
 
 void chunkStagingGetPending(const ChunkStaging *st, int *pn, const ChunkIndexEntry **par){
+  assert( st!=0 && pn!=0 && par!=0 );
+  assert( st->nPending>=0 && st->nPending<=st->nPendingAlloc );
   *pn = st->nPending;
   *par = st->aPending;
 }
 
 void chunkStagingGetRecent(const ChunkStaging *st, int *pn, const ChunkIndexEntry **par){
+  assert( st!=0 && pn!=0 && par!=0 );
+  assert( st->nRecent>=0 && st->nRecent<=st->nRecentAlloc );
+  assert( st->nRecentUncommitted>=0 && st->nRecentUncommitted<=st->nRecent );
   *pn = st->nRecent;
   *par = st->aRecent;
 }
@@ -141,6 +146,8 @@ static int csPendHTEnsure(ChunkStore *cs){
 
 int csSearchPending(ChunkStore *cs, const ProllyHash *pHash, int *pIdx){
   int i; u32 b; int rc;
+  assert( cs!=0 && pHash!=0 && pIdx!=0 );
+  assert( cs->staging.nPending>=0 && cs->staging.nPending<=cs->staging.nPendingAlloc );
   *pIdx = -1;
   if( cs->staging.nPending==0 ) return SQLITE_OK;
   if( cs->staging.nPending < CS_PEND_HT_MIN_COUNT ){
@@ -213,6 +220,10 @@ static int csRecentHTEnsure(ChunkStore *cs){
 
 int csSearchRecent(ChunkStore *cs, const ProllyHash *pHash, int *pIdx){
   int i; u32 b; int rc;
+  assert( cs!=0 && pHash!=0 && pIdx!=0 );
+  assert( cs->staging.nRecent>=0 && cs->staging.nRecent<=cs->staging.nRecentAlloc );
+  assert( cs->staging.nRecentUncommitted>=0
+       && cs->staging.nRecentUncommitted<=cs->staging.nRecent );
   *pIdx = -1;
   if( cs->staging.nRecent==0 ) return SQLITE_OK;
   if( cs->staging.nRecent < CS_RECENT_HT_MIN_COUNT ){
@@ -247,6 +258,8 @@ int csSearchRecent(ChunkStore *cs, const ProllyHash *pHash, int *pIdx){
 }
 
 int csGrowPending(ChunkStore *cs){
+  assert( cs!=0 );
+  assert( cs->staging.nPending>=0 && cs->staging.nPending<=cs->staging.nPendingAlloc );
   if( cs->staging.nPending >= cs->staging.nPendingAlloc ){
     i64 nNew = cs->staging.nPendingAlloc ? (i64)cs->staging.nPendingAlloc * 2
                                          : CS_INIT_PENDING_ALLOC;
@@ -269,7 +282,11 @@ int csGrowPending(ChunkStore *cs){
 }
 
 int csGrowRecent(ChunkStore *cs, int nAdd){
-  i64 nNeed = (i64)cs->staging.nRecent + nAdd;
+  i64 nNeed;
+  assert( cs!=0 );
+  assert( nAdd>=0 );
+  assert( cs->staging.nRecent>=0 && cs->staging.nRecent<=cs->staging.nRecentAlloc );
+  nNeed = (i64)cs->staging.nRecent + nAdd;
   if( nNeed > cs->staging.nRecentAlloc ){
     i64 nNew = cs->staging.nRecentAlloc ? (i64)cs->staging.nRecentAlloc * 2
                                         : CS_INIT_PENDING_ALLOC;
@@ -293,7 +310,14 @@ int csGrowRecent(ChunkStore *cs, int nAdd){
 }
 
 int csGrowWriteBuf(ChunkStore *cs, int nNeeded){
-  i64 nRequired = cs->staging.nWriteBuf + (i64)nNeeded;
+  i64 nRequired;
+  assert( cs!=0 );
+  assert( nNeeded>=0 );
+  assert( cs->staging.nWriteBuf>=0
+       && cs->staging.nWriteBuf<=cs->staging.nWriteBufAlloc );
+  assert( cs->staging.nCommittedWriteBuf>=0
+       && cs->staging.nCommittedWriteBuf<=cs->staging.nWriteBuf );
+  nRequired = cs->staging.nWriteBuf + (i64)nNeeded;
   if( nRequired > cs->staging.nWriteBufAlloc ){
     i64 nNew = cs->staging.nWriteBufAlloc ? cs->staging.nWriteBufAlloc : CS_INIT_WRITEBUF_SIZE;
     u8 *pNew;

--- a/src/chunk_wal.c
+++ b/src/chunk_wal.c
@@ -9,22 +9,31 @@
 #include <string.h>
 
 i64 walStateGetOffset(const WalState *w){
+  assert( w!=0 );
+  assert( w->iWalOffset>=0 );
   return w->iWalOffset;
 }
 
 i64 walStateGetDataSize(const WalState *w){
+  assert( w!=0 );
+  assert( w->nWalData>=0 );
   return w->nWalData;
 }
 
 void walStateSetOffset(WalState *w, i64 iOffset){
+  assert( w!=0 );
+  assert( iOffset>=0 );
   w->iWalOffset = iOffset;
 }
 
 void walStateSetDataSize(WalState *w, i64 nData){
+  assert( w!=0 );
+  assert( nData>=0 );
   w->nWalData = nData;
 }
 
 static void csCaptureReplayState(ChunkStore *cs, ChunkStoreReplayState *pSaved){
+  assert( cs!=0 && pSaved!=0 );
   memset(pSaved, 0, sizeof(*pSaved));
   pSaved->aIndex = cs->index.aIndex;
   pSaved->nIndex = cs->index.nIndex;
@@ -214,14 +223,17 @@ int csReplayWal(ChunkStore *cs){
   i64 resumePos = 0;
   int damageAction = 0;
   int sawMidStream = 0;
-  int nPendingBefore = cs->staging.nPending;
-  int nRootedPending = cs->staging.nPending;
+  int nPendingBefore;
+  int nRootedPending;
   int nRootRecordsSeen = 0;
   int sawDamage = 0;
   ChunkStore tmpRefs;
   int haveTmpRefs = 0;
   int rc = SQLITE_OK;
 
+  assert( cs!=0 );
+  nPendingBefore = cs->staging.nPending;
+  nRootedPending = cs->staging.nPending;
   memset(&tmpRefs, 0, sizeof(tmpRefs));
 
   if( cs->wal.iWalOffset <= 0 || !cs->file.pFile ) return SQLITE_OK;

--- a/src/doltlite_add.c
+++ b/src/doltlite_add.c
@@ -108,6 +108,9 @@ int addNameIndexInit(
   struct TableEntry *aEntry,
   int nEntry
 ){
+  assert( pIdx!=0 );
+  assert( nEntry>=0 );
+  assert( nEntry==0 || aEntry!=0 );
   return doltliteNameIndexInit(pIdx, aEntry, nEntry,
                                (int)sizeof(struct TableEntry),
                                (int)offsetof(struct TableEntry, zName));

--- a/src/doltlite_branch.c
+++ b/src/doltlite_branch.c
@@ -816,6 +816,7 @@ int doltliteCheckoutBranchForRebase(sqlite3 *db, const char *zBranch){
   char *zCurrentBranch = 0;
   int rc;
 
+  assert( db!=0 && zBranch!=0 && zBranch[0]!=0 );
   if( !cs || !zBranch || branchNameEmpty(zBranch) ) return SQLITE_ERROR;
   memset(&m, 0, sizeof(m));
 

--- a/src/doltlite_cherry_pick.c
+++ b/src/doltlite_cherry_pick.c
@@ -69,7 +69,7 @@ int applyMergedCatalogAndCommit(
   int *pnConflicts,
   char *hexBuf
 ){
-  ChunkStore *cs = doltliteGetChunkStore(db);
+  ChunkStore *cs;
   DoltliteTxnState savedState;
   ProllyHash mergedCatHash;
   ProllyHash liveMergedCatHash;
@@ -80,6 +80,10 @@ int applyMergedCatalogAndCommit(
   const char *zOpLabel;
   int rc;
 
+  assert( db!=0 && context!=0 );
+  assert( ancCatHash!=0 && ourCatHash!=0 && theirCatHash!=0 );
+  assert( ourHead!=0 && zMessage!=0 && pnConflicts!=0 );
+  cs = doltliteGetChunkStore(db);
   memset(&savedState, 0, sizeof(savedState));
   if( hexBuf ) hexBuf[0] = '\0';
   bPreferOurMaster = (sqlite3_strnicmp(zMessage, "Revert", 6)==0);

--- a/src/doltlite_commit_cmd.c
+++ b/src/doltlite_commit_cmd.c
@@ -516,9 +516,14 @@ static int doltliteCommitCreateObject(
 ){
   ProllyHash parentHash;
   char *zParsedName = 0, *zParsedEmail = 0;
-  const char *zMessage = opts->zMessage;
-  const char *zAuthor = opts->zAuthor;
+  const char *zMessage;
+  const char *zAuthor;
   int rc;
+
+  assert( db!=0 && context!=0 && opts!=0 );
+  assert( pCatalogHash!=0 && pCommitHashOut!=0 );
+  zMessage = opts->zMessage;
+  zAuthor = opts->zAuthor;
   doltliteGetSessionHead(db, &parentHash);
 
   if( opts->amend ){

--- a/src/doltlite_core.c
+++ b/src/doltlite_core.c
@@ -19,13 +19,16 @@
 #include <time.h>
 
 void doltliteTxnStateClear(DoltliteTxnState *p){
+  assert( p!=0 );
   sqlite3_free(p->zSessionBranch);
   memset(p, 0, sizeof(*p));
 }
 
 int doltliteSaveTxnState(sqlite3 *db, DoltliteTxnState *p){
-  ChunkStore *cs = doltliteGetChunkStore(db);
+  ChunkStore *cs;
   int rc;
+  assert( db!=0 && p!=0 );
+  cs = doltliteGetChunkStore(db);
 
   memset(p, 0, sizeof(*p));
   if( !cs ) return SQLITE_ERROR;
@@ -53,8 +56,11 @@ int doltliteSaveTxnState(sqlite3 *db, DoltliteTxnState *p){
 }
 
 int doltliteRestoreTxnState(sqlite3 *db, DoltliteTxnState *p){
-  ChunkStore *cs = doltliteGetChunkStore(db);
+  ChunkStore *cs;
   int rc;
+  assert( db!=0 && p!=0 );
+  assert( p->zSessionBranch!=0 );
+  cs = doltliteGetChunkStore(db);
 
   if( !cs ) return SQLITE_ERROR;
 
@@ -99,6 +105,7 @@ int doltliteRefreshAndConfirmHead(
   ProllyHash branchTip;
   int found = 0;
   int rc;
+  assert( db!=0 && cs!=0 && pExpectedHead!=0 );
 
   rc = chunkStoreLockAndRefresh(cs);
   if( rc!=SQLITE_OK ) return rc;
@@ -355,11 +362,16 @@ int doltliteCreateAndStoreCommitWithTime(
   i64 explicitTimestamp,
   ProllyHash *pCommitHash
 ){
-  ChunkStore *cs = doltliteGetChunkStore(db);
+  ChunkStore *cs;
   DoltliteCommit c;
   u8 *commitData = 0;
   int nCommitData = 0;
   int rc, i;
+  assert( db!=0 && pParent!=0 && pCatalog!=0 && pCommitHash!=0 );
+  assert( nExtraParents>=0 );
+  assert( nExtraParents==0 || aExtraParents!=0 );
+  cs = doltliteGetChunkStore(db);
+  assert( cs!=0 );
 
   memset(&c, 0, sizeof(c));
   memcpy(&c.parentHash, pParent, sizeof(ProllyHash));
@@ -391,10 +403,15 @@ int doltliteAdvanceBranch(
   const ProllyHash *pCatalogHash,
   const ProllyHash *pWorkingCatHash
 ){
-  ChunkStore *cs = doltliteGetChunkStore(db);
-  const char *branch = doltliteGetSessionBranch(db);
+  ChunkStore *cs;
+  const char *branch;
   DoltliteTxnState saved;
   int rc;
+  assert( db!=0 && pNewHead!=0 && pCatalogHash!=0 );
+  cs = doltliteGetChunkStore(db);
+  assert( cs!=0 );
+  branch = doltliteGetSessionBranch(db);
+  assert( branch!=0 && branch[0]!=0 );
 
   rc = doltliteSaveTxnState(db, &saved);
   if( rc!=SQLITE_OK ) return rc;
@@ -539,6 +556,8 @@ int doltliteDetectPostMergeConstraintViolations(
 }
 
 int doltliteSavepointIsTopLevelTxn(sqlite3 *db){
+  assert( db!=0 );
+  assert( db->nSavepoint>=0 );
   return db->pSavepoint!=0 && db->nSavepoint==0;
 }
 

--- a/src/doltlite_gc.c
+++ b/src/doltlite_gc.c
@@ -99,6 +99,9 @@ static int gcQueuePush(
   int nParentItems,
   int iChild
 ){
+  assert( q!=0 && h!=0 );
+  assert( q->nItems>=0 && q->nItems<=q->nAlloc );
+  assert( q->iHead>=0 && q->iHead<=q->nItems );
   if( prollyHashIsEmpty(h) ) return SQLITE_OK;
   if( q->nItems >= q->nAlloc ){
     i64 nNew = q->nAlloc ? (i64)q->nAlloc * 2 : (i64)256;
@@ -127,6 +130,9 @@ static int gcQueuePush(
 }
 
 static int gcQueuePop(GcQueue *q, GcQueueItem *pItem){
+  assert( q!=0 && pItem!=0 );
+  assert( q->iHead>=0 && q->iHead<=q->nItems );
+  assert( q->nItems<=q->nAlloc );
   if( q->iHead >= q->nItems ) return 0;
   *pItem = q->aItems[q->iHead];
   q->iHead++;

--- a/src/doltlite_merge.c
+++ b/src/doltlite_merge.c
@@ -1104,6 +1104,7 @@ static char *schemaColumnWithoutChecks(const char *zDef){
 }
 
 static void schemaIrClear(SchemaIr *pIr){
+  assert( pIr!=0 );
   freeColumns(pIr->aCols, pIr->nCols);
   sqlite3_free(pIr->zFkSig);
   sqlite3_free(pIr->zCheckSig);
@@ -1111,10 +1112,14 @@ static void schemaIrClear(SchemaIr *pIr){
 }
 
 static int schemaIrNoteColumnConstraints(SchemaIr *pIr, const char *zDef){
-  const char *zEnd = zDef + strlen(zDef);
-  const char *zFk = schemaFindToken(zDef, zEnd, "REFERENCES", 10);
-  const char *zCk = zDef;
+  const char *zEnd;
+  const char *zFk;
+  const char *zCk;
   int rc;
+  assert( pIr!=0 && zDef!=0 );
+  zEnd = zDef + strlen(zDef);
+  zFk = schemaFindToken(zDef, zEnd, "REFERENCES", 10);
+  zCk = zDef;
   if( zFk ){
     pIr->hasFk = 1;
     rc = schemaAppendSig(&pIr->zFkSig, zFk, (int)(zEnd - zFk));
@@ -1146,6 +1151,7 @@ static int schemaIrBuild(const char *zSql, SchemaIr *pIr){
   const char *segStart;
   int rc = SQLITE_OK;
   int nAlloc = 0;
+  assert( pIr!=0 );
 
   memset(pIr, 0, sizeof(*pIr));
   if( !zSql ) return SQLITE_OK;
@@ -3341,6 +3347,7 @@ int doltliteMergeCatalogs(
   MergeConflictTable *aConflictTables = 0;
   int nConflictTables = 0;
 
+  assert( db!=0 && ancestor!=0 && ours!=0 && theirs!=0 && pMergedHash!=0 );
   rc = loadMergeCatalogs(db, ancestor, ours, theirs,
                          &aAnc, &nAnc, &iNextAnc,
                          &aOurs, &nOurs, &iNextOurs,

--- a/src/doltlite_merge_cmd.c
+++ b/src/doltlite_merge_cmd.c
@@ -44,6 +44,7 @@ int mergeFastForward(
   const ProllyHash *pOurHead,
   const ProllyHash *pTheirHead
 ){
+  assert( db!=0 && cs!=0 && pOurHead!=0 && pTheirHead!=0 );
   DoltliteCommit theirCommit;
   DoltliteTxnState savedState;
   int graphLocked = 0;

--- a/src/doltlite_merge_cmd.c
+++ b/src/doltlite_merge_cmd.c
@@ -44,13 +44,13 @@ int mergeFastForward(
   const ProllyHash *pOurHead,
   const ProllyHash *pTheirHead
 ){
-  assert( db!=0 && cs!=0 && pOurHead!=0 && pTheirHead!=0 );
   DoltliteCommit theirCommit;
   DoltliteTxnState savedState;
   int graphLocked = 0;
   int rc;
   char hx[PROLLY_HASH_SIZE*2+1];
 
+  assert( db!=0 && cs!=0 && pOurHead!=0 && pTheirHead!=0 );
   memset(&theirCommit, 0, sizeof(theirCommit));
   memset(&savedState, 0, sizeof(savedState));
 

--- a/src/doltlite_rebase.c
+++ b/src/doltlite_rebase.c
@@ -55,6 +55,8 @@ static int doltliteRebaseCollectReplaySet(
   int upstreamInit = 0;
   int visitedInit = 0;
   int i, j;
+  assert( db!=0 && pHeadHash!=0 && pUpstreamHash!=0 );
+  assert( paReplay!=0 && pnReplay!=0 );
 
   *paReplay = 0;
   *pnReplay = 0;
@@ -173,8 +175,8 @@ static int doltliteRebaseLinearReplay(
   const char *zUpstream,
   char **pzFinalMessage
 ){
-  ChunkStore *cs = doltliteGetChunkStore(db);
-  int sealTopLevel = db->pSavepoint!=0 && db->nSavepoint==0;
+  ChunkStore *cs;
+  int sealTopLevel;
   ProllyHash upstreamHash, headHash;
   ProllyHash *aReplay = 0;
   int nReplay = 0;
@@ -185,6 +187,9 @@ static int doltliteRebaseLinearReplay(
   int i;
   char *zFailedMsg = 0;
   int bConflict = 0;
+  assert( db!=0 && context!=0 && zUpstream!=0 && pzFinalMessage!=0 );
+  cs = doltliteGetChunkStore(db);
+  sealTopLevel = db->pSavepoint!=0 && db->nSavepoint==0;
 
   *pzFinalMessage = 0;
   memset(&saved, 0, sizeof(saved));

--- a/src/doltlite_reset.c
+++ b/src/doltlite_reset.c
@@ -331,6 +331,8 @@ static void doltliteResetFunc(
   u8 isMerging = 0;
   int bSucceeded = 0;
 
+  assert( context!=0 );
+  assert( argc>=0 );
   if( !cs ){
     sqlite3_result_error(context, doltliteVcUnavailableMessage(db), -1);
     goto reset_cleanup;

--- a/src/doltlite_workspace.c
+++ b/src/doltlite_workspace.c
@@ -482,13 +482,6 @@ static int wsApplyRowToStaged(WorkspaceVtab *p, WorkspaceRow *r, int makeStaged)
   sqlite3 *db;
   ChunkStore *cs;
   ProllyCache *pCache;
-  assert( p!=0 && r!=0 );
-  assert( p->zTableName!=0 );
-  assert( makeStaged==0 || makeStaged==1 );
-  assert( r->staged==0 || r->staged==1 );
-  db = p->db;
-  cs = doltliteGetChunkStore(db);
-  pCache = doltliteGetCache(db);
   ProllyHash headHash, headCat, stagedCat, newRoot, newCat;
   struct TableEntry *aTables = 0;
   int nTables = 0;
@@ -497,16 +490,32 @@ static int wsApplyRowToStaged(WorkspaceVtab *p, WorkspaceRow *r, int makeStaged)
   u8 *pCatBuf = 0;
   int nCatBuf = 0;
   int rc;
+  const u8 *pHeadVal;
+  int nHeadVal;
+  const u8 *pWorkVal;
+  int nWorkVal;
+  const u8 *pSrc;
+  int nSrc;
+  const u8 *pTgt;
+  int nTgt;
+
+  assert( p!=0 && r!=0 );
+  assert( p->zTableName!=0 );
+  assert( makeStaged==0 || makeStaged==1 );
+  assert( r->staged==0 || r->staged==1 );
+  db = p->db;
+  cs = doltliteGetChunkStore(db);
+  pCache = doltliteGetCache(db);
 
   /* Staging rewrites data by PK and secondary indexes by old/new index key. */
-  const u8 *pHeadVal = (r->diffType==PROLLY_DIFF_ADD)    ? 0 : r->pOldVal;
-  int        nHeadVal = (r->diffType==PROLLY_DIFF_ADD)    ? 0 : r->nOldVal;
-  const u8 *pWorkVal = (r->diffType==PROLLY_DIFF_DELETE) ? 0 : r->pNewVal;
-  int        nWorkVal = (r->diffType==PROLLY_DIFF_DELETE) ? 0 : r->nNewVal;
-  const u8 *pSrc = makeStaged ? pHeadVal : pWorkVal;
-  int        nSrc = makeStaged ? nHeadVal : nWorkVal;
-  const u8 *pTgt = makeStaged ? pWorkVal : pHeadVal;
-  int        nTgt = makeStaged ? nWorkVal : nHeadVal;
+  pHeadVal = (r->diffType==PROLLY_DIFF_ADD)    ? 0 : r->pOldVal;
+  nHeadVal = (r->diffType==PROLLY_DIFF_ADD)    ? 0 : r->nOldVal;
+  pWorkVal = (r->diffType==PROLLY_DIFF_DELETE) ? 0 : r->pNewVal;
+  nWorkVal = (r->diffType==PROLLY_DIFF_DELETE) ? 0 : r->nNewVal;
+  pSrc = makeStaged ? pHeadVal : pWorkVal;
+  nSrc = makeStaged ? nHeadVal : nWorkVal;
+  pTgt = makeStaged ? pWorkVal : pHeadVal;
+  nTgt = makeStaged ? nWorkVal : nHeadVal;
 
   if( !cs || !pCache ) return SQLITE_ERROR;
   doltliteGetSessionHead(db, &headHash);

--- a/src/doltlite_workspace.c
+++ b/src/doltlite_workspace.c
@@ -479,9 +479,16 @@ static int wsApplyRowToIndex(
 }
 
 static int wsApplyRowToStaged(WorkspaceVtab *p, WorkspaceRow *r, int makeStaged){
-  sqlite3 *db = p->db;
-  ChunkStore *cs = doltliteGetChunkStore(db);
-  ProllyCache *pCache = doltliteGetCache(db);
+  sqlite3 *db;
+  ChunkStore *cs;
+  ProllyCache *pCache;
+  assert( p!=0 && r!=0 );
+  assert( p->zTableName!=0 );
+  assert( makeStaged==0 || makeStaged==1 );
+  assert( r->staged==0 || r->staged==1 );
+  db = p->db;
+  cs = doltliteGetChunkStore(db);
+  pCache = doltliteGetCache(db);
   ProllyHash headHash, headCat, stagedCat, newRoot, newCat;
   struct TableEntry *aTables = 0;
   int nTables = 0;
@@ -561,6 +568,8 @@ static int wsUpdate(sqlite3_vtab *pBase, int argc, sqlite3_value **argv,
   WorkspaceVtab *p = (WorkspaceVtab*)pBase;
   WorkspaceRow *r;
   int newStaged;
+  assert( pBase!=0 && argv!=0 );
+  assert( p->db!=0 && p->zTableName!=0 );
   (void)pRowid;
   if( argc==1 ){
     pBase->zErrMsg = sqlite3_mprintf(

--- a/src/prolly_cursor.c
+++ b/src/prolly_cursor.c
@@ -266,9 +266,14 @@ int prollyCursorNext(ProllyCursor *cur){
   int level;
   ProllyCacheEntry *pNode;
 
+  assert( cur!=0 );
   assert( cur->eState==PROLLY_CURSOR_VALID );
+  assert( cur->iLevel>=0 && cur->iLevel<PROLLY_CURSOR_MAX_DEPTH );
 
   pLeaf = cur->aLevel[cur->iLevel].pEntry;
+  assert( pLeaf!=0 );
+  assert( cur->aLevel[cur->iLevel].idx>=0
+       && cur->aLevel[cur->iLevel].idx<(int)pLeaf->node.nItems );
   if( cur->aLevel[cur->iLevel].idx < pLeaf->node.nItems - 1 ){
     cur->aLevel[cur->iLevel].idx++;
     return SQLITE_OK;

--- a/src/prolly_hashset.c
+++ b/src/prolly_hashset.c
@@ -5,14 +5,20 @@
 #include <string.h>
 
 static u32 prollyHashSetSlotIndex(const ProllyHash *h, int nSlots){
-  u32 v = (u32)h->data[0] | ((u32)h->data[1]<<8) |
+  u32 v;
+  assert( h!=0 );
+  assert( nSlots>0 && (nSlots & (nSlots-1))==0 );
+  v = (u32)h->data[0] | ((u32)h->data[1]<<8) |
           ((u32)h->data[2]<<16) | ((u32)h->data[3]<<24);
   return v & (nSlots - 1);
 }
 
 int prollyHashSetInit(ProllyHashSet *hs, int nCapacity){
   i64 n = 256;
-  i64 want = (i64)nCapacity * 2;
+  i64 want;
+  assert( hs!=0 );
+  assert( nCapacity>=0 );
+  want = (i64)nCapacity * 2;
   while( n < want ) n *= 2;
   if( n > (i64)0x7fffffff/(i64)sizeof(ProllyHash) ) return SQLITE_NOMEM;
   hs->aSlots = sqlite3_malloc64((sqlite3_uint64)n * sizeof(ProllyHash));
@@ -35,8 +41,12 @@ void prollyHashSetFree(ProllyHashSet *hs){
 }
 
 int prollyHashSetContains(ProllyHashSet *hs, const ProllyHash *h){
-  u32 idx = prollyHashSetSlotIndex(h, hs->nSlots);
+  u32 idx;
   int i;
+  assert( hs!=0 && h!=0 );
+  assert( hs->nSlots>0 && hs->aSlots!=0 && hs->aUsed!=0 );
+  assert( hs->nUsed>=0 && hs->nUsed<=hs->nSlots );
+  idx = prollyHashSetSlotIndex(h, hs->nSlots);
   for(i=0; i<hs->nSlots; i++){
     u32 slot = (idx + i) & (hs->nSlots - 1);
     if( !hs->aUsed[slot] ) return 0;
@@ -50,6 +60,9 @@ static int prollyHashSetGrow(ProllyHashSet *hs);
 int prollyHashSetAdd(ProllyHashSet *hs, const ProllyHash *h){
   u32 idx;
   int i;
+  assert( hs!=0 && h!=0 );
+  assert( hs->nSlots>0 && hs->aSlots!=0 && hs->aUsed!=0 );
+  assert( hs->nUsed>=0 && hs->nUsed<=hs->nSlots );
   if( hs->nUsed >= hs->nSlots / 2 ){
     int rc = prollyHashSetGrow(hs);
     if( rc!=SQLITE_OK ) return rc;
@@ -73,7 +86,10 @@ int prollyHashSetAdd(ProllyHashSet *hs, const ProllyHash *h){
 static int prollyHashSetGrow(ProllyHashSet *hs){
   ProllyHashSet newHs;
   int i, rc;
-  i64 newSize = (i64)hs->nSlots * 2;
+  i64 newSize;
+  assert( hs!=0 );
+  assert( hs->nSlots>0 );
+  newSize = (i64)hs->nSlots * 2;
   if( newSize > (i64)0x7fffffff/(i64)sizeof(ProllyHash) ) return SQLITE_NOMEM;
   newHs.aSlots = sqlite3_malloc64((sqlite3_uint64)newSize * sizeof(ProllyHash));
   newHs.aUsed = sqlite3_malloc64((sqlite3_uint64)newSize);

--- a/src/prolly_mutate.c
+++ b/src/prolly_mutate.c
@@ -1337,6 +1337,7 @@ replace_batch_cleanup:
 int prollyMutateFlush(ProllyMutator *pMut){
   int rc;
 
+  assert( pMut!=0 && pMut->pEdits!=0 && pMut->pStore!=0 );
   if( prollyMutMapIsEmpty(pMut->pEdits) ){
     memcpy(&pMut->newRoot, &pMut->oldRoot, sizeof(ProllyHash));
     return SQLITE_OK;

--- a/src/prolly_mutmap.c
+++ b/src/prolly_mutmap.c
@@ -47,6 +47,10 @@ static u64 keyPrefix64(const u8 *pKey, int nKey){
 }
 
 static ProllyMutMapEntry *entryAtOrder(ProllyMutMap *mm, int idx){
+  assert( mm!=0 );
+  assert( mm->aEntries!=0 && mm->aOrder!=0 );
+  assert( idx>=0 && idx<mm->nEntries );
+  assert( mm->aOrder[idx]>=0 && mm->aOrder[idx]<mm->nEntries );
   return &mm->aEntries[mm->aOrder[idx]];
 }
 
@@ -462,6 +466,9 @@ static int rankEntryWithoutOrder(ProllyMutMap *mm, int phys){
 }
 
 static int ensureCapacity(ProllyMutMap *mm){
+  assert( mm!=0 );
+  assert( mm->nEntries>=0 && mm->nAlloc>=0 );
+  assert( mm->nEntries<=mm->nAlloc );
   if( mm->nEntries >= mm->nAlloc ){
     int nNew = mm->nAlloc ? mm->nAlloc * 2 : MUTMAP_INIT_CAP;
     ProllyMutMapEntry *aNew;
@@ -495,6 +502,9 @@ static int ensureCapacity(ProllyMutMap *mm){
 
 static void insertOrderEntry(ProllyMutMap *mm, int idx, int phys){
   int shifted = mm->nEntries - idx;
+  assert( mm!=0 );
+  assert( idx>=0 && idx<=mm->nEntries );
+  assert( phys>=0 && phys<=mm->nEntries );
   if( idx < mm->nEntries ){
     memmove(&mm->aOrder[idx+1], &mm->aOrder[idx],
             (mm->nEntries - idx) * sizeof(int));
@@ -570,6 +580,8 @@ int prollyMutMapInsert(
   const u8 *pKey, int nKey, i64 intKey,
   const u8 *pVal, int nVal
 ){
+  assert( mm!=0 );
+  assert( nKey>=0 && nVal>=0 );
   int found = 0, idx = 0, rc, phys = -1;
   u8 keyBuf[8];
   prepKey(mm, &pKey, &nKey, intKey, keyBuf);
@@ -980,6 +992,8 @@ int prollyMutMapFindRc(
 }
 
 ProllyMutMapEntry *prollyMutMapEntryAt(ProllyMutMap *mm, int idx){
+  assert( mm!=0 );
+  assert( idx>=0 && idx<mm->nEntries );
   ensureOrder(mm);
   return entryAtOrder(mm, idx);
 }
@@ -1002,7 +1016,11 @@ int prollyMutMapResolveSortedPos(
 }
 
 int prollyMutMapOrderIndexFromEntry(ProllyMutMap *mm, ProllyMutMapEntry *pEntry){
-  int phys = (int)(pEntry - mm->aEntries);
+  int phys;
+  assert( mm!=0 && pEntry!=0 );
+  assert( mm->aEntries!=0 );
+  phys = (int)(pEntry - mm->aEntries);
+  assert( phys>=0 && phys<mm->nEntries );
   if( mm->keepSorted ){
     int found = 0;
     int idx = bsearch_key(mm, pEntry->pKey, pEntry->nKey, &found);
@@ -1039,6 +1057,8 @@ int prollyMutMapIterValid(ProllyMutMapIter *it){
 }
 
 ProllyMutMapEntry *prollyMutMapIterEntry(ProllyMutMapIter *it){
+  assert( it!=0 && it->pMap!=0 );
+  assert( prollyMutMapIterValid(it) );
   return entryAtOrder(it->pMap, it->idx);
 }
 

--- a/src/prolly_mutmap.c
+++ b/src/prolly_mutmap.c
@@ -580,10 +580,10 @@ int prollyMutMapInsert(
   const u8 *pKey, int nKey, i64 intKey,
   const u8 *pVal, int nVal
 ){
-  assert( mm!=0 );
-  assert( nKey>=0 && nVal>=0 );
   int found = 0, idx = 0, rc, phys = -1;
   u8 keyBuf[8];
+  assert( mm!=0 );
+  assert( nKey>=0 && nVal>=0 );
   prepKey(mm, &pKey, &nKey, intKey, keyBuf);
 
   if( mm->keepSorted || !mm->orderDirty ){


### PR DESCRIPTION
## Summary

Another assert campaign, this time outside the prolly B-tree modules (siblings of #1742/#1743).

Load-bearing invariants promoted to `assert()`:

| Area | Checks |
|------|--------|
| **prolly_mutmap** | Ordered entry access bounds, capacity/order helpers, iterator validity, insert preconditions |
| **chunk_staging** | pending/recent/write-buf counts vs alloc; uncommitted ≤ recent; search/grow entry |
| **doltlite_gc** | Mark queue head/items/alloc consistency |
| **doltlite_core** | Txn save/restore, head confirm, create-commit, advance-branch, savepoint mode |
| **doltlite_workspace** | Stage apply / update entry state |
| **prolly_cursor** | `next` leaf bounds |
| **doltlite_add** / **merge_cmd** | Name-index init; fast-forward pointers |

Release builds still use `-DNDEBUG` (asserts compiled out), same as the btree campaign. Debug / `SQLITE_DEBUG` builds enforce them.

## Test plan

- [x] `make doltlite`
- [x] Compile-check with `-DSQLITE_DEBUG` (no `-DNDEBUG`) for touched translation units
- [x] `doltlite_gc.sh` — 58/58
- [x] `doltlite_commit.sh` — 62/62
- [x] `doltlite_workspace.sh` — 7/7
- [x] `doltlite_merge.sh` — 94/94