### PR TITLE
Reconstruct all-column-PK rows in dolt_blame

### DIFF
--- a/src/doltlite_blame.c
+++ b/src/doltlite_blame.c
@@ -272,6 +272,15 @@ static int blameCollectLiveRows(
       if( !r->pCurVal ){ prollyCursorClose(&cur); return SQLITE_NOMEM; }
       memcpy(r->pCurVal, pVal, nVal);
       r->nCurVal = nVal;
+    }else if( r->pKey && r->nKey>0 ){
+      /* All-column-PK rows store an empty value; the row lives in the sort
+      ** key. Rebuild the record so PK columns render and ancestor comparison
+      ** sees real data instead of matching every empty value. */
+      BlameVtab *v = (BlameVtab*)pCur->base.pVtab;
+      rc = doltliteRecordFromClusteredKey(v->db, v->zTableName,
+                                          r->pKey, r->nKey,
+                                          &r->pCurVal, &r->nCurVal);
+      if( rc!=SQLITE_OK ){ prollyCursorClose(&cur); return rc; }
     }
 
     pCur->nRows++;
@@ -289,13 +298,15 @@ static int blameSeekRowInTree(
   u8 flags,
   const BlameRow *pRow,
   const u8 **ppVal,
-  int *pnVal
+  int *pnVal,
+  int *pFound
 ){
   ProllyCursor cur;
   int res, rc;
 
   *ppVal = 0;
   *pnVal = 0;
+  *pFound = 0;
 
   if( prollyHashIsEmpty(pRoot) ) return SQLITE_OK;
   prollyCursorInit(&cur, cs, pCache, pRoot, flags);
@@ -312,6 +323,7 @@ static int blameSeekRowInTree(
     return SQLITE_OK;
   }
 
+  *pFound = 1;
   prollyCursorValue(&cur, ppVal, pnVal);
   prollyCursorClose(&cur);
   return SQLITE_OK;
@@ -424,6 +436,10 @@ static int blameCompareAgainstRef(
     BlameRow *r = &pCur->aRows[i];
     const u8 *pRefVal = 0;
     int nRefVal = 0;
+    int refFound = 0;
+    u8 *pRefRebuilt = 0;
+    const u8 *pRefEff;
+    int nRefEff;
     if( r->blamed ) continue;
 
     if( haveRef ){
@@ -437,20 +453,38 @@ static int blameCompareAgainstRef(
           refCurValid = prollyCursorIsValid(&refCur);
         }
         if( refCurValid && cmp==0 ){
+          refFound = 1;
           prollyCursorValue(&refCur, &pRefVal, &nRefVal);
         }
       }else{
         rc = blameSeekRowInTree(cs, pCache, &refRoot, refFlags, r,
-                                &pRefVal, &nRefVal);
+                                &pRefVal, &nRefVal, &refFound);
         if( rc!=SQLITE_OK ) goto blame_compare_done;
       }
     }
 
-    if( !blameRowValueEqual(r->pCurVal, r->nCurVal, pRefVal, nRefVal) ){
-      rc = blameAssign(r, pCommitHash, pCommit);
+    /* A matched all-column-PK row stores an empty value in the ref too, so
+    ** rebuild it from the key like the live side; otherwise the reconstructed
+    ** live record would compare unequal to the empty ref and look changed.
+    ** An absent ref row keeps an empty value here and stays a real change. */
+    pRefEff = pRefVal;
+    nRefEff = nRefVal;
+    if( refFound && !(pRefVal && nRefVal>0)
+     && !(refFlags & PROLLY_NODE_INTKEY) && r->pKey && r->nKey>0 ){
+      int nR = 0;
+      rc = doltliteRecordFromClusteredKey(db, zTableName, r->pKey, r->nKey,
+                                          &pRefRebuilt, &nR);
       if( rc!=SQLITE_OK ) goto blame_compare_done;
+      pRefEff = pRefRebuilt;
+      nRefEff = nR;
+    }
+
+    if( !blameRowValueEqual(r->pCurVal, r->nCurVal, pRefEff, nRefEff) ){
+      rc = blameAssign(r, pCommitHash, pCommit);
+      if( rc!=SQLITE_OK ){ sqlite3_free(pRefRebuilt); goto blame_compare_done; }
       pCur->nUnresolved--;
     }
+    sqlite3_free(pRefRebuilt);
   }
 
 blame_compare_done:

--- a/test/vc_oracle_blame_test.sh
+++ b/test/vc_oracle_blame_test.sh
@@ -110,6 +110,26 @@ INSERT INTO t VALUES (2, 1, 'x');
 SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'C3');
 " "SELECT CONCAT('BL|', a, '-', b, '|', message) FROM dolt_blame_t ORDER BY a, b;"
 
+echo "--- all-column PK (empty value record; row lives in the key) ---"
+
+oracle "all_column_pk_int" "
+CREATE TABLE t(a INTEGER, b INTEGER, PRIMARY KEY(a, b));
+INSERT INTO t VALUES (1, 1), (1, 2);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'C1');
+INSERT INTO t VALUES (2, 1);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'C2');
+INSERT INTO t VALUES (3, 3);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'C3');
+" "SELECT CONCAT('BL|', a, '-', b, '|', message) FROM dolt_blame_t ORDER BY a, b;"
+
+oracle "all_column_pk_text" "
+CREATE TABLE t(a VARCHAR(16), b VARCHAR(16), PRIMARY KEY(a, b));
+INSERT INTO t VALUES ('p', 'q'), ('p', 'r');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'C1');
+INSERT INTO t VALUES ('s', 't');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'C2');
+" "SELECT CONCAT('BL|', a, '-', b, '|', message) FROM dolt_blame_t ORDER BY a, b;"
+
 echo "--- NULL values ---"
 
 oracle "null_values" "


### PR DESCRIPTION
## Problem

When a table's `PRIMARY KEY` covers **every** column, the row is clustered with an **empty value record** — all data lives in the sort key. `dolt_blame` read PK columns only from the value record (`bmColumn`), and attribution (`blameCompareAgainstRef`) compared value records. So for such a table:

- every PK column rendered **NULL**, and
- attribution compared empty-vs-empty (always "equal"), so **no commit was ever assigned** — committer/message blank for the whole table.

Every other reader (dolt_history, dolt_at, diff_table, patch, constraint_violations) already rebuilds the record from the key via `doltliteRecordFromClusteredKey`; blame was the lone omission.

## Fix

Rebuild the record from the sort key when the stored value is empty:

- **Live side** (`blameCollectLiveRows`): reconstruct `pCurVal` from the key — fixes column display and gives attribution real data (so `bmColumn` needs no change).
- **Ref side** (`blameCompareAgainstRef`): reconstruct the matched ref row the same way, gated on a new `found` flag from `blameSeekRowInTree`. Without the gate, an *absent* ref row (no key to rebuild) correctly stays empty and reads as a real change → gets blamed; a *present* ref row rebuilds to the same record → compares equal → not a change.

Rowid tables and subset-PK clustered tables are unaffected (`doltliteRecordFromClusteredKey` returns empty for rowid tables; subset-PK tables have a non-empty value so the new branch isn't taken).

## Testing

Adds two all-column-PK cases to the blame oracle suite (`test/vc_oracle_blame_test.sh`), comparing doltlite against Dolt 2.1.8:

- `all_column_pk_int` — composite integer PK
- `all_column_pk_text` — composite `VARCHAR` PK (exercises text sort-key decode; `VARCHAR` rather than `TEXT` because MySQL/Dolt rejects `TEXT` in a PK without a key length)

**Fail-before**: both cases fail on unfixed code (doltlite returns `BL|-|` — empty PK, no attribution — vs Dolt's correct blame). **Pass-after**: blame oracle 25/25. Full DoltLite VC battery: 89 suites, 0 failures.

Built on post-refactor master (#1745); independent of #1747 and #1748.

🤖 Generated with [Claude Code](https://claude.com/claude-code)