### PR TITLE
Fail merge on index-info alloc failure instead of committing stale indexes

### DIFF
--- a/src/doltlite_merge.c
+++ b/src/doltlite_merge.c
@@ -2794,6 +2794,7 @@ do_merge_entry:
                                                     pIdx->zName);
                         if( rc!=SQLITE_OK ){
                           sqlite3_free(aIdxInfo);
+                          sqlite3_free(aPatches);
                           return rc;
                         }
                         continue;
@@ -2810,6 +2811,12 @@ do_merge_entry:
                         nIdxInfo++;
                       }
                     }
+                  }else{
+                    /* Proceeding here would merge the table's rows but leave
+                    ** its secondary indexes stale, then return success. Fail
+                    ** the merge instead of committing a corrupt result. */
+                    sqlite3_free(aPatches);
+                    return SQLITE_NOMEM;
                   }
                 }
               }


### PR DESCRIPTION
## Problem

In `mergeCatalogPass1` (`src/doltlite_merge.c`), the per-table secondary-index array is allocated under a bare guard:

```c
aIdxInfo = sqlite3_malloc(nIdx * (int)sizeof(MergeIndexInfo));
if( aIdxInfo ){
  ... populate, run inline index maintenance ...
}
/* no else */
```

On allocation failure the block is skipped, `nIdxInfo` stays 0, `mergeTableRows` runs with no index maintenance, and the function returns `SQLITE_OK`. The merge is then committed with secondary indexes that omit the merged row changes — silent corruption on OOM, where every other allocation on this path returns `SQLITE_NOMEM`.

## Fix

Return `SQLITE_NOMEM` when the allocation fails. Also free the accumulated `aPatches` list (built for earlier table entries in the same merge) on that return and on the adjacent needs-rebuild error return, matching the existing `mergeTableRows`-error cleanup so neither path leaks.

## Testing

OOM-only trigger, so there's no natural fail-before test (latent fix). Verified the change builds and the normal path is unaffected: merge / schema-merge / index-vc-matrix / merge-index-conflict / large-merge suites all pass (248 checks total).

Based on current master (includes #1747). Independent of #1748/#1752.

🤖 Generated with [Claude Code](https://claude.com/claude-code)