### PR TITLE
Resolve ref ~/^ operators iteratively to bound stack and memory

### DIFF
--- a/src/doltlite_ref.c
+++ b/src/doltlite_ref.c
@@ -123,59 +123,64 @@ static int doltliteWalkFirstParent(
 
 int doltliteResolveRef(sqlite3 *db, const char *zRef, ProllyHash *pCommit){
   ChunkStore *cs = doltliteGetChunkStore(db);
-  int len, j, n, rc;
-  int suffix_pos = -1;
-  char suffix_op = 0;
+  int len, base_len, i, rc;
   char *base_buf = 0;
 
   if( !zRef || !cs ) return SQLITE_ERROR;
 
+  /* A ref may carry a suffix of ~N / ^N parent-walk operators. Peel that
+  ** suffix off right-to-left to find the base ref, then apply the operators
+  ** left-to-right. This is iterative on purpose: recursing once per operator
+  ** let a long "^^^..." argument exhaust the stack. */
   len = (int)strlen(zRef);
-  for(j=len-1; j>=0; j--){
-    if( zRef[j]=='~' || zRef[j]=='^' ){
-      int k, allDigits = 1;
-      for(k=j+1; k<len; k++){
-        if( zRef[k]<'0' || zRef[k]>'9' ){ allDigits = 0; break; }
-      }
-      if( allDigits ){
-        suffix_pos = j;
-        suffix_op = zRef[j];
-      }
+  base_len = len;
+  for(;;){
+    int q = base_len;
+    while( q>0 && zRef[q-1]>='0' && zRef[q-1]<='9' ) q--;
+    if( q>0 && (zRef[q-1]=='~' || zRef[q-1]=='^') ){
+      base_len = q-1;
+    }else{
       break;
     }
   }
 
-  if( suffix_pos<0 ){
-    return doltliteResolveBaseRef(db, zRef, pCommit);
-  }
-
-  if( suffix_pos==len-1 ){
-    n = 1;
-  }else{
-    n = atoi(zRef + suffix_pos + 1);
-    if( n<0 ) return SQLITE_ERROR;
-    if( n==0 && suffix_op=='^' ) return SQLITE_ERROR;
-  }
-
-  if( suffix_pos==0 ){
+  if( base_len==len ){
+    /* No operator suffix: resolve the ref as-is (including "", which is not
+    ** a shorthand for HEAD and must fail like any unknown ref). */
+    rc = doltliteResolveBaseRef(db, zRef, pCommit);
+  }else if( base_len==0 ){
+    /* The ref is nothing but operators (e.g. "^", "~2"): the base is HEAD. */
     rc = doltliteResolveBaseRef(db, "HEAD", pCommit);
   }else{
-    base_buf = sqlite3_malloc(suffix_pos + 1);
+    base_buf = sqlite3_malloc(base_len + 1);
     if( !base_buf ) return SQLITE_NOMEM;
-    memcpy(base_buf, zRef, suffix_pos);
-    base_buf[suffix_pos] = '\0';
-    rc = doltliteResolveRef(db, base_buf, pCommit);
+    memcpy(base_buf, zRef, base_len);
+    base_buf[base_len] = '\0';
+    rc = doltliteResolveBaseRef(db, base_buf, pCommit);
     sqlite3_free(base_buf);
   }
-
   if( rc!=SQLITE_OK ) return rc;
 
-  if( suffix_op=='~' ){
-    rc = doltliteWalkFirstParent(db, pCommit, n);
-  }else{
-    rc = doltliteSelectParent(db, pCommit, n-1);
+  for(i=base_len; i<len; ){
+    char op = zRef[i++];
+    int d = i;
+    int n;
+    while( i<len && zRef[i]>='0' && zRef[i]<='9' ) i++;
+    if( i==d ){
+      n = 1;
+    }else{
+      n = atoi(zRef + d);
+      if( n<0 ) return SQLITE_ERROR;
+      if( n==0 && op=='^' ) return SQLITE_ERROR;
+    }
+    if( op=='~' ){
+      rc = doltliteWalkFirstParent(db, pCommit, n);
+    }else{
+      rc = doltliteSelectParent(db, pCommit, n-1);
+    }
+    if( rc==SQLITE_NOTFOUND ) rc = SQLITE_ERROR;
+    if( rc!=SQLITE_OK ) return rc;
   }
-  if( rc==SQLITE_NOTFOUND ) rc = SQLITE_ERROR;
   return rc;
 }
 

--- a/test/vc_oracle_ancestor_spec_test.sh
+++ b/test/vc_oracle_ancestor_spec_test.sh
@@ -168,6 +168,11 @@ oracle_both_error "head_tilde3_caret2" "$MERGED" "HEAD~3^2"
 oracle_both_error "head_tilde1_caret2" "$MERGED" "HEAD~1^2"
 oracle_both_error "nonmerge_branch_caret2" "$MERGED" "feat^2"
 
+# A long operator chain walks past the root and must error cleanly. The
+# resolver applies operators iteratively; the earlier recursive form used
+# O(depth) stack and O(depth^2) transient memory on inputs like this.
+oracle_both_error "head_many_carets" "$MERGED" "HEAD$(printf '^%.0s' $(seq 1 64))"
+
 echo ""
 echo "--- F4: LCA must be deterministic on criss-cross merge ---"
 


### PR DESCRIPTION
## Problem

`doltliteResolveRef` (`src/doltlite_ref.c`) handled a ref's trailing `~N`/`^N` parent-walk operators by recursing: it peeled the rightmost operator, recursed on the base prefix, and applied the operator on the way back up. So:

- recursion depth was **O(strlen(zRef))** — one frame per operator, and
- each frame `sqlite3_malloc`'d a copy of its base prefix, so live allocation across the recursion was **O(n²)**.

Ref strings come straight from SQL text arguments (`dolt_merge_base`, `dolt_hashof`, branch/tag start points, log/diff/cherry-pick/revert), bounded only by `SQLITE_MAX_LENGTH`. So a crafted argument like a long run of `^` is a resource-exhaustion DoS from untrusted input.

Measured on the recursive version (`HEAD` + N carets, `dolt_log`):

| carets | peak RSS |
|--------|----------|
| 20k    | 212 MB   |
| 50k    | 1.4 GB   |
| 80k    | 3.6 GB   |
| 120k   | 8.0 GB   |

It fails `malloc` (clean-ish error) before the stack blows on a large-stack build; a smaller-stack build stack-overflows and crashes instead.

## Fix

Peel the operator suffix right-to-left to locate the base ref, resolve it **once**, then apply the operators left-to-right in a loop. Same semantics, **O(1)** extra stack and a single base-ref allocation. Peak RSS for the 120k case drops from ~8 GB to a flat **~5 MB**.

## Testing

- The ancestor-spec oracle suite (`vc_oracle_ancestor_spec_test.sh`) already pins the `~`/`^`/`~N`/`^N`/`~~`/`^^`/`^2~1`/`~0` and error-case semantics against Dolt — all pass with the iterative rewrite (proves behavior preserved). Added a long-operator-chain case.
- Manually verified equivalence (`HEAD^`, `HEAD~2`, `HEAD^^`, `HEAD~1^`) and that the 120k-caret input now returns a clean error at ~5 MB instead of consuming gigabytes.
- Full DoltLite VC battery green; C regression suite 309888/0.

Based on current master (includes #1747). Independent of #1748/#1752/#1753.

🤖 Generated with [Claude Code](https://claude.com/claude-code)