### PR TITLE
Bounds-check node offset totals before size arithmetic

### DIFF
--- a/src/prolly_node.c
+++ b/src/prolly_node.c
@@ -17,7 +17,7 @@ int prollyNodeParseSparse(ProllyNode *pNode, const u8 *pData, int nData,
   u16 count;
   int nOffsets;
   int minSize;
-  int expectedSize;
+  i64 expectedSize;
   u32 totalKeyBytes;
   u32 totalValBytes;
   const u8 *pCur;
@@ -82,15 +82,18 @@ int prollyNodeParseSparse(ProllyNode *pNode, const u8 *pData, int nData,
   pNode->pKeyData = pCur;
 
   totalKeyBytes = PROLLY_GET_U32((const u8*)&pNode->aKeyOff[count]);
+  totalValBytes = PROLLY_GET_U32((const u8*)&pNode->aValOff[count]);
+  if( totalKeyBytes > (u32)nData || totalValBytes > (u32)nData ){
+    return SQLITE_CORRUPT;
+  }
+
   pNode->pValData = pCur + totalKeyBytes;
 
-  totalValBytes = PROLLY_GET_U32((const u8*)&pNode->aValOff[count]);
-  expectedSize = minSize + (int)totalKeyBytes + (int)totalValBytes;
+  expectedSize = (i64)minSize + totalKeyBytes + totalValBytes;
   if( hasCounts ){
-    expectedSize += (int)count * 8;
+    expectedSize += (i64)count * 8;
   }
-  if( totalKeyBytes > (u32)nData || totalValBytes > (u32)nData
-   || expectedSize != nData ){
+  if( expectedSize != nData ){
     return SQLITE_CORRUPT;
   }
   if( nDataPhys<nData ){


### PR DESCRIPTION
## What

`prollyNodeParseSparse` read the key/value byte totals (`totalKeyBytes`, `totalValBytes`) from the on-disk offset-array tail and folded them into the expected-size computation **before** validating them against `nData`:

```c
totalKeyBytes = PROLLY_GET_U32(...);
pNode->pValData = pCur + totalKeyBytes;                 // pointer from unvalidated total
totalValBytes = PROLLY_GET_U32(...);
expectedSize = minSize + (int)totalKeyBytes + (int)totalValBytes;  // signed overflow
...
if( totalKeyBytes > (u32)nData || totalValBytes > (u32)nData || expectedSize != nData )
    return SQLITE_CORRUPT;
```

A crafted/corrupt node — reachable from a ~24-byte buffer with `count=1` whose offset-tail `u32`s decode to `0x40000000` each — makes `minSize + (int)totalKeyBytes + (int)totalValBytes` exceed `INT_MAX`, which is signed-integer-overflow UB. The `pValData` pointer was also computed from the unvalidated total.

This is not exploitable (later reads are hash-verified and the `expectedSize != nData` / per-offset checks reject the node), but it is undefined behavior that `-fsanitize=undefined` traps, and it sits directly on the `fuzz_prolly_node` path.

## Fix

- Move the `totalKeyBytes` / `totalValBytes` range checks **ahead of** both the `pValData` pointer computation and the size arithmetic.
- Widen `expectedSize` to `i64` so the sum cannot overflow regardless of caller bounds.

Behavior is unchanged for every input: malformed nodes still return `SQLITE_CORRUPT`, valid nodes still parse identically.

## Verification

- UBSAN fail-before/pass-after on the exact arithmetic with the crafted values (`minSize=24`, `totalKeyBytes=totalValBytes=0x40000000`, `nData=24`): the old expression aborts with `signed integer overflow: 1073741848 + 1073741824 cannot be represented in type 'int'`; the new code returns `SQLITE_CORRUPT` with no UB.
- `prolly_node.o` compiles cleanly in-tree under `-Wdeclaration-after-statement`.
- Existing `fuzz_prolly_node` corpus + ASAN/UBSAN CI exercise this parser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)