### PR TITLE
Group live/committed/savepoint VC state in one struct

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -740,16 +740,16 @@ int sqlite3BtreeOpen(
     }else{
       memset(&p->headCommit, 0, sizeof(ProllyHash));
     }
-    p->stagedCatalog = stagedCatalog;
-    p->isMerging = isMerging;
-    p->mergeCommitHash = mergeCommitHash;
-    p->conflictsCatalogHash = conflictsCatalogHash;
+    p->vc.stagedCatalog = stagedCatalog;
+    p->vc.isMerging = isMerging;
+    p->vc.mergeCommitHash = mergeCommitHash;
+    p->vc.conflictsCatalogHash = conflictsCatalogHash;
     p->isRebasing = isRebasing;
     p->preRebaseWorkingCat = preRebaseCat;
     p->rebaseOntoCommit = rebaseOnto;
     p->zRebaseOrigBranch = zRebaseOrigBranch;
     p->zRebaseReturnBranch = zRebaseReturnBranch;
-    p->constraintViolationsHash = constraintViolationsHash;
+    p->vc.constraintViolationsHash = constraintViolationsHash;
   }
 
   p->cat.iNextTable = 2;
@@ -1779,11 +1779,11 @@ int doltliteCheckRepoGraphIntegrity(Btree *p, int mxErr, int *pnErr){
       rc = integrityCheckChunkGraph(&ctx, &aTk[i].commitHash);
     }
   }
-  if( rc==SQLITE_OK && p->isMerging ){
-    rc = integrityCheckChunkGraph(&ctx, &p->mergeCommitHash);
+  if( rc==SQLITE_OK && p->vc.isMerging ){
+    rc = integrityCheckChunkGraph(&ctx, &p->vc.mergeCommitHash);
   }
   if( rc==SQLITE_OK ){
-    rc = integrityCheckChunkGraph(&ctx, &p->conflictsCatalogHash);
+    rc = integrityCheckChunkGraph(&ctx, &p->vc.conflictsCatalogHash);
   }
 
   prollyHashSetFree(&ctx.seen);

--- a/src/prolly_btree_catalog.c
+++ b/src/prolly_btree_catalog.c
@@ -2135,10 +2135,10 @@ int doltliteHardReset(sqlite3 *db, const ProllyHash *catHash){
     return rc;
   }
 
-  oldStagedCatalog = pBtree->stagedCatalog;
-  oldIsMerging = pBtree->isMerging;
-  oldMergeCommitHash = pBtree->mergeCommitHash;
-  oldConflictsCatalogHash = pBtree->conflictsCatalogHash;
+  oldStagedCatalog = pBtree->vc.stagedCatalog;
+  oldIsMerging = pBtree->vc.isMerging;
+  oldMergeCommitHash = pBtree->vc.mergeCommitHash;
+  oldConflictsCatalogHash = pBtree->vc.conflictsCatalogHash;
 
   invalidateCursors(pBt, 0, SQLITE_ABORT);
 
@@ -2150,10 +2150,10 @@ int doltliteHardReset(sqlite3 *db, const ProllyHash *catHash){
       rc = deserializeCatalog(pBtree, oldCatData, nOldCatData);
     }
     sqlite3_free(oldCatData);
-    pBtree->stagedCatalog = oldStagedCatalog;
-    pBtree->isMerging = oldIsMerging;
-    pBtree->mergeCommitHash = oldMergeCommitHash;
-    pBtree->conflictsCatalogHash = oldConflictsCatalogHash;
+    pBtree->vc.stagedCatalog = oldStagedCatalog;
+    pBtree->vc.isMerging = oldIsMerging;
+    pBtree->vc.mergeCommitHash = oldMergeCommitHash;
+    pBtree->vc.conflictsCatalogHash = oldConflictsCatalogHash;
     return rc;
   }
 
@@ -2167,7 +2167,7 @@ int doltliteHardReset(sqlite3 *db, const ProllyHash *catHash){
     invalidateSchema(pBtree);
   }
 
-  memcpy(&pBtree->stagedCatalog, catHash, sizeof(ProllyHash));
+  memcpy(&pBtree->vc.stagedCatalog, catHash, sizeof(ProllyHash));
 
   {
     const char *zBr = pBtree->zBranch ? pBtree->zBranch : "main";
@@ -2189,10 +2189,10 @@ int doltliteHardReset(sqlite3 *db, const ProllyHash *catHash){
         return rc;
       }
     }
-    pBtree->stagedCatalog = oldStagedCatalog;
-    pBtree->isMerging = oldIsMerging;
-    pBtree->mergeCommitHash = oldMergeCommitHash;
-    pBtree->conflictsCatalogHash = oldConflictsCatalogHash;
+    pBtree->vc.stagedCatalog = oldStagedCatalog;
+    pBtree->vc.isMerging = oldIsMerging;
+    pBtree->vc.mergeCommitHash = oldMergeCommitHash;
+    pBtree->vc.conflictsCatalogHash = oldConflictsCatalogHash;
     if( pBtree->db ){
       sqlite3ExpirePreparedStatements(pBtree->db, 0);
       sqlite3ResetAllSchemasOfConnection(pBtree->db);

--- a/src/prolly_btree_int.h
+++ b/src/prolly_btree_int.h
@@ -302,6 +302,17 @@ struct BtCursorOps {
   int (*xCursorIsValidNN)(BtCursor*);
 };
 
+/* Working-set version-control state, tracked live, mirrored at commit, and
+** snapshotted per savepoint. Grouped so a new field is added once and the
+** three copies stay in sync. In-memory only; persisted field-by-field. */
+typedef struct DoltVcState {
+  ProllyHash stagedCatalog;
+  u8 isMerging;
+  ProllyHash mergeCommitHash;
+  ProllyHash conflictsCatalogHash;
+  ProllyHash constraintViolationsHash;
+} DoltVcState;
+
 struct Btree {
   sqlite3 *db;
   BtShared *pBt;
@@ -345,11 +356,7 @@ struct Btree {
     int nTables;
     Pgno iNextTable;
     Pgno iLargestRootPage;
-    ProllyHash stagedCatalog;
-    u8 isMerging;
-    ProllyHash mergeCommitHash;
-    ProllyHash conflictsCatalogHash;
-    ProllyHash constraintViolationsHash;
+    DoltVcState vc;
     u8 isRebasing;
     ProllyHash preRebaseWorkingCat;
     ProllyHash rebaseOntoCommit;
@@ -359,11 +366,7 @@ struct Btree {
   } *aSavepointTables;
 
   ProllyHash committedCatalogHash;
-  ProllyHash committedStagedCatalog;
-  u8 committedIsMerging;
-  ProllyHash committedMergeCommitHash;
-  ProllyHash committedConflictsCatalogHash;
-  ProllyHash committedConstraintViolationsHash;
+  DoltVcState committedVc;
   u32 committedAMeta[16];
   ProllyHash catalogCacheHash;
   u8 *pCatalogCache;
@@ -373,10 +376,7 @@ struct Btree {
   char *zAuthorName;
   char *zAuthorEmail;
   ProllyHash headCommit;
-  ProllyHash stagedCatalog;
-  u8 isMerging;
-  ProllyHash mergeCommitHash;
-  ProllyHash conflictsCatalogHash;
+  DoltVcState vc;
 
   u8 isRebasing;
   ProllyHash preRebaseWorkingCat;
@@ -384,7 +384,6 @@ struct Btree {
   char *zRebaseOrigBranch;
   char *zRebaseReturnBranch;
 
-  ProllyHash constraintViolationsHash;
   /* Transient: a constraint-violation batch open across a merge detection
   ** pass, so appends accumulate in memory and persist once. Owned by
   ** doltlite_constraint_violations.c. */

--- a/src/prolly_btree_state.c
+++ b/src/prolly_btree_state.c
@@ -397,10 +397,10 @@ int btreeReloadBranchWorkingStateInto(
     *pLoadedCatHash = catHash;
   }
 
-  p->stagedCatalog = stagedCatalog;
-  p->isMerging = isMerging;
-  p->mergeCommitHash = mergeCommitHash;
-  p->conflictsCatalogHash = conflictsCatalogHash;
+  p->vc.stagedCatalog = stagedCatalog;
+  p->vc.isMerging = isMerging;
+  p->vc.mergeCommitHash = mergeCommitHash;
+  p->vc.conflictsCatalogHash = conflictsCatalogHash;
   p->isRebasing = isRebasing;
   p->preRebaseWorkingCat = preRebaseCat;
   p->rebaseOntoCommit = rebaseOnto;
@@ -408,7 +408,7 @@ int btreeReloadBranchWorkingStateInto(
   p->zRebaseOrigBranch = zRebaseOrigBranch;
   sqlite3_free(p->zRebaseReturnBranch);
   p->zRebaseReturnBranch = zRebaseReturnBranch;
-  p->constraintViolationsHash = constraintViolationsHash;
+  p->vc.constraintViolationsHash = constraintViolationsHash;
   return SQLITE_OK;
 }
 
@@ -417,11 +417,7 @@ void btreeStoreCommittedFromCurrent(Btree *p, const ProllyHash *pCatHash){
   if( pCatHash ){
     p->committedCatalogHash = *pCatHash;
   }
-  p->committedStagedCatalog = p->stagedCatalog;
-  p->committedIsMerging = p->isMerging;
-  p->committedMergeCommitHash = p->mergeCommitHash;
-  p->committedConflictsCatalogHash = p->conflictsCatalogHash;
-  p->committedConstraintViolationsHash = p->constraintViolationsHash;
+  p->committedVc = p->vc;
   memcpy(p->committedAMeta, p->aMeta, sizeof(p->committedAMeta));
 }
 
@@ -580,7 +576,7 @@ void doltliteSetSessionHead(sqlite3 *db, const ProllyHash *pHead){
 
 void doltliteGetSessionStaged(sqlite3 *db, ProllyHash *pStaged){
   if( db && db->nDb>0 && db->aDb[0].pBt ){
-    memcpy(pStaged, &db->aDb[0].pBt->stagedCatalog, sizeof(ProllyHash));
+    memcpy(pStaged, &db->aDb[0].pBt->vc.stagedCatalog, sizeof(ProllyHash));
   }else{
     memset(pStaged, 0, sizeof(ProllyHash));
   }
@@ -597,7 +593,7 @@ static void sessionStateSyncSavepoints(Btree *p){
 void doltliteSetSessionStaged(sqlite3 *db, const ProllyHash *pStaged){
   if( db && db->nDb>0 && db->aDb[0].pBt ){
     sessionStateSyncSavepoints(db->aDb[0].pBt);
-    memcpy(&db->aDb[0].pBt->stagedCatalog, pStaged, sizeof(ProllyHash));
+    memcpy(&db->aDb[0].pBt->vc.stagedCatalog, pStaged, sizeof(ProllyHash));
   }
 }
 
@@ -606,9 +602,9 @@ void doltliteGetSessionMergeState(sqlite3 *db, u8 *pIsMerging,
                                    ProllyHash *pConflictsCatalog){
   if( db && db->nDb>0 && db->aDb[0].pBt ){
     Btree *p = db->aDb[0].pBt;
-    if( pIsMerging ) *pIsMerging = p->isMerging;
-    if( pMergeCommit ) memcpy(pMergeCommit, &p->mergeCommitHash, sizeof(ProllyHash));
-    if( pConflictsCatalog ) memcpy(pConflictsCatalog, &p->conflictsCatalogHash, sizeof(ProllyHash));
+    if( pIsMerging ) *pIsMerging = p->vc.isMerging;
+    if( pMergeCommit ) memcpy(pMergeCommit, &p->vc.mergeCommitHash, sizeof(ProllyHash));
+    if( pConflictsCatalog ) memcpy(pConflictsCatalog, &p->vc.conflictsCatalogHash, sizeof(ProllyHash));
   }else{
     if( pIsMerging ) *pIsMerging = 0;
     if( pMergeCommit ) memset(pMergeCommit, 0, sizeof(ProllyHash));
@@ -622,11 +618,11 @@ void doltliteSetSessionMergeState(sqlite3 *db, u8 isMerging,
   if( db && db->nDb>0 && db->aDb[0].pBt ){
     Btree *p = db->aDb[0].pBt;
     sessionStateSyncSavepoints(p);
-    p->isMerging = isMerging;
-    if( pMergeCommit ) memcpy(&p->mergeCommitHash, pMergeCommit, sizeof(ProllyHash));
-    else memset(&p->mergeCommitHash, 0, sizeof(ProllyHash));
-    if( pConflictsCatalog ) memcpy(&p->conflictsCatalogHash, pConflictsCatalog, sizeof(ProllyHash));
-    else memset(&p->conflictsCatalogHash, 0, sizeof(ProllyHash));
+    p->vc.isMerging = isMerging;
+    if( pMergeCommit ) memcpy(&p->vc.mergeCommitHash, pMergeCommit, sizeof(ProllyHash));
+    else memset(&p->vc.mergeCommitHash, 0, sizeof(ProllyHash));
+    if( pConflictsCatalog ) memcpy(&p->vc.conflictsCatalogHash, pConflictsCatalog, sizeof(ProllyHash));
+    else memset(&p->vc.conflictsCatalogHash, 0, sizeof(ProllyHash));
   }
 }
 
@@ -686,8 +682,8 @@ void doltliteGetSessionConflictsCatalog(sqlite3 *db, ProllyHash *pHash){
   {
     Btree *p = db->aDb[0].pBt;
     if( !db->autoCommit || sqlite3_txn_state(db, "main")!=SQLITE_TXN_NONE || db->pSavepoint ){
-      if( p->isMerging ){
-        memcpy(pHash, &p->conflictsCatalogHash, sizeof(*pHash));
+      if( p->vc.isMerging ){
+        memcpy(pHash, &p->vc.conflictsCatalogHash, sizeof(*pHash));
       }
       return;
     }
@@ -718,14 +714,14 @@ void doltliteGetSessionConflictsCatalog(sqlite3 *db, ProllyHash *pHash){
 
 void doltliteSetSessionConflictsCatalog(sqlite3 *db, const ProllyHash *pHash){
   if( db && db->nDb>0 && db->aDb[0].pBt ){
-    memcpy(&db->aDb[0].pBt->conflictsCatalogHash, pHash, sizeof(ProllyHash));
+    memcpy(&db->aDb[0].pBt->vc.conflictsCatalogHash, pHash, sizeof(ProllyHash));
   }
 }
 
 void doltliteGetSessionConstraintViolationsCatalog(sqlite3 *db, ProllyHash *pHash){
   if( pHash ) memset(pHash, 0, sizeof(*pHash));
   if( db && db->nDb>0 && db->aDb[0].pBt && pHash ){
-    memcpy(pHash, &db->aDb[0].pBt->constraintViolationsHash, sizeof(ProllyHash));
+    memcpy(pHash, &db->aDb[0].pBt->vc.constraintViolationsHash, sizeof(ProllyHash));
   }
 }
 
@@ -748,14 +744,14 @@ int doltliteGetSessionTableRoot(
 void doltliteSetSessionConstraintViolationsCatalog(sqlite3 *db, const ProllyHash *pHash){
   static const ProllyHash emptyHash = {{0}};
   if( db && db->nDb>0 && db->aDb[0].pBt ){
-    memcpy(&db->aDb[0].pBt->constraintViolationsHash,
+    memcpy(&db->aDb[0].pBt->vc.constraintViolationsHash,
            pHash ? pHash : &emptyHash, sizeof(ProllyHash));
   }
 }
 
 int doltliteSessionHasConstraintViolations(sqlite3 *db){
   if( !db || db->nDb<=0 || !db->aDb[0].pBt ) return 0;
-  return !prollyHashIsEmpty(&db->aDb[0].pBt->constraintViolationsHash);
+  return !prollyHashIsEmpty(&db->aDb[0].pBt->vc.constraintViolationsHash);
 }
 
 void *doltliteGetCvBatch(sqlite3 *db){
@@ -781,12 +777,12 @@ int doltliteSeedSessionHashes(
     Btree *pBt = db->aDb[i].pBt;
     if( !pBt || pBt->pOps!=&prollyBtreeOps || !pBt->pBt ) continue;
     if( &pBt->pBt->store!=cs ) continue;
-    rc = xPush(pCtx, &pBt->stagedCatalog);
-    if( rc==SQLITE_OK ) rc = xPush(pCtx, &pBt->mergeCommitHash);
-    if( rc==SQLITE_OK ) rc = xPush(pCtx, &pBt->conflictsCatalogHash);
+    rc = xPush(pCtx, &pBt->vc.stagedCatalog);
+    if( rc==SQLITE_OK ) rc = xPush(pCtx, &pBt->vc.mergeCommitHash);
+    if( rc==SQLITE_OK ) rc = xPush(pCtx, &pBt->vc.conflictsCatalogHash);
     if( rc==SQLITE_OK ) rc = xPush(pCtx, &pBt->preRebaseWorkingCat);
     if( rc==SQLITE_OK ) rc = xPush(pCtx, &pBt->rebaseOntoCommit);
-    if( rc==SQLITE_OK ) rc = xPush(pCtx, &pBt->constraintViolationsHash);
+    if( rc==SQLITE_OK ) rc = xPush(pCtx, &pBt->vc.constraintViolationsHash);
     /* The live catalog's roots: table 1 can be the runtime master-root view,
     ** which is intentionally absent from the persisted catalog — without this
     ** a GC collects it while the open session still reads through it. */
@@ -827,15 +823,15 @@ int doltliteSaveWorkingSetWithHash(sqlite3 *db, const ProllyHash *pWorkingCatHas
   }
 
   rc = btreeStoreWorkingSetBlob(cs, zBranch, &workingCatHash,
-                                &pBtree->headCommit, &pBtree->stagedCatalog,
-                                pBtree->isMerging, &pBtree->mergeCommitHash,
-                                &pBtree->conflictsCatalogHash,
+                                &pBtree->headCommit, &pBtree->vc.stagedCatalog,
+                                pBtree->vc.isMerging, &pBtree->vc.mergeCommitHash,
+                                &pBtree->vc.conflictsCatalogHash,
                                 pBtree->isRebasing,
                                 &pBtree->preRebaseWorkingCat,
                                 &pBtree->rebaseOntoCommit,
                                 pBtree->zRebaseOrigBranch,
                                 pBtree->zRebaseReturnBranch,
-                                &pBtree->constraintViolationsHash);
+                                &pBtree->vc.constraintViolationsHash);
   if( rc!=SQLITE_OK ) return rc;
 
   if( pBtree->isRebasing
@@ -896,20 +892,20 @@ int doltliteLoadWorkingSet(sqlite3 *db, const char *zBranch){
   if( !cs ) return SQLITE_ERROR;
 
   rc = btreeLoadWorkingSetBlob(cs, zBranch, 0, 0,
-                               &pBtree->stagedCatalog,
-                               &pBtree->isMerging, &pBtree->mergeCommitHash,
-                               &pBtree->conflictsCatalogHash,
+                               &pBtree->vc.stagedCatalog,
+                               &pBtree->vc.isMerging, &pBtree->vc.mergeCommitHash,
+                               &pBtree->vc.conflictsCatalogHash,
                                &pBtree->isRebasing,
                                &pBtree->preRebaseWorkingCat,
                                &pBtree->rebaseOntoCommit,
                                &zNewRebaseOrigBranch,
                                &zNewRebaseReturnBranch,
-                               &pBtree->constraintViolationsHash);
+                               &pBtree->vc.constraintViolationsHash);
   if( rc == SQLITE_NOTFOUND ){
-    memset(&pBtree->stagedCatalog, 0, sizeof(ProllyHash));
-    pBtree->isMerging = 0;
-    memset(&pBtree->mergeCommitHash, 0, sizeof(ProllyHash));
-    memset(&pBtree->conflictsCatalogHash, 0, sizeof(ProllyHash));
+    memset(&pBtree->vc.stagedCatalog, 0, sizeof(ProllyHash));
+    pBtree->vc.isMerging = 0;
+    memset(&pBtree->vc.mergeCommitHash, 0, sizeof(ProllyHash));
+    memset(&pBtree->vc.conflictsCatalogHash, 0, sizeof(ProllyHash));
     pBtree->isRebasing = 0;
     memset(&pBtree->preRebaseWorkingCat, 0, sizeof(ProllyHash));
     memset(&pBtree->rebaseOntoCommit, 0, sizeof(ProllyHash));
@@ -917,7 +913,7 @@ int doltliteLoadWorkingSet(sqlite3 *db, const char *zBranch){
     pBtree->zRebaseOrigBranch = 0;
     sqlite3_free(pBtree->zRebaseReturnBranch);
     pBtree->zRebaseReturnBranch = 0;
-    memset(&pBtree->constraintViolationsHash, 0, sizeof(ProllyHash));
+    memset(&pBtree->vc.constraintViolationsHash, 0, sizeof(ProllyHash));
     return SQLITE_OK;
   }
   if( rc==SQLITE_OK ){

--- a/src/prolly_btree_txn.c
+++ b/src/prolly_btree_txn.c
@@ -59,11 +59,7 @@ void freeSavepointTables(struct SavepointTableState *pState){
     sqlite3_free(pState->aTables);
     pState->aTables = 0;
   }
-  memset(&pState->stagedCatalog, 0, sizeof(pState->stagedCatalog));
-  pState->isMerging = 0;
-  memset(&pState->mergeCommitHash, 0, sizeof(pState->mergeCommitHash));
-  memset(&pState->conflictsCatalogHash, 0, sizeof(pState->conflictsCatalogHash));
-  memset(&pState->constraintViolationsHash, 0, sizeof(pState->constraintViolationsHash));
+  memset(&pState->vc, 0, sizeof(pState->vc));
   pState->isRebasing = 0;
   pState->bSchemaChangedTxn = 0;
   pState->bMasterRootChangedTxn = 0;
@@ -120,11 +116,7 @@ static void captureSavepointSessionState(
   pState->iNextTable = pBtree->cat.iNextTable;
   pState->iLargestRootPage = pBtree->aMeta[BTREE_LARGEST_ROOT_PAGE];
   memcpy(pState->aMeta, pBtree->aMeta, sizeof(pState->aMeta));
-  pState->stagedCatalog = pBtree->stagedCatalog;
-  pState->isMerging = pBtree->isMerging;
-  pState->mergeCommitHash = pBtree->mergeCommitHash;
-  pState->conflictsCatalogHash = pBtree->conflictsCatalogHash;
-  pState->constraintViolationsHash = pBtree->constraintViolationsHash;
+  pState->vc = pBtree->vc;
   pState->isRebasing = pBtree->isRebasing;
   pState->preRebaseWorkingCat = pBtree->preRebaseWorkingCat;
   pState->rebaseOntoCommit = pBtree->rebaseOntoCommit;
@@ -140,11 +132,7 @@ static void restoreSavepointSessionState(
   Btree *pBtree,
   struct SavepointTableState *pState
 ){
-  pBtree->stagedCatalog = pState->stagedCatalog;
-  pBtree->isMerging = pState->isMerging;
-  pBtree->mergeCommitHash = pState->mergeCommitHash;
-  pBtree->conflictsCatalogHash = pState->conflictsCatalogHash;
-  pBtree->constraintViolationsHash = pState->constraintViolationsHash;
+  pBtree->vc = pState->vc;
   memcpy(pBtree->aMeta, pState->aMeta, sizeof(pBtree->aMeta));
   pBtree->aMeta[BTREE_LARGEST_ROOT_PAGE] = pState->iLargestRootPage;
   pBtree->isRebasing = pState->isRebasing;
@@ -837,15 +825,15 @@ int prollyBtreeCommitPhaseTwo(Btree *p, int bCleanup){
         const char *zBr = p->zBranch ? p->zBranch : "main";
         rc = btreeStoreWorkingSetBlob(&pBt->store, zBr, &catHash,
                                       &p->headCommit,
-                                      &p->stagedCatalog, p->isMerging,
-                                      &p->mergeCommitHash,
-                                      &p->conflictsCatalogHash,
+                                      &p->vc.stagedCatalog, p->vc.isMerging,
+                                      &p->vc.mergeCommitHash,
+                                      &p->vc.conflictsCatalogHash,
                                       p->isRebasing,
                                       &p->preRebaseWorkingCat,
                                       &p->rebaseOntoCommit,
                                       p->zRebaseOrigBranch,
                                       p->zRebaseReturnBranch,
-                                      &p->constraintViolationsHash);
+                                      &p->vc.constraintViolationsHash);
         if( rc!=SQLITE_OK ){
           sqlite3_free(catData);
           chunkStoreRollback(&pBt->store);
@@ -910,11 +898,7 @@ int prollyBtreeCommitPhaseTwo(Btree *p, int bCleanup){
     rc = chunkStoreCommit(&pBt->store);
     if( rc==SQLITE_OK ){
       p->committedCatalogHash = catHash;
-      p->committedStagedCatalog = p->stagedCatalog;
-      p->committedIsMerging = p->isMerging;
-      p->committedMergeCommitHash = p->mergeCommitHash;
-      p->committedConflictsCatalogHash = p->conflictsCatalogHash;
-      p->committedConstraintViolationsHash = p->constraintViolationsHash;
+      p->committedVc = p->vc;
       memcpy(p->committedAMeta, p->aMeta, sizeof(p->committedAMeta));
       btreeMarkWorkingStateChanged(p, 1);
       if( bReloadSchema ){
@@ -1141,11 +1125,7 @@ int restoreFromCommitted(Btree *p){
     }
     if( rc!=SQLITE_OK ) return rc;
   }
-  p->stagedCatalog = p->committedStagedCatalog;
-  p->isMerging = p->committedIsMerging;
-  p->mergeCommitHash = p->committedMergeCommitHash;
-  p->conflictsCatalogHash = p->committedConflictsCatalogHash;
-  p->constraintViolationsHash = p->committedConstraintViolationsHash;
+  p->vc = p->committedVc;
   memcpy(p->aMeta, p->committedAMeta, sizeof(p->aMeta));
   return SQLITE_OK;
 }
@@ -1244,12 +1224,12 @@ int prollyBtreeRollback(Btree *p, int tripCode, int writeOnly){
       prollyHashCompute(catData, nCatData, &catHash);
 
       btreeFillWorkingSetBlob(wsBuf, &catHash, &p->headCommit,
-                              &p->stagedCatalog, p->isMerging,
-                              &p->mergeCommitHash, &p->conflictsCatalogHash,
+                              &p->vc.stagedCatalog, p->vc.isMerging,
+                              &p->vc.mergeCommitHash, &p->vc.conflictsCatalogHash,
                               p->isRebasing, &p->preRebaseWorkingCat,
                               &p->rebaseOntoCommit,
                               p->zRebaseOrigBranch, p->zRebaseReturnBranch,
-                              &p->constraintViolationsHash);
+                              &p->vc.constraintViolationsHash);
       prollyHashCompute(wsBuf, WS_TOTAL_SIZE, &wsHashWouldBe);
 
       if( chunkStoreGetBranchWorkingSet(&pBt->store, zBr, &wsHashOnDisk)
@@ -1262,15 +1242,15 @@ int prollyBtreeRollback(Btree *p, int tripCode, int writeOnly){
         rc = chunkStorePut(&pBt->store, catData, nCatData, &catHash);
         if( rc==SQLITE_OK ){
           rc = btreeStoreWorkingSetBlob(&pBt->store, zBr, &catHash,
-                                        &p->headCommit, &p->stagedCatalog,
-                                        p->isMerging, &p->mergeCommitHash,
-                                        &p->conflictsCatalogHash,
+                                        &p->headCommit, &p->vc.stagedCatalog,
+                                        p->vc.isMerging, &p->vc.mergeCommitHash,
+                                        &p->vc.conflictsCatalogHash,
                                         p->isRebasing,
                                         &p->preRebaseWorkingCat,
                                         &p->rebaseOntoCommit,
                                         p->zRebaseOrigBranch,
                                         p->zRebaseReturnBranch,
-                                        &p->constraintViolationsHash);
+                                        &p->vc.constraintViolationsHash);
         }
         if( rc==SQLITE_OK ){
           rc = chunkStoreSerializeRefs(&pBt->store);
@@ -1372,15 +1352,15 @@ static int persistRolledBackSessionState(Btree *p, BtShared *pBt){
   sqlite3_free(catData);
   if( rc!=SQLITE_OK ) return rc;
   rc = btreeStoreWorkingSetBlob(&pBt->store, zBr, &catHash,
-                                &p->headCommit, &p->stagedCatalog,
-                                p->isMerging, &p->mergeCommitHash,
-                                &p->conflictsCatalogHash,
+                                &p->headCommit, &p->vc.stagedCatalog,
+                                p->vc.isMerging, &p->vc.mergeCommitHash,
+                                &p->vc.conflictsCatalogHash,
                                 p->isRebasing,
                                 &p->preRebaseWorkingCat,
                                 &p->rebaseOntoCommit,
                                 p->zRebaseOrigBranch,
                                 p->zRebaseReturnBranch,
-                                &p->constraintViolationsHash);
+                                &p->vc.constraintViolationsHash);
   if( rc!=SQLITE_OK ) return rc;
   rc = chunkStoreSerializeRefs(&pBt->store);
   if( rc!=SQLITE_OK ) return rc;


### PR DESCRIPTION
## What

The working-set version-control fields — `stagedCatalog`, `isMerging`, `mergeCommitHash`, `conflictsCatalogHash`, `constraintViolationsHash` — were declared **three times** in `struct Btree`:

1. Live (`p->stagedCatalog`, …)
2. A `committed*` mirror (`p->committedStagedCatalog`, …)
3. Inside `SavepointTableState` (`pState->stagedCatalog`, …)

…and copied field-by-field in **five** places: commit (`btreeStoreCommittedFromCurrent` + the inline commit block in txn.c), rollback-to-committed, savepoint capture, savepoint restore, and free. Adding a VC field meant editing all three declarations plus every copy site — and missing one silently drops the field from a snapshot (a standing correctness hazard around merge/conflict/rollback state).

## Change

Introduce `DoltVcState` holding those five fields and embed it as `Btree.vc`, `Btree.committedVc`, and `SavepointTableState.vc`. The five copy blocks collapse to single struct assignments:

```c
p->committedVc = p->vc;   // commit-mirror
p->vc = p->committedVc;   // rollback-to-committed
pState->vc = pBtree->vc;  // savepoint capture
pBtree->vc = pState->vc;  // savepoint restore
memset(&pState->vc, 0, sizeof(pState->vc));  // free
```

A new VC field is now added once (to the struct) and propagates to all three copies automatically.

**In-memory only.** The working set is still persisted field-by-field via `btreeStoreWorkingSetBlob`/`btreeLoadWorkingSetBlob`, so the on-disk format is unchanged. Pure refactor, no behavior change. Net −25 lines.

## Verification

- Full `doltlite` CLI + `libdoltlite.a` rebuild, clean (`-Werror`, no warnings).
- 11 state-sensitive shell suites pass: savepoint, merge, conflicts, conflict_rows, rebase, reset, snapshot_isolation, rollback_durability, staging, commit, working_set.
- 6 C tests pass: sql_transaction, invariant, three_way_diff, catalog_serialize_determinism, sequence_reload, prepared_stmt_reuse — these exercise the savepoint capture/restore and commit/rollback paths directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)