### PR TITLE
Propagate dirty working state errors

### DIFF
--- a/src/doltlite_branch.c
+++ b/src/doltlite_branch.c
@@ -585,10 +585,13 @@ struct CheckoutMutationCtx {
 ** (falling back to HEAD). Returns an error code; callers handle reporting. */
 static int checkoutCaptureOldCatalog(sqlite3 *db, ChunkStore *cs,
                                      ProllyHash *pOldCatHash){
-  if( doltliteHasUncommittedChanges(db) ){
+  int dirty;
+  int rc = doltliteHasUncommittedChanges(db, &dirty);
+  if( rc!=SQLITE_OK ) return rc;
+  if( dirty ){
     u8 *oldCatData = 0;
     int nOldCat = 0;
-    int rc = doltliteFlushAndSerializeCatalog(db, &oldCatData, &nOldCat);
+    rc = doltliteFlushAndSerializeCatalog(db, &oldCatData, &nOldCat);
     if( rc!=SQLITE_OK ) return rc;
     rc = chunkStorePut(cs, oldCatData, nOldCat, pOldCatHash);
     sqlite3_free(oldCatData);
@@ -1559,8 +1562,7 @@ static int brIsDirty(
   *pDirty = 0;
 
   if( strcmp(br->zName, doltliteGetSessionBranch(db))==0 ){
-    *pDirty = doltliteHasUncommittedChanges(db) ? 1 : 0;
-    return SQLITE_OK;
+    return doltliteHasUncommittedChanges(db, pDirty);
   }
   if( prollyHashIsEmpty(&br->workingSetHash) ){
     return SQLITE_OK;

--- a/src/doltlite_cherry_pick.c
+++ b/src/doltlite_cherry_pick.c
@@ -299,6 +299,7 @@ static void doltliteCherryPickFunc(
   ProllyHash pickHash, ourHead;
   DoltliteCommit pickCommit, parentCommit, ourCommit;
   int nConflicts = 0;
+  int dirty = 0;
   int rc;
   char hexBuf[PROLLY_HASH_SIZE*2+1];
 
@@ -323,7 +324,12 @@ static void doltliteCherryPickFunc(
     return;
   }
 
-  if( doltliteHasUncommittedChanges(db) ){
+  rc = doltliteHasUncommittedChanges(db, &dirty);
+  if( rc!=SQLITE_OK ){
+    sqlite3_result_error_code(context, rc);
+    return;
+  }
+  if( dirty ){
     sqlite3_result_error(context,
       "cannot cherry-pick with uncommitted changes", -1);
     return;

--- a/src/doltlite_commit.c
+++ b/src/doltlite_commit.c
@@ -169,11 +169,15 @@ int doltliteRefIsStaged(const char *zRef){
 
 int doltliteResolveCatalogHashForRef(sqlite3 *db, const char *zRef,
                                      ProllyHash *pCatHash){
+  int dirty;
+  int rc;
   if( !zRef ){
     return doltliteGetHeadCatalogHash(db, pCatHash);
   }
   if( doltliteRefIsWorking(zRef) ){
-    if( doltliteHasUncommittedChanges(db) ){
+    rc = doltliteHasUncommittedChanges(db, &dirty);
+    if( rc!=SQLITE_OK ) return rc;
+    if( dirty ){
       return doltliteFlushCatalogToHash(db, pCatHash);
     }
     return doltliteGetPersistedWorkingCatalogHash(db, pCatHash);

--- a/src/doltlite_core.c
+++ b/src/doltlite_core.c
@@ -137,16 +137,20 @@ int doltliteRefreshAndConfirmHead(
   return SQLITE_OK;
 }
 
-int doltliteHasUncommittedChanges(sqlite3 *db){
+int doltliteHasUncommittedChanges(sqlite3 *db, int *pDirty){
   ProllyHash headCatHash, stagedHash, workingCatHash;
   u8 *wCatData = 0; int nWCat = 0;
   int rc;
 
+  if( !db || !pDirty ) return SQLITE_MISUSE;
+  *pDirty = 0;
+
   rc = doltliteGetHeadCatalogHash(db, &headCatHash);
-  if( rc!=SQLITE_OK ) return 0;
+  if( rc!=SQLITE_OK ) return rc;
   if( prollyHashIsEmpty(&headCatHash) ){
     sqlite3_stmt *pStmt = 0;
-    int hasUserTables = 0;
+    int stepRc;
+    int finalizeRc;
     rc = sqlite3_prepare_v2(db,
       "SELECT 1 FROM sqlite_master "
       "WHERE type='table' "
@@ -154,32 +158,42 @@ int doltliteHasUncommittedChanges(sqlite3 *db){
       "AND name NOT LIKE 'dolt_%' "
       "LIMIT 1",
       -1, &pStmt, 0);
-    if( rc==SQLITE_OK && sqlite3_step(pStmt)==SQLITE_ROW ){
-      hasUserTables = 1;
+    if( rc!=SQLITE_OK ) return rc;
+    stepRc = sqlite3_step(pStmt);
+    if( stepRc==SQLITE_ROW ){
+      *pDirty = 1;
+      rc = SQLITE_OK;
+    }else if( stepRc==SQLITE_DONE ){
+      rc = SQLITE_OK;
+    }else{
+      rc = stepRc;
     }
-    sqlite3_finalize(pStmt);
-    return hasUserTables;
+    finalizeRc = sqlite3_finalize(pStmt);
+    return rc==SQLITE_OK ? finalizeRc : rc;
   }
 
   doltliteGetSessionStaged(db, &stagedHash);
   if( !prollyHashIsEmpty(&stagedHash)
    && prollyHashCompare(&headCatHash, &stagedHash)!=0 ){
-    return 1;
+    *pDirty = 1;
+    return SQLITE_OK;
   }
 
   {
     ChunkStore *cs = doltliteGetChunkStore(db);
-    if( cs ){
-      rc = doltliteFlushAndSerializeCatalog(db, &wCatData, &nWCat);
-      if( rc==SQLITE_OK ){
-        rc = chunkStorePut(cs, wCatData, nWCat, &workingCatHash);
-        sqlite3_free(wCatData);
-        if( rc==SQLITE_OK && prollyHashCompare(&headCatHash, &workingCatHash)!=0 ){
-          return 1;
-        }
-      }
+    if( !cs ) return SQLITE_ERROR;
+    rc = doltliteFlushAndSerializeCatalog(db, &wCatData, &nWCat);
+    if( rc!=SQLITE_OK ){
+      sqlite3_free(wCatData);
+      return rc;
     }
-    return 0;
+    rc = chunkStorePut(cs, wCatData, nWCat, &workingCatHash);
+    sqlite3_free(wCatData);
+    if( rc!=SQLITE_OK ) return rc;
+    if( prollyHashCompare(&headCatHash, &workingCatHash)!=0 ){
+      *pDirty = 1;
+    }
+    return SQLITE_OK;
   }
 }
 

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -964,7 +964,7 @@ int doltliteConstraintViolationBatchEnd(sqlite3 *db, int commit);
 int doltliteGetWorkingTableState(sqlite3 *db, const char *zTable,
                                  ProllyHash *pRoot, u8 *pFlags,
                                  ProllyHash *pSchemaHash);
-int doltliteHasUncommittedChanges(sqlite3 *db);
+int doltliteHasUncommittedChanges(sqlite3 *db, int *pDirty);
 void doltliteTxnStateClear(DoltliteTxnState *p);
 int doltliteSaveTxnState(sqlite3 *db, DoltliteTxnState *p);
 int doltliteRestoreTxnState(sqlite3 *db, DoltliteTxnState *p);

--- a/src/doltlite_merge_cmd.c
+++ b/src/doltlite_merge_cmd.c
@@ -160,6 +160,7 @@ static void doltliteMergeFunc(
   int nMergeConflicts = 0;
   DoltliteCommit ourCommit, theirCommit, ancCommit;
   int graphLocked = 0;
+  int dirty = 0;
   int rc, i;
 
   memset(&ourCommit, 0, sizeof(ourCommit));
@@ -244,7 +245,12 @@ static void doltliteMergeFunc(
     return;
   }
 
-  if( doltliteHasUncommittedChanges(db) ){
+  rc = doltliteHasUncommittedChanges(db, &dirty);
+  if( rc!=SQLITE_OK ){
+    sqlite3_result_error_code(context, rc);
+    return;
+  }
+  if( dirty ){
     sqlite3_result_error(context,
       "uncommitted changes \xe2\x80\x94 commit or reset before merging", -1);
     return;

--- a/src/doltlite_rebase.c
+++ b/src/doltlite_rebase.c
@@ -185,6 +185,7 @@ static int doltliteRebaseLinearReplay(
   int savedInit = 0;
   int rc;
   int i;
+  int dirty = 0;
   char *zFailedMsg = 0;
   int bConflict = 0;
   assert( db!=0 && context!=0 && zUpstream!=0 && pzFinalMessage!=0 );
@@ -195,7 +196,13 @@ static int doltliteRebaseLinearReplay(
   memset(&saved, 0, sizeof(saved));
   memset(&upstreamCommit, 0, sizeof(upstreamCommit));
 
-  if( doltliteHasUncommittedChanges(db) ){
+  rc = doltliteHasUncommittedChanges(db, &dirty);
+  if( rc!=SQLITE_OK ){
+    sqlite3_result_error_code(context, rc);
+    if( sealTopLevel ) (void)doltliteVcSealTopLevelSavepointTxn(db);
+    return rc;
+  }
+  if( dirty ){
     sqlite3_result_error(context,
       "cannot start a rebase with uncommitted changes", -1);
     if( sealTopLevel ) (void)doltliteVcSealTopLevelSavepointTxn(db);
@@ -880,6 +887,7 @@ static void doltliteRebaseInteractiveStart(
   ProllyHash *aReplay = 0;
   int nReplay = 0;
   int rc;
+  int dirty = 0;
   u8 curIsRebasing = 0;
   int bWorkingBranchCreated = 0;
   const char *zFailMsg = 0;
@@ -899,7 +907,12 @@ static void doltliteRebaseInteractiveStart(
     return;
   }
 
-  if( doltliteHasUncommittedChanges(db) ){
+  rc = doltliteHasUncommittedChanges(db, &dirty);
+  if( rc!=SQLITE_OK ){
+    sqlite3_result_error_code(context, rc);
+    return;
+  }
+  if( dirty ){
     sqlite3_result_error(context,
       "cannot start a rebase with uncommitted changes", -1);
     return;

--- a/src/doltlite_remote_sql.c
+++ b/src/doltlite_remote_sql.c
@@ -445,6 +445,7 @@ static void doltPullFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   const char *zBranch;
   ProllyHash trackingCommit, localCommit;
   DoltliteTxnState savedState;
+  int dirty = 0;
   int rc;
 
   if( !cs ){ doltliteVcResultError(ctx, db, "no database"); return; }
@@ -547,11 +548,17 @@ static void doltPullFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
     }
   }
 
-  if( strcmp(zBranch, doltliteGetSessionBranch(db))==0
-   && doltliteHasUncommittedChanges(db) ){
-    remoteSqlRestoreAndReport(ctx, db, cs, &savedState, SQLITE_ERROR,
-                              "cannot pull with uncommitted changes");
-    return;
+  if( strcmp(zBranch, doltliteGetSessionBranch(db))==0 ){
+    rc = doltliteHasUncommittedChanges(db, &dirty);
+    if( rc!=SQLITE_OK ){
+      remoteSqlRestoreAndReport(ctx, db, cs, &savedState, rc, 0);
+      return;
+    }
+    if( dirty ){
+      remoteSqlRestoreAndReport(ctx, db, cs, &savedState, SQLITE_ERROR,
+                                "cannot pull with uncommitted changes");
+      return;
+    }
   }
 
   /* Advance and persist the branch under the graph lock, first re-confirming
@@ -607,6 +614,7 @@ static void doltCloneFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   DoltliteRemote *pRemote = 0;
   const char *zUrl;
   DoltliteTxnState savedState;
+  int dirty = 0;
   int rc;
 
   if( !cs ){ doltliteVcResultError(ctx, db, "no database"); return; }
@@ -626,7 +634,12 @@ static void doltCloneFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   }
   memset(&savedState, 0, sizeof(savedState));
 
-  if( doltliteHasUncommittedChanges(db) ){
+  rc = doltliteHasUncommittedChanges(db, &dirty);
+  if( rc!=SQLITE_OK ){
+    sqlite3_result_error_code(ctx, rc);
+    return;
+  }
+  if( dirty ){
     doltliteVcResultError(ctx, db,
       "database has uncommitted changes — clone into a fresh database");
     return;

--- a/test/catalog_serialize_determinism_test.c
+++ b/test/catalog_serialize_determinism_test.c
@@ -8,17 +8,21 @@
 ** unstable dirty flags.
 **
 ** For every context below, a clean tree must also serialize to a hash the
-** engine itself considers clean (doltliteHasUncommittedChanges == 0).
+** engine itself considers clean (doltliteHasUncommittedChanges reports
+** SQLITE_OK and dirty == 0).
 */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
 #include "sqlite3.h"
+#include "prolly_hash.h"
 
 extern int doltliteFlushAndSerializeCatalog(sqlite3 *db,
                                             unsigned char **ppOut, int *pnOut);
-extern int doltliteHasUncommittedChanges(sqlite3 *db);
+extern int doltliteHasUncommittedChanges(sqlite3 *db, int *pDirty);
+extern void doltliteGetSessionHead(sqlite3 *db, ProllyHash *pHead);
+extern void doltliteSetSessionHead(sqlite3 *db, const ProllyHash *pHead);
 
 static int nPass = 0;
 static int nFail = 0;
@@ -167,7 +171,11 @@ int main(int argc, char **argv){
 
     snprintf(zLabel, sizeof(zLabel), "clean_tree_not_dirty[%s]",
              aCtx[i].zName);
-    check(zLabel, doltliteHasUncommittedChanges(db)==0);
+    {
+      int dirty = 0;
+      rc = doltliteHasUncommittedChanges(db, &dirty);
+      check(zLabel, rc==SQLITE_OK && dirty==0);
+    }
 
     sqlite3_close(db);
 
@@ -191,7 +199,24 @@ int main(int argc, char **argv){
       sqlite3_free(pAfter);
     }
     snprintf(zLabel, sizeof(zLabel), "reopen_not_dirty[%s]", aCtx[i].zName);
-    check(zLabel, doltliteHasUncommittedChanges(db)==0);
+    {
+      int dirty = 0;
+      rc = doltliteHasUncommittedChanges(db, &dirty);
+      check(zLabel, rc==SQLITE_OK && dirty==0);
+    }
+    {
+      ProllyHash savedHead;
+      ProllyHash missingHead;
+      int dirty = 1;
+      memset(&missingHead, 0xa5, sizeof(missingHead));
+      doltliteGetSessionHead(db, &savedHead);
+      doltliteSetSessionHead(db, &missingHead);
+      rc = doltliteHasUncommittedChanges(db, &dirty);
+      snprintf(zLabel, sizeof(zLabel), "missing_head_error[%s]",
+               aCtx[i].zName);
+      check(zLabel, rc==SQLITE_NOTFOUND && dirty==0);
+      doltliteSetSessionHead(db, &savedHead);
+    }
     sqlite3_close(db);
   }
   sqlite3_free(aRef);


### PR DESCRIPTION
## Summary
- make dirty working-state inspection return an SQLite status separately from the dirty flag
- fail merge, checkout, rebase, cherry-pick, pull, clone, ref resolution, and branch metadata reads when inspection fails
- add deterministic missing-HEAD coverage proving inspection errors are not reported as a clean tree

## Testing
- `make -j4 doltlite catalog_serialize_determinism_test oom_dolt_fault_test`
- `./catalog_serialize_determinism_test` (80 passed)
- `./oom_dolt_fault_test` (7 operation families passed)
- focused branch, merge, cherry-pick/revert, rebase, and remote suites
- `bash test/run_doltlite_tests.sh` (89/89 suites passed; 309,909 C regression assertions)
- `bash test/lint_orphaned_suites.sh`
- `bash test/dead_code_check.sh`

`make devtest` was also attempted. The unfiltered upstream runner reached 2,545/2,546 Tcl files, reported the expected DoltLite storage compatibility divergences, and stalled in `fts5aa.test`; it was stopped after three minutes. The repository-specific gated suite above passed cleanly.