### PR TITLE
Reject commit metadata allocation failures

### DIFF
--- a/src/doltlite_core.c
+++ b/src/doltlite_core.c
@@ -378,8 +378,20 @@ int doltliteCreateAndStoreCommitWithTime(
   memcpy(&c.catalogHash, pCatalog, sizeof(ProllyHash));
   c.timestamp = explicitTimestamp ? explicitTimestamp : (i64)time(0);
   c.zName  = sqlite3_mprintf("%s", zAuthorName  ? zAuthorName  : doltliteGetAuthorName(db));
+  if( c.zName==0 ){
+    rc = SQLITE_NOMEM;
+    goto create_commit_done;
+  }
   c.zEmail = sqlite3_mprintf("%s", zAuthorEmail ? zAuthorEmail : doltliteGetAuthorEmail(db));
-  c.zMessage = sqlite3_mprintf("%s", zMessage);
+  if( c.zEmail==0 ){
+    rc = SQLITE_NOMEM;
+    goto create_commit_done;
+  }
+  c.zMessage = sqlite3_mprintf("%s", zMessage ? zMessage : "");
+  if( c.zMessage==0 ){
+    rc = SQLITE_NOMEM;
+    goto create_commit_done;
+  }
 
   if( nExtraParents > 0 && aExtraParents ){
     c.aParents[0] = *pParent;
@@ -392,6 +404,7 @@ int doltliteCreateAndStoreCommitWithTime(
 
   rc = doltliteCommitSerialize(&c, &commitData, &nCommitData);
   if( rc==SQLITE_OK ) rc = chunkStorePut(cs, commitData, nCommitData, pCommitHash);
+create_commit_done:
   sqlite3_free(commitData);
   doltliteCommitClear(&c);
   return rc;

--- a/test/oom_dolt_fault_test.c
+++ b/test/oom_dolt_fault_test.c
@@ -132,6 +132,10 @@ static void cleanupFiles(const char *base){
 
 static int setupBase(sqlite3 *db){
   int rc;
+  rc = execSilent(db,
+      "SELECT dolt_config('user.name','oom-author'),"
+      "       dolt_config('user.email','oom@example.com')");
+  if( rc ) return rc;
   rc = execSilent(db, "CREATE TABLE t(a INTEGER PRIMARY KEY, b TEXT)");
   if( rc ) return rc;
   rc = execSilent(db, "INSERT INTO t VALUES(1,'one'),(2,'two'),(3,'three')");
@@ -144,6 +148,33 @@ static int setupBase(sqlite3 *db){
 
 typedef int (*OpFn)(sqlite3 *db);
 
+static int verifyLatestCommitMetadata(sqlite3 *db){
+  sqlite3_stmt *stmt = 0;
+  const char *zName;
+  const char *zEmail;
+  const char *zMessage;
+  int rc;
+  int frc;
+  rc = sqlite3_prepare_v2(db,
+      "SELECT committer,email,message FROM dolt_log LIMIT 1",
+      -1, &stmt, 0);
+  if( rc!=SQLITE_OK ) return rc;
+  rc = sqlite3_step(stmt);
+  if( rc==SQLITE_ROW ){
+    zName = (const char*)sqlite3_column_text(stmt, 0);
+    zEmail = (const char*)sqlite3_column_text(stmt, 1);
+    zMessage = (const char*)sqlite3_column_text(stmt, 2);
+    rc = zName && strcmp(zName, "oom-author")==0
+      && zEmail && strcmp(zEmail, "oom@example.com")==0
+      && zMessage && strcmp(zMessage, "iter")==0
+      ? SQLITE_OK : SQLITE_CORRUPT;
+  }else if( rc==SQLITE_DONE ){
+    rc = SQLITE_CORRUPT;
+  }
+  frc = sqlite3_finalize(stmt);
+  return rc==SQLITE_OK ? frc : rc;
+}
+
 static int opCommit(sqlite3 *db){
   int rc;
   rc = execSilent(db, "INSERT INTO t VALUES(4,'four')");
@@ -151,7 +182,8 @@ static int opCommit(sqlite3 *db){
   rc = execSilent(db, "SELECT dolt_add('-A')");
   if( rc ) return rc;
   rc = execSilent(db, "SELECT dolt_commit('-m','iter')");
-  return rc;
+  if( rc ) return rc;
+  return verifyLatestCommitMetadata(db);
 }
 
 static int opBranchCreate(sqlite3 *db){


### PR DESCRIPTION
## Summary

- fail commit creation with `SQLITE_NOMEM` when author, email, or message allocation fails
- prevent partially allocated metadata from being serialized as empty strings and stored as a valid commit
- strengthen the Dolt OOM oracle so any successful commit must retain its configured author, email, and message

Before the fix, the oracle found three corrupt-success fault points, one for each metadata field. After the fix, all three return an accepted OOM error and no commit with missing metadata is accepted.

## Testing

- `make -j4 oom_dolt_fault_test && ./oom_dolt_fault_test` (7 operations, 500 fault points each; 0 bugs)
- `DOLTLITE=./build/doltlite bash test/doltlite_commit.sh` (62/62)
- `DOLTLITE=./build/doltlite bash test/doltlite_merge.sh` (94/94)
- `DOLTLITE=./build/doltlite bash test/doltlite_rebase.sh` (8/8)
- `DOLTLITE=./build/doltlite bash test/doltlite_cherry_pick.sh` (98/98)
- `bash test/run_doltlite_tests.sh` (89/89 suites; C regression test 309,909/309,909)
- `bash test/lint_orphaned_suites.sh`
- `bash test/dead_code_check.sh`
- `make devtest` (reproduces the existing DoltLite baseline: 1,621 upstream incompatibility failures and stalls at 2,545/2,546)
