### PR TITLE
Bound total request-read time in remote server

### DIFF
--- a/src/doltlite_remotesrv.c
+++ b/src/doltlite_remotesrv.c
@@ -123,6 +123,20 @@ static int remoteSrvCommitPending(ChunkStore *pStore){
 #define MAX_REQUEST_BYTES  (128 * 1024 * 1024)  /* 128 MiB total body */
 #define MAX_RESPONSE_BYTES MAX_REQUEST_BYTES    /* 128 MiB total reply */
 
+/* Per-request read deadlines. The per-recv socket timeout only bounds a
+** single recv, so a client dribbling one byte per recv could pin a worker
+** for MAX_HEADER_SIZE * timeout. The whole header must arrive within one
+** timeout window; the body gets that same grace then must sustain
+** BODY_MIN_RATE, which aborts a slow-loris while allowing a genuinely slow
+** large upload. */
+#define SERVER_BODY_MIN_RATE     (64 * 1024)
+
+static i64 monotonicMs(void){
+  struct timespec ts;
+  clock_gettime(CLOCK_MONOTONIC, &ts);
+  return (i64)ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
+}
+
 /* Grow *pp to at least need bytes, capped at MAX_RESPONSE_BYTES. Uses
 ** sqlite3_realloc64 so sizes above 2 GiB-on-int truncation never under-alloc.
 ** Returns SQLITE_OK, SQLITE_NOMEM, or SQLITE_TOOBIG. */
@@ -150,12 +164,17 @@ static int remoteSrvGrowBuf(u8 **pp, i64 *pnAlloc, i64 need){
   return SQLITE_OK;
 }
 
-static int readExact(DoltliteConn *fd, u8 *pBuf, int nBytes){
+static int readExact(DoltliteConn *fd, u8 *pBuf, int nBytes,
+                     i64 startMs, int graceMs){
   int nRead = 0;
   while( nRead < nBytes ){
     int n = doltliteConnRead(fd, pBuf + nRead, nBytes - nRead);
     if( n <= 0 ) return -1;
     nRead += n;
+    if( monotonicMs() - startMs
+        > graceMs + (i64)nRead * 1000 / SERVER_BODY_MIN_RATE ){
+      return -1;
+    }
   }
   return 0;
 }
@@ -199,7 +218,8 @@ static int parseRequest(
   char *zMethod, int nMethodMax,
   char *zPath, int nPathMax,
   char *zAuth, int nAuthMax,
-  u8 **ppBody, int *pnBody
+  u8 **ppBody, int *pnBody,
+  int timeoutMs
 ){
   char aBuf[MAX_HEADER_SIZE];
   int nBuf = 0;
@@ -207,6 +227,7 @@ static int parseRequest(
   int contentLength = 0;
   int seenContentLength = 0;
   int seenAuthorization = 0;
+  i64 startMs = monotonicMs();
   char *p;
 
   *ppBody = 0;
@@ -216,6 +237,7 @@ static int parseRequest(
   while( nBuf < MAX_HEADER_SIZE-1 ){
     int n = doltliteConnRead(fd, &aBuf[nBuf], 1);
     if( n <= 0 ) return -1;
+    if( monotonicMs() - startMs > timeoutMs ) return -1;
     nBuf++;
     if( nBuf>=4
      && aBuf[nBuf-4]=='\r' && aBuf[nBuf-3]=='\n'
@@ -299,7 +321,7 @@ static int parseRequest(
   if( contentLength > 0 ){
     u8 *pBody = (u8*)sqlite3_malloc(contentLength);
     if( !pBody ) return -1;
-    if( readExact(fd, pBody, contentLength)!=0 ){
+    if( readExact(fd, pBody, contentLength, monotonicMs(), timeoutMs)!=0 ){
       sqlite3_free(pBody);
       return -1;
     }
@@ -765,7 +787,8 @@ static void handleRequest(DoltliteServer *pSrv, DoltliteConn *fd){
 
   rc = parseRequest(fd, zMethod, sizeof(zMethod),
                     zPath, sizeof(zPath),
-                    zAuth, sizeof(zAuth), &pBody, &nBody);
+                    zAuth, sizeof(zAuth), &pBody, &nBody,
+                    pSrv->timeoutMs);
   if( rc!=0 ){
     if( rc==-2 ){
       sendPayloadTooLarge(fd);

--- a/test/remotesrv_stall_test.sh
+++ b/test/remotesrv_stall_test.sh
@@ -107,6 +107,35 @@ def expect_closed(s):
         pass
     s.close()
 
+def expect_dribble_closed(prefix):
+    # Dribble bytes slower than the total request deadline but faster than the
+    # per-recv timeout, so every recv succeeds yet the connection must still be
+    # cut. Without a total deadline this pins a worker indefinitely.
+    s = socket.create_connection(("127.0.0.1", port), timeout=2)
+    s.sendall(prefix)
+    start = time.monotonic()
+    closed_at = None
+    for _ in range(20):
+        try:
+            s.sendall(b"X")
+        except OSError:
+            closed_at = time.monotonic() - start
+            break
+        s.settimeout(1.0)
+        try:
+            if s.recv(4096) == b"":
+                closed_at = time.monotonic() - start
+                break
+        except socket.timeout:
+            pass
+        except OSError:
+            closed_at = time.monotonic() - start
+            break
+        time.sleep(0.5)
+    s.close()
+    assert closed_at is not None, "server never cut the dribbling client"
+    assert closed_at < 8, closed_at
+
 header = connect(b"G")
 body = connect(
     b"POST /repo.db/chunks HTTP/1.1\r\n"
@@ -117,6 +146,16 @@ expect_closed(header)
 expect_closed(body)
 print("  PASS: partial headers and bodies do not block healthy requests")
 print("  PASS: plaintext read deadlines close stalled clients")
+
+# A never-ending header, one byte at a time.
+expect_dribble_closed(b"GET /repo.db/roo")
+# A body that never reaches its declared Content-Length.
+expect_dribble_closed(
+    b"POST /repo.db/chunks HTTP/1.1\r\n"
+    b"Host: localhost\r\nContent-Length: 100000\r\n\r\n"
+)
+healthy_request()
+print("  PASS: dribbling header and body clients are cut by the request deadline")
 PY
 stop_server_with_stalled_clients "$PORT"
 


### PR DESCRIPTION
## Vulnerability (slow-loris DoS)

`doltlite-remotesrv` runs a fixed pool of 4 blocking workers (`SERVER_WORKERS`). The per-recv socket timeout (`--timeout-ms`, default 30s) only bounds a *single* `recv`, but the request readers make many:

- `parseRequest` reads the request header **one byte at a time** (`while … doltliteConnRead(fd, &aBuf[nBuf], 1)`), up to `MAX_HEADER_SIZE` (4096) iterations.
- `readExact` reads the body up to `Content-Length` bytes.

A client that dribbles one byte per recv — each arriving just under the per-recv timeout — keeps every `recv` "successful", so the worker never times out and stays pinned for up to `MAX_HEADER_SIZE × timeout` (hours). Four such connections starve the whole pool. Auth is only checked *after* the full header is read, so `--auth-keys` does not mitigate it. (Medium severity; server is designed for trusted networks / reverse-proxy fronting, default bind loopback.)

## Fix

Add a per-request read deadline derived from the configured `timeoutMs` (mod_reqtimeout style):

- **Header:** the entire header must arrive within one `timeoutMs` window.
- **Body:** an initial `timeoutMs` grace, then a required minimum sustained throughput of `SERVER_BODY_MIN_RATE` (64 KiB/s) — the deadline scales with bytes received, so a dribbler is cut just past the grace while a genuinely slow *large* upload is still allowed.

Deadlines use a monotonic clock (`clock_gettime(CLOCK_MONOTONIC)`), and derive from `--timeout-ms` so operators can tune them (and the test runs fast at 2s).

This bounds worker-hold time; it does not convert the blocking pool to async I/O (out of scope) — a determined attacker can still occupy workers for bounded windows, but no longer indefinitely at zero cost.

## Verification (fail-before / pass-after)

Extended `test/remotesrv_stall_test.sh` with dribbling header and body clients (bytes paced under the per-recv timeout but past the total deadline):

- **Unfixed binary:** `AssertionError: server never cut the dribbling client`.
- **Fixed binary:** `PASS: dribbling header and body clients are cut by the request deadline`.

The suite's existing silent-partial-request and healthy-request (<1.5s) checks still pass, and `http_remote_content_length_test.sh`, `remotesrv_http_test.sh`, `remotesrv_http_concurrency_test.sh`, and `remotesrv_http_partial_failure_test.sh` (real push/pull with large bodies) all pass — confirming legitimate uploads are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)