### PR TITLE
Propagate VC savepoint allocation failures

### DIFF
--- a/src/doltlite_add.c
+++ b/src/doltlite_add.c
@@ -210,7 +210,7 @@ static int addWriteStagedCatalog(
   }
   sqlite3_free(buf);
   if( rc==SQLITE_OK ){
-    doltliteSetSessionStaged(db, &newStagedHash);
+    rc = doltliteSetSessionStaged(db, &newStagedHash);
   }
   return rc;
 }
@@ -363,8 +363,7 @@ static int addStageAllTables(
   }
 
   if( useWorkingHash ){
-    doltliteSetSessionStaged(db, pWorkingHash);
-    rc = SQLITE_OK;
+    rc = doltliteSetSessionStaged(db, pWorkingHash);
   }else{
     addAlignStagedEntriesToWorking(aWorking, nWorking, aNew, nNew);
     rc = addWriteStagedCatalog(db, cs, aNew, nNew);
@@ -913,9 +912,9 @@ static int doltliteStageArgsAndPersist(
 
   rc = doltlitePersistWorkingSet(db);
   if( rc!=SQLITE_OK ){
-    doltliteSetSessionStaged(db, &savedStaged);
+    int restoreRc = doltliteSetSessionStaged(db, &savedStaged);
     sqlite3_result_error_code(context, rc);
-    return rc;
+    return restoreRc==SQLITE_OK ? rc : restoreRc;
   }
   return SQLITE_OK;
 }

--- a/src/doltlite_branch.c
+++ b/src/doltlite_branch.c
@@ -615,21 +615,27 @@ static void checkoutSaveSession(sqlite3 *db, CheckoutMutationCtx *p){
                                 &p->zSavedRebaseReturnBranch);
 }
 
-static void checkoutRestoreSession(sqlite3 *db, CheckoutMutationCtx *p){
+static int checkoutRestoreSession(sqlite3 *db, CheckoutMutationCtx *p){
+  int rc;
   doltliteSetSessionBranch(db, p->zCurrentBranch);
   doltliteSetSessionHead(db, &p->savedSessionHead);
-  doltliteSetSessionStaged(db, &p->savedSessionStaged);
-  doltliteSetSessionMergeState(db, p->savedIsMerging,
-                               &p->savedMergeCommit,
-                               &p->savedConflictsCatalog);
-  doltliteSetSessionRebaseState(db, p->savedIsRebasing,
-                                &p->savedPreRebaseCat,
-                                &p->savedRebaseOnto,
-                                p->zSavedRebaseOrigBranch,
-                                p->zSavedRebaseReturnBranch);
-  if( p->haveOldState ){
-    doltliteSwitchCatalog(db, &p->oldCatHash);
+  rc = doltliteSetSessionRebaseState(db, p->savedIsRebasing,
+                                     &p->savedPreRebaseCat,
+                                     &p->savedRebaseOnto,
+                                     p->zSavedRebaseOrigBranch,
+                                     p->zSavedRebaseReturnBranch);
+  if( rc==SQLITE_OK ){
+    rc = doltliteSetSessionStaged(db, &p->savedSessionStaged);
   }
+  if( rc==SQLITE_OK ){
+    rc = doltliteSetSessionMergeState(db, p->savedIsMerging,
+                                      &p->savedMergeCommit,
+                                      &p->savedConflictsCatalog);
+  }
+  if( rc==SQLITE_OK && p->haveOldState ){
+    rc = doltliteSwitchCatalog(db, &p->oldCatHash);
+  }
+  return rc;
 }
 
 static int checkoutRestoreDurableState(
@@ -670,7 +676,8 @@ static int checkoutMutateRefs(sqlite3 *db, ChunkStore *cs, void *pArg){
     ProllyHash staged;
     doltliteGetSessionStaged(db, &staged);
     if( prollyHashIsEmpty(&staged) ){
-      doltliteSetSessionStaged(db, &p->targetCatHash);
+      rc = doltliteSetSessionStaged(db, &p->targetCatHash);
+      if( rc!=SQLITE_OK ) return rc;
     }
   }
 
@@ -686,7 +693,8 @@ static int checkoutMutateRefs(sqlite3 *db, ChunkStore *cs, void *pArg){
     rc = doltliteUpdateBranchWorkingState(db, p->zCurrentBranch,
                                           &p->oldCatHash, &p->oldCommitHash);
     if( rc!=SQLITE_OK ){
-      checkoutRestoreSession(db, p);
+      int restoreRc = checkoutRestoreSession(db, p);
+      if( restoreRc!=SQLITE_OK ) rc = restoreRc;
       return rc;
     }
   }
@@ -695,7 +703,8 @@ static int checkoutMutateRefs(sqlite3 *db, ChunkStore *cs, void *pArg){
     rc = doltliteUpdateBranchWorkingState(db, p->zTargetBranch,
                                           &p->targetCatHash, &p->targetCommit);
     if( rc!=SQLITE_OK ){
-      checkoutRestoreSession(db, p);
+      int restoreRc = checkoutRestoreSession(db, p);
+      if( restoreRc!=SQLITE_OK ) rc = restoreRc;
     }
   }
   return rc;
@@ -790,18 +799,20 @@ static void doltConnectBranchFunc(
     ProllyHash staged;
     doltliteGetSessionStaged(db, &staged);
     if( prollyHashIsEmpty(&staged) ){
-      doltliteSetSessionStaged(db, &targetCatHash);
+      rc = doltliteSetSessionStaged(db, &targetCatHash);
     }
   }
   if( rc!=SQLITE_OK ){
-    checkoutRestoreSession(db, &m);
+    int restoreRc = checkoutRestoreSession(db, &m);
+    if( restoreRc!=SQLITE_OK ) rc = restoreRc;
     sqlite3_free(zCurrentBranch);
     sqlite3_result_error_code(ctx, rc);
     return;
   }
   rc = refreshBranchScopedTables(db);
   if( rc!=SQLITE_OK ){
-    checkoutRestoreSession(db, &m);
+    int restoreRc = checkoutRestoreSession(db, &m);
+    if( restoreRc!=SQLITE_OK ) rc = restoreRc;
     sqlite3_free(zCurrentBranch);
     sqlite3_result_error_code(ctx, rc);
     return;
@@ -838,10 +849,11 @@ int doltliteCheckoutBranchForRebase(sqlite3 *db, const char *zBranch){
 
   rc = doltliteMutateRefs(db, checkoutMutateRefs, &m);
   if( rc!=SQLITE_OK ){
-    checkoutRestoreSession(db, &m);
+    int restoreRc = checkoutRestoreSession(db, &m);
+    if( restoreRc!=SQLITE_OK ) rc = restoreRc;
     {
-      int restoreRc = doltliteMutateRefs(db, checkoutRestoreDurableState, &m);
-      if( restoreRc!=SQLITE_OK ) rc = restoreRc;
+      int durableRc = doltliteMutateRefs(db, checkoutRestoreDurableState, &m);
+      if( durableRc!=SQLITE_OK ) rc = durableRc;
     }
   }
   sqlite3_free(zCurrentBranch);
@@ -1233,7 +1245,7 @@ static int doltliteCheckoutTables(
       rc = doltliteSwitchCatalog(db, &newWorkingHash);
     }
     if( rc==SQLITE_OK && zSourceRef ){
-      doltliteSetSessionStaged(db, &newWorkingHash);
+      rc = doltliteSetSessionStaged(db, &newWorkingHash);
     }
     if( rc==SQLITE_OK ){
       rc = doltlitePersistWorkingSet(db);
@@ -1364,10 +1376,11 @@ static void doltCheckoutFunc(sqlite3_context *ctx, int argc, sqlite3_value **arg
   m.zCurrentBranch = zCurrentBranch;
   rc = doltliteMutateRefs(db, checkoutMutateRefs, &m);
   if( rc!=SQLITE_OK ){
-    checkoutRestoreSession(db, &m);
+    int restoreRc = checkoutRestoreSession(db, &m);
+    if( restoreRc!=SQLITE_OK ) rc = restoreRc;
     {
-      int restoreRc = doltliteMutateRefs(db, checkoutRestoreDurableState, &m);
-      if( restoreRc!=SQLITE_OK ) rc = restoreRc;
+      int durableRc = doltliteMutateRefs(db, checkoutRestoreDurableState, &m);
+      if( durableRc!=SQLITE_OK ) rc = durableRc;
     }
   }
   sqlite3_free(zCurrentBranch);
@@ -1395,10 +1408,11 @@ static void doltCheckoutFunc(sqlite3_context *ctx, int argc, sqlite3_value **arg
       m.zCurrentBranch = zCurrentBranch;
       rc = doltliteMutateRefs(db, checkoutMutateRefs, &m);
       if( rc!=SQLITE_OK ){
-        checkoutRestoreSession(db, &m);
+        int restoreRc = checkoutRestoreSession(db, &m);
+        if( restoreRc!=SQLITE_OK ) rc = restoreRc;
         {
-          int restoreRc = doltliteMutateRefs(db, checkoutRestoreDurableState, &m);
-          if( restoreRc!=SQLITE_OK ) rc = restoreRc;
+          int durableRc = doltliteMutateRefs(db, checkoutRestoreDurableState, &m);
+          if( durableRc!=SQLITE_OK ) rc = durableRc;
         }
       }
       sqlite3_free(zCurrentBranch);

--- a/src/doltlite_cherry_pick.c
+++ b/src/doltlite_cherry_pick.c
@@ -134,9 +134,11 @@ int applyMergedCatalogAndCommit(
   }
   if( rc!=SQLITE_OK ) goto apply_rollback;
 
-  doltliteSetSessionStaged(db, &liveMergedCatHash);
-  rc = doltliteUpdateBranchWorkingState(db,
-      doltliteGetSessionBranch(db), &liveMergedCatHash, NULL);
+  rc = doltliteSetSessionStaged(db, &liveMergedCatHash);
+  if( rc==SQLITE_OK ){
+    rc = doltliteUpdateBranchWorkingState(db,
+        doltliteGetSessionBranch(db), &liveMergedCatHash, NULL);
+  }
   if( rc!=SQLITE_OK ) goto apply_rollback;
 
   if( graphLocked ){
@@ -183,14 +185,19 @@ int applyMergedCatalogAndCommit(
         if( rc==SQLITE_OK ){
           doltliteSetSessionBranch(db, savedState.zSessionBranch);
           doltliteSetSessionHead(db, &savedState.sessionHead);
-          doltliteSetSessionStaged(db, &savedState.sessionStaged);
-          doltliteSetSessionMergeState(db, savedState.sessionIsMerging,
-                                       &savedState.sessionMergeCommit,
-                                       &savedState.sessionConflictsCatalog);
-          {
-            extern int doltliteClearAllConstraintViolations(sqlite3*);
-            doltliteClearAllConstraintViolations(db);
-          }
+          rc = doltliteSetSessionStaged(db, &savedState.sessionStaged);
+        }
+        if( rc==SQLITE_OK ){
+          rc = doltliteSetSessionMergeState(
+              db, savedState.sessionIsMerging,
+              &savedState.sessionMergeCommit,
+              &savedState.sessionConflictsCatalog);
+        }
+        if( rc==SQLITE_OK ){
+          extern int doltliteClearAllConstraintViolations(sqlite3*);
+          rc = doltliteClearAllConstraintViolations(db);
+        }
+        if( rc==SQLITE_OK ){
           rc = doltlitePersistWorkingSet(db);
         }
         doltliteTxnStateClear(&savedState);

--- a/src/doltlite_commit_cmd.c
+++ b/src/doltlite_commit_cmd.c
@@ -491,7 +491,7 @@ static int doltliteCommitStageModifiedOnly(sqlite3 *db, sqlite3_context *context
     }
     sqlite3_free(buf);
     if( rc==SQLITE_OK ){
-      doltliteSetSessionStaged(db, &newStagedHash);
+      rc = doltliteSetSessionStaged(db, &newStagedHash);
     }
   }
 
@@ -710,7 +710,11 @@ static void doltliteCommitFunc(
       sqlite3_result_error(context, "failed to flush", -1);
       return;
     }
-    doltliteSetSessionStaged(db, &catalogHash);
+    rc = doltliteSetSessionStaged(db, &catalogHash);
+    if( rc!=SQLITE_OK ){
+      sqlite3_result_error_code(context, rc);
+      return;
+    }
   }else if( addModifiedOnly ){
     rc = doltliteCommitStageModifiedOnly(db, context);
     if( rc!=SQLITE_OK ) return;
@@ -751,7 +755,11 @@ static void doltliteCommitFunc(
         ProllyHash refreshedCat;
         (void)sqlite3_exec(db, "ANALYZE", 0, 0, 0);
         if( doltliteFlushCatalogToHash(db, &refreshedCat)==SQLITE_OK ){
-          doltliteSetSessionStaged(db, &refreshedCat);
+          rc = doltliteSetSessionStaged(db, &refreshedCat);
+          if( rc!=SQLITE_OK ){
+            sqlite3_result_error_code(context, rc);
+            return;
+          }
         }
       }
     }
@@ -819,7 +827,11 @@ static void doltliteCommitFunc(
     u8 wasMerging = 0;
     doltliteGetSessionMergeState(db, &wasMerging, 0, 0);
     if( wasMerging ){
-      doltliteClearSessionMergeState(db);
+      rc = doltliteClearSessionMergeState(db);
+      if( rc!=SQLITE_OK ){
+        sqlite3_result_error_code(context, rc);
+        return;
+      }
     }
   }
 

--- a/src/doltlite_conflicts.c
+++ b/src/doltlite_conflicts.c
@@ -362,20 +362,21 @@ static int storeConflictBytes(
 ){
   int rc;
   DoltliteVcTxnMode mode;
-  extern void doltliteSetSessionConflictsCatalog(sqlite3*, const ProllyHash*);
-  extern void doltliteSetSessionMergeState(sqlite3*, u8, const ProllyHash*, const ProllyHash*);
 
   rc = doltliteEnsureWriteTxnAndSavepoints(db);
   if( rc!=SQLITE_OK ) return rc;
   if( nTables==0 ){
-    doltliteSetSessionConflictsCatalog(db, &(ProllyHash){{0}});
+    rc = doltliteSetSessionConflictsCatalog(db, &(ProllyHash){{0}});
   }else{
     ProllyHash newHash;
     rc = chunkStorePut(cs, pData, nData, &newHash);
     if( rc!=SQLITE_OK ) return rc;
-    doltliteSetSessionConflictsCatalog(db, &newHash);
-    doltliteSetSessionMergeState(db, 1, 0, &newHash);
+    rc = doltliteSetSessionConflictsCatalog(db, &newHash);
+    if( rc==SQLITE_OK ){
+      rc = doltliteSetSessionMergeState(db, 1, 0, &newHash);
+    }
   }
+  if( rc!=SQLITE_OK ) return rc;
   mode = doltliteVcTxnMode(db);
   if( mode==DOLTLITE_VC_TXN_AUTOCOMMIT_LIKE ){
     rc = doltlitePersistWorkingSet(db);

--- a/src/doltlite_constraint_violations.c
+++ b/src/doltlite_constraint_violations.c
@@ -323,18 +323,20 @@ static int storeUpdatedViolations(
   ConstraintViolationTable *aTables, int nTables
 ){
   int totalRows = 0;
+  int rc;
   int i;
   for(i=0; i<nTables; i++) totalRows += aTables[i].nRows;
 
   if( totalRows==0 ){
     static const ProllyHash emptyHash = {{0}};
-    doltliteSetSessionConstraintViolationsCatalog(db, &emptyHash);
+    rc = doltliteSetSessionConstraintViolationsCatalog(db, &emptyHash);
   }else{
     ProllyHash newHash;
-    int rc = serializeViolations(cs, aTables, nTables, &newHash);
+    rc = serializeViolations(cs, aTables, nTables, &newHash);
     if( rc!=SQLITE_OK ) return rc;
-    doltliteSetSessionConstraintViolationsCatalog(db, &newHash);
+    rc = doltliteSetSessionConstraintViolationsCatalog(db, &newHash);
   }
+  if( rc!=SQLITE_OK ) return rc;
   if( doltliteVcTxnMode(db)==DOLTLITE_VC_TXN_AUTOCOMMIT_LIKE ){
     return doltlitePersistWorkingSet(db);
   }
@@ -348,15 +350,17 @@ static int storeViolationBytes(
   int nData,
   int nTables
 ){
+  int rc;
   if( nTables==0 ){
     static const ProllyHash emptyHash = {{0}};
-    doltliteSetSessionConstraintViolationsCatalog(db, &emptyHash);
+    rc = doltliteSetSessionConstraintViolationsCatalog(db, &emptyHash);
   }else{
     ProllyHash newHash;
-    int rc = chunkStorePut(cs, pData, nData, &newHash);
+    rc = chunkStorePut(cs, pData, nData, &newHash);
     if( rc!=SQLITE_OK ) return rc;
-    doltliteSetSessionConstraintViolationsCatalog(db, &newHash);
+    rc = doltliteSetSessionConstraintViolationsCatalog(db, &newHash);
   }
+  if( rc!=SQLITE_OK ) return rc;
   if( doltliteVcTxnMode(db)==DOLTLITE_VC_TXN_AUTOCOMMIT_LIKE ){
     return doltlitePersistWorkingSet(db);
   }
@@ -613,7 +617,8 @@ int doltliteAppendConstraintViolation(
 
 int doltliteClearAllConstraintViolations(sqlite3 *db){
   static const ProllyHash emptyHash = {{0}};
-  doltliteSetSessionConstraintViolationsCatalog(db, &emptyHash);
+  int rc = doltliteSetSessionConstraintViolationsCatalog(db, &emptyHash);
+  if( rc!=SQLITE_OK ) return rc;
   if( doltliteVcTxnMode(db)==DOLTLITE_VC_TXN_AUTOCOMMIT_LIKE ){
     return doltlitePersistWorkingSet(db);
   }

--- a/src/doltlite_core.c
+++ b/src/doltlite_core.c
@@ -77,13 +77,17 @@ int doltliteRestoreTxnState(sqlite3 *db, DoltliteTxnState *p){
 
   doltliteSetSessionBranch(db, p->zSessionBranch);
   doltliteSetSessionHead(db, &p->sessionHead);
-  doltliteSetSessionStaged(db, &p->sessionStaged);
-  doltliteSetSessionMergeState(db, p->sessionIsMerging,
-                               &p->sessionMergeCommit,
-                               &p->sessionConflictsCatalog);
-  doltliteSetSessionConstraintViolationsCatalog(
-      db, &p->sessionConstraintViolationsCatalog);
-  return SQLITE_OK;
+  rc = doltliteSetSessionStaged(db, &p->sessionStaged);
+  if( rc==SQLITE_OK ){
+    rc = doltliteSetSessionMergeState(db, p->sessionIsMerging,
+                                      &p->sessionMergeCommit,
+                                      &p->sessionConflictsCatalog);
+  }
+  if( rc==SQLITE_OK ){
+    rc = doltliteSetSessionConstraintViolationsCatalog(
+        db, &p->sessionConstraintViolationsCatalog);
+  }
+  return rc;
 }
 
 int doltliteRestoreTxnStateOnFailure(
@@ -442,7 +446,10 @@ int doltliteAdvanceBranch(
   }
 
   doltliteSetSessionHead(db, pNewHead);
-  doltliteSetSessionStaged(db, pCatalogHash);
+  rc = doltliteSetSessionStaged(db, pCatalogHash);
+  if( rc!=SQLITE_OK ){
+    return doltliteRestoreTxnStateOnFailure(db, &saved, rc);
+  }
   if( pWorkingCatHash && !prollyHashIsEmpty(pWorkingCatHash) ){
     rc = doltliteSwitchCatalog(db, pWorkingCatHash);
   }else{
@@ -667,10 +674,12 @@ int doltliteRollbackAutocommitConflict(
   sqlite3RollbackAll(db, SQLITE_OK);
   rc = doltliteRestoreTxnState(db, pSaved);
   if( rc==SQLITE_OK ){
-    doltliteSetSessionMergeState(db, pSaved->sessionIsMerging,
-                                 &pSaved->sessionMergeCommit,
-                                 &pSaved->sessionConflictsCatalog);
-    doltliteSetSessionConstraintViolationsCatalog(
+    rc = doltliteSetSessionMergeState(db, pSaved->sessionIsMerging,
+                                      &pSaved->sessionMergeCommit,
+                                      &pSaved->sessionConflictsCatalog);
+  }
+  if( rc==SQLITE_OK ){
+    rc = doltliteSetSessionConstraintViolationsCatalog(
         db, &pSaved->sessionConstraintViolationsCatalog);
   }
   doltliteTxnStateClear(pSaved);

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -1074,29 +1074,29 @@ void doltliteSetSessionBranch(sqlite3 *db, const char *zBranch);
 void doltliteGetSessionHead(sqlite3 *db, ProllyHash *pHead);
 void doltliteSetSessionHead(sqlite3 *db, const ProllyHash *pHead);
 void doltliteGetSessionStaged(sqlite3 *db, ProllyHash *pStaged);
-void doltliteSetSessionStaged(sqlite3 *db, const ProllyHash *pStaged);
+int doltliteSetSessionStaged(sqlite3 *db, const ProllyHash *pStaged);
 void doltliteGetSessionMergeState(sqlite3 *db, u8 *pIsMerging,
                                   ProllyHash *pMergeCommit,
                                   ProllyHash *pConflictsCatalog);
-void doltliteSetSessionMergeState(sqlite3 *db, u8 isMerging,
-                                  const ProllyHash *pMergeCommit,
-                                  const ProllyHash *pConflictsCatalog);
-void doltliteClearSessionMergeState(sqlite3 *db);
+int doltliteSetSessionMergeState(sqlite3 *db, u8 isMerging,
+                                 const ProllyHash *pMergeCommit,
+                                 const ProllyHash *pConflictsCatalog);
+int doltliteClearSessionMergeState(sqlite3 *db);
 void doltliteGetSessionRebaseState(sqlite3 *db, u8 *pIsRebasing,
                                    ProllyHash *pPreRebaseCat,
                                    ProllyHash *pRebaseOnto,
                                    const char **pzOrigBranch,
                                    const char **pzReturnBranch);
-void doltliteSetSessionRebaseState(sqlite3 *db, u8 isRebasing,
-                                   const ProllyHash *pPreRebaseCat,
-                                   const ProllyHash *pRebaseOnto,
-                                   const char *zOrigBranch,
-                                   const char *zReturnBranch);
-void doltliteClearSessionRebaseState(sqlite3 *db);
+int doltliteSetSessionRebaseState(sqlite3 *db, u8 isRebasing,
+                                  const ProllyHash *pPreRebaseCat,
+                                  const ProllyHash *pRebaseOnto,
+                                  const char *zOrigBranch,
+                                  const char *zReturnBranch);
+int doltliteClearSessionRebaseState(sqlite3 *db);
 void doltliteGetSessionConflictsCatalog(sqlite3 *db, ProllyHash *pHash);
-void doltliteSetSessionConflictsCatalog(sqlite3 *db, const ProllyHash *pHash);
+int doltliteSetSessionConflictsCatalog(sqlite3 *db, const ProllyHash *pHash);
 void doltliteGetSessionConstraintViolationsCatalog(sqlite3 *db, ProllyHash *pHash);
-void doltliteSetSessionConstraintViolationsCatalog(sqlite3 *db, const ProllyHash *pHash);
+int doltliteSetSessionConstraintViolationsCatalog(sqlite3 *db, const ProllyHash *pHash);
 int doltliteSessionHasConstraintViolations(sqlite3 *db);
 int doltliteSeedSessionHashes(sqlite3 *db, ChunkStore *cs,
                               int (*xPush)(void*, const ProllyHash*),

--- a/src/doltlite_merge.c
+++ b/src/doltlite_merge.c
@@ -3331,9 +3331,9 @@ static int recordMergeConflicts(
       aConflictTables, nConflictTables,
       &conflictsHash);
   if( rc!=SQLITE_OK ) return rc;
-  doltliteSetSessionConflictsCatalog(db, &conflictsHash);
-  doltliteSetSessionMergeState(db, 1, 0, &conflictsHash);
-  return SQLITE_OK;
+  rc = doltliteSetSessionConflictsCatalog(db, &conflictsHash);
+  if( rc!=SQLITE_OK ) return rc;
+  return doltliteSetSessionMergeState(db, 1, 0, &conflictsHash);
 }
 
 int doltliteMergeCatalogs(

--- a/src/doltlite_merge_cmd.c
+++ b/src/doltlite_merge_cmd.c
@@ -24,15 +24,15 @@ int mergeAbortInPlace(sqlite3 *db){
   if( rc!=SQLITE_OK ) return rc;
   rc = doltliteHardReset(db, &headCatHash);
   if( rc!=SQLITE_OK ) return rc;
-  doltliteSetSessionStaged(db, &headCatHash);
-  doltliteClearSessionMergeState(db);
-  {
+  rc = doltliteSetSessionStaged(db, &headCatHash);
+  if( rc==SQLITE_OK ) rc = doltliteClearSessionMergeState(db);
+  if( rc==SQLITE_OK ){
     extern int doltliteClearAllConstraintViolations(sqlite3*);
-  if( doltliteSessionHasConstraintViolations(db) ){
-      doltliteClearAllConstraintViolations(db);
+    if( doltliteSessionHasConstraintViolations(db) ){
+      rc = doltliteClearAllConstraintViolations(db);
     }
   }
-  rc = doltlitePersistWorkingSet(db);
+  if( rc==SQLITE_OK ) rc = doltlitePersistWorkingSet(db);
   if( rc!=SQLITE_OK ) return rc;
   return doltliteVcSealActiveSavepoints(db);
 }
@@ -324,7 +324,16 @@ static void doltliteMergeFunc(
     if( nMergeConflicts>0 ){
       ProllyHash conflictsHash;
       doltliteGetSessionConflictsCatalog(db, &conflictsHash);
-      doltliteSetSessionMergeState(db, 1, &theirHead, &conflictsHash);
+      rc = doltliteSetSessionMergeState(db, 1, &theirHead, &conflictsHash);
+      if( rc!=SQLITE_OK ){
+        doltliteCommitClear(&ourCommit);
+        doltliteCommitClear(&theirCommit);
+        doltliteTxnStateClear(&savedState);
+        freeSchemaMergeActions(aSchemaActions, nSchemaActions);
+        doltliteFreeNameList(azReindex, nReindex);
+        sqlite3_result_error_code(context, rc);
+        return;
+      }
     }
 
     rc = doltliteRefreshAndConfirmHead(db, cs, &ourHead);
@@ -427,7 +436,9 @@ static void doltliteMergeFunc(
       rc = doltlitePrimeSchemaCache(db);
     }
     if( rc==SQLITE_OK ){
-      doltliteSetSessionStaged(db, &mergedCatHash);
+      rc = doltliteSetSessionStaged(db, &mergedCatHash);
+    }
+    if( rc==SQLITE_OK ){
       rc = doltliteUpdateBranchWorkingState(db,
           doltliteGetSessionBranch(db), &mergedCatHash, NULL);
     }
@@ -487,12 +498,19 @@ static void doltliteMergeFunc(
         if( rc==SQLITE_OK ){
           doltliteSetSessionBranch(db, savedState.zSessionBranch);
           doltliteSetSessionHead(db, &savedState.sessionHead);
-          doltliteSetSessionStaged(db, &savedState.sessionStaged);
-          doltliteSetSessionMergeState(db, savedState.sessionIsMerging,
-                                       &savedState.sessionMergeCommit,
-                                       &savedState.sessionConflictsCatalog);
-          doltliteSetSessionConstraintViolationsCatalog(
+          rc = doltliteSetSessionStaged(db, &savedState.sessionStaged);
+        }
+        if( rc==SQLITE_OK ){
+          rc = doltliteSetSessionMergeState(
+              db, savedState.sessionIsMerging,
+              &savedState.sessionMergeCommit,
+              &savedState.sessionConflictsCatalog);
+        }
+        if( rc==SQLITE_OK ){
+          rc = doltliteSetSessionConstraintViolationsCatalog(
               db, &savedState.sessionConstraintViolationsCatalog);
+        }
+        if( rc==SQLITE_OK ){
           rc = doltlitePersistWorkingSet(db);
         }
         doltliteTxnStateClear(&savedState);
@@ -507,10 +525,13 @@ static void doltliteMergeFunc(
       case DOLTLITE_VC_TXN_NESTED_SAVEPOINT:
         rc = doltliteRestoreTxnState(db, &savedState);
         if( rc==SQLITE_OK ){
-          doltliteSetSessionMergeState(db, savedState.sessionIsMerging,
-                                       &savedState.sessionMergeCommit,
-                                       &savedState.sessionConflictsCatalog);
-          doltliteSetSessionConstraintViolationsCatalog(
+          rc = doltliteSetSessionMergeState(
+              db, savedState.sessionIsMerging,
+              &savedState.sessionMergeCommit,
+              &savedState.sessionConflictsCatalog);
+        }
+        if( rc==SQLITE_OK ){
+          rc = doltliteSetSessionConstraintViolationsCatalog(
               db, &savedState.sessionConstraintViolationsCatalog);
         }
         doltliteTxnStateClear(&savedState);
@@ -556,10 +577,13 @@ static void doltliteMergeFunc(
     case DOLTLITE_VC_TXN_NESTED_SAVEPOINT:
       rc = doltliteRestoreTxnState(db, &savedState);
       if( rc==SQLITE_OK ){
-        doltliteSetSessionMergeState(db, savedState.sessionIsMerging,
-                                     &savedState.sessionMergeCommit,
-                                     &savedState.sessionConflictsCatalog);
-        doltliteSetSessionConstraintViolationsCatalog(
+        rc = doltliteSetSessionMergeState(
+            db, savedState.sessionIsMerging,
+            &savedState.sessionMergeCommit,
+            &savedState.sessionConflictsCatalog);
+      }
+      if( rc==SQLITE_OK ){
+        rc = doltliteSetSessionConstraintViolationsCatalog(
             db, &savedState.sessionConstraintViolationsCatalog);
       }
       doltliteTxnStateClear(&savedState);
@@ -588,7 +612,12 @@ static void doltliteMergeFunc(
     char hexBuf[PROLLY_HASH_SIZE*2+1];
     char msg[256];
 
-    doltliteSetSessionStaged(db, &mergedCatHash);
+    rc = doltliteSetSessionStaged(db, &mergedCatHash);
+    if( rc!=SQLITE_OK ){
+      sqlite3_result_error_code(context,
+          doltliteRestoreTxnStateOnFailure(db, &savedState, rc));
+      return;
+    }
 
     if( zMessage && zMessage[0] ){
       sqlite3_snprintf(sizeof(msg), msg, "%s", zMessage);

--- a/src/doltlite_rebase.c
+++ b/src/doltlite_rebase.c
@@ -250,8 +250,11 @@ static int doltliteRebaseLinearReplay(
     goto rollback;
   }
   doltliteSetSessionHead(db, &upstreamHash);
-  doltliteSetSessionStaged(db, &upstreamCommit.catalogHash);
-  rc = doltliteAdvanceBranch(db, &upstreamHash, &upstreamCommit.catalogHash, 0);
+  rc = doltliteSetSessionStaged(db, &upstreamCommit.catalogHash);
+  if( rc==SQLITE_OK ){
+    rc = doltliteAdvanceBranch(
+        db, &upstreamHash, &upstreamCommit.catalogHash, 0);
+  }
   doltliteCommitClear(&upstreamCommit);
   memset(&upstreamCommit, 0, sizeof(upstreamCommit));
   if( rc!=SQLITE_OK ) goto rollback;
@@ -550,12 +553,14 @@ static int rebaseRestoreBranchState(sqlite3 *db, const char *zBranch){
   }
   doltliteSetSessionBranch(db, zBranch);
   doltliteSetSessionHead(db, &headHash);
-  doltliteSetSessionStaged(db, &headCommit.catalogHash);
-  doltliteClearSessionMergeState(db);
+  rc = doltliteSetSessionStaged(db, &headCommit.catalogHash);
+  if( rc==SQLITE_OK ) rc = doltliteClearSessionMergeState(db);
   memset(&emptyHash, 0, sizeof(emptyHash));
-  doltliteSetSessionConstraintViolationsCatalog(db, &emptyHash);
+  if( rc==SQLITE_OK ){
+    rc = doltliteSetSessionConstraintViolationsCatalog(db, &emptyHash);
+  }
   doltliteCommitClear(&headCommit);
-  return SQLITE_OK;
+  return rc;
 }
 
 static int rebaseCreateAndPopulatePlanTable(
@@ -673,8 +678,8 @@ static int rebaseAdvanceWorkingBranch(
   if( rc!=SQLITE_OK ) return rc;
 
   doltliteSetSessionHead(db, pNewHead);
-  doltliteSetSessionStaged(db, pCatalogHash);
-  rc = doltliteSwitchCatalog(db, pCatalogHash);
+  rc = doltliteSetSessionStaged(db, pCatalogHash);
+  if( rc==SQLITE_OK ) rc = doltliteSwitchCatalog(db, pCatalogHash);
   if( rc!=SQLITE_OK ) return rc;
 
   return doltlitePersistWorkingSetWithHash(db, 0);
@@ -737,7 +742,7 @@ static int rebaseReplayPlanGroup(
       rc = doltliteSwitchCatalog(db, pCurCat);
     }
     if( rc==SQLITE_OK ){
-      doltliteSetSessionStaged(db, pCurCat);
+      rc = doltliteSetSessionStaged(db, pCurCat);
     }
     if( rc==SQLITE_OK ){
       rc = rebaseAdvanceWorkingBranch(db, &newCommit, pCurCat);
@@ -800,7 +805,8 @@ static int rebaseDiscardWorkingBranch(
   rc2 = sqlite3FaultSim(953) ? SQLITE_IOERR :
       sqlite3_exec(db, "DROP TABLE IF EXISTS main.dolt_rebase", 0, 0, 0);
   rebaseKeepFirstError(&rc, rc2);
-  doltliteClearSessionRebaseState(db);
+  rc2 = doltliteClearSessionRebaseState(db);
+  rebaseKeepFirstError(&rc, rc2);
   rc2 = doltlitePersistWorkingSet(db);
   rebaseKeepFirstError(&rc, rc2);
 
@@ -839,12 +845,15 @@ static int rebaseAbortConflictedContinue(
 
   rc2 = sqlite3_exec(db, "DROP TABLE IF EXISTS main.dolt_rebase", 0, 0, 0);
   rebaseKeepFirstError(&rc, rc2);
-  doltliteClearSessionRebaseState(db);
-  doltliteClearSessionMergeState(db);
+  rc2 = doltliteClearSessionRebaseState(db);
+  rebaseKeepFirstError(&rc, rc2);
+  rc2 = doltliteClearSessionMergeState(db);
+  rebaseKeepFirstError(&rc, rc2);
   if( zOrigBranch && zOrigBranch[0] ){
     rc2 = rebaseRestoreBranchState(db, zOrigBranch);
     rebaseKeepFirstError(&rc, rc2);
-    doltliteClearSessionRebaseState(db);
+    rc2 = doltliteClearSessionRebaseState(db);
+    rebaseKeepFirstError(&rc, rc2);
   }
   if( cs && zReturnBranch && zReturnBranch[0] ){
     rc2 = rebaseRestoreReturnBranchWorkingState(db, zReturnBranch);
@@ -980,9 +989,9 @@ static void doltliteRebaseInteractiveStart(
     goto fail;
   }
 
-  doltliteSetSessionRebaseState(db, 1, &preRebaseCat, &upstreamHash,
-                                zOrig, zReturnBranch);
-  rc = doltlitePersistWorkingSet(db);
+  rc = doltliteSetSessionRebaseState(db, 1, &preRebaseCat, &upstreamHash,
+                                     zOrig, zReturnBranch);
+  if( rc==SQLITE_OK ) rc = doltlitePersistWorkingSet(db);
   if( rc!=SQLITE_OK ) goto fail;
   rc = doltliteVcSealBranchStyleTxn(db);
   if( rc!=SQLITE_OK ) goto fail;
@@ -1187,8 +1196,8 @@ static void doltliteRebaseInteractiveContinue(
   rc = doltliteMutateRefs(db, rebaseFinalizeContinueRefs, &refsCtx);
   if( rc!=SQLITE_OK ) goto abort_err;
 
-  doltliteClearSessionRebaseState(db);
-  rc = doltlitePersistWorkingSet(db);
+  rc = doltliteClearSessionRebaseState(db);
+  if( rc==SQLITE_OK ) rc = doltlitePersistWorkingSet(db);
   if( rc!=SQLITE_OK ) goto abort_err;
 
   rc = doltliteCheckoutBranchForRebase(db, zOrigBranch);

--- a/src/doltlite_remote_sql.c
+++ b/src/doltlite_remote_sql.c
@@ -138,7 +138,7 @@ static int remoteSqlResetSessionToCommit(
   rc = doltliteHardReset(db, &catHash);
   if( rc==SQLITE_OK ){
     doltliteSetSessionHead(db, pCommitHash);
-    doltliteSetSessionStaged(db, &catHash);
+    rc = doltliteSetSessionStaged(db, &catHash);
   }
   return rc;
 }

--- a/src/doltlite_reset.c
+++ b/src/doltlite_reset.c
@@ -139,7 +139,7 @@ static int resetStageNamedPaths(
     }
     sqlite3_free(buf);
     if( rc==SQLITE_OK ){
-      doltliteSetSessionStaged(db, &newStagedHash);
+      rc = doltliteSetSessionStaged(db, &newStagedHash);
     }
   }
 
@@ -475,7 +475,11 @@ static void doltliteResetFunc(
       goto reset_cleanup;
     }
 
-    doltliteClearSessionMergeState(db);
+    rc = doltliteClearSessionMergeState(db);
+    if( rc!=SQLITE_OK ){
+      sqlite3_result_error_code(context, rc);
+      goto reset_cleanup;
+    }
   }else{
     rc = doltliteGetHeadCatalogHash(db, &targetCatHash);
     if( rc!=SQLITE_OK ){
@@ -485,7 +489,11 @@ static void doltliteResetFunc(
   }
 
   if( !isSoft ){
-    doltliteSetSessionStaged(db, &targetCatHash);
+    rc = doltliteSetSessionStaged(db, &targetCatHash);
+    if( rc!=SQLITE_OK ){
+      sqlite3_result_error_code(context, rc);
+      goto reset_cleanup;
+    }
   }
 
   if( isHard ){
@@ -519,17 +527,21 @@ static void doltliteResetFunc(
       goto reset_cleanup;
     }
 
-    doltliteClearSessionMergeState(db);
+    rc = doltliteClearSessionMergeState(db);
 
-    {
+    if( rc==SQLITE_OK ){
       extern int doltliteClearAllConstraintViolations(sqlite3*);
       if( doltliteSessionHasConstraintViolations(db) ){
-        doltliteClearAllConstraintViolations(db);
+        rc = doltliteClearAllConstraintViolations(db);
       }
     }
 
-    doltliteSetSessionStaged(db, &origStagedAfterReset);
-    rc = doltlitePersistWorkingSet(db);
+    if( rc==SQLITE_OK ){
+      rc = doltliteSetSessionStaged(db, &origStagedAfterReset);
+    }
+    if( rc==SQLITE_OK ){
+      rc = doltlitePersistWorkingSet(db);
+    }
     if( rc!=SQLITE_OK ){
       sqlite3_result_error_code(context, rc);
       goto reset_cleanup;

--- a/src/doltlite_workspace.c
+++ b/src/doltlite_workspace.c
@@ -567,7 +567,7 @@ static int wsApplyRowToStaged(WorkspaceVtab *p, WorkspaceRow *r, int makeStaged)
   if( rc==SQLITE_OK ) rc = chunkStorePut(cs, pCatBuf, nCatBuf, &newCat);
   sqlite3_free(pCatBuf);
   doltliteFreeCatalog(aTables, nTables);
-  if( rc==SQLITE_OK ) doltliteSetSessionStaged(db, &newCat);
+  if( rc==SQLITE_OK ) rc = doltliteSetSessionStaged(db, &newCat);
   return rc;
 }
 

--- a/src/prolly_btree_state.c
+++ b/src/prolly_btree_state.c
@@ -586,15 +586,19 @@ void doltliteGetSessionStaged(sqlite3 *db, ProllyHash *pStaged){
 ** captureSavepointSessionState when a level is pushed, and levels push
 ** lazily at write time. Mutating this state is a write: push any pending
 ** levels first so ROLLBACK TO restores the pre-mutation values. */
-static void sessionStateSyncSavepoints(Btree *p){
-  if( p->inTrans==TRANS_WRITE ) syncBtreeSavepoints(p);
+static int sessionStateSyncSavepoints(Btree *p){
+  if( p->inTrans==TRANS_WRITE ) return syncBtreeSavepoints(p);
+  return SQLITE_OK;
 }
 
-void doltliteSetSessionStaged(sqlite3 *db, const ProllyHash *pStaged){
+int doltliteSetSessionStaged(sqlite3 *db, const ProllyHash *pStaged){
   if( db && db->nDb>0 && db->aDb[0].pBt ){
-    sessionStateSyncSavepoints(db->aDb[0].pBt);
-    memcpy(&db->aDb[0].pBt->vc.stagedCatalog, pStaged, sizeof(ProllyHash));
+    Btree *p = db->aDb[0].pBt;
+    int rc = sessionStateSyncSavepoints(p);
+    if( rc!=SQLITE_OK ) return rc;
+    memcpy(&p->vc.stagedCatalog, pStaged, sizeof(ProllyHash));
   }
+  return SQLITE_OK;
 }
 
 void doltliteGetSessionMergeState(sqlite3 *db, u8 *pIsMerging,
@@ -612,22 +616,24 @@ void doltliteGetSessionMergeState(sqlite3 *db, u8 *pIsMerging,
   }
 }
 
-void doltliteSetSessionMergeState(sqlite3 *db, u8 isMerging,
-                                   const ProllyHash *pMergeCommit,
-                                   const ProllyHash *pConflictsCatalog){
+int doltliteSetSessionMergeState(sqlite3 *db, u8 isMerging,
+                                  const ProllyHash *pMergeCommit,
+                                  const ProllyHash *pConflictsCatalog){
   if( db && db->nDb>0 && db->aDb[0].pBt ){
     Btree *p = db->aDb[0].pBt;
-    sessionStateSyncSavepoints(p);
+    int rc = sessionStateSyncSavepoints(p);
+    if( rc!=SQLITE_OK ) return rc;
     p->vc.isMerging = isMerging;
     if( pMergeCommit ) memcpy(&p->vc.mergeCommitHash, pMergeCommit, sizeof(ProllyHash));
     else memset(&p->vc.mergeCommitHash, 0, sizeof(ProllyHash));
     if( pConflictsCatalog ) memcpy(&p->vc.conflictsCatalogHash, pConflictsCatalog, sizeof(ProllyHash));
     else memset(&p->vc.conflictsCatalogHash, 0, sizeof(ProllyHash));
   }
+  return SQLITE_OK;
 }
 
-void doltliteClearSessionMergeState(sqlite3 *db){
-  doltliteSetSessionMergeState(db, 0, 0, 0);
+int doltliteClearSessionMergeState(sqlite3 *db){
+  return doltliteSetSessionMergeState(db, 0, 0, 0);
 }
 
 void doltliteGetSessionRebaseState(sqlite3 *db, u8 *pIsRebasing,
@@ -651,28 +657,48 @@ void doltliteGetSessionRebaseState(sqlite3 *db, u8 *pIsRebasing,
   }
 }
 
-void doltliteSetSessionRebaseState(sqlite3 *db, u8 isRebasing,
-                                    const ProllyHash *pPreRebaseCat,
-                                    const ProllyHash *pRebaseOnto,
-                                    const char *zOrigBranch,
-                                    const char *zReturnBranch){
+int doltliteSetSessionRebaseState(sqlite3 *db, u8 isRebasing,
+                                   const ProllyHash *pPreRebaseCat,
+                                   const ProllyHash *pRebaseOnto,
+                                   const char *zOrigBranch,
+                                   const char *zReturnBranch){
   if( db && db->nDb>0 && db->aDb[0].pBt ){
     Btree *p = db->aDb[0].pBt;
-    sessionStateSyncSavepoints(p);
+    char *zNewOrigBranch = 0;
+    char *zNewReturnBranch = 0;
+    int rc;
+    if( zOrigBranch ){
+      zNewOrigBranch = sqlite3_mprintf("%s", zOrigBranch);
+      if( !zNewOrigBranch ) return SQLITE_NOMEM;
+    }
+    if( zReturnBranch ){
+      zNewReturnBranch = sqlite3_mprintf("%s", zReturnBranch);
+      if( !zNewReturnBranch ){
+        sqlite3_free(zNewOrigBranch);
+        return SQLITE_NOMEM;
+      }
+    }
+    rc = sessionStateSyncSavepoints(p);
+    if( rc!=SQLITE_OK ){
+      sqlite3_free(zNewOrigBranch);
+      sqlite3_free(zNewReturnBranch);
+      return rc;
+    }
     p->isRebasing = isRebasing;
     if( pPreRebaseCat ) memcpy(&p->preRebaseWorkingCat, pPreRebaseCat, sizeof(ProllyHash));
     else memset(&p->preRebaseWorkingCat, 0, sizeof(ProllyHash));
     if( pRebaseOnto ) memcpy(&p->rebaseOntoCommit, pRebaseOnto, sizeof(ProllyHash));
     else memset(&p->rebaseOntoCommit, 0, sizeof(ProllyHash));
     sqlite3_free(p->zRebaseOrigBranch);
-    p->zRebaseOrigBranch = zOrigBranch ? sqlite3_mprintf("%s", zOrigBranch) : 0;
+    p->zRebaseOrigBranch = zNewOrigBranch;
     sqlite3_free(p->zRebaseReturnBranch);
-    p->zRebaseReturnBranch = zReturnBranch ? sqlite3_mprintf("%s", zReturnBranch) : 0;
+    p->zRebaseReturnBranch = zNewReturnBranch;
   }
+  return SQLITE_OK;
 }
 
-void doltliteClearSessionRebaseState(sqlite3 *db){
-  doltliteSetSessionRebaseState(db, 0, 0, 0, 0, 0);
+int doltliteClearSessionRebaseState(sqlite3 *db){
+  return doltliteSetSessionRebaseState(db, 0, 0, 0, 0, 0);
 }
 
 void doltliteGetSessionConflictsCatalog(sqlite3 *db, ProllyHash *pHash){
@@ -712,10 +738,14 @@ void doltliteGetSessionConflictsCatalog(sqlite3 *db, ProllyHash *pHash){
   }
 }
 
-void doltliteSetSessionConflictsCatalog(sqlite3 *db, const ProllyHash *pHash){
+int doltliteSetSessionConflictsCatalog(sqlite3 *db, const ProllyHash *pHash){
   if( db && db->nDb>0 && db->aDb[0].pBt ){
-    memcpy(&db->aDb[0].pBt->vc.conflictsCatalogHash, pHash, sizeof(ProllyHash));
+    Btree *p = db->aDb[0].pBt;
+    int rc = sessionStateSyncSavepoints(p);
+    if( rc!=SQLITE_OK ) return rc;
+    memcpy(&p->vc.conflictsCatalogHash, pHash, sizeof(ProllyHash));
   }
+  return SQLITE_OK;
 }
 
 void doltliteGetSessionConstraintViolationsCatalog(sqlite3 *db, ProllyHash *pHash){
@@ -741,12 +771,16 @@ int doltliteGetSessionTableRoot(
   return SQLITE_OK;
 }
 
-void doltliteSetSessionConstraintViolationsCatalog(sqlite3 *db, const ProllyHash *pHash){
+int doltliteSetSessionConstraintViolationsCatalog(sqlite3 *db, const ProllyHash *pHash){
   static const ProllyHash emptyHash = {{0}};
   if( db && db->nDb>0 && db->aDb[0].pBt ){
-    memcpy(&db->aDb[0].pBt->vc.constraintViolationsHash,
+    Btree *p = db->aDb[0].pBt;
+    int rc = sessionStateSyncSavepoints(p);
+    if( rc!=SQLITE_OK ) return rc;
+    memcpy(&p->vc.constraintViolationsHash,
            pHash ? pHash : &emptyHash, sizeof(ProllyHash));
   }
+  return SQLITE_OK;
 }
 
 int doltliteSessionHasConstraintViolations(sqlite3 *db){

--- a/src/prolly_btree_txn.c
+++ b/src/prolly_btree_txn.c
@@ -109,10 +109,23 @@ static int captureSavepointCatalogSnapshot(
   return SQLITE_OK;
 }
 
-static void captureSavepointSessionState(
+static int captureSavepointSessionState(
   Btree *pBtree,
   struct SavepointTableState *pState
 ){
+  char *zOrigBranch = 0;
+  char *zReturnBranch = 0;
+  if( pBtree->zRebaseOrigBranch ){
+    zOrigBranch = sqlite3_mprintf("%s", pBtree->zRebaseOrigBranch);
+    if( !zOrigBranch ) return SQLITE_NOMEM;
+  }
+  if( pBtree->zRebaseReturnBranch ){
+    zReturnBranch = sqlite3_mprintf("%s", pBtree->zRebaseReturnBranch);
+    if( !zReturnBranch ){
+      sqlite3_free(zOrigBranch);
+      return SQLITE_NOMEM;
+    }
+  }
   pState->iNextTable = pBtree->cat.iNextTable;
   pState->iLargestRootPage = pBtree->aMeta[BTREE_LARGEST_ROOT_PAGE];
   memcpy(pState->aMeta, pBtree->aMeta, sizeof(pState->aMeta));
@@ -120,12 +133,9 @@ static void captureSavepointSessionState(
   pState->isRebasing = pBtree->isRebasing;
   pState->preRebaseWorkingCat = pBtree->preRebaseWorkingCat;
   pState->rebaseOntoCommit = pBtree->rebaseOntoCommit;
-  sqlite3_free(pState->zRebaseOrigBranch);
-  pState->zRebaseOrigBranch = pBtree->zRebaseOrigBranch
-      ? sqlite3_mprintf("%s", pBtree->zRebaseOrigBranch) : 0;
-  sqlite3_free(pState->zRebaseReturnBranch);
-  pState->zRebaseReturnBranch = pBtree->zRebaseReturnBranch
-      ? sqlite3_mprintf("%s", pBtree->zRebaseReturnBranch) : 0;
+  pState->zRebaseOrigBranch = zOrigBranch;
+  pState->zRebaseReturnBranch = zReturnBranch;
+  return SQLITE_OK;
 }
 
 static void restoreSavepointSessionState(
@@ -139,11 +149,11 @@ static void restoreSavepointSessionState(
   pBtree->preRebaseWorkingCat = pState->preRebaseWorkingCat;
   pBtree->rebaseOntoCommit = pState->rebaseOntoCommit;
   sqlite3_free(pBtree->zRebaseOrigBranch);
-  pBtree->zRebaseOrigBranch = pState->zRebaseOrigBranch
-      ? sqlite3_mprintf("%s", pState->zRebaseOrigBranch) : 0;
+  pBtree->zRebaseOrigBranch = pState->zRebaseOrigBranch;
+  pState->zRebaseOrigBranch = 0;
   sqlite3_free(pBtree->zRebaseReturnBranch);
-  pBtree->zRebaseReturnBranch = pState->zRebaseReturnBranch
-      ? sqlite3_mprintf("%s", pState->zRebaseReturnBranch) : 0;
+  pBtree->zRebaseReturnBranch = pState->zRebaseReturnBranch;
+  pState->zRebaseReturnBranch = 0;
 }
 
 static int captureSavepointTables(
@@ -600,6 +610,7 @@ static int restoreTablesFromSavepoint(
 
 int pushSavepoint(Btree *pBtree, int bStatement){
   struct SavepointTableState *pState;
+  int rc;
 
   assert( pBtree!=0 );
   PROLLY_ASSERT_WRITE_TXN(pBtree);
@@ -635,10 +646,17 @@ int pushSavepoint(Btree *pBtree, int bStatement){
   memset(&pState->rebaseOntoCommit, 0, sizeof(pState->rebaseOntoCommit));
   pState->zRebaseOrigBranch = 0;
   pState->zRebaseReturnBranch = 0;
-  captureSavepointSessionState(pBtree, pState);
+  rc = captureSavepointSessionState(pBtree, pState);
+  if( rc!=SQLITE_OK ){
+    freeSavepointTables(pState);
+    return rc;
+  }
   if( !bStatement ){
-    int rc = captureSavepointTables(pBtree, pState);
-    if( rc!=SQLITE_OK ) return rc;
+    rc = captureSavepointTables(pBtree, pState);
+    if( rc!=SQLITE_OK ){
+      freeSavepointTables(pState);
+      return rc;
+    }
   }
 
   pBtree->nSavepoint++;

--- a/test/oom_dolt_fault_test.c
+++ b/test/oom_dolt_fault_test.c
@@ -5,6 +5,7 @@
 #include <sys/types.h>
 #include <sys/wait.h>
 #include "sqlite3.h"
+#include "doltlite_internal.h"
 
 #ifndef MAX_FAIL_N
 # define MAX_FAIL_N 500
@@ -147,6 +148,10 @@ static int setupBase(sqlite3 *db){
 }
 
 typedef int (*OpFn)(sqlite3 *db);
+typedef int (*OpSetupFn)(sqlite3 *db);
+
+static ProllyHash gSavepointPreRebase;
+static ProllyHash gSavepointRebaseOnto;
 
 static int verifyLatestCommitMetadata(sqlite3 *db){
   sqlite3_stmt *stmt = 0;
@@ -233,19 +238,101 @@ static int opDiffTable(sqlite3 *db){
     "SELECT to_a, to_b, diff_type FROM dolt_diff_t LIMIT 16");
 }
 
+static int setupSavepointState(sqlite3 *db){
+  int rc;
+  rc = doltliteGetHeadCatalogHash(db, &gSavepointPreRebase);
+  if( rc!=SQLITE_OK ) return rc;
+  doltliteGetSessionHead(db, &gSavepointRebaseOnto);
+  return doltliteSetSessionRebaseState(db, 1, &gSavepointPreRebase,
+                                       &gSavepointRebaseOnto, "main", "main");
+}
+
+static int opSavepointState(sqlite3 *db){
+  ProllyHash stagedBefore;
+  ProllyHash stagedAfter;
+  ProllyHash preRebase;
+  ProllyHash rebaseOnto;
+  const char *zOrig = 0;
+  const char *zReturn = 0;
+  u8 isRebasing = 0;
+  int stateRestored;
+  int rc;
+
+  doltliteGetSessionStaged(db, &stagedBefore);
+  rc = execSilent(db, "INSERT INTO t VALUES(4,'four')");
+  if( rc ) return rc;
+  rc = execSilent(db, "BEGIN IMMEDIATE; SAVEPOINT state_sp");
+  if( rc ) return rc;
+  rc = execSilent(db, "SELECT dolt_add('-A')");
+  if( rc ) return rc;
+  rc = execSilent(db, "ROLLBACK TO state_sp");
+  if( rc ) return rc;
+
+  doltliteGetSessionStaged(db, &stagedAfter);
+  doltliteGetSessionRebaseState(db, &isRebasing, &preRebase, &rebaseOnto,
+                               &zOrig, &zReturn);
+  stateRestored =
+      memcmp(&stagedAfter, &stagedBefore, sizeof(stagedAfter))==0
+   && isRebasing
+   && memcmp(&preRebase, &gSavepointPreRebase, sizeof(preRebase))==0
+   && memcmp(&rebaseOnto, &gSavepointRebaseOnto, sizeof(rebaseOnto))==0
+   && zOrig && strcmp(zOrig, "main")==0
+   && zReturn && strcmp(zReturn, "main")==0;
+  (void)execSilent(db, "ROLLBACK");
+  return stateRestored ? SQLITE_OK : SQLITE_CORRUPT;
+}
+
+static int opRebaseStateSet(sqlite3 *db){
+  ProllyHash newPreRebase;
+  ProllyHash newRebaseOnto;
+  ProllyHash actualPreRebase;
+  ProllyHash actualRebaseOnto;
+  const char *zOrig = 0;
+  const char *zReturn = 0;
+  u8 isRebasing = 0;
+  int rc;
+  int stateValid;
+
+  memset(&newPreRebase, 0x91, sizeof(newPreRebase));
+  memset(&newRebaseOnto, 0x92, sizeof(newRebaseOnto));
+  rc = doltliteSetSessionRebaseState(db, 1, &newPreRebase, &newRebaseOnto,
+                                     "new-orig", "new-return");
+  doltliteGetSessionRebaseState(db, &isRebasing, &actualPreRebase,
+                               &actualRebaseOnto, &zOrig, &zReturn);
+  if( rc==SQLITE_OK ){
+    stateValid = isRebasing
+      && memcmp(&actualPreRebase, &newPreRebase, sizeof(newPreRebase))==0
+      && memcmp(&actualRebaseOnto, &newRebaseOnto, sizeof(newRebaseOnto))==0
+      && zOrig && strcmp(zOrig, "new-orig")==0
+      && zReturn && strcmp(zReturn, "new-return")==0;
+  }else{
+    stateValid = isRebasing
+      && memcmp(&actualPreRebase, &gSavepointPreRebase,
+                sizeof(gSavepointPreRebase))==0
+      && memcmp(&actualRebaseOnto, &gSavepointRebaseOnto,
+                sizeof(gSavepointRebaseOnto))==0
+      && zOrig && strcmp(zOrig, "main")==0
+      && zReturn && strcmp(zReturn, "main")==0;
+  }
+  return stateValid ? rc : SQLITE_CORRUPT;
+}
+
 typedef struct OpEntry {
   const char *name;
   OpFn fn;
+  OpSetupFn setup;
 } OpEntry;
 
 static OpEntry kOps[] = {
-  { "dolt_commit",       opCommit },
-  { "dolt_branch_create", opBranchCreate },
-  { "dolt_branch_delete", opBranchDelete },
-  { "dolt_checkout",     opCheckout },
-  { "dolt_log_scan",     opLogScan },
-  { "dolt_merge",        opMerge },
-  { "dolt_diff_table",   opDiffTable },
+  { "dolt_commit",         opCommit, 0 },
+  { "dolt_branch_create",  opBranchCreate, 0 },
+  { "dolt_branch_delete",  opBranchDelete, 0 },
+  { "dolt_checkout",       opCheckout, 0 },
+  { "dolt_log_scan",       opLogScan, 0 },
+  { "dolt_merge",          opMerge, 0 },
+  { "dolt_diff_table",     opDiffTable, 0 },
+  { "savepoint_vc_state",  opSavepointState, setupSavepointState },
+  { "rebase_state_set",    opRebaseStateSet, setupSavepointState },
 };
 #define N_OPS (int)(sizeof(kOps)/sizeof(kOps[0]))
 
@@ -275,6 +362,14 @@ static int childRunOp(OpEntry *op, long long failAt){
     sqlite3_close(db);
     cleanupFiles(kDbBase);
     return CHILD_BUG;
+  }
+  if( op->setup ){
+    rc = op->setup(db);
+    if( rc!=SQLITE_OK ){
+      sqlite3_close(db);
+      cleanupFiles(kDbBase);
+      return CHILD_BUG;
+    }
   }
   resetOom(failAt);
   orc = op->fn(db);
@@ -366,7 +461,7 @@ int main(void){
   {
     int totalBugs = 0;
     int i;
-    printf("OOM fault-injection sweep across %d dolt_* ops, MAX_FAIL_N=%d\n",
+    printf("OOM fault-injection sweep across %d operations, MAX_FAIL_N=%d\n",
            N_OPS, MAX_FAIL_N);
     for( i=0; i<N_OPS; i++ ){
       int opBugs;


### PR DESCRIPTION
## Summary

- make VC savepoint capture fail atomically when rebase-state snapshot allocation fails
- return and propagate savepoint-sync failures from staged, merge, rebase, conflict, and constraint-violation state setters
- allocate rebase replacement strings before mutating live state and restore rollback snapshots without allocation
- add stateful OOM invariants for savepoint rollback and rebase-state replacement

Before this change, 8 injected allocation failures returned success while leaving savepoint-managed VC state unrestorable. The updated sweep rejects those failures and preserves the prior state.

## Testing

- `./oom_dolt_fault_test` — 9 operations, 4,500 fault iterations, 0 bugs
- `bash test/doltlite_savepoint.sh ./doltlite` — 128/128
- `./doltlite_regression_test_c all` — 309,909/309,909
- `DOLTLITE_BUILD_DIR="$PWD" bash test/run_doltlite_tests.sh` — 89/89 suites
- `bash test/lint_orphaned_suites.sh`
- `DOLTLITE_BUILD_DIR="$PWD" bash test/dead_code_check.sh`
- `git diff --check`

`make devtest` was also attempted. It reproduced the repository's existing DoltLite/SQLite upstream-suite baseline (1,621 known incompatibilities) and the existing stall at test 2545/2546; no new result was attributable to this patch.
