### PR TITLE
Propagate schema hash refresh failures

### DIFF
--- a/src/doltlite_branch.c
+++ b/src/doltlite_branch.c
@@ -839,7 +839,11 @@ static void doltConnectBranchFunc(
   sqlite3_result_int(ctx, 0);
 }
 
-int doltliteCheckoutBranchForRebase(sqlite3 *db, const char *zBranch){
+static int checkoutBranchForRebase(
+  sqlite3 *db,
+  const char *zBranch,
+  const ProllyHash *pKnownOldCatHash
+){
   ChunkStore *cs = doltliteGetChunkStore(db);
   CheckoutMutationCtx m;
   char *zCurrentBranch = 0;
@@ -853,10 +857,14 @@ int doltliteCheckoutBranchForRebase(sqlite3 *db, const char *zBranch){
   zCurrentBranch = sqlite3_mprintf("%s", doltliteGetSessionBranch(db));
   if( !zCurrentBranch ) return SQLITE_NOMEM;
 
-  rc = checkoutCaptureOldCatalog(db, cs, &m.oldCatHash);
-  if( rc!=SQLITE_OK ){
-    sqlite3_free(zCurrentBranch);
-    return rc;
+  if( pKnownOldCatHash ){
+    memcpy(&m.oldCatHash, pKnownOldCatHash, sizeof(ProllyHash));
+  }else{
+    rc = checkoutCaptureOldCatalog(db, cs, &m.oldCatHash);
+    if( rc!=SQLITE_OK ){
+      sqlite3_free(zCurrentBranch);
+      return rc;
+    }
   }
 
   m.haveOldState = 1;
@@ -876,6 +884,19 @@ int doltliteCheckoutBranchForRebase(sqlite3 *db, const char *zBranch){
   }
   sqlite3_free(zCurrentBranch);
   return rc;
+}
+
+int doltliteCheckoutBranchForRebase(sqlite3 *db, const char *zBranch){
+  return checkoutBranchForRebase(db, zBranch, 0);
+}
+
+int doltliteCheckoutBranchForRebaseWithOldCatalog(
+  sqlite3 *db,
+  const char *zBranch,
+  const ProllyHash *pOldCatHash
+){
+  if( !pOldCatHash ) return SQLITE_MISUSE;
+  return checkoutBranchForRebase(db, zBranch, pOldCatHash);
 }
 
 /* A restored table's indexes must follow it: named indexes present only in

--- a/src/doltlite_core.c
+++ b/src/doltlite_core.c
@@ -202,33 +202,61 @@ int doltliteHasUncommittedChanges(sqlite3 *db, int *pDirty){
   }
 }
 
-void doltliteUpdateSchemaHashes(sqlite3 *db){
+int doltliteUpdateSchemaHashes(sqlite3 *db){
   sqlite3_stmt *pStmt = 0;
+  int rc;
+  int rc2;
   /* One scan of sqlite_master covers every table and index; both key their
-  ** catalog entry by rootpage and canonicalize by their own name. */
-  if( sqlite3_prepare_v2(
-        db,
-        "SELECT name, rootpage, sql "
-        "FROM main.sqlite_master "
-        "WHERE type IN ('table','index') AND sql IS NOT NULL",
-        -1, &pStmt, 0
-      )==SQLITE_OK ){
-    while( sqlite3_step(pStmt)==SQLITE_ROW ){
-      const char *zName = (const char*)sqlite3_column_text(pStmt, 0);
-      Pgno iRoot = (Pgno)sqlite3_column_int(pStmt, 1);
-      const char *zCreate = (const char*)sqlite3_column_text(pStmt, 2);
-      if( zName && zCreate ){
-        ProllyHash h;
-        char *zCanon = doltliteCanonicalizeSchemaSql(zCreate, zName);
-        if( zCanon ){
-          prollyHashCompute(zCanon, (int)strlen(zCanon), &h);
-          sqlite3_free(zCanon);
-          doltliteSetTableSchemaHash(db, iRoot, &h);
-        }
-      }
-    }
+  ** catalog entry by rootpage and canonicalize by their own name. Virtual
+  ** tables have rootpage zero and no corresponding catalog entry. */
+  if( !db ) return SQLITE_MISUSE;
+  rc = sqlite3_prepare_v2(
+      db,
+      "SELECT name, rootpage, sql "
+      "FROM main.sqlite_master "
+      "WHERE type IN ('table','index') AND sql IS NOT NULL AND rootpage>0",
+      -1, &pStmt, 0);
+  if( rc!=SQLITE_OK ){
     sqlite3_finalize(pStmt);
+    return rc;
   }
+  while( (rc = sqlite3_step(pStmt))==SQLITE_ROW ){
+    const char *zName = (const char*)sqlite3_column_text(pStmt, 0);
+    i64 iRoot = sqlite3_column_int64(pStmt, 1);
+    const char *zCreate = (const char*)sqlite3_column_text(pStmt, 2);
+    ProllyHash h;
+    char *zCanon;
+    if( !zName || !zCreate ){
+      rc = db->mallocFailed ? SQLITE_NOMEM : SQLITE_CORRUPT;
+      break;
+    }
+    if( iRoot<=0 || iRoot>(i64)0xffffffff ){
+      rc = SQLITE_CORRUPT;
+      break;
+    }
+    if( sqlite3FaultSim(954) ){
+      rc = SQLITE_NOMEM;
+      break;
+    }
+    zCanon = doltliteCanonicalizeSchemaSql(zCreate, zName);
+    if( !zCanon ){
+      rc = SQLITE_NOMEM;
+      break;
+    }
+    prollyHashCompute(zCanon, (int)strlen(zCanon), &h);
+    sqlite3_free(zCanon);
+    rc = doltliteSetTableSchemaHash(db, (Pgno)iRoot, &h);
+    if( rc==SQLITE_NOTFOUND ){
+      rc = SQLITE_CORRUPT;
+    }
+    if( rc!=SQLITE_OK ){
+      break;
+    }
+  }
+  if( rc==SQLITE_DONE ) rc = SQLITE_OK;
+  rc2 = sqlite3_finalize(pStmt);
+  if( rc==SQLITE_OK ) rc = rc2;
+  return rc;
 }
 
 int doltliteLoadLiveSchemaSql(

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -948,7 +948,8 @@ int doltliteRegisterBlameTables(sqlite3 *db);
 int doltliteRegisterAtTables(sqlite3 *db);
 int doltliteRegisterAtTablesForCatalog(sqlite3 *db, const ProllyHash *pCatHash);
 int doltliteRefreshConstraintViolationTables(sqlite3 *db);
-void doltliteSetTableSchemaHash(sqlite3 *db, Pgno iTable, const ProllyHash *pH);
+int doltliteSetTableSchemaHash(sqlite3 *db, Pgno iTable, const ProllyHash *pH);
+int doltliteUpdateSchemaHashes(sqlite3 *db);
 
 /* Post-merge constraint detectors (defined in doltlite_merge_constraints.c). */
 int doltliteDetectMergeFkViolations(sqlite3 *db, const ProllyHash *pAncCatHash,

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -1114,6 +1114,11 @@ int doltlitePersistWorkingSetWithHash(sqlite3 *db, const ProllyHash *pWorkingCat
 int doltliteLoadWorkingSet(sqlite3 *db, const char *zBranch);
 int doltliteGetPersistedWorkingCatalogHash(sqlite3 *db, ProllyHash *pCatHash);
 int doltliteCheckoutBranchForRebase(sqlite3 *db, const char *zBranch);
+int doltliteCheckoutBranchForRebaseWithOldCatalog(
+  sqlite3 *db,
+  const char *zBranch,
+  const ProllyHash *pOldCatHash
+);
 DoltliteVcTxnMode doltliteVcTxnMode(sqlite3 *db);
 int doltliteVcSealActiveSavepoints(sqlite3 *db);
 int doltliteVcSealSavepointError(sqlite3 *db);

--- a/src/doltlite_rebase.c
+++ b/src/doltlite_rebase.c
@@ -1217,7 +1217,12 @@ static void doltliteRebaseInteractiveContinue(
   if( rc==SQLITE_OK ) rc = doltlitePersistWorkingSet(db);
   if( rc!=SQLITE_OK ) goto abort_err;
 
-  rc = doltliteCheckoutBranchForRebase(db, zOrigBranch);
+  /* curCat is already the exact flushed catalog installed by the replay and
+  ** persisted above. Under a caller savepoint, the live SQLite schema is
+  ** transitional until checkout completes, so do not re-prepare and
+  ** re-serialize it merely to capture the branch being discarded. */
+  rc = doltliteCheckoutBranchForRebaseWithOldCatalog(
+      db, zOrigBranch, &curCat);
   if( rc!=SQLITE_OK ) goto abort_err;
   rc = doltliteMutateRefs(db, rebaseDeleteWorkingBranchRefs, zWorking);
   if( rc!=SQLITE_OK ) goto abort_err;

--- a/src/prolly_btree_catalog.c
+++ b/src/prolly_btree_catalog.c
@@ -1709,9 +1709,12 @@ int doltliteFlushAndSerializeCatalog(sqlite3 *db, u8 **ppOut, int *pnOut){
   rc = flushDeferredEdits(pBtree, pBt);
   if( rc!=SQLITE_OK ) return rc;
 
-  {
-    extern void doltliteUpdateSchemaHashes(sqlite3 *db);
-    doltliteUpdateSchemaHashes(db);
+  /* A new connection starts with only the runtime sqlite_master entry.
+  ** Repository seeding runs before that schema can be queried, and there
+  ** are no user-table hashes to refresh in that state. */
+  if( pBtree->cat.n>1 ){
+    rc = doltliteUpdateSchemaHashes(db);
+    if( rc!=SQLITE_OK ) return rc;
   }
   return serializeCatalog(db->aDb[0].pBt, ppOut, pnOut);
 }

--- a/src/prolly_btree_int.h
+++ b/src/prolly_btree_int.h
@@ -42,6 +42,7 @@
 
 void doltliteGetSessionHead(sqlite3 *db, ProllyHash *pHead);
 char *doltliteCanonicalizeSchemaSql(const char *zSql, const char *zName);
+int doltliteUpdateSchemaHashes(sqlite3 *db);
 int doltliteLoadLiveSchemaSql(sqlite3 *db, const char *zType,
                               const char *zDb,
                               const char *zName, const char *zTblName,

--- a/src/prolly_btree_mutation.c
+++ b/src/prolly_btree_mutation.c
@@ -1528,17 +1528,20 @@ void sqlite3BtreeIncrblobCursor(BtCursor *pCur){
 #endif
 
 
-void doltliteSetTableSchemaHash(sqlite3 *db, Pgno iTable, const ProllyHash *pH){
+int doltliteSetTableSchemaHash(sqlite3 *db, Pgno iTable, const ProllyHash *pH){
   Btree *pBtree;
   int i;
-  if( !db || db->nDb<=0 || !db->aDb[0].pBt ) return;
+  if( !db || db->nDb<=0 || !db->aDb[0].pBt || !pH ){
+    return SQLITE_MISUSE;
+  }
   pBtree = db->aDb[0].pBt;
   for(i=0; i<pBtree->cat.n; i++){
     if( pBtree->cat.a[i].iTable==iTable ){
       memcpy(&pBtree->cat.a[i].schemaHash, pH, sizeof(ProllyHash));
-      return;
+      return SQLITE_OK;
     }
   }
+  return SQLITE_NOTFOUND;
 }
 
 /* Declared in doltlite_internal.h. Forward-declared here because that

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -27,7 +27,6 @@ typedef unsigned char u8;
 typedef unsigned int Pgno;
 
 extern int doltliteFlushAndSerializeCatalog(sqlite3 *db, u8 **ppOut, int *pnOut);
-extern void doltliteSetTableSchemaHash(sqlite3 *db, Pgno iTable, const ProllyHash *pH);
 extern int doltliteRemoteSrvCommitPendingForTest(ChunkStore *pStore);
 extern int doltliteRemoteSrvApplyRefsForTest(
   ChunkStore *pStore, const u8 *pBody, int nBody
@@ -1041,7 +1040,8 @@ static void run_savepoint_catalog_restore(void){
 
   memset(&fakeHash, 0x5a, sizeof(fakeHash));
   check("savepoint_begin", execSql(db, "SAVEPOINT sp;")==SQLITE_OK);
-  doltliteSetTableSchemaHash(db, iTable, &fakeHash);
+  check("set_fake_schema_hash",
+      doltliteSetTableSchemaHash(db, iTable, &fakeHash)==SQLITE_OK);
   check("rollback_to", execSql(db, "ROLLBACK TO sp;")==SQLITE_OK);
   check("release_sp", execSql(db, "RELEASE sp;")==SQLITE_OK);
 
@@ -1152,6 +1152,108 @@ static void run_session_string_setter_oom(void){
       strcmp(queryScalarText(
           db, "SELECT dolt_config('user.email')"),
           "original@example.com")==0);
+
+  sqlite3_close(db);
+  removeDbFiles(dbpath);
+}
+
+static int denySchemaMasterRead(
+  void *pCtx,
+  int action,
+  const char *zArg1,
+  const char *zArg2,
+  const char *zDb,
+  const char *zTrigger
+){
+  (void)pCtx;
+  (void)zArg2;
+  (void)zDb;
+  (void)zTrigger;
+  if( action==SQLITE_READ && zArg1
+   && strcmp(zArg1, "sqlite_master")==0 ){
+    return SQLITE_DENY;
+  }
+  return SQLITE_OK;
+}
+
+static void run_schema_hash_error_propagation(void){
+  sqlite3 *db = 0;
+  char dbpath[256];
+  ProllyHash fakeHash;
+  const char *zResult;
+  int nLogBefore;
+
+  printf("=== Schema Hash Error Propagation Test ===\n\n");
+  make_dbpath(dbpath, sizeof(dbpath), "test_schema_hash_error_propagation");
+  removeDbFiles(dbpath);
+
+  check("schema_hash_open_db", sqlite3_open(dbpath, &db)==SQLITE_OK);
+  if( !db ) return;
+
+  check("schema_hash_create_base", execSql(db,
+      "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);")==SQLITE_OK);
+  check("schema_hash_commit_base",
+      strlen(queryScalarText(
+          db, "SELECT dolt_commit('-A', '-m', 'base')"))==40);
+
+  check("schema_hash_set_authorizer",
+      sqlite3_set_authorizer(db, denySchemaMasterRead, 0)==SQLITE_OK);
+  check("schema_hash_prepare_error_propagated",
+      doltliteUpdateSchemaHashes(db)==SQLITE_AUTH);
+  check("schema_hash_clear_authorizer",
+      sqlite3_set_authorizer(db, 0, 0)==SQLITE_OK);
+
+  memset(&fakeHash, 0x5a, sizeof(fakeHash));
+  check("schema_hash_missing_table_reported",
+      doltliteSetTableSchemaHash(
+          db, (Pgno)0x7ffffffe, &fakeHash)==SQLITE_NOTFOUND);
+
+  check("schema_hash_create_virtual_table", execSql(db,
+      "CREATE VIRTUAL TABLE docs USING fts5(body);")==SQLITE_OK);
+  check("schema_hash_virtual_root_ignored",
+      doltliteUpdateSchemaHashes(db)==SQLITE_OK);
+  check("schema_hash_commit_virtual_table",
+      strlen(queryScalarText(
+          db, "SELECT dolt_commit('-A', '-m', 'virtual table')"))==40);
+
+  check("schema_hash_alter_table", execSql(db,
+      "ALTER TABLE t ADD COLUMN extra TEXT;")==SQLITE_OK);
+  nLogBefore = atoi(queryScalarText(db, "SELECT count(*) FROM dolt_log"));
+
+  gRegressionFaultCode = 954;
+  gRegressionFaultHits = 0;
+  sqlite3_test_control(SQLITE_TESTCTRL_FAULT_INSTALL, regressionFaultCallback);
+  zResult = queryScalarText(
+      db, "SELECT dolt_commit('-A', '-m', 'schema change')");
+  sqlite3_test_control(SQLITE_TESTCTRL_FAULT_INSTALL, 0);
+  gRegressionFaultCode = 0;
+
+  check("schema_hash_canonicalization_failure_injected",
+      gRegressionFaultHits==1);
+  check("schema_hash_commit_reports_refresh_failure",
+      strstr(zResult, "ERROR:")!=0);
+  check("schema_hash_failed_commit_does_not_advance_log",
+      atoi(queryScalarText(db, "SELECT count(*) FROM dolt_log"))==nLogBefore);
+  check("schema_hash_failed_commit_keeps_ddl",
+      strcmp(queryScalarText(db,
+          "SELECT count(*) FROM pragma_table_info('t') "
+          "WHERE name='extra'"), "1")==0);
+
+  check("schema_hash_retry_commit_succeeds",
+      strlen(queryScalarText(
+          db, "SELECT dolt_commit('-A', '-m', 'schema change')"))==40);
+  check("schema_hash_retry_records_schema_diff",
+      strcmp(queryScalarText(db,
+          "SELECT count(*) FROM dolt_schema_diff('HEAD~1','HEAD','t')"),
+          "1")==0);
+
+  sqlite3_close(db);
+  db = 0;
+  check("schema_hash_reopen_db", sqlite3_open(dbpath, &db)==SQLITE_OK);
+  check("schema_hash_reopen_has_column",
+      strcmp(queryScalarText(db,
+          "SELECT count(*) FROM pragma_table_info('t') "
+          "WHERE name='extra'"), "1")==0);
 
   sqlite3_close(db);
   removeDbFiles(dbpath);
@@ -8472,6 +8574,7 @@ static const RegressionCase aCases[] = {
   { "checkout_persist_failure", "Checkout Persist Failure Test", run_checkout_persist_failure },
   { "savepoint_catalog_restore", "Savepoint Catalog Restore Test", run_savepoint_catalog_restore },
   { "session_string_setter_oom", "Session String Setter OOM Test", run_session_string_setter_oom },
+  { "schema_hash_error_propagation", "Schema Hash Error Propagation Test", run_schema_hash_error_propagation },
   { "refs_blob_corruption", "Refs Blob Corruption Test", run_refs_blob_corruption },
   { "refresh_error_propagation", "Refresh Error Propagation Test", run_refresh_error_propagation },
   { "conflicts_blob_corruption", "Conflicts Blob Corruption Test", run_conflicts_blob_corruption },

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -6125,10 +6125,8 @@ mmap1 mmap1-6.2  # mmap_size reads back 0 / mmap stats 0
 # multiplex VFS over a chunk store: journal_mode is not configurable on
 # doltlite-format databases (dominant failure: the multiplex tests set
 # journal_mode=delete/truncate per cycle), multiplex chunk-boundary and
-# size/journal-shape expectations differ, and 1.9.2 surfaces residual
-# SQLITE_MISUSE warnings from the wrapper open path. The native
-# initialized-wrapper contract is covered by doltlite_recover_vfs_wrappers.
-multiplex multiplex-1.9.2
+# size/journal-shape expectations differ. The native initialized-wrapper
+# contract is covered by doltlite_recover_vfs_wrappers.
 multiplex multiplex-2.1.3
 multiplex multiplex-2.2.3
 multiplex multiplex-2.4.4
@@ -6228,7 +6226,6 @@ multiplex multiplex-2.6.2.6436.off
 multiplex multiplex-2.6.2.6855.off
 multiplex multiplex-2.6.2.7274.off
 multiplex multiplex-2.6.2.7693.off
-multiplex multiplex-2.7.3
 multiplex multiplex-3.1.2
 multiplex multiplex-3.2.1a
 


### PR DESCRIPTION
## Summary

- make schema-hash refresh and catalog mutation result-bearing so prepare, scan, canonicalization, and missing-entry failures stop catalog serialization
- ignore rootpage-zero virtual tables and preserve the runtime-only catalog state used while seeding a new repository
- add regression coverage proving a failed schema-changing commit does not advance history, remains retryable, records the schema diff, and persists after reopen

## Testing

- schema hash error propagation: 19/19
- C regression suite: 309929/309929
- schema diff: 49/49
- schema merge: 94/94
- stable catalog numbers: 12/12
- rebase schema: 23/23
- schema cookie: 5/5
- writable schema: 3/3
- savepoint catalog restore: 128/128
- OOM harness: 3500 operations, 0 bugs
- full project suite: 89/89
- orphan-suite lint: pass
- dead-code check: pass
- `git diff --check`: pass

`make devtest` reproduces the existing branch baseline: 1621 failures and a stall at test 2545/2546; it was stopped after 2m15s.