### PR TITLE
Preserve session strings on allocation failure

### DIFF
--- a/src/doltlite_branch.c
+++ b/src/doltlite_branch.c
@@ -427,6 +427,7 @@ static void doltBranchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv)
     case MODE_MOVE: {
       BranchMoveCtx m;
       int renamingCurrent;
+      char *zPreparedBranch = 0;
       if( nPositional>2 ){
         branchError(ctx, hadSavepoint, "too many arguments");
         return;
@@ -443,14 +444,23 @@ static void doltBranchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv)
       m.zSrc = aPositional[0];
       m.zDest = aPositional[1];
       renamingCurrent = strcmp(m.zSrc, doltliteGetSessionBranch(db))==0;
+      if( renamingCurrent ){
+        rc = doltlitePrepareSessionBranch(db, m.zDest, &zPreparedBranch);
+        if( rc!=SQLITE_OK ){
+          branchErrorCode(ctx, hadSavepoint, rc);
+          return;
+        }
+      }
       rc = doltliteMutateRefs(db, mutateBranchMove, &m);
       if( rc!=SQLITE_OK ){
+        sqlite3_free(zPreparedBranch);
         branchNamedResultError(ctx, hadSavepoint, rc,
           "source branch not found", "destination already exists");
         return;
       }
       if( renamingCurrent ){
-        doltliteSetSessionBranch(db, m.zDest);
+        assert( zPreparedBranch!=0 );
+        doltliteInstallPreparedSessionBranch(db, zPreparedBranch);
       }
       break;
     }
@@ -620,13 +630,15 @@ static void checkoutSaveSession(sqlite3 *db, CheckoutMutationCtx *p){
 
 static int checkoutRestoreSession(sqlite3 *db, CheckoutMutationCtx *p){
   int rc;
-  doltliteSetSessionBranch(db, p->zCurrentBranch);
-  doltliteSetSessionHead(db, &p->savedSessionHead);
-  rc = doltliteSetSessionRebaseState(db, p->savedIsRebasing,
-                                     &p->savedPreRebaseCat,
-                                     &p->savedRebaseOnto,
-                                     p->zSavedRebaseOrigBranch,
-                                     p->zSavedRebaseReturnBranch);
+  rc = doltliteSetSessionBranch(db, p->zCurrentBranch);
+  if( rc==SQLITE_OK ){
+    doltliteSetSessionHead(db, &p->savedSessionHead);
+    rc = doltliteSetSessionRebaseState(db, p->savedIsRebasing,
+                                       &p->savedPreRebaseCat,
+                                       &p->savedRebaseOnto,
+                                       p->zSavedRebaseOrigBranch,
+                                       p->zSavedRebaseReturnBranch);
+  }
   if( rc==SQLITE_OK ){
     rc = doltliteSetSessionStaged(db, &p->savedSessionStaged);
   }
@@ -669,7 +681,8 @@ static int checkoutMutateRefs(sqlite3 *db, ChunkStore *cs, void *pArg){
                             &p->targetCommit, &p->targetCatHash);
   if( rc!=SQLITE_OK ) return rc;
 
-  doltliteSetSessionBranch(db, p->zTargetBranch);
+  rc = doltliteSetSessionBranch(db, p->zTargetBranch);
+  if( rc!=SQLITE_OK ) return rc;
   doltliteSetSessionHead(db, &p->targetCommit);
 
   rc = doltliteLoadWorkingSet(db, p->zTargetBranch);
@@ -795,9 +808,11 @@ static void doltConnectBranchFunc(
     return;
   }
 
-  doltliteSetSessionBranch(db, zBranch);
-  doltliteSetSessionHead(db, &targetCommit);
-  rc = doltliteLoadWorkingSet(db, zBranch);
+  rc = doltliteSetSessionBranch(db, zBranch);
+  if( rc==SQLITE_OK ){
+    doltliteSetSessionHead(db, &targetCommit);
+    rc = doltliteLoadWorkingSet(db, zBranch);
+  }
   if( rc==SQLITE_OK ){
     ProllyHash staged;
     doltliteGetSessionStaged(db, &staged);
@@ -1457,6 +1472,11 @@ checkout_done:
   }
   if( rc==SQLITE_BUSY ){
     doltliteVcResultError(ctx, db, "database is locked by another connection");
+    return;
+  }
+  if( rc==SQLITE_NOMEM ){
+    (void)doltliteVcSealSavepointError(db);
+    sqlite3_result_error_nomem(ctx);
     return;
   }
   if( rc!=SQLITE_OK ){

--- a/src/doltlite_cherry_pick.c
+++ b/src/doltlite_cherry_pick.c
@@ -183,7 +183,9 @@ int applyMergedCatalogAndCommit(
       case DOLTLITE_VC_TXN_AUTOCOMMIT_LIKE:
         rc = doltliteHardReset(db, &savedState.sessionCatalogHash);
         if( rc==SQLITE_OK ){
-          doltliteSetSessionBranch(db, savedState.zSessionBranch);
+          rc = doltliteSetSessionBranch(db, savedState.zSessionBranch);
+        }
+        if( rc==SQLITE_OK ){
           doltliteSetSessionHead(db, &savedState.sessionHead);
           rc = doltliteSetSessionStaged(db, &savedState.sessionStaged);
         }

--- a/src/doltlite_config.c
+++ b/src/doltlite_config.c
@@ -48,16 +48,23 @@ static void doltliteConfigFunc(sqlite3_context *context, int argc, sqlite3_value
     }
   }else{
 
+    int eValType = sqlite3_value_type(argv[1]);
     const char *zVal = (const char*)sqlite3_value_text(argv[1]);
+    int rc;
+    if( !zVal && eValType!=SQLITE_NULL ){
+      sqlite3_result_error_nomem(context);
+      return;
+    }
     if( strcmp(zKey, "user.name")==0 ){
-      doltliteSetAuthorName(db, zVal);
-      sqlite3_result_int(context, 0);
+      rc = doltliteSetAuthorName(db, zVal);
     }else if( strcmp(zKey, "user.email")==0 ){
-      doltliteSetAuthorEmail(db, zVal);
-      sqlite3_result_int(context, 0);
+      rc = doltliteSetAuthorEmail(db, zVal);
     }else{
       sqlite3_result_error(context, "unknown config key (valid: user.name, user.email)", -1);
+      return;
     }
+    if( rc==SQLITE_OK ) sqlite3_result_int(context, 0);
+    else sqlite3_result_error_code(context, rc);
   }
 }
 

--- a/src/doltlite_core.c
+++ b/src/doltlite_core.c
@@ -75,7 +75,8 @@ int doltliteRestoreTxnState(sqlite3 *db, DoltliteTxnState *p){
   rc = doltliteSwitchCatalog(db, &p->sessionCatalogHash);
   if( rc!=SQLITE_OK ) return rc;
 
-  doltliteSetSessionBranch(db, p->zSessionBranch);
+  rc = doltliteSetSessionBranch(db, p->zSessionBranch);
+  if( rc!=SQLITE_OK ) return rc;
   doltliteSetSessionHead(db, &p->sessionHead);
   rc = doltliteSetSessionStaged(db, &p->sessionStaged);
   if( rc==SQLITE_OK ){

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -1070,7 +1070,10 @@ int doltliteWriteBranchCleanWorkingState(sqlite3 *db, const char *zBranch,
 int doltliteCheckRepoGraphIntegrity(Btree *p, int mxErr, int *pnErr);
 
 const char *doltliteGetSessionBranch(sqlite3 *db);
-void doltliteSetSessionBranch(sqlite3 *db, const char *zBranch);
+int doltlitePrepareSessionBranch(sqlite3 *db, const char *zBranch,
+                                 char **pzPrepared);
+void doltliteInstallPreparedSessionBranch(sqlite3 *db, char *zPrepared);
+int doltliteSetSessionBranch(sqlite3 *db, const char *zBranch);
 void doltliteGetSessionHead(sqlite3 *db, ProllyHash *pHead);
 void doltliteSetSessionHead(sqlite3 *db, const ProllyHash *pHead);
 void doltliteGetSessionStaged(sqlite3 *db, ProllyHash *pStaged);
@@ -1120,9 +1123,9 @@ typedef int (*DoltliteRefsMutation)(sqlite3 *db, ChunkStore *cs, void *pArg);
 int doltliteMutateRefs(sqlite3 *db, DoltliteRefsMutation xMutate, void *pArg);
 
 const char *doltliteGetAuthorName(sqlite3 *db);
-void doltliteSetAuthorName(sqlite3 *db, const char *zName);
+int doltliteSetAuthorName(sqlite3 *db, const char *zName);
 const char *doltliteGetAuthorEmail(sqlite3 *db);
-void doltliteSetAuthorEmail(sqlite3 *db, const char *zEmail);
+int doltliteSetAuthorEmail(sqlite3 *db, const char *zEmail);
 
 #ifndef DOLTLITE_SCHEMAENTRY_DEFINED
 #define DOLTLITE_SCHEMAENTRY_DEFINED

--- a/src/doltlite_merge_cmd.c
+++ b/src/doltlite_merge_cmd.c
@@ -502,7 +502,9 @@ static void doltliteMergeFunc(
       case DOLTLITE_VC_TXN_AUTOCOMMIT_LIKE:
         rc = doltliteHardReset(db, &savedState.sessionCatalogHash);
         if( rc==SQLITE_OK ){
-          doltliteSetSessionBranch(db, savedState.zSessionBranch);
+          rc = doltliteSetSessionBranch(db, savedState.zSessionBranch);
+        }
+        if( rc==SQLITE_OK ){
           doltliteSetSessionHead(db, &savedState.sessionHead);
           rc = doltliteSetSessionStaged(db, &savedState.sessionStaged);
         }

--- a/src/doltlite_rebase.c
+++ b/src/doltlite_rebase.c
@@ -558,7 +558,11 @@ static int rebaseRestoreBranchState(sqlite3 *db, const char *zBranch){
     doltliteCommitClear(&headCommit);
     return rc;
   }
-  doltliteSetSessionBranch(db, zBranch);
+  rc = doltliteSetSessionBranch(db, zBranch);
+  if( rc!=SQLITE_OK ){
+    doltliteCommitClear(&headCommit);
+    return rc;
+  }
   doltliteSetSessionHead(db, &headHash);
   rc = doltliteSetSessionStaged(db, &headCommit.catalogHash);
   if( rc==SQLITE_OK ) rc = doltliteClearSessionMergeState(db);

--- a/src/doltlite_remote_sql.c
+++ b/src/doltlite_remote_sql.c
@@ -133,7 +133,8 @@ static int remoteSqlResetSessionToCommit(
   if( rc!=SQLITE_OK ) return rc;
 
   if( zBranch ){
-    doltliteSetSessionBranch(db, zBranch);
+    rc = doltliteSetSessionBranch(db, zBranch);
+    if( rc!=SQLITE_OK ) return rc;
   }
   rc = doltliteHardReset(db, &catHash);
   if( rc==SQLITE_OK ){

--- a/src/prolly_btree_state.c
+++ b/src/prolly_btree_state.c
@@ -519,13 +519,55 @@ const char *doltliteGetSessionBranch(sqlite3 *db){
   return "main";
 }
 
-void doltliteSetSessionBranch(sqlite3 *db, const char *zBranch){
-  if( db && db->nDb>0 && db->aDb[0].pBt ){
-    Btree *p = db->aDb[0].pBt;
-    assert( zBranch!=0 );
-    sqlite3_free(p->zBranch);
-    p->zBranch = sqlite3_mprintf("%s", zBranch);
+static int replaceSessionString(char **pzDest, const char *zValue){
+  char *zNew = 0;
+  if( zValue ){
+    if( sqlite3FaultSim(955) ) return SQLITE_NOMEM;
+    zNew = sqlite3_mprintf("%s", zValue);
+    if( !zNew ) return SQLITE_NOMEM;
   }
+  sqlite3_free(*pzDest);
+  *pzDest = zNew;
+  return SQLITE_OK;
+}
+
+int doltlitePrepareSessionBranch(
+  sqlite3 *db,
+  const char *zBranch,
+  char **pzPrepared
+){
+  if( !db || db->nDb<=0 || !db->aDb[0].pBt
+   || !zBranch || !pzPrepared ){
+    return SQLITE_MISUSE;
+  }
+  *pzPrepared = 0;
+  if( strcmp(doltliteGetSessionBranch(db), zBranch)==0 ){
+    return SQLITE_OK;
+  }
+  if( sqlite3FaultSim(955) ) return SQLITE_NOMEM;
+  *pzPrepared = sqlite3_mprintf("%s", zBranch);
+  return *pzPrepared ? SQLITE_OK : SQLITE_NOMEM;
+}
+
+void doltliteInstallPreparedSessionBranch(
+  sqlite3 *db,
+  char *zPrepared
+){
+  Btree *p;
+  assert( db!=0 && db->nDb>0 && db->aDb[0].pBt!=0 );
+  assert( zPrepared!=0 );
+  p = db->aDb[0].pBt;
+  sqlite3_free(p->zBranch);
+  p->zBranch = zPrepared;
+}
+
+int doltliteSetSessionBranch(sqlite3 *db, const char *zBranch){
+  char *zPrepared = 0;
+  int rc = doltlitePrepareSessionBranch(db, zBranch, &zPrepared);
+  if( rc==SQLITE_OK && zPrepared ){
+    doltliteInstallPreparedSessionBranch(db, zPrepared);
+  }
+  return rc;
 }
 
 const char *doltliteGetAuthorName(sqlite3 *db){
@@ -536,12 +578,17 @@ const char *doltliteGetAuthorName(sqlite3 *db){
   return "doltlite";
 }
 
-void doltliteSetAuthorName(sqlite3 *db, const char *zName){
-  if( db && db->nDb>0 && db->aDb[0].pBt ){
-    Btree *p = db->aDb[0].pBt;
-    sqlite3_free(p->zAuthorName);
-    p->zAuthorName = zName ? sqlite3_mprintf("%s", zName) : 0;
+int doltliteSetAuthorName(sqlite3 *db, const char *zName){
+  Btree *p;
+  if( !db || db->nDb<=0 || !db->aDb[0].pBt ){
+    return SQLITE_MISUSE;
   }
+  p = db->aDb[0].pBt;
+  if( (p->zAuthorName==0 && zName==0)
+   || (p->zAuthorName && zName && strcmp(p->zAuthorName, zName)==0) ){
+    return SQLITE_OK;
+  }
+  return replaceSessionString(&p->zAuthorName, zName);
 }
 
 const char *doltliteGetAuthorEmail(sqlite3 *db){
@@ -552,12 +599,17 @@ const char *doltliteGetAuthorEmail(sqlite3 *db){
   return "";
 }
 
-void doltliteSetAuthorEmail(sqlite3 *db, const char *zEmail){
-  if( db && db->nDb>0 && db->aDb[0].pBt ){
-    Btree *p = db->aDb[0].pBt;
-    sqlite3_free(p->zAuthorEmail);
-    p->zAuthorEmail = zEmail ? sqlite3_mprintf("%s", zEmail) : 0;
+int doltliteSetAuthorEmail(sqlite3 *db, const char *zEmail){
+  Btree *p;
+  if( !db || db->nDb<=0 || !db->aDb[0].pBt ){
+    return SQLITE_MISUSE;
   }
+  p = db->aDb[0].pBt;
+  if( (p->zAuthorEmail==0 && zEmail==0)
+   || (p->zAuthorEmail && zEmail && strcmp(p->zAuthorEmail, zEmail)==0) ){
+    return SQLITE_OK;
+  }
+  return replaceSessionString(&p->zAuthorEmail, zEmail);
 }
 
 void doltliteGetSessionHead(sqlite3 *db, ProllyHash *pHead){

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -1055,6 +1055,108 @@ static void run_savepoint_catalog_restore(void){
   sqlite3_close(db);
 }
 
+static void run_session_string_setter_oom(void){
+  sqlite3 *db = 0;
+  char dbpath[256];
+  int rc;
+
+  printf("=== Session String Setter OOM Test ===\n\n");
+  make_dbpath(dbpath, sizeof(dbpath), "test_session_string_setter_oom");
+  removeDbFiles(dbpath);
+
+  check("session_string_open_db", sqlite3_open(dbpath, &db)==SQLITE_OK);
+  if( !db ) return;
+
+  check("session_string_create_base", execSql(db,
+      "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
+      "INSERT INTO t VALUES(1, 'main');")==SQLITE_OK);
+  check("session_string_commit_base",
+      strlen(queryScalarText(
+          db, "SELECT dolt_commit('-A', '-m', 'base')"))==40);
+  check("session_string_create_feature",
+      execSql(db, "SELECT dolt_branch('feature')")==SQLITE_OK);
+  check("session_string_checkout_feature",
+      execSql(db, "SELECT dolt_checkout('feature')")==SQLITE_OK);
+  check("session_string_update_feature",
+      execSql(db, "UPDATE t SET v='feature' WHERE id=1")==SQLITE_OK);
+  check("session_string_commit_feature",
+      strlen(queryScalarText(
+          db, "SELECT dolt_commit('-A', '-m', 'feature')"))==40);
+  check("session_string_checkout_main",
+      execSql(db, "SELECT dolt_checkout('main')")==SQLITE_OK);
+  check("session_string_main_value_before_fault",
+      strcmp(queryScalarText(db, "SELECT v FROM t WHERE id=1"), "main")==0);
+
+  gRegressionFaultCode = 955;
+  gRegressionFaultHits = 0;
+  sqlite3_test_control(SQLITE_TESTCTRL_FAULT_INSTALL, regressionFaultCallback);
+  rc = execSqlSilent(db, "SELECT dolt_checkout('feature')");
+  sqlite3_test_control(SQLITE_TESTCTRL_FAULT_INSTALL, 0);
+  gRegressionFaultCode = 0;
+  check("session_branch_oom_injected", gRegressionFaultHits==1);
+  check("session_branch_oom_reported", rc==SQLITE_NOMEM);
+  check("session_branch_preserved_after_oom",
+      strcmp(queryScalarText(db, "SELECT active_branch()"), "main")==0);
+  check("session_catalog_preserved_after_branch_oom",
+      strcmp(queryScalarText(db, "SELECT v FROM t WHERE id=1"), "main")==0);
+  check("session_branch_retry_succeeds",
+      execSql(db, "SELECT dolt_checkout('feature')")==SQLITE_OK);
+  check("session_branch_retry_loads_feature",
+      strcmp(queryScalarText(db, "SELECT v FROM t WHERE id=1"), "feature")==0);
+
+  gRegressionFaultCode = 955;
+  gRegressionFaultHits = 0;
+  sqlite3_test_control(SQLITE_TESTCTRL_FAULT_INSTALL, regressionFaultCallback);
+  rc = execSqlSilent(db,
+      "SELECT dolt_branch('-m', 'feature', 'renamed')");
+  sqlite3_test_control(SQLITE_TESTCTRL_FAULT_INSTALL, 0);
+  gRegressionFaultCode = 0;
+  check("session_branch_rename_oom_injected", gRegressionFaultHits==1);
+  check("session_branch_rename_oom_reported", rc==SQLITE_NOMEM);
+  check("session_branch_rename_preserves_active_branch",
+      strcmp(queryScalarText(db, "SELECT active_branch()"), "feature")==0);
+  check("session_branch_rename_preserves_refs",
+      strcmp(queryScalarText(db,
+          "SELECT "
+          "(SELECT count(*) FROM dolt_branches WHERE name='feature') || ',' || "
+          "(SELECT count(*) FROM dolt_branches WHERE name='renamed')"),
+          "1,0")==0);
+
+  check("session_author_name_seed", execSql(db,
+      "SELECT dolt_config('user.name', 'Original Name')")==SQLITE_OK);
+  gRegressionFaultCode = 955;
+  gRegressionFaultHits = 0;
+  sqlite3_test_control(SQLITE_TESTCTRL_FAULT_INSTALL, regressionFaultCallback);
+  rc = execSqlSilent(db,
+      "SELECT dolt_config('user.name', 'Replacement Name')");
+  sqlite3_test_control(SQLITE_TESTCTRL_FAULT_INSTALL, 0);
+  gRegressionFaultCode = 0;
+  check("session_author_name_oom_injected", gRegressionFaultHits==1);
+  check("session_author_name_oom_reported", rc==SQLITE_NOMEM);
+  check("session_author_name_preserved",
+      strcmp(queryScalarText(
+          db, "SELECT dolt_config('user.name')"), "Original Name")==0);
+
+  check("session_author_email_seed", execSql(db,
+      "SELECT dolt_config('user.email', 'original@example.com')")==SQLITE_OK);
+  gRegressionFaultCode = 955;
+  gRegressionFaultHits = 0;
+  sqlite3_test_control(SQLITE_TESTCTRL_FAULT_INSTALL, regressionFaultCallback);
+  rc = execSqlSilent(db,
+      "SELECT dolt_config('user.email', 'replacement@example.com')");
+  sqlite3_test_control(SQLITE_TESTCTRL_FAULT_INSTALL, 0);
+  gRegressionFaultCode = 0;
+  check("session_author_email_oom_injected", gRegressionFaultHits==1);
+  check("session_author_email_oom_reported", rc==SQLITE_NOMEM);
+  check("session_author_email_preserved",
+      strcmp(queryScalarText(
+          db, "SELECT dolt_config('user.email')"),
+          "original@example.com")==0);
+
+  sqlite3_close(db);
+  removeDbFiles(dbpath);
+}
+
 static void run_refs_blob_corruption(void){
   ChunkStore cs;
   ChunkStore cs2;
@@ -8369,6 +8471,7 @@ static const RegressionCase aCases[] = {
   { "concurrent_refs", "Concurrent Refs Test", run_concurrent_refs },
   { "checkout_persist_failure", "Checkout Persist Failure Test", run_checkout_persist_failure },
   { "savepoint_catalog_restore", "Savepoint Catalog Restore Test", run_savepoint_catalog_restore },
+  { "session_string_setter_oom", "Session String Setter OOM Test", run_session_string_setter_oom },
   { "refs_blob_corruption", "Refs Blob Corruption Test", run_refs_blob_corruption },
   { "refresh_error_propagation", "Refresh Error Propagation Test", run_refresh_error_propagation },
   { "conflicts_blob_corruption", "Conflicts Blob Corruption Test", run_conflicts_blob_corruption },


### PR DESCRIPTION
## Summary

- make the session branch, author name, and author email setters allocate-before-replace and return allocation errors without changing the prior value
- propagate branch setter failures through checkout, transaction restoration, merge/cherry-pick recovery, rebase, remotes, and `dolt_config`
- preallocate current-branch rename state before mutating refs so OOM cannot leave the session pointing at a renamed-away branch
- add deterministic fault coverage for checkout, current-branch rename, author name, and author email state preservation

## Testing

- session string setter OOM regression: 27/27
- config suite: 28/28
- branch edge suite: 76/76
- C regression suite: 309936/309936
- OOM harness: 9 operations x 500 iterations, 0 bugs
- full project suite: 89/89
- orphan-suite lint: pass
- dead-code check: pass
- `git diff --check`: pass

`make devtest` reproduces the existing baseline: 1621 failures and a stall at test 2545/2546; it was stopped by the 150-second guard.