### PR TITLE
Add dolt_verify_constraints with Dolt oracle coverage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,7 +80,8 @@ make DOLTLITE_PROLLY=0 sqlite3   # stock SQLite, for oracle/perf comparison
   create-commit helpers), `doltlite_branch` (branch/checkout), `doltlite_merge`
   (+ `doltlite_merge_constraints`), `doltlite_diff` / `doltlite_diff_stat` /
   `doltlite_diff_table`, `doltlite_log`, `doltlite_history`, `doltlite_blame`,
-  `doltlite_tag`, `doltlite_conflicts`, `doltlite_constraint_violations`,
+  `doltlite_tag`, `doltlite_conflicts`, `doltlite_constraint_violations` /
+  `doltlite_verify_constraints`,
   `doltlite_schemas` / `doltlite_schema_diff`, `doltlite_patch`,
   `doltlite_status`, `doltlite_workspace`, `doltlite_ignore`, `doltlite_hashof`,
   `doltlite_gc`, `doltlite_remote` / `doltlite_http_remote` /

--- a/README.md
+++ b/README.md
@@ -619,30 +619,7 @@ violations the loser (highest rowid) is evicted from the base
 table into the violations vtable so the remaining value
 stays unique. `dolt_commit` refuses to proceed while any row
 remains in `dolt_constraint_violations_*`; pass `--force` to
-bypass the guard.
-
-#### Verify Constraints
-
-`dolt_verify_constraints` re-scans the working set (or the whole
-database) and writes any foreign-key, unique-index, or CHECK
-violations into `dolt_constraint_violations_*`. It returns `1` if
-any violations were found, else `0`.
-
-```sql
--- Working-set changes vs HEAD only (default)
-SELECT dolt_verify_constraints();
--- 0 or 1
-
--- Every row (ignore HEAD; equivalent to Dolt --all)
-SELECT dolt_verify_constraints('--all');
-
--- Restrict to named tables
-SELECT dolt_verify_constraints('child');
-SELECT dolt_verify_constraints('--all', 'child', 'other');
-
--- Report without persisting into dolt_constraint_violations
-SELECT dolt_verify_constraints('--all', '--output-only');
-```
+bypass the guard. Re-scan anytime with `SELECT dolt_verify_constraints([--all] [--output-only] [table...]);` (returns 0 or 1).
 
 #### Cherry-Pick
 

--- a/README.md
+++ b/README.md
@@ -621,6 +621,29 @@ stays unique. `dolt_commit` refuses to proceed while any row
 remains in `dolt_constraint_violations_*`; pass `--force` to
 bypass the guard.
 
+#### Verify Constraints
+
+`dolt_verify_constraints` re-scans the working set (or the whole
+database) and writes any foreign-key, unique-index, or CHECK
+violations into `dolt_constraint_violations_*`. It returns `1` if
+any violations were found, else `0`.
+
+```sql
+-- Working-set changes vs HEAD only (default)
+SELECT dolt_verify_constraints();
+-- 0 or 1
+
+-- Every row (ignore HEAD; equivalent to Dolt --all)
+SELECT dolt_verify_constraints('--all');
+
+-- Restrict to named tables
+SELECT dolt_verify_constraints('child');
+SELECT dolt_verify_constraints('--all', 'child', 'other');
+
+-- Report without persisting into dolt_constraint_violations
+SELECT dolt_verify_constraints('--all', '--output-only');
+```
+
 #### Cherry-Pick
 
 Apply the changes from a specific commit onto the current branch:

--- a/main.mk
+++ b/main.mk
@@ -603,7 +603,7 @@ PROLLY_OBJS = $(DOLTLITE_AUTH_OBJS) \
               doltlite_diff.o doltlite_diff_table.o doltlite_workspace.o doltlite_branch.o doltlite_tag.o doltlite_ancestor.o doltlite_merge.o doltlite_conflicts.o \
               doltlite_gc.o doltlite_chunk_walk.o doltlite_history.o doltlite_at.o doltlite_blame.o doltlite_schema_diff.o doltlite_patch.o doltlite_schemas.o doltlite_diff_stat.o doltlite_record.o \
               doltlite_ignore.o doltlite_hashof.o \
-              doltlite_constraint_violations.o \
+              doltlite_constraint_violations.o doltlite_verify_constraints.o \
               doltlite_merge_constraints.o \
               doltlite_dbpage.o \
               doltlite_remote.o doltlite_remote_sql.o \
@@ -657,6 +657,7 @@ ifeq ($(DOLTLITE_PROLLY),1)
     $(TOP)/src/doltlite_schema_diff.c $(TOP)/src/doltlite_patch.c $(TOP)/src/doltlite_schemas.c \
     $(TOP)/src/doltlite_diff_stat.c $(TOP)/src/doltlite_record.c $(TOP)/src/doltlite_ignore.c \
     $(TOP)/src/doltlite_hashof.c $(TOP)/src/doltlite_constraint_violations.c \
+    $(TOP)/src/doltlite_verify_constraints.c \
     $(TOP)/src/doltlite_merge_constraints.c $(TOP)/src/doltlite_dbpage.c \
     $(TOP)/src/doltlite_remote.c $(TOP)/src/doltlite_remote_sql.c \
     $(TOP)/src/doltlite_http_remote.c $(TOP)/src/doltlite_remotesrv.c
@@ -1661,6 +1662,9 @@ doltlite_hashof.o:	$(TOP)/src/doltlite_hashof.c $(DEPS_OBJ_COMMON)
 
 doltlite_constraint_violations.o:	$(TOP)/src/doltlite_constraint_violations.c $(DEPS_OBJ_COMMON)
 	$(T.cc.sqlite) -c $(TOP)/src/doltlite_constraint_violations.c
+
+doltlite_verify_constraints.o:	$(TOP)/src/doltlite_verify_constraints.c $(DEPS_OBJ_COMMON)
+	$(T.cc.sqlite) -c $(TOP)/src/doltlite_verify_constraints.c
 
 doltlite_merge_constraints.o:	$(TOP)/src/doltlite_merge_constraints.c $(DEPS_OBJ_COMMON)
 	$(T.cc.sqlite) -c $(TOP)/src/doltlite_merge_constraints.c

--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -24,6 +24,7 @@ extern int doltlitePatchRegister(sqlite3 *db);
 extern int doltliteRemoteSqlRegister(sqlite3 *db);
 extern int doltliteHashofRegister(sqlite3 *db);
 extern int doltliteConstraintViolationsRegister(sqlite3 *db);
+extern int doltliteVerifyConstraintsRegister(sqlite3 *db);
 
 int doltliteRegister(sqlite3 *db){
   int rc;
@@ -56,6 +57,7 @@ int doltliteRegister(sqlite3 *db){
   if( (rc = doltliteRemoteSqlRegister(db))!=SQLITE_OK ) return rc;
   if( (rc = doltliteHashofRegister(db))!=SQLITE_OK ) return rc;
   if( (rc = doltliteConstraintViolationsRegister(db))!=SQLITE_OK ) return rc;
+  if( (rc = doltliteVerifyConstraintsRegister(db))!=SQLITE_OK ) return rc;
   return doltliteMaybeSeedRepo(db);
 }
 

--- a/src/doltlite_cherry_pick.c
+++ b/src/doltlite_cherry_pick.c
@@ -153,15 +153,18 @@ int applyMergedCatalogAndCommit(
     rc = doltliteConstraintViolationBatchBegin(db);
     if( rc==SQLITE_OK ){
       rc = doltliteDetectMergeFkViolations(db, ancCatHash,
-                                           &zDetectErrMsg, &nViolations);
+                                           &zDetectErrMsg, &nViolations,
+                                           0, 0);
     }
     if( rc==SQLITE_OK ){
       rc = doltliteDetectMergeUniqueViolations(db, ancCatHash,
-                                               &zDetectErrMsg, &nUnique);
+                                               &zDetectErrMsg, &nUnique,
+                                               0, 0);
     }
     if( rc==SQLITE_OK ){
       rc = doltliteDetectMergeCheckViolations(db, ancCatHash,
-                                              &zDetectErrMsg, &nCheck);
+                                              &zDetectErrMsg, &nCheck,
+                                              0, 0);
     }
     {
       int erc = doltliteConstraintViolationBatchEnd(db, rc==SQLITE_OK);

--- a/src/doltlite_core.c
+++ b/src/doltlite_core.c
@@ -496,6 +496,17 @@ int doltliteDetectPostMergeConstraintViolations(
   const ProllyHash *pAncCatHash,
   int *pnViolations
 ){
+  return doltliteDetectConstraintViolationsFiltered(
+      db, pAncCatHash, 0, 0, pnViolations);
+}
+
+int doltliteDetectConstraintViolationsFiltered(
+  sqlite3 *db,
+  const ProllyHash *pAncCatHash,
+  const char **azTables,
+  int nTables,
+  int *pnViolations
+){
   int nViolations = 0;
   int nUnique = 0;
   int nCheck = 0;
@@ -534,15 +545,18 @@ int doltliteDetectPostMergeConstraintViolations(
   rc = doltliteConstraintViolationBatchBegin(db);
   if( rc==SQLITE_OK ){
     rc = doltliteDetectMergeFkViolations(db, pAncCatHash,
-                                         &zDetectErrMsg, &nViolations);
+                                         &zDetectErrMsg, &nViolations,
+                                         azTables, nTables);
   }
   if( rc==SQLITE_OK ){
     rc = doltliteDetectMergeUniqueViolations(db, pAncCatHash,
-                                             &zDetectErrMsg, &nUnique);
+                                             &zDetectErrMsg, &nUnique,
+                                             azTables, nTables);
   }
   if( rc==SQLITE_OK ){
     rc = doltliteDetectMergeCheckViolations(db, pAncCatHash,
-                                            &zDetectErrMsg, &nCheck);
+                                            &zDetectErrMsg, &nCheck,
+                                            azTables, nTables);
   }
   {
     int erc = doltliteConstraintViolationBatchEnd(db, rc==SQLITE_OK);

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -886,6 +886,14 @@ int doltliteReportConstraintViolations(
 int doltliteDetectPostMergeConstraintViolations(
   sqlite3 *db, const ProllyHash *pAncCatHash, int *pnViolations
 );
+int doltliteDetectConstraintViolationsFiltered(
+  sqlite3 *db,
+  const ProllyHash *pAncCatHash,
+  const char **azTables,
+  int nTables,
+  int *pnViolations
+);
+int doltliteVerifyConstraintsRegister(sqlite3 *db);
 int doltliteRefreshAndConfirmHead(
   sqlite3 *db, ChunkStore *cs, const ProllyHash *pExpectedHead
 );
@@ -950,13 +958,18 @@ int doltliteRegisterAtTablesForCatalog(sqlite3 *db, const ProllyHash *pCatHash);
 int doltliteRefreshConstraintViolationTables(sqlite3 *db);
 void doltliteSetTableSchemaHash(sqlite3 *db, Pgno iTable, const ProllyHash *pH);
 
-/* Post-merge constraint detectors (defined in doltlite_merge_constraints.c). */
+/* Post-merge / verify constraint detectors (doltlite_merge_constraints.c).
+** azTables/nTables optionally restrict which tables are scanned; nTables<=0
+** means all user tables. */
 int doltliteDetectMergeFkViolations(sqlite3 *db, const ProllyHash *pAncCatHash,
-                                    char **pzErrMsg, int *pnFound);
+                                    char **pzErrMsg, int *pnFound,
+                                    const char **azTables, int nTables);
 int doltliteDetectMergeUniqueViolations(sqlite3 *db, const ProllyHash *pAncCatHash,
-                                        char **pzErrMsg, int *pnFound);
+                                        char **pzErrMsg, int *pnFound,
+                                        const char **azTables, int nTables);
 int doltliteDetectMergeCheckViolations(sqlite3 *db, const ProllyHash *pAncCatHash,
-                                       char **pzErrMsg, int *pnFound);
+                                       char **pzErrMsg, int *pnFound,
+                                       const char **azTables, int nTables);
 
 int doltliteConstraintViolationBatchBegin(sqlite3 *db);
 int doltliteConstraintViolationBatchEnd(sqlite3 *db, int commit);

--- a/src/doltlite_merge_cmd.c
+++ b/src/doltlite_merge_cmd.c
@@ -454,15 +454,18 @@ static void doltliteMergeFunc(
     int vrc = doltliteConstraintViolationBatchBegin(db);
     if( vrc == SQLITE_OK ){
       vrc = doltliteDetectMergeFkViolations(db, &ancCatHash,
-                                            &zDetectErrMsg, &nViolations);
+                                            &zDetectErrMsg, &nViolations,
+                                            0, 0);
     }
     if( vrc == SQLITE_OK ){
       vrc = doltliteDetectMergeUniqueViolations(db, &ancCatHash,
-                                                &zDetectErrMsg, &nUnique);
+                                                &zDetectErrMsg, &nUnique,
+                                                0, 0);
     }
     if( vrc == SQLITE_OK ){
       vrc = doltliteDetectMergeCheckViolations(db, &ancCatHash,
-                                               &zDetectErrMsg, &nCheck);
+                                               &zDetectErrMsg, &nCheck,
+                                               0, 0);
     }
     {
       int erc = doltliteConstraintViolationBatchEnd(db, vrc==SQLITE_OK);

--- a/src/doltlite_merge_constraints.c
+++ b/src/doltlite_merge_constraints.c
@@ -131,6 +131,21 @@ static int catalogTableChanged(
       doltliteFindTableByName(aCur, nCur, zTable));
 }
 
+
+static int cvTableAllowed(
+  const char *zTable,
+  const char **azTables,
+  int nTables
+){
+  int i;
+  if( !zTable ) return 0;
+  if( nTables<=0 || !azTables ) return 1;
+  for(i=0; i<nTables; i++){
+    if( azTables[i] && sqlite3_stricmp(azTables[i], zTable)==0 ) return 1;
+  }
+  return 0;
+}
+
 static int loadAncestorAndCurrentCatalogs(
   sqlite3 *db,
   const ProllyHash *pAncCatHash,
@@ -1048,7 +1063,9 @@ int doltliteDetectMergeUniqueViolations(
   sqlite3 *db,
   const ProllyHash *pAncCatHash,
   char **pzErrMsg,
-  int *pnFound
+  int *pnFound,
+  const char **azTables,
+  int nTables
 ){
   sqlite3_stmt *pTbls = 0;
   struct TableEntry *aAnc = 0;
@@ -1084,6 +1101,10 @@ int doltliteDetectMergeUniqueViolations(
     if( !zTableRaw ) continue;
     zTable = sqlite3_mprintf("%s", zTableRaw);
     if( !zTable ){ rc = SQLITE_NOMEM; break; }
+    if( !cvTableAllowed(zTable, azTables, nTables) ){
+      sqlite3_free(zTable);
+      continue;
+    }
     if( !catalogTableChanged(aAnc, nAnc, aCur, nCur, zTable) ){
       sqlite3_free(zTable);
       continue;
@@ -1268,7 +1289,9 @@ int doltliteDetectMergeCheckViolations(
   sqlite3 *db,
   const ProllyHash *pAncCatHash,
   char **pzErrMsg,
-  int *pnFound
+  int *pnFound,
+  const char **azTables,
+  int nTables
 ){
   sqlite3_stmt *pTbls = 0;
   struct TableEntry *aAnc = 0;
@@ -1311,6 +1334,11 @@ int doltliteDetectMergeCheckViolations(
       sqlite3_free(zSql);
       rc = SQLITE_NOMEM;
       break;
+    }
+    if( !cvTableAllowed(zTable, azTables, nTables) ){
+      sqlite3_free(zTable);
+      sqlite3_free(zSql);
+      continue;
     }
     if( !catalogTableChanged(aAnc, nAnc, aCur, nCur, zTable) ){
       sqlite3_free(zTable);
@@ -1576,7 +1604,9 @@ int doltliteDetectMergeFkViolations(
   sqlite3 *db,
   const ProllyHash *pAncCatHash,
   char **pzErrMsg,
-  int *pnFound
+  int *pnFound,
+  const char **azTables,
+  int nTables
 ){
   sqlite3_stmt *pTbls = 0;
   struct TableEntry *aAnc = 0;
@@ -1623,6 +1653,10 @@ int doltliteDetectMergeFkViolations(
     if( !zTableRaw ) continue;
     zTable = sqlite3_mprintf("%s", zTableRaw);
     if( !zTable ){ rc = SQLITE_NOMEM; break; }
+    if( !cvTableAllowed(zTable, azTables, nTables) ){
+      sqlite3_free(zTable);
+      continue;
+    }
     childChanged = catalogTableChanged(aAnc, nAnc, aCur, nCur, zTable);
     memset(&childPk, 0, sizeof(childPk));
     hasRowid = tableHasRowid(db, zTable);

--- a/src/doltlite_verify_constraints.c
+++ b/src/doltlite_verify_constraints.c
@@ -1,0 +1,346 @@
+
+#ifdef DOLTLITE_PROLLY
+
+#include "sqliteInt.h"
+#include "prolly_hash.h"
+#include "doltlite_commit.h"
+#include "doltlite_internal.h"
+#include "doltlite_constraint_violations.h"
+
+#include <string.h>
+
+/*
+** SELECT dolt_verify_constraints([--all] [--output-only] [table...]);
+**
+** Mirrors Dolt's dolt_verify_constraints stored procedure:
+**   - Default: only tables that differ from HEAD are scanned, but every
+**     violating row in those tables is reported (not just rows new since HEAD).
+**   - --all: scan every table against an empty ancestor catalog.
+**   - Optional table names restrict which tables are scanned.
+**   - --output-only computes violations but does not persist them.
+** Returns 0 if no violations, 1 if any were found.
+*/
+
+static int tableExists(sqlite3 *db, const char *zName){
+  sqlite3_stmt *pStmt = 0;
+  char *zSql;
+  int found = 0;
+  int rc;
+
+  zSql = sqlite3_mprintf(
+      "SELECT 1 FROM main.sqlite_master WHERE type='table' AND name=%Q",
+      zName);
+  if( !zSql ) return -1;
+  rc = sqlite3_prepare_v2(db, zSql, -1, &pStmt, 0);
+  sqlite3_free(zSql);
+  if( rc!=SQLITE_OK ) return -1;
+  if( sqlite3_step(pStmt)==SQLITE_ROW ) found = 1;
+  sqlite3_finalize(pStmt);
+  return found;
+}
+
+/* Collect user table names that differ between two catalogs. */
+static int collectChangedTables(
+  sqlite3 *db,
+  const ProllyHash *pAncCat,
+  char ***pazOut,
+  int *pnOut
+){
+  struct TableEntry *aAnc = 0, *aCur = 0;
+  int nAnc = 0, nCur = 0;
+  char **az = 0;
+  int n = 0, nAlloc = 0;
+  sqlite3_stmt *pTbls = 0;
+  int rc, stepRc;
+
+  *pazOut = 0;
+  *pnOut = 0;
+
+  if( pAncCat && !prollyHashIsEmpty(pAncCat) ){
+    rc = doltliteLoadCatalog(db, pAncCat, &aAnc, &nAnc, 0);
+    if( rc!=SQLITE_OK ) return rc;
+  }
+  {
+    ProllyHash curHash;
+    rc = doltliteFlushCatalogToHash(db, &curHash);
+    if( rc!=SQLITE_OK ){
+      doltliteFreeCatalog(aAnc, nAnc);
+      return rc;
+    }
+    rc = doltliteLoadCatalog(db, &curHash, &aCur, &nCur, 0);
+    if( rc!=SQLITE_OK ){
+      doltliteFreeCatalog(aAnc, nAnc);
+      return rc;
+    }
+  }
+
+  rc = sqlite3_prepare_v2(db,
+      "SELECT name FROM main.sqlite_master WHERE type='table' "
+      "AND name NOT LIKE 'sqlite_%' AND name NOT LIKE 'dolt_%'",
+      -1, &pTbls, 0);
+  if( rc!=SQLITE_OK ){
+    doltliteFreeCatalog(aAnc, nAnc);
+    doltliteFreeCatalog(aCur, nCur);
+    return rc;
+  }
+
+  while( (stepRc = sqlite3_step(pTbls))==SQLITE_ROW ){
+    const char *zName = (const char*)sqlite3_column_text(pTbls, 0);
+    struct TableEntry *pA, *pC;
+    if( !zName ) continue;
+    pA = doltliteFindTableByName(aAnc, nAnc, zName);
+    pC = doltliteFindTableByName(aCur, nCur, zName);
+    if( pA && pC
+     && prollyHashCompare(&pA->root, &pC->root)==0
+     && prollyHashCompare(&pA->schemaHash, &pC->schemaHash)==0 ){
+      continue;
+    }
+    if( !pA && !pC ) continue;
+    if( n >= nAlloc ){
+      int nNew = nAlloc ? nAlloc*2 : 8;
+      char **azNew = sqlite3_realloc(az, nNew * (int)sizeof(char*));
+      if( !azNew ){ rc = SQLITE_NOMEM; break; }
+      az = azNew;
+      nAlloc = nNew;
+    }
+    az[n] = sqlite3_mprintf("%s", zName);
+    if( !az[n] ){ rc = SQLITE_NOMEM; break; }
+    n++;
+  }
+  if( rc==SQLITE_OK && stepRc!=SQLITE_DONE && stepRc!=SQLITE_ROW ){
+    rc = stepRc;
+  }
+  if( rc==SQLITE_DONE ) rc = SQLITE_OK;
+  sqlite3_finalize(pTbls);
+  doltliteFreeCatalog(aAnc, nAnc);
+  doltliteFreeCatalog(aCur, nCur);
+  if( rc!=SQLITE_OK ){
+    int i;
+    for(i=0; i<n; i++) sqlite3_free(az[i]);
+    sqlite3_free(az);
+    return rc;
+  }
+  *pazOut = az;
+  *pnOut = n;
+  return SQLITE_OK;
+}
+
+static void freeStringList(char **az, int n){
+  int i;
+  for(i=0; i<n; i++) sqlite3_free(az[i]);
+  sqlite3_free(az);
+}
+
+static void doltVerifyConstraintsFunc(
+  sqlite3_context *context,
+  int argc,
+  sqlite3_value **argv
+){
+  sqlite3 *db = sqlite3_context_db_handle(context);
+  int bAll = 0;
+  int bOutputOnly = 0;
+  const char **azArgTables = 0;
+  int nArgTables = 0;
+  int nArgAlloc = 0;
+  char **azChanged = 0;
+  int nChanged = 0;
+  const char **azScan = 0;
+  int nScan = 0;
+  int i;
+  int rc;
+  int nViolations = 0;
+  ProllyHash headCat;
+  ProllyHash emptyCat;
+  ProllyHash savedCv;
+  int hasSavedCv = 0;
+  DoltliteCommit headCommit;
+  ProllyHash headHash;
+  const ProllyHash *pDetectAnc = 0;
+
+  memset(&headCat, 0, sizeof(headCat));
+  memset(&emptyCat, 0, sizeof(emptyCat));
+  memset(&savedCv, 0, sizeof(savedCv));
+  memset(&headCommit, 0, sizeof(headCommit));
+  memset(&headHash, 0, sizeof(headHash));
+
+  for(i=0; i<argc; i++){
+    const char *zArg = (const char*)sqlite3_value_text(argv[i]);
+    int exists;
+    if( !zArg || !zArg[0] ){
+      sqlite3_result_error(context, "invalid empty argument", -1);
+      goto cleanup;
+    }
+    if( strcmp(zArg, "--all")==0 || strcmp(zArg, "-a")==0 ){
+      bAll = 1;
+      continue;
+    }
+    if( strcmp(zArg, "--output-only")==0 ){
+      bOutputOnly = 1;
+      continue;
+    }
+    if( zArg[0]=='-' ){
+      char *zErr = sqlite3_mprintf(
+          "unknown flag '%s' (supported: --all, --output-only)", zArg);
+      if( zErr ){
+        sqlite3_result_error(context, zErr, -1);
+        sqlite3_free(zErr);
+      }else{
+        sqlite3_result_error_nomem(context);
+      }
+      goto cleanup;
+    }
+    exists = tableExists(db, zArg);
+    if( exists<0 ){
+      sqlite3_result_error_nomem(context);
+      goto cleanup;
+    }
+    if( !exists ){
+      char *zErr = sqlite3_mprintf("table not found: %s", zArg);
+      if( zErr ){
+        sqlite3_result_error(context, zErr, -1);
+        sqlite3_free(zErr);
+      }else{
+        sqlite3_result_error_nomem(context);
+      }
+      goto cleanup;
+    }
+    if( nArgTables >= nArgAlloc ){
+      int nNew = nArgAlloc ? nArgAlloc*2 : 4;
+      const char **azNew = sqlite3_realloc(
+          (void*)azArgTables, nNew * (int)sizeof(const char*));
+      if( !azNew ){
+        sqlite3_result_error_nomem(context);
+        goto cleanup;
+      }
+      azArgTables = azNew;
+      nArgAlloc = nNew;
+    }
+    azArgTables[nArgTables++] = zArg;
+  }
+
+  if( bOutputOnly ){
+    doltliteGetSessionConstraintViolationsCatalog(db, &savedCv);
+    hasSavedCv = 1;
+  }
+
+  rc = doltliteClearAllConstraintViolations(db);
+  if( rc!=SQLITE_OK ){
+    sqlite3_result_error_code(context, rc);
+    goto cleanup;
+  }
+
+  doltliteGetSessionHead(db, &headHash);
+  if( !prollyHashIsEmpty(&headHash) ){
+    rc = doltliteLoadCommit(db, &headHash, &headCommit);
+    if( rc!=SQLITE_OK ){
+      sqlite3_result_error_code(context, rc);
+      goto cleanup;
+    }
+    memcpy(&headCat, &headCommit.catalogHash, sizeof(headCat));
+    doltliteCommitClear(&headCommit);
+  }
+
+  /*
+  ** Detection always uses an empty ancestor so every violating row in a
+  ** scanned table is reported (matching Dolt, which records both sides of a
+  ** unique-index collision). The default mode instead restricts the *set* of
+  ** tables to those that differ from HEAD.
+  */
+  pDetectAnc = &emptyCat;
+
+  if( bAll ){
+    azScan = azArgTables;
+    nScan = nArgTables;
+  }else{
+    rc = collectChangedTables(db, &headCat, &azChanged, &nChanged);
+    if( rc!=SQLITE_OK ){
+      sqlite3_result_error_code(context, rc);
+      goto cleanup;
+    }
+    if( nArgTables>0 ){
+      /* Intersection of named tables and changed tables. */
+      char **azInter = 0;
+      int nInter = 0, nInterAlloc = 0;
+      int j;
+      for(i=0; i<nArgTables; i++){
+        int hit = 0;
+        for(j=0; j<nChanged; j++){
+          if( sqlite3_stricmp(azArgTables[i], azChanged[j])==0 ){
+            hit = 1;
+            break;
+          }
+        }
+        if( !hit ) continue;
+        if( nInter >= nInterAlloc ){
+          int nNew = nInterAlloc ? nInterAlloc*2 : 4;
+          char **azNew = sqlite3_realloc(azInter, nNew * (int)sizeof(char*));
+          if( !azNew ){
+            freeStringList(azInter, nInter);
+            sqlite3_result_error_nomem(context);
+            goto cleanup;
+          }
+          azInter = azNew;
+          nInterAlloc = nNew;
+        }
+        azInter[nInter] = sqlite3_mprintf("%s", azArgTables[i]);
+        if( !azInter[nInter] ){
+          freeStringList(azInter, nInter);
+          sqlite3_result_error_nomem(context);
+          goto cleanup;
+        }
+        nInter++;
+      }
+      freeStringList(azChanged, nChanged);
+      azChanged = azInter;
+      nChanged = nInter;
+    }
+    if( nChanged==0 ){
+      /* No changed tables: nothing to scan. */
+      sqlite3_result_int(context, 0);
+      goto cleanup_refresh;
+    }
+    azScan = (const char**)azChanged;
+    nScan = nChanged;
+  }
+
+  rc = doltliteDetectConstraintViolationsFiltered(
+      db, pDetectAnc, azScan, nScan, &nViolations);
+  if( rc!=SQLITE_OK ){
+    sqlite3_result_error_code(context, rc);
+    goto cleanup;
+  }
+
+  if( bOutputOnly && hasSavedCv ){
+    doltliteSetSessionConstraintViolationsCatalog(db, &savedCv);
+    if( doltliteVcTxnMode(db)==DOLTLITE_VC_TXN_AUTOCOMMIT_LIKE ){
+      rc = doltlitePersistWorkingSet(db);
+    }else{
+      rc = doltliteSaveWorkingSet(db);
+    }
+    if( rc!=SQLITE_OK ){
+      sqlite3_result_error_code(context, rc);
+      goto cleanup;
+    }
+  }
+
+cleanup_refresh:
+  rc = doltliteRefreshConstraintViolationTables(db);
+  if( rc!=SQLITE_OK ){
+    sqlite3_result_error_code(context, rc);
+    goto cleanup;
+  }
+
+  sqlite3_result_int(context, nViolations>0 ? 1 : 0);
+
+cleanup:
+  freeStringList(azChanged, nChanged);
+  sqlite3_free((void*)azArgTables);
+}
+
+int doltliteVerifyConstraintsRegister(sqlite3 *db){
+  return sqlite3_create_function(db, "dolt_verify_constraints", -1,
+                                 DOLTLITE_COMMAND_FUNC_FLAGS, 0,
+                                 doltVerifyConstraintsFunc, 0, 0);
+}
+
+#endif

--- a/test/vc_oracle_verify_constraints_test.sh
+++ b/test/vc_oracle_verify_constraints_test.sh
@@ -1,0 +1,246 @@
+#!/bin/bash
+#
+# Oracle coverage for dolt_verify_constraints.
+# Doltlite exposes SELECT dolt_verify_constraints(...) -> 0/1.
+# Dolt exposes CALL dolt_verify_constraints(...) -> violations column.
+# Both sides are normalized to R|rc=N lines plus optional follow-up R|* rows.
+
+set -u
+set -o pipefail
+
+DOLTLITE="${1:-./doltlite}"
+DOLT="${2:-dolt}"
+TMPROOT=$(mktemp -d)
+trap "rm -rf $TMPROOT" EXIT
+pass=0; fail=0
+FAILED_NAMES=""
+source "$(dirname "$0")/lib/vc_oracle_common.sh"
+
+normalize() {
+  tr -d '\r' | sed -E 's/, /,/g' | sort
+}
+
+translate_setup_for_dolt() {
+  vc_oracle_translate_for_dolt "$1" \
+    | sed -E \
+      -e 's/PRAGMA[[:space:]]+foreign_keys[[:space:]]*=[[:space:]]*OFF/SET FOREIGN_KEY_CHECKS=0/Ig' \
+      -e 's/PRAGMA[[:space:]]+foreign_keys[[:space:]]*=[[:space:]]*ON/SET FOREIGN_KEY_CHECKS=1/Ig' \
+      -e 's/PRAGMA[[:space:]]+foreign_keys[[:space:]]*=[[:space:]]*0/SET FOREIGN_KEY_CHECKS=0/Ig' \
+      -e 's/PRAGMA[[:space:]]+foreign_keys[[:space:]]*=[[:space:]]*1/SET FOREIGN_KEY_CHECKS=1/Ig'
+}
+
+# name setup verify_args follow_sql allow_empty
+# verify_args: empty string, or SQL arg list like "'--all'" or "'child'"
+run_oracle() {
+  local name="$1" setup="$2" verify_args="$3" follow="$4" allow_empty="$5"
+  local dir="$TMPROOT/$name"
+  mkdir -p "$dir/dl" "$dir/dt"
+
+  local dl_verify
+  if [ -z "$verify_args" ]; then
+    dl_verify="SELECT CONCAT('R|rc=', dolt_verify_constraints());"
+  else
+    dl_verify="SELECT CONCAT('R|rc=', dolt_verify_constraints($verify_args));"
+  fi
+
+  local dl_out
+  dl_out=$(printf "%s\n.headers off\n.mode list\n%s\n%s\n" \
+             "$setup" "$dl_verify" "$follow" \
+           | "$DOLTLITE" "$dir/dl/db" 2>"$dir/dl.err" \
+           | grep '^R|' \
+           | tr -d '"' \
+           | normalize)
+
+  local dolt_setup call_sql
+  dolt_setup=$(translate_setup_for_dolt "$setup")
+  if [ -z "$verify_args" ]; then
+    call_sql="CALL dolt_verify_constraints();"
+  else
+    call_sql="CALL dolt_verify_constraints($verify_args);"
+  fi
+
+  # One Dolt session: setup + CALL + capture return + follow queries.
+  local dt_raw
+  dt_raw=$(
+    cd "$dir/dt" || exit 1
+    vc_oracle_init_repo
+    {
+      printf 'SET @@autocommit = 0;\n'
+      printf 'SET @@dolt_force_transaction_commit = 1;\n'
+      printf 'SET @@dolt_allow_commit_conflicts = 1;\n'
+      printf '%s\n' "$dolt_setup"
+      printf '%s\n' "$call_sql"
+      printf '%s\n' "$(vc_oracle_translate_for_dolt "$follow")"
+    } | "$DOLT" sql -c -r csv 2>"$dir/dt.err"
+  )
+
+  # CALL emits a header "violations" then 0/1. Grab the last 0/1 line before R| rows.
+  local dt_rc
+  dt_rc=$(printf '%s\n' "$dt_raw" | tr -d '"' | awk '
+    $0=="0" || $0=="1" { v=$0 }
+    END { if (v=="") print "missing"; else print v }
+  ')
+  local dt_follow
+  dt_follow=$(printf '%s\n' "$dt_raw" | tr -d '"' | grep '^R|' | normalize)
+
+  local dt_out
+  if [ "$dt_rc" = "missing" ]; then
+    dt_out=$(printf '%s\n' "$dt_follow" | normalize)
+  else
+    dt_out=$(printf 'R|rc=%s\n%s\n' "$dt_rc" "$dt_follow" | grep -v '^$' | normalize)
+  fi
+
+  if [ "$allow_empty" = "1" ]; then
+    vc_oracle_assert_match_allow_empty "$name" "$dl_out" "$dt_out"
+  else
+    vc_oracle_assert_match "$name" "$dl_out" "$dt_out"
+  fi
+
+  if [ "$fail" -gt 0 ] && echo "$FAILED_NAMES" | grep -q " $name\|$name"; then
+    echo "    doltlite stderr: $(tr '\n' ' ' <"$dir/dl.err" | head -c 300)"
+    echo "    dolt stderr:     $(tr '\n' ' ' <"$dir/dt.err" | head -c 300)"
+    echo "    dolt raw:        $(printf '%s' "$dt_raw" | tr '\n' '|' | head -c 400)"
+  fi
+}
+
+echo "=== Version Control Oracle Tests: dolt_verify_constraints ==="
+echo ""
+
+FK_SETUP="
+CREATE TABLE parent(pk INTEGER PRIMARY KEY, v INT UNIQUE);
+CREATE TABLE child(pk INTEGER PRIMARY KEY, v INT REFERENCES parent(v));
+CREATE TABLE otherTable(pk INTEGER PRIMARY KEY);
+INSERT INTO parent VALUES (1,10),(2,20);
+SELECT dolt_commit('-Am', 'init');
+PRAGMA foreign_keys=OFF;
+INSERT INTO child VALUES (1,99);
+PRAGMA foreign_keys=ON;
+"
+
+# CONCAT + backticks: Dolt is MySQL-dialect (|| is logical OR; "table" is a string).
+FOLLOW_AGG="SELECT CONCAT('R|agg=', tn, ':', nv) FROM (SELECT \`table\` AS tn, num_violations AS nv FROM dolt_constraint_violations) x ORDER BY 1;"
+FOLLOW_AGG_COUNT="SELECT CONCAT('R|agg_count=', count(*)) FROM dolt_constraint_violations;"
+FOLLOW_CHILD_ROWS="SELECT CONCAT('R|row=', CASE violation_type WHEN 'foreign key' THEN 'FK' WHEN 'unique index' THEN 'UQ' WHEN 'check constraint' THEN 'CK' WHEN 1 THEN 'FK' WHEN 2 THEN 'UQ' WHEN 3 THEN 'CK' ELSE '?' END, ':', pk) FROM dolt_constraint_violations_child ORDER BY pk;"
+
+echo "--- FK: working-set orphan ---"
+run_oracle "fk_working_set" "$FK_SETUP" "" \
+  "$FOLLOW_AGG
+$FOLLOW_CHILD_ROWS" 0
+
+echo "--- FK: named table with violations ---"
+run_oracle "fk_named_child" "$FK_SETUP" "'child'" \
+  "$FOLLOW_AGG" 0
+
+echo "--- FK: named table with no violations ---"
+run_oracle "fk_named_other" "$FK_SETUP" "'otherTable'" \
+  "$FOLLOW_AGG_COUNT" 1
+
+echo "--- FK: default clean after force-commit ---"
+run_oracle "fk_default_clean_after_commit" \
+"$FK_SETUP
+SELECT dolt_commit('-Am', 'commit orphan', '--force');
+" \
+"" \
+"$FOLLOW_AGG_COUNT" 1
+
+echo "--- FK: --all after force-commit ---"
+run_oracle "fk_all_after_commit" \
+"$FK_SETUP
+SELECT dolt_commit('-Am', 'commit orphan', '--force');
+" \
+"'--all'" \
+"$FOLLOW_AGG" 0
+
+echo "--- FK: --all --output-only ---"
+run_oracle "fk_output_only" \
+"$FK_SETUP
+SELECT dolt_commit('-Am', 'commit orphan', '--force');
+" \
+"'--all', '--output-only'" \
+"$FOLLOW_AGG_COUNT" 1
+
+UNIQUE_SETUP="
+CREATE TABLE otherTable(pk INTEGER PRIMARY KEY);
+CREATE TABLE t(pk INTEGER PRIMARY KEY, col1 INT UNIQUE);
+SELECT dolt_commit('-Am', 'init');
+SELECT dolt_branch('branch1');
+INSERT INTO t VALUES (1, 1);
+SELECT dolt_commit('-Am', 'insert on main');
+SELECT dolt_checkout('branch1');
+INSERT INTO t VALUES (2, 1);
+SELECT dolt_commit('-Am', 'insert on branch1');
+SELECT dolt_checkout('main');
+BEGIN;
+SELECT dolt_merge('branch1');
+COMMIT;
+"
+
+FOLLOW_T_ROWS="SELECT CONCAT('R|row=', CASE violation_type WHEN 'foreign key' THEN 'FK' WHEN 'unique index' THEN 'UQ' WHEN 'check constraint' THEN 'CK' WHEN 1 THEN 'FK' WHEN 2 THEN 'UQ' WHEN 3 THEN 'CK' ELSE '?' END, ':', pk, ':', col1) FROM dolt_constraint_violations_t ORDER BY pk;"
+
+echo "--- unique: after merge ---"
+run_oracle "unique_after_merge" "$UNIQUE_SETUP" "" \
+  "$FOLLOW_AGG
+$FOLLOW_T_ROWS" 0
+
+echo "--- unique: re-verify after clearing ---"
+run_oracle "unique_reverify" \
+"$UNIQUE_SETUP
+DELETE FROM dolt_constraint_violations_t;
+" \
+"" \
+"$FOLLOW_AGG
+$FOLLOW_T_ROWS" 0
+
+echo "--- unique: named otherTable ---"
+run_oracle "unique_named_other" \
+"$UNIQUE_SETUP
+DELETE FROM dolt_constraint_violations_t;
+" \
+"'otherTable'" \
+"$FOLLOW_AGG_COUNT" 1
+
+echo "--- unique: --all after force-commit ---"
+run_oracle "unique_all_after_commit" \
+"$UNIQUE_SETUP
+SELECT dolt_commit('-Am', 'commit with violations', '--force');
+DELETE FROM dolt_constraint_violations_t;
+" \
+"'--all'" \
+"$FOLLOW_AGG
+$FOLLOW_T_ROWS" 0
+
+echo "--- unique: --all --output-only ---"
+run_oracle "unique_output_only" \
+"$UNIQUE_SETUP
+SELECT dolt_commit('-Am', 'commit with violations', '--force');
+DELETE FROM dolt_constraint_violations_t;
+" \
+"'--all', '--output-only'" \
+"$FOLLOW_AGG_COUNT" 1
+
+echo "--- clean database ---"
+run_oracle "clean_no_violations" \
+"
+CREATE TABLE t(pk INTEGER PRIMARY KEY, v INT UNIQUE);
+INSERT INTO t VALUES (1,1),(2,2);
+SELECT dolt_commit('-Am', 'clean');
+" \
+"" \
+"$FOLLOW_AGG_COUNT" 1
+
+run_oracle "clean_all_no_violations" \
+"
+CREATE TABLE t(pk INTEGER PRIMARY KEY, v INT UNIQUE);
+INSERT INTO t VALUES (1,1),(2,2);
+SELECT dolt_commit('-Am', 'clean');
+" \
+"'--all'" \
+"$FOLLOW_AGG_COUNT" 1
+
+echo ""
+echo "Results: $pass passed, $fail failed"
+if [ "$fail" -ne 0 ]; then
+  echo "FAILED:$FAILED_NAMES"
+  exit 1
+fi
+exit 0

--- a/tool/mksqlite3c.tcl
+++ b/tool/mksqlite3c.tcl
@@ -624,7 +624,7 @@ proc emit_doltlite_engine_block {} {
     doltlite_conflicts.c doltlite_gc.c doltlite_chunk_walk.c
     doltlite_history.c doltlite_at.c doltlite_blame.c doltlite_schema_diff.c doltlite_patch.c
     doltlite_schemas.c doltlite_diff_stat.c doltlite_record.c doltlite_ignore.c
-    doltlite_hashof.c doltlite_constraint_violations.c doltlite_merge_constraints.c
+    doltlite_hashof.c doltlite_constraint_violations.c doltlite_verify_constraints.c doltlite_merge_constraints.c
     doltlite_dbpage.c doltlite_remote.c doltlite_remote_sql.c doltlite_http_remote.c
     doltlite_remotesrv.c
   } {


### PR DESCRIPTION
## Summary

- New SQL function `dolt_verify_constraints` (`SELECT dolt_verify_constraints(...)`)
  - Default: tables changed vs HEAD; reports all violating rows in those tables
  - `--all`: every table
  - Optional table name args
  - `--output-only`: compute without persisting to `dolt_constraint_violations`
  - Returns `0` / `1` (no violations / found)
- Detectors take an optional table allowlist; merge/cherry-pick pass unrestricted
- Oracle suite `test/vc_oracle_verify_constraints_test.sh` (FK + unique + flags)

## Test plan

- [x] `make doltlite`
- [x] `bash test/vc_oracle_verify_constraints_test.sh build/doltlite dolt` — 13/13
- [x] `DOLTLITE=build/doltlite bash test/doltlite_merge.sh` — 94/94
- [x] `bash test/vc_oracle_constraint_violations_test.sh build/doltlite dolt` — 5/5
- [ ] CI full suite