### PR TITLE
Honor PRAGMA fullfsync in the chunk store

### DIFF
--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -206,6 +206,11 @@ static int csCanonicalFilename(
   return rc;
 }
 
+static int csSyncFile(ChunkStore *cs){
+  return sqlite3OsSync(cs->file.pFile,
+                       cs->fullFsync ? SQLITE_SYNC_FULL : SQLITE_SYNC_NORMAL);
+}
+
 static int csRollbackFailedAppend(ChunkStore *cs, i64 origFileSize){
   sqlite3_int64 sizeNow = -1;
   int rc = SQLITE_OK;
@@ -217,7 +222,7 @@ static int csRollbackFailedAppend(ChunkStore *cs, i64 origFileSize){
     rc = sqlite3OsFileSize(cs->file.pFile, &sizeNow);
   }
   if( rc==SQLITE_OK && sizeNow==origFileSize ){
-    (void)sqlite3OsSync(cs->file.pFile, SQLITE_SYNC_NORMAL);
+    (void)csSyncFile(cs);
     return SQLITE_OK;
   }
 
@@ -232,7 +237,7 @@ static int csRollbackFailedAppend(ChunkStore *cs, i64 origFileSize){
     rc = sqlite3OsFileSize(cs->file.pFile, &sizeNow);
   }
   if( rc==SQLITE_OK && sizeNow==origFileSize ){
-    (void)sqlite3OsSync(cs->file.pFile, SQLITE_SYNC_NORMAL);
+    (void)csSyncFile(cs);
     return SQLITE_OK;
   }
   return rc==SQLITE_OK ? SQLITE_IOERR_TRUNCATE : rc;
@@ -686,7 +691,7 @@ static void csWriteCleanCloseMarker(ChunkStore *cs){
 
   rc = sqlite3OsWrite(cs->file.pFile, rootRec, sizeof(rootRec), markerStart);
   if( rc==SQLITE_OK ){
-    rc = sqlite3OsSync(cs->file.pFile, SQLITE_SYNC_NORMAL);
+    rc = csSyncFile(cs);
   }
   if( rc==SQLITE_OK ){
     cs->file.iFileSize = markerNext;
@@ -2012,7 +2017,7 @@ static int csCommitToFile(ChunkStore *cs){
   }
 
   CRASH_CHECK_WRITE();
-  rc = sqlite3OsSync(cs->file.pFile, SQLITE_SYNC_NORMAL);
+  rc = csSyncFile(cs);
 
 #ifdef SQLITE_TEST
   }

--- a/src/chunk_store.h
+++ b/src/chunk_store.h
@@ -164,6 +164,7 @@ struct ChunkStore {
 
   u8 readOnly;
   u8 isMemory;
+  u8 fullFsync;           /* PRAGMA fullfsync: syncs use SQLITE_SYNC_FULL */
   u8 snapshotPinned;
   u8 corruptMidStream;    /* WAL replay found mid-stream damage; chunk reads
                           ** and commits fail SQLITE_CORRUPT, but open itself

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -906,7 +906,9 @@ int sqlite3BtreeSetMmapLimit(Btree *p, sqlite3_int64 szMmap){
 }
 
 int prollyBtreeSetPagerFlags(Btree *p, unsigned pgFlags){
-  (void)p; (void)pgFlags;
+  if( p && p->pBt ){
+    p->pBt->store.fullFsync = (pgFlags & PAGER_FULLFSYNC) ? 1 : 0;
+  }
   return SQLITE_OK;
 }
 int sqlite3BtreeSetPagerFlags(Btree *p, unsigned pgFlags){

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -1089,30 +1089,6 @@ rowid rowid-4.5  # sqlite_search_count metric; joined row result (4) matches sto
 # DoltLite lets the write/release complete, so the following rollback/transaction
 # labels see different savepoint state.
 select2 select2-3.3  # sqlite_search_count metric; SELECT f1 WHERE f2==2000 returns 1000 on both
-# trans-9.*: the ".5" labels assert sqlite_fullsync_count/sqlite_sync_count > 0 —
-# SQLite-pager fsync instrumentation that doltlite's prolly backend never drives
-# (counters stay 0); ".6" asserts journal_mode=delete vs doltlite's wal. The actual
-# rollback-integrity tests (.1/.2: signature unchanged after BEGIN;DELETE;INSERT;ROLLBACK)
-# were reproduced and pass byte-identically — committed state is correctly restored.
-trans trans-9.10.5-2112
-trans trans-9.12.5-2544
-trans trans-9.14.5-3089
-trans trans-9.16.5-3802
-trans trans-9.18.5-4593
-trans trans-9.2.5-1024
-trans trans-9.20.5-5551
-trans trans-9.22.5-6736
-trans trans-9.24.5-8156
-trans trans-9.26.5-9897
-trans trans-9.28.5-11982
-trans trans-9.30.5-14544
-trans trans-9.32.5-17576
-trans trans-9.34.5-21225
-trans trans-9.36.5-25685
-trans trans-9.38.5-30883
-trans trans-9.4.5-1224
-trans trans-9.6.5-1480
-trans trans-9.8.5-1766
 # trigger1-6.*: assert the unordered scan order of sqlite_master rows. After
 # DROP TABLE t1 leaves a rowid gap, doltlite compacts schema rowids (t2,v1) while
 # stock keeps original rowids (v1,t2), so the rows come back in a different order.
@@ -4641,29 +4617,9 @@ autovacuum autovacuum-9.5  # file_pages: chunk-store size, no page reclamation
 
 # ── avtrans ──
 # avtrans is trans.test under auto_vacuum=full (now an accepted no-op, so
-# the old setup-cascade entries are gone). Remaining: the read-back probe
-# and the fullsync counter — the chunk store commits through its own sync
-# path, so the stock pager fullsync instrumentation counter stays 0.
+# the old setup-cascade entries are gone). Remaining: only the auto_vacuum
+# read-back probe.
 avtrans avtrans-1.0.1  # PRAGMA auto_vacuum reads back 0, not 1
-avtrans avtrans-9.2.5-1024  # sqlite_fullsync_count stays 0 (chunk-store sync path)
-avtrans avtrans-9.4.5-1224  # sqlite_fullsync_count stays 0 (chunk-store sync path)
-avtrans avtrans-9.6.5-1480  # sqlite_fullsync_count stays 0 (chunk-store sync path)
-avtrans avtrans-9.8.5-1766  # sqlite_fullsync_count stays 0 (chunk-store sync path)
-avtrans avtrans-9.10.5-2112  # sqlite_fullsync_count stays 0 (chunk-store sync path)
-avtrans avtrans-9.12.5-2544  # sqlite_fullsync_count stays 0 (chunk-store sync path)
-avtrans avtrans-9.14.5-3089  # sqlite_fullsync_count stays 0 (chunk-store sync path)
-avtrans avtrans-9.16.5-3802  # sqlite_fullsync_count stays 0 (chunk-store sync path)
-avtrans avtrans-9.18.5-4593  # sqlite_fullsync_count stays 0 (chunk-store sync path)
-avtrans avtrans-9.20.5-5551  # sqlite_fullsync_count stays 0 (chunk-store sync path)
-avtrans avtrans-9.22.5-6736  # sqlite_fullsync_count stays 0 (chunk-store sync path)
-avtrans avtrans-9.24.5-8156  # sqlite_fullsync_count stays 0 (chunk-store sync path)
-avtrans avtrans-9.26.5-9897  # sqlite_fullsync_count stays 0 (chunk-store sync path)
-avtrans avtrans-9.28.5-11982  # sqlite_fullsync_count stays 0 (chunk-store sync path)
-avtrans avtrans-9.30.5-14544  # sqlite_fullsync_count stays 0 (chunk-store sync path)
-avtrans avtrans-9.32.5-17576  # sqlite_fullsync_count stays 0 (chunk-store sync path)
-avtrans avtrans-9.34.5-21225  # sqlite_fullsync_count stays 0 (chunk-store sync path)
-avtrans avtrans-9.36.5-25685  # sqlite_fullsync_count stays 0 (chunk-store sync path)
-avtrans avtrans-9.38.5-30883  # sqlite_fullsync_count stays 0 (chunk-store sync path)
 
 # corrupt8 pokes stock pointer-map page bytes by offset. DoltLite's chunk-store
 # file does not use SQLite pointer-map pages, so the raw write is not a valid


### PR DESCRIPTION
## What

`prollyBtreeSetPagerFlags` was a no-op, so doltlite's chunk store always synced with `SQLITE_SYNC_NORMAL` and **ignored `PRAGMA fullfsync` entirely** — a user could not opt into `F_FULLFSYNC` durability the way stock SQLite allows.

- Record the `PAGER_FULLFSYNC` bit on the `ChunkStore` (`store.fullFsync`) from `prollyBtreeSetPagerFlags`.
- Route every chunk-store sync (commit point, clean-close marker, failed-append rollback) through a `csSyncFile` helper that passes `SQLITE_SYNC_FULL` when the flag is set.

On macOS `SQLITE_SYNC_FULL` reaches `fcntl(F_FULLFSYNC)` in the reused unix VFS (`os_unix.c`), which forces the drive to flush its write cache to stable media; elsewhere it degrades to a normal `fsync`, exactly matching stock SQLite. `checkpoint_fullfsync` (`PAGER_CKPT_FULLFSYNC`) is intentionally left alone — it maps to stock WAL checkpoint semantics the chunk store doesn't share.

## Un-gated tests

`trans.test` and `avtrans.test` set `PRAGMA fullfsync=ON` and assert `sqlite_fullsync_count>0` after a commit (the `9.*.5` labels). Those were listed as known divergences **solely because the chunk store never issued a full sync** (the counter stayed 0). With this change they pass, so the stale entries are removed from `known_testfixture_divergences.txt`:

- **19** `trans trans-9.*.5-*` entries removed (trans.test now has **zero** divergences).
- **19** `avtrans avtrans-9.*.5-*` entries removed; `avtrans-1.0.1` (the unrelated `auto_vacuum` read-back divergence) is kept.
- Stale explanatory comments updated.

The regression harness (`run_testfixture.sh`) fails on a fixed-but-still-listed entry, so removing them is required, not optional.

## Verification

Built `testfixture` (SQLITE_TEST) and ran the harness:

- `trans.test`: **0 errors / 329 tests**, all `9.*.5` labels `Ok`.
- `avtrans.test`: 315 tests, only `avtrans-1.0.1` remains as a known divergence; all fullsync labels pass.
- `pragma4.test` / `vacuum-into.test` (which set plain `fullfsync=1` but don't assert the counter): unchanged, existing divergences intact — confirming no regression.
- The change can only move `sqlite_fullsync_count` under `fullfsync=ON`; it cannot alter query results or `sqlite_sync_count`, and it doesn't touch the `checkpoint_fullfsync` path (`wal2-14`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)