### PR TITLE
Honor PRAGMA cache_size to grow the prolly node cache

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -879,7 +879,21 @@ int sqlite3BtreeNewDb(Btree *p){
 }
 
 int prollyBtreeSetCacheSize(Btree *p, int mxPage){
-  (void)p; (void)mxPage;
+  i64 nEntry;
+  if( !p || !p->pBt ) return SQLITE_OK;
+  if( mxPage>0 ){
+    nEntry = mxPage;
+  }else{
+    /* Negative cache_size is a KiB budget. Map it to node-cache entries via
+    ** the page size, mirroring how the stock pager turns KiB into pages. */
+    u32 pgsz = p->pBt->pageSize>0 ? p->pBt->pageSize : PROLLY_DEFAULT_PAGE_SIZE;
+    nEntry = (-(i64)mxPage * 1024) / pgsz;
+  }
+  /* cache_size only grows the node cache. The stock default (-2000) and
+  ** memory-shrink requests must not drop it below the engine's baseline,
+  ** which the prolly backend relies on for its aggressive node caching. */
+  if( nEntry < PROLLY_DEFAULT_CACHE_SIZE ) nEntry = PROLLY_DEFAULT_CACHE_SIZE;
+  p->pBt->cache.nCapacity = (int)nEntry;
   return SQLITE_OK;
 }
 int sqlite3BtreeSetCacheSize(Btree *p, int mxPage){


### PR DESCRIPTION
## What

`prollyBtreeSetCacheSize` was a no-op, so the prolly node cache stayed pinned at its 16384-entry default (`PROLLY_DEFAULT_CACHE_SIZE`) no matter what `PRAGMA cache_size` was set to. Map the pragma onto the cache capacity:

- **positive N** → N entries
- **negative N** → KiB budget, converted to entries via the page size (`-N*1024 / pageSize`), mirroring how the stock pager turns a KiB `cache_size` into pages.

Resizing is live: `nCapacity` is a soft cap the LRU enforces on the next insert, so no rebuild is needed. The hash-bucket count stays as initialized (fine — it only affects chain length, not correctness).

## Grow-only semantics (deliberate)

`cache_size` only **grows** the cache. Anything mapping below the 16384 baseline is clamped to it. This is because SQLite applies its compile-time default (`-2000`, i.e. ~500 entries at a 4 KiB page size) via this same hook **at every database open** — honoring it verbatim would silently shrink doltlite's deliberately-large node cache and regress the engine. Clamping means:

- the default and typical/shrink requests leave `nCapacity` at exactly 16384 — **identical to today's behavior**, so the change is strictly additive and can't regress existing workloads;
- large explicit values grow the cache so big working sets keep more of the tree resident.

(Shrinking below the baseline for memory-constrained embeddings would need explicit-vs-default plumbing and is out of scope.)

## Verification

White-box probe of `cache.nCapacity`:

| `PRAGMA cache_size` | `nCapacity` |
|---|---|
| *(none / default -2000)* | 16384 |
| `50000` | 50000 |
| `100` | 16384 (floored) |
| `-262144` (256 MiB) | 65536 |

Black-box correctness (cache is transparent — results must not vary): identical, correct results (`20000 / 400020000 / 20000`) across `cache_size` = 500000, 100, and -1048576.

Regression: 5 `doltlite_pragma_*` suites pass; harness over the cache-behavior inherited tests (`cache`, `cachespill`, `dbstatus2`, `shared3`) reports no unexpected failures and no now-fixed entries (doltlite still doesn't model stock pager pages, so nothing to un-gate).

Independent of #1767/#1768 — different hook (`SetCacheSize`), no overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)