### PR TITLE
Bound HTTP remote client requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -785,6 +785,8 @@ Start serving a directory of databases:
 HTTPS clients verify the server certificate and hostname using the system
 trust store. Set `DOLTLITE_CA_FILE` for a private CA. Client credentials live
 in `~/.doltlite/creds` and can be created with `SELECT dolt_creds_new();`.
+HTTP and HTTPS requests have a 30-second deadline by default. Set
+`DOLTLITE_HTTP_TIMEOUT_MS` to a positive number of milliseconds to tune it.
 
 Every `.db` file in that directory becomes accessible at
 `http://host:8080/filename.db` or its configured HTTPS URL. The server supports

--- a/src/doltlite_http_remote.c
+++ b/src/doltlite_http_remote.c
@@ -22,6 +22,7 @@ struct HttpRemote {
   char *zHost;
   int port;
   int useTls;
+  int timeoutMs;
   char *zBasePath;
 
 #ifdef DOLTLITE_HAVE_AUTH
@@ -42,10 +43,11 @@ struct HttpRemote {
 };
 
 #define HTTP_RESP_MAX_BYTES ((i64)128 * 1024 * 1024)
+#define HTTP_TIMEOUT_MS 30000
 
 #ifdef DOLTLITE_HAVE_AUTH
 typedef DoltliteConn HttpConn;
-#define httpConnOpen(H,P,T) doltliteConnOpen((H),(P),(T))
+#define httpConnOpen(H,P,T,M) doltliteConnOpenTimeout((H),(P),(T),(M))
 #define httpConnWriteAll(C,B,N) doltliteConnWriteAll((C),(B),(N))
 #define httpConnRead(C,B,N) doltliteConnRead((C),(B),(N))
 #define httpConnClose(C) doltliteConnClose((C))
@@ -53,32 +55,30 @@ typedef DoltliteConn HttpConn;
 typedef struct HttpConn HttpConn;
 struct HttpConn {
   int fd;
+  i64 deadlineMs;
 };
 
-static HttpConn *httpConnOpen(const char *zHost, int port, int useTls){
-  struct addrinfo hints;
-  struct addrinfo *pRes = 0;
-  struct addrinfo *pAi;
+static int httpConnApplyDeadline(HttpConn *pConn){
+  i64 remaining = pConn->deadlineMs - doltliteMonotonicMs();
+  if( remaining<=0 ) return 1;
+  if( remaining>0x7fffffff ) remaining = 0x7fffffff;
+  return doltliteSocketSetTimeout(pConn->fd, (int)remaining);
+}
+
+static HttpConn *httpConnOpen(
+  const char *zHost,
+  int port,
+  int useTls,
+  int timeoutMs
+){
   char zPort[16];
-  int fd = -1;
+  i64 deadlineMs = doltliteMonotonicMs() + timeoutMs;
+  int fd;
   HttpConn *pConn;
 
   if( useTls ) return 0;
-  if( doltliteNetInit()!=0 ) return 0;
   sqlite3_snprintf(sizeof(zPort), zPort, "%d", port);
-  memset(&hints, 0, sizeof(hints));
-  hints.ai_family = AF_UNSPEC;
-  hints.ai_socktype = SOCK_STREAM;
-  if( getaddrinfo(zHost, zPort, &hints, &pRes)!=0 ) return 0;
-
-  for(pAi=pRes; pAi; pAi=pAi->ai_next){
-    fd = (int)socket(pAi->ai_family, pAi->ai_socktype, pAi->ai_protocol);
-    if( fd<0 ) continue;
-    if( connect(fd, pAi->ai_addr, (int)pAi->ai_addrlen)==0 ) break;
-    doltliteCloseSocket(fd);
-    fd = -1;
-  }
-  freeaddrinfo(pRes);
+  fd = doltliteTcpConnect(zHost, zPort, timeoutMs);
   if( fd<0 ) return 0;
 
   pConn = sqlite3_malloc(sizeof(HttpConn));
@@ -87,6 +87,12 @@ static HttpConn *httpConnOpen(const char *zHost, int port, int useTls){
     return 0;
   }
   pConn->fd = fd;
+  pConn->deadlineMs = deadlineMs;
+  if( httpConnApplyDeadline(pConn)!=0 ){
+    doltliteCloseSocket(fd);
+    sqlite3_free(pConn);
+    return 0;
+  }
   return pConn;
 }
 
@@ -94,7 +100,9 @@ static int httpConnWriteAll(HttpConn *pConn, const void *pBuf, int nBuf){
   const char *z = (const char*)pBuf;
   int nSent = 0;
   while( nSent<nBuf ){
-    int n = send(pConn->fd, z+nSent, nBuf-nSent, 0);
+    int n;
+    if( httpConnApplyDeadline(pConn)!=0 ) return 1;
+    n = send(pConn->fd, z+nSent, nBuf-nSent, 0);
     if( n<=0 ) return 1;
     nSent += n;
   }
@@ -102,6 +110,7 @@ static int httpConnWriteAll(HttpConn *pConn, const void *pBuf, int nBuf){
 }
 
 static int httpConnRead(HttpConn *pConn, void *pBuf, int nBuf){
+  if( httpConnApplyDeadline(pConn)!=0 ) return -1;
   return recv(pConn->fd, (char*)pBuf, nBuf, 0);
 }
 
@@ -185,7 +194,7 @@ static int httpRequest(
   *ppResp = 0;
   *pnResp = 0;
 
-  conn = httpConnOpen(p->zHost, p->port, p->useTls);
+  conn = httpConnOpen(p->zHost, p->port, p->useTls, p->timeoutMs);
   if( !conn ) return SQLITE_ERROR;
 
 #ifdef DOLTLITE_HAVE_AUTH
@@ -710,6 +719,9 @@ DoltliteRemote *doltliteHttpRemoteOpen(const char *zUrl){
   int useTls;
   int nUserPath;
   int nBasePath;
+  const char *zTimeout;
+  char *zTimeoutEnd = 0;
+  long timeoutMs;
 
   if( !zUrl ) return 0;
 
@@ -772,6 +784,17 @@ DoltliteRemote *doltliteHttpRemoteOpen(const char *zUrl){
   p->zHost[nHost] = 0;
 
   p->port = port;
+  timeoutMs = HTTP_TIMEOUT_MS;
+  zTimeout = getenv("DOLTLITE_HTTP_TIMEOUT_MS");
+  if( zTimeout && zTimeout[0] ){
+    errno = 0;
+    timeoutMs = strtol(zTimeout, &zTimeoutEnd, 10);
+    if( errno!=0 || zTimeoutEnd==zTimeout || zTimeoutEnd[0]!=0
+     || timeoutMs<=0 || timeoutMs>0x7fffffff ){
+      timeoutMs = HTTP_TIMEOUT_MS;
+    }
+  }
+  p->timeoutMs = (int)timeoutMs;
 
   nBasePath = nUserPath;
   if( nBasePath <= 0 ){

--- a/src/doltlite_net.h
+++ b/src/doltlite_net.h
@@ -1,6 +1,9 @@
 #ifndef DOLTLITE_NET_H
 #define DOLTLITE_NET_H
 
+#include <errno.h>
+#include <string.h>
+
 /* Thin cross-platform socket shim shared by doltlite_tls.c and
  * doltlite_remotesrv.c. Socket handles are kept as int to match
  * mbedtls_net_context, which stores its fd as int on Windows too. */
@@ -15,6 +18,10 @@ typedef WSAPOLLFD doltlite_pollfd;
 #define doltliteCloseSocket closesocket
 #define doltlitePoll(fds, n, ms) WSAPoll((fds), (n), (ms))
 #define doltliteShutdownSocket(fd) shutdown((fd), SD_BOTH)
+
+static inline long long doltliteMonotonicMs(void) {
+  return (long long)GetTickCount64();
+}
 
 static inline int doltliteSocketSetTimeout(int fd, int timeoutMs) {
   DWORD timeout = (DWORD)timeoutMs;
@@ -42,14 +49,22 @@ static inline int doltliteNetInit(void) {
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <netdb.h>
+#include <fcntl.h>
 #include <poll.h>
 #include <sys/time.h>
+#include <time.h>
 #include <unistd.h>
 
 typedef struct pollfd doltlite_pollfd;
 #define doltliteCloseSocket close
 #define doltlitePoll(fds, n, ms) poll((fds), (n), (ms))
 #define doltliteShutdownSocket(fd) shutdown((fd), SHUT_RDWR)
+
+static inline long long doltliteMonotonicMs(void) {
+  struct timespec ts;
+  clock_gettime(CLOCK_MONOTONIC, &ts);
+  return (long long)ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
+}
 
 static inline int doltliteSocketSetTimeout(int fd, int timeoutMs) {
   struct timeval timeout;
@@ -64,5 +79,101 @@ static inline int doltliteSocketSetTimeout(int fd, int timeoutMs) {
 static inline int doltliteNetInit(void) { return 0; }
 
 #endif
+
+static inline int doltliteSocketSetBlocking(int fd, int blocking) {
+#ifdef _WIN32
+  u_long mode = blocking ? 0 : 1;
+  return ioctlsocket(fd, FIONBIO, &mode) == 0 ? 0 : 1;
+#else
+  int flags = fcntl(fd, F_GETFL, 0);
+  if (flags < 0) return 1;
+  if (blocking) {
+    flags &= ~O_NONBLOCK;
+  } else {
+    flags |= O_NONBLOCK;
+  }
+  return fcntl(fd, F_SETFL, flags) == 0 ? 0 : 1;
+#endif
+}
+
+static inline int doltliteSocketConnectPending(void) {
+#ifdef _WIN32
+  int err = WSAGetLastError();
+  return err == WSAEWOULDBLOCK || err == WSAEINPROGRESS
+      || err == WSAEALREADY;
+#else
+  return errno == EINPROGRESS || errno == EWOULDBLOCK
+      || errno == EALREADY || errno == EINTR;
+#endif
+}
+
+static inline int doltliteTcpConnect(
+  const char *host,
+  const char *port,
+  int timeoutMs
+) {
+  struct addrinfo hints;
+  struct addrinfo *res = NULL;
+  struct addrinfo *ai;
+  long long deadline = timeoutMs > 0
+                     ? doltliteMonotonicMs() + timeoutMs : 0;
+  int fd = -1;
+
+  if (doltliteNetInit() != 0) return -1;
+  memset(&hints, 0, sizeof(hints));
+  hints.ai_family = AF_UNSPEC;
+  hints.ai_socktype = SOCK_STREAM;
+  if (getaddrinfo(host, port, &hints, &res) != 0) return -1;
+
+  for (ai = res; ai != NULL; ai = ai->ai_next) {
+    int connected = 0;
+    int rc;
+    fd = (int)socket(ai->ai_family, ai->ai_socktype, ai->ai_protocol);
+    if (fd < 0) continue;
+
+    if (timeoutMs <= 0) {
+      connected = connect(fd, ai->ai_addr, (int)ai->ai_addrlen) == 0;
+    } else if (doltliteSocketSetBlocking(fd, 0) == 0) {
+      rc = connect(fd, ai->ai_addr, (int)ai->ai_addrlen);
+      if (rc == 0) {
+        connected = 1;
+      } else if (doltliteSocketConnectPending()) {
+        doltlite_pollfd pfd;
+        long long remaining = deadline - doltliteMonotonicMs();
+        int waitMs = remaining > 0x7fffffff
+                   ? 0x7fffffff : (int)remaining;
+        int soError = 0;
+#ifdef _WIN32
+        int nSoError = (int)sizeof(soError);
+#else
+        socklen_t nSoError = (socklen_t)sizeof(soError);
+#endif
+        pfd.fd = fd;
+        pfd.events = POLLOUT;
+        pfd.revents = 0;
+        if (remaining > 0 && doltlitePoll(&pfd, 1, waitMs) > 0
+         && getsockopt(fd, SOL_SOCKET, SO_ERROR,
+#ifdef _WIN32
+                       (char *)&soError,
+#else
+                       &soError,
+#endif
+                       &nSoError) == 0
+         && soError == 0) {
+          connected = 1;
+        }
+      }
+      if (doltliteSocketSetBlocking(fd, 1) != 0) connected = 0;
+    }
+
+    if (connected) break;
+    doltliteCloseSocket(fd);
+    fd = -1;
+    if (deadline && doltliteMonotonicMs() >= deadline) break;
+  }
+
+  freeaddrinfo(res);
+  return fd;
+}
 
 #endif

--- a/src/doltlite_tls.c
+++ b/src/doltlite_tls.c
@@ -20,6 +20,7 @@
 struct DoltliteConn {
   int useTls;
   int ownsConf;
+  long long deadlineMs;
   mbedtls_net_context net;
 
   mbedtls_ssl_context ssl;
@@ -44,6 +45,15 @@ static void configureSocket(int fd) {
 #else
   (void)fd;
 #endif
+}
+
+static int connApplyDeadline(DoltliteConn *c) {
+  long long remaining;
+  if (c->deadlineMs == 0) return 0;
+  remaining = c->deadlineMs - doltliteMonotonicMs();
+  if (remaining <= 0) return 1;
+  if (remaining > 0x7fffffff) remaining = 0x7fffffff;
+  return doltliteSocketSetTimeout(c->net.fd, (int)remaining);
 }
 
 static int connSend(void *pCtx, const unsigned char *pBuf, size_t nBuf) {
@@ -109,7 +119,12 @@ static int loadTrustRoots(mbedtls_x509_crt *ca) {
 #endif
 }
 
-DoltliteConn *doltliteConnOpen(const char *host, int port, int useTls) {
+DoltliteConn *doltliteConnOpenTimeout(
+  const char *host,
+  int port,
+  int useTls,
+  int timeoutMs
+) {
   DoltliteConn *c = (DoltliteConn *)calloc(1, sizeof(*c));
   char portstr[16];
   int ret;
@@ -117,13 +132,16 @@ DoltliteConn *doltliteConnOpen(const char *host, int port, int useTls) {
   if (!c) return NULL;
   c->useTls = useTls;
   c->ownsConf = 1;
+  if (timeoutMs > 0) {
+    c->deadlineMs = doltliteMonotonicMs() + timeoutMs;
+  }
   mbedtls_net_init(&c->net);
 
   snprintf(portstr, sizeof(portstr), "%d", port);
-  if (mbedtls_net_connect(&c->net, host, portstr, MBEDTLS_NET_PROTO_TCP) != 0) {
-    goto fail_net;
-  }
+  c->net.fd = doltliteTcpConnect(host, portstr, timeoutMs);
+  if (c->net.fd < 0) goto fail_net;
   configureSocket(c->net.fd);
+  if (connApplyDeadline(c) != 0) goto fail_net;
   if (!useTls) {
     return c;
   }
@@ -157,6 +175,7 @@ DoltliteConn *doltliteConnOpen(const char *host, int port, int useTls) {
   mbedtls_ssl_set_bio(&c->ssl, &c->net, connSend, mbedtls_net_recv, NULL);
 
   do {
+    if (connApplyDeadline(c) != 0) goto fail_tls;
     ret = mbedtls_ssl_handshake(&c->ssl);
   } while (ret == MBEDTLS_ERR_SSL_WANT_READ || ret == MBEDTLS_ERR_SSL_WANT_WRITE);
   if (ret != 0) goto fail_tls;
@@ -176,11 +195,16 @@ fail_net:
   return NULL;
 }
 
+DoltliteConn *doltliteConnOpen(const char *host, int port, int useTls) {
+  return doltliteConnOpenTimeout(host, port, useTls, 0);
+}
+
 int doltliteConnWriteAll(DoltliteConn *c, const void *buf, int nbuf) {
   const unsigned char *p = (const unsigned char *)buf;
   int off = 0;
   while (off < nbuf) {
     int n;
+    if (connApplyDeadline(c) != 0) return 1;
     if (c->useTls) {
       n = mbedtls_ssl_write(&c->ssl, p + off, (size_t)(nbuf - off));
     } else {
@@ -196,6 +220,7 @@ int doltliteConnWriteAll(DoltliteConn *c, const void *buf, int nbuf) {
 int doltliteConnRead(DoltliteConn *c, void *buf, int nbuf) {
   int n;
   for (;;) {
+    if (connApplyDeadline(c) != 0) return -1;
     if (c->useTls) {
       n = mbedtls_ssl_read(&c->ssl, (unsigned char *)buf, (size_t)nbuf);
     } else {

--- a/src/doltlite_tls.h
+++ b/src/doltlite_tls.h
@@ -10,6 +10,12 @@ extern "C" {
 typedef struct DoltliteConn DoltliteConn;
 
 DoltliteConn *doltliteConnOpen(const char *host, int port, int useTls);
+DoltliteConn *doltliteConnOpenTimeout(
+  const char *host,
+  int port,
+  int useTls,
+  int timeoutMs
+);
 
 typedef struct DoltliteTlsServer DoltliteTlsServer;
 

--- a/test/remotesrv_stall_test.sh
+++ b/test/remotesrv_stall_test.sh
@@ -1,21 +1,24 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+DOLTLITE="${1:-$(dirname "$0")/../build/doltlite}"
 REMOTESRV="${2:-$(dirname "$0")/../build/doltlite-remotesrv}"
 
 if ! command -v python3 >/dev/null 2>&1; then
   echo "SKIP: python3 not available"
   exit 0
 fi
-if [ ! -x "$REMOTESRV" ]; then
-  echo "SKIP: doltlite-remotesrv binary not found ($REMOTESRV)"
+if [ ! -x "$DOLTLITE" ] || [ ! -x "$REMOTESRV" ]; then
+  echo "SKIP: doltlite/doltlite-remotesrv binaries not found ($DOLTLITE, $REMOTESRV)"
   exit 0
 fi
 
 TMP="$(mktemp -d "${TMPDIR:-/tmp}/doltlite-remotesrv-stall.XXXXXX")"
 SRV_PID=""
 CLIENT_PID=""
+BLACKHOLE_PID=""
 cleanup() {
+  [ -n "$BLACKHOLE_PID" ] && { kill "$BLACKHOLE_PID" 2>/dev/null || true; wait "$BLACKHOLE_PID" 2>/dev/null || true; }
   [ -n "$CLIENT_PID" ] && { kill "$CLIENT_PID" 2>/dev/null || true; wait "$CLIENT_PID" 2>/dev/null || true; }
   [ -n "$SRV_PID" ] && { kill "$SRV_PID" 2>/dev/null || true; wait "$SRV_PID" 2>/dev/null || true; }
   rm -rf "$TMP"
@@ -75,6 +78,79 @@ PY
   CLIENT_PID=""
   echo "  PASS: shutdown interrupts active and queued stalled clients"
 }
+
+echo "=== stalled remote server ==="
+python3 - "$TMP/blackhole.port" <<'PY' &
+import socket
+import sys
+import time
+
+server = socket.socket()
+server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+server.bind(("127.0.0.1", 0))
+server.listen(1)
+with open(sys.argv[1], "w") as f:
+    f.write(str(server.getsockname()[1]))
+
+conn, _ = server.accept()
+request = b""
+while b"\r\n\r\n" not in request:
+    data = conn.recv(4096)
+    if not data:
+        break
+    request += data
+
+response = b"HTTP/1.1 200 OK\r\nContent-Length: 20\r\n\r\n" + b"x" * 20
+for byte in response:
+    try:
+        conn.sendall(bytes([byte]))
+    except OSError:
+        break
+    time.sleep(0.2)
+conn.close()
+server.close()
+PY
+BLACKHOLE_PID=$!
+
+BLACKHOLE_PORT=""
+for _ in $(seq 1 50); do
+  BLACKHOLE_PORT="$(cat "$TMP/blackhole.port" 2>/dev/null || true)"
+  [ -n "$BLACKHOLE_PORT" ] && break
+  sleep 0.1
+done
+if [ -z "$BLACKHOLE_PORT" ]; then
+  echo "FAIL: stalled remote did not start"
+  exit 1
+fi
+
+python3 - "$DOLTLITE" "$TMP/client.db" "$BLACKHOLE_PORT" <<'PY'
+import os
+import subprocess
+import sys
+import time
+
+env = os.environ.copy()
+env["DOLTLITE_HTTP_TIMEOUT_MS"] = "750"
+url = "http://127.0.0.1:{}/repo.db".format(sys.argv[3])
+start = time.monotonic()
+try:
+    result = subprocess.run(
+        [sys.argv[1], sys.argv[2], "SELECT dolt_clone('{}');".format(url)],
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        timeout=4,
+    )
+except subprocess.TimeoutExpired as exc:
+    raise AssertionError("HTTP remote client ignored its deadline") from exc
+elapsed = time.monotonic() - start
+assert result.returncode != 0, result.stdout
+assert 0.3 < elapsed < 3.0, elapsed
+print("  PASS: HTTP remote client cuts a dribbling response at its deadline")
+PY
+kill "$BLACKHOLE_PID" 2>/dev/null || true
+wait "$BLACKHOLE_PID" 2>/dev/null || true
+BLACKHOLE_PID=""
 
 echo "=== plaintext stalled clients ==="
 start_server "$TMP/plain.log"


### PR DESCRIPTION
## Summary
- bound TCP connection attempts with nonblocking connect and poll
- carry one request deadline through TLS handshakes, writes, and reads
- default to 30 seconds with a validated `DOLTLITE_HTTP_TIMEOUT_MS` override
- extend the existing stall suite with a dribbling HTTP response regression

## Tests
- `bash test/remotesrv_stall_test.sh build/doltlite build/doltlite-remotesrv`
- `bash test/http_remote_content_length_test.sh build/doltlite build/doltlite-remotesrv`
- `bash test/remotesrv_http_test.sh build/doltlite build/doltlite-remotesrv`
- `bash test/remotesrv_http_concurrency_test.sh build/doltlite build/doltlite-remotesrv`
- `bash test/remotesrv_http_partial_failure_test.sh build/doltlite build/doltlite-remotesrv`
- `bash test/remotesrv_http_force_push_test.sh build/doltlite build/doltlite-remotesrv`
- `bash test/remote_https_auth_test.sh build/doltlite build/doltlite-remotesrv`
- `bash test/amalgamation_http_remote_test.sh build`
- `bash test/run_doltlite_regression_case.sh all` (309,956 passed)
- `bash test/lint_orphaned_suites.sh`
- `bash test/dead_code_check.sh`
- `make -C build devtest` (known local baseline: 1,620 stock divergence failures, final case hangs)