### PR TITLE
Validate external decimal fields

### DIFF
--- a/main.mk
+++ b/main.mk
@@ -631,7 +631,7 @@ ifeq ($(DOLTLITE_PROLLY),1)
     $(TOP)/src/doltlite_ancestor.h $(TOP)/src/doltlite_chunk_walk.h \
     $(TOP)/src/doltlite_commit.h $(TOP)/src/doltlite_constraint_violations.h \
     $(TOP)/src/doltlite_ignore.h $(TOP)/src/doltlite_internal.h \
-    $(TOP)/src/doltlite_merge_int.h \
+    $(TOP)/src/doltlite_merge_int.h $(TOP)/src/doltlite_parse.h \
     $(TOP)/src/doltlite_name_index.h \
     $(TOP)/src/doltlite_record.h $(TOP)/src/doltlite_remote.h $(TOP)/src/doltlite_remotesrv.h \
     $(TOP)/src/doltlite_creds.h $(TOP)/src/doltlite_net.h $(TOP)/src/doltlite_tls.h \
@@ -1399,7 +1399,8 @@ prolly_hash.o:	$(TOP)/src/prolly_hash.c $(DEPS_OBJ_COMMON) \
 prolly_xxhash.o:	$(TOP)/src/prolly_xxhash.c $(DEPS_OBJ_COMMON)
 	$(T.cc.sqlite) -c $(TOP)/src/prolly_xxhash.c
 
-doltlite_creds.o:	$(TOP)/src/doltlite_creds.c $(DEPS_OBJ_COMMON) \
+doltlite_creds.o:	$(TOP)/src/doltlite_creds.c \
+		$(TOP)/src/doltlite_parse.h $(DEPS_OBJ_COMMON) \
 		$(TOP)/ext/ed25519/ed25519.h
 	$(T.cc.sqlite) -I$(TOP)/ext/ed25519 -c $(TOP)/src/doltlite_creds.c
 
@@ -1600,7 +1601,8 @@ doltlite_commit_ancestors.o:	$(TOP)/src/doltlite_commit_ancestors.c $(DEPS_OBJ_C
 doltlite_status.o:	$(TOP)/src/doltlite_status.c $(DEPS_OBJ_COMMON)
 	$(T.cc.sqlite) -c $(TOP)/src/doltlite_status.c
 
-doltlite_ref.o:	$(TOP)/src/doltlite_ref.c $(DEPS_OBJ_COMMON)
+doltlite_ref.o:	$(TOP)/src/doltlite_ref.c \
+		$(TOP)/src/doltlite_parse.h $(DEPS_OBJ_COMMON)
 	$(T.cc.sqlite) -c $(TOP)/src/doltlite_ref.c
 
 doltlite_diff.o:	$(TOP)/src/doltlite_diff.c $(DEPS_OBJ_COMMON)
@@ -1687,10 +1689,12 @@ doltlite_remote.o:	$(TOP)/src/doltlite_remote.c $(DEPS_OBJ_COMMON)
 doltlite_remote_sql.o:	$(TOP)/src/doltlite_remote_sql.c $(DEPS_OBJ_COMMON)
 	$(T.cc.sqlite) -c $(TOP)/src/doltlite_remote_sql.c
 
-doltlite_http_remote.o:	$(TOP)/src/doltlite_http_remote.c $(DEPS_OBJ_COMMON)
+doltlite_http_remote.o:	$(TOP)/src/doltlite_http_remote.c \
+		$(TOP)/src/doltlite_parse.h $(DEPS_OBJ_COMMON)
 	$(T.cc.sqlite) -c $(TOP)/src/doltlite_http_remote.c
 
-doltlite_remotesrv.o:	$(TOP)/src/doltlite_remotesrv.c $(DEPS_OBJ_COMMON)
+doltlite_remotesrv.o:	$(TOP)/src/doltlite_remotesrv.c \
+		$(TOP)/src/doltlite_parse.h $(DEPS_OBJ_COMMON)
 	$(T.cc.sqlite) -c $(TOP)/src/doltlite_remotesrv.c
 
 build.o:	$(TOP)/src/build.c $(DEPS_OBJ_COMMON)
@@ -2930,7 +2934,8 @@ all: doltlite-lib
 #
 # doltlite-remotesrv: standalone HTTP server for serving doltlite databases.
 #
-doltlite-remotesrv$(T.exe):	$(TOP)/src/remotesrv_main.c $(LIBOBJS0)
+doltlite-remotesrv$(T.exe):	$(TOP)/src/remotesrv_main.c \
+		$(TOP)/src/doltlite_parse.h $(LIBOBJS0)
 	$(T.link) -o $@ $(TOP)/src/remotesrv_main.c $(LIBOBJS0) \
 		$(LDFLAGS.libsqlite3)
 all: doltlite-remotesrv$(T.exe)

--- a/src/doltlite_creds.c
+++ b/src/doltlite_creds.c
@@ -1,9 +1,11 @@
 #include "doltlite_creds.h"
+#include "doltlite_parse.h"
 
 #include "ed25519.h"
 #include "sha512.h"
 
 #include <errno.h>
+#include <limits.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -348,12 +350,19 @@ static int jsonFindLong(const char *json, const char *key, long *out) {
     const char *kstart = p + 1;
     if (strncmp(kstart, key, keylen) == 0 && kstart[keylen] == '"') {
       const char *q = kstart + keylen + 1;
-      char *end;
-      long v;
+      const char *end;
+      uint64_t v;
       while (*q == ' ' || *q == ':' || *q == '\t') q++;
-      v = strtol(q, &end, 10);
-      if (end == q) return 0;
-      *out = v;
+      end = q;
+      while (*end >= '0' && *end <= '9') end++;
+      if (doltliteParseDecimal(q, end, LONG_MAX, &v) !=
+          DOLTLITE_DECIMAL_OK) {
+        return 0;
+      }
+      q = end;
+      while (*q == ' ' || *q == '\t' || *q == '\r' || *q == '\n') q++;
+      if (*q != ',' && *q != '}') return 0;
+      *out = (long)v;
       return 1;
     }
     p = kstart;

--- a/src/doltlite_http_remote.c
+++ b/src/doltlite_http_remote.c
@@ -8,13 +8,13 @@
 #include "doltlite_commit.h"
 #include "doltlite_creds.h"
 #include "doltlite_net.h"
+#include "doltlite_parse.h"
 #ifdef DOLTLITE_HAVE_AUTH
 #include "doltlite_tls.h"
 #endif
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <errno.h>
 
 typedef struct HttpRemote HttpRemote;
 struct HttpRemote {
@@ -44,6 +44,16 @@ struct HttpRemote {
 
 #define HTTP_RESP_MAX_BYTES ((i64)128 * 1024 * 1024)
 #define HTTP_TIMEOUT_MS 30000
+
+static int httpHeaderNameEquals(
+  const u8 *zName,
+  int nName,
+  const char *zExpected
+){
+  int nExpected = (int)strlen(zExpected);
+  return nName==nExpected
+      && sqlite3_strnicmp((const char*)zName, zExpected, nExpected)==0;
+}
 
 #ifdef DOLTLITE_HAVE_AUTH
 typedef DoltliteConn HttpConn;
@@ -246,61 +256,109 @@ static int httpRequest(
   if( rc != SQLITE_OK ) return rc;
 
   {
-    int i;
-    int statusStart = -1;
-    for(i=0; i<nRaw-3; i++){
-      if( pRaw[i]==' ' && statusStart<0 ){
-        statusStart = i + 1;
-      }else if( statusStart>=0 && (pRaw[i]==' ' || pRaw[i]=='\r') ){
-
-        char aBuf[4];
-        int len = i - statusStart;
-        if( len>=1 && len<=3 ){
-          memcpy(aBuf, pRaw+statusStart, len);
-          aBuf[len] = 0;
-          *pStatus = atoi(aBuf);
-        }
-        break;
-      }
-    }
-  }
-
-  {
-    int i;
+    int i = 0;
     int bodyStart = -1;
     int contentLength = -1;
+    int seenContentLength = 0;
+    int seenTransferEncoding = 0;
+    int statusStart;
+    int statusEnd;
+    uint64_t value;
 
-    for(i=0; i<nRaw-3; i++){
+    while( i<nRaw && pRaw[i]!=' ' && pRaw[i]!='\r' && pRaw[i]!='\n' ) i++;
+    if( i>=nRaw || pRaw[i]!=' ' ){
+      sqlite3_free(pRaw);
+      return SQLITE_PROTOCOL;
+    }
+    statusStart = ++i;
+    while( i<nRaw && pRaw[i]!=' ' && pRaw[i]!='\r' && pRaw[i]!='\n' ) i++;
+    statusEnd = i;
+    if( statusEnd-statusStart!=3
+     || doltliteParseDecimal(
+          (const char*)pRaw+statusStart, (const char*)pRaw+statusEnd,
+          999, &value)!=DOLTLITE_DECIMAL_OK
+     || value<100 ){
+      sqlite3_free(pRaw);
+      return SQLITE_PROTOCOL;
+    }
+    *pStatus = (int)value;
 
-      if( (i==0 || pRaw[i-1]=='\n') &&
-          nRaw-i > 16 &&
-          (pRaw[i]=='C' || pRaw[i]=='c') ){
+    while( i+1<nRaw && !(pRaw[i]=='\r' && pRaw[i+1]=='\n') ) i++;
+    if( i+1>=nRaw ){
+      sqlite3_free(pRaw);
+      return SQLITE_PROTOCOL;
+    }
+    i += 2;
+    while( i<nRaw ){
+      int lineStart = i;
+      int lineEnd;
+      int colon;
+      int valueStart;
+      int valueEnd;
+      int parseRc;
 
-        if( sqlite3_strnicmp((const char*)pRaw+i, "Content-Length:", 15)==0 ){
-          contentLength = atoi((const char*)pRaw+i+15);
-        }
-      }
-      if( pRaw[i]=='\r' && pRaw[i+1]=='\n' && pRaw[i+2]=='\r' && pRaw[i+3]=='\n' ){
-        bodyStart = i + 4;
+      if( i+1<nRaw && pRaw[i]=='\r' && pRaw[i+1]=='\n' ){
+        bodyStart = i + 2;
         break;
+      }
+      while( i+1<nRaw && !(pRaw[i]=='\r' && pRaw[i+1]=='\n') ) i++;
+      if( i+1>=nRaw ){
+        sqlite3_free(pRaw);
+        return SQLITE_PROTOCOL;
+      }
+      lineEnd = i;
+      i += 2;
+
+      colon = lineStart;
+      while( colon<lineEnd && pRaw[colon]!=':' ) colon++;
+      if( colon==lineStart || colon==lineEnd ) continue;
+
+      valueStart = colon + 1;
+      while( valueStart<lineEnd
+          && (pRaw[valueStart]==' ' || pRaw[valueStart]=='\t') ){
+        valueStart++;
+      }
+      valueEnd = lineEnd;
+      while( valueEnd>valueStart
+          && (pRaw[valueEnd-1]==' ' || pRaw[valueEnd-1]=='\t') ){
+        valueEnd--;
+      }
+
+      if( httpHeaderNameEquals(
+            pRaw+lineStart, colon-lineStart, "Content-Length") ){
+        if( seenContentLength ){
+          sqlite3_free(pRaw);
+          return SQLITE_PROTOCOL;
+        }
+        seenContentLength = 1;
+        parseRc = doltliteParseDecimal(
+            (const char*)pRaw+valueStart, (const char*)pRaw+valueEnd,
+            (uint64_t)HTTP_RESP_MAX_BYTES, &value);
+        if( parseRc!=DOLTLITE_DECIMAL_OK ){
+          sqlite3_free(pRaw);
+          return parseRc==DOLTLITE_DECIMAL_RANGE
+               ? SQLITE_TOOBIG : SQLITE_PROTOCOL;
+        }
+        contentLength = (int)value;
+      }else if( httpHeaderNameEquals(
+                   pRaw+lineStart, colon-lineStart, "Transfer-Encoding") ){
+        seenTransferEncoding = 1;
       }
     }
 
-    if( bodyStart < 0 ){
-
+    if( bodyStart<0 || seenTransferEncoding ){
       sqlite3_free(pRaw);
-      return SQLITE_OK;
+      return SQLITE_PROTOCOL;
     }
 
     {
       int nAvail = nRaw - bodyStart;
-      int nCopy;
-      if( contentLength >= 0 && contentLength <= nAvail ){
-        nCopy = contentLength;
-      }else{
-        nCopy = nAvail;
+      int nCopy = contentLength>=0 ? contentLength : nAvail;
+      if( contentLength>=0 && contentLength!=nAvail ){
+        sqlite3_free(pRaw);
+        return SQLITE_PROTOCOL;
       }
-      if( nCopy > 0 ){
+      if( nCopy>0 ){
         *ppResp = sqlite3_malloc(nCopy);
         if( !*ppResp ){
           sqlite3_free(pRaw);
@@ -720,8 +778,7 @@ DoltliteRemote *doltliteHttpRemoteOpen(const char *zUrl){
   int nUserPath;
   int nBasePath;
   const char *zTimeout;
-  char *zTimeoutEnd = 0;
-  long timeoutMs;
+  uint64_t timeoutMs;
 
   if( !zUrl ) return 0;
 
@@ -749,11 +806,16 @@ DoltliteRemote *doltliteHttpRemoteOpen(const char *zUrl){
     while( *c && *c != ':' && *c != '/' ) c++;
     nHost = (int)(c - zHostStart);
     if( *c == ':' ){
+      uint64_t value;
       zPortStart = c + 1;
       c = zPortStart;
       while( *c && *c != '/' ) c++;
-      port = atoi(zPortStart);
-      if( port <= 0 ) port = useTls ? 443 : 80;
+      if( doltliteParseDecimal(zPortStart, c, 65535, &value)
+          !=DOLTLITE_DECIMAL_OK
+       || value==0 ){
+        return 0;
+      }
+      port = (int)value;
       if( *c == '/' ) zPathStart = c;
     }else if( *c == '/' ){
       zPathStart = c;
@@ -787,10 +849,10 @@ DoltliteRemote *doltliteHttpRemoteOpen(const char *zUrl){
   timeoutMs = HTTP_TIMEOUT_MS;
   zTimeout = getenv("DOLTLITE_HTTP_TIMEOUT_MS");
   if( zTimeout && zTimeout[0] ){
-    errno = 0;
-    timeoutMs = strtol(zTimeout, &zTimeoutEnd, 10);
-    if( errno!=0 || zTimeoutEnd==zTimeout || zTimeoutEnd[0]!=0
-     || timeoutMs<=0 || timeoutMs>0x7fffffff ){
+    if( doltliteParseDecimal(
+          zTimeout, zTimeout+strlen(zTimeout), 0x7fffffff, &timeoutMs)
+          !=DOLTLITE_DECIMAL_OK
+     || timeoutMs==0 ){
       timeoutMs = HTTP_TIMEOUT_MS;
     }
   }

--- a/src/doltlite_parse.h
+++ b/src/doltlite_parse.h
@@ -1,0 +1,41 @@
+#ifndef DOLTLITE_PARSE_H
+#define DOLTLITE_PARSE_H
+
+#include <stdint.h>
+
+#define DOLTLITE_DECIMAL_OK       0
+#define DOLTLITE_DECIMAL_INVALID  1
+#define DOLTLITE_DECIMAL_RANGE    2
+
+/*
+** Parse the non-empty decimal span [zBegin,zEnd) without accepting signs,
+** whitespace, or trailing characters. Return DOLTLITE_DECIMAL_RANGE when
+** the value exceeds mxValue, before performing overflowing arithmetic.
+*/
+static int doltliteParseDecimal(
+  const char *zBegin,
+  const char *zEnd,
+  uint64_t mxValue,
+  uint64_t *pValue
+){
+  const char *z = zBegin;
+  uint64_t value = 0;
+
+  if( !z || !zEnd || z>=zEnd || !pValue ){
+    return DOLTLITE_DECIMAL_INVALID;
+  }
+  while( z<zEnd ){
+    unsigned int digit;
+    if( *z<'0' || *z>'9' ) return DOLTLITE_DECIMAL_INVALID;
+    digit = (unsigned int)(*z - '0');
+    if( digit>mxValue || value>(mxValue-digit)/10 ){
+      return DOLTLITE_DECIMAL_RANGE;
+    }
+    value = value*10 + digit;
+    z++;
+  }
+  *pValue = value;
+  return DOLTLITE_DECIMAL_OK;
+}
+
+#endif

--- a/src/doltlite_ref.c
+++ b/src/doltlite_ref.c
@@ -6,6 +6,7 @@
 #include "chunk_store.h"
 #include "doltlite_commit.h"
 #include "doltlite_internal.h"
+#include "doltlite_parse.h"
 
 static int doltliteValidateCommitHash(
   sqlite3 *db,
@@ -169,8 +170,12 @@ int doltliteResolveRef(sqlite3 *db, const char *zRef, ProllyHash *pCommit){
     if( i==d ){
       n = 1;
     }else{
-      n = atoi(zRef + d);
-      if( n<0 ) return SQLITE_ERROR;
+      uint64_t value;
+      if( doltliteParseDecimal(zRef+d, zRef+i, 0x7fffffff, &value)
+          !=DOLTLITE_DECIMAL_OK ){
+        return SQLITE_ERROR;
+      }
+      n = (int)value;
       if( n==0 && op=='^' ) return SQLITE_ERROR;
     }
     if( op=='~' ){

--- a/src/doltlite_remotesrv.c
+++ b/src/doltlite_remotesrv.c
@@ -9,6 +9,7 @@
 #include "doltlite_commit.h"
 #include "doltlite_tls.h"
 #include "doltlite_creds.h"
+#include "doltlite_parse.h"
 
 #include <string.h>
 #include <stdio.h>
@@ -194,21 +195,15 @@ static int parseContentLength(
   const char *zEnd,
   int *pnValue
 ){
-  i64 nValue = 0;
   const char *p = zValue;
+  uint64_t nValue;
+  int rc;
 
   while( p<zEnd && (*p==' ' || *p=='\t') ) p++;
   while( zEnd>p && (zEnd[-1]==' ' || zEnd[-1]=='\t') ) zEnd--;
-  if( p==zEnd ) return -1;
-
-  while( p<zEnd ){
-    int digit;
-    if( *p<'0' || *p>'9' ) return -1;
-    digit = *p - '0';
-    if( nValue>(MAX_REQUEST_BYTES-digit)/10 ) return -2;
-    nValue = nValue*10 + digit;
-    p++;
-  }
+  rc = doltliteParseDecimal(p, zEnd, MAX_REQUEST_BYTES, &nValue);
+  if( rc==DOLTLITE_DECIMAL_RANGE ) return -2;
+  if( rc!=DOLTLITE_DECIMAL_OK ) return -1;
   *pnValue = (int)nValue;
   return 0;
 }

--- a/src/remotesrv_main.c
+++ b/src/remotesrv_main.c
@@ -9,6 +9,7 @@
 #include <unistd.h>
 #endif
 #include "doltlite_remotesrv.h"
+#include "doltlite_parse.h"
 
 static void usage(const char *prog){
   fprintf(stderr,
@@ -49,7 +50,14 @@ int main(int argc, char **argv){
 
   for(i=1; i<argc; i++){
     if( strcmp(argv[i], "-p")==0 && i+1<argc ){
-      o.port = atoi(argv[++i]);
+      uint64_t value;
+      const char *z = argv[++i];
+      if( doltliteParseDecimal(z, z+strlen(z), 65535, &value)
+          !=DOLTLITE_DECIMAL_OK ){
+        fprintf(stderr, "Error: invalid port: %s\n", z);
+        return 1;
+      }
+      o.port = (int)value;
     }else if( strcmp(argv[i], "--bind")==0 && i+1<argc ){
       o.zBindAddr = argv[++i];
     }else if( strcmp(argv[i], "--cert")==0 && i+1<argc ){
@@ -61,7 +69,14 @@ int main(int argc, char **argv){
     }else if( strcmp(argv[i], "--audience")==0 && i+1<argc ){
       o.audience = argv[++i];
     }else if( strcmp(argv[i], "--timeout-ms")==0 && i+1<argc ){
-      o.timeoutMs = atoi(argv[++i]);
+      uint64_t value;
+      const char *z = argv[++i];
+      if( doltliteParseDecimal(z, z+strlen(z), 0x7fffffff, &value)
+          !=DOLTLITE_DECIMAL_OK ){
+        fprintf(stderr, "Error: invalid timeout: %s\n", z);
+        return 1;
+      }
+      o.timeoutMs = (int)value;
     }else if( strcmp(argv[i], "-h")==0 || strcmp(argv[i], "--help")==0 ){
       usage(argv[0]);
       return 0;
@@ -83,11 +98,6 @@ int main(int argc, char **argv){
     fprintf(stderr, "Error: --cert and --key must be given together\n");
     return 1;
   }
-  if( o.timeoutMs<0 ){
-    fprintf(stderr, "Error: --timeout-ms must not be negative\n");
-    return 1;
-  }
-
   signal(SIGINT, onSignal);
   signal(SIGTERM, onSignal);
 

--- a/test/creds_verify_kat.c
+++ b/test/creds_verify_kat.c
@@ -30,7 +30,11 @@ static char *encodeRaw(const unsigned char *p, size_t n) {
   return z;
 }
 
-static char *tokenForKid(const DoltliteCreds *c, const char *kid) {
+static char *tokenForKid(
+  const DoltliteCreds *c,
+  const char *kid,
+  const char *exp
+) {
   char *header = NULL, *claims = NULL, *h64 = NULL, *c64 = NULL;
   char *input = NULL, *s64 = NULL, *token = NULL;
   unsigned char sig[DOLTLITE_SIG_LEN];
@@ -42,14 +46,14 @@ static char *tokenForKid(const DoltliteCreds *c, const char *kid) {
   snprintf(header, n,
            "{\"alg\":\"EdDSA\",\"kid\":\"%s\",\"dolt_token_version\":\"2023.01\"}",
            kid);
-  n = strlen(kid) * 2 + strlen(AUD) + 160;
+  n = strlen(kid) * 2 + strlen(AUD) + strlen(exp) + 160;
   claims = (char *)malloc(n);
   if (!claims) goto done;
   snprintf(claims, n,
            "{\"iss\":\"dolt-client.dolthub.com\","
            "\"sub\":\"doltClientCredentials/%s\",\"aud\":\"%s\","
-           "\"iat\":%ld,\"exp\":%ld}",
-           kid, AUD, IAT, IAT + 30);
+           "\"iat\":%ld,\"exp\":%s}",
+           kid, AUD, IAT, exp);
   h64 = encodeRaw((const unsigned char *)header, strlen(header));
   c64 = encodeRaw((const unsigned char *)claims, strlen(claims));
   if (!h64 || !c64) goto done;
@@ -82,6 +86,7 @@ int main(int argc, char **argv) {
   DoltliteCreds *c = NULL;
   char *jwt = NULL, *kid = NULL, *kidOut = NULL;
   char *bearer = NULL, *tampered = NULL;
+  char *invalidExp = NULL, *overflowExp = NULL;
   int i;
 
   for (i = 0; i < 32; i++) seed[i] = (unsigned char)i;
@@ -125,6 +130,15 @@ int main(int argc, char **argv) {
   check("malformed token rejected",
         doltliteCredsVerifyBearer("not-a-jwt", AUD, authDir, MID, NULL) != 0);
 
+  invalidExp = tokenForKid(c, kid, "1700000030x");
+  check("signed token with trailing exp text rejected",
+        invalidExp &&
+        doltliteCredsVerifyBearer(invalidExp, AUD, authDir, MID, NULL) != 0);
+  overflowExp = tokenForKid(c, kid, "999999999999999999999999");
+  check("signed token with overflowing exp rejected",
+        overflowExp &&
+        doltliteCredsVerifyBearer(overflowExp, AUD, authDir, MID, NULL) != 0);
+
   tampered = (char *)malloc(strlen(jwt) + 1);
   strcpy(tampered, jwt);
   {
@@ -142,7 +156,7 @@ int main(int argc, char **argv) {
           doltliteCredsSave(c, outsideDir) == 0);
     traversalKid = (char *)malloc(n);
     snprintf(traversalKid, n, "../outside/%s", kid);
-    traversalJwt = tokenForKid(c, traversalKid);
+    traversalJwt = tokenForKid(c, traversalKid, "1700000030");
     check("signed token cannot traverse auth-key directory",
           traversalJwt &&
               doltliteCredsVerifyBearer(traversalJwt, AUD, authDir, MID, NULL) != 0);
@@ -154,6 +168,8 @@ int main(int argc, char **argv) {
   free(kid);
   free(bearer);
   free(tampered);
+  free(invalidExp);
+  free(overflowExp);
   doltliteCredsFree(c);
 
   printf("\n%s: %d failure(s)\n", failures ? "FAILED" : "OK", failures);

--- a/test/http_remote_content_length_test.sh
+++ b/test/http_remote_content_length_test.sh
@@ -29,6 +29,19 @@ cleanup() {
 }
 trap cleanup EXIT
 
+if "$REMOTESRV" -p 12x "$TMP/srv" >"$TMP/bad-cli.out" 2>&1 \
+ || ! grep -q "invalid port" "$TMP/bad-cli.out"; then
+  echo "FAIL: server accepted a malformed CLI port"
+  exit 1
+fi
+if "$REMOTESRV" --timeout-ms 999999999999 "$TMP/srv" \
+    >"$TMP/bad-timeout.out" 2>&1 \
+ || ! grep -q "invalid timeout" "$TMP/bad-timeout.out"; then
+  echo "FAIL: server accepted an overflowing CLI timeout"
+  exit 1
+fi
+echo "remote server checked CLI numbers: PASS"
+
 mkdir -p "$TMP/srv"
 "$REMOTESRV" -p 0 --bind 127.0.0.1 "$TMP/srv" >"$TMP/srv.log" 2>&1 &
 SRV_PID=$!
@@ -53,6 +66,39 @@ import sys
 
 upstream_port = int(sys.argv[1])
 marker = sys.argv[2]
+mode_path = sys.argv[3]
+
+def response_mode():
+    try:
+        with open(mode_path, "r") as f:
+            return f.read().strip()
+    except OSError:
+        return ""
+
+def alter_response(response, mode):
+    head, sep, body = response.partition(b"\r\n\r\n")
+    if not sep:
+        return response
+    lines = head.split(b"\r\n")
+    length_index = next(
+        (i for i, line in enumerate(lines)
+         if line.lower().startswith(b"content-length:")),
+        None,
+    )
+    if length_index is None:
+        return response
+    length = len(body)
+    if mode == "invalid":
+        lines[length_index] = f"Content-Length: {length}x".encode()
+    elif mode == "duplicate":
+        lines.insert(length_index + 1, f"Content-Length: {length}".encode())
+    elif mode == "overflow":
+        lines[length_index] = b"Content-Length: 999999999999999999999999"
+    elif mode == "truncated":
+        lines[length_index] = f"Content-Length: {length + 1}".encode()
+    elif mode == "transfer":
+        lines.append(b"Transfer-Encoding: chunked")
+    return b"\r\n".join(lines) + sep + body
 
 class Handler(socketserver.BaseRequestHandler):
     def handle(self):
@@ -95,11 +141,16 @@ class Handler(socketserver.BaseRequestHandler):
         with socket.create_connection(("127.0.0.1", upstream_port), timeout=5) as s:
             s.sendall(head + b"\r\n\r\n" + body)
             s.shutdown(socket.SHUT_WR)
+            response = b""
             while True:
                 chunk = s.recv(65536)
                 if not chunk:
                     break
-                self.request.sendall(chunk)
+                response += chunk
+        mode = response_mode()
+        if mode and path.endswith("/refs"):
+            response = alter_response(response, mode)
+        self.request.sendall(response)
 
 class Server(socketserver.ThreadingTCPServer):
     allow_reuse_address = True
@@ -109,7 +160,9 @@ with Server(("127.0.0.1", 0), Handler) as srv:
     srv.serve_forever()
 PY
 
-python3 "$TMP/proxy.py" "$SRV_PORT" "$TMP/commit-content-length-ok" >"$TMP/proxy.log" 2>"$TMP/proxy.err" &
+: >"$TMP/response-mode"
+python3 "$TMP/proxy.py" "$SRV_PORT" "$TMP/commit-content-length-ok" \
+  "$TMP/response-mode" >"$TMP/proxy.log" 2>"$TMP/proxy.err" &
 PROXY_PID=$!
 
 PROXY_PORT=""
@@ -142,5 +195,24 @@ if [ ! -f "$TMP/commit-content-length-ok" ]; then
   echo "FAIL: proxy did not observe Content-Length: 0 on POST /commit"
   exit 1
 fi
+
+bad_url="http://127.0.0.1:${PROXY_PORT}junk/repo.db"
+if "$DOLTLITE" "$TMP/bad-port.db" "SELECT dolt_clone('$bad_url');" \
+    >"$TMP/bad-port.out" 2>&1; then
+  echo "FAIL: URL port with trailing characters was accepted"
+  exit 1
+fi
+echo "http remote checked URL port: PASS"
+
+for mode in invalid duplicate overflow truncated transfer; do
+  printf '%s\n' "$mode" >"$TMP/response-mode"
+  if "$DOLTLITE" "$TMP/bad-response-$mode.db" \
+      "SELECT dolt_clone('$URL');" >"$TMP/bad-response-$mode.out" 2>&1; then
+    echo "FAIL: malformed $mode response framing was accepted"
+    exit 1
+  fi
+done
+: >"$TMP/response-mode"
+echo "http remote strict response framing: PASS"
 
 echo "http remote empty POST Content-Length: PASS"

--- a/test/vc_oracle_hashof_test.sh
+++ b/test/vc_oracle_hashof_test.sh
@@ -120,6 +120,27 @@ different() {
   fi
 }
 
+both_error() {
+  local name="$1" db="$2" query="$3"
+  local dl_rc dt_rc
+  "$DOLTLITE" "$TMPROOT/$db.db" "$query" \
+    >/dev/null 2>"$TMPROOT/$name.dl.err"
+  dl_rc=$?
+  (cd "$TMPROOT/$db.dolt" && "$DOLT" sql -q "$query") \
+    >/dev/null 2>"$TMPROOT/$name.dt.err"
+  dt_rc=$?
+  if [ "$dl_rc" -ne 0 ] && [ "$dt_rc" -ne 0 ]; then
+    pass=$((pass+1))
+    echo "  PASS: $name"
+  else
+    fail=$((fail+1))
+    FAILED_NAMES="$FAILED_NAMES $name"
+    echo "  FAIL: $name (expected both engines to reject the query)"
+    echo "    doltlite exit: $dl_rc"
+    echo "    dolt exit:     $dt_rc"
+  fi
+}
+
 shape() {
   local name="$1" h="$2" dl dt
   dl=$(pair_dl "$h"); dt=$(pair_dt "$h")
@@ -452,6 +473,9 @@ shape "main_hash_shape" "$H_MAIN"
 
 H_HEAD_PARENT=$(run_hash_on "$DB" "SELECT dolt_hashof('HEAD~1');")
 different "HEAD_differs_from_HEAD_parent" "$H_HEAD" "$H_HEAD_PARENT"
+
+both_error "oversized_parent_number_is_rejected" "$DB" \
+  "SELECT dolt_hashof('HEAD^4294967297');"
 
 H_ID_OUT=$(query_pair_separate "$DB" \
   "SELECT dolt_hashof('$(pair_dl "$H_HEAD")');" \

--- a/tool/mksqlite3c.tcl
+++ b/tool/mksqlite3c.tcl
@@ -248,7 +248,7 @@ if {$doltlite} {
     prolly_three_way_merge.h prolly_xxhash.h prolly_btree_int.h
     doltlite_ancestor.h doltlite_chunk_walk.h doltlite_commit.h
     doltlite_constraint_violations.h doltlite_ignore.h doltlite_internal.h
-    doltlite_merge_int.h doltlite_name_index.h
+    doltlite_merge_int.h doltlite_name_index.h doltlite_parse.h
     doltlite_record.h doltlite_remote.h doltlite_remotesrv.h doltlite_vtab_util.h
     doltlite_creds.h doltlite_net.h doltlite_tls.h
   } {


### PR DESCRIPTION
## Summary
- add one exact, overflow-safe decimal span parser shared by refs, remotes, HTTP framing, and auth
- reject wrapped ancestor counts, malformed/out-of-range URL and server ports, invalid server timeouts, and malformed JWT expiration values
- make HTTP clients reject duplicate, invalid, overflowing, truncated, or transfer-encoded response framing instead of accepting the bytes that happened to arrive
- keep request-deadline configuration from #1771 on the same checked parsing path
- wire the new header into object and amalgamation dependencies

## Tests
- `bash test/vc_oracle_hashof_test.sh build/doltlite dolt` (33 passed)
- `bash test/http_remote_content_length_test.sh build/doltlite build/doltlite-remotesrv`
- `bash test/remotesrv_stall_test.sh build/doltlite build/doltlite-remotesrv`
- `bash test/remotesrv_http_test.sh build/doltlite build/doltlite-remotesrv` (29 passed)
- `bash test/remotesrv_http_concurrency_test.sh build/doltlite build/doltlite-remotesrv` (13 passed)
- `bash test/remotesrv_http_partial_failure_test.sh build/doltlite build/doltlite-remotesrv` (9 passed)
- `bash test/remotesrv_http_force_push_test.sh build/doltlite build/doltlite-remotesrv` (11 passed)
- `bash test/remote_https_auth_test.sh build/doltlite build/doltlite-remotesrv` (15 passed)
- `bash test/creds_verify_test.sh`
- `bash test/creds_kat_test.sh`
- forced amalgamation regeneration + `bash test/amalgamation_http_remote_test.sh build`
- `bash test/run_doltlite_regression_case.sh all` (309,956 passed)
- `bash test/lint_orphaned_suites.sh`
- `bash test/dead_code_check.sh`
- `make -C build devtest` (known local baseline reproduced: 1,620 stock divergences and the final case hung; interrupted at 2m23s)