### PR TITLE
Extract shared dolt_* command scaffolding into doltlite_cmd.c

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,7 +77,9 @@ make DOLTLITE_PROLLY=0 sqlite3   # stock SQLite, for oracle/perf comparison
   `doltlite_add` / `doltlite_reset` / `doltlite_merge_cmd` /
   `doltlite_cherry_pick` / `doltlite_revert` / `doltlite_rebase` /
   `doltlite_config` (SQL commands), `doltlite_core` (txn seal, catalog flush,
-  create-commit helpers), `doltlite_branch` (branch/checkout), `doltlite_merge`
+  create-commit helpers), `doltlite_cmd` (shared command scaffolding: option
+  errors, peer-branch BUSY, conflict/CV txn-mode outcomes), `doltlite_branch`
+  (branch/checkout), `doltlite_merge`
   (catalog in `doltlite_merge`, rows in `doltlite_merge_rows`, schema IR in
   `doltlite_merge_schema`, plus `doltlite_merge_constraints`), `doltlite_diff` / `doltlite_diff_stat` /
   `doltlite_diff_table`, `doltlite_log`, `doltlite_history`, `doltlite_blame`,

--- a/main.mk
+++ b/main.mk
@@ -599,7 +599,7 @@ PROLLY_OBJS = $(DOLTLITE_AUTH_OBJS) \
               prolly_mutate.o prolly_check.o prolly_diff.o prolly_three_way_diff.o prolly_three_way_merge.o \
               prolly_btree.o prolly_btree_catalog.o prolly_btree_cursor.o prolly_btree_mutation.o \
               prolly_btree_orig.o prolly_btree_state.o prolly_btree_txn.o pager_shim.o sortkey.o \
-              doltlite.o doltlite_core.o doltlite_add.o doltlite_commit_cmd.o doltlite_reset.o doltlite_merge_cmd.o doltlite_cherry_pick.o doltlite_revert.o doltlite_rebase.o doltlite_config.o doltlite_commit.o doltlite_ref.o doltlite_log.o doltlite_commit_ancestors.o doltlite_status.o \
+              doltlite.o doltlite_core.o doltlite_cmd.o doltlite_add.o doltlite_commit_cmd.o doltlite_reset.o doltlite_merge_cmd.o doltlite_cherry_pick.o doltlite_revert.o doltlite_rebase.o doltlite_config.o doltlite_commit.o doltlite_ref.o doltlite_log.o doltlite_commit_ancestors.o doltlite_status.o \
               doltlite_diff.o doltlite_diff_table.o doltlite_workspace.o doltlite_branch.o doltlite_tag.o doltlite_ancestor.o doltlite_merge.o doltlite_merge_rows.o doltlite_merge_schema.o doltlite_conflicts.o \
               doltlite_gc.o doltlite_chunk_walk.o doltlite_history.o doltlite_at.o doltlite_blame.o doltlite_schema_diff.o doltlite_patch.o doltlite_schemas.o doltlite_diff_stat.o doltlite_record.o \
               doltlite_ignore.o doltlite_hashof.o \
@@ -644,7 +644,7 @@ ifeq ($(DOLTLITE_PROLLY),1)
     $(TOP)/src/prolly_hashset.c $(TOP)/src/prolly_check.c \
     $(TOP)/src/chunk_wal.c $(TOP)/src/chunk_refs.c $(TOP)/src/chunk_index.c \
     $(TOP)/src/chunk_staging.c $(TOP)/src/chunk_file.c \
-    $(TOP)/src/doltlite.c $(TOP)/src/doltlite_core.c $(TOP)/src/doltlite_add.c \
+    $(TOP)/src/doltlite.c $(TOP)/src/doltlite_core.c $(TOP)/src/doltlite_cmd.c $(TOP)/src/doltlite_add.c \
     $(TOP)/src/doltlite_commit_cmd.c $(TOP)/src/doltlite_reset.c \
     $(TOP)/src/doltlite_merge_cmd.c $(TOP)/src/doltlite_cherry_pick.c \
     $(TOP)/src/doltlite_revert.c $(TOP)/src/doltlite_rebase.c \
@@ -1563,6 +1563,9 @@ doltlite.o:	$(TOP)/src/doltlite.c $(DEPS_OBJ_COMMON)
 
 doltlite_core.o:	$(TOP)/src/doltlite_core.c $(DEPS_OBJ_COMMON)
 	$(T.cc.sqlite) -c $(TOP)/src/doltlite_core.c
+
+doltlite_cmd.o:	$(TOP)/src/doltlite_cmd.c $(DEPS_OBJ_COMMON)
+	$(T.cc.sqlite) -c $(TOP)/src/doltlite_cmd.c
 
 doltlite_add.o:	$(TOP)/src/doltlite_add.c $(DEPS_OBJ_COMMON)
 	$(T.cc.sqlite) -c $(TOP)/src/doltlite_add.c

--- a/src/doltlite_add.c
+++ b/src/doltlite_add.c
@@ -949,13 +949,7 @@ static void doltliteAddFunc(
      || strcmp(arg, ".")==0 ){
       stageAll = 1;
     }else if( arg[0]=='-' ){
-      char *zErr = sqlite3_mprintf("unknown option `%s`", arg);
-      if( zErr ){
-        sqlite3_result_error(context, zErr, -1);
-        sqlite3_free(zErr);
-      }else{
-        sqlite3_result_error_nomem(context);
-      }
+      doltliteCmdResultUnknownOption(context, arg);
       goto add_cleanup;
     }
   }

--- a/src/doltlite_cherry_pick.c
+++ b/src/doltlite_cherry_pick.c
@@ -182,58 +182,14 @@ int applyMergedCatalogAndCommit(
     sqlite3_free(zDetectErrMsg);
 
     if( nViolations + nUnique + nCheck > 0 ){
-      switch( doltliteVcTxnMode(db) ){
-      case DOLTLITE_VC_TXN_AUTOCOMMIT_LIKE:
-        rc = doltliteHardReset(db, &savedState.sessionCatalogHash);
-        if( rc==SQLITE_OK ){
-          rc = doltliteSetSessionBranch(db, savedState.zSessionBranch);
-        }
-        if( rc==SQLITE_OK ){
-          doltliteSetSessionHead(db, &savedState.sessionHead);
-          rc = doltliteSetSessionStaged(db, &savedState.sessionStaged);
-        }
-        if( rc==SQLITE_OK ){
-          rc = doltliteSetSessionMergeState(
-              db, savedState.sessionIsMerging,
-              &savedState.sessionMergeCommit,
-              &savedState.sessionConflictsCatalog);
-        }
-        if( rc==SQLITE_OK ){
-          extern int doltliteClearAllConstraintViolations(sqlite3*);
-          rc = doltliteClearAllConstraintViolations(db);
-        }
-        if( rc==SQLITE_OK ){
-          rc = doltlitePersistWorkingSet(db);
-        }
-        doltliteTxnStateClear(&savedState);
-        if( rc!=SQLITE_OK ){
-          return rc;
-        }
-        sqlite3_result_error(context,
-          "Committing this transaction resulted in a working set with "
-          "constraint violations, transaction rolled back.", -1);
-        break;
-      case DOLTLITE_VC_TXN_PLAIN:
-        rc = doltliteReportConstraintViolations(db, context, zOpLabel);
-        if( rc!=SQLITE_OK ) goto apply_rollback;
-        rc = doltliteVcSealActiveSavepoints(db);
-        if( rc!=SQLITE_OK ) goto apply_rollback;
-        doltliteTxnStateClear(&savedState);
-        break;
-      case DOLTLITE_VC_TXN_NESTED_SAVEPOINT:
-        rc = doltliteRestoreTxnStateOnFailure(db, &savedState, SQLITE_OK);
-        if( rc!=SQLITE_OK ) return rc;
-        sqlite3_result_error(context,
+      return doltliteCmdFinishWithConstraintViolations(
+          db, context, &savedState, zOpLabel, 1,
           "Merge aborted: would have introduced constraint violations. "
           "The merge and the would-be violations have been rolled back "
           "with the enclosing savepoint, so dolt_constraint_violations "
           "is empty. Re-run the merge in autocommit mode (outside a "
           "transaction) to inspect the violations in "
-          "dolt_constraint_violations.",
-          -1);
-        break;
-      }
-      return SQLITE_OK;
+          "dolt_constraint_violations.");
     }
   }
 
@@ -242,30 +198,8 @@ int applyMergedCatalogAndCommit(
       chunkStoreUnlock(cs);
       graphLocked = 0;
     }
-    switch( doltliteVcTxnMode(db) ){
-    case DOLTLITE_VC_TXN_AUTOCOMMIT_LIKE:
-      rc = doltliteRollbackAutocommitConflict(db, context, &savedState);
-      if( rc!=SQLITE_OK ) return rc;
-      return SQLITE_OK;
-    case DOLTLITE_VC_TXN_PLAIN:
-      rc = doltliteReportConflicts(db, context, *pnConflicts, zOpLabel);
-      if( rc!=SQLITE_OK ) goto apply_rollback;
-      rc = doltliteVcSealActiveSavepoints(db);
-      if( rc!=SQLITE_OK ) goto apply_rollback;
-      doltliteTxnStateClear(&savedState);
-      return SQLITE_OK;
-    case DOLTLITE_VC_TXN_NESTED_SAVEPOINT:
-      rc = doltliteRestoreTxnStateOnFailure(db, &savedState, SQLITE_OK);
-      if( rc!=SQLITE_OK ) return rc;
-      {
-        char msg[256];
-        sqlite3_snprintf(sizeof(msg), msg,
-          "%s has %d conflict(s). Resolve and then commit with dolt_commit.",
-          zOpLabel, *pnConflicts);
-        sqlite3_result_error(context, msg, -1);
-      }
-      return SQLITE_OK;
-    }
+    return doltliteCmdFinishWithConflicts(
+        db, context, &savedState, *pnConflicts, zOpLabel, 1);
   }
 
   rc = doltliteCreateAndStoreCommit(db, ourHead, &liveMergedCatHash,
@@ -398,9 +332,7 @@ static void doltliteCherryPickFunc(
   doltliteCommitClear(&ourCommit);
 
   if( rc==SQLITE_BUSY ){
-    sqlite3_result_error(context,
-      "cherry-pick conflict: another connection committed to this branch. Please retry your transaction.",
-      -1);
+    doltliteCmdResultPeerBranchBusy(context, "cherry-pick");
     return;
   }
   if( rc!=SQLITE_OK ){

--- a/src/doltlite_cmd.c
+++ b/src/doltlite_cmd.c
@@ -1,0 +1,281 @@
+#ifdef DOLTLITE_PROLLY
+
+#include "sqliteInt.h"
+#include "prolly_hash.h"
+#include "chunk_store.h"
+#include "doltlite_internal.h"
+
+#include <string.h>
+
+/*
+** Shared scaffolding for dolt_* SQL command functions: argv option errors,
+** peer-branch BUSY messages, and the three-way VC txn outcome switch for
+** merge conflicts / constraint violations.
+*/
+
+void doltliteCmdResultUnknownOption(sqlite3_context *ctx, const char *zOpt){
+  char *zErr = sqlite3_mprintf("unknown option `%s`", zOpt ? zOpt : "");
+  if( zErr ){
+    sqlite3_result_error(ctx, zErr, -1);
+    sqlite3_free(zErr);
+  }else{
+    sqlite3_result_error_nomem(ctx);
+  }
+}
+
+void doltliteCmdResultMissingOptionValue(
+  sqlite3_context *ctx,
+  const char *zOptName
+){
+  char *zErr = sqlite3_mprintf("no value for option `%s'",
+                               zOptName ? zOptName : "");
+  if( zErr ){
+    sqlite3_result_error(ctx, zErr, -1);
+    sqlite3_free(zErr);
+  }else{
+    sqlite3_result_error_nomem(ctx);
+  }
+}
+
+const char *doltliteCmdTakeValueArg(
+  sqlite3_context *ctx,
+  int argc,
+  sqlite3_value **argv,
+  int *pI,
+  const char *zOptName
+){
+  int i = *pI;
+  if( i+1>=argc ){
+    doltliteCmdResultMissingOptionValue(ctx, zOptName);
+    return 0;
+  }
+  *pI = i+1;
+  return (const char*)sqlite3_value_text(argv[i+1]);
+}
+
+void doltliteCmdResultPeerBranchBusy(sqlite3_context *ctx, const char *zOp){
+  char *zErr = sqlite3_mprintf(
+    "%s conflict: another connection committed to this branch. "
+    "Please retry your transaction.",
+    zOp ? zOp : "branch");
+  if( zErr ){
+    sqlite3_result_error(ctx, zErr, -1);
+    sqlite3_free(zErr);
+  }else{
+    sqlite3_result_error_nomem(ctx);
+  }
+}
+
+int doltliteReportConflicts(
+  sqlite3 *db,
+  sqlite3_context *ctx,
+  int nConflicts,
+  const char *zOp
+){
+  char msg[256];
+  int rc;
+  rc = doltliteRegisterConflictTables(db);
+  if( rc!=SQLITE_OK ) return rc;
+  rc = doltlitePersistOrSaveWorkingSet(db);
+  if( rc!=SQLITE_OK ) return rc;
+  sqlite3_snprintf(sizeof(msg), msg,
+    "%s has %d conflict(s). Resolve and then commit with dolt_commit.",
+    zOp, nConflicts);
+  sqlite3_result_error(ctx, msg, -1);
+  return SQLITE_OK;
+}
+
+int doltliteReportConstraintViolations(
+  sqlite3 *db,
+  sqlite3_context *ctx,
+  const char *zOp
+){
+  char msg[256];
+  int rc;
+  rc = doltlitePersistOrSaveWorkingSet(db);
+  if( rc!=SQLITE_OK ) return rc;
+  sqlite3_snprintf(sizeof(msg), msg,
+    "%s resulted in constraint violations. Resolve the rows in "
+    "dolt_constraint_violations and then commit with dolt_commit.",
+    zOp);
+  sqlite3_result_error(ctx, msg, -1);
+  return SQLITE_OK;
+}
+
+void doltliteReportAutocommitConflictRollback(sqlite3_context *ctx){
+  sqlite3_result_error(ctx,
+    "Merge conflict detected, @autocommit transaction rolled back. "
+    "@autocommit must be disabled so that merge conflicts can be "
+    "resolved using the dolt_conflicts and dolt_schema_conflicts "
+    "tables before manually committing the transaction. "
+    "Alternatively, to commit transactions with merge conflicts, set "
+    "@@dolt_allow_commit_conflicts = 1",
+    -1);
+}
+
+int doltliteRollbackAutocommitConflict(
+  sqlite3 *db,
+  sqlite3_context *ctx,
+  DoltliteTxnState *pSaved
+){
+  int rc;
+  int hadTopLevelSavepoint = db->pSavepoint!=0 && db->nSavepoint==0;
+  sqlite3RollbackAll(db, SQLITE_OK);
+  rc = doltliteRestoreTxnState(db, pSaved);
+  if( rc==SQLITE_OK ){
+    rc = doltliteSetSessionMergeState(db, pSaved->sessionIsMerging,
+                                      &pSaved->sessionMergeCommit,
+                                      &pSaved->sessionConflictsCatalog);
+  }
+  if( rc==SQLITE_OK ){
+    rc = doltliteSetSessionConstraintViolationsCatalog(
+        db, &pSaved->sessionConstraintViolationsCatalog);
+  }
+  doltliteTxnStateClear(pSaved);
+  if( rc==SQLITE_OK && hadTopLevelSavepoint ){
+    rc = doltliteVcSealTopLevelSavepointTxn(db);
+  }
+  if( rc==SQLITE_OK ){
+    doltliteReportAutocommitConflictRollback(ctx);
+  }
+  return rc;
+}
+
+static int cmdRollbackAutocommitConstraintViolations(
+  sqlite3 *db,
+  sqlite3_context *ctx,
+  DoltliteTxnState *pSaved
+){
+  int rc = doltliteHardReset(db, &pSaved->sessionCatalogHash);
+  if( rc==SQLITE_OK ){
+    rc = doltliteSetSessionBranch(db, pSaved->zSessionBranch);
+  }
+  if( rc==SQLITE_OK ){
+    doltliteSetSessionHead(db, &pSaved->sessionHead);
+    rc = doltliteSetSessionStaged(db, &pSaved->sessionStaged);
+  }
+  if( rc==SQLITE_OK ){
+    rc = doltliteSetSessionMergeState(
+        db, pSaved->sessionIsMerging,
+        &pSaved->sessionMergeCommit,
+        &pSaved->sessionConflictsCatalog);
+  }
+  if( rc==SQLITE_OK ){
+    rc = doltliteSetSessionConstraintViolationsCatalog(
+        db, &pSaved->sessionConstraintViolationsCatalog);
+  }
+  if( rc==SQLITE_OK ){
+    rc = doltlitePersistWorkingSet(db);
+  }
+  doltliteTxnStateClear(pSaved);
+  if( rc!=SQLITE_OK ){
+    sqlite3_result_error_code(ctx, rc);
+    return rc;
+  }
+  sqlite3_result_error(ctx,
+    "Committing this transaction resulted in a working set with "
+    "constraint violations, transaction rolled back.", -1);
+  return SQLITE_OK;
+}
+
+int doltliteCmdFinishWithConflicts(
+  sqlite3 *db,
+  sqlite3_context *ctx,
+  DoltliteTxnState *pSaved,
+  int nConflicts,
+  const char *zOp,
+  int bSealOnPlain
+){
+  int rc;
+  switch( doltliteVcTxnMode(db) ){
+  case DOLTLITE_VC_TXN_AUTOCOMMIT_LIKE:
+    rc = doltliteRollbackAutocommitConflict(db, ctx, pSaved);
+    if( rc!=SQLITE_OK ) sqlite3_result_error_code(ctx, rc);
+    return rc==SQLITE_OK ? SQLITE_OK : rc;
+  case DOLTLITE_VC_TXN_PLAIN:
+    rc = doltliteReportConflicts(db, ctx, nConflicts, zOp);
+    if( rc!=SQLITE_OK ){
+      sqlite3_result_error_code(ctx,
+          doltliteRestoreTxnStateOnFailure(db, pSaved, rc));
+      return rc;
+    }
+    if( bSealOnPlain ){
+      rc = doltliteVcSealActiveSavepoints(db);
+      if( rc!=SQLITE_OK ){
+        sqlite3_result_error_code(ctx,
+            doltliteRestoreTxnStateOnFailure(db, pSaved, rc));
+        return rc;
+      }
+    }
+    doltliteTxnStateClear(pSaved);
+    return SQLITE_OK;
+  case DOLTLITE_VC_TXN_NESTED_SAVEPOINT:
+    rc = doltliteRestoreTxnStateOnFailure(db, pSaved, SQLITE_OK);
+    if( rc!=SQLITE_OK ){
+      sqlite3_result_error_code(ctx, rc);
+      return rc;
+    }
+    {
+      char msg[256];
+      sqlite3_snprintf(sizeof(msg), msg,
+        "%s has %d conflict(s). Resolve and then commit with dolt_commit.",
+        zOp ? zOp : "Operation", nConflicts);
+      sqlite3_result_error(ctx, msg, -1);
+    }
+    return SQLITE_OK;
+  }
+  return SQLITE_OK;
+}
+
+int doltliteCmdFinishWithConstraintViolations(
+  sqlite3 *db,
+  sqlite3_context *ctx,
+  DoltliteTxnState *pSaved,
+  const char *zOp,
+  int bSealOnPlain,
+  const char *zNestedMsg
+){
+  int rc;
+  switch( doltliteVcTxnMode(db) ){
+  case DOLTLITE_VC_TXN_AUTOCOMMIT_LIKE:
+    return cmdRollbackAutocommitConstraintViolations(db, ctx, pSaved);
+  case DOLTLITE_VC_TXN_PLAIN:
+    rc = doltliteReportConstraintViolations(db, ctx, zOp);
+    if( rc!=SQLITE_OK ){
+      sqlite3_result_error_code(ctx,
+          doltliteRestoreTxnStateOnFailure(db, pSaved, rc));
+      return rc;
+    }
+    if( bSealOnPlain ){
+      rc = doltliteVcSealActiveSavepoints(db);
+      if( rc!=SQLITE_OK ){
+        sqlite3_result_error_code(ctx,
+            doltliteRestoreTxnStateOnFailure(db, pSaved, rc));
+        return rc;
+      }
+    }
+    doltliteTxnStateClear(pSaved);
+    return SQLITE_OK;
+  case DOLTLITE_VC_TXN_NESTED_SAVEPOINT:
+    rc = doltliteRestoreTxnStateOnFailure(db, pSaved, SQLITE_OK);
+    if( rc!=SQLITE_OK ){
+      sqlite3_result_error_code(ctx, rc);
+      return rc;
+    }
+    if( zNestedMsg ){
+      sqlite3_result_error(ctx, zNestedMsg, -1);
+    }else{
+      sqlite3_result_error(ctx,
+        "Merge aborted: would have introduced constraint violations. "
+        "The merge and the would-be violations have been rolled back "
+        "with the enclosing savepoint, so dolt_constraint_violations "
+        "is empty. Re-run the operation outside a nested SAVEPOINT to "
+        "inspect the violations in dolt_constraint_violations.",
+        -1);
+    }
+    return SQLITE_OK;
+  }
+  return SQLITE_OK;
+}
+
+#endif

--- a/src/doltlite_commit_cmd.c
+++ b/src/doltlite_commit_cmd.c
@@ -100,49 +100,32 @@ static int doltliteCommitParseOptions(
           }else if( i+1<argc ){
             opts->zMessage = (const char*)sqlite3_value_text(argv[++i]);
           }else{
-            sqlite3_result_error(context, "no value for option `message'", -1);
+            doltliteCmdResultMissingOptionValue(context, "message");
             return SQLITE_ERROR;
           }
           break;
         }else{
-          char *zErr = sqlite3_mprintf("unknown option `-%c'", arg[j]);
-          if( zErr ){
-            sqlite3_result_error(context, zErr, -1);
-            sqlite3_free(zErr);
-          }else{
-            sqlite3_result_error_nomem(context);
-          }
+          char opt[3] = { '-', (char)arg[j], 0 };
+          doltliteCmdResultUnknownOption(context, opt);
           return SQLITE_ERROR;
         }
       }
     }else if( strcmp(arg, "-m")==0 ){
-      if( i+1<argc ){
-        opts->zMessage = (const char*)sqlite3_value_text(argv[++i]);
-      }else{
-        sqlite3_result_error(context, "no value for option `message'", -1);
-        return SQLITE_ERROR;
-      }
+      opts->zMessage = doltliteCmdTakeValueArg(
+          context, argc, argv, &i, "message");
+      if( !opts->zMessage ) return SQLITE_ERROR;
     }else if( strcmp(arg, "--message")==0 ){
-      if( i+1<argc ){
-        opts->zMessage = (const char*)sqlite3_value_text(argv[++i]);
-      }else{
-        sqlite3_result_error(context, "no value for option `message'", -1);
-        return SQLITE_ERROR;
-      }
+      opts->zMessage = doltliteCmdTakeValueArg(
+          context, argc, argv, &i, "message");
+      if( !opts->zMessage ) return SQLITE_ERROR;
     }else if( strcmp(arg, "--author")==0 ){
-      if( i+1<argc ){
-        opts->zAuthor = (const char*)sqlite3_value_text(argv[++i]);
-      }else{
-        sqlite3_result_error(context, "no value for option `author'", -1);
-        return SQLITE_ERROR;
-      }
+      opts->zAuthor = doltliteCmdTakeValueArg(
+          context, argc, argv, &i, "author");
+      if( !opts->zAuthor ) return SQLITE_ERROR;
     }else if( strcmp(arg, "--date")==0 ){
-      if( i+1<argc ){
-        opts->zDate = (const char*)sqlite3_value_text(argv[++i]);
-      }else{
-        sqlite3_result_error(context, "no value for option `date'", -1);
-        return SQLITE_ERROR;
-      }
+      opts->zDate = doltliteCmdTakeValueArg(
+          context, argc, argv, &i, "date");
+      if( !opts->zDate ) return SQLITE_ERROR;
     }else if( strcmp(arg, "--amend")==0 ){
       opts->amend = 1;
     }else if( strcmp(arg, "--allow-empty")==0 ){
@@ -156,13 +139,7 @@ static int doltliteCommitParseOptions(
     }else if( strcmp(arg, "-a")==0 || strcmp(arg, "--all")==0 ){
       opts->addModifiedOnly = 1;
     }else if( arg[0]=='-' ){
-      char *zErr = sqlite3_mprintf("unknown option `%s`", arg);
-      if( zErr ){
-        sqlite3_result_error(context, zErr, -1);
-        sqlite3_free(zErr);
-      }else{
-        sqlite3_result_error_nomem(context);
-      }
+      doltliteCmdResultUnknownOption(context, arg);
       return SQLITE_ERROR;
     }else{
       char *zErr = sqlite3_mprintf(
@@ -813,9 +790,7 @@ static void doltliteCommitFunc(
 
   rc = doltliteRefreshAndConfirmHead(db, cs, &sessionHeadBeforeLock);
   if( rc==SQLITE_BUSY ){
-    sqlite3_result_error(context,
-      "commit conflict: another connection committed to this branch. "
-      "Please retry your transaction.", -1);
+    doltliteCmdResultPeerBranchBusy(context, "commit");
     return;
   }
   if( rc!=SQLITE_OK ){

--- a/src/doltlite_core.c
+++ b/src/doltlite_core.c
@@ -518,42 +518,6 @@ int doltlitePersistOrSaveWorkingSet(sqlite3 *db){
   return doltliteSaveWorkingSet(db);
 }
 
-int doltliteReportConflicts(
-  sqlite3 *db,
-  sqlite3_context *ctx,
-  int nConflicts,
-  const char *zOp
-){
-  char msg[256];
-  int rc;
-  rc = doltliteRegisterConflictTables(db);
-  if( rc!=SQLITE_OK ) return rc;
-  rc = doltlitePersistOrSaveWorkingSet(db);
-  if( rc!=SQLITE_OK ) return rc;
-  sqlite3_snprintf(sizeof(msg), msg,
-    "%s has %d conflict(s). Resolve and then commit with dolt_commit.",
-    zOp, nConflicts);
-  sqlite3_result_error(ctx, msg, -1);
-  return SQLITE_OK;
-}
-
-int doltliteReportConstraintViolations(
-  sqlite3 *db,
-  sqlite3_context *ctx,
-  const char *zOp
-){
-  char msg[256];
-  int rc;
-  rc = doltlitePersistOrSaveWorkingSet(db);
-  if( rc!=SQLITE_OK ) return rc;
-  sqlite3_snprintf(sizeof(msg), msg,
-    "%s resulted in constraint violations. Resolve the rows in "
-    "dolt_constraint_violations and then commit with dolt_commit.",
-    zOp);
-  sqlite3_result_error(ctx, msg, -1);
-  return SQLITE_OK;
-}
-
 int doltliteDetectPostMergeConstraintViolations(
   sqlite3 *db,
   const ProllyHash *pAncCatHash,
@@ -709,45 +673,5 @@ int doltlitePrimeSchemaCache(sqlite3 *db){
   sqlite3_finalize(pStmt);
   return rc;
 }
-
-void doltliteReportAutocommitConflictRollback(sqlite3_context *ctx){
-  sqlite3_result_error(ctx,
-    "Merge conflict detected, @autocommit transaction rolled back. "
-    "@autocommit must be disabled so that merge conflicts can be "
-    "resolved using the dolt_conflicts and dolt_schema_conflicts "
-    "tables before manually committing the transaction. "
-    "Alternatively, to commit transactions with merge conflicts, set "
-    "@@dolt_allow_commit_conflicts = 1",
-    -1);
-}
-
-int doltliteRollbackAutocommitConflict(
-  sqlite3 *db,
-  sqlite3_context *ctx,
-  DoltliteTxnState *pSaved
-){
-  int rc;
-  int hadTopLevelSavepoint = db->pSavepoint!=0 && db->nSavepoint==0;
-  sqlite3RollbackAll(db, SQLITE_OK);
-  rc = doltliteRestoreTxnState(db, pSaved);
-  if( rc==SQLITE_OK ){
-    rc = doltliteSetSessionMergeState(db, pSaved->sessionIsMerging,
-                                      &pSaved->sessionMergeCommit,
-                                      &pSaved->sessionConflictsCatalog);
-  }
-  if( rc==SQLITE_OK ){
-    rc = doltliteSetSessionConstraintViolationsCatalog(
-        db, &pSaved->sessionConstraintViolationsCatalog);
-  }
-  doltliteTxnStateClear(pSaved);
-  if( rc==SQLITE_OK && hadTopLevelSavepoint ){
-    rc = doltliteVcSealTopLevelSavepointTxn(db);
-  }
-  if( rc==SQLITE_OK ){
-    doltliteReportAutocommitConflictRollback(ctx);
-  }
-  return rc;
-}
-
 
 #endif

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -877,6 +877,25 @@ int doltliteAdvanceBranch(
   const ProllyHash *pWorkingCatHash
 );
 int doltlitePersistOrSaveWorkingSet(sqlite3 *db);
+/* Shared dolt_* command scaffolding (doltlite_cmd.c). */
+void doltliteCmdResultUnknownOption(sqlite3_context *ctx, const char *zOpt);
+void doltliteCmdResultMissingOptionValue(
+  sqlite3_context *ctx, const char *zOptName
+);
+const char *doltliteCmdTakeValueArg(
+  sqlite3_context *ctx, int argc, sqlite3_value **argv, int *pI,
+  const char *zOptName
+);
+void doltliteCmdResultPeerBranchBusy(sqlite3_context *ctx, const char *zOp);
+int doltliteCmdFinishWithConflicts(
+  sqlite3 *db, sqlite3_context *ctx, DoltliteTxnState *pSaved,
+  int nConflicts, const char *zOp, int bSealOnPlain
+);
+int doltliteCmdFinishWithConstraintViolations(
+  sqlite3 *db, sqlite3_context *ctx, DoltliteTxnState *pSaved,
+  const char *zOp, int bSealOnPlain, const char *zNestedMsg
+);
+
 int doltliteReportConflicts(
   sqlite3 *db, sqlite3_context *ctx, int nConflicts, const char *zOp
 );

--- a/src/doltlite_merge_cmd.c
+++ b/src/doltlite_merge_cmd.c
@@ -69,9 +69,7 @@ int mergeFastForward(
   if( rc==SQLITE_BUSY ){
     doltliteTxnStateClear(&savedState);
     doltliteCommitClear(&theirCommit);
-    sqlite3_result_error(context,
-      "merge conflict: another connection committed to this branch. Please retry your transaction.",
-      -1);
+    doltliteCmdResultPeerBranchBusy(context, "merge");
     return rc;
   }
   if( rc!=SQLITE_OK ){
@@ -179,20 +177,10 @@ static void doltliteMergeFunc(
     }else if( strcmp(arg, "--no-ff")==0 ){
       noFastForward = 1;
     }else if( strcmp(arg, "-m")==0 || strcmp(arg, "--message")==0 ){
-      if( i+1<argc ){
-        zMessage = (const char*)sqlite3_value_text(argv[++i]);
-      }else{
-        sqlite3_result_error(context, "-m requires a message", -1);
-        return;
-      }
+      zMessage = doltliteCmdTakeValueArg(context, argc, argv, &i, "message");
+      if( !zMessage ) return;
     }else if( arg[0]=='-' ){
-      char *zErr = sqlite3_mprintf("unknown option `%s`", arg);
-      if( zErr ){
-        sqlite3_result_error(context, zErr, -1);
-        sqlite3_free(zErr);
-      }else{
-        sqlite3_result_error_nomem(context);
-      }
+      doltliteCmdResultUnknownOption(context, arg);
       return;
     }else if( !zBranch ){
       zBranch = arg;
@@ -349,9 +337,7 @@ static void doltliteMergeFunc(
       doltliteCommitClear(&theirCommit);
       freeSchemaMergeActions(aSchemaActions, nSchemaActions);
       doltliteFreeNameList(azReindex, nReindex);
-      sqlite3_result_error(context,
-        "merge conflict: another connection committed to this branch. Please retry your transaction.",
-        -1);
+      doltliteCmdResultPeerBranchBusy(context, "merge");
       return;
     }
     if( rc!=SQLITE_OK ){
@@ -501,74 +487,14 @@ static void doltliteMergeFunc(
     }
     sqlite3_free(zDetectErrMsg);
     if( nViolations + nUnique + nCheck > 0 ){
-      switch( doltliteVcTxnMode(db) ){
-      case DOLTLITE_VC_TXN_AUTOCOMMIT_LIKE:
-        rc = doltliteHardReset(db, &savedState.sessionCatalogHash);
-        if( rc==SQLITE_OK ){
-          rc = doltliteSetSessionBranch(db, savedState.zSessionBranch);
-        }
-        if( rc==SQLITE_OK ){
-          doltliteSetSessionHead(db, &savedState.sessionHead);
-          rc = doltliteSetSessionStaged(db, &savedState.sessionStaged);
-        }
-        if( rc==SQLITE_OK ){
-          rc = doltliteSetSessionMergeState(
-              db, savedState.sessionIsMerging,
-              &savedState.sessionMergeCommit,
-              &savedState.sessionConflictsCatalog);
-        }
-        if( rc==SQLITE_OK ){
-          rc = doltliteSetSessionConstraintViolationsCatalog(
-              db, &savedState.sessionConstraintViolationsCatalog);
-        }
-        if( rc==SQLITE_OK ){
-          rc = doltlitePersistWorkingSet(db);
-        }
-        doltliteTxnStateClear(&savedState);
-        if( rc!=SQLITE_OK ){
-          sqlite3_result_error_code(context, rc);
-        }else{
-          sqlite3_result_error(context,
-            "Committing this transaction resulted in a working set with "
-            "constraint violations, transaction rolled back.", -1);
-        }
-        break;
-      case DOLTLITE_VC_TXN_NESTED_SAVEPOINT:
-        rc = doltliteRestoreTxnState(db, &savedState);
-        if( rc==SQLITE_OK ){
-          rc = doltliteSetSessionMergeState(
-              db, savedState.sessionIsMerging,
-              &savedState.sessionMergeCommit,
-              &savedState.sessionConflictsCatalog);
-        }
-        if( rc==SQLITE_OK ){
-          rc = doltliteSetSessionConstraintViolationsCatalog(
-              db, &savedState.sessionConstraintViolationsCatalog);
-        }
-        doltliteTxnStateClear(&savedState);
-        if( rc!=SQLITE_OK ){
-          sqlite3_result_error_code(context, rc);
-        }else{
-          sqlite3_result_error(context,
-            "Merge aborted: would have introduced constraint violations. "
-            "The merge and the would-be violations have been rolled back "
-            "with the enclosing savepoint, so dolt_constraint_violations "
-            "is empty. To inspect the violations, re-run the merge inside "
-            "a plain BEGIN/COMMIT transaction (no SAVEPOINT) so the "
-            "violations are preserved instead of rolled back.",
-            -1);
-        }
-        break;
-      case DOLTLITE_VC_TXN_PLAIN:
-        rc = doltliteReportConstraintViolations(db, context, "Merge");
-        if( rc!=SQLITE_OK ){
-          sqlite3_result_error_code(context,
-              doltliteRestoreTxnStateOnFailure(db, &savedState, rc));
-          return;
-        }
-        doltliteTxnStateClear(&savedState);
-        break;
-      }
+      (void)doltliteCmdFinishWithConstraintViolations(
+          db, context, &savedState, "Merge", 0,
+          "Merge aborted: would have introduced constraint violations. "
+          "The merge and the would-be violations have been rolled back "
+          "with the enclosing savepoint, so dolt_constraint_violations "
+          "is empty. To inspect the violations, re-run the merge inside "
+          "a plain BEGIN/COMMIT transaction (no SAVEPOINT) so the "
+          "violations are preserved instead of rolled back.");
       return;
     }
   }
@@ -578,46 +504,9 @@ static void doltliteMergeFunc(
       chunkStoreUnlock(cs);
       graphLocked = 0;
     }
-    switch( doltliteVcTxnMode(db) ){
-    case DOLTLITE_VC_TXN_AUTOCOMMIT_LIKE:
-      rc = doltliteRollbackAutocommitConflict(db, context, &savedState);
-      if( rc!=SQLITE_OK ){
-        sqlite3_result_error_code(context, rc);
-      }
-      return;
-    case DOLTLITE_VC_TXN_NESTED_SAVEPOINT:
-      rc = doltliteRestoreTxnState(db, &savedState);
-      if( rc==SQLITE_OK ){
-        rc = doltliteSetSessionMergeState(
-            db, savedState.sessionIsMerging,
-            &savedState.sessionMergeCommit,
-            &savedState.sessionConflictsCatalog);
-      }
-      if( rc==SQLITE_OK ){
-        rc = doltliteSetSessionConstraintViolationsCatalog(
-            db, &savedState.sessionConstraintViolationsCatalog);
-      }
-      doltliteTxnStateClear(&savedState);
-      if( rc!=SQLITE_OK ){
-        sqlite3_result_error_code(context, rc);
-      }else{
-        char msg[256];
-        sqlite3_snprintf(sizeof(msg), msg,
-          "Merge has %d conflict(s). Resolve and then commit with dolt_commit.",
-          nMergeConflicts);
-        sqlite3_result_error(context, msg, -1);
-      }
-      return;
-    case DOLTLITE_VC_TXN_PLAIN:
-      rc = doltliteReportConflicts(db, context, nMergeConflicts, "Merge");
-      if( rc!=SQLITE_OK ){
-        sqlite3_result_error_code(context,
-            doltliteRestoreTxnStateOnFailure(db, &savedState, rc));
-        return;
-      }
-      doltliteTxnStateClear(&savedState);
-      break;
-    }
+    (void)doltliteCmdFinishWithConflicts(
+        db, context, &savedState, nMergeConflicts, "Merge", 0);
+    return;
   }else{
     ProllyHash commitHash;
     char hexBuf[PROLLY_HASH_SIZE*2+1];
@@ -647,9 +536,7 @@ static void doltliteMergeFunc(
     ** confirm is staled by intervening lock-cycling SQL (ANALYZE, etc.). */
     rc = doltliteRefreshAndConfirmHead(db, cs, &ourHead);
     if( rc==SQLITE_BUSY ){
-      sqlite3_result_error(context,
-        "merge conflict: another connection committed to this branch. Please retry your transaction.",
-        -1);
+      doltliteCmdResultPeerBranchBusy(context, "merge");
       doltliteRestoreTxnStateOnFailure(db, &savedState, rc);
       return;
     }

--- a/src/doltlite_rebase.c
+++ b/src/doltlite_rebase.c
@@ -1353,13 +1353,7 @@ static void doltliteRebaseFunc(
   }
 
   if( zArg0[0]=='-' ){
-    char *zErr = sqlite3_mprintf("unknown option `%s`", zArg0);
-    if( zErr ){
-      sqlite3_result_error(context, zErr, -1);
-      sqlite3_free(zErr);
-    }else{
-      sqlite3_result_error_nomem(context);
-    }
+    doltliteCmdResultUnknownOption(context, zArg0);
     goto rebase_cleanup;
   }
   if( argc!=1 ){

--- a/src/doltlite_remote_sql.c
+++ b/src/doltlite_remote_sql.c
@@ -253,13 +253,8 @@ static void doltPushFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
     if( zOpt && strcmp(zOpt, "--force")==0 ){
       bForce = 1;
     }else{
-      char *zErr = sqlite3_mprintf("unknown option `%s`", zOpt ? zOpt : "");
-      if( zErr ){
-        doltliteVcResultError(ctx, db, zErr);
-        sqlite3_free(zErr);
-      }else{
-        sqlite3_result_error_nomem(ctx);
-      }
+      (void)doltliteVcSealSavepointError(db);
+      doltliteCmdResultUnknownOption(ctx, zOpt);
       return;
     }
   }
@@ -584,11 +579,13 @@ static void doltPullFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   if( rc==SQLITE_OK ) rc = doltliteRemotePersistRefs(cs);
   chunkStoreUnlock(cs);
   if( rc!=SQLITE_OK ){
-    remoteSqlRestoreAndReport(ctx, db, cs, &savedState, rc,
-      rc==SQLITE_BUSY
-        ? "pull conflict: another connection committed to this branch. "
-          "Please retry."
-        : "failed to update branch");
+    if( rc==SQLITE_BUSY ){
+      doltliteCmdResultPeerBranchBusy(ctx, "pull");
+      (void)doltliteRestoreTxnStateOnFailure(db, &savedState, rc);
+    }else{
+      remoteSqlRestoreAndReport(ctx, db, cs, &savedState, rc,
+                                "failed to update branch");
+    }
     return;
   }
 

--- a/src/doltlite_reset.c
+++ b/src/doltlite_reset.c
@@ -351,9 +351,7 @@ static void doltliteResetFunc(
     if( strcmp(arg, "--hard")==0 ){ isHard = 1; }
     else if( strcmp(arg, "--soft")==0 ){ isSoft = 1; }
     else if( arg[0]=='-' ){
-      char *zErr = sqlite3_mprintf("unknown option `%s`", arg);
-      sqlite3_result_error(context, zErr ? zErr : "unknown option", -1);
-      sqlite3_free(zErr);
+      doltliteCmdResultUnknownOption(context, arg);
       sqlite3_free(azPaths);
       azPaths = 0;
       goto reset_cleanup;

--- a/src/doltlite_revert.c
+++ b/src/doltlite_revert.c
@@ -219,9 +219,7 @@ static void doltliteRevertFunc(
   doltliteCommitClear(&ourCommit);
 
   if( rc==SQLITE_BUSY ){
-    sqlite3_result_error(context,
-      "revert conflict: another connection committed to this branch. Please retry your transaction.",
-      -1);
+    doltliteCmdResultPeerBranchBusy(context, "revert");
     return;
   }
   if( rc!=SQLITE_OK ){

--- a/src/doltlite_tag.c
+++ b/src/doltlite_tag.c
@@ -86,20 +86,14 @@ static void doltTagFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
     const char *arg = (const char*)sqlite3_value_text(argv[i]);
     if( !arg ) continue;
     if( strcmp(arg, "-m")==0 || strcmp(arg, "--message")==0 ){
-      if( i+1<argc ) zMessage = (const char*)sqlite3_value_text(argv[++i]);
-      else{ doltliteVcResultError(ctx, db, "-m requires a message"); return; }
+      zMessage = doltliteCmdTakeValueArg(ctx, argc, argv, &i, "message");
+      if( !zMessage ){ tagSealSavepointError(ctx); return; }
     }else if( strcmp(arg, "--author")==0 ){
-      if( i+1<argc ) zAuthor = (const char*)sqlite3_value_text(argv[++i]);
-      else{ doltliteVcResultError(ctx, db, "--author requires 'name <email>'"); return; }
+      zAuthor = doltliteCmdTakeValueArg(ctx, argc, argv, &i, "author");
+      if( !zAuthor ){ tagSealSavepointError(ctx); return; }
     }else if( arg[0]=='-' ){
-      char *zErr = sqlite3_mprintf("unknown option `%s`", arg);
-      if( zErr ){
-        tagSealSavepointError(ctx);
-        sqlite3_result_error(ctx, zErr, -1);
-        sqlite3_free(zErr);
-      }else{
-        sqlite3_result_error_nomem(ctx);
-      }
+      tagSealSavepointError(ctx);
+      doltliteCmdResultUnknownOption(ctx, arg);
       return;
     }else if( !zCommitRef ){
       zCommitRef = arg;

--- a/tool/mksqlite3c.tcl
+++ b/tool/mksqlite3c.tcl
@@ -614,7 +614,7 @@ proc emit_doltlite_engine_block {} {
     prolly_btree.c prolly_btree_catalog.c prolly_btree_cursor.c
     prolly_btree_mutation.c prolly_btree_orig.c prolly_btree_state.c
     prolly_btree_txn.c pager_shim.c sortkey.c
-    doltlite.c doltlite_core.c doltlite_add.c doltlite_commit_cmd.c
+    doltlite.c doltlite_core.c doltlite_cmd.c doltlite_add.c doltlite_commit_cmd.c
     doltlite_reset.c doltlite_merge_cmd.c doltlite_cherry_pick.c
     doltlite_revert.c doltlite_rebase.c doltlite_config.c
     doltlite_commit.c doltlite_ref.c doltlite_log.c


### PR DESCRIPTION
## Summary

Add `doltlite_cmd.c` for the shared scaffolding every `dolt_*` SQL command was reimplementing:

- **Argv helpers** — unknown option, missing option value, take next text arg
- **Peer-branch BUSY** — one formatter for “another connection committed…”
- **VC txn outcomes** — `doltliteCmdFinishWithConflicts` / `…ConstraintViolations` (autocommit / plain / nested-savepoint)
- **Report/rollback helpers** — moved from `doltlite_core.c` (`ReportConflicts`, `ReportConstraintViolations`, `RollbackAutocommitConflict`, …)

Call sites updated: merge, cherry-pick/revert, commit, add, reset, rebase, tag, remote SQL. `bSealOnPlain` keeps existing seal-vs-leave-open behavior per command.

No intentional product behavior change beyond consolidating duplicate error paths.

## Test plan

- [x] `make doltlite`
- [x] `doltlite_merge.sh`, `doltlite_conflicts.sh`, `doltlite_cherry_pick.sh`, `doltlite_commit.sh`, `doltlite_reset.sh`, `doltlite_tag.sh`, `doltlite_staging.sh`, `doltlite_conflict_rows.sh`
- [ ] CI full suite