### PR TITLE
Adopt DOLTLITE_GROW_ARRAY in the remaining vtab row buffers

### DIFF
--- a/src/doltlite_commit_ancestors.c
+++ b/src/doltlite_commit_ancestors.c
@@ -148,17 +148,10 @@ static int caNext(sqlite3_vtab_cursor *pCursor){
 }
 
 static int caEnqueue(CommitAncestorsCursor *pCur, const ProllyHash *p){
+  int rc;
   if( prollyHashIsEmpty(p) ) return SQLITE_OK;
-  if( pCur->qTail >= pCur->qAlloc ){
-    i64 nNew = pCur->qAlloc ? (i64)pCur->qAlloc * 2 : (i64)16;
-    ProllyHash *tmp;
-    if( nNew > (i64)0x7fffffff/(i64)sizeof(ProllyHash) ) return SQLITE_NOMEM;
-    tmp = sqlite3_realloc(pCur->aQueue,
-                          (int)(nNew * (i64)sizeof(ProllyHash)));
-    if( !tmp ) return SQLITE_NOMEM;
-    pCur->aQueue = tmp;
-    pCur->qAlloc = (int)nNew;
-  }
+  rc = DOLTLITE_GROW_ARRAY(&pCur->aQueue, &pCur->qAlloc, pCur->qTail+1, 16);
+  if( rc!=SQLITE_OK ) return rc;
   pCur->aQueue[pCur->qTail++] = *p;
   return SQLITE_OK;
 }

--- a/src/doltlite_diff.c
+++ b/src/doltlite_diff.c
@@ -189,19 +189,13 @@ static int batchAppend(DoltliteDiffCursor *pCur,
                        const char *zTableName,
                        const DoltliteCommit *pCommit,
                        u8 dataChange, u8 schemaChange){
-  DiffSummaryRow *aNew, *r;
-  int nNew;
+  DiffSummaryRow *r;
+  int rc;
   if( pCur->zFilterTable && strcmp(pCur->zFilterTable, zTableName)!=0 ){
     return SQLITE_OK;
   }
-  if( pCur->nBatch>=pCur->nBatchAlloc ){
-    nNew = pCur->nBatchAlloc ? pCur->nBatchAlloc*2 : 16;
-    aNew = sqlite3_realloc(pCur->aBatch,
-                           nNew*(int)sizeof(DiffSummaryRow));
-    if( !aNew ) return SQLITE_NOMEM;
-    pCur->aBatch = aNew;
-    pCur->nBatchAlloc = nNew;
-  }
+  rc = DOLTLITE_GROW_ARRAY(&pCur->aBatch, &pCur->nBatchAlloc, pCur->nBatch+1, 16);
+  if( rc!=SQLITE_OK ) return rc;
   r = &pCur->aBatch[pCur->nBatch];
   memset(r, 0, sizeof(*r));
   memcpy(r->zCommitHex, zCommitHex, PROLLY_HASH_SIZE*2+1);

--- a/src/doltlite_patch.c
+++ b/src/doltlite_patch.c
@@ -90,15 +90,10 @@ static int patchAppendRow(
   const char *zSql
 ){
   PatchRow *p;
+  int rc;
   if( !zSql || !zSql[0] ) return SQLITE_OK;
-  if( pCur->nRow>=pCur->nAlloc ){
-    int nNew = pCur->nAlloc ? pCur->nAlloc*2 : 32;
-    PatchRow *aNew = sqlite3_realloc64(pCur->aRow,
-                                      (sqlite3_uint64)nNew*sizeof(PatchRow));
-    if( !aNew ) return SQLITE_NOMEM;
-    pCur->aRow = aNew;
-    pCur->nAlloc = nNew;
-  }
+  rc = DOLTLITE_GROW_ARRAY(&pCur->aRow, &pCur->nAlloc, pCur->nRow+1, 32);
+  if( rc!=SQLITE_OK ) return rc;
   p = &pCur->aRow[pCur->nRow];
   memset(p, 0, sizeof(*p));
   p->zTable = sqlite3_mprintf("%s", zTable ? zTable : "");

--- a/src/doltlite_schema_diff.c
+++ b/src/doltlite_schema_diff.c
@@ -60,24 +60,17 @@ static int appendSchemaEntry(
   char *zType,
   Pgno iRootpage
 ){
-  SchemaEntry *aEntries = *paEntries;
+  SchemaEntry *aEntries;
   int nEntries = *pnEntries;
-  int nAlloc = *pnAlloc;
-  if( nEntries >= nAlloc ){
-    int nNew = nAlloc ? nAlloc*2 : 16;
-    SchemaEntry *aNew = sqlite3_realloc(aEntries, nNew*(int)sizeof(SchemaEntry));
-    if( !aNew ) return SQLITE_NOMEM;
-    aEntries = aNew;
-    nAlloc = nNew;
-  }
+  int rc = DOLTLITE_GROW_ARRAY(paEntries, pnAlloc, nEntries+1, 16);
+  if( rc!=SQLITE_OK ) return rc;
+  aEntries = *paEntries;
   aEntries[nEntries].zName = zName;
   aEntries[nEntries].zTblName = zTblName;
   aEntries[nEntries].zSql = zSql;
   aEntries[nEntries].zType = zType;
   aEntries[nEntries].iRootpage = iRootpage;
-  *paEntries = aEntries;
   *pnEntries = nEntries + 1;
-  *pnAlloc = nAlloc;
   return SQLITE_OK;
 }
 
@@ -89,13 +82,8 @@ static int appendSchemaDiffRow(
   const char *zToSql
 ){
   SchemaDiffRow *r;
-  if( pCur->nRows >= pCur->nAlloc ){
-    int nNew = pCur->nAlloc ? pCur->nAlloc*2 : 16;
-    SchemaDiffRow *aNew = sqlite3_realloc(pCur->aRows, nNew*(int)sizeof(SchemaDiffRow));
-    if( !aNew ) return SQLITE_NOMEM;
-    pCur->aRows = aNew;
-    pCur->nAlloc = nNew;
-  }
+  int rc = DOLTLITE_GROW_ARRAY(&pCur->aRows, &pCur->nAlloc, pCur->nRows+1, 16);
+  if( rc!=SQLITE_OK ) return rc;
   r = &pCur->aRows[pCur->nRows];
   memset(r, 0, sizeof(*r));
   r->zFromName = sqlite3_mprintf("%s", zFromName ? zFromName : "");

--- a/src/doltlite_status.c
+++ b/src/doltlite_status.c
@@ -170,16 +170,9 @@ static int statusTableName(sqlite3 *db, const struct TableEntry *pEntry, char **
 
 static int addRow(DoltliteStatusCursor *pCur, const char *zName,
                   int staged, const char *zStatus){
-  StatusRow *aNew;
   StatusRow *pRow;
-  int nNew;
-  if( pCur->nRows>=pCur->nRowsAlloc ){
-    nNew = pCur->nRowsAlloc ? pCur->nRowsAlloc*2 : 16;
-    aNew = sqlite3_realloc(pCur->aRows, nNew*(int)sizeof(StatusRow));
-    if( !aNew ) return SQLITE_NOMEM;
-    pCur->aRows = aNew;
-    pCur->nRowsAlloc = nNew;
-  }
+  int rc = DOLTLITE_GROW_ARRAY(&pCur->aRows, &pCur->nRowsAlloc, pCur->nRows+1, 16);
+  if( rc!=SQLITE_OK ) return rc;
   pRow = &pCur->aRows[pCur->nRows];
   pRow->zName = sqlite3_mprintf("%s", zName);
   if( !pRow->zName ) return SQLITE_NOMEM;


### PR DESCRIPTION
## What

Follow-up to the cursor-dedup PR, sweeping the virtual-table row-buffer scaffolding flagged in the code review.

The reconnaissance turned up that the proposed grow helper **already exists** — `DOLTLITE_GROW_ARRAY` / `doltliteGrowArrayImpl` in `doltlite_internal.h` (already used by `doltlite_blame.c`, `doltlite_merge_rows.c`, `doltlite_merge_schema.c`, `doltlite_remote.c`). Six call sites still hand-rolled the same `*2`-doubling `sqlite3_realloc` loop:

| file | buffer |
|---|---|
| `doltlite_status.c` | `dolt_status` rows |
| `doltlite_patch.c` | `dolt_patch` rows |
| `doltlite_diff.c` | `dolt_diff` batch rows |
| `doltlite_schema_diff.c` | `dolt_schema_diff` rows **and** the internal `SchemaEntry[]` |
| `doltlite_commit_ancestors.c` | `dolt_commit_ancestors` BFS queue |

Each is replaced with the shared helper. **Net −37 lines.**

## Why it's also a small correctness win

The `status`, `diff`, and `schema_diff` loops computed `nNew*sizeof(elem)` with **no integer-overflow guard**. `DOLTLITE_GROW_ARRAY` always applies the `i64`-clamped guard, so those sites are now overflow-safe. Behavior is identical for all reachable counts (the helper only *adds* a guard and caps at `INT_MAX`, which the `int` counters already bound).

## Deliberately NOT swept

The review also mentioned the `xConnect`/`xBestIndex`/`xEof`/`xNext`/`xRowid` boilerplate. Those are **not** safely shareable and are left alone:
- `xEof`/`xNext`/`xRowid` receive only an opaque `sqlite3_vtab_cursor*`, and each cursor is a distinct struct — sharing them needs a common cursor-prefix struct or a codegen macro, not a drop-in function.
- The materialize-all vtabs' `xBestIndex` bodies consume constraints (EQ-omit / PK-range); some rowids are non-standard (`iRow+1`, FNV content hash).

Consolidating those adds real risk without a correctness benefit, so this PR stays scoped to the mechanical grow-loop adoption.

## Testing

- Clean build under `-Wdeclaration-after-statement`.
- Manually exercised all five surfaces (`dolt_status`, `dolt_patch`, `dolt_diff`, `dolt_schema_diff`, `dolt_commit_ancestors`) — correct output.
- Native suites: `doltlite_schema_diff.sh` 49/0, `doltlite_diff_table.sh` 41/0.
- Oracle suites vs real Dolt: `status` 40/0, `patch` 76/0, `diff` 67/0, `schema_diff` 60/0, `commit_ancestors` 9/0.
- One pre-existing native failure (`doltlite_diff.sh: diff_summary_no_such_table`) reproduces identically on clean master without this change, so it is unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)