### PR TITLE
Add macOS ASan/UBSan sanitizer job

### DIFF
--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -137,6 +137,89 @@ jobs:
           libdoltlite.a -lz -lpthread -lm
         ./doltlite_regression_test_c all
 
+  # Same ASan/UBSan coverage as the Linux job above, but on macOS/arm64 to
+  # catch platform-specific undefined behavior and memory bugs the Linux x86
+  # job can't. Apple's ASan has no leak detector, so detect_leaks/LSan is
+  # dropped here; the Linux job retains leak coverage. Dolt-dependent oracles
+  # are omitted (no macOS Dolt install) — the stock-SQLite oracles, native VC
+  # suites, and the C corpus exercise the same C paths under the sanitizers.
+  asan-ubsan-macos:
+    runs-on: macos-latest
+    timeout-minutes: 60
+
+    env:
+      ASAN_CFLAGS: -O1 -g -fsanitize=address,undefined -fno-omit-frame-pointer -fno-sanitize-recover=all
+      ASAN_OPTIONS: abort_on_error=1:halt_on_error=1:print_stacktrace=1
+      UBSAN_OPTIONS: abort_on_error=1:halt_on_error=1:print_stacktrace=1
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install dependencies
+      run: brew install tcl-tk
+
+    - name: Configure
+      run: |
+        mkdir -p build && cd build
+        export PATH="$(brew --prefix tcl-tk)/bin:$PATH"
+        ../configure
+
+    - name: Build with ASan/UBSan
+      run: |
+        cd build
+        make \
+          CFLAGS="$ASAN_CFLAGS" \
+          LDFLAGS="-fsanitize=address,undefined" \
+          doltlite
+        make DOLTLITE_PROLLY=0 sqlite3
+
+    - name: SQL oracle tests (vs stock SQLite)
+      run: |
+        cd build
+        bash ../test/sql_oracle_test.sh ./doltlite ./sqlite3 || exit 1
+        for f in ../test/oracle_*_test.sh; do
+          [ "$(basename "$f")" = "oracle_import_test.sh" ] && continue
+          echo "--- $(basename "$f") ---"
+          bash "$f" ./doltlite ./sqlite3 || exit 1
+        done
+      timeout-minutes: 20
+
+    - name: Correctness regression tests
+      run: cd build && bash ../test/correctness_test.sh ./doltlite
+
+    - name: VC virtual-table read suites
+      run: |
+        cd build
+        for s in doltlite_at doltlite_history doltlite_diff doltlite_diff_table \
+                 doltlite_diff_table_range \
+                 doltlite_schema_diff doltlite_workspace doltlite_conflicts \
+                 doltlite_conflict_rows doltlite_comparison doltlite_merge; do
+          echo "=== $s ==="
+          bash ../test/$s.sh ./doltlite || exit 1
+        done
+
+    - name: VC ref-mutation + remote suites
+      run: |
+        cd build
+        for s in doltlite_branch doltlite_default_branch doltlite_tag \
+                 doltlite_gc remote_test; do
+          echo "=== $s ==="
+          bash ../test/$s.sh ./doltlite || exit 1
+        done
+
+    - name: C regression corpus (ASan/UBSan)
+      run: |
+        cd build
+        make \
+          CFLAGS="$ASAN_CFLAGS" \
+          LDFLAGS="-fsanitize=address,undefined" \
+          libdoltlite.a
+        cc $ASAN_CFLAGS \
+          -I. -I../src \
+          -o doltlite_regression_test_c ../test/doltlite_regression_test_c.c \
+          libdoltlite.a -lz -lpthread -lm
+        ./doltlite_regression_test_c all
+
   tsan:
     runs-on: ubuntu-latest
     timeout-minutes: 30


### PR DESCRIPTION
## What

Adds an `asan-ubsan-macos` job to `sanitizers.yml`, mirroring the existing Linux `asan-ubsan` job on `macos-latest`. Addresses the review finding that dynamic analysis (ASan/UBSan/TSan) ran **only on Linux x86**, leaving macOS/arm64-specific UB and memory bugs uncovered.

## macOS adaptations vs the Linux job
- **No leak detector.** Apple's ASan has no LSan, so `detect_leaks` and the LSan suppressions file are dropped. The Linux job keeps full leak coverage.
- **No Dolt dependency.** There's no macOS Dolt install, so the Dolt-only oracle steps (`oracle_import`, the `vc_oracle_*` sweep) are omitted. Coverage comes from the stock-SQLite oracles, the native VC read / ref-mutation / remote suites, and the ~310k-check C regression corpus — all of which drive the same C paths under the sanitizers.

## Validated locally on macOS/arm64 before opening

The ASan/UBSan build is clean, and **every step the job runs passes**:
- Build with `-fsanitize=address,undefined -fno-sanitize-recover=all`: clean (only a pre-existing `sprintf` deprecation in upstream shell code).
- SQL oracle vs stock SQLite: **559/0**; targeted oracles green.
- Correctness suite: 44/0.
- VC read-vtab suites (`diff`/`at`/`history`/`diff_table`/`schema_diff`/`workspace`/`conflicts`/`merge`/…): all 0 failed.
- VC ref-mutation + remote (`branch`/`tag`/`gc`/`remote_test`/…): all 0 failed.
- C regression corpus under ASan/UBSan: **309,956 / 0**.

No sanitizer abort was triggered anywhere, so the job should be green on first run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)