### PR TITLE
Reject empty sourced feature-oracle suite

### DIFF
--- a/test/vc_oracle_feature_interaction_test.sh
+++ b/test/vc_oracle_feature_interaction_test.sh
@@ -58,6 +58,10 @@ done
 
 echo ""
 echo "=== Results: $pass passed, $fail failed ==="
+if [ $((pass + fail)) -eq 0 ]; then
+  echo "ERROR: no oracle cases executed (sourced feature suite is empty or missing)"
+  exit 1
+fi
 if [ "$fail" -gt 0 ]; then
   echo "Failures:$FAILED_NAMES"
   exit 1


### PR DESCRIPTION
## Summary
- Fail `test/vc_oracle_feature_interaction_test.sh` when zero oracle cases run (`pass + fail == 0`).
- Prevents empty or missing sourced family fragments from reporting success with `0 passed, 0 failed` and exit 0.

## Background
Found while testing #1781: emptying the five family sources left the runner at `0 passed, 0 failed` with exit 0 because the only failure gate was `$fail -gt 0`. The both-empty guard in `vc_oracle_common.sh` only applies when an oracle call actually runs.

## Test plan
- [x] Reproduced: empty family files → `0 passed, 0 failed`, exit 0 (before fix)
- [x] After fix: empty family files → error message + exit 1
- [x] Family files restored; guard does not trip when any cases execute