### PR TITLE
Resolve WORKING/STAGED in dolt_schema_diff

### DIFF
--- a/src/doltlite_schema_diff.c
+++ b/src/doltlite_schema_diff.c
@@ -733,22 +733,11 @@ static int sdResolveOne(
   const char *zWhich,
   ProllyHash *pCatHash
 ){
-  ProllyHash commitHash;
-  int rc;
-
-  rc = doltliteResolveRef(db, zRef, &commitHash);
+  int rc = doltliteResolveCatalogHashForRef(db, zRef, pCatHash);
   if( rc!=SQLITE_OK ){
     sqlite3_free(pVtab->zErrMsg);
     pVtab->zErrMsg = sqlite3_mprintf(
       "dolt_schema_diff: %s '%s' could not be resolved", zWhich, zRef);
-    return SQLITE_ERROR;
-  }
-  rc = doltliteCommitCatalogHash(db, &commitHash, pCatHash);
-  if( rc!=SQLITE_OK ){
-    sqlite3_free(pVtab->zErrMsg);
-    pVtab->zErrMsg = sqlite3_mprintf(
-      "dolt_schema_diff: %s '%s' resolved to a hash but the "
-      "commit could not be loaded", zWhich, zRef);
     return SQLITE_ERROR;
   }
   return SQLITE_OK;
@@ -829,8 +818,8 @@ static int sdParseArgs(
         return SQLITE_NOMEM;
       }
 
-      rc = doltliteResolveRef(db, zRangeFrom, &probe);
-      if( rc==SQLITE_OK ) rc = doltliteResolveRef(db, zRangeTo, &probe);
+      rc = doltliteResolveCatalogHashForRef(db, zRangeFrom, &probe);
+      if( rc==SQLITE_OK ) rc = doltliteResolveCatalogHashForRef(db, zRangeTo, &probe);
       if( rc!=SQLITE_OK ){
         sqlite3_free(zRangeFrom);
         sqlite3_free(zRangeTo);

--- a/src/doltlite_schema_diff.c
+++ b/src/doltlite_schema_diff.c
@@ -819,11 +819,22 @@ static int sdParseArgs(
       }
 
       rc = doltliteResolveCatalogHashForRef(db, zRangeFrom, &probe);
-      if( rc==SQLITE_OK ) rc = doltliteResolveCatalogHashForRef(db, zRangeTo, &probe);
+      if( rc==SQLITE_OK ){
+        rc = doltliteResolveCatalogHashForRef(db, zRangeTo, &probe);
+        if( rc!=SQLITE_OK ){
+          sqlite3_free(pVtab->zErrMsg);
+          pVtab->zErrMsg = sqlite3_mprintf(
+            "dolt_schema_diff: to_ref '%s' could not be resolved", zRangeTo);
+        }
+      }else{
+        sqlite3_free(pVtab->zErrMsg);
+        pVtab->zErrMsg = sqlite3_mprintf(
+          "dolt_schema_diff: from_ref '%s' could not be resolved", zRangeFrom);
+      }
       if( rc!=SQLITE_OK ){
         sqlite3_free(zRangeFrom);
         sqlite3_free(zRangeTo);
-        return rc;
+        return SQLITE_ERROR;
       }
 
       zFromRef = zRangeFrom;

--- a/test/doltlite_schema_diff.sh
+++ b/test/doltlite_schema_diff.sh
@@ -386,4 +386,26 @@ run_test_match "rebase_replay_u_to_stmt" \
 
 rm -f "$DB"
 
+# WORKING / STAGED pseudo-refs must resolve like the other dolt_* surfaces.
+# Before the catalog-aware resolver fix, schema_diff only accepted commit refs,
+# so HEAD/WORKING (and HEAD..WORKING, HEAD/STAGED) errored with
+# "to_ref 'WORKING' could not be resolved".
+DB=/tmp/test_sd_working_$$.db; rm -f "$DB"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'a');
+SELECT dolt_commit('-A','-m','c1');" | $DOLTLITE "$DB" > /dev/null 2>&1
+echo "CREATE TABLE w(id INTEGER PRIMARY KEY, x TEXT);" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+run_test "working_count" "SELECT count(*) FROM dolt_schema_diff('HEAD','WORKING');" "1" "$DB"
+run_test "working_to_name" "SELECT to_table_name FROM dolt_schema_diff('HEAD','WORKING');" "w" "$DB"
+run_test "working_from_empty" "SELECT length(from_table_name) FROM dolt_schema_diff('HEAD','WORKING');" "0" "$DB"
+run_test "working_range_count" "SELECT count(*) FROM dolt_schema_diff('HEAD..WORKING');" "1" "$DB"
+run_test "working_self_empty" "SELECT count(*) FROM dolt_schema_diff('WORKING','WORKING');" "0" "$DB"
+
+echo "SELECT dolt_add('-A');" | $DOLTLITE "$DB" > /dev/null 2>&1
+run_test "staged_count" "SELECT count(*) FROM dolt_schema_diff('HEAD','STAGED');" "1" "$DB"
+run_test "staged_to_name" "SELECT to_table_name FROM dolt_schema_diff('HEAD','STAGED');" "w" "$DB"
+
+rm -f "$DB"
+
 dltest_finish

--- a/test/doltlite_schema_diff.sh
+++ b/test/doltlite_schema_diff.sh
@@ -61,6 +61,14 @@ run_test_match "bad_to_ref_errors" \
 run_test_match "bad_single_arg_errors" \
   "SELECT count(*) FROM dolt_schema_diff('definitely_not_a_ref');" \
   "Error" "$DB"
+# A malformed range endpoint must name the unresolvable ref, not emit a
+# generic error, matching the two-arg form.
+run_test_match "bad_range_from_names_endpoint" \
+  "SELECT count(*) FROM dolt_schema_diff('does-not-exist..HEAD');" \
+  "from_ref 'does-not-exist' could not be resolved" "$DB"
+run_test_match "bad_range_to_names_endpoint" \
+  "SELECT count(*) FROM dolt_schema_diff('HEAD..does-not-exist');" \
+  "to_ref 'does-not-exist' could not be resolved" "$DB"
 
 rm -f "$DB"
 

--- a/test/vc_oracle_schema_diff_test.sh
+++ b/test/vc_oracle_schema_diff_test.sh
@@ -906,6 +906,35 @@ filter_check() {
 filter_check "filter_by_index_name" "idx" "ROW|~|idx"
 filter_check "filter_by_owning_table" "t" ""
 
+echo "--- WORKING / STAGED pseudo-refs ---"
+
+oracle "working_added_table" "
+$SEED
+CREATE TABLE u(id INTEGER PRIMARY KEY, x TEXT);
+" "HEAD" "WORKING"
+
+oracle "working_dropped_table" "
+$SEED
+DROP TABLE t;
+" "HEAD" "WORKING"
+
+oracle "working_no_change" "
+$SEED
+" "HEAD" "WORKING" "" "EXPECT_EMPTY"
+
+oracle "staged_added_table" "
+$SEED
+CREATE TABLE u(id INTEGER PRIMARY KEY, x TEXT);
+SELECT dolt_add('-A');
+" "HEAD" "STAGED"
+
+oracle "staged_to_working" "
+$SEED
+CREATE TABLE u(id INTEGER PRIMARY KEY, x TEXT);
+SELECT dolt_add('-A');
+CREATE TABLE w2(id INTEGER PRIMARY KEY);
+" "STAGED" "WORKING"
+
 echo ""
 echo "=== Results: $pass passed, $fail failed ==="
 if [ $fail -gt 0 ]; then


### PR DESCRIPTION
## Bug (found by Ito QA on #1781, but pre-existing on master)

`dolt_schema_diff('HEAD','WORKING')` errored with `dolt_schema_diff: to_ref 'WORKING' could not be resolved`, even though the per-table diff surfaces (`dolt_diff_<t>('HEAD','WORKING')`) accept those pseudo-refs. Confirmed on clean master (independent of #1781).

## Cause

`sdResolveOne` resolved every endpoint with `doltliteResolveRef` (commit-refs only) + `doltliteCommitCatalogHash`. The range (`..`) path's validation probe did the same. Neither understands `WORKING`/`STAGED`.

## Fix

Route both the endpoint resolver and the range probe through `doltliteResolveCatalogHashForRef` — the shared catalog-aware resolver that handles `HEAD`/`WORKING`/`STAGED` and commit refs (AGENTS.md names it as *the* resolver for these). Also collapses the two-step resolve-then-load-catalog into one call (−14 lines in source).

## Testing (fail-before / pass-after)

Added 7 WORKING/STAGED cases to `test/doltlite_schema_diff.sh` (two-arg, `HEAD..WORKING` range, `WORKING`/`WORKING` self, and `HEAD`/`STAGED`):
- **Before** (unfixed engine): all 7 fail (`49 passed, 7 failed`).
- **After**: `56 passed, 0 failed`.
- Oracle vs real Dolt unchanged: `60 passed, 0 failed`.
- Clean build under `-Werror`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)