### PR TITLE
Split pull request CI into build and test phases

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,7 +1,7 @@
 name: Benchmark
 
 on:
-  pull_request:
+  workflow_call:
 
 permissions:
   contents: read
@@ -19,28 +19,13 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Install dependencies
-      run: |
-        bash .github/scripts/install-apt-deps.sh tcl-dev build-essential zlib1g-dev
+    - name: Download optimized build
+      uses: actions/download-artifact@v4
+      with:
+        name: benchmark-build
 
-    - name: Configure
-      run: |
-        mkdir -p build && cd build
-        TCL_CONFIG=$(find /usr/lib -name tclConfig.sh -print -quit 2>/dev/null)
-        if [ -n "$TCL_CONFIG" ]; then
-          ../configure --with-tcl=$(dirname $TCL_CONFIG)
-        else
-          ../configure
-        fi
-
-    - name: Build doltlite and stock SQLite
-      run: |
-        cd build
-        make doltlite
-        make doltlite-lib
-        cc -O2 -I. -I../src -o bench_timer_doltlite ../test/sysbench_timer.c libdoltlite.a -lpthread -lz -lm
-        make DOLTLITE_PROLLY=0 sqlite3 sqlite3.o
-        cc -O2 -I. -I../src -o bench_timer_sqlite ../test/sysbench_timer.c sqlite3.o -lpthread -lz -lm
+    - name: Extract optimized build
+      run: tar -xzf benchmark-build.tar.gz
 
     - name: Run benchmark
       id: bench
@@ -140,28 +125,13 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Install dependencies
-      run: |
-        bash .github/scripts/install-apt-deps.sh tcl-dev build-essential zlib1g-dev
+    - name: Download optimized build
+      uses: actions/download-artifact@v4
+      with:
+        name: benchmark-build
 
-    - name: Configure
-      run: |
-        mkdir -p build && cd build
-        TCL_CONFIG=$(find /usr/lib -name tclConfig.sh -print -quit 2>/dev/null)
-        if [ -n "$TCL_CONFIG" ]; then
-          ../configure --with-tcl=$(dirname $TCL_CONFIG)
-        else
-          ../configure
-        fi
-
-    - name: Build doltlite and stock SQLite
-      run: |
-        cd build
-        make doltlite
-        make doltlite-lib
-        cc -O2 -I. -I../src -o bench_timer_doltlite ../test/sysbench_timer.c libdoltlite.a -lpthread -lz -lm
-        make DOLTLITE_PROLLY=0 sqlite3 sqlite3.o
-        cc -O2 -I. -I../src -o bench_timer_sqlite ../test/sysbench_timer.c sqlite3.o -lpthread -lz -lm
+    - name: Extract optimized build
+      run: tar -xzf benchmark-build.tar.gz
 
     - name: Run benchmark
       id: bench
@@ -235,24 +205,13 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Install dependencies
-      run: |
-        bash .github/scripts/install-apt-deps.sh tcl-dev build-essential zlib1g-dev
+    - name: Download optimized build
+      uses: actions/download-artifact@v4
+      with:
+        name: benchmark-build
 
-    - name: Configure
-      run: |
-        mkdir -p build && cd build
-        TCL_CONFIG=$(find /usr/lib -name tclConfig.sh -print -quit 2>/dev/null)
-        if [ -n "$TCL_CONFIG" ]; then
-          ../configure --with-tcl=$(dirname $TCL_CONFIG)
-        else
-          ../configure
-        fi
-
-    - name: Build doltlite
-      run: |
-        cd build
-        make doltlite
+    - name: Extract optimized build
+      run: tar -xzf benchmark-build.tar.gz
 
     - name: Run version-control performance benchmarks
       id: bench

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,76 +1,23 @@
 name: Build-Test
 
 on:
-  pull_request:
-  workflow_dispatch:
+  workflow_call:
 
 jobs:
   wasm:
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    env:
-      EMSDK_VERSION: 3.1.74
-      WABT_VERSION: 1.0.36
 
     steps:
     - uses: actions/checkout@v4
 
-    - name: Cache Emscripten SDK
-      uses: actions/cache@v4
+    - name: Download wasm build
+      uses: actions/download-artifact@v4
       with:
-        path: ${{ runner.tool_cache }}/emsdk
-        key: emsdk-${{ runner.os }}-${{ env.EMSDK_VERSION }}
+        name: ci-wasm-build
 
-    - name: Install Emscripten SDK
-      run: |
-        EMSDK_DIR="${RUNNER_TOOL_CACHE}/emsdk"
-        if [ ! -d "$EMSDK_DIR/.git" ]; then
-          rm -rf "$EMSDK_DIR"
-          git clone https://github.com/emscripten-core/emsdk.git "$EMSDK_DIR"
-        fi
-        cd "$EMSDK_DIR"
-        git fetch --tags --quiet
-        ./emsdk install "$EMSDK_VERSION"
-        ./emsdk activate "$EMSDK_VERSION"
-        echo "EMSDK=$EMSDK_DIR" >> "$GITHUB_ENV"
-
-    - name: Cache WABT
-      uses: actions/cache@v4
-      with:
-        path: ${{ runner.tool_cache }}/wabt-${{ env.WABT_VERSION }}
-        key: wabt-${{ runner.os }}-${{ env.WABT_VERSION }}
-
-    - name: Install WABT
-      run: |
-        WABT_DIR="${RUNNER_TOOL_CACHE}/wabt-${WABT_VERSION}"
-        if [ ! -x "$WABT_DIR/bin/wasm-strip" ]; then
-          rm -rf "$WABT_DIR"
-          mkdir -p "$WABT_DIR"
-          curl -fsSL "https://github.com/WebAssembly/wabt/releases/download/${WABT_VERSION}/wabt-${WABT_VERSION}-ubuntu-20.04.tar.gz" \
-            | tar -xz --strip-components=1 -C "$WABT_DIR"
-        fi
-        echo "$WABT_DIR/bin" >> "$GITHUB_PATH"
-
-    - name: Configure
-      run: |
-        source "$EMSDK/emsdk_env.sh"
-        ./configure
-
-    - name: Build generated SQLite files
-      run: |
-        make sqlite3.c sqlite3.h sqlite3ext.h
-
-    - name: Build native DoltLite
-      run: |
-        mkdir -p build
-        cd build
-        ../configure
-        make doltlite
-
-    - name: Build DoltLite wasm targets
-      run: |
-        source "$EMSDK/emsdk_env.sh"
-        make -C ext/wasm fiddle npm
+    - name: Extract wasm build
+      run: tar -xzf ci-wasm-build.tar.gz
 
     - name: Smoke test DoltLite wasm runtime
       run: |
@@ -89,11 +36,6 @@ jobs:
         chmod +x packaging/npm/assemble.sh packaging/npm/test-package.sh
         bash packaging/npm/test-package.sh
 
-    - name: Build wasm distribution zip
-      run: |
-        source "$EMSDK/emsdk_env.sh"
-        make -C ext/wasm dist
-
     - name: Upload wasm artifacts
       uses: actions/upload-artifact@v4
       with:
@@ -102,50 +44,30 @@ jobs:
           ext/wasm/jswasm/*
           ext/wasm/sqlite-wasm-*.zip
 
-  development-builds:
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    env:
-      CFLAGS: -O2 -g -Werror
-
-    steps:
-    - uses: actions/checkout@v4
-
-    - name: Install dependencies
-      run: bash .github/scripts/install-apt-deps.sh tcl-dev build-essential zlib1g-dev
-
-    - name: Configure
-      run: |
-        mkdir -p build && cd build
-        TCL_CONFIG=$(find /usr/lib -name tclConfig.sh -print -quit 2>/dev/null)
-        if [ -n "$TCL_CONFIG" ]; then
-          ../configure --with-tcl=$(dirname $TCL_CONFIG)
-        else
-          ../configure
-        fi
-
-    - name: Build development test configurations
-      run: |
-        cd build
-        make DOLTLITE_PROLLY=1 testfixture
-        ./testfixture ../test/testrunner.tcl --buildonly --jobs 2 mdevtest
-
   build-and-test:
     name: ${{ matrix.platform }}
     runs-on: ${{ matrix.runs-on }}
     timeout-minutes: 20
     env:
       CFLAGS: -O2 -g -Werror
+      DOLTLITE_AMALG_HTTP_PROBE: ${{ github.workspace }}/build/amalgamation_http_probe${{ matrix.exe }}
+      DOLTLITE_BLAKE3_KAT_BIN: ${{ github.workspace }}/build/blake3_kat${{ matrix.exe }}
+      DOLTLITE_CREDS_KAT_BIN: ${{ github.workspace }}/build/creds_kat${{ matrix.exe }}
+      DOLTLITE_CREDS_VERIFY_BIN: ${{ github.workspace }}/build/creds_verify_kat${{ matrix.exe }}
+      DOLTLITE_TLS_TEST_BIN: ${{ github.workspace }}/build/tls_test${{ matrix.exe }}
     strategy:
       fail-fast: false
       matrix:
         include:
           - platform: ubuntu
             runs-on: ubuntu-latest
+            exe: ''
           - platform: windows
             runs-on: windows-latest
+            exe: .exe
           - platform: macos
             runs-on: macos-latest
+            exe: ''
 
     steps:
     - uses: actions/checkout@v4
@@ -164,7 +86,7 @@ jobs:
 
     - name: Install dependencies (macOS)
       if: matrix.platform == 'macos'
-      run: brew install tcl-tk ripgrep
+      run: brew install ripgrep
 
     - name: Install Dolt
       if: matrix.platform == 'ubuntu'
@@ -173,65 +95,19 @@ jobs:
           | sudo tar -xz -C /usr/local --strip-components=1
         dolt version
 
-    - name: Configure
-      if: matrix.platform == 'ubuntu'
-      run: |
-        mkdir -p build && cd build
-        TCL_CONFIG=$(find /usr/lib -name tclConfig.sh -print -quit 2>/dev/null)
-        if [ -n "$TCL_CONFIG" ]; then
-          ../configure --with-tcl=$(dirname $TCL_CONFIG)
-        else
-          ../configure
-        fi
+    - name: Download checked build
+      uses: actions/download-artifact@v4
+      with:
+        name: checked-build-${{ matrix.platform }}
 
-    - name: Configure Windows
+    - name: Extract checked build
+      if: matrix.platform != 'windows'
+      run: tar -xzf checked-build-${{ matrix.platform }}.tar.gz
+
+    - name: Extract checked Windows build
       if: matrix.platform == 'windows'
       shell: msys2 {0}
-      run: |
-        mkdir -p build && cd build
-        ../configure
-
-    - name: Configure (macOS)
-      if: matrix.platform == 'macos'
-      run: |
-        mkdir -p build && cd build
-        export PATH="$(brew --prefix tcl-tk)/bin:$PATH"
-        ../configure
-
-    - name: Build
-      if: matrix.platform != 'windows'
-      run: |
-        cd build
-        set -o pipefail
-        {
-          make DOLTLITE_PROLLY_CHECK=1 doltlite
-          make DOLTLITE_PROLLY_CHECK=1 doltlite-remotesrv
-          make DOLTLITE_PROLLY_CHECK=1 doltlite-lib
-          # doltlite_parity.sh compares against the package-built stock
-          # SQLite CLI instead of whatever sqlite3 the runner image provides.
-          make DOLTLITE_PROLLY=0 sqlite3
-          # Stock SQLite lib for concurrent_branch_test
-          make libsqlite3.a USE_AMALGAMATION=0
-        } 2>&1 | tee build.log
-        DOLTLITE_CHECK_AMALGAMATION=0 bash ../test/assert_doltlite_artifacts.sh .
-        if grep -E "warning:" build.log; then
-          echo "::error::compiler warnings in the build (see above); the build must be warning-free"
-          exit 1
-        fi
-
-    - name: Build Windows
-      if: matrix.platform == 'windows'
-      shell: msys2 {0}
-      run: |
-        cd build
-        make -j$(nproc) DOLTLITE_PROLLY_CHECK=1 doltlite.exe doltlite-remotesrv.exe doltlite-lib
-        DOLTLITE_CHECK_AMALGAMATION=0 DOLTLITE_CHECK_SHARED=0 bash ../test/assert_doltlite_artifacts.sh .
-        cp -f "$(command -v sqlite3)" sqlite3
-
-    - name: Lint
-      if: matrix.platform != 'windows'
-      run: cd build && make lint
-      timeout-minutes: 1
+      run: tar -xzf checked-build-windows.tar.gz
 
     - name: Basic smoke tests
       if: matrix.platform != 'windows'
@@ -426,7 +302,6 @@ jobs:
         bash ../test/remotesrv_stall_test.sh ./doltlite.exe ./doltlite-remotesrv.exe
         bash ../test/remotesrv_http_partial_failure_test.sh ./doltlite.exe ./doltlite-remotesrv.exe
         bash ../test/remotesrv_http_force_push_test.sh ./doltlite.exe ./doltlite-remotesrv.exe
-        make DOLTLITE_PROLLY=1 DOLTLITE_PROLLY_CHECK=1 sqlite3.c sqlite3.h
         bash ../test/amalgamation_windows_source_test.sh ./sqlite3.c
         REMOTESRV=./doltlite-remotesrv.exe bash ../test/amalgamation_http_remote_test.sh .
       timeout-minutes: 20
@@ -483,8 +358,6 @@ jobs:
       if: matrix.platform != 'windows'
       run: |
         cd build
-        rm -f sqlite3.c .target_source
-        make DOLTLITE_PROLLY=1 DOLTLITE_PROLLY_CHECK=1 sqlite3.c sqlite3.h
         bash ../test/amalgamation_http_remote_test.sh .
       timeout-minutes: 5
 
@@ -494,29 +367,19 @@ jobs:
       if: matrix.platform != 'windows'
       run: |
         cd build
-        # Quickstart
-        gcc $CFLAGS -o quickstart ../examples/quickstart.c -I. libdoltlite.a -lpthread -lz -lm
         ./quickstart
-        # Concurrent branch test
-        cc $CFLAGS -g -O0 -I. -I../src -DDOLTLITE_PROLLY=1 -D_HAVE_SQLITE_CONFIG_H -DBUILD_sqlite \
-          -o concurrent_branch_test ../test/concurrent_branch_test.c \
-          libsqlite3.a -lz -lpthread -lm
         ./concurrent_branch_test
 
     - name: Concurrent write test
       if: matrix.platform != 'windows'
       run: |
         cd build
-        gcc $CFLAGS -g -O0 -I. -o concurrent_write_test ../test/concurrent_write_test.c \
-          libdoltlite.a -lz -lpthread -lm
         ./concurrent_write_test
 
     - name: Native crash recovery test
       if: matrix.platform == 'ubuntu'
       run: |
         cd build
-        cc $CFLAGS -I. -o crash_recovery_test ../test/crash_recovery_test.c \
-          libdoltlite.a -lz -lpthread -lm
         ./crash_recovery_test
       timeout-minutes: 10
 
@@ -524,13 +387,13 @@ jobs:
       if: matrix.platform == 'macos'
       run: |
         cd build
-        gcc $CFLAGS -g -O0 -I. -o prepared_stmt_reuse_test ../test/prepared_stmt_reuse_test.c \
-          libdoltlite.a -lz -lpthread -lm
         ./prepared_stmt_reuse_test
 
     - name: Windows native C regression tests
       if: matrix.platform == 'windows'
       shell: msys2 {0}
+      env:
+        DOLTLITE_REGRESSION_PREBUILT: 1
       run: cd build && bash ../test/run_doltlite_regression_case.sh all_except=backup_safety
       timeout-minutes: 15
 
@@ -538,7 +401,6 @@ jobs:
       if: matrix.platform == 'ubuntu'
       run: |
         cd build
-        make doltlite-c-tests-build
         bash ../test/run_c_tests.sh . specialized
       timeout-minutes: 15
 
@@ -548,12 +410,4 @@ jobs:
 
     - name: Go integration test
       if: matrix.platform == 'ubuntu'
-      uses: actions/setup-go@v5
-      with:
-        go-version: '1.23'
-    - if: matrix.platform == 'ubuntu'
-      run: |
-        cd examples/go
-        CGO_CFLAGS="-I../../build" CGO_LDFLAGS="../../build/libdoltlite.a -lz -lpthread -lm" \
-          go build -tags libsqlite3 -o quickstart .
-        ./quickstart
+      run: build/go_quickstart

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -822,7 +822,20 @@ jobs:
         ./testfixture ../test/testrunner.tcl \
           --buildonly --jobs 4 mdevtest
 
-    - name: Build assert-enabled dirty-check probe
+  assert-build:
+    name: assert-enabled
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install dependencies
+      run: |
+        bash .github/scripts/install-apt-deps.sh \
+          build-essential tcl-dev zlib1g-dev
+
+    - name: Build dirty-check probe
       env:
         CFLAGS: -g -O0 -Werror
       run: |

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -166,7 +166,6 @@ jobs:
           make -j$(nproc) DOLTLITE_PROLLY_CHECK=1 \
             doltlite.exe doltlite-remotesrv.exe doltlite-lib
           make DOLTLITE_PROLLY=1 DOLTLITE_PROLLY_CHECK=1 sqlite3.c sqlite3.h
-          make doltlite-regression-test-c-build
         } 2>&1 | tee build.log
         DOLTLITE_CHECK_AMALGAMATION=0 DOLTLITE_CHECK_SHARED=0 \
           bash ../test/assert_doltlite_artifacts.sh .

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -39,7 +39,7 @@ jobs:
 
     - name: Install macOS build dependencies
       if: matrix.platform == 'macos'
-      run: brew install tcl-tk
+      run: brew install ripgrep tcl-tk
 
     - name: Install Go toolchain
       if: matrix.platform == 'ubuntu'
@@ -101,10 +101,10 @@ jobs:
         set -o pipefail
         {
           make DOLTLITE_PROLLY_CHECK=1 doltlite-c-tests-build
-          cc $CFLAGS -I. -I../src \
+          cc $CFLAGS -Wno-comment -I. -I../src \
             -o threadtest4 ../test/threadtest4.c sqlite3.c \
             -ldl -lpthread -lm -lz
-          cc $CFLAGS -I. -I../src \
+          cc $CFLAGS -Wno-comment -I. -I../src \
             -o threadtest5 ../test/threadtest5.c sqlite3.c \
             -ldl -lpthread -lm -lz
           gcc $CFLAGS -o quickstart \
@@ -286,7 +286,8 @@ jobs:
           sqllogictest.c md5.o sqlite3.o -lpthread -lm -lodbc
         cp ../../sqlite3.c sqlite3.c
         cp ../../sqlite3.h sqlite3.h
-        gcc -Werror -g -O2 -DSQLITE_NO_SYNC=1 -DSQLITE_THREADSAFE=1 \
+        gcc -Werror -Wno-comment -g -O2 \
+          -DSQLITE_NO_SYNC=1 -DSQLITE_THREADSAFE=1 \
           -DSQLITE_OMIT_LOAD_EXTENSION -c sqlite3.c \
           -o sqlite3-doltlite.o
         gcc -Werror -g -O2 -o sqllogictest-doltlite \
@@ -315,7 +316,7 @@ jobs:
     timeout-minutes: 20
     env:
       CC: clang
-      CFLAGS: -O1 -g -Werror -fprofile-instr-generate -fcoverage-mapping
+      CFLAGS: -O1 -g -Werror -Wno-comment -fprofile-instr-generate -fcoverage-mapping
       LDFLAGS: -fprofile-instr-generate
 
     steps:
@@ -447,10 +448,12 @@ jobs:
         include:
           - platform: ubuntu
             runs-on: ubuntu-latest
+            warning-flags: ''
           - platform: macos
             runs-on: macos-latest
+            warning-flags: -Wno-deprecated-declarations
     env:
-      ASAN_CFLAGS: -O1 -g -Werror -fsanitize=address,undefined -fno-omit-frame-pointer -fno-sanitize-recover=all
+      ASAN_CFLAGS: -O1 -g -Werror ${{ matrix.warning-flags }} -fsanitize=address,undefined -fno-omit-frame-pointer -fno-sanitize-recover=all
       ASAN_LDFLAGS: -fsanitize=address,undefined
 
     steps:
@@ -515,7 +518,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
-      TSAN_CFLAGS: -O1 -g -Werror -fsanitize=thread -fno-omit-frame-pointer
+      TSAN_CFLAGS: -O1 -g -Werror -Wno-comment -fsanitize=thread -fno-omit-frame-pointer
       TSAN_LDFLAGS: -fsanitize=thread
 
     steps:
@@ -730,7 +733,9 @@ jobs:
           ../configure
           make doltlite
           cd ..
-          make -C ext/wasm fiddle npm dist
+          make -C ext/wasm \
+            emcc_opt='-Oz -Wno-limited-postlink-optimizations' \
+            fiddle npm dist
         } 2>&1 | tee wasm-build.log
         if grep -E "warning:" wasm-build.log; then
           echo "::error::compiler warnings in wasm build"

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -1,0 +1,849 @@
+name: CI Build
+
+on:
+  workflow_call:
+
+jobs:
+  checked:
+    name: checked-${{ matrix.platform }}
+    runs-on: ${{ matrix.runs-on }}
+    timeout-minutes: 20
+    env:
+      CFLAGS: -O2 -g -Werror
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - platform: ubuntu
+            runs-on: ubuntu-latest
+          - platform: windows
+            runs-on: windows-latest
+          - platform: macos
+            runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install Linux build dependencies
+      if: matrix.platform == 'ubuntu'
+      run: |
+        bash .github/scripts/install-apt-deps.sh \
+          build-essential fossil tcl-dev unixodbc-dev zlib1g-dev
+
+    - name: Install Windows build dependencies
+      if: matrix.platform == 'windows'
+      uses: msys2/setup-msys2@v2
+      with:
+        msystem: MINGW64
+        install: mingw-w64-x86_64-gcc mingw-w64-x86_64-python mingw-w64-x86_64-tcl mingw-w64-x86_64-zlib make perl tcl openssl
+
+    - name: Install macOS build dependencies
+      if: matrix.platform == 'macos'
+      run: brew install tcl-tk
+
+    - name: Install Go toolchain
+      if: matrix.platform == 'ubuntu'
+      uses: actions/setup-go@v5
+      with:
+        go-version: '1.23'
+
+    - name: Configure Unix build
+      if: matrix.platform != 'windows'
+      run: |
+        mkdir -p build
+        cd build
+        if [ "${{ matrix.platform }}" = "macos" ]; then
+          export PATH="$(brew --prefix tcl-tk)/bin:$PATH"
+          ../configure
+        else
+          TCL_CONFIG=$(find /usr/lib -name tclConfig.sh -print -quit 2>/dev/null)
+          if [ -n "$TCL_CONFIG" ]; then
+            ../configure --with-tcl=$(dirname "$TCL_CONFIG")
+          else
+            ../configure
+          fi
+        fi
+
+    - name: Configure Windows build
+      if: matrix.platform == 'windows'
+      shell: msys2 {0}
+      run: |
+        mkdir -p build
+        cd build
+        ../configure
+
+    - name: Build checked Unix binaries
+      if: matrix.platform != 'windows'
+      run: |
+        cd build
+        set -o pipefail
+        {
+          make -j2 DOLTLITE_PROLLY_CHECK=1 \
+            doltlite doltlite-remotesrv doltlite-lib
+          make DOLTLITE_PROLLY=0 sqlite3
+          make libsqlite3.a USE_AMALGAMATION=0
+          make DOLTLITE_PROLLY=1 DOLTLITE_PROLLY_CHECK=1 \
+            sqlite3.c sqlite3.h
+        } 2>&1 | tee build.log
+        DOLTLITE_CHECK_AMALGAMATION=0 \
+          bash ../test/assert_doltlite_artifacts.sh .
+        if grep -E "warning:" build.log; then
+          echo "::error::compiler warnings in checked build"
+          exit 1
+        fi
+        make lint
+
+    - name: Build Linux-only test binaries
+      if: matrix.platform == 'ubuntu'
+      run: |
+        cd build
+        set -o pipefail
+        {
+          make DOLTLITE_PROLLY_CHECK=1 doltlite-c-tests-build
+          cc $CFLAGS -I. -I../src \
+            -o threadtest4 ../test/threadtest4.c sqlite3.c \
+            -ldl -lpthread -lm -lz
+          cc $CFLAGS -I. -I../src \
+            -o threadtest5 ../test/threadtest5.c sqlite3.c \
+            -ldl -lpthread -lm -lz
+          gcc $CFLAGS -o quickstart \
+            ../examples/quickstart.c -I. libdoltlite.a -lpthread -lz -lm
+          cc $CFLAGS -O0 -I. -I../src \
+            -DDOLTLITE_PROLLY=1 -D_HAVE_SQLITE_CONFIG_H -DBUILD_sqlite \
+            -o concurrent_branch_test ../test/concurrent_branch_test.c \
+            libsqlite3.a -lz -lpthread -lm
+          gcc $CFLAGS -O0 -I. \
+            -o concurrent_write_test ../test/concurrent_write_test.c \
+            libdoltlite.a -lz -lpthread -lm
+          cc $CFLAGS -I. \
+            -o crash_recovery_test ../test/crash_recovery_test.c \
+            libdoltlite.a -lz -lpthread -lm
+          (
+            cd ../examples/go
+            CGO_CFLAGS="-I../../build" \
+              CGO_LDFLAGS="../../build/libdoltlite.a -lz -lpthread -lm" \
+              go build -tags libsqlite3 -o ../../build/go_quickstart .
+          )
+        } 2>&1 | tee -a build.log
+        if grep -E "warning:" build.log; then
+          echo "::error::compiler warnings in checked build"
+          exit 1
+        fi
+
+    - name: Build macOS-only test binaries
+      if: matrix.platform == 'macos'
+      run: |
+        cd build
+        set -o pipefail
+        {
+          gcc $CFLAGS -o quickstart \
+            ../examples/quickstart.c -I. libdoltlite.a -lpthread -lz -lm
+          cc $CFLAGS -O0 -I. -I../src \
+            -DDOLTLITE_PROLLY=1 -D_HAVE_SQLITE_CONFIG_H -DBUILD_sqlite \
+            -o concurrent_branch_test ../test/concurrent_branch_test.c \
+            libsqlite3.a -lz -lpthread -lm
+          gcc $CFLAGS -O0 -I. \
+            -o concurrent_write_test ../test/concurrent_write_test.c \
+            libdoltlite.a -lz -lpthread -lm
+          gcc $CFLAGS -O0 -I. \
+            -o prepared_stmt_reuse_test ../test/prepared_stmt_reuse_test.c \
+            libdoltlite.a -lz -lpthread -lm
+        } 2>&1 | tee -a build.log
+        if grep -E "warning:" build.log; then
+          echo "::error::compiler warnings in checked build"
+          exit 1
+        fi
+
+    - name: Build Windows binaries
+      if: matrix.platform == 'windows'
+      shell: msys2 {0}
+      run: |
+        cd build
+        set -o pipefail
+        {
+          make -j$(nproc) DOLTLITE_PROLLY_CHECK=1 \
+            doltlite.exe doltlite-remotesrv.exe doltlite-lib
+          make DOLTLITE_PROLLY=1 DOLTLITE_PROLLY_CHECK=1 sqlite3.c sqlite3.h
+          make doltlite-regression-test-c-build
+        } 2>&1 | tee build.log
+        DOLTLITE_CHECK_AMALGAMATION=0 DOLTLITE_CHECK_SHARED=0 \
+          bash ../test/assert_doltlite_artifacts.sh .
+        cp -f "$(command -v sqlite3)" sqlite3
+        if grep -E "warning:" build.log; then
+          echo "::error::compiler warnings in checked build"
+          exit 1
+        fi
+
+    - name: Build standalone Unix test probes
+      if: matrix.platform != 'windows'
+      run: |
+        cd build
+        set -o pipefail
+        {
+          cc $CFLAGS -Wall \
+            -I../src -I../ext/ed25519 \
+            ../test/doltlite_creds_kat.c ../src/doltlite_creds.c \
+            ../ext/ed25519/fe.c ../ext/ed25519/ge.c \
+            ../ext/ed25519/sc.c ../ext/ed25519/sha512.c \
+            ../ext/ed25519/keypair.c ../ext/ed25519/sign.c \
+            ../ext/ed25519/verify.c ../ext/ed25519/add_scalar.c \
+            -o creds_kat
+          cc $CFLAGS -Wall \
+            -I../src -I../ext/ed25519 \
+            ../test/creds_verify_kat.c ../src/doltlite_creds.c \
+            ../ext/ed25519/fe.c ../ext/ed25519/ge.c \
+            ../ext/ed25519/sc.c ../ext/ed25519/sha512.c \
+            ../ext/ed25519/keypair.c ../ext/ed25519/sign.c \
+            ../ext/ed25519/verify.c ../ext/ed25519/add_scalar.c \
+            -o creds_verify_kat
+          cc $CFLAGS -I../src -I../ext/mbedtls/include \
+            ../test/doltlite_tls_test_main.c ../src/doltlite_tls.c \
+            ../ext/mbedtls/library/*.c \
+            -o tls_test
+          blake_objects=(blake3.o blake3_portable.o blake3_dispatch.o)
+          for object in blake3_sse2.o blake3_sse41.o blake3_avx2.o blake3_avx512.o blake3_neon.o; do
+            [ ! -f "$object" ] || blake_objects+=("$object")
+          done
+          cc $CFLAGS ../test/blake3_kat.c \
+            prolly_hash.o "${blake_objects[@]}" \
+            -I../src -I../ext/blake3 -DDOLTLITE_PROLLY=1 \
+            -lm -o blake3_kat
+          probe_libs=(-lz -lpthread -lm)
+          if [ "${{ matrix.platform }}" = "ubuntu" ]; then
+            probe_libs+=(-ldl)
+          fi
+          cc $CFLAGS -Wno-comment -I. \
+            ../test/amalgamation_http_probe.c sqlite3.c \
+            "${probe_libs[@]}" -o amalgamation_http_probe
+        } 2>&1 | tee -a build.log
+        if grep -E "warning:" build.log; then
+          echo "::error::compiler warnings in standalone probes"
+          exit 1
+        fi
+
+    - name: Build standalone Windows test probes
+      if: matrix.platform == 'windows'
+      shell: msys2 {0}
+      run: |
+        cd build
+        set -o pipefail
+        {
+          cc $CFLAGS -Wall \
+            -I../src -I../ext/ed25519 \
+            ../test/doltlite_creds_kat.c ../src/doltlite_creds.c \
+            ../ext/ed25519/fe.c ../ext/ed25519/ge.c \
+            ../ext/ed25519/sc.c ../ext/ed25519/sha512.c \
+            ../ext/ed25519/keypair.c ../ext/ed25519/sign.c \
+            ../ext/ed25519/verify.c ../ext/ed25519/add_scalar.c \
+            -lws2_32 -lbcrypt -lcrypt32 -o creds_kat.exe
+          cc $CFLAGS -Wall \
+            -I../src -I../ext/ed25519 \
+            ../test/creds_verify_kat.c ../src/doltlite_creds.c \
+            ../ext/ed25519/fe.c ../ext/ed25519/ge.c \
+            ../ext/ed25519/sc.c ../ext/ed25519/sha512.c \
+            ../ext/ed25519/keypair.c ../ext/ed25519/sign.c \
+            ../ext/ed25519/verify.c ../ext/ed25519/add_scalar.c \
+            -lws2_32 -lbcrypt -lcrypt32 -o creds_verify_kat.exe
+          cc $CFLAGS -I../src -I../ext/mbedtls/include \
+            ../test/doltlite_tls_test_main.c ../src/doltlite_tls.c \
+            ../ext/mbedtls/library/*.c \
+            -lws2_32 -lbcrypt -lcrypt32 -o tls_test.exe
+          blake_objects=(blake3.o blake3_portable.o blake3_dispatch.o)
+          for object in blake3_sse2.o blake3_sse41.o blake3_avx2.o blake3_avx512.o blake3_neon.o; do
+            [ ! -f "$object" ] || blake_objects+=("$object")
+          done
+          cc $CFLAGS ../test/blake3_kat.c \
+            prolly_hash.o "${blake_objects[@]}" \
+            -I../src -I../ext/blake3 -DDOLTLITE_PROLLY=1 \
+            -lm -o blake3_kat.exe
+          cc $CFLAGS -Wno-comment -I. \
+            ../test/amalgamation_http_probe.c sqlite3.c \
+            -lz -lpthread -lm -lws2_32 -lbcrypt -lcrypt32 \
+            -o amalgamation_http_probe.exe
+        } 2>&1 | tee -a build.log
+        if grep -E "warning:" build.log; then
+          echo "::error::compiler warnings in standalone probes"
+          exit 1
+        fi
+
+    - name: Build sqllogictest runners
+      if: matrix.platform == 'ubuntu'
+      run: |
+        fossil clone https://www.sqlite.org/sqllogictest/ /tmp/sqllogictest.fossil
+        mkdir -p build/sqllogictest
+        cd build/sqllogictest
+        fossil open /tmp/sqllogictest.fossil db57eba95d7c412bb413da5480c8be24109a8faf
+        perl ../../test/patch_sqllogictest.pl \
+          < src/sqllogictest.c > src/sqllogictest.c.patched
+        mv src/sqllogictest.c.patched src/sqllogictest.c
+        cd src
+        gcc -Werror -g -O2 -DSQLITE_NO_SYNC=1 -DSQLITE_THREADSAFE=0 \
+          -DSQLITE_OMIT_LOAD_EXTENSION -c md5.c
+        gcc -Werror -g -O2 -DSQLITE_NO_SYNC=1 -DSQLITE_THREADSAFE=0 \
+          -DSQLITE_OMIT_LOAD_EXTENSION -c sqlite3.c
+        gcc -Werror -g -O2 -o sqllogictest-stock \
+          sqllogictest.c md5.o sqlite3.o -lpthread -lm -lodbc
+        cp ../../sqlite3.c sqlite3.c
+        cp ../../sqlite3.h sqlite3.h
+        gcc -Werror -g -O2 -DSQLITE_NO_SYNC=1 -DSQLITE_THREADSAFE=1 \
+          -DSQLITE_OMIT_LOAD_EXTENSION -c sqlite3.c \
+          -o sqlite3-doltlite.o
+        gcc -Werror -g -O2 -o sqllogictest-doltlite \
+          sqllogictest.c md5.o sqlite3-doltlite.o \
+          -lpthread -lm -lz -lodbc
+
+    - name: Package checked build
+      if: matrix.platform != 'windows'
+      run: tar -czf checked-build-${{ matrix.platform }}.tar.gz build
+
+    - name: Package checked Windows build
+      if: matrix.platform == 'windows'
+      shell: msys2 {0}
+      run: tar -czf checked-build-windows.tar.gz build
+
+    - name: Upload checked build
+      uses: actions/upload-artifact@v4
+      with:
+        name: checked-build-${{ matrix.platform }}
+        path: checked-build-${{ matrix.platform }}.tar.gz
+        retention-days: 1
+
+  coverage-build:
+    name: coverage
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      CC: clang
+      CFLAGS: -O1 -g -Werror -fprofile-instr-generate -fcoverage-mapping
+      LDFLAGS: -fprofile-instr-generate
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install dependencies
+      run: |
+        bash .github/scripts/install-apt-deps.sh \
+          build-essential clang llvm tcl-dev zlib1g-dev
+
+    - name: Configure
+      run: |
+        mkdir -p build-coverage
+        cd build-coverage
+        TCL_CONFIG=$(find /usr/lib -name tclConfig.sh -print -quit 2>/dev/null)
+        if [ -n "$TCL_CONFIG" ]; then
+          ../configure --with-tcl=$(dirname "$TCL_CONFIG")
+        else
+          ../configure
+        fi
+
+    - name: Build
+      run: |
+        cd build-coverage
+        set -o pipefail
+        {
+          make -j2 DOLTLITE_PROLLY_CHECK=1 \
+            doltlite doltlite-remotesrv doltlite-lib testfixture \
+            doltlite-c-tests-build doltlite-regression-test-c-build
+          make DOLTLITE_PROLLY=0 sqlite3
+          blake_objects=(blake3.o blake3_portable.o blake3_dispatch.o)
+          for object in blake3_sse2.o blake3_sse41.o blake3_avx2.o blake3_avx512.o blake3_neon.o; do
+            [ ! -f "$object" ] || blake_objects+=("$object")
+          done
+          clang $CFLAGS ../test/blake3_kat.c \
+            prolly_hash.o "${blake_objects[@]}" \
+            -I../src -I../ext/blake3 -DDOLTLITE_PROLLY=1 \
+            $LDFLAGS -lm -o blake3_kat_test
+        } 2>&1 | tee build.log
+        if grep -E "warning:" build.log; then
+          echo "::error::compiler warnings in coverage build"
+          exit 1
+        fi
+        find . -type f -name '*.profraw' -delete
+
+    - name: Package
+      run: |
+        mkdir -p coverage-artifact/build-coverage
+        cp build-coverage/doltlite \
+          build-coverage/doltlite-remotesrv \
+          build-coverage/doltlite_regression_test_c \
+          build-coverage/testfixture \
+          build-coverage/prolly_hash.o \
+          build-coverage/blake3*.o \
+          build-coverage/*_test \
+          coverage-artifact/build-coverage/
+        cp build-coverage/sqlite3 \
+          coverage-artifact/build-coverage/sqlite3-stock
+        llvm-strip --strip-debug coverage-artifact/build-coverage/*
+        tar -C coverage-artifact -czf coverage-build.tar.gz build-coverage
+
+    - name: Upload
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage-build
+        path: coverage-build.tar.gz
+        retention-days: 1
+
+  benchmark-build:
+    name: optimized-benchmark
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install dependencies
+      run: |
+        bash .github/scripts/install-apt-deps.sh \
+          build-essential tcl-dev zlib1g-dev
+
+    - name: Configure
+      run: |
+        mkdir -p build
+        cd build
+        TCL_CONFIG=$(find /usr/lib -name tclConfig.sh -print -quit 2>/dev/null)
+        if [ -n "$TCL_CONFIG" ]; then
+          ../configure --with-tcl=$(dirname "$TCL_CONFIG")
+        else
+          ../configure
+        fi
+
+    - name: Build
+      run: |
+        cd build
+        set -o pipefail
+        {
+          make -j2 doltlite doltlite-lib
+          cc -O2 -Werror -I. -I../src \
+            -o bench_timer_doltlite ../test/sysbench_timer.c \
+            libdoltlite.a -lpthread -lz -lm
+          make DOLTLITE_PROLLY=0 sqlite3 sqlite3.o
+          cc -O2 -Werror -I. -I../src \
+            -o bench_timer_sqlite ../test/sysbench_timer.c \
+            sqlite3.o -lpthread -lz -lm
+        } 2>&1 | tee build.log
+        if grep -E "warning:" build.log; then
+          echo "::error::compiler warnings in optimized build"
+          exit 1
+        fi
+
+    - name: Package
+      run: tar -czf benchmark-build.tar.gz build
+
+    - name: Upload
+      uses: actions/upload-artifact@v4
+      with:
+        name: benchmark-build
+        path: benchmark-build.tar.gz
+        retention-days: 1
+
+  asan-ubsan-build:
+    name: asan-ubsan-${{ matrix.platform }}
+    runs-on: ${{ matrix.runs-on }}
+    timeout-minutes: 20
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - platform: ubuntu
+            runs-on: ubuntu-latest
+          - platform: macos
+            runs-on: macos-latest
+    env:
+      ASAN_CFLAGS: -O1 -g -Werror -fsanitize=address,undefined -fno-omit-frame-pointer -fno-sanitize-recover=all
+      ASAN_LDFLAGS: -fsanitize=address,undefined
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install Linux dependencies
+      if: matrix.platform == 'ubuntu'
+      run: |
+        bash .github/scripts/install-apt-deps.sh \
+          build-essential tcl-dev zlib1g-dev
+
+    - name: Install macOS dependencies
+      if: matrix.platform == 'macos'
+      run: brew install tcl-tk
+
+    - name: Configure
+      run: |
+        mkdir -p build
+        cd build
+        if [ "${{ matrix.platform }}" = "macos" ]; then
+          export PATH="$(brew --prefix tcl-tk)/bin:$PATH"
+          ../configure
+        else
+          TCL_CONFIG=$(find /usr/lib -name tclConfig.sh -print -quit 2>/dev/null)
+          if [ -n "$TCL_CONFIG" ]; then
+            ../configure --with-tcl=$(dirname "$TCL_CONFIG")
+          else
+            ../configure
+          fi
+        fi
+
+    - name: Build
+      run: |
+        cd build
+        set -o pipefail
+        {
+          make CFLAGS="$ASAN_CFLAGS" LDFLAGS="$ASAN_LDFLAGS" \
+            doltlite libdoltlite.a
+          make DOLTLITE_PROLLY=0 sqlite3
+          cc $ASAN_CFLAGS -I. -I../src \
+            -o doltlite_regression_test_c \
+            ../test/doltlite_regression_test_c.c \
+            libdoltlite.a $ASAN_LDFLAGS -lz -lpthread -lm
+        } 2>&1 | tee build.log
+        if grep -E "warning:" build.log; then
+          echo "::error::compiler warnings in sanitizer build"
+          exit 1
+        fi
+
+    - name: Package
+      run: tar -czf asan-ubsan-${{ matrix.platform }}.tar.gz build
+
+    - name: Upload
+      uses: actions/upload-artifact@v4
+      with:
+        name: asan-ubsan-${{ matrix.platform }}
+        path: asan-ubsan-${{ matrix.platform }}.tar.gz
+        retention-days: 1
+
+  tsan-build:
+    name: tsan
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      TSAN_CFLAGS: -O1 -g -Werror -fsanitize=thread -fno-omit-frame-pointer
+      TSAN_LDFLAGS: -fsanitize=thread
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install dependencies
+      run: |
+        bash .github/scripts/install-apt-deps.sh \
+          build-essential clang zlib1g-dev
+
+    - name: Configure
+      run: |
+        mkdir -p build
+        cd build
+        CC=clang ../configure
+
+    - name: Build
+      run: |
+        cd build
+        set -o pipefail
+        {
+          make CC=clang CFLAGS="$TSAN_CFLAGS" LDFLAGS="$TSAN_LDFLAGS" \
+            sqlite3.c sqlite3.h
+          clang $TSAN_CFLAGS -I. -I../src \
+            -o threadtest4 ../test/threadtest4.c sqlite3.c \
+            $TSAN_LDFLAGS -ldl -lpthread -lm -lz
+          clang $TSAN_CFLAGS -I. -I../src \
+            -o threadtest5 ../test/threadtest5.c sqlite3.c \
+            $TSAN_LDFLAGS -ldl -lpthread -lm -lz
+          make CC=clang CFLAGS="$TSAN_CFLAGS" LDFLAGS="$TSAN_LDFLAGS" \
+            doltlite doltlite-remotesrv
+        } 2>&1 | tee build.log
+        if grep -E "warning:" build.log; then
+          echo "::error::compiler warnings in TSan build"
+          exit 1
+        fi
+
+    - name: Package
+      run: tar -czf tsan-build.tar.gz build
+
+    - name: Upload
+      uses: actions/upload-artifact@v4
+      with:
+        name: tsan-build
+        path: tsan-build.tar.gz
+        retention-days: 1
+
+  crash-build:
+    name: crash
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install dependencies
+      run: |
+        bash .github/scripts/install-apt-deps.sh \
+          build-essential libtommath-dev tcl-dev zlib1g-dev
+
+    - name: Configure
+      run: |
+        mkdir -p build-crash
+        cd build-crash
+        TCL_CONFIG=$(find /usr/lib -name tclConfig.sh -print -quit 2>/dev/null)
+        if [ -n "$TCL_CONFIG" ]; then
+          ../configure --with-tcl=$(dirname "$TCL_CONFIG")
+        else
+          ../configure
+        fi
+
+    - name: Build
+      run: |
+        cd build-crash
+        TCL_CONFIG=$(find /usr/lib -name tclConfig.sh -print -quit 2>/dev/null)
+        . "$TCL_CONFIG"
+        set -o pipefail
+        make OPTIONS='-DSQLITE_TEST=1 -DSQLITE_CRASH_TEST=1' \
+          OPTS="$TCL_INCLUDE_SPEC" \
+          libdoltlite.a doltlite-crashtest crash_recovery_test_sqlite_test \
+          2>&1 | tee build.log
+        if grep -E "warning:" build.log; then
+          echo "::error::compiler warnings in crash-test build"
+          exit 1
+        fi
+
+    - name: Package
+      run: tar -czf crash-build.tar.gz build-crash
+
+    - name: Upload
+      uses: actions/upload-artifact@v4
+      with:
+        name: crash-build
+        path: crash-build.tar.gz
+        retention-days: 1
+
+  fuzz-build:
+    name: libfuzzer
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      FUZZ_CFLAGS: -O1 -g -Werror -fsanitize=fuzzer-no-link,address -fno-omit-frame-pointer -fno-sanitize-recover=address
+      FUZZ_LDFLAGS: -fsanitize=fuzzer-no-link,address
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install dependencies
+      run: |
+        bash .github/scripts/install-apt-deps.sh \
+          build-essential clang tcl-dev zlib1g-dev
+
+    - name: Configure
+      run: |
+        mkdir -p build-fuzz
+        cd build-fuzz
+        TCL_CONFIG=$(find /usr/lib -name tclConfig.sh -print -quit 2>/dev/null)
+        if [ -n "$TCL_CONFIG" ]; then
+          ../configure --with-tcl=$(dirname "$TCL_CONFIG")
+        else
+          ../configure
+        fi
+
+    - name: Build
+      run: |
+        cd build-fuzz
+        set -o pipefail
+        {
+          make CC=clang CFLAGS="$FUZZ_CFLAGS" LDFLAGS="$FUZZ_LDFLAGS" \
+            libdoltlite.a
+          for target in fuzz_replaywal fuzz_prolly_node fuzz_deserialize_refs fuzz_read_index fuzz_deserialize_catalog; do
+            clang -O1 -g -Werror \
+              -fsanitize=fuzzer,address -fno-omit-frame-pointer \
+              -fno-sanitize-recover=address \
+              -DDOLTLITE_PROLLY=1 -D_HAVE_SQLITE_CONFIG_H \
+              -I. -I../src \
+              -o "$target" "../test/$target.c" libdoltlite.a \
+              -lz -lpthread
+          done
+        } 2>&1 | tee build.log
+        if grep -E "warning:" build.log; then
+          echo "::error::compiler warnings in libFuzzer build"
+          exit 1
+        fi
+
+    - name: Package
+      run: tar -czf fuzz-build.tar.gz build-fuzz
+
+    - name: Upload
+      uses: actions/upload-artifact@v4
+      with:
+        name: fuzz-build
+        path: fuzz-build.tar.gz
+        retention-days: 1
+
+  wasm-build:
+    name: wasm
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      EMSDK_VERSION: 3.1.74
+      WABT_VERSION: 1.0.36
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Cache Emscripten SDK
+      uses: actions/cache@v4
+      with:
+        path: ${{ runner.tool_cache }}/emsdk
+        key: emsdk-${{ runner.os }}-${{ env.EMSDK_VERSION }}
+
+    - name: Install Emscripten SDK
+      run: |
+        EMSDK_DIR="${RUNNER_TOOL_CACHE}/emsdk"
+        if [ ! -d "$EMSDK_DIR/.git" ]; then
+          rm -rf "$EMSDK_DIR"
+          git clone https://github.com/emscripten-core/emsdk.git "$EMSDK_DIR"
+        fi
+        cd "$EMSDK_DIR"
+        git fetch --tags --quiet
+        ./emsdk install "$EMSDK_VERSION"
+        ./emsdk activate "$EMSDK_VERSION"
+        echo "EMSDK=$EMSDK_DIR" >> "$GITHUB_ENV"
+
+    - name: Cache WABT
+      uses: actions/cache@v4
+      with:
+        path: ${{ runner.tool_cache }}/wabt-${{ env.WABT_VERSION }}
+        key: wabt-${{ runner.os }}-${{ env.WABT_VERSION }}
+
+    - name: Install WABT
+      run: |
+        WABT_DIR="${RUNNER_TOOL_CACHE}/wabt-${WABT_VERSION}"
+        if [ ! -x "$WABT_DIR/bin/wasm-strip" ]; then
+          rm -rf "$WABT_DIR"
+          mkdir -p "$WABT_DIR"
+          curl -fsSL "https://github.com/WebAssembly/wabt/releases/download/${WABT_VERSION}/wabt-${WABT_VERSION}-ubuntu-20.04.tar.gz" \
+            | tar -xz --strip-components=1 -C "$WABT_DIR"
+        fi
+        echo "$WABT_DIR/bin" >> "$GITHUB_PATH"
+
+    - name: Build
+      run: |
+        source "$EMSDK/emsdk_env.sh"
+        set -o pipefail
+        {
+          ./configure
+          make sqlite3.c sqlite3.h sqlite3ext.h
+          mkdir -p build
+          cd build
+          ../configure
+          make doltlite
+          cd ..
+          make -C ext/wasm fiddle npm dist
+        } 2>&1 | tee wasm-build.log
+        if grep -E "warning:" wasm-build.log; then
+          echo "::error::compiler warnings in wasm build"
+          exit 1
+        fi
+
+    - name: Package
+      run: |
+        tar -czf ci-wasm-build.tar.gz \
+          build/doltlite \
+          ext/wasm/jswasm \
+          ext/wasm/sqlite-wasm-*.zip
+
+    - name: Upload
+      uses: actions/upload-artifact@v4
+      with:
+        name: ci-wasm-build
+        path: ci-wasm-build.tar.gz
+        retention-days: 1
+
+  compat-build:
+    name: compatibility-references
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Install dependencies
+      run: |
+        bash .github/scripts/install-apt-deps.sh \
+          build-essential tcl-dev zlib1g-dev
+
+    - name: Cache old-version binaries
+      uses: actions/cache@v4
+      with:
+        path: .compat-cache
+        key: compat-bins-${{ runner.os }}-${{ github.base_ref || github.ref_name }}
+        restore-keys: |
+          compat-bins-${{ runner.os }}-
+
+    - name: Build compatibility references
+      run: |
+        DOLTLITE_COMPAT_JOBS=4 \
+          bash test/doltlite_compat_test.sh --build-only
+
+    - name: Package
+      run: tar -czf compat-build.tar.gz .compat-cache
+
+    - name: Upload
+      uses: actions/upload-artifact@v4
+      with:
+        name: compat-build
+        path: compat-build.tar.gz
+        retention-days: 1
+
+  development-builds:
+    name: development-configurations
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      CFLAGS: -O2 -g -Werror
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install dependencies
+      run: |
+        bash .github/scripts/install-apt-deps.sh \
+          build-essential tcl-dev zlib1g-dev
+
+    - name: Configure
+      run: |
+        mkdir -p build
+        cd build
+        TCL_CONFIG=$(find /usr/lib -name tclConfig.sh -print -quit 2>/dev/null)
+        if [ -n "$TCL_CONFIG" ]; then
+          ../configure --with-tcl=$(dirname "$TCL_CONFIG")
+        else
+          ../configure
+        fi
+
+    - name: Compile development configurations
+      run: |
+        cd build
+        make DOLTLITE_PROLLY=1 testfixture
+        ./testfixture ../test/testrunner.tcl \
+          --buildonly --jobs 4 mdevtest
+
+  no-dead-code:
+    name: no-dead-code
+    needs: checked
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: No orphaned test suites
+      run: bash test/lint_orphaned_suites.sh
+
+    - name: Install dependencies
+      run: |
+        bash .github/scripts/install-apt-deps.sh build-essential zlib1g-dev
+
+    - name: Download checked build
+      uses: actions/download-artifact@v4
+      with:
+        name: checked-build-ubuntu
+
+    - name: Extract checked build
+      run: tar -xzf checked-build-ubuntu.tar.gz
+
+    - name: Dead-code gate
+      run: bash test/dead_code_check.sh

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -277,6 +277,11 @@ jobs:
         perl ../../test/patch_sqllogictest.pl \
           < src/sqllogictest.c > src/sqllogictest.c.patched
         mv src/sqllogictest.c.patched src/sqllogictest.c
+        # unixODBC declares SQLGetData's indicator as SQLLEN*. The pinned
+        # upstream source still uses the 32-bit SQLINTEGER typedef.
+        grep -q 'SQLINTEGER indicator' src/slt_odbc3.c
+        perl -pi -e 's/SQLINTEGER indicator/SQLLEN indicator/g' \
+          src/slt_odbc3.c
         cd src
         gcc -Werror -g -O2 -DSQLITE_NO_SYNC=1 -DSQLITE_THREADSAFE=0 \
           -DSQLITE_OMIT_LOAD_EXTENSION -c md5.c

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -82,6 +82,7 @@ jobs:
             doltlite doltlite-remotesrv doltlite-lib
           make DOLTLITE_PROLLY=0 sqlite3
           make libsqlite3.a USE_AMALGAMATION=0
+          rm -f sqlite3.c .target_source
           make DOLTLITE_PROLLY=1 DOLTLITE_PROLLY_CHECK=1 \
             sqlite3.c sqlite3.h
         } 2>&1 | tee build.log

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -28,7 +28,7 @@ jobs:
       if: matrix.platform == 'ubuntu'
       run: |
         bash .github/scripts/install-apt-deps.sh \
-          build-essential fossil ripgrep tcl-dev unixodbc-dev zlib1g-dev
+          build-essential ripgrep tcl-dev zlib1g-dev
 
     - name: Install Windows build dependencies
       if: matrix.platform == 'windows'
@@ -166,6 +166,10 @@ jobs:
           make -j$(nproc) DOLTLITE_PROLLY_CHECK=1 \
             doltlite.exe doltlite-remotesrv.exe doltlite-lib
           make DOLTLITE_PROLLY=1 DOLTLITE_PROLLY_CHECK=1 sqlite3.c sqlite3.h
+          cc $CFLAGS -I. -I../src \
+            -o doltlite_regression_test_c \
+            ../test/doltlite_regression_test_c.c libdoltlite.a \
+            -lz -lpthread -lm -lws2_32 -lbcrypt -lcrypt32
         } 2>&1 | tee build.log
         DOLTLITE_CHECK_AMALGAMATION=0 DOLTLITE_CHECK_SHARED=0 \
           bash ../test/assert_doltlite_artifacts.sh .
@@ -267,8 +271,45 @@ jobs:
           exit 1
         fi
 
+    - name: Package checked build
+      if: matrix.platform != 'windows'
+      run: tar -czf checked-build-${{ matrix.platform }}.tar.gz build
+
+    - name: Package checked Windows build
+      if: matrix.platform == 'windows'
+      shell: msys2 {0}
+      run: tar -czf checked-build-windows.tar.gz build
+
+    - name: Upload checked build
+      uses: actions/upload-artifact@v4
+      with:
+        name: checked-build-${{ matrix.platform }}
+        path: checked-build-${{ matrix.platform }}.tar.gz
+        retention-days: 1
+
+  sqllogictest-build:
+    name: sqllogictest
+    needs: checked
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install dependencies
+      run: |
+        bash .github/scripts/install-apt-deps.sh \
+          build-essential fossil unixodbc-dev
+
+    - name: Download checked Linux build
+      uses: actions/download-artifact@v4
+      with:
+        name: checked-build-ubuntu
+
+    - name: Extract checked Linux build
+      run: tar -xzf checked-build-ubuntu.tar.gz
+
     - name: Build sqllogictest runners
-      if: matrix.platform == 'ubuntu'
       run: |
         fossil clone https://www.sqlite.org/sqllogictest/ /tmp/sqllogictest.fossil
         mkdir -p build/sqllogictest
@@ -299,20 +340,14 @@ jobs:
           sqllogictest.c md5.o sqlite3-doltlite.o \
           -lpthread -lm -lz -lodbc
 
-    - name: Package checked build
-      if: matrix.platform != 'windows'
-      run: tar -czf checked-build-${{ matrix.platform }}.tar.gz build
+    - name: Package
+      run: tar -czf sqllogictest-build.tar.gz build/sqllogictest
 
-    - name: Package checked Windows build
-      if: matrix.platform == 'windows'
-      shell: msys2 {0}
-      run: tar -czf checked-build-windows.tar.gz build
-
-    - name: Upload checked build
+    - name: Upload
       uses: actions/upload-artifact@v4
       with:
-        name: checked-build-${{ matrix.platform }}
-        path: checked-build-${{ matrix.platform }}.tar.gz
+        name: sqllogictest-build
+        path: sqllogictest-build.tar.gz
         retention-days: 1
 
   coverage-build:
@@ -739,7 +774,11 @@ jobs:
           ../configure
           make doltlite
           cd ..
-          make -C ext/wasm fiddle npm dist
+          make -C ext/wasm fiddle npm
+          mkdir -p ci-wasm-runtime
+          cp -a ext/wasm/jswasm/. ci-wasm-runtime/
+          make -C ext/wasm dist
+          cp -a ci-wasm-runtime/. ext/wasm/jswasm/
         } 2>&1 | tee wasm-build.log
         if grep -E "warning:" wasm-build.log; then
           echo "::error::compiler warnings in wasm build"
@@ -799,9 +838,15 @@ jobs:
         retention-days: 1
 
   development-builds:
-    name: development-configurations
+    name: development-${{ matrix.configuration }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        configuration:
+          - All-Debug
+          - All-O0
     env:
       CFLAGS: -O2 -g -Werror
 
@@ -829,7 +874,8 @@ jobs:
         cd build
         make DOLTLITE_PROLLY=1 testfixture
         ./testfixture ../test/testrunner.tcl \
-          --buildonly --jobs 4 mdevtest
+          --buildonly --jobs 4 \
+          --config ${{ matrix.configuration }} mdevtest
 
   assert-build:
     name: assert-enabled

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -28,7 +28,7 @@ jobs:
       if: matrix.platform == 'ubuntu'
       run: |
         bash .github/scripts/install-apt-deps.sh \
-          build-essential fossil tcl-dev unixodbc-dev zlib1g-dev
+          build-essential fossil ripgrep tcl-dev unixodbc-dev zlib1g-dev
 
     - name: Install Windows build dependencies
       if: matrix.platform == 'windows'
@@ -46,6 +46,7 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version: '1.23'
+        cache: false
 
     - name: Configure Unix build
       if: matrix.platform != 'windows'
@@ -680,6 +681,7 @@ jobs:
     timeout-minutes: 20
     env:
       EMSDK_VERSION: 3.1.74
+      EMCC_CFLAGS: -Wno-limited-postlink-optimizations
       WABT_VERSION: 1.0.36
 
     steps:
@@ -733,9 +735,7 @@ jobs:
           ../configure
           make doltlite
           cd ..
-          make -C ext/wasm \
-            emcc_opt='-Oz -Wno-limited-postlink-optimizations' \
-            fiddle npm dist
+          make -C ext/wasm fiddle npm dist
         } 2>&1 | tee wasm-build.log
         if grep -E "warning:" wasm-build.log; then
           echo "::error::compiler warnings in wasm build"

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -289,7 +289,6 @@ jobs:
 
   sqllogictest-build:
     name: sqllogictest
-    needs: checked
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -299,15 +298,19 @@ jobs:
     - name: Install dependencies
       run: |
         bash .github/scripts/install-apt-deps.sh \
-          build-essential fossil unixodbc-dev
+          build-essential fossil tcl-dev unixodbc-dev zlib1g-dev
 
-    - name: Download checked Linux build
-      uses: actions/download-artifact@v4
-      with:
-        name: checked-build-ubuntu
-
-    - name: Extract checked Linux build
-      run: tar -xzf checked-build-ubuntu.tar.gz
+    - name: Generate DoltLite amalgamation
+      run: |
+        mkdir -p build
+        cd build
+        TCL_CONFIG=$(find /usr/lib -name tclConfig.sh -print -quit 2>/dev/null)
+        if [ -n "$TCL_CONFIG" ]; then
+          ../configure --with-tcl=$(dirname "$TCL_CONFIG")
+        else
+          ../configure
+        fi
+        make DOLTLITE_PROLLY=1 DOLTLITE_PROLLY_CHECK=1 sqlite3.c sqlite3.h
 
     - name: Build sqllogictest runners
       run: |
@@ -778,7 +781,8 @@ jobs:
           mkdir -p ci-wasm-runtime
           cp -a ext/wasm/jswasm/. ci-wasm-runtime/
           make -C ext/wasm dist
-          cp -a ci-wasm-runtime/. ext/wasm/jswasm/
+          rm -rf ext/wasm/jswasm
+          mv ci-wasm-runtime ext/wasm/jswasm
         } 2>&1 | tee wasm-build.log
         if grep -E "warning:" wasm-build.log; then
           echo "::error::compiler warnings in wasm build"

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  build:
+    name: Build all binaries
+    uses: ./.github/workflows/ci-build.yml
+
+  build-test:
+    name: Build-Test
+    needs: build
+    uses: ./.github/workflows/build-test.yml
+
+  test-suite:
+    name: Test Suite
+    needs: build
+    uses: ./.github/workflows/test.yml
+
+  sanitizers:
+    name: Sanitizers
+    needs: build
+    uses: ./.github/workflows/sanitizers.yml
+
+  smoke:
+    name: Smoke
+    needs: build
+    uses: ./.github/workflows/smoke.yml
+
+  benchmark:
+    name: Benchmark
+    needs: build
+    uses: ./.github/workflows/benchmark.yml

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -5,8 +5,16 @@ on:
 
 jobs:
   asan-ubsan:
+    name: asan-ubsan-${{ matrix.suite }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        suite:
+          - oracles
+          - native
+          - c-regression
 
     steps:
     - uses: actions/checkout@v4
@@ -16,6 +24,7 @@ jobs:
         bash .github/scripts/install-apt-deps.sh tcl-dev build-essential zlib1g-dev
 
     - name: Install Dolt
+      if: matrix.suite == 'oracles'
       run: |
         curl -fsSL https://github.com/dolthub/dolt/releases/latest/download/dolt-linux-amd64.tar.gz \
           | sudo tar -xz -C /usr/local --strip-components=1
@@ -44,6 +53,7 @@ jobs:
     # suites makes every new oracle sanitizer-covered automatically instead
     # of relying on a hand-maintained subset that can silently drift.
     - name: SQL oracle tests (vs stock SQLite and Dolt)
+      if: matrix.suite == 'oracles'
       run: |
         cd build
         bash ../test/sql_oracle_test.sh ./doltlite ./sqlite3 || exit 1
@@ -56,6 +66,7 @@ jobs:
       timeout-minutes: 15
 
     - name: Version control oracle tests (vs Dolt)
+      if: matrix.suite == 'oracles'
       run: |
         cd build
         for f in ../test/vc_oracle_*_test.sh; do
@@ -65,6 +76,7 @@ jobs:
       timeout-minutes: 25
 
     - name: Correctness regression tests
+      if: matrix.suite == 'native'
       run: cd build && bash ../test/correctness_test.sh ./doltlite
 
     # Version-control virtual tables decode stored values and rebuild rows
@@ -73,6 +85,7 @@ jobs:
     # here). The oracle suites above are stock-SQL semantics and the C
     # corpus is C-API level; neither exercises these SQL vtab read paths.
     - name: VC virtual-table read suites
+      if: matrix.suite == 'native'
       run: |
         cd build
         for s in doltlite_at doltlite_history doltlite_diff doltlite_diff_table \
@@ -89,6 +102,7 @@ jobs:
     # read-vtab suites above never exercise under ASan. Kept to fast,
     # self-contained suites (no server, no external Dolt) to stay in budget.
     - name: VC ref-mutation + remote suites
+      if: matrix.suite == 'native'
       run: |
         cd build
         for s in doltlite_branch doltlite_default_branch doltlite_tag \
@@ -100,6 +114,7 @@ jobs:
     # The C regression corpus (~310k checks) under ASan/UBSan with leak
     # detection — where the #1325/#1328 use-after-frees and leaks lived.
     - name: C regression corpus (ASan/UBSan)
+      if: matrix.suite == 'c-regression'
       run: cd build && ./doltlite_regression_test_c all
 
   # Same ASan/UBSan coverage as the Linux job above, but on macOS/arm64 to

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -1,8 +1,7 @@
 name: Sanitizers
 
 on:
-  pull_request:
-  workflow_dispatch:
+  workflow_call:
 
 jobs:
   asan-ubsan:
@@ -22,33 +21,13 @@ jobs:
           | sudo tar -xz -C /usr/local --strip-components=1
         dolt version
 
-    - name: Configure
-      run: |
-        mkdir -p build && cd build
-        TCL_CONFIG=$(find /usr/lib -name tclConfig.sh -print -quit 2>/dev/null)
-        if [ -n "$TCL_CONFIG" ]; then
-          ../configure --with-tcl=$(dirname $TCL_CONFIG)
-        else
-          ../configure
-        fi
+    - name: Download ASan/UBSan build
+      uses: actions/download-artifact@v4
+      with:
+        name: asan-ubsan-ubuntu
 
-    # Build doltlite + the stock sqlite3 shell oracle target with
-    # ASan + UBSan. `-fno-sanitize-recover=all` turns every sanitizer
-    # finding into an immediate abort so the test suite cannot
-    # silently paper over a new one. `-fno-omit-frame-pointer` keeps
-    # backtraces readable; `-O1` is the usual sanitizer-friendly
-    # compromise between speed and accurate error location.
-    - name: Build with ASan/UBSan
-      run: |
-        cd build
-        make \
-          CFLAGS="-O1 -g -fsanitize=address,undefined -fno-omit-frame-pointer -fno-sanitize-recover=all" \
-          LDFLAGS="-fsanitize=address,undefined" \
-          doltlite
-        # Build true stock sqlite3 (without the prolly engine swap)
-        # so the SQL oracle compares against upstream behavior, not
-        # against another doltlite build.
-        make DOLTLITE_PROLLY=0 sqlite3
+    - name: Extract ASan/UBSan build
+      run: tar -xzf asan-ubsan-ubuntu.tar.gz
 
     # ASan options: log to stderr, abort on error, leak detection
     # on. A suppressions file (build/lsan.supp) is created right
@@ -120,22 +99,8 @@ jobs:
 
     # The C regression corpus (~310k checks) under ASan/UBSan with leak
     # detection — where the #1325/#1328 use-after-frees and leaks lived.
-    # Reuses the objects built above; only the archive and link are new.
-    # No stdbuf here: its LD_PRELOAD loads ahead of the ASan runtime and
-    # aborts the process. Buffered stdout is lost if LSan exits nonzero,
-    # but the sanitizer report itself goes to unbuffered stderr.
     - name: C regression corpus (ASan/UBSan)
-      run: |
-        cd build
-        make \
-          CFLAGS="-O1 -g -fsanitize=address,undefined -fno-omit-frame-pointer -fno-sanitize-recover=all" \
-          LDFLAGS="-fsanitize=address,undefined" \
-          libdoltlite.a
-        cc -O1 -g -fsanitize=address,undefined -fno-omit-frame-pointer -fno-sanitize-recover=all \
-          -I. -I../src \
-          -o doltlite_regression_test_c ../test/doltlite_regression_test_c.c \
-          libdoltlite.a -lz -lpthread -lm
-        ./doltlite_regression_test_c all
+      run: cd build && ./doltlite_regression_test_c all
 
   # Same ASan/UBSan coverage as the Linux job above, but on macOS/arm64 to
   # catch platform-specific undefined behavior and memory bugs the Linux x86
@@ -155,23 +120,13 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Install dependencies
-      run: brew install tcl-tk
+    - name: Download ASan/UBSan build
+      uses: actions/download-artifact@v4
+      with:
+        name: asan-ubsan-macos
 
-    - name: Configure
-      run: |
-        mkdir -p build && cd build
-        export PATH="$(brew --prefix tcl-tk)/bin:$PATH"
-        ../configure
-
-    - name: Build with ASan/UBSan
-      run: |
-        cd build
-        make \
-          CFLAGS="$ASAN_CFLAGS" \
-          LDFLAGS="-fsanitize=address,undefined" \
-          doltlite
-        make DOLTLITE_PROLLY=0 sqlite3
+    - name: Extract ASan/UBSan build
+      run: tar -xzf asan-ubsan-macos.tar.gz
 
     - name: SQL oracle tests (vs stock SQLite)
       run: |
@@ -208,17 +163,7 @@ jobs:
         done
 
     - name: C regression corpus (ASan/UBSan)
-      run: |
-        cd build
-        make \
-          CFLAGS="$ASAN_CFLAGS" \
-          LDFLAGS="-fsanitize=address,undefined" \
-          libdoltlite.a
-        cc $ASAN_CFLAGS \
-          -I. -I../src \
-          -o doltlite_regression_test_c ../test/doltlite_regression_test_c.c \
-          libdoltlite.a -lz -lpthread -lm
-        ./doltlite_regression_test_c all
+      run: cd build && ./doltlite_regression_test_c all
 
   tsan:
     runs-on: ubuntu-latest
@@ -234,40 +179,15 @@ jobs:
 
     - name: Install dependencies
       run: |
-        bash .github/scripts/install-apt-deps.sh clang build-essential zlib1g-dev
+        bash .github/scripts/install-apt-deps.sh zlib1g-dev
 
-    - name: Configure
-      run: |
-        mkdir -p build && cd build
-        CC=clang ../configure
+    - name: Download TSan build
+      uses: actions/download-artifact@v4
+      with:
+        name: tsan-build
 
-    - name: Build DoltLite amalgamation with TSan
-      run: |
-        cd build
-        make \
-          CC=clang \
-          CFLAGS="$TSAN_CFLAGS" \
-          LDFLAGS="$TSAN_LDFLAGS" \
-          sqlite3.c sqlite3.h
-
-    - name: Build pthread stress tests
-      run: |
-        cd build
-        clang $TSAN_CFLAGS -I. -I../src \
-          -o threadtest4 ../test/threadtest4.c sqlite3.c \
-          $TSAN_LDFLAGS -ldl -lpthread -lm -lz
-        clang $TSAN_CFLAGS -I. -I../src \
-          -o threadtest5 ../test/threadtest5.c sqlite3.c \
-          $TSAN_LDFLAGS -ldl -lpthread -lm -lz
-
-    - name: Build DoltLite remote server with TSan
-      run: |
-        cd build
-        make \
-          CC=clang \
-          CFLAGS="$TSAN_CFLAGS" \
-          LDFLAGS="$TSAN_LDFLAGS" \
-          doltlite doltlite-remotesrv
+    - name: Extract TSan build
+      run: tar -xzf tsan-build.tar.gz
 
     - name: Run threadtest4 serialized
       run: |
@@ -298,36 +218,3 @@ jobs:
         bash ../test/remotesrv_http_concurrency_test.sh \
           ./doltlite ./doltlite-remotesrv
       timeout-minutes: 10
-
-  no-dead-code:
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-
-    steps:
-    - uses: actions/checkout@v4
-
-    # Fast structural check (no build): every test suite must actually run.
-    - name: No orphaned test suites
-      run: bash test/lint_orphaned_suites.sh
-
-    - name: Install dependencies
-      run: |
-        bash .github/scripts/install-apt-deps.sh tcl-dev build-essential zlib1g-dev
-
-    - name: Configure
-      run: |
-        mkdir -p build && cd build
-        TCL_CONFIG=$(find /usr/lib -name tclConfig.sh -print -quit 2>/dev/null)
-        if [ -n "$TCL_CONFIG" ]; then
-          ../configure --with-tcl=$(dirname $TCL_CONFIG)
-        else
-          ../configure
-        fi
-
-    # The gate compiles the doltlite sources with -fsyntax-only, so it only
-    # needs the generated headers, not a full build.
-    - name: Generate headers
-      run: cd build && make doltlite.h sqlite3.h parse.h opcodes.h keywordhash.h
-
-    - name: Dead-code gate
-      run: bash test/dead_code_check.sh

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,7 +1,7 @@
 name: Smoke
 
 on:
-  pull_request:
+  workflow_call:
 
 jobs:
   vc-fuzz:
@@ -13,21 +13,19 @@ jobs:
 
     - name: Install dependencies
       run: |
-        bash .github/scripts/install-apt-deps.sh build-essential zlib1g-dev python3
+        bash .github/scripts/install-apt-deps.sh zlib1g-dev python3
 
-    - name: Configure
-      run: |
-        mkdir -p build-vc-fuzz && cd build-vc-fuzz
-        ../configure
+    - name: Download checked build
+      uses: actions/download-artifact@v4
+      with:
+        name: checked-build-ubuntu
 
-    - name: Build DoltLite
-      run: |
-        cd build-vc-fuzz
-        make DOLTLITE_PROLLY_CHECK=1 doltlite
+    - name: Extract checked build
+      run: tar -xzf checked-build-ubuntu.tar.gz
 
     - name: Run stateful version-control fuzzer
       run: |
-        cd build-vc-fuzz
+        cd build
         DOLTLITE_VC_STATEFUL_SECONDS=600 bash ../test/vc_stateful_fuzzer.sh ./doltlite
       timeout-minutes: 12
 
@@ -43,28 +41,30 @@ jobs:
 
     - name: Install dependencies
       run: |
-        bash .github/scripts/install-apt-deps.sh tcl-dev libtommath-dev build-essential zlib1g-dev clang
+        bash .github/scripts/install-apt-deps.sh zlib1g-dev
+
+    - name: Download checked build
+      uses: actions/download-artifact@v4
+      with:
+        name: checked-build-ubuntu
+
+    - name: Download crash build
+      uses: actions/download-artifact@v4
+      with:
+        name: crash-build
+
+    - name: Download libFuzzer build
+      uses: actions/download-artifact@v4
+      with:
+        name: fuzz-build
+
+    - name: Extract prebuilt binaries
+      run: |
+        tar -xzf checked-build-ubuntu.tar.gz
+        tar -xzf crash-build.tar.gz
+        tar -xzf fuzz-build.tar.gz
 
     # ── 1) crash-sqlite ──────────────────────────────────────────────
-    - name: Configure SQLITE_TEST build (build-crash)
-      run: |
-        mkdir -p build-crash && cd build-crash
-        TCL_CONFIG=$(find /usr/lib -name tclConfig.sh -print -quit 2>/dev/null)
-        if [ -n "$TCL_CONFIG" ]; then
-          ../configure --with-tcl=$(dirname "$TCL_CONFIG")
-        else
-          ../configure
-        fi
-
-    - name: Build crash-test binaries
-      run: |
-        cd build-crash
-        TCL_CONFIG=$(find /usr/lib -name tclConfig.sh -print -quit 2>/dev/null)
-        . "$TCL_CONFIG"
-        make OPTIONS='-DSQLITE_TEST=1 -DSQLITE_CRASH_TEST=1' \
-          OPTS="$TCL_INCLUDE_SPEC" \
-          libdoltlite.a doltlite-crashtest crash_recovery_test_sqlite_test
-
     - name: Native crash recovery test (SQLITE_TEST)
       run: |
         cd build-crash
@@ -76,58 +76,12 @@ jobs:
         bash ../test/crash_injection_test.sh ./doltlite-crashtest
 
     # ── 2) history-independence ──────────────────────────────────────
-    - name: Configure history-independence build (build)
-      run: |
-        mkdir -p build && cd build
-        TCL_CONFIG=$(find /usr/lib -name tclConfig.sh -print -quit 2>/dev/null)
-        if [ -n "$TCL_CONFIG" ]; then
-          ../configure --with-tcl=$(dirname "$TCL_CONFIG")
-        else
-          ../configure
-        fi
-
-    - name: Build doltlite for history-independence
-      run: |
-        cd build
-        make doltlite
-
     - name: History independence tests
       run: |
         cd build
         bash ../test/history_independence_test.sh ./doltlite
 
     # ── 3) fuzz-replaywal ────────────────────────────────────────────
-    - name: Configure libFuzzer build (build-fuzz)
-      run: |
-        mkdir -p build-fuzz && cd build-fuzz
-        TCL_CONFIG=$(find /usr/lib -name tclConfig.sh -print -quit 2>/dev/null)
-        if [ -n "$TCL_CONFIG" ]; then
-          ../configure --with-tcl=$(dirname "$TCL_CONFIG")
-        else
-          ../configure
-        fi
-
-    - name: Build libdoltlite.a with libFuzzer + ASan
-      run: |
-        cd build-fuzz
-        make CC=clang \
-          CFLAGS="-O1 -g -fsanitize=fuzzer-no-link,address -fno-omit-frame-pointer -fno-sanitize-recover=address" \
-          LDFLAGS="-fsanitize=fuzzer-no-link,address" \
-          libdoltlite.a
-
-    - name: Compile fuzz harnesses
-      run: |
-        for target in fuzz_replaywal fuzz_prolly_node fuzz_deserialize_refs fuzz_read_index fuzz_deserialize_catalog; do
-          clang -O1 -g \
-            -fsanitize=fuzzer,address -fno-omit-frame-pointer -fno-sanitize-recover=address \
-            -DDOLTLITE_PROLLY=1 -D_HAVE_SQLITE_CONFIG_H \
-            -I"$GITHUB_WORKSPACE/build-fuzz" -I"$GITHUB_WORKSPACE/src" \
-            -o "$GITHUB_WORKSPACE/build-fuzz/$target" \
-            "$GITHUB_WORKSPACE/test/$target.c" \
-            "$GITHUB_WORKSPACE/build-fuzz/libdoltlite.a" \
-            -lz -lpthread
-        done
-
     - name: Run csReplayWal fuzzer (1m)
       env:
         ASAN_OPTIONS: abort_on_error=1:halt_on_error=1:print_stacktrace=1:detect_leaks=0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,85 +1,24 @@
 name: Test Suite
 
 on:
-  pull_request:
+  workflow_call:
 
 jobs:
-  coverage-build:
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    env:
-      CC: clang
-      CFLAGS: -O1 -g -fprofile-instr-generate -fcoverage-mapping
-      LDFLAGS: -fprofile-instr-generate
-
-    steps:
-    - uses: actions/checkout@v4
-
-    - name: Install dependencies
-      run: |
-        bash .github/scripts/install-apt-deps.sh \
-          build-essential clang llvm tcl-dev zlib1g-dev
-
-    - name: Configure instrumented build
-      run: |
-        mkdir -p build-coverage
-        cd build-coverage
-        TCL_CONFIG=$(find /usr/lib -name tclConfig.sh -print -quit 2>/dev/null)
-        if [ -n "$TCL_CONFIG" ]; then
-          ../configure --with-tcl=$(dirname "$TCL_CONFIG")
-        else
-          ../configure
-        fi
-
-    - name: Build shared coverage targets
-      run: |
-        cd build-coverage
-        make -j2 DOLTLITE_PROLLY_CHECK=1 \
-          doltlite doltlite-remotesrv doltlite-lib testfixture \
-          doltlite-c-tests-build doltlite-regression-test-c-build
-        make DOLTLITE_PROLLY=0 sqlite3
-        find . -type f -name '*.profraw' -delete
-
-    - name: Package instrumented build
-      run: |
-        mkdir -p coverage-artifact/build-coverage
-        cp build-coverage/doltlite \
-          build-coverage/doltlite-remotesrv \
-          build-coverage/doltlite_regression_test_c \
-          build-coverage/testfixture \
-          build-coverage/prolly_hash.o \
-          build-coverage/blake3*.o \
-          build-coverage/*_test \
-          coverage-artifact/build-coverage/
-        cp build-coverage/sqlite3 \
-          coverage-artifact/build-coverage/sqlite3-stock
-        llvm-strip --strip-debug coverage-artifact/build-coverage/*
-        tar -C coverage-artifact -czf coverage-build.tar.gz build-coverage
-
-    - name: Upload instrumented build
-      uses: actions/upload-artifact@v4
-      with:
-        name: coverage-build
-        path: coverage-build.tar.gz
-        retention-days: 1
-
   scaling:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
     - uses: actions/checkout@v4
 
-    - name: Install dependencies
-      run: |
-        bash .github/scripts/install-apt-deps.sh tcl-dev build-essential zlib1g-dev
+    - name: Download optimized build
+      uses: actions/download-artifact@v4
+      with:
+        name: benchmark-build
 
-    # Plain build: DOLTLITE_PROLLY_CHECK adds a full-tree walk to every
-    # commit, which swamps the curves this suite gates on.
-    - name: Build
+    - name: Extract optimized build
       run: |
-        mkdir -p build-plain && cd build-plain
-        ../configure
-        make doltlite
+        tar -xzf benchmark-build.tar.gz
+        mv build build-plain
 
     - name: Scaling curves
       run: bash test/doltlite_scaling.sh build-plain/doltlite
@@ -91,21 +30,13 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Configure
-      run: |
-        mkdir -p build && cd build
-        TCL_CONFIG=$(find /usr/lib -name tclConfig.sh -print -quit 2>/dev/null)
-        if [ -n "$TCL_CONFIG" ]; then
-          ../configure --with-tcl=$(dirname $TCL_CONFIG)
-        else
-          ../configure
-        fi
+    - name: Download checked build
+      uses: actions/download-artifact@v4
+      with:
+        name: checked-build-ubuntu
 
-    - name: Build concurrency stress
-      run: |
-        cd build
-        make DOLTLITE_PROLLY_CHECK=1 concurrent_stress_test
-      timeout-minutes: 5
+    - name: Extract checked build
+      run: tar -xzf checked-build-ubuntu.tar.gz
 
     - name: Run concurrency stress
       run: |
@@ -120,21 +51,13 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Configure
-      run: |
-        mkdir -p build && cd build
-        TCL_CONFIG=$(find /usr/lib -name tclConfig.sh -print -quit 2>/dev/null)
-        if [ -n "$TCL_CONFIG" ]; then
-          ../configure --with-tcl=$(dirname $TCL_CONFIG)
-        else
-          ../configure
-        fi
+    - name: Download checked build
+      uses: actions/download-artifact@v4
+      with:
+        name: checked-build-ubuntu
 
-    - name: Build prolly txn stress
-      run: |
-        cd build
-        make DOLTLITE_PROLLY_CHECK=1 prolly_txn_stress_test
-      timeout-minutes: 5
+    - name: Extract checked build
+      run: tar -xzf checked-build-ubuntu.tar.gz
 
     - name: Run prolly txn stress (loop)
       run: |
@@ -161,22 +84,13 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Configure
-      run: |
-        mkdir -p build && cd build
-        TCL_CONFIG=$(find /usr/lib -name tclConfig.sh -print -quit 2>/dev/null)
-        if [ -n "$TCL_CONFIG" ]; then
-          ../configure --with-tcl=$(dirname $TCL_CONFIG)
-        else
-          ../configure
-        fi
+    - name: Download checked build
+      uses: actions/download-artifact@v4
+      with:
+        name: checked-build-ubuntu
 
-    - name: Build version-control concurrency stress
-      run: |
-        cd build
-        make DOLTLITE_PROLLY_CHECK=1 vc_concurrency_test
-        make DOLTLITE_PROLLY_CHECK=1 vc_ref_mutation_stress_test
-      timeout-minutes: 5
+    - name: Extract checked build
+      run: tar -xzf checked-build-ubuntu.tar.gz
 
     - name: Run version-control concurrency stress
       run: |
@@ -206,27 +120,15 @@ jobs:
 
     - name: Install dependencies
       run: |
-        bash .github/scripts/install-apt-deps.sh build-essential zlib1g-dev
+        bash .github/scripts/install-apt-deps.sh zlib1g-dev
 
-    - name: Configure
-      run: |
-        mkdir -p build && cd build
-        ../configure
+    - name: Download checked build
+      uses: actions/download-artifact@v4
+      with:
+        name: checked-build-ubuntu
 
-    - name: Build DoltLite amalgamation
-      run: |
-        cd build
-        make sqlite3.c sqlite3.h
-
-    - name: Build pthread stress tests
-      run: |
-        cd build
-        cc -O2 -g -I. -I../src \
-          -o threadtest4 ../test/threadtest4.c sqlite3.c \
-          -ldl -lpthread -lm -lz
-        cc -O2 -g -I. -I../src \
-          -o threadtest5 ../test/threadtest5.c sqlite3.c \
-          -ldl -lpthread -lm -lz
+    - name: Extract checked build
+      run: tar -xzf checked-build-ubuntu.tar.gz
 
     - name: Run threadtest4 serialized
       run: |
@@ -254,63 +156,25 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install dependencies
-      run: bash .github/scripts/install-apt-deps.sh build-essential zlib1g-dev tcl-dev fossil unixodbc-dev
+      run: bash .github/scripts/install-apt-deps.sh zlib1g-dev unixodbc
 
-    - name: Build doltlite amalgamation
-      run: |
-        mkdir -p build && cd build
-        TCL_CONFIG=$(find /usr/lib -name tclConfig.sh -print -quit 2>/dev/null)
-        if [ -n "$TCL_CONFIG" ]; then
-          ../configure --with-tcl=$(dirname $TCL_CONFIG)
-        else
-          ../configure
-        fi
-        make sqlite3.c sqlite3.h
+    - name: Download checked build
+      uses: actions/download-artifact@v4
+      with:
+        name: checked-build-ubuntu
 
-    - name: Clone sqllogictest (official SQLite Fossil repo)
-      run: |
-        fossil clone https://www.sqlite.org/sqllogictest/ /tmp/sqllogictest.fossil
-        mkdir -p /tmp/sqllogictest && cd /tmp/sqllogictest
-        # Pin to a fixed check-in so query-record line numbers (the keys of the
-        # per-assertion divergence list) stay stable across runs.
-        fossil open /tmp/sqllogictest.fossil db57eba95d7c412bb413da5480c8be24109a8faf
-        # Make the runner emit a "!DIVERGE <query-line>" token per divergent
-        # query record (both runners are built from this patched source).
-        perl "$GITHUB_WORKSPACE/test/patch_sqllogictest.pl" < src/sqllogictest.c > src/sqllogictest.c.patched
-        mv src/sqllogictest.c.patched src/sqllogictest.c
-
-    - name: Build stock sqllogictest C runner (reference)
-      run: |
-        cd /tmp/sqllogictest/src
-        gcc -g -O2 -DSQLITE_NO_SYNC=1 -DSQLITE_THREADSAFE=0 \
-          -DSQLITE_OMIT_LOAD_EXTENSION -c md5.c
-        gcc -g -O2 -DSQLITE_NO_SYNC=1 -DSQLITE_THREADSAFE=0 \
-          -DSQLITE_OMIT_LOAD_EXTENSION -c sqlite3.c
-        gcc -g -O2 -o sqllogictest-stock sqllogictest.c md5.o sqlite3.o -lpthread -lm -lodbc
-
-    - name: Build sqllogictest C runner with doltlite
-      run: |
-        cd /tmp/sqllogictest/src
-        # Replace bundled SQLite amalgamation with doltlite's
-        cp $GITHUB_WORKSPACE/build/sqlite3.c sqlite3.c
-        cp $GITHUB_WORKSPACE/build/sqlite3.h sqlite3.h
-        # doltlite's amalgamation has the prolly storage engine baked in, which
-        # needs a threadsafe build (THREADSAFE=0 turns btree-mutex entry points
-        # into no-op macros the engine's orig/shim split can't reconcile).
-        gcc -g -O2 -DSQLITE_NO_SYNC=1 -DSQLITE_THREADSAFE=1 \
-          -DSQLITE_OMIT_LOAD_EXTENSION -c sqlite3.c
-        gcc -g -O2 -o sqllogictest-doltlite sqllogictest.c md5.o sqlite3.o -lpthread -lm -lz -lodbc
+    - name: Extract checked build
+      run: tar -xzf checked-build-ubuntu.tar.gz
 
     - name: Run full sqllogictest suite
       run: |
         bash test/run_sqllogictest.sh \
-          /tmp/sqllogictest/src/sqllogictest-doltlite \
-          /tmp/sqllogictest/src/sqllogictest-stock \
-          /tmp/sqllogictest/test
+          build/sqllogictest/src/sqllogictest-doltlite \
+          build/sqllogictest/src/sqllogictest-stock \
+          build/sqllogictest/test
 
   oracle-tests:
     name: oracle-tests-${{ matrix.bucket }}
-    needs: coverage-build
     runs-on: ubuntu-latest
     timeout-minutes: 20
     strategy:
@@ -385,7 +249,6 @@ jobs:
 
   sqlite-regression:
     name: sqlite-regression-${{ matrix.bucket }}
-    needs: coverage-build
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
@@ -407,7 +270,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        bash .github/scripts/install-apt-deps.sh tcl-dev build-essential zlib1g-dev
+        bash .github/scripts/install-apt-deps.sh build-essential zlib1g-dev
 
     - name: Download instrumented build
       uses: actions/download-artifact@v4
@@ -463,7 +326,6 @@ jobs:
 
   coverage-native:
     name: coverage-native-${{ matrix.suite }}
-    needs: coverage-build
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
@@ -471,6 +333,7 @@ jobs:
       CFLAGS: -O1 -g -fprofile-instr-generate -fcoverage-mapping
       LDFLAGS: -fprofile-instr-generate
       DOLTLITE_REGRESSION_PREBUILT: 1
+      DOLTLITE_BLAKE3_KAT_BIN: ${{ github.workspace }}/build-coverage/blake3_kat_test
     strategy:
       fail-fast: false
       matrix:
@@ -526,7 +389,6 @@ jobs:
         retention-days: 1
 
   coverage-remotes:
-    needs: coverage-build
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
@@ -572,7 +434,6 @@ jobs:
 
   source-coverage:
     needs:
-      - coverage-build
       - oracle-tests
       - sqlite-regression
       - coverage-native
@@ -696,26 +557,22 @@ jobs:
       run: |
         bash .github/scripts/install-apt-deps.sh tcl-dev build-essential zlib1g-dev
 
-    - name: Cache old-version binaries
-      uses: actions/cache@v4
+    - name: Download checked build
+      uses: actions/download-artifact@v4
       with:
-        path: .compat-cache
-        key: compat-bins-${{ runner.os }}-${{ github.base_ref || github.ref_name }}
-        restore-keys: |
-          compat-bins-${{ runner.os }}-
+        name: checked-build-ubuntu
 
-    - name: Configure
+    - name: Download compatibility references
+      uses: actions/download-artifact@v4
+      with:
+        name: compat-build
+
+    - name: Extract prebuilt binaries
       run: |
-        mkdir -p build && cd build
-        TCL_CONFIG=$(find /usr/lib -name tclConfig.sh -print -quit 2>/dev/null)
-        if [ -n "$TCL_CONFIG" ]; then
-          ../configure --with-tcl=$(dirname $TCL_CONFIG)
-        else
-          ../configure
-        fi
-
-    - name: Build doltlite
-      run: cd build && make -j4 doltlite
+        tar -xzf checked-build-ubuntu.tar.gz
+        tar -xzf compat-build.tar.gz
 
     - name: Cross-version compatibility tests
+      env:
+        DOLTLITE_COMPAT_PREBUILT: 1
       run: bash test/doltlite_compat_test.sh build/doltlite

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -158,13 +158,13 @@ jobs:
     - name: Install dependencies
       run: bash .github/scripts/install-apt-deps.sh zlib1g-dev unixodbc
 
-    - name: Download checked build
+    - name: Download sqllogictest build
       uses: actions/download-artifact@v4
       with:
-        name: checked-build-ubuntu
+        name: sqllogictest-build
 
-    - name: Extract checked build
-      run: tar -xzf checked-build-ubuntu.tar.gz
+    - name: Extract sqllogictest build
+      run: tar -xzf sqllogictest-build.tar.gz
 
     - name: Run full sqllogictest suite
       run: |

--- a/README.md
+++ b/README.md
@@ -1003,8 +1003,18 @@ bash ../test/doltlite_attach_sqlite.sh   # ATTACH standard SQLite databases
 
 ### Source Coverage
 
-CI builds the non-amalgamated engine once with LLVM source-coverage
-instrumentation. The existing Linux correctness jobs consume that build and
+Pull-request CI has two global phases. The first phase builds every binary and
+generated source needed by the suite, rejects compiler warnings, and publishes
+short-lived artifacts. It includes checked Linux, macOS, and Windows builds;
+LLVM coverage; optimized benchmarks; ASan/UBSan and TSan; crash-test and
+libFuzzer targets; WebAssembly; historical compatibility references; and
+assert-enabled development configurations. The second phase starts only after
+every build is green and runs all tests against those immutable artifacts.
+This avoids recompiling the same engine in each test shard and prevents test
+jobs from consuming a partially successful build set.
+
+The LLVM job builds the non-amalgamated engine once with source-coverage
+instrumentation. The existing Linux correctness jobs consume that artifact and
 run the complete SQLite Tcl regression buckets, differential oracles,
 deterministic shell and C suites, and the credential/TLS/HTTP remote
 integration suites. Each parallel job uploads a small pool of raw profiles; a
@@ -1013,10 +1023,10 @@ the DoltLite-owned `src/` implementation files. The workflow fails if an owned
 source file with executable lines receives zero line coverage.
 
 Timing and scale gates, concurrency and fault stress, sanitizers, and
-platform-specific jobs keep their optimized or specialized builds. They do not
-contribute profiles. macOS and Windows still run their platform checks, but
-deterministic Linux correctness tests are not repeated outside the
-instrumented jobs.
+platform-specific jobs consume their optimized or specialized phase-one
+artifacts. They do not contribute profiles. macOS and Windows still run their
+platform checks, but deterministic Linux correctness tests are not repeated
+outside the instrumented jobs.
 
 The aggregate source-coverage percentages are informational; no percentage
 floor is currently set. CI updates a single coverage comment on the pull

--- a/README.md
+++ b/README.md
@@ -1012,6 +1012,9 @@ assert-enabled development configurations. The second phase starts only after
 every build is green and runs all tests against those immutable artifacts.
 This avoids recompiling the same engine in each test shard and prevents test
 jobs from consuming a partially successful build set.
+Independent development configurations and sanitizer surfaces are sharded by
+purpose so the complete pull-request workflow remains within its 20-minute
+wall-clock budget without reducing coverage.
 
 The LLVM job builds the non-amalgamated engine once with source-coverage
 instrumentation. The existing Linux correctness jobs consume that artifact and

--- a/test/amalgamation_http_probe.c
+++ b/test/amalgamation_http_probe.c
@@ -1,0 +1,102 @@
+#include "sqlite3.h"
+#include <stdio.h>
+#include <stdlib.h>
+
+extern int doltliteInstallAutoExt(void);
+
+static int exec_sql(sqlite3 *db, const char *zSql){
+  char *zErr = 0;
+  int rc = sqlite3_exec(db, zSql, 0, 0, &zErr);
+  if( rc!=SQLITE_OK ){
+    fprintf(stderr, "%s\n", zErr ? zErr : sqlite3_errmsg(db));
+    sqlite3_free(zErr);
+    return 1;
+  }
+  return 0;
+}
+
+static int scalar_int(sqlite3 *db, const char *zSql, int *pVal){
+  sqlite3_stmt *pStmt = 0;
+  int rc = sqlite3_prepare_v2(db, zSql, -1, &pStmt, 0);
+  if( rc!=SQLITE_OK ){
+    fprintf(stderr, "%s\n", sqlite3_errmsg(db));
+    return 1;
+  }
+  rc = sqlite3_step(pStmt);
+  if( rc!=SQLITE_ROW ){
+    fprintf(stderr, "expected row, got rc=%d\n", rc);
+    sqlite3_finalize(pStmt);
+    return 1;
+  }
+  *pVal = sqlite3_column_int(pStmt, 0);
+  sqlite3_finalize(pStmt);
+  return 0;
+}
+
+int main(int argc, char **argv){
+  sqlite3 *db = 0;
+  int n = 0;
+  char *zSql;
+  const char *zSrc;
+  const char *zClone;
+  const char *zUrl;
+
+  if( argc!=4 ){
+    fprintf(stderr, "usage: %s SRC_DB CLONE_DB HTTP_URL\n", argv[0]);
+    return 1;
+  }
+  zSrc = argv[1];
+  zClone = argv[2];
+  zUrl = argv[3];
+
+  if( doltliteInstallAutoExt()!=SQLITE_OK ){
+    fprintf(stderr, "doltliteInstallAutoExt failed\n");
+    return 1;
+  }
+
+  if( sqlite3_open(zSrc, &db)!=SQLITE_OK ){
+    fprintf(stderr, "%s\n", db ? sqlite3_errmsg(db) : "sqlite3_open failed");
+    return 1;
+  }
+  if( exec_sql(db,
+        "CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT);"
+        "INSERT INTO users VALUES(1,'alice'),(2,'bob'),(3,'charlie');"
+        "SELECT dolt_add('-A');"
+        "SELECT dolt_commit('-m','initial');") ){
+    sqlite3_close(db);
+    return 1;
+  }
+  zSql = sqlite3_mprintf(
+      "SELECT dolt_remote('add','origin',%Q);"
+      "SELECT dolt_push('origin','main');", zUrl);
+  if( !zSql || exec_sql(db, zSql) ){
+    sqlite3_free(zSql);
+    sqlite3_close(db);
+    return 1;
+  }
+  sqlite3_free(zSql);
+  sqlite3_close(db);
+
+  if( sqlite3_open(zClone, &db)!=SQLITE_OK ){
+    fprintf(stderr, "%s\n", db ? sqlite3_errmsg(db) : "sqlite3_open failed");
+    return 1;
+  }
+  zSql = sqlite3_mprintf("SELECT dolt_clone(%Q);", zUrl);
+  if( !zSql || exec_sql(db, zSql) ){
+    sqlite3_free(zSql);
+    sqlite3_close(db);
+    return 1;
+  }
+  sqlite3_free(zSql);
+  if( scalar_int(db, "SELECT count(*) FROM users;", &n) ){
+    sqlite3_close(db);
+    return 1;
+  }
+  sqlite3_close(db);
+
+  if( n!=3 ){
+    fprintf(stderr, "expected 3 cloned users, got %d\n", n);
+    return 1;
+  }
+  return 0;
+}

--- a/test/amalgamation_http_remote_test.sh
+++ b/test/amalgamation_http_remote_test.sh
@@ -29,113 +29,16 @@ case "$(uname -s)" in
   MINGW*|MSYS*|CYGWIN*) probe_libs+=(-lws2_32 -lbcrypt -lcrypt32) ;;
 esac
 
-probe_c="$tmp/amalg_http_probe.c"
-cat >"$probe_c" <<'EOF'
-#include "sqlite3.h"
-#include <stdio.h>
-#include <stdlib.h>
-
-extern int doltliteInstallAutoExt(void);
-
-static int exec_sql(sqlite3 *db, const char *zSql){
-  char *zErr = 0;
-  int rc = sqlite3_exec(db, zSql, 0, 0, &zErr);
-  if( rc!=SQLITE_OK ){
-    fprintf(stderr, "%s\n", zErr ? zErr : sqlite3_errmsg(db));
-    sqlite3_free(zErr);
-    return 1;
-  }
-  return 0;
-}
-
-static int scalar_int(sqlite3 *db, const char *zSql, int *pVal){
-  sqlite3_stmt *pStmt = 0;
-  int rc = sqlite3_prepare_v2(db, zSql, -1, &pStmt, 0);
-  if( rc!=SQLITE_OK ){
-    fprintf(stderr, "%s\n", sqlite3_errmsg(db));
-    return 1;
-  }
-  rc = sqlite3_step(pStmt);
-  if( rc!=SQLITE_ROW ){
-    fprintf(stderr, "expected row, got rc=%d\n", rc);
-    sqlite3_finalize(pStmt);
-    return 1;
-  }
-  *pVal = sqlite3_column_int(pStmt, 0);
-  sqlite3_finalize(pStmt);
-  return 0;
-}
-
-int main(int argc, char **argv){
-  sqlite3 *db = 0;
-  int n = 0;
-  char *zSql;
-  const char *zSrc;
-  const char *zClone;
-  const char *zUrl;
-
-  if( argc!=4 ){
-    fprintf(stderr, "usage: %s SRC_DB CLONE_DB HTTP_URL\n", argv[0]);
-    return 1;
-  }
-  zSrc = argv[1];
-  zClone = argv[2];
-  zUrl = argv[3];
-
-  if( doltliteInstallAutoExt()!=SQLITE_OK ){
-    fprintf(stderr, "doltliteInstallAutoExt failed\n");
-    return 1;
-  }
-
-  if( sqlite3_open(zSrc, &db)!=SQLITE_OK ){
-    fprintf(stderr, "%s\n", db ? sqlite3_errmsg(db) : "sqlite3_open failed");
-    return 1;
-  }
-  if( exec_sql(db,
-        "CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT);"
-        "INSERT INTO users VALUES(1,'alice'),(2,'bob'),(3,'charlie');"
-        "SELECT dolt_add('-A');"
-        "SELECT dolt_commit('-m','initial');") ){
-    sqlite3_close(db);
-    return 1;
-  }
-  zSql = sqlite3_mprintf(
-      "SELECT dolt_remote('add','origin',%Q);"
-      "SELECT dolt_push('origin','main');", zUrl);
-  if( !zSql || exec_sql(db, zSql) ){
-    sqlite3_free(zSql);
-    sqlite3_close(db);
-    return 1;
-  }
-  sqlite3_free(zSql);
-  sqlite3_close(db);
-
-  if( sqlite3_open(zClone, &db)!=SQLITE_OK ){
-    fprintf(stderr, "%s\n", db ? sqlite3_errmsg(db) : "sqlite3_open failed");
-    return 1;
-  }
-  zSql = sqlite3_mprintf("SELECT dolt_clone(%Q);", zUrl);
-  if( !zSql || exec_sql(db, zSql) ){
-    sqlite3_free(zSql);
-    sqlite3_close(db);
-    return 1;
-  }
-  sqlite3_free(zSql);
-  if( scalar_int(db, "SELECT count(*) FROM users;", &n) ){
-    sqlite3_close(db);
-    return 1;
-  }
-  sqlite3_close(db);
-
-  if( n!=3 ){
-    fprintf(stderr, "expected 3 cloned users, got %d\n", n);
-    return 1;
-  }
-  return 0;
-}
-EOF
-
-"$cc_bin" -w -I. "$probe_c" ./sqlite3.c "${probe_libs[@]}" -o "$tmp/amalg_http_probe"
+probe="${DOLTLITE_AMALG_HTTP_PROBE:-}"
+if [ -z "$probe" ]; then
+  probe="$tmp/amalg_http_probe"
+  "$cc_bin" -Wno-comment -I. ../test/amalgamation_http_probe.c \
+    ./sqlite3.c "${probe_libs[@]}" -o "$probe"
+fi
+if [ ! -x "$probe" ]; then
+  echo "FAIL: amalgamation HTTP probe not found at $probe"
+  exit 1
+fi
 
 mkdir -p "$tmp/srv"
 "$remotesrv" -p 0 --bind 127.0.0.1 "$tmp/srv" >"$tmp/srv.log" 2>&1 &
@@ -153,5 +56,5 @@ if [ -z "$port" ]; then
   exit 1
 fi
 
-"$tmp/amalg_http_probe" "$tmp/src.db" "$tmp/clone.db" "http://127.0.0.1:$port/repo.db"
+"$probe" "$tmp/src.db" "$tmp/clone.db" "http://127.0.0.1:$port/repo.db"
 echo "amalgamation plaintext HTTP remote: PASS"

--- a/test/blake3_kat.c
+++ b/test/blake3_kat.c
@@ -1,0 +1,84 @@
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include "blake3.h"
+
+typedef struct ProllyHash { uint8_t data[20]; } ProllyHash;
+extern void prollyHashCompute(const void *pData, int nData, ProllyHash *pOut);
+
+static void print_hex(const uint8_t *p, int n){
+  int i;
+  for(i=0; i<n; i++) printf("%02x", p[i]);
+}
+
+int main(int argc, char **argv){
+  const char *test;
+  if( argc<2 ){
+    fprintf(stderr, "usage: %s <test>\n", argv[0]);
+    return 2;
+  }
+  test = argv[1];
+
+  if( !strcmp(test, "empty-blake3-32") ){
+    blake3_hasher h;
+    uint8_t out[32];
+    blake3_hasher_init(&h);
+    blake3_hasher_update(&h, "", 0);
+    blake3_hasher_finalize(&h, out, 32);
+    print_hex(out, 32);
+    printf("\n");
+    return 0;
+  }
+
+  if( !strcmp(test, "prolly-empty") ){
+    ProllyHash h;
+    prollyHashCompute("", 0, &h);
+    print_hex(h.data, 20);
+    printf("\n");
+    return 0;
+  }
+  if( !strcmp(test, "prolly-abc") ){
+    ProllyHash h;
+    prollyHashCompute("abc", 3, &h);
+    print_hex(h.data, 20);
+    printf("\n");
+    return 0;
+  }
+  if( !strcmp(test, "prolly-1024") ){
+    uint8_t buf[1024];
+    int i;
+    ProllyHash h;
+    for(i=0; i<1024; i++) buf[i] = (uint8_t)(i % 256);
+    prollyHashCompute(buf, 1024, &h);
+    print_hex(h.data, 20);
+    printf("\n");
+    return 0;
+  }
+  if( !strcmp(test, "prolly-4096") ){
+    uint8_t *buf = malloc(4096);
+    int i;
+    ProllyHash h;
+    if( !buf ) return 1;
+    for(i=0; i<4096; i++) buf[i] = (uint8_t)(i % 256);
+    prollyHashCompute(buf, 4096, &h);
+    free(buf);
+    print_hex(h.data, 20);
+    printf("\n");
+    return 0;
+  }
+  if( !strcmp(test, "prolly-16384") ){
+    uint8_t *buf = malloc(16384);
+    int i;
+    ProllyHash h;
+    if( !buf ) return 1;
+    for(i=0; i<16384; i++) buf[i] = (uint8_t)(i % 256);
+    prollyHashCompute(buf, 16384, &h);
+    free(buf);
+    print_hex(h.data, 20);
+    printf("\n");
+    return 0;
+  }
+  fprintf(stderr, "unknown test: %s\n", test);
+  return 2;
+}

--- a/test/blake3_kat_test.sh
+++ b/test/blake3_kat_test.sh
@@ -39,106 +39,54 @@ hash_via_doltlite() {
 }
 
 
-cat > "$TMP/blake3_kat.c" <<'EOF'
-#include <stdio.h>
-#include <stdint.h>
-#include <stdlib.h>
-#include <string.h>
-#include "blake3.h"
-
-typedef struct ProllyHash { uint8_t data[20]; } ProllyHash;
-extern void prollyHashCompute(const void *pData, int nData, ProllyHash *pOut);
-
-static void print_hex(const uint8_t *p, int n) {
-  for (int i = 0; i < n; i++) printf("%02x", p[i]);
-}
-
-int main(int argc, char **argv) {
-  if (argc < 2) { fprintf(stderr, "usage: %s <test>\n", argv[0]); return 2; }
-  const char *test = argv[1];
-
-  if (!strcmp(test, "empty-blake3-32")) {
-    /* full 32-byte BLAKE3 digest of the empty input */
-    blake3_hasher h; uint8_t out[32];
-    blake3_hasher_init(&h);
-    blake3_hasher_update(&h, "", 0);
-    blake3_hasher_finalize(&h, out, 32);
-    print_hex(out, 32); printf("\n"); return 0;
-  }
-
-  if (!strcmp(test, "prolly-empty")) {
-    ProllyHash h; prollyHashCompute("", 0, &h);
-    print_hex(h.data, 20); printf("\n"); return 0;
-  }
-  if (!strcmp(test, "prolly-abc")) {
-    ProllyHash h; prollyHashCompute("abc", 3, &h);
-    print_hex(h.data, 20); printf("\n"); return 0;
-  }
-  if (!strcmp(test, "prolly-1024")) {
-    uint8_t buf[1024];
-    for (int i = 0; i < 1024; i++) buf[i] = (uint8_t)(i % 256);
-    ProllyHash h; prollyHashCompute(buf, 1024, &h);
-    print_hex(h.data, 20); printf("\n"); return 0;
-  }
-  if (!strcmp(test, "prolly-4096")) {
-    uint8_t *buf = malloc(4096);
-    for (int i = 0; i < 4096; i++) buf[i] = (uint8_t)(i % 256);
-    ProllyHash h; prollyHashCompute(buf, 4096, &h);
-    free(buf);
-    print_hex(h.data, 20); printf("\n"); return 0;
-  }
-  if (!strcmp(test, "prolly-16384")) {
-    uint8_t *buf = malloc(16384);
-    for (int i = 0; i < 16384; i++) buf[i] = (uint8_t)(i % 256);
-    ProllyHash h; prollyHashCompute(buf, 16384, &h);
-    free(buf);
-    print_hex(h.data, 20); printf("\n"); return 0;
-  }
-  fprintf(stderr, "unknown test: %s\n", test);
-  return 2;
-}
-EOF
-
 echo "=== BLAKE3 KAT (vendored) ==="
 HERE=$(cd "$(dirname "$0")/.." && pwd)
-blake_objects=(blake3.o blake3_portable.o blake3_dispatch.o)
-for object in blake3_sse2.o blake3_sse41.o blake3_avx2.o blake3_avx512.o blake3_neon.o; do
-  if [ -f "$object" ]; then
-    blake_objects+=("$object")
-  fi
-done
-"${CC:-cc}" ${CFLAGS:-"-O2"} "$TMP/blake3_kat.c" \
-   prolly_hash.o "${blake_objects[@]}" \
-   -I "$HERE/src" -I "$HERE/ext/blake3" -DDOLTLITE_PROLLY=1 \
-   ${LDFLAGS:-} -lm \
-   -o "$TMP/blake3_kat" 2>"$TMP/build.err" || {
-    echo "  build failed:"
-    cat "$TMP/build.err"
-    exit 1
-  }
+BIN="${DOLTLITE_BLAKE3_KAT_BIN:-}"
+if [ -z "$BIN" ]; then
+  BIN="$TMP/blake3_kat"
+  blake_objects=(blake3.o blake3_portable.o blake3_dispatch.o)
+  for object in blake3_sse2.o blake3_sse41.o blake3_avx2.o blake3_avx512.o blake3_neon.o; do
+    if [ -f "$object" ]; then
+      blake_objects+=("$object")
+    fi
+  done
+  "${CC:-cc}" ${CFLAGS:-"-O2"} "$HERE/test/blake3_kat.c" \
+     prolly_hash.o "${blake_objects[@]}" \
+     -I "$HERE/src" -I "$HERE/ext/blake3" -DDOLTLITE_PROLLY=1 \
+     ${LDFLAGS:-} -lm \
+     -o "$BIN" 2>"$TMP/build.err" || {
+      echo "  build failed:"
+      cat "$TMP/build.err"
+      exit 1
+    }
+fi
+if [ ! -x "$BIN" ]; then
+  echo "BLAKE3 KAT binary not found at $BIN"
+  exit 1
+fi
 
 check "empty (32-byte BLAKE3)" \
-  "$($TMP/blake3_kat empty-blake3-32)" \
+  "$($BIN empty-blake3-32)" \
   "af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262"
 
 check "prollyHashCompute(empty)" \
-  "$($TMP/blake3_kat prolly-empty)" \
+  "$($BIN prolly-empty)" \
   "af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9"
 
 check "prollyHashCompute(\"abc\")" \
-  "$($TMP/blake3_kat prolly-abc)" \
+  "$($BIN prolly-abc)" \
   "6437b3ac38465133ffb63b75273a8db548c55846"
 
 check "prollyHashCompute(0..255 x 4, 1024 B = 1 chunk)" \
-  "$($TMP/blake3_kat prolly-1024)" \
+  "$($BIN prolly-1024)" \
   "882179b8dbccd285cda241d968cfcccb3156c5ed"
 
 check "prollyHashCompute(0..255 x 16, 4096 B = 4 chunks)" \
-  "$($TMP/blake3_kat prolly-4096)" \
+  "$($BIN prolly-4096)" \
   "0b3dda6fbfe01c93d79388632f66c5c1fa781382"
 
 check "prollyHashCompute(0..255 x 64, 16384 B = 16 chunks)" \
-  "$($TMP/blake3_kat prolly-16384)" \
+  "$($BIN prolly-16384)" \
   "d49d367e4b0011a34510a28a1eb0caeb3e51e77f"
 
 echo

--- a/test/crash_recovery_test.c
+++ b/test/crash_recovery_test.c
@@ -337,8 +337,9 @@ static void test_04_two_commits_kill_after_second(void){
 
   {
     sqlite3 *db = 0;
+    int nLog;
     sqlite3_open(dbpath, &db);
-    int nLog = exec_user_commit_count(db);
+    nLog = exec_user_commit_count(db);
     check("test_04: at least commit-1 present", nLog>=1);
     if( nLog>=2 ){
       int cnt = queryScalarInt(db, "SELECT count(*) FROM t", -1);
@@ -392,8 +393,9 @@ static void test_05_kill_during_second_commit(void){
     check("test_05: db opens", rc==SQLITE_OK);
     if( rc==SQLITE_OK ){
       int nLog = exec_user_commit_count(db);
+      int hasStable;
       check("test_05: at least stable-commit present", nLog>=1);
-      int hasStable = queryScalarInt(db,
+      hasStable = queryScalarInt(db,
         "SELECT count(*) FROM t WHERE val='stable'", -1);
       check("test_05: stable row survives crash", hasStable==1);
     }
@@ -437,8 +439,9 @@ static void test_06_reopen_then_crash(void){
   verify_consistency(dbpath, "test_06");
   {
     sqlite3 *db = 0;
+    int hasFirst;
     sqlite3_open(dbpath, &db);
-    int hasFirst = queryScalarInt(db,
+    hasFirst = queryScalarInt(db,
       "SELECT count(*) FROM t WHERE val='persisted'", -1);
     check("test_06: first commit data survives", hasFirst==1);
     sqlite3_close(db);
@@ -533,6 +536,7 @@ static void test_08_branch_crash(void){
     check("test_08: db opens", rc==SQLITE_OK);
     if( rc==SQLITE_OK ){
       sqlite3_stmt *stmt = 0;
+      int nLog;
       rc = sqlite3_prepare_v2(db,
         "SELECT name, hash FROM dolt_branches", -1, &stmt, 0);
       check("test_08: branches queryable", rc==SQLITE_OK);
@@ -546,7 +550,7 @@ static void test_08_branch_crash(void){
       }
       sqlite3_finalize(stmt);
 
-      int nLog = exec_user_commit_count(db);
+      nLog = exec_user_commit_count(db);
       check("test_08: dolt_log consistent", nLog>=0);
     }
     sqlite3_close(db);
@@ -640,11 +644,11 @@ static void test_11_increasing_data_kill(void){
   if( pid==0 ){
     sqlite3 *db = 0;
     int i, j;
+    int row_id = 1;
     char sql[256];
     sqlite3_open(dbpath, &db);
     execSql(db, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
 
-    int row_id = 1;
     for( i=1; i<=5; i++ ){
       for( j=0; j<i*10; j++ ){
         snprintf(sql, sizeof(sql),
@@ -728,8 +732,9 @@ static void test_12_gc_crash(void){
     check("test_12: db opens after GC crash", rc==SQLITE_OK);
     if( rc==SQLITE_OK ){
       int cnt = queryScalarInt(db, "SELECT count(*) FROM t", -1);
+      int nLog;
       check("test_12: table queryable after GC crash", cnt>=0);
-      int nLog = exec_user_commit_count(db);
+      nLog = exec_user_commit_count(db);
       check("test_12: dolt_log works after GC crash", nLog>=1);
     }
     sqlite3_close(db);
@@ -816,8 +821,9 @@ static void test_14_gc_with_branches_crash(void){
   verify_consistency(dbpath, "test_14");
   {
     sqlite3 *db = 0;
+    int nBranch;
     sqlite3_open(dbpath, &db);
-    int nBranch = queryScalarInt(db,
+    nBranch = queryScalarInt(db,
       "SELECT count(*) FROM dolt_branches", -1);
     check("test_14: both branches survive GC crash", nBranch==2);
     sqlite3_close(db);
@@ -1146,8 +1152,9 @@ static void test_21_drop_table_crash(void){
     check("test_21: db opens", rc==SQLITE_OK);
     if( rc==SQLITE_OK ){
       int cnt_t = queryScalarInt(db, "SELECT count(*) FROM t", -1);
+      int cnt_t2;
       check("test_21: table t exists", cnt_t==1);
-      int cnt_t2 = queryScalarInt(db, "SELECT count(*) FROM t2", -2);
+      cnt_t2 = queryScalarInt(db, "SELECT count(*) FROM t2", -2);
       check("test_21: t2 state consistent",
             cnt_t2==1 || cnt_t2==-2);
     }
@@ -1196,9 +1203,10 @@ static void test_22_multi_table_commit_crash(void){
         int allOk = 1;
         for( i=1; i<=10; i++ ){
           char sql[128];
+          int cnt;
           snprintf(sql, sizeof(sql),
                    "SELECT count(*) FROM t%d", i);
-          int cnt = queryScalarInt(db, sql, -1);
+          cnt = queryScalarInt(db, sql, -1);
           if( cnt!=1 ) allOk = 0;
         }
         check("test_22: all 10 tables present if committed", allOk);
@@ -1250,8 +1258,9 @@ static void test_23_merge_crash(void){
   verify_consistency(dbpath, "test_23");
   {
     sqlite3 *db = 0;
+    int cnt;
     sqlite3_open(dbpath, &db);
-    int cnt = queryScalarInt(db, "SELECT count(*) FROM t", -1);
+    cnt = queryScalarInt(db, "SELECT count(*) FROM t", -1);
     check("test_23: row count is 1 or 2",
           cnt==1 || cnt==2);
     sqlite3_close(db);
@@ -1316,8 +1325,9 @@ static void test_24_repeated_crash_cycles(void){
 
   {
     sqlite3 *db = 0;
+    int hasSeed;
     sqlite3_open(dbpath, &db);
-    int hasSeed = queryScalarInt(db,
+    hasSeed = queryScalarInt(db,
       "SELECT count(*) FROM t WHERE val='seed'", -1);
     check("test_24: seed row always present", hasSeed==1);
     sqlite3_close(db);
@@ -1350,10 +1360,12 @@ static void test_25_tag_crash(void){
   verify_consistency(dbpath, "test_25");
   {
     sqlite3 *db = 0;
+    int nLog;
+    int cnt;
     sqlite3_open(dbpath, &db);
-    int nLog = exec_user_commit_count(db);
+    nLog = exec_user_commit_count(db);
     check("test_25: commit present", nLog>=1);
-    int cnt = queryScalarInt(db, "SELECT count(*) FROM t", -1);
+    cnt = queryScalarInt(db, "SELECT count(*) FROM t", -1);
     check("test_25: data intact", cnt==1);
     sqlite3_close(db);
   }
@@ -1398,8 +1410,9 @@ static void test_26_blob_data_crash(void){
       check("test_26: commit atomic (0 or 1)", nLog==0 || nLog==1);
       if( nLog==1 ){
         int cnt = queryScalarInt(db, "SELECT count(*) FROM t", -1);
+        int blobLen;
         check("test_26: all 50 blob rows if committed", cnt==50);
-        int blobLen = queryScalarInt(db,
+        blobLen = queryScalarInt(db,
           "SELECT length(data) FROM t WHERE id=0", -1);
         check("test_26: blob data intact", blobLen==1024);
       }
@@ -1443,10 +1456,12 @@ static void test_27_uncommitted_changes_crash(void){
 
   {
     sqlite3 *db = 0;
+    int nLog;
+    int committed;
     sqlite3_open(dbpath, &db);
-    int nLog = exec_user_commit_count(db);
+    nLog = exec_user_commit_count(db);
     check("test_27: only baseline commit", nLog==1);
-    int committed = queryScalarInt(db,
+    committed = queryScalarInt(db,
       "SELECT count(*) FROM t WHERE val='committed'", -1);
     check("test_27: committed data present", committed==1);
     sqlite3_close(db);
@@ -1544,8 +1559,9 @@ static void test_29_gc_after_many_commits(void){
     check("test_29: db opens after GC crash", rc==SQLITE_OK);
     if( rc==SQLITE_OK ){
       int nLog = exec_user_commit_count(db);
+      int cnt;
       check("test_29: all 10 commits present", nLog==10);
-      int cnt = queryScalarInt(db, "SELECT count(*) FROM t", -1);
+      cnt = queryScalarInt(db, "SELECT count(*) FROM t", -1);
       check("test_29: all 10 rows present", cnt==10);
     }
     sqlite3_close(db);

--- a/test/creds_kat_test.sh
+++ b/test/creds_kat_test.sh
@@ -9,26 +9,32 @@ case "$(uname -s)" in MINGW*|MSYS*|CYGWIN*) DOLTLITE_EXTRA_LIBS="-lws2_32 -lbcry
 TMP=$(mktemp -d)
 trap 'rm -rf "$TMP"' EXIT
 
-BIN="$TMP/creds_kat"
+BIN="${DOLTLITE_CREDS_KAT_BIN:-$TMP/creds_kat}"
 
 echo "=== doltlite creds KAT ==="
-"$CC" -O2 -Wall \
-  -I "$HERE/src" -I "$HERE/ext/ed25519" \
-  "$HERE/test/doltlite_creds_kat.c" \
-  "$HERE/src/doltlite_creds.c" \
-  "$HERE/ext/ed25519/fe.c" \
-  "$HERE/ext/ed25519/ge.c" \
-  "$HERE/ext/ed25519/sc.c" \
-  "$HERE/ext/ed25519/sha512.c" \
-  "$HERE/ext/ed25519/keypair.c" \
-  "$HERE/ext/ed25519/sign.c" \
-  "$HERE/ext/ed25519/verify.c" \
-  "$HERE/ext/ed25519/add_scalar.c" \
-  $DOLTLITE_EXTRA_LIBS \
-  -o "$BIN" 2>"$TMP/build.err" || {
-  echo "  build failed:"
-  cat "$TMP/build.err"
+if [ -z "${DOLTLITE_CREDS_KAT_BIN:-}" ]; then
+  "$CC" -O2 -Wall \
+    -I "$HERE/src" -I "$HERE/ext/ed25519" \
+    "$HERE/test/doltlite_creds_kat.c" \
+    "$HERE/src/doltlite_creds.c" \
+    "$HERE/ext/ed25519/fe.c" \
+    "$HERE/ext/ed25519/ge.c" \
+    "$HERE/ext/ed25519/sc.c" \
+    "$HERE/ext/ed25519/sha512.c" \
+    "$HERE/ext/ed25519/keypair.c" \
+    "$HERE/ext/ed25519/sign.c" \
+    "$HERE/ext/ed25519/verify.c" \
+    "$HERE/ext/ed25519/add_scalar.c" \
+    $DOLTLITE_EXTRA_LIBS \
+    -o "$BIN" 2>"$TMP/build.err" || {
+    echo "  build failed:"
+    cat "$TMP/build.err"
+    exit 1
+  }
+fi
+if [ ! -x "$BIN" ]; then
+  echo "credential KAT binary not found at $BIN"
   exit 1
-}
+fi
 
 DOLTLITE_CREDS_DIR="$TMP/creds" "$BIN" "$TMP/creds"

--- a/test/creds_verify_test.sh
+++ b/test/creds_verify_test.sh
@@ -9,27 +9,33 @@ case "$(uname -s)" in MINGW*|MSYS*|CYGWIN*) DOLTLITE_EXTRA_LIBS="-lws2_32 -lbcry
 TMP=$(mktemp -d)
 trap 'rm -rf "$TMP"' EXIT
 
-BIN="$TMP/creds_verify_kat"
+BIN="${DOLTLITE_CREDS_VERIFY_BIN:-$TMP/creds_verify_kat}"
 mkdir -p "$TMP/authkeys" "$TMP/empty" "$TMP/outside"
 
 echo "=== doltlite credential-verify KAT ==="
-"$CC" -O2 -Wall \
-  -I "$HERE/src" -I "$HERE/ext/ed25519" \
-  "$HERE/test/creds_verify_kat.c" \
-  "$HERE/src/doltlite_creds.c" \
-  "$HERE/ext/ed25519/fe.c" \
-  "$HERE/ext/ed25519/ge.c" \
-  "$HERE/ext/ed25519/sc.c" \
-  "$HERE/ext/ed25519/sha512.c" \
-  "$HERE/ext/ed25519/keypair.c" \
-  "$HERE/ext/ed25519/sign.c" \
-  "$HERE/ext/ed25519/verify.c" \
-  "$HERE/ext/ed25519/add_scalar.c" \
-  $DOLTLITE_EXTRA_LIBS \
-  -o "$BIN" 2>"$TMP/build.err" || {
-  echo "  build failed:"
-  cat "$TMP/build.err"
+if [ -z "${DOLTLITE_CREDS_VERIFY_BIN:-}" ]; then
+  "$CC" -O2 -Wall \
+    -I "$HERE/src" -I "$HERE/ext/ed25519" \
+    "$HERE/test/creds_verify_kat.c" \
+    "$HERE/src/doltlite_creds.c" \
+    "$HERE/ext/ed25519/fe.c" \
+    "$HERE/ext/ed25519/ge.c" \
+    "$HERE/ext/ed25519/sc.c" \
+    "$HERE/ext/ed25519/sha512.c" \
+    "$HERE/ext/ed25519/keypair.c" \
+    "$HERE/ext/ed25519/sign.c" \
+    "$HERE/ext/ed25519/verify.c" \
+    "$HERE/ext/ed25519/add_scalar.c" \
+    $DOLTLITE_EXTRA_LIBS \
+    -o "$BIN" 2>"$TMP/build.err" || {
+    echo "  build failed:"
+    cat "$TMP/build.err"
+    exit 1
+  }
+fi
+if [ ! -x "$BIN" ]; then
+  echo "credential verify binary not found at $BIN"
   exit 1
-}
+fi
 
 "$BIN" "$TMP/authkeys" "$TMP/empty" "$TMP/outside"

--- a/test/doltlite_compat_test.sh
+++ b/test/doltlite_compat_test.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+MODE=test
+if [ "${1:-}" = "--build-only" ]; then
+  MODE=build-only
+  shift
+fi
+
 DOLTLITE="${1:-$(dirname "$0")/../build/doltlite}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -17,10 +23,12 @@ ok()   { echo "PASS: $1"; pass=$((pass+1)); }
 bad()  { echo "FAIL: $1"; fail=$((fail+1)); }
 check(){ if [ "$2" = "0" ]; then ok "$1"; else bad "$1${3:+ — $3}"; fi; }
 
-DOLTLITE="$(cd "$(dirname "$DOLTLITE")" && pwd)/$(basename "$DOLTLITE")"
-if [ ! -x "$DOLTLITE" ]; then
-  echo "ERROR: current doltlite binary not found: $DOLTLITE"
-  exit 1
+if [ "$MODE" = "test" ]; then
+  DOLTLITE="$(cd "$(dirname "$DOLTLITE")" && pwd)/$(basename "$DOLTLITE")"
+  if [ ! -x "$DOLTLITE" ]; then
+    echo "ERROR: current doltlite binary not found: $DOLTLITE"
+    exit 1
+  fi
 fi
 if ! git -C "$REPO_ROOT" rev-parse v0.11.0 >/dev/null 2>&1; then
   echo "ERROR: git tags unavailable (shallow clone?); fetch tags first:"
@@ -92,6 +100,10 @@ build_old() {  # build_old <tag> -> echoes binary path, rc!=0 on failure
   local tag="$1"
   local bin="$CACHE_DIR/$tag/doltlite"
   if [ -x "$bin" ]; then echo "$bin"; return 0; fi
+  if [ "${DOLTLITE_COMPAT_PREBUILT:-0}" = "1" ]; then
+    echo "ERROR: prebuilt compatibility binary missing: $bin" >&2
+    return 1
+  fi
   local wt="$CACHE_DIR/src-$tag"
   mkdir -p "$CACHE_DIR/$tag"
   rm -rf "$wt"
@@ -200,6 +212,18 @@ fi
 echo "current: $cur_desc (series $cur_series, chunk store v$cur_csv)"
 echo "tags: $TAGS"
 echo
+
+if [ "$MODE" = "build-only" ]; then
+  for tag in $TAGS; do
+    echo "-- $tag: building compatibility binary"
+    if ! build_old "$tag" >/dev/null; then
+      echo "ERROR: failed to build $tag (see $CACHE_DIR/$tag/build.log)"
+      exit 1
+    fi
+  done
+  echo "Built all compatibility binaries."
+  exit 0
+fi
 
 for tag in $TAGS; do
   old_sig=$(format_signature "$tag")

--- a/test/doltlite_creds_kat.c
+++ b/test/doltlite_creds_kat.c
@@ -28,8 +28,6 @@ static void check_str(const char *name, const char *got, const char *want) {
   }
 }
 
-static const char *SEED_HEX =
-    "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f";
 static const char *PUB_HEX =
     "03a107bff3ce10be1d70dd18e74bc09967e4d6309ba50d5f1ddc8664125531b8";
 static const char *MSG = "doltlite auth";

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -7015,10 +7015,10 @@ static int mutmapAssertMatchesModel(
   ProllyMutMap *pMap,
   const MutMapModel *pModel
 ){
-  (void)zLabel;
   int ok = 1;
   int i;
   ProllyMutMapIter it;
+  (void)zLabel;
   if( prollyMutMapCount(pMap)!=pModel->n ){
     return 0;
   }

--- a/test/testrunner.tcl
+++ b/test/testrunner.tcl
@@ -1578,6 +1578,12 @@ proc add_devtest_jobs {lBld patternlist} {
   global TRG
 
   foreach b $lBld {
+    if {$TRG(config)!="" && [lsearch -exact [split $TRG(config) ,] $b]<0} {
+      continue
+    }
+    if {[lsearch -exact [split $TRG(omitconfig) ,] $b]>=0} {
+      continue
+    }
     set bld [add_build_job $b $TRG(testfixture)]
     add_tcl_jobs $bld veryquick $patternlist SHELL
     add_fuzztest_jobs $b $patternlist

--- a/test/tls_test.sh
+++ b/test/tls_test.sh
@@ -19,15 +19,22 @@ if command -v openssl >/dev/null 2>&1; then
 fi
 
 echo "=== doltlite TLS test ==="
-"$CC" -O2 -I "$HERE/src" -I "$HERE/ext/mbedtls/include" \
-  "$HERE/test/doltlite_tls_test_main.c" \
-  "$HERE/src/doltlite_tls.c" \
-  "$HERE"/ext/mbedtls/library/*.c \
-  $DOLTLITE_EXTRA_LIBS \
-  -o "$TMP/tls_test" 2>"$TMP/build.err" || {
-  echo "  build failed:"
-  cat "$TMP/build.err"
+BIN="${DOLTLITE_TLS_TEST_BIN:-$TMP/tls_test}"
+if [ -z "${DOLTLITE_TLS_TEST_BIN:-}" ]; then
+  "$CC" -O2 -I "$HERE/src" -I "$HERE/ext/mbedtls/include" \
+    "$HERE/test/doltlite_tls_test_main.c" \
+    "$HERE/src/doltlite_tls.c" \
+    "$HERE"/ext/mbedtls/library/*.c \
+    $DOLTLITE_EXTRA_LIBS \
+    -o "$BIN" 2>"$TMP/build.err" || {
+    echo "  build failed:"
+    cat "$TMP/build.err"
+    exit 1
+  }
+fi
+if [ ! -x "$BIN" ]; then
+  echo "TLS test binary not found at $BIN"
   exit 1
-}
+fi
 
-"$TMP/tls_test" ${FAKE:+"$FAKE"}
+"$BIN" ${FAKE:+"$FAKE"}


### PR DESCRIPTION
## Summary

- add a single pull-request CI orchestrator with a global build barrier
- build checked platform, coverage, benchmark, sanitizer, crash, fuzz, wasm, compatibility, and development variants once
- upload immutable short-lived artifacts and run every test workflow only after all builds pass
- remove configure, make, and compiler invocations from phase-two workflows
- prebuild KAT and amalgamation probes while preserving compile-on-demand local test behavior
- split historical compatibility binary construction from compatibility assertions

## Why

PR CI currently performs at least 18 native builds, including four identical optimized benchmark builds and repeated checked Linux builds for stress and smoke tests. This structure fails late, spends runner time recompiling the same source, and lets tests start before other build variants are known-good.

The new graph is:

1. `Build all binaries` — all ABI/configuration-specific producers run in parallel, with `-Werror` or warning-log gates.
2. `Build-Test`, `Test Suite`, `Sanitizers`, `Smoke`, and `Benchmark` — consume named artifacts and run tests only.

Release/tag and scheduled upstream-drift/nightly workflows remain separate.

## Local validation

- `actionlint .github/workflows/*.yml`
- parsed all workflow YAML
- shell syntax checks for modified test runners
- oracle bucket, orphan-suite, and crash-coverage manifest guards
- clean out-of-tree checked macOS build with `-Werror`
- prebuilt credentials, credential verification, TLS, BLAKE3, and amalgamation HTTP probes
- quickstart, concurrent branch/write, and prepared-statement binaries
- compatibility build-only and prebuilt-test modes against `v0.11.0`
