### PR TITLE
refactor: add chunk_store_int.h for private chunk_store helpers

### DIFF
--- a/main.mk
+++ b/main.mk
@@ -828,6 +828,7 @@ SRC += \
   $(TOP)/src/prolly_cache.h \
   $(TOP)/src/chunk_store.c \
   $(TOP)/src/chunk_store.h \
+  $(TOP)/src/chunk_store_int.h \
   $(TOP)/src/prolly_cursor.c \
   $(TOP)/src/prolly_cursor.h \
   $(TOP)/src/prolly_mutmap.c \

--- a/main.mk
+++ b/main.mk
@@ -1477,7 +1477,7 @@ prolly_node.o:	$(TOP)/src/prolly_node.c $(DEPS_OBJ_COMMON)
 prolly_cache.o:	$(TOP)/src/prolly_cache.c $(DEPS_OBJ_COMMON)
 	$(T.cc.sqlite) -c $(TOP)/src/prolly_cache.c
 
-chunk_store.o:	$(TOP)/src/chunk_store.c $(DEPS_OBJ_COMMON)
+chunk_store.o:	$(TOP)/src/chunk_store.c $(TOP)/src/chunk_store_int.h $(DEPS_OBJ_COMMON)
 	$(T.cc.sqlite) -c $(TOP)/src/chunk_store.c
 
 chunk_wal.o:	$(TOP)/src/chunk_wal.c $(DEPS_OBJ_COMMON)

--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -2,14 +2,8 @@
 
 #ifdef DOLTLITE_PROLLY
 
-#include "chunk_store.h"
-#include "prolly_hash.h"
-#include "prolly_encoding.h"
+#include "chunk_store_int.h"
 #include "../ext/blake3/blake3.h"
-#include <string.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <limits.h>
 #ifdef SQLITE_CRASH_TEST
 #include <unistd.h>
 #endif
@@ -91,10 +85,6 @@ static int csFileLockNB(sqlite3_vfs *pVfs, const char *path,
   return csFileLock(pVfs, path, ppFile, pzName);
 }
 
-typedef sqlite3_file *CsFileLock;
-# define CS_FILE_LOCK_INIT 0
-# define CS_GRAPH_LOCK(cs) ((cs)->pGraphLockFile)
-
 static int csReloadFromDisk(ChunkStore *cs);
 
 static int csCrashWriteInjectionActive(void){
@@ -114,9 +104,6 @@ static int csReloadInjectionActive(void){
 }
 #endif
 
-#define CS_RECENT_FAST_PATH_MAX 16384
-#define CS_WRITEBUF_RETAIN_MAX (64*1024)
-#define CS_PENDING_DRAIN_LIMIT (64*1024*1024)
 
 static i64 csPendingDrainLimit(void){
 #if defined(SQLITE_TEST) || defined(DOLTLITE_MECH_REPRO)

--- a/src/chunk_store_int.h
+++ b/src/chunk_store_int.h
@@ -1,0 +1,23 @@
+#ifndef CHUNK_STORE_INT_H
+#define CHUNK_STORE_INT_H
+
+/* Private declarations shared by the chunk_store implementation modules. */
+
+#include "chunk_store.h"
+#include "prolly_hash.h"
+#include "prolly_encoding.h"
+
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <limits.h>
+
+typedef sqlite3_file *CsFileLock;
+# define CS_FILE_LOCK_INIT 0
+# define CS_GRAPH_LOCK(cs) ((cs)->pGraphLockFile)
+
+#define CS_RECENT_FAST_PATH_MAX 16384
+#define CS_WRITEBUF_RETAIN_MAX (64*1024)
+#define CS_PENDING_DRAIN_LIMIT (64*1024*1024)
+
+#endif /* CHUNK_STORE_INT_H */

--- a/tool/mksqlite3c.tcl
+++ b/tool/mksqlite3c.tcl
@@ -241,7 +241,7 @@ set available_hdr(sqlite3session.h) 0
 if {$doltlite} {
   foreach hdr {
     blake3.h blake3_impl.h btree_orig_api.h btree_orig_prefix.h pager_shim.h record_codec.h sortkey.h
-    chunk_file.h chunk_index.h chunk_refs.h chunk_staging.h chunk_store.h chunk_wal.h
+    chunk_file.h chunk_index.h chunk_refs.h chunk_staging.h chunk_store.h chunk_store_int.h chunk_wal.h
     prolly_cache.h prolly_check.h prolly_chunk_walk.h prolly_chunker.h prolly_cursor.h
     prolly_diff.h prolly_encoding.h prolly_hash.h prolly_hashset.h prolly_mutate.h
     prolly_mutmap.h prolly_node.h prolly_record.h prolly_three_way_diff.h


### PR DESCRIPTION
## Summary
- Add `src/chunk_store_int.h` with shared private macros/typedefs for the chunk_store split series.
- Include it from `chunk_store.c`; register in `main.mk` EXTRA and `tool/mksqlite3c.tcl` available_hdr.
- No function body moves — scaffold only for B1–B3 extractions.

## Test plan
- [x] `make chunk_store.o`
- [x] `make lint`