### PR TITLE
refactor: add doltlite_branch_int.h for branch/checkout split

### DIFF
--- a/main.mk
+++ b/main.mk
@@ -632,7 +632,7 @@ ifeq ($(DOLTLITE_PROLLY),1)
     $(TOP)/src/doltlite_catalog_types.h $(TOP)/src/doltlite_commit.h \
     $(TOP)/src/doltlite_constraint_violations.h \
     $(TOP)/src/doltlite_ignore.h $(TOP)/src/doltlite_internal.h \
-    $(TOP)/src/doltlite_merge_int.h $(TOP)/src/doltlite_parse.h \
+    $(TOP)/src/doltlite_branch_int.h $(TOP)/src/doltlite_merge_int.h $(TOP)/src/doltlite_parse.h \
     $(TOP)/src/doltlite_name_index.h \
     $(TOP)/src/doltlite_record.h $(TOP)/src/doltlite_remote.h $(TOP)/src/doltlite_remotesrv.h \
     $(TOP)/src/doltlite_creds.h $(TOP)/src/doltlite_net.h $(TOP)/src/doltlite_tls.h \
@@ -1615,7 +1615,7 @@ doltlite_ref.o:	$(TOP)/src/doltlite_ref.c \
 doltlite_diff.o:	$(TOP)/src/doltlite_diff.c $(DEPS_OBJ_COMMON)
 	$(T.cc.sqlite) -c $(TOP)/src/doltlite_diff.c
 
-doltlite_branch.o:	$(TOP)/src/doltlite_branch.c $(DEPS_OBJ_COMMON)
+doltlite_branch.o:	$(TOP)/src/doltlite_branch.c $(TOP)/src/doltlite_branch_int.h $(DEPS_OBJ_COMMON)
 	$(T.cc.sqlite) -c $(TOP)/src/doltlite_branch.c
 
 doltlite_tag.o:	$(TOP)/src/doltlite_tag.c $(DEPS_OBJ_COMMON)

--- a/src/doltlite_branch.c
+++ b/src/doltlite_branch.c
@@ -1,6 +1,7 @@
 
 #ifdef DOLTLITE_PROLLY
 
+#include "doltlite_branch_int.h"
 #include "sqliteInt.h"
 #include "prolly_hash.h"
 #include "chunk_store.h"
@@ -18,15 +19,7 @@ static void activeBranchFunc(sqlite3_context *ctx, int argc, sqlite3_value **arg
   sqlite3_result_text(ctx, doltliteGetSessionBranch(db), -1, SQLITE_TRANSIENT);
 }
 
-typedef struct BranchMutationCtx BranchMutationCtx;
-struct BranchMutationCtx {
-  const char *zName;
-  ProllyHash head;
-  int isDelete;
-  int force;
-};
-
-static int branchNameEmpty(const char *zName){
+int branchNameEmpty(const char *zName){
   return zName==0 || zName[0]==0;
 }
 
@@ -58,7 +51,7 @@ static void branchNamedResultError(
   doltliteRefResultError(ctx, rc, zNotFound, zExists);
 }
 
-static int mutateBranchRef(sqlite3 *db, ChunkStore *cs, void *pArg){
+int mutateBranchRef(sqlite3 *db, ChunkStore *cs, void *pArg){
   BranchMutationCtx *p = (BranchMutationCtx*)pArg;
 
   if( p->isDelete ){

--- a/src/doltlite_branch_int.h
+++ b/src/doltlite_branch_int.h
@@ -1,0 +1,22 @@
+#ifndef DOLTLITE_BRANCH_INT_H
+#define DOLTLITE_BRANCH_INT_H
+
+/* Private declarations shared by the branch/checkout implementation modules. */
+
+#include "sqliteInt.h"
+#include "prolly_hash.h"
+#include "chunk_store.h"
+#include "doltlite_internal.h"
+
+typedef struct BranchMutationCtx BranchMutationCtx;
+struct BranchMutationCtx {
+  const char *zName;
+  ProllyHash head;
+  int isDelete;
+  int force;
+};
+
+int branchNameEmpty(const char *zName);
+int mutateBranchRef(sqlite3 *db, ChunkStore *cs, void *pArg);
+
+#endif /* DOLTLITE_BRANCH_INT_H */

--- a/tool/mksqlite3c.tcl
+++ b/tool/mksqlite3c.tcl
@@ -248,7 +248,7 @@ if {$doltlite} {
     prolly_three_way_merge.h prolly_xxhash.h prolly_btree_int.h
     doltlite_ancestor.h doltlite_catalog_types.h doltlite_chunk_walk.h doltlite_commit.h
     doltlite_constraint_violations.h doltlite_ignore.h doltlite_internal.h
-    doltlite_merge_int.h doltlite_name_index.h doltlite_parse.h
+    doltlite_branch_int.h doltlite_merge_int.h doltlite_name_index.h doltlite_parse.h
     doltlite_record.h doltlite_remote.h doltlite_remotesrv.h doltlite_vtab_util.h
     doltlite_creds.h doltlite_net.h doltlite_tls.h
   } {


### PR DESCRIPTION
## Summary
- Add `src/doltlite_branch_int.h` with `BranchMutationCtx` and declarations for `branchNameEmpty` / `mutateBranchRef`.
- Promote those symbols from `static` in `doltlite_branch.c`.
- Register header in `main.mk` EXTRA and `tool/mksqlite3c.tcl` available_hdr.

Scaffold for C1–C2b branch/checkout extractions. Pure refactor.

## Test plan
- [x] `make doltlite_branch.o`
- [x] `make lint`