### PR TITLE
Restructure performance regression testing

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -9,264 +9,243 @@ permissions:
   pull-requests: write
 
 jobs:
-  int-keys:
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-
-    env:
-      BENCH_RUNS: 5
-
-    steps:
-    - uses: actions/checkout@v4
-
-    - name: Download optimized build
-      uses: actions/download-artifact@v4
-      with:
-        name: benchmark-build
-
-    - name: Extract optimized build
-      run: tar -xzf benchmark-build.tar.gz
-
-    - name: Run benchmark
-      id: bench
-      run: |
-        cd build
-        # Capture script exit code separately from the output capture.
-        # Piping to `tee` would mask a ceiling-check failure (tee always
-        # exits 0), letting the job report green on a regression. Stash
-        # the rc and propagate it after the PR-comment step has run, so
-        # results are still visible on a failing run.
-        set +e
-        BENCH_SECTION_MODE=full bash ../test/sysbench_compare.sh > /tmp/bench_results.md
-        bench_rc=$?
-        set -e
-        cat /tmp/bench_results.md
-        echo "bench_rc=$bench_rc" >> "$GITHUB_OUTPUT"
-
-    - name: Comment PR with results
-      continue-on-error: true
-      uses: actions/github-script@v7
-      with:
-        script: |
-          // Read from file so the multi-line markdown (and any backticks /
-          // template-literal-unsafe chars in it) never has to round-trip
-          // through YAML scalars or JS template-literal parsing.
-          const fs = require('fs');
-          const body = fs.readFileSync('/tmp/bench_results.md', 'utf8');
-
-          if (!context.issue.number) {
-            console.log('No PR context (push event) — skipping comment');
-            return;
-          }
-
-          // Find existing classic benchmark comment
-          const comments = await github.rest.issues.listComments({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            issue_number: context.issue.number,
-          });
-          const botComment = comments.data.find(c =>
-            c.body.includes('<!-- benchmark:classic -->') ||
-            c.body.includes('## Sysbench-Style Benchmark: Doltlite vs SQLite')
-          );
-
-          if (botComment) {
-            await github.rest.issues.updateComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              comment_id: botComment.id,
-              body: body,
-            });
-          } else {
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body: body,
-            });
-          }
-
-    - name: Enforce ceiling
-      run: |
-        rc="${{ steps.bench.outputs.bench_rc }}"
-        if [ "$rc" != "0" ]; then
-          echo "Benchmark exceeded performance ceiling (rc=$rc)" >&2
-          exit "$rc"
-        fi
-
-  # Runs non-INTKEY sysbench variants as separate matrix jobs. At 100k rows
-  # each suite is large enough that running all three serially risks hitting
-  # the job timeout before benchmark results can be posted.
-  non-int-keys:
+  sysbench-relative:
     name: ${{ matrix.suite.name }}-keys
     runs-on: ubuntu-latest
     timeout-minutes: 20
-
     strategy:
       fail-fast: false
       matrix:
         suite:
+          - name: int
+            script: sysbench_compare.sh
           - name: textpk
             script: sysbench_compare_textpk.sh
-            output: /tmp/bench_textpk.md
-            marker: '<!-- benchmark:textpk -->'
           - name: blobpk
             script: sysbench_compare_blobpk.sh
-            output: /tmp/bench_blobpk.md
-            marker: '<!-- benchmark:blobpk -->'
           - name: compositepk
             script: sysbench_compare_compositepk.sh
-            output: /tmp/bench_compositepk.md
-            marker: '<!-- benchmark:compositepk -->'
-
-    env:
-      BENCH_RUNS: 5
 
     steps:
     - uses: actions/checkout@v4
 
-    - name: Download optimized build
+    - name: Download paired optimized build
       uses: actions/download-artifact@v4
       with:
         name: benchmark-build
 
-    - name: Extract optimized build
+    - name: Extract paired optimized build
       run: tar -xzf benchmark-build.tar.gz
 
-    - name: Run benchmark
-      id: bench
+    - name: Measure candidate against PR base
+      env:
+        BENCH_RUNS: 5
+        BENCH_AC_WRITE_RUNS: 9
+        BENCH_BASELINE_LABEL: PR base
+        BENCH_CANDIDATE_LABEL: PR candidate
+        BENCH_BASELINE_KIND: doltlite
+        BENCH_CANDIDATE_KIND: doltlite
+        BENCH_GATE_MODE: none
       run: |
-        cd build
-        # The script enforces the configured individual and average ceilings;
-        # capture rc separately so results are still posted on a failure.
-        set +e
-        bash ../test/${{ matrix.suite.script }} > "${{ matrix.suite.output }}"
-        bench_rc=$?
-        set -e
-        cat "${{ matrix.suite.output }}"
-        echo "bench_rc=$bench_rc" >> "$GITHUB_OUTPUT"
+        artifact="$GITHUB_WORKSPACE/benchmark-artifact"
+        results="$RUNNER_TEMP/benchmark-results"
+        mkdir -p "$results"
+        BENCH_BASELINE_BINARY="$artifact/baseline/doltlite" \
+          BENCH_CANDIDATE_BINARY="$artifact/candidate/doltlite" \
+          BENCH_BASELINE_TIMER="$artifact/baseline/bench_timer_doltlite" \
+          BENCH_CANDIDATE_TIMER="$artifact/candidate/bench_timer_doltlite" \
+          BENCH_RESULTS_OUTPUT="$results/${{ matrix.suite.name }}.tsv" \
+          BENCH_SAMPLES_OUTPUT="$results/${{ matrix.suite.name }}-samples.tsv" \
+          bash "test/${{ matrix.suite.script }}" \
+          > "$results/${{ matrix.suite.name }}.md"
+        cat "$results/${{ matrix.suite.name }}.md"
 
-    - name: Comment PR with results
-      continue-on-error: true
-      uses: actions/github-script@v7
+    - name: Upload paired measurements
+      uses: actions/upload-artifact@v4
       with:
-        script: |
-          // Read from file so the multi-line markdown (and any backticks /
-          // template-literal-unsafe chars in it) never has to round-trip
-          // through YAML scalars or JS template-literal parsing.
-          const fs = require('fs');
-          const body = fs.readFileSync('${{ matrix.suite.output }}', 'utf8');
+        name: benchmark-result-${{ matrix.suite.name }}
+        path: ${{ runner.temp }}/benchmark-results
+        retention-days: 14
 
-          if (!context.issue.number) {
-            console.log('No PR context (push event) — skipping comment');
-            return;
-          }
-
-          const marker = '${{ matrix.suite.marker }}';
-          const comments = await github.rest.issues.listComments({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            issue_number: context.issue.number,
-          });
-          const botComment = comments.data.find(c => c.body.includes(marker));
-
-          if (botComment) {
-            await github.rest.issues.updateComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              comment_id: botComment.id,
-              body: body,
-            });
-          } else {
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body: body,
-            });
-          }
-
-    - name: Enforce ceiling
-      run: |
-        rc="${{ steps.bench.outputs.bench_rc }}"
-        if [ "$rc" != "0" ]; then
-          echo "Benchmark exceeded performance ceiling (rc=$rc)" >&2
-          exit "$rc"
-        fi
-
-  vc-perf:
-    name: version-control-perf
+  vc-relative:
+    name: version-control
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
-    env:
-      VC_PERF_RUNS: 3
-
     steps:
     - uses: actions/checkout@v4
 
-    - name: Download optimized build
+    - name: Download paired optimized build
       uses: actions/download-artifact@v4
       with:
         name: benchmark-build
 
-    - name: Extract optimized build
+    - name: Extract paired optimized build
       run: tar -xzf benchmark-build.tar.gz
 
-    - name: Run version-control performance benchmarks
-      id: bench
+    - name: Measure candidate against PR base
+      env:
+        VC_PERF_RUNS: 5
+        VC_PERF_BASELINE_LABEL: PR base
+        VC_PERF_CANDIDATE_LABEL: PR candidate
       run: |
-        cd build
-        # Capture rc separately so benchmark output is still posted when
-        # a ceiling fails.
-        set +e
-        bash ../test/vc_perf_ceiling.sh ./doltlite > /tmp/bench_vc_perf.md
-        bench_rc=$?
-        set -e
-        cat /tmp/bench_vc_perf.md
-        echo "bench_rc=$bench_rc" >> "$GITHUB_OUTPUT"
+        artifact="$GITHUB_WORKSPACE/benchmark-artifact"
+        results="$RUNNER_TEMP/benchmark-results"
+        mkdir -p "$results"
+        VC_PERF_BASELINE="$artifact/baseline/doltlite" \
+          VC_PERF_RESULTS_OUTPUT="$results/vc.tsv" \
+          VC_PERF_SAMPLES_OUTPUT="$results/vc-samples.tsv" \
+          bash test/vc_perf_ceiling.sh "$artifact/candidate/doltlite" \
+          > "$results/vc.md"
+        cat "$results/vc.md"
 
-    - name: Comment PR with results
+    - name: Upload paired measurements
+      uses: actions/upload-artifact@v4
+      with:
+        name: benchmark-result-vc
+        path: ${{ runner.temp }}/benchmark-results
+        retention-days: 14
+
+  relative-report:
+    name: relative-performance-gate
+    if: always()
+    needs:
+      - sysbench-relative
+      - vc-relative
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Download paired measurements
+      continue-on-error: true
+      uses: actions/download-artifact@v4
+      with:
+        pattern: benchmark-result-*
+        path: benchmark-results
+        merge-multiple: true
+
+    - name: Download paired build metadata
+      uses: actions/download-artifact@v4
+      with:
+        name: benchmark-build
+
+    - name: Extract paired build metadata
+      run: tar -xzf benchmark-build.tar.gz
+
+    - name: Test relative comparison policy
+      run: python3 test/benchmark_compare_test.py
+
+    - name: Generate relative performance report
+      id: report
+      run: |
+        report="$RUNNER_TEMP/benchmark-relative.md"
+        required="int textpk blobpk compositepk vc"
+        missing=""
+        for suite in $required; do
+          if [ ! -s "benchmark-results/$suite.tsv" ]; then
+            missing="$missing $suite"
+          fi
+        done
+
+        if [ -n "$missing" ]; then
+          {
+            echo '<!-- benchmark:relative -->'
+            echo '## DoltLite performance vs PR base'
+            echo ''
+            echo "**FAILED:** missing benchmark results:${missing}"
+          } > "$report"
+          report_rc=1
+        else
+          baseline=$(cat benchmark-artifact/baseline-sha)
+          candidate=$(cat benchmark-artifact/candidate-sha)
+          set +e
+          python3 test/benchmark_compare.py \
+            --input "int=benchmark-results/int.tsv" \
+            --input "textpk=benchmark-results/textpk.tsv" \
+            --input "blobpk=benchmark-results/blobpk.tsv" \
+            --input "compositepk=benchmark-results/compositepk.tsv" \
+            --input "vc=benchmark-results/vc.tsv" \
+            --baseline-ref "$baseline" \
+            --candidate-ref "$candidate" \
+            --individual-ratio 1.25 \
+            --aggregate-ratio 1.15 \
+            --min-delta-us 5000 \
+            --suite-individual "vc=1.50:25000" \
+            --output "$report"
+          report_rc=$?
+          set -e
+          if [ ! -s "$report" ]; then
+            {
+              echo '<!-- benchmark:relative -->'
+              echo '## DoltLite performance vs PR base'
+              echo ''
+              echo '**FAILED:** unable to generate the benchmark comparison.'
+            } > "$report"
+            report_rc=1
+          fi
+        fi
+        cat "$report"
+        cat "$report" >> "$GITHUB_STEP_SUMMARY"
+        cp "$report" benchmark-results/summary.md
+        echo "report_rc=$report_rc" >> "$GITHUB_OUTPUT"
+
+    - name: Comment PR with relative performance
+      if: always()
       continue-on-error: true
       uses: actions/github-script@v7
       with:
         script: |
           const fs = require('fs');
-          const body = fs.readFileSync('/tmp/bench_vc_perf.md', 'utf8');
-
-          if (!context.issue.number) {
-            console.log('No PR context (push event) — skipping comment');
+          const path = 'benchmark-results/summary.md';
+          if (!fs.existsSync(path) || !context.issue.number) {
+            console.log('No report or PR context — skipping comment');
             return;
           }
-
-          const marker = '<!-- benchmark:vc-perf -->';
-          const comments = await github.rest.issues.listComments({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            issue_number: context.issue.number,
-          });
-          const botComment = comments.data.find(c => c.body.includes(marker));
-
-          if (botComment) {
-            await github.rest.issues.updateComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              comment_id: botComment.id,
-              body: body,
-            });
-          } else {
-            await github.rest.issues.createComment({
+          const body = fs.readFileSync(path, 'utf8');
+          const marker = '<!-- benchmark:relative -->';
+          const comments = await github.paginate(
+            github.rest.issues.listComments,
+            {
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
-              body: body,
+              per_page: 100,
+            }
+          );
+          const existing = comments.find(comment =>
+            comment.body.includes(marker)
+          );
+          const target = {
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+          };
+          if (existing) {
+            await github.rest.issues.updateComment({
+              ...target,
+              comment_id: existing.id,
+              body,
+            });
+          } else {
+            await github.rest.issues.createComment({
+              ...target,
+              issue_number: context.issue.number,
+              body,
             });
           }
 
-    - name: Enforce ceiling
+    - name: Upload relative performance report
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: doltlite-relative-performance
+        path: benchmark-results
+        retention-days: 14
+
+    - name: Enforce relative performance gate
+      if: always()
       run: |
-        rc="${{ steps.bench.outputs.bench_rc }}"
-        if [ "$rc" != "0" ]; then
-          echo "Version-control benchmark exceeded performance ceiling (rc=$rc)" >&2
-          exit "$rc"
-        fi
+        rc="${{ steps.report.outputs.report_rc }}"
+        if [ -z "$rc" ]; then rc=1; fi
+        exit "$rc"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -47,13 +47,12 @@ jobs:
         BENCH_CANDIDATE_KIND: doltlite
         BENCH_GATE_MODE: none
       run: |
-        artifact="$GITHUB_WORKSPACE/benchmark-artifact"
         results="$RUNNER_TEMP/benchmark-results"
         mkdir -p "$results"
-        BENCH_BASELINE_BINARY="$artifact/baseline/doltlite" \
-          BENCH_CANDIDATE_BINARY="$artifact/candidate/doltlite" \
-          BENCH_BASELINE_TIMER="$artifact/baseline/bench_timer_doltlite" \
-          BENCH_CANDIDATE_TIMER="$artifact/candidate/bench_timer_doltlite" \
+        BENCH_BASELINE_BINARY="$GITHUB_WORKSPACE/benchmark-baseline/doltlite" \
+          BENCH_CANDIDATE_BINARY="$GITHUB_WORKSPACE/build/doltlite" \
+          BENCH_BASELINE_TIMER="$GITHUB_WORKSPACE/benchmark-baseline/bench_timer_doltlite" \
+          BENCH_CANDIDATE_TIMER="$GITHUB_WORKSPACE/build/bench_timer_doltlite" \
           BENCH_RESULTS_OUTPUT="$results/${{ matrix.suite.name }}.tsv" \
           BENCH_SAMPLES_OUTPUT="$results/${{ matrix.suite.name }}-samples.tsv" \
           bash "test/${{ matrix.suite.script }}" \
@@ -89,13 +88,12 @@ jobs:
         VC_PERF_BASELINE_LABEL: PR base
         VC_PERF_CANDIDATE_LABEL: PR candidate
       run: |
-        artifact="$GITHUB_WORKSPACE/benchmark-artifact"
         results="$RUNNER_TEMP/benchmark-results"
         mkdir -p "$results"
-        VC_PERF_BASELINE="$artifact/baseline/doltlite" \
+        VC_PERF_BASELINE="$GITHUB_WORKSPACE/benchmark-baseline/doltlite" \
           VC_PERF_RESULTS_OUTPUT="$results/vc.tsv" \
           VC_PERF_SAMPLES_OUTPUT="$results/vc-samples.tsv" \
-          bash test/vc_perf_ceiling.sh "$artifact/candidate/doltlite" \
+          bash test/vc_perf_ceiling.sh "$GITHUB_WORKSPACE/build/doltlite" \
           > "$results/vc.md"
         cat "$results/vc.md"
 
@@ -158,8 +156,8 @@ jobs:
           } > "$report"
           report_rc=1
         else
-          baseline=$(cat benchmark-artifact/baseline-sha)
-          candidate=$(cat benchmark-artifact/candidate-sha)
+          baseline=$(cat benchmark-baseline-sha)
+          candidate=$(cat benchmark-candidate-sha)
           set +e
           python3 test/benchmark_compare.py \
             --input "int=benchmark-results/int.tsv" \

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -106,7 +106,9 @@ jobs:
 
   relative-report:
     name: relative-performance-gate
-    if: always()
+    # Still publish diagnostics when a producer fails, but do not turn a
+    # cancelled workflow into a misleading missing-results failure.
+    if: ${{ always() && !cancelled() }}
     needs:
       - sysbench-relative
       - vc-relative

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -486,12 +486,12 @@ jobs:
 
     - name: Package
       run: |
-        mkdir benchmark-artifact
-        mv build benchmark-artifact/candidate
-        mv benchmark-base/build benchmark-artifact/baseline
-        git rev-parse HEAD > benchmark-artifact/candidate-sha
-        git -C benchmark-base rev-parse HEAD > benchmark-artifact/baseline-sha
-        tar -czf benchmark-build.tar.gz benchmark-artifact
+        mv benchmark-base/build benchmark-baseline
+        git rev-parse HEAD > benchmark-candidate-sha
+        git -C benchmark-base rev-parse HEAD > benchmark-baseline-sha
+        tar -czf benchmark-build.tar.gz \
+          build benchmark-baseline \
+          benchmark-candidate-sha benchmark-baseline-sha
 
     - name: Upload
       uses: actions/upload-artifact@v4

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -434,7 +434,14 @@ jobs:
     timeout-minutes: 15
 
     steps:
-    - uses: actions/checkout@v4
+    - name: Check out candidate
+      uses: actions/checkout@v4
+
+    - name: Check out PR base
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.pull_request.base.sha || github.event.repository.default_branch }}
+        path: benchmark-base
 
     - name: Install dependencies
       run: |
@@ -443,28 +450,34 @@ jobs:
 
     - name: Configure
       run: |
-        mkdir -p build
-        cd build
         TCL_CONFIG=$(find /usr/lib -name tclConfig.sh -print -quit 2>/dev/null)
-        if [ -n "$TCL_CONFIG" ]; then
-          ../configure --with-tcl=$(dirname "$TCL_CONFIG")
-        else
-          ../configure
-        fi
+        for source in . benchmark-base; do
+          mkdir -p "$source/build"
+          if [ -n "$TCL_CONFIG" ]; then
+            (cd "$source/build" && ../configure --with-tcl=$(dirname "$TCL_CONFIG"))
+          else
+            (cd "$source/build" && ../configure)
+          fi
+        done
 
     - name: Build
       run: |
-        cd build
         set -o pipefail
         {
-          make -j2 doltlite doltlite-lib
-          cc -O2 -Werror -I. -I../src \
-            -o bench_timer_doltlite ../test/sysbench_timer.c \
-            libdoltlite.a -lpthread -lz -lm
-          make DOLTLITE_PROLLY=0 sqlite3 sqlite3.o
-          cc -O2 -Werror -I. -I../src \
-            -o bench_timer_sqlite ../test/sysbench_timer.c \
-            sqlite3.o -lpthread -lz -lm
+          (
+            cd build
+            make -j2 doltlite doltlite-lib
+            cc -O2 -Werror -I. -I../src \
+              -o bench_timer_doltlite ../test/sysbench_timer.c \
+              libdoltlite.a -lpthread -lz -lm
+          )
+          (
+            cd benchmark-base/build
+            make -j2 doltlite doltlite-lib
+            cc -O2 -Werror -I. -I../src \
+              -o bench_timer_doltlite ../test/sysbench_timer.c \
+              libdoltlite.a -lpthread -lz -lm
+          )
         } 2>&1 | tee build.log
         if grep -E "warning:" build.log; then
           echo "::error::compiler warnings in optimized build"
@@ -472,7 +485,13 @@ jobs:
         fi
 
     - name: Package
-      run: tar -czf benchmark-build.tar.gz build
+      run: |
+        mkdir benchmark-artifact
+        mv build benchmark-artifact/candidate
+        mv benchmark-base/build benchmark-artifact/baseline
+        git rev-parse HEAD > benchmark-artifact/candidate-sha
+        git -C benchmark-base rev-parse HEAD > benchmark-artifact/baseline-sha
+        tar -czf benchmark-build.tar.gz benchmark-artifact
 
     - name: Upload
       uses: actions/upload-artifact@v4

--- a/.github/workflows/nightly-performance.yml
+++ b/.github/workflows/nightly-performance.yml
@@ -1,0 +1,293 @@
+name: Nightly performance
+
+on:
+  schedule:
+    - cron: '0 7 * * *'
+  workflow_dispatch:
+    inputs:
+      runs:
+        description: Paired repetitions for each sysbench-style workload
+        required: false
+        default: "21"
+      vc-runs:
+        description: Repetitions for each version-control benchmark
+        required: false
+        default: "15"
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: nightly-performance
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install dependencies
+      run: |
+        bash .github/scripts/install-apt-deps.sh \
+          build-essential tcl-dev zlib1g-dev
+
+    - name: Configure
+      run: |
+        mkdir build-nightly
+        cd build-nightly
+        TCL_CONFIG=$(find /usr/lib -name tclConfig.sh -print -quit 2>/dev/null)
+        if [ -n "$TCL_CONFIG" ]; then
+          ../configure --with-tcl=$(dirname "$TCL_CONFIG")
+        else
+          ../configure
+        fi
+
+    - name: Build DoltLite and SQLite benchmark binaries
+      run: |
+        cd build-nightly
+        set -o pipefail
+        {
+          make -j2 doltlite doltlite-lib
+          cc -O2 -Werror -I. -I../src \
+            -o bench_timer_doltlite ../test/sysbench_timer.c \
+            libdoltlite.a -lpthread -lz -lm
+          make DOLTLITE_PROLLY=0 sqlite3 sqlite3.o
+          cc -O2 -Werror -I. -I../src \
+            -o bench_timer_sqlite ../test/sysbench_timer.c \
+            sqlite3.o -lpthread -lz -lm
+        } 2>&1 | tee build.log
+        if grep -E "warning:" build.log; then
+          echo "::error::compiler warnings in nightly benchmark build"
+          exit 1
+        fi
+
+    - name: Package
+      run: tar -czf nightly-benchmark-build.tar.gz build-nightly
+
+    - name: Upload
+      uses: actions/upload-artifact@v4
+      with:
+        name: nightly-benchmark-build
+        path: nightly-benchmark-build.tar.gz
+        retention-days: 1
+
+  sysbench:
+    name: ${{ matrix.suite.name }}-keys
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 75
+    strategy:
+      fail-fast: false
+      matrix:
+        suite:
+          - name: int
+            script: sysbench_compare.sh
+          - name: textpk
+            script: sysbench_compare_textpk.sh
+          - name: blobpk
+            script: sysbench_compare_blobpk.sh
+          - name: compositepk
+            script: sysbench_compare_compositepk.sh
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Download nightly benchmark build
+      uses: actions/download-artifact@v4
+      with:
+        name: nightly-benchmark-build
+
+    - name: Extract nightly benchmark build
+      run: tar -xzf nightly-benchmark-build.tar.gz
+
+    - name: Run absolute benchmark
+      id: benchmark
+      env:
+        BENCH_RUNS: ${{ github.event.inputs.runs || '21' }}
+        BENCH_AC_WRITE_RUNS: ${{ github.event.inputs.runs || '21' }}
+      run: |
+        results="$RUNNER_TEMP/nightly-results"
+        mkdir -p "$results"
+        set +e
+        (
+          cd build-nightly
+          BENCH_RESULTS_OUTPUT="$results/${{ matrix.suite.name }}.tsv" \
+            BENCH_SAMPLES_OUTPUT="$results/${{ matrix.suite.name }}-samples.tsv" \
+            bash "../test/${{ matrix.suite.script }}"
+        ) > "$results/${{ matrix.suite.name }}.md" \
+          2> "$results/${{ matrix.suite.name }}.stderr"
+        bench_rc=$?
+        set -e
+        echo "$bench_rc" > "$results/${{ matrix.suite.name }}.status"
+        cat "$results/${{ matrix.suite.name }}.md"
+        cat "$results/${{ matrix.suite.name }}.stderr" >&2
+        echo "bench_rc=$bench_rc" >> "$GITHUB_OUTPUT"
+
+    - name: Upload nightly measurements
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: nightly-performance-${{ matrix.suite.name }}
+        path: ${{ runner.temp }}/nightly-results
+        retention-days: 30
+
+    - name: Enforce absolute ceiling
+      if: always()
+      run: |
+        rc="${{ steps.benchmark.outputs.bench_rc }}"
+        if [ -z "$rc" ]; then rc=1; fi
+        exit "$rc"
+
+  version-control:
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 75
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Download nightly benchmark build
+      uses: actions/download-artifact@v4
+      with:
+        name: nightly-benchmark-build
+
+    - name: Extract nightly benchmark build
+      run: tar -xzf nightly-benchmark-build.tar.gz
+
+    - name: Run absolute version-control benchmark
+      id: benchmark
+      env:
+        VC_PERF_RUNS: ${{ github.event.inputs.vc-runs || '15' }}
+      run: |
+        results="$RUNNER_TEMP/nightly-results"
+        mkdir -p "$results"
+        set +e
+        (
+          cd build-nightly
+          VC_PERF_RESULTS_OUTPUT="$results/vc.tsv" \
+            VC_PERF_SAMPLES_OUTPUT="$results/vc-samples.tsv" \
+            bash ../test/vc_perf_ceiling.sh ./doltlite
+        ) > "$results/vc.md" 2> "$results/vc.stderr"
+        bench_rc=$?
+        set -e
+        echo "$bench_rc" > "$results/vc.status"
+        cat "$results/vc.md"
+        cat "$results/vc.stderr" >&2
+        echo "bench_rc=$bench_rc" >> "$GITHUB_OUTPUT"
+
+    - name: Upload nightly measurements
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: nightly-performance-vc
+        path: ${{ runner.temp }}/nightly-results
+        retention-days: 30
+
+    - name: Enforce absolute ceiling
+      if: always()
+      run: |
+        rc="${{ steps.benchmark.outputs.bench_rc }}"
+        if [ -z "$rc" ]; then rc=1; fi
+        exit "$rc"
+
+  report:
+    if: always()
+    needs:
+      - sysbench
+      - version-control
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Download nightly measurements
+      continue-on-error: true
+      uses: actions/download-artifact@v4
+      with:
+        pattern: nightly-performance-*
+        path: nightly-results
+        merge-multiple: true
+
+    - name: Compose nightly report
+      id: report
+      run: |
+        summary="$RUNNER_TEMP/nightly-performance.md"
+        issue_body="$RUNNER_TEMP/nightly-performance-failure.md"
+        suites="int textpk blobpk compositepk vc"
+        failed=0
+        {
+          echo "## Nightly DoltLite performance"
+          echo ""
+          echo "Absolute SQLite multipliers and version-control latency ceilings."
+          echo ""
+        } > "$summary"
+        {
+          echo "Nightly performance exceeded one or more absolute ceilings."
+          echo ""
+        } > "$issue_body"
+
+        for suite in $suites; do
+          status_file="nightly-results/$suite.status"
+          report_file="nightly-results/$suite.md"
+          stderr_file="nightly-results/$suite.stderr"
+          status=1
+          if [ -s "$status_file" ]; then
+            status=$(cat "$status_file")
+          fi
+          if [ -s "$report_file" ]; then
+            cat "$report_file" >> "$summary"
+            echo "" >> "$summary"
+          else
+            echo "**${suite}: missing report**" >> "$summary"
+            echo "" >> "$summary"
+          fi
+          if [ "$status" != "0" ]; then
+            failed=1
+            {
+              echo "### ${suite}"
+              echo ""
+              if [ -s "$stderr_file" ]; then
+                echo '```text'
+                tail -n 80 "$stderr_file"
+                echo '```'
+              else
+                echo "Benchmark did not produce diagnostic output."
+              fi
+              echo ""
+            } >> "$issue_body"
+          fi
+        done
+
+        cat "$summary" >> "$GITHUB_STEP_SUMMARY"
+        cp "$summary" nightly-results/summary.md
+        cp "$issue_body" nightly-results/failure.md
+        echo "failed=$failed" >> "$GITHUB_OUTPUT"
+        echo "summary=$summary" >> "$GITHUB_OUTPUT"
+        echo "issue_body=$issue_body" >> "$GITHUB_OUTPUT"
+
+    - name: Upload combined nightly report
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: nightly-performance-report
+        path: nightly-results
+        retention-days: 30
+
+    - name: Report regression as GitHub issue
+      if: steps.report.outputs.failed == '1'
+      uses: ./.github/actions/report-failure-issue
+      with:
+        label: nightly-performance-regression
+        title: "Nightly performance regression"
+        body-file: ${{ steps.report.outputs.issue_body }}
+        token: ${{ secrets.GITHUB_TOKEN }}
+        label-description: Nightly absolute performance ceiling failure
+
+    - name: Fail when a ceiling regressed
+      if: steps.report.outputs.failed == '1'
+      run: exit 1

--- a/README.md
+++ b/README.md
@@ -903,12 +903,22 @@ standard behavior); reads are concurrent.
 Doltlite retains SQLite's SQL engine and C API while replacing its storage
 engine, so the natural question is: what does version control cost?
 
-Every PR runs sysbench-style benchmarks comparing doltlite against stock SQLite:
-the int-key suite in [`test/sysbench_compare.sh`](test/sysbench_compare.sh), plus
-TEXT, BLOB, and composite-primary-key variants. CI enforces a 2.5x ceiling on
-individual read/write ratios and a 2x ceiling on section averages, with wider
-autocommit-write ceilings for expected durability variance. The per-release
-numbers are published with each release on the
+Every PR builds the exact PR base and candidate with the same optimized
+toolchain, then runs paired sysbench-style benchmarks on the same runners. The
+int-key suite in [`test/sysbench_compare.sh`](test/sysbench_compare.sh) runs
+alongside TEXT, BLOB, and composite-primary-key variants. Baseline and candidate
+execution order alternates on each repetition to reduce host-load bias. CI
+fails when an individual workload regresses by more than 25% and 5ms, or when
+a section, suite, or overall runtime regresses by more than 15% and 5ms.
+Short, process-startup-bound version-control operations use a 50% and 25ms
+individual gate; their aggregate still uses the 15% suite gate.
+
+A scheduled nightly workflow runs longer, higher-sample comparisons against
+stock SQLite and enforces the absolute multiplier ceilings. It also runs the
+version-control latency ceilings with additional repetitions. A regression
+opens or updates a `nightly-performance-regression` issue, while every run
+publishes raw samples and a combined report. The per-release SQLite comparison
+is still published with each release on the
 [GitHub releases page](https://github.com/dolthub/doltlite/releases).
 
 ### Algorithmic Complexity

--- a/test/benchmark_compare.py
+++ b/test/benchmark_compare.py
@@ -1,0 +1,363 @@
+#!/usr/bin/env python3
+
+import argparse
+import dataclasses
+import pathlib
+import sys
+from collections import defaultdict
+
+
+@dataclasses.dataclass(frozen=True)
+class Result:
+    suite: str
+    section: str
+    test: str
+    baseline_us: int
+    candidate_us: int
+
+    @property
+    def valid(self):
+        return self.baseline_us > 0 and self.candidate_us >= 0
+
+    @property
+    def ratio(self):
+        if not self.valid:
+            return None
+        return self.candidate_us / self.baseline_us
+
+    @property
+    def delta_us(self):
+        if not self.valid:
+            return None
+        return self.candidate_us - self.baseline_us
+
+
+def parse_input(spec):
+    if "=" not in spec:
+        raise ValueError(f"input must be SUITE=PATH: {spec}")
+    suite, path_text = spec.split("=", 1)
+    if not suite or not path_text:
+        raise ValueError(f"input must be SUITE=PATH: {spec}")
+    path = pathlib.Path(path_text)
+    results = []
+    seen = set()
+    with path.open(encoding="utf-8") as source:
+        for line_number, line in enumerate(source, 1):
+            columns = line.rstrip("\n").split("\t")
+            if len(columns) != 4:
+                raise ValueError(
+                    f"{path}:{line_number}: expected 4 tab-separated columns"
+                )
+            section, test, baseline, candidate = columns
+            key = (section, test)
+            if key in seen:
+                raise ValueError(
+                    f"{path}:{line_number}: duplicate result {section}/{test}"
+                )
+            seen.add(key)
+            try:
+                baseline_us = int(baseline)
+                candidate_us = int(candidate)
+            except ValueError as exc:
+                raise ValueError(
+                    f"{path}:{line_number}: timings must be integers"
+                ) from exc
+            results.append(
+                Result(
+                    suite=suite,
+                    section=section,
+                    test=test,
+                    baseline_us=baseline_us,
+                    candidate_us=candidate_us,
+                )
+            )
+    if not results:
+        raise ValueError(f"{path}: no benchmark results")
+    return results
+
+
+def total_ratio(results):
+    if not results or any(not result.valid for result in results):
+        return None
+    baseline = sum(result.baseline_us for result in results)
+    candidate = sum(result.candidate_us for result in results)
+    if baseline <= 0:
+        return None
+    return candidate / baseline
+
+
+def total_delta(results):
+    if not results or any(not result.valid for result in results):
+        return None
+    return sum(result.candidate_us - result.baseline_us for result in results)
+
+
+def format_time(value):
+    if value is None or value < 0:
+        return "invalid"
+    if value >= 1_000_000:
+        return f"{value / 1_000_000:.2f}s"
+    if value >= 1_000:
+        return f"{value / 1_000:.2f}ms"
+    return f"{value}us"
+
+
+def format_delta(value):
+    if value is None:
+        return "invalid"
+    sign = "+" if value >= 0 else "-"
+    return f"{sign}{format_time(abs(value))}"
+
+
+def format_ratio(value):
+    if value is None:
+        return "invalid"
+    return f"{value:.3f}x"
+
+
+def analyze(
+    results,
+    individual_ratio,
+    aggregate_ratio,
+    min_delta_us,
+    individual_overrides=None,
+):
+    individual_overrides = individual_overrides or {}
+    individual_failures = set()
+    for result in results:
+        key = (result.suite, result.section, result.test)
+        result_ratio, result_delta = individual_overrides.get(
+            result.suite,
+            (individual_ratio, min_delta_us),
+        )
+        if not result.valid:
+            individual_failures.add(key)
+        elif (
+            result.ratio > result_ratio
+            and result.delta_us > result_delta
+        ):
+            individual_failures.add(key)
+
+    sections = defaultdict(list)
+    suites = defaultdict(list)
+    for result in results:
+        sections[(result.suite, result.section)].append(result)
+        suites[result.suite].append(result)
+
+    section_ratios = {
+        key: total_ratio(group) for key, group in sections.items()
+    }
+    suite_ratios = {
+        key: total_ratio(group) for key, group in suites.items()
+    }
+    section_failures = {
+        key
+        for key, ratio in section_ratios.items()
+        if ratio is None
+        or (
+            ratio > aggregate_ratio
+            and total_delta(sections[key]) > min_delta_us
+        )
+    }
+    suite_failures = {
+        key
+        for key, ratio in suite_ratios.items()
+        if ratio is None
+        or (
+            ratio > aggregate_ratio
+            and total_delta(suites[key]) > min_delta_us
+        )
+    }
+    overall_ratio = total_ratio(results)
+    overall_failed = (
+        overall_ratio is None
+        or (
+            overall_ratio > aggregate_ratio
+            and total_delta(results) > min_delta_us
+        )
+    )
+    failed = bool(
+        individual_failures
+        or section_failures
+        or suite_failures
+        or overall_failed
+    )
+    return {
+        "failed": failed,
+        "individual_failures": individual_failures,
+        "section_failures": section_failures,
+        "suite_failures": suite_failures,
+        "section_ratios": section_ratios,
+        "suite_ratios": suite_ratios,
+        "overall_ratio": overall_ratio,
+    }
+
+
+def render(
+    results,
+    analysis,
+    baseline_ref,
+    candidate_ref,
+    individual_ratio,
+    aggregate_ratio,
+    min_delta_us,
+    individual_overrides=None,
+):
+    suites = defaultdict(list)
+    for result in results:
+        suites[result.suite].append(result)
+
+    status = "PASS" if not analysis["failed"] else "FAIL"
+    lines = [
+        "<!-- benchmark:relative -->",
+        "## DoltLite performance vs PR base",
+        "",
+        f"- **Baseline:** `{baseline_ref}`",
+        f"- **Candidate:** `{candidate_ref}`",
+        f"- **Overall:** {format_ratio(analysis['overall_ratio'])} — **{status}**",
+        (
+            f"- **Gates:** individual > {individual_ratio:.2f}x with more "
+            f"than {format_time(min_delta_us)} regression; section, suite, "
+            f"or overall > {aggregate_ratio:.2f}x with the same minimum delta"
+        ),
+    ]
+    for suite, (ratio, delta) in sorted((individual_overrides or {}).items()):
+        lines.append(
+            f"- **{suite} individual gate:** > {ratio:.2f}x with more than "
+            f"{format_time(delta)} regression"
+        )
+    lines.extend(
+        [
+            "",
+            "| Suite | Workloads | Baseline total | Candidate total | Ratio | Result |",
+            "|---|---:|---:|---:|---:|---|",
+        ]
+    )
+    for suite in sorted(suites):
+        group = suites[suite]
+        ratio = analysis["suite_ratios"][suite]
+        suite_status = "FAIL" if suite in analysis["suite_failures"] else "PASS"
+        baseline_total = (
+            sum(result.baseline_us for result in group)
+            if all(result.valid for result in group)
+            else None
+        )
+        candidate_total = (
+            sum(result.candidate_us for result in group)
+            if all(result.valid for result in group)
+            else None
+        )
+        lines.append(
+            f"| {suite} | {len(group)} | "
+            f"{format_time(baseline_total)} | "
+            f"{format_time(candidate_total)} | "
+            f"{format_ratio(ratio)} | {suite_status} |"
+        )
+
+    for suite in sorted(suites):
+        lines.extend(
+            [
+                "",
+                "<details>",
+                f"<summary>{suite} details</summary>",
+                "",
+                "| Section | Test | Baseline | Candidate | Delta | Ratio | Result |",
+                "|---|---|---:|---:|---:|---:|---|",
+            ]
+        )
+        for result in suites[suite]:
+            key = (result.suite, result.section, result.test)
+            row_status = (
+                "FAIL"
+                if key in analysis["individual_failures"]
+                else "PASS"
+            )
+            delta = format_delta(result.delta_us)
+            lines.append(
+                f"| {result.section} | `{result.test}` | "
+                f"{format_time(result.baseline_us)} | "
+                f"{format_time(result.candidate_us)} | {delta} | "
+                f"{format_ratio(result.ratio)} | {row_status} |"
+            )
+        lines.extend(["", "</details>"])
+
+    if analysis["failed"]:
+        lines.extend(
+            [
+                "",
+                "**FAILED:** Candidate performance exceeded a regression gate.",
+            ]
+        )
+    else:
+        lines.extend(["", "All relative performance gates passed."])
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        description="Compare paired DoltLite benchmark medians"
+    )
+    parser.add_argument(
+        "--input",
+        action="append",
+        required=True,
+        help="Benchmark result in SUITE=PATH form; may be repeated",
+    )
+    parser.add_argument("--baseline-ref", required=True)
+    parser.add_argument("--candidate-ref", required=True)
+    parser.add_argument("--individual-ratio", type=float, default=1.25)
+    parser.add_argument("--aggregate-ratio", type=float, default=1.15)
+    parser.add_argument("--min-delta-us", type=int, default=5000)
+    parser.add_argument(
+        "--suite-individual",
+        action="append",
+        default=[],
+        metavar="SUITE=RATIO:MIN_DELTA_US",
+        help="Override the individual gate for one suite; may be repeated",
+    )
+    parser.add_argument("--output", required=True)
+    args = parser.parse_args(argv)
+
+    try:
+        results = []
+        for spec in args.input:
+            results.extend(parse_input(spec))
+    except (OSError, ValueError) as exc:
+        parser.error(str(exc))
+
+    individual_overrides = {}
+    try:
+        for spec in args.suite_individual:
+            suite, value = spec.split("=", 1)
+            ratio, delta = value.split(":", 1)
+            individual_overrides[suite] = (float(ratio), int(delta))
+    except ValueError:
+        parser.error(
+            "--suite-individual must be SUITE=RATIO:MIN_DELTA_US"
+        )
+
+    analysis = analyze(
+        results,
+        args.individual_ratio,
+        args.aggregate_ratio,
+        args.min_delta_us,
+        individual_overrides,
+    )
+    report = render(
+        results,
+        analysis,
+        args.baseline_ref,
+        args.candidate_ref,
+        args.individual_ratio,
+        args.aggregate_ratio,
+        args.min_delta_us,
+        individual_overrides,
+    )
+    pathlib.Path(args.output).write_text(report, encoding="utf-8")
+    print(report, end="")
+    return 1 if analysis["failed"] else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/benchmark_compare_test.py
+++ b/test/benchmark_compare_test.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+
+import importlib.util
+import pathlib
+import tempfile
+import unittest
+
+
+MODULE_PATH = pathlib.Path(__file__).with_name("benchmark_compare.py")
+SPEC = importlib.util.spec_from_file_location("benchmark_compare", MODULE_PATH)
+benchmark_compare = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(benchmark_compare)
+
+
+def result(name, baseline, candidate, section="reads"):
+    return benchmark_compare.Result(
+        suite="int",
+        section=section,
+        test=name,
+        baseline_us=baseline,
+        candidate_us=candidate,
+    )
+
+
+class BenchmarkCompareTest(unittest.TestCase):
+    def analyze(self, results):
+        return benchmark_compare.analyze(results, 1.25, 1.15, 5000)
+
+    def test_passes_small_absolute_regression(self):
+        analysis = self.analyze([result("tiny", 1000, 1400)])
+        self.assertFalse(analysis["failed"])
+
+    def test_fails_large_individual_regression(self):
+        analysis = self.analyze(
+            [
+                result("slow", 100_000, 130_000),
+                result("steady", 1_000_000, 1_000_000),
+            ]
+        )
+        self.assertTrue(analysis["failed"])
+        self.assertIn(
+            ("int", "reads", "slow"),
+            analysis["individual_failures"],
+        )
+
+    def test_fails_aggregate_regression(self):
+        analysis = self.analyze(
+            [
+                result("one", 100_000, 114_000),
+                result("two", 100_000, 118_000),
+            ]
+        )
+        self.assertTrue(analysis["failed"])
+        self.assertIn(("int", "reads"), analysis["section_failures"])
+
+    def test_exact_thresholds_pass(self):
+        individual = self.analyze(
+            [
+                result("boundary", 100_000, 125_000),
+                result("offset", 100_000, 105_000),
+            ]
+        )
+        aggregate = self.analyze(
+            [
+                result("one", 100_000, 115_000),
+                result("two", 100_000, 115_000),
+            ]
+        )
+        self.assertFalse(individual["failed"])
+        self.assertFalse(aggregate["failed"])
+
+    def test_invalid_timing_always_fails(self):
+        analysis = self.analyze([result("crash", 100_000, -1)])
+        self.assertTrue(analysis["failed"])
+
+    def test_formats_faster_candidate_delta(self):
+        self.assertEqual(benchmark_compare.format_delta(-1500), "-1.50ms")
+
+    def test_suite_specific_individual_gate(self):
+        analysis = benchmark_compare.analyze(
+            [
+                result("startup_bound", 60_000, 85_000),
+                result("steady", 1_000_000, 1_000_000),
+            ],
+            1.25,
+            1.15,
+            5000,
+            {"int": (1.50, 25_000)},
+        )
+        self.assertFalse(analysis["failed"])
+
+    def test_parses_result_file(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = pathlib.Path(directory) / "result.tsv"
+            path.write_text("reads\tpoint\t100\t110\n", encoding="utf-8")
+            parsed = benchmark_compare.parse_input(f"text={path}")
+        self.assertEqual(
+            parsed,
+            [
+                benchmark_compare.Result(
+                    suite="text",
+                    section="reads",
+                    test="point",
+                    baseline_us=100,
+                    candidate_us=110,
+                )
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/lib/sysbench_benchmark.sh
+++ b/test/lib/sysbench_benchmark.sh
@@ -1,0 +1,342 @@
+#!/usr/bin/env bash
+
+# Shared measurement and ceiling logic for the sysbench-style workload
+# generators. The caller must define TMPDIR, READ_TESTS, WRITE_TESTS, and
+# WRITE_TESTS_AC before invoking run_section().
+
+BENCH_BASELINE_BINARY="${BENCH_BASELINE_BINARY:-$SQLITE3}"
+BENCH_CANDIDATE_BINARY="${BENCH_CANDIDATE_BINARY:-$DOLTLITE}"
+BENCH_BASELINE_TIMER="${BENCH_BASELINE_TIMER:-$BENCH_TIMER_SQLITE}"
+BENCH_CANDIDATE_TIMER="${BENCH_CANDIDATE_TIMER:-$BENCH_TIMER_DOLTLITE}"
+BENCH_BASELINE_KIND="${BENCH_BASELINE_KIND:-sqlite}"
+BENCH_CANDIDATE_KIND="${BENCH_CANDIDATE_KIND:-doltlite}"
+BENCH_BASELINE_LABEL="${BENCH_BASELINE_LABEL:-SQLite}"
+BENCH_CANDIDATE_LABEL="${BENCH_CANDIDATE_LABEL:-DoltLite}"
+BENCH_GATE_MODE="${BENCH_GATE_MODE:-absolute}"
+BENCH_SECTION_MODE="${BENCH_SECTION_MODE:-full}"
+
+BENCH_RESULTS_FILE="$TMPDIR/bench_results.tsv"
+BENCH_SAMPLES_FILE="$TMPDIR/bench_samples.tsv"
+: > "$BENCH_RESULTS_FILE"
+printf 'section\ttest\trun\tbaseline_us\tcandidate_us\n' \
+  > "$BENCH_SAMPLES_FILE"
+
+fmt_us() {
+  python3 - "$1" <<'PYEOF'
+import sys
+print(f"{int(sys.argv[1]):,}")
+PYEOF
+}
+
+run_bench() {
+  local id="$1"
+  local kind="$2"
+  local binary="$3"
+  local timer="$4"
+  local sql_file="$5"
+  local db_template="$6"
+  local db="$db_template"
+  if [ "$db" != ":memory:" ]; then
+    db="/tmp/bench_${id}_${RANDOM}_$$.db"
+    rm -f "$db"
+  fi
+
+  local bench_sql_file="$sql_file"
+  local sqlite_pragmas="${SQLITE_BENCH_PRAGMAS:-}"
+  if [ "$kind" = "sqlite" ] && [ "$db_template" != ":memory:" ]; then
+    sqlite_pragmas="$SQLITE_FILE_CACHE_PRAGMA $sqlite_pragmas"
+  fi
+  if [ "$kind" = "sqlite" ] && [ -n "$sqlite_pragmas" ]; then
+    bench_sql_file="$TMPDIR/pragma_${id}_${RANDOM}_$$.sql"
+    printf "%s\n" "$sqlite_pragmas" > "$bench_sql_file"
+    cat "$sql_file" >> "$bench_sql_file"
+  fi
+
+  if [ -x "$timer" ]; then
+    "$timer" "$db" "$bench_sql_file"
+    if [ "$db" != ":memory:" ]; then rm -f "$db"; fi
+    return
+  fi
+
+  local output
+  output=$(sed \
+    -e "s/\.print BENCH_START/SELECT 'TS_START:' || CAST((julianday('now')*86400000000) AS INTEGER);/" \
+    -e "s/\.print BENCH_END/SELECT 'TS_END:' || CAST((julianday('now')*86400000000) AS INTEGER);/" \
+    "$bench_sql_file" | "$binary" "$db" 2>&1)
+  if [ "$db" != ":memory:" ]; then rm -f "$db"; fi
+  echo "$output" | python3 -c "
+import sys, re
+start = end = None
+for line in sys.stdin:
+    m = re.search(r'TS_START:(\\d+)', line)
+    if m: start = int(m.group(1))
+    m = re.search(r'TS_END:(\\d+)', line)
+    if m: end = int(m.group(1))
+if start is not None and end is not None:
+    print(end - start)
+else:
+    print(-1)
+"
+}
+
+bench_runs_for_test() {
+  case "$1" in
+    *_ac) echo "$BENCH_AC_WRITE_RUNS" ;;
+    *) echo "${BENCH_RUNS:-5}" ;;
+  esac
+}
+
+bench_runs_summary() {
+  local base_runs="${BENCH_RUNS:-5}"
+  if [ "$BENCH_AC_WRITE_RUNS" = "$base_runs" ]; then
+    echo "median of ${base_runs} paired invocations per test"
+  else
+    echo "median of ${base_runs} paired invocations per test; autocommit writes use ${BENCH_AC_WRITE_RUNS}"
+  fi
+}
+
+median_us() {
+  python3 - "$@" <<'PYEOF'
+import sys
+vals = sorted(int(v) for v in sys.argv[1:] if int(v) >= 0)
+if not vals:
+    print(-1)
+else:
+    print(vals[len(vals)//2])
+PYEOF
+}
+
+run_bench_pair_stable() {
+  local section="$1"
+  local test_name="$2"
+  local sql_file="$3"
+  local baseline_db="$4"
+  local candidate_db="$5"
+  local runs i baseline_sample candidate_sample
+  local baseline_samples=()
+  local candidate_samples=()
+  runs=$(bench_runs_for_test "$test_name")
+
+  for ((i=1; i<=runs; i++)); do
+    if [ $((i % 2)) -eq 1 ]; then
+      baseline_sample=$(run_bench \
+        baseline "$BENCH_BASELINE_KIND" "$BENCH_BASELINE_BINARY" \
+        "$BENCH_BASELINE_TIMER" "$sql_file" "$baseline_db")
+      candidate_sample=$(run_bench \
+        candidate "$BENCH_CANDIDATE_KIND" "$BENCH_CANDIDATE_BINARY" \
+        "$BENCH_CANDIDATE_TIMER" "$sql_file" "$candidate_db")
+    else
+      candidate_sample=$(run_bench \
+        candidate "$BENCH_CANDIDATE_KIND" "$BENCH_CANDIDATE_BINARY" \
+        "$BENCH_CANDIDATE_TIMER" "$sql_file" "$candidate_db")
+      baseline_sample=$(run_bench \
+        baseline "$BENCH_BASELINE_KIND" "$BENCH_BASELINE_BINARY" \
+        "$BENCH_BASELINE_TIMER" "$sql_file" "$baseline_db")
+    fi
+    baseline_samples+=("$baseline_sample")
+    candidate_samples+=("$candidate_sample")
+    printf '%s\t%s\t%d\t%s\t%s\n' \
+      "$section" "$test_name" "$i" "$baseline_sample" "$candidate_sample" \
+      >> "$BENCH_SAMPLES_FILE"
+  done
+
+  printf '%s\t%s\n' \
+    "$(median_us "${baseline_samples[@]}")" \
+    "$(median_us "${candidate_samples[@]}")"
+}
+
+run_section() {
+  local section="$1"
+  local tests="$2"
+  local baseline_db="$3"
+  local candidate_db="$4"
+  local ratio_sum=0
+  local ratio_count=0
+  local avg_ratio="--"
+  local t pair baseline candidate baseline_display candidate_display ratio
+
+  echo "| Test | $BENCH_BASELINE_LABEL (us) | $BENCH_CANDIDATE_LABEL (us) | Multiplier |"
+  echo "|------|------------:|--------------:|-----------:|"
+  for t in $tests; do
+    pair=$(run_bench_pair_stable \
+      "$section" "$t" "$TMPDIR/$t.sql" "$baseline_db" "$candidate_db")
+    IFS=$'\t' read -r baseline candidate <<< "$pair"
+    baseline_display="$baseline"
+    candidate_display="$candidate"
+    if [ "$baseline" -eq -1 ] 2>/dev/null; then baseline_display="crash"; fi
+    if [ "$candidate" -eq -1 ] 2>/dev/null; then candidate_display="crash"; fi
+    if [ "$baseline" -ge 0 ] 2>/dev/null; then
+      baseline_display=$(fmt_us "$baseline")
+    fi
+    if [ "$candidate" -ge 0 ] 2>/dev/null; then
+      candidate_display=$(fmt_us "$candidate")
+    fi
+    if [ "$baseline" -gt 0 ] 2>/dev/null \
+        && [ "$candidate" -ge 0 ] 2>/dev/null; then
+      ratio=$(python3 -c "print(f'{$candidate/$baseline:.2f}')")
+      ratio_sum=$(python3 -c "print($ratio_sum + ($candidate/$baseline))")
+      ratio_count=$((ratio_count + 1))
+    else
+      ratio="--"
+    fi
+    printf '%s\t%s\t%s\t%s\n' \
+      "$section" "$t" "$baseline" "$candidate" >> "$BENCH_RESULTS_FILE"
+    echo "| $t | $baseline_display | $candidate_display | ${ratio} |"
+  done
+  if [ "$ratio_count" -gt 0 ]; then
+    avg_ratio=$(python3 -c "print(f'{($ratio_sum/$ratio_count):.2f}')")
+  fi
+  echo "| Average |  |  | ${avg_ratio} |"
+}
+
+benchmark_autocommit_note() {
+  if [ "$BENCH_BASELINE_KIND" = "sqlite" ]; then
+    echo "_SQLite uses WAL mode with synchronous=FULL in this section so_"
+    echo "_the comparison uses SQLite's durable WAL autocommit path._"
+  fi
+}
+
+benchmark_gate_note() {
+  if [ "$BENCH_GATE_MODE" = "absolute" ]; then
+    echo "_Individual ratios gated at ${BENCH_MAX_MULTIPLIER}×; section averages gated at ${BENCH_AVG_MAX_MULTIPLIER}×. Autocommit writes use ${BENCH_AC_WRITE_MAX_MULTIPLIER}× / ${BENCH_AC_WRITE_AVG_MAX_MULTIPLIER}×._"
+  else
+    echo "_Threshold enforcement is applied after all paired suites are aggregated._"
+  fi
+}
+
+check_ceiling() {
+  local section="$1"
+  local tests="$2"
+  local max="$3"
+  local failed=0
+  local t line baseline candidate over ratio
+  for t in $tests; do
+    line=$(awk -F '\t' -v section="$section" -v test="$t" \
+      '$1==section && $2==test {print $3 "\t" $4; exit}' \
+      "$BENCH_RESULTS_FILE")
+    baseline="${line%%$'\t'*}"
+    candidate="${line#*$'\t'}"
+    if ! [ "$baseline" -gt 0 ] 2>/dev/null \
+        || ! [ "$candidate" -ge 0 ] 2>/dev/null; then
+      echo "FAIL: $section/$t did not produce valid timings" >&2
+      failed=1
+      continue
+    fi
+    over=$(python3 -c "r=$candidate/$baseline; print(1 if r>$max else 0)")
+    if [ "$over" = "1" ]; then
+      ratio=$(python3 -c "print(f'{$candidate/$baseline:.2f}')")
+      echo "FAIL: $section/$t = ${ratio}x (ceiling: ${max}x)" >&2
+      failed=1
+    fi
+  done
+  return "$failed"
+}
+
+check_average_ceiling() {
+  local section="$1"
+  local tests="$2"
+  local max="$3"
+  local ratio
+  ratio=$(python3 - "$BENCH_RESULTS_FILE" "$section" "$tests" <<'PYEOF'
+import sys
+path, section, tests = sys.argv[1], sys.argv[2], sys.argv[3].split()
+wanted = set(tests)
+ratios = []
+with open(path) as f:
+    for line in f:
+        cols = line.rstrip("\n").split("\t")
+        if len(cols) < 4 or cols[0] != section or cols[1] not in wanted:
+            continue
+        baseline, candidate = int(cols[2]), int(cols[3])
+        if baseline > 0 and candidate >= 0:
+            ratios.append(candidate / baseline)
+if len(ratios) == len(wanted):
+    print(f"{sum(ratios) / len(ratios):.2f}")
+PYEOF
+)
+  if [ -z "$ratio" ]; then
+    echo "FAIL: $section average is missing valid timings" >&2
+    return 1
+  fi
+  if python3 -c "r=$ratio; raise SystemExit(0 if r>$max else 1)"; then
+    echo "FAIL: $section average = ${ratio}x (ceiling: ${max}x)" >&2
+    return 1
+  fi
+  return 0
+}
+
+benchmark_copy_results() {
+  if [ -n "${BENCH_RESULTS_OUTPUT:-}" ]; then
+    mkdir -p "$(dirname "$BENCH_RESULTS_OUTPUT")"
+    cp "$BENCH_RESULTS_FILE" "$BENCH_RESULTS_OUTPUT"
+  fi
+  if [ -n "${BENCH_SAMPLES_OUTPUT:-}" ]; then
+    mkdir -p "$(dirname "$BENCH_SAMPLES_OUTPUT")"
+    cp "$BENCH_SAMPLES_FILE" "$BENCH_SAMPLES_OUTPUT"
+  fi
+}
+
+benchmark_finish() {
+  local ceiling_ok=0
+  benchmark_copy_results
+
+  if [ "$BENCH_GATE_MODE" = "none" ]; then
+    echo ""
+    echo "Raw measurements recorded; threshold enforcement is deferred."
+    return 0
+  fi
+  if [ "$BENCH_GATE_MODE" != "absolute" ]; then
+    echo "unknown BENCH_GATE_MODE: $BENCH_GATE_MODE" >&2
+    return 2
+  fi
+
+  echo ""
+  echo "### Performance Ceiling Check (${BENCH_MAX_MULTIPLIER}x individual, ${BENCH_AVG_MAX_MULTIPLIER}x average; autocommit writes: ${BENCH_AC_WRITE_MAX_MULTIPLIER}x / ${BENCH_AC_WRITE_AVG_MAX_MULTIPLIER}x)"
+  echo ""
+
+  if [ "$BENCH_SECTION_MODE" = "autocommit" ]; then
+    check_ceiling "ac_reads" "$READ_TESTS" "$BENCH_MAX_MULTIPLIER" \
+      || ceiling_ok=1
+    check_ceiling "ac_writes" "$WRITE_TESTS_AC" \
+      "$BENCH_AC_WRITE_MAX_MULTIPLIER" || ceiling_ok=1
+    check_average_ceiling "ac_reads" "$READ_TESTS" \
+      "$BENCH_AVG_MAX_MULTIPLIER" || ceiling_ok=1
+    check_average_ceiling "ac_writes" "$WRITE_TESTS_AC" \
+      "$BENCH_AC_WRITE_AVG_MAX_MULTIPLIER" || ceiling_ok=1
+  else
+    check_ceiling "mem_reads" "$READ_TESTS" "$BENCH_MAX_MULTIPLIER" \
+      || ceiling_ok=1
+    check_ceiling "mem_writes" "$WRITE_TESTS" "$BENCH_MAX_MULTIPLIER" \
+      || ceiling_ok=1
+    check_ceiling "file_reads" "$READ_TESTS" "$BENCH_MAX_MULTIPLIER" \
+      || ceiling_ok=1
+    check_ceiling "file_writes" "$WRITE_TESTS" "$BENCH_MAX_MULTIPLIER" \
+      || ceiling_ok=1
+    check_average_ceiling "mem_reads" "$READ_TESTS" \
+      "$BENCH_AVG_MAX_MULTIPLIER" || ceiling_ok=1
+    check_average_ceiling "mem_writes" "$WRITE_TESTS" \
+      "$BENCH_AVG_MAX_MULTIPLIER" || ceiling_ok=1
+    check_average_ceiling "file_reads" "$READ_TESTS" \
+      "$BENCH_AVG_MAX_MULTIPLIER" || ceiling_ok=1
+    check_average_ceiling "file_writes" "$WRITE_TESTS" \
+      "$BENCH_AVG_MAX_MULTIPLIER" || ceiling_ok=1
+    if [ "$BENCH_SECTION_MODE" = "full" ]; then
+      check_ceiling "ac_reads" "$READ_TESTS" "$BENCH_MAX_MULTIPLIER" \
+        || ceiling_ok=1
+      check_ceiling "ac_writes" "$WRITE_TESTS_AC" \
+        "$BENCH_AC_WRITE_MAX_MULTIPLIER" || ceiling_ok=1
+      check_average_ceiling "ac_reads" "$READ_TESTS" \
+        "$BENCH_AVG_MAX_MULTIPLIER" || ceiling_ok=1
+      check_average_ceiling "ac_writes" "$WRITE_TESTS_AC" \
+        "$BENCH_AC_WRITE_AVG_MAX_MULTIPLIER" || ceiling_ok=1
+    fi
+  fi
+
+  if [ "$ceiling_ok" = "0" ]; then
+    echo "All tests within ceilings."
+  else
+    echo ""
+    echo "**FAILED**: One or more tests exceeded their ceiling."
+    return 1
+  fi
+}

--- a/test/sysbench_compare.sh
+++ b/test/sysbench_compare.sh
@@ -20,13 +20,6 @@ BENCH_SECTION_MODE=${BENCH_SECTION_MODE:-full}
 cleanup() { rm -rf "$TMPDIR"; }
 trap cleanup EXIT
 
-fmt_us() {
-  python3 - "$1" <<'PYEOF'
-import sys
-print(f"{int(sys.argv[1]):,}")
-PYEOF
-}
-
 python3 << PYEOF
 import random, string, os
 
@@ -327,143 +320,16 @@ make_test("types_delete_insert_ac",   prep_with_types, w_types_delete_insert_aut
 make_test("oltp_read_write_ac",       prep_main, w_read_write_autocommit)
 PYEOF
 
-run_bench() {
-  local engine="$1" binary="$2" sql_file="$3" db_template="$4"
-  local db="$db_template"
-  if [ "$db" != ":memory:" ]; then
-    db="/tmp/bench_${engine}_${RANDOM}_$$.db"
-    rm -f "$db"
-  fi
-  local bench_sql_file="$sql_file"
-  local sqlite_pragmas="${SQLITE_BENCH_PRAGMAS:-}"
-  if [ "$engine" = "sqlite" ] && [ "$db_template" != ":memory:" ]; then
-    sqlite_pragmas="$SQLITE_FILE_CACHE_PRAGMA $sqlite_pragmas"
-  fi
-  if [ "$engine" = "sqlite" ] && [ -n "$sqlite_pragmas" ]; then
-    bench_sql_file="$TMPDIR/pragma_${engine}_${RANDOM}_$$.sql"
-    printf "%s\n" "$sqlite_pragmas" > "$bench_sql_file"
-    cat "$sql_file" >> "$bench_sql_file"
-  fi
-  local timer=""
-  if [ "$engine" = "sqlite" ] && [ -x "$BENCH_TIMER_SQLITE" ]; then
-    timer="$BENCH_TIMER_SQLITE"
-  elif [ "$engine" = "doltlite" ] && [ -x "$BENCH_TIMER_DOLTLITE" ]; then
-    timer="$BENCH_TIMER_DOLTLITE"
-  fi
-  if [ -n "$timer" ]; then
-    "$timer" "$db" "$bench_sql_file"
-    if [ "$db" != ":memory:" ]; then rm -f "$db"; fi
-    return
-  fi
-  local output
-  output=$(sed \
-    -e "s/\.print BENCH_START/SELECT 'TS_START:' || CAST((julianday('now')*86400000000) AS INTEGER);/" \
-    -e "s/\.print BENCH_END/SELECT 'TS_END:' || CAST((julianday('now')*86400000000) AS INTEGER);/" \
-    "$bench_sql_file" | "$binary" "$db" 2>&1)
-  if [ "$db" != ":memory:" ]; then rm -f "$db"; fi
-  echo "$output" | python3 -c "
-import sys, re
-start = end = None
-for line in sys.stdin:
-    m = re.search(r'TS_START:(\d+)', line)
-    if m: start = int(m.group(1))
-    m = re.search(r'TS_END:(\d+)', line)
-    if m: end = int(m.group(1))
-if start is not None and end is not None:
-    print(end - start)
-else:
-    print(-1)
-"
-}
-
-bench_runs_for_test() {
-  case "$1" in
-    *_ac) echo "$BENCH_AC_WRITE_RUNS" ;;
-    *) echo "${BENCH_RUNS:-5}" ;;
-  esac
-}
-
-bench_runs_summary() {
-  local base_runs="${BENCH_RUNS:-5}"
-  if [ "$BENCH_AC_WRITE_RUNS" = "$base_runs" ]; then
-    echo "median of ${base_runs} invocations per test"
-  else
-    echo "median of ${base_runs} invocations per test; autocommit writes use ${BENCH_AC_WRITE_RUNS}"
-  fi
-}
-
-median_us() {
-  python3 - "$@" <<'PYEOF'
-import sys
-vals = sorted(int(v) for v in sys.argv[1:] if int(v) >= 0)
-if not vals:
-    print(-1)
-else:
-    print(vals[len(vals)//2])
-PYEOF
-}
-
-run_bench_stable() {
-  local test_name="$1" engine="$2" binary="$3" sql_file="$4" db_template="$5"
-  local runs
-  local i
-  local sample
-  local samples=""
-  runs=$(bench_runs_for_test "$test_name")
-  for ((i=0; i<runs; i++)); do
-    sample=$(run_bench "$engine" "$binary" "$sql_file" "$db_template")
-    if [ -z "$samples" ]; then
-      samples="$sample"
-    else
-      samples="$samples $sample"
-    fi
-  done
-  median_us $samples
-}
-
 READ_TESTS="oltp_point_select oltp_range_select oltp_sum_range oltp_order_range oltp_distinct_range oltp_index_scan select_random_points select_random_ranges covering_index_scan groupby_scan index_join index_join_scan types_table_scan table_scan oltp_read_only"
 WRITE_TESTS="oltp_bulk_insert oltp_insert oltp_update_index oltp_update_non_index oltp_delete_insert oltp_write_only types_delete_insert oltp_read_write"
 WRITE_TESTS_AC="oltp_bulk_insert_ac oltp_insert_ac oltp_update_index_ac oltp_update_non_index_ac oltp_delete_insert_ac oltp_write_only_ac types_delete_insert_ac oltp_read_write_ac"
 
-BENCH_RESULTS_FILE="$TMPDIR/bench_results.tsv"
-: > "$BENCH_RESULTS_FILE"
-
-run_section() {
-  local section="$1" tests="$2" db_sq="$3" db_dl="$4"
-  local ratio_sum=0
-  local ratio_count=0
-  local avg_ratio="--"
-  echo "| Test | SQLite (us) | Doltlite (us) | Multiplier |"
-  echo "|------|------------:|--------------:|-----------:|"
-  for t in $tests; do
-  s=$(run_bench_stable "$t" sqlite "$SQLITE3" "$TMPDIR/$t.sql" "$db_sq")
-  d=$(run_bench_stable "$t" doltlite "$DOLTLITE" "$TMPDIR/$t.sql" "$db_dl")
-  s_display="$s"
-  d_display="$d"
-  if [ "$s" -eq -1 ] 2>/dev/null; then s_display="crash"; fi
-  if [ "$d" -eq -1 ] 2>/dev/null; then d_display="crash"; fi
-  if [ "$s" -ge 0 ] 2>/dev/null; then s_display=$(fmt_us "$s"); fi
-  if [ "$d" -ge 0 ] 2>/dev/null; then d_display=$(fmt_us "$d"); fi
-  if [ "$s" -gt 0 ] 2>/dev/null && [ "$d" -ge 0 ] 2>/dev/null; then
-    ratio=$(python3 -c "print(f'{$d/$s:.2f}')")
-    ratio_sum=$(python3 -c "print($ratio_sum + ($d/$s))")
-    ratio_count=$((ratio_count + 1))
-  else
-    ratio="--"
-  fi
-  printf '%s\t%s\t%s\t%s\n' "$section" "$t" "$s" "$d" >> "$BENCH_RESULTS_FILE"
-  echo "| $t | $s_display | $d_display | ${ratio} |"
-  done
-  if [ "$ratio_count" -gt 0 ]; then
-    avg_ratio=$(python3 -c "print(f'{($ratio_sum/$ratio_count):.2f}')")
-  fi
-  echo "| Average |  |  | ${avg_ratio} |"
-}
+source "$(dirname "$0")/lib/sysbench_benchmark.sh"
 
 case "$BENCH_SECTION_MODE" in
   full)
     echo "<!-- benchmark:classic -->"
-    echo "## Sysbench-Style Benchmark: Doltlite vs SQLite"
+    echo "## Sysbench-Style Benchmark: $BENCH_CANDIDATE_LABEL vs $BENCH_BASELINE_LABEL"
     echo ""
     echo "### In-Memory"
     echo ""
@@ -489,8 +355,7 @@ case "$BENCH_SECTION_MODE" in
     echo ""
     echo "_Each statement runs as its own transaction — exposes per-commit_"
     echo "_fixed costs that the wrapped-in-BEGIN/COMMIT tests amortize away._"
-    echo "_SQLite uses WAL mode with synchronous=FULL in this section so_"
-    echo "_the comparison uses SQLite's durable WAL autocommit path._"
+    benchmark_autocommit_note
     echo ""
     echo "#### Reads"
     echo ""
@@ -506,7 +371,7 @@ case "$BENCH_SECTION_MODE" in
     ;;
   wrapped)
     echo "<!-- benchmark:classic -->"
-    echo "## Sysbench-Style Benchmark: Doltlite vs SQLite"
+    echo "## Sysbench-Style Benchmark: $BENCH_CANDIDATE_LABEL vs $BENCH_BASELINE_LABEL"
     echo ""
     echo "### In-Memory"
     echo ""
@@ -529,14 +394,13 @@ case "$BENCH_SECTION_MODE" in
     run_section "file_writes" "$WRITE_TESTS" "$TMPDIR/bench_file" "$TMPDIR/bench_file"
     ;;
   autocommit)
-    echo "## Sysbench-Style Benchmark (autocommit): Doltlite vs SQLite"
+    echo "## Sysbench-Style Benchmark (autocommit): $BENCH_CANDIDATE_LABEL vs $BENCH_BASELINE_LABEL"
     echo ""
     echo "### File-Backed (autocommit)"
     echo ""
     echo "_Each statement runs as its own transaction — exposes per-commit_"
     echo "_fixed costs that the wrapped-in-BEGIN/COMMIT tests amortize away._"
-    echo "_SQLite uses WAL mode with synchronous=FULL in this section so_"
-    echo "_the comparison uses SQLite's durable WAL autocommit path._"
+    benchmark_autocommit_note
     echo ""
     echo "#### Reads"
     echo ""
@@ -559,91 +423,4 @@ esac
 echo ""
 echo "_${ROWS} rows, $(bench_runs_summary), workload-only timing via host monotonic clock when available._"
 
-check_ceiling() {
-  local section="$1" tests="$2" max="$3"
-  local failed=0
-  for t in $tests; do
-    local line
-    line=$(awk -F '\t' -v section="$section" -v test="$t" \
-      '$1==section && $2==test {print $3 "\t" $4; exit}' \
-      "$BENCH_RESULTS_FILE")
-    s="${line%%$'\t'*}"
-    d="${line#*$'\t'}"
-    if [ "$s" -gt 0 ] 2>/dev/null && [ "$d" -ge 0 ] 2>/dev/null; then
-      over=$(python3 -c "r=$d/$s; print(1 if r>$max else 0)")
-      if [ "$over" = "1" ]; then
-        ratio=$(python3 -c "print(f'{$d/$s:.2f}')")
-        echo "FAIL: $section/$t = ${ratio}x (ceiling: ${max}x)" >&2
-        failed=1
-      fi
-    fi
-  done
-  return $failed
-}
-
-check_average_ceiling() {
-  local section="$1" tests="$2" max="$3"
-  local ratio
-  ratio=$(python3 - "$BENCH_RESULTS_FILE" "$section" "$tests" <<'PYEOF'
-import sys
-path, section, tests = sys.argv[1], sys.argv[2], sys.argv[3].split()
-wanted = set(tests)
-ratios = []
-with open(path) as f:
-    for line in f:
-        cols = line.rstrip("\n").split("\t")
-        if len(cols) < 4 or cols[0] != section or cols[1] not in wanted:
-            continue
-        s, d = int(cols[2]), int(cols[3])
-        if s > 0 and d >= 0:
-            ratios.append(d / s)
-if ratios:
-    print(f"{sum(ratios) / len(ratios):.2f}")
-else:
-    print("")
-PYEOF
-)
-  if [ -n "$ratio" ]; then
-    over=$(python3 -c "r=$ratio; print(1 if r>$max else 0)")
-    if [ "$over" = "1" ]; then
-      echo "FAIL: $section average = ${ratio}x (ceiling: ${max}x)" >&2
-      return 1
-    fi
-  fi
-  return 0
-}
-
-echo ""
-echo "### Performance Ceiling Check (${BENCH_MAX_MULTIPLIER}x individual, ${BENCH_AVG_MAX_MULTIPLIER}x average; autocommit writes: ${BENCH_AC_WRITE_MAX_MULTIPLIER}x / ${BENCH_AC_WRITE_AVG_MAX_MULTIPLIER}x)"
-echo ""
-
-ceiling_ok=0
-if [ "$BENCH_SECTION_MODE" = "autocommit" ]; then
-  check_ceiling "ac_reads" "$READ_TESTS" "$BENCH_MAX_MULTIPLIER" || ceiling_ok=1
-  check_ceiling "ac_writes" "$WRITE_TESTS_AC" "$BENCH_AC_WRITE_MAX_MULTIPLIER" || ceiling_ok=1
-  check_average_ceiling "ac_reads" "$READ_TESTS" "$BENCH_AVG_MAX_MULTIPLIER" || ceiling_ok=1
-  check_average_ceiling "ac_writes" "$WRITE_TESTS_AC" "$BENCH_AC_WRITE_AVG_MAX_MULTIPLIER" || ceiling_ok=1
-else
-  check_ceiling "mem_reads" "$READ_TESTS" "$BENCH_MAX_MULTIPLIER" || ceiling_ok=1
-  check_ceiling "mem_writes" "$WRITE_TESTS" "$BENCH_MAX_MULTIPLIER" || ceiling_ok=1
-  check_ceiling "file_reads" "$READ_TESTS" "$BENCH_MAX_MULTIPLIER" || ceiling_ok=1
-  check_ceiling "file_writes" "$WRITE_TESTS" "$BENCH_MAX_MULTIPLIER" || ceiling_ok=1
-  check_average_ceiling "mem_reads" "$READ_TESTS" "$BENCH_AVG_MAX_MULTIPLIER" || ceiling_ok=1
-  check_average_ceiling "mem_writes" "$WRITE_TESTS" "$BENCH_AVG_MAX_MULTIPLIER" || ceiling_ok=1
-  check_average_ceiling "file_reads" "$READ_TESTS" "$BENCH_AVG_MAX_MULTIPLIER" || ceiling_ok=1
-  check_average_ceiling "file_writes" "$WRITE_TESTS" "$BENCH_AVG_MAX_MULTIPLIER" || ceiling_ok=1
-  if [ "$BENCH_SECTION_MODE" = "full" ]; then
-    check_ceiling "ac_reads" "$READ_TESTS" "$BENCH_MAX_MULTIPLIER" || ceiling_ok=1
-    check_ceiling "ac_writes" "$WRITE_TESTS_AC" "$BENCH_AC_WRITE_MAX_MULTIPLIER" || ceiling_ok=1
-    check_average_ceiling "ac_reads" "$READ_TESTS" "$BENCH_AVG_MAX_MULTIPLIER" || ceiling_ok=1
-    check_average_ceiling "ac_writes" "$WRITE_TESTS_AC" "$BENCH_AC_WRITE_AVG_MAX_MULTIPLIER" || ceiling_ok=1
-  fi
-fi
-
-if [ "$ceiling_ok" = "0" ]; then
-  echo "All tests within ceilings."
-else
-  echo ""
-  echo "**FAILED**: One or more tests exceeded their ceiling."
-  exit 1
-fi
+benchmark_finish

--- a/test/sysbench_compare_blobpk.sh
+++ b/test/sysbench_compare_blobpk.sh
@@ -19,13 +19,6 @@ TMPDIR=$(mktemp -d)
 cleanup() { rm -rf "$TMPDIR"; }
 trap cleanup EXIT
 
-fmt_us() {
-  python3 - "$1" <<'PYEOF'
-import sys
-print(f"{int(sys.argv[1]):,}")
-PYEOF
-}
-
 python3 << PYEOF
 import random, string, os
 
@@ -329,145 +322,18 @@ make_test("types_delete_insert_ac",   prep_with_types, w_types_delete_insert_aut
 make_test("oltp_read_write_ac",       prep_main, w_read_write_autocommit)
 PYEOF
 
-run_bench() {
-  local engine="$1" binary="$2" sql_file="$3" db_template="$4"
-  local db="$db_template"
-  if [ "$db" != ":memory:" ]; then
-    db="/tmp/bench_${engine}_${RANDOM}_$$.db"
-    rm -f "$db"
-  fi
-  local bench_sql_file="$sql_file"
-  local sqlite_pragmas="${SQLITE_BENCH_PRAGMAS:-}"
-  if [ "$engine" = "sqlite" ] && [ "$db_template" != ":memory:" ]; then
-    sqlite_pragmas="$SQLITE_FILE_CACHE_PRAGMA $sqlite_pragmas"
-  fi
-  if [ "$engine" = "sqlite" ] && [ -n "$sqlite_pragmas" ]; then
-    bench_sql_file="$TMPDIR/pragma_${engine}_${RANDOM}_$$.sql"
-    printf "%s\n" "$sqlite_pragmas" > "$bench_sql_file"
-    cat "$sql_file" >> "$bench_sql_file"
-  fi
-  local timer=""
-  if [ "$engine" = "sqlite" ] && [ -x "$BENCH_TIMER_SQLITE" ]; then
-    timer="$BENCH_TIMER_SQLITE"
-  elif [ "$engine" = "doltlite" ] && [ -x "$BENCH_TIMER_DOLTLITE" ]; then
-    timer="$BENCH_TIMER_DOLTLITE"
-  fi
-  if [ -n "$timer" ]; then
-    "$timer" "$db" "$bench_sql_file"
-    if [ "$db" != ":memory:" ]; then rm -f "$db"; fi
-    return
-  fi
-  local output
-  output=$(sed \
-    -e "s/\.print BENCH_START/SELECT 'TS_START:' || CAST((julianday('now')*86400000000) AS INTEGER);/" \
-    -e "s/\.print BENCH_END/SELECT 'TS_END:' || CAST((julianday('now')*86400000000) AS INTEGER);/" \
-    "$bench_sql_file" | "$binary" "$db" 2>&1)
-  if [ "$db" != ":memory:" ]; then rm -f "$db"; fi
-  echo "$output" | python3 -c "
-import sys, re
-start = end = None
-for line in sys.stdin:
-    m = re.search(r'TS_START:(\d+)', line)
-    if m: start = int(m.group(1))
-    m = re.search(r'TS_END:(\d+)', line)
-    if m: end = int(m.group(1))
-if start is not None and end is not None:
-    print(end - start)
-else:
-    print(-1)
-"
-}
-
-bench_runs_for_test() {
-  case "$1" in
-    *_ac) echo "$BENCH_AC_WRITE_RUNS" ;;
-    *) echo "${BENCH_RUNS:-5}" ;;
-  esac
-}
-
-bench_runs_summary() {
-  local base_runs="${BENCH_RUNS:-5}"
-  if [ "$BENCH_AC_WRITE_RUNS" = "$base_runs" ]; then
-    echo "median of ${base_runs} invocations per test"
-  else
-    echo "median of ${base_runs} invocations per test; autocommit writes use ${BENCH_AC_WRITE_RUNS}"
-  fi
-}
-
-median_us() {
-  python3 - "$@" <<'PYEOF'
-import sys
-vals = sorted(int(v) for v in sys.argv[1:] if int(v) >= 0)
-if not vals:
-    print(-1)
-else:
-    print(vals[len(vals)//2])
-PYEOF
-}
-
-run_bench_stable() {
-  local test_name="$1" engine="$2" binary="$3" sql_file="$4" db_template="$5"
-  local runs
-  local i
-  local sample
-  local samples=""
-  runs=$(bench_runs_for_test "$test_name")
-  for ((i=0; i<runs; i++)); do
-    sample=$(run_bench "$engine" "$binary" "$sql_file" "$db_template")
-    if [ -z "$samples" ]; then
-      samples="$sample"
-    else
-      samples="$samples $sample"
-    fi
-  done
-  median_us $samples
-}
-
 READ_TESTS="oltp_point_select oltp_range_select oltp_sum_range oltp_order_range oltp_distinct_range oltp_index_scan select_random_points select_random_ranges covering_index_scan groupby_scan index_join index_join_scan types_table_scan table_scan oltp_read_only"
 WRITE_TESTS="oltp_bulk_insert oltp_insert oltp_update_index oltp_update_non_index oltp_delete_insert oltp_write_only types_delete_insert oltp_read_write"
 WRITE_TESTS_AC="oltp_bulk_insert_ac oltp_insert_ac oltp_update_index_ac oltp_update_non_index_ac oltp_delete_insert_ac oltp_write_only_ac types_delete_insert_ac oltp_read_write_ac"
 
-BENCH_RESULTS_FILE="$TMPDIR/bench_results.tsv"
-: > "$BENCH_RESULTS_FILE"
-
-run_section() {
-  local section="$1" tests="$2" db_sq="$3" db_dl="$4"
-  local ratio_sum=0
-  local ratio_count=0
-  local avg_ratio="--"
-  echo "| Test | SQLite (us) | Doltlite (us) | Multiplier |"
-  echo "|------|------------:|--------------:|-----------:|"
-  for t in $tests; do
-  s=$(run_bench_stable "$t" sqlite "$SQLITE3" "$TMPDIR/$t.sql" "$db_sq")
-  d=$(run_bench_stable "$t" doltlite "$DOLTLITE" "$TMPDIR/$t.sql" "$db_dl")
-  s_display="$s"
-  d_display="$d"
-  if [ "$s" -eq -1 ] 2>/dev/null; then s_display="crash"; fi
-  if [ "$d" -eq -1 ] 2>/dev/null; then d_display="crash"; fi
-  if [ "$s" -ge 0 ] 2>/dev/null; then s_display=$(fmt_us "$s"); fi
-  if [ "$d" -ge 0 ] 2>/dev/null; then d_display=$(fmt_us "$d"); fi
-  if [ "$s" -gt 0 ] 2>/dev/null && [ "$d" -ge 0 ] 2>/dev/null; then
-    ratio=$(python3 -c "print(f'{$d/$s:.2f}')")
-    ratio_sum=$(python3 -c "print($ratio_sum + ($d/$s))")
-    ratio_count=$((ratio_count + 1))
-  else
-    ratio="--"
-  fi
-  printf '%s\t%s\t%s\t%s\n' "$section" "$t" "$s" "$d" >> "$BENCH_RESULTS_FILE"
-  echo "| $t | $s_display | $d_display | ${ratio} |"
-  done
-  if [ "$ratio_count" -gt 0 ]; then
-    avg_ratio=$(python3 -c "print(f'{($ratio_sum/$ratio_count):.2f}')")
-  fi
-  echo "| Average |  |  | ${avg_ratio} |"
-}
+source "$(dirname "$0")/lib/sysbench_benchmark.sh"
 
 echo "<!-- benchmark:blobpk -->"
-echo "## Sysbench-Style Benchmark (BLOB PK): Doltlite vs SQLite"
+echo "## Sysbench-Style Benchmark (BLOB PK): $BENCH_CANDIDATE_LABEL vs $BENCH_BASELINE_LABEL"
 echo ""
 echo "_Companion to the classic Sysbench-Style Benchmark. Every workload here"
 echo "runs against tables with a 16-byte big-endian \`BLOB PRIMARY KEY\`._"
-echo "_Individual ratios gated at ${BENCH_MAX_MULTIPLIER}×; section averages gated at ${BENCH_AVG_MAX_MULTIPLIER}×. Autocommit writes use ${BENCH_AC_WRITE_MAX_MULTIPLIER}× / ${BENCH_AC_WRITE_AVG_MAX_MULTIPLIER}×._"
+benchmark_gate_note
 echo ""
 echo "### In-Memory"
 echo ""
@@ -494,8 +360,7 @@ echo "### File-Backed (autocommit)"
 echo ""
 echo "_Each statement runs as its own transaction — exposes per-commit_"
 echo "_fixed costs that the wrapped-in-BEGIN/COMMIT tests amortize away._"
-echo "_SQLite uses WAL mode with synchronous=FULL in this section so_"
-echo "_the comparison uses SQLite's durable WAL autocommit path._"
+benchmark_autocommit_note
 echo ""
 echo "#### Reads"
 echo ""
@@ -512,82 +377,4 @@ SQLITE_BENCH_PRAGMAS="$SQLITE_AUTOCOMMIT_PRAGMAS" run_section "ac_writes" "$WRIT
 echo ""
 echo "_${ROWS} rows, $(bench_runs_summary), workload-only timing via host monotonic clock when available._"
 
-check_ceiling() {
-  local section="$1" tests="$2" max="$3"
-  local failed=0
-  for t in $tests; do
-    local line
-    line=$(awk -F '\t' -v section="$section" -v test="$t" \
-      '$1==section && $2==test {print $3 "\t" $4; exit}' \
-      "$BENCH_RESULTS_FILE")
-    s="${line%%$'\t'*}"
-    d="${line#*$'\t'}"
-    if [ "$s" -gt 0 ] 2>/dev/null && [ "$d" -ge 0 ] 2>/dev/null; then
-      over=$(python3 -c "r=$d/$s; print(1 if r>$max else 0)")
-      if [ "$over" = "1" ]; then
-        ratio=$(python3 -c "print(f'{$d/$s:.2f}')")
-        echo "FAIL: $section/$t = ${ratio}x (ceiling: ${max}x)" >&2
-        failed=1
-      fi
-    fi
-  done
-  return $failed
-}
-
-check_average_ceiling() {
-  local section="$1" tests="$2" max="$3"
-  local ratio
-  ratio=$(python3 - "$BENCH_RESULTS_FILE" "$section" "$tests" <<'PYEOF'
-import sys
-path, section, tests = sys.argv[1], sys.argv[2], sys.argv[3].split()
-wanted = set(tests)
-ratios = []
-with open(path) as f:
-    for line in f:
-        cols = line.rstrip("\n").split("\t")
-        if len(cols) < 4 or cols[0] != section or cols[1] not in wanted:
-            continue
-        s, d = int(cols[2]), int(cols[3])
-        if s > 0 and d >= 0:
-            ratios.append(d / s)
-if ratios:
-    print(f"{sum(ratios) / len(ratios):.2f}")
-else:
-    print("")
-PYEOF
-)
-  if [ -n "$ratio" ]; then
-    over=$(python3 -c "r=$ratio; print(1 if r>$max else 0)")
-    if [ "$over" = "1" ]; then
-      echo "FAIL: $section average = ${ratio}x (ceiling: ${max}x)" >&2
-      return 1
-    fi
-  fi
-  return 0
-}
-
-echo ""
-echo "### Performance Ceiling Check (${BENCH_MAX_MULTIPLIER}x individual, ${BENCH_AVG_MAX_MULTIPLIER}x average; autocommit writes: ${BENCH_AC_WRITE_MAX_MULTIPLIER}x / ${BENCH_AC_WRITE_AVG_MAX_MULTIPLIER}x)"
-echo ""
-
-ceiling_ok=0
-check_ceiling "mem_reads"   "$READ_TESTS"     "$BENCH_MAX_MULTIPLIER" || ceiling_ok=1
-check_ceiling "mem_writes"  "$WRITE_TESTS"    "$BENCH_MAX_MULTIPLIER" || ceiling_ok=1
-check_ceiling "file_reads"  "$READ_TESTS"     "$BENCH_MAX_MULTIPLIER" || ceiling_ok=1
-check_ceiling "file_writes" "$WRITE_TESTS"    "$BENCH_MAX_MULTIPLIER" || ceiling_ok=1
-check_ceiling "ac_reads"    "$READ_TESTS"     "$BENCH_MAX_MULTIPLIER" || ceiling_ok=1
-check_ceiling "ac_writes"   "$WRITE_TESTS_AC" "$BENCH_AC_WRITE_MAX_MULTIPLIER" || ceiling_ok=1
-check_average_ceiling "mem_reads"   "$READ_TESTS"     "$BENCH_AVG_MAX_MULTIPLIER" || ceiling_ok=1
-check_average_ceiling "mem_writes"  "$WRITE_TESTS"    "$BENCH_AVG_MAX_MULTIPLIER" || ceiling_ok=1
-check_average_ceiling "file_reads"  "$READ_TESTS"     "$BENCH_AVG_MAX_MULTIPLIER" || ceiling_ok=1
-check_average_ceiling "file_writes" "$WRITE_TESTS"    "$BENCH_AVG_MAX_MULTIPLIER" || ceiling_ok=1
-check_average_ceiling "ac_reads"    "$READ_TESTS"     "$BENCH_AVG_MAX_MULTIPLIER" || ceiling_ok=1
-check_average_ceiling "ac_writes"   "$WRITE_TESTS_AC" "$BENCH_AC_WRITE_AVG_MAX_MULTIPLIER" || ceiling_ok=1
-
-if [ "$ceiling_ok" = "0" ]; then
-  echo "All tests within ceilings."
-else
-  echo ""
-  echo "**FAILED**: One or more tests exceeded their ceiling."
-  exit 1
-fi
+benchmark_finish

--- a/test/sysbench_compare_compositepk.sh
+++ b/test/sysbench_compare_compositepk.sh
@@ -19,13 +19,6 @@ TMPDIR=$(mktemp -d)
 cleanup() { rm -rf "$TMPDIR"; }
 trap cleanup EXIT
 
-fmt_us() {
-  python3 - "$1" <<'PYEOF'
-import sys
-print(f"{int(sys.argv[1]):,}")
-PYEOF
-}
-
 python3 << PYEOF
 import random, string, os
 
@@ -345,145 +338,18 @@ make_test("types_delete_insert_ac",   prep_with_types, w_types_delete_insert_aut
 make_test("oltp_read_write_ac",       prep_main, w_read_write_autocommit)
 PYEOF
 
-run_bench() {
-  local engine="$1" binary="$2" sql_file="$3" db_template="$4"
-  local db="$db_template"
-  if [ "$db" != ":memory:" ]; then
-    db="/tmp/bench_${engine}_${RANDOM}_$$.db"
-    rm -f "$db"
-  fi
-  local bench_sql_file="$sql_file"
-  local sqlite_pragmas="${SQLITE_BENCH_PRAGMAS:-}"
-  if [ "$engine" = "sqlite" ] && [ "$db_template" != ":memory:" ]; then
-    sqlite_pragmas="$SQLITE_FILE_CACHE_PRAGMA $sqlite_pragmas"
-  fi
-  if [ "$engine" = "sqlite" ] && [ -n "$sqlite_pragmas" ]; then
-    bench_sql_file="$TMPDIR/pragma_${engine}_${RANDOM}_$$.sql"
-    printf "%s\n" "$sqlite_pragmas" > "$bench_sql_file"
-    cat "$sql_file" >> "$bench_sql_file"
-  fi
-  local timer=""
-  if [ "$engine" = "sqlite" ] && [ -x "$BENCH_TIMER_SQLITE" ]; then
-    timer="$BENCH_TIMER_SQLITE"
-  elif [ "$engine" = "doltlite" ] && [ -x "$BENCH_TIMER_DOLTLITE" ]; then
-    timer="$BENCH_TIMER_DOLTLITE"
-  fi
-  if [ -n "$timer" ]; then
-    "$timer" "$db" "$bench_sql_file"
-    if [ "$db" != ":memory:" ]; then rm -f "$db"; fi
-    return
-  fi
-  local output
-  output=$(sed \
-    -e "s/\.print BENCH_START/SELECT 'TS_START:' || CAST((julianday('now')*86400000000) AS INTEGER);/" \
-    -e "s/\.print BENCH_END/SELECT 'TS_END:' || CAST((julianday('now')*86400000000) AS INTEGER);/" \
-    "$bench_sql_file" | "$binary" "$db" 2>&1)
-  if [ "$db" != ":memory:" ]; then rm -f "$db"; fi
-  echo "$output" | python3 -c "
-import sys, re
-start = end = None
-for line in sys.stdin:
-    m = re.search(r'TS_START:(\d+)', line)
-    if m: start = int(m.group(1))
-    m = re.search(r'TS_END:(\d+)', line)
-    if m: end = int(m.group(1))
-if start is not None and end is not None:
-    print(end - start)
-else:
-    print(-1)
-"
-}
-
-bench_runs_for_test() {
-  case "$1" in
-    *_ac) echo "$BENCH_AC_WRITE_RUNS" ;;
-    *) echo "${BENCH_RUNS:-5}" ;;
-  esac
-}
-
-bench_runs_summary() {
-  local base_runs="${BENCH_RUNS:-5}"
-  if [ "$BENCH_AC_WRITE_RUNS" = "$base_runs" ]; then
-    echo "median of ${base_runs} invocations per test"
-  else
-    echo "median of ${base_runs} invocations per test; autocommit writes use ${BENCH_AC_WRITE_RUNS}"
-  fi
-}
-
-median_us() {
-  python3 - "$@" <<'PYEOF'
-import sys
-vals = sorted(int(v) for v in sys.argv[1:] if int(v) >= 0)
-if not vals:
-    print(-1)
-else:
-    print(vals[len(vals)//2])
-PYEOF
-}
-
-run_bench_stable() {
-  local test_name="$1" engine="$2" binary="$3" sql_file="$4" db_template="$5"
-  local runs
-  local i
-  local sample
-  local samples=""
-  runs=$(bench_runs_for_test "$test_name")
-  for ((i=0; i<runs; i++)); do
-    sample=$(run_bench "$engine" "$binary" "$sql_file" "$db_template")
-    if [ -z "$samples" ]; then
-      samples="$sample"
-    else
-      samples="$samples $sample"
-    fi
-  done
-  median_us $samples
-}
-
 READ_TESTS="oltp_point_select oltp_range_select oltp_sum_range oltp_order_range oltp_distinct_range oltp_index_scan select_random_points select_random_ranges covering_index_scan groupby_scan index_join index_join_scan types_table_scan table_scan oltp_read_only"
 WRITE_TESTS="oltp_bulk_insert oltp_insert oltp_update_index oltp_update_non_index oltp_delete_insert oltp_write_only types_delete_insert oltp_read_write"
 WRITE_TESTS_AC="oltp_bulk_insert_ac oltp_insert_ac oltp_update_index_ac oltp_update_non_index_ac oltp_delete_insert_ac oltp_write_only_ac types_delete_insert_ac oltp_read_write_ac"
 
-BENCH_RESULTS_FILE="$TMPDIR/bench_results.tsv"
-: > "$BENCH_RESULTS_FILE"
-
-run_section() {
-  local section="$1" tests="$2" db_sq="$3" db_dl="$4"
-  local ratio_sum=0
-  local ratio_count=0
-  local avg_ratio="--"
-  echo "| Test | SQLite (us) | Doltlite (us) | Multiplier |"
-  echo "|------|------------:|--------------:|-----------:|"
-  for t in $tests; do
-  s=$(run_bench_stable "$t" sqlite "$SQLITE3" "$TMPDIR/$t.sql" "$db_sq")
-  d=$(run_bench_stable "$t" doltlite "$DOLTLITE" "$TMPDIR/$t.sql" "$db_dl")
-  s_display="$s"
-  d_display="$d"
-  if [ "$s" -eq -1 ] 2>/dev/null; then s_display="crash"; fi
-  if [ "$d" -eq -1 ] 2>/dev/null; then d_display="crash"; fi
-  if [ "$s" -ge 0 ] 2>/dev/null; then s_display=$(fmt_us "$s"); fi
-  if [ "$d" -ge 0 ] 2>/dev/null; then d_display=$(fmt_us "$d"); fi
-  if [ "$s" -gt 0 ] 2>/dev/null && [ "$d" -ge 0 ] 2>/dev/null; then
-    ratio=$(python3 -c "print(f'{$d/$s:.2f}')")
-    ratio_sum=$(python3 -c "print($ratio_sum + ($d/$s))")
-    ratio_count=$((ratio_count + 1))
-  else
-    ratio="--"
-  fi
-  printf '%s\t%s\t%s\t%s\n' "$section" "$t" "$s" "$d" >> "$BENCH_RESULTS_FILE"
-  echo "| $t | $s_display | $d_display | ${ratio} |"
-  done
-  if [ "$ratio_count" -gt 0 ]; then
-    avg_ratio=$(python3 -c "print(f'{($ratio_sum/$ratio_count):.2f}')")
-  fi
-  echo "| Average |  |  | ${avg_ratio} |"
-}
+source "$(dirname "$0")/lib/sysbench_benchmark.sh"
 
 echo "<!-- benchmark:compositepk -->"
-echo "## Sysbench-Style Benchmark (composite PK): Doltlite vs SQLite"
+echo "## Sysbench-Style Benchmark (composite PK): $BENCH_CANDIDATE_LABEL vs $BENCH_BASELINE_LABEL"
 echo ""
 echo "_Companion to the classic Sysbench-Style Benchmark. Every workload here"
 echo "runs against tables with a 2-column INTEGER \`PRIMARY KEY(a, b) WITHOUT ROWID\`._"
-echo "_Individual ratios gated at ${BENCH_MAX_MULTIPLIER}×; section averages gated at ${BENCH_AVG_MAX_MULTIPLIER}×. Autocommit writes use ${BENCH_AC_WRITE_MAX_MULTIPLIER}× / ${BENCH_AC_WRITE_AVG_MAX_MULTIPLIER}×._"
+benchmark_gate_note
 echo ""
 echo "### In-Memory"
 echo ""
@@ -510,8 +376,7 @@ echo "### File-Backed (autocommit)"
 echo ""
 echo "_Each statement runs as its own transaction — exposes per-commit_"
 echo "_fixed costs that the wrapped-in-BEGIN/COMMIT tests amortize away._"
-echo "_SQLite uses WAL mode with synchronous=FULL in this section so_"
-echo "_the comparison uses SQLite's durable WAL autocommit path._"
+benchmark_autocommit_note
 echo ""
 echo "#### Reads"
 echo ""
@@ -528,82 +393,4 @@ SQLITE_BENCH_PRAGMAS="$SQLITE_AUTOCOMMIT_PRAGMAS" run_section "ac_writes" "$WRIT
 echo ""
 echo "_${ROWS} rows, $(bench_runs_summary), workload-only timing via host monotonic clock when available._"
 
-check_ceiling() {
-  local section="$1" tests="$2" max="$3"
-  local failed=0
-  for t in $tests; do
-    local line
-    line=$(awk -F '\t' -v section="$section" -v test="$t" \
-      '$1==section && $2==test {print $3 "\t" $4; exit}' \
-      "$BENCH_RESULTS_FILE")
-    s="${line%%$'\t'*}"
-    d="${line#*$'\t'}"
-    if [ "$s" -gt 0 ] 2>/dev/null && [ "$d" -ge 0 ] 2>/dev/null; then
-      over=$(python3 -c "r=$d/$s; print(1 if r>$max else 0)")
-      if [ "$over" = "1" ]; then
-        ratio=$(python3 -c "print(f'{$d/$s:.2f}')")
-        echo "FAIL: $section/$t = ${ratio}x (ceiling: ${max}x)" >&2
-        failed=1
-      fi
-    fi
-  done
-  return $failed
-}
-
-check_average_ceiling() {
-  local section="$1" tests="$2" max="$3"
-  local ratio
-  ratio=$(python3 - "$BENCH_RESULTS_FILE" "$section" "$tests" <<'PYEOF'
-import sys
-path, section, tests = sys.argv[1], sys.argv[2], sys.argv[3].split()
-wanted = set(tests)
-ratios = []
-with open(path) as f:
-    for line in f:
-        cols = line.rstrip("\n").split("\t")
-        if len(cols) < 4 or cols[0] != section or cols[1] not in wanted:
-            continue
-        s, d = int(cols[2]), int(cols[3])
-        if s > 0 and d >= 0:
-            ratios.append(d / s)
-if ratios:
-    print(f"{sum(ratios) / len(ratios):.2f}")
-else:
-    print("")
-PYEOF
-)
-  if [ -n "$ratio" ]; then
-    over=$(python3 -c "r=$ratio; print(1 if r>$max else 0)")
-    if [ "$over" = "1" ]; then
-      echo "FAIL: $section average = ${ratio}x (ceiling: ${max}x)" >&2
-      return 1
-    fi
-  fi
-  return 0
-}
-
-echo ""
-echo "### Performance Ceiling Check (${BENCH_MAX_MULTIPLIER}x individual, ${BENCH_AVG_MAX_MULTIPLIER}x average; autocommit writes: ${BENCH_AC_WRITE_MAX_MULTIPLIER}x / ${BENCH_AC_WRITE_AVG_MAX_MULTIPLIER}x)"
-echo ""
-
-ceiling_ok=0
-check_ceiling "mem_reads"   "$READ_TESTS"     "$BENCH_MAX_MULTIPLIER" || ceiling_ok=1
-check_ceiling "mem_writes"  "$WRITE_TESTS"    "$BENCH_MAX_MULTIPLIER" || ceiling_ok=1
-check_ceiling "file_reads"  "$READ_TESTS"     "$BENCH_MAX_MULTIPLIER" || ceiling_ok=1
-check_ceiling "file_writes" "$WRITE_TESTS"    "$BENCH_MAX_MULTIPLIER" || ceiling_ok=1
-check_ceiling "ac_reads"    "$READ_TESTS"     "$BENCH_MAX_MULTIPLIER" || ceiling_ok=1
-check_ceiling "ac_writes"   "$WRITE_TESTS_AC" "$BENCH_AC_WRITE_MAX_MULTIPLIER" || ceiling_ok=1
-check_average_ceiling "mem_reads"   "$READ_TESTS"     "$BENCH_AVG_MAX_MULTIPLIER" || ceiling_ok=1
-check_average_ceiling "mem_writes"  "$WRITE_TESTS"    "$BENCH_AVG_MAX_MULTIPLIER" || ceiling_ok=1
-check_average_ceiling "file_reads"  "$READ_TESTS"     "$BENCH_AVG_MAX_MULTIPLIER" || ceiling_ok=1
-check_average_ceiling "file_writes" "$WRITE_TESTS"    "$BENCH_AVG_MAX_MULTIPLIER" || ceiling_ok=1
-check_average_ceiling "ac_reads"    "$READ_TESTS"     "$BENCH_AVG_MAX_MULTIPLIER" || ceiling_ok=1
-check_average_ceiling "ac_writes"   "$WRITE_TESTS_AC" "$BENCH_AC_WRITE_AVG_MAX_MULTIPLIER" || ceiling_ok=1
-
-if [ "$ceiling_ok" = "0" ]; then
-  echo "All tests within ceilings."
-else
-  echo ""
-  echo "**FAILED**: One or more tests exceeded their ceiling."
-  exit 1
-fi
+benchmark_finish

--- a/test/sysbench_compare_textpk.sh
+++ b/test/sysbench_compare_textpk.sh
@@ -19,13 +19,6 @@ TMPDIR=$(mktemp -d)
 cleanup() { rm -rf "$TMPDIR"; }
 trap cleanup EXIT
 
-fmt_us() {
-  python3 - "$1" <<'PYEOF'
-import sys
-print(f"{int(sys.argv[1]):,}")
-PYEOF
-}
-
 python3 << PYEOF
 import random, string, os
 
@@ -329,145 +322,18 @@ make_test("types_delete_insert_ac",   prep_with_types, w_types_delete_insert_aut
 make_test("oltp_read_write_ac",       prep_main, w_read_write_autocommit)
 PYEOF
 
-run_bench() {
-  local engine="$1" binary="$2" sql_file="$3" db_template="$4"
-  local db="$db_template"
-  if [ "$db" != ":memory:" ]; then
-    db="/tmp/bench_${engine}_${RANDOM}_$$.db"
-    rm -f "$db"
-  fi
-  local bench_sql_file="$sql_file"
-  local sqlite_pragmas="${SQLITE_BENCH_PRAGMAS:-}"
-  if [ "$engine" = "sqlite" ] && [ "$db_template" != ":memory:" ]; then
-    sqlite_pragmas="$SQLITE_FILE_CACHE_PRAGMA $sqlite_pragmas"
-  fi
-  if [ "$engine" = "sqlite" ] && [ -n "$sqlite_pragmas" ]; then
-    bench_sql_file="$TMPDIR/pragma_${engine}_${RANDOM}_$$.sql"
-    printf "%s\n" "$sqlite_pragmas" > "$bench_sql_file"
-    cat "$sql_file" >> "$bench_sql_file"
-  fi
-  local timer=""
-  if [ "$engine" = "sqlite" ] && [ -x "$BENCH_TIMER_SQLITE" ]; then
-    timer="$BENCH_TIMER_SQLITE"
-  elif [ "$engine" = "doltlite" ] && [ -x "$BENCH_TIMER_DOLTLITE" ]; then
-    timer="$BENCH_TIMER_DOLTLITE"
-  fi
-  if [ -n "$timer" ]; then
-    "$timer" "$db" "$bench_sql_file"
-    if [ "$db" != ":memory:" ]; then rm -f "$db"; fi
-    return
-  fi
-  local output
-  output=$(sed \
-    -e "s/\.print BENCH_START/SELECT 'TS_START:' || CAST((julianday('now')*86400000000) AS INTEGER);/" \
-    -e "s/\.print BENCH_END/SELECT 'TS_END:' || CAST((julianday('now')*86400000000) AS INTEGER);/" \
-    "$bench_sql_file" | "$binary" "$db" 2>&1)
-  if [ "$db" != ":memory:" ]; then rm -f "$db"; fi
-  echo "$output" | python3 -c "
-import sys, re
-start = end = None
-for line in sys.stdin:
-    m = re.search(r'TS_START:(\d+)', line)
-    if m: start = int(m.group(1))
-    m = re.search(r'TS_END:(\d+)', line)
-    if m: end = int(m.group(1))
-if start is not None and end is not None:
-    print(end - start)
-else:
-    print(-1)
-"
-}
-
-bench_runs_for_test() {
-  case "$1" in
-    *_ac) echo "$BENCH_AC_WRITE_RUNS" ;;
-    *) echo "${BENCH_RUNS:-5}" ;;
-  esac
-}
-
-bench_runs_summary() {
-  local base_runs="${BENCH_RUNS:-5}"
-  if [ "$BENCH_AC_WRITE_RUNS" = "$base_runs" ]; then
-    echo "median of ${base_runs} invocations per test"
-  else
-    echo "median of ${base_runs} invocations per test; autocommit writes use ${BENCH_AC_WRITE_RUNS}"
-  fi
-}
-
-median_us() {
-  python3 - "$@" <<'PYEOF'
-import sys
-vals = sorted(int(v) for v in sys.argv[1:] if int(v) >= 0)
-if not vals:
-    print(-1)
-else:
-    print(vals[len(vals)//2])
-PYEOF
-}
-
-run_bench_stable() {
-  local test_name="$1" engine="$2" binary="$3" sql_file="$4" db_template="$5"
-  local runs
-  local i
-  local sample
-  local samples=""
-  runs=$(bench_runs_for_test "$test_name")
-  for ((i=0; i<runs; i++)); do
-    sample=$(run_bench "$engine" "$binary" "$sql_file" "$db_template")
-    if [ -z "$samples" ]; then
-      samples="$sample"
-    else
-      samples="$samples $sample"
-    fi
-  done
-  median_us $samples
-}
-
 READ_TESTS="oltp_point_select oltp_range_select oltp_sum_range oltp_order_range oltp_distinct_range oltp_index_scan select_random_points select_random_ranges covering_index_scan groupby_scan index_join index_join_scan types_table_scan table_scan oltp_read_only"
 WRITE_TESTS="oltp_bulk_insert oltp_insert oltp_update_index oltp_update_non_index oltp_delete_insert oltp_write_only types_delete_insert oltp_read_write"
 WRITE_TESTS_AC="oltp_bulk_insert_ac oltp_insert_ac oltp_update_index_ac oltp_update_non_index_ac oltp_delete_insert_ac oltp_write_only_ac types_delete_insert_ac oltp_read_write_ac"
 
-BENCH_RESULTS_FILE="$TMPDIR/bench_results.tsv"
-: > "$BENCH_RESULTS_FILE"
-
-run_section() {
-  local section="$1" tests="$2" db_sq="$3" db_dl="$4"
-  local ratio_sum=0
-  local ratio_count=0
-  local avg_ratio="--"
-  echo "| Test | SQLite (us) | Doltlite (us) | Multiplier |"
-  echo "|------|------------:|--------------:|-----------:|"
-  for t in $tests; do
-  s=$(run_bench_stable "$t" sqlite "$SQLITE3" "$TMPDIR/$t.sql" "$db_sq")
-  d=$(run_bench_stable "$t" doltlite "$DOLTLITE" "$TMPDIR/$t.sql" "$db_dl")
-  s_display="$s"
-  d_display="$d"
-  if [ "$s" -eq -1 ] 2>/dev/null; then s_display="crash"; fi
-  if [ "$d" -eq -1 ] 2>/dev/null; then d_display="crash"; fi
-  if [ "$s" -ge 0 ] 2>/dev/null; then s_display=$(fmt_us "$s"); fi
-  if [ "$d" -ge 0 ] 2>/dev/null; then d_display=$(fmt_us "$d"); fi
-  if [ "$s" -gt 0 ] 2>/dev/null && [ "$d" -ge 0 ] 2>/dev/null; then
-    ratio=$(python3 -c "print(f'{$d/$s:.2f}')")
-    ratio_sum=$(python3 -c "print($ratio_sum + ($d/$s))")
-    ratio_count=$((ratio_count + 1))
-  else
-    ratio="--"
-  fi
-  printf '%s\t%s\t%s\t%s\n' "$section" "$t" "$s" "$d" >> "$BENCH_RESULTS_FILE"
-  echo "| $t | $s_display | $d_display | ${ratio} |"
-  done
-  if [ "$ratio_count" -gt 0 ]; then
-    avg_ratio=$(python3 -c "print(f'{($ratio_sum/$ratio_count):.2f}')")
-  fi
-  echo "| Average |  |  | ${avg_ratio} |"
-}
+source "$(dirname "$0")/lib/sysbench_benchmark.sh"
 
 echo "<!-- benchmark:textpk -->"
-echo "## Sysbench-Style Benchmark (TEXT PK): Doltlite vs SQLite"
+echo "## Sysbench-Style Benchmark (TEXT PK): $BENCH_CANDIDATE_LABEL vs $BENCH_BASELINE_LABEL"
 echo ""
 echo "_Companion to the classic Sysbench-Style Benchmark. Every workload here"
 echo "runs against tables with a 32-char hex \`TEXT PRIMARY KEY\` (UUID-shaped)._"
-echo "_Individual ratios gated at ${BENCH_MAX_MULTIPLIER}×; section averages gated at ${BENCH_AVG_MAX_MULTIPLIER}×. Autocommit writes use ${BENCH_AC_WRITE_MAX_MULTIPLIER}× / ${BENCH_AC_WRITE_AVG_MAX_MULTIPLIER}×._"
+benchmark_gate_note
 echo ""
 echo "### In-Memory"
 echo ""
@@ -494,8 +360,7 @@ echo "### File-Backed (autocommit)"
 echo ""
 echo "_Each statement runs as its own transaction — exposes per-commit_"
 echo "_fixed costs that the wrapped-in-BEGIN/COMMIT tests amortize away._"
-echo "_SQLite uses WAL mode with synchronous=FULL in this section so_"
-echo "_the comparison uses SQLite's durable WAL autocommit path._"
+benchmark_autocommit_note
 echo ""
 echo "#### Reads"
 echo ""
@@ -512,82 +377,4 @@ SQLITE_BENCH_PRAGMAS="$SQLITE_AUTOCOMMIT_PRAGMAS" run_section "ac_writes" "$WRIT
 echo ""
 echo "_${ROWS} rows, $(bench_runs_summary), workload-only timing via host monotonic clock when available._"
 
-check_ceiling() {
-  local section="$1" tests="$2" max="$3"
-  local failed=0
-  for t in $tests; do
-    local line
-    line=$(awk -F '\t' -v section="$section" -v test="$t" \
-      '$1==section && $2==test {print $3 "\t" $4; exit}' \
-      "$BENCH_RESULTS_FILE")
-    s="${line%%$'\t'*}"
-    d="${line#*$'\t'}"
-    if [ "$s" -gt 0 ] 2>/dev/null && [ "$d" -ge 0 ] 2>/dev/null; then
-      over=$(python3 -c "r=$d/$s; print(1 if r>$max else 0)")
-      if [ "$over" = "1" ]; then
-        ratio=$(python3 -c "print(f'{$d/$s:.2f}')")
-        echo "FAIL: $section/$t = ${ratio}x (ceiling: ${max}x)" >&2
-        failed=1
-      fi
-    fi
-  done
-  return $failed
-}
-
-check_average_ceiling() {
-  local section="$1" tests="$2" max="$3"
-  local ratio
-  ratio=$(python3 - "$BENCH_RESULTS_FILE" "$section" "$tests" <<'PYEOF'
-import sys
-path, section, tests = sys.argv[1], sys.argv[2], sys.argv[3].split()
-wanted = set(tests)
-ratios = []
-with open(path) as f:
-    for line in f:
-        cols = line.rstrip("\n").split("\t")
-        if len(cols) < 4 or cols[0] != section or cols[1] not in wanted:
-            continue
-        s, d = int(cols[2]), int(cols[3])
-        if s > 0 and d >= 0:
-            ratios.append(d / s)
-if ratios:
-    print(f"{sum(ratios) / len(ratios):.2f}")
-else:
-    print("")
-PYEOF
-)
-  if [ -n "$ratio" ]; then
-    over=$(python3 -c "r=$ratio; print(1 if r>$max else 0)")
-    if [ "$over" = "1" ]; then
-      echo "FAIL: $section average = ${ratio}x (ceiling: ${max}x)" >&2
-      return 1
-    fi
-  fi
-  return 0
-}
-
-echo ""
-echo "### Performance Ceiling Check (${BENCH_MAX_MULTIPLIER}x individual, ${BENCH_AVG_MAX_MULTIPLIER}x average; autocommit writes: ${BENCH_AC_WRITE_MAX_MULTIPLIER}x / ${BENCH_AC_WRITE_AVG_MAX_MULTIPLIER}x)"
-echo ""
-
-ceiling_ok=0
-check_ceiling "mem_reads"   "$READ_TESTS"     "$BENCH_MAX_MULTIPLIER" || ceiling_ok=1
-check_ceiling "mem_writes"  "$WRITE_TESTS"    "$BENCH_MAX_MULTIPLIER" || ceiling_ok=1
-check_ceiling "file_reads"  "$READ_TESTS"     "$BENCH_MAX_MULTIPLIER" || ceiling_ok=1
-check_ceiling "file_writes" "$WRITE_TESTS"    "$BENCH_MAX_MULTIPLIER" || ceiling_ok=1
-check_ceiling "ac_reads"    "$READ_TESTS"     "$BENCH_MAX_MULTIPLIER" || ceiling_ok=1
-check_ceiling "ac_writes"   "$WRITE_TESTS_AC" "$BENCH_AC_WRITE_MAX_MULTIPLIER" || ceiling_ok=1
-check_average_ceiling "mem_reads"   "$READ_TESTS"     "$BENCH_AVG_MAX_MULTIPLIER" || ceiling_ok=1
-check_average_ceiling "mem_writes"  "$WRITE_TESTS"    "$BENCH_AVG_MAX_MULTIPLIER" || ceiling_ok=1
-check_average_ceiling "file_reads"  "$READ_TESTS"     "$BENCH_AVG_MAX_MULTIPLIER" || ceiling_ok=1
-check_average_ceiling "file_writes" "$WRITE_TESTS"    "$BENCH_AVG_MAX_MULTIPLIER" || ceiling_ok=1
-check_average_ceiling "ac_reads"    "$READ_TESTS"     "$BENCH_AVG_MAX_MULTIPLIER" || ceiling_ok=1
-check_average_ceiling "ac_writes"   "$WRITE_TESTS_AC" "$BENCH_AC_WRITE_AVG_MAX_MULTIPLIER" || ceiling_ok=1
-
-if [ "$ceiling_ok" = "0" ]; then
-  echo "All tests within ceilings."
-else
-  echo ""
-  echo "**FAILED**: One or more tests exceeded their ceiling."
-  exit 1
-fi
+benchmark_finish

--- a/test/vc_perf_ceiling.sh
+++ b/test/vc_perf_ceiling.sh
@@ -9,6 +9,14 @@ if [ ! -x "$DOLTLITE" ]; then
   echo "doltlite binary not found: $DOLTLITE" >&2
   exit 1
 fi
+VC_PERF_BASELINE="${VC_PERF_BASELINE:-}"
+if [ -n "$VC_PERF_BASELINE" ] && [ ! -x "$VC_PERF_BASELINE" ]; then
+  echo "baseline doltlite binary not found: $VC_PERF_BASELINE" >&2
+  exit 1
+fi
+FIXTURE_DOLTLITE="${VC_PERF_BASELINE:-$DOLTLITE}"
+VC_PERF_BASELINE_LABEL="${VC_PERF_BASELINE_LABEL:-PR base}"
+VC_PERF_CANDIDATE_LABEL="${VC_PERF_CANDIDATE_LABEL:-PR candidate}"
 
 RUNS=${VC_PERF_RUNS:-3}
 TABLES=${VC_PERF_TABLES:-800}
@@ -20,15 +28,19 @@ MERGE_ROWS=${VC_PERF_MERGE_ROWS:-100000}
 MERGE_CHANGE_ROWS=${VC_PERF_MERGE_CHANGE_ROWS:-2000}
 TMPDIR=$(mktemp -d)
 trap 'rm -rf "$TMPDIR"' EXIT
+RESULTS_FILE="$TMPDIR/vc_results.tsv"
+SAMPLES_FILE="$TMPDIR/vc_samples.tsv"
+: > "$RESULTS_FILE"
+printf 'section\ttest\trun\tbaseline_us\tcandidate_us\n' > "$SAMPLES_FILE"
 
-ms_now() {
+us_now() {
   python3 - <<'PYEOF'
 import time
-print(int(time.time() * 1000))
+print(time.monotonic_ns() // 1000)
 PYEOF
 }
 
-median_ms() {
+median_us() {
   python3 - "$@" <<'PYEOF'
 import sys
 vals = sorted(int(v) for v in sys.argv[1:])
@@ -39,13 +51,13 @@ PYEOF
 run_sql() {
   local db="$1"
   local sql="$2"
-  printf '%s\n' "$sql" | "$DOLTLITE" "$db" >/dev/null
+  printf '%s\n' "$sql" | "$FIXTURE_DOLTLITE" "$db" >/dev/null
 }
 
 run_sql_file() {
   local db="$1"
   local file="$2"
-  "$DOLTLITE" "$db" < "$file" >/dev/null
+  "$FIXTURE_DOLTLITE" "$db" < "$file" >/dev/null
 }
 
 cte() {
@@ -190,43 +202,105 @@ prepare_fixtures() {
 failures=0
 rows=""
 
+time_sql() {
+  local binary="$1"
+  local db="$2"
+  local sql="$3"
+  local out="$4"
+  local err="$5"
+  local allow_error="$6"
+  local start end rc
+  start=$(us_now)
+  set +e
+  printf '%s\n' "$sql" | "$binary" "$db" >"$out" 2>"$err"
+  rc=$?
+  set -e
+  end=$(us_now)
+  if [ "$rc" -ne 0 ] && [ "$allow_error" != "1" ]; then
+    cat "$err" >&2
+    return "$rc"
+  fi
+  echo $((end-start))
+}
+
 bench_sql() {
   local name="$1"
   local seed="$2"
   local sql="$3"
   local ceiling="$4"
   local allow_error="${5:-0}"
-  local vals=()
-  local db start end elapsed out err
+  local candidate_vals=()
+  local baseline_vals=()
+  local candidate_db baseline_db candidate_us baseline_us out err
 
   for ((r=1; r<=RUNS; r++)); do
-    db="$TMPDIR/${name}_${r}.db"
-    cp "$seed" "$db"
-    out="$TMPDIR/${name}_${r}.out"
-    err="$TMPDIR/${name}_${r}.err"
-    start=$(ms_now)
-    if ! printf '%s\n' "$sql" | "$DOLTLITE" "$db" >"$out" 2>"$err"; then
-      if [ "$allow_error" = "1" ]; then
-        :
+    candidate_db="$TMPDIR/${name}_candidate_${r}.db"
+    cp "$seed" "$candidate_db"
+    out="$TMPDIR/${name}_candidate_${r}.out"
+    err="$TMPDIR/${name}_candidate_${r}.err"
+
+    if [ -n "$VC_PERF_BASELINE" ]; then
+      baseline_db="$TMPDIR/${name}_baseline_${r}.db"
+      cp "$seed" "$baseline_db"
+      if [ $((r % 2)) -eq 1 ]; then
+        if ! baseline_us=$(time_sql "$VC_PERF_BASELINE" "$baseline_db" \
+            "$sql" "$TMPDIR/${name}_baseline_${r}.out" \
+            "$TMPDIR/${name}_baseline_${r}.err" "$allow_error"); then
+          echo "Baseline benchmark $name failed on run $r" >&2
+          return 1
+        fi
+        if ! candidate_us=$(time_sql "$DOLTLITE" "$candidate_db" \
+            "$sql" "$out" "$err" "$allow_error"); then
+          echo "Candidate benchmark $name failed on run $r" >&2
+          return 1
+        fi
       else
-        echo "Benchmark $name failed on run $r:" >&2
-        cat "$err" >&2
+        if ! candidate_us=$(time_sql "$DOLTLITE" "$candidate_db" \
+            "$sql" "$out" "$err" "$allow_error"); then
+          echo "Candidate benchmark $name failed on run $r" >&2
+          return 1
+        fi
+        if ! baseline_us=$(time_sql "$VC_PERF_BASELINE" "$baseline_db" \
+            "$sql" "$TMPDIR/${name}_baseline_${r}.out" \
+            "$TMPDIR/${name}_baseline_${r}.err" "$allow_error"); then
+          echo "Baseline benchmark $name failed on run $r" >&2
+          return 1
+        fi
+      fi
+      baseline_vals+=("$baseline_us")
+      printf 'vc\t%s\t%d\t%s\t%s\n' \
+        "$name" "$r" "$baseline_us" "$candidate_us" >> "$SAMPLES_FILE"
+    else
+      if ! candidate_us=$(time_sql "$DOLTLITE" "$candidate_db" \
+          "$sql" "$out" "$err" "$allow_error"); then
+        echo "Benchmark $name failed on run $r" >&2
         return 1
       fi
+      printf 'vc\t%s\t%d\t0\t%s\n' \
+        "$name" "$r" "$candidate_us" >> "$SAMPLES_FILE"
     fi
-    end=$(ms_now)
-    elapsed=$((end-start))
-    vals+=("$elapsed")
+    candidate_vals+=("$candidate_us")
   done
 
-  local median
-  median=$(median_ms "${vals[@]}")
-  local status="PASS"
-  if [ "$median" -gt "$ceiling" ]; then
-    status="FAIL"
-    failures=$((failures+1))
+  local candidate_median baseline_median ratio status
+  candidate_median=$(median_us "${candidate_vals[@]}")
+  if [ -n "$VC_PERF_BASELINE" ]; then
+    baseline_median=$(median_us "${baseline_vals[@]}")
+    ratio=$(python3 -c \
+      "print(f'{$candidate_median/$baseline_median:.3f}')")
+    rows="${rows}| $name | $(python3 -c "print(f'{$baseline_median/1000:.2f}')") | $(python3 -c "print(f'{$candidate_median/1000:.2f}')") | ${ratio}x |\n"
+    printf 'vc\t%s\t%s\t%s\n' \
+      "$name" "$baseline_median" "$candidate_median" >> "$RESULTS_FILE"
+  else
+    status="PASS"
+    if [ "$candidate_median" -gt $((ceiling * 1000)) ]; then
+      status="FAIL"
+      failures=$((failures+1))
+    fi
+    rows="${rows}| $name | $(python3 -c "print(f'{$candidate_median/1000:.2f}')") | $ceiling | $status |\n"
+    printf 'vc\t%s\t%d\t%s\n' \
+      "$name" "$((ceiling * 1000))" "$candidate_median" >> "$RESULTS_FILE"
   fi
-  rows="${rows}| $name | $median | $ceiling | $status |\n"
 }
 
 prepare_fixtures
@@ -258,7 +332,29 @@ bench_sql "merge_data_conflicts" "$MERGE_CONFLICT_DB" \
 bench_sql "merge_data_conflicts_with_resolve" "$MERGE_CONFLICT_DB" \
   "BEGIN; SELECT dolt_merge('feat'); SELECT dolt_conflicts_resolve('--ours','t'); SELECT count(*) FROM dolt_conflicts; ROLLBACK;" 250 1
 
-cat <<EOF
+if [ -n "${VC_PERF_RESULTS_OUTPUT:-}" ]; then
+  mkdir -p "$(dirname "$VC_PERF_RESULTS_OUTPUT")"
+  cp "$RESULTS_FILE" "$VC_PERF_RESULTS_OUTPUT"
+fi
+if [ -n "${VC_PERF_SAMPLES_OUTPUT:-}" ]; then
+  mkdir -p "$(dirname "$VC_PERF_SAMPLES_OUTPUT")"
+  cp "$SAMPLES_FILE" "$VC_PERF_SAMPLES_OUTPUT"
+fi
+
+if [ -n "$VC_PERF_BASELINE" ]; then
+  cat <<EOF
+<!-- benchmark:vc-perf -->
+## Version-Control Performance: $VC_PERF_CANDIDATE_LABEL vs $VC_PERF_BASELINE_LABEL
+
+Runs: median of $RUNS paired executions per benchmark, excluding fixture setup.
+Execution order alternates between baseline and candidate on each repetition.
+
+| Benchmark | $VC_PERF_BASELINE_LABEL median ms | $VC_PERF_CANDIDATE_LABEL median ms | Ratio |
+|---|---:|---:|---:|
+$(printf "%b" "$rows")
+EOF
+else
+  cat <<EOF
 <!-- benchmark:vc-perf -->
 ## Version-Control Performance Ceilings
 
@@ -275,8 +371,9 @@ rows per side.
 |---|---:|---:|---|
 $(printf "%b" "$rows")
 EOF
+fi
 
-if [ "$failures" -ne 0 ]; then
+if [ -z "$VC_PERF_BASELINE" ] && [ "$failures" -ne 0 ]; then
   echo "$failures version-control benchmark(s) exceeded their ceiling." >&2
   exit 1
 fi


### PR DESCRIPTION
## Summary

- replace PR SQLite and fixed-latency ceilings with paired PR-base versus candidate benchmarks
- alternate baseline/candidate execution and aggregate one relative performance gate
- move long SQLite and absolute version-control ceilings to a scheduled nightly workflow
- publish raw samples and report nightly regressions through the shared issue reporter
- consolidate duplicated benchmark timing and ceiling code

## Relative gate

- individual workloads: 1.25x and 5ms minimum regression
- sections, suites, and overall: 1.15x and 5ms minimum regression
- startup-bound VC individuals: 1.50x and 25ms minimum regression

## Validation

- comparator policy unit tests (8 tests)
- reduced paired sysbench runs in deferred and absolute-gate modes
- reduced absolute and relative version-control runs
- full-size five-sample DoltLite-vs-itself VC calibration (0.976x overall, pass)
- shell syntax checks
- workflow YAML parsing and actionlint
- orphaned-suite lint
- `git diff --check`

Fixes #1788