### PR TITLE
refactor: extract chunk_store_lock.c

### DIFF
--- a/main.mk
+++ b/main.mk
@@ -595,7 +595,7 @@ endif
 
 PROLLY_OBJS = $(DOLTLITE_AUTH_OBJS) \
               prolly_hash.o prolly_xxhash.o blake3.o blake3_portable.o blake3_dispatch.o $(BLAKE3_SIMD_OBJS) prolly_hashset.o prolly_node.o prolly_cache.o \
-              chunk_store.o chunk_wal.o chunk_refs.o chunk_index.o chunk_staging.o chunk_file.o prolly_cursor.o prolly_mutmap.o prolly_chunker.o \
+              chunk_store.o chunk_store_lock.o chunk_wal.o chunk_refs.o chunk_index.o chunk_staging.o chunk_file.o prolly_cursor.o prolly_mutmap.o prolly_chunker.o \
               prolly_mutate.o prolly_check.o prolly_diff.o prolly_three_way_diff.o prolly_three_way_merge.o \
               prolly_btree.o prolly_btree_catalog.o prolly_btree_cursor.o prolly_btree_cursor_count.o prolly_btree_mutation.o \
               prolly_btree_orig.o prolly_btree_state.o prolly_btree_txn.o pager_shim.o sortkey.o \
@@ -643,7 +643,7 @@ ifeq ($(DOLTLITE_PROLLY),1)
     $(TOP)/ext/blake3/blake3_dispatch.c $(TOP)/ext/blake3/blake3.h \
     $(TOP)/ext/blake3/blake3_impl.h \
     $(TOP)/src/prolly_hashset.c $(TOP)/src/prolly_check.c \
-    $(TOP)/src/chunk_wal.c $(TOP)/src/chunk_refs.c $(TOP)/src/chunk_index.c \
+    $(TOP)/src/chunk_store_lock.c $(TOP)/src/chunk_wal.c $(TOP)/src/chunk_refs.c $(TOP)/src/chunk_index.c \
     $(TOP)/src/chunk_staging.c $(TOP)/src/chunk_file.c \
     $(TOP)/src/doltlite.c $(TOP)/src/doltlite_core.c $(TOP)/src/doltlite_cmd.c $(TOP)/src/doltlite_add.c \
     $(TOP)/src/doltlite_commit_cmd.c $(TOP)/src/doltlite_reset.c \
@@ -1481,6 +1481,9 @@ prolly_cache.o:	$(TOP)/src/prolly_cache.c $(DEPS_OBJ_COMMON)
 
 chunk_store.o:	$(TOP)/src/chunk_store.c $(TOP)/src/chunk_store_int.h $(DEPS_OBJ_COMMON)
 	$(T.cc.sqlite) -c $(TOP)/src/chunk_store.c
+
+chunk_store_lock.o:	$(TOP)/src/chunk_store_lock.c $(TOP)/src/chunk_store_int.h $(DEPS_OBJ_COMMON)
+	$(T.cc.sqlite) -c $(TOP)/src/chunk_store_lock.c
 
 chunk_wal.o:	$(TOP)/src/chunk_wal.c $(DEPS_OBJ_COMMON)
 	$(T.cc.sqlite) -c $(TOP)/src/chunk_wal.c

--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -8,84 +8,6 @@
 #include <unistd.h>
 #endif
 
-static int csFileLockHeld(sqlite3_file *pFile){
-  return pFile!=0;
-}
-
-static char *csLockPath(const char *path){
-  const char *zBase = strrchr(path, '/');
-  int nDir = 0;
-
-  if( zBase ){
-    nDir = (int)(zBase - path) + 1;
-    zBase++;
-  }else{
-    zBase = path;
-  }
-  return sqlite3_mprintf("%.*s.%s-lock", nDir, path, zBase);
-}
-
-static int csFileLock(sqlite3_vfs *pVfs, const char *path,
-                      sqlite3_file **ppFile, char **pzName){
-  char *zRaw = csLockPath(path);
-  char *zLock = 0;
-  sqlite3_file *pFile = 0;
-  int flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE
-            | SQLITE_OPEN_MAIN_DB;
-  int rc;
-
-  *ppFile = 0;
-  *pzName = 0;
-  if( !zRaw ) return SQLITE_NOMEM;
-  /* Opened with SQLITE_OPEN_MAIN_DB, so the name must carry the VFS's
-  ** double-nul terminator (csLockPath returns a singly-terminated string). */
-  rc = chunkStoreDupFilenameDoubleNul(zRaw, &zLock);
-  sqlite3_free(zRaw);
-  if( rc!=SQLITE_OK ) return rc;
-  rc = sqlite3OsOpenMalloc(pVfs, zLock, &pFile, flags, 0);
-  if( rc!=SQLITE_OK ){
-    sqlite3_free(zLock);
-    return rc;
-  }
-  /* SQLite's unix VFS asserts the lock ladder under SQLITE_DEBUG: from
-  ** NO_LOCK the only legal step is SHARED, then escalate. Jumping straight
-  ** to EXCLUSIVE works with NDEBUG but aborts debug builds (e.g. assert
-  ** smoke in development-builds). */
-  rc = sqlite3OsLock(pFile, SQLITE_LOCK_SHARED);
-  if( rc==SQLITE_OK ){
-    rc = sqlite3OsLock(pFile, SQLITE_LOCK_EXCLUSIVE);
-  }
-  if( rc!=SQLITE_OK ){
-    sqlite3OsUnlock(pFile, SQLITE_LOCK_NONE);
-    sqlite3OsCloseFree(pFile);
-    sqlite3_free(zLock);
-    return rc;
-  }
-  *ppFile = pFile;
-  /* The unix VFS aliases unixFile.zPath to this buffer (it does not copy),
-  ** and SQLite's xOpen contract requires the name to stay valid until close.
-  ** Hand ownership to the caller, which frees it via csFileUnlock. */
-  *pzName = zLock;
-  return SQLITE_OK;
-}
-
-static void csFileUnlock(sqlite3_file *pFile, char **pzName){
-  if( pFile ){
-    sqlite3OsUnlock(pFile, SQLITE_LOCK_NONE);
-    sqlite3OsCloseFree(pFile);
-  }
-  if( pzName ){
-    sqlite3_free(*pzName);
-    *pzName = 0;
-  }
-}
-
-static int csFileLockNB(sqlite3_vfs *pVfs, const char *path,
-                        sqlite3_file **ppFile, char **pzName){
-  return csFileLock(pVfs, path, ppFile, pzName);
-}
-
-static int csReloadFromDisk(ChunkStore *cs);
 
 static int csCrashWriteInjectionActive(void){
 #ifdef SQLITE_TEST
@@ -137,7 +59,7 @@ static int csOpenFile(
   return rc;
 }
 
-static int csFileSizeByName(sqlite3_vfs *pVfs, const char *zPath, i64 *pSize){
+int csFileSizeByName(sqlite3_vfs *pVfs, const char *zPath, i64 *pSize){
   sqlite3_file *pFile = 0;
   int flags = SQLITE_OPEN_READONLY | SQLITE_OPEN_MAIN_DB;
   int rc;
@@ -269,46 +191,6 @@ static int csRestoreCommittedRefsState(ChunkStore *cs){
 /* Repair a stale refs table (cleared by an OOM rollback) by reloading it
 ** from the committed refs blob. Called before refs lookups that would
 ** otherwise read an empty table as a valid empty database. */
-int chunkStoreEnsureRefsFresh(ChunkStore *cs){
-  int rc;
-  if( !cs->bRefsStale ) return SQLITE_OK;
-  rc = chunkStoreReloadRefs(cs);
-  if( rc==SQLITE_OK ) cs->bRefsStale = 0;
-  return rc;
-}
-
-static int csReloadFromDiskPreservingLocalRefs(ChunkStore *cs){
-  int rc;
-  int preserveRefs;
-  ProllyHash savedRefsHash;
-  SavedRefsState savedRefs;
-
-  /* Reloading drops aRecent; never do that with uncommitted refs to it. */
-  if( cs->staging.nRecentUncommitted > 0 ){
-    return SQLITE_BUSY_SNAPSHOT;
-  }
-
-  preserveRefs = cs->staging.nPending > 0
-              && prollyHashCompare(&cs->refs.refsHash,
-                                   &cs->refs.committedRefsHash)!=0;
-  memset(&savedRefs, 0, sizeof(savedRefs));
-  if( preserveRefs ){
-    savedRefsHash = cs->refs.refsHash;
-    csDetachSavedRefsState(cs, &savedRefs);
-  }
-
-  rc = csReloadFromDisk(cs);
-
-  if( preserveRefs ){
-    if( rc==SQLITE_OK ){
-      csFreeRefsState(cs);
-    }
-    csRestoreSavedRefsState(cs, &savedRefs);
-    cs->refs.refsHash = savedRefsHash;
-  }
-  return rc;
-}
-
 void csSerializeManifest(const ChunkStore *cs, u8 *aBuf){
   memset(aBuf, 0, CHUNK_MANIFEST_SIZE);
   CS_WRITE_U32(aBuf + CS_MANIFEST_MAGIC_OFF, CHUNK_STORE_MAGIC);
@@ -791,7 +673,7 @@ int chunkStoreFindBranch(ChunkStore *cs, const char *zName, ProllyHash *pCommit)
 ** commit or crash garbage grows it), and a sealed tail root record carrying
 ** this handle's live refs hash (so uncommitted local ref changes, or any
 ** size-coincident rewrite, force the slow path). */
-static int csDiskStateMatchesMemory(ChunkStore *cs){
+int csDiskStateMatchesMemory(ChunkStore *cs){
   int bMoved = 0;
   i64 contentEnd;
   i64 physSize = 0;
@@ -2188,181 +2070,6 @@ int chunkStoreReloadRefs(ChunkStore *cs){
 
 const char *chunkStoreFilename(ChunkStore *cs){
   return cs->file.zFilename;
-}
-
-int chunkStoreLockAndRefreshChanged(ChunkStore *cs, int *pChanged){
-  int changed = 0;
-  int rc;
-  if( pChanged ) *pChanged = 0;
-  if( cs->isMemory ) return SQLITE_OK;
-  if( cs->pLockMutex && sqlite3_mutex_try(cs->pLockMutex)!=SQLITE_OK ){
-    return SQLITE_BUSY;
-  }
-  if( cs->lockDepth > 0 ){
-    cs->lockDepth++;
-    return SQLITE_OK;
-  }
-  if( !cs->file.zFilename ){
-    if( cs->pLockMutex ) sqlite3_mutex_leave(cs->pLockMutex);
-    return SQLITE_ERROR;
-  }
-  rc = csFileLockNB(cs->file.pVfs, cs->file.zFilename, &CS_GRAPH_LOCK(cs), &cs->pGraphLockName);
-  if( rc!=SQLITE_OK ){
-    if( cs->pLockMutex ) sqlite3_mutex_leave(cs->pLockMutex);
-    return rc;
-  }
-  rc = chunkStoreRefreshIfChanged(cs, &changed);
-  if( rc!=SQLITE_OK ){
-    csFileUnlock(CS_GRAPH_LOCK(cs), &cs->pGraphLockName);
-    CS_GRAPH_LOCK(cs) = CS_FILE_LOCK_INIT;
-    if( cs->pLockMutex ) sqlite3_mutex_leave(cs->pLockMutex);
-    return rc;
-  }
-  cs->lockDepth = 1;
-  if( pChanged ) *pChanged = changed;
-  return SQLITE_OK;
-}
-
-int chunkStoreLockAndRefresh(ChunkStore *cs){
-  return chunkStoreLockAndRefreshChanged(cs, 0);
-}
-
-void chunkStoreUnlock(ChunkStore *cs){
-  if( cs->lockDepth > 0 ){
-    cs->lockDepth--;
-    if( cs->lockDepth == 0 && csFileLockHeld(CS_GRAPH_LOCK(cs)) ){
-      csFileUnlock(CS_GRAPH_LOCK(cs), &cs->pGraphLockName);
-      CS_GRAPH_LOCK(cs) = CS_FILE_LOCK_INIT;
-    }
-    if( cs->pLockMutex ) sqlite3_mutex_leave(cs->pLockMutex);
-  }else if( csFileLockHeld(CS_GRAPH_LOCK(cs)) ){
-    csFileUnlock(CS_GRAPH_LOCK(cs), &cs->pGraphLockName);
-    CS_GRAPH_LOCK(cs) = CS_FILE_LOCK_INIT;
-  }
-}
-
-static int csDetectExternalChanges(ChunkStore *cs, int *pChanged){
-  int bMoved = 0;
-  int rc;
-
-  *pChanged = 0;
-  if( cs->isMemory ) return SQLITE_OK;
-
-  if( cs->file.pFile==0 ){
-    int exists = 0;
-    rc = sqlite3OsAccess(cs->file.pVfs, cs->file.zFilename,
-                         SQLITE_ACCESS_EXISTS, &exists);
-    if( rc!=SQLITE_OK ) return rc;
-    if( exists ){
-      i64 mainSize = 0;
-      rc = csFileSizeByName(cs->file.pVfs, cs->file.zFilename, &mainSize);
-      if( rc!=SQLITE_OK ) return rc;
-      if( mainSize > 0 ){
-        *pChanged = 1;
-      }
-    }
-    return SQLITE_OK;
-  }
-
-  /* Recheck HAS_MOVED on each lock; GC may atomically replace the file. */
-  rc = sqlite3OsFileControl(cs->file.pFile, SQLITE_FCNTL_HAS_MOVED, &bMoved);
-  if( rc!=SQLITE_OK ) return rc;
-  if( bMoved ){
-    *pChanged = 1;
-    return SQLITE_OK;
-  }
-
-  {
-    i64 fileSize = 0;
-    rc = sqlite3OsFileSize(cs->file.pFile, &fileSize);
-    if( rc!=SQLITE_OK ) return rc;
-    if( fileSize > cs->file.iFileSize ){
-      *pChanged = 1;
-    }
-  }
-  return SQLITE_OK;
-}
-
-int chunkStoreHasExternalChanges(ChunkStore *cs, int *pChanged){
-  return csDetectExternalChanges(cs, pChanged);
-}
-
-int chunkStoreRefreshIfChanged(ChunkStore *cs, int *pChanged){
-  int rc;
-  int bChanged = 0;
-  if( cs->isMemory ){
-    *pChanged = 0;
-    return SQLITE_OK;
-  }
-  *pChanged = 0;
-  if( cs->snapshotPinned ) return SQLITE_OK;
-  rc = csDetectExternalChanges(cs, &bChanged);
-  if( rc!=SQLITE_OK ) return rc;
-  if( !bChanged ) return SQLITE_OK;
-
-  rc = csReloadFromDisk(cs);
-  if( rc!=SQLITE_OK ) return rc;
-  *pChanged = 1;
-  return SQLITE_OK;
-}
-
-int chunkStoreForceRefresh(ChunkStore *cs){
-  int rc;
-  int wasPinned;
-  if( cs->isMemory ) return SQLITE_OK;
-  /* Only the outermost lock holder reloads; a reentrant (inner) holder runs
-  ** under the outer scope's already-current view, so a multi-step VC op that
-  ** holds the lock across sub-operations keeps the in-memory state it builds. */
-  if( cs->lockDepth != 1 ) return SQLITE_OK;
-  /* Fast path: when the tail root record proves the on-disk store still
-  ** matches this handle's state, the reload — which replays the entire WAL —
-  ** is a no-op and can be skipped. Local uncommitted appends fall through so
-  ** the reload path keeps reporting SQLITE_BUSY_SNAPSHOT. */
-  if( cs->staging.nRecentUncommitted==0 && csDiskStateMatchesMemory(cs) ){
-    return SQLITE_OK;
-  }
-  /* Reload even under a pinned snapshot — the VC write needs the true on-disk
-  ** branch tips. Unpin around it (the heuristic refresh path suppresses reloads
-  ** while pinned), then restore the pin. */
-  wasPinned = cs->snapshotPinned;
-  cs->snapshotPinned = 0;
-  rc = csReloadFromDiskPreservingLocalRefs(cs);
-  cs->snapshotPinned = wasPinned;
-  return rc;
-}
-
-static int csReloadFromDisk(ChunkStore *cs){
-  ChunkStore tmp;
-  ChunkStoreReloadState saved;
-  char *zOldFilename;
-  int rc;
-  /* Direct refresh also reaches the reload path. */
-  if( cs->staging.nRecentUncommitted > 0 ){
-    return SQLITE_BUSY_SNAPSHOT;
-  }
-  rc = chunkStoreOpen(&tmp, cs->file.pVfs, cs->file.zFilename,
-                      SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_MAIN_DB);
-  if( rc!=SQLITE_OK ) return rc;
-
-  /* Reload must not replace a writable store with a fallback read-only one. */
-  if( tmp.readOnly && !cs->readOnly ){
-    chunkStoreClose(&tmp);
-    return SQLITE_BUSY;
-  }
-
-  csCaptureReloadState(cs, &saved);
-  csAdoptOpenedStoreState(cs, &tmp);
-
-  /* pFile->zPath aliases zFilename; keep each filename with its file. */
-  zOldFilename = cs->file.zFilename;
-  cs->file.zFilename = tmp.file.zFilename;
-  tmp.file.zFilename = 0;
-
-  csFreeReloadState(&saved);
-  sqlite3_free(zOldFilename);
-  chunkStoreClose(&tmp);
-
-  return SQLITE_OK;
 }
 
 #endif

--- a/src/chunk_store_int.h
+++ b/src/chunk_store_int.h
@@ -20,4 +20,17 @@ typedef sqlite3_file *CsFileLock;
 #define CS_WRITEBUF_RETAIN_MAX (64*1024)
 #define CS_PENDING_DRAIN_LIMIT (64*1024*1024)
 
+
+int csFileLockHeld(sqlite3_file *pFile);
+int csFileLock(sqlite3_vfs *pVfs, const char *path,
+               sqlite3_file **ppFile, char **pzName);
+void csFileUnlock(sqlite3_file *pFile, char **pzName);
+int csFileLockNB(sqlite3_vfs *pVfs, const char *path,
+                 sqlite3_file **ppFile, char **pzName);
+int csReloadFromDisk(ChunkStore *cs);
+int csReloadFromDiskPreservingLocalRefs(ChunkStore *cs);
+int csFileSizeByName(sqlite3_vfs *pVfs, const char *zPath, i64 *pSize);
+int csDiskStateMatchesMemory(ChunkStore *cs);
+
 #endif /* CHUNK_STORE_INT_H */
+

--- a/src/chunk_store_lock.c
+++ b/src/chunk_store_lock.c
@@ -1,0 +1,306 @@
+#ifdef DOLTLITE_PROLLY
+
+#include "chunk_store_int.h"
+#include "prolly_hash.h"
+#include "prolly_encoding.h"
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <limits.h>
+
+int csFileLockHeld(sqlite3_file *pFile){
+  return pFile!=0;
+}
+
+static char *csLockPath(const char *path){
+  const char *zBase = strrchr(path, '/');
+  int nDir = 0;
+
+  if( zBase ){
+    nDir = (int)(zBase - path) + 1;
+    zBase++;
+  }else{
+    zBase = path;
+  }
+  return sqlite3_mprintf("%.*s.%s-lock", nDir, path, zBase);
+}
+
+int csFileLock(sqlite3_vfs *pVfs, const char *path,
+                      sqlite3_file **ppFile, char **pzName){
+  char *zRaw = csLockPath(path);
+  char *zLock = 0;
+  sqlite3_file *pFile = 0;
+  int flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE
+            | SQLITE_OPEN_MAIN_DB;
+  int rc;
+
+  *ppFile = 0;
+  *pzName = 0;
+  if( !zRaw ) return SQLITE_NOMEM;
+  /* Opened with SQLITE_OPEN_MAIN_DB, so the name must carry the VFS's
+  ** double-nul terminator (csLockPath returns a singly-terminated string). */
+  rc = chunkStoreDupFilenameDoubleNul(zRaw, &zLock);
+  sqlite3_free(zRaw);
+  if( rc!=SQLITE_OK ) return rc;
+  rc = sqlite3OsOpenMalloc(pVfs, zLock, &pFile, flags, 0);
+  if( rc!=SQLITE_OK ){
+    sqlite3_free(zLock);
+    return rc;
+  }
+  /* SQLite's unix VFS asserts the lock ladder under SQLITE_DEBUG: from
+  ** NO_LOCK the only legal step is SHARED, then escalate. Jumping straight
+  ** to EXCLUSIVE works with NDEBUG but aborts debug builds (e.g. assert
+  ** smoke in development-builds). */
+  rc = sqlite3OsLock(pFile, SQLITE_LOCK_SHARED);
+  if( rc==SQLITE_OK ){
+    rc = sqlite3OsLock(pFile, SQLITE_LOCK_EXCLUSIVE);
+  }
+  if( rc!=SQLITE_OK ){
+    sqlite3OsUnlock(pFile, SQLITE_LOCK_NONE);
+    sqlite3OsCloseFree(pFile);
+    sqlite3_free(zLock);
+    return rc;
+  }
+  *ppFile = pFile;
+  /* The unix VFS aliases unixFile.zPath to this buffer (it does not copy),
+  ** and SQLite's xOpen contract requires the name to stay valid until close.
+  ** Hand ownership to the caller, which frees it via csFileUnlock. */
+  *pzName = zLock;
+  return SQLITE_OK;
+}
+
+void csFileUnlock(sqlite3_file *pFile, char **pzName){
+  if( pFile ){
+    sqlite3OsUnlock(pFile, SQLITE_LOCK_NONE);
+    sqlite3OsCloseFree(pFile);
+  }
+  if( pzName ){
+    sqlite3_free(*pzName);
+    *pzName = 0;
+  }
+}
+
+int csFileLockNB(sqlite3_vfs *pVfs, const char *path,
+                        sqlite3_file **ppFile, char **pzName){
+  return csFileLock(pVfs, path, ppFile, pzName);
+}
+
+
+int chunkStoreEnsureRefsFresh(ChunkStore *cs){
+  int rc;
+  if( !cs->bRefsStale ) return SQLITE_OK;
+  rc = chunkStoreReloadRefs(cs);
+  if( rc==SQLITE_OK ) cs->bRefsStale = 0;
+  return rc;
+}
+
+int csReloadFromDiskPreservingLocalRefs(ChunkStore *cs){
+  int rc;
+  int preserveRefs;
+  ProllyHash savedRefsHash;
+  SavedRefsState savedRefs;
+
+  /* Reloading drops aRecent; never do that with uncommitted refs to it. */
+  if( cs->staging.nRecentUncommitted > 0 ){
+    return SQLITE_BUSY_SNAPSHOT;
+  }
+
+  preserveRefs = cs->staging.nPending > 0
+              && prollyHashCompare(&cs->refs.refsHash,
+                                   &cs->refs.committedRefsHash)!=0;
+  memset(&savedRefs, 0, sizeof(savedRefs));
+  if( preserveRefs ){
+    savedRefsHash = cs->refs.refsHash;
+    csDetachSavedRefsState(cs, &savedRefs);
+  }
+
+  rc = csReloadFromDisk(cs);
+
+  if( preserveRefs ){
+    if( rc==SQLITE_OK ){
+      csFreeRefsState(cs);
+    }
+    csRestoreSavedRefsState(cs, &savedRefs);
+    cs->refs.refsHash = savedRefsHash;
+  }
+  return rc;
+}
+
+
+int chunkStoreLockAndRefreshChanged(ChunkStore *cs, int *pChanged){
+  int changed = 0;
+  int rc;
+  if( pChanged ) *pChanged = 0;
+  if( cs->isMemory ) return SQLITE_OK;
+  if( cs->pLockMutex && sqlite3_mutex_try(cs->pLockMutex)!=SQLITE_OK ){
+    return SQLITE_BUSY;
+  }
+  if( cs->lockDepth > 0 ){
+    cs->lockDepth++;
+    return SQLITE_OK;
+  }
+  if( !cs->file.zFilename ){
+    if( cs->pLockMutex ) sqlite3_mutex_leave(cs->pLockMutex);
+    return SQLITE_ERROR;
+  }
+  rc = csFileLockNB(cs->file.pVfs, cs->file.zFilename, &CS_GRAPH_LOCK(cs), &cs->pGraphLockName);
+  if( rc!=SQLITE_OK ){
+    if( cs->pLockMutex ) sqlite3_mutex_leave(cs->pLockMutex);
+    return rc;
+  }
+  rc = chunkStoreRefreshIfChanged(cs, &changed);
+  if( rc!=SQLITE_OK ){
+    csFileUnlock(CS_GRAPH_LOCK(cs), &cs->pGraphLockName);
+    CS_GRAPH_LOCK(cs) = CS_FILE_LOCK_INIT;
+    if( cs->pLockMutex ) sqlite3_mutex_leave(cs->pLockMutex);
+    return rc;
+  }
+  cs->lockDepth = 1;
+  if( pChanged ) *pChanged = changed;
+  return SQLITE_OK;
+}
+
+int chunkStoreLockAndRefresh(ChunkStore *cs){
+  return chunkStoreLockAndRefreshChanged(cs, 0);
+}
+
+void chunkStoreUnlock(ChunkStore *cs){
+  if( cs->lockDepth > 0 ){
+    cs->lockDepth--;
+    if( cs->lockDepth == 0 && csFileLockHeld(CS_GRAPH_LOCK(cs)) ){
+      csFileUnlock(CS_GRAPH_LOCK(cs), &cs->pGraphLockName);
+      CS_GRAPH_LOCK(cs) = CS_FILE_LOCK_INIT;
+    }
+    if( cs->pLockMutex ) sqlite3_mutex_leave(cs->pLockMutex);
+  }else if( csFileLockHeld(CS_GRAPH_LOCK(cs)) ){
+    csFileUnlock(CS_GRAPH_LOCK(cs), &cs->pGraphLockName);
+    CS_GRAPH_LOCK(cs) = CS_FILE_LOCK_INIT;
+  }
+}
+
+static int csDetectExternalChanges(ChunkStore *cs, int *pChanged){
+  int bMoved = 0;
+  int rc;
+
+  *pChanged = 0;
+  if( cs->isMemory ) return SQLITE_OK;
+
+  if( cs->file.pFile==0 ){
+    int exists = 0;
+    rc = sqlite3OsAccess(cs->file.pVfs, cs->file.zFilename,
+                         SQLITE_ACCESS_EXISTS, &exists);
+    if( rc!=SQLITE_OK ) return rc;
+    if( exists ){
+      i64 mainSize = 0;
+      rc = csFileSizeByName(cs->file.pVfs, cs->file.zFilename, &mainSize);
+      if( rc!=SQLITE_OK ) return rc;
+      if( mainSize > 0 ){
+        *pChanged = 1;
+      }
+    }
+    return SQLITE_OK;
+  }
+
+  /* Recheck HAS_MOVED on each lock; GC may atomically replace the file. */
+  rc = sqlite3OsFileControl(cs->file.pFile, SQLITE_FCNTL_HAS_MOVED, &bMoved);
+  if( rc!=SQLITE_OK ) return rc;
+  if( bMoved ){
+    *pChanged = 1;
+    return SQLITE_OK;
+  }
+
+  {
+    i64 fileSize = 0;
+    rc = sqlite3OsFileSize(cs->file.pFile, &fileSize);
+    if( rc!=SQLITE_OK ) return rc;
+    if( fileSize > cs->file.iFileSize ){
+      *pChanged = 1;
+    }
+  }
+  return SQLITE_OK;
+}
+
+int chunkStoreHasExternalChanges(ChunkStore *cs, int *pChanged){
+  return csDetectExternalChanges(cs, pChanged);
+}
+
+int chunkStoreRefreshIfChanged(ChunkStore *cs, int *pChanged){
+  int rc;
+  int bChanged = 0;
+  if( cs->isMemory ){
+    *pChanged = 0;
+    return SQLITE_OK;
+  }
+  *pChanged = 0;
+  if( cs->snapshotPinned ) return SQLITE_OK;
+  rc = csDetectExternalChanges(cs, &bChanged);
+  if( rc!=SQLITE_OK ) return rc;
+  if( !bChanged ) return SQLITE_OK;
+
+  rc = csReloadFromDisk(cs);
+  if( rc!=SQLITE_OK ) return rc;
+  *pChanged = 1;
+  return SQLITE_OK;
+}
+
+int chunkStoreForceRefresh(ChunkStore *cs){
+  int rc;
+  int wasPinned;
+  if( cs->isMemory ) return SQLITE_OK;
+  /* Only the outermost lock holder reloads; a reentrant (inner) holder runs
+  ** under the outer scope's already-current view, so a multi-step VC op that
+  ** holds the lock across sub-operations keeps the in-memory state it builds. */
+  if( cs->lockDepth != 1 ) return SQLITE_OK;
+  /* Fast path: when the tail root record proves the on-disk store still
+  ** matches this handle's state, the reload — which replays the entire WAL —
+  ** is a no-op and can be skipped. Local uncommitted appends fall through so
+  ** the reload path keeps reporting SQLITE_BUSY_SNAPSHOT. */
+  if( cs->staging.nRecentUncommitted==0 && csDiskStateMatchesMemory(cs) ){
+    return SQLITE_OK;
+  }
+  /* Reload even under a pinned snapshot — the VC write needs the true on-disk
+  ** branch tips. Unpin around it (the heuristic refresh path suppresses reloads
+  ** while pinned), then restore the pin. */
+  wasPinned = cs->snapshotPinned;
+  cs->snapshotPinned = 0;
+  rc = csReloadFromDiskPreservingLocalRefs(cs);
+  cs->snapshotPinned = wasPinned;
+  return rc;
+}
+
+int csReloadFromDisk(ChunkStore *cs){
+  ChunkStore tmp;
+  ChunkStoreReloadState saved;
+  char *zOldFilename;
+  int rc;
+  /* Direct refresh also reaches the reload path. */
+  if( cs->staging.nRecentUncommitted > 0 ){
+    return SQLITE_BUSY_SNAPSHOT;
+  }
+  rc = chunkStoreOpen(&tmp, cs->file.pVfs, cs->file.zFilename,
+                      SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_MAIN_DB);
+  if( rc!=SQLITE_OK ) return rc;
+
+  /* Reload must not replace a writable store with a fallback read-only one. */
+  if( tmp.readOnly && !cs->readOnly ){
+    chunkStoreClose(&tmp);
+    return SQLITE_BUSY;
+  }
+
+  csCaptureReloadState(cs, &saved);
+  csAdoptOpenedStoreState(cs, &tmp);
+
+  /* pFile->zPath aliases zFilename; keep each filename with its file. */
+  zOldFilename = cs->file.zFilename;
+  cs->file.zFilename = tmp.file.zFilename;
+  tmp.file.zFilename = 0;
+
+  csFreeReloadState(&saved);
+  sqlite3_free(zOldFilename);
+  chunkStoreClose(&tmp);
+
+  return SQLITE_OK;
+}
+
+
+#endif

--- a/test/lint_layers.sh
+++ b/test/lint_layers.sh
@@ -110,3 +110,13 @@ else
   echo "lint_layers: $NFAIL violation(s) found"
   exit 1
 fi
+
+# chunk_store split: require lock module; cap at 1200.
+if [ ! -f "$SRCDIR/chunk_store_lock.c" ]; then
+  lint "$SRCDIR/chunk_store_lock.c: missing — chunk_store lock must stay split"
+else
+  nline=$(wc -l < "$SRCDIR/chunk_store_lock.c" | tr -d ' ')
+  if [ "$nline" -gt 1200 ]; then
+    lint "$SRCDIR/chunk_store_lock.c:$nline lines — chunk_store_lock.c must stay at or below 1200 lines"
+  fi
+fi

--- a/tool/mksqlite3c.tcl
+++ b/tool/mksqlite3c.tcl
@@ -608,7 +608,7 @@ proc emit_doltlite_engine_block {} {
   foreach f {
     prolly_hash.c prolly_xxhash.c blake3.c blake3_portable.c blake3_dispatch.c
     prolly_hashset.c prolly_node.c prolly_cache.c
-    chunk_store.c chunk_wal.c chunk_refs.c chunk_index.c chunk_staging.c chunk_file.c
+    chunk_store.c chunk_store_lock.c chunk_wal.c chunk_refs.c chunk_index.c chunk_staging.c chunk_file.c
     prolly_cursor.c prolly_mutmap.c prolly_chunker.c prolly_mutate.c prolly_check.c
     prolly_diff.c prolly_three_way_diff.c prolly_three_way_merge.c
     prolly_btree.c prolly_btree_catalog.c prolly_btree_cursor.c


### PR DESCRIPTION
## Summary
- New `src/chunk_store_lock.c` (~300 LOC): file lock helpers, `csReloadFromDisk*`, `chunkStoreLockAndRefresh*`, Unlock, ForceRefresh, external-change detection.
- Promote cross-TU helpers used by remaining `chunk_store.c` open/commit paths; declare in `chunk_store_int.h`.
- Object rule depends on `chunk_store_int.h` (already on master from #1794).
- `main.mk` / amalgamation / lint updates.

Pure mechanical refactor (gravity-well series B1). Independent of cursor/branch PRs.

## Test plan
- [x] `make doltlite` + `make lint`
- [x] `chunk_store_fork_lock_test` — 8 passed
- [x] smoke insert/select