### PR TITLE
Stabilize and publish nightly performance reports

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -160,6 +160,11 @@ jobs:
         else
           baseline=$(cat benchmark-baseline-sha)
           candidate=$(cat benchmark-candidate-sha)
+          expected_candidate=$(git rev-parse HEAD)
+          expected_baseline="${{ github.event.pull_request.base.sha }}"
+          if [ -z "$expected_baseline" ]; then
+            expected_baseline="$baseline"
+          fi
           set +e
           python3 test/benchmark_compare.py \
             --input "int=benchmark-results/int.tsv" \
@@ -169,6 +174,8 @@ jobs:
             --input "vc=benchmark-results/vc.tsv" \
             --baseline-ref "$baseline" \
             --candidate-ref "$candidate" \
+            --expected-baseline-ref "$expected_baseline" \
+            --expected-candidate-ref "$expected_candidate" \
             --individual-ratio 1.25 \
             --aggregate-ratio 1.15 \
             --min-delta-us 5000 \

--- a/.github/workflows/nightly-performance.yml
+++ b/.github/workflows/nightly-performance.yml
@@ -2,21 +2,22 @@ name: Nightly performance
 
 on:
   schedule:
-    - cron: '0 7 * * *'
+    - cron: '30 9 * * *'
   workflow_dispatch:
     inputs:
       runs:
         description: Paired repetitions for each sysbench-style workload
         required: false
-        default: "21"
+        default: "55"
       vc-runs:
         description: Repetitions for each version-control benchmark
         required: false
-        default: "15"
+        default: "101"
 
 permissions:
-  contents: read
+  contents: write
   issues: write
+  pull-requests: write
 
 concurrency:
   group: nightly-performance
@@ -79,7 +80,7 @@ jobs:
     name: ${{ matrix.suite.name }}-keys
     needs: build
     runs-on: ubuntu-latest
-    timeout-minutes: 75
+    timeout-minutes: 150
     strategy:
       fail-fast: false
       matrix:
@@ -107,11 +108,12 @@ jobs:
     - name: Run absolute benchmark
       id: benchmark
       env:
-        BENCH_RUNS: ${{ github.event.inputs.runs || '21' }}
-        BENCH_AC_WRITE_RUNS: ${{ github.event.inputs.runs || '21' }}
+        BENCH_RUNS: ${{ github.event.inputs.runs || '55' }}
+        BENCH_AC_WRITE_RUNS: ${{ github.event.inputs.runs || '55' }}
       run: |
         results="$RUNNER_TEMP/nightly-results"
         mkdir -p "$results"
+        started_at=$(date +%s)
         set +e
         (
           cd build-nightly
@@ -122,7 +124,10 @@ jobs:
           2> "$results/${{ matrix.suite.name }}.stderr"
         bench_rc=$?
         set -e
+        finished_at=$(date +%s)
         echo "$bench_rc" > "$results/${{ matrix.suite.name }}.status"
+        echo "$((finished_at - started_at))" \
+          > "$results/${{ matrix.suite.name }}.duration"
         cat "$results/${{ matrix.suite.name }}.md"
         cat "$results/${{ matrix.suite.name }}.stderr" >&2
         echo "bench_rc=$bench_rc" >> "$GITHUB_OUTPUT"
@@ -145,7 +150,7 @@ jobs:
   version-control:
     needs: build
     runs-on: ubuntu-latest
-    timeout-minutes: 75
+    timeout-minutes: 150
 
     steps:
     - uses: actions/checkout@v4
@@ -161,10 +166,11 @@ jobs:
     - name: Run absolute version-control benchmark
       id: benchmark
       env:
-        VC_PERF_RUNS: ${{ github.event.inputs.vc-runs || '15' }}
+        VC_PERF_RUNS: ${{ github.event.inputs.vc-runs || '101' }}
       run: |
         results="$RUNNER_TEMP/nightly-results"
         mkdir -p "$results"
+        started_at=$(date +%s)
         set +e
         (
           cd build-nightly
@@ -174,7 +180,9 @@ jobs:
         ) > "$results/vc.md" 2> "$results/vc.stderr"
         bench_rc=$?
         set -e
+        finished_at=$(date +%s)
         echo "$bench_rc" > "$results/vc.status"
+        echo "$((finished_at - started_at))" > "$results/vc.duration"
         cat "$results/vc.md"
         cat "$results/vc.stderr" >&2
         echo "bench_rc=$bench_rc" >> "$GITHUB_OUTPUT"
@@ -195,7 +203,7 @@ jobs:
         exit "$rc"
 
   report:
-    if: always()
+    if: ${{ always() && !cancelled() }}
     needs:
       - sysbench
       - version-control
@@ -204,6 +212,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
 
     - name: Download nightly measurements
       continue-on-error: true
@@ -213,38 +223,34 @@ jobs:
         path: nightly-results
         merge-multiple: true
 
+    - name: Test report generation and publication guards
+      run: |
+        python3 test/nightly_performance_report_test.py
+        python3 test/publish_performance_report_test.py
+
     - name: Compose nightly report
       id: report
       run: |
-        summary="$RUNNER_TEMP/nightly-performance.md"
+        summary="$RUNNER_TEMP/performance-report.md"
         issue_body="$RUNNER_TEMP/nightly-performance-failure.md"
+        generator_stderr="$RUNNER_TEMP/performance-report.stderr"
         suites="int textpk blobpk compositepk vc"
         failed=0
+        valid=1
+        generated_at=$(date -u '+%Y-%m-%d %H:%M UTC')
+        generated_date=$(date -u '+%Y-%m-%d')
+        run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
         {
-          echo "## Nightly DoltLite performance"
-          echo ""
-          echo "Absolute SQLite multipliers and version-control latency ceilings."
-          echo ""
-        } > "$summary"
-        {
-          echo "Nightly performance exceeded one or more absolute ceilings."
+          echo "Nightly performance failed or produced incomplete results."
           echo ""
         } > "$issue_body"
 
         for suite in $suites; do
           status_file="nightly-results/$suite.status"
-          report_file="nightly-results/$suite.md"
           stderr_file="nightly-results/$suite.stderr"
           status=1
           if [ -s "$status_file" ]; then
             status=$(cat "$status_file")
-          fi
-          if [ -s "$report_file" ]; then
-            cat "$report_file" >> "$summary"
-            echo "" >> "$summary"
-          else
-            echo "**${suite}: missing report**" >> "$summary"
-            echo "" >> "$summary"
           fi
           if [ "$status" != "0" ]; then
             failed=1
@@ -263,12 +269,46 @@ jobs:
           fi
         done
 
+        set +e
+        python3 test/nightly_performance_report.py \
+          --results-dir nightly-results \
+          --commit "$GITHUB_SHA" \
+          --run-url "$run_url" \
+          --generated-at "$generated_at" \
+          --runner "${ImageOS:-ubuntu-latest} ${ImageVersion:-}" \
+          --output "$summary" \
+          2> "$generator_stderr"
+        generator_rc=$?
+        set -e
+        if [ "$generator_rc" -ne 0 ]; then
+          valid=0
+          failed=1
+          {
+            echo "### Report generation"
+            echo ""
+            echo '```text'
+            cat "$generator_stderr"
+            echo '```'
+          } >> "$issue_body"
+          {
+            echo "## Nightly DoltLite performance"
+            echo ""
+            echo "**FAILED:** unable to generate the checked-in report."
+            echo ""
+            echo '```text'
+            cat "$generator_stderr"
+            echo '```'
+          } > "$summary"
+        fi
+
         cat "$summary" >> "$GITHUB_STEP_SUMMARY"
-        cp "$summary" nightly-results/summary.md
+        cp "$summary" nightly-results/performance-report.md
         cp "$issue_body" nightly-results/failure.md
         echo "failed=$failed" >> "$GITHUB_OUTPUT"
-        echo "summary=$summary" >> "$GITHUB_OUTPUT"
+        echo "valid=$valid" >> "$GITHUB_OUTPUT"
+        echo "report=$summary" >> "$GITHUB_OUTPUT"
         echo "issue_body=$issue_body" >> "$GITHUB_OUTPUT"
+        echo "generated_date=$generated_date" >> "$GITHUB_OUTPUT"
 
     - name: Upload combined nightly report
       if: always()
@@ -279,7 +319,10 @@ jobs:
         retention-days: 30
 
     - name: Report regression as GitHub issue
-      if: steps.report.outputs.failed == '1'
+      if: >-
+        ${{ always() &&
+            github.ref == 'refs/heads/master' &&
+            steps.report.outputs.failed == '1' }}
       uses: ./.github/actions/report-failure-issue
       with:
         label: nightly-performance-regression
@@ -288,6 +331,24 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
         label-description: Nightly absolute performance ceiling failure
 
+    - name: Publish rolling performance report PR
+      if: >-
+        ${{ always() &&
+            github.ref == 'refs/heads/master' &&
+            steps.report.outputs.valid == '1' }}
+      env:
+        GH_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN }}
+        PERFORMANCE_REPORT_REVIEWER: ${{ vars.PERFORMANCE_REPORT_REVIEWER }}
+      run: |
+        python3 tool/publish-performance-report.py \
+          --report "${{ steps.report.outputs.report }}" \
+          --repository "$GITHUB_REPOSITORY" \
+          --run-id "$GITHUB_RUN_ID" \
+          --run-attempt "$GITHUB_RUN_ATTEMPT" \
+          --run-url "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+          --generated-date "${{ steps.report.outputs.generated_date }}" \
+          --reviewer "$PERFORMANCE_REPORT_REVIEWER"
+
     - name: Fail when a ceiling regressed
-      if: steps.report.outputs.failed == '1'
+      if: ${{ always() && steps.report.outputs.failed == '1' }}
       run: exit 1

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   pull_request:
+    paths-ignore:
+      - '**/*.md'
   workflow_dispatch:
 
 permissions:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,9 +152,7 @@ Rules that override convenience:
   (fails on the unfixed engine, passes with the fix). Latent/defensive fixes may
   legitimately have no such test.
 - When local validation would take more than ~15 min, push a PR and let CI run
-  the buckets/corpus/suites in parallel; spot-check locally. The perf-ceiling
-  jobs (int/text/blob/composite-PK) are the only flaky CI — every other job is
-  deterministic, so a red non-perf job is a real signal.
+  the buckets/corpus/suites in parallel; spot-check locally.
 
 ## PR / git workflow
 

--- a/README.md
+++ b/README.md
@@ -914,6 +914,9 @@ standard behavior); reads are concurrent.
 
 ## Performance
 
+The latest automated DoltLite-versus-SQLite measurements are published in the
+[nightly performance report](performance-report.md).
+
 ### Sysbench OLTP Benchmarks: Doltlite vs SQLite
 
 Doltlite retains SQLite's SQL engine and C API while replacing its storage
@@ -929,12 +932,15 @@ a section, suite, or overall runtime regresses by more than 15% and 5ms.
 Short, process-startup-bound version-control operations use a 50% and 25ms
 individual gate; their aggregate still uses the 15% suite gate.
 
-A scheduled nightly workflow runs longer, higher-sample comparisons against
-stock SQLite and enforces the absolute multiplier ceilings. It also runs the
-version-control latency ceilings with additional repetitions. A regression
-opens or updates a `nightly-performance-regression` issue, while every run
-publishes raw samples and a combined report. The per-release SQLite comparison
-is still published with each release on the
+A scheduled workflow starts nightly at 09:30 UTC, after the nightly fuzzing
+window. Four parallel workers run 55 paired samples per SQL workload against
+stock SQLite, while the version-control latency suite runs 101 samples per
+benchmark. A regression opens or updates a
+`nightly-performance-regression` issue. Each structurally complete run also
+publishes raw samples as 30-day artifacts and opens a rolling, reviewable PR
+for `performance-report.md`; the next run safely merges the prior report before
+opening its own. The per-release SQLite comparison is still published with
+each release on the
 [GitHub releases page](https://github.com/dolthub/doltlite/releases).
 
 ### Algorithmic Complexity

--- a/performance-report.md
+++ b/performance-report.md
@@ -1,0 +1,11 @@
+# DoltLite Performance Report
+
+The scheduled performance workflow publishes DoltLite-versus-SQLite SQL
+workload measurements and version-control latency results here.
+
+The first generated report will replace this placeholder after the nightly
+workflow runs. Each report records the tested commit, sample counts, wall-clock
+duration, median timings, run-to-run variability, and a link to the retained
+raw measurements.
+
+See [Performance](README.md#performance) for the benchmark methodology.

--- a/test/benchmark_compare.py
+++ b/test/benchmark_compare.py
@@ -294,6 +294,29 @@ def render(
     return "\n".join(lines)
 
 
+def render_provenance_failure(
+    baseline_ref,
+    candidate_ref,
+    expected_baseline_ref,
+    expected_candidate_ref,
+):
+    return "\n".join(
+        [
+            "<!-- benchmark:relative -->",
+            "## DoltLite performance vs PR base",
+            "",
+            "**FAILED:** benchmark revision provenance does not match "
+            "the workflow inputs.",
+            "",
+            "| Revision | Packaged | Expected |",
+            "|---|---|---|",
+            f"| Baseline | `{baseline_ref}` | `{expected_baseline_ref}` |",
+            f"| Candidate | `{candidate_ref}` | `{expected_candidate_ref}` |",
+            "",
+        ]
+    )
+
+
 def main(argv=None):
     parser = argparse.ArgumentParser(
         description="Compare paired DoltLite benchmark medians"
@@ -306,6 +329,8 @@ def main(argv=None):
     )
     parser.add_argument("--baseline-ref", required=True)
     parser.add_argument("--candidate-ref", required=True)
+    parser.add_argument("--expected-baseline-ref", required=True)
+    parser.add_argument("--expected-candidate-ref", required=True)
     parser.add_argument("--individual-ratio", type=float, default=1.25)
     parser.add_argument("--aggregate-ratio", type=float, default=1.15)
     parser.add_argument("--min-delta-us", type=int, default=5000)
@@ -318,6 +343,20 @@ def main(argv=None):
     )
     parser.add_argument("--output", required=True)
     args = parser.parse_args(argv)
+
+    if (
+        args.baseline_ref != args.expected_baseline_ref
+        or args.candidate_ref != args.expected_candidate_ref
+    ):
+        report = render_provenance_failure(
+            args.baseline_ref,
+            args.candidate_ref,
+            args.expected_baseline_ref,
+            args.expected_candidate_ref,
+        )
+        pathlib.Path(args.output).write_text(report, encoding="utf-8")
+        print(report, end="")
+        return 1
 
     try:
         results = []

--- a/test/benchmark_compare_test.py
+++ b/test/benchmark_compare_test.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 
+import contextlib
 import importlib.util
+import io
 import pathlib
 import tempfile
 import unittest
@@ -106,6 +108,36 @@ class BenchmarkCompareTest(unittest.TestCase):
                 )
             ],
         )
+
+    def test_rejects_swapped_revision_provenance(self):
+        with tempfile.TemporaryDirectory() as directory:
+            directory = pathlib.Path(directory)
+            timings = directory / "result.tsv"
+            report = directory / "report.md"
+            timings.write_text(
+                "reads\tpoint\t100\t110\n", encoding="utf-8"
+            )
+            with contextlib.redirect_stdout(io.StringIO()):
+                rc = benchmark_compare.main(
+                    [
+                        "--input",
+                        f"int={timings}",
+                        "--baseline-ref",
+                        "candidate-sha",
+                        "--candidate-ref",
+                        "baseline-sha",
+                        "--expected-baseline-ref",
+                        "baseline-sha",
+                        "--expected-candidate-ref",
+                        "candidate-sha",
+                        "--output",
+                        str(report),
+                    ]
+                )
+            output = report.read_text(encoding="utf-8")
+        self.assertEqual(rc, 1)
+        self.assertIn("revision provenance", output)
+        self.assertIn("| Baseline | `candidate-sha` | `baseline-sha` |", output)
 
 
 if __name__ == "__main__":

--- a/test/nightly_performance_report.py
+++ b/test/nightly_performance_report.py
@@ -1,0 +1,368 @@
+#!/usr/bin/env python3
+
+import argparse
+import csv
+import pathlib
+import statistics
+import sys
+from dataclasses import dataclass
+
+
+SYSBENCH_SUITES = ("int", "textpk", "blobpk", "compositepk")
+ALL_SUITES = SYSBENCH_SUITES + ("vc",)
+SAMPLE_HEADER = (
+    "section",
+    "test",
+    "run",
+    "baseline_us",
+    "candidate_us",
+)
+
+
+@dataclass(frozen=True)
+class Result:
+    section: str
+    test: str
+    baseline_us: int
+    candidate_us: int
+
+
+@dataclass(frozen=True)
+class Sample:
+    run: int
+    baseline_us: int
+    candidate_us: int
+
+
+@dataclass(frozen=True)
+class Suite:
+    name: str
+    results: tuple
+    samples: dict
+    status: int
+    duration_seconds: int
+
+
+def read_integer(path, description):
+    try:
+        value = int(path.read_text(encoding="utf-8").strip())
+    except (OSError, ValueError) as exc:
+        raise ValueError(f"invalid {description}: {path}") from exc
+    if value < 0:
+        raise ValueError(f"negative {description}: {path}")
+    return value
+
+
+def read_results(path):
+    results = []
+    try:
+        rows = path.read_text(encoding="utf-8").splitlines()
+    except OSError as exc:
+        raise ValueError(f"unable to read results: {path}") from exc
+    for line_number, line in enumerate(rows, 1):
+        columns = line.split("\t")
+        if len(columns) != 4:
+            raise ValueError(
+                f"{path}:{line_number}: expected four tab-separated columns"
+            )
+        section, test, baseline_text, candidate_text = columns
+        try:
+            baseline = int(baseline_text)
+            candidate = int(candidate_text)
+        except ValueError as exc:
+            raise ValueError(
+                f"{path}:{line_number}: timing is not an integer"
+            ) from exc
+        if not section or not test or baseline <= 0 or candidate < 0:
+            raise ValueError(f"{path}:{line_number}: invalid result")
+        results.append(Result(section, test, baseline, candidate))
+    if not results:
+        raise ValueError(f"empty results: {path}")
+    if len({(result.section, result.test) for result in results}) != len(
+        results
+    ):
+        raise ValueError(f"duplicate result: {path}")
+    return tuple(results)
+
+
+def read_samples(path):
+    samples = {}
+    try:
+        handle = path.open(newline="", encoding="utf-8")
+    except OSError as exc:
+        raise ValueError(f"unable to read samples: {path}") from exc
+    with handle:
+        reader = csv.reader(handle, delimiter="\t")
+        try:
+            header = tuple(next(reader))
+        except StopIteration as exc:
+            raise ValueError(f"empty samples: {path}") from exc
+        if header != SAMPLE_HEADER:
+            raise ValueError(f"unexpected sample header: {path}")
+        for line_number, columns in enumerate(reader, 2):
+            if len(columns) != 5:
+                raise ValueError(
+                    f"{path}:{line_number}: expected five columns"
+                )
+            section, test, run_text, baseline_text, candidate_text = columns
+            try:
+                sample = Sample(
+                    int(run_text),
+                    int(baseline_text),
+                    int(candidate_text),
+                )
+            except ValueError as exc:
+                raise ValueError(
+                    f"{path}:{line_number}: sample is not an integer"
+                ) from exc
+            if (
+                not section
+                or not test
+                or sample.run <= 0
+                or sample.baseline_us < 0
+                or sample.candidate_us < 0
+            ):
+                raise ValueError(f"{path}:{line_number}: invalid sample")
+            samples.setdefault((section, test), []).append(sample)
+    if not samples:
+        raise ValueError(f"no samples: {path}")
+    for key, values in samples.items():
+        runs = [sample.run for sample in values]
+        if runs != list(range(1, len(values) + 1)):
+            raise ValueError(f"non-contiguous sample runs for {key}: {path}")
+    return {key: tuple(values) for key, values in samples.items()}
+
+
+def load_suite(results_dir, name):
+    results = read_results(results_dir / f"{name}.tsv")
+    samples = read_samples(results_dir / f"{name}-samples.tsv")
+    result_keys = {(result.section, result.test) for result in results}
+    if result_keys != set(samples):
+        raise ValueError(f"result/sample workload mismatch for {name}")
+    return Suite(
+        name=name,
+        results=results,
+        samples=samples,
+        status=read_integer(
+            results_dir / f"{name}.status", f"{name} status"
+        ),
+        duration_seconds=read_integer(
+            results_dir / f"{name}.duration", f"{name} duration"
+        ),
+    )
+
+
+def median_relative_mad(values):
+    median = statistics.median(values)
+    if median <= 0:
+        return 0.0
+    mad = statistics.median(abs(value - median) for value in values)
+    return 100.0 * mad / median
+
+
+def workload_noise(suite, result):
+    values = suite.samples[(result.section, result.test)]
+    if suite.name == "vc":
+        return median_relative_mad(
+            [sample.candidate_us for sample in values]
+        )
+    ratios = []
+    for sample in values:
+        if sample.baseline_us <= 0:
+            raise ValueError(
+                f"invalid baseline sample for {suite.name}/"
+                f"{result.section}/{result.test}"
+            )
+        ratios.append(sample.candidate_us / sample.baseline_us)
+    return median_relative_mad(ratios)
+
+
+def suite_noise(suite):
+    return statistics.median(
+        workload_noise(suite, result) for result in suite.results
+    )
+
+
+def sample_count_text(suite):
+    counts = sorted({len(values) for values in suite.samples.values()})
+    if len(counts) == 1:
+        return str(counts[0])
+    return f"{counts[0]}–{counts[-1]}"
+
+
+def format_duration(seconds):
+    hours, remainder = divmod(seconds, 3600)
+    minutes, seconds = divmod(remainder, 60)
+    if hours:
+        return f"{hours}h {minutes}m {seconds}s"
+    if minutes:
+        return f"{minutes}m {seconds}s"
+    return f"{seconds}s"
+
+
+def format_time(microseconds):
+    if microseconds >= 1_000_000:
+        return f"{microseconds / 1_000_000:.2f}s"
+    if microseconds >= 1_000:
+        return f"{microseconds / 1_000:.2f}ms"
+    return f"{microseconds}µs"
+
+
+def escape_markdown(value):
+    return value.replace("|", "\\|").replace("`", "\\`")
+
+
+def individual_limit(result):
+    return 10.0 if result.section == "ac_writes" else 2.5
+
+
+def render_sysbench_summary(suite):
+    baseline = sum(result.baseline_us for result in suite.results)
+    candidate = sum(result.candidate_us for result in suite.results)
+    ratio = candidate / baseline
+    result = "PASS" if suite.status == 0 else "FAIL"
+    return (
+        f"| {suite.name} | {len(suite.results)} | "
+        f"{sample_count_text(suite)} | "
+        f"{format_duration(suite.duration_seconds)} | "
+        f"{format_time(baseline)} | {format_time(candidate)} | "
+        f"{ratio:.3f}× | {suite_noise(suite):.2f}% | **{result}** |"
+    )
+
+
+def render_sysbench_details(suite):
+    lines = [
+        "<details>",
+        f"<summary>{suite.name} workload details</summary>",
+        "",
+        "| Section | Workload | SQLite median | DoltLite median | "
+        "Ratio | Paired-ratio MAD | Result |",
+        "|---|---|---:|---:|---:|---:|---|",
+    ]
+    for result in suite.results:
+        ratio = result.candidate_us / result.baseline_us
+        status = "PASS" if ratio <= individual_limit(result) else "FAIL"
+        lines.append(
+            f"| {escape_markdown(result.section)} | "
+            f"`{escape_markdown(result.test)}` | "
+            f"{format_time(result.baseline_us)} | "
+            f"{format_time(result.candidate_us)} | {ratio:.3f}× | "
+            f"{workload_noise(suite, result):.2f}% | {status} |"
+        )
+    lines.extend(["", "</details>", ""])
+    return lines
+
+
+def render_vc(suite):
+    lines = [
+        "## Version-control latency",
+        "",
+        f"Wall time: {format_duration(suite.duration_seconds)}. "
+        f"Samples per benchmark: {sample_count_text(suite)}.",
+        "",
+        "| Benchmark | Median | Ceiling | Ceiling used | MAD | Result |",
+        "|---|---:|---:|---:|---:|---|",
+    ]
+    for result in suite.results:
+        used = result.candidate_us / result.baseline_us
+        status = "PASS" if used <= 1.0 else "FAIL"
+        lines.append(
+            f"| `{escape_markdown(result.test)}` | "
+            f"{format_time(result.candidate_us)} | "
+            f"{format_time(result.baseline_us)} | {used:.1%} | "
+            f"{workload_noise(suite, result):.2f}% | {status} |"
+        )
+    result = "PASS" if suite.status == 0 else "FAIL"
+    lines.extend(["", f"Version-control ceiling result: **{result}**.", ""])
+    return lines
+
+
+def render_report(suites, commit, run_url, generated_at, runner):
+    overall_failed = any(suite.status != 0 for suite in suites)
+    overall = "FAIL" if overall_failed else "PASS"
+    by_name = {suite.name: suite for suite in suites}
+    lines = [
+        "# DoltLite Performance Report",
+        "",
+        f"> Nightly result: **{overall}**  ",
+        f"> Generated: {generated_at}  ",
+        f"> Commit: [`{commit}`]"
+        f"(https://github.com/dolthub/doltlite/commit/{commit})  ",
+        f"> Runner: {runner}  ",
+        f"> [GitHub Actions run]({run_url})",
+        "",
+        "This report compares optimized DoltLite against stock SQLite on the "
+        "same GitHub-hosted runner. Baseline and candidate execution order "
+        "alternates on each repetition. Reported timings are medians; MAD is "
+        "the median absolute deviation and describes run-to-run noise.",
+        "",
+        "## SQL workload summary",
+        "",
+        "| Key shape | Workloads | Samples/workload | Wall time | "
+        "SQLite median total | DoltLite median total | Ratio | "
+        "Median paired-ratio MAD | Result |",
+        "|---|---:|---:|---:|---:|---:|---:|---:|---|",
+    ]
+    for name in SYSBENCH_SUITES:
+        lines.append(render_sysbench_summary(by_name[name]))
+    lines.extend(
+        [
+            "",
+            "The absolute ceiling is 2.5× per ordinary workload and 2.0× "
+            "for a section average. Durable autocommit writes use 10.0× "
+            "and 5.0× ceilings respectively.",
+            "",
+        ]
+    )
+    for name in SYSBENCH_SUITES:
+        lines.extend(render_sysbench_details(by_name[name]))
+    lines.extend(render_vc(by_name["vc"]))
+    lines.extend(
+        [
+            "## Reproducing",
+            "",
+            "The workload definitions live in `test/sysbench_compare*.sh` "
+            "and `test/vc_perf_ceiling.sh`. The nightly workflow retains "
+            "the complete raw samples and generated reports as Actions "
+            "artifacts for 30 days.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def parse_args(argv):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--results-dir", type=pathlib.Path, required=True)
+    parser.add_argument("--commit", required=True)
+    parser.add_argument("--run-url", required=True)
+    parser.add_argument("--generated-at", required=True)
+    parser.add_argument(
+        "--runner", default="GitHub Actions ubuntu-latest"
+    )
+    parser.add_argument("--output", type=pathlib.Path, required=True)
+    return parser.parse_args(argv)
+
+
+def main(argv=None):
+    args = parse_args(argv)
+    try:
+        suites = [
+            load_suite(args.results_dir, name) for name in ALL_SUITES
+        ]
+        report = render_report(
+            suites,
+            args.commit,
+            args.run_url,
+            args.generated_at,
+            args.runner,
+        )
+        args.output.write_text(report, encoding="utf-8")
+    except (OSError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/nightly_performance_report_test.py
+++ b/test/nightly_performance_report_test.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+
+import importlib.util
+import pathlib
+import tempfile
+import unittest
+
+
+MODULE_PATH = pathlib.Path(__file__).with_name(
+    "nightly_performance_report.py"
+)
+SPEC = importlib.util.spec_from_file_location(
+    "nightly_performance_report", MODULE_PATH
+)
+nightly_report = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(nightly_report)
+
+
+class NightlyPerformanceReportTest(unittest.TestCase):
+    def write_suite(self, directory, name, status=0):
+        if name == "vc":
+            results = "vc\tstatus_clean\t200000\t100000\n"
+            samples = [
+                ("vc", "status_clean", 1, 0, 90000),
+                ("vc", "status_clean", 2, 0, 100000),
+                ("vc", "status_clean", 3, 0, 110000),
+            ]
+        else:
+            results = (
+                "mem_reads\tpoint\t100\t150\n"
+                "ac_writes\tinsert_ac\t100\t500\n"
+            )
+            samples = [
+                ("mem_reads", "point", 1, 100, 140),
+                ("mem_reads", "point", 2, 100, 150),
+                ("mem_reads", "point", 3, 100, 160),
+                ("ac_writes", "insert_ac", 1, 100, 480),
+                ("ac_writes", "insert_ac", 2, 100, 500),
+                ("ac_writes", "insert_ac", 3, 100, 520),
+            ]
+        (directory / f"{name}.tsv").write_text(
+            results, encoding="utf-8"
+        )
+        with (directory / f"{name}-samples.tsv").open(
+            "w", encoding="utf-8"
+        ) as handle:
+            handle.write(
+                "section\ttest\trun\tbaseline_us\tcandidate_us\n"
+            )
+            for row in samples:
+                handle.write("\t".join(str(value) for value in row) + "\n")
+        (directory / f"{name}.status").write_text(
+            f"{status}\n", encoding="utf-8"
+        )
+        (directory / f"{name}.duration").write_text(
+            "3723\n", encoding="utf-8"
+        )
+
+    def write_all_suites(self, directory):
+        for name in nightly_report.ALL_SUITES:
+            self.write_suite(directory, name)
+
+    def test_generates_complete_pass_report(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            directory = pathlib.Path(temporary)
+            self.write_all_suites(directory)
+            suites = [
+                nightly_report.load_suite(directory, name)
+                for name in nightly_report.ALL_SUITES
+            ]
+            report = nightly_report.render_report(
+                suites,
+                "abc123",
+                "https://example.test/run",
+                "2026-07-25 09:30 UTC",
+                "ubuntu24 20260720.1",
+            )
+        self.assertIn("Nightly result: **PASS**", report)
+        self.assertIn("| int | 2 | 3 | 1h 2m 3s |", report)
+        self.assertIn("Median paired-ratio MAD", report)
+        self.assertIn("Version-control latency", report)
+        self.assertIn("50.0%", report)
+
+    def test_failed_status_marks_overall_report_failed(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            directory = pathlib.Path(temporary)
+            self.write_all_suites(directory)
+            self.write_suite(directory, "blobpk", status=1)
+            suites = [
+                nightly_report.load_suite(directory, name)
+                for name in nightly_report.ALL_SUITES
+            ]
+            report = nightly_report.render_report(
+                suites,
+                "abc123",
+                "https://example.test/run",
+                "now",
+                "ubuntu24",
+            )
+        self.assertIn("Nightly result: **FAIL**", report)
+        self.assertRegex(report, r"\| blobpk .* \*\*FAIL\*\* \|")
+
+    def test_rejects_result_without_matching_samples(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            directory = pathlib.Path(temporary)
+            self.write_suite(directory, "int")
+            sample_path = directory / "int-samples.tsv"
+            sample_path.write_text(
+                sample_path.read_text(encoding="utf-8").replace(
+                    "mem_reads\tpoint", "mem_reads\tother"
+                ),
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(ValueError, "workload mismatch"):
+                nightly_report.load_suite(directory, "int")
+
+    def test_rejects_noncontiguous_sample_runs(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            directory = pathlib.Path(temporary)
+            self.write_suite(directory, "vc")
+            sample_path = directory / "vc-samples.tsv"
+            sample_path.write_text(
+                sample_path.read_text(encoding="utf-8").replace(
+                    "vc\tstatus_clean\t2", "vc\tstatus_clean\t4"
+                ),
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(ValueError, "non-contiguous"):
+                nightly_report.load_suite(directory, "vc")
+
+    def test_main_writes_report(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            directory = pathlib.Path(temporary)
+            self.write_all_suites(directory)
+            output = directory / "performance-report.md"
+            rc = nightly_report.main(
+                [
+                    "--results-dir",
+                    str(directory),
+                    "--commit",
+                    "abc123",
+                    "--run-url",
+                    "https://example.test/run",
+                    "--generated-at",
+                    "2026-07-25 09:30 UTC",
+                    "--output",
+                    str(output),
+                ]
+            )
+            report = output.read_text(encoding="utf-8")
+        self.assertEqual(rc, 0)
+        self.assertIn("# DoltLite Performance Report", report)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/publish_performance_report_test.py
+++ b/test/publish_performance_report_test.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+
+import importlib.util
+import pathlib
+import unittest
+from unittest import mock
+
+
+MODULE_PATH = (
+    pathlib.Path(__file__).parents[1]
+    / "tool"
+    / "publish-performance-report.py"
+)
+SPEC = importlib.util.spec_from_file_location(
+    "publish_performance_report", MODULE_PATH
+)
+publisher = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(publisher)
+
+
+def pull_request(**overrides):
+    value = {
+        "number": 42,
+        "author": {"login": "report-bot"},
+        "headRefName": "automation/performance-report-123-1",
+        "headRefOid": "abcdef123456",
+        "files": [{"path": "performance-report.md"}],
+    }
+    value.update(overrides)
+    return value
+
+
+class PublishPerformanceReportTest(unittest.TestCase):
+    def test_accepts_expected_bot_report(self):
+        publisher.validate_previous_pr(pull_request(), "report-bot")
+
+    def test_rejects_unexpected_author(self):
+        with self.assertRaisesRegex(publisher.PublishError, "author"):
+            publisher.validate_previous_pr(pull_request(), "other-bot")
+
+    def test_rejects_unexpected_branch(self):
+        with self.assertRaisesRegex(publisher.PublishError, "branch"):
+            publisher.validate_previous_pr(
+                pull_request(headRefName="feature/not-a-report"),
+                "report-bot",
+            )
+
+    def test_rejects_additional_files(self):
+        with self.assertRaisesRegex(publisher.PublishError, "expected only"):
+            publisher.validate_previous_pr(
+                pull_request(
+                    files=[
+                        {"path": "performance-report.md"},
+                        {"path": "src/doltlite.c"},
+                    ]
+                ),
+                "report-bot",
+            )
+
+    @mock.patch.object(publisher, "command")
+    @mock.patch.object(publisher, "gh_json")
+    def test_merges_valid_existing_report(self, gh_json, command):
+        gh_json.side_effect = [
+            [{"number": 42}],
+            pull_request(),
+        ]
+        merged = publisher.merge_previous_report(
+            "dolthub/doltlite", "report-bot"
+        )
+        self.assertEqual(merged, 42)
+        command.assert_called_once_with(
+            [
+                "gh",
+                "pr",
+                "merge",
+                "42",
+                "--repo",
+                "dolthub/doltlite",
+                "--squash",
+                "--delete-branch",
+                "--match-head-commit",
+                "abcdef123456",
+            ]
+        )
+
+    @mock.patch.object(publisher, "gh_json")
+    def test_rejects_multiple_existing_reports(self, gh_json):
+        gh_json.return_value = [{"number": 42}, {"number": 43}]
+        with self.assertRaisesRegex(publisher.PublishError, "multiple open"):
+            publisher.merge_previous_report(
+                "dolthub/doltlite", "report-bot"
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/vc_perf_ceiling.sh
+++ b/test/vc_perf_ceiling.sh
@@ -60,6 +60,11 @@ run_sql_file() {
   "$FIXTURE_DOLTLITE" "$db" < "$file" >/dev/null
 }
 
+remove_sample_db() {
+  local db="$1"
+  rm -f "$db" "$db-lock" "$db-wal" "$db-shm" "$db-journal"
+}
+
 cte() {
   echo "WITH RECURSIVE c(i) AS (SELECT $1 UNION ALL SELECT i+1 FROM c WHERE i<$2)"
 }
@@ -280,6 +285,13 @@ bench_sql() {
         "$name" "$r" "$candidate_us" >> "$SAMPLES_FILE"
     fi
     candidate_vals+=("$candidate_us")
+    remove_sample_db "$candidate_db"
+    rm -f "$out" "$err"
+    if [ -n "$VC_PERF_BASELINE" ]; then
+      remove_sample_db "$baseline_db"
+      rm -f "$TMPDIR/${name}_baseline_${r}.out" \
+        "$TMPDIR/${name}_baseline_${r}.err"
+    fi
   done
 
   local candidate_median baseline_median ratio status

--- a/tool/publish-performance-report.py
+++ b/tool/publish-performance-report.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import os
+import pathlib
+import shutil
+import subprocess
+import sys
+
+
+REPORT_PATH = "performance-report.md"
+LABEL = "automated-performance-report"
+BRANCH_PREFIX = "automation/performance-report-"
+
+
+class PublishError(RuntimeError):
+    pass
+
+
+def command(arguments, check=True):
+    result = subprocess.run(
+        arguments,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=None,
+    )
+    if check and result.returncode:
+        raise PublishError(
+            f"command failed ({result.returncode}): {' '.join(arguments)}"
+        )
+    return result
+
+
+def gh_json(arguments):
+    result = command(["gh", *arguments])
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise PublishError(f"invalid gh JSON for: {' '.join(arguments)}") from exc
+
+
+def validate_previous_pr(pr, current_login):
+    author = (pr.get("author") or {}).get("login")
+    if author != current_login:
+        raise PublishError(
+            f"refusing to merge PR #{pr.get('number')}: "
+            f"author is {author!r}, expected {current_login!r}"
+        )
+    branch = pr.get("headRefName", "")
+    if not branch.startswith(BRANCH_PREFIX):
+        raise PublishError(
+            f"refusing to merge PR #{pr.get('number')}: "
+            f"unexpected branch {branch!r}"
+        )
+    files = [entry.get("path") for entry in pr.get("files", [])]
+    if files != [REPORT_PATH]:
+        raise PublishError(
+            f"refusing to merge PR #{pr.get('number')}: "
+            f"expected only {REPORT_PATH}, found {files}"
+        )
+    if not pr.get("headRefOid"):
+        raise PublishError(
+            f"refusing to merge PR #{pr.get('number')}: missing head commit"
+        )
+
+
+def merge_previous_report(repository, current_login):
+    existing = gh_json(
+        [
+            "pr",
+            "list",
+            "--repo",
+            repository,
+            "--state",
+            "open",
+            "--label",
+            LABEL,
+            "--json",
+            "number",
+        ]
+    )
+    if len(existing) > 1:
+        numbers = ", ".join(f"#{pr['number']}" for pr in existing)
+        raise PublishError(
+            f"multiple open performance report PRs found: {numbers}"
+        )
+    if not existing:
+        return None
+
+    number = existing[0]["number"]
+    pr = gh_json(
+        [
+            "pr",
+            "view",
+            str(number),
+            "--repo",
+            repository,
+            "--json",
+            "number,author,headRefName,headRefOid,files",
+        ]
+    )
+    validate_previous_pr(pr, current_login)
+    command(
+        [
+            "gh",
+            "pr",
+            "merge",
+            str(number),
+            "--repo",
+            repository,
+            "--squash",
+            "--delete-branch",
+            "--match-head-commit",
+            pr["headRefOid"],
+        ]
+    )
+    return number
+
+
+def publish_report(args):
+    report = args.report.resolve()
+    if not report.is_file() or report.stat().st_size == 0:
+        raise PublishError(f"report is missing or empty: {report}")
+    if not os.environ.get("GH_TOKEN"):
+        raise PublishError("GH_TOKEN is required")
+
+    login = command(["gh", "api", "user", "--jq", ".login"]).stdout.strip()
+    if not login:
+        raise PublishError("unable to determine report bot login")
+    command(["gh", "auth", "setup-git"])
+
+    merged = merge_previous_report(args.repository, login)
+    if merged is not None:
+        print(f"Merged previous performance report PR #{merged}")
+
+    command(["git", "fetch", "origin", "master"])
+    branch = f"{BRANCH_PREFIX}{args.run_id}-{args.run_attempt}"
+    command(["git", "switch", "-C", branch, "origin/master"])
+    shutil.copyfile(report, REPORT_PATH)
+    command(["git", "diff", "--check"])
+    command(["git", "add", REPORT_PATH])
+    if command(["git", "diff", "--cached", "--quiet"], check=False).returncode == 0:
+        raise PublishError("generated performance report is unchanged")
+
+    command(["git", "config", "user.name", "doltlite performance bot"])
+    command(
+        [
+            "git",
+            "config",
+            "user.email",
+            "performance-bot@users.noreply.github.com",
+        ]
+    )
+    command(
+        [
+            "git",
+            "commit",
+            "-m",
+            f"Update nightly performance report ({args.generated_date})",
+        ]
+    )
+    command(["git", "push", "origin", f"HEAD:refs/heads/{branch}"])
+
+    command(
+        [
+            "gh",
+            "label",
+            "create",
+            LABEL,
+            "--repo",
+            args.repository,
+            "--color",
+            "1d76db",
+            "--description",
+            "Automated nightly performance report",
+        ],
+        check=False,
+    )
+    body = (
+        f"Automated performance results from [{args.generated_date}]"
+        f"({args.run_url}).\n\n"
+        "This PR changes only `performance-report.md`. If it remains open, "
+        "the next successful nightly run will merge it before publishing "
+        "the next report."
+    )
+    create = [
+        "gh",
+        "pr",
+        "create",
+        "--repo",
+        args.repository,
+        "--base",
+        "master",
+        "--head",
+        branch,
+        "--title",
+        f"Nightly performance report — {args.generated_date}",
+        "--body",
+        body,
+        "--label",
+        LABEL,
+    ]
+    url = command(create).stdout.strip()
+    if not url:
+        raise PublishError("gh pr create did not return a PR URL")
+    print(f"Created {url}")
+    if args.reviewer:
+        review = command(
+            [
+                "gh",
+                "pr",
+                "edit",
+                url,
+                "--repo",
+                args.repository,
+                "--add-reviewer",
+                args.reviewer,
+            ],
+            check=False,
+        )
+        if review.returncode:
+            print(
+                f"warning: unable to request review from {args.reviewer}",
+                file=sys.stderr,
+            )
+
+
+def parse_args(argv):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--report", type=pathlib.Path, required=True)
+    parser.add_argument("--repository", required=True)
+    parser.add_argument("--run-id", required=True)
+    parser.add_argument("--run-attempt", default="1")
+    parser.add_argument("--run-url", required=True)
+    parser.add_argument("--generated-date", required=True)
+    parser.add_argument("--reviewer", default="")
+    return parser.parse_args(argv)
+
+
+def main(argv=None):
+    args = parse_args(argv)
+    try:
+        publish_report(args)
+    except PublishError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- stagger nightly performance after fuzz and expand sampling to 55 SQL / 101 VC repetitions
- publish a durable root performance report through a guarded rolling bot PR
- skip full CI for Markdown-only PRs and remove obsolete flaky-performance guidance
- validate packaged benchmark SHAs against independent workflow provenance

## Safety

The publisher only merges one bot-authored PR from the expected branch prefix when its exact head changes only `performance-report.md`. It uses an expected-head merge guard and refuses conflicts, extra files, unexpected authors, or multiple report PRs.

The relative comparator now rejects packaged baseline/candidate SHA labels that do not match the PR base and workflow checkout, addressing Ito QA feedback on #1798.

## Validation

- benchmark comparator tests: 9 passed
- nightly report generator tests: 5 passed
- report publisher guard tests: 6 passed
- reduced VC benchmark: 39/39 samples produced
- actionlint and shell/Python syntax checks passed

Follow-up to #1798.