### PR TITLE
Self-test lint_layers so a dead guard cannot stay silent

### DIFF
--- a/main.mk
+++ b/main.mk
@@ -307,6 +307,7 @@ all:	lint doltlite$(T.exe)
 lint:
 	@bash $(TOP)/test/lint_layers.sh $(TOP)/src
 	@bash $(TOP)/test/lint_no_raw_os_fileio.sh $(TOP)/src
+	@bash $(TOP)/test/lint_layers_selftest.sh
 
 ########################################################################
 ########################################################################

--- a/test/lint_layers_selftest.sh
+++ b/test/lint_layers_selftest.sh
@@ -48,7 +48,34 @@ fi
 
 WORK=$(mktemp -d)
 trap 'rm -rf "$WORK"' EXIT
-cp "$SRC"/*.c "$SRC"/*.h "$WORK"/ 2>/dev/null
+
+# An unverified fixture is the same defect this whole file exists to prevent: a
+# partial copy still lints clean, so every behavioural assertion below would pass
+# while proving nothing. Abort loudly rather than report coverage we do not have.
+setup_failed() {
+  echo "SETUP FAILED: $1" >&2
+  echo "  The behavioural checks below would pass against an incomplete fixture" >&2
+  echo "  and prove nothing, so this is an error rather than a test failure." >&2
+  exit 2
+}
+
+cp_err="$WORK/.cp.err"
+if ! cp "$SRC"/*.c "$SRC"/*.h "$WORK"/ 2>"$cp_err"; then
+  setup_failed "could not copy src/ into $WORK:
+$(sed 's/^/    /' "$cp_err")"
+fi
+rm -f "$cp_err"
+
+# cp can also return 0 having copied less than asked, so compare counts instead
+# of trusting the status alone.
+want=$(ls "$SRC"/*.c "$SRC"/*.h 2>/dev/null | wc -l | tr -d ' ')
+got=$(ls "$WORK"/*.c "$WORK"/*.h 2>/dev/null | wc -l | tr -d ' ')
+if [ "$want" -eq 0 ]; then
+  setup_failed "no .c/.h files found in $SRC"
+fi
+if [ "$got" -ne "$want" ]; then
+  setup_failed "fixture is incomplete: copied $got of $want files from $SRC"
+fi
 
 expect_clean() {
   local name="$1" out

--- a/test/lint_layers_selftest.sh
+++ b/test/lint_layers_selftest.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+
+# lint_layers.sh decides pass/fail from a violation log and exits immediately, so
+# a guard appended below that decision is dead code: it compiles, reads correctly
+# in review, and never runs. That happened -- the chunk_store_lock.c guard shipped
+# below the verdict and stayed dead across two merges before a third merge moved
+# it above by accident. Nothing noticed, because a dead guard is silent by
+# definition.
+#
+# Two checks. The structural one covers every guard, including ones not written
+# yet, and is what would have caught that bug immediately. The behavioural ones
+# confirm the guards actually reject the states they describe, so the structural
+# check is not the only thing standing between us and a silent lint.
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/.." && pwd)"
+LINT="$HERE/lint_layers.sh"
+SRC="$REPO_ROOT/src"
+
+PASS=0
+FAIL=0
+ERRORS=""
+ok() { PASS=$((PASS+1)); }
+bad() { FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $1\n  $2"; }
+
+echo "=== lint_layers self-test ==="
+
+# --- structural: nothing may report a violation after the verdict is computed ---
+
+verdict_line=$(grep -n '^NFAIL=' "$LINT" | head -1 | cut -d: -f1)
+if [ -z "$verdict_line" ]; then
+  bad "verdict_line_found" "no NFAIL= line in lint_layers.sh; update this self-test"
+else
+  ok
+  stranded=$(awk -v v="$verdict_line" 'NR>v && /lint "/ {print NR": "$0}' "$LINT")
+  if [ -n "$stranded" ]; then
+    bad "no_guard_after_verdict" \
+        "these guards sit below the verdict at line $verdict_line and can never run:
+$stranded"
+  else
+    ok
+  fi
+fi
+
+# --- behavioural: the guards reject what they claim to reject ---
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+cp "$SRC"/*.c "$SRC"/*.h "$WORK"/ 2>/dev/null
+
+expect_clean() {
+  local name="$1" out
+  out=$(bash "$LINT" "$WORK" 2>&1)
+  if [ $? -eq 0 ]; then ok; else bad "$name" "expected a clean pass, got:
+$out"; fi
+}
+
+# The message must name the offending file: a guard that fires with the wrong
+# subject is as unhelpful as one that does not fire.
+expect_violation() {
+  local name="$1" needle="$2" out rc
+  out=$(bash "$LINT" "$WORK" 2>&1)
+  rc=$?
+  if [ "$rc" -eq 0 ]; then
+    bad "$name" "expected a violation, but lint passed"
+  elif ! printf '%s' "$out" | grep -q -- "$needle"; then
+    bad "$name" "exited $rc but never mentioned '$needle':
+$out"
+  else
+    ok
+  fi
+}
+
+expect_clean "baseline_unperturbed_src_passes"
+
+# One module per guard family, so a family whose guard goes dead is caught.
+# GUARDED is "<file>:<cap>" -- the cap each guard enforces.
+GUARDED="
+chunk_store_lock.c:1200
+prolly_btree_cursor_count.c:1500
+prolly_btree_cursor_payload.c:1500
+doltlite_branches.c:1500
+doltlite_merge_pass1.c:1500
+"
+
+for entry in $GUARDED; do
+  file="${entry%%:*}"
+  cap="${entry##*:}"
+  [ -f "$WORK/$file" ] || { bad "guarded_file_present:$file" "not in src/"; continue; }
+
+  mv "$WORK/$file" "$WORK/.hidden"
+  expect_violation "missing_is_rejected:$file" "$file"
+  mv "$WORK/.hidden" "$WORK/$file"
+
+  cp "$WORK/$file" "$WORK/.orig"
+  python3 - "$WORK/$file" "$cap" <<'PY'
+import sys
+path, cap = sys.argv[1], int(sys.argv[2])
+have = open(path).read().count("\n")
+with open(path, "a") as fh:
+    fh.write("\n".join(["/* pad */"] * (cap + 6 - have)) + "\n")
+PY
+  expect_violation "oversized_is_rejected:$file" "$file"
+  mv "$WORK/.orig" "$WORK/$file"
+done
+
+expect_clean "restored_src_passes_again"
+
+echo
+echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"
+if [ "$FAIL" -gt 0 ]; then
+  echo -e "$ERRORS"
+  exit 1
+fi


### PR DESCRIPTION
Investigating the report against #1799. **The finding was real, and is already fixed on master — but it was fixed by accident**, which is the part worth acting on.

## Verification

The report's mechanism is exactly right: `lint_layers.sh` computes `NFAIL`, prints a verdict and exits immediately, so a guard appended below that point never runs.

Its line numbers didn't match master, which is what made this look like a false positive at first. Tracing the guard's position against the verdict explains why:

| commit | guard | `NFAIL=` | state |
|---|---:|---:|---|
| `60a05b51c3` — refactor: extract chunk_store_lock.c | 116 | 104 | **DEAD** |
| `91931b9b2d` — merge #1799 | 116 | 104 | **DEAD** |
| `ffa8456a8f` — merge #1796 | 126 | 114 | **DEAD** |
| `8df59293af` — merge #1797 | **55** | 132 | LIVE |
| `42125d60a2` — master | **55** | 132 | LIVE |

So it shipped dead, survived two merges, and became live only when a third merge happened to reorder it above the verdict. On current master both reported states are rejected properly:

```
$ mv src/chunk_store_lock.c /tmp/ && bash test/lint_layers.sh
LINT: src/chunk_store_lock.c: missing — chunk_store lock must stay split
lint_layers: 1 violation(s) found        # exit 1

$ # padded to 1306 lines
LINT: src/chunk_store_lock.c:1306 lines — chunk_store_lock.c must stay at or below 1200 lines
lint_layers: 1 violation(s) found        # exit 1

$ make lint   # with the file missing
make: *** [lint] Error 1                 # exit 2
```

No fix is needed for the guard itself.

## What does need fixing

Nothing detected a dead guard for three PRs, because a dead guard is silent by construction — and five extraction PRs have now each appended a guard to this file, so the next one can land dead the same way. The gap is feedback, not the guard.

**Structural check** — refuses any violation reported below the verdict. Covers every guard including ones not written yet, and would have caught this immediately:

```
FAIL: no_guard_after_verdict
  these guards sit below the verdict at line 122 and can never run:
134:   lint "$SRCDIR/chunk_store_lock.c: missing — chunk_store lock must stay split"
138:     lint "$SRCDIR/chunk_store_lock.c:$nline lines — ... at or below 1200 lines"
```

**Behavioural checks** — for one module per guard family, hide it and then oversize it against a scratch copy of `src/`, asserting the guard fires *and* names the offending file. So the structural check isn't the only thing standing between us and a silent lint.

Wired into `make lint`, where the lint it guards already runs (`ci-build.yml:96`). ~8s.

## Testing

Confirmed non-vacuous by restoring the original arrangement: `lint_layers.sh` still prints `all checks passed` and exits 0, while the self-test fails three ways (structural + both behavioural). `make lint` then exits non-zero instead of passing. Restored, all six check/lint scripts pass and the tree is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
