### PR TITLE
Retry noisy relative benchmarks before failing

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -12,7 +12,9 @@ jobs:
   sysbench-relative:
     name: ${{ matrix.suite.name }}-keys
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    # Passing suites still run once. The extra time is only available when a
+    # valid regression result triggers up to two automatic remeasurements.
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
@@ -48,18 +50,23 @@ jobs:
         BENCH_GATE_MODE: none
       run: |
         results="$RUNNER_TEMP/benchmark-results"
-        mkdir -p "$results"
         BENCH_BASELINE_BINARY="$GITHUB_WORKSPACE/benchmark-baseline/doltlite" \
           BENCH_CANDIDATE_BINARY="$GITHUB_WORKSPACE/build/doltlite" \
           BENCH_BASELINE_TIMER="$GITHUB_WORKSPACE/benchmark-baseline/bench_timer_doltlite" \
           BENCH_CANDIDATE_TIMER="$GITHUB_WORKSPACE/build/bench_timer_doltlite" \
-          BENCH_RESULTS_OUTPUT="$results/${{ matrix.suite.name }}.tsv" \
-          BENCH_SAMPLES_OUTPUT="$results/${{ matrix.suite.name }}-samples.tsv" \
-          bash "test/${{ matrix.suite.script }}" \
-          > "$results/${{ matrix.suite.name }}.md"
+          python3 test/benchmark_retry.py \
+            --suite "${{ matrix.suite.name }}" \
+            --results-dir "$results" \
+            --max-attempts 3 \
+            --individual-ratio 1.25 \
+            --aggregate-ratio 1.15 \
+            --min-delta-us 5000 \
+            --individual-min-delta-us 5000 \
+            -- bash "test/${{ matrix.suite.script }}"
         cat "$results/${{ matrix.suite.name }}.md"
 
     - name: Upload paired measurements
+      if: always()
       uses: actions/upload-artifact@v4
       with:
         name: benchmark-result-${{ matrix.suite.name }}
@@ -89,15 +96,20 @@ jobs:
         VC_PERF_CANDIDATE_LABEL: PR candidate
       run: |
         results="$RUNNER_TEMP/benchmark-results"
-        mkdir -p "$results"
         VC_PERF_BASELINE="$GITHUB_WORKSPACE/benchmark-baseline/doltlite" \
-          VC_PERF_RESULTS_OUTPUT="$results/vc.tsv" \
-          VC_PERF_SAMPLES_OUTPUT="$results/vc-samples.tsv" \
-          bash test/vc_perf_ceiling.sh "$GITHUB_WORKSPACE/build/doltlite" \
-          > "$results/vc.md"
+          python3 test/benchmark_retry.py \
+            --suite vc \
+            --results-dir "$results" \
+            --max-attempts 3 \
+            --individual-ratio 1.50 \
+            --aggregate-ratio 1.15 \
+            --min-delta-us 5000 \
+            --individual-min-delta-us 25000 \
+            -- bash test/vc_perf_ceiling.sh "$GITHUB_WORKSPACE/build/doltlite"
         cat "$results/vc.md"
 
     - name: Upload paired measurements
+      if: always()
       uses: actions/upload-artifact@v4
       with:
         name: benchmark-result-vc
@@ -135,7 +147,9 @@ jobs:
       run: tar -xzf benchmark-build.tar.gz
 
     - name: Test relative comparison policy
-      run: python3 test/benchmark_compare_test.py
+      run: |
+        python3 test/benchmark_compare_test.py
+        python3 test/benchmark_retry_test.py
 
     - name: Generate relative performance report
       id: report
@@ -144,7 +158,8 @@ jobs:
         required="int textpk blobpk compositepk vc"
         missing=""
         for suite in $required; do
-          if [ ! -s "benchmark-results/$suite.tsv" ]; then
+          if [ ! -s "benchmark-results/$suite.tsv" ] ||
+             [ ! -s "benchmark-results/$suite-attempts.tsv" ]; then
             missing="$missing $suite"
           fi
         done
@@ -172,6 +187,11 @@ jobs:
             --input "blobpk=benchmark-results/blobpk.tsv" \
             --input "compositepk=benchmark-results/compositepk.tsv" \
             --input "vc=benchmark-results/vc.tsv" \
+            --attempt-history "int=benchmark-results/int-attempts.tsv" \
+            --attempt-history "textpk=benchmark-results/textpk-attempts.tsv" \
+            --attempt-history "blobpk=benchmark-results/blobpk-attempts.tsv" \
+            --attempt-history "compositepk=benchmark-results/compositepk-attempts.tsv" \
+            --attempt-history "vc=benchmark-results/vc-attempts.tsv" \
             --baseline-ref "$baseline" \
             --candidate-ref "$candidate" \
             --expected-baseline-ref "$expected_baseline" \

--- a/README.md
+++ b/README.md
@@ -930,7 +930,10 @@ execution order alternates on each repetition to reduce host-load bias. CI
 fails when an individual workload regresses by more than 25% and 5ms, or when
 a section, suite, or overall runtime regresses by more than 15% and 5ms.
 Short, process-startup-bound version-control operations use a 50% and 25ms
-individual gate; their aggregate still uses the 15% suite gate.
+individual gate; their aggregate still uses the 15% suite gate. A suite that
+exceeds a gate is measured again automatically and only fails CI after three
+consecutive failing attempts. Command, result-format, and revision-provenance
+errors fail immediately instead of being retried.
 
 A scheduled workflow starts nightly at 09:30 UTC, after the nightly fuzzing
 window. Four parallel workers run 55 paired samples per SQL workload against

--- a/test/benchmark_compare.py
+++ b/test/benchmark_compare.py
@@ -32,6 +32,48 @@ class Result:
         return self.candidate_us - self.baseline_us
 
 
+def parse_attempt_history(spec):
+    if "=" not in spec:
+        raise ValueError(f"attempt history must be SUITE=PATH: {spec}")
+    suite, path_text = spec.split("=", 1)
+    if not suite or not path_text:
+        raise ValueError(f"attempt history must be SUITE=PATH: {spec}")
+    path = pathlib.Path(path_text)
+    statuses = []
+    with path.open(encoding="utf-8") as source:
+        header = source.readline().rstrip("\n")
+        if header != "attempt\tstatus":
+            raise ValueError(f"{path}: invalid attempt history header")
+        for line_number, line in enumerate(source, 2):
+            columns = line.rstrip("\n").split("\t")
+            if len(columns) != 2:
+                raise ValueError(
+                    f"{path}:{line_number}: expected attempt and status"
+                )
+            attempt, status = columns
+            if attempt != str(len(statuses) + 1):
+                raise ValueError(
+                    f"{path}:{line_number}: attempts must be consecutive"
+                )
+            if status not in ("pass", "regression"):
+                raise ValueError(
+                    f"{path}:{line_number}: invalid status {status}"
+                )
+            statuses.append(status)
+    if not statuses:
+        raise ValueError(f"{path}: no benchmark attempts")
+    if statuses[-1] == "pass":
+        if any(status != "regression" for status in statuses[:-1]):
+            raise ValueError(f"{path}: pass must end the attempt history")
+    elif len(statuses) != 3 or any(
+        status != "regression" for status in statuses
+    ):
+        raise ValueError(
+            f"{path}: final regression requires three consecutive failures"
+        )
+    return suite, statuses
+
+
 def parse_input(spec):
     if "=" not in spec:
         raise ValueError(f"input must be SUITE=PATH: {spec}")
@@ -190,7 +232,49 @@ def analyze(
         "section_ratios": section_ratios,
         "suite_ratios": suite_ratios,
         "overall_ratio": overall_ratio,
+        "overall_failed": overall_failed,
     }
+
+
+def validate_retry_confirmation(results, analysis, attempt_histories):
+    result_suites = {result.suite for result in results}
+    history_suites = set(attempt_histories)
+    if result_suites != history_suites:
+        missing = sorted(result_suites - history_suites)
+        extra = sorted(history_suites - result_suites)
+        details = []
+        if missing:
+            details.append(f"missing: {', '.join(missing)}")
+        if extra:
+            details.append(f"unexpected: {', '.join(extra)}")
+        raise ValueError(
+            "attempt histories do not match benchmark suites ("
+            + "; ".join(details)
+            + ")"
+        )
+
+    failed_suites = {
+        suite for suite, _section, _test in analysis["individual_failures"]
+    }
+    failed_suites.update(
+        suite for suite, _section in analysis["section_failures"]
+    )
+    failed_suites.update(analysis["suite_failures"])
+    confirmed_suites = {
+        suite
+        for suite, statuses in attempt_histories.items()
+        if statuses[-1] == "regression"
+    }
+    unconfirmed = sorted(failed_suites - confirmed_suites)
+    if unconfirmed:
+        raise ValueError(
+            "benchmark regression lacks three-failure confirmation: "
+            + ", ".join(unconfirmed)
+        )
+    if analysis["overall_failed"] and not confirmed_suites:
+        raise ValueError(
+            "overall benchmark regression lacks three-failure confirmation"
+        )
 
 
 def render(
@@ -202,6 +286,7 @@ def render(
     aggregate_ratio,
     min_delta_us,
     individual_overrides=None,
+    attempt_histories=None,
 ):
     suites = defaultdict(list)
     for result in results:
@@ -226,6 +311,25 @@ def render(
             f"- **{suite} individual gate:** > {ratio:.2f}x with more than "
             f"{format_time(delta)} regression"
         )
+    retried = []
+    for suite, statuses in sorted((attempt_histories or {}).items()):
+        if len(statuses) == 1:
+            continue
+        if statuses[-1] == "pass":
+            retried.append(
+                f"{suite} passed attempt {len(statuses)} after "
+                f"{len(statuses) - 1} transient gate "
+                f"{'failure' if len(statuses) == 2 else 'failures'}"
+            )
+        else:
+            retried.append(
+                f"{suite} exceeded its gate in {len(statuses)} "
+                "consecutive attempts"
+            )
+    lines.append(
+        "- **Automatic retries:** "
+        + ("; ".join(retried) if retried else "none")
+    )
     lines.extend(
         [
             "",
@@ -341,6 +445,13 @@ def main(argv=None):
         metavar="SUITE=RATIO:MIN_DELTA_US",
         help="Override the individual gate for one suite; may be repeated",
     )
+    parser.add_argument(
+        "--attempt-history",
+        action="append",
+        default=[],
+        metavar="SUITE=PATH",
+        help="Validated retry history for one suite; may be repeated",
+    )
     parser.add_argument("--output", required=True)
     args = parser.parse_args(argv)
 
@@ -362,6 +473,12 @@ def main(argv=None):
         results = []
         for spec in args.input:
             results.extend(parse_input(spec))
+        attempt_histories = {}
+        for spec in args.attempt_history:
+            suite, statuses = parse_attempt_history(spec)
+            if suite in attempt_histories:
+                raise ValueError(f"duplicate attempt history for {suite}")
+            attempt_histories[suite] = statuses
     except (OSError, ValueError) as exc:
         parser.error(str(exc))
 
@@ -383,6 +500,15 @@ def main(argv=None):
         args.min_delta_us,
         individual_overrides,
     )
+    if attempt_histories:
+        try:
+            validate_retry_confirmation(
+                results,
+                analysis,
+                attempt_histories,
+            )
+        except ValueError as exc:
+            parser.error(str(exc))
     report = render(
         results,
         analysis,
@@ -392,6 +518,7 @@ def main(argv=None):
         args.aggregate_ratio,
         args.min_delta_us,
         individual_overrides,
+        attempt_histories,
     )
     pathlib.Path(args.output).write_text(report, encoding="utf-8")
     print(report, end="")

--- a/test/benchmark_compare_test.py
+++ b/test/benchmark_compare_test.py
@@ -109,6 +109,115 @@ class BenchmarkCompareTest(unittest.TestCase):
             ],
         )
 
+    def test_parses_three_consecutive_regressions(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = pathlib.Path(directory) / "attempts.tsv"
+            path.write_text(
+                "attempt\tstatus\n"
+                "1\tregression\n"
+                "2\tregression\n"
+                "3\tregression\n",
+                encoding="utf-8",
+            )
+            suite, statuses = benchmark_compare.parse_attempt_history(
+                f"int={path}"
+            )
+        self.assertEqual(suite, "int")
+        self.assertEqual(
+            statuses,
+            ["regression", "regression", "regression"],
+        )
+
+    def test_rejects_unconfirmed_final_regression(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = pathlib.Path(directory) / "attempts.tsv"
+            path.write_text(
+                "attempt\tstatus\n1\tregression\n2\tregression\n",
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(
+                ValueError,
+                "requires three consecutive failures",
+            ):
+                benchmark_compare.parse_attempt_history(f"int={path}")
+
+    def test_report_describes_transient_retry(self):
+        results = [result("point", 100_000, 101_000)]
+        analysis = self.analyze(results)
+        report = benchmark_compare.render(
+            results,
+            analysis,
+            "base",
+            "candidate",
+            1.25,
+            1.15,
+            5000,
+            attempt_histories={"int": ["regression", "pass"]},
+        )
+        self.assertIn(
+            "int passed attempt 2 after 1 transient gate failure",
+            report,
+        )
+
+    def test_main_accepts_attempt_history(self):
+        with tempfile.TemporaryDirectory() as directory:
+            directory = pathlib.Path(directory)
+            timings = directory / "result.tsv"
+            attempts = directory / "attempts.tsv"
+            report = directory / "report.md"
+            timings.write_text(
+                "reads\tpoint\t100000\t101000\n",
+                encoding="utf-8",
+            )
+            attempts.write_text(
+                "attempt\tstatus\n1\tregression\n2\tpass\n",
+                encoding="utf-8",
+            )
+            with contextlib.redirect_stdout(io.StringIO()):
+                rc = benchmark_compare.main(
+                    [
+                        "--input",
+                        f"int={timings}",
+                        "--attempt-history",
+                        f"int={attempts}",
+                        "--baseline-ref",
+                        "base",
+                        "--candidate-ref",
+                        "candidate",
+                        "--expected-baseline-ref",
+                        "base",
+                        "--expected-candidate-ref",
+                        "candidate",
+                        "--output",
+                        str(report),
+                    ]
+                )
+            output = report.read_text(encoding="utf-8")
+        self.assertEqual(rc, 0)
+        self.assertIn("int passed attempt 2", output)
+
+    def test_rejects_regression_without_three_failed_attempts(self):
+        results = [result("point", 100_000, 140_000)]
+        analysis = self.analyze(results)
+        with self.assertRaisesRegex(
+            ValueError,
+            "lacks three-failure confirmation",
+        ):
+            benchmark_compare.validate_retry_confirmation(
+                results,
+                analysis,
+                {"int": ["pass"]},
+            )
+
+    def test_accepts_regression_after_three_failed_attempts(self):
+        results = [result("point", 100_000, 140_000)]
+        analysis = self.analyze(results)
+        benchmark_compare.validate_retry_confirmation(
+            results,
+            analysis,
+            {"int": ["regression", "regression", "regression"]},
+        )
+
     def test_rejects_swapped_revision_provenance(self):
         with tempfile.TemporaryDirectory() as directory:
             directory = pathlib.Path(directory)

--- a/test/benchmark_retry.py
+++ b/test/benchmark_retry.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+
+import argparse
+import os
+import pathlib
+import shutil
+import subprocess
+import sys
+
+import benchmark_compare
+
+
+def write_history(path, statuses):
+    lines = ["attempt\tstatus"]
+    lines.extend(
+        f"{attempt}\t{status}"
+        for attempt, status in enumerate(statuses, 1)
+    )
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def promote_attempt(attempt_dir, results_dir, suite):
+    for suffix in (".tsv", "-samples.tsv", ".md"):
+        source = attempt_dir / f"{suite}{suffix}"
+        shutil.copy2(source, results_dir / source.name)
+
+
+def run_with_retries(
+    suite,
+    results_dir,
+    command,
+    max_attempts,
+    individual_ratio,
+    aggregate_ratio,
+    min_delta_us,
+    individual_min_delta_us,
+    command_runner=subprocess.run,
+):
+    results_dir = pathlib.Path(results_dir)
+    attempts_dir = results_dir / "attempts"
+    history_path = results_dir / f"{suite}-attempts.tsv"
+    results_dir.mkdir(parents=True, exist_ok=True)
+    statuses = []
+
+    for attempt in range(1, max_attempts + 1):
+        attempt_dir = attempts_dir / f"attempt-{attempt}"
+        attempt_dir.mkdir(parents=True, exist_ok=True)
+        result_path = attempt_dir / f"{suite}.tsv"
+        samples_path = attempt_dir / f"{suite}-samples.tsv"
+        markdown_path = attempt_dir / f"{suite}.md"
+        gate_path = attempt_dir / f"{suite}-gate.md"
+
+        environment = os.environ.copy()
+        environment.update(
+            {
+                "BENCH_RESULTS_OUTPUT": str(result_path),
+                "BENCH_SAMPLES_OUTPUT": str(samples_path),
+                "VC_PERF_RESULTS_OUTPUT": str(result_path),
+                "VC_PERF_SAMPLES_OUTPUT": str(samples_path),
+            }
+        )
+        with markdown_path.open("w", encoding="utf-8") as output:
+            completed = command_runner(
+                command,
+                env=environment,
+                stdout=output,
+                check=False,
+            )
+
+        if completed.returncode:
+            statuses.append("command_error")
+            write_history(history_path, statuses)
+            print(
+                f"{suite} attempt {attempt}/{max_attempts}: "
+                f"command failed with exit code {completed.returncode}",
+                file=sys.stderr,
+            )
+            return completed.returncode
+
+        required = (result_path, samples_path, markdown_path)
+        missing = [
+            str(path)
+            for path in required
+            if not path.is_file() or path.stat().st_size == 0
+        ]
+        if missing:
+            statuses.append("invalid_result")
+            write_history(history_path, statuses)
+            print(
+                f"{suite} attempt {attempt}/{max_attempts}: "
+                f"missing result files: {', '.join(missing)}",
+                file=sys.stderr,
+            )
+            return 2
+
+        try:
+            results = benchmark_compare.parse_input(
+                f"{suite}={result_path}"
+            )
+        except (OSError, ValueError) as exc:
+            statuses.append("invalid_result")
+            write_history(history_path, statuses)
+            print(
+                f"{suite} attempt {attempt}/{max_attempts}: {exc}",
+                file=sys.stderr,
+            )
+            return 2
+
+        analysis = benchmark_compare.analyze(
+            results,
+            individual_ratio,
+            aggregate_ratio,
+            min_delta_us,
+            {suite: (individual_ratio, individual_min_delta_us)},
+        )
+        report = benchmark_compare.render(
+            results,
+            analysis,
+            "PR base",
+            "PR candidate",
+            individual_ratio,
+            aggregate_ratio,
+            min_delta_us,
+            {suite: (individual_ratio, individual_min_delta_us)},
+        )
+        gate_path.write_text(report, encoding="utf-8")
+
+        status = "regression" if analysis["failed"] else "pass"
+        statuses.append(status)
+        write_history(history_path, statuses)
+        if status == "pass":
+            promote_attempt(attempt_dir, results_dir, suite)
+            print(
+                f"{suite} attempt {attempt}/{max_attempts}: passed"
+            )
+            return 0
+
+        if attempt < max_attempts:
+            print(
+                f"{suite} attempt {attempt}/{max_attempts}: "
+                "performance gate exceeded; retrying"
+            )
+            continue
+
+        # A valid measurement is always published. The aggregate report job
+        # enforces the gate after this third consecutive regression.
+        promote_attempt(attempt_dir, results_dir, suite)
+        print(
+            f"{suite} attempt {attempt}/{max_attempts}: "
+            "performance gate exceeded in all attempts"
+        )
+        return 0
+
+    raise AssertionError("retry loop did not return")
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        description=(
+            "Retry a paired benchmark only when its performance gate fails"
+        )
+    )
+    parser.add_argument("--suite", required=True)
+    parser.add_argument("--results-dir", required=True)
+    parser.add_argument("--max-attempts", type=int, default=3)
+    parser.add_argument("--individual-ratio", type=float, default=1.25)
+    parser.add_argument("--aggregate-ratio", type=float, default=1.15)
+    parser.add_argument("--min-delta-us", type=int, default=5000)
+    parser.add_argument("--individual-min-delta-us", type=int, default=5000)
+    parser.add_argument("command", nargs=argparse.REMAINDER)
+    args = parser.parse_args(argv)
+
+    command = args.command
+    if command and command[0] == "--":
+        command = command[1:]
+    if not command:
+        parser.error("a benchmark command is required after --")
+    if args.max_attempts < 1:
+        parser.error("--max-attempts must be at least 1")
+
+    return run_with_retries(
+        args.suite,
+        args.results_dir,
+        command,
+        args.max_attempts,
+        args.individual_ratio,
+        args.aggregate_ratio,
+        args.min_delta_us,
+        args.individual_min_delta_us,
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/benchmark_retry_test.py
+++ b/test/benchmark_retry_test.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+
+import importlib.util
+import pathlib
+import tempfile
+import types
+import unittest
+
+
+MODULE_PATH = pathlib.Path(__file__).with_name("benchmark_retry.py")
+SPEC = importlib.util.spec_from_file_location("benchmark_retry", MODULE_PATH)
+benchmark_retry = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(benchmark_retry)
+
+
+class FakeRunner:
+    def __init__(self, outcomes):
+        self.outcomes = list(outcomes)
+        self.calls = 0
+
+    def __call__(self, command, env, stdout, check):
+        del command, check
+        outcome = self.outcomes[self.calls]
+        self.calls += 1
+        if isinstance(outcome, int):
+            return types.SimpleNamespace(returncode=outcome)
+
+        baseline, candidate = outcome
+        pathlib.Path(env["BENCH_RESULTS_OUTPUT"]).write_text(
+            f"reads\tpoint\t{baseline}\t{candidate}\n",
+            encoding="utf-8",
+        )
+        pathlib.Path(env["BENCH_SAMPLES_OUTPUT"]).write_text(
+            "section\ttest\trun\tbaseline_us\tcandidate_us\n"
+            f"reads\tpoint\t1\t{baseline}\t{candidate}\n",
+            encoding="utf-8",
+        )
+        stdout.write("benchmark output\n")
+        return types.SimpleNamespace(returncode=0)
+
+
+class BenchmarkRetryTest(unittest.TestCase):
+    def run_retry(self, directory, outcomes):
+        runner = FakeRunner(outcomes)
+        rc = benchmark_retry.run_with_retries(
+            "int",
+            directory,
+            ["fake-benchmark"],
+            3,
+            1.25,
+            1.15,
+            5000,
+            5000,
+            runner,
+        )
+        return rc, runner
+
+    def test_first_pass_uses_one_attempt(self):
+        with tempfile.TemporaryDirectory() as directory:
+            rc, runner = self.run_retry(directory, [(100_000, 101_000)])
+            history = pathlib.Path(directory, "int-attempts.tsv").read_text()
+        self.assertEqual(rc, 0)
+        self.assertEqual(runner.calls, 1)
+        self.assertEqual(history, "attempt\tstatus\n1\tpass\n")
+
+    def test_regression_then_pass_promotes_second_attempt(self):
+        with tempfile.TemporaryDirectory() as directory:
+            directory = pathlib.Path(directory)
+            rc, runner = self.run_retry(
+                directory,
+                [(100_000, 140_000), (100_000, 101_000)],
+            )
+            history = (directory / "int-attempts.tsv").read_text()
+            result = (directory / "int.tsv").read_text()
+        self.assertEqual(rc, 0)
+        self.assertEqual(runner.calls, 2)
+        self.assertIn("1\tregression\n2\tpass\n", history)
+        self.assertEqual(result, "reads\tpoint\t100000\t101000\n")
+
+    def test_three_regressions_promote_final_attempt(self):
+        with tempfile.TemporaryDirectory() as directory:
+            directory = pathlib.Path(directory)
+            rc, runner = self.run_retry(
+                directory,
+                [
+                    (100_000, 130_000),
+                    (100_000, 140_000),
+                    (100_000, 150_000),
+                ],
+            )
+            history = (directory / "int-attempts.tsv").read_text()
+            result = (directory / "int.tsv").read_text()
+        self.assertEqual(rc, 0)
+        self.assertEqual(runner.calls, 3)
+        self.assertIn(
+            "1\tregression\n2\tregression\n3\tregression\n",
+            history,
+        )
+        self.assertEqual(result, "reads\tpoint\t100000\t150000\n")
+
+    def test_command_error_is_not_retried(self):
+        with tempfile.TemporaryDirectory() as directory:
+            directory = pathlib.Path(directory)
+            rc, runner = self.run_retry(directory, [7])
+            history = (directory / "int-attempts.tsv").read_text()
+        self.assertEqual(rc, 7)
+        self.assertEqual(runner.calls, 1)
+        self.assertEqual(history, "attempt\tstatus\n1\tcommand_error\n")
+        self.assertFalse((directory / "int.tsv").exists())
+
+    def test_missing_output_is_not_retried(self):
+        class MissingOutputRunner:
+            calls = 0
+
+            def __call__(self, command, env, stdout, check):
+                del command, env, check
+                self.calls += 1
+                stdout.write("incomplete output\n")
+                return types.SimpleNamespace(returncode=0)
+
+        with tempfile.TemporaryDirectory() as directory:
+            runner = MissingOutputRunner()
+            rc = benchmark_retry.run_with_retries(
+                "int",
+                directory,
+                ["fake-benchmark"],
+                3,
+                1.25,
+                1.15,
+                5000,
+                5000,
+                runner,
+            )
+        self.assertEqual(rc, 2)
+        self.assertEqual(runner.calls, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- retry an individual paired benchmark suite only after it produces a valid performance-gate failure
- require three consecutive failed measurements before the relative performance gate reports a regression
- fail command, malformed-result, and revision-provenance errors immediately without retrying
- retain raw results, samples, reports, and a validated attempt history for every measurement
- keep the normal one-attempt CI path unchanged and document the policy

## Validation

- `python3 test/benchmark_compare_test.py` (15 tests)
- `python3 test/benchmark_retry_test.py` (5 tests)
- Python bytecode compilation
- `bash test/lint_layers.sh`
- shell syntax checks for benchmark scripts
- actionlint across all workflows
- retry-runner CLI artifact-promotion smoke test
- `git diff --check`