### PR TITLE
Confirm exact benchmark gates across retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -932,8 +932,10 @@ a section, suite, or overall runtime regresses by more than 15% and 5ms.
 Short, process-startup-bound version-control operations use a 50% and 25ms
 individual gate; their aggregate still uses the 15% suite gate. A suite that
 exceeds a gate is measured again automatically and only fails CI after three
-consecutive failing attempts. Command, result-format, and revision-provenance
-errors fail immediately instead of being retried.
+consecutive failures of the same individual, section, or suite gate. Different
+metrics failing on later attempts do not confirm the original regression.
+Command, result-format, and revision-provenance errors fail immediately instead
+of being retried.
 
 A scheduled workflow starts nightly at 09:30 UTC, after the nightly fuzzing
 window. Four parallel workers run 55 paired samples per SQL workload against

--- a/test/benchmark_compare.py
+++ b/test/benchmark_compare.py
@@ -2,6 +2,7 @@
 
 import argparse
 import dataclasses
+import json
 import pathlib
 import sys
 from collections import defaultdict
@@ -32,6 +33,35 @@ class Result:
         return self.candidate_us - self.baseline_us
 
 
+@dataclasses.dataclass(frozen=True)
+class AttemptHistory:
+    suite: str
+    failures: tuple
+
+    @property
+    def confirmed_failures(self):
+        if len(self.failures) != 3:
+            return frozenset()
+        return frozenset.intersection(*self.failures)
+
+
+def validate_gate_id(path, line_number, suite, value):
+    if not isinstance(value, list) or not value:
+        raise ValueError(f"{path}:{line_number}: invalid gate identifier")
+    expected_lengths = {"individual": 4, "section": 3, "suite": 2}
+    kind = value[0]
+    if kind not in expected_lengths or len(value) != expected_lengths[kind]:
+        raise ValueError(f"{path}:{line_number}: invalid gate identifier")
+    if not all(isinstance(part, str) and part for part in value):
+        raise ValueError(f"{path}:{line_number}: invalid gate identifier")
+    if value[1] != suite:
+        raise ValueError(
+            f"{path}:{line_number}: gate suite {value[1]} "
+            f"does not match history suite {suite}"
+        )
+    return tuple(value)
+
+
 def parse_attempt_history(spec):
     if "=" not in spec:
         raise ValueError(f"attempt history must be SUITE=PATH: {spec}")
@@ -39,19 +69,29 @@ def parse_attempt_history(spec):
     if not suite or not path_text:
         raise ValueError(f"attempt history must be SUITE=PATH: {spec}")
     path = pathlib.Path(path_text)
-    statuses = []
+    failures = []
     with path.open(encoding="utf-8") as source:
         header = source.readline().rstrip("\n")
-        if header != "attempt\tstatus":
+        if header != f"suite\t{suite}":
+            recorded_suite = (
+                header.split("\t", 1)[1] if "\t" in header else ""
+            )
+            raise ValueError(
+                f"{path}: history suite {recorded_suite or '<missing>'} "
+                f"does not match requested suite {suite}"
+            )
+        columns_header = source.readline().rstrip("\n")
+        if columns_header != "attempt\tstatus\tfailed_gates":
             raise ValueError(f"{path}: invalid attempt history header")
-        for line_number, line in enumerate(source, 2):
+        for line_number, line in enumerate(source, 3):
             columns = line.rstrip("\n").split("\t")
-            if len(columns) != 2:
+            if len(columns) != 3:
                 raise ValueError(
-                    f"{path}:{line_number}: expected attempt and status"
+                    f"{path}:{line_number}: expected attempt, status, "
+                    "and failed gates"
                 )
-            attempt, status = columns
-            if attempt != str(len(statuses) + 1):
+            attempt, status, gates_text = columns
+            if attempt != str(len(failures) + 1):
                 raise ValueError(
                     f"{path}:{line_number}: attempts must be consecutive"
                 )
@@ -59,19 +99,48 @@ def parse_attempt_history(spec):
                 raise ValueError(
                     f"{path}:{line_number}: invalid status {status}"
                 )
-            statuses.append(status)
-    if not statuses:
+            try:
+                gates_json = json.loads(gates_text)
+            except json.JSONDecodeError as exc:
+                raise ValueError(
+                    f"{path}:{line_number}: invalid failed-gates JSON"
+                ) from exc
+            if not isinstance(gates_json, list):
+                raise ValueError(
+                    f"{path}:{line_number}: failed gates must be a list"
+                )
+            validated_gates = [
+                validate_gate_id(path, line_number, suite, value)
+                for value in gates_json
+            ]
+            gates = frozenset(validated_gates)
+            if len(gates) != len(validated_gates):
+                raise ValueError(
+                    f"{path}:{line_number}: duplicate failed gate"
+                )
+            expected_status = "regression" if gates else "pass"
+            if status != expected_status:
+                raise ValueError(
+                    f"{path}:{line_number}: status does not match failed gates"
+                )
+            failures.append(gates)
+    if not failures:
         raise ValueError(f"{path}: no benchmark attempts")
-    if statuses[-1] == "pass":
-        if any(status != "regression" for status in statuses[:-1]):
-            raise ValueError(f"{path}: pass must end the attempt history")
-    elif len(statuses) != 3 or any(
-        status != "regression" for status in statuses
-    ):
+    if len(failures) > 3:
+        raise ValueError(f"{path}: at most three attempts are allowed")
+
+    candidates = failures[0]
+    for attempt, gates in enumerate(failures[1:], 2):
+        if not candidates:
+            raise ValueError(
+                f"{path}: attempt {attempt} follows a resolved history"
+            )
+        candidates = candidates.intersection(gates)
+    if candidates and len(failures) < 3:
         raise ValueError(
-            f"{path}: final regression requires three consecutive failures"
+            f"{path}: possible regression requires three attempts"
         )
-    return suite, statuses
+    return suite, AttemptHistory(suite, tuple(failures))
 
 
 def parse_input(spec):
@@ -236,7 +305,24 @@ def analyze(
     }
 
 
-def validate_retry_confirmation(results, analysis, attempt_histories):
+def failure_ids(analysis, include_overall=True):
+    failures = {
+        ("individual", suite, section, test)
+        for suite, section, test in analysis["individual_failures"]
+    }
+    failures.update(
+        ("section", suite, section)
+        for suite, section in analysis["section_failures"]
+    )
+    failures.update(
+        ("suite", suite) for suite in analysis["suite_failures"]
+    )
+    if include_overall and analysis["overall_failed"]:
+        failures.add(("overall",))
+    return failures
+
+
+def apply_retry_confirmation(results, analysis, attempt_histories):
     result_suites = {result.suite for result in results}
     history_suites = set(attempt_histories)
     if result_suites != history_suites:
@@ -252,29 +338,78 @@ def validate_retry_confirmation(results, analysis, attempt_histories):
             + "; ".join(details)
             + ")"
         )
+    for suite, history in attempt_histories.items():
+        if history.suite != suite:
+            raise ValueError(
+                f"history suite {history.suite} does not match "
+                f"requested suite {suite}"
+            )
 
-    failed_suites = {
-        suite for suite, _section, _test in analysis["individual_failures"]
+    confirmed = set()
+    for history in attempt_histories.values():
+        confirmed.update(history.confirmed_failures)
+
+    observed = failure_ids(analysis, include_overall=False)
+    inconsistent = sorted(confirmed - observed)
+    if inconsistent:
+        raise ValueError(
+            "confirmed gates do not match final benchmark results: "
+            + ", ".join(format_gate_id(gate) for gate in inconsistent)
+        )
+
+    individual_failures = {
+        key
+        for key in analysis["individual_failures"]
+        if ("individual", *key) in confirmed
     }
-    failed_suites.update(
-        suite for suite, _section in analysis["section_failures"]
+    section_failures = {
+        key
+        for key in analysis["section_failures"]
+        if ("section", *key) in confirmed
+    }
+    suite_failures = {
+        key
+        for key in analysis["suite_failures"]
+        if ("suite", key) in confirmed
+    }
+
+    confirmed_analysis = dict(analysis)
+    confirmed_analysis.update(
+        {
+            "failed": bool(
+                individual_failures
+                or section_failures
+                or suite_failures
+            ),
+            "individual_failures": individual_failures,
+            "section_failures": section_failures,
+            "suite_failures": suite_failures,
+            # Overall fan-in is measured once. In practice its 15% gate is
+            # dominated by the per-suite aggregate gates, which are retried.
+            "overall_failed": False,
+            "observed_individual_failures": analysis[
+                "individual_failures"
+            ],
+            "observed_section_failures": analysis["section_failures"],
+            "observed_suite_failures": analysis["suite_failures"],
+            "observed_overall_failed": analysis["overall_failed"],
+            "confirmed_failure_ids": frozenset(confirmed),
+        }
     )
-    failed_suites.update(analysis["suite_failures"])
-    confirmed_suites = {
-        suite
-        for suite, statuses in attempt_histories.items()
-        if statuses[-1] == "regression"
-    }
-    unconfirmed = sorted(failed_suites - confirmed_suites)
-    if unconfirmed:
-        raise ValueError(
-            "benchmark regression lacks three-failure confirmation: "
-            + ", ".join(unconfirmed)
-        )
-    if analysis["overall_failed"] and not confirmed_suites:
-        raise ValueError(
-            "overall benchmark regression lacks three-failure confirmation"
-        )
+    return confirmed_analysis
+
+
+def format_gate_id(gate):
+    kind = gate[0]
+    if kind == "individual":
+        return f"individual `{gate[1]} / {gate[2]} / {gate[3]}`"
+    if kind == "section":
+        return f"section `{gate[1]} / {gate[2]}`"
+    if kind == "suite":
+        return f"suite `{gate[1]}`"
+    if kind == "overall":
+        return "overall aggregate"
+    raise ValueError(f"unknown gate kind: {kind}")
 
 
 def render(
@@ -292,14 +427,19 @@ def render(
     for result in results:
         suites[result.suite].append(result)
 
-    status = "PASS" if not analysis["failed"] else "FAIL"
+    gate_status = "PASS" if not analysis["failed"] else "FAIL"
+    failed_gates = analysis.get(
+        "confirmed_failure_ids",
+        frozenset(failure_ids(analysis)),
+    )
     lines = [
         "<!-- benchmark:relative -->",
         "## DoltLite performance vs PR base",
         "",
         f"- **Baseline:** `{baseline_ref}`",
         f"- **Candidate:** `{candidate_ref}`",
-        f"- **Overall:** {format_ratio(analysis['overall_ratio'])} — **{status}**",
+        f"- **Overall ratio:** {format_ratio(analysis['overall_ratio'])}",
+        f"- **Gate result:** **{gate_status}**",
         (
             f"- **Gates:** individual > {individual_ratio:.2f}x with more "
             f"than {format_time(min_delta_us)} regression; section, suite, "
@@ -311,20 +451,31 @@ def render(
             f"- **{suite} individual gate:** > {ratio:.2f}x with more than "
             f"{format_time(delta)} regression"
         )
+    if failed_gates:
+        lines.extend(["- **Confirmed failed gates:**"])
+        lines.extend(
+            f"    - {format_gate_id(gate)}"
+            for gate in sorted(failed_gates)
+        )
+    else:
+        lines.append("- **Confirmed failed gates:** none")
+
     retried = []
-    for suite, statuses in sorted((attempt_histories or {}).items()):
-        if len(statuses) == 1:
+    for suite, history in sorted((attempt_histories or {}).items()):
+        attempt_count = len(history.failures)
+        if attempt_count == 1:
             continue
-        if statuses[-1] == "pass":
+        confirmed_count = len(history.confirmed_failures)
+        if confirmed_count:
             retried.append(
-                f"{suite} passed attempt {len(statuses)} after "
-                f"{len(statuses) - 1} transient gate "
-                f"{'failure' if len(statuses) == 2 else 'failures'}"
+                f"{suite} confirmed {confirmed_count} exact "
+                f"{'gate' if confirmed_count == 1 else 'gates'} "
+                f"in {attempt_count} attempts"
             )
         else:
             retried.append(
-                f"{suite} exceeded its gate in {len(statuses)} "
-                "consecutive attempts"
+                f"{suite} cleared after {attempt_count} attempts; "
+                "no gate failed every time"
             )
     lines.append(
         "- **Automatic retries:** "
@@ -340,7 +491,15 @@ def render(
     for suite in sorted(suites):
         group = suites[suite]
         ratio = analysis["suite_ratios"][suite]
-        suite_status = "FAIL" if suite in analysis["suite_failures"] else "PASS"
+        if suite in analysis["suite_failures"]:
+            suite_status = "FAIL"
+        elif suite in analysis.get(
+            "observed_suite_failures",
+            analysis["suite_failures"],
+        ):
+            suite_status = "TRANSIENT"
+        else:
+            suite_status = "PASS"
         baseline_total = (
             sum(result.baseline_us for result in group)
             if all(result.valid for result in group)
@@ -371,11 +530,15 @@ def render(
         )
         for result in suites[suite]:
             key = (result.suite, result.section, result.test)
-            row_status = (
-                "FAIL"
-                if key in analysis["individual_failures"]
-                else "PASS"
-            )
+            if key in analysis["individual_failures"]:
+                row_status = "FAIL"
+            elif key in analysis.get(
+                "observed_individual_failures",
+                analysis["individual_failures"],
+            ):
+                row_status = "TRANSIENT"
+            else:
+                row_status = "PASS"
             delta = format_delta(result.delta_us)
             lines.append(
                 f"| {result.section} | `{result.test}` | "
@@ -389,7 +552,8 @@ def render(
         lines.extend(
             [
                 "",
-                "**FAILED:** Candidate performance exceeded a regression gate.",
+                "**FAILED:** Candidate performance exceeded the confirmed "
+                "regression gates listed above.",
             ]
         )
     else:
@@ -502,7 +666,7 @@ def main(argv=None):
     )
     if attempt_histories:
         try:
-            validate_retry_confirmation(
+            analysis = apply_retry_confirmation(
                 results,
                 analysis,
                 attempt_histories,

--- a/test/benchmark_compare_test.py
+++ b/test/benchmark_compare_test.py
@@ -3,6 +3,7 @@
 import contextlib
 import importlib.util
 import io
+import json
 import pathlib
 import tempfile
 import unittest
@@ -22,6 +23,25 @@ def result(name, baseline, candidate, section="reads"):
         baseline_us=baseline,
         candidate_us=candidate,
     )
+
+
+def attempt_history(suite, attempts):
+    return benchmark_compare.AttemptHistory(
+        suite,
+        tuple(frozenset(gates) for gates in attempts),
+    )
+
+
+def history_text(suite, attempts):
+    lines = [f"suite\t{suite}", "attempt\tstatus\tfailed_gates"]
+    for number, gates in enumerate(attempts, 1):
+        status = "regression" if gates else "pass"
+        encoded = json.dumps(
+            [list(gate) for gate in sorted(gates)],
+            separators=(",", ":"),
+        )
+        lines.append(f"{number}\t{status}\t{encoded}")
+    return "\n".join(lines) + "\n"
 
 
 class BenchmarkCompareTest(unittest.TestCase):
@@ -113,33 +133,119 @@ class BenchmarkCompareTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as directory:
             path = pathlib.Path(directory) / "attempts.tsv"
             path.write_text(
-                "attempt\tstatus\n"
-                "1\tregression\n"
-                "2\tregression\n"
-                "3\tregression\n",
+                history_text(
+                    "int",
+                    [
+                        {("individual", "int", "reads", "point")},
+                        {("individual", "int", "reads", "point")},
+                        {("individual", "int", "reads", "point")},
+                    ],
+                ),
                 encoding="utf-8",
             )
-            suite, statuses = benchmark_compare.parse_attempt_history(
+            suite, history = benchmark_compare.parse_attempt_history(
                 f"int={path}"
             )
         self.assertEqual(suite, "int")
         self.assertEqual(
-            statuses,
-            ["regression", "regression", "regression"],
+            history.confirmed_failures,
+            {("individual", "int", "reads", "point")},
         )
 
-    def test_rejects_unconfirmed_final_regression(self):
+    def test_rotating_failures_have_no_confirmation(self):
         with tempfile.TemporaryDirectory() as directory:
             path = pathlib.Path(directory) / "attempts.tsv"
             path.write_text(
-                "attempt\tstatus\n1\tregression\n2\tregression\n",
+                history_text(
+                    "int",
+                    [
+                        {("individual", "int", "reads", "one")},
+                        {("individual", "int", "reads", "two")},
+                    ],
+                ),
+                encoding="utf-8",
+            )
+            _suite, history = benchmark_compare.parse_attempt_history(
+                f"int={path}"
+            )
+        self.assertEqual(history.confirmed_failures, frozenset())
+
+    def test_confirmation_is_three_way_gate_intersection(self):
+        gate_a = ("individual", "int", "reads", "one")
+        gate_b = ("individual", "int", "reads", "two")
+        gate_c = ("individual", "int", "reads", "three")
+        history = attempt_history(
+            "int",
+            [
+                {gate_a, gate_b},
+                {gate_b, gate_c},
+                {gate_a, gate_b, gate_c},
+            ],
+        )
+        self.assertEqual(history.confirmed_failures, {gate_b})
+
+    def test_rejects_two_attempt_history_with_live_candidate(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = pathlib.Path(directory) / "attempts.tsv"
+            gate = ("individual", "int", "reads", "point")
+            path.write_text(
+                history_text("int", [{gate}, {gate}]),
                 encoding="utf-8",
             )
             with self.assertRaisesRegex(
                 ValueError,
-                "requires three consecutive failures",
+                "possible regression requires three attempts",
             ):
                 benchmark_compare.parse_attempt_history(f"int={path}")
+
+    def test_rejects_history_with_mismatched_embedded_suite(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = pathlib.Path(directory) / "int-attempts.tsv"
+            path.write_text(
+                history_text("int", [set()]),
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(
+                ValueError,
+                "history suite int does not match requested suite vc",
+            ):
+                benchmark_compare.parse_attempt_history(f"vc={path}")
+
+    def test_main_rejects_ito_mismatched_history_reproduction(self):
+        with tempfile.TemporaryDirectory() as directory:
+            directory = pathlib.Path(directory)
+            timings = directory / "vc.tsv"
+            attempts = directory / "int-attempts.tsv"
+            report = directory / "report.md"
+            timings.write_text(
+                "vc\tstatus\t100000\t101000\n",
+                encoding="utf-8",
+            )
+            attempts.write_text(
+                history_text("int", [set()]),
+                encoding="utf-8",
+            )
+            with contextlib.redirect_stderr(io.StringIO()):
+                with self.assertRaises(SystemExit) as raised:
+                    benchmark_compare.main(
+                        [
+                            "--input",
+                            f"vc={timings}",
+                            "--attempt-history",
+                            f"vc={attempts}",
+                            "--baseline-ref",
+                            "base",
+                            "--candidate-ref",
+                            "candidate",
+                            "--expected-baseline-ref",
+                            "base",
+                            "--expected-candidate-ref",
+                            "candidate",
+                            "--output",
+                            str(report),
+                        ]
+                    )
+        self.assertEqual(raised.exception.code, 2)
 
     def test_report_describes_transient_retry(self):
         results = [result("point", 100_000, 101_000)]
@@ -152,10 +258,18 @@ class BenchmarkCompareTest(unittest.TestCase):
             1.25,
             1.15,
             5000,
-            attempt_histories={"int": ["regression", "pass"]},
+            attempt_histories={
+                "int": attempt_history(
+                    "int",
+                    [
+                        {("individual", "int", "reads", "point")},
+                        set(),
+                    ],
+                )
+            },
         )
         self.assertIn(
-            "int passed attempt 2 after 1 transient gate failure",
+            "int cleared after 2 attempts; no gate failed every time",
             report,
         )
 
@@ -170,7 +284,13 @@ class BenchmarkCompareTest(unittest.TestCase):
                 encoding="utf-8",
             )
             attempts.write_text(
-                "attempt\tstatus\n1\tregression\n2\tpass\n",
+                history_text(
+                    "int",
+                    [
+                        {("individual", "int", "reads", "point")},
+                        set(),
+                    ],
+                ),
                 encoding="utf-8",
             )
             with contextlib.redirect_stdout(io.StringIO()):
@@ -194,28 +314,95 @@ class BenchmarkCompareTest(unittest.TestCase):
                 )
             output = report.read_text(encoding="utf-8")
         self.assertEqual(rc, 0)
-        self.assertIn("int passed attempt 2", output)
+        self.assertIn("int cleared after 2 attempts", output)
 
-    def test_rejects_regression_without_three_failed_attempts(self):
+    def test_filters_regression_without_exact_confirmation(self):
         results = [result("point", 100_000, 140_000)]
+        analysis = self.analyze(results)
+        confirmed = benchmark_compare.apply_retry_confirmation(
+            results,
+            analysis,
+            {"int": attempt_history("int", [set()])},
+        )
+        self.assertFalse(confirmed["failed"])
+        self.assertEqual(confirmed["individual_failures"], set())
+
+    def test_accepts_same_gate_after_three_failed_attempts(self):
+        results = [result("point", 100_000, 140_000)]
+        analysis = self.analyze(results)
+        gate = ("individual", "int", "reads", "point")
+        confirmed = benchmark_compare.apply_retry_confirmation(
+            results,
+            analysis,
+            {"int": attempt_history("int", [{gate}, {gate}, {gate}])},
+        )
+        self.assertTrue(confirmed["failed"])
+        self.assertEqual(confirmed["confirmed_failure_ids"], {gate})
+
+    def test_rejects_confirmed_gate_absent_from_final_results(self):
+        results = [result("point", 100_000, 101_000)]
+        analysis = self.analyze(results)
+        gate = ("individual", "int", "reads", "point")
+        with self.assertRaisesRegex(
+            ValueError,
+            "confirmed gates do not match final benchmark results",
+        ):
+            benchmark_compare.apply_retry_confirmation(
+                results,
+                analysis,
+                {"int": attempt_history("int", [{gate}, {gate}, {gate}])},
+            )
+
+    def test_rejects_direct_history_with_mismatched_suite(self):
+        results = [result("point", 100_000, 101_000)]
         analysis = self.analyze(results)
         with self.assertRaisesRegex(
             ValueError,
-            "lacks three-failure confirmation",
+            "history suite vc does not match requested suite int",
         ):
-            benchmark_compare.validate_retry_confirmation(
+            benchmark_compare.apply_retry_confirmation(
                 results,
                 analysis,
-                {"int": ["pass"]},
+                {"int": attempt_history("vc", [set()])},
             )
 
-    def test_accepts_regression_after_three_failed_attempts(self):
-        results = [result("point", 100_000, 140_000)]
-        analysis = self.analyze(results)
-        benchmark_compare.validate_retry_confirmation(
+    def test_report_lists_confirmed_failed_gate_separately_from_overall(self):
+        results = [
+            result("point", 100_000, 140_000),
+            result("other", 100_000, 140_000),
+            result("steady", 1_000_000, 1_000_000),
+        ]
+        raw = self.analyze(results)
+        gates = {
+            ("individual", "int", "reads", "point"),
+            ("individual", "int", "reads", "other"),
+        }
+        analysis = benchmark_compare.apply_retry_confirmation(
+            results,
+            raw,
+            {"int": attempt_history("int", [gates, gates, gates])},
+        )
+        report = benchmark_compare.render(
             results,
             analysis,
-            {"int": ["regression", "regression", "regression"]},
+            "base",
+            "candidate",
+            1.25,
+            1.15,
+            5000,
+            attempt_histories={
+                "int": attempt_history("int", [gates, gates, gates])
+            },
+        )
+        self.assertIn("**Overall ratio:** 1.067x", report)
+        self.assertIn("**Gate result:** **FAIL**", report)
+        self.assertIn(
+            "individual `int / reads / point`",
+            report,
+        )
+        self.assertIn(
+            "individual `int / reads / other`",
+            report,
         )
 
     def test_rejects_swapped_revision_provenance(self):

--- a/test/benchmark_retry.py
+++ b/test/benchmark_retry.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import argparse
+import json
 import os
 import pathlib
 import shutil
@@ -10,12 +11,14 @@ import sys
 import benchmark_compare
 
 
-def write_history(path, statuses):
-    lines = ["attempt\tstatus"]
-    lines.extend(
-        f"{attempt}\t{status}"
-        for attempt, status in enumerate(statuses, 1)
-    )
+def write_history(path, suite, records):
+    lines = [f"suite\t{suite}", "attempt\tstatus\tfailed_gates"]
+    for attempt, (status, failures) in enumerate(records, 1):
+        encoded = json.dumps(
+            [list(gate) for gate in sorted(failures)],
+            separators=(",", ":"),
+        )
+        lines.append(f"{attempt}\t{status}\t{encoded}")
     path.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
 
@@ -40,7 +43,8 @@ def run_with_retries(
     attempts_dir = results_dir / "attempts"
     history_path = results_dir / f"{suite}-attempts.tsv"
     results_dir.mkdir(parents=True, exist_ok=True)
-    statuses = []
+    records = []
+    candidates = None
 
     for attempt in range(1, max_attempts + 1):
         attempt_dir = attempts_dir / f"attempt-{attempt}"
@@ -68,8 +72,8 @@ def run_with_retries(
             )
 
         if completed.returncode:
-            statuses.append("command_error")
-            write_history(history_path, statuses)
+            records.append(("command_error", frozenset()))
+            write_history(history_path, suite, records)
             print(
                 f"{suite} attempt {attempt}/{max_attempts}: "
                 f"command failed with exit code {completed.returncode}",
@@ -84,8 +88,8 @@ def run_with_retries(
             if not path.is_file() or path.stat().st_size == 0
         ]
         if missing:
-            statuses.append("invalid_result")
-            write_history(history_path, statuses)
+            records.append(("invalid_result", frozenset()))
+            write_history(history_path, suite, records)
             print(
                 f"{suite} attempt {attempt}/{max_attempts}: "
                 f"missing result files: {', '.join(missing)}",
@@ -98,8 +102,8 @@ def run_with_retries(
                 f"{suite}={result_path}"
             )
         except (OSError, ValueError) as exc:
-            statuses.append("invalid_result")
-            write_history(history_path, statuses)
+            records.append(("invalid_result", frozenset()))
+            write_history(history_path, suite, records)
             print(
                 f"{suite} attempt {attempt}/{max_attempts}: {exc}",
                 file=sys.stderr,
@@ -125,20 +129,38 @@ def run_with_retries(
         )
         gate_path.write_text(report, encoding="utf-8")
 
-        status = "regression" if analysis["failed"] else "pass"
-        statuses.append(status)
-        write_history(history_path, statuses)
-        if status == "pass":
-            promote_attempt(attempt_dir, results_dir, suite)
-            print(
-                f"{suite} attempt {attempt}/{max_attempts}: passed"
+        failures = frozenset(
+            benchmark_compare.failure_ids(
+                analysis,
+                include_overall=False,
             )
+        )
+        status = "regression" if failures else "pass"
+        records.append((status, failures))
+        write_history(history_path, suite, records)
+
+        if candidates is None:
+            candidates = failures
+        else:
+            candidates = candidates.intersection(failures)
+
+        if not candidates:
+            promote_attempt(attempt_dir, results_dir, suite)
+            if attempt == 1 and not failures:
+                print(f"{suite} attempt {attempt}/{max_attempts}: passed")
+            else:
+                print(
+                    f"{suite} attempt {attempt}/{max_attempts}: "
+                    "no exact gate remains unbroken"
+                )
             return 0
 
         if attempt < max_attempts:
             print(
                 f"{suite} attempt {attempt}/{max_attempts}: "
-                "performance gate exceeded; retrying"
+                f"{len(candidates)} exact performance "
+                f"{'gate remains' if len(candidates) == 1 else 'gates remain'}; "
+                "retrying"
             )
             continue
 
@@ -147,7 +169,9 @@ def run_with_retries(
         promote_attempt(attempt_dir, results_dir, suite)
         print(
             f"{suite} attempt {attempt}/{max_attempts}: "
-            "performance gate exceeded in all attempts"
+            f"{len(candidates)} exact performance "
+            f"{'gate exceeded' if len(candidates) == 1 else 'gates exceeded'} "
+            "in all attempts"
         )
         return 0
 

--- a/test/benchmark_retry_test.py
+++ b/test/benchmark_retry_test.py
@@ -25,14 +25,24 @@ class FakeRunner:
         if isinstance(outcome, int):
             return types.SimpleNamespace(returncode=outcome)
 
-        baseline, candidate = outcome
+        if isinstance(outcome, tuple):
+            baseline, candidate = outcome
+            rows = [("reads", "point", baseline, candidate)]
+        else:
+            rows = outcome
         pathlib.Path(env["BENCH_RESULTS_OUTPUT"]).write_text(
-            f"reads\tpoint\t{baseline}\t{candidate}\n",
+            "".join(
+                f"{section}\t{test}\t{baseline}\t{candidate}\n"
+                for section, test, baseline, candidate in rows
+            ),
             encoding="utf-8",
         )
         pathlib.Path(env["BENCH_SAMPLES_OUTPUT"]).write_text(
             "section\ttest\trun\tbaseline_us\tcandidate_us\n"
-            f"reads\tpoint\t1\t{baseline}\t{candidate}\n",
+            + "".join(
+                f"{section}\t{test}\t1\t{baseline}\t{candidate}\n"
+                for section, test, baseline, candidate in rows
+            ),
             encoding="utf-8",
         )
         stdout.write("benchmark output\n")
@@ -61,7 +71,12 @@ class BenchmarkRetryTest(unittest.TestCase):
             history = pathlib.Path(directory, "int-attempts.tsv").read_text()
         self.assertEqual(rc, 0)
         self.assertEqual(runner.calls, 1)
-        self.assertEqual(history, "attempt\tstatus\n1\tpass\n")
+        self.assertEqual(
+            history,
+            "suite\tint\n"
+            "attempt\tstatus\tfailed_gates\n"
+            "1\tpass\t[]\n",
+        )
 
     def test_regression_then_pass_promotes_second_attempt(self):
         with tempfile.TemporaryDirectory() as directory:
@@ -74,7 +89,8 @@ class BenchmarkRetryTest(unittest.TestCase):
             result = (directory / "int.tsv").read_text()
         self.assertEqual(rc, 0)
         self.assertEqual(runner.calls, 2)
-        self.assertIn("1\tregression\n2\tpass\n", history)
+        self.assertIn("1\tregression\t", history)
+        self.assertIn("2\tpass\t[]\n", history)
         self.assertEqual(result, "reads\tpoint\t100000\t101000\n")
 
     def test_three_regressions_promote_final_attempt(self):
@@ -90,13 +106,46 @@ class BenchmarkRetryTest(unittest.TestCase):
             )
             history = (directory / "int-attempts.tsv").read_text()
             result = (directory / "int.tsv").read_text()
+            _suite, parsed = (
+                benchmark_retry.benchmark_compare.parse_attempt_history(
+                    f"int={directory / 'int-attempts.tsv'}"
+                )
+            )
         self.assertEqual(rc, 0)
         self.assertEqual(runner.calls, 3)
         self.assertIn(
-            "1\tregression\n2\tregression\n3\tregression\n",
-            history,
+            ("individual", "int", "reads", "point"),
+            parsed.confirmed_failures,
         )
         self.assertEqual(result, "reads\tpoint\t100000\t150000\n")
+
+    def test_rotating_individual_failures_stop_without_confirmation(self):
+        steady = ("reads", "steady", 1_000_000, 1_000_000)
+        with tempfile.TemporaryDirectory() as directory:
+            directory = pathlib.Path(directory)
+            rc, runner = self.run_retry(
+                directory,
+                [
+                    [
+                        ("reads", "one", 100_000, 140_000),
+                        ("reads", "two", 100_000, 100_000),
+                        steady,
+                    ],
+                    [
+                        ("reads", "one", 100_000, 100_000),
+                        ("reads", "two", 100_000, 140_000),
+                        steady,
+                    ],
+                ],
+            )
+            _suite, history = (
+                benchmark_retry.benchmark_compare.parse_attempt_history(
+                    f"int={directory / 'int-attempts.tsv'}"
+                )
+            )
+        self.assertEqual(rc, 0)
+        self.assertEqual(runner.calls, 2)
+        self.assertEqual(history.confirmed_failures, frozenset())
 
     def test_command_error_is_not_retried(self):
         with tempfile.TemporaryDirectory() as directory:
@@ -105,7 +154,12 @@ class BenchmarkRetryTest(unittest.TestCase):
             history = (directory / "int-attempts.tsv").read_text()
         self.assertEqual(rc, 7)
         self.assertEqual(runner.calls, 1)
-        self.assertEqual(history, "attempt\tstatus\n1\tcommand_error\n")
+        self.assertEqual(
+            history,
+            "suite\tint\n"
+            "attempt\tstatus\tfailed_gates\n"
+            "1\tcommand_error\t[]\n",
+        )
         self.assertFalse((directory / "int.tsv").exists())
 
     def test_missing_output_is_not_retried(self):


### PR DESCRIPTION
## Summary

- require the same individual, section, or suite gate to fail on all three attempts before CI reports a regression
- stop retrying as soon as the exact failed-gate intersection becomes empty, so unrelated noisy metrics cannot confirm one another
- embed suite identity and exact gate IDs in retry histories and reject mismatched or inconsistent artifacts
- separate the overall ratio from the gate result and enumerate every confirmed failed gate in the report
- mark one-off failures in the selected final measurement as transient diagnostics

This also fixes Ito GATE-3 from #1806: an `int` history relabeled by the caller as `vc` now fails closed.

At a 5% independent false-failure rate for one metric, exact three-attempt confirmation reduces that metric’s false confirmation probability to `0.05^3 = 0.0125%` (about 1 in 8,000).

## Validation

- `python3 test/benchmark_compare_test.py` (22 tests)
- `python3 test/benchmark_retry_test.py` (6 tests)
- Python bytecode compilation
- benchmark shell syntax checks
- `bash test/lint_layers.sh`
- actionlint across all workflows
- `git diff --check`