### PR TITLE
Harden benchmark retry artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -935,7 +935,9 @@ exceeds a gate is measured again automatically and only fails CI after three
 consecutive failures of the same individual, section, or suite gate. Different
 metrics failing on later attempts do not confirm the original regression.
 Command, result-format, and revision-provenance errors fail immediately instead
-of being retried.
+of being retried. Retry logs identify the current attempt, elapsed time, and
+exact gates still eligible for confirmation. The selected result and its retry
+history carry a shared producer identity so stale artifacts cannot be paired.
 
 A scheduled workflow starts nightly at 09:30 UTC, after the nightly fuzzing
 window. Four parallel workers run 55 paired samples per SQL workload against

--- a/test/benchmark_compare.py
+++ b/test/benchmark_compare.py
@@ -36,6 +36,7 @@ class Result:
 @dataclasses.dataclass(frozen=True)
 class AttemptHistory:
     suite: str
+    producer_id: str
     failures: tuple
 
     @property
@@ -80,10 +81,16 @@ def parse_attempt_history(spec):
                 f"{path}: history suite {recorded_suite or '<missing>'} "
                 f"does not match requested suite {suite}"
             )
+        producer_header = source.readline().rstrip("\n")
+        if not producer_header.startswith("producer_id\t"):
+            raise ValueError(f"{path}: missing producer identity")
+        producer_id = producer_header.split("\t", 1)[1]
+        if not producer_id:
+            raise ValueError(f"{path}: missing producer identity")
         columns_header = source.readline().rstrip("\n")
         if columns_header != "attempt\tstatus\tfailed_gates":
             raise ValueError(f"{path}: invalid attempt history header")
-        for line_number, line in enumerate(source, 3):
+        for line_number, line in enumerate(source, 4):
             columns = line.rstrip("\n").split("\t")
             if len(columns) != 3:
                 raise ValueError(
@@ -140,10 +147,10 @@ def parse_attempt_history(spec):
         raise ValueError(
             f"{path}: possible regression requires three attempts"
         )
-    return suite, AttemptHistory(suite, tuple(failures))
+    return suite, AttemptHistory(suite, producer_id, tuple(failures))
 
 
-def parse_input(spec):
+def parse_input_artifact(spec):
     if "=" not in spec:
         raise ValueError(f"input must be SUITE=PATH: {spec}")
     suite, path_text = spec.split("=", 1)
@@ -152,8 +159,29 @@ def parse_input(spec):
     path = pathlib.Path(path_text)
     results = []
     seen = set()
+    metadata = {}
     with path.open(encoding="utf-8") as source:
         for line_number, line in enumerate(source, 1):
+            if line.startswith("# "):
+                if results:
+                    raise ValueError(
+                        f"{path}:{line_number}: metadata follows results"
+                    )
+                columns = line[2:].rstrip("\n").split("\t", 1)
+                if len(columns) != 2 or columns[0] not in (
+                    "suite",
+                    "producer_id",
+                ):
+                    raise ValueError(
+                        f"{path}:{line_number}: invalid result metadata"
+                    )
+                key, value = columns
+                if key in metadata or not value:
+                    raise ValueError(
+                        f"{path}:{line_number}: invalid result metadata"
+                    )
+                metadata[key] = value
+                continue
             columns = line.rstrip("\n").split("\t")
             if len(columns) != 4:
                 raise ValueError(
@@ -184,6 +212,16 @@ def parse_input(spec):
             )
     if not results:
         raise ValueError(f"{path}: no benchmark results")
+    if "suite" in metadata and metadata["suite"] != suite:
+        raise ValueError(
+            f"{path}: result suite {metadata['suite']} "
+            f"does not match requested suite {suite}"
+        )
+    return results, metadata
+
+
+def parse_input(spec):
+    results, _metadata = parse_input_artifact(spec)
     return results
 
 
@@ -322,7 +360,12 @@ def failure_ids(analysis, include_overall=True):
     return failures
 
 
-def apply_retry_confirmation(results, analysis, attempt_histories):
+def apply_retry_confirmation(
+    results,
+    analysis,
+    attempt_histories,
+    result_metadata,
+):
     result_suites = {result.suite for result in results}
     history_suites = set(attempt_histories)
     if result_suites != history_suites:
@@ -343,6 +386,21 @@ def apply_retry_confirmation(results, analysis, attempt_histories):
             raise ValueError(
                 f"history suite {history.suite} does not match "
                 f"requested suite {suite}"
+            )
+        metadata = result_metadata.get(suite, {})
+        if metadata.get("suite") != suite:
+            raise ValueError(
+                f"result for {suite} is missing matching suite identity"
+            )
+        producer_id = metadata.get("producer_id")
+        if not producer_id:
+            raise ValueError(
+                f"result for {suite} is missing producer identity"
+            )
+        if producer_id != history.producer_id:
+            raise ValueError(
+                f"result/history producer mismatch for {suite}: "
+                f"{producer_id} != {history.producer_id}"
             )
 
     confirmed = set()
@@ -635,8 +693,14 @@ def main(argv=None):
 
     try:
         results = []
+        result_metadata = {}
         for spec in args.input:
-            results.extend(parse_input(spec))
+            parsed, metadata = parse_input_artifact(spec)
+            suite = parsed[0].suite
+            if suite in result_metadata:
+                raise ValueError(f"duplicate benchmark input for {suite}")
+            results.extend(parsed)
+            result_metadata[suite] = metadata
         attempt_histories = {}
         for spec in args.attempt_history:
             suite, statuses = parse_attempt_history(spec)
@@ -670,6 +734,7 @@ def main(argv=None):
                 results,
                 analysis,
                 attempt_histories,
+                result_metadata,
             )
         except ValueError as exc:
             parser.error(str(exc))

--- a/test/benchmark_compare_test.py
+++ b/test/benchmark_compare_test.py
@@ -14,6 +14,8 @@ SPEC = importlib.util.spec_from_file_location("benchmark_compare", MODULE_PATH)
 benchmark_compare = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(benchmark_compare)
 
+PRODUCER_ID = "producer-current"
+
 
 def result(name, baseline, candidate, section="reads"):
     return benchmark_compare.Result(
@@ -25,15 +27,20 @@ def result(name, baseline, candidate, section="reads"):
     )
 
 
-def attempt_history(suite, attempts):
+def attempt_history(suite, attempts, producer_id=PRODUCER_ID):
     return benchmark_compare.AttemptHistory(
         suite,
+        producer_id,
         tuple(frozenset(gates) for gates in attempts),
     )
 
 
-def history_text(suite, attempts):
-    lines = [f"suite\t{suite}", "attempt\tstatus\tfailed_gates"]
+def history_text(suite, attempts, producer_id=PRODUCER_ID):
+    lines = [
+        f"suite\t{suite}",
+        f"producer_id\t{producer_id}",
+        "attempt\tstatus\tfailed_gates",
+    ]
     for number, gates in enumerate(attempts, 1):
         status = "regression" if gates else "pass"
         encoded = json.dumps(
@@ -42,6 +49,23 @@ def history_text(suite, attempts):
         )
         lines.append(f"{number}\t{status}\t{encoded}")
     return "\n".join(lines) + "\n"
+
+
+def result_text(suite, body, producer_id=PRODUCER_ID):
+    return (
+        f"# suite\t{suite}\n"
+        f"# producer_id\t{producer_id}\n"
+        f"{body}"
+    )
+
+
+def result_metadata(suite="int", producer_id=PRODUCER_ID):
+    return {
+        suite: {
+            "suite": suite,
+            "producer_id": producer_id,
+        }
+    }
 
 
 class BenchmarkCompareTest(unittest.TestCase):
@@ -280,7 +304,10 @@ class BenchmarkCompareTest(unittest.TestCase):
             attempts = directory / "attempts.tsv"
             report = directory / "report.md"
             timings.write_text(
-                "reads\tpoint\t100000\t101000\n",
+                result_text(
+                    "int",
+                    "reads\tpoint\t100000\t101000\n",
+                ),
                 encoding="utf-8",
             )
             attempts.write_text(
@@ -316,6 +343,51 @@ class BenchmarkCompareTest(unittest.TestCase):
         self.assertEqual(rc, 0)
         self.assertIn("int cleared after 2 attempts", output)
 
+    def test_main_rejects_ito_stale_history_reproduction(self):
+        gate = ("individual", "int", "reads", "point")
+        with tempfile.TemporaryDirectory() as directory:
+            directory = pathlib.Path(directory)
+            timings = directory / "current-result.tsv"
+            attempts = directory / "stale-attempts.tsv"
+            report = directory / "report.md"
+            timings.write_text(
+                result_text(
+                    "int",
+                    "reads\tpoint\t100000\t140000\n",
+                    producer_id="current-run",
+                ),
+                encoding="utf-8",
+            )
+            attempts.write_text(
+                history_text(
+                    "int",
+                    [{gate}, {gate}, {gate}],
+                    producer_id="stale-run",
+                ),
+                encoding="utf-8",
+            )
+            with contextlib.redirect_stderr(io.StringIO()):
+                with self.assertRaises(SystemExit) as raised:
+                    benchmark_compare.main(
+                        [
+                            "--input",
+                            f"int={timings}",
+                            "--attempt-history",
+                            f"int={attempts}",
+                            "--baseline-ref",
+                            "base",
+                            "--candidate-ref",
+                            "candidate",
+                            "--expected-baseline-ref",
+                            "base",
+                            "--expected-candidate-ref",
+                            "candidate",
+                            "--output",
+                            str(report),
+                        ]
+                    )
+        self.assertEqual(raised.exception.code, 2)
+
     def test_filters_regression_without_exact_confirmation(self):
         results = [result("point", 100_000, 140_000)]
         analysis = self.analyze(results)
@@ -323,6 +395,7 @@ class BenchmarkCompareTest(unittest.TestCase):
             results,
             analysis,
             {"int": attempt_history("int", [set()])},
+            result_metadata(),
         )
         self.assertFalse(confirmed["failed"])
         self.assertEqual(confirmed["individual_failures"], set())
@@ -335,6 +408,7 @@ class BenchmarkCompareTest(unittest.TestCase):
             results,
             analysis,
             {"int": attempt_history("int", [{gate}, {gate}, {gate}])},
+            result_metadata(),
         )
         self.assertTrue(confirmed["failed"])
         self.assertEqual(confirmed["confirmed_failure_ids"], {gate})
@@ -351,6 +425,7 @@ class BenchmarkCompareTest(unittest.TestCase):
                 results,
                 analysis,
                 {"int": attempt_history("int", [{gate}, {gate}, {gate}])},
+                result_metadata(),
             )
 
     def test_rejects_direct_history_with_mismatched_suite(self):
@@ -364,6 +439,27 @@ class BenchmarkCompareTest(unittest.TestCase):
                 results,
                 analysis,
                 {"int": attempt_history("vc", [set()])},
+                result_metadata(),
+            )
+
+    def test_rejects_stale_history_producer(self):
+        results = [result("point", 100_000, 101_000)]
+        analysis = self.analyze(results)
+        with self.assertRaisesRegex(
+            ValueError,
+            "result/history producer mismatch for int",
+        ):
+            benchmark_compare.apply_retry_confirmation(
+                results,
+                analysis,
+                {
+                    "int": attempt_history(
+                        "int",
+                        [set()],
+                        producer_id="stale-run",
+                    )
+                },
+                result_metadata(producer_id="current-run"),
             )
 
     def test_report_lists_confirmed_failed_gate_separately_from_overall(self):
@@ -381,6 +477,7 @@ class BenchmarkCompareTest(unittest.TestCase):
             results,
             raw,
             {"int": attempt_history("int", [gates, gates, gates])},
+            result_metadata(),
         )
         report = benchmark_compare.render(
             results,

--- a/test/benchmark_retry.py
+++ b/test/benchmark_retry.py
@@ -7,12 +7,18 @@ import pathlib
 import shutil
 import subprocess
 import sys
+import time
+import uuid
 
 import benchmark_compare
 
 
-def write_history(path, suite, records):
-    lines = [f"suite\t{suite}", "attempt\tstatus\tfailed_gates"]
+def write_history(path, suite, producer_id, records):
+    lines = [
+        f"suite\t{suite}",
+        f"producer_id\t{producer_id}",
+        "attempt\tstatus\tfailed_gates",
+    ]
     for attempt, (status, failures) in enumerate(records, 1):
         encoded = json.dumps(
             [list(gate) for gate in sorted(failures)],
@@ -22,10 +28,56 @@ def write_history(path, suite, records):
     path.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
 
-def promote_attempt(attempt_dir, results_dir, suite):
-    for suffix in (".tsv", "-samples.tsv", ".md"):
-        source = attempt_dir / f"{suite}{suffix}"
-        shutil.copy2(source, results_dir / source.name)
+def promote_attempt(
+    attempt_dir,
+    results_dir,
+    suite,
+    producer_id,
+    copy_function=shutil.copy2,
+    replace_function=os.replace,
+):
+    sources = [
+        attempt_dir / f"{suite}{suffix}"
+        for suffix in (".tsv", "-samples.tsv", ".md")
+    ]
+    missing = [
+        str(path)
+        for path in sources
+        if not path.is_file() or path.stat().st_size == 0
+    ]
+    if missing:
+        raise FileNotFoundError(
+            "cannot promote incomplete benchmark attempt: "
+            + ", ".join(missing)
+        )
+
+    staged = []
+    promoted = []
+    try:
+        for source in sources:
+            destination = results_dir / source.name
+            temporary = results_dir / (
+                f".{source.name}.{producer_id}.staged"
+            )
+            if source.name == f"{suite}.tsv":
+                with temporary.open("w", encoding="utf-8") as output:
+                    output.write(f"# suite\t{suite}\n")
+                    output.write(f"# producer_id\t{producer_id}\n")
+                    with source.open(encoding="utf-8") as input_file:
+                        shutil.copyfileobj(input_file, output)
+            else:
+                copy_function(source, temporary)
+            staged.append((temporary, destination))
+
+        for temporary, destination in staged:
+            replace_function(temporary, destination)
+            promoted.append(destination)
+    except Exception:
+        for temporary, _destination in staged:
+            temporary.unlink(missing_ok=True)
+        for destination in promoted:
+            destination.unlink(missing_ok=True)
+        raise
 
 
 def run_with_retries(
@@ -38,15 +90,23 @@ def run_with_retries(
     min_delta_us,
     individual_min_delta_us,
     command_runner=subprocess.run,
+    producer_id=None,
 ):
     results_dir = pathlib.Path(results_dir)
     attempts_dir = results_dir / "attempts"
     history_path = results_dir / f"{suite}-attempts.tsv"
     results_dir.mkdir(parents=True, exist_ok=True)
+    producer_id = producer_id or uuid.uuid4().hex
     records = []
     candidates = None
+    suite_started = time.monotonic()
 
     for attempt in range(1, max_attempts + 1):
+        attempt_started = time.monotonic()
+        print(
+            f"{suite}: starting attempt {attempt}/{max_attempts}",
+            flush=True,
+        )
         attempt_dir = attempts_dir / f"attempt-{attempt}"
         attempt_dir.mkdir(parents=True, exist_ok=True)
         result_path = attempt_dir / f"{suite}.tsv"
@@ -73,11 +133,13 @@ def run_with_retries(
 
         if completed.returncode:
             records.append(("command_error", frozenset()))
-            write_history(history_path, suite, records)
+            write_history(history_path, suite, producer_id, records)
             print(
                 f"{suite} attempt {attempt}/{max_attempts}: "
-                f"command failed with exit code {completed.returncode}",
+                f"command failed with exit code {completed.returncode} "
+                f"after {time.monotonic() - attempt_started:.1f}s",
                 file=sys.stderr,
+                flush=True,
             )
             return completed.returncode
 
@@ -89,11 +151,12 @@ def run_with_retries(
         ]
         if missing:
             records.append(("invalid_result", frozenset()))
-            write_history(history_path, suite, records)
+            write_history(history_path, suite, producer_id, records)
             print(
                 f"{suite} attempt {attempt}/{max_attempts}: "
                 f"missing result files: {', '.join(missing)}",
                 file=sys.stderr,
+                flush=True,
             )
             return 2
 
@@ -103,10 +166,11 @@ def run_with_retries(
             )
         except (OSError, ValueError) as exc:
             records.append(("invalid_result", frozenset()))
-            write_history(history_path, suite, records)
+            write_history(history_path, suite, producer_id, records)
             print(
                 f"{suite} attempt {attempt}/{max_attempts}: {exc}",
                 file=sys.stderr,
+                flush=True,
             )
             return 2
 
@@ -137,7 +201,25 @@ def run_with_retries(
         )
         status = "regression" if failures else "pass"
         records.append((status, failures))
-        write_history(history_path, suite, records)
+        write_history(history_path, suite, producer_id, records)
+
+        attempt_elapsed = time.monotonic() - attempt_started
+        cumulative_elapsed = time.monotonic() - suite_started
+        failure_summary = (
+            "; ".join(
+                benchmark_compare.format_gate_id(gate)
+                for gate in sorted(failures)
+            )
+            if failures
+            else "none"
+        )
+        print(
+            f"{suite}: completed attempt {attempt}/{max_attempts} "
+            f"in {attempt_elapsed:.1f}s "
+            f"({cumulative_elapsed:.1f}s cumulative); "
+            f"failed gates: {failure_summary}",
+            flush=True,
+        )
 
         if candidates is None:
             candidates = failures
@@ -145,33 +227,69 @@ def run_with_retries(
             candidates = candidates.intersection(failures)
 
         if not candidates:
-            promote_attempt(attempt_dir, results_dir, suite)
+            try:
+                promote_attempt(
+                    attempt_dir,
+                    results_dir,
+                    suite,
+                    producer_id,
+                )
+            except OSError as exc:
+                print(
+                    f"{suite}: canonical artifact promotion failed: {exc}",
+                    file=sys.stderr,
+                    flush=True,
+                )
+                return 2
             if attempt == 1 and not failures:
-                print(f"{suite} attempt {attempt}/{max_attempts}: passed")
+                print(
+                    f"{suite}: passed on attempt {attempt}/{max_attempts}",
+                    flush=True,
+                )
             else:
                 print(
-                    f"{suite} attempt {attempt}/{max_attempts}: "
-                    "no exact gate remains unbroken"
+                    f"{suite}: stopping after attempt "
+                    f"{attempt}/{max_attempts}; no exact gate "
+                    "failed on every attempt",
+                    flush=True,
                 )
             return 0
 
         if attempt < max_attempts:
             print(
-                f"{suite} attempt {attempt}/{max_attempts}: "
-                f"{len(candidates)} exact performance "
-                f"{'gate remains' if len(candidates) == 1 else 'gates remain'}; "
-                "retrying"
+                f"{suite}: retrying after attempt {attempt}/{max_attempts}; "
+                "gates still eligible for confirmation: "
+                + "; ".join(
+                    benchmark_compare.format_gate_id(gate)
+                    for gate in sorted(candidates)
+                ),
+                flush=True,
             )
             continue
 
         # A valid measurement is always published. The aggregate report job
         # enforces the gate after this third consecutive regression.
-        promote_attempt(attempt_dir, results_dir, suite)
+        try:
+            promote_attempt(
+                attempt_dir,
+                results_dir,
+                suite,
+                producer_id,
+            )
+        except OSError as exc:
+            print(
+                f"{suite}: canonical artifact promotion failed: {exc}",
+                file=sys.stderr,
+                flush=True,
+            )
+            return 2
         print(
-            f"{suite} attempt {attempt}/{max_attempts}: "
-            f"{len(candidates)} exact performance "
-            f"{'gate exceeded' if len(candidates) == 1 else 'gates exceeded'} "
-            "in all attempts"
+            f"{suite}: confirmed after {attempt}/{max_attempts} attempts: "
+            + "; ".join(
+                benchmark_compare.format_gate_id(gate)
+                for gate in sorted(candidates)
+            ),
+            flush=True,
         )
         return 0
 

--- a/test/benchmark_retry.py
+++ b/test/benchmark_retry.py
@@ -52,6 +52,7 @@ def promote_attempt(
         )
 
     staged = []
+    backups = []
     promoted = []
     try:
         for source in sources:
@@ -69,15 +70,43 @@ def promote_attempt(
                 copy_function(source, temporary)
             staged.append((temporary, destination))
 
+        for _temporary, destination in staged:
+            if destination.exists():
+                backup = results_dir / (
+                    f".{destination.name}.{producer_id}.backup"
+                )
+                replace_function(destination, backup)
+                backups.append((backup, destination))
+
         for temporary, destination in staged:
             replace_function(temporary, destination)
             promoted.append(destination)
-    except Exception:
+    except Exception as promotion_error:
+        rollback_errors = []
+        for destination in reversed(promoted):
+            try:
+                destination.unlink(missing_ok=True)
+            except OSError as exc:
+                rollback_errors.append(exc)
+        for backup, destination in reversed(backups):
+            try:
+                replace_function(backup, destination)
+            except OSError as exc:
+                rollback_errors.append(exc)
         for temporary, _destination in staged:
-            temporary.unlink(missing_ok=True)
-        for destination in promoted:
-            destination.unlink(missing_ok=True)
+            try:
+                temporary.unlink(missing_ok=True)
+            except OSError as exc:
+                rollback_errors.append(exc)
+        if rollback_errors:
+            raise OSError(
+                "benchmark artifact promotion and rollback failed: "
+                + "; ".join(str(exc) for exc in rollback_errors)
+            ) from promotion_error
         raise
+    else:
+        for backup, _destination in backups:
+            backup.unlink(missing_ok=True)
 
 
 def run_with_retries(

--- a/test/benchmark_retry_test.py
+++ b/test/benchmark_retry_test.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python3
 
+import contextlib
 import importlib.util
+import io
 import pathlib
+import shutil
 import tempfile
 import types
 import unittest
@@ -11,6 +14,8 @@ MODULE_PATH = pathlib.Path(__file__).with_name("benchmark_retry.py")
 SPEC = importlib.util.spec_from_file_location("benchmark_retry", MODULE_PATH)
 benchmark_retry = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(benchmark_retry)
+
+PRODUCER_ID = "producer-current"
 
 
 class FakeRunner:
@@ -62,6 +67,7 @@ class BenchmarkRetryTest(unittest.TestCase):
             5000,
             5000,
             runner,
+            PRODUCER_ID,
         )
         return rc, runner
 
@@ -74,6 +80,7 @@ class BenchmarkRetryTest(unittest.TestCase):
         self.assertEqual(
             history,
             "suite\tint\n"
+            f"producer_id\t{PRODUCER_ID}\n"
             "attempt\tstatus\tfailed_gates\n"
             "1\tpass\t[]\n",
         )
@@ -91,7 +98,12 @@ class BenchmarkRetryTest(unittest.TestCase):
         self.assertEqual(runner.calls, 2)
         self.assertIn("1\tregression\t", history)
         self.assertIn("2\tpass\t[]\n", history)
-        self.assertEqual(result, "reads\tpoint\t100000\t101000\n")
+        self.assertEqual(
+            result,
+            "# suite\tint\n"
+            f"# producer_id\t{PRODUCER_ID}\n"
+            "reads\tpoint\t100000\t101000\n",
+        )
 
     def test_three_regressions_promote_final_attempt(self):
         with tempfile.TemporaryDirectory() as directory:
@@ -117,7 +129,12 @@ class BenchmarkRetryTest(unittest.TestCase):
             ("individual", "int", "reads", "point"),
             parsed.confirmed_failures,
         )
-        self.assertEqual(result, "reads\tpoint\t100000\t150000\n")
+        self.assertEqual(
+            result,
+            "# suite\tint\n"
+            f"# producer_id\t{PRODUCER_ID}\n"
+            "reads\tpoint\t100000\t150000\n",
+        )
 
     def test_rotating_individual_failures_stop_without_confirmation(self):
         steady = ("reads", "steady", 1_000_000, 1_000_000)
@@ -157,6 +174,7 @@ class BenchmarkRetryTest(unittest.TestCase):
         self.assertEqual(
             history,
             "suite\tint\n"
+            f"producer_id\t{PRODUCER_ID}\n"
             "attempt\tstatus\tfailed_gates\n"
             "1\tcommand_error\t[]\n",
         )
@@ -187,6 +205,66 @@ class BenchmarkRetryTest(unittest.TestCase):
             )
         self.assertEqual(rc, 2)
         self.assertEqual(runner.calls, 1)
+
+    def test_promotion_copy_failure_leaves_no_canonical_files(self):
+        with tempfile.TemporaryDirectory() as directory:
+            directory = pathlib.Path(directory)
+            attempt = directory / "attempt"
+            results = directory / "results"
+            attempt.mkdir()
+            results.mkdir()
+            (attempt / "int.tsv").write_text(
+                "reads\tpoint\t100\t101\n",
+                encoding="utf-8",
+            )
+            (attempt / "int-samples.tsv").write_text(
+                "section\ttest\trun\tbaseline_us\tcandidate_us\n"
+                "reads\tpoint\t1\t100\t101\n",
+                encoding="utf-8",
+            )
+            (attempt / "int.md").write_text(
+                "benchmark report\n",
+                encoding="utf-8",
+            )
+
+            def fail_on_markdown(source, destination):
+                if pathlib.Path(source).suffix == ".md":
+                    raise FileNotFoundError("injected markdown copy failure")
+                return shutil.copy2(source, destination)
+
+            with self.assertRaisesRegex(
+                FileNotFoundError,
+                "injected markdown copy failure",
+            ):
+                benchmark_retry.promote_attempt(
+                    attempt,
+                    results,
+                    "int",
+                    PRODUCER_ID,
+                    copy_function=fail_on_markdown,
+                )
+
+            self.assertEqual(list(results.iterdir()), [])
+            self.assertTrue((attempt / "int.tsv").is_file())
+            self.assertTrue((attempt / "int-samples.tsv").is_file())
+            self.assertTrue((attempt / "int.md").is_file())
+
+    def test_live_log_identifies_attempts_gates_and_elapsed_time(self):
+        with tempfile.TemporaryDirectory() as directory:
+            output = io.StringIO()
+            with contextlib.redirect_stdout(output):
+                rc, runner = self.run_retry(
+                    directory,
+                    [(100_000, 140_000), (100_000, 101_000)],
+                )
+            log = output.getvalue()
+        self.assertEqual(rc, 0)
+        self.assertEqual(runner.calls, 2)
+        self.assertIn("int: starting attempt 1/3", log)
+        self.assertIn("int: starting attempt 2/3", log)
+        self.assertIn("failed gates: individual `int / reads / point`", log)
+        self.assertIn("s cumulative)", log)
+        self.assertIn("no exact gate failed on every attempt", log)
 
 
 if __name__ == "__main__":

--- a/test/benchmark_retry_test.py
+++ b/test/benchmark_retry_test.py
@@ -249,6 +249,69 @@ class BenchmarkRetryTest(unittest.TestCase):
             self.assertTrue((attempt / "int-samples.tsv").is_file())
             self.assertTrue((attempt / "int.md").is_file())
 
+    def test_promotion_replace_failure_restores_canonical_files(self):
+        with tempfile.TemporaryDirectory() as directory:
+            directory = pathlib.Path(directory)
+            attempt = directory / "attempt"
+            results = directory / "results"
+            attempt.mkdir()
+            results.mkdir()
+            new_contents = {
+                "int.tsv": "reads\tpoint\t100\t101\n",
+                "int-samples.tsv": (
+                    "section\ttest\trun\tbaseline_us\tcandidate_us\n"
+                    "reads\tpoint\t1\t100\t101\n"
+                ),
+                "int.md": "new benchmark report\n",
+            }
+            old_contents = {
+                "int.tsv": "old result\n",
+                "int-samples.tsv": "old samples\n",
+                "int.md": "old benchmark report\n",
+            }
+            for name, contents in new_contents.items():
+                (attempt / name).write_text(contents, encoding="utf-8")
+            for name, contents in old_contents.items():
+                (results / name).write_text(contents, encoding="utf-8")
+
+            failed = False
+
+            def fail_once_during_exposure(source, destination):
+                nonlocal failed
+                source = pathlib.Path(source)
+                destination = pathlib.Path(destination)
+                if (
+                    not failed
+                    and source.name.endswith(".staged")
+                    and destination.name == "int-samples.tsv"
+                ):
+                    failed = True
+                    raise OSError("injected replacement failure")
+                return source.replace(destination)
+
+            with self.assertRaisesRegex(
+                OSError,
+                "injected replacement failure",
+            ):
+                benchmark_retry.promote_attempt(
+                    attempt,
+                    results,
+                    "int",
+                    PRODUCER_ID,
+                    replace_function=fail_once_during_exposure,
+                )
+
+            self.assertTrue(failed)
+            self.assertEqual(
+                {
+                    path.name: path.read_text(encoding="utf-8")
+                    for path in results.iterdir()
+                },
+                old_contents,
+            )
+            for name in new_contents:
+                self.assertTrue((attempt / name).is_file())
+
     def test_live_log_identifies_attempts_gates_and_elapsed_time(self):
         with tempfile.TemporaryDirectory() as directory:
             output = io.StringIO()


### PR DESCRIPTION
Follow-up to #1809.

This closes the two artifact-integrity gaps identified by Ito and makes retry behavior easier to diagnose in live CI logs.

- assign one producer ID to each suite retry run and embed it in both the selected result and attempt history
- reject stale or mixed result/history artifacts before rendering or enforcing a performance conclusion
- preflight and stage the result, samples, and markdown before exposing canonical artifact names
- report promotion failures cleanly without leaving Ito's partial canonical state
- log each attempt number, exact failing/continuing gates, per-attempt duration, cumulative duration, and stop/confirmation reason

Validation:
- `python3 test/benchmark_compare_test.py` (24 tests)
- `python3 test/benchmark_retry_test.py` (8 tests)
- `python3 -m py_compile test/benchmark_compare.py test/benchmark_compare_test.py test/benchmark_retry.py test/benchmark_retry_test.py`
- benchmark shell syntax checks
- `bash test/lint_layers.sh`
- `git diff --check`