### PR TITLE
Pin that ROLLBACK does not revert dolt_checkout

### DIFF
--- a/test/vc_oracle_checkout_test.sh
+++ b/test/vc_oracle_checkout_test.sh
@@ -1109,6 +1109,26 @@ SELECT dolt_checkout('main', 't');
 " "SELECT 'Q|' || (SELECT count(*) FROM sqlite_master WHERE name = 'idx') || '|' || (SELECT b FROM t WHERE a = 1);" \
 "SELECT concat('Q|', (SELECT count(*) FROM information_schema.statistics WHERE table_name = 't' AND index_name = 'idx'), '|', (SELECT b FROM t WHERE a = 1));"
 
+# ROLLBACK does not revert dolt_checkout: the session stays on the branch it
+# checked out, and later writes land there. Reported once as state corruption
+# because dolt_default_branch() still says "main" -- that is the repo default,
+# not the session branch. Dolt behaves the same way, so this pins the parity and
+# keeps someone from "fixing" it into a divergence.
+oracle "checkout_survives_rollback" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1, 'base');
+SELECT dolt_commit('-Am', 'base');
+SELECT dolt_branch('feature');
+SELECT dolt_checkout('feature');
+INSERT INTO t VALUES (20, 'feature_wip');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES (10, 'main_wip');
+BEGIN;
+SELECT dolt_checkout('feature');
+ROLLBACK;
+"
+
+
 echo ""
 echo "=== Results: $pass passed, $fail failed ==="
 if [ $fail -gt 0 ]; then


### PR DESCRIPTION
**Verified: not an issue, and not a divergence. No fix needed.** This PR adds the parity case so the question stays settled.

## What the report got right

The underlying behavior is real: **`ROLLBACK` does not revert `dolt_checkout`.**

```
before       : main    rows=1,10
in txn       : feature rows=1,20
post-rollback: feature rows=1,20   <- checkout survived
```

## What it got wrong

The claimed inconsistency — session showing `main` while feature's data is live, and writes silently misattributed — doesn't exist. After rollback **every surface agrees on `feature`**:

| surface | value |
|---|---|
| `active_branch()` | `feature` |
| branch whose head `= hashof('HEAD')` | `feature` |
| visible rows | `1,20` (feature's) |
| `dolt_status` | 1 |
| where a later write lands | `feature` |

And nothing is lost: `main` still holds its own uncommitted `main_wip` afterwards.

The `after_rollback_branch|main` in the report is `dolt_default_branch()` — the *repo's default branch*, a different concept from the session's current branch. It says `main` because main **is** the default branch. I hit the same trap first time round with a `dolt_branches WHERE hash=dolt_hashof('HEAD')` probe, which is ambiguous while both branches sit on the same commit; re-running with the branches on distinct commits resolved it to `feature`.

## Why there's nothing to fix

Dolt does the same thing — verified against dolt 2.2.2 with the identical sequence:

```
before       : main
in txn       : feature
post-rollback: feature
```

Per *Dolt is the reference implementation*, that makes this the intended semantics. The suggested change — snapshotting branch and head into the savepoint state so rollback restores them — would make DoltLite **diverge from Dolt** on a surface the oracle suites compare.

## The test

One case in `vc_oracle_checkout_test.sh`, which already compares `active_branch()`, rows, and `dolt_status` across both engines — so it pins the whole post-rollback state, not just the branch name. Extending the existing checkout oracle rather than adding a suite, since these are per-surface singletons.

Non-vacuity: assertions go 64 → 65, and `vc_oracle_assert_match` fails when both sides come back empty, so it can't pass degenerately. Suite is 65/65 against dolt 2.2.2; all six check/lint scripts pass.

If this behavior is ever considered wrong, it should change in Dolt first — this case will then fail and point straight at the decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
