### PR TITLE
Fix nightly performance report publication

### DIFF
--- a/test/nightly_performance_report.py
+++ b/test/nightly_performance_report.py
@@ -284,11 +284,15 @@ def render_report(suites, commit, run_url, generated_at, runner):
     lines = [
         "# DoltLite Performance Report",
         "",
-        f"> Nightly result: **{overall}**  ",
-        f"> Generated: {generated_at}  ",
+        f"> Nightly result: **{overall}**",
+        ">",
+        f"> Generated: {generated_at}",
+        ">",
         f"> Commit: [`{commit}`]"
-        f"(https://github.com/dolthub/doltlite/commit/{commit})  ",
-        f"> Runner: {runner}  ",
+        f"(https://github.com/dolthub/doltlite/commit/{commit})",
+        ">",
+        f"> Runner: {runner}",
+        ">",
         f"> [GitHub Actions run]({run_url})",
         "",
         "This report compares optimized DoltLite against stock SQLite on the "

--- a/test/nightly_performance_report_test.py
+++ b/test/nightly_performance_report_test.py
@@ -80,6 +80,12 @@ class NightlyPerformanceReportTest(unittest.TestCase):
         self.assertIn("Median paired-ratio MAD", report)
         self.assertIn("Version-control latency", report)
         self.assertIn("50.0%", report)
+        self.assertFalse(
+            any(
+                line.endswith((" ", "\t"))
+                for line in report.splitlines()
+            )
+        )
 
     def test_failed_status_marks_overall_report_failed(self):
         with tempfile.TemporaryDirectory() as temporary:


### PR DESCRIPTION
The scheduled benchmark suites all succeeded in [run 30153812089](https://github.com/dolthub/doltlite/actions/runs/30153812089), but the report publication step failed because the generated Markdown used two trailing spaces for hard line breaks and the publisher correctly runs `git diff --check`.

This replaces those hard breaks with blank blockquote lines and adds a generated-report invariant rejecting all trailing spaces and tabs.

Validated with:
- the exact downloaded artifacts from failed run 30153812089
- `python3 test/nightly_performance_report_test.py`
- `python3 test/publish_performance_report_test.py`
- `python3 -m py_compile ...`
- `git diff --check`