### PR TITLE
Harden nightly report publication

### DIFF
--- a/.github/workflows/nightly-performance.yml
+++ b/.github/workflows/nightly-performance.yml
@@ -13,6 +13,10 @@ on:
         description: Repetitions for each version-control benchmark
         required: false
         default: "101"
+      source_run_id:
+        description: Existing nightly run ID to republish without benchmarking
+        required: false
+        default: ""
 
 permissions:
   contents: write
@@ -25,6 +29,7 @@ concurrency:
 
 jobs:
   build:
+    if: ${{ !inputs.source_run_id }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
@@ -222,6 +227,9 @@ jobs:
         pattern: nightly-performance-*
         path: nightly-results
         merge-multiple: true
+        repository: ${{ github.repository }}
+        run-id: ${{ inputs.source_run_id || github.run_id }}
+        github-token: ${{ github.token }}
 
     - name: Test report generation and publication guards
       run: |
@@ -230,6 +238,9 @@ jobs:
 
     - name: Compose nightly report
       id: report
+      env:
+        GH_TOKEN: ${{ github.token }}
+        SOURCE_RUN_ID: ${{ inputs.source_run_id }}
       run: |
         summary="$RUNNER_TEMP/performance-report.md"
         issue_body="$RUNNER_TEMP/nightly-performance-failure.md"
@@ -239,7 +250,29 @@ jobs:
         valid=1
         generated_at=$(date -u '+%Y-%m-%d %H:%M UTC')
         generated_date=$(date -u '+%Y-%m-%d')
+        report_commit="$GITHUB_SHA"
         run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+        if [ -n "$SOURCE_RUN_ID" ]; then
+          source_name=$(gh api \
+            "repos/${GITHUB_REPOSITORY}/actions/runs/${SOURCE_RUN_ID}" \
+            --jq '.name')
+          source_branch=$(gh api \
+            "repos/${GITHUB_REPOSITORY}/actions/runs/${SOURCE_RUN_ID}" \
+            --jq '.head_branch')
+          if [ "$source_name" != "Nightly performance" ] ||
+             [ "$source_branch" != "master" ]; then
+            echo "::error::source run must be a master Nightly performance run"
+            exit 1
+          fi
+          report_commit=$(gh api \
+            "repos/${GITHUB_REPOSITORY}/actions/runs/${SOURCE_RUN_ID}" \
+            --jq '.head_sha')
+          source_created_at=$(gh api \
+            "repos/${GITHUB_REPOSITORY}/actions/runs/${SOURCE_RUN_ID}" \
+            --jq '.created_at')
+          generated_date=$(date -u -d "$source_created_at" '+%Y-%m-%d')
+          run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${SOURCE_RUN_ID}"
+        fi
         {
           echo "Nightly performance failed or produced incomplete results."
           echo ""
@@ -272,7 +305,7 @@ jobs:
         set +e
         python3 test/nightly_performance_report.py \
           --results-dir nightly-results \
-          --commit "$GITHUB_SHA" \
+          --commit "$report_commit" \
           --run-url "$run_url" \
           --generated-at "$generated_at" \
           --runner "${ImageOS:-ubuntu-latest} ${ImageVersion:-}" \
@@ -309,6 +342,7 @@ jobs:
         echo "report=$summary" >> "$GITHUB_OUTPUT"
         echo "issue_body=$issue_body" >> "$GITHUB_OUTPUT"
         echo "generated_date=$generated_date" >> "$GITHUB_OUTPUT"
+        echo "run_url=$run_url" >> "$GITHUB_OUTPUT"
 
     - name: Upload combined nightly report
       if: always()
@@ -334,10 +368,11 @@ jobs:
     - name: Publish rolling performance report PR
       if: >-
         ${{ always() &&
-            github.ref == 'refs/heads/master' &&
+            (github.ref == 'refs/heads/master' ||
+             inputs.source_run_id != '') &&
             steps.report.outputs.valid == '1' }}
       env:
-        GH_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN }}
+        GH_TOKEN: ${{ github.token }}
         PERFORMANCE_REPORT_REVIEWER: ${{ vars.PERFORMANCE_REPORT_REVIEWER }}
       run: |
         python3 tool/publish-performance-report.py \
@@ -345,7 +380,7 @@ jobs:
           --repository "$GITHUB_REPOSITORY" \
           --run-id "$GITHUB_RUN_ID" \
           --run-attempt "$GITHUB_RUN_ATTEMPT" \
-          --run-url "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+          --run-url "${{ steps.report.outputs.run_url }}" \
           --generated-date "${{ steps.report.outputs.generated_date }}" \
           --reviewer "$PERFORMANCE_REPORT_REVIEWER"
 

--- a/test/publish_performance_report_test.py
+++ b/test/publish_performance_report_test.py
@@ -61,7 +61,14 @@ class PublishPerformanceReportTest(unittest.TestCase):
     @mock.patch.object(publisher, "gh_json")
     def test_merges_valid_existing_report(self, gh_json, command):
         gh_json.side_effect = [
-            [{"number": 42}],
+            [
+                {
+                    "number": 42,
+                    "headRefName": (
+                        "automation/performance-report-123-1"
+                    ),
+                }
+            ],
             pull_request(),
         ]
         merged = publisher.merge_previous_report(
@@ -85,11 +92,32 @@ class PublishPerformanceReportTest(unittest.TestCase):
 
     @mock.patch.object(publisher, "gh_json")
     def test_rejects_multiple_existing_reports(self, gh_json):
-        gh_json.return_value = [{"number": 42}, {"number": 43}]
+        gh_json.return_value = [
+            {
+                "number": 42,
+                "headRefName": "automation/performance-report-123-1",
+            },
+            {
+                "number": 43,
+                "headRefName": "automation/performance-report-456-1",
+            },
+        ]
         with self.assertRaisesRegex(publisher.PublishError, "multiple open"):
             publisher.merge_previous_report(
                 "dolthub/doltlite", "report-bot"
             )
+
+    @mock.patch.object(publisher, "gh_json")
+    def test_ignores_unrelated_open_pull_requests(self, gh_json):
+        gh_json.return_value = [
+            {"number": 41, "headRefName": "feature/unrelated"}
+        ]
+        self.assertIsNone(
+            publisher.merge_previous_report(
+                "dolthub/doltlite",
+                "report-bot",
+            )
+        )
 
 
 if __name__ == "__main__":

--- a/test/publish_performance_report_test.py
+++ b/test/publish_performance_report_test.py
@@ -39,7 +39,7 @@ class PublishPerformanceReportTest(unittest.TestCase):
         ):
             self.assertEqual(
                 publisher.report_login(),
-                "github-actions[bot]",
+                "app/github-actions",
             )
         command.assert_not_called()
 

--- a/test/publish_performance_report_test.py
+++ b/test/publish_performance_report_test.py
@@ -31,6 +31,27 @@ def pull_request(**overrides):
 
 
 class PublishPerformanceReportTest(unittest.TestCase):
+    @mock.patch.object(publisher, "command")
+    def test_uses_actions_bot_identity_in_github_actions(self, command):
+        with mock.patch.dict(
+            publisher.os.environ,
+            {"GITHUB_ACTIONS": "true"},
+        ):
+            self.assertEqual(
+                publisher.report_login(),
+                "github-actions[bot]",
+            )
+        command.assert_not_called()
+
+    @mock.patch.object(publisher, "command")
+    def test_discovers_login_outside_github_actions(self, command):
+        command.return_value.stdout = "report-bot\n"
+        with mock.patch.dict(
+            publisher.os.environ,
+            {"GITHUB_ACTIONS": ""},
+        ):
+            self.assertEqual(publisher.report_login(), "report-bot")
+
     def test_accepts_expected_bot_report(self):
         publisher.validate_previous_pr(pull_request(), "report-bot")
 

--- a/tool/publish-performance-report.py
+++ b/tool/publish-performance-report.py
@@ -67,7 +67,7 @@ def validate_previous_pr(pr, current_login):
 
 
 def merge_previous_report(repository, current_login):
-    existing = gh_json(
+    open_pull_requests = gh_json(
         [
             "pr",
             "list",
@@ -75,12 +75,17 @@ def merge_previous_report(repository, current_login):
             repository,
             "--state",
             "open",
-            "--label",
-            LABEL,
+            "--limit",
+            "100",
             "--json",
-            "number",
+            "number,headRefName",
         ]
     )
+    existing = [
+        pr
+        for pr in open_pull_requests
+        if pr.get("headRefName", "").startswith(BRANCH_PREFIX)
+    ]
     if len(existing) > 1:
         numbers = ", ".join(f"#{pr['number']}" for pr in existing)
         raise PublishError(
@@ -161,7 +166,18 @@ def publish_report(args):
             f"Update nightly performance report ({args.generated_date})",
         ]
     )
-    command(["git", "push", "origin", f"HEAD:refs/heads/{branch}"])
+    # This branch is uniquely owned by one workflow run and attempt. Force
+    # updating it makes a failed publication safe to rerun after its first
+    # attempt pushed the commit but failed before creating the PR.
+    command(
+        [
+            "git",
+            "push",
+            "--force",
+            "origin",
+            f"HEAD:refs/heads/{branch}",
+        ]
+    )
 
     command(
         [
@@ -199,13 +215,29 @@ def publish_report(args):
         f"Nightly performance report — {args.generated_date}",
         "--body",
         body,
-        "--label",
-        LABEL,
     ]
     url = command(create).stdout.strip()
     if not url:
         raise PublishError("gh pr create did not return a PR URL")
     print(f"Created {url}")
+    label = command(
+        [
+            "gh",
+            "pr",
+            "edit",
+            url,
+            "--repo",
+            args.repository,
+            "--add-label",
+            LABEL,
+        ],
+        check=False,
+    )
+    if label.returncode:
+        print(
+            f"warning: unable to add label {LABEL}",
+            file=sys.stderr,
+        )
     if args.reviewer:
         review = command(
             [

--- a/tool/publish-performance-report.py
+++ b/tool/publish-performance-report.py
@@ -43,7 +43,8 @@ def gh_json(arguments):
 
 def report_login():
     if os.environ.get("GITHUB_ACTIONS") == "true":
-        return "github-actions[bot]"
+        # gh renders GitHub App authors with an "app/" prefix.
+        return "app/github-actions"
     login = command(["gh", "api", "user", "--jq", ".login"]).stdout.strip()
     if not login:
         raise PublishError("unable to determine report bot login")

--- a/tool/publish-performance-report.py
+++ b/tool/publish-performance-report.py
@@ -41,6 +41,15 @@ def gh_json(arguments):
         raise PublishError(f"invalid gh JSON for: {' '.join(arguments)}") from exc
 
 
+def report_login():
+    if os.environ.get("GITHUB_ACTIONS") == "true":
+        return "github-actions[bot]"
+    login = command(["gh", "api", "user", "--jq", ".login"]).stdout.strip()
+    if not login:
+        raise PublishError("unable to determine report bot login")
+    return login
+
+
 def validate_previous_pr(pr, current_login):
     author = (pr.get("author") or {}).get("login")
     if author != current_login:
@@ -131,9 +140,7 @@ def publish_report(args):
     if not os.environ.get("GH_TOKEN"):
         raise PublishError("GH_TOKEN is required")
 
-    login = command(["gh", "api", "user", "--jq", ".login"]).stdout.strip()
-    if not login:
-        raise PublishError("unable to determine report bot login")
+    login = report_login()
     command(["gh", "auth", "setup-git"])
 
     merged = merge_previous_report(args.repository, login)


### PR DESCRIPTION
The 2026-07-26 nightly benchmarks and report generation succeeded, but publication failed because `RELEASE_BOT_TOKEN` can push release repositories and cannot create PRs or labels in doltlite.

This change:
- uses the per-run `github.token` for report publication
- discovers prior report PRs by the reserved automation branch prefix instead of depending on a label
- creates the PR before applying the cosmetic label
- makes a run/attempt branch safe to update on publication retry
- adds a validated report-only `source_run_id` recovery mode so retained artifacts can be republished without rerunning two hours of benchmarks

The repository Actions setting now allows PR creation while its default workflow permission remains read-only; this workflow continues to request only its explicit scopes.

Validation:
- `python3 test/publish_performance_report_test.py` (7 tests)
- `python3 test/nightly_performance_report_test.py` (5 tests)
- Python compilation
- workflow YAML parse
- report-compose shell syntax
- `git diff --check`