### PR TITLE
Never persist merge conflicts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -206,6 +206,16 @@ Rules that override convenience:
 
 ## Version-control correctness invariants
 
+- **Conflicts are never persisted.** A conflicted merge lives only in the
+  transaction that produced it: `COMMIT` is refused while any conflict remains,
+  an autocommit merge that conflicts is rolled back whole, and the persist path
+  declines to make a conflicted working set durable. Nothing conflicted reaches
+  disk, so no later connection inherits a merge to finish. Dolt allows this
+  behind `@@dolt_allow_commit_conflicts`, which DoltLite does not implement, so
+  conflict *persistence* is a deliberate divergence — compare in-transaction
+  behaviour against Dolt, not what survives a commit. Constraint violations are
+  unaffected and still persist.
+
 Subtle rules that are easy to break silently — hold them when touching VC code:
 
 - **Re-confirm under the lock.** Multi-step ops (merge / cherry-pick / revert /

--- a/README.md
+++ b/README.md
@@ -603,6 +603,13 @@ SELECT dolt_commit('-A', '-m', 'msg');
 -- Error: "cannot commit: unresolved merge conflicts"
 ```
 
+Conflicts are never persisted as conflicts. They live only in the transaction
+that produced them, so inspect and resolve them there; `COMMIT` is refused while
+any remain, and an autocommit merge that conflicts is rolled back whole. Either
+way nothing conflicted reaches disk, and no later connection inherits a merge to
+finish. Dolt differs here — it can commit a working set holding conflicts — so
+this is a deliberate divergence, not a gap.
+
 #### Constraint Violations on Merge
 
 Merges apply cell-by-cell at the prolly layer and don't run

--- a/src/doltlite_cmd.c
+++ b/src/doltlite_cmd.c
@@ -104,12 +104,10 @@ int doltliteReportConstraintViolations(
 
 void doltliteReportAutocommitConflictRollback(sqlite3_context *ctx){
   sqlite3_result_error(ctx,
-    "Merge conflict detected, @autocommit transaction rolled back. "
-    "@autocommit must be disabled so that merge conflicts can be "
-    "resolved using the dolt_conflicts and dolt_schema_conflicts "
-    "tables before manually committing the transaction. "
-    "Alternatively, to commit transactions with merge conflicts, set "
-    "@@dolt_allow_commit_conflicts = 1",
+    "cannot merge: conflicts detected, autocommit transaction rolled back. "
+    "Run the merge inside BEGIN/COMMIT to inspect dolt_conflicts and "
+    "dolt_schema_conflicts, resolve with dolt_conflicts_resolve(), then commit "
+    "with dolt_commit(). Conflicts are never committed as conflicts",
     -1);
 }
 

--- a/src/doltlite_reset.c
+++ b/src/doltlite_reset.c
@@ -388,11 +388,10 @@ static void doltliteResetFunc(
     sqlite3_free(azPaths);
     azPaths = 0;
     sqlite3_result_error(context,
-      "Merge conflict detected, transaction rolled back. "
-      "Merge conflicts must be resolved using the dolt_conflicts and "
-      "dolt_schema_conflicts tables before committing a transaction. "
-      "To commit transactions with merge conflicts, set "
-      "@@dolt_allow_commit_conflicts = 1", -1);
+      "cannot merge: conflicts detected, transaction rolled back. "
+      "Resolve conflicts via dolt_conflicts and dolt_schema_conflicts with "
+      "dolt_conflicts_resolve(), then commit with dolt_commit(). Conflicts are "
+      "never committed as conflicts", -1);
     goto reset_cleanup;
   }
 

--- a/src/prolly_btree_state.c
+++ b/src/prolly_btree_state.c
@@ -969,11 +969,20 @@ int doltliteSaveWorkingSet(sqlite3 *db){
 
 int doltlitePersistWorkingSetWithHash(sqlite3 *db, const ProllyHash *pWorkingCatHash){
   ChunkStore *cs = doltliteGetChunkStore(db);
+  Btree *p;
   int rc;
 
   if( !cs ) return SQLITE_ERROR;
   rc = doltliteSaveWorkingSetWithHash(db, pWorkingCatHash);
   if( rc!=SQLITE_OK ) return rc;
+  /* Saving keeps the working set in the pending chunk set, which is where an
+  ** unresolved conflict is allowed to live; committing is what would make it
+  ** durable, and DoltLite never persists conflicts. Callers reach here from
+  ** paths that persist as a side effect before diagnosing the conflict
+  ** themselves -- dolt_commit's staging, for one -- so this stays silent and
+  ** leaves the refusal to that caller and to commit phase one. */
+  p = (db && db->nDb>0) ? db->aDb[0].pBt : 0;
+  if( p && !prollyHashIsEmpty(&p->vc.conflictsCatalogHash) ) return SQLITE_OK;
   rc = chunkStoreSerializeRefs(cs);
   if( rc!=SQLITE_OK ) return rc;
   return chunkStoreCommit(cs);

--- a/src/prolly_btree_txn.c
+++ b/src/prolly_btree_txn.c
@@ -787,8 +787,33 @@ int sqlite3BtreeBeginTrans(Btree *p, int wrFlag, int *pSchemaVersion){
   return p->pOps->xBeginTrans(p, wrFlag, pSchemaVersion);
 }
 
+/* DoltLite never persists a conflicted working set: unresolved conflicts are
+** inspectable inside the transaction that produced them and nowhere else. Phase
+** one is the only commit phase permitted to fail, so the veto belongs here --
+** phase two would already have written the working-set blob. A non-empty
+** conflicts catalog is the same predicate dolt_commit refuses on, and it covers
+** schema conflicts too, since those live in that catalog as zero-conflict
+** entries.
+**
+** Only the caller's own commit is refused. The dolt_* commands run inner SQL
+** while conflicts are legitimately present -- dolt_commit's -A staging, for one --
+** and those inner statements commit too; vetoing them would mask each command's
+** own diagnosis with a bare "constraint failed". nVdbeExec counts nested
+** VdbeExec calls, so it is >1 exactly when this commit belongs to a statement
+** running inside a SQL function. */
 int prollyBtreeCommitPhaseOne(Btree *p, const char *zSuperJrnl){
-  (void)p; (void)zSuperJrnl;
+  (void)zSuperJrnl;
+  if( !p || p->inTrans!=TRANS_WRITE ) return SQLITE_OK;
+  if( p->pBt && p->pBt->inCatalogSerialize ) return SQLITE_OK;
+  if( p->db->nVdbeExec>1 ) return SQLITE_OK;
+  if( !prollyHashIsEmpty(&p->vc.conflictsCatalogHash) ){
+    /* The halt path in vdbeaux discards this message, so the actionable
+    ** wording lives in the dolt_merge error the caller already saw; this code
+    ** is the backstop that makes the refusal unconditional. */
+    sqlite3ErrorWithMsg(p->db, SQLITE_CONSTRAINT,
+      "cannot merge: unresolved conflicts cannot be committed");
+    return SQLITE_CONSTRAINT;
+  }
   return SQLITE_OK;
 }
 int sqlite3BtreeCommitPhaseOne(Btree *p, const char *zSuperJrnl){
@@ -911,6 +936,21 @@ int prollyBtreeCommitPhaseTwo(Btree *p, int bCleanup){
           prollyCursorReleaseAll(&pC->pCur);
         }
       }
+    }
+
+    /* Phase one already refused the caller's own commit when conflicts are
+    ** unresolved, so reaching here with a non-empty conflicts catalog means this
+    ** is a statement commit nested inside a dolt_* command -- dolt_commit's
+    ** staging, typically. Those must not be failed, or the command's own
+    ** diagnosis is replaced by a bare "constraint failed", but they must not
+    ** make the conflict durable either. Leaving the batch pending satisfies
+    ** both: the chunks stay in the pending set exactly as an in-transaction save
+    ** leaves them, and only a later conflict-free commit flushes them. */
+    if( !prollyHashIsEmpty(&p->vc.conflictsCatalogHash) ){
+      chunkStoreUnlock(&pBt->store);
+      pBt->store.snapshotPinned = 0;
+      p->inTrans = TRANS_READ;
+      return SQLITE_OK;
     }
 
     rc = chunkStoreCommit(&pBt->store);

--- a/test/doltlite_behavior.sh
+++ b/test/doltlite_behavior.sh
@@ -261,7 +261,7 @@ SELECT dolt_commit('-A','-m','add w INTEGER');" | $DOLTLITE "$DB/b1" > /dev/null
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test_match "schema_merge_same_col_diff_type" \
   "SELECT dolt_merge('b1');" \
-  "Merge conflict detected.*dolt_schema_conflicts" "$DB"
+  "cannot merge: conflicts detected.*dolt_schema_conflicts" "$DB"
 
 rm -f "$DB"
 

--- a/test/doltlite_conflicts.sh
+++ b/test/doltlite_conflicts.sh
@@ -129,7 +129,7 @@ echo "CREATE TABLE t(id INTEGER PRIMARY KEY, name TEXT); INSERT INTO t VALUES(1,
 echo "SELECT dolt_branch('other'); SELECT dolt_checkout('other'); UPDATE t SET name='A' WHERE id=1; UPDATE t SET name='B' WHERE id=2; UPDATE t SET name='C' WHERE id=3; SELECT dolt_commit('-A','-m','other');" | $DOLTLITE "$DB8" > /dev/null 2>&1
 echo "SELECT dolt_checkout('main'); UPDATE t SET name='a2' WHERE id=1; UPDATE t SET name='b2' WHERE id=2; UPDATE t SET name='c2' WHERE id=3; SELECT dolt_commit('-A','-m','main');" | $DOLTLITE "$DB8" > /dev/null 2>&1
 
-run_test_match "multi_row_conflict" "SELECT dolt_merge('other');" "Merge conflict detected" "$DB8"
+run_test_match "multi_row_conflict" "SELECT dolt_merge('other');" "cannot merge: conflicts detected" "$DB8"
 run_test_match "multi_row_conflict_count" \
   "BEGIN; SELECT dolt_merge('other'); SELECT 'MRC|' || num_conflicts FROM dolt_conflicts; ROLLBACK;" \
   "^MRC\\|3$" "$DB8"

--- a/test/doltlite_gc_commit_classify.sh
+++ b/test/doltlite_gc_commit_classify.sh
@@ -82,21 +82,23 @@ run_test_lastline "integrity_ok_with_102_byte_merge_commit" \
 db_rm "$DB"
 
 # The conflicts ("DLC") and constraint-violations ("DCV") blobs lead with
-# 'D' == CATALOG_FORMAT_V3, so an unresolved merge conflict in the working
-# set made the walker read them as catalogs with an absurd table count and
-# fail the mark phase the same way. Committing the conflicted transaction
-# persists the conflict, so the blob stays reachable across connections.
-run_test_match "gc_ok_with_unresolved_conflict" \
-  "CREATE TABLE t(k INTEGER PRIMARY KEY, v TEXT);
-   INSERT INTO t VALUES (1,'base');
+# 'D' == CATALOG_FORMAT_V3, so a leftover one in the working set made the walker
+# read it as a catalog with an absurd table count and fail the mark phase. A
+# conflict can no longer reach disk at all -- COMMIT refuses while any remain --
+# so the walker can never meet a DLC blob and the hazard is now exercised through
+# the violations blob, which is still committable and still leads with 'D'.
+run_test_match "gc_ok_with_unresolved_violation" \
+  "CREATE TABLE parent(id INTEGER PRIMARY KEY);
+   CREATE TABLE child(id INTEGER PRIMARY KEY, pid INT REFERENCES parent(id));
+   INSERT INTO parent VALUES (1);
    SELECT dolt_commit('-A','-m','seed') IS NOT NULL;
    SELECT dolt_branch('feat');
-   UPDATE t SET v='ours' WHERE k=1;
-   SELECT dolt_commit('-A','-m','ours') IS NOT NULL;
    SELECT dolt_checkout('feat');
-   UPDATE t SET v='theirs' WHERE k=1;
-   SELECT dolt_commit('-A','-m','theirs') IS NOT NULL;
+   INSERT INTO child VALUES (11,1);
+   SELECT dolt_commit('-A','-m','child') IS NOT NULL;
    SELECT dolt_checkout('main');
+   DELETE FROM parent WHERE id=1;
+   SELECT dolt_commit('-A','-m','drop parent') IS NOT NULL;
    BEGIN;
    SELECT dolt_merge('feat');
    COMMIT;
@@ -104,13 +106,13 @@ run_test_match "gc_ok_with_unresolved_conflict" \
   "chunks removed" \
   "$DB"
 
-run_test_lastline "integrity_ok_with_unresolved_conflict" \
+run_test_lastline "integrity_ok_with_unresolved_violation" \
   "PRAGMA integrity_check;" \
   "ok" \
   "$DB"
 
-run_test_lastline "conflict_survives_gc" \
-  "SELECT count(*) FROM dolt_conflicts;" \
+run_test_lastline "violation_survives_gc" \
+  "SELECT count(*) FROM dolt_constraint_violations;" \
   "1" \
   "$DB"
 

--- a/test/doltlite_merge_status.sh
+++ b/test/doltlite_merge_status.sh
@@ -21,14 +21,16 @@ echo "UPDATE t SET v='feat' WHERE id=1; SELECT dolt_commit('-Am','theirs');" | $
 echo "UPDATE t SET v='main' WHERE id=1; SELECT dolt_commit('-Am','ours');" | $DOLTLITE "$DB" > /dev/null 2>&1
 FEATURE_HASH=$(echo "SELECT dolt_hashof('feature');" | $DOLTLITE "$DB" 2>/dev/null | tail -1)
 run_test_lastline "conflict_in_session" \
-  "BEGIN; SELECT dolt_merge('feature'); COMMIT; $MS" \
+  "BEGIN; SELECT dolt_merge('feature'); $MS ROLLBACK;" \
   "1|feature|$FEATURE_HASH|refs/heads/main|t" "$DB"
 run_test "row_count_merging" "SELECT count(*) FROM dolt_merge_status;" "1" "$DB"
 
-# Merge state lives in the working set, so a later connection -- which never saw
-# the dolt_merge call -- must still report the merge.
-run_test "conflict_persists_across_connections" "$MS" \
-  "1|feature|$FEATURE_HASH|refs/heads/main|t" "$DB"
+# A conflicted merge cannot be committed, so it never outlives the transaction
+# that produced it and a later connection sees no merge at all.
+run_test_lastline "conflict_commit_is_refused" \
+  "BEGIN; SELECT dolt_merge('feature'); COMMIT;" \
+  "Error near line 1: constraint failed" "$DB"
+run_test "conflict_does_not_outlive_transaction" "$MS" "0|~|~|~|~" "$DB"
 
 # Resolving and committing ends the merge.
 echo "BEGIN; SELECT dolt_conflicts_resolve('--ours','t'); SELECT dolt_commit('-m','resolved');" | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -64,27 +66,27 @@ DB5=/tmp/test_ms_multi_$$.db; rm -f "$DB5"
 echo "CREATE TABLE zeta(id INTEGER PRIMARY KEY, v TEXT); CREATE TABLE alpha(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO zeta VALUES(1,'b'); INSERT INTO alpha VALUES(1,'b'); SELECT dolt_commit('-Am','base'); SELECT dolt_branch('src');" | $DOLTLITE "$DB5" > /dev/null 2>&1
 echo "UPDATE zeta SET v='t'; UPDATE alpha SET v='t'; SELECT dolt_commit('-Am','theirs');" | $DOLTLITE "$DB5/src" > /dev/null 2>&1
 echo "UPDATE zeta SET v='o'; UPDATE alpha SET v='o'; SELECT dolt_commit('-Am','ours');" | $DOLTLITE "$DB5" > /dev/null 2>&1
-echo "BEGIN; SELECT dolt_merge('src'); COMMIT;" | $DOLTLITE "$DB5" > /dev/null 2>&1
-run_test "unmerged_tables_sorted" \
-  "SELECT unmerged_tables FROM dolt_merge_status;" "alpha, zeta" "$DB5"
+run_test_lastline "unmerged_tables_sorted" \
+  "BEGIN; SELECT dolt_merge('src'); SELECT unmerged_tables FROM dolt_merge_status; ROLLBACK;" \
+  "alpha, zeta" "$DB5"
 
 # Constraint violations count as unmerged even when the conflict is elsewhere.
 DB6=/tmp/test_ms_cv_$$.db; rm -f "$DB6"
 echo "CREATE TABLE parent(id INTEGER PRIMARY KEY); CREATE TABLE child(id INTEGER PRIMARY KEY, pid INT REFERENCES parent(id)); CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO parent VALUES(1); INSERT INTO t VALUES(1,'b'); SELECT dolt_commit('-Am','base'); SELECT dolt_branch('src');" | $DOLTLITE "$DB6" > /dev/null 2>&1
 echo "INSERT INTO child VALUES(11,1); UPDATE t SET v='theirs'; SELECT dolt_commit('-Am','theirs');" | $DOLTLITE "$DB6/src" > /dev/null 2>&1
 echo "DELETE FROM parent WHERE id=1; UPDATE t SET v='ours'; SELECT dolt_commit('-Am','ours');" | $DOLTLITE "$DB6" > /dev/null 2>&1
-echo "BEGIN; SELECT dolt_merge('src'); COMMIT;" | $DOLTLITE "$DB6" > /dev/null 2>&1
-run_test "unmerged_tables_includes_violations" \
-  "SELECT unmerged_tables FROM dolt_merge_status;" "child, t" "$DB6"
+run_test_lastline "unmerged_tables_includes_violations" \
+  "BEGIN; SELECT dolt_merge('src'); SELECT unmerged_tables FROM dolt_merge_status; ROLLBACK;" \
+  "child, t" "$DB6"
 
 # A schema conflict makes the table unmerged even with no row conflict.
 DB7=/tmp/test_ms_schema_$$.db; rm -f "$DB7"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'b'); SELECT dolt_commit('-Am','base'); SELECT dolt_branch('src');" | $DOLTLITE "$DB7" > /dev/null 2>&1
 echo "ALTER TABLE t ADD COLUMN c1 INT DEFAULT 1; SELECT dolt_commit('-Am','their col');" | $DOLTLITE "$DB7/src" > /dev/null 2>&1
 echo "ALTER TABLE t ADD COLUMN c1 TEXT DEFAULT 'x'; SELECT dolt_commit('-Am','our col');" | $DOLTLITE "$DB7" > /dev/null 2>&1
-echo "BEGIN; SELECT dolt_merge('src'); COMMIT;" | $DOLTLITE "$DB7" > /dev/null 2>&1
-run_test "unmerged_tables_includes_schema_conflict" \
-  "SELECT unmerged_tables FROM dolt_merge_status;" "t" "$DB7"
+run_test_lastline "unmerged_tables_includes_schema_conflict" \
+  "BEGIN; SELECT dolt_merge('src'); SELECT unmerged_tables FROM dolt_merge_status; ROLLBACK;" \
+  "t" "$DB7"
 
 # target follows the branch merged into, not the default branch.
 DB8=/tmp/test_ms_target_$$.db; rm -f "$DB8"
@@ -92,7 +94,7 @@ echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'b'
 echo "UPDATE t SET v='t'; SELECT dolt_commit('-Am','theirs');" | $DOLTLITE "$DB8/src" > /dev/null 2>&1
 echo "UPDATE t SET v='o'; SELECT dolt_commit('-Am','ours');" | $DOLTLITE "$DB8/dev" > /dev/null 2>&1
 run_test_lastline "target_is_merged_into_branch" \
-  "BEGIN; SELECT dolt_merge('src'); COMMIT; SELECT target FROM dolt_merge_status;" \
+  "BEGIN; SELECT dolt_merge('src'); SELECT target FROM dolt_merge_status; ROLLBACK;" \
   "refs/heads/dev" "$DB8/dev"
 
 # Merging a raw commit hash reports that hash as the source, matching Dolt.
@@ -102,26 +104,41 @@ echo "UPDATE t SET v='t'; SELECT dolt_commit('-Am','theirs');" | $DOLTLITE "$DB9
 echo "UPDATE t SET v='o'; SELECT dolt_commit('-Am','ours');" | $DOLTLITE "$DB9" > /dev/null 2>&1
 SRC_HASH=$(echo "SELECT dolt_hashof('src');" | $DOLTLITE "$DB9" 2>/dev/null | tail -1)
 run_test_lastline "source_is_hash_for_hash_spec" \
-  "BEGIN; SELECT dolt_merge('$SRC_HASH'); COMMIT; SELECT source || '|' || source_commit FROM dolt_merge_status;" \
+  "BEGIN; SELECT dolt_merge('$SRC_HASH'); SELECT source || '|' || source_commit FROM dolt_merge_status; ROLLBACK;" \
   "$SRC_HASH|$SRC_HASH" "$DB9"
 
-# With no session spec to consult, a later connection recovers the branch name
-# from the persisted merge commit.
-run_test "source_derived_next_connection" \
-  "SELECT source FROM dolt_merge_status;" "src" "$DB9"
+# source is recovered from the persisted merge commit when the session that ran
+# the merge is gone. Only a violations-only merge can be committed, so that is the
+# shape that still reaches this path: derivation by branch name, and the fallback
+# to the raw hash when no branch head matches the recorded commit.
+mk_cv_persisted() {  # $1=db  $2=extra src commits after capturing the hash
+  local db="$1"
+  rm -f "$db"
+  echo "CREATE TABLE parent(id INTEGER PRIMARY KEY);
+        CREATE TABLE child(id INTEGER PRIMARY KEY, pid INT REFERENCES parent(id));
+        INSERT INTO parent VALUES(1);
+        SELECT dolt_commit('-Am','seed');
+        SELECT dolt_branch('src');" | $DOLTLITE "$db" > /dev/null 2>&1
+  echo "INSERT INTO child VALUES(11,1); SELECT dolt_commit('-Am','child');" \
+    | $DOLTLITE "$db/src" > /dev/null 2>&1
+}
 
-# A merge commit no branch points at falls back to the hash rather than naming
-# an unrelated branch.
-DB10=/tmp/test_ms_mid_$$.db; rm -f "$DB10"
-echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'b'); SELECT dolt_commit('-Am','base'); SELECT dolt_branch('src');" | $DOLTLITE "$DB10" > /dev/null 2>&1
-echo "UPDATE t SET v='t1'; SELECT dolt_commit('-Am','t1');" | $DOLTLITE "$DB10/src" > /dev/null 2>&1
-MID_HASH=$(echo "SELECT dolt_hashof('src');" | $DOLTLITE "$DB10" 2>/dev/null | tail -1)
-echo "INSERT INTO t VALUES(5,'t2'); SELECT dolt_commit('-Am','t2');" | $DOLTLITE "$DB10/src" > /dev/null 2>&1
-echo "UPDATE t SET v='o'; SELECT dolt_commit('-Am','ours');" | $DOLTLITE "$DB10" > /dev/null 2>&1
-echo "BEGIN; SELECT dolt_merge('$MID_HASH'); COMMIT;" | $DOLTLITE "$DB10" > /dev/null 2>&1
+DB10=/tmp/test_ms_deriv_$$.db
+mk_cv_persisted "$DB10"
+echo "DELETE FROM parent WHERE id=1; SELECT dolt_commit('-Am','drop parent');" | $DOLTLITE "$DB10" > /dev/null 2>&1
+echo "BEGIN; SELECT dolt_merge('src'); COMMIT;" | $DOLTLITE "$DB10" > /dev/null 2>&1
+run_test "source_derived_next_connection" \
+  "SELECT source FROM dolt_merge_status;" "src" "$DB10"
+
+DB11=/tmp/test_ms_mid_$$.db
+mk_cv_persisted "$DB11"
+MID_HASH=$(echo "SELECT dolt_hashof('src');" | $DOLTLITE "$DB11" 2>/dev/null | tail -1)
+echo "INSERT INTO child VALUES(12,1); SELECT dolt_commit('-Am','src moves on');" | $DOLTLITE "$DB11/src" > /dev/null 2>&1
+echo "DELETE FROM parent WHERE id=1; SELECT dolt_commit('-Am','drop parent');" | $DOLTLITE "$DB11" > /dev/null 2>&1
+echo "BEGIN; SELECT dolt_merge('$MID_HASH'); COMMIT;" | $DOLTLITE "$DB11" > /dev/null 2>&1
 run_test "source_falls_back_to_hash" \
   "SELECT source || '|' || source_commit FROM dolt_merge_status;" \
-  "$MID_HASH|$MID_HASH" "$DB10"
+  "$MID_HASH|$MID_HASH" "$DB11"
 
 # A merge stopped only by constraint violations -- no row conflict anywhere -- is
 # still an unfinished merge, so it must report as one.

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -3677,7 +3677,10 @@ static void run_begin_write_refreshes_working_set_metadata(void){
     "SELECT dolt_add('-A');")==SQLITE_OK);
   doltliteGetSessionStaged(db1, &stagedExpected);
   memset(&mergeExpected, 0x55, sizeof(mergeExpected));
-  memset(&conflictsExpected, 0x66, sizeof(conflictsExpected));
+  /* The conflicts catalog stays empty: a non-empty one is never written to disk,
+  ** so no connection can refresh one from disk and a distinctive value here would
+  ** simply never arrive. The merge flag and merge commit still prove the refresh. */
+  memset(&conflictsExpected, 0, sizeof(conflictsExpected));
   doltliteSetSessionMergeState(db1, 1, &mergeExpected, &conflictsExpected);
   check("persist_merge_state_for_begin_write_refresh",
         persist_working_set(db1)==SQLITE_OK);
@@ -3695,7 +3698,7 @@ static void run_begin_write_refreshes_working_set_metadata(void){
   check("begin_write_refreshes_merge_flag", isMergingAfter==1);
   check("begin_write_refreshes_merge_commit",
         memcmp(&mergeAfter, &mergeExpected, sizeof(ProllyHash))==0);
-  check("begin_write_refreshes_conflicts_catalog",
+  check("begin_write_refreshes_conflicts_catalog_empty",
         memcmp(&conflictsAfter, &conflictsExpected, sizeof(ProllyHash))==0);
   check("rollback_begin_write_refresh_txn", execSql(db2, "ROLLBACK;")==SQLITE_OK);
 
@@ -4406,7 +4409,10 @@ static void run_btree_commit_failure_transactional(void){
   check("begin_write_txn", execSql(db, "BEGIN; INSERT INTO t VALUES(2,'b');")==SQLITE_OK);
   memset(&dummyStaged, 0x71, sizeof(dummyStaged));
   memset(&dummyMerge, 0x72, sizeof(dummyMerge));
-  memset(&dummyConflicts, 0x73, sizeof(dummyConflicts));
+  /* Empty, so the commit gets far enough to hit the injected write failure:
+  ** unresolved conflicts are refused before any write is attempted. The staged
+  ** and merge-commit values below still carry the restoration check. */
+  memset(&dummyConflicts, 0, sizeof(dummyConflicts));
   doltliteSetSessionStaged(db, &dummyStaged);
   doltliteSetSessionMergeState(db, 1, &dummyMerge, &dummyConflicts);
 

--- a/test/doltlite_reset.sh
+++ b/test/doltlite_reset.sh
@@ -204,11 +204,11 @@ run_test_match "merge_conflicts_present_before_reset_guard" \
 
 run_test_match "no_arg_reset_rejected_during_merge_conflict" \
   "BEGIN; SELECT dolt_merge('feat'); SELECT dolt_reset(); SELECT 'GC2|' || count(*) FROM dolt_conflicts_t; ROLLBACK;" \
-  "Merge conflict detected" "$DB8"
+  "cannot merge: conflicts detected" "$DB8"
 
 run_test_match "soft_reset_rejected_during_merge_conflict" \
   "BEGIN; SELECT dolt_merge('feat'); SELECT dolt_reset('--soft'); SELECT 'GS|' || count(*) FROM dolt_conflicts_t; ROLLBACK;" \
-  "Merge conflict detected" "$DB8"
+  "cannot merge: conflicts detected" "$DB8"
 
 run_test_match "reset_guard_preserves_conflicts" \
   "BEGIN; SELECT dolt_merge('feat'); SELECT dolt_reset('--soft'); SELECT 'GP|' || count(*) FROM dolt_conflicts_t; ROLLBACK;" \

--- a/test/doltlite_schema_merge.sh
+++ b/test/doltlite_schema_merge.sh
@@ -462,28 +462,35 @@ SELECT dolt_merge('feat');
 COMMIT;
 EOF
 
+# Conflicts are never committed, so the merge and every inspection of it have to
+# share one session; sc() re-runs the merge and discards it afterwards.
+sc() { printf "BEGIN;\nSELECT dolt_merge('feat');\n%s\nROLLBACK;\n" "$1"; }
+
 run_test "schema_conflicts_columns" \
   "SELECT group_concat(name, '|') FROM (SELECT name FROM pragma_table_info('dolt_schema_conflicts') ORDER BY cid);" \
   "table_name|base_schema|our_schema|their_schema|description" "$DB"
-run_test "schema_conflicts_summary" \
-  "SELECT \"table\" || '|' || num_conflicts FROM dolt_conflicts;" \
+run_test_lastline "schema_conflicts_summary" \
+  "$(sc "SELECT \"table\" || '|' || num_conflicts FROM dolt_conflicts;")" \
   "t|0" "$DB"
-run_test "schema_conflicts_status" \
-  "SELECT table_name || '|' || staged || '|' || status FROM dolt_status WHERE status='schema conflict';" \
+run_test_lastline "schema_conflicts_status" \
+  "$(sc "SELECT table_name || '|' || staged || '|' || status FROM dolt_status WHERE status='schema conflict';")" \
   "t|0|schema conflict" "$DB"
-run_test "schema_conflicts_row" \
-  "SELECT table_name || '|' || (base_schema LIKE 'CREATE TABLE t%') || '|' || (our_schema LIKE '%extra INTEGER%') || '|' || (their_schema LIKE '%extra TEXT%') || '|' || description FROM dolt_schema_conflicts;" \
+run_test_lastline "schema_conflicts_row" \
+  "$(sc "SELECT table_name || '|' || (base_schema LIKE 'CREATE TABLE t%') || '|' || (our_schema LIKE '%extra INTEGER%') || '|' || (their_schema LIKE '%extra TEXT%') || '|' || description FROM dolt_schema_conflicts;")" \
   "t|1|1|1|both branches add column 'extra' with different definitions" "$DB"
 run_test_match "schema_conflicts_resolve_refused" \
-  "SELECT dolt_conflicts_resolve('--ours','t');" \
+  "$(sc "SELECT dolt_conflicts_resolve('--ours','t');")" \
   "Unable to automatically resolve schema conflicts|Error" "$DB"
 run_test_match "schema_conflicts_commit_refused" \
-  "SELECT dolt_commit('-Am','must fail');" \
+  "$(sc "SELECT dolt_commit('-Am','must fail');")" \
   "unresolved schema conflicts|Error" "$DB"
-run_test "schema_conflicts_persist_reopen" \
-  "SELECT count(*) FROM dolt_schema_conflicts;" "1" "$DB"
+
+# The COMMIT in the setup above was refused, so nothing conflicted reached disk.
+run_test "schema_conflicts_not_persisted" \
+  "SELECT (SELECT count(*) FROM dolt_schema_conflicts) || '|' || (SELECT count(*) FROM dolt_conflicts);" \
+  "0|0" "$DB"
 run_test_match "schema_conflicts_abort" \
-  "SELECT dolt_merge('--abort');" "^[0-9]+$" "$DB"
+  "BEGIN; SELECT dolt_merge('feat'); SELECT dolt_merge('--abort');" "^[0-9]+$" "$DB"
 run_test "schema_conflicts_abort_clears" \
   "SELECT (SELECT count(*) FROM dolt_schema_conflicts) || '|' || (SELECT count(*) FROM dolt_conflicts) || '|' || (SELECT count(*) FROM dolt_status WHERE status='schema conflict');" \
   "0|0|0" "$DB"

--- a/test/vc_oracle_cross_connection_state_test.sh
+++ b/test/vc_oracle_cross_connection_state_test.sh
@@ -205,105 +205,17 @@ paired_branch_query "branches" "side_connection_recovers_its_working_set" "side"
    SELECT CONCAT('Q|status|', table_name, '|', status) FROM dolt_status;"
 
 echo ""
-echo "--- conflict handoff and partial resolution ---"
-
-setup_pair "resolve" "
-CREATE TABLE a(id INTEGER PRIMARY KEY, v INT);
-CREATE TABLE b(id INTEGER PRIMARY KEY, v INT);
-INSERT INTO a VALUES(1, 10);
-INSERT INTO b VALUES(1, 20);
-SELECT dolt_commit('-A', '-m', 'base');
-SELECT dolt_branch('feature');
-SELECT dolt_checkout('feature');
-UPDATE a SET v=100 WHERE id=1;
-UPDATE b SET v=200 WHERE id=1;
-SELECT dolt_commit('-A', '-m', 'feature');
-SELECT dolt_checkout('main');
-UPDATE a SET v=1000 WHERE id=1;
-UPDATE b SET v=2000 WHERE id=1;
-SELECT dolt_commit('-A', '-m', 'main');
-"
-
-# Connection A persists a conflicted merge transaction.
-dl_exec_conflicting_merge "resolve" "
-BEGIN;
-SELECT dolt_merge('feature');
-COMMIT;
-"
-dt_exec "resolve" "
-SET @@autocommit=0;
-SET @@dolt_allow_commit_conflicts=1;
-CALL dolt_merge('feature');
-COMMIT;
-"
-
-# Connection B recovers the conflict summary and row payload.
-paired_query "resolve" "conflicts_visible_to_next_connection" \
-  "SELECT 'Q|summary|' || \"table\" || '|' || num_conflicts FROM dolt_conflicts ORDER BY \"table\";
-   SELECT 'Q|a|' || base_v || '|' || our_v || '|' || their_v FROM dolt_conflicts_a;
-   SELECT 'Q|b|' || base_v || '|' || our_v || '|' || their_v FROM dolt_conflicts_b;" \
-  "SELECT CONCAT('Q|summary|', \`table\`, '|', num_conflicts) FROM dolt_conflicts ORDER BY \`table\`;
-   SELECT CONCAT('Q|a|', base_v, '|', our_v, '|', their_v) FROM dolt_conflicts_a;
-   SELECT CONCAT('Q|b|', base_v, '|', our_v, '|', their_v) FROM dolt_conflicts_b;"
-
-# Connection B resolves one table.  Connection C sees the partial resolution
-# while the other table remains conflicted.
-dl_exec "resolve" "SELECT dolt_conflicts_resolve('--ours', 'a');"
-dt_exec "resolve" "CALL dolt_conflicts_resolve('--ours', 'a');"
-paired_query "resolve" "partial_resolution_visible_to_next_connection" \
-  "SELECT 'Q|summary|' || \"table\" || '|' || num_conflicts FROM dolt_conflicts ORDER BY \"table\";
-   SELECT 'Q|a-value|' || v FROM a WHERE id=1;
-   SELECT 'Q|b|' || base_v || '|' || our_v || '|' || their_v FROM dolt_conflicts_b;" \
-  "SELECT CONCAT('Q|summary|', \`table\`, '|', num_conflicts) FROM dolt_conflicts ORDER BY \`table\`;
-   SELECT CONCAT('Q|a-value|', v) FROM a WHERE id=1;
-   SELECT CONCAT('Q|b|', base_v, '|', our_v, '|', their_v) FROM dolt_conflicts_b;"
-
-# Connection C resolves the final table with the other side.  Connection D
-# sees both choices and no remaining conflicts.
-dl_exec "resolve" "SELECT dolt_conflicts_resolve('--theirs', 'b');"
-dt_exec "resolve" "CALL dolt_conflicts_resolve('--theirs', 'b');"
-paired_query "resolve" "completed_resolution_visible_to_next_connection" \
-  "SELECT 'Q|a-value|' || v FROM a WHERE id=1;
-   SELECT 'Q|b-value|' || v FROM b WHERE id=1;
-   SELECT 'Q|conflict-count|' || count(*) FROM dolt_conflicts;" \
-  "SELECT CONCAT('Q|a-value|', v) FROM a WHERE id=1;
-   SELECT CONCAT('Q|b-value|', v) FROM b WHERE id=1;
-   SELECT CONCAT('Q|conflict-count|', count(*)) FROM dolt_conflicts;"
-
-echo ""
-echo "--- abort handoff ---"
-
-setup_pair "abort" "
-CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
-INSERT INTO t VALUES(1, 10);
-SELECT dolt_commit('-A', '-m', 'base');
-SELECT dolt_branch('feature');
-SELECT dolt_checkout('feature');
-UPDATE t SET v=100 WHERE id=1;
-SELECT dolt_commit('-A', '-m', 'feature');
-SELECT dolt_checkout('main');
-UPDATE t SET v=1000 WHERE id=1;
-SELECT dolt_commit('-A', '-m', 'main');
-"
-dl_exec_conflicting_merge "abort" "BEGIN; SELECT dolt_merge('feature'); COMMIT;"
-dt_exec "abort" "
-SET @@autocommit=0;
-SET @@dolt_allow_commit_conflicts=1;
-CALL dolt_merge('feature');
-COMMIT;
-"
-
-# A later connection aborts the recovered merge, and another connection sees
-# the exact pre-merge working state restored.
-dl_exec "abort" "SELECT dolt_merge('--abort');"
-dt_exec "abort" "CALL dolt_merge('--abort');"
-paired_query "abort" "aborted_conflict_cleanup_visible_to_next_connection" \
-  "SELECT 'Q|row|' || v FROM t WHERE id=1;
-   SELECT 'Q|conflict-count|' || count(*) FROM dolt_conflicts;
-   SELECT 'Q|status-count|' || count(*) FROM dolt_status;" \
-  "SELECT CONCAT('Q|row|', v) FROM t WHERE id=1;
-   SELECT CONCAT('Q|conflict-count|', count(*)) FROM dolt_conflicts;
-   SELECT CONCAT('Q|status-count|', count(*)) FROM dolt_status;"
+# Conflict handoff is deliberately not compared here. Dolt can commit a
+# transaction holding unresolved conflicts, so its conflicts outlive the
+# connection that made them and can be inspected, partially resolved and
+# aborted from later ones. DoltLite refuses that commit outright -- a conflict
+# never reaches disk -- so there is no shared behaviour for an oracle to diff.
+# The DoltLite contract is asserted directly instead:
+#   test/doltlite_merge_status.sh  conflict_commit_is_refused,
+#                                  conflict_does_not_outlive_transaction
+#   test/doltlite_conflicts.sh     in-transaction inspect/resolve/abort
+# Everything above this point -- working and staged handoff, branch-local
+# working sets -- is unaffected and still compared against Dolt.
 
 echo ""
 echo "=== Results: $pass passed, $fail failed ==="

--- a/test/vc_oracle_merge_status_test.sh
+++ b/test/vc_oracle_merge_status_test.sh
@@ -58,9 +58,11 @@ coalesce(unmerged_tables,'~')) FROM dolt_merge_status"
 # merged into. Cross-connection persistence is covered by
 # test/doltlite_merge_status.sh.
 #
-# DoltLite needs an explicit transaction for a conflicted merge to survive;
-# Dolt needs dolt_allow_commit_conflicts for the same reason. That difference is
-# in the harness, not in dolt_merge_status, so each side gets its own wrapper.
+# A conflicted merge is never committable in DoltLite, so the status has to be
+# read inside the transaction that produced it. Dolt would let the commit through
+# behind dolt_allow_commit_conflicts, but reading in-session gives the same answer
+# there, so both sides are compared at the same point and the projection is part
+# of the script rather than a follow-up connection.
 oracle() {
   local name="$1" setup="$2" merge="${3:-}" after="${4:-}"
   local dir="$TMPROOT/$name"
@@ -83,14 +85,21 @@ $(vc_oracle_translate_for_dolt "$setup")"
 BEGIN;
 SELECT dolt_merge('$merge');
 $after
-COMMIT;"
+$DL_PROJECT;
+ROLLBACK;"
     dt_script="$dt_script
 CALL dolt_merge('$merge');
-$(vc_oracle_translate_for_dolt "$after")"
+$(vc_oracle_translate_for_dolt "$after")
+$DT_PROJECT;"
+  else
+    dl_script="$dl_script
+$DL_PROJECT;"
+    dt_script="$dt_script
+$DT_PROJECT;"
   fi
 
   local dl_out
-  dl_out=$(printf '%s\n.headers off\n.mode list\n%s;\n' "$dl_script" "$DL_PROJECT" \
+  dl_out=$(printf '.headers off\n.mode list\n%s\n' "$dl_script" \
            | "$DOLTLITE" "$dir/dl/db" 2>"$dir/dl.err" \
            | grep -F '|' \
            | tail -1 \
@@ -99,8 +108,7 @@ $(vc_oracle_translate_for_dolt "$after")"
   (
     cd "$dir/dt" || exit 1
     vc_oracle_init_repo
-    printf '%s\n%s;\n' "$dt_script" "$DT_PROJECT" \
-      | "$DOLT" sql -r csv 2>"$dir/dt.err"
+    printf '%s\n' "$dt_script" | "$DOLT" sql -r csv 2>"$dir/dt.err"
   ) > "$dir/dt.raw"
 
   local dt_out

--- a/test/vc_oracle_reset_test.sh
+++ b/test/vc_oracle_reset_test.sh
@@ -735,7 +735,7 @@ SELECT dolt_commit('-m', 'feat1');
 SELECT dolt_checkout('main');
 SELECT dolt_merge('feature');
 SELECT dolt_reset();
-" "Merge conflict detected"
+" "(Merge conflict detected|cannot merge: conflicts detected)"
 
 oracle_error_match "reset_soft_during_merge_conflict" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
@@ -753,7 +753,7 @@ SELECT dolt_commit('-m', 'feat1');
 SELECT dolt_checkout('main');
 SELECT dolt_merge('feature');
 SELECT dolt_reset('--soft');
-" "Merge conflict detected"
+" "(Merge conflict detected|cannot merge: conflicts detected)"
 
 echo "--- savepoint parity ---"
 

--- a/test/vc_oracle_schema_merge_test.sh
+++ b/test/vc_oracle_schema_merge_test.sh
@@ -221,16 +221,24 @@ DT_T2=$(dt_repo_for_db "$DB")
   | "$DOLT" sql -c) >"$TMPROOT/schema_conflicts_persist.dt.out" \
       2>"$TMPROOT/schema_conflicts_persist.dt.err" || true
 expect_dual_value "schema_conflicts_transaction_state" "$DB" "1|1|0|1" \
-  "SELECT (SELECT count(*) FROM dolt_schema_conflicts) || '|' || (SELECT count(*) FROM dolt_conflicts) || '|' || (SELECT coalesce(sum(num_conflicts),-1) FROM dolt_conflicts) || '|' || (SELECT count(*) FROM dolt_status WHERE status='schema conflict');" \
+  "BEGIN; SELECT dolt_merge('feat'); SELECT (SELECT count(*) FROM dolt_schema_conflicts) || '|' || (SELECT count(*) FROM dolt_conflicts) || '|' || (SELECT coalesce(sum(num_conflicts),-1) FROM dolt_conflicts) || '|' || (SELECT count(*) FROM dolt_status WHERE status='schema conflict');" \
   "SELECT CONCAT((SELECT count(*) FROM dolt_schema_conflicts), '|', (SELECT count(*) FROM dolt_conflicts), '|', (SELECT coalesce(sum(num_conflicts),-1) FROM dolt_conflicts), '|', (SELECT count(*) FROM dolt_status WHERE status='schema conflict'));"
 expect_dual_value "schema_conflicts_schema_rows" "$DB" "t|1|1|1" \
-  "SELECT table_name || '|' || (base_schema LIKE '%CREATE TABLE%') || '|' || (our_schema LIKE '%extra%') || '|' || (their_schema LIKE '%extra%') FROM dolt_schema_conflicts;" \
+  "BEGIN; SELECT dolt_merge('feat'); SELECT table_name || '|' || (base_schema LIKE '%CREATE TABLE%') || '|' || (our_schema LIKE '%extra%') || '|' || (their_schema LIKE '%extra%') FROM dolt_schema_conflicts;" \
   "SELECT CONCAT(table_name, '|', base_schema LIKE '%CREATE TABLE%', '|', our_schema LIKE '%extra%', '|', their_schema LIKE '%extra%') FROM dolt_schema_conflicts;"
 run_dual_command_outcome "schema_conflicts_resolve_refused" "$DB" \
-  "SELECT dolt_conflicts_resolve('--ours','t');" \
+  "BEGIN; SELECT dolt_merge('feat'); SELECT dolt_conflicts_resolve('--ours','t');" \
   "CALL dolt_conflicts_resolve('--ours','t');" error
-run_dual_command_outcome "schema_conflicts_abort" "$DB" \
-  "SELECT dolt_merge('--abort');" "CALL dolt_merge('--abort');" ok
+# No outcome comparison for the abort itself: DoltLite can only reach an active
+# merge inside the transaction that created it, and that transaction necessarily
+# carries the expected conflict error, which output_is_error cannot tell apart
+# from a real failure. The abort is compared by its effect in
+# schema_conflicts_abort_clears below, and exercised directly in
+# test/doltlite_schema_merge.sh. Dolt still holds a committed conflicted merge at
+# this point, so it needs the abort run for the next comparison to line up.
+DT_AB=$(dt_repo_for_db "$DB")
+(cd "$DT_AB" && printf '%s\n' "CALL dolt_merge('--abort');" | "$DOLT" sql) \
+  >"$TMPROOT/schema_conflicts_abort.dt.out" 2>"$TMPROOT/schema_conflicts_abort.dt.err" || true
 expect_dual_value "schema_conflicts_abort_clears" "$DB" "0|0|0" \
   "SELECT (SELECT count(*) FROM dolt_schema_conflicts) || '|' || (SELECT count(*) FROM dolt_conflicts) || '|' || (SELECT count(*) FROM dolt_status WHERE status='schema conflict');" \
   "SELECT CONCAT((SELECT count(*) FROM dolt_schema_conflicts), '|', (SELECT count(*) FROM dolt_conflicts), '|', (SELECT count(*) FROM dolt_status WHERE status='schema conflict'));"

--- a/test/vc_stateful_fuzzer.py
+++ b/test/vc_stateful_fuzzer.py
@@ -191,7 +191,9 @@ def merge_branch(doltlite, db_path, branches, model, rng):
         "SELECT dolt_merge(%s);" % sql_quote(source),
         "merge_%s_into_%s" % (source, target),
         timeout=30,
-        allowed_errors=("Merge conflict detected",),
+        # An autocommit merge that conflicts is rolled back whole, so the model
+        # below still matches: the target keeps the state it had before.
+        allowed_errors=("cannot merge: conflicts detected",),
     )
     merged = query_rows(doltlite, db_path, target)
     model[target]["working"] = dict(merged)


### PR DESCRIPTION
Closes #1791 by removing the behaviour `@@dolt_allow_commit_conflicts` would have gated, rather than implementing it. **A conflicted merge now lives only in the transaction that produced it.**

## The messages

Both sites advertised `@@dolt_allow_commit_conflicts = 1`, which DoltLite has no implementation of and cannot even parse — `SET` isn't SQLite syntax.

Worth recording *why*: they were **inherited verbatim from Dolt**, where the advice is correct. Dolt emits that exact string, `@@dolt_allow_commit_conflicts` clause and all. So this was parity-copied text for a variable that was never ported, not invented advice.

## The behaviour underneath

DoltLite already behaved as though the flag were permanently on: `BEGIN; merge; COMMIT` persisted a conflicted working set that later connections inherited. Dolt refuses that by default. Closing it took **two** durability routes:

- **Commit phase one** refuses the caller's own commit — and *only* theirs. The `dolt_*` commands run inner SQL while conflicts are legitimately present, and failing those replaced each command's own diagnosis with a bare `constraint failed`. Nesting is detected via `db->nVdbeExec`.
- **Phase two and the persist path** leave a conflicted batch *pending* instead of durable. This is where `dolt_commit`'s `-A` staging was quietly making conflicts permanent before reaching its own conflict check — found by backtracing `chunkStoreCommit`, not by reading.

Constraint violations are untouched and still persist.

```
BEGIN; SELECT dolt_merge('f');        -- reports N conflicts, inspectable here
SELECT * FROM dolt_conflicts;         -- works
COMMIT;                               -- refused, nothing reaches disk
```

`dolt_commit` keeps its own message (`cannot commit: unresolved merge conflicts…`); resolve-then-commit works unchanged; clean commits are unaffected.

One limitation I couldn't fix cleanly: the COMMIT-time text is `constraint failed`, because `vdbeaux.c:3446` discards the message and overriding that means editing upstream SQLite above `btree.h`. The actionable wording comes from the merge error, which fires first.

## Coverage that described now-unreachable states

Three pieces were repointed rather than dropped — each was testing something that can no longer happen:

- **GC walker guard** used a conflicts blob to prove the mark phase survives a leading `'D'` byte (`CATALOG_FORMAT_V3`). A conflicts blob can't be on disk now, so it uses the **violations** blob — still committable, still leads with `'D'`. Verified it still exercises the path.
- **`dolt_merge_status` cross-connection `source` derivation** is only reachable via a violations-only merge now, so those two cases use one. Without that the derivation branch would have been dead code.
- **A C regression test** fabricated a non-empty conflicts hash purely as a distinctive value to prove `BEGIN IMMEDIATE` refreshes metadata from disk. No connection can refresh a conflicted state from disk any more, so it uses the merge commit instead.

## Oracle suites

Conflict persistence is now a deliberate divergence from Dolt, so cases that compared it compare **in-transaction state on both sides** instead. The cross-connection conflict handoff has no shared behaviour left to diff at all — removed from the oracle with the relocation recorded inline, and asserted natively in `doltlite_merge_status.sh` (`conflict_commit_is_refused`, `conflict_does_not_outlive_transaction`).

## Testing

| | |
|---|---|
| native suites | **91/91** |
| C regression assertions | **309,956/309,956** |
| gated C tests | 24/24 |
| merge / conflicts / conflicts_table / conflicts_resolve oracles | 74 / 9 / 13 / 28 |
| schema_merge / reset / merge_status / constraint_violations oracles | 53 / 43 / 10 / 5 |
| pk_shapes_conflicts / cross_connection / checkout / autoinc | 16 / 5 / 65 / 13 |
| check + lint scripts | 6/6 |

Conflict surface clean under ASan+UBSan. The full oracle sweep exceeds the local budget, so the remainder runs in CI.

Documented in README (user-facing contract) and AGENTS.md (as a VC invariant, flagging that in-transaction behaviour is what to compare against Dolt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
