### PR TITLE
Export only the public API from libdoltlite

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,13 @@ Dolt functions included.
 Loadable-extension authors use `doltliteext.h` (the rebranded `sqlite3ext.h`,
 shipped in the amalgamation zip alongside `doltlite.c`/`doltlite.h`).
 
+The shared library exports only `sqlite3_*` and the `doltliteServe*` entry
+points from `doltlite_remotesrv.h`. Everything else — the prolly, chunk-store
+and `doltlite*` internals, and statically linked mbedtls, BLAKE3 and ed25519 —
+is hidden, so linking `libdoltlite` cannot collide with a host's own copy of
+those libraries. The static archive is deliberately unfiltered for tests and
+tooling that need the internals.
+
 ```bash
 cd build
 ../configure

--- a/main.mk
+++ b/main.mk
@@ -307,6 +307,7 @@ all:	lint doltlite$(T.exe)
 lint:
 	@bash $(TOP)/test/lint_layers.sh $(TOP)/src
 	@bash $(TOP)/test/lint_no_raw_os_fileio.sh $(TOP)/src
+	@bash $(TOP)/test/lint_export_filters.sh $(TOP)/src
 	@bash $(TOP)/test/lint_layers_selftest.sh
 
 ########################################################################
@@ -2980,9 +2981,20 @@ LDFLAGS.libdoltlite.os-specific = $(subst $(libsqlite3.DLL),libdoltlite$(T.dll),
 libdoltlite.comma := ,
 LDFLAGS.libdoltlite.soname = $(if $(filter .so,$(T.dll)),-Wl$(libdoltlite.comma)-soname$(libdoltlite.comma)libdoltlite.so.0,)
 
-libdoltlite$(T.dll):	$(LIBOBJS0)
+# Restrict the shared library's export table to sqlite3_* plus DoltLite's
+# documented embedding entry points. Unfiltered, the link also exports every
+# cross-file prolly/chunk/doltlite helper and all of vendored mbedtls, BLAKE3
+# and ed25519, which collides with a host that links any of those itself.
+# The static archive is deliberately unfiltered: the C unit tests link it and
+# call internals directly.
+libdoltlite.exports.file = $(if $(filter .so,$(T.dll)),$(TOP)/src/libdoltlite.map,$(if $(filter .dylib,$(T.dll)),$(TOP)/src/libdoltlite.sym,))
+libdoltlite.exports.flag = $(if $(filter .so,$(T.dll)),--version-script,$(if $(filter .dylib,$(T.dll)),-exported_symbols_list,))
+LDFLAGS.libdoltlite.exports = $(if $(libdoltlite.exports.file),-Wl$(libdoltlite.comma)$(libdoltlite.exports.flag)$(libdoltlite.comma)$(libdoltlite.exports.file),)
+
+libdoltlite$(T.dll):	$(LIBOBJS0) $(libdoltlite.exports.file)
 	$(T.link.shared) -o $@ $(LIBOBJS0) $(LDFLAGS.libsqlite3) \
-		$(LDFLAGS.libdoltlite.os-specific) $(LDFLAGS.libdoltlite.soname)
+		$(LDFLAGS.libdoltlite.os-specific) $(LDFLAGS.libdoltlite.soname) \
+		$(LDFLAGS.libdoltlite.exports)
 	$(if $(filter .so,$(T.dll)),ln -sf libdoltlite$(T.dll) libdoltlite$(T.dll).0)
 
 doltlite-lib: libdoltlite$(T.lib) libdoltlite$(T.dll) doltlite.h

--- a/src/libdoltlite.map
+++ b/src/libdoltlite.map
@@ -1,0 +1,19 @@
+/* Export filter for libdoltlite.so (GNU ld / lld version script).
+**
+** Upstream SQLite ships one amalgamated translation unit, so every helper is
+** static and nothing but the public API is global. DoltLite is split across
+** ~84 files whose cross-file helpers must be extern, and it statically links
+** vendored mbedtls, BLAKE3 and ed25519. Without this filter the shared library
+** exports all of that -- so a host application that links mbedtls or BLAKE3
+** itself collides with ours, or silently interposes one implementation on the
+** other.
+**
+** Keep in sync with libdoltlite.sym, the Mach-O form of the same list.
+*/
+{
+  global:
+    sqlite3_*;
+    doltliteServe*;
+  local:
+    *;
+};

--- a/src/libdoltlite.sym
+++ b/src/libdoltlite.sym
@@ -1,0 +1,5 @@
+# Export filter for libdoltlite.dylib (ld64 -exported_symbols_list).
+# Mach-O form of src/libdoltlite.map; keep the two in sync. See that file for
+# why the filter exists. Names carry the Mach-O leading underscore.
+_sqlite3_*
+_doltliteServe*

--- a/test/assert_doltlite_artifacts.sh
+++ b/test/assert_doltlite_artifacts.sh
@@ -89,6 +89,40 @@ if [ "${DOLTLITE_CHECK_SHARED:-1}" != 0 ]; then
   fi
 fi
 
+# Hold the shared library to the export filter in src/libdoltlite.map (ELF) and
+# src/libdoltlite.sym (Mach-O); see those files for why it exists.
+if [ "${DOLTLITE_CHECK_EXPORTS:-1}" != 0 ] && command -v nm >/dev/null 2>&1; then
+  shared=""
+  for cand in ./libdoltlite.so ./libdoltlite.dylib; do
+    if [ -f "$cand" ]; then shared="$cand"; fi
+  done
+  if [ -n "$shared" ]; then
+    case "$(uname -s)" in
+      Darwin) exported=$(nm -gU "$shared" | awk 'NF>=2{print $NF}' | sed 's/^_//') ;;
+      *)      exported=$(nm -D --defined-only "$shared" | awk 'NF>=2{print $NF}') ;;
+    esac
+    # _init/_fini/__bss_start/_edata/_end are defined by the linker itself,
+    # after version-script processing, so `local: *` cannot hide them.
+    leaked=$(printf '%s\n' "$exported" \
+             | grep -vE '^(sqlite3_|doltliteServe)' \
+             | grep -vE '^(_init|_fini|__bss_start|_edata|_end)$' \
+             | sort -u || true)
+    if [ -n "$leaked" ]; then
+      n=$(printf '%s\n' "$leaked" | wc -l | tr -d ' ')
+      echo "libdoltlite exports: $n symbol(s) outside sqlite3_*/doltliteServe*" >&2
+      # awk rather than head: head closes the pipe early, which under pipefail
+      # surfaces as a broken-pipe error instead of this diagnostic.
+      printf '%s\n' "$leaked" \
+        | awk 'NR<=20{print "  " $0} END{if(NR>20) print "  ... and " NR-20 " more"}' >&2
+      echo "Widen src/libdoltlite.map and src/libdoltlite.sym only for genuinely" >&2
+      echo "public API; otherwise the new symbol belongs behind the filter." >&2
+      exit 1
+    fi
+    n=$(printf '%s\n' "$exported" | sort -u | wc -l | tr -d ' ')
+    echo "libdoltlite exports: $n symbols, all public API"
+  fi
+fi
+
 if [ "${DOLTLITE_CHECK_AMALGAMATION:-1}" != 0 ] && [ -f ./sqlite3.c ]; then
   for source in prolly_btree.c prolly_btree_catalog.c prolly_btree_cursor.c \
                 prolly_btree_mutation.c prolly_btree_orig.c \

--- a/test/lint_export_filters.sh
+++ b/test/lint_export_filters.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+#
+# The libdoltlite export filter is spelled twice because ld and ld64 take
+# different formats: src/libdoltlite.map (ELF version script) and
+# src/libdoltlite.sym (Mach-O exported symbols list, names underscore-prefixed).
+# Drift between them means one platform ships a different ABI than the other,
+# and CI only notices on whichever platform lost a symbol. Compare the pattern
+# sets directly.
+
+SRCDIR="${1:-src}"
+MAP="$SRCDIR/libdoltlite.map"
+SYM="$SRCDIR/libdoltlite.sym"
+rc=0
+
+for f in "$MAP" "$SYM"; do
+  if [ ! -f "$f" ]; then
+    echo "LINT: $f: missing — libdoltlite must ship an export filter"
+    exit 1
+  fi
+done
+
+map_pats=$(sed 's;/\*.*\*/;;' "$MAP" \
+           | sed -n '/global:/,/local:/p' \
+           | grep -oE '[A-Za-z_][A-Za-z0-9_]*\*?;' \
+           | tr -d ';' | sort -u)
+
+sym_pats=$(grep -vE '^\s*(#|$)' "$SYM" | sed 's/^_//' | sort -u)
+
+if [ "$map_pats" != "$sym_pats" ]; then
+  echo "LINT: $MAP and $SYM declare different export patterns"
+  diff <(printf '%s\n' "$map_pats") <(printf '%s\n' "$sym_pats") \
+    | sed 's/^/LINT:   /'
+  rc=1
+fi
+
+if ! grep -qE '^\s*local:' "$MAP"; then
+  echo "LINT: $MAP: no 'local: *;' clause — nothing would be hidden"
+  rc=1
+fi
+
+if [ "$rc" = 0 ]; then
+  echo "lint_export_filters: all checks passed"
+fi
+
+exit $rc


### PR DESCRIPTION
## Problem

`libdoltlite.{so,dylib}` exported **3743** symbols, **3453** of them internal:

- 1105 `mbedtls_*`
- all of vendored BLAKE3 (`blake3_compress_in_place`, `blake3_hash_many`, …) and ed25519
- 183 `prolly*` / 64 `chunk*`
- ~250 unprefixed names like `catAdd`, `catFind`, `advanceTreeCursor`, `btreeSerialType`

Stock `libsqlite3` exports zero non-`sqlite3` symbols. The cause is structural: upstream ships one amalgamated TU so every helper is `static`, whereas DoltLite's ~84-file split forces cross-file helpers to be extern. There was no `-fvisibility=hidden` and no export list anywhere in the build.

An embedding host that links mbedtls or BLAKE3 itself gets a duplicate symbol, or — worse, depending on link order — silently interposes one implementation on the other.

## Fix

Filter the shared-library link to `sqlite3_*` plus the `doltliteServe*` entry points documented in `doltlite_remotesrv.h`. **3743 exports → 290** (284 `sqlite3_*` + 6 server functions). Zero foreign-namespace symbols remain.

The static archive is deliberately left unfiltered: the C unit tests link it and call internals directly, and nothing in-tree links the shared library (the CLI, `doltlite-remotesrv`, testfixture and every C test link `LIBOBJS0` objects), so no in-tree consumer is affected.

Two filter files, because `ld` and `ld64` take different formats:
- `src/libdoltlite.map` — ELF version script
- `src/libdoltlite.sym` — Mach-O exported symbols list

Windows/MSVC builds are unaffected (the `$(if)` yields no flag for non-`.so`/`.dylib`).

## Guards

Drift between the two files would mean one platform ships a different ABI than the other, so:

- `test/lint_export_filters.sh` (new, wired into `make lint`) compares the pattern sets and requires a `local:` clause. Negative-tested against pattern drift, a missing `local:` clause, and a missing file.
- `test/assert_doltlite_artifacts.sh` now asserts the built export table. It runs in the `checked` job on **both ubuntu and macos**, plus the release workflow.

## Verification (macOS, local)

- All four artifact probes still link and run: CLI, `libdoltlite.a`, shared library, amalgamation
- A probe calling `doltliteServeAsync` through the filtered dylib starts and stops a server — the README's documented embedding path still works
- `dlsym` no longer resolves `blake3_hasher_init`, `catAdd`, `mbedtls_ssl_init`, `prollyCursorNext`; `sqlite3_open` and `doltliteServeAsync` still resolve
- **Fail-before:** relinked without the filter, the guard exits 1 and reports 3453 leaked symbols
- 24/24 C tests pass (0 not-built, 0 stale); 91/91 shell suites, 309,956 assertions

## Needs CI

I have no ELF linker locally, so the `--version-script` path is validated by the ubuntu `checked` job rather than on my machine. A syntax error there fails at link with a clear message and affects nothing else.

## Follow-up, not in this PR

The Android build lives in `dolthub/doltlite-android` and builds per-ABI `libdoltlite.so` with the NDK; it picks this up only if it links through `main.mk`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)