### PR TITLE
fix: report conflicts and constraint violations together

### DIFF
--- a/src/doltlite_cherry_pick.c
+++ b/src/doltlite_cherry_pick.c
@@ -182,6 +182,10 @@ int applyMergedCatalogAndCommit(
     sqlite3_free(zDetectErrMsg);
 
     if( nViolations + nUnique + nCheck > 0 ){
+      if( *pnConflicts > 0 ){
+        return doltliteCmdFinishWithConflictsAndConstraintViolations(
+            db, context, &savedState, *pnConflicts, zOpLabel, 1, 0);
+      }
       return doltliteCmdFinishWithConstraintViolations(
           db, context, &savedState, zOpLabel, 1,
           "Merge aborted: would have introduced constraint violations. "

--- a/src/doltlite_cmd.c
+++ b/src/doltlite_cmd.c
@@ -102,6 +102,27 @@ int doltliteReportConstraintViolations(
   return SQLITE_OK;
 }
 
+int doltliteReportConflictsAndConstraintViolations(
+  sqlite3 *db,
+  sqlite3_context *ctx,
+  int nConflicts,
+  const char *zOp
+){
+  char msg[384];
+  int rc;
+  rc = doltliteRegisterConflictTables(db);
+  if( rc!=SQLITE_OK ) return rc;
+  rc = doltlitePersistOrSaveWorkingSet(db);
+  if( rc!=SQLITE_OK ) return rc;
+  sqlite3_snprintf(sizeof(msg), msg,
+    "%s has %d conflict(s) and constraint violations. Resolve "
+    "dolt_conflicts and dolt_constraint_violations, then commit with "
+    "dolt_commit.",
+    zOp ? zOp : "Operation", nConflicts);
+  sqlite3_result_error(ctx, msg, -1);
+  return SQLITE_OK;
+}
+
 void doltliteReportAutocommitConflictRollback(sqlite3_context *ctx){
   sqlite3_result_error(ctx,
     "cannot merge: conflicts detected, autocommit transaction rolled back. "
@@ -139,9 +160,8 @@ int doltliteRollbackAutocommitConflict(
   return rc;
 }
 
-static int cmdRollbackAutocommitConstraintViolations(
+static int cmdRollbackAutocommitToSaved(
   sqlite3 *db,
-  sqlite3_context *ctx,
   DoltliteTxnState *pSaved
 ){
   int rc = doltliteHardReset(db, &pSaved->sessionCatalogHash);
@@ -166,6 +186,15 @@ static int cmdRollbackAutocommitConstraintViolations(
     rc = doltlitePersistWorkingSet(db);
   }
   doltliteTxnStateClear(pSaved);
+  return rc;
+}
+
+static int cmdRollbackAutocommitConstraintViolations(
+  sqlite3 *db,
+  sqlite3_context *ctx,
+  DoltliteTxnState *pSaved
+){
+  int rc = cmdRollbackAutocommitToSaved(db, pSaved);
   if( rc!=SQLITE_OK ){
     sqlite3_result_error_code(ctx, rc);
     return rc;
@@ -270,6 +299,87 @@ int doltliteCmdFinishWithConstraintViolations(
         "is empty. Re-run the operation outside a nested SAVEPOINT to "
         "inspect the violations in dolt_constraint_violations.",
         -1);
+    }
+    return SQLITE_OK;
+  }
+  return SQLITE_OK;
+}
+
+static int cmdRollbackAutocommitConflictsAndCVs(
+  sqlite3 *db,
+  sqlite3_context *ctx,
+  DoltliteTxnState *pSaved,
+  int nConflicts,
+  const char *zOp
+){
+  char msg[384];
+  int rc = cmdRollbackAutocommitToSaved(db, pSaved);
+  if( rc!=SQLITE_OK ){
+    sqlite3_result_error_code(ctx, rc);
+    return rc;
+  }
+  sqlite3_snprintf(sizeof(msg), msg,
+    "%s has %d conflict(s) and constraint violations; transaction "
+    "rolled back. Run inside BEGIN/COMMIT to inspect dolt_conflicts and "
+    "dolt_constraint_violations.",
+    zOp ? zOp : "Operation", nConflicts);
+  sqlite3_result_error(ctx, msg, -1);
+  return SQLITE_OK;
+}
+
+int doltliteCmdFinishWithConflictsAndConstraintViolations(
+  sqlite3 *db,
+  sqlite3_context *ctx,
+  DoltliteTxnState *pSaved,
+  int nConflicts,
+  const char *zOp,
+  int bSealOnPlain,
+  const char *zNestedMsg
+){
+  int rc;
+  if( nConflicts<=0 ){
+    return doltliteCmdFinishWithConstraintViolations(
+        db, ctx, pSaved, zOp, bSealOnPlain, zNestedMsg);
+  }
+  switch( doltliteVcTxnMode(db) ){
+  case DOLTLITE_VC_TXN_AUTOCOMMIT_LIKE:
+    return cmdRollbackAutocommitConflictsAndCVs(
+        db, ctx, pSaved, nConflicts, zOp);
+  case DOLTLITE_VC_TXN_PLAIN:
+    rc = doltliteReportConflictsAndConstraintViolations(
+        db, ctx, nConflicts, zOp);
+    if( rc!=SQLITE_OK ){
+      sqlite3_result_error_code(ctx,
+          doltliteRestoreTxnStateOnFailure(db, pSaved, rc));
+      return rc;
+    }
+    if( bSealOnPlain ){
+      rc = doltliteVcSealActiveSavepoints(db);
+      if( rc!=SQLITE_OK ){
+        sqlite3_result_error_code(ctx,
+            doltliteRestoreTxnStateOnFailure(db, pSaved, rc));
+        return rc;
+      }
+    }
+    doltliteTxnStateClear(pSaved);
+    return SQLITE_OK;
+  case DOLTLITE_VC_TXN_NESTED_SAVEPOINT:
+    rc = doltliteRestoreTxnStateOnFailure(db, pSaved, SQLITE_OK);
+    if( rc!=SQLITE_OK ){
+      sqlite3_result_error_code(ctx, rc);
+      return rc;
+    }
+    if( zNestedMsg ){
+      sqlite3_result_error(ctx, zNestedMsg, -1);
+    }else{
+      char msg[384];
+      sqlite3_snprintf(sizeof(msg), msg,
+        "%s has %d conflict(s) and constraint violations. The merge and "
+        "would-be violations have been rolled back with the enclosing "
+        "savepoint. Re-run inside BEGIN/COMMIT (no nested SAVEPOINT) to "
+        "inspect dolt_conflicts and dolt_constraint_violations.",
+        zOp ? zOp : "Operation", nConflicts);
+      sqlite3_result_error(ctx, msg, -1);
     }
     return SQLITE_OK;
   }

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -872,12 +872,20 @@ int doltliteCmdFinishWithConstraintViolations(
   sqlite3 *db, sqlite3_context *ctx, DoltliteTxnState *pSaved,
   const char *zOp, int bSealOnPlain, const char *zNestedMsg
 );
+int doltliteCmdFinishWithConflictsAndConstraintViolations(
+  sqlite3 *db, sqlite3_context *ctx, DoltliteTxnState *pSaved,
+  int nConflicts, const char *zOp, int bSealOnPlain,
+  const char *zNestedMsg
+);
 
 int doltliteReportConflicts(
   sqlite3 *db, sqlite3_context *ctx, int nConflicts, const char *zOp
 );
 int doltliteReportConstraintViolations(
   sqlite3 *db, sqlite3_context *ctx, const char *zOp
+);
+int doltliteReportConflictsAndConstraintViolations(
+  sqlite3 *db, sqlite3_context *ctx, int nConflicts, const char *zOp
 );
 int doltliteDetectPostMergeConstraintViolations(
   sqlite3 *db, const ProllyHash *pAncCatHash, int *pnViolations

--- a/src/doltlite_merge_cmd.c
+++ b/src/doltlite_merge_cmd.c
@@ -451,21 +451,27 @@ int doltliteMergeRef(
       ** dolt_merge_status reports it, before the finish path persists the
       ** working set. Redundant when conflicts already set it, and the
       ** autocommit/nested-savepoint modes inside the finish call roll it back
-      ** with the rest of the merge. */
+      ** with the rest of the merge. When row/schema conflicts are also
+      ** present, report both so the caller does not miss dolt_conflicts. */
       ProllyHash cvConflictsHash;
       doltliteGetSessionConflictsCatalog(db, &cvConflictsHash);
       if( doltliteSetSessionMergeState(db, 1, &theirHead,
                                       &cvConflictsHash)==SQLITE_OK ){
         (void)doltliteSetSessionMergeSourceSpec(db, zBranch, &theirHead);
       }
-      (void)doltliteCmdFinishWithConstraintViolations(
-          db, context, &savedState, "Merge", 0,
-          "Merge aborted: would have introduced constraint violations. "
-          "The merge and the would-be violations have been rolled back "
-          "with the enclosing savepoint, so dolt_constraint_violations "
-          "is empty. To inspect the violations, re-run the merge inside "
-          "a plain BEGIN/COMMIT transaction (no SAVEPOINT) so the "
-          "violations are preserved instead of rolled back.");
+      if( nMergeConflicts>0 ){
+        (void)doltliteCmdFinishWithConflictsAndConstraintViolations(
+            db, context, &savedState, nMergeConflicts, "Merge", 0, 0);
+      }else{
+        (void)doltliteCmdFinishWithConstraintViolations(
+            db, context, &savedState, "Merge", 0,
+            "Merge aborted: would have introduced constraint violations. "
+            "The merge and the would-be violations have been rolled back "
+            "with the enclosing savepoint, so dolt_constraint_violations "
+            "is empty. To inspect the violations, re-run the merge inside "
+            "a plain BEGIN/COMMIT transaction (no SAVEPOINT) so the "
+            "violations are preserved instead of rolled back.");
+      }
       return SQLITE_ERROR;
     }
   }

--- a/test/doltlite_merge.sh
+++ b/test/doltlite_merge.sh
@@ -172,6 +172,65 @@ run_test "constraint_violation_no_conflicts" "SELECT count(*) FROM dolt_conflict
 run_test "constraint_violation_no_violations" "SELECT count(*) FROM dolt_constraint_violations;" "0" "$DB11"
 run_test "constraint_violation_state_restored" "SELECT group_concat(id || ':' || u || ':' || v, ',') FROM (SELECT id, u, v FROM t ORDER BY id);" "1:9:main1,2:2:base2" "$DB11"
 
+# Same-cell data conflict plus a unique CV on the same merge. The finish path
+# used to report only constraint violations and return early, so callers never
+# saw that dolt_conflicts was also populated under BEGIN/COMMIT.
+DB11B=/tmp/test_merge11b_$$.db; rm -f "$DB11B"
+cat <<'EOF' | $DOLTLITE "$DB11B" > /dev/null 2>&1
+CREATE TABLE t(id INTEGER PRIMARY KEY, u INT UNIQUE, v TEXT);
+INSERT INTO t VALUES(1,1,'base'),(2,2,'base');
+SELECT dolt_commit('-Am','init');
+SELECT dolt_checkout('-b','feat');
+UPDATE t SET v='feat' WHERE id=1;
+UPDATE t SET u=9 WHERE id=2;
+SELECT dolt_commit('-Am','feat');
+SELECT dolt_checkout('main');
+UPDATE t SET v='main', u=9 WHERE id=1;
+SELECT dolt_commit('-Am','main');
+EOF
+run_test_match "conflict_and_cv_autocommit_msg" \
+  "SELECT dolt_merge('feat');" \
+  "conflict.*constraint violations|constraint violations.*conflict|rolled back" \
+  "$DB11B"
+run_test "conflict_and_cv_autocommit_clean_conflicts" \
+  "SELECT count(*) FROM dolt_conflicts;" "0" "$DB11B"
+run_test "conflict_and_cv_autocommit_clean_cvs" \
+  "SELECT count(*) FROM dolt_constraint_violations;" "0" "$DB11B"
+
+DB11C=/tmp/test_merge11c_$$.db; rm -f "$DB11C"
+cat <<'EOF' | $DOLTLITE "$DB11C" > /dev/null 2>&1
+CREATE TABLE t(id INTEGER PRIMARY KEY, u INT UNIQUE, v TEXT);
+INSERT INTO t VALUES(1,1,'base'),(2,2,'base');
+SELECT dolt_commit('-Am','init');
+SELECT dolt_checkout('-b','feat');
+UPDATE t SET v='feat' WHERE id=1;
+UPDATE t SET u=9 WHERE id=2;
+SELECT dolt_commit('-Am','feat');
+SELECT dolt_checkout('main');
+UPDATE t SET v='main', u=9 WHERE id=1;
+SELECT dolt_commit('-Am','main');
+EOF
+TX_BOTH=$(echo "BEGIN;
+SELECT dolt_merge('feat');
+SELECT 'TX|' || (SELECT count(*) FROM dolt_conflicts) || '|' ||
+  (SELECT count(*) FROM dolt_constraint_violations) || '|' ||
+  (SELECT is_merging FROM dolt_merge_status);
+ROLLBACK;" | $DOLTLITE "$DB11C" 2>&1)
+echo "$TX_BOTH" | grep -E 'conflict\(s\) and constraint violations' >/dev/null
+if [ $? -eq 0 ]; then
+  PASS=$((PASS+1))
+else
+  FAIL=$((FAIL+1))
+  ERRORS="$ERRORS\nFAIL: conflict_and_cv_tx_message\n  expected message containing 'conflict(s) and constraint violations'\n  got:\n$TX_BOTH"
+fi
+TX_BOTH_COUNTS=$(echo "$TX_BOTH" | grep '^TX|')
+if [ "$TX_BOTH_COUNTS" = "TX|1|1|1" ]; then
+  PASS=$((PASS+1))
+else
+  FAIL=$((FAIL+1))
+  ERRORS="$ERRORS\nFAIL: conflict_and_cv_tx_persists_both\n  expected: TX|1|1|1\n  got:      $TX_BOTH_COUNTS"
+fi
+
 DB12=/tmp/test_merge12_$$.db; rm -f "$DB12"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, u INT UNIQUE, v TEXT); INSERT INTO t VALUES(1,1,'base1'),(2,2,'base2'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB12" > /dev/null 2>&1
 echo "SELECT dolt_branch('feat'); SELECT dolt_checkout('feat'); UPDATE t SET u=9, v='feat2' WHERE id=2; SELECT dolt_commit('-A','-m','feat_unique');" | $DOLTLITE "$DB12" > /dev/null 2>&1


### PR DESCRIPTION
## Summary

- When a merge (or cherry-pick) produces **both** row/schema conflicts and constraint violations, the finish path no longer reports only CVs.
- New shared helper `doltliteCmdFinishWithConflictsAndConstraintViolations` covers autocommit rollback, plain `BEGIN` persist, and nested-savepoint rollback, and names both `dolt_conflicts` and `dolt_constraint_violations` in the error.
- Wire `dolt_merge` and cherry-pick through the combined path when both outcomes are present.

## Validation

- `make -C build doltlite`
- `DOLTLITE=./build/doltlite bash test/doltlite_merge.sh` (99/99)