### PR TITLE
refactor: split merge constraint detectors into FK/unique/CHECK

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,7 +82,8 @@ make DOLTLITE_PROLLY=0 sqlite3   # stock SQLite, for oracle/perf comparison
   (branch/checkout), `doltlite_merge` (catalog orchestration in
   `doltlite_merge`, pass1/pass2 in `doltlite_merge_pass1` /
   `doltlite_merge_pass2`, rows in `doltlite_merge_rows`, schema IR in
-  `doltlite_merge_schema`, plus `doltlite_merge_constraints`),
+  `doltlite_merge_schema`, plus constraint detectors in
+  `doltlite_merge_constraints` / `_unique` / `_check` / `_fk`),
   `doltlite_diff` / `doltlite_diff_stat` /
   `doltlite_diff_table`, `doltlite_log`, `doltlite_history`, `doltlite_blame`,
   `doltlite_tag`, `doltlite_conflicts`, `doltlite_constraint_violations` /

--- a/main.mk
+++ b/main.mk
@@ -609,6 +609,9 @@ PROLLY_OBJS = $(DOLTLITE_AUTH_OBJS) \
               doltlite_ignore.o doltlite_hashof.o \
               doltlite_constraint_violations.o doltlite_verify_constraints.o \
               doltlite_merge_constraints.o \
+              doltlite_merge_constraints_unique.o \
+              doltlite_merge_constraints_check.o \
+              doltlite_merge_constraints_fk.o \
               doltlite_dbpage.o \
               doltlite_remote.o doltlite_remote_sql.o \
               doltlite_http_remote.o doltlite_remotesrv.o
@@ -636,7 +639,7 @@ ifeq ($(DOLTLITE_PROLLY),1)
     $(TOP)/src/doltlite_catalog_types.h $(TOP)/src/doltlite_commit.h \
     $(TOP)/src/doltlite_constraint_violations.h \
     $(TOP)/src/doltlite_ignore.h $(TOP)/src/doltlite_internal.h \
-    $(TOP)/src/doltlite_branch_int.h $(TOP)/src/doltlite_merge_int.h $(TOP)/src/doltlite_parse.h \
+    $(TOP)/src/doltlite_branch_int.h $(TOP)/src/doltlite_merge_int.h $(TOP)/src/doltlite_merge_constraints_int.h $(TOP)/src/doltlite_parse.h \
     $(TOP)/src/doltlite_name_index.h \
     $(TOP)/src/doltlite_record.h $(TOP)/src/doltlite_remote.h $(TOP)/src/doltlite_remotesrv.h \
     $(TOP)/src/doltlite_creds.h $(TOP)/src/doltlite_net.h $(TOP)/src/doltlite_tls.h \
@@ -669,7 +672,11 @@ ifeq ($(DOLTLITE_PROLLY),1)
     $(TOP)/src/doltlite_merge_status.c \
     $(TOP)/src/doltlite_hashof.c $(TOP)/src/doltlite_constraint_violations.c \
     $(TOP)/src/doltlite_verify_constraints.c \
-    $(TOP)/src/doltlite_merge_constraints.c $(TOP)/src/doltlite_dbpage.c \
+    $(TOP)/src/doltlite_merge_constraints.c \
+    $(TOP)/src/doltlite_merge_constraints_unique.c \
+    $(TOP)/src/doltlite_merge_constraints_check.c \
+    $(TOP)/src/doltlite_merge_constraints_fk.c \
+    $(TOP)/src/doltlite_dbpage.c \
     $(TOP)/src/doltlite_remote.c $(TOP)/src/doltlite_remote_sql.c \
     $(TOP)/src/doltlite_http_remote.c $(TOP)/src/doltlite_remotesrv.c
   ifeq ($(DOLTLITE_PROLLY_CHECK),1)
@@ -1715,8 +1722,17 @@ doltlite_constraint_violations.o:	$(TOP)/src/doltlite_constraint_violations.c $(
 doltlite_verify_constraints.o:	$(TOP)/src/doltlite_verify_constraints.c $(DEPS_OBJ_COMMON)
 	$(T.cc.sqlite) -c $(TOP)/src/doltlite_verify_constraints.c
 
-doltlite_merge_constraints.o:	$(TOP)/src/doltlite_merge_constraints.c $(DEPS_OBJ_COMMON)
+doltlite_merge_constraints.o:	$(TOP)/src/doltlite_merge_constraints.c $(TOP)/src/doltlite_merge_constraints_int.h $(DEPS_OBJ_COMMON)
 	$(T.cc.sqlite) -c $(TOP)/src/doltlite_merge_constraints.c
+
+doltlite_merge_constraints_unique.o:	$(TOP)/src/doltlite_merge_constraints_unique.c $(TOP)/src/doltlite_merge_constraints_int.h $(DEPS_OBJ_COMMON)
+	$(T.cc.sqlite) -c $(TOP)/src/doltlite_merge_constraints_unique.c
+
+doltlite_merge_constraints_check.o:	$(TOP)/src/doltlite_merge_constraints_check.c $(TOP)/src/doltlite_merge_constraints_int.h $(DEPS_OBJ_COMMON)
+	$(T.cc.sqlite) -c $(TOP)/src/doltlite_merge_constraints_check.c
+
+doltlite_merge_constraints_fk.o:	$(TOP)/src/doltlite_merge_constraints_fk.c $(TOP)/src/doltlite_merge_constraints_int.h $(DEPS_OBJ_COMMON)
+	$(T.cc.sqlite) -c $(TOP)/src/doltlite_merge_constraints_fk.c
 
 doltlite_merge.o:	$(TOP)/src/doltlite_merge.c $(TOP)/src/doltlite_merge_int.h $(DEPS_OBJ_COMMON)
 	$(T.cc.sqlite) -c $(TOP)/src/doltlite_merge.c

--- a/src/doltlite_merge_constraints.c
+++ b/src/doltlite_merge_constraints.c
@@ -1,18 +1,8 @@
-
 #ifdef DOLTLITE_PROLLY
 
-#include "sqliteInt.h"
-#include "prolly_hash.h"
-#include "prolly_cursor.h"
-#include "prolly_cache.h"
-#include "chunk_store.h"
-#include "doltlite_internal.h"
-#include "doltlite_record.h"
-#include "doltlite_constraint_violations.h"
+#include "doltlite_merge_constraints_int.h"
 
-#include <string.h>
-
-static int copyCursorRow(
+int copyCursorRow(
   ProllyCursor *pCur,
   u8 **ppKey, int *pnKey,
   u8 **ppVal, int *pnVal
@@ -44,7 +34,7 @@ static int copyCursorRow(
   return SQLITE_OK;
 }
 
-static int fetchRowByRowid(
+int fetchRowByRowid(
   ChunkStore *cs,
   ProllyCache *pCache,
   const ProllyHash *pRoot,
@@ -76,7 +66,7 @@ static int fetchRowByRowid(
   return rc;
 }
 
-static int fetchRowByBlobKey(
+int fetchRowByBlobKey(
   ChunkStore *cs,
   ProllyCache *pCache,
   const ProllyHash *pRoot,
@@ -108,9 +98,7 @@ static int fetchRowByBlobKey(
   return rc;
 }
 
-static int tableHasRowid(sqlite3 *db, const char *zTable);
-
-static int tableEntryDiffers(
+int tableEntryDiffers(
   const struct TableEntry *a,
   const struct TableEntry *b
 ){
@@ -121,7 +109,7 @@ static int tableEntryDiffers(
   return 0;
 }
 
-static int catalogTableChanged(
+int catalogTableChanged(
   struct TableEntry *aAnc, int nAnc,
   struct TableEntry *aCur, int nCur,
   const char *zTable
@@ -132,7 +120,7 @@ static int catalogTableChanged(
 }
 
 
-static int cvTableAllowed(
+int cvTableAllowed(
   const char *zTable,
   const char **azTables,
   int nTables
@@ -146,7 +134,7 @@ static int cvTableAllowed(
   return 0;
 }
 
-static int loadAncestorAndCurrentCatalogs(
+int loadAncestorAndCurrentCatalogs(
   sqlite3 *db,
   const ProllyHash *pAncCatHash,
   struct TableEntry **paAnc, int *pnAnc,
@@ -181,21 +169,14 @@ static int loadAncestorAndCurrentCatalogs(
   return rc;
 }
 
-typedef struct MergePkInfo MergePkInfo;
-struct MergePkInfo {
-  int nPk;
-  char **azPk;
-  char *zPkCols;
-};
-
-static void freeMergePkInfo(MergePkInfo *pPk){
+void freeMergePkInfo(MergePkInfo *pPk){
   if( !pPk ) return;
   doltliteFreeStringArray(pPk->azPk, pPk->nPk);
   sqlite3_free(pPk->zPkCols);
   memset(pPk, 0, sizeof(*pPk));
 }
 
-static int loadMergePkInfo(sqlite3 *db, const char *zTable, MergePkInfo *pPk){
+int loadMergePkInfo(sqlite3 *db, const char *zTable, MergePkInfo *pPk){
   sqlite3_stmt *pStmt = 0;
   sqlite3_str *pCols = 0;
   char *zQuery = 0;
@@ -269,30 +250,7 @@ static int loadMergePkInfo(sqlite3 *db, const char *zTable, MergePkInfo *pPk){
   return SQLITE_OK;
 }
 
-/* FK specs whose parent-side column is unnamed (azTo[i]==0) reference the
-** parent's primary key positionally; fill those slots from zParent's PK. */
-static int backfillParentPk(sqlite3 *db, const char *zParent,
-                            char **azTo, int nCol){
-  int i, needParentPk = 0;
-  MergePkInfo parentPk;
-  int rc;
-  for(i=0; i<nCol; i++) if( !azTo[i] ) needParentPk = 1;
-  if( !needParentPk ) return SQLITE_OK;
-  memset(&parentPk, 0, sizeof(parentPk));
-  rc = loadMergePkInfo(db, zParent, &parentPk);
-  if( rc == SQLITE_OK ){
-    for(i=0; i<nCol; i++){
-      if( !azTo[i] && i < parentPk.nPk ){
-        azTo[i] = sqlite3_mprintf("%s", parentPk.azPk[i]);
-      }
-    }
-  }
-  freeMergePkInfo(&parentPk);
-  return rc;
-}
-
-
-static u8 *buildRecordFromStmtCols(
+u8 *buildRecordFromStmtCols(
   sqlite3_stmt *pStmt,
   int iStart,
   int nField,
@@ -339,7 +297,7 @@ static u8 *buildRecordFromStmtCols(
   return pOut;
 }
 
-static int recordPrefixEquals(
+int recordPrefixEquals(
   const u8 *pLeft, int nLeft,
   const u8 *pRight, int nRight,
   int nField
@@ -364,136 +322,7 @@ static int recordPrefixEquals(
   return 1;
 }
 
-static int tableColumnIndex(const DoltliteColInfo *pCols, const char *zName){
-  int i;
-  for(i=0; i<pCols->nCol; i++){
-    if( pCols->azName[i] && sqlite3_stricmp(pCols->azName[i], zName)==0 ){
-      return i;
-    }
-  }
-  return -1;
-}
-
-static int recordFieldEqualsInt64(
-  const u8 *pRec,
-  int nRec,
-  int serialType,
-  int off,
-  i64 v
-){
-  i64 got;
-  int nByte;
-  if( serialType==8 ) return v==0;
-  if( serialType==9 ) return v==1;
-  if( serialType<1 || serialType>6 ) return 0;
-  nByte = dlSerialTypeLen((u64)serialType);
-  if( off<0 || off+nByte>nRec ) return 0;
-  got = dlReadIntBytes(pRec + off, nByte);
-  return got==v;
-}
-
-static int fkParentExistsInCatalog(
-  sqlite3 *db,
-  struct TableEntry *aCur, int nCur,
-  const char *zParentTable,
-  char **azTo,
-  int nCol,
-  const u8 *pChildFkRec,
-  int nChildFkRec,
-  int *pExists
-){
-  ChunkStore *cs;
-  ProllyCache *pCache;
-  struct TableEntry *pParent;
-  DoltliteColInfo parentCols;
-  DoltliteRecordInfo childInfo;
-  int *aiParentCol = 0;
-  ProllyCursor cur;
-  int res = 0;
-  int rc;
-  int i;
-
-  *pExists = 0;
-  if( !aCur || nCur==0 ) return SQLITE_OK;
-  pParent = doltliteFindTableByName(aCur, nCur, zParentTable);
-  if( !pParent || prollyHashIsEmpty(&pParent->root) ) return SQLITE_OK;
-
-  rc = doltliteParseRecordStrict(pChildFkRec, nChildFkRec, &childInfo);
-  if( rc!=SQLITE_OK ) return rc;
-  if( childInfo.nField<nCol ) return SQLITE_CORRUPT;
-
-  memset(&parentCols, 0, sizeof(parentCols));
-  rc = doltliteGetColumnNames(db, zParentTable, &parentCols);
-  if( rc!=SQLITE_OK ) return rc;
-
-  aiParentCol = sqlite3_malloc64((sqlite3_int64)nCol * sizeof(int));
-  if( !aiParentCol ){
-    doltliteFreeColInfo(&parentCols);
-    return SQLITE_NOMEM;
-  }
-  for(i=0; i<nCol; i++){
-    aiParentCol[i] = tableColumnIndex(&parentCols, azTo[i]);
-    if( aiParentCol[i]<0 ){
-      sqlite3_free(aiParentCol);
-      doltliteFreeColInfo(&parentCols);
-      return SQLITE_ERROR;
-    }
-  }
-
-  cs = doltliteGetChunkStore(db);
-  pCache = doltliteGetCache(db);
-  if( !cs || !pCache ){
-    sqlite3_free(aiParentCol);
-    doltliteFreeColInfo(&parentCols);
-    return SQLITE_ERROR;
-  }
-
-  prollyCursorInit(&cur, cs, pCache, &pParent->root, pParent->flags);
-  rc = prollyCursorFirst(&cur, &res);
-  while( rc==SQLITE_OK && res==0 && prollyCursorIsValid(&cur) ){
-    const u8 *pParentVal = 0;
-    int nParentVal = 0;
-    DoltliteRecordInfo parentInfo;
-    int match = 1;
-
-    prollyCursorValue(&cur, &pParentVal, &nParentVal);
-    rc = doltliteParseRecordStrict(pParentVal, nParentVal, &parentInfo);
-    if( rc!=SQLITE_OK ) break;
-
-    for(i=0; i<nCol && match; i++){
-      int iParent = aiParentCol[i];
-      int iParentRec = parentCols.aColToRec[iParent];
-      if( (pParent->flags & PROLLY_NODE_INTKEY)
-       && parentCols.iPkCol==iParent ){
-        match = recordFieldEqualsInt64(
-            pChildFkRec, nChildFkRec,
-            childInfo.aType[i], childInfo.aOffset[i],
-            prollyCursorIntKey(&cur));
-      }else{
-        if( iParentRec<0 || iParentRec>=parentInfo.nField ){
-          match = 0;
-        }else{
-          match = doltliteFieldValuesEqual(
-              childInfo.aType[i], pChildFkRec, nChildFkRec,
-              childInfo.aOffset[i],
-              parentInfo.aType[iParentRec], pParentVal, nParentVal,
-              parentInfo.aOffset[iParentRec]);
-        }
-      }
-    }
-    if( match ){
-      *pExists = 1;
-      break;
-    }
-    rc = prollyCursorNext(&cur);
-  }
-  prollyCursorClose(&cur);
-  sqlite3_free(aiParentCol);
-  doltliteFreeColInfo(&parentCols);
-  return rc==SQLITE_DONE ? SQLITE_OK : rc;
-}
-
-static int fetchRowByPkRecord(
+int fetchRowByPkRecord(
   ChunkStore *cs,
   ProllyCache *pCache,
   const ProllyHash *pRoot,
@@ -535,98 +364,7 @@ static int fetchRowByPkRecord(
   return SQLITE_NOTFOUND;
 }
 
-static char *buildFkViolationInfo(
-  sqlite3 *db,
-  const char *zChildTable,
-  int fkid
-){
-  sqlite3_stmt *pStmt = 0;
-  sqlite3_str *pJson;
-  sqlite3_str *pCols;
-  sqlite3_str *pRefCols;
-  char *zColsBuf = 0;
-  char *zRefColsBuf = 0;
-  char *zParentBuf = 0;
-  char *zOnUpBuf = 0;
-  char *zOnDelBuf = 0;
-  char *zQuery;
-  char *zResult;
-  int rc;
-  int nMatches = 0;
-  int fatal = 0;
-
-  pJson = sqlite3_str_new(0);
-  pCols = sqlite3_str_new(0);
-  pRefCols = sqlite3_str_new(0);
-
-  zQuery = sqlite3_mprintf("PRAGMA main.foreign_key_list(%Q)", zChildTable);
-  if( !zQuery ){
-    fatal = 1;
-  }else{
-    rc = sqlite3_prepare_v2(db, zQuery, -1, &pStmt, 0);
-    sqlite3_free(zQuery);
-    if( rc != SQLITE_OK ){
-      fatal = 1;
-    }else{
-      while( sqlite3_step(pStmt) == SQLITE_ROW ){
-        int id = sqlite3_column_int(pStmt, 0);
-        const char *zParent, *zFrom, *zTo, *zOnUp, *zOnDel;
-        if( id != fkid ) continue;
-        zParent = (const char*)sqlite3_column_text(pStmt, 2);
-        zFrom   = (const char*)sqlite3_column_text(pStmt, 3);
-        zTo     = (const char*)sqlite3_column_text(pStmt, 4);
-        zOnUp   = (const char*)sqlite3_column_text(pStmt, 5);
-        zOnDel  = (const char*)sqlite3_column_text(pStmt, 6);
-        if( nMatches>0 ){
-          sqlite3_str_appendall(pCols, ", ");
-          sqlite3_str_appendall(pRefCols, ", ");
-        }
-        sqlite3_str_appendf(pCols, "\"%w\"", zFrom ? zFrom : "");
-        sqlite3_str_appendf(pRefCols, "\"%w\"", zTo ? zTo : "");
-        if( nMatches==0 ){
-          if( zParent ) zParentBuf = sqlite3_mprintf("%s", zParent);
-          zOnUpBuf  = sqlite3_mprintf("%s", zOnUp  ? zOnUp  : "NO ACTION");
-          zOnDelBuf = sqlite3_mprintf("%s", zOnDel ? zOnDel : "NO ACTION");
-        }
-        nMatches++;
-      }
-    }
-  }
-  sqlite3_finalize(pStmt);
-
-  zColsBuf    = sqlite3_str_finish(pCols);
-  zRefColsBuf = sqlite3_str_finish(pRefCols);
-
-  if( fatal ){
-    sqlite3_free(sqlite3_str_finish(pJson));
-    sqlite3_free(zColsBuf);
-    sqlite3_free(zRefColsBuf);
-    sqlite3_free(zParentBuf);
-    sqlite3_free(zOnUpBuf);
-    sqlite3_free(zOnDelBuf);
-    return 0;
-  }
-
-  sqlite3_str_appendall(pJson, "{");
-  sqlite3_str_appendf(pJson,
-      "\"Columns\": [%s], \"ReferencedTable\": \"%w\", "
-      "\"ReferencedColumns\": [%s], "
-      "\"OnUpdate\": \"%w\", \"OnDelete\": \"%w\"}",
-      zColsBuf ? zColsBuf : "",
-      zParentBuf ? zParentBuf : "",
-      zRefColsBuf ? zRefColsBuf : "",
-      zOnUpBuf ? zOnUpBuf : "NO ACTION",
-      zOnDelBuf ? zOnDelBuf : "NO ACTION");
-  zResult = sqlite3_str_finish(pJson);
-  sqlite3_free(zColsBuf);
-  sqlite3_free(zRefColsBuf);
-  sqlite3_free(zParentBuf);
-  sqlite3_free(zOnUpBuf);
-  sqlite3_free(zOnDelBuf);
-  return zResult;
-}
-
-static int fetchAncestorRowByName(
+int fetchAncestorRowByName(
   sqlite3 *db,
   struct TableEntry *aAnc, int nAnc,
   const char *zTable,
@@ -657,7 +395,7 @@ static int fetchAncestorRowByName(
   return rc;
 }
 
-static int fetchAncestorRowByKey(
+int fetchAncestorRowByKey(
   sqlite3 *db,
   struct TableEntry *aAnc, int nAnc,
   const char *zTable,
@@ -690,7 +428,7 @@ static int fetchAncestorRowByKey(
   return rc;
 }
 
-static int isRowPreExisting(
+int isRowPreExisting(
   const u8 *pMergedVal, int nMergedVal,
   const u8 *pAncVal, int nAncVal
 ){
@@ -700,7 +438,7 @@ static int isRowPreExisting(
   return memcmp(pMergedVal, pAncVal, nMergedVal)==0 ? 1 : 0;
 }
 
-static int tableHasRowid(sqlite3 *db, const char *zTable){
+int tableHasRowid(sqlite3 *db, const char *zTable){
   sqlite3_stmt *pStmt = 0;
   char *zQuery;
   int rc;
@@ -712,7 +450,7 @@ static int tableHasRowid(sqlite3 *db, const char *zTable){
   return rc == SQLITE_OK ? 1 : 0;
 }
 
-static int fetchOrphanRow(
+int fetchOrphanRow(
   sqlite3 *db,
   const char *zTable,
   i64 rowid,
@@ -743,7 +481,7 @@ static int fetchOrphanRow(
                          ppKey, pnKey, ppVal, pnVal);
 }
 
-static int fetchRowByPkFromTable(
+int fetchRowByPkFromTable(
   sqlite3 *db,
   const char *zTable,
   const u8 *pPkRec, int nPkRec,
@@ -776,1004 +514,5 @@ static int fetchRowByPkFromTable(
                             ppKey, pnKey, ppVal, pnVal);
 }
 
-static int appendUniqueViolationByRowid(
-  sqlite3 *db,
-  struct TableEntry *aAnc, int nAnc,
-  const char *zTable,
-  const char *zIndexName,
-  const char *zCols,
-  sqlite3_int64 rowid,
-  int *pAppended
-){
-  u8 *pKey = 0;
-  int nKey = 0;
-  u8 *pVal = 0;
-  int nVal = 0;
-  char *zInfo = 0;
-  int rc;
-
-  if( pAppended ) *pAppended = 0;
-  rc = fetchOrphanRow(db, zTable, rowid, &pKey, &nKey, &pVal, &nVal);
-  if( rc==SQLITE_NOTFOUND ) return SQLITE_OK;
-  if( rc!=SQLITE_OK ) return rc;
-
-  if( aAnc ){
-    u8 *pAncVal = 0;
-    int nAncVal = 0;
-    int ancRc = fetchAncestorRowByName(db, aAnc, nAnc, zTable,
-                                       rowid, &pAncVal, &nAncVal);
-    int preExisting = (ancRc==SQLITE_OK)
-        && isRowPreExisting(pVal, nVal, pAncVal, nAncVal);
-    sqlite3_free(pAncVal);
-    if( preExisting ){
-      sqlite3_free(pKey);
-      sqlite3_free(pVal);
-      return SQLITE_OK;
-    }
-  }
-
-  zInfo = sqlite3_mprintf(
-      "{\"Columns\": [%s], \"Name\": \"%w\"}",
-      zCols, zIndexName);
-  rc = doltliteAppendConstraintViolation(
-      db, zTable, DOLTLITE_CV_UNIQUE_INDEX,
-      rowid, pKey, nKey, pVal, nVal, zInfo);
-  sqlite3_free(zInfo);
-  sqlite3_free(pKey);
-  sqlite3_free(pVal);
-  if( rc==SQLITE_OK && pAppended ) *pAppended = 1;
-  return rc;
-}
-
-static int appendUniqueViolationByPk(
-  sqlite3 *db,
-  struct TableEntry *aAnc, int nAnc,
-  const char *zTable,
-  const char *zIndexName,
-  const char *zCols,
-  const MergePkInfo *pPk,
-  const u8 *pPkRec, int nPkRec,
-  int *pAppended
-){
-  u8 *pKey = 0;
-  int nKey = 0;
-  u8 *pVal = 0;
-  int nVal = 0;
-  char *zInfo = 0;
-  int rc;
-
-  if( pAppended ) *pAppended = 0;
-  rc = fetchRowByPkFromTable(db, zTable, pPkRec, nPkRec, pPk->nPk,
-                             &pKey, &nKey, &pVal, &nVal);
-  if( rc==SQLITE_NOTFOUND ) return SQLITE_OK;
-  if( rc!=SQLITE_OK ) return rc;
-
-  if( aAnc ){
-    u8 *pAncVal = 0;
-    int nAncVal = 0;
-    int ancRc = fetchAncestorRowByKey(db, aAnc, nAnc, zTable,
-                                      pKey, nKey, &pAncVal, &nAncVal);
-    int preExisting = (ancRc==SQLITE_OK)
-        && isRowPreExisting(pVal, nVal, pAncVal, nAncVal);
-    sqlite3_free(pAncVal);
-    if( preExisting ){
-      sqlite3_free(pKey);
-      sqlite3_free(pVal);
-      return SQLITE_OK;
-    }
-  }
-
-  zInfo = sqlite3_mprintf(
-      "{\"Columns\": [%s], \"Name\": \"%w\"}",
-      zCols, zIndexName);
-  rc = doltliteAppendConstraintViolation(
-      db, zTable, DOLTLITE_CV_UNIQUE_INDEX,
-      0, pKey, nKey, pVal, nVal, zInfo);
-  sqlite3_free(zInfo);
-  sqlite3_free(pKey);
-  sqlite3_free(pVal);
-  if( rc==SQLITE_OK && pAppended ) *pAppended = 1;
-  return rc;
-}
-
-static int uniqueIndexRowHasNull(sqlite3_stmt *pScan, int colFirst, int colLast){
-  int i;
-  for(i=colFirst; i<colLast; i++){
-    if( sqlite3_column_type(pScan, i) == SQLITE_NULL ) return 1;
-  }
-  return 0;
-}
-
-static int detectUniqueViolationsForIndex(
-  sqlite3 *db,
-  struct TableEntry *aAnc, int nAnc,
-  const char *zTable,
-  const char *zIndexName,
-  const char *zCols,
-  char **pzErrMsg,
-  int *pnFound
-){
-  sqlite3_stmt *pScan = 0;
-  char *zQuery;
-  char *zWinnerKey = 0;
-  sqlite3_int64 winnerRowid = 0;
-  int winnerHandled = 0;
-  int rc;
-  (void)pzErrMsg;
-
-  zQuery = sqlite3_mprintf(
-    "SELECT rowid, %s FROM main.\"%w\" NOT INDEXED ORDER BY %s, rowid",
-    zCols, zTable, zCols);
-  if( !zQuery ) return SQLITE_NOMEM;
-  rc = sqlite3_prepare_v2(db, zQuery, -1, &pScan, 0);
-  sqlite3_free(zQuery);
-  if( rc != SQLITE_OK ) return rc;
-
-  while( (rc = sqlite3_step(pScan)) == SQLITE_ROW ){
-    sqlite3_int64 rowid = sqlite3_column_int64(pScan, 0);
-    int nc = sqlite3_column_count(pScan);
-    int i;
-    sqlite3_str *pS;
-    char *zRowKey;
-    int isDup;
-
-    if( uniqueIndexRowHasNull(pScan, 1, nc) ) continue;
-
-    pS = sqlite3_str_new(0);
-    for(i=1; i<nc; i++){
-      const char *zV = (const char*)sqlite3_column_text(pScan, i);
-      sqlite3_str_appendf(pS, "%s%Q", i>1?"|":"", zV ? zV : "");
-    }
-    zRowKey = sqlite3_str_finish(pS);
-    if( !zRowKey ){ rc = SQLITE_NOMEM; break; }
-
-    isDup = zWinnerKey && strcmp(zWinnerKey, zRowKey)==0;
-    if( !isDup ){
-      sqlite3_free(zWinnerKey);
-      zWinnerKey = zRowKey;
-      winnerRowid = rowid;
-      winnerHandled = 0;
-      continue;
-    }
-    sqlite3_free(zRowKey);
-
-    if( !winnerHandled ){
-      int appended = 0;
-      rc = appendUniqueViolationByRowid(db, aAnc, nAnc, zTable, zIndexName,
-                                        zCols, winnerRowid, &appended);
-      if( rc != SQLITE_OK ) break;
-      if( appended && pnFound ) (*pnFound)++;
-      winnerHandled = 1;
-    }
-
-    {
-      int appended = 0;
-      rc = appendUniqueViolationByRowid(db, aAnc, nAnc, zTable, zIndexName,
-                                        zCols, rowid, &appended);
-      if( rc != SQLITE_OK ) break;
-      if( appended && pnFound ) (*pnFound)++;
-    }
-  }
-  sqlite3_free(zWinnerKey);
-  if( rc == SQLITE_DONE ) rc = SQLITE_OK;
-  sqlite3_finalize(pScan);
-  return rc;
-}
-
-static int detectUniqueViolationsForIndexWithoutRowid(
-  sqlite3 *db,
-  struct TableEntry *aAnc, int nAnc,
-  const char *zTable,
-  const char *zIndexName,
-  const char *zCols,
-  const MergePkInfo *pPk,
-  int *pnFound
-){
-  sqlite3_stmt *pScan = 0;
-  sqlite3_str *pSql = 0;
-  char *zQuery = 0;
-  char *zWinnerKey = 0;
-  u8 *pWinnerPkRec = 0;
-  int nWinnerPkRec = 0;
-  int winnerHandled = 0;
-  int rc;
-
-  pSql = sqlite3_str_new(0);
-  sqlite3_str_appendf(pSql,
-      "SELECT %s, %s FROM main.\"%w\" NOT INDEXED ORDER BY %s, %s",
-      zCols, pPk->zPkCols, zTable, zCols, pPk->zPkCols);
-  zQuery = sqlite3_str_finish(pSql);
-  if( !zQuery ) return SQLITE_NOMEM;
-  rc = sqlite3_prepare_v2(db, zQuery, -1, &pScan, 0);
-  sqlite3_free(zQuery);
-  if( rc!=SQLITE_OK ) return rc;
-
-  while( (rc = sqlite3_step(pScan)) == SQLITE_ROW ){
-    int nc = sqlite3_column_count(pScan);
-    int nDupKeyCol = nc - pPk->nPk;
-    sqlite3_str *pS;
-    char *zRowKey = 0;
-    int i, isDup;
-
-    if( uniqueIndexRowHasNull(pScan, 0, nDupKeyCol) ) continue;
-
-    pS = sqlite3_str_new(0);
-    for(i=0; i<nDupKeyCol; i++){
-      const char *zV = (const char*)sqlite3_column_text(pScan, i);
-      sqlite3_str_appendf(pS, "%s%Q", i>0?"|":"", zV ? zV : "");
-    }
-    zRowKey = sqlite3_str_finish(pS);
-    if( !zRowKey ){ rc = SQLITE_NOMEM; break; }
-
-    isDup = zWinnerKey && strcmp(zWinnerKey, zRowKey)==0;
-    if( !isDup ){
-      u8 *pPkRec = 0;
-      int nPkRec = 0;
-      pPkRec = buildRecordFromStmtCols(pScan, nDupKeyCol, pPk->nPk, &nPkRec);
-      if( !pPkRec ){
-        sqlite3_free(zRowKey);
-        rc = SQLITE_NOMEM;
-        break;
-      }
-      sqlite3_free(zWinnerKey);
-      sqlite3_free(pWinnerPkRec);
-      zWinnerKey = zRowKey;
-      pWinnerPkRec = pPkRec;
-      nWinnerPkRec = nPkRec;
-      winnerHandled = 0;
-      continue;
-    }
-    sqlite3_free(zRowKey);
-
-    {
-      u8 *pPkRec = 0; int nPkRec = 0;
-      pPkRec = buildRecordFromStmtCols(pScan, nDupKeyCol, pPk->nPk, &nPkRec);
-      if( !pPkRec ){ rc = SQLITE_NOMEM; break; }
-      if( !winnerHandled ){
-        int appended = 0;
-        rc = appendUniqueViolationByPk(db, aAnc, nAnc, zTable, zIndexName,
-                                       zCols, pPk, pWinnerPkRec, nWinnerPkRec,
-                                       &appended);
-        if( rc != SQLITE_OK ){
-          sqlite3_free(pPkRec);
-          break;
-        }
-        if( appended && pnFound ) (*pnFound)++;
-        winnerHandled = 1;
-      }
-      {
-        int appended = 0;
-        rc = appendUniqueViolationByPk(db, aAnc, nAnc, zTable, zIndexName,
-                                       zCols, pPk, pPkRec, nPkRec, &appended);
-        sqlite3_free(pPkRec);
-        if( rc != SQLITE_OK ) break;
-        if( appended && pnFound ) (*pnFound)++;
-      }
-    }
-  }
-
-  sqlite3_free(zWinnerKey);
-  sqlite3_free(pWinnerPkRec);
-  if( rc == SQLITE_DONE ) rc = SQLITE_OK;
-  sqlite3_finalize(pScan);
-  return rc;
-}
-
-int doltliteDetectMergeUniqueViolations(
-  sqlite3 *db,
-  const ProllyHash *pAncCatHash,
-  char **pzErrMsg,
-  int *pnFound,
-  const char **azTables,
-  int nTables
-){
-  sqlite3_stmt *pTbls = 0;
-  struct TableEntry *aAnc = 0;
-  int nAnc = 0;
-  struct TableEntry *aCur = 0;
-  int nCur = 0;
-  int rc;
-
-  if( pnFound ) *pnFound = 0;
-
-  rc = loadAncestorAndCurrentCatalogs(db, pAncCatHash, &aAnc, &nAnc,
-                                      &aCur, &nCur);
-  if( rc!=SQLITE_OK ) return rc;
-
-  rc = sqlite3_prepare_v2(db,
-      "SELECT name FROM main.sqlite_master WHERE type='table' "
-      "AND name NOT LIKE 'sqlite_%' AND name NOT LIKE 'dolt_%'",
-      -1, &pTbls, 0);
-  if( rc != SQLITE_OK ){
-    doltliteFreeCatalog(aAnc, nAnc);
-    doltliteFreeCatalog(aCur, nCur);
-    return rc;
-  }
-
-  while( (rc = sqlite3_step(pTbls)) == SQLITE_ROW ){
-    const char *zTableRaw = (const char*)sqlite3_column_text(pTbls, 0);
-    char *zTable;
-    sqlite3_stmt *pIdxList = 0;
-    char *zIdxQ;
-    int hasRowid = 1;
-    MergePkInfo pkInfo;
-
-    if( !zTableRaw ) continue;
-    zTable = sqlite3_mprintf("%s", zTableRaw);
-    if( !zTable ){ rc = SQLITE_NOMEM; break; }
-    if( !cvTableAllowed(zTable, azTables, nTables) ){
-      sqlite3_free(zTable);
-      continue;
-    }
-    if( !catalogTableChanged(aAnc, nAnc, aCur, nCur, zTable) ){
-      sqlite3_free(zTable);
-      continue;
-    }
-    memset(&pkInfo, 0, sizeof(pkInfo));
-    hasRowid = tableHasRowid(db, zTable);
-    if( !hasRowid ){
-      rc = loadMergePkInfo(db, zTable, &pkInfo);
-      if( rc != SQLITE_OK ){
-        sqlite3_free(zTable);
-        break;
-      }
-    }
-
-    zIdxQ = sqlite3_mprintf("PRAGMA main.index_list(%Q)", zTable);
-    if( !zIdxQ ){ sqlite3_free(zTable); rc = SQLITE_NOMEM; break; }
-    rc = sqlite3_prepare_v2(db, zIdxQ, -1, &pIdxList, 0);
-    sqlite3_free(zIdxQ);
-    if( rc != SQLITE_OK ){
-      freeMergePkInfo(&pkInfo);
-      sqlite3_free(zTable);
-      break;
-    }
-
-    while( sqlite3_step(pIdxList) == SQLITE_ROW ){
-      int unique = sqlite3_column_int(pIdxList, 2);
-      const char *zIdxRaw;
-      const char *zOrigin;
-      char *zIdx;
-      char *zColsQ;
-      sqlite3_stmt *pCols = 0;
-      sqlite3_str *pColList;
-      char *zColList;
-      int idxRc;
-
-      if( !unique ) continue;
-      zIdxRaw = (const char*)sqlite3_column_text(pIdxList, 1);
-      if( !zIdxRaw ) continue;
-
-      zOrigin = (const char*)sqlite3_column_text(pIdxList, 3);
-      if( zOrigin && strcmp(zOrigin, "pk")==0 ) continue;
-
-      zIdx = sqlite3_mprintf("%s", zIdxRaw);
-      if( !zIdx ) break;
-      zColsQ = sqlite3_mprintf("PRAGMA main.index_xinfo(%Q)", zIdx);
-      if( !zColsQ ){ sqlite3_free(zIdx); break; }
-      idxRc = sqlite3_prepare_v2(db, zColsQ, -1, &pCols, 0);
-      sqlite3_free(zColsQ);
-      if( idxRc != SQLITE_OK ){ sqlite3_free(zIdx); continue; }
-
-      pColList = sqlite3_str_new(0);
-      while( sqlite3_step(pCols) == SQLITE_ROW ){
-        int cno = sqlite3_column_int(pCols, 1);
-        int isKey = sqlite3_column_int(pCols, 5);
-        const char *zCol = (const char*)sqlite3_column_text(pCols, 2);
-        if( cno < 0 || !zCol || !isKey ) continue;
-        if( sqlite3_str_length(pColList) > 0 ){
-          sqlite3_str_appendall(pColList, ", ");
-        }
-        sqlite3_str_appendf(pColList, "\"%w\"", zCol);
-      }
-      sqlite3_finalize(pCols);
-      zColList = sqlite3_str_finish(pColList);
-      if( zColList && *zColList ){
-        if( hasRowid ){
-          rc = detectUniqueViolationsForIndex(db, aAnc, nAnc, zTable,
-                                               zIdx, zColList, pzErrMsg,
-                                               pnFound);
-        }else{
-          rc = detectUniqueViolationsForIndexWithoutRowid(
-              db, aAnc, nAnc, zTable, zIdx, zColList, &pkInfo, pnFound);
-        }
-      }
-      sqlite3_free(zColList);
-      sqlite3_free(zIdx);
-      if( rc != SQLITE_OK ) break;
-    }
-
-    sqlite3_finalize(pIdxList);
-    freeMergePkInfo(&pkInfo);
-    sqlite3_free(zTable);
-    if( rc != SQLITE_OK ) break;
-  }
-  if( rc == SQLITE_DONE ) rc = SQLITE_OK;
-  sqlite3_finalize(pTbls);
-  doltliteFreeCatalog(aAnc, nAnc);
-  doltliteFreeCatalog(aCur, nCur);
-  return rc;
-}
-
-static int nextCheckClause(
-  const char *zSql, int *pOffset, char **pzExpr, char **pzName
-){
-  const char *p = zSql + *pOffset;
-  const char *pEnd;
-  char lastConstraintName[128] = {0};
-  int depth;
-  const char *pExprStart;
-
-  *pzExpr = 0;
-  *pzName = 0;
-
-  while( *p ){
-    if( (p[0]=='C' || p[0]=='c')
-     && sqlite3_strnicmp(p, "CONSTRAINT", 10)==0
-     && (p[10]==' ' || p[10]=='\t' || p[10]=='\n') ){
-      int i = 0;
-      p += 10;
-      while( *p==' ' || *p=='\t' || *p=='\n' ) p++;
-      while( *p && *p!=' ' && *p!='\t' && *p!='\n' && *p!='(' && i<127 ){
-        lastConstraintName[i++] = *p++;
-      }
-      lastConstraintName[i] = 0;
-      continue;
-    }
-    if( (p[0]=='C' || p[0]=='c')
-     && sqlite3_strnicmp(p, "CHECK", 5)==0
-     && (p[5]==' ' || p[5]=='\t' || p[5]=='(' || p[5]=='\n') ){
-      p += 5;
-      while( *p==' ' || *p=='\t' || *p=='\n' ) p++;
-      if( *p!='(' ){ p++; lastConstraintName[0] = 0; continue; }
-      p++;
-      pExprStart = p;
-      depth = 1;
-      while( *p && depth>0 ){
-        char c = *p;
-        if( c=='\'' ){
-          p++;
-          while( *p && !(*p=='\'' && p[1]!='\'') ){
-            if( *p=='\'' && p[1]=='\'' ) p++;
-            p++;
-          }
-          if( *p=='\'' ) p++;
-          continue;
-        }
-        if( c=='"' ){
-          p++;
-          while( *p && *p!='"' ) p++;
-          if( *p=='"' ) p++;
-          continue;
-        }
-        if( c=='(' ) depth++;
-        else if( c==')' ) depth--;
-        if( depth>0 ) p++;
-      }
-      if( depth!=0 ) return -1;
-      pEnd = p;
-      p++;
-      *pzExpr = sqlite3_malloc((int)(pEnd - pExprStart) + 1);
-      if( !*pzExpr ) return -1;
-      memcpy(*pzExpr, pExprStart, (size_t)(pEnd - pExprStart));
-      (*pzExpr)[pEnd - pExprStart] = 0;
-      if( lastConstraintName[0] ){
-        *pzName = sqlite3_mprintf("%s", lastConstraintName);
-      }
-      *pOffset = (int)(p - zSql);
-      return 1;
-    }
-    if( *p=='\'' ){
-      p++;
-      while( *p && !(*p=='\'' && p[1]!='\'') ){
-        if( *p=='\'' && p[1]=='\'' ) p++;
-        p++;
-      }
-      if( *p=='\'' ) p++;
-      continue;
-    }
-    if( *p=='"' ){
-      p++;
-      while( *p && *p!='"' ) p++;
-      if( *p=='"' ) p++;
-      continue;
-    }
-    if( *p==',' ) lastConstraintName[0] = 0;
-    p++;
-  }
-  *pOffset = (int)(p - zSql);
-  return 0;
-}
-
-int doltliteDetectMergeCheckViolations(
-  sqlite3 *db,
-  const ProllyHash *pAncCatHash,
-  char **pzErrMsg,
-  int *pnFound,
-  const char **azTables,
-  int nTables
-){
-  sqlite3_stmt *pTbls = 0;
-  struct TableEntry *aAnc = 0;
-  int nAnc = 0;
-  struct TableEntry *aCur = 0;
-  int nCur = 0;
-  int rc;
-  int stepRc;
-
-  if( pnFound ) *pnFound = 0;
-
-  rc = loadAncestorAndCurrentCatalogs(db, pAncCatHash, &aAnc, &nAnc,
-                                      &aCur, &nCur);
-  if( rc!=SQLITE_OK ) return rc;
-
-  rc = sqlite3_prepare_v2(db,
-      "SELECT name, sql FROM main.sqlite_master WHERE type='table' "
-      "AND name NOT LIKE 'sqlite_%' AND name NOT LIKE 'dolt_%'",
-      -1, &pTbls, 0);
-  if( rc != SQLITE_OK ){
-    doltliteFreeCatalog(aAnc, nAnc);
-    doltliteFreeCatalog(aCur, nCur);
-    return rc;
-  }
-
-  while( (stepRc = sqlite3_step(pTbls)) == SQLITE_ROW ){
-    const char *zTableRaw = (const char*)sqlite3_column_text(pTbls, 0);
-    const char *zSqlRaw   = (const char*)sqlite3_column_text(pTbls, 1);
-    char *zTable;
-    char *zSql;
-    int offset = 0;
-    int hasRowid = 1;
-    MergePkInfo pkInfo;
-
-    if( !zTableRaw || !zSqlRaw ) continue;
-    zTable = sqlite3_mprintf("%s", zTableRaw);
-    zSql   = sqlite3_mprintf("%s", zSqlRaw);
-    if( !zTable || !zSql ){
-      sqlite3_free(zTable);
-      sqlite3_free(zSql);
-      rc = SQLITE_NOMEM;
-      break;
-    }
-    if( !cvTableAllowed(zTable, azTables, nTables) ){
-      sqlite3_free(zTable);
-      sqlite3_free(zSql);
-      continue;
-    }
-    if( !catalogTableChanged(aAnc, nAnc, aCur, nCur, zTable) ){
-      sqlite3_free(zTable);
-      sqlite3_free(zSql);
-      continue;
-    }
-    memset(&pkInfo, 0, sizeof(pkInfo));
-    hasRowid = tableHasRowid(db, zTable);
-    if( !hasRowid ){
-      rc = loadMergePkInfo(db, zTable, &pkInfo);
-      if( rc != SQLITE_OK ){
-        sqlite3_free(zTable);
-        sqlite3_free(zSql);
-        break;
-      }
-    }
-
-    for(;;){
-      char *zExpr = 0;
-      char *zCkName = 0;
-      int clauseRc = nextCheckClause(zSql, &offset, &zExpr, &zCkName);
-      char *zQuery;
-      sqlite3_stmt *pQ = 0;
-      int prepareRc;
-
-      if( clauseRc <= 0 ){
-        sqlite3_free(zExpr);
-        sqlite3_free(zCkName);
-        break;
-      }
-
-      if( hasRowid ){
-        zQuery = sqlite3_mprintf(
-            "SELECT rowid FROM main.\"%w\" NOT INDEXED WHERE NOT (%s)",
-            zTable, zExpr);
-      }else{
-        zQuery = sqlite3_mprintf(
-            "SELECT %s FROM main.\"%w\" NOT INDEXED WHERE NOT (%s)",
-            pkInfo.zPkCols, zTable, zExpr);
-      }
-      if( !zQuery ){
-        sqlite3_free(zExpr);
-        sqlite3_free(zCkName);
-        rc = SQLITE_NOMEM;
-        break;
-      }
-      prepareRc = sqlite3_prepare_v2(db, zQuery, -1, &pQ, 0);
-      sqlite3_free(zQuery);
-      if( prepareRc != SQLITE_OK ){
-        sqlite3_free(zExpr);
-        sqlite3_free(zCkName);
-        continue;
-      }
-
-      while( sqlite3_step(pQ) == SQLITE_ROW ){
-        u8 *pKey = 0; int nKey = 0;
-        u8 *pVal = 0; int nVal = 0;
-        char *zInfo;
-        int appendRc;
-        i64 intKey = 0;
-
-        if( hasRowid ){
-          intKey = sqlite3_column_int64(pQ, 0);
-          rc = fetchOrphanRow(db, zTable, intKey, &pKey, &nKey, &pVal, &nVal);
-        }else{
-          u8 *pPkRec = 0; int nPkRec = 0;
-          pPkRec = buildRecordFromStmtCols(pQ, 0, pkInfo.nPk, &nPkRec);
-          if( !pPkRec ){ rc = SQLITE_NOMEM; break; }
-          rc = fetchRowByPkFromTable(db, zTable, pPkRec, nPkRec, pkInfo.nPk,
-                                     &pKey, &nKey, &pVal, &nVal);
-          sqlite3_free(pPkRec);
-        }
-        if( rc == SQLITE_NOTFOUND ){ rc = SQLITE_OK; continue; }
-        if( rc != SQLITE_OK ){
-          sqlite3_free(pKey);
-          sqlite3_free(pVal);
-          break;
-        }
-
-        if( aAnc ){
-          u8 *pAncVal = 0; int nAncVal = 0;
-          int ancRc = hasRowid
-              ? fetchAncestorRowByName(db, aAnc, nAnc, zTable,
-                                       intKey, &pAncVal, &nAncVal)
-              : fetchAncestorRowByKey(db, aAnc, nAnc, zTable,
-                                      pKey, nKey, &pAncVal, &nAncVal);
-          int preExisting = (ancRc==SQLITE_OK)
-              && isRowPreExisting(pVal, nVal, pAncVal, nAncVal);
-          sqlite3_free(pAncVal);
-          if( preExisting ){
-            sqlite3_free(pKey);
-            sqlite3_free(pVal);
-            continue;
-          }
-        }
-
-        zInfo = sqlite3_mprintf(
-            "{\"Name\": \"%w\", \"Expression\": \"%w\"}",
-            zCkName ? zCkName : "", zExpr);
-        appendRc = doltliteAppendConstraintViolation(
-            db, zTable, DOLTLITE_CV_CHECK_CONSTRAINT,
-            intKey, pKey, nKey, pVal, nVal, zInfo);
-        sqlite3_free(zInfo);
-        sqlite3_free(pKey);
-        sqlite3_free(pVal);
-        if( appendRc != SQLITE_OK ){ rc = appendRc; break; }
-        if( pnFound ) (*pnFound)++;
-      }
-      sqlite3_finalize(pQ);
-      sqlite3_free(zExpr);
-      sqlite3_free(zCkName);
-      if( rc != SQLITE_OK ) break;
-    }
-
-    sqlite3_free(zTable);
-    sqlite3_free(zSql);
-    freeMergePkInfo(&pkInfo);
-    if( rc != SQLITE_OK ) break;
-  }
-  if( rc == SQLITE_OK && stepRc != SQLITE_DONE && stepRc != SQLITE_ROW ){
-    rc = stepRc;
-  }
-  sqlite3_finalize(pTbls);
-  doltliteFreeCatalog(aAnc, nAnc);
-  doltliteFreeCatalog(aCur, nCur);
-  return rc;
-}
-
-static int detectFkViolationsForSpec(
-  sqlite3 *db,
-  struct TableEntry *aCur, int nCur,
-  struct TableEntry *aAnc, int nAnc,
-  const char *zChildTable,
-  int hasRowid,
-  const MergePkInfo *pChildPk,
-  const char *zParentTable,
-  int fkid,
-  char **azFrom,
-  char **azTo,
-  int nCol,
-  int *pnFound
-){
-  sqlite3_str *pSql = 0;
-  char *zQuery = 0;
-  sqlite3_stmt *pStmt = 0;
-  int nKeyCol;
-  int rc;
-
-  pSql = sqlite3_str_new(0);
-  sqlite3_str_appendf(pSql, "SELECT %s", hasRowid ? "rowid" : pChildPk->zPkCols);
-  for(int i=0; i<nCol; i++){
-    sqlite3_str_appendf(pSql, ", c.\"%w\"", azFrom[i]);
-  }
-  sqlite3_str_appendf(pSql, " FROM main.\"%w\" AS c WHERE ", zChildTable);
-  for(int i=0; i<nCol; i++){
-    if( i>0 ) sqlite3_str_appendall(pSql, " AND ");
-    sqlite3_str_appendf(pSql, "c.\"%w\" IS NOT NULL", azFrom[i]);
-  }
-  sqlite3_str_appendf(pSql, " AND NOT EXISTS (SELECT 1 FROM main.\"%w\" AS p WHERE ",
-      zParentTable);
-  for(int i=0; i<nCol; i++){
-    if( i>0 ) sqlite3_str_appendall(pSql, " AND ");
-    sqlite3_str_appendf(pSql, "p.\"%w\" = c.\"%w\"", azTo[i], azFrom[i]);
-  }
-  sqlite3_str_appendall(pSql, ")");
-  zQuery = sqlite3_str_finish(pSql);
-  if( !zQuery ) return SQLITE_NOMEM;
-
-  rc = sqlite3_prepare_v2(db, zQuery, -1, &pStmt, 0);
-  sqlite3_free(zQuery);
-  if( rc!=SQLITE_OK ) return rc;
-  nKeyCol = hasRowid ? 1 : pChildPk->nPk;
-
-  while( sqlite3_step(pStmt)==SQLITE_ROW ){
-    u8 *pKey = 0; int nKey = 0;
-    u8 *pVal = 0; int nVal = 0;
-    u8 *pChildFkRec = 0; int nChildFkRec = 0;
-    i64 intKey = 0;
-    char *zInfo;
-    int appendRc;
-
-    if( hasRowid ){
-      intKey = sqlite3_column_int64(pStmt, 0);
-      rc = fetchOrphanRow(db, zChildTable, intKey, &pKey, &nKey, &pVal, &nVal);
-    }else{
-      u8 *pPkRec = 0; int nPkRec = 0;
-      pPkRec = buildRecordFromStmtCols(pStmt, 0, pChildPk->nPk, &nPkRec);
-      if( !pPkRec ){ rc = SQLITE_NOMEM; break; }
-      rc = fetchRowByPkFromTable(db, zChildTable, pPkRec, nPkRec, pChildPk->nPk,
-                                 &pKey, &nKey, &pVal, &nVal);
-      sqlite3_free(pPkRec);
-    }
-    if( rc == SQLITE_NOTFOUND ){ rc = SQLITE_OK; continue; }
-    if( rc != SQLITE_OK ){
-      sqlite3_free(pKey);
-      sqlite3_free(pVal);
-      break;
-    }
-
-    pChildFkRec = buildRecordFromStmtCols(pStmt, nKeyCol, nCol, &nChildFkRec);
-    if( !pChildFkRec ){
-      sqlite3_free(pKey);
-      sqlite3_free(pVal);
-      rc = SQLITE_NOMEM;
-      break;
-    }
-    {
-      int parentExists = 0;
-      rc = fkParentExistsInCatalog(db, aCur, nCur, zParentTable,
-                                   azTo, nCol, pChildFkRec, nChildFkRec,
-                                   &parentExists);
-      sqlite3_free(pChildFkRec);
-      pChildFkRec = 0;
-      if( rc!=SQLITE_OK ){
-        sqlite3_free(pKey);
-        sqlite3_free(pVal);
-        break;
-      }
-      if( parentExists ){
-        sqlite3_free(pKey);
-        sqlite3_free(pVal);
-        continue;
-      }
-    }
-
-    if( aAnc ){
-      u8 *pAncVal = 0; int nAncVal = 0;
-      int ancRc = hasRowid
-          ? fetchAncestorRowByName(db, aAnc, nAnc, zChildTable,
-                                   intKey, &pAncVal, &nAncVal)
-          : fetchAncestorRowByKey(db, aAnc, nAnc, zChildTable,
-                                  pKey, nKey, &pAncVal, &nAncVal);
-      int preExisting = (ancRc==SQLITE_OK)
-          && isRowPreExisting(pVal, nVal, pAncVal, nAncVal);
-      sqlite3_free(pAncVal);
-      if( preExisting ){
-        sqlite3_free(pKey);
-        sqlite3_free(pVal);
-        continue;
-      }
-    }
-
-    zInfo = buildFkViolationInfo(db, zChildTable, fkid);
-    appendRc = doltliteAppendConstraintViolation(
-        db, zChildTable, DOLTLITE_CV_FOREIGN_KEY,
-        intKey, pKey, nKey, pVal, nVal, zInfo);
-    sqlite3_free(zInfo);
-    sqlite3_free(pKey);
-    sqlite3_free(pVal);
-    if( appendRc != SQLITE_OK ){
-      rc = appendRc;
-      break;
-    }
-    if( pnFound ) (*pnFound)++;
-  }
-
-  if( rc==SQLITE_DONE ) rc = SQLITE_OK;
-  sqlite3_finalize(pStmt);
-  return rc;
-}
-
-int doltliteDetectMergeFkViolations(
-  sqlite3 *db,
-  const ProllyHash *pAncCatHash,
-  char **pzErrMsg,
-  int *pnFound,
-  const char **azTables,
-  int nTables
-){
-  sqlite3_stmt *pTbls = 0;
-  struct TableEntry *aAnc = 0;
-  int nAnc = 0;
-  struct TableEntry *aCur = 0;
-  int nCur = 0;
-  int rc;
-  int nFound = 0;
-  int stepRc;
-
-  (void)pzErrMsg;
-
-  if( pnFound ) *pnFound = 0;
-
-  rc = loadAncestorAndCurrentCatalogs(db, pAncCatHash, &aAnc, &nAnc,
-                                      &aCur, &nCur);
-  if( rc!=SQLITE_OK ) return rc;
-
-  rc = sqlite3_prepare_v2(db,
-      "SELECT name FROM main.sqlite_master WHERE type='table' "
-      "AND name NOT LIKE 'sqlite_%' AND name NOT LIKE 'dolt_%'",
-      -1, &pTbls, 0);
-  if( rc != SQLITE_OK ){
-    doltliteFreeCatalog(aAnc, nAnc);
-    doltliteFreeCatalog(aCur, nCur);
-    return rc;
-  }
-
-  while( (stepRc = sqlite3_step(pTbls)) == SQLITE_ROW ){
-    const char *zTableRaw = (const char*)sqlite3_column_text(pTbls, 0);
-    char *zTable = 0;
-    char *zFkQ = 0;
-    sqlite3_stmt *pFk = 0;
-    int hasRowid = 1;
-    MergePkInfo childPk;
-    int curId = -1;
-    char *zParent = 0;
-    char **azFrom = 0;
-    char **azTo = 0;
-    int nCol = 0;
-    int nAlloc = 0;
-    int childChanged;
-
-    if( !zTableRaw ) continue;
-    zTable = sqlite3_mprintf("%s", zTableRaw);
-    if( !zTable ){ rc = SQLITE_NOMEM; break; }
-    if( !cvTableAllowed(zTable, azTables, nTables) ){
-      sqlite3_free(zTable);
-      continue;
-    }
-    childChanged = catalogTableChanged(aAnc, nAnc, aCur, nCur, zTable);
-    memset(&childPk, 0, sizeof(childPk));
-    hasRowid = tableHasRowid(db, zTable);
-    if( !hasRowid ){
-      rc = loadMergePkInfo(db, zTable, &childPk);
-      if( rc != SQLITE_OK ){
-        sqlite3_free(zTable);
-        break;
-      }
-    }
-
-    zFkQ = sqlite3_mprintf("PRAGMA main.foreign_key_list(%Q)", zTable);
-    if( !zFkQ ){
-      freeMergePkInfo(&childPk);
-      sqlite3_free(zTable);
-      rc = SQLITE_NOMEM;
-      break;
-    }
-    rc = sqlite3_prepare_v2(db, zFkQ, -1, &pFk, 0);
-    sqlite3_free(zFkQ);
-    if( rc != SQLITE_OK ){
-      freeMergePkInfo(&childPk);
-      sqlite3_free(zTable);
-      break;
-    }
-
-    while( sqlite3_step(pFk) == SQLITE_ROW ){
-      int id = sqlite3_column_int(pFk, 0);
-      const char *zParentRaw = (const char*)sqlite3_column_text(pFk, 2);
-      const char *zFromRaw = (const char*)sqlite3_column_text(pFk, 3);
-      const char *zToRaw = (const char*)sqlite3_column_text(pFk, 4);
-
-      if( curId>=0 && id!=curId ){
-        int parentChanged = catalogTableChanged(aAnc, nAnc, aCur, nCur, zParent);
-        if( childChanged || parentChanged ){
-          struct TableEntry *aCheckAnc = parentChanged ? 0 : aAnc;
-          int nCheckAnc = parentChanged ? 0 : nAnc;
-          rc = backfillParentPk(db, zParent, azTo, nCol);
-          if( rc != SQLITE_OK ) break;
-          rc = detectFkViolationsForSpec(db, aCur, nCur, aCheckAnc, nCheckAnc,
-              zTable, hasRowid, &childPk, zParent, curId,
-              azFrom, azTo, nCol, &nFound);
-        }
-        doltliteFreeStringArray(azFrom, nCol);
-        doltliteFreeStringArray(azTo, nCol);
-        azFrom = 0; azTo = 0; nCol = 0; nAlloc = 0;
-        sqlite3_free(zParent); zParent = 0;
-        if( rc != SQLITE_OK ) break;
-      }
-
-      if( curId != id ){
-        curId = id;
-        zParent = sqlite3_mprintf("%s", zParentRaw ? zParentRaw : "");
-        if( !zParent ){ rc = SQLITE_NOMEM; break; }
-      }
-
-      if( nCol >= nAlloc ){
-        int nNew = nAlloc ? nAlloc*2 : 4;
-        char **azFromNew;
-        char **azToNew;
-        azFromNew = sqlite3_realloc64(azFrom, (sqlite3_int64)nNew * sizeof(char*));
-        if( !azFromNew ){
-          rc = SQLITE_NOMEM;
-          break;
-        }
-        azFrom = azFromNew;
-        azToNew = sqlite3_realloc64(azTo, (sqlite3_int64)nNew * sizeof(char*));
-        if( !azToNew ){
-          rc = SQLITE_NOMEM;
-          break;
-        }
-        azTo = azToNew;
-        nAlloc = nNew;
-      }
-      azFrom[nCol] = sqlite3_mprintf("%s", zFromRaw ? zFromRaw : "");
-      azTo[nCol] = zToRaw ? sqlite3_mprintf("%s", zToRaw) : 0;
-      if( !azFrom[nCol] || (zToRaw && !azTo[nCol]) ){
-        rc = SQLITE_NOMEM;
-        break;
-      }
-      nCol++;
-    }
-
-    if( rc==SQLITE_ROW || rc==SQLITE_DONE ){
-      rc = SQLITE_OK;
-    }
-    if( rc==SQLITE_OK && curId>=0 ){
-      int parentChanged = catalogTableChanged(aAnc, nAnc, aCur, nCur, zParent);
-      if( childChanged || parentChanged ){
-        struct TableEntry *aCheckAnc = parentChanged ? 0 : aAnc;
-        int nCheckAnc = parentChanged ? 0 : nAnc;
-        rc = backfillParentPk(db, zParent, azTo, nCol);
-        if( rc==SQLITE_OK ){
-          rc = detectFkViolationsForSpec(db, aCur, nCur, aCheckAnc, nCheckAnc,
-              zTable, hasRowid, &childPk, zParent, curId,
-              azFrom, azTo, nCol, &nFound);
-        }
-      }
-    }
-
-    doltliteFreeStringArray(azFrom, nCol);
-    doltliteFreeStringArray(azTo, nCol);
-    sqlite3_free(zParent);
-    sqlite3_finalize(pFk);
-    freeMergePkInfo(&childPk);
-    sqlite3_free(zTable);
-    if( rc != SQLITE_OK ) break;
-  }
-
-  if( rc == SQLITE_OK && stepRc != SQLITE_DONE && stepRc != SQLITE_ROW ){
-    rc = stepRc;
-  }
-  sqlite3_finalize(pTbls);
-  doltliteFreeCatalog(aAnc, nAnc);
-  doltliteFreeCatalog(aCur, nCur);
-  if( pnFound ) *pnFound = nFound;
-  return rc;
-}
 
 #endif

--- a/src/doltlite_merge_constraints_check.c
+++ b/src/doltlite_merge_constraints_check.c
@@ -1,0 +1,278 @@
+#ifdef DOLTLITE_PROLLY
+
+#include "doltlite_merge_constraints_int.h"
+
+static int nextCheckClause(
+  const char *zSql, int *pOffset, char **pzExpr, char **pzName
+){
+  const char *p = zSql + *pOffset;
+  const char *pEnd;
+  char lastConstraintName[128] = {0};
+  int depth;
+  const char *pExprStart;
+
+  *pzExpr = 0;
+  *pzName = 0;
+
+  while( *p ){
+    if( (p[0]=='C' || p[0]=='c')
+     && sqlite3_strnicmp(p, "CONSTRAINT", 10)==0
+     && (p[10]==' ' || p[10]=='\t' || p[10]=='\n') ){
+      int i = 0;
+      p += 10;
+      while( *p==' ' || *p=='\t' || *p=='\n' ) p++;
+      while( *p && *p!=' ' && *p!='\t' && *p!='\n' && *p!='(' && i<127 ){
+        lastConstraintName[i++] = *p++;
+      }
+      lastConstraintName[i] = 0;
+      continue;
+    }
+    if( (p[0]=='C' || p[0]=='c')
+     && sqlite3_strnicmp(p, "CHECK", 5)==0
+     && (p[5]==' ' || p[5]=='\t' || p[5]=='(' || p[5]=='\n') ){
+      p += 5;
+      while( *p==' ' || *p=='\t' || *p=='\n' ) p++;
+      if( *p!='(' ){ p++; lastConstraintName[0] = 0; continue; }
+      p++;
+      pExprStart = p;
+      depth = 1;
+      while( *p && depth>0 ){
+        char c = *p;
+        if( c=='\'' ){
+          p++;
+          while( *p && !(*p=='\'' && p[1]!='\'') ){
+            if( *p=='\'' && p[1]=='\'' ) p++;
+            p++;
+          }
+          if( *p=='\'' ) p++;
+          continue;
+        }
+        if( c=='"' ){
+          p++;
+          while( *p && *p!='"' ) p++;
+          if( *p=='"' ) p++;
+          continue;
+        }
+        if( c=='(' ) depth++;
+        else if( c==')' ) depth--;
+        if( depth>0 ) p++;
+      }
+      if( depth!=0 ) return -1;
+      pEnd = p;
+      p++;
+      *pzExpr = sqlite3_malloc((int)(pEnd - pExprStart) + 1);
+      if( !*pzExpr ) return -1;
+      memcpy(*pzExpr, pExprStart, (size_t)(pEnd - pExprStart));
+      (*pzExpr)[pEnd - pExprStart] = 0;
+      if( lastConstraintName[0] ){
+        *pzName = sqlite3_mprintf("%s", lastConstraintName);
+      }
+      *pOffset = (int)(p - zSql);
+      return 1;
+    }
+    if( *p=='\'' ){
+      p++;
+      while( *p && !(*p=='\'' && p[1]!='\'') ){
+        if( *p=='\'' && p[1]=='\'' ) p++;
+        p++;
+      }
+      if( *p=='\'' ) p++;
+      continue;
+    }
+    if( *p=='"' ){
+      p++;
+      while( *p && *p!='"' ) p++;
+      if( *p=='"' ) p++;
+      continue;
+    }
+    if( *p==',' ) lastConstraintName[0] = 0;
+    p++;
+  }
+  *pOffset = (int)(p - zSql);
+  return 0;
+}
+
+int doltliteDetectMergeCheckViolations(
+  sqlite3 *db,
+  const ProllyHash *pAncCatHash,
+  char **pzErrMsg,
+  int *pnFound,
+  const char **azTables,
+  int nTables
+){
+  sqlite3_stmt *pTbls = 0;
+  struct TableEntry *aAnc = 0;
+  int nAnc = 0;
+  struct TableEntry *aCur = 0;
+  int nCur = 0;
+  int rc;
+  int stepRc;
+
+  if( pnFound ) *pnFound = 0;
+
+  rc = loadAncestorAndCurrentCatalogs(db, pAncCatHash, &aAnc, &nAnc,
+                                      &aCur, &nCur);
+  if( rc!=SQLITE_OK ) return rc;
+
+  rc = sqlite3_prepare_v2(db,
+      "SELECT name, sql FROM main.sqlite_master WHERE type='table' "
+      "AND name NOT LIKE 'sqlite_%' AND name NOT LIKE 'dolt_%'",
+      -1, &pTbls, 0);
+  if( rc != SQLITE_OK ){
+    doltliteFreeCatalog(aAnc, nAnc);
+    doltliteFreeCatalog(aCur, nCur);
+    return rc;
+  }
+
+  while( (stepRc = sqlite3_step(pTbls)) == SQLITE_ROW ){
+    const char *zTableRaw = (const char*)sqlite3_column_text(pTbls, 0);
+    const char *zSqlRaw   = (const char*)sqlite3_column_text(pTbls, 1);
+    char *zTable;
+    char *zSql;
+    int offset = 0;
+    int hasRowid = 1;
+    MergePkInfo pkInfo;
+
+    if( !zTableRaw || !zSqlRaw ) continue;
+    zTable = sqlite3_mprintf("%s", zTableRaw);
+    zSql   = sqlite3_mprintf("%s", zSqlRaw);
+    if( !zTable || !zSql ){
+      sqlite3_free(zTable);
+      sqlite3_free(zSql);
+      rc = SQLITE_NOMEM;
+      break;
+    }
+    if( !cvTableAllowed(zTable, azTables, nTables) ){
+      sqlite3_free(zTable);
+      sqlite3_free(zSql);
+      continue;
+    }
+    if( !catalogTableChanged(aAnc, nAnc, aCur, nCur, zTable) ){
+      sqlite3_free(zTable);
+      sqlite3_free(zSql);
+      continue;
+    }
+    memset(&pkInfo, 0, sizeof(pkInfo));
+    hasRowid = tableHasRowid(db, zTable);
+    if( !hasRowid ){
+      rc = loadMergePkInfo(db, zTable, &pkInfo);
+      if( rc != SQLITE_OK ){
+        sqlite3_free(zTable);
+        sqlite3_free(zSql);
+        break;
+      }
+    }
+
+    for(;;){
+      char *zExpr = 0;
+      char *zCkName = 0;
+      int clauseRc = nextCheckClause(zSql, &offset, &zExpr, &zCkName);
+      char *zQuery;
+      sqlite3_stmt *pQ = 0;
+      int prepareRc;
+
+      if( clauseRc <= 0 ){
+        sqlite3_free(zExpr);
+        sqlite3_free(zCkName);
+        break;
+      }
+
+      if( hasRowid ){
+        zQuery = sqlite3_mprintf(
+            "SELECT rowid FROM main.\"%w\" NOT INDEXED WHERE NOT (%s)",
+            zTable, zExpr);
+      }else{
+        zQuery = sqlite3_mprintf(
+            "SELECT %s FROM main.\"%w\" NOT INDEXED WHERE NOT (%s)",
+            pkInfo.zPkCols, zTable, zExpr);
+      }
+      if( !zQuery ){
+        sqlite3_free(zExpr);
+        sqlite3_free(zCkName);
+        rc = SQLITE_NOMEM;
+        break;
+      }
+      prepareRc = sqlite3_prepare_v2(db, zQuery, -1, &pQ, 0);
+      sqlite3_free(zQuery);
+      if( prepareRc != SQLITE_OK ){
+        sqlite3_free(zExpr);
+        sqlite3_free(zCkName);
+        continue;
+      }
+
+      while( sqlite3_step(pQ) == SQLITE_ROW ){
+        u8 *pKey = 0; int nKey = 0;
+        u8 *pVal = 0; int nVal = 0;
+        char *zInfo;
+        int appendRc;
+        i64 intKey = 0;
+
+        if( hasRowid ){
+          intKey = sqlite3_column_int64(pQ, 0);
+          rc = fetchOrphanRow(db, zTable, intKey, &pKey, &nKey, &pVal, &nVal);
+        }else{
+          u8 *pPkRec = 0; int nPkRec = 0;
+          pPkRec = buildRecordFromStmtCols(pQ, 0, pkInfo.nPk, &nPkRec);
+          if( !pPkRec ){ rc = SQLITE_NOMEM; break; }
+          rc = fetchRowByPkFromTable(db, zTable, pPkRec, nPkRec, pkInfo.nPk,
+                                     &pKey, &nKey, &pVal, &nVal);
+          sqlite3_free(pPkRec);
+        }
+        if( rc == SQLITE_NOTFOUND ){ rc = SQLITE_OK; continue; }
+        if( rc != SQLITE_OK ){
+          sqlite3_free(pKey);
+          sqlite3_free(pVal);
+          break;
+        }
+
+        if( aAnc ){
+          u8 *pAncVal = 0; int nAncVal = 0;
+          int ancRc = hasRowid
+              ? fetchAncestorRowByName(db, aAnc, nAnc, zTable,
+                                       intKey, &pAncVal, &nAncVal)
+              : fetchAncestorRowByKey(db, aAnc, nAnc, zTable,
+                                      pKey, nKey, &pAncVal, &nAncVal);
+          int preExisting = (ancRc==SQLITE_OK)
+              && isRowPreExisting(pVal, nVal, pAncVal, nAncVal);
+          sqlite3_free(pAncVal);
+          if( preExisting ){
+            sqlite3_free(pKey);
+            sqlite3_free(pVal);
+            continue;
+          }
+        }
+
+        zInfo = sqlite3_mprintf(
+            "{\"Name\": \"%w\", \"Expression\": \"%w\"}",
+            zCkName ? zCkName : "", zExpr);
+        appendRc = doltliteAppendConstraintViolation(
+            db, zTable, DOLTLITE_CV_CHECK_CONSTRAINT,
+            intKey, pKey, nKey, pVal, nVal, zInfo);
+        sqlite3_free(zInfo);
+        sqlite3_free(pKey);
+        sqlite3_free(pVal);
+        if( appendRc != SQLITE_OK ){ rc = appendRc; break; }
+        if( pnFound ) (*pnFound)++;
+      }
+      sqlite3_finalize(pQ);
+      sqlite3_free(zExpr);
+      sqlite3_free(zCkName);
+      if( rc != SQLITE_OK ) break;
+    }
+
+    sqlite3_free(zTable);
+    sqlite3_free(zSql);
+    freeMergePkInfo(&pkInfo);
+    if( rc != SQLITE_OK ) break;
+  }
+  if( rc == SQLITE_OK && stepRc != SQLITE_DONE && stepRc != SQLITE_ROW ){
+    rc = stepRc;
+  }
+  sqlite3_finalize(pTbls);
+  doltliteFreeCatalog(aAnc, nAnc);
+  doltliteFreeCatalog(aCur, nCur);
+  return rc;
+}
+
+
+#endif

--- a/src/doltlite_merge_constraints_fk.c
+++ b/src/doltlite_merge_constraints_fk.c
@@ -1,0 +1,558 @@
+#ifdef DOLTLITE_PROLLY
+
+#include "doltlite_merge_constraints_int.h"
+
+/* FK specs whose parent-side column is unnamed (azTo[i]==0) reference the
+** parent's primary key positionally; fill those slots from zParent's PK. */
+static int backfillParentPk(sqlite3 *db, const char *zParent,
+                            char **azTo, int nCol){
+  int i, needParentPk = 0;
+  MergePkInfo parentPk;
+  int rc;
+  for(i=0; i<nCol; i++) if( !azTo[i] ) needParentPk = 1;
+  if( !needParentPk ) return SQLITE_OK;
+  memset(&parentPk, 0, sizeof(parentPk));
+  rc = loadMergePkInfo(db, zParent, &parentPk);
+  if( rc == SQLITE_OK ){
+    for(i=0; i<nCol; i++){
+      if( !azTo[i] && i < parentPk.nPk ){
+        azTo[i] = sqlite3_mprintf("%s", parentPk.azPk[i]);
+      }
+    }
+  }
+  freeMergePkInfo(&parentPk);
+  return rc;
+}
+
+
+static int tableColumnIndex(const DoltliteColInfo *pCols, const char *zName){
+  int i;
+  for(i=0; i<pCols->nCol; i++){
+    if( pCols->azName[i] && sqlite3_stricmp(pCols->azName[i], zName)==0 ){
+      return i;
+    }
+  }
+  return -1;
+}
+
+static int recordFieldEqualsInt64(
+  const u8 *pRec,
+  int nRec,
+  int serialType,
+  int off,
+  i64 v
+){
+  i64 got;
+  int nByte;
+  if( serialType==8 ) return v==0;
+  if( serialType==9 ) return v==1;
+  if( serialType<1 || serialType>6 ) return 0;
+  nByte = dlSerialTypeLen((u64)serialType);
+  if( off<0 || off+nByte>nRec ) return 0;
+  got = dlReadIntBytes(pRec + off, nByte);
+  return got==v;
+}
+
+static int fkParentExistsInCatalog(
+  sqlite3 *db,
+  struct TableEntry *aCur, int nCur,
+  const char *zParentTable,
+  char **azTo,
+  int nCol,
+  const u8 *pChildFkRec,
+  int nChildFkRec,
+  int *pExists
+){
+  ChunkStore *cs;
+  ProllyCache *pCache;
+  struct TableEntry *pParent;
+  DoltliteColInfo parentCols;
+  DoltliteRecordInfo childInfo;
+  int *aiParentCol = 0;
+  ProllyCursor cur;
+  int res = 0;
+  int rc;
+  int i;
+
+  *pExists = 0;
+  if( !aCur || nCur==0 ) return SQLITE_OK;
+  pParent = doltliteFindTableByName(aCur, nCur, zParentTable);
+  if( !pParent || prollyHashIsEmpty(&pParent->root) ) return SQLITE_OK;
+
+  rc = doltliteParseRecordStrict(pChildFkRec, nChildFkRec, &childInfo);
+  if( rc!=SQLITE_OK ) return rc;
+  if( childInfo.nField<nCol ) return SQLITE_CORRUPT;
+
+  memset(&parentCols, 0, sizeof(parentCols));
+  rc = doltliteGetColumnNames(db, zParentTable, &parentCols);
+  if( rc!=SQLITE_OK ) return rc;
+
+  aiParentCol = sqlite3_malloc64((sqlite3_int64)nCol * sizeof(int));
+  if( !aiParentCol ){
+    doltliteFreeColInfo(&parentCols);
+    return SQLITE_NOMEM;
+  }
+  for(i=0; i<nCol; i++){
+    aiParentCol[i] = tableColumnIndex(&parentCols, azTo[i]);
+    if( aiParentCol[i]<0 ){
+      sqlite3_free(aiParentCol);
+      doltliteFreeColInfo(&parentCols);
+      return SQLITE_ERROR;
+    }
+  }
+
+  cs = doltliteGetChunkStore(db);
+  pCache = doltliteGetCache(db);
+  if( !cs || !pCache ){
+    sqlite3_free(aiParentCol);
+    doltliteFreeColInfo(&parentCols);
+    return SQLITE_ERROR;
+  }
+
+  prollyCursorInit(&cur, cs, pCache, &pParent->root, pParent->flags);
+  rc = prollyCursorFirst(&cur, &res);
+  while( rc==SQLITE_OK && res==0 && prollyCursorIsValid(&cur) ){
+    const u8 *pParentVal = 0;
+    int nParentVal = 0;
+    DoltliteRecordInfo parentInfo;
+    int match = 1;
+
+    prollyCursorValue(&cur, &pParentVal, &nParentVal);
+    rc = doltliteParseRecordStrict(pParentVal, nParentVal, &parentInfo);
+    if( rc!=SQLITE_OK ) break;
+
+    for(i=0; i<nCol && match; i++){
+      int iParent = aiParentCol[i];
+      int iParentRec = parentCols.aColToRec[iParent];
+      if( (pParent->flags & PROLLY_NODE_INTKEY)
+       && parentCols.iPkCol==iParent ){
+        match = recordFieldEqualsInt64(
+            pChildFkRec, nChildFkRec,
+            childInfo.aType[i], childInfo.aOffset[i],
+            prollyCursorIntKey(&cur));
+      }else{
+        if( iParentRec<0 || iParentRec>=parentInfo.nField ){
+          match = 0;
+        }else{
+          match = doltliteFieldValuesEqual(
+              childInfo.aType[i], pChildFkRec, nChildFkRec,
+              childInfo.aOffset[i],
+              parentInfo.aType[iParentRec], pParentVal, nParentVal,
+              parentInfo.aOffset[iParentRec]);
+        }
+      }
+    }
+    if( match ){
+      *pExists = 1;
+      break;
+    }
+    rc = prollyCursorNext(&cur);
+  }
+  prollyCursorClose(&cur);
+  sqlite3_free(aiParentCol);
+  doltliteFreeColInfo(&parentCols);
+  return rc==SQLITE_DONE ? SQLITE_OK : rc;
+}
+
+static char *buildFkViolationInfo(
+  sqlite3 *db,
+  const char *zChildTable,
+  int fkid
+){
+  sqlite3_stmt *pStmt = 0;
+  sqlite3_str *pJson;
+  sqlite3_str *pCols;
+  sqlite3_str *pRefCols;
+  char *zColsBuf = 0;
+  char *zRefColsBuf = 0;
+  char *zParentBuf = 0;
+  char *zOnUpBuf = 0;
+  char *zOnDelBuf = 0;
+  char *zQuery;
+  char *zResult;
+  int rc;
+  int nMatches = 0;
+  int fatal = 0;
+
+  pJson = sqlite3_str_new(0);
+  pCols = sqlite3_str_new(0);
+  pRefCols = sqlite3_str_new(0);
+
+  zQuery = sqlite3_mprintf("PRAGMA main.foreign_key_list(%Q)", zChildTable);
+  if( !zQuery ){
+    fatal = 1;
+  }else{
+    rc = sqlite3_prepare_v2(db, zQuery, -1, &pStmt, 0);
+    sqlite3_free(zQuery);
+    if( rc != SQLITE_OK ){
+      fatal = 1;
+    }else{
+      while( sqlite3_step(pStmt) == SQLITE_ROW ){
+        int id = sqlite3_column_int(pStmt, 0);
+        const char *zParent, *zFrom, *zTo, *zOnUp, *zOnDel;
+        if( id != fkid ) continue;
+        zParent = (const char*)sqlite3_column_text(pStmt, 2);
+        zFrom   = (const char*)sqlite3_column_text(pStmt, 3);
+        zTo     = (const char*)sqlite3_column_text(pStmt, 4);
+        zOnUp   = (const char*)sqlite3_column_text(pStmt, 5);
+        zOnDel  = (const char*)sqlite3_column_text(pStmt, 6);
+        if( nMatches>0 ){
+          sqlite3_str_appendall(pCols, ", ");
+          sqlite3_str_appendall(pRefCols, ", ");
+        }
+        sqlite3_str_appendf(pCols, "\"%w\"", zFrom ? zFrom : "");
+        sqlite3_str_appendf(pRefCols, "\"%w\"", zTo ? zTo : "");
+        if( nMatches==0 ){
+          if( zParent ) zParentBuf = sqlite3_mprintf("%s", zParent);
+          zOnUpBuf  = sqlite3_mprintf("%s", zOnUp  ? zOnUp  : "NO ACTION");
+          zOnDelBuf = sqlite3_mprintf("%s", zOnDel ? zOnDel : "NO ACTION");
+        }
+        nMatches++;
+      }
+    }
+  }
+  sqlite3_finalize(pStmt);
+
+  zColsBuf    = sqlite3_str_finish(pCols);
+  zRefColsBuf = sqlite3_str_finish(pRefCols);
+
+  if( fatal ){
+    sqlite3_free(sqlite3_str_finish(pJson));
+    sqlite3_free(zColsBuf);
+    sqlite3_free(zRefColsBuf);
+    sqlite3_free(zParentBuf);
+    sqlite3_free(zOnUpBuf);
+    sqlite3_free(zOnDelBuf);
+    return 0;
+  }
+
+  sqlite3_str_appendall(pJson, "{");
+  sqlite3_str_appendf(pJson,
+      "\"Columns\": [%s], \"ReferencedTable\": \"%w\", "
+      "\"ReferencedColumns\": [%s], "
+      "\"OnUpdate\": \"%w\", \"OnDelete\": \"%w\"}",
+      zColsBuf ? zColsBuf : "",
+      zParentBuf ? zParentBuf : "",
+      zRefColsBuf ? zRefColsBuf : "",
+      zOnUpBuf ? zOnUpBuf : "NO ACTION",
+      zOnDelBuf ? zOnDelBuf : "NO ACTION");
+  zResult = sqlite3_str_finish(pJson);
+  sqlite3_free(zColsBuf);
+  sqlite3_free(zRefColsBuf);
+  sqlite3_free(zParentBuf);
+  sqlite3_free(zOnUpBuf);
+  sqlite3_free(zOnDelBuf);
+  return zResult;
+}
+
+static int detectFkViolationsForSpec(
+  sqlite3 *db,
+  struct TableEntry *aCur, int nCur,
+  struct TableEntry *aAnc, int nAnc,
+  const char *zChildTable,
+  int hasRowid,
+  const MergePkInfo *pChildPk,
+  const char *zParentTable,
+  int fkid,
+  char **azFrom,
+  char **azTo,
+  int nCol,
+  int *pnFound
+){
+  sqlite3_str *pSql = 0;
+  char *zQuery = 0;
+  sqlite3_stmt *pStmt = 0;
+  int nKeyCol;
+  int rc;
+
+  pSql = sqlite3_str_new(0);
+  sqlite3_str_appendf(pSql, "SELECT %s", hasRowid ? "rowid" : pChildPk->zPkCols);
+  for(int i=0; i<nCol; i++){
+    sqlite3_str_appendf(pSql, ", c.\"%w\"", azFrom[i]);
+  }
+  sqlite3_str_appendf(pSql, " FROM main.\"%w\" AS c WHERE ", zChildTable);
+  for(int i=0; i<nCol; i++){
+    if( i>0 ) sqlite3_str_appendall(pSql, " AND ");
+    sqlite3_str_appendf(pSql, "c.\"%w\" IS NOT NULL", azFrom[i]);
+  }
+  sqlite3_str_appendf(pSql, " AND NOT EXISTS (SELECT 1 FROM main.\"%w\" AS p WHERE ",
+      zParentTable);
+  for(int i=0; i<nCol; i++){
+    if( i>0 ) sqlite3_str_appendall(pSql, " AND ");
+    sqlite3_str_appendf(pSql, "p.\"%w\" = c.\"%w\"", azTo[i], azFrom[i]);
+  }
+  sqlite3_str_appendall(pSql, ")");
+  zQuery = sqlite3_str_finish(pSql);
+  if( !zQuery ) return SQLITE_NOMEM;
+
+  rc = sqlite3_prepare_v2(db, zQuery, -1, &pStmt, 0);
+  sqlite3_free(zQuery);
+  if( rc!=SQLITE_OK ) return rc;
+  nKeyCol = hasRowid ? 1 : pChildPk->nPk;
+
+  while( sqlite3_step(pStmt)==SQLITE_ROW ){
+    u8 *pKey = 0; int nKey = 0;
+    u8 *pVal = 0; int nVal = 0;
+    u8 *pChildFkRec = 0; int nChildFkRec = 0;
+    i64 intKey = 0;
+    char *zInfo;
+    int appendRc;
+
+    if( hasRowid ){
+      intKey = sqlite3_column_int64(pStmt, 0);
+      rc = fetchOrphanRow(db, zChildTable, intKey, &pKey, &nKey, &pVal, &nVal);
+    }else{
+      u8 *pPkRec = 0; int nPkRec = 0;
+      pPkRec = buildRecordFromStmtCols(pStmt, 0, pChildPk->nPk, &nPkRec);
+      if( !pPkRec ){ rc = SQLITE_NOMEM; break; }
+      rc = fetchRowByPkFromTable(db, zChildTable, pPkRec, nPkRec, pChildPk->nPk,
+                                 &pKey, &nKey, &pVal, &nVal);
+      sqlite3_free(pPkRec);
+    }
+    if( rc == SQLITE_NOTFOUND ){ rc = SQLITE_OK; continue; }
+    if( rc != SQLITE_OK ){
+      sqlite3_free(pKey);
+      sqlite3_free(pVal);
+      break;
+    }
+
+    pChildFkRec = buildRecordFromStmtCols(pStmt, nKeyCol, nCol, &nChildFkRec);
+    if( !pChildFkRec ){
+      sqlite3_free(pKey);
+      sqlite3_free(pVal);
+      rc = SQLITE_NOMEM;
+      break;
+    }
+    {
+      int parentExists = 0;
+      rc = fkParentExistsInCatalog(db, aCur, nCur, zParentTable,
+                                   azTo, nCol, pChildFkRec, nChildFkRec,
+                                   &parentExists);
+      sqlite3_free(pChildFkRec);
+      pChildFkRec = 0;
+      if( rc!=SQLITE_OK ){
+        sqlite3_free(pKey);
+        sqlite3_free(pVal);
+        break;
+      }
+      if( parentExists ){
+        sqlite3_free(pKey);
+        sqlite3_free(pVal);
+        continue;
+      }
+    }
+
+    if( aAnc ){
+      u8 *pAncVal = 0; int nAncVal = 0;
+      int ancRc = hasRowid
+          ? fetchAncestorRowByName(db, aAnc, nAnc, zChildTable,
+                                   intKey, &pAncVal, &nAncVal)
+          : fetchAncestorRowByKey(db, aAnc, nAnc, zChildTable,
+                                  pKey, nKey, &pAncVal, &nAncVal);
+      int preExisting = (ancRc==SQLITE_OK)
+          && isRowPreExisting(pVal, nVal, pAncVal, nAncVal);
+      sqlite3_free(pAncVal);
+      if( preExisting ){
+        sqlite3_free(pKey);
+        sqlite3_free(pVal);
+        continue;
+      }
+    }
+
+    zInfo = buildFkViolationInfo(db, zChildTable, fkid);
+    appendRc = doltliteAppendConstraintViolation(
+        db, zChildTable, DOLTLITE_CV_FOREIGN_KEY,
+        intKey, pKey, nKey, pVal, nVal, zInfo);
+    sqlite3_free(zInfo);
+    sqlite3_free(pKey);
+    sqlite3_free(pVal);
+    if( appendRc != SQLITE_OK ){
+      rc = appendRc;
+      break;
+    }
+    if( pnFound ) (*pnFound)++;
+  }
+
+  if( rc==SQLITE_DONE ) rc = SQLITE_OK;
+  sqlite3_finalize(pStmt);
+  return rc;
+}
+
+int doltliteDetectMergeFkViolations(
+  sqlite3 *db,
+  const ProllyHash *pAncCatHash,
+  char **pzErrMsg,
+  int *pnFound,
+  const char **azTables,
+  int nTables
+){
+  sqlite3_stmt *pTbls = 0;
+  struct TableEntry *aAnc = 0;
+  int nAnc = 0;
+  struct TableEntry *aCur = 0;
+  int nCur = 0;
+  int rc;
+  int nFound = 0;
+  int stepRc;
+
+  (void)pzErrMsg;
+
+  if( pnFound ) *pnFound = 0;
+
+  rc = loadAncestorAndCurrentCatalogs(db, pAncCatHash, &aAnc, &nAnc,
+                                      &aCur, &nCur);
+  if( rc!=SQLITE_OK ) return rc;
+
+  rc = sqlite3_prepare_v2(db,
+      "SELECT name FROM main.sqlite_master WHERE type='table' "
+      "AND name NOT LIKE 'sqlite_%' AND name NOT LIKE 'dolt_%'",
+      -1, &pTbls, 0);
+  if( rc != SQLITE_OK ){
+    doltliteFreeCatalog(aAnc, nAnc);
+    doltliteFreeCatalog(aCur, nCur);
+    return rc;
+  }
+
+  while( (stepRc = sqlite3_step(pTbls)) == SQLITE_ROW ){
+    const char *zTableRaw = (const char*)sqlite3_column_text(pTbls, 0);
+    char *zTable = 0;
+    char *zFkQ = 0;
+    sqlite3_stmt *pFk = 0;
+    int hasRowid = 1;
+    MergePkInfo childPk;
+    int curId = -1;
+    char *zParent = 0;
+    char **azFrom = 0;
+    char **azTo = 0;
+    int nCol = 0;
+    int nAlloc = 0;
+    int childChanged;
+
+    if( !zTableRaw ) continue;
+    zTable = sqlite3_mprintf("%s", zTableRaw);
+    if( !zTable ){ rc = SQLITE_NOMEM; break; }
+    if( !cvTableAllowed(zTable, azTables, nTables) ){
+      sqlite3_free(zTable);
+      continue;
+    }
+    childChanged = catalogTableChanged(aAnc, nAnc, aCur, nCur, zTable);
+    memset(&childPk, 0, sizeof(childPk));
+    hasRowid = tableHasRowid(db, zTable);
+    if( !hasRowid ){
+      rc = loadMergePkInfo(db, zTable, &childPk);
+      if( rc != SQLITE_OK ){
+        sqlite3_free(zTable);
+        break;
+      }
+    }
+
+    zFkQ = sqlite3_mprintf("PRAGMA main.foreign_key_list(%Q)", zTable);
+    if( !zFkQ ){
+      freeMergePkInfo(&childPk);
+      sqlite3_free(zTable);
+      rc = SQLITE_NOMEM;
+      break;
+    }
+    rc = sqlite3_prepare_v2(db, zFkQ, -1, &pFk, 0);
+    sqlite3_free(zFkQ);
+    if( rc != SQLITE_OK ){
+      freeMergePkInfo(&childPk);
+      sqlite3_free(zTable);
+      break;
+    }
+
+    while( sqlite3_step(pFk) == SQLITE_ROW ){
+      int id = sqlite3_column_int(pFk, 0);
+      const char *zParentRaw = (const char*)sqlite3_column_text(pFk, 2);
+      const char *zFromRaw = (const char*)sqlite3_column_text(pFk, 3);
+      const char *zToRaw = (const char*)sqlite3_column_text(pFk, 4);
+
+      if( curId>=0 && id!=curId ){
+        int parentChanged = catalogTableChanged(aAnc, nAnc, aCur, nCur, zParent);
+        if( childChanged || parentChanged ){
+          struct TableEntry *aCheckAnc = parentChanged ? 0 : aAnc;
+          int nCheckAnc = parentChanged ? 0 : nAnc;
+          rc = backfillParentPk(db, zParent, azTo, nCol);
+          if( rc != SQLITE_OK ) break;
+          rc = detectFkViolationsForSpec(db, aCur, nCur, aCheckAnc, nCheckAnc,
+              zTable, hasRowid, &childPk, zParent, curId,
+              azFrom, azTo, nCol, &nFound);
+        }
+        doltliteFreeStringArray(azFrom, nCol);
+        doltliteFreeStringArray(azTo, nCol);
+        azFrom = 0; azTo = 0; nCol = 0; nAlloc = 0;
+        sqlite3_free(zParent); zParent = 0;
+        if( rc != SQLITE_OK ) break;
+      }
+
+      if( curId != id ){
+        curId = id;
+        zParent = sqlite3_mprintf("%s", zParentRaw ? zParentRaw : "");
+        if( !zParent ){ rc = SQLITE_NOMEM; break; }
+      }
+
+      if( nCol >= nAlloc ){
+        int nNew = nAlloc ? nAlloc*2 : 4;
+        char **azFromNew;
+        char **azToNew;
+        azFromNew = sqlite3_realloc64(azFrom, (sqlite3_int64)nNew * sizeof(char*));
+        if( !azFromNew ){
+          rc = SQLITE_NOMEM;
+          break;
+        }
+        azFrom = azFromNew;
+        azToNew = sqlite3_realloc64(azTo, (sqlite3_int64)nNew * sizeof(char*));
+        if( !azToNew ){
+          rc = SQLITE_NOMEM;
+          break;
+        }
+        azTo = azToNew;
+        nAlloc = nNew;
+      }
+      azFrom[nCol] = sqlite3_mprintf("%s", zFromRaw ? zFromRaw : "");
+      azTo[nCol] = zToRaw ? sqlite3_mprintf("%s", zToRaw) : 0;
+      if( !azFrom[nCol] || (zToRaw && !azTo[nCol]) ){
+        rc = SQLITE_NOMEM;
+        break;
+      }
+      nCol++;
+    }
+
+    if( rc==SQLITE_ROW || rc==SQLITE_DONE ){
+      rc = SQLITE_OK;
+    }
+    if( rc==SQLITE_OK && curId>=0 ){
+      int parentChanged = catalogTableChanged(aAnc, nAnc, aCur, nCur, zParent);
+      if( childChanged || parentChanged ){
+        struct TableEntry *aCheckAnc = parentChanged ? 0 : aAnc;
+        int nCheckAnc = parentChanged ? 0 : nAnc;
+        rc = backfillParentPk(db, zParent, azTo, nCol);
+        if( rc==SQLITE_OK ){
+          rc = detectFkViolationsForSpec(db, aCur, nCur, aCheckAnc, nCheckAnc,
+              zTable, hasRowid, &childPk, zParent, curId,
+              azFrom, azTo, nCol, &nFound);
+        }
+      }
+    }
+
+    doltliteFreeStringArray(azFrom, nCol);
+    doltliteFreeStringArray(azTo, nCol);
+    sqlite3_free(zParent);
+    sqlite3_finalize(pFk);
+    freeMergePkInfo(&childPk);
+    sqlite3_free(zTable);
+    if( rc != SQLITE_OK ) break;
+  }
+
+  if( rc == SQLITE_OK && stepRc != SQLITE_DONE && stepRc != SQLITE_ROW ){
+    rc = stepRc;
+  }
+  sqlite3_finalize(pTbls);
+  doltliteFreeCatalog(aAnc, nAnc);
+  doltliteFreeCatalog(aCur, nCur);
+  if( pnFound ) *pnFound = nFound;
+  return rc;
+}
+
+
+#endif

--- a/src/doltlite_merge_constraints_int.h
+++ b/src/doltlite_merge_constraints_int.h
@@ -1,0 +1,86 @@
+#ifndef DOLTLITE_MERGE_CONSTRAINTS_INT_H
+#define DOLTLITE_MERGE_CONSTRAINTS_INT_H
+
+/* Private declarations shared by merge constraint-violation detectors. */
+
+#include "sqliteInt.h"
+#include "prolly_hash.h"
+#include "prolly_cursor.h"
+#include "prolly_cache.h"
+#include "chunk_store.h"
+#include "doltlite_internal.h"
+#include "doltlite_record.h"
+#include "doltlite_constraint_violations.h"
+
+#include <string.h>
+
+typedef struct MergePkInfo MergePkInfo;
+struct MergePkInfo {
+  int nPk;
+  char **azPk;
+  char *zPkCols;
+};
+
+void freeMergePkInfo(MergePkInfo *pPk);
+int loadMergePkInfo(sqlite3 *db, const char *zTable, MergePkInfo *pPk);
+
+int copyCursorRow(
+  ProllyCursor *pCur,
+  u8 **ppKey, int *pnKey,
+  u8 **ppVal, int *pnVal
+);
+int fetchRowByRowid(
+  ChunkStore *cs, ProllyCache *pCache, const ProllyHash *pRoot, u8 flags,
+  i64 targetRowid, u8 **ppKey, int *pnKey, u8 **ppVal, int *pnVal
+);
+int fetchRowByBlobKey(
+  ChunkStore *cs, ProllyCache *pCache, const ProllyHash *pRoot, u8 flags,
+  const u8 *pKey, int nKey, u8 **ppKey, int *pnKey, u8 **ppVal, int *pnVal
+);
+int tableEntryDiffers(const struct TableEntry *a, const struct TableEntry *b);
+int catalogTableChanged(
+  struct TableEntry *aAnc, int nAnc,
+  struct TableEntry *aCur, int nCur,
+  const char *zTable
+);
+int cvTableAllowed(const char *zTable, const char **azTables, int nTables);
+int loadAncestorAndCurrentCatalogs(
+  sqlite3 *db, const ProllyHash *pAncCatHash,
+  struct TableEntry **paAnc, int *pnAnc,
+  struct TableEntry **paCur, int *pnCur
+);
+u8 *buildRecordFromStmtCols(
+  sqlite3_stmt *pStmt, int iStart, int nField, int *pnOut
+);
+int recordPrefixEquals(
+  const u8 *pLeft, int nLeft, const u8 *pRight, int nRight, int nField
+);
+int fetchRowByPkRecord(
+  ChunkStore *cs, ProllyCache *pCache, const ProllyHash *pRoot, u8 flags,
+  const u8 *pPkRec, int nPkRec, int nPkField,
+  u8 **ppKey, int *pnKey, u8 **ppVal, int *pnVal
+);
+int fetchAncestorRowByName(
+  sqlite3 *db, struct TableEntry *aAnc, int nAnc, const char *zTable,
+  i64 rowid, u8 **ppAncVal, int *pnAncVal
+);
+int fetchAncestorRowByKey(
+  sqlite3 *db, struct TableEntry *aAnc, int nAnc, const char *zTable,
+  const u8 *pKey, int nKey, u8 **ppAncVal, int *pnAncVal
+);
+int isRowPreExisting(
+  const u8 *pMergedVal, int nMergedVal,
+  const u8 *pAncVal, int nAncVal
+);
+int tableHasRowid(sqlite3 *db, const char *zTable);
+int fetchOrphanRow(
+  sqlite3 *db, const char *zTable, i64 rowid,
+  u8 **ppKey, int *pnKey, u8 **ppVal, int *pnVal
+);
+int fetchRowByPkFromTable(
+  sqlite3 *db, const char *zTable,
+  const u8 *pPkRec, int nPkRec, int nPkField,
+  u8 **ppKey, int *pnKey, u8 **ppVal, int *pnVal
+);
+
+#endif /* DOLTLITE_MERGE_CONSTRAINTS_INT_H */

--- a/src/doltlite_merge_constraints_unique.c
+++ b/src/doltlite_merge_constraints_unique.c
@@ -1,0 +1,425 @@
+#ifdef DOLTLITE_PROLLY
+
+#include "doltlite_merge_constraints_int.h"
+
+static int appendUniqueViolationByRowid(
+  sqlite3 *db,
+  struct TableEntry *aAnc, int nAnc,
+  const char *zTable,
+  const char *zIndexName,
+  const char *zCols,
+  sqlite3_int64 rowid,
+  int *pAppended
+){
+  u8 *pKey = 0;
+  int nKey = 0;
+  u8 *pVal = 0;
+  int nVal = 0;
+  char *zInfo = 0;
+  int rc;
+
+  if( pAppended ) *pAppended = 0;
+  rc = fetchOrphanRow(db, zTable, rowid, &pKey, &nKey, &pVal, &nVal);
+  if( rc==SQLITE_NOTFOUND ) return SQLITE_OK;
+  if( rc!=SQLITE_OK ) return rc;
+
+  if( aAnc ){
+    u8 *pAncVal = 0;
+    int nAncVal = 0;
+    int ancRc = fetchAncestorRowByName(db, aAnc, nAnc, zTable,
+                                       rowid, &pAncVal, &nAncVal);
+    int preExisting = (ancRc==SQLITE_OK)
+        && isRowPreExisting(pVal, nVal, pAncVal, nAncVal);
+    sqlite3_free(pAncVal);
+    if( preExisting ){
+      sqlite3_free(pKey);
+      sqlite3_free(pVal);
+      return SQLITE_OK;
+    }
+  }
+
+  zInfo = sqlite3_mprintf(
+      "{\"Columns\": [%s], \"Name\": \"%w\"}",
+      zCols, zIndexName);
+  rc = doltliteAppendConstraintViolation(
+      db, zTable, DOLTLITE_CV_UNIQUE_INDEX,
+      rowid, pKey, nKey, pVal, nVal, zInfo);
+  sqlite3_free(zInfo);
+  sqlite3_free(pKey);
+  sqlite3_free(pVal);
+  if( rc==SQLITE_OK && pAppended ) *pAppended = 1;
+  return rc;
+}
+
+static int appendUniqueViolationByPk(
+  sqlite3 *db,
+  struct TableEntry *aAnc, int nAnc,
+  const char *zTable,
+  const char *zIndexName,
+  const char *zCols,
+  const MergePkInfo *pPk,
+  const u8 *pPkRec, int nPkRec,
+  int *pAppended
+){
+  u8 *pKey = 0;
+  int nKey = 0;
+  u8 *pVal = 0;
+  int nVal = 0;
+  char *zInfo = 0;
+  int rc;
+
+  if( pAppended ) *pAppended = 0;
+  rc = fetchRowByPkFromTable(db, zTable, pPkRec, nPkRec, pPk->nPk,
+                             &pKey, &nKey, &pVal, &nVal);
+  if( rc==SQLITE_NOTFOUND ) return SQLITE_OK;
+  if( rc!=SQLITE_OK ) return rc;
+
+  if( aAnc ){
+    u8 *pAncVal = 0;
+    int nAncVal = 0;
+    int ancRc = fetchAncestorRowByKey(db, aAnc, nAnc, zTable,
+                                      pKey, nKey, &pAncVal, &nAncVal);
+    int preExisting = (ancRc==SQLITE_OK)
+        && isRowPreExisting(pVal, nVal, pAncVal, nAncVal);
+    sqlite3_free(pAncVal);
+    if( preExisting ){
+      sqlite3_free(pKey);
+      sqlite3_free(pVal);
+      return SQLITE_OK;
+    }
+  }
+
+  zInfo = sqlite3_mprintf(
+      "{\"Columns\": [%s], \"Name\": \"%w\"}",
+      zCols, zIndexName);
+  rc = doltliteAppendConstraintViolation(
+      db, zTable, DOLTLITE_CV_UNIQUE_INDEX,
+      0, pKey, nKey, pVal, nVal, zInfo);
+  sqlite3_free(zInfo);
+  sqlite3_free(pKey);
+  sqlite3_free(pVal);
+  if( rc==SQLITE_OK && pAppended ) *pAppended = 1;
+  return rc;
+}
+
+static int uniqueIndexRowHasNull(sqlite3_stmt *pScan, int colFirst, int colLast){
+  int i;
+  for(i=colFirst; i<colLast; i++){
+    if( sqlite3_column_type(pScan, i) == SQLITE_NULL ) return 1;
+  }
+  return 0;
+}
+
+static int detectUniqueViolationsForIndex(
+  sqlite3 *db,
+  struct TableEntry *aAnc, int nAnc,
+  const char *zTable,
+  const char *zIndexName,
+  const char *zCols,
+  char **pzErrMsg,
+  int *pnFound
+){
+  sqlite3_stmt *pScan = 0;
+  char *zQuery;
+  char *zWinnerKey = 0;
+  sqlite3_int64 winnerRowid = 0;
+  int winnerHandled = 0;
+  int rc;
+  (void)pzErrMsg;
+
+  zQuery = sqlite3_mprintf(
+    "SELECT rowid, %s FROM main.\"%w\" NOT INDEXED ORDER BY %s, rowid",
+    zCols, zTable, zCols);
+  if( !zQuery ) return SQLITE_NOMEM;
+  rc = sqlite3_prepare_v2(db, zQuery, -1, &pScan, 0);
+  sqlite3_free(zQuery);
+  if( rc != SQLITE_OK ) return rc;
+
+  while( (rc = sqlite3_step(pScan)) == SQLITE_ROW ){
+    sqlite3_int64 rowid = sqlite3_column_int64(pScan, 0);
+    int nc = sqlite3_column_count(pScan);
+    int i;
+    sqlite3_str *pS;
+    char *zRowKey;
+    int isDup;
+
+    if( uniqueIndexRowHasNull(pScan, 1, nc) ) continue;
+
+    pS = sqlite3_str_new(0);
+    for(i=1; i<nc; i++){
+      const char *zV = (const char*)sqlite3_column_text(pScan, i);
+      sqlite3_str_appendf(pS, "%s%Q", i>1?"|":"", zV ? zV : "");
+    }
+    zRowKey = sqlite3_str_finish(pS);
+    if( !zRowKey ){ rc = SQLITE_NOMEM; break; }
+
+    isDup = zWinnerKey && strcmp(zWinnerKey, zRowKey)==0;
+    if( !isDup ){
+      sqlite3_free(zWinnerKey);
+      zWinnerKey = zRowKey;
+      winnerRowid = rowid;
+      winnerHandled = 0;
+      continue;
+    }
+    sqlite3_free(zRowKey);
+
+    if( !winnerHandled ){
+      int appended = 0;
+      rc = appendUniqueViolationByRowid(db, aAnc, nAnc, zTable, zIndexName,
+                                        zCols, winnerRowid, &appended);
+      if( rc != SQLITE_OK ) break;
+      if( appended && pnFound ) (*pnFound)++;
+      winnerHandled = 1;
+    }
+
+    {
+      int appended = 0;
+      rc = appendUniqueViolationByRowid(db, aAnc, nAnc, zTable, zIndexName,
+                                        zCols, rowid, &appended);
+      if( rc != SQLITE_OK ) break;
+      if( appended && pnFound ) (*pnFound)++;
+    }
+  }
+  sqlite3_free(zWinnerKey);
+  if( rc == SQLITE_DONE ) rc = SQLITE_OK;
+  sqlite3_finalize(pScan);
+  return rc;
+}
+
+static int detectUniqueViolationsForIndexWithoutRowid(
+  sqlite3 *db,
+  struct TableEntry *aAnc, int nAnc,
+  const char *zTable,
+  const char *zIndexName,
+  const char *zCols,
+  const MergePkInfo *pPk,
+  int *pnFound
+){
+  sqlite3_stmt *pScan = 0;
+  sqlite3_str *pSql = 0;
+  char *zQuery = 0;
+  char *zWinnerKey = 0;
+  u8 *pWinnerPkRec = 0;
+  int nWinnerPkRec = 0;
+  int winnerHandled = 0;
+  int rc;
+
+  pSql = sqlite3_str_new(0);
+  sqlite3_str_appendf(pSql,
+      "SELECT %s, %s FROM main.\"%w\" NOT INDEXED ORDER BY %s, %s",
+      zCols, pPk->zPkCols, zTable, zCols, pPk->zPkCols);
+  zQuery = sqlite3_str_finish(pSql);
+  if( !zQuery ) return SQLITE_NOMEM;
+  rc = sqlite3_prepare_v2(db, zQuery, -1, &pScan, 0);
+  sqlite3_free(zQuery);
+  if( rc!=SQLITE_OK ) return rc;
+
+  while( (rc = sqlite3_step(pScan)) == SQLITE_ROW ){
+    int nc = sqlite3_column_count(pScan);
+    int nDupKeyCol = nc - pPk->nPk;
+    sqlite3_str *pS;
+    char *zRowKey = 0;
+    int i, isDup;
+
+    if( uniqueIndexRowHasNull(pScan, 0, nDupKeyCol) ) continue;
+
+    pS = sqlite3_str_new(0);
+    for(i=0; i<nDupKeyCol; i++){
+      const char *zV = (const char*)sqlite3_column_text(pScan, i);
+      sqlite3_str_appendf(pS, "%s%Q", i>0?"|":"", zV ? zV : "");
+    }
+    zRowKey = sqlite3_str_finish(pS);
+    if( !zRowKey ){ rc = SQLITE_NOMEM; break; }
+
+    isDup = zWinnerKey && strcmp(zWinnerKey, zRowKey)==0;
+    if( !isDup ){
+      u8 *pPkRec = 0;
+      int nPkRec = 0;
+      pPkRec = buildRecordFromStmtCols(pScan, nDupKeyCol, pPk->nPk, &nPkRec);
+      if( !pPkRec ){
+        sqlite3_free(zRowKey);
+        rc = SQLITE_NOMEM;
+        break;
+      }
+      sqlite3_free(zWinnerKey);
+      sqlite3_free(pWinnerPkRec);
+      zWinnerKey = zRowKey;
+      pWinnerPkRec = pPkRec;
+      nWinnerPkRec = nPkRec;
+      winnerHandled = 0;
+      continue;
+    }
+    sqlite3_free(zRowKey);
+
+    {
+      u8 *pPkRec = 0; int nPkRec = 0;
+      pPkRec = buildRecordFromStmtCols(pScan, nDupKeyCol, pPk->nPk, &nPkRec);
+      if( !pPkRec ){ rc = SQLITE_NOMEM; break; }
+      if( !winnerHandled ){
+        int appended = 0;
+        rc = appendUniqueViolationByPk(db, aAnc, nAnc, zTable, zIndexName,
+                                       zCols, pPk, pWinnerPkRec, nWinnerPkRec,
+                                       &appended);
+        if( rc != SQLITE_OK ){
+          sqlite3_free(pPkRec);
+          break;
+        }
+        if( appended && pnFound ) (*pnFound)++;
+        winnerHandled = 1;
+      }
+      {
+        int appended = 0;
+        rc = appendUniqueViolationByPk(db, aAnc, nAnc, zTable, zIndexName,
+                                       zCols, pPk, pPkRec, nPkRec, &appended);
+        sqlite3_free(pPkRec);
+        if( rc != SQLITE_OK ) break;
+        if( appended && pnFound ) (*pnFound)++;
+      }
+    }
+  }
+
+  sqlite3_free(zWinnerKey);
+  sqlite3_free(pWinnerPkRec);
+  if( rc == SQLITE_DONE ) rc = SQLITE_OK;
+  sqlite3_finalize(pScan);
+  return rc;
+}
+
+int doltliteDetectMergeUniqueViolations(
+  sqlite3 *db,
+  const ProllyHash *pAncCatHash,
+  char **pzErrMsg,
+  int *pnFound,
+  const char **azTables,
+  int nTables
+){
+  sqlite3_stmt *pTbls = 0;
+  struct TableEntry *aAnc = 0;
+  int nAnc = 0;
+  struct TableEntry *aCur = 0;
+  int nCur = 0;
+  int rc;
+
+  if( pnFound ) *pnFound = 0;
+
+  rc = loadAncestorAndCurrentCatalogs(db, pAncCatHash, &aAnc, &nAnc,
+                                      &aCur, &nCur);
+  if( rc!=SQLITE_OK ) return rc;
+
+  rc = sqlite3_prepare_v2(db,
+      "SELECT name FROM main.sqlite_master WHERE type='table' "
+      "AND name NOT LIKE 'sqlite_%' AND name NOT LIKE 'dolt_%'",
+      -1, &pTbls, 0);
+  if( rc != SQLITE_OK ){
+    doltliteFreeCatalog(aAnc, nAnc);
+    doltliteFreeCatalog(aCur, nCur);
+    return rc;
+  }
+
+  while( (rc = sqlite3_step(pTbls)) == SQLITE_ROW ){
+    const char *zTableRaw = (const char*)sqlite3_column_text(pTbls, 0);
+    char *zTable;
+    sqlite3_stmt *pIdxList = 0;
+    char *zIdxQ;
+    int hasRowid = 1;
+    MergePkInfo pkInfo;
+
+    if( !zTableRaw ) continue;
+    zTable = sqlite3_mprintf("%s", zTableRaw);
+    if( !zTable ){ rc = SQLITE_NOMEM; break; }
+    if( !cvTableAllowed(zTable, azTables, nTables) ){
+      sqlite3_free(zTable);
+      continue;
+    }
+    if( !catalogTableChanged(aAnc, nAnc, aCur, nCur, zTable) ){
+      sqlite3_free(zTable);
+      continue;
+    }
+    memset(&pkInfo, 0, sizeof(pkInfo));
+    hasRowid = tableHasRowid(db, zTable);
+    if( !hasRowid ){
+      rc = loadMergePkInfo(db, zTable, &pkInfo);
+      if( rc != SQLITE_OK ){
+        sqlite3_free(zTable);
+        break;
+      }
+    }
+
+    zIdxQ = sqlite3_mprintf("PRAGMA main.index_list(%Q)", zTable);
+    if( !zIdxQ ){ sqlite3_free(zTable); rc = SQLITE_NOMEM; break; }
+    rc = sqlite3_prepare_v2(db, zIdxQ, -1, &pIdxList, 0);
+    sqlite3_free(zIdxQ);
+    if( rc != SQLITE_OK ){
+      freeMergePkInfo(&pkInfo);
+      sqlite3_free(zTable);
+      break;
+    }
+
+    while( sqlite3_step(pIdxList) == SQLITE_ROW ){
+      int unique = sqlite3_column_int(pIdxList, 2);
+      const char *zIdxRaw;
+      const char *zOrigin;
+      char *zIdx;
+      char *zColsQ;
+      sqlite3_stmt *pCols = 0;
+      sqlite3_str *pColList;
+      char *zColList;
+      int idxRc;
+
+      if( !unique ) continue;
+      zIdxRaw = (const char*)sqlite3_column_text(pIdxList, 1);
+      if( !zIdxRaw ) continue;
+
+      zOrigin = (const char*)sqlite3_column_text(pIdxList, 3);
+      if( zOrigin && strcmp(zOrigin, "pk")==0 ) continue;
+
+      zIdx = sqlite3_mprintf("%s", zIdxRaw);
+      if( !zIdx ) break;
+      zColsQ = sqlite3_mprintf("PRAGMA main.index_xinfo(%Q)", zIdx);
+      if( !zColsQ ){ sqlite3_free(zIdx); break; }
+      idxRc = sqlite3_prepare_v2(db, zColsQ, -1, &pCols, 0);
+      sqlite3_free(zColsQ);
+      if( idxRc != SQLITE_OK ){ sqlite3_free(zIdx); continue; }
+
+      pColList = sqlite3_str_new(0);
+      while( sqlite3_step(pCols) == SQLITE_ROW ){
+        int cno = sqlite3_column_int(pCols, 1);
+        int isKey = sqlite3_column_int(pCols, 5);
+        const char *zCol = (const char*)sqlite3_column_text(pCols, 2);
+        if( cno < 0 || !zCol || !isKey ) continue;
+        if( sqlite3_str_length(pColList) > 0 ){
+          sqlite3_str_appendall(pColList, ", ");
+        }
+        sqlite3_str_appendf(pColList, "\"%w\"", zCol);
+      }
+      sqlite3_finalize(pCols);
+      zColList = sqlite3_str_finish(pColList);
+      if( zColList && *zColList ){
+        if( hasRowid ){
+          rc = detectUniqueViolationsForIndex(db, aAnc, nAnc, zTable,
+                                               zIdx, zColList, pzErrMsg,
+                                               pnFound);
+        }else{
+          rc = detectUniqueViolationsForIndexWithoutRowid(
+              db, aAnc, nAnc, zTable, zIdx, zColList, &pkInfo, pnFound);
+        }
+      }
+      sqlite3_free(zColList);
+      sqlite3_free(zIdx);
+      if( rc != SQLITE_OK ) break;
+    }
+
+    sqlite3_finalize(pIdxList);
+    freeMergePkInfo(&pkInfo);
+    sqlite3_free(zTable);
+    if( rc != SQLITE_OK ) break;
+  }
+  if( rc == SQLITE_DONE ) rc = SQLITE_OK;
+  sqlite3_finalize(pTbls);
+  doltliteFreeCatalog(aAnc, nAnc);
+  doltliteFreeCatalog(aCur, nCur);
+  return rc;
+}
+
+
+#endif

--- a/test/lint_layers.sh
+++ b/test/lint_layers.sh
@@ -117,16 +117,36 @@ do
   fi
 done
 
-for f in "$SRCDIR"/doltlite_merge_cmd.c "$SRCDIR"/doltlite_merge_constraints.c; do
+if [ ! -f "$SRCDIR"/doltlite_merge_cmd.c ]; then
+  lint "$SRCDIR/doltlite_merge_cmd.c: missing — expected doltlite merge command module"
+else
+  nline=$(wc -l < "$SRCDIR"/doltlite_merge_cmd.c | tr -d ' ')
+  if [ "$nline" -gt 2000 ]; then
+    lint "$SRCDIR/doltlite_merge_cmd.c:$nline lines — doltlite merge cmd must stay at or below 2000 lines"
+  fi
+fi
+
+# Constraint detectors: require the FK/unique/CHECK split so the monolith
+# cannot return. Cap shared helpers + each detector at 1500.
+for f in \
+  "$SRCDIR"/doltlite_merge_constraints.c \
+  "$SRCDIR"/doltlite_merge_constraints_unique.c \
+  "$SRCDIR"/doltlite_merge_constraints_check.c \
+  "$SRCDIR"/doltlite_merge_constraints_fk.c
+do
   if [ ! -f "$f" ]; then
-    lint "$f: missing — expected doltlite merge command/constraints module"
+    lint "$f: missing — doltlite merge constraints must stay split (shared/unique/check/fk)"
     continue
   fi
   nline=$(wc -l < "$f" | tr -d ' ')
-  if [ "$nline" -gt 2000 ]; then
-    lint "$f:$nline lines — doltlite merge cmd/constraints must stay at or below 2000 lines"
+  if [ "$nline" -gt 1500 ]; then
+    lint "$f:$nline lines — doltlite merge constraint modules must stay at or below 1500 lines"
   fi
 done
+
+if [ ! -f "$SRCDIR"/doltlite_merge_constraints_int.h ]; then
+  lint "$SRCDIR/doltlite_merge_constraints_int.h: missing — merge constraints private header"
+fi
 
 for f in "$SRCDIR"/prolly_*.c; do
   while IFS= read -r line; do

--- a/tool/mksqlite3c.tcl
+++ b/tool/mksqlite3c.tcl
@@ -248,7 +248,8 @@ if {$doltlite} {
     prolly_three_way_merge.h prolly_xxhash.h prolly_btree_int.h
     doltlite_ancestor.h doltlite_catalog_types.h doltlite_chunk_walk.h doltlite_commit.h
     doltlite_constraint_violations.h doltlite_ignore.h doltlite_internal.h
-    doltlite_branch_int.h doltlite_merge_int.h doltlite_name_index.h doltlite_parse.h
+    doltlite_branch_int.h doltlite_merge_int.h doltlite_merge_constraints_int.h
+    doltlite_name_index.h doltlite_parse.h
     doltlite_record.h doltlite_remote.h doltlite_remotesrv.h doltlite_vtab_util.h
     doltlite_creds.h doltlite_net.h doltlite_tls.h
   } {

--- a/tool/mksqlite3c.tcl
+++ b/tool/mksqlite3c.tcl
@@ -627,7 +627,7 @@ proc emit_doltlite_engine_block {} {
     doltlite_conflicts.c doltlite_gc.c doltlite_chunk_walk.c
     doltlite_history.c doltlite_at.c doltlite_blame.c doltlite_schema_diff.c doltlite_patch.c
     doltlite_schemas.c doltlite_diff_stat.c doltlite_record.c doltlite_ignore.c
-    doltlite_hashof.c doltlite_constraint_violations.c doltlite_verify_constraints.c doltlite_merge_constraints.c
+    doltlite_hashof.c doltlite_constraint_violations.c doltlite_verify_constraints.c doltlite_merge_constraints.c doltlite_merge_constraints_unique.c doltlite_merge_constraints_check.c doltlite_merge_constraints_fk.c
     doltlite_dbpage.c doltlite_remote.c doltlite_remote_sql.c doltlite_http_remote.c
     doltlite_remotesrv.c
   } {


### PR DESCRIPTION
## Summary

- Split `doltlite_merge_constraints.c` (~1.8k lines) the same way merge core was split:
  - `doltlite_merge_constraints.c` — shared catalog/row helpers
  - `doltlite_merge_constraints_int.h` — private shared types/API
  - `doltlite_merge_constraints_unique.c` — unique-index violations
  - `doltlite_merge_constraints_check.c` — CHECK violations
  - `doltlite_merge_constraints_fk.c` — foreign-key violations
- Wire `main.mk`, amalgamation (`mksqlite3c.tcl`), `AGENTS.md`, and `lint_layers` so the four modules must exist and stay ≤1500 lines (re-monolith cannot slip past).

Behavior is intended to be unchanged; this is a reviewability/size-lint refactor only.

## Validation

- `bash test/lint_layers.sh src`
- `bash test/lint_layers_selftest.sh` (14/14)
- `make -C build doltlite`
- `DOLTLITE=./build/doltlite bash test/doltlite_merge.sh` (94/94)
- `DOLTLITE=./build/doltlite bash test/doltlite_merge_status.sh` (28/28)