### PR TITLE
Harden generated-column schema merges and oracle coverage

### DIFF
--- a/src/doltlite_merge.c
+++ b/src/doltlite_merge.c
@@ -5,8 +5,8 @@
 /* Catalog three-way merge: table roots, schema objects, conflicts, reindex. */
 
 /* Rewrite every record in theirs' table root from theirs' column order into
-** the merged column order (ours' columns, then theirs' added columns), keyed
-** by column name. A merged column absent from a their-record is emitted as
+** the merged column order (ours' columns, then theirs' added columns), using
+** the ancestor to retain renamed-column identity. A missing field is emitted as
 ** NULL; trailing NULLs are dropped so an unchanged row re-encodes identically
 ** to the ancestor's. This lets the positional cell-level three-way merge run
 ** across a dual ADD COLUMN divergence: without it, theirs' added-column value
@@ -16,14 +16,15 @@ int normalizeTheirsToMergedLayout(
   sqlite3 *db,
   const ProllyHash *pTheirsRoot,
   u8 flags,
+  const char *zAncSql,
   const char *zOursSql,
   const char *zTheirsSql,
   ProllyHash *pOutRoot
 ){
   ChunkStore *cs = doltliteGetChunkStore(db);
   ProllyCache *cache = doltliteGetCache(db);
-  ParsedColumn *aOurs = 0, *aTheirs = 0;
-  int nOurs = 0, nTheirs = 0;
+  ParsedColumn *aAnc = 0, *aOurs = 0, *aTheirs = 0;
+  int nAnc = 0, nOurs = 0, nTheirs = 0;
   int *aMap = 0;
   int nMerged;
   ProllyMutMap mm;
@@ -34,21 +35,41 @@ int normalizeTheirsToMergedLayout(
   int rc, res, j;
 
   memset(pOutRoot, 0, sizeof(*pOutRoot));
-  rc = parseColumns(zOursSql, &aOurs, &nOurs);
+  rc = parseColumns(zAncSql, &aAnc, &nAnc);
   if( rc!=SQLITE_OK ) return rc;
+  rc = parseColumns(zOursSql, &aOurs, &nOurs);
+  if( rc!=SQLITE_OK ){ freeColumns(aAnc, nAnc); return rc; }
   rc = parseColumns(zTheirsSql, &aTheirs, &nTheirs);
-  if( rc!=SQLITE_OK ){ freeColumns(aOurs, nOurs); return rc; }
+  if( rc!=SQLITE_OK ){
+    freeColumns(aAnc, nAnc);
+    freeColumns(aOurs, nOurs);
+    return rc;
+  }
 
   nMerged = nOurs;
   aMap = sqlite3_malloc((nTheirs>0 ? nTheirs : 1) * (int)sizeof(int));
   if( !aMap ){ rc = SQLITE_NOMEM; goto done; }
   for(j=0; j<nTheirs; j++){
-    int oi, found = -1;
-    for(oi=0; oi<nOurs; oi++){
-      if( aOurs[oi].zName && aTheirs[j].zName
-       && sqlite3_stricmp(aOurs[oi].zName, aTheirs[j].zName)==0 ){
-        found = oi;
-        break;
+    int found = parsedColumnIndexByName(
+        aOurs, nOurs, aTheirs[j].zName);
+    if( found<0 ){
+      int ai = parsedColumnIndexByName(
+          aAnc, nAnc, aTheirs[j].zName);
+      if( ai<0 && j<nAnc
+       && sqlite3_stricmp(aTheirs[j].zName, aAnc[j].zName)!=0
+       && parsedColumnIndexByName(aTheirs, nTheirs, aAnc[j].zName)<0
+       && parsedColumnDefinitionsMatch(&aTheirs[j], &aAnc[j]) ){
+        ai = j;
+      }
+      if( ai>=0 ){
+        found = parsedColumnIndexByName(
+            aOurs, nOurs, aAnc[ai].zName);
+        if( found<0 && ai<nOurs
+         && sqlite3_stricmp(aOurs[ai].zName, aAnc[ai].zName)!=0
+         && parsedColumnIndexByName(aOurs, nOurs, aAnc[ai].zName)<0
+         && parsedColumnDefinitionsMatch(&aOurs[ai], &aAnc[ai]) ){
+          found = ai;
+        }
       }
     }
     aMap[j] = (found>=0) ? found : nMerged++;
@@ -138,6 +159,7 @@ done:
   if( curInit ) prollyCursorClose(&cur);
   if( mmInit ) prollyMutMapFree(&mm);
   sqlite3_free(aMap);
+  freeColumns(aAnc, nAnc);
   freeColumns(aOurs, nOurs);
   freeColumns(aTheirs, nTheirs);
   return rc;
@@ -903,6 +925,7 @@ int tryResolveSchemaDivergence(
   char **azAddCols = 0;
   int nAddCols = 0;
   int schemaChoice = SCHEMA_MERGE_DEFAULT;
+  int resolvedDivergence = 0;
   char *zSchemaErr = 0;
   int rc;
 
@@ -923,7 +946,8 @@ int tryResolveSchemaDivergence(
    && theirSchEntry && theirSchEntry->zSql ){
     rc = trySchemaColumnMerge(
       ancSchEntry->zSql, ourSchEntry->zSql, theirSchEntry->zSql,
-      &azAddCols, &nAddCols, &schemaChoice, &zSchemaErr);
+      &azAddCols, &nAddCols, &schemaChoice,
+      &resolvedDivergence, &zSchemaErr);
   }else{
     rc = SQLITE_ERROR;
     zSchemaErr = sqlite3_mprintf("cannot load schemas for merge");
@@ -954,12 +978,23 @@ int tryResolveSchemaDivergence(
   if( schemaChoice!=SCHEMA_MERGE_DEFAULT ){
     if( ppSchemaActions && pnSchemaActions ){
       rc = recordSchemaAddColumns(ppSchemaActions, pnSchemaActions, zName,
-                                  0, 0);
-      if( rc!=SQLITE_OK ) return rc;
+                                  azAddCols, nAddCols);
+      if( rc!=SQLITE_OK ){
+        freeAddedColumns(azAddCols, nAddCols);
+        return rc;
+      }
+      azAddCols = 0;
+      nAddCols = 0;
     }
     *pSchemaChoice = schemaChoice;
     freeAddedColumns(azAddCols, nAddCols);
     return SQLITE_OK;
+  }
+
+  if( nAddCols==0 && resolvedDivergence
+   && ppSchemaActions && pnSchemaActions ){
+    rc = recordSchemaAddColumns(ppSchemaActions, pnSchemaActions, zName, 0, 0);
+    if( rc!=SQLITE_OK ) return rc;
   }
 
   if( nAddCols>0 ){

--- a/src/doltlite_merge_int.h
+++ b/src/doltlite_merge_int.h
@@ -79,6 +79,15 @@ int parseColumns(
   ParsedColumn **ppCols, int *pnCols
 );
 void freeColumns(ParsedColumn *aCols, int nCols);
+int parsedColumnIndexByName(
+  ParsedColumn *aCols,
+  int nCols,
+  const char *zName
+);
+int parsedColumnDefinitionsMatch(
+  const ParsedColumn *pA,
+  const ParsedColumn *pB
+);
 
 int trySchemaColumnMerge(
   const char *zAncSql,
@@ -86,6 +95,7 @@ int trySchemaColumnMerge(
   const char *zTheirsSql,
   char ***ppAddCols, int *pnAddCols,
   int *pSchemaChoice,
+  int *pResolvedDivergence,
   char **pzErrDetail
 );
 
@@ -166,6 +176,7 @@ int normalizeTheirsToMergedLayout(
   sqlite3 *db,
   const ProllyHash *pTheirsRoot,
   u8 flags,
+  const char *zAncSql,
   const char *zOursSql,
   const char *zTheirsSql,
   ProllyHash *pOutRoot

--- a/src/doltlite_merge_pass1.c
+++ b/src/doltlite_merge_pass1.c
@@ -446,9 +446,11 @@ static int mergePass1BothSides(
       SchemaEntry *ourSE = findSchemaEntry(c->aOursSchema, c->nOursSchema, zName);
       SchemaEntry *theirSE = findSchemaEntry(
           c->aTheirsSchema, c->nTheirsSchema, zName);
-      if( ourSE && ourSE->zSql && theirSE && theirSE->zSql ){
+      SchemaEntry *ancSE = findSchemaEntry(c->aAncSchema, c->nAncSchema, zName);
+      if( ancSE && ancSE->zSql && ourSE && ourSE->zSql
+       && theirSE && theirSE->zSql ){
         rc = normalizeTheirsToMergedLayout(c->db, &theirsEntry->root,
-                                           c->aOurs[iOurs].flags,
+                                           c->aOurs[iOurs].flags, ancSE->zSql,
                                            ourSE->zSql, theirSE->zSql,
                                            &theirsNormRoot);
         if( rc!=SQLITE_OK ) return rc;

--- a/src/doltlite_merge_schema.c
+++ b/src/doltlite_merge_schema.c
@@ -207,14 +207,142 @@ void freeColumns(ParsedColumn *aCols, int nCols){
   sqlite3_free(aCols);
 }
 
-static ParsedColumn *findColumn(ParsedColumn *aCols, int nCols, const char *zName){
+int parsedColumnIndexByName(
+  ParsedColumn *aCols,
+  int nCols,
+  const char *zName
+){
   int i;
   for(i=0; i<nCols; i++){
-    if( aCols[i].zName && sqlite3_stricmp(aCols[i].zName, zName)==0 ){
-      return &aCols[i];
+    if( aCols[i].zName && zName
+     && sqlite3_stricmp(aCols[i].zName, zName)==0 ){
+      return i;
     }
   }
-  return 0;
+  return -1;
+}
+
+static ParsedColumn *findColumn(ParsedColumn *aCols, int nCols, const char *zName){
+  int i = parsedColumnIndexByName(aCols, nCols, zName);
+  return i>=0 ? &aCols[i] : 0;
+}
+
+static const char *schemaColumnDefinitionTail(const char *zDef){
+  const char *p = zDef;
+  char close = 0;
+
+  while( *p && isspace((unsigned char)*p) ) p++;
+  if( *p=='"' || *p=='`' || *p=='[' ){
+    close = *p=='[' ? ']' : *p;
+    p++;
+    while( *p ){
+      if( *p==close ){
+        p++;
+        if( *p==close ){
+          p++;
+          continue;
+        }
+        break;
+      }
+      p++;
+    }
+  }else{
+    while( *p && !isspace((unsigned char)*p) && *p!='(' && *p!=',' ) p++;
+  }
+  while( *p && isspace((unsigned char)*p) ) p++;
+  return p;
+}
+
+int parsedColumnDefinitionsMatch(
+  const ParsedColumn *pA,
+  const ParsedColumn *pB
+){
+  return sqlite3_stricmp(schemaColumnDefinitionTail(pA->zDef),
+                         schemaColumnDefinitionTail(pB->zDef))==0;
+}
+
+static const char *schemaFindToken(
+  const char *z,
+  const char *zEnd,
+  const char *zKw,
+  int nKw
+);
+
+static const char *schemaGeneratedTailStart(const char *zDef){
+  const char *zEnd = zDef + strlen(zDef);
+  const char *zGenerated;
+  const char *zAs;
+  const char *p;
+
+  zGenerated = schemaFindToken(zDef, zEnd, "GENERATED", 9);
+  if( zGenerated ){
+    p = zGenerated + 9;
+    while( p<zEnd && isspace((unsigned char)*p) ) p++;
+    if( zEnd-p>=6 && sqlite3_strnicmp(p, "ALWAYS", 6)==0 ){
+      p += 6;
+      while( p<zEnd && isspace((unsigned char)*p) ) p++;
+    }
+    if( zEnd-p<2 || sqlite3_strnicmp(p, "AS", 2)!=0 ) return 0;
+    zAs = p;
+  }else{
+    zAs = schemaFindToken(zDef, zEnd, "AS", 2);
+    if( !zAs ) return 0;
+  }
+
+  p = zAs + 2;
+  while( p<zEnd && isspace((unsigned char)*p) ) p++;
+  if( p>=zEnd || *p!='(' ) return 0;
+  {
+    int depth = 0;
+    char quote = 0;
+    do{
+      if( quote ){
+        if( *p==quote ){
+          if( p+1<zEnd && p[1]==quote ){
+            p += 2;
+            continue;
+          }
+          quote = 0;
+        }
+      }else if( *p=='\'' || *p=='"' || *p=='`' || *p=='[' ){
+        quote = *p=='[' ? ']' : *p;
+      }else if( *p=='(' ){
+        depth++;
+      }else if( *p==')' ){
+        depth--;
+      }
+      p++;
+    }while( p<zEnd && depth>0 );
+    if( depth!=0 ) return 0;
+  }
+  while( p<zEnd && isspace((unsigned char)*p) ) p++;
+  if( zEnd-p>=7 && sqlite3_strnicmp(p, "VIRTUAL", 7)==0 ){
+    p += 7;
+  }else if( zEnd-p>=6 && sqlite3_strnicmp(p, "STORED", 6)==0 ){
+    p += 6;
+  }
+  while( p<zEnd && isspace((unsigned char)*p) ) p++;
+  return p==zEnd ? (zGenerated ? zGenerated : zAs) : 0;
+}
+
+static int schemaColumnsMergeEquivalent(
+  const char *zOurs,
+  const char *zTheirs
+){
+  const char *zOurTail;
+  const char *zTheirTail;
+  int nOurs;
+  int nTheirs;
+
+  if( strcmp(zOurs, zTheirs)==0 ) return 1;
+  zOurTail = schemaGeneratedTailStart(zOurs);
+  zTheirTail = schemaGeneratedTailStart(zTheirs);
+  if( !zOurTail && !zTheirTail ) return 0;
+  nOurs = zOurTail ? (int)(zOurTail-zOurs) : (int)strlen(zOurs);
+  nTheirs = zTheirTail ? (int)(zTheirTail-zTheirs) : (int)strlen(zTheirs);
+  while( nOurs>0 && isspace((unsigned char)zOurs[nOurs-1]) ) nOurs--;
+  while( nTheirs>0 && isspace((unsigned char)zTheirs[nTheirs-1]) ) nTheirs--;
+  return nOurs==nTheirs && sqlite3_strnicmp(zOurs, zTheirs, nOurs)==0;
 }
 
 
@@ -241,8 +369,9 @@ static const char *schemaFindToken(
   const char *p = z;
   if( !z || !zEnd || zEnd<=z || nKw<=0 ) return 0;
   while( p<zEnd ){
-    if( *p=='\'' || *p=='"' ){
-      char q = *p++;
+    if( *p=='\'' || *p=='"' || *p=='`' || *p=='[' ){
+      char q = *p=='[' ? ']' : *p;
+      p++;
       while( p<zEnd ){
         if( *p==q ){
           p++;
@@ -606,6 +735,7 @@ int trySchemaColumnMerge(
   const char *zTheirsSql,
   char ***ppAddCols, int *pnAddCols,
   int *pSchemaChoice,
+  int *pResolvedDivergence,
   char **pzErrDetail
 ){
   ParsedColumn *aAnc=0, *aOurs=0, *aTheirs=0;
@@ -618,6 +748,7 @@ int trySchemaColumnMerge(
   *ppAddCols = 0;
   *pnAddCols = 0;
   *pSchemaChoice = SCHEMA_MERGE_DEFAULT;
+  *pResolvedDivergence = 0;
 
   rc = schemaConstraintModifyDeleteChoice(
       zAncSql, zOursSql, zTheirsSql, pSchemaChoice);
@@ -637,12 +768,33 @@ int trySchemaColumnMerge(
       ParsedColumn *ourCol = findColumn(aOurs, nOurs, aTheirs[i].zName);
       if( ourCol ){
 
-        if( strcmp(ourCol->zDef, aTheirs[i].zDef)!=0 ){
+        if( !schemaColumnsMergeEquivalent(ourCol->zDef, aTheirs[i].zDef) ){
 
           if( pzErrDetail ){
             *pzErrDetail = sqlite3_mprintf(
               "both branches add column '%s' with different definitions",
               aTheirs[i].zName);
+          }
+          rc = SQLITE_ERROR;
+          goto schema_merge_cleanup;
+        }
+        if( strcmp(ourCol->zDef, aTheirs[i].zDef)!=0 ){
+          *pResolvedDivergence = 1;
+        }
+
+      }else if( i<nAnc
+             && sqlite3_stricmp(aTheirs[i].zName, aAnc[i].zName)!=0
+             && !findColumn(aTheirs, nTheirs, aAnc[i].zName)
+             && parsedColumnDefinitionsMatch(&aTheirs[i], &aAnc[i]) ){
+        ParsedColumn *ourAncestor = findColumn(
+            aOurs, nOurs, aAnc[i].zName);
+        if( ourAncestor && strcmp(ourAncestor->zDef, aAnc[i].zDef)==0 ){
+          *pSchemaChoice = SCHEMA_MERGE_THEIRS;
+        }else{
+          if( pzErrDetail ){
+            *pzErrDetail = sqlite3_mprintf(
+              "column '%s' renamed on one branch and modified on another",
+              aAnc[i].zName);
           }
           rc = SQLITE_ERROR;
           goto schema_merge_cleanup;
@@ -717,9 +869,28 @@ int trySchemaColumnMerge(
 
   }
 
-  if( nAdd > 0 ){
-    *pSchemaChoice = SCHEMA_MERGE_DEFAULT;
+  if( *pSchemaChoice==SCHEMA_MERGE_THEIRS ){
+    int j;
+    for(j=0; j<nAdd; j++) sqlite3_free(azAdd[j]);
+    sqlite3_free(azAdd);
+    azAdd = 0;
+    nAdd = 0;
+    nAddAlloc = 0;
+    for(i=0; i<nOurs; i++){
+      if( !findColumn(aAnc, nAnc, aOurs[i].zName)
+       && !findColumn(aTheirs, nTheirs, aOurs[i].zName) ){
+        rc = DOLTLITE_GROW_ARRAY(&azAdd, &nAddAlloc, nAdd+1, 4);
+        if( rc!=SQLITE_OK ) goto schema_merge_cleanup;
+        azAdd[nAdd] = sqlite3_mprintf("%s", aOurs[i].zDef);
+        if( !azAdd[nAdd] ){
+          rc = SQLITE_NOMEM;
+          goto schema_merge_cleanup;
+        }
+        nAdd++;
+      }
+    }
   }
+
   *ppAddCols = azAdd;
   *pnAddCols = nAdd;
   azAdd = 0; nAdd = 0;
@@ -744,12 +915,14 @@ int doltliteTableSchemaConflictDetail(
   char **azAdd = 0;
   int nAdd = 0;
   int schemaChoice = SCHEMA_MERGE_DEFAULT;
+  int resolvedDivergence = 0;
   int i, rc;
 
   *pzDetail = 0;
   if( !zAncestorSql || !zOurSql || !zTheirSql ) return SQLITE_OK;
   rc = trySchemaColumnMerge(zAncestorSql, zOurSql, zTheirSql,
-                            &azAdd, &nAdd, &schemaChoice, pzDetail);
+                            &azAdd, &nAdd, &schemaChoice,
+                            &resolvedDivergence, pzDetail);
   for(i=0; i<nAdd; i++) sqlite3_free(azAdd[i]);
   sqlite3_free(azAdd);
   if( rc==SQLITE_ERROR ) return SQLITE_OK;

--- a/test/vc_oracle_schema_merge_test.sh
+++ b/test/vc_oracle_schema_merge_test.sh
@@ -936,6 +936,188 @@ expect_dual_value "check_delete_vs_modify_reverse_keeps_modify" "$DB" "1" \
   "SELECT count(*) FROM information_schema.check_constraints WHERE check_clause LIKE '%> 5%';"
 
 echo ""
+echo "--- Generated Columns ---"
+
+DB="$TMPROOT/gc1.db"; rm -f "$DB"
+cat <<'SQL' | dl_setup "$DB" "gc1"
+CREATE TABLE t(id INTEGER PRIMARY KEY, a INT);
+INSERT INTO t VALUES(1,5);
+SELECT dolt_commit('-Am','ancestor');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+ALTER TABLE t ADD COLUMN doubled INT GENERATED ALWAYS AS (a * 2) VIRTUAL;
+INSERT INTO t(id,a) VALUES(2,7);
+SELECT dolt_commit('-Am','feat_generated');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES(3,11);
+SELECT dolt_commit('-Am','main_row');
+SQL
+expect_merge_ok "generated_add_vs_insert" "$DB"
+expect_dual_value "generated_add_vs_insert_values" "$DB" "1:5:10,2:7:14,3:11:22" \
+  "SELECT group_concat(id || ':' || a || ':' || doubled, ',') FROM (SELECT id,a,doubled FROM t ORDER BY id);" \
+  "SELECT GROUP_CONCAT(CONCAT(id, ':', a, ':', doubled) ORDER BY id SEPARATOR ',') FROM t;"
+
+DB="$TMPROOT/gc2.db"; rm -f "$DB"
+cat <<'SQL' | dl_setup "$DB" "gc2"
+CREATE TABLE t(id INTEGER PRIMARY KEY, a INT);
+INSERT INTO t VALUES(1,5);
+SELECT dolt_commit('-Am','ancestor');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+ALTER TABLE t ADD COLUMN doubled INT GENERATED ALWAYS AS (a * 2) VIRTUAL;
+INSERT INTO t(id,a) VALUES(2,7);
+SELECT dolt_commit('-Am','feat_generated');
+SELECT dolt_checkout('main');
+ALTER TABLE t ADD COLUMN doubled INT GENERATED ALWAYS AS (a * 2) VIRTUAL;
+INSERT INTO t(id,a) VALUES(3,11);
+SELECT dolt_commit('-Am','main_generated');
+SQL
+expect_merge_ok "generated_both_add_identical" "$DB"
+expect_dual_value "generated_both_add_identical_values" "$DB" "1:10,2:14,3:22" \
+  "SELECT group_concat(id || ':' || doubled, ',') FROM (SELECT id,doubled FROM t ORDER BY id);" \
+  "SELECT GROUP_CONCAT(CONCAT(id, ':', doubled) ORDER BY id SEPARATOR ',') FROM t;"
+
+DB="$TMPROOT/gc3.db"; rm -f "$DB"
+cat <<'SQL' | dl_setup "$DB" "gc3"
+CREATE TABLE t(id INTEGER PRIMARY KEY, a INT);
+INSERT INTO t VALUES(1,5);
+SELECT dolt_commit('-Am','ancestor');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+ALTER TABLE t ADD COLUMN computed INT AS (a * 2) VIRTUAL;
+INSERT INTO t(id,a) VALUES(2,7);
+SELECT dolt_commit('-Am','feat_generated');
+SELECT dolt_checkout('main');
+ALTER TABLE t ADD COLUMN computed INT GENERATED ALWAYS AS (a * 3) VIRTUAL;
+INSERT INTO t(id,a) VALUES(3,11);
+SELECT dolt_commit('-Am','main_generated');
+SQL
+expect_merge_ok "generated_both_add_different_expression_ours_wins" "$DB"
+expect_dual_value "generated_both_add_different_expression_ours_value" "$DB" \
+  "1:15,2:21,3:33" \
+  "SELECT group_concat(id || ':' || computed, ',') FROM (SELECT id,computed FROM t ORDER BY id);" \
+  "SELECT GROUP_CONCAT(CONCAT(id, ':', computed) ORDER BY id SEPARATOR ',') FROM t;"
+
+DB="$TMPROOT/gc4.db"; rm -f "$DB"
+cat <<'SQL' | dl_setup "$DB" "gc4"
+CREATE TABLE t(id INTEGER PRIMARY KEY, a INT);
+INSERT INTO t VALUES(1,5);
+SELECT dolt_commit('-Am','ancestor');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+ALTER TABLE t ADD COLUMN doubled INT GENERATED ALWAYS AS (a * 2) VIRTUAL;
+SELECT dolt_commit('-Am','feat_doubled');
+SELECT dolt_checkout('main');
+ALTER TABLE t ADD COLUMN tripled INT GENERATED ALWAYS AS (a * 3) VIRTUAL;
+SELECT dolt_commit('-Am','main_tripled');
+SQL
+expect_merge_ok "generated_both_add_different_columns" "$DB"
+expect_dual_value "generated_both_add_different_columns_values" "$DB" "10|15" \
+  "SELECT doubled || '|' || tripled FROM t WHERE id=1;" \
+  "SELECT CONCAT(doubled, '|', tripled) FROM t WHERE id=1;"
+
+DB="$TMPROOT/gc5.db"; rm -f "$DB"
+cat <<'SQL' | dl_setup "$DB" "gc5"
+CREATE TABLE t(id INTEGER PRIMARY KEY, a INT);
+INSERT INTO t VALUES(1,5);
+SELECT dolt_commit('-Am','ancestor');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+ALTER TABLE t ADD COLUMN doubled INT GENERATED ALWAYS AS (a * 2) VIRTUAL;
+CREATE INDEX idx_doubled ON t(doubled);
+INSERT INTO t(id,a) VALUES(2,7);
+SELECT dolt_commit('-Am','feat_generated_index');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES(3,11);
+SELECT dolt_commit('-Am','main_row');
+SQL
+expect_merge_ok "generated_index_vs_insert" "$DB"
+expect_dual_value "generated_index_vs_insert_seek" "$DB" "2" \
+  "SELECT id FROM t WHERE doubled=14;" \
+  "SELECT id FROM t WHERE doubled=14;"
+
+DB="$TMPROOT/gc6.db"; rm -f "$DB"
+cat <<'SQL' | dl_setup "$DB" "gc6"
+CREATE TABLE t(id INTEGER PRIMARY KEY, a INT, label TEXT);
+INSERT INTO t VALUES(1,5,'one');
+SELECT dolt_commit('-Am','ancestor');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+ALTER TABLE t ADD COLUMN doubled INT GENERATED ALWAYS AS (a * 2) VIRTUAL;
+INSERT INTO t(id,a,label) VALUES(2,7,'two');
+SELECT dolt_commit('-Am','feat_generated');
+SELECT dolt_checkout('main');
+ALTER TABLE t RENAME COLUMN label TO note;
+INSERT INTO t(id,a,note) VALUES(3,11,'three');
+SELECT dolt_commit('-Am','main_rename_unrelated');
+SQL
+expect_merge_ok "generated_add_vs_unrelated_rename" "$DB"
+expect_dual_value "generated_add_vs_unrelated_rename_values" "$DB" \
+  "1:one:10,2:two:14,3:three:22" \
+  "SELECT group_concat(id || ':' || note || ':' || doubled, ',') FROM (SELECT id,note,doubled FROM t ORDER BY id);" \
+  "SELECT GROUP_CONCAT(CONCAT(id, ':', note, ':', doubled) ORDER BY id SEPARATOR ',') FROM t;"
+
+DB="$TMPROOT/gc6r.db"; rm -f "$DB"
+cat <<'SQL' | dl_setup "$DB" "gc6r"
+CREATE TABLE t(id INTEGER PRIMARY KEY, a INT, label TEXT);
+INSERT INTO t VALUES(1,5,'one');
+SELECT dolt_commit('-Am','ancestor');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+ALTER TABLE t RENAME COLUMN label TO note;
+INSERT INTO t(id,a,note) VALUES(2,7,'two');
+SELECT dolt_commit('-Am','feat_rename_unrelated');
+SELECT dolt_checkout('main');
+ALTER TABLE t ADD COLUMN doubled INT GENERATED ALWAYS AS (a * 2) VIRTUAL;
+INSERT INTO t(id,a,label) VALUES(3,11,'three');
+SELECT dolt_commit('-Am','main_generated');
+SQL
+expect_merge_ok "generated_add_vs_unrelated_rename_reverse" "$DB"
+expect_dual_value "generated_add_vs_unrelated_rename_reverse_values" "$DB" \
+  "1:one:10,2:two:14,3:three:22" \
+  "SELECT group_concat(id || ':' || note || ':' || doubled, ',') FROM (SELECT id,note,doubled FROM t ORDER BY id);" \
+  "SELECT GROUP_CONCAT(CONCAT(id, ':', note, ':', doubled) ORDER BY id SEPARATOR ',') FROM t;"
+
+DB="$TMPROOT/gc7.db"; rm -f "$DB"
+cat <<'SQL' | dl_setup "$DB" "gc7"
+CREATE TABLE t(id INTEGER PRIMARY KEY, a INT);
+INSERT INTO t VALUES(1,5);
+SELECT dolt_commit('-Am','ancestor');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+ALTER TABLE t ADD COLUMN x INT GENERATED ALWAYS AS (a * 2) VIRTUAL;
+SELECT dolt_commit('-Am','feat_generated');
+SELECT dolt_checkout('main');
+ALTER TABLE t ADD COLUMN x INT;
+SELECT dolt_commit('-Am','main_plain');
+SQL
+expect_merge_ok "generated_vs_plain_ours_plain" "$DB"
+expect_dual_value "generated_vs_plain_ours_plain_value" "$DB" "null" \
+  "SELECT CASE WHEN x IS NULL THEN 'null' ELSE CAST(x AS TEXT) END FROM t WHERE id=1;" \
+  "SELECT CASE WHEN x IS NULL THEN 'null' ELSE CAST(x AS CHAR) END FROM t WHERE id=1;"
+
+DB="$TMPROOT/gc8.db"; rm -f "$DB"
+cat <<'SQL' | dl_setup "$DB" "gc8"
+CREATE TABLE t(id INTEGER PRIMARY KEY, a INT);
+INSERT INTO t VALUES(1,5);
+SELECT dolt_commit('-Am','ancestor');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+ALTER TABLE t ADD COLUMN x INT;
+INSERT INTO t(id,a,x) VALUES(2,7,99);
+SELECT dolt_commit('-Am','feat_plain');
+SELECT dolt_checkout('main');
+ALTER TABLE t ADD COLUMN x INT GENERATED ALWAYS AS (a * 2) VIRTUAL;
+INSERT INTO t(id,a) VALUES(3,11);
+SELECT dolt_commit('-Am','main_generated');
+SQL
+expect_merge_ok "generated_vs_plain_ours_generated" "$DB"
+expect_dual_value "generated_vs_plain_ours_generated_value" "$DB" \
+  "1:10,2:14,3:22" \
+  "SELECT group_concat(id || ':' || x, ',') FROM (SELECT id,x FROM t ORDER BY id);" \
+  "SELECT GROUP_CONCAT(CONCAT(id, ':', x) ORDER BY id SEPARATOR ',') FROM t;"
+
+echo ""
 echo "======================================="
 echo "Results: $pass passed, $fail failed"
 echo "======================================="


### PR DESCRIPTION
## Summary

- preserve ancestor column identity when normalizing divergent row layouts, so one-sided column renames do not duplicate or misplace data
- treat equivalent generated-column spellings as compatible while retaining the correct schema choice and follow-up actions
- add 18 passing Dolt-oracle assertions across generated-column inserts, identical and divergent additions, indexes, unrelated renames, and plain-column collisions

The deeper oracle pass also exposed two defects in Dolt itself. They are tracked upstream as dolthub/dolt#11362 and dolthub/dolt#11363 and are not encoded as DoltLite parity expectations here.

## Validation

- `make -C build doltlite`
- `make lint`
- `DOLTLITE=build/doltlite bash test/doltlite_schema_merge.sh` (101 passed)
- `bash test/vc_oracle_schema_merge_test.sh build/doltlite dolt` (71 passed)
- `bash test/run_doltlite_tests.sh` before the final rebase (91 suites passed; 0 failed)
- `git diff origin/master --check`

Co-Authored-By: OpenAI Codex <noreply@openai.com>
