### PR TITLE
Install the documented embedding headers and remotesrv binary

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -95,6 +95,11 @@ jobs:
         fi
         make lint
 
+    - name: Install layout
+      if: matrix.platform != 'windows'
+      run: bash test/install_layout_test.sh build
+      timeout-minutes: 10
+
     - name: Build Linux-only test binaries
       if: matrix.platform == 'ubuntu'
       run: |

--- a/README.md
+++ b/README.md
@@ -169,6 +169,22 @@ gcc -o myapp myapp.c -I/path/to/build libdoltlite.a -lpthread -lz
 gcc -o myapp myapp.c -I/path/to/build -L/path/to/build -ldoltlite -lpthread -lz
 ```
 
+`make install` places the same `doltlite.h`, `doltlite_remotesrv.h`,
+`libdoltlite.a`, `libdoltlite.{so,dylib}`, `doltlite` and `doltlite-remotesrv`
+that the release packages do. Installed under the default `/usr/local` prefix,
+those are already on the compiler's search path:
+
+```bash
+sudo make install                       # honours --prefix and DESTDIR
+gcc -o myapp myapp.c -ldoltlite -lpthread -lz
+```
+
+Being a SQLite fork, `make install` additionally installs SQLite's own
+`sqlite3.h`, `libsqlite3.*`, `sqlite3.pc` and man page — built from this tree,
+so they are DoltLite under SQLite's name. The release packages deliberately
+ship none of those, to avoid colliding with a system SQLite. Pass
+`--prefix` somewhere private if that matters to you.
+
 The API is the standard [SQLite C API](https://sqlite.org/cintro.html) —
 `sqlite3_open`, `sqlite3_exec`, `sqlite3_prepare_v2`, etc. Dolt features are
 called as SQL functions (`dolt_commit`, `dolt_branch`, `dolt_merge`, ...) and

--- a/main.mk
+++ b/main.mk
@@ -3027,15 +3027,24 @@ doltlite-remotesrv$(T.exe):	$(TOP)/src/remotesrv_main.c \
 		$(LDFLAGS.libsqlite3)
 all: doltlite-remotesrv$(T.exe)
 
-# The Linux shared library carries SONAME libdoltlite.so.0, so a program linked
-# against it resolves that name at runtime and not libdoltlite.so. Install the
-# versioned file with the unversioned link beside it -- the same split the deb
+# The Linux shared library carries SONAME libdoltlite.so.0, so that is the name
+# a consumer resolves at runtime, not libdoltlite.so. Install it under the
+# SONAME with the unversioned developer link beside it -- the same split the deb
 # makes between libdoltlite0 and libdoltlite-dev. Darwin's install_name is the
-# unversioned dylib, so it needs no link.
+# unversioned dylib, so there the suffix is empty and no link is made.
+#
+# Installing straight to the SONAME, rather than installing libdoltlite.so and
+# renaming it, keeps this idempotent and never unlinks a working library before
+# its replacement exists: a rename over the previous install would leave nothing
+# behind if it failed, and re-running the install would rename the dev symlink
+# onto its own target.
+libdoltlite.soname.suffix = $(if $(filter .so,$(T.dll)),.0,)
+
 install-doltlite-lib: libdoltlite$(T.lib) libdoltlite$(T.dll) $(install-dir.lib)
 	$(INSTALL.noexec) libdoltlite$(T.lib) "$(install-dir.lib)"
-	$(INSTALL) libdoltlite$(T.dll) "$(install-dir.lib)"
-	$(if $(filter .so,$(T.dll)),cd "$(install-dir.lib)" && rm -f libdoltlite.so.0 && mv libdoltlite.so libdoltlite.so.0 && ln -s libdoltlite.so.0 libdoltlite.so)
+	$(INSTALL) libdoltlite$(T.dll) \
+		"$(install-dir.lib)/libdoltlite$(T.dll)$(libdoltlite.soname.suffix)"
+	$(if $(libdoltlite.soname.suffix),ln -sf libdoltlite$(T.dll)$(libdoltlite.soname.suffix) "$(install-dir.lib)/libdoltlite$(T.dll)")
 
 # The headers README tells embedders to include: doltlite.h for the SQLite C
 # API under our name, doltlite_remotesrv.h for doltliteServeAsync et al. The

--- a/main.mk
+++ b/main.mk
@@ -3027,9 +3027,15 @@ doltlite-remotesrv$(T.exe):	$(TOP)/src/remotesrv_main.c \
 		$(LDFLAGS.libsqlite3)
 all: doltlite-remotesrv$(T.exe)
 
+# The Linux shared library carries SONAME libdoltlite.so.0, so a program linked
+# against it resolves that name at runtime and not libdoltlite.so. Install the
+# versioned file with the unversioned link beside it -- the same split the deb
+# makes between libdoltlite0 and libdoltlite-dev. Darwin's install_name is the
+# unversioned dylib, so it needs no link.
 install-doltlite-lib: libdoltlite$(T.lib) libdoltlite$(T.dll) $(install-dir.lib)
 	$(INSTALL.noexec) libdoltlite$(T.lib) "$(install-dir.lib)"
 	$(INSTALL) libdoltlite$(T.dll) "$(install-dir.lib)"
+	$(if $(filter .so,$(T.dll)),cd "$(install-dir.lib)" && rm -f libdoltlite.so.0 && mv libdoltlite.so libdoltlite.so.0 && ln -s libdoltlite.so.0 libdoltlite.so)
 
 # The headers README tells embedders to include: doltlite.h for the SQLite C
 # API under our name, doltlite_remotesrv.h for doltliteServeAsync et al. The

--- a/main.mk
+++ b/main.mk
@@ -3031,8 +3031,17 @@ install-doltlite-lib: libdoltlite$(T.lib) libdoltlite$(T.dll) $(install-dir.lib)
 	$(INSTALL.noexec) libdoltlite$(T.lib) "$(install-dir.lib)"
 	$(INSTALL) libdoltlite$(T.dll) "$(install-dir.lib)"
 
-install-shell-0: doltlite$(T.exe) $(install-dir.bin)
-	$(INSTALL) doltlite$(T.exe) "$(install-dir.bin)"
+# The headers README tells embedders to include: doltlite.h for the SQLite C
+# API under our name, doltlite_remotesrv.h for doltliteServeAsync et al. The
+# deb and Homebrew packages install exactly these two; a source install has to
+# provide the same names or "#include <doltlite.h>" only works from a package.
+install-doltlite-headers: doltlite.h $(install-dir.include)
+	$(INSTALL.noexec) doltlite.h "$(TOP)/src/doltlite_remotesrv.h" \
+		"$(install-dir.include)"
+install: install-doltlite-headers
+
+install-shell-0: doltlite$(T.exe) doltlite-remotesrv$(T.exe) $(install-dir.bin)
+	$(INSTALL) doltlite$(T.exe) doltlite-remotesrv$(T.exe) "$(install-dir.bin)"
 install-shell-1:
 install: install-shell-$(HAVE_WASI_SDK) install-doltlite-lib
 

--- a/test/install_layout_test.sh
+++ b/test/install_layout_test.sh
@@ -25,8 +25,14 @@ ok()   { echo "  PASS: $1"; pass=$((pass+1)); }
 bad()  { echo "  FAIL: $1"; fail=$((fail+1)); }
 have() { if [ -e "$2" ]; then ok "$1"; else bad "$1 (missing $2)"; fi; }
 
+# USE_AMALGAMATION=0 because `install` pulls in install-lib -> libsqlite3.a,
+# which by default recompiles the generated sqlite3.c. That amalgamation's
+# "Begin file" banners sit inside block comments, so a caller with -Werror in
+# CFLAGS (CI does) dies on -Wcomment -- unrelated to install layout, and the
+# objects the non-amalgamated build needs are already present.
 echo "=== staging make install ==="
-if ! ( cd "$BUILD_DIR" && make install DESTDIR="$TMP/stage" ) >"$TMP/install.log" 2>&1; then
+if ! ( cd "$BUILD_DIR" && make install USE_AMALGAMATION=0 DESTDIR="$TMP/stage" ) \
+     >"$TMP/install.log" 2>&1; then
   echo "FAIL: make install failed"
   tail -30 "$TMP/install.log"
   exit 1

--- a/test/install_layout_test.sh
+++ b/test/install_layout_test.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# `make install` must place the files the README documents, and they must
+# actually work: an embedder following "Using as a C Library" includes
+# <doltlite.h>, and the in-process server section includes
+# <doltlite_remotesrv.h>. Both were missing from a source install for a while
+# because the header rule inherited from upstream installs sqlite3.h only,
+# while the deb and Homebrew packages install the doltlite names. Staged via
+# DESTDIR, so this needs no privileges and touches nothing outside TMPDIR.
+set -uo pipefail
+
+BUILD_DIR="${1:-build}"
+CC="${CC:-cc}"
+
+if [ ! -f "$BUILD_DIR/Makefile" ]; then
+  echo "SKIP: no configured build in $BUILD_DIR"
+  exit 0
+fi
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/doltlite-install-layout.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+pass=0
+fail=0
+ok()   { echo "  PASS: $1"; pass=$((pass+1)); }
+bad()  { echo "  FAIL: $1"; fail=$((fail+1)); }
+have() { if [ -e "$2" ]; then ok "$1"; else bad "$1 (missing $2)"; fi; }
+
+echo "=== staging make install ==="
+if ! ( cd "$BUILD_DIR" && make install DESTDIR="$TMP/stage" ) >"$TMP/install.log" 2>&1; then
+  echo "FAIL: make install failed"
+  tail -30 "$TMP/install.log"
+  exit 1
+fi
+
+# Derive the prefix from the staged tree rather than assuming /usr/local, so a
+# build configured with --prefix elsewhere still validates.
+hdr="$(find "$TMP/stage" -name doltlite.h -print -quit 2>/dev/null)"
+if [ -z "$hdr" ]; then
+  echo "FAIL: doltlite.h was not installed anywhere under DESTDIR"
+  find "$TMP/stage" -type f | sed 's/^/    /' | head -30
+  exit 1
+fi
+P="$(cd "$(dirname "$hdr")/.." && pwd)"
+# pwd resolves symlinks (macOS /var -> /private/var), so strip on the marker.
+echo "prefix: $(printf '%s' "$P" | sed 's|.*/stage||')"
+
+echo "=== 1. Documented files are present ==="
+have "include/doltlite.h"            "$P/include/doltlite.h"
+have "include/doltlite_remotesrv.h"  "$P/include/doltlite_remotesrv.h"
+have "bin/doltlite"                  "$P/bin/doltlite"
+have "bin/doltlite-remotesrv"        "$P/bin/doltlite-remotesrv"
+have "lib/libdoltlite.a"             "$P/lib/libdoltlite.a"
+shared=""
+for cand in "$P/lib/libdoltlite.so" "$P/lib/libdoltlite.dylib"; do
+  if [ -e "$cand" ]; then shared="$cand"; fi
+done
+if [ -n "$shared" ]; then ok "lib/libdoltlite.{so,dylib}"
+else bad "lib/libdoltlite.{so,dylib} (missing)"; fi
+
+echo "=== 2. Installed binaries run the prolly engine ==="
+got=$("$P/bin/doltlite" :memory: 'SELECT doltlite_engine();' 2>&1)
+if [ "$got" = "prolly" ]; then ok "installed doltlite reports prolly"
+else bad "installed doltlite reports prolly (got: $got)"; fi
+if "$P/bin/doltlite-remotesrv" -h 2>&1 | grep -q 'auth-keys'; then
+  ok "installed doltlite-remotesrv runs"
+else
+  bad "installed doltlite-remotesrv runs"
+fi
+
+echo "=== 3. Both documented headers compile and link ==="
+cat >"$TMP/probe.c" <<'EOF'
+#include <doltlite.h>
+#include <doltlite_remotesrv.h>
+#include <stdio.h>
+int main(void){
+  sqlite3 *db = 0; sqlite3_stmt *st = 0;
+  DoltliteServer *srv;
+  if( sqlite3_open(":memory:", &db)!=SQLITE_OK ) return 1;
+  if( sqlite3_prepare_v2(db, "SELECT doltlite_engine()", -1, &st, 0)!=SQLITE_OK ) return 2;
+  if( sqlite3_step(st)!=SQLITE_ROW ) return 3;
+  printf("%s\n", sqlite3_column_text(st, 0));
+  sqlite3_finalize(st); sqlite3_close(db);
+  srv = doltliteServeAsync(".", 0, "127.0.0.1");
+  if( !srv ) return 4;
+  doltliteServerStop(srv);
+  return 0;
+}
+EOF
+probe_libs=(-lz -lpthread -lm)
+case "$(uname -s)" in
+  Linux*) probe_libs+=(-ldl) ;;
+  MINGW*|MSYS*|CYGWIN*) probe_libs+=(-lws2_32 -lbcrypt -lcrypt32) ;;
+esac
+
+if "$CC" -w -I"$P/include" "$TMP/probe.c" "$P/lib/libdoltlite.a" \
+     "${probe_libs[@]}" -o "$TMP/static" 2>"$TMP/static.err"; then
+  got=$("$TMP/static" 2>&1)
+  if [ "$got" = "prolly" ]; then ok "static link via <doltlite.h>"
+  else bad "static link via <doltlite.h> (ran, got: $got)"; fi
+else
+  bad "static link via <doltlite.h> (compile/link failed)"
+  sed 's/^/    /' "$TMP/static.err" | head -10
+fi
+
+if [ -n "$shared" ]; then
+  if "$CC" -w -I"$P/include" "$TMP/probe.c" -L"$P/lib" -ldoltlite \
+       "${probe_libs[@]}" -o "$TMP/shared" 2>"$TMP/shared.err"; then
+    case "$(uname -s)" in
+      Darwin) got=$(DYLD_LIBRARY_PATH="$P/lib" "$TMP/shared" 2>&1) ;;
+      *)      got=$(LD_LIBRARY_PATH="$P/lib" "$TMP/shared" 2>&1) ;;
+    esac
+    if [ "$got" = "prolly" ]; then ok "shared link via <doltlite.h>"
+    else bad "shared link via <doltlite.h> (ran, got: $got)"; fi
+  else
+    bad "shared link via <doltlite.h> (compile/link failed)"
+    sed 's/^/    /' "$TMP/shared.err" | head -10
+  fi
+fi
+
+echo ""
+echo "======================================="
+echo "Results: $pass passed, $fail failed"
+echo "======================================="
+[ "$fail" -eq 0 ] && exit 0 || exit 1

--- a/test/install_layout_test.sh
+++ b/test/install_layout_test.sh
@@ -30,11 +30,25 @@ have() { if [ -e "$2" ]; then ok "$1"; else bad "$1 (missing $2)"; fi; }
 # "Begin file" banners sit inside block comments, so a caller with -Werror in
 # CFLAGS (CI does) dies on -Wcomment -- unrelated to install layout, and the
 # objects the non-amalgamated build needs are already present.
+stage_install() {
+  ( cd "$BUILD_DIR" && make install USE_AMALGAMATION=0 DESTDIR="$TMP/stage" )
+}
+
 echo "=== staging make install ==="
-if ! ( cd "$BUILD_DIR" && make install USE_AMALGAMATION=0 DESTDIR="$TMP/stage" ) \
-     >"$TMP/install.log" 2>&1; then
+if ! stage_install >"$TMP/install.log" 2>&1; then
   echo "FAIL: make install failed"
   tail -30 "$TMP/install.log"
+  exit 1
+fi
+
+# Install a second time over the first. Installing into a populated prefix is
+# the normal case (upgrades), and it is where a rename-based SONAME install
+# breaks: the dev symlink gets renamed onto its own target and the library stops
+# loading. A single install on a fresh runner would never show it.
+echo "=== staging make install again, over the first ==="
+if ! stage_install >"$TMP/install2.log" 2>&1; then
+  echo "FAIL: second make install failed"
+  tail -30 "$TMP/install2.log"
   exit 1
 fi
 


### PR DESCRIPTION
## Problem

README tells C embedders to `#include <doltlite.h>` (README "Using as a C Library") and points the in-process server API at `doltlite_remotesrv.h` (README:819). A source `make install` shipped **neither**.

A staged `make install DESTDIR=…` on master places:

```
bin/doltlite                 ✅
bin/doltlite-remotesrv       ❌ missing
include/doltlite.h           ❌ missing
include/doltlite_remotesrv.h ❌ missing
lib/libdoltlite.a            ✅
lib/libdoltlite.dylib        ✅
```

Two causes. `install-headers` (`main.mk:2192`) is inherited from upstream and installs `sqlite3.h`/`sqlite3ext.h` only; `install-doltlite-lib` (`main.mk:3030`) installs the libraries and no headers at all. And `install-shell-0` installed only the shell, never `doltlite-remotesrv`.

So the documented embedding flow worked from a `.deb` or a `brew install` — where `packaging/nfpm/libdoltlite-dev.yaml:29` and `packaging/homebrew/doltlite.rb:25` install the doltlite header names by hand — and silently did not work from source. An embedder had to hand-declare `doltliteServeAsync` or reach into the build tree.

## Fix

Install both headers and the remotesrv binary, so a source install carries the same six files the packages do.

## Left alone deliberately

Because this is a SQLite fork, `make install` **also** installs `sqlite3.h`, `sqlite3ext.h`, `libsqlite3.{a,dylib,0.dylib,3.54.0.dylib}`, `sqlite3.pc`, the `sqlite3.1` man page and the Tcl extension — all built from this tree, so they are DoltLite wearing SQLite's name. `/usr/local/lib/libsqlite3.dylib` will shadow a real SQLite for anything linking `-lsqlite3` from `/usr/local`.

The packages ship none of that on purpose ("spoofing the canonical SQLite header path collides with the system's sqlite3 packages"). Whether a source install should follow them is a separate policy call with real breakage either way, so this PR does not touch it — it just documents the behavior in the README instead of leaving it a surprise. Happy to do it as a follow-up if you want source and package installs to match exactly.

## Tests

`test/install_layout_test.sh` (new):

- stages `make install` under `DESTDIR` — no privileges, nothing written outside `TMPDIR`
- asserts the six documented files
- runs both installed binaries (`doltlite_engine()` → `prolly`, `doltlite-remotesrv -h`)
- compiles **and runs** a probe that includes `<doltlite.h>` *and* `<doltlite_remotesrv.h>` against the installed tree, both statically and dynamically — so a missing header, a broken header, or a symbol hidden by the #1819 export filter all fail here

It derives the prefix from the staged tree rather than assuming `/usr/local`, so a build configured with `--prefix` elsewhere still validates.

**Fail-before:** exit 1 on master with a diagnostic listing what actually got installed. Exit 0 with the fix, 10/10 assertions.

Wired into the `checked` job on ubuntu and macos (skipped on windows, where `make install` under msys2 is a different story).

`make lint` and `assert_doltlite_artifacts.sh` still pass, the latter still reporting 290 exported symbols.

🤖 Generated with [Claude Code](https://claude.com/claude-code)