### PR TITLE
test: merge OOM restore, NOCASE reindex, dual-add case oracle

### DIFF
--- a/test/doltlite_merge_nocase_reindex.sh
+++ b/test/doltlite_merge_nocase_reindex.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+# NOCASE secondary indexes skip inline mutmap patching during three-way row
+# merge (mergeIndexNeedsRebuild) and are rebuilt via REINDEX after the merged
+# catalog is live. This suite checks that the post-merge index matches a full
+# rebuild: same INDEXED BY results before/after REINDEX, and after drop+recreate.
+. "$(dirname "$0")/lib/doltlite_test_common.sh"
+
+echo "=== Doltlite Merge NOCASE Index Reindex Property ==="
+echo ""
+
+DB=/tmp/test_merge_nocase_$$.db
+rm -f "$DB"
+
+cat <<'EOF' | $DOLTLITE "$DB" > /dev/null 2>&1
+CREATE TABLE t(
+  id INTEGER PRIMARY KEY,
+  name TEXT COLLATE NOCASE,
+  score INT
+);
+CREATE INDEX idx_name ON t(name COLLATE NOCASE);
+INSERT INTO t VALUES
+  (1, 'Alpha', 10),
+  (2, 'beta', 20),
+  (3, 'GAMMA', 30);
+SELECT dolt_commit('-Am', 'init');
+SELECT dolt_checkout('-b', 'feat');
+UPDATE t SET score = 21 WHERE id = 2;
+INSERT INTO t VALUES (4, 'delta', 40);
+SELECT dolt_commit('-Am', 'feat_side');
+SELECT dolt_checkout('main');
+UPDATE t SET score = 11 WHERE id = 1;
+INSERT INTO t VALUES (5, 'EPSILON', 50);
+SELECT dolt_commit('-Am', 'main_side');
+SELECT dolt_merge('feat');
+EOF
+
+run_test "nocase_merge_row_count" \
+  "SELECT count(*) FROM t;" "5" "$DB"
+run_test "nocase_merge_scores" \
+  "SELECT group_concat(id || ':' || score, ',') FROM (SELECT id, score FROM t ORDER BY id);" \
+  "1:11,2:21,3:30,4:40,5:50" "$DB"
+
+# Index seek uses NOCASE: 'alpha' matches Alpha.
+run_test "nocase_merge_idx_seek_alpha" \
+  "SELECT id || ':' || score FROM t INDEXED BY idx_name WHERE name = 'alpha';" \
+  "1:11" "$DB"
+run_test "nocase_merge_idx_seek_delta" \
+  "SELECT id || ':' || score FROM t INDEXED BY idx_name WHERE name = 'DELTA';" \
+  "4:40" "$DB"
+run_test "nocase_merge_idx_order" \
+  "SELECT group_concat(id, ',') FROM (SELECT id FROM t INDEXED BY idx_name WHERE name >= 'a' ORDER BY name, id);" \
+  "1,2,4,5,3" "$DB"
+
+PRE_REINDEX=$(echo "SELECT group_concat(id || ':' || name || ':' || score, ',') FROM (SELECT id, name, score FROM t INDEXED BY idx_name WHERE name >= 'a' ORDER BY name, id);" | $DOLTLITE "$DB" 2>/dev/null | tail -1)
+
+echo "REINDEX idx_name;" | $DOLTLITE "$DB" > /dev/null 2>&1
+POST_REINDEX=$(echo "SELECT group_concat(id || ':' || name || ':' || score, ',') FROM (SELECT id, name, score FROM t INDEXED BY idx_name WHERE name >= 'a' ORDER BY name, id);" | $DOLTLITE "$DB" 2>/dev/null | tail -1)
+
+if [ -n "$PRE_REINDEX" ] && [ "$PRE_REINDEX" = "$POST_REINDEX" ]; then
+  PASS=$((PASS+1))
+else
+  FAIL=$((FAIL+1))
+  ERRORS="$ERRORS\nFAIL: nocase_merge_reindex_idempotent\n  pre:  $PRE_REINDEX\n  post: $POST_REINDEX"
+fi
+
+echo "DROP INDEX idx_name; CREATE INDEX idx_name ON t(name COLLATE NOCASE);" | $DOLTLITE "$DB" > /dev/null 2>&1
+FRESH=$(echo "SELECT group_concat(id || ':' || name || ':' || score, ',') FROM (SELECT id, name, score FROM t INDEXED BY idx_name WHERE name >= 'a' ORDER BY name, id);" | $DOLTLITE "$DB" 2>/dev/null | tail -1)
+
+if [ -n "$POST_REINDEX" ] && [ "$POST_REINDEX" = "$FRESH" ]; then
+  PASS=$((PASS+1))
+else
+  FAIL=$((FAIL+1))
+  ERRORS="$ERRORS\nFAIL: nocase_merge_matches_fresh_index\n  reindex: $POST_REINDEX\n  fresh:   $FRESH"
+fi
+
+run_test_lastline "nocase_merge_integrity" "PRAGMA integrity_check;" "ok" "$DB"
+
+# DESC + NOCASE also takes the rebuild path (mergeIndexNeedsRebuild).
+DB2=/tmp/test_merge_nocase_desc_$$.db
+rm -f "$DB2"
+cat <<'EOF' | $DOLTLITE "$DB2" > /dev/null 2>&1
+CREATE TABLE t(id INTEGER PRIMARY KEY, name TEXT COLLATE NOCASE, v INT);
+CREATE INDEX idx_nd ON t(name COLLATE NOCASE DESC, v);
+INSERT INTO t VALUES (1, 'a', 1), (2, 'B', 2);
+SELECT dolt_commit('-Am', 'init');
+SELECT dolt_checkout('-b', 'feat');
+INSERT INTO t VALUES (3, 'c', 3);
+SELECT dolt_commit('-Am', 'feat');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES (4, 'D', 4);
+SELECT dolt_commit('-Am', 'main');
+SELECT dolt_merge('feat');
+EOF
+
+run_test "nocase_desc_merge_count" "SELECT count(*) FROM t;" "4" "$DB2"
+run_test "nocase_desc_idx_seek" \
+  "SELECT id FROM t INDEXED BY idx_nd WHERE name = 'b';" "2" "$DB2"
+PRE2=$(echo "SELECT group_concat(id, ',') FROM (SELECT id FROM t INDEXED BY idx_nd WHERE name >= 'a' ORDER BY name DESC, v, id);" | $DOLTLITE "$DB2" 2>/dev/null | tail -1)
+echo "REINDEX idx_nd;" | $DOLTLITE "$DB2" > /dev/null 2>&1
+POST2=$(echo "SELECT group_concat(id, ',') FROM (SELECT id FROM t INDEXED BY idx_nd WHERE name >= 'a' ORDER BY name DESC, v, id);" | $DOLTLITE "$DB2" 2>/dev/null | tail -1)
+if [ -n "$PRE2" ] && [ "$PRE2" = "$POST2" ]; then
+  PASS=$((PASS+1))
+else
+  FAIL=$((FAIL+1))
+  ERRORS="$ERRORS\nFAIL: nocase_desc_reindex_idempotent\n  pre:  $PRE2\n  post: $POST2"
+fi
+rm -f "$DB2"
+rm -f "$DB"
+
+dltest_finish

--- a/test/lib/doltlite_suite_manifest.sh
+++ b/test/lib/doltlite_suite_manifest.sh
@@ -16,6 +16,7 @@ doltlite_tag.sh
 doltlite_merge.sh
 doltlite_merge_status.sh
 doltlite_merge_index_conflict.sh
+doltlite_merge_nocase_reindex.sh
 doltlite_index_vc_matrix.sh
 doltlite_stats_merge.sh
 large_merge_test.sh

--- a/test/oom_dolt_fault_test.c
+++ b/test/oom_dolt_fault_test.c
@@ -277,6 +277,33 @@ static int opMerge(sqlite3 *db){
   return execSilent(db, "SELECT dolt_merge('br_merge')");
 }
 
+/* Divergent three-way merge: both sides insert rows so catalog pass1/pass2
+** and row merge run. Setup leaves main ready to merge feat. */
+static int setupThreeWayMerge(sqlite3 *db){
+  int rc;
+  rc = execSilent(db, "SELECT dolt_branch('feat')");
+  if( rc ) return rc;
+  rc = execSilent(db, "SELECT dolt_checkout('feat')");
+  if( rc ) return rc;
+  rc = execSilent(db, "INSERT INTO t VALUES(20,'feat')");
+  if( rc ) return rc;
+  rc = execSilent(db, "SELECT dolt_add('-A')");
+  if( rc ) return rc;
+  rc = execSilent(db, "SELECT dolt_commit('-m','feat-side')");
+  if( rc ) return rc;
+  rc = execSilent(db, "SELECT dolt_checkout('main')");
+  if( rc ) return rc;
+  rc = execSilent(db, "INSERT INTO t VALUES(10,'main')");
+  if( rc ) return rc;
+  rc = execSilent(db, "SELECT dolt_add('-A')");
+  if( rc ) return rc;
+  return execSilent(db, "SELECT dolt_commit('-m','main-side')");
+}
+
+static int opThreeWayMerge(sqlite3 *db){
+  return execSilent(db, "SELECT dolt_merge('feat')");
+}
+
 static int opDiffTable(sqlite3 *db){
   int rc = execSilent(db, "INSERT INTO t VALUES(50,'diffed')");
   if( rc ) return rc;
@@ -370,29 +397,36 @@ typedef struct OpEntry {
   const char *zOptionalBranch;
   int iOptionalRow;
   const char *zOptionalValue;
+  int iOptionalRow2;
+  const char *zOptionalValue2;
   const char *zOptionalHeadMessage;
+  const char *zOptionalHeadMessage2;
   int allowRebaseState;
 } OpEntry;
 
 static OpEntry kOps[] = {
   { "dolt_commit",         opCommit, 0,
-    0, 4, "four", "iter", 0 },
+    0, 4, "four", 0, 0, "iter", 0, 0 },
   { "dolt_branch_create",  opBranchCreate, 0,
-    "br_iter", 0, 0, 0, 0 },
+    "br_iter", 0, 0, 0, 0, 0, 0, 0 },
   { "dolt_branch_delete",  opBranchDelete, 0,
-    "br_del", 0, 0, 0, 0 },
+    "br_del", 0, 0, 0, 0, 0, 0, 0 },
   { "dolt_checkout",       opCheckout, 0,
-    "br_co", 0, 0, 0, 0 },
+    "br_co", 0, 0, 0, 0, 0, 0, 0 },
   { "dolt_log_scan",       opLogScan, 0,
-    0, 0, 0, 0, 0 },
+    0, 0, 0, 0, 0, 0, 0, 0 },
   { "dolt_merge",          opMerge, 0,
-    "br_merge", 99, "merge-branch", "for-merge", 0 },
+    "br_merge", 99, "merge-branch", 0, 0, "for-merge", 0, 0 },
+  /* Setup leaves HEAD at main-side; success advances to the merge commit. */
+  { "dolt_three_way_merge", opThreeWayMerge, setupThreeWayMerge,
+    "feat", 10, "main", 20, "feat",
+    "Merge branch 'feat' into main", "main-side", 0 },
   { "dolt_diff_table",     opDiffTable, 0,
-    0, 50, "diffed", 0, 0 },
+    0, 50, "diffed", 0, 0, 0, 0, 0 },
   { "savepoint_vc_state",  opSavepointState, setupSavepointState,
-    0, 4, "four", 0, 1 },
+    0, 4, "four", 0, 0, 0, 0, 1 },
   { "rebase_state_set",    opRebaseStateSet, setupSavepointState,
-    0, 0, 0, 0, 1 },
+    0, 0, 0, 0, 0, 0, 0, 1 },
 };
 #define N_OPS (int)(sizeof(kOps)/sizeof(kOps[0]))
 
@@ -539,7 +573,9 @@ static int verifyReopenedState(
         "SELECT message FROM dolt_log LIMIT 1", zText, sizeof(zText)));
   if( strcmp(zText, "base")!=0
    && (!op->zOptionalHeadMessage
-       || strcmp(zText, op->zOptionalHeadMessage)!=0) ){
+       || strcmp(zText, op->zOptionalHeadMessage)!=0)
+   && (!op->zOptionalHeadMessage2
+       || strcmp(zText, op->zOptionalHeadMessage2)!=0) ){
     *pzInvariant = "allowed HEAD message";
     return SQLITE_CORRUPT;
   }
@@ -554,7 +590,17 @@ static int verifyReopenedState(
     *pzInvariant = "base working rows preserved";
     return SQLITE_CORRUPT;
   }
-  if( op->iOptionalRow>0 ){
+  if( op->iOptionalRow>0 && op->iOptionalRow2>0 ){
+    zSql = sqlite3_mprintf(
+        "SELECT count(*) FROM t WHERE NOT ("
+        "(a=1 AND b='one') OR "
+        "(a=2 AND b='two') OR "
+        "(a=3 AND b='three') OR "
+        "(a=%d AND b=%Q) OR "
+        "(a=%d AND b=%Q))",
+        op->iOptionalRow, op->zOptionalValue,
+        op->iOptionalRow2, op->zOptionalValue2);
+  }else if( op->iOptionalRow>0 ){
     zSql = sqlite3_mprintf(
         "SELECT count(*) FROM t WHERE NOT ("
         "(a=1 AND b='one') OR "

--- a/test/vc_oracle_merge_test.sh
+++ b/test/vc_oracle_merge_test.sh
@@ -1595,6 +1595,25 @@ SELECT dolt_commit('-Am', 'main_change');
 SELECT dolt_merge('feature');
 "
 
+# Mixed-case shared columns in the ancestor CREATE TABLE: dual ADD COLUMN must
+# still three-way merge row edits/deletes (column-name remap is case-insensitive).
+oracle_error_poststate "dual_addcol_mixed_case_shared_cols" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, Name TEXT, Score INT);
+INSERT INTO t VALUES (1, 'alice', 10), (2, 'bob', 20);
+SELECT dolt_commit('-Am', 'base');
+SELECT dolt_checkout('-b', 'feature');
+ALTER TABLE t ADD COLUMN FeatNote TEXT;
+UPDATE t SET Name = 'ALICE', Score = 11, FeatNote = 'f1' WHERE id = 1;
+DELETE FROM t WHERE id = 2;
+SELECT dolt_commit('-Am', 'feat_change');
+SELECT dolt_checkout('main');
+ALTER TABLE t ADD COLUMN MainNote TEXT;
+UPDATE t SET MainNote = 'm1' WHERE id = 1;
+SELECT dolt_commit('-Am', 'main_change');
+SELECT dolt_merge('feature');
+" "SELECT id || '|' || Name || '|' || Score || '|' || coalesce(MainNote,'~') || '|' || coalesce(FeatNote,'~') FROM t" \
+"SELECT CONCAT(id, '|', Name, '|', Score, '|', coalesce(MainNote,'~'), '|', coalesce(FeatNote,'~')) FROM t"
+
 echo ""
 echo "=== Results: $pass passed, $fail failed ==="
 if [ $fail -gt 0 ]; then


### PR DESCRIPTION
## Summary

Remaining merge-correctness tests from the deep-dive action plan, in one PR:

1. **OOM mid-merge restore** — extend `oom_dolt_fault_test` with `dolt_three_way_merge` (divergent inserts on both sides, then merge under Nth-malloc failure). Reopen invariants: no merge state, coherent HEAD/rows (success or clean restore). Preferring a C fault-injection suite over a Dolt oracle (Dolt cannot drive our allocator).

2. **NOCASE unique/secondary reindex property** — custom suite `doltlite_merge_nocase_reindex.sh` (SQLite `COLLATE NOCASE` is not a Dolt surface). After three-way merge, `INDEXED BY` results equal post-`REINDEX` and equal drop+recreate (covers `mergeIndexNeedsRebuild` → post-merge REINDEX).

3. **Dual-add mixed-case shared columns** — Dolt oracle case on `vc_oracle_merge_test.sh`: ancestor `Name`/`Score`, dual ADD COLUMN + row edit/delete; post-state matches Dolt.

## Validation

- `make -C build oom_dolt_fault_test && ./build/oom_dolt_fault_test` — `dolt_three_way_merge` bugs=0 (and full 10-op sweep clean)
- `DOLTLITE=./build/doltlite bash test/doltlite_merge_nocase_reindex.sh` — 11/11
- Dual-add mixed-case oracle vs `dolt` — pass