### PR TITLE
Reject rebase when the source branch moves

### DIFF
--- a/src/doltlite_rebase.c
+++ b/src/doltlite_rebase.c
@@ -183,6 +183,7 @@ static int doltliteRebaseLinearReplay(
   DoltliteTxnState saved;
   DoltliteCommit upstreamCommit;
   int savedInit = 0;
+  int graphLocked = 0;
   int rc;
   int i;
   int dirty = 0;
@@ -259,8 +260,16 @@ static int doltliteRebaseLinearReplay(
   doltliteSetSessionHead(db, &upstreamHash);
   rc = doltliteSetSessionStaged(db, &upstreamCommit.catalogHash);
   if( rc==SQLITE_OK ){
+    rc = doltliteRefreshAndConfirmHead(db, cs, &headHash);
+    if( rc==SQLITE_OK ) graphLocked = 1;
+  }
+  if( rc==SQLITE_OK ){
     rc = doltliteAdvanceBranch(
         db, &upstreamHash, &upstreamCommit.catalogHash, 0);
+  }
+  if( graphLocked ){
+    chunkStoreUnlock(cs);
+    graphLocked = 0;
   }
   doltliteCommitClear(&upstreamCommit);
   memset(&upstreamCommit, 0, sizeof(upstreamCommit));
@@ -327,6 +336,7 @@ static int doltliteRebaseLinearReplay(
   return SQLITE_OK;
 
 rollback:
+  if( graphLocked ) chunkStoreUnlock(cs);
   if( savedInit ){
     (void)doltliteRestoreTxnStateOnFailure(db, &saved, rc);
   }
@@ -771,14 +781,21 @@ typedef struct RebaseFinalizeRefsCtx RebaseFinalizeRefsCtx;
 struct RebaseFinalizeRefsCtx {
   const char *zOrigBranch;
   const char *zWorkingBranch;
+  const ProllyHash *pExpectedOrigHead;
   const ProllyHash *pCurHead;
   const ProllyHash *pCurCat;
 };
 
 static int rebaseFinalizeContinueRefs(sqlite3 *db, ChunkStore *cs, void *pArg){
   RebaseFinalizeRefsCtx *p = (RebaseFinalizeRefsCtx*)pArg;
+  ProllyHash origHead;
   int rc;
   UNUSED_PARAMETER(db);
+  rc = chunkStoreFindBranch(cs, p->zOrigBranch, &origHead);
+  if( rc!=SQLITE_OK ) return rc;
+  if( prollyHashCompare(&origHead, p->pExpectedOrigHead)!=0 ){
+    return SQLITE_BUSY;
+  }
   rc = chunkStoreUpdateBranch(cs, p->zOrigBranch, p->pCurHead);
   if( rc!=SQLITE_OK ) return rc;
   rc = chunkStoreWriteBranchWorkingCatalog(cs, p->zOrigBranch,
@@ -1006,7 +1023,7 @@ static void doltliteRebaseInteractiveStart(
     goto fail;
   }
 
-  rc = doltliteSetSessionRebaseState(db, 1, &preRebaseCat, &upstreamHash,
+  rc = doltliteSetSessionRebaseState(db, 1, &preRebaseCat, &headHash,
                                      zOrig, zReturnBranch);
   if( rc==SQLITE_OK ) rc = doltlitePersistWorkingSet(db);
   if( rc!=SQLITE_OK ) goto fail;
@@ -1124,13 +1141,15 @@ static void doltliteRebaseInteractiveContinue(
   int bSkipConstraintDetect = (!db->autoCommit || db->pSavepoint!=0);
   ProllyHash curCat;
   ProllyHash curHead;
+  ProllyHash expectedOrigHead;
   RebaseFinalizeRefsCtx refsCtx;
   char *zPlanErr = 0;
 
   memset(&curCat, 0, sizeof(curCat));
   memset(&curHead, 0, sizeof(curHead));
+  memset(&expectedOrigHead, 0, sizeof(expectedOrigHead));
 
-  doltliteGetSessionRebaseState(db, &isRebasing, 0, 0,
+  doltliteGetSessionRebaseState(db, &isRebasing, 0, &expectedOrigHead,
                                 &zOrigBranchConst, &zReturnBranchConst);
   if( !isRebasing || !zOrigBranchConst || !zReturnBranchConst ){
     sqlite3_result_error(context, "no rebase in progress", -1);
@@ -1208,6 +1227,7 @@ static void doltliteRebaseInteractiveContinue(
   memset(&refsCtx, 0, sizeof(refsCtx));
   refsCtx.zOrigBranch = zOrigBranch;
   refsCtx.zWorkingBranch = zWorking;
+  refsCtx.pExpectedOrigHead = &expectedOrigHead;
   refsCtx.pCurHead = &curHead;
   refsCtx.pCurCat = &curCat;
   rc = doltliteMutateRefs(db, rebaseFinalizeContinueRefs, &refsCtx);

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -6172,6 +6172,62 @@ static void run_rebase_continue_conflict_abort_restores_durable_state(void){
   removeDbFiles(dbpath);
 }
 
+static void run_rebase_concurrent_peer_commit_is_preserved(void){
+  sqlite3 *db1 = 0;
+  sqlite3 *db2 = 0;
+  sqlite3 *db3 = 0;
+  char dbpath[256];
+  const char *res;
+
+  printf("=== Rebase Concurrent Peer Commit Preservation Test ===\n\n");
+  make_dbpath(dbpath, sizeof(dbpath),
+              "test_rebase_concurrent_peer_commit_is_preserved");
+  removeDbFiles(dbpath);
+
+  check("open_db1_for_rebase_concurrent_peer", open_db(dbpath, &db1)==SQLITE_OK);
+  check("setup_repo_for_rebase_concurrent_peer", execSql(db1,
+    "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
+    "INSERT INTO t VALUES(1,'base');"
+    "SELECT dolt_commit('-A','-m','base');"
+    "SELECT dolt_checkout('-b','feat');"
+    "INSERT INTO t VALUES(2,'feat');"
+    "SELECT dolt_commit('-A','-m','feat');"
+    "SELECT dolt_checkout('main');"
+    "INSERT INTO t VALUES(3,'main');"
+    "SELECT dolt_commit('-A','-m','main');"
+    "SELECT dolt_checkout('feat');")==SQLITE_OK);
+  check("start_rebase_before_peer_commit",
+        strstr(queryScalarText(db1, "SELECT dolt_rebase('-i','main')"),
+               "interactive rebase started")!=0);
+
+  check("open_db2_for_rebase_concurrent_peer", open_db(dbpath, &db2)==SQLITE_OK);
+  check("checkout_feat_for_rebase_concurrent_peer",
+        strcmp(queryScalarText(db2, "SELECT dolt_checkout('feat')"), "0")==0);
+  check("commit_rebase_concurrent_peer", execSql(db2,
+    "INSERT INTO t VALUES(4,'peer');"
+    "SELECT dolt_commit('-A','-m','peer');")==SQLITE_OK);
+
+  res = queryScalarText(db1, "SELECT dolt_rebase('--continue')");
+  check("rebase_rejects_concurrent_peer_commit", strstr(res, "ERROR:")!=0);
+
+  sqlite3_close(db2);
+  sqlite3_close(db1);
+
+  check("open_db3_after_rebase_concurrent_peer", open_db(dbpath, &db3)==SQLITE_OK);
+  check("checkout_feat_after_rebase_concurrent_peer",
+        strcmp(queryScalarText(db3, "SELECT dolt_checkout('feat')"), "0")==0);
+  check("rebase_concurrent_peer_row_is_preserved",
+        strcmp(queryScalarText(db3, "SELECT v FROM t WHERE id=4"), "peer")==0);
+  check("rebase_concurrent_peer_remains_head",
+        strcmp(queryScalarText(db3, "SELECT message FROM dolt_log LIMIT 1"), "peer")==0);
+  check("rebase_concurrent_working_branch_removed",
+        strcmp(queryScalarText(db3,
+          "SELECT count(*) FROM dolt_branches WHERE name='dolt_rebase_feat'"), "0")==0);
+
+  sqlite3_close(db3);
+  removeDbFiles(dbpath);
+}
+
 static void run_branch_copy_existing_dest_preserves_durable_state(void){
   sqlite3 *db = 0;
   char dbpath[256];
@@ -8678,6 +8734,7 @@ static const RegressionCase aCases[] = {
   { "rebase_plan_read_error_is_not_partial", "Rebase Plan Read Error Is Not Partial Test", run_rebase_plan_read_error_is_not_partial },
   { "rebase_recovery_failure_is_reported", "Rebase Recovery Failure Is Reported Test", run_rebase_recovery_failure_is_reported },
   { "rebase_continue_conflict_abort_restores_durable_state", "Rebase Continue Conflict Abort Restores Durable State Test", run_rebase_continue_conflict_abort_restores_durable_state },
+  { "rebase_concurrent_peer_commit_is_preserved", "Rebase Concurrent Peer Commit Preservation Test", run_rebase_concurrent_peer_commit_is_preserved },
   { "rebase_main_table_schema_guard", "Rebase Main Table Schema Guard Test", run_rebase_main_table_schema_guard },
   { "rebase_temp_shadow_ignored", "Rebase Temp Shadow Ignored Test", run_rebase_temp_shadow_ignored },
   { "remote_add_duplicate_preserves_durable_state", "Remote Add Duplicate Preserves Durable State Test", run_remote_add_duplicate_preserves_durable_state },


### PR DESCRIPTION
## Summary

- reconfirm the source branch tip while holding the refs lock before a linear rebase advances it
- retain the original interactive-rebase tip and compare it under the refs lock during continue
- return a conflict instead of silently replacing a concurrent peer commit
- add a two-connection regression proving the peer commit and row remain reachable

## Fail-before evidence

The new regression failed against master because rebase continue succeeded, discarded the peer row, and replaced the peer commit at the branch tip.

## Tests

- doltlite_regression_test_c rebase_concurrent_peer_commit_is_preserved
- doltlite_regression_test_c rebase_abort_after_reopen
- doltlite_regression_test_c rebase_continue_conflict_abort_restores_durable_state
- doltlite_regression_test_c rebase_plan_read_error_is_not_partial
- doltlite_regression_test_c rebase_recovery_failure_is_reported
- multi_process_merge_rebase_test: 20/20
- test/run_doltlite_tests.sh: all 90 DoltLite-backed suites passed; the parity suite initially lacked its separately built stock SQLite executable
- doltlite_parity.sh with a clean DOLTLITE_PROLLY=0 SQLite build: 119/119
- make lint

Co-Authored-By: OpenAI Codex <noreply@openai.com>