### PR TITLE
fix: merge nightly performance report PRs without squash

### DIFF
--- a/tool/publish-performance-report.py
+++ b/tool/publish-performance-report.py
@@ -125,7 +125,7 @@ def merge_previous_report(repository, current_login):
             str(number),
             "--repo",
             repository,
-            "--squash",
+            "--merge",
             "--delete-branch",
             "--match-head-commit",
             pr["headRefOid"],


### PR DESCRIPTION
## Summary

- Nightly performance publication failed with `Squash merges are not allowed on this repository` when merging the previous `automation/performance-report-*` PR.
- Benchmarks and report generation had already succeeded; only the publisher step died, so no new report PR was opened.
- Switch `tool/publish-performance-report.py` from `gh pr merge --squash` to `--merge` to match repo policy (`allow_squash_merge: false`, `allow_merge_commit: true`).

## Validation

- Inspected failed job log: https://github.com/dolthub/doltlite/actions/runs/30443281476/job/90570980992
- Confirmed repo settings and the single `--squash` call site in the publisher.