### PR TITLE
Preserve concurrent refs during fetch

### DIFF
--- a/src/doltlite_remote.c
+++ b/src/doltlite_remote.c
@@ -844,6 +844,89 @@ int doltlitePush(
   return rc;
 }
 
+static int installFetchedRefs(
+  ChunkStore *pLocal,
+  ChunkStore *pRemoteRefs,
+  const char *zRemoteName,
+  const char *zBranch,
+  const ProllyHash *pRemoteCommit
+){
+  ChunkStore nextRefs;
+  SavedRefsState savedRefs;
+  ProllyHash oldRefsHash;
+  ProllyHash oldCommittedRefsHash;
+  u8 *currentData = 0;
+  u8 *nextData = 0;
+  int nCurrentData = 0;
+  int nNextData = 0;
+  const SequenceRef *aRemSeq = 0;
+  int nRemSeq = 0;
+  int refsDetached = 0;
+  int locked = 0;
+  int i;
+  int rc;
+
+  memset(&nextRefs, 0, sizeof(nextRefs));
+  memset(&savedRefs, 0, sizeof(savedRefs));
+
+  rc = chunkStoreLockAndRefresh(pLocal);
+  if( rc==SQLITE_OK ){
+    locked = 1;
+    rc = chunkStoreForceRefresh(pLocal);
+  }
+  if( rc==SQLITE_OK ){
+    rc = chunkStoreSerializeRefsToBlob(
+        pLocal, &currentData, &nCurrentData);
+  }
+  if( rc==SQLITE_OK ){
+    rc = chunkStoreLoadRefsFromBlob(
+        &nextRefs, currentData, nCurrentData);
+  }
+  if( rc==SQLITE_OK ){
+    refsTableGetSequences(&pRemoteRefs->refs, &nRemSeq, &aRemSeq);
+    for(i=0; i<nRemSeq && rc==SQLITE_OK; i++){
+      if( aRemSeq[i].zTableName ){
+        rc = chunkStoreBumpSequence(
+            &nextRefs, aRemSeq[i].zTableName, aRemSeq[i].iSeq);
+      }
+    }
+  }
+  if( rc==SQLITE_OK ){
+    rc = chunkStoreUpdateTracking(
+        &nextRefs, zRemoteName, zBranch, pRemoteCommit);
+  }
+  if( rc==SQLITE_OK ){
+    rc = chunkStoreSerializeRefsToBlob(&nextRefs, &nextData, &nNextData);
+  }
+  if( rc==SQLITE_OK ){
+    memcpy(&oldRefsHash, refsTableGetHash(&pLocal->refs),
+           sizeof(oldRefsHash));
+    memcpy(&oldCommittedRefsHash, &pLocal->refs.committedRefsHash,
+           sizeof(oldCommittedRefsHash));
+    csDetachSavedRefsState(pLocal, &savedRefs);
+    refsDetached = 1;
+    rc = chunkStoreInstallRefsBlob(pLocal, nextData, nNextData);
+  }
+  if( rc==SQLITE_OK ) rc = chunkStoreCommit(pLocal);
+
+  if( refsDetached ){
+    if( rc==SQLITE_OK ){
+      csFreeSavedRefsState(&savedRefs);
+    }else{
+      csFreeRefsState(pLocal);
+      csRestoreSavedRefsState(pLocal, &savedRefs);
+      memcpy(&pLocal->refs.refsHash, &oldRefsHash, sizeof(oldRefsHash));
+      memcpy(&pLocal->refs.committedRefsHash, &oldCommittedRefsHash,
+             sizeof(oldCommittedRefsHash));
+    }
+  }
+  if( locked ) chunkStoreUnlock(pLocal);
+  chunkStoreClose(&nextRefs);
+  sqlite3_free(currentData);
+  sqlite3_free(nextData);
+  return rc;
+}
+
 int doltliteFetch(
   ChunkStore *pLocal,
   DoltliteRemote *pRemote,
@@ -855,87 +938,66 @@ int doltliteFetch(
   ProllyHash remoteCommit;
   ProllyHash trackingCommit;
   DoltliteRemote *pLocalDst = 0;
+  ChunkStore remoteRefs;
   int rc;
 
   memset(&remoteCommit, 0, sizeof(remoteCommit));
   memset(&trackingCommit, 0, sizeof(trackingCommit));
+  memset(&remoteRefs, 0, sizeof(remoteRefs));
 
   rc = pRemote->xGetRefs(pRemote, &refsData, &nRefsData);
   if( rc!=SQLITE_OK ) return rc;
 
-  {
-    ChunkStore tmpCs;
-    int iSeq;
-    const SequenceRef *aRemSeq = 0;
-    int nRemSeq = 0;
-    memset(&tmpCs, 0, sizeof(tmpCs));
-
-    rc = chunkStoreLoadRefsFromBlob(&tmpCs, refsData, nRefsData);
-    if( rc==SQLITE_OK ){
-      rc = chunkStoreFindBranch(&tmpCs, zBranch, &remoteCommit);
-    }
-    if( rc!=SQLITE_OK ){
-      chunkStoreClose(&tmpCs);
-      sqlite3_free(refsData);
-      return rc==SQLITE_NOTFOUND ? SQLITE_NOTFOUND : rc;
-    }
-
-    if( prollyHashIsEmpty(&remoteCommit) ){
-      chunkStoreClose(&tmpCs);
-      sqlite3_free(refsData);
-      return SQLITE_NOTFOUND;
-    }
-
-    rc = chunkStoreFindTracking(pLocal, zRemoteName, zBranch, &trackingCommit);
-    if( rc==SQLITE_OK ){
-      if( prollyHashCompare(&trackingCommit, &remoteCommit)==0 ){
-        int seqWouldAdvance = 0;
-        rc = remoteSequencesWouldAdvance(pLocal, &tmpCs, &seqWouldAdvance);
-        if( rc!=SQLITE_OK ){
-          chunkStoreClose(&tmpCs);
-          sqlite3_free(refsData);
-          return rc;
-        }
-        if( !seqWouldAdvance ){
-          chunkStoreClose(&tmpCs);
-          sqlite3_free(refsData);
-          return SQLITE_OK;
-        }
-      }
-    }else if( rc!=SQLITE_NOTFOUND ){
-      chunkStoreClose(&tmpCs);
-      sqlite3_free(refsData);
-      return rc;
-    }
-
-    refsTableGetSequences(&tmpCs.refs, &nRemSeq, &aRemSeq);
-    for(iSeq=0; iSeq<nRemSeq; iSeq++){
-      if( aRemSeq[iSeq].zTableName ){
-        rc = chunkStoreBumpSequence(pLocal, aRemSeq[iSeq].zTableName,
-                                    aRemSeq[iSeq].iSeq);
-        if( rc!=SQLITE_OK ){
-          chunkStoreClose(&tmpCs);
-          sqlite3_free(refsData);
-          return rc;
-        }
-      }
-    }
-    chunkStoreClose(&tmpCs);
-  }
+  rc = chunkStoreLoadRefsFromBlob(&remoteRefs, refsData, nRefsData);
   sqlite3_free(refsData);
+  if( rc==SQLITE_OK ){
+    rc = chunkStoreFindBranch(&remoteRefs, zBranch, &remoteCommit);
+  }
+  if( rc!=SQLITE_OK ){
+    chunkStoreClose(&remoteRefs);
+    return rc==SQLITE_NOTFOUND ? SQLITE_NOTFOUND : rc;
+  }
+
+  if( prollyHashIsEmpty(&remoteCommit) ){
+    chunkStoreClose(&remoteRefs);
+    return SQLITE_NOTFOUND;
+  }
+
+  rc = chunkStoreFindTracking(pLocal, zRemoteName, zBranch, &trackingCommit);
+  if( rc==SQLITE_OK ){
+    if( prollyHashCompare(&trackingCommit, &remoteCommit)==0 ){
+      int seqWouldAdvance = 0;
+      rc = remoteSequencesWouldAdvance(pLocal, &remoteRefs, &seqWouldAdvance);
+      if( rc!=SQLITE_OK ){
+        chunkStoreClose(&remoteRefs);
+        return rc;
+      }
+      if( !seqWouldAdvance ){
+        chunkStoreClose(&remoteRefs);
+        return SQLITE_OK;
+      }
+    }
+  }else if( rc!=SQLITE_NOTFOUND ){
+    chunkStoreClose(&remoteRefs);
+    return rc;
+  }
 
   pLocalDst = doltliteLocalAsRemote(pLocal);
-  if( !pLocalDst ) return SQLITE_NOMEM;
+  if( !pLocalDst ){
+    chunkStoreClose(&remoteRefs);
+    return SQLITE_NOMEM;
+  }
 
   rc = doltliteSyncChunks(pRemote, pLocalDst, &remoteCommit, 1);
 
   pLocalDst->xClose(pLocalDst);
-  if( rc!=SQLITE_OK ) return rc;
+  if( rc==SQLITE_OK ){
+    rc = installFetchedRefs(
+        pLocal, &remoteRefs, zRemoteName, zBranch, &remoteCommit);
+  }
 
-  rc = chunkStoreUpdateTracking(pLocal, zRemoteName, zBranch, &remoteCommit);
-  if( rc!=SQLITE_OK ) return rc;
-
-  return doltliteRemotePersistRefs(pLocal);
+  chunkStoreClose(&remoteRefs);
+  return rc;
 }
 
 int doltliteClone(ChunkStore *pLocal, DoltliteRemote *pRemote){

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -1529,6 +1529,72 @@ static void run_remote_refs_corruption(void){
   removeDbFiles(clonePath);
 }
 
+static void run_fetch_preserves_concurrent_local_refs(void){
+  sqlite3 *remoteDb = 0;
+  sqlite3 *localDb1 = 0;
+  sqlite3 *localDb2 = 0;
+  sqlite3 *localDb3 = 0;
+  char remotePath[256];
+  char localPath[256];
+  char sql[1024];
+  char remoteHead[128];
+
+  printf("=== Fetch Preserves Concurrent Local Refs Test ===\n\n");
+  make_dbpath(remotePath, sizeof(remotePath),
+              "test_fetch_preserves_concurrent_local_refs_remote");
+  make_dbpath(localPath, sizeof(localPath),
+              "test_fetch_preserves_concurrent_local_refs_local");
+  removeDbFiles(remotePath);
+  removeDbFiles(localPath);
+
+  check("open_remote_for_concurrent_fetch",
+        open_db(remotePath, &remoteDb)==SQLITE_OK);
+  check("setup_remote_for_concurrent_fetch", execSql(remoteDb,
+    "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
+    "INSERT INTO t VALUES(1,'base');"
+    "SELECT dolt_commit('-A','-m','base');")==SQLITE_OK);
+
+  check("open_local1_for_concurrent_fetch",
+        open_db(localPath, &localDb1)==SQLITE_OK);
+  snprintf(sql, sizeof(sql), "SELECT dolt_clone('file://%s')", remotePath);
+  check("clone_for_concurrent_fetch", execSql(localDb1, sql)==SQLITE_OK);
+  check("pin_local1_before_concurrent_fetch", execSql(localDb1,
+    "BEGIN;"
+    "SELECT count(*) FROM dolt_branches;")==SQLITE_OK);
+
+  check("open_local2_for_concurrent_fetch",
+        open_db(localPath, &localDb2)==SQLITE_OK);
+  check("create_peer_branch_during_fetch",
+        strcmp(queryScalarText(localDb2,
+          "SELECT dolt_branch('peer_keep')"), "0")==0);
+
+  check("advance_remote_for_concurrent_fetch", execSql(remoteDb,
+    "INSERT INTO t VALUES(2,'remote');"
+    "SELECT dolt_commit('-A','-m','remote');")==SQLITE_OK);
+  sqlite3_snprintf(sizeof(remoteHead), remoteHead, "%s",
+                   queryScalarText(remoteDb, "SELECT dolt_hashof('HEAD')"));
+  check("fetch_with_stale_local_refs",
+        strcmp(queryScalarText(localDb1,
+          "SELECT dolt_fetch('origin','main')"), "0")==0);
+
+  sqlite3_close(localDb2);
+  sqlite3_close(localDb1);
+  sqlite3_close(remoteDb);
+
+  check("reopen_after_concurrent_fetch",
+        open_db(localPath, &localDb3)==SQLITE_OK);
+  check("fetch_preserves_peer_branch",
+        strcmp(queryScalarText(localDb3,
+          "SELECT count(*) FROM dolt_branches WHERE name='peer_keep'"), "1")==0);
+  check("fetch_updates_tracking_branch",
+        strcmp(queryScalarText(localDb3,
+          "SELECT dolt_hashof('origin/main')"), remoteHead)==0);
+
+  sqlite3_close(localDb3);
+  removeDbFiles(remotePath);
+  removeDbFiles(localPath);
+}
+
 static void run_chunk_walk_corruption(void){
   static const u8 badCatalog[] = {
     'D','L','C','T',
@@ -8587,6 +8653,7 @@ static const RegressionCase aCases[] = {
   { "status_error_propagation", "Status Error Propagation Test", run_status_error_propagation },
   { "status_many_table_renames", "Status Many Table Renames Test", run_status_many_table_renames },
   { "remote_refs_corruption", "Remote Refs Corruption Test", run_remote_refs_corruption },
+  { "fetch_preserves_concurrent_local_refs", "Fetch Preserves Concurrent Local Refs Test", run_fetch_preserves_concurrent_local_refs },
   { "chunk_walk_corruption", "Chunk Walk Corruption Test", run_chunk_walk_corruption },
   { "catalog_deserialize_corruption", "Catalog Deserialize Corruption Test", run_catalog_deserialize_corruption },
   { "ancestor_missing_start", "Ancestor Missing Start Test", run_ancestor_missing_start },


### PR DESCRIPTION
## Summary

- hold the local graph lock and force-refresh refs before installing fetched tracking state
- construct the new refs blob from that current local snapshot, merging remote sequences and the requested tracking ref
- restore the prior in-memory refs if installation or persistence fails
- add a pinned-snapshot, two-connection regression proving fetch preserves a peer-created local branch

Pull inherits the fix because it fetches before advancing or merging the local branch.

## Fail-before evidence

Against master, the new regression passed 11 assertions and failed only because the peer-created local branch disappeared after the stale connection fetched. With this change it passes 12/12 and the tracking ref matches the remote tip.

## Tests

- test/run_doltlite_tests.sh: 91/91 suites, including 309968/309968 regression assertions and 119/119 SQLite parity checks
- test/remote_test.sh: 97/97
- test/vc_oracle_fetch_pull_convergence_test.sh: 29/29 against Dolt
- targeted persistence, corruption, clone, push, and concurrent-refs regression cases
- post-rebase regression: 12/12
- post-rebase remote_test.sh: 97/97
- make lint

Co-Authored-By: OpenAI Codex <noreply@openai.com>