### PR TITLE
ci: nightly full large_scale (1M + 10M + 100M)

### DIFF
--- a/.github/workflows/nightly-scale.yml
+++ b/.github/workflows/nightly-scale.yml
@@ -1,0 +1,176 @@
+name: Nightly scale
+
+# Full large_scale_test (1M + 10M) with the script's strict wall-clock
+# ceilings. PR only runs --quick (100K). Separate from Nightly stress
+# (race soaks on checked builds) and Nightly performance (sysbench vs
+# SQLite): this is correctness + absolute latency at multi-million row
+# size on an optimized binary (PROLLY_CHECK would inflate commit cost
+# and defeat the time gates).
+#
+# Silent when clean; on failure opens/updates a sticky tracking issue
+# via report-failure-issue.
+
+on:
+  schedule:
+    # After Nightly stress (06:00 UTC); before Nightly performance (09:30).
+    - cron: '0 7 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: nightly-scale
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install dependencies
+      run: |
+        bash .github/scripts/install-apt-deps.sh \
+          build-essential tcl-dev zlib1g-dev
+
+    - name: Configure
+      run: |
+        mkdir build
+        cd build
+        TCL_CONFIG=$(find /usr/lib -name tclConfig.sh -print -quit 2>/dev/null)
+        if [ -n "$TCL_CONFIG" ]; then
+          ../configure --with-tcl=$(dirname "$TCL_CONFIG")
+        else
+          ../configure
+        fi
+
+    - name: Build optimized doltlite (no PROLLY_CHECK)
+      run: |
+        cd build
+        set -o pipefail
+        {
+          # Plain optimized build: time gates in large_scale_test.sh are
+          # meaningless under DOLTLITE_PROLLY_CHECK (full-tree walk per commit).
+          make -j2 doltlite
+        } 2>&1 | tee build.log
+        if grep -E "warning:" build.log; then
+          echo "::error::compiler warnings in nightly scale build"
+          exit 1
+        fi
+        test -x ./doltlite
+
+    - name: Package
+      run: tar -czf nightly-scale-build.tar.gz build
+
+    - name: Upload
+      uses: actions/upload-artifact@v4
+      with:
+        name: nightly-scale-build
+        path: nightly-scale-build.tar.gz
+        retention-days: 1
+
+  large-full:
+    name: large-scale-full
+    needs: build
+    runs-on: ubuntu-latest
+    # Full mode: 1M suite + 10M insert/commit/diff/clone. Script ceilings
+    # are tens of minutes of work at most; leave headroom for cold runners.
+    timeout-minutes: 180
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install dependencies
+      run: |
+        bash .github/scripts/install-apt-deps.sh zlib1g-dev
+
+    - name: Download build
+      uses: actions/download-artifact@v4
+      with:
+        name: nightly-scale-build
+
+    - name: Extract build
+      run: tar -xzf nightly-scale-build.tar.gz
+
+    - name: Run full large_scale_test (1M + 10M, strict time gates)
+      id: scale
+      run: |
+        set -uo pipefail
+        WS="$GITHUB_WORKSPACE"
+        outdir="$WS/scale-artifacts/large-full"
+        mkdir -p "$outdir"
+        log="$outdir/run.log"
+
+        echo "=== nightly scale: large_scale_test.sh full mode ===" | tee "$log"
+        echo "Binary: $WS/build/doltlite" | tee -a "$log"
+        "$WS/build/doltlite" -version 2>&1 | tee -a "$log" || true
+
+        # No --quick: N1=1_000_000, N10=10_000_000, with the script's
+        # hard second ceilings (insert/commit/diff/clone).
+        if bash "$WS/test/large_scale_test.sh" "$WS/build/doltlite" \
+             >>"$log" 2>&1; then
+          echo "failed=" >> "$GITHUB_OUTPUT"
+          echo "clean."
+          tail -n 40 "$log" || true
+        else
+          echo "failed=1" >> "$GITHUB_OUTPUT"
+          echo "FAIL: large_scale_test full mode"
+          tail -n 80 "$log" || true
+        fi
+
+    - name: Compose failure report
+      if: steps.scale.outputs.failed == '1'
+      run: |
+        set -euo pipefail
+        WS="$GITHUB_WORKSPACE"
+        BODY="$RUNNER_TEMP/scale-body.md"
+        {
+          echo "Nightly full **large_scale_test** failed (1M + 10M, strict wall-clock ceilings)."
+          echo ""
+          echo "PR only runs \`bash test/large_scale_test.sh ./doltlite --quick\` (100K)."
+          echo "This job runs full mode with no \`--quick\`."
+          echo ""
+          echo "Full log is the \`nightly-scale-large-full\` artifact on the run."
+          echo ""
+          echo "Reproduce locally (optimized build, not PROLLY_CHECK):"
+          echo '```bash'
+          echo "mkdir -p build && cd build && ../configure && make -j\$(nproc) doltlite"
+          echo "bash ../test/large_scale_test.sh ./doltlite"
+          echo '```'
+          echo ""
+          echo "Last 100 lines of the run log:"
+          echo ""
+          echo '```'
+          tail -n 100 "$WS/scale-artifacts/large-full/run.log" 2>/dev/null || echo "(no log)"
+          echo '```'
+        } > "$BODY"
+        cat "$BODY"
+
+    - name: Upload scale log
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: nightly-scale-large-full
+        path: scale-artifacts/large-full/
+        if-no-files-found: warn
+        retention-days: 14
+
+    - name: Report failure as GitHub issue
+      if: steps.scale.outputs.failed == '1'
+      uses: ./.github/actions/report-failure-issue
+      with:
+        label: nightly-scale-large-full
+        title: "Nightly scale failure: large_scale full (1M+10M)"
+        body-file: ${{ runner.temp }}/scale-body.md
+        token: ${{ secrets.GITHUB_TOKEN }}
+        label-description: Nightly full large_scale_test (1M+10M) failure
+
+    - name: Fail the job if scale failed
+      if: steps.scale.outputs.failed == '1'
+      run: |
+        echo "::error::nightly scale failure in large_scale_test full mode"
+        exit 1

--- a/.github/workflows/nightly-scale.yml
+++ b/.github/workflows/nightly-scale.yml
@@ -1,11 +1,11 @@
 name: Nightly scale
 
-# Full large_scale_test (1M + 10M) with the script's strict wall-clock
-# ceilings. PR only runs --quick (100K). Separate from Nightly stress
-# (race soaks on checked builds) and Nightly performance (sysbench vs
-# SQLite): this is correctness + absolute latency at multi-million row
-# size on an optimized binary (PROLLY_CHECK would inflate commit cost
-# and defeat the time gates).
+# Full large_scale_test (1M + 10M + 100M) with the script's strict
+# wall-clock ceilings. PR only runs --quick (100K). Separate from
+# Nightly stress (race soaks on checked builds) and Nightly performance
+# (sysbench vs SQLite): this is correctness + absolute latency at
+# multi-million row size on an optimized binary (PROLLY_CHECK would
+# inflate commit cost and defeat the time gates).
 #
 # Silent when clean; on failure opens/updates a sticky tracking issue
 # via report-failure-issue.
@@ -77,9 +77,10 @@ jobs:
     name: large-scale-full
     needs: build
     runs-on: ubuntu-latest
-    # Full mode: 1M suite + 10M insert/commit/diff/clone. Script ceilings
-    # are tens of minutes of work at most; leave headroom for cold runners.
-    timeout-minutes: 180
+    # Full mode: 1M suite + 10M + 100M insert/commit/diff/clone.
+    # 100M insert ceiling alone is 20m; clone/commit add more. Stay under
+    # GitHub's 6h job limit with headroom for cold runners / disk pressure.
+    timeout-minutes: 360
 
     steps:
     - uses: actions/checkout@v4
@@ -87,6 +88,13 @@ jobs:
     - name: Install dependencies
       run: |
         bash .github/scripts/install-apt-deps.sh zlib1g-dev
+
+    - name: Free runner disk before large DBs
+      run: |
+        # 100M + clone can need tens of GB; reclaim common GHA bloat first.
+        sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+          /usr/local/share/boost "$AGENT_TOOLSDIRECTORY" 2>/dev/null || true
+        df -h
 
     - name: Download build
       uses: actions/download-artifact@v4
@@ -96,7 +104,7 @@ jobs:
     - name: Extract build
       run: tar -xzf nightly-scale-build.tar.gz
 
-    - name: Run full large_scale_test (1M + 10M, strict time gates)
+    - name: Run full large_scale_test (1M + 10M + 100M, strict time gates)
       id: scale
       run: |
         set -uo pipefail
@@ -107,10 +115,10 @@ jobs:
 
         echo "=== nightly scale: large_scale_test.sh full mode ===" | tee "$log"
         echo "Binary: $WS/build/doltlite" | tee -a "$log"
+        df -h | tee -a "$log"
         "$WS/build/doltlite" -version 2>&1 | tee -a "$log" || true
 
-        # No --quick: N1=1_000_000, N10=10_000_000, with the script's
-        # hard second ceilings (insert/commit/diff/clone).
+        # No --quick: N1=1M, N10=10M, N100=100M with hard second ceilings.
         if bash "$WS/test/large_scale_test.sh" "$WS/build/doltlite" \
              >>"$log" 2>&1; then
           echo "failed=" >> "$GITHUB_OUTPUT"
@@ -129,14 +137,14 @@ jobs:
         WS="$GITHUB_WORKSPACE"
         BODY="$RUNNER_TEMP/scale-body.md"
         {
-          echo "Nightly full **large_scale_test** failed (1M + 10M, strict wall-clock ceilings)."
+          echo "Nightly full **large_scale_test** failed (1M + 10M + 100M, strict wall-clock ceilings)."
           echo ""
           echo "PR only runs \`bash test/large_scale_test.sh ./doltlite --quick\` (100K)."
           echo "This job runs full mode with no \`--quick\`."
           echo ""
           echo "Full log is the \`nightly-scale-large-full\` artifact on the run."
           echo ""
-          echo "Reproduce locally (optimized build, not PROLLY_CHECK):"
+          echo "Reproduce locally (optimized build, not PROLLY_CHECK; needs disk for 100M + clone):"
           echo '```bash'
           echo "mkdir -p build && cd build && ../configure && make -j\$(nproc) doltlite"
           echo "bash ../test/large_scale_test.sh ./doltlite"
@@ -164,10 +172,10 @@ jobs:
       uses: ./.github/actions/report-failure-issue
       with:
         label: nightly-scale-large-full
-        title: "Nightly scale failure: large_scale full (1M+10M)"
+        title: "Nightly scale failure: large_scale full (1M+10M+100M)"
         body-file: ${{ runner.temp }}/scale-body.md
         token: ${{ secrets.GITHUB_TOKEN }}
-        label-description: Nightly full large_scale_test (1M+10M) failure
+        label-description: Nightly full large_scale_test (1M+10M+100M) failure
 
     - name: Fail the job if scale failed
       if: steps.scale.outputs.failed == '1'

--- a/test/large_scale_test.sh
+++ b/test/large_scale_test.sh
@@ -67,7 +67,11 @@ if [ "$QUICK" = "1" ]; then
   N1_CLONE_MAX=15
   N1_COMMIT_MAX=15
   N10=0
+  N100=0
 else
+  # Full mode is for Nightly scale (not PR). Ceilings are absolute wall-clock
+  # seconds on an optimized (non-PROLLY_CHECK) binary; 10x row counts get
+  # roughly 10x insert/commit/clone budgets.
   echo "=== FULL MODE ==="
   N1=1000000
   N1_INSERT_MAX=30
@@ -79,6 +83,10 @@ else
   N10_INSERT_MAX=120
   N10_COMMIT_MAX=60
   N10_CLONE_MAX=60
+  N100=100000000
+  N100_INSERT_MAX=1200
+  N100_COMMIT_MAX=600
+  N100_CLONE_MAX=600
 fi
 
 echo ""
@@ -240,8 +248,9 @@ check "10M diff count" "10" "$result"
 echo ""
 echo "--- 16. Clone 10M ---"
 t0=$(ts)
-"$DB" "$TMPDIR/10m.db" "SELECT dolt_remote('add','origin','file://$TMPDIR/10m_remote'); SELECT dolt_push('origin','main');" > /dev/null 2>&1
-"$DB" "$TMPDIR/10m_clone" "SELECT dolt_clone('file://$TMPDIR/10m_remote');" > /dev/null 2>&1
+remote_uri=$(file_uri "$TMPDIR/10m_remote")
+"$DB" "$TMPDIR/10m.db" "SELECT dolt_remote('add','origin','$remote_uri'); SELECT dolt_push('origin','main');" > /dev/null 2>&1
+"$DB" "$TMPDIR/10m_clone" "SELECT dolt_clone('$remote_uri');" > /dev/null 2>&1
 elapsed=$(( $(ts) - t0 ))
 echo "  ${elapsed}s"
 check_time "clone 10M" "$elapsed" "$N10_CLONE_MAX"
@@ -258,6 +267,76 @@ check "10M near-end" "row_9000000" "$result"
 
 m10_size=$(stat -f%z "$TMPDIR/10m.db" 2>/dev/null || stat -c%s "$TMPDIR/10m.db" 2>/dev/null)
 echo "  10M database: $((m10_size / 1048576))MB"
+
+# Drop 10M artifacts before the 100M tier so runner disk is not holding
+# two multi-GB trees plus clones at once.
+rm -rf "$TMPDIR/10m.db" "$TMPDIR/10m.db-wal" "$TMPDIR/10m.db-lock" \
+       "$TMPDIR/10m_clone" "$TMPDIR/10m_remote" 2>/dev/null || true
+fi
+
+if [ "$N100" -gt 0 ]; then
+echo ""
+echo "══════════════════════════════════════"
+echo "  100M-row test"
+echo "══════════════════════════════════════"
+
+echo ""
+echo "--- 18. Insert 100M rows ---"
+"$DB" "$TMPDIR/100m.db" "CREATE TABLE huge(id INTEGER PRIMARY KEY, name TEXT, val INTEGER);" > /dev/null 2>&1
+t0=$(ts)
+batch_insert "$TMPDIR/100m.db" "huge" "$N100" "x, 'row_'||x, x%1000"
+elapsed=$(( $(ts) - t0 ))
+echo "  ${elapsed}s"
+check_time "insert 100M" "$elapsed" "$N100_INSERT_MAX"
+
+result=$("$DB" "$TMPDIR/100m.db" "SELECT count(*) FROM huge;")
+check "100M count" "$N100" "$result"
+
+echo ""
+echo "--- 19. Commit 100M ---"
+t0=$(ts)
+"$DB" "$TMPDIR/100m.db" "SELECT dolt_add('-A'); SELECT dolt_commit('-m','100M');" > /dev/null 2>&1
+elapsed=$(( $(ts) - t0 ))
+echo "  ${elapsed}s"
+check_time "commit 100M" "$elapsed" "$N100_COMMIT_MAX"
+
+echo ""
+echo "--- 20. Update + diff 10 rows in 100M ---"
+t0=$(ts)
+result=$("$DB" "$TMPDIR/100m.db" "
+UPDATE huge SET val=val+1 WHERE id<=10;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','update 10 rows');
+SELECT count(*) FROM dolt_diff_huge WHERE diff_type='modified';" 2>/dev/null | tail -1)
+elapsed=$(( $(ts) - t0 ))
+echo "  ${elapsed}s"
+# Point update of 10 rows should stay near-constant vs tree height; leave
+# headroom over the 10M 30s budget without going linear in N.
+check_time "update+diff 10 rows in 100M" "$elapsed" 60
+check "100M diff count" "10" "$result"
+
+echo ""
+echo "--- 21. Clone 100M ---"
+t0=$(ts)
+remote_uri=$(file_uri "$TMPDIR/100m_remote")
+"$DB" "$TMPDIR/100m.db" "SELECT dolt_remote('add','origin','$remote_uri'); SELECT dolt_push('origin','main');" > /dev/null 2>&1
+"$DB" "$TMPDIR/100m_clone" "SELECT dolt_clone('$remote_uri');" > /dev/null 2>&1
+elapsed=$(( $(ts) - t0 ))
+echo "  ${elapsed}s"
+check_time "clone 100M" "$elapsed" "$N100_CLONE_MAX"
+
+result=$("$DB" "$TMPDIR/100m_clone" "SELECT count(*) FROM huge;")
+check "100M clone count" "$N100" "$result"
+
+echo ""
+echo "--- 22. Point lookups 100M ---"
+result=$("$DB" "$TMPDIR/100m.db" "SELECT name FROM huge WHERE id=50000000;")
+check "100M midpoint" "row_50000000" "$result"
+result=$("$DB" "$TMPDIR/100m.db" "SELECT name FROM huge WHERE id=90000000;")
+check "100M near-end" "row_90000000" "$result"
+
+m100_size=$(stat -f%z "$TMPDIR/100m.db" 2>/dev/null || stat -c%s "$TMPDIR/100m.db" 2>/dev/null)
+echo "  100M database: $((m100_size / 1048576))MB"
 fi
 
 echo ""


### PR DESCRIPTION
## Summary

Adds **Nightly scale** — dedicated workflow running full `large_scale_test` on an optimized binary:

```bash
bash test/large_scale_test.sh ./doltlite   # 1M + 10M + 100M
```

PR only gates `--quick` (100K).

| Decision | Choice |
|---|---|
| Workflow | **B** — `nightly-scale.yml` |
| Time gates | **Strict** script ceilings |
| Sizes | **1M + 10M + 100M** day one |
| Scope | large_scale only (no timing suite) |

### 100M tier

| Op | Ceiling |
|---|---|
| insert 100M | 1200s (20m) |
| commit 100M | 600s (10m) |
| update+diff 10 rows | 60s |
| clone 100M | 600s (10m) |

Also: free 10M DBs before 100M; GHA disk reclaim step; job timeout 360m.

## Test plan

- [ ] `workflow_dispatch` after merge — confirm 1M/10M/100M complete under ceilings
- [ ] Watch disk (`df`) in the log; sticky issue on fail is by design under strict mode
- [ ] PR still only runs `--quick`