### PR TITLE
Anchor crash-coverage mappings to a case, and reject duplicate ratchet baselines

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -309,6 +309,7 @@ jobs:
           echo "::error::files in more than one regression bucket:"; echo "$dups"; exit 1
         fi
         bash test/check_testfixture_crash_coverage.sh
+        bash test/check_testfixture_crash_coverage_test.sh
         bash test/check_testfixture_exception_inventory.sh
         bash test/check_testfixture_exception_inventory_test.sh
         bash test/check_testfixture_inventory_issues_alive_test.sh

--- a/test/check_testfixture_crash_coverage.sh
+++ b/test/check_testfixture_crash_coverage.sh
@@ -36,8 +36,8 @@ if ! awk '
   {
     sub(/#.*/, "")
     if (NF == 0) next
-    if (NF != 3) {
-      printf "%s:%d: expected 3 fields, found %d\n", FILENAME, NR, NF
+    if (NF != 4) {
+      printf "%s:%d: expected 4 fields, found %d\n", FILENAME, NR, NF
       bad = 1
     }
   }
@@ -56,11 +56,80 @@ report_set "unbucketed crash entries without replacement coverage" "$TMP_DIR/mis
 report_set "coverage mappings for tests that are not unbucketed crashes" "$TMP_DIR/stale"
 
 awk '
-  { sub(/#.*/, ""); if (NF) print $1, $2, $3 }
+  { sub(/#.*/, ""); if (NF) print $1, $2, $3, $4 }
 ' "$COVERAGE_FILE" | sort | uniq -d > "$TMP_DIR/duplicates"
 report_set "duplicate coverage mappings" "$TMP_DIR/duplicates"
 
-while read -r source kind target; do
+# Resolve <case> to a line in the replacement and echo "<line>\t<text>". The
+# case has to match exactly one candidate: zero means the replacement no longer
+# covers the behavior this mapping claims, and several means the locator points
+# nowhere in particular. Candidates are restricted per kind so that a weak case
+# name like a bare test number cannot collide with ordinary content.
+resolve_case() {
+  local path="$1" kind="$2" name="$3" pattern
+  local escaped
+  escaped=$(printf '%s' "$name" | sed -E 's/[][(){}.*+?^$|\\]/\\&/g')
+  case "$kind" in
+    testfixture)
+      pattern="do_[a-z_]*test[[:space:]]+$escaped([[:space:]]|\{|$)"
+      ;;
+    c-test)
+      # a function definition, or an entry in a dispatch table like kOps[]
+      pattern="^([a-z]+[[:space:]]+)*[a-z]+[[:space:]]+$escaped\(|\"$escaped\""
+      ;;
+    workflow-script)
+      pattern="^[[:space:]]*echo \"---.*[^[:alnum:]]$escaped([^[:alnum:]]|\$)|^$escaped\(\)"
+      ;;
+  esac
+  # No match is an ordinary outcome, so keep grep's exit status from tripping
+  # set -e through the command substitution.
+  local matches
+  matches=$(grep -nE "$pattern" "$path" 2>/dev/null || true)
+  if [ -z "$matches" ]; then
+    printf 'none\n'
+    return 0
+  fi
+  # Split on the first colon only: matched lines contain colons of their own
+  # ("--- Scenario 1: ..."), which -F: would eat. Truncation happens in awk
+  # rather than through head, which would SIGPIPE the writer under pipefail.
+  printf '%s\n' "$matches" | awk '
+    {
+      p = index($0, ":")
+      if (NR <= 2) {
+        line[NR] = substr($0, 1, p - 1)
+        t = substr($0, p + 1)
+        gsub(/^[[:space:]]+|[[:space:]]+$/, "", t)
+        text[NR] = t
+      }
+    }
+    END {
+      if (NR > 1) { printf "many\t%s,%s\n", line[1], line[2]; exit }
+      printf "%s\t%s\n", line[1], text[1]
+    }'
+}
+
+check_case() {
+  local source="$1" path="$2" kind="$3" name="$4" got
+  got=$(resolve_case "$path" "$kind" "$name")
+  case "${got%%$'\t'*}" in
+    none)
+      echo "ERROR: $source maps to $kind $path case '$name', which does not exist"
+      FAIL=1
+      ;;
+    many)
+      echo "ERROR: $source maps to $kind $path case '$name', which is ambiguous" \
+           "(lines ${got#*$'\t'})"
+      FAIL=1
+      ;;
+    *)
+      RESOLVED="$RESOLVED$source -> $path:${got%%$'\t'*} (${got#*$'\t'})
+"
+      ;;
+  esac
+}
+
+RESOLVED=""
+while read -r source kind target acase; do
   [ -n "${source:-}" ] || continue
   case "$kind" in
     testfixture)
@@ -70,6 +139,8 @@ while read -r source kind target; do
       elif ! grep -Fqx "$target" "$BUCKET_DIR"/*.txt; then
         echo "ERROR: $source maps to testfixture $target, but it is not in a regression bucket"
         FAIL=1
+      else
+        check_case "$source" "test/$target.test" "$kind" "$acase"
       fi
       ;;
     c-test)
@@ -82,6 +153,8 @@ while read -r source kind target; do
           | grep -Eq "^[[:space:]]*$target[[:space:]]*$"; then
         echo "ERROR: $source maps to C test $target, but it is not gating"
         FAIL=1
+      else
+        check_case "$source" "test/$target.c" "$kind" "$acase"
       fi
       ;;
     workflow-script)
@@ -91,6 +164,8 @@ while read -r source kind target; do
       elif ! grep -R -Fq "$target" "$ROOT_DIR/.github/workflows"; then
         echo "ERROR: $source maps to script $target, but no workflow runs it"
         FAIL=1
+      else
+        check_case "$source" "test/$target" "$kind" "$acase"
       fi
       ;;
     *)
@@ -98,10 +173,11 @@ while read -r source kind target; do
       FAIL=1
       ;;
   esac
-done < <(awk '{ sub(/#.*/, ""); if (NF) print $1, $2, $3 }' "$COVERAGE_FILE")
+done < <(awk '{ sub(/#.*/, ""); if (NF) print $1, $2, $3, $4 }' "$COVERAGE_FILE")
 
 if [ "$FAIL" -ne 0 ]; then
   exit 1
 fi
 
+printf '%s' "$RESOLVED" | sort | sed 's/^/  /'
 echo "OK: $(wc -l < "$TMP_DIR/excluded" | tr -d ' ') unbucketed crash tests have gated replacement coverage"

--- a/test/check_testfixture_crash_coverage_test.sh
+++ b/test/check_testfixture_crash_coverage_test.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+#
+# Self-test for the crash-coverage checker, whose job is to prove that a
+# crash-listed file excluded from every regression bucket still has deterministic
+# replacement coverage. The case anchor is the part worth testing: a mapping
+# naming a replacement that no longer covers the behavior has to fail rather than
+# pass on the strength of the file's name.
+#
+# Cases assert on the reported reason, not just a non-zero exit. Checking the
+# exit alone hid a bug where an unresolvable anchor tripped set -e through a
+# command substitution, so every negative case "passed" without the checker ever
+# reaching its own diagnostic.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CHECKER="$SCRIPT_DIR/check_testfixture_crash_coverage.sh"
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+CRASHES="$TMP_DIR/crashes"
+COVERAGE="$TMP_DIR/coverage"
+BUCKETS="$TMP_DIR/buckets"
+mkdir -p "$BUCKETS"
+
+# Replacements are resolved against the real test/ tree, so the fixtures name
+# real replacements and real cases. That also means this fails if one of those
+# cases is renamed away, which is the point.
+REPLACEMENT=doltlite_recover_savepointfault
+if [ ! -f "$SCRIPT_DIR/$REPLACEMENT.test" ]; then
+  echo "SKIP: $REPLACEMENT.test is not present"
+  exit 0
+fi
+
+printf '%s\n' 'malloc # excluded, needs replacement coverage' > "$CRASHES"
+printf '%s\n' 'somethingelse' "$REPLACEMENT" > "$BUCKETS/bucket.txt"
+
+run_check() {
+  bash "$CHECKER" "$CRASHES" "$COVERAGE" "$BUCKETS" 2>&1
+}
+
+expect_ok() {
+  local label="$1" out
+  if ! out=$(run_check); then
+    echo "ERROR: checker rejected $label"
+    printf '%s\n' "$out" | sed 's/^/    /'
+    exit 1
+  fi
+}
+
+# Fails, and for the stated reason rather than incidentally.
+expect_reason() {
+  local label="$1" want="$2" out
+  if out=$(run_check); then
+    echo "ERROR: checker accepted $label"
+    exit 1
+  fi
+  if ! printf '%s\n' "$out" | grep -q "$want"; then
+    echo "ERROR: $label failed for the wrong reason (wanted /$want/)"
+    printf '%s\n' "$out" | sed 's/^/    /'
+    exit 1
+  fi
+}
+
+printf '%s\n' "malloc testfixture $REPLACEMENT 1 # real case" > "$COVERAGE"
+expect_ok "a mapping naming a real case"
+
+printf '%s\n' "malloc testfixture $REPLACEMENT # no case field" > "$COVERAGE"
+expect_reason "a mapping with no case anchor" "expected 4 fields"
+
+printf '%s\n' "malloc testfixture $REPLACEMENT 99 # no such case" > "$COVERAGE"
+expect_reason "a case absent from the replacement" "does not exist"
+
+# An anchor matching several candidates points nowhere in particular. "Crash"
+# appears in most of the scenario banners in crash_injection_test.sh.
+printf '%s\n' 'malloc workflow-script crash_injection_test.sh Crash # ambiguous' \
+  > "$COVERAGE"
+expect_reason "an ambiguous case anchor" "is ambiguous"
+
+printf '%s\n' 'malloc testfixture doltlite_recover_nonexistent 1 # gone' \
+  > "$COVERAGE"
+expect_reason "a replacement file that does not exist" "missing testfixture"
+
+printf '%s\n' "malloc unknown-kind $REPLACEMENT 1 # bad kind" > "$COVERAGE"
+expect_reason "an unknown coverage kind" "unknown coverage kind"
+
+printf '%s\n' \
+  "malloc testfixture $REPLACEMENT 1 # dup" \
+  "malloc testfixture $REPLACEMENT 1 # dup" > "$COVERAGE"
+expect_reason "a duplicate mapping" "duplicate coverage mappings"
+
+: > "$COVERAGE"
+expect_reason "an excluded crash test with no coverage" \
+  "without replacement coverage"
+
+printf '%s\n' \
+  "malloc testfixture $REPLACEMENT 1 # real" \
+  "notacrash testfixture $REPLACEMENT 2 # stale" > "$COVERAGE"
+expect_reason "a mapping for a test that is not an unbucketed crash" \
+  "not unbucketed crashes"
+
+# A replacement that exists but is not gated proves nothing.
+printf '%s\n' 'somethingelse' > "$BUCKETS/bucket.txt"
+printf '%s\n' "malloc testfixture $REPLACEMENT 1 # ungated" > "$COVERAGE"
+expect_reason "a replacement outside every regression bucket" \
+  "not in a regression bucket"
+
+echo "OK: testfixture crash coverage checker self-test"

--- a/test/check_testfixture_exception_inventory.sh
+++ b/test/check_testfixture_exception_inventory.sh
@@ -130,11 +130,27 @@ if [ ! -f "$RATCHET_FILE" ]; then
   exit 1
 fi
 
+# Exactly one line per name. Printing every match let a duplicated name yield a
+# multiline value that then failed every numeric comparison without recording a
+# failure, so the ratchet reported that it held while enforcing nothing.
 ratchet_for() {
   awk -v want="$1" '
-    { sub(/#.*/, ""); if (NF >= 2 && $1 == want) { print $2; found = 1 } }
-    END { if (!found) print "missing" }
+    { sub(/#.*/, ""); if (NF >= 2 && $1 == want) { value = $2; n++ } }
+    END {
+      if (n == 0) { print "missing"; exit }
+      if (n > 1) { print "duplicate"; exit }
+      print value
+    }
   ' "$RATCHET_FILE"
+}
+
+# Whole-string test. grep -E '^[0-9]+$' matches line by line, so it accepts a
+# multiline value on the strength of its first line.
+is_count() {
+  case "$1" in
+    '' | *[!0-9]*) return 1 ;;
+    *) return 0 ;;
+  esac
 }
 
 RATCHET_FAIL=0
@@ -144,7 +160,10 @@ check_ratchet() {
   if [ "$baseline" = "missing" ]; then
     echo "ERROR: ratchet baseline has no '$name' line"
     RATCHET_FAIL=1
-  elif ! printf '%s' "$baseline" | grep -qE '^[0-9]+$'; then
+  elif [ "$baseline" = "duplicate" ]; then
+    echo "ERROR: ratchet baseline lists '$name' more than once"
+    RATCHET_FAIL=1
+  elif ! is_count "$baseline"; then
     echo "ERROR: ratchet baseline for '$name' is not a number: $baseline"
     RATCHET_FAIL=1
   elif [ "$actual" -gt "$baseline" ]; then

--- a/test/check_testfixture_exception_inventory_test.sh
+++ b/test/check_testfixture_exception_inventory_test.sh
@@ -18,6 +18,9 @@ printf '%s\n' \
   'gamma # exits before the summary' > "$CRASHES"
 
 RATCHET="$TMP_DIR/ratchet"
+RATCHET_SEED="$TMP_DIR/ratchet-seed"
+printf '%s\n' 'gates 3' 'intentional 1' 'unsupported 1' 'harness 1' \
+  'engine-gap 0' > "$RATCHET_SEED"
 
 # Baseline matching the 3-gate fixture below, so ratchet cases can move it
 # without disturbing the format cases.
@@ -145,5 +148,18 @@ expect_failure "an empty ratchet baseline"
 printf '%s\n' 'gates lots' 'intentional 1' 'unsupported 1' 'harness 1' \
   'engine-gap 0' > "$RATCHET"
 expect_failure "a non-numeric ratchet baseline"
+
+# A name listed twice used to yield a multiline value that failed every numeric
+# comparison without recording a failure, so the ratchet reported holding while
+# enforcing nothing. Each duplicated name is covered because the guard is in the
+# shared lookup, and a per-name typo would slip past a single case.
+for dup in gates intentional unsupported harness engine-gap; do
+  {
+    printf '%s\n' 'gates 3' 'intentional 1' 'unsupported 1' 'harness 1' \
+      'engine-gap 0'
+    grep -E "^$dup " "$RATCHET_SEED"
+  } > "$RATCHET"
+  expect_failure "a ratchet baseline listing '$dup' twice"
+done
 
 echo "OK: testfixture exception inventory checker self-test"

--- a/test/known_testfixture_crash_coverage.txt
+++ b/test/known_testfixture_crash_coverage.txt
@@ -1,19 +1,28 @@
 # Deterministic coverage for crash-listed testfixture files that cannot run in
 # a regression bucket. Format:
 #
-#   <excluded-test> <testfixture|c-test|workflow-script> <replacement>
+#   <excluded-test> <testfixture|c-test|workflow-script> <replacement> <case>
 #
 # Multiple replacements may cover distinct behavior from one excluded file.
+#
+# <case> anchors the mapping to the specific case inside the replacement, so
+# naming a file that no longer covers the behavior fails instead of passing on
+# the strength of its name. The checker resolves it to a line and prints
+# file:line; it must match exactly one case, and it is resolved rather than
+# pinned so that editing a replacement above the case does not invalidate it.
+# Resolution per kind: `do_*test <case>` for testfixture, a function definition
+# or kOps[] entry for c-test, a `--- ... ---` section or function for
+# workflow-script.
 
-backup_ioerr testfixture doltlite_recover_backup_fault # backup/restore OOM and persistent I/O errors
-corrupt4 c-test corruption_test # malformed chunk data, metadata, indexes, and truncated writes
-crash8 workflow-script crash_injection_test.sh # first and later commit crash durability
-ioerr2 testfixture doltlite_recover_shared_ioerr # persistent I/O errors preserve writer and peer state
-malloc testfixture doltlite_recover_savepointfault # OOM during savepoint rollback and release
-malloc c-test oom_dolt_fault_test # fork-isolated OOM sweeps over Dolt operations
-malloc3 testfixture doltlite_recover_postcommit_oom # OOM result agrees with durable statement state
-malloc3 c-test oom_dolt_fault_test # prepare, execute, and version-control allocation failures
-pagerfault testfixture doltlite_recover_cacheflush_oom # OOM during dirty-cache flush and merged scans
-pagerfault testfixture doltlite_recover_savepointfault # OOM while restoring transaction state
-pagerfault2 testfixture doltlite_recover_cacheflush_oom # large dirty-state OOM and rollback integrity
-pagerfault2 testfixture doltlite_recover_postcommit_oom # durable state remains consistent after OOM
+backup_ioerr testfixture doltlite_recover_backup_fault 1.1 # backup/restore OOM and persistent I/O errors
+corrupt4 c-test corruption_test test_corrupt_chunk_data # malformed chunk data, metadata, indexes, and truncated writes
+crash8 workflow-script crash_injection_test.sh 1 # first and later commit crash durability
+ioerr2 testfixture doltlite_recover_shared_ioerr 1.1 # persistent I/O errors preserve writer and peer state
+malloc testfixture doltlite_recover_savepointfault 1 # OOM during savepoint rollback and release
+malloc c-test oom_dolt_fault_test dolt_commit # fork-isolated OOM sweeps over Dolt operations
+malloc3 testfixture doltlite_recover_postcommit_oom 1.1 # OOM result agrees with durable statement state
+malloc3 c-test oom_dolt_fault_test savepoint_vc_state # prepare, execute, and version-control allocation failures
+pagerfault testfixture doltlite_recover_cacheflush_oom 1.1 # OOM during dirty-cache flush and merged scans
+pagerfault testfixture doltlite_recover_savepointfault 2 # OOM while restoring transaction state
+pagerfault2 testfixture doltlite_recover_cacheflush_oom 1.2 # large dirty-state OOM and rollback integrity
+pagerfault2 testfixture doltlite_recover_postcommit_oom 1.1 # durable state remains consistent after OOM


### PR DESCRIPTION
Two things: the recovery-test locator you asked for, plus ito's duplicate-ratchet finding against the now-merged #1841.

## 1. Crash-coverage mappings point at a case, not just a file

`known_testfixture_crash_coverage.txt` named the replacement for an excluded crash-listed file but nothing inside it. A reader had to know the path convention to find the coverage, and a mapping kept passing on the strength of the file's *name* even if the case it claimed had been renamed or deleted.

A `<case>` field now anchors each mapping, and the checker resolves it to a line:

```
backup_ioerr -> test/doltlite_recover_backup_fault.test:51 (do_test 1.1 {)
corrupt4     -> test/corruption_test.c:391 (static void test_corrupt_chunk_data(void){)
crash8       -> test/crash_injection_test.sh:42 (echo "--- Scenario 1: Crash during first commit ---")
malloc       -> test/doltlite_recover_savepointfault.test:8 (do_malloc_test 1 -sqlprep {)
malloc       -> test/oom_dolt_fault_test.c:408 ({ "dolt_commit", opCommit, 0,)
pagerfault   -> test/doltlite_recover_savepointfault.test:20 (do_malloc_test 2 -sqlprep {)
```

**Resolved rather than pinned.** A literal `file:51` rots whenever a replacement is edited above the case, and a wrong-but-in-range number can't be detected at all. The anchor survives unrelated edits and fails exactly when the named case stops existing — the risk worth catching. It must match exactly one candidate, since an ambiguous anchor points nowhere in particular, and candidates are restricted per kind so a weak name like a bare test number can't collide with ordinary content.

Note the two `pagerfault`/`malloc` rows that both map to `doltlite_recover_savepointfault` now resolve to **different lines** (8 and 20), which is the mapping's "distinct behavior from one excluded file" case finally being visible.

The two `oom_dolt_fault_test` rows anchor to `kOps[]` entries, since that file drives cases from a table rather than per-case functions.

### The self-test found a bug in my own checker

This checker had no self-test. Adding one immediately found that an **unresolvable anchor tripped `set -e` through the resolve pipeline under `pipefail`**, killing the script before it could print its own diagnostic — exit 1 with no output. The failure was real but the reason was invisible, and any wrong-anchor mapping would have looked like an unrelated breakage.

Worth calling out: my first version of the self-test asserted only on exit codes and **passed against that bug**. Cases now assert on the reported reason. I verified the finished self-test rejects the original buggy shape.

That also caught a second mistake — my "ambiguous anchor" fixture used `-sqlprep`, which never matched at all, so it was failing as "does not exist". The real ambiguity case uses `Crash` against the scenario banners in `crash_injection_test.sh` (lines 42, 88).

## 2. Duplicate ratchet baselines were accepted — ito's finding

Confirmed exactly as reported:

```
OK: 3 testfixture gates classified (...)
test/check_testfixture_exception_inventory.sh: line 150: [: 3
3: integer expression expected
test/check_testfixture_exception_inventory.sh: line 155: [: 3
3: integer expression expected
OK: testfixture exception ratchet holds
exit=0
```

`ratchet_for` printed *every* matching line, so a name listed twice produced a multiline value. It passed the `missing` check; then passed my numeric guard, because `grep -E '^[0-9]+$'` matches **line by line** and the first line was a number; then failed both `[ -gt ]` and `[ -lt ]` with "integer expression expected" — neither of which records a failure. The ratchet reported holding while enforcing nothing.

Fix: require exactly one line per name, and test the value as a whole string (`case`) rather than with a line-wise grep, so a multiline value can't satisfy it either way. Both halves matter — the grep flaw was the reason my existing non-numeric guard didn't already catch this.

Self-test covers **each of the five names** duplicated, not just one, since the guard lives in the shared lookup and a per-name typo would slip past a single case. All five report `lists '<name>' more than once`, and the self-test rejects the pre-fix checker.

## Verification

All six checks green locally:

```
check_testfixture_crash_coverage                   OK
check_testfixture_crash_coverage_test              OK
check_testfixture_exception_inventory              OK
check_testfixture_exception_inventory_test         OK
check_testfixture_inventory_issues_alive           OK
check_testfixture_inventory_issues_alive_test      OK
```

`check_testfixture_crash_coverage_test.sh` is wired into the same `sqlite-regression` step as the checker it covers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)