### PR TITLE
fix: PRAGMA writable_schema works in default CLI

### DIFF
--- a/src/shell.c.in
+++ b/src/shell.c.in
@@ -5304,7 +5304,21 @@ static void open_db(ShellState *p, int openFlags){
     {
       int testmode_on = ShellHasFlag(p,SHFLG_TestingMode);
       sqlite3_db_config(p->db, SQLITE_DBCONFIG_TRUSTED_SCHEMA, testmode_on,0);
+#ifdef DOLTLITE_PROLLY
+      /* Upstream shell turns DEFENSIVE on unless --unsafe-testing. Under
+      ** defensive mode, PRAGMA writable_schema=ON is a silent no-op (the
+      ** WriteSchema bit cannot be set), so the CLI always reports 0 and
+      ** looks broken next to stock sqlite3 CLIs that leave defensive off.
+      ** Keep defensive off by default; --safe and `.dbconfig defensive on`
+      ** still enable it, and --unsafe-testing still forces it off. */
+      if( testmode_on ){
+        sqlite3_db_config(p->db, SQLITE_DBCONFIG_DEFENSIVE, 0, 0);
+      }else if( p->bSafeModePersist ){
+        sqlite3_db_config(p->db, SQLITE_DBCONFIG_DEFENSIVE, 1, 0);
+      }
+#else
       sqlite3_db_config(p->db, SQLITE_DBCONFIG_DEFENSIVE, !testmode_on,0);
+#endif
     }
 
 #ifndef SQLITE_OMIT_LOAD_EXTENSION

--- a/test/doltlite_writable_schema.sh
+++ b/test/doltlite_writable_schema.sh
@@ -4,6 +4,20 @@
 echo "=== Doltlite writable_schema catalog poke tests ==="
 echo ""
 
+# Default CLI must honor PRAGMA writable_schema without a prior
+# `.dbconfig defensive off` (see issue #1846 — not a prolly no-op).
+DB=/tmp/test_dl_writable_schema_pragma_$$.db; rm -f "$DB"
+run_test "writable_schema_default_off" \
+  "PRAGMA writable_schema;" \
+  "0" "$DB"
+run_test "writable_schema_on_roundtrip" \
+  "PRAGMA writable_schema=ON; PRAGMA writable_schema;" \
+  "1" "$DB"
+run_test "writable_schema_off_roundtrip" \
+  "PRAGMA writable_schema=ON; PRAGMA writable_schema=OFF; PRAGMA writable_schema;" \
+  "0" "$DB"
+rm -f "$DB"
+
 DB=/tmp/test_dl_writable_schema_root_$$.db; rm -f "$DB"
 cat <<'SQL' | "$DOLTLITE" "$DB" >/dev/null
 CREATE TABLE t1(oid INTEGER PRIMARY KEY, a INT);


### PR DESCRIPTION
## Summary

`PRAGMA writable_schema=ON` always left the flag at **0** in the default `doltlite` CLI. That is **not** a prolly/pager no-op (unlike `journal_mode` / `auto_vacuum` in #1846).

**Root cause:** `open_db()` forced `SQLITE_DBCONFIG_DEFENSIVE` on unless `--unsafe-testing`. Under defensive mode, SQLite intentionally ignores `PRAGMA writable_schema=ON`, so the CLI looked broken next to stock sqlite3 (which leaves defensive off).

**Fix:** For `DOLTLITE_PROLLY` builds, leave defensive **off** by default. Still:
- `--safe` → defensive on
- `--unsafe-testing` → defensive off
- `.dbconfig defensive on|off` still works

Library C API was already fine (defensive off at `sqlite3_open`).

## Test plan

- [x] `bash test/doltlite_writable_schema.sh ./doltlite` → 6 passed (includes new default round-trip cases)
- [x] CLI: `PRAGMA writable_schema=ON` → reports `1` without prior `.dbconfig defensive off`