### PR TITLE
Make linear rebase publish atomically

### DIFF
--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -1147,6 +1147,7 @@ int doltliteSaveWorkingSet(sqlite3 *db);
 int doltlitePersistWorkingSet(sqlite3 *db);
 int doltliteSaveWorkingSetWithHash(sqlite3 *db, const ProllyHash *pWorkingCatHash);
 int doltlitePersistWorkingSetWithHash(sqlite3 *db, const ProllyHash *pWorkingCatHash);
+void doltliteAdoptRollbackBaseline(sqlite3 *db, const ProllyHash *pCatalogHash);
 int doltliteLoadWorkingSet(sqlite3 *db, const char *zBranch);
 int doltliteGetPersistedWorkingCatalogHash(sqlite3 *db, ProllyHash *pCatHash);
 int doltliteCheckoutBranchForRebase(sqlite3 *db, const char *zBranch);

--- a/src/doltlite_rebase.c
+++ b/src/doltlite_rebase.c
@@ -18,6 +18,72 @@
 #include <ctype.h>
 #include <time.h>
 
+typedef struct RebaseFinalizeRefsCtx RebaseFinalizeRefsCtx;
+struct RebaseFinalizeRefsCtx {
+  const char *zOrigBranch;
+  const char *zWorkingBranch;
+  const ProllyHash *pExpectedOrigHead;
+  const ProllyHash *pCurHead;
+  const ProllyHash *pCurCat;
+};
+
+typedef struct RebaseCreateRefsCtx RebaseCreateRefsCtx;
+struct RebaseCreateRefsCtx {
+  const char *zWorkingBranch;
+  const ProllyHash *pHead;
+  const ProllyHash *pCatalog;
+};
+
+typedef struct RebaseAbortRefsCtx RebaseAbortRefsCtx;
+struct RebaseAbortRefsCtx {
+  const char *zOrigBranch;
+  const char *zWorkingBranch;
+  const ProllyHash *pExpectedOrigHead;
+  const ProllyHash *pOrigCatalog;
+};
+
+static char *rebaseBuildWorkingBranchName(const char *zOrigBranch);
+static int rebaseRestoreBranchState(sqlite3 *db, const char *zBranch);
+static int rebaseFinalizeContinueRefs(sqlite3*, ChunkStore*, void*);
+static int rebaseFinalizeLinearRefs(sqlite3*, ChunkStore*, void*);
+static int rebaseDeleteWorkingBranchRefs(sqlite3*, ChunkStore*, void*);
+
+static int rebaseCreateWorkingBranchRefs(
+  sqlite3 *db,
+  ChunkStore *cs,
+  void *pArg
+){
+  RebaseCreateRefsCtx *p = (RebaseCreateRefsCtx*)pArg;
+  ProllyHash probe;
+  int rc;
+  rc = chunkStoreFindBranch(cs, p->zWorkingBranch, &probe);
+  if( rc==SQLITE_OK ) return SQLITE_CONSTRAINT;
+  if( rc!=SQLITE_NOTFOUND ) return rc;
+  rc = chunkStoreAddBranch(cs, p->zWorkingBranch, p->pHead);
+  if( rc!=SQLITE_OK ) return rc;
+  return doltliteWriteBranchCleanWorkingState(
+      db, p->zWorkingBranch, p->pCatalog, p->pHead);
+}
+
+static int rebaseAbortLinearRefs(
+  sqlite3 *db,
+  ChunkStore *cs,
+  void *pArg
+){
+  RebaseAbortRefsCtx *p = (RebaseAbortRefsCtx*)pArg;
+  ProllyHash origHead;
+  int rc;
+  rc = chunkStoreFindBranch(cs, p->zOrigBranch, &origHead);
+  if( rc!=SQLITE_OK ) return rc;
+  if( prollyHashCompare(&origHead, p->pExpectedOrigHead)==0 ){
+    rc = doltliteWriteBranchCleanWorkingState(
+        db, p->zOrigBranch, p->pOrigCatalog, p->pExpectedOrigHead);
+    if( rc!=SQLITE_OK ) return rc;
+  }
+  rc = chunkStoreDeleteBranch(cs, p->zWorkingBranch);
+  return rc==SQLITE_NOTFOUND ? SQLITE_OK : rc;
+}
+
 static int rebaseRestoreReturnBranchWorkingState(
   sqlite3 *db,
   const char *zBranch
@@ -169,6 +235,32 @@ cleanup:
   return rc;
 }
 
+static int rebaseSwitchToWorkingBranch(sqlite3 *db, const char *zBranch){
+  ChunkStore *cs = doltliteGetChunkStore(db);
+  DoltliteCommit c;
+  ProllyHash headHash;
+  ProllyHash emptyHash;
+  int rc;
+
+  if( !cs || !zBranch || !zBranch[0] ) return SQLITE_ERROR;
+  rc = chunkStoreFindBranch(cs, zBranch, &headHash);
+  if( rc!=SQLITE_OK ) return rc;
+  memset(&c, 0, sizeof(c));
+  rc = doltliteLoadCommit(db, &headHash, &c);
+  if( rc!=SQLITE_OK ) return rc;
+  rc = doltliteSetSessionBranch(db, zBranch);
+  if( rc==SQLITE_OK ) doltliteSetSessionHead(db, &headHash);
+  if( rc==SQLITE_OK ) rc = doltliteSetSessionStaged(db, &c.catalogHash);
+  if( rc==SQLITE_OK ) rc = doltliteSwitchCatalog(db, &c.catalogHash);
+  if( rc==SQLITE_OK ) rc = doltliteClearSessionMergeState(db);
+  memset(&emptyHash, 0, sizeof(emptyHash));
+  if( rc==SQLITE_OK ){
+    rc = doltliteSetSessionConstraintViolationsCatalog(db, &emptyHash);
+  }
+  doltliteCommitClear(&c);
+  return rc;
+}
+
 static int doltliteRebaseLinearReplay(
   sqlite3 *db,
   sqlite3_context *context,
@@ -178,11 +270,20 @@ static int doltliteRebaseLinearReplay(
   ChunkStore *cs;
   int sealTopLevel;
   ProllyHash upstreamHash, headHash;
+  ProllyHash lockedHead;
+  ProllyHash curHead, curCat;
+  ProllyHash origCat;
   ProllyHash *aReplay = 0;
   int nReplay = 0;
-  DoltliteTxnState saved;
   DoltliteCommit upstreamCommit;
-  int savedInit = 0;
+  DoltliteCommit origCommit;
+  DoltliteCommit finalCommit;
+  RebaseCreateRefsCtx createCtx;
+  RebaseAbortRefsCtx abortCtx;
+  RebaseFinalizeRefsCtx refsCtx;
+  char *zOrig = 0;
+  char *zWorking = 0;
+  int workingCreated = 0;
   int graphLocked = 0;
   int rc;
   int i;
@@ -194,8 +295,13 @@ static int doltliteRebaseLinearReplay(
   sealTopLevel = db->pSavepoint!=0 && db->nSavepoint==0;
 
   *pzFinalMessage = 0;
-  memset(&saved, 0, sizeof(saved));
   memset(&upstreamCommit, 0, sizeof(upstreamCommit));
+  memset(&origCommit, 0, sizeof(origCommit));
+  memset(&finalCommit, 0, sizeof(finalCommit));
+  memset(&curHead, 0, sizeof(curHead));
+  memset(&curCat, 0, sizeof(curCat));
+  memset(&origCat, 0, sizeof(origCat));
+  memset(&lockedHead, 0, sizeof(lockedHead));
 
   rc = doltliteHasUncommittedChanges(db, &dirty);
   if( rc!=SQLITE_OK ){
@@ -210,11 +316,23 @@ static int doltliteRebaseLinearReplay(
     return SQLITE_ERROR;
   }
 
+  zOrig = sqlite3_mprintf("%s", doltliteGetSessionBranch(db));
+  zWorking = rebaseBuildWorkingBranchName(zOrig);
+  if( !zOrig || !zWorking ){
+    sqlite3_free(zOrig);
+    sqlite3_free(zWorking);
+    sqlite3_result_error_code(context, SQLITE_NOMEM);
+    if( sealTopLevel ) (void)doltliteVcSealTopLevelSavepointTxn(db);
+    return SQLITE_NOMEM;
+  }
+
   rc = doltliteResolveRef(db, zUpstream, &upstreamHash);
   if( rc!=SQLITE_OK ){
     char *zErr = sqlite3_mprintf("branch not found: %s", zUpstream);
     sqlite3_result_error(context, zErr ? zErr : "branch not found", -1);
     sqlite3_free(zErr);
+    sqlite3_free(zOrig);
+    sqlite3_free(zWorking);
     if( sealTopLevel ) (void)doltliteVcSealTopLevelSavepointTxn(db);
     return SQLITE_ERROR;
   }
@@ -222,6 +340,8 @@ static int doltliteRebaseLinearReplay(
   doltliteGetSessionHead(db, &headHash);
   if( prollyHashIsEmpty(&headHash) ){
     sqlite3_result_error(context, "no commits on current branch", -1);
+    sqlite3_free(zOrig);
+    sqlite3_free(zWorking);
     if( sealTopLevel ) (void)doltliteVcSealTopLevelSavepointTxn(db);
     return SQLITE_ERROR;
   }
@@ -229,50 +349,50 @@ static int doltliteRebaseLinearReplay(
   rc = doltliteRebaseCollectReplaySet(db, &headHash, &upstreamHash,
                                       &aReplay, &nReplay);
   if( rc!=SQLITE_OK ){
+    sqlite3_free(zOrig);
+    sqlite3_free(zWorking);
     sqlite3_result_error_code(context, rc);
     if( sealTopLevel ) (void)doltliteVcSealTopLevelSavepointTxn(db);
     return rc;
   }
   if( nReplay==0 ){
     sqlite3_free(aReplay);
+    sqlite3_free(zOrig);
+    sqlite3_free(zWorking);
     sqlite3_result_error(context, "didn't identify any commits!", -1);
     if( sealTopLevel ) (void)doltliteVcSealTopLevelSavepointTxn(db);
     return SQLITE_ERROR;
   }
 
-  rc = doltliteSaveTxnState(db, &saved);
-  if( rc!=SQLITE_OK ){
-    sqlite3_free(aReplay);
-    sqlite3_result_error_code(context, rc);
-    if( sealTopLevel ) (void)doltliteVcSealTopLevelSavepointTxn(db);
-    return rc;
-  }
-  savedInit = 1;
-
+  rc = doltliteLoadCommit(db, &headHash, &origCommit);
+  if( rc!=SQLITE_OK ) goto rollback;
+  origCat = origCommit.catalogHash;
   rc = doltliteLoadCommit(db, &upstreamHash, &upstreamCommit);
   if( rc!=SQLITE_OK ) goto rollback;
 
-  rc = doltliteSwitchCatalog(db, &upstreamCommit.catalogHash);
-  if( rc!=SQLITE_OK ){
-    doltliteCommitClear(&upstreamCommit);
+  rc = chunkStoreLockAndRefresh(cs);
+  if( rc!=SQLITE_OK ) goto rollback;
+  graphLocked = 1;
+  rc = chunkStoreForceRefresh(cs);
+  if( rc!=SQLITE_OK ) goto rollback;
+  rc = chunkStoreFindBranch(cs, zOrig, &lockedHead);
+  if( rc!=SQLITE_OK ) goto rollback;
+  if( prollyHashCompare(&lockedHead, &headHash)!=0 ){
+    rc = SQLITE_BUSY;
     goto rollback;
   }
-  doltliteSetSessionHead(db, &upstreamHash);
-  rc = doltliteSetSessionStaged(db, &upstreamCommit.catalogHash);
-  if( rc==SQLITE_OK ){
-    rc = doltliteRefreshAndConfirmHead(db, cs, &headHash);
-    if( rc==SQLITE_OK ) graphLocked = 1;
-  }
-  if( rc==SQLITE_OK ){
-    rc = doltliteAdvanceBranch(
-        db, &upstreamHash, &upstreamCommit.catalogHash, 0);
-  }
-  if( graphLocked ){
-    chunkStoreUnlock(cs);
-    graphLocked = 0;
-  }
+
+  memset(&createCtx, 0, sizeof(createCtx));
+  createCtx.zWorkingBranch = zWorking;
+  createCtx.pHead = &upstreamHash;
+  createCtx.pCatalog = &upstreamCommit.catalogHash;
+  rc = doltliteMutateRefs(db, rebaseCreateWorkingBranchRefs, &createCtx);
+  if( rc==SQLITE_OK ) workingCreated = 1;
   doltliteCommitClear(&upstreamCommit);
   memset(&upstreamCommit, 0, sizeof(upstreamCommit));
+  if( rc!=SQLITE_OK ) goto rollback;
+
+  rc = rebaseSwitchToWorkingBranch(db, zWorking);
   if( rc!=SQLITE_OK ) goto rollback;
 
   for(i=0; i<nReplay; i++){
@@ -327,20 +447,56 @@ static int doltliteRebaseLinearReplay(
     if( nConflicts>0 ){ bConflict = 1; rc = SQLITE_ERROR; goto rollback; }
   }
 
-  doltliteTxnStateClear(&saved);
+  doltliteGetSessionHead(db, &curHead);
+  rc = doltliteLoadCommit(db, &curHead, &finalCommit);
+  if( rc!=SQLITE_OK ) goto rollback;
+  curCat = finalCommit.catalogHash;
+  doltliteCommitClear(&finalCommit);
+  memset(&finalCommit, 0, sizeof(finalCommit));
+
+  memset(&refsCtx, 0, sizeof(refsCtx));
+  refsCtx.zOrigBranch = zOrig;
+  refsCtx.zWorkingBranch = zWorking;
+  refsCtx.pExpectedOrigHead = &headHash;
+  refsCtx.pCurHead = &curHead;
+  refsCtx.pCurCat = &curCat;
+  rc = doltliteMutateRefs(db, rebaseFinalizeLinearRefs, &refsCtx);
+  if( rc!=SQLITE_OK ) goto rollback;
+  workingCreated = 0;
+
+  rc = rebaseRestoreBranchState(db, zOrig);
+  if( rc!=SQLITE_OK ) goto rollback;
+
+  chunkStoreUnlock(cs);
+  graphLocked = 0;
+  doltliteCommitClear(&origCommit);
   sqlite3_free(aReplay);
   sqlite3_free(zFailedMsg);
   *pzFinalMessage = sqlite3_mprintf(
     "Successfully rebased and updated refs/heads/%s",
-    doltliteGetSessionBranch(db));
+    zOrig);
+  sqlite3_free(zOrig);
+  sqlite3_free(zWorking);
   return SQLITE_OK;
 
 rollback:
-  if( graphLocked ) chunkStoreUnlock(cs);
-  if( savedInit ){
-    (void)doltliteRestoreTxnStateOnFailure(db, &saved, rc);
+  doltliteCommitClear(&upstreamCommit);
+  doltliteCommitClear(&finalCommit);
+  if( workingCreated ){
+    memset(&abortCtx, 0, sizeof(abortCtx));
+    abortCtx.zOrigBranch = zOrig;
+    abortCtx.zWorkingBranch = zWorking;
+    abortCtx.pExpectedOrigHead = &headHash;
+    abortCtx.pOrigCatalog = &origCommit.catalogHash;
+    (void)doltliteMutateRefs(db, rebaseAbortLinearRefs, &abortCtx);
   }
-  (void)cs;
+  doltliteCommitClear(&origCommit);
+  if( rebaseRestoreBranchState(db, zOrig)==SQLITE_OK ){
+    if( workingCreated && db->autoCommit && !prollyHashIsEmpty(&origCat) ){
+      doltliteAdoptRollbackBaseline(db, &origCat);
+    }
+  }
+  if( graphLocked ) chunkStoreUnlock(cs);
   sqlite3_free(aReplay);
   {
     char *zErr;
@@ -364,6 +520,8 @@ rollback:
     }
   }
   sqlite3_free(zFailedMsg);
+  sqlite3_free(zOrig);
+  sqlite3_free(zWorking);
   if( sealTopLevel ) (void)doltliteVcSealTopLevelSavepointTxn(db);
   return SQLITE_ERROR;
 }
@@ -777,20 +935,10 @@ static int rebaseReplayPlanGroup(
   return SQLITE_OK;
 }
 
-typedef struct RebaseFinalizeRefsCtx RebaseFinalizeRefsCtx;
-struct RebaseFinalizeRefsCtx {
-  const char *zOrigBranch;
-  const char *zWorkingBranch;
-  const ProllyHash *pExpectedOrigHead;
-  const ProllyHash *pCurHead;
-  const ProllyHash *pCurCat;
-};
-
 static int rebaseFinalizeContinueRefs(sqlite3 *db, ChunkStore *cs, void *pArg){
   RebaseFinalizeRefsCtx *p = (RebaseFinalizeRefsCtx*)pArg;
   ProllyHash origHead;
   int rc;
-  UNUSED_PARAMETER(db);
   rc = chunkStoreFindBranch(cs, p->zOrigBranch, &origHead);
   if( rc!=SQLITE_OK ) return rc;
   if( prollyHashCompare(&origHead, p->pExpectedOrigHead)!=0 ){
@@ -798,16 +946,27 @@ static int rebaseFinalizeContinueRefs(sqlite3 *db, ChunkStore *cs, void *pArg){
   }
   rc = chunkStoreUpdateBranch(cs, p->zOrigBranch, p->pCurHead);
   if( rc!=SQLITE_OK ) return rc;
-  rc = chunkStoreWriteBranchWorkingCatalog(cs, p->zOrigBranch,
-                                           p->pCurCat, p->pCurHead);
+  rc = doltliteWriteBranchCleanWorkingState(
+      db, p->zOrigBranch, p->pCurCat, p->pCurHead);
   if( rc!=SQLITE_OK ) return rc;
   return SQLITE_OK;
 }
 
+static int rebaseFinalizeLinearRefs(sqlite3 *db, ChunkStore *cs, void *pArg){
+  RebaseFinalizeRefsCtx *p = (RebaseFinalizeRefsCtx*)pArg;
+  int rc;
+  rc = rebaseFinalizeContinueRefs(db, cs, pArg);
+  if( rc!=SQLITE_OK ) return rc;
+  rc = chunkStoreDeleteBranch(cs, p->zWorkingBranch);
+  return rc==SQLITE_NOTFOUND ? SQLITE_OK : rc;
+}
+
 static int rebaseDeleteWorkingBranchRefs(sqlite3 *db, ChunkStore *cs, void *pArg){
   const char *zWorkingBranch = (const char*)pArg;
+  int rc;
   UNUSED_PARAMETER(db);
-  return chunkStoreDeleteBranch(cs, zWorkingBranch);
+  rc = chunkStoreDeleteBranch(cs, zWorkingBranch);
+  return rc==SQLITE_NOTFOUND ? SQLITE_OK : rc;
 }
 
 static void rebaseKeepFirstError(int *pRc, int rc){

--- a/src/prolly_btree_state.c
+++ b/src/prolly_btree_state.c
@@ -992,6 +992,17 @@ int doltlitePersistWorkingSet(sqlite3 *db){
   return doltlitePersistWorkingSetWithHash(db, 0);
 }
 
+void doltliteAdoptRollbackBaseline(
+  sqlite3 *db,
+  const ProllyHash *pCatalogHash
+){
+  Btree *pBtree;
+  if( !db || db->nDb<=0 || !pCatalogHash ) return;
+  pBtree = db->aDb[0].pBt;
+  if( !pBtree ) return;
+  btreeStoreCommittedFromCurrent(pBtree, pCatalogHash);
+}
+
 int doltliteGetPersistedWorkingCatalogHash(sqlite3 *db, ProllyHash *pCatHash){
   ChunkStore *cs = doltliteGetChunkStore(db);
   Btree *pBtree;

--- a/test/oom_dolt_fault_test.c
+++ b/test/oom_dolt_fault_test.c
@@ -304,6 +304,37 @@ static int opThreeWayMerge(sqlite3 *db){
   return execSilent(db, "SELECT dolt_merge('feat')");
 }
 
+static int setupLinearRebase(sqlite3 *db){
+  int rc;
+  rc = execSilent(db, "SELECT dolt_checkout('-b','feat')");
+  if( rc ) return rc;
+  rc = execSilent(db, "INSERT INTO t VALUES(4,'feat-one')");
+  if( rc ) return rc;
+  rc = execSilent(db, "SELECT dolt_add('-A')");
+  if( rc ) return rc;
+  rc = execSilent(db, "SELECT dolt_commit('-m','feat-one')");
+  if( rc ) return rc;
+  rc = execSilent(db, "INSERT INTO t VALUES(6,'feat-two')");
+  if( rc ) return rc;
+  rc = execSilent(db, "SELECT dolt_add('-A')");
+  if( rc ) return rc;
+  rc = execSilent(db, "SELECT dolt_commit('-m','feat-two')");
+  if( rc ) return rc;
+  rc = execSilent(db, "SELECT dolt_checkout('main')");
+  if( rc ) return rc;
+  rc = execSilent(db, "INSERT INTO t VALUES(5,'main')");
+  if( rc ) return rc;
+  rc = execSilent(db, "SELECT dolt_add('-A')");
+  if( rc ) return rc;
+  rc = execSilent(db, "SELECT dolt_commit('-m','main')");
+  if( rc ) return rc;
+  return execSilent(db, "SELECT dolt_checkout('feat')");
+}
+
+static int opLinearRebase(sqlite3 *db){
+  return execSilent(db, "SELECT dolt_rebase('main')");
+}
+
 static int opDiffTable(sqlite3 *db){
   int rc = execSilent(db, "INSERT INTO t VALUES(50,'diffed')");
   if( rc ) return rc;
@@ -402,6 +433,10 @@ typedef struct OpEntry {
   const char *zOptionalHeadMessage;
   const char *zOptionalHeadMessage2;
   int allowRebaseState;
+  const char *zActiveBranch;
+  const char *zStateInvariantSql;
+  int iOptionalRow3;
+  const char *zOptionalValue3;
 } OpEntry;
 
 static OpEntry kOps[] = {
@@ -421,6 +456,14 @@ static OpEntry kOps[] = {
   { "dolt_three_way_merge", opThreeWayMerge, setupThreeWayMerge,
     "feat", 10, "main", 20, "feat",
     "Merge branch 'feat' into main", "main-side", 0 },
+  { "dolt_rebase_linear",   opLinearRebase, setupLinearRebase,
+    "feat", 4, "feat-one", 5, "main", "feat-two", 0, 0, "feat",
+    "SELECT "
+      "EXISTS(SELECT 1 FROM t WHERE a=4 AND b='feat-one') AND "
+      "EXISTS(SELECT 1 FROM t WHERE a=6 AND b='feat-two') AND "
+      "((EXISTS(SELECT 1 FROM t WHERE a=5 AND b='main')) OR "
+       "(NOT EXISTS(SELECT 1 FROM t WHERE a=5))) AND "
+      "NOT EXISTS(SELECT 1 FROM dolt_status)", 6, "feat-two" },
   { "dolt_diff_table",     opDiffTable, 0,
     0, 50, "diffed", 0, 0, 0, 0, 0 },
   { "savepoint_vc_state",  opSavepointState, setupSavepointState,
@@ -509,10 +552,25 @@ static int verifyReopenedState(
     return SQLITE_CORRUPT;
   }
 
+  if( op->zActiveBranch ){
+    zSql = sqlite3_mprintf("SELECT dolt_checkout(%Q)", op->zActiveBranch);
+    if( !zSql ){
+      *pzInvariant = "verify branch SQL allocation";
+      return SQLITE_NOMEM;
+    }
+    rc = execSilent(db, zSql);
+    sqlite3_free(zSql);
+    zSql = 0;
+    if( rc!=SQLITE_OK ){
+      *pzInvariant = "verify branch checkout";
+      return rc;
+    }
+  }
+
   VERIFY_INVARIANT("active branch",
       querySingleText(db, "SELECT active_branch()", zText, sizeof(zText)));
-  if( strcmp(zText, "main")!=0 ){
-    *pzInvariant = "active branch is main";
+  if( strcmp(zText, op->zActiveBranch ? op->zActiveBranch : "main")!=0 ){
+    *pzInvariant = "active branch";
     return SQLITE_CORRUPT;
   }
 
@@ -542,12 +600,23 @@ static int verifyReopenedState(
     *pzInvariant = "exactly one main branch";
     return SQLITE_CORRUPT;
   }
-  VERIFY_INVARIANT("HEAD/main equality",
-      querySingleInt(db,
-        "SELECT count(*) FROM dolt_branches "
-        "WHERE name='main' AND hash=dolt_hashof('HEAD')", &n));
+  zSql = sqlite3_mprintf(
+      "SELECT count(*) FROM dolt_branches "
+      "WHERE name=%Q AND hash=dolt_hashof('HEAD')",
+      op->zActiveBranch ? op->zActiveBranch : "main");
+  if( !zSql ){
+    *pzInvariant = "HEAD/branch SQL allocation";
+    return SQLITE_NOMEM;
+  }
+  rc = querySingleInt(db, zSql, &n);
+  sqlite3_free(zSql);
+  zSql = 0;
+  if( rc!=SQLITE_OK ){
+    *pzInvariant = "HEAD/branch equality query";
+    return rc;
+  }
   if( n!=1 ){
-    *pzInvariant = "HEAD equals main";
+    *pzInvariant = "HEAD equals active branch";
     return SQLITE_CORRUPT;
   }
 
@@ -590,7 +659,19 @@ static int verifyReopenedState(
     *pzInvariant = "base working rows preserved";
     return SQLITE_CORRUPT;
   }
-  if( op->iOptionalRow>0 && op->iOptionalRow2>0 ){
+  if( op->iOptionalRow>0 && op->iOptionalRow2>0 && op->iOptionalRow3>0 ){
+    zSql = sqlite3_mprintf(
+        "SELECT count(*) FROM t WHERE NOT ("
+        "(a=1 AND b='one') OR "
+        "(a=2 AND b='two') OR "
+        "(a=3 AND b='three') OR "
+        "(a=%d AND b=%Q) OR "
+        "(a=%d AND b=%Q) OR "
+        "(a=%d AND b=%Q))",
+        op->iOptionalRow, op->zOptionalValue,
+        op->iOptionalRow2, op->zOptionalValue2,
+        op->iOptionalRow3, op->zOptionalValue3);
+  }else if( op->iOptionalRow>0 && op->iOptionalRow2>0 ){
     zSql = sqlite3_mprintf(
         "SELECT count(*) FROM t WHERE NOT ("
         "(a=1 AND b='one') OR "
@@ -625,6 +706,15 @@ static int verifyReopenedState(
   if( rc!=SQLITE_OK || n!=0 ){
     *pzInvariant = "only complete working rows";
     return rc==SQLITE_OK ? SQLITE_CORRUPT : rc;
+  }
+
+  if( op->zStateInvariantSql ){
+    VERIFY_INVARIANT("complete operation state",
+        querySingleInt(db, op->zStateInvariantSql, &n));
+    if( n!=1 ){
+      *pzInvariant = "complete operation state";
+      return SQLITE_CORRUPT;
+    }
   }
 
   rc = sqlite3_prepare_v2(db,
@@ -766,16 +856,36 @@ static int childRunOp(OpEntry *op, long long failAt){
     return CHILD_BUG;
   }
   vrc = verifyReopenedState(verifyDb, op, &zInvariant);
-  crc = sqlite3_close(verifyDb);
-  cleanupFiles(kDbBase);
   if( vrc!=SQLITE_OK ){
+    char zHeadMessage[128] = "";
+    int nRow4 = -1;
+    int nRow5 = -1;
+    int nRow6 = -1;
+    int nStatus = -1;
+    (void)querySingleText(verifyDb,
+        "SELECT message FROM dolt_log LIMIT 1",
+        zHeadMessage, sizeof(zHeadMessage));
+    (void)querySingleInt(verifyDb,
+        "SELECT count(*) FROM t WHERE a=4", &nRow4);
+    (void)querySingleInt(verifyDb,
+        "SELECT count(*) FROM t WHERE a=5", &nRow5);
+    (void)querySingleInt(verifyDb,
+        "SELECT count(*) FROM t WHERE a=6", &nRow6);
+    (void)querySingleInt(verifyDb,
+        "SELECT count(*) FROM dolt_status", &nStatus);
     fprintf(stderr,
         "  BUG[%s,N=%lld]: reopen invariant \"%s\" rc=%d "
-        "after op rc=%d triggered=%lld nCall=%lld\n",
+        "after op rc=%d triggered=%lld nCall=%lld "
+        "head=%s rows=%d/%d/%d status=%d\n",
         op->name, failAt, zInvariant ? zInvariant : "unknown",
-        vrc, orc, triggered, ncall);
+        vrc, orc, triggered, ncall, zHeadMessage,
+        nRow4, nRow5, nRow6, nStatus);
+    sqlite3_close(verifyDb);
+    cleanupFiles(kDbBase);
     return CHILD_BUG;
   }
+  crc = sqlite3_close(verifyDb);
+  cleanupFiles(kDbBase);
   if( crc!=SQLITE_OK ){
     fprintf(stderr,
         "  BUG[%s,N=%lld]: verification close rc=%d after op rc=%d\n",
@@ -793,13 +903,19 @@ static int sweepOp(OpEntry *op){
   int nOk = 0;
   int nErrOk = 0;
   long long nMax = MAX_FAIL_N;
+  long long nStart = 1;
   long long n;
+  const char *zFailAt = getenv("OOM_DOLT_FAIL_AT");
   pid_t pid;
   pid_t r;
   int status;
   fflush(stdout);
   fflush(stderr);
-  for( n=1; n<=nMax; n++ ){
+  if( zFailAt && zFailAt[0] ){
+    nStart = strtoll(zFailAt, 0, 10);
+    nMax = nStart;
+  }
+  for( n=nStart; n<=nMax; n++ ){
     pid = fork();
     if( pid<0 ){
       fprintf(stderr, "  fork failed at N=%lld\n", n);
@@ -833,13 +949,14 @@ static int sweepOp(OpEntry *op){
       }
     }
   }
-  printf("  [%s] swept N=1..%lld, ok=%d, errOk=%d, bugs=%d\n",
-         op->name, n-1, nOk, nErrOk, opBugs);
+  printf("  [%s] swept N=%lld..%lld, ok=%d, errOk=%d, bugs=%d\n",
+         op->name, nStart, n-1, nOk, nErrOk, opBugs);
   fflush(stdout);
   return opBugs;
 }
 
 int main(void){
+  const char *zOnlyOp = getenv("OOM_DOLT_OP");
   int rc = installOomAllocator();
   if( rc!=SQLITE_OK ){
     fprintf(stderr, "Failed to install OOM allocator: rc=%d\n", rc);
@@ -859,6 +976,7 @@ int main(void){
            N_OPS, MAX_FAIL_N);
     for( i=0; i<N_OPS; i++ ){
       int opBugs;
+      if( zOnlyOp && strcmp(zOnlyOp, kOps[i].name)!=0 ) continue;
       printf("[%d/%d] sweeping op: %s\n", i+1, N_OPS, kOps[i].name);
       opBugs = sweepOp(&kOps[i]);
       if( opBugs>0 ){


### PR DESCRIPTION
## Summary

Closes #1844.

Linear rebase no longer advances the real branch to upstream and then publishes each replayed commit one at a time. It now:

- confirms the original HEAD while holding the graph lock
- creates an isolated `dolt_rebase_<branch>` working branch
- replays every commit there
- publishes the final original-branch head and clean working set, and deletes the scratch branch, in one CAS-protected refs mutation
- atomically restores the original clean working state on abort

The abort path also restores the B-tree rollback baseline after switching back to the original catalog. This prevents SQLite autocommit error unwinding from reinstalling the scratch catalog under the unchanged original HEAD.

Interactive rebase retains its existing checkout-then-delete sequence so nested and top-level savepoint behavior is unchanged.

## Regression coverage

`oom_dolt_fault_test` now builds a two-commit feature branch over a diverged main branch, runs linear rebase under fork-isolated allocation failures, closes and reopens the database, and accepts only these states:

1. original `feat-two` branch with feature rows 4 and 6
2. fully rebased `feat-two` branch with feature rows 4 and 6 plus main row 5

It rejects upstream-only state, partial replay, dirty staged/working hybrids, and leaked scratch refs. The new test fails before the fix at allocation point 82 and passes after it.

## Test plan

- [x] linear rebase allocation sweep: 500/500 clean
- [x] full allocation harness: 11 operations, 5,500 iterations, 0 bugs
- [x] `doltlite_rebase.sh`: 8 passed
- [x] `doltlite_rebase_schema.sh`: 23 passed
- [x] `doltlite_savepoint.sh`: 128 passed
- [x] `multi_process_merge_rebase_test`: 20 passed
- [x] `doltlite_parity.sh` with a separately built stock SQLite 3.54.0: 119 passed
- [x] `make lint`

Co-Authored-By: OpenAI Codex <noreply@openai.com>