### PR TITLE
Keep failed cherry-picks atomic

### DIFF
--- a/src/doltlite_cherry_pick.c
+++ b/src/doltlite_cherry_pick.c
@@ -58,6 +58,42 @@ int doltliteLoadHeadAndParentedCommit(
   return SQLITE_OK;
 }
 
+typedef struct ApplyAbortRefsCtx ApplyAbortRefsCtx;
+struct ApplyAbortRefsCtx {
+  const char *zBranch;
+  const ProllyHash *pExpectedHead;
+  const ProllyHash *pCatalog;
+};
+
+static int applyAbortRefs(sqlite3 *db, ChunkStore *cs, void *pArg){
+  ApplyAbortRefsCtx *p = (ApplyAbortRefsCtx*)pArg;
+  ProllyHash head;
+  int rc;
+  rc = chunkStoreFindBranch(cs, p->zBranch, &head);
+  if( rc!=SQLITE_OK ) return rc;
+  if( prollyHashCompare(&head, p->pExpectedHead)!=0 ) return SQLITE_OK;
+  return doltliteUpdateBranchWorkingState(
+      db, p->zBranch, p->pCatalog, p->pExpectedHead);
+}
+
+static int applyRestoreOriginalBranch(
+  sqlite3 *db,
+  const char *zBranch,
+  const ProllyHash *pHead,
+  const ProllyHash *pCatalog,
+  int opRc
+){
+  ApplyAbortRefsCtx ctx;
+  int rc;
+  memset(&ctx, 0, sizeof(ctx));
+  ctx.zBranch = zBranch;
+  ctx.pExpectedHead = pHead;
+  ctx.pCatalog = pCatalog;
+  rc = doltliteMutateRefs(db, applyAbortRefs, &ctx);
+  if( db->autoCommit ) doltliteAdoptRollbackBaseline(db, pCatalog);
+  return rc==SQLITE_OK ? opRc : rc;
+}
+
 int applyMergedCatalogAndCommit(
   sqlite3 *db,
   sqlite3_context *context,
@@ -78,6 +114,7 @@ int applyMergedCatalogAndCommit(
   int graphLocked = 0;
   int bPreferOurMaster;
   const char *zOpLabel;
+  const char *zBranch;
   int rc;
 
   assert( db!=0 && context!=0 );
@@ -88,12 +125,19 @@ int applyMergedCatalogAndCommit(
   if( hexBuf ) hexBuf[0] = '\0';
   bPreferOurMaster = (sqlite3_strnicmp(zMessage, "Revert", 6)==0);
   zOpLabel = bPreferOurMaster ? "Revert" : "Cherry-pick";
+  zBranch = doltliteGetSessionBranch(db);
 
   rc = doltliteEnsureWriteTxnAndSavepoints(db);
-  if( rc!=SQLITE_OK ) return rc;
+  if( rc!=SQLITE_OK ){
+    return applyRestoreOriginalBranch(
+        db, zBranch, ourHead, ourCatHash, rc);
+  }
 
   rc = doltliteSaveTxnState(db, &savedState);
-  if( rc!=SQLITE_OK ) return rc;
+  if( rc!=SQLITE_OK ){
+    return applyRestoreOriginalBranch(
+        db, zBranch, ourHead, ourCatHash, rc);
+  }
 
   {
     char **azReindex = 0;

--- a/test/oom_dolt_fault_test.c
+++ b/test/oom_dolt_fault_test.c
@@ -335,6 +335,23 @@ static int opLinearRebase(sqlite3 *db){
   return execSilent(db, "SELECT dolt_rebase('main')");
 }
 
+static int setupCherryPick(sqlite3 *db){
+  int rc;
+  rc = execSilent(db, "SELECT dolt_checkout('-b','feat')");
+  if( rc ) return rc;
+  rc = execSilent(db, "INSERT INTO t VALUES(4,'picked')");
+  if( rc ) return rc;
+  rc = execSilent(db, "SELECT dolt_add('-A')");
+  if( rc ) return rc;
+  rc = execSilent(db, "SELECT dolt_commit('-m','pick-one')");
+  if( rc ) return rc;
+  return execSilent(db, "SELECT dolt_checkout('main')");
+}
+
+static int opCherryPick(sqlite3 *db){
+  return execSilent(db, "SELECT dolt_cherry_pick('feat')");
+}
+
 static int opDiffTable(sqlite3 *db){
   int rc = execSilent(db, "INSERT INTO t VALUES(50,'diffed')");
   if( rc ) return rc;
@@ -464,6 +481,14 @@ static OpEntry kOps[] = {
       "((EXISTS(SELECT 1 FROM t WHERE a=5 AND b='main')) OR "
        "(NOT EXISTS(SELECT 1 FROM t WHERE a=5))) AND "
       "NOT EXISTS(SELECT 1 FROM dolt_status)", 6, "feat-two" },
+  { "dolt_cherry_pick",     opCherryPick, setupCherryPick,
+    "feat", 4, "picked", 0, 0, "pick-one", 0, 0, 0,
+    "SELECT ("
+      "(message='base' AND NOT EXISTS(SELECT 1 FROM t WHERE a=4)) OR "
+      "(message='pick-one' AND EXISTS("
+        "SELECT 1 FROM t WHERE a=4 AND b='picked'))"
+      ") AND NOT EXISTS(SELECT 1 FROM dolt_status) "
+    "FROM dolt_log LIMIT 1", 0, 0 },
   { "dolt_diff_table",     opDiffTable, 0,
     0, 50, "diffed", 0, 0, 0, 0, 0 },
   { "savepoint_vc_state",  opSavepointState, setupSavepointState,


### PR DESCRIPTION
## Summary

- restore the original branch working and staged state when cherry-pick setup fails
- align the in-memory rollback baseline with the recovered durable catalog
- add cherry-pick to the allocation-failure harness with an exact all-or-nothing reopened-state invariant

## Reproduction

Before this change, injected allocation failure 97 returned an error but left the picked row in the working set after reopen while HEAD remained at the original commit.

## Validation

- full allocation-failure sweep: 11 operations x 500 failure points, zero invariant violations
- cherry-pick/revert shell suite: 98 passed
- dirty-revert shell suite: 14 passed
- savepoint/transaction shell suite: 128 passed
- C regression suite: 309,980 passed
- lint

Closes #1845.

Co-Authored-By: OpenAI Codex <noreply@openai.com>