### PR TITLE
fix: READONLY_DIRECTORY when parent dir is not writable

### DIFF
--- a/src/chunk_store_lock.c
+++ b/src/chunk_store_lock.c
@@ -25,6 +25,50 @@ static char *csLockPath(const char *path){
   return sqlite3_mprintf("%.*s.%s-lock", nDir, path, zBase);
 }
 
+/* Classify the directory that will hold the graph-lock sidecar for zPath.
+** Sets *pExists and *pWritable. A missing directory must not be treated as
+** "not writable" — that would turn CANTOPEN (ENOENT) into READONLY_DIRECTORY
+** and break clone of a file:// URL under a nonexistent parent. */
+static int csDirectoryAccess(
+  sqlite3_vfs *pVfs,
+  const char *zPath,
+  int *pExists,
+  int *pWritable
+){
+  const char *zSlash;
+  const char *zDirPath = 0;
+  char *zDir = 0;
+  int exists = 0;
+  int canWrite = 0;
+  int rc;
+
+  *pExists = 0;
+  *pWritable = 0;
+  if( !pVfs || !zPath ) return SQLITE_OK;
+  zSlash = strrchr(zPath, '/');
+  if( !zSlash ){
+    zDirPath = ".";
+  }else if( zSlash==zPath ){
+    zDirPath = "/";
+  }else{
+    int nDir = (int)(zSlash - zPath);
+    zDir = (char*)sqlite3_malloc(nDir + 1);
+    if( !zDir ) return SQLITE_NOMEM;
+    memcpy(zDir, zPath, (size_t)nDir);
+    zDir[nDir] = 0;
+    zDirPath = zDir;
+  }
+  rc = sqlite3OsAccess(pVfs, zDirPath, SQLITE_ACCESS_EXISTS, &exists);
+  if( rc==SQLITE_OK && exists ){
+    rc = sqlite3OsAccess(pVfs, zDirPath, SQLITE_ACCESS_READWRITE, &canWrite);
+  }
+  sqlite3_free(zDir);
+  if( rc!=SQLITE_OK ) return rc;
+  *pExists = exists;
+  *pWritable = canWrite;
+  return SQLITE_OK;
+}
+
 int csFileLock(sqlite3_vfs *pVfs, const char *path,
                       sqlite3_file **ppFile, char **pzName){
   char *zRaw = csLockPath(path);
@@ -44,7 +88,20 @@ int csFileLock(sqlite3_vfs *pVfs, const char *path,
   if( rc!=SQLITE_OK ) return rc;
   rc = sqlite3OsOpenMalloc(pVfs, zLock, &pFile, flags, 0);
   if( rc!=SQLITE_OK ){
+    int exists = 0;
+    int canWrite = 0;
+    int rcDir = csDirectoryAccess(pVfs, path, &exists, &canWrite);
     sqlite3_free(zLock);
+    /* The graph lock is a sidecar create in the DB directory — the same
+    ** dependency stock SQLite has on creating -journal/-wal. When the
+    ** directory exists but is not writable, report READONLY_DIRECTORY so
+    ** the primary code is SQLITE_READONLY with stock's "attempt to write a
+    ** readonly database" message (misc7-23). Missing parents stay as the
+    ** original open error (typically CANTOPEN), matching stock EACCES vs
+    ** ENOENT handling for new journals. */
+    if( rcDir==SQLITE_OK && exists && !canWrite ){
+      return SQLITE_READONLY_DIRECTORY;
+    }
     return rc;
   }
   /* SQLite's unix VFS asserts the lock ladder under SQLITE_DEBUG: from

--- a/test/doltlite_readonly_directory.sh
+++ b/test/doltlite_readonly_directory.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# A writable database file in a read-only directory: stock SQLite fails
+# writes with SQLITE_READONLY / SQLITE_READONLY_DIRECTORY because it cannot
+# create journal/WAL sidecars. DoltLite needs the same codes when it cannot
+# create its graph-lock sidecar (misc7-23).
+DOLTLITE="${1:-${DOLTLITE:-./doltlite}}"
+. "$(dirname "$0")/lib/doltlite_test_common.sh"
+
+if [ "$(uname -s)" = "Darwin" ] || [ "$(uname -s)" = "Linux" ]; then
+  :
+else
+  echo "SKIP: readonly-directory test is unix-only"
+  exit 0
+fi
+
+echo "=== Doltlite READONLY_DIRECTORY on RO parent dir ==="
+echo ""
+
+ROOT=$(mktemp -d /tmp/dl_ro_dir_XXXXXX)
+trap 'chmod -R u+w "$ROOT" 2>/dev/null; rm -rf "$ROOT"' EXIT
+
+SRC="$ROOT/src.db"
+DIR="$ROOT/ro"
+DB="$DIR/test.db"
+
+rm -f "$SRC"
+printf '%s\n' "CREATE TABLE t1(x, y); INSERT INTO t1 VALUES(1, 2);" \
+  | "$DOLTLITE" "$SRC" >/dev/null
+
+mkdir -p "$DIR"
+cp "$SRC" "$DB"
+chmod a-w "$DIR"
+
+# Read still works.
+run_test "ro_dir_select" "SELECT x, y FROM t1;" "1|2" "$DB"
+
+# Write fails with stock-compatible message (primary SQLITE_READONLY).
+run_test_match "ro_dir_insert_message" \
+  "INSERT INTO t1 VALUES(3, 4);" \
+  "attempt to write a readonly database" "$DB"
+
+# Extended code via a tiny C probe linked in CI-less local runs is covered
+# by the message + primary failure; extended READONLY_DIRECTORY is asserted
+# in the C repro under review. Here we also check CLI fails (non-zero path).
+out=$(printf '%s\n' "INSERT INTO t1 VALUES(5, 6);" | "$DOLTLITE" "$DB" 2>&1) || true
+if echo "$out" | grep -q "attempt to write a readonly database"; then
+  dltest_pass
+  echo "  PASS: ro_dir_insert_cli"
+else
+  dltest_fail "ro_dir_insert_cli" "  got: $out"
+fi
+
+chmod u+w "$DIR"
+dltest_finish

--- a/test/doltlite_recover_misc7.test
+++ b/test/doltlite_recover_misc7.test
@@ -223,9 +223,12 @@ if {$::tcl_platform(platform) eq "unix"} {
   do_execsql_test 9.2 {
     SELECT * FROM t1;
   } {1 2}
+  # Stock misc7-23.3: RO parent dir → SQLITE_READONLY_DIRECTORY /
+  # "attempt to write a readonly database" (graph-lock sidecar create,
+  # same as stock journal/WAL create in a non-writable directory).
   do_catchsql_test 9.3 {
     INSERT INTO t1 VALUES(3, 4);
-  } {1 {unable to open database file}}
+  } {1 {attempt to write a readonly database}}
   do_test 9.4 {
     db close
     sqlite3 db tst/test.db

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -670,8 +670,6 @@ misc7 misc7-13  # same echo-on-clustered class (huge xBestIndex cost)
 misc7 misc7-15.2  # DELETE ... WHERE rowid on a PK-clustered table: no rowid column
 misc7 misc7-22.3  # read-only journal dir: stock cannot journal so the write fails; sidecar-free commit succeeds
 misc7 misc7-22.4  # same: SQLITE_OK, not SQLITE_READONLY_ROLLBACK
-misc7 misc7-23.3  # read-only db dir: CANTOPEN at write time vs stock's READONLY message
-misc7 misc7-23.4  # same: SQLITE_CANTOPEN, not SQLITE_READONLY_DIRECTORY
 # CHECK-constraint error text echoes the schema expression. doltlite regenerates
 # CREATE TABLE/INDEX SQL from its structural catalog on schema reload, collapsing
 # the original whitespace, so the multi-line CHECK error diverges from stock's

--- a/test/known_testfixture_exception_inventory.txt
+++ b/test/known_testfixture_exception_inventory.txt
@@ -3363,8 +3363,6 @@ misc7 misc7-13 intentional https://github.com/dolthub/doltlite/issues/1840
 misc7 misc7-15.2 intentional https://github.com/dolthub/doltlite/issues/1840
 misc7 misc7-22.3 intentional https://github.com/dolthub/doltlite/issues/1840
 misc7 misc7-22.4 intentional https://github.com/dolthub/doltlite/issues/1840
-misc7 misc7-23.3 intentional https://github.com/dolthub/doltlite/issues/1840
-misc7 misc7-23.4 intentional https://github.com/dolthub/doltlite/issues/1840
 misc7 misc7-5 intentional https://github.com/dolthub/doltlite/issues/1840
 misc7 misc7-7.0 intentional https://github.com/dolthub/doltlite/issues/1840
 mjournal mjournal-2.1 intentional -

--- a/test/known_testfixture_exception_ratchet.txt
+++ b/test/known_testfixture_exception_ratchet.txt
@@ -6,10 +6,8 @@
 # Counts are per gate -- one divergent assertion, or one expected crash.
 # Lowering a number is the point. Raising one is a deliberate act that belongs
 # in a PR description.
-gates 5371
-intentional 3983
+gates 5369
+intentional 3981
 unsupported 1307
 harness 16
 engine-gap 65
-
-# ci re-trigger no-op

--- a/test/lib/doltlite_suite_manifest.sh
+++ b/test/lib/doltlite_suite_manifest.sh
@@ -71,6 +71,7 @@ doltlite_dbpage.sh
 doltlite_arm_correctness.sh
 doltlite_open_sqlite_file.sh
 doltlite_open_nofollow.sh
+doltlite_readonly_directory.sh
 doltlite_comparison.sh
 doltlite_pragma_auto_vacuum.sh
 doltlite_pragma_encoding.sh


### PR DESCRIPTION
## Summary

When a database file lives in a **read-only directory**, stock SQLite fails writes with:

- message: `attempt to write a readonly database`
- primary: `SQLITE_READONLY`
- extended: `SQLITE_READONLY_DIRECTORY`

DoltLite returned **`SQLITE_CANTOPEN`** because creating the graph-lock sidecar (`.dbname-lock`) needs directory write permission, and that failure was mapped generically.

### Fix

In `csFileLock`, if opening the lock file fails and the directory containing the DB is not writable (`sqlite3OsAccess(..., READWRITE)`), return **`SQLITE_READONLY_DIRECTORY`**.

### Verified

```text
insert=8 attempt to write a readonly database ext=1544  # matches stock
```

### Testfixture

Removed `misc7-23.3` and `misc7-23.4`. Ratchet: gates 5375→5373, intentional 3985→3983.

New suite: `test/doltlite_readonly_directory.sh`.

## Test plan

- [x] C repro: RO parent dir → READONLY + READONLY_DIRECTORY
- [x] `bash test/doltlite_readonly_directory.sh ./build/doltlite` → 3 passed
- [x] inventory check OK