### PR TITLE
fix: honor SQLITE_OPEN_NOFOLLOW on symlink opens

### DIFF
--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -74,7 +74,8 @@ int chunkStoreDupFilenameDoubleNul(const char *z, char **pzOut){
 static int csCanonicalFilename(
   sqlite3_vfs *pVfs,
   const char *zFilename,
-  char **pzOut
+  char **pzOut,
+  int flags
 ){
   int nPath;
   int rc;
@@ -100,7 +101,16 @@ static int csCanonicalFilename(
     }
   }
 #endif
-  if( rc==SQLITE_OK || rc==SQLITE_OK_SYMLINK ){
+  /* Match stock pagerOpen: FullPathname returns OK_SYMLINK when the path
+  ** traverses a symlink; SQLITE_OPEN_NOFOLLOW must refuse that open. */
+  if( rc==SQLITE_OK_SYMLINK ){
+    if( flags & SQLITE_OPEN_NOFOLLOW ){
+      sqlite3_free(zFull);
+      return SQLITE_CANTOPEN_SYMLINK;
+    }
+    rc = SQLITE_OK;
+  }
+  if( rc==SQLITE_OK ){
     rc = chunkStoreDupFilenameDoubleNul(zFull, pzOut);
     sqlite3_free(zFull);
     return rc;
@@ -288,7 +298,7 @@ int chunkStoreOpen(
     return SQLITE_CANTOPEN;
   }
 
-  rc = csCanonicalFilename(pVfs, zFilename, &cs->file.zFilename);
+  rc = csCanonicalFilename(pVfs, zFilename, &cs->file.zFilename, flags);
   if( rc!=SQLITE_OK ){
     chunkStoreClose(cs);
     return rc;
@@ -316,7 +326,8 @@ int chunkStoreOpen(
     /* Honor SQLITE_OPEN_READONLY even when the file is writable. */
     int wantReadOnly = (flags & SQLITE_OPEN_READONLY)!=0;
     int openFlags = (wantReadOnly ? SQLITE_OPEN_READONLY : SQLITE_OPEN_READWRITE)
-                  | SQLITE_OPEN_MAIN_DB;
+                  | SQLITE_OPEN_MAIN_DB
+                  | (flags & SQLITE_OPEN_NOFOLLOW);
     int outFlags = 0;
     rc = csOpenFile(pVfs, cs->file.zFilename, &cs->file.pFile, openFlags, &outFlags);
     if( rc != SQLITE_OK ){
@@ -325,7 +336,8 @@ int chunkStoreOpen(
         chunkStoreClose(cs);
         return rc;
       }
-      openFlags = SQLITE_OPEN_READONLY | SQLITE_OPEN_MAIN_DB;
+      openFlags = SQLITE_OPEN_READONLY | SQLITE_OPEN_MAIN_DB
+                | (flags & SQLITE_OPEN_NOFOLLOW);
       rc = csOpenFile(pVfs, cs->file.zFilename, &cs->file.pFile, openFlags, 0);
       if( rc != SQLITE_OK ){
         chunkStoreClose(cs);

--- a/test/doltlite_open_nofollow.sh
+++ b/test/doltlite_open_nofollow.sh
@@ -19,6 +19,8 @@ trap 'rm -rf "$TMP"' EXIT
 
 cat > "$TMP/nofollow.c" <<'EOF'
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 #include <unistd.h>
 #include "sqlite3.h"
 
@@ -26,8 +28,10 @@ int main(void){
   sqlite3 *db = 0;
   int rc;
   char realp[512], linkp[512];
-  snprintf(realp, sizeof(realp), "%s/real.db", getenv("DL_TMP"));
-  snprintf(linkp, sizeof(linkp), "%s/link.db", getenv("DL_TMP"));
+  const char *tmp = getenv("DL_TMP");
+  if( !tmp || !tmp[0] ){ fprintf(stderr, "DL_TMP not set\n"); return 1; }
+  snprintf(realp, sizeof(realp), "%s/real.db", tmp);
+  snprintf(linkp, sizeof(linkp), "%s/link.db", tmp);
   unlink(realp); unlink(linkp);
 
   rc = sqlite3_open(realp, &db);

--- a/test/doltlite_open_nofollow.sh
+++ b/test/doltlite_open_nofollow.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+# SQLITE_OPEN_NOFOLLOW must refuse a path that is a symlink (symlink-1.1.2).
+# Exercised via the C API; the CLI has no -nofollow flag.
+DOLTLITE_SRC="$(cd "$(dirname "$0")/.." && pwd)"
+BUILD="${DOLTLITE_BUILD_DIR:-$DOLTLITE_SRC/build}"
+
+if [ ! -f "$BUILD/libdoltlite.a" ]; then
+  echo "SKIP: no libdoltlite.a in $BUILD"
+  exit 0
+fi
+
+case "$(uname -s)" in
+  Darwin|Linux) ;;
+  *) echo "SKIP: nofollow test is unix-only"; exit 0 ;;
+esac
+
+TMP=$(mktemp -d /tmp/dl_nofollow_XXXXXX)
+trap 'rm -rf "$TMP"' EXIT
+
+cat > "$TMP/nofollow.c" <<'EOF'
+#include <stdio.h>
+#include <unistd.h>
+#include "sqlite3.h"
+
+int main(void){
+  sqlite3 *db = 0;
+  int rc;
+  char realp[512], linkp[512];
+  snprintf(realp, sizeof(realp), "%s/real.db", getenv("DL_TMP"));
+  snprintf(linkp, sizeof(linkp), "%s/link.db", getenv("DL_TMP"));
+  unlink(realp); unlink(linkp);
+
+  rc = sqlite3_open(realp, &db);
+  if( rc!=SQLITE_OK ){ fprintf(stderr, "open real failed %d\n", rc); return 1; }
+  sqlite3_exec(db, "CREATE TABLE t(x);", 0, 0, 0);
+  sqlite3_close(db);
+
+  if( symlink(realp, linkp)!=0 ){ perror("symlink"); return 1; }
+
+  rc = sqlite3_open_v2(linkp, &db,
+                       SQLITE_OPEN_READWRITE | SQLITE_OPEN_NOFOLLOW, 0);
+  if( rc==SQLITE_OK ){
+    fprintf(stderr, "FAIL: NOFOLLOW open of symlink succeeded\n");
+    sqlite3_close(db);
+    return 1;
+  }
+  if( (rc & 0xff)!=SQLITE_CANTOPEN ){
+    fprintf(stderr, "FAIL: expected CANTOPEN, got %d (%s)\n",
+            rc, sqlite3_errstr(rc));
+    return 1;
+  }
+
+  /* Without NOFOLLOW, following the symlink still works. */
+  rc = sqlite3_open_v2(linkp, &db, SQLITE_OPEN_READWRITE, 0);
+  if( rc!=SQLITE_OK ){
+    fprintf(stderr, "FAIL: follow-symlink open failed %d\n", rc);
+    return 1;
+  }
+  sqlite3_close(db);
+  printf("OK: NOFOLLOW refuses symlink; follow succeeds\n");
+  return 0;
+}
+EOF
+
+cc -O2 -I"$BUILD" -I"$DOLTLITE_SRC/src" -o "$TMP/nofollow" "$TMP/nofollow.c" \
+  "$BUILD/libdoltlite.a" -lpthread -lz -lm || {
+  echo "SKIP: could not link nofollow probe"
+  exit 0
+}
+
+DL_TMP="$TMP" "$TMP/nofollow"

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -2483,17 +2483,15 @@ shared8 shared8-1.4  # shared-cache schema sharing premise inapplicable
 shared8 shared8-1.5  # shared-cache schema sharing premise inapplicable
 shared8 shared8-1.6  # shared-cache schema sharing premise inapplicable
 shared8 shared8-1.7  # shared-cache schema sharing premise inapplicable
-symlink symlink-1.1.2  # opens through renamed/symlinked paths succeed (deferred open)
-symlink symlink-1.1.4  # opens through renamed/symlinked paths succeed (deferred open)
-symlink symlink-2.1.2  # opens through renamed/symlinked paths succeed (deferred open)
-symlink symlink-2.1.4  # opens through renamed/symlinked paths succeed (deferred open)
-symlink symlink-2.1.7  # opens through renamed/symlinked paths succeed (deferred open)
-symlink symlink-2.2.2  # opens through renamed/symlinked paths succeed (deferred open)
-symlink symlink-2.2.4  # opens through renamed/symlinked paths succeed (deferred open)
-symlink symlink-2.2.7  # opens through renamed/symlinked paths succeed (deferred open)
-symlink symlink-4.2.2  # opens through renamed/symlinked paths succeed (deferred open)
-symlink symlink-4.3.2  # opens through renamed/symlinked paths succeed (deferred open)
-symlink symlink-4.4.2  # opens through renamed/symlinked paths succeed (deferred open)
+symlink symlink-2.1.2  # no -journal/-wal sidecars; journal_mode fixed at wal
+symlink symlink-2.1.4  # no -journal/-wal sidecars; journal_mode fixed at wal
+symlink symlink-2.1.7  # no -journal/-wal sidecars; journal_mode fixed at wal
+symlink symlink-2.2.2  # no -journal/-wal sidecars; journal_mode fixed at wal
+symlink symlink-2.2.4  # no -journal/-wal sidecars; journal_mode fixed at wal
+symlink symlink-2.2.7  # no -journal/-wal sidecars; journal_mode fixed at wal
+symlink symlink-4.2.2  # no -journal/-wal sidecars; journal_mode fixed at wal
+symlink symlink-4.3.2  # no -journal/-wal sidecars; journal_mode fixed at wal
+symlink symlink-4.4.2  # no -journal/-wal sidecars; journal_mode fixed at wal
 syscall syscall-7.2  # fault-injected syscall error text; chunk-store file size
 syscall syscall-7.3  # fault-injected syscall error text; chunk-store file size
 syscall syscall-8.1  # fault-injected syscall error text; chunk-store file size

--- a/test/known_testfixture_exception_inventory.txt
+++ b/test/known_testfixture_exception_inventory.txt
@@ -4285,8 +4285,6 @@ strict2 strict2-3.0 intentional -
 subjournal subjournal-2.1 intentional -
 superlock * intentional -
 swarmvtab swarmvtab-2.3 intentional -
-symlink symlink-1.1.2 intentional -
-symlink symlink-1.1.4 intentional -
 symlink symlink-2.1.2 intentional -
 symlink symlink-2.1.4 intentional -
 symlink symlink-2.1.7 intentional -

--- a/test/known_testfixture_exception_ratchet.txt
+++ b/test/known_testfixture_exception_ratchet.txt
@@ -6,8 +6,8 @@
 # Counts are per gate -- one divergent assertion, or one expected crash.
 # Lowering a number is the point. Raising one is a deliberate act that belongs
 # in a PR description.
-gates 5375
-intentional 3985
+gates 5373
+intentional 3983
 unsupported 1305
 harness 16
 engine-gap 69

--- a/test/lib/doltlite_suite_manifest.sh
+++ b/test/lib/doltlite_suite_manifest.sh
@@ -70,6 +70,7 @@ doltlite_attach_sqlite.sh
 doltlite_dbpage.sh
 doltlite_arm_correctness.sh
 doltlite_open_sqlite_file.sh
+doltlite_open_nofollow.sh
 doltlite_comparison.sh
 doltlite_pragma_auto_vacuum.sh
 doltlite_pragma_encoding.sh


### PR DESCRIPTION
## Summary

`sqlite3_open_v2(..., SQLITE_OPEN_NOFOLLOW)` on a symlink path succeeded; stock refuses it.

**Cause:** `csCanonicalFilename` treated `SQLITE_OK_SYMLINK` from `FullPathname` as success and resolved through the link, so the subsequent open never saw a symlink.

**Fix:** Match stock `pagerOpen` — if `SQLITE_OPEN_NOFOLLOW` is set and FullPathname returns `OK_SYMLINK`, return `SQLITE_CANTOPEN_SYMLINK`. Also pass `NOFOLLOW` through to `csOpenFile`.

### Verified

`symlink.test` failures go from **11 → 9**:

| Fixed | Still failing (known #1836) |
|---|---|
| 1.1.2, 1.1.4 (`-nofollow`) | 2.* / 4.* journal, wal, journal_mode |

Removed gates `symlink-1.1.2` and `symlink-1.1.4`; corrected comments on remaining symlink gates. Ratchet −2.

New probe: `test/doltlite_open_nofollow.sh`.

## Test plan

- [x] `./testfixture ../test/symlink.test` — no 1.1.2 / 1.1.4 failures
- [x] `bash test/doltlite_open_nofollow.sh`
- [x] inventory check OK