### PR TITLE
Reject commits after database rename

### DIFF
--- a/src/chunk_store_commit.c
+++ b/src/chunk_store_commit.c
@@ -9,6 +9,13 @@
 
 /* Chunk-store commit/rollback path. */
 
+static int csFileHasMovedNoFault(ChunkStore *cs){
+  int bMoved = 0;
+  if( cs->file.pFile==0 ) return 0;
+  sqlite3OsFileControlHint(cs->file.pFile, SQLITE_FCNTL_HAS_MOVED, &bMoved);
+  return bMoved;
+}
+
 static int csCrashWriteInjectionActive(void){
 #ifdef SQLITE_TEST
   const char *zEnv = getenv("DOLTLITE_CRASH_WRITE");
@@ -510,6 +517,10 @@ int chunkStoreCommit(ChunkStore *cs){
       cs->refs.refsHash = savedRefsHash;
     }
     acquiredLock = 1;
+  }
+  if( cs->movedReadOnly || (!acquiredLock && csFileHasMovedNoFault(cs)) ){
+    if( acquiredLock ) chunkStoreUnlock(cs);
+    return SQLITE_READONLY;
   }
   rc = csCommitToFile(cs);
   if( acquiredLock ) chunkStoreUnlock(cs);

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -4507,6 +4507,48 @@ static void run_btree_commit_failure_transactional(void){
   removeDbFiles(dbpath);
 }
 
+static void run_commit_rejects_renamed_database(void){
+#ifndef _WIN32
+  sqlite3 *db = 0;
+  char dbpath[256];
+  char renamedPath[320];
+  int rc;
+
+  printf("=== Commit Rejects Renamed Database Test ===\n\n");
+  make_dbpath(dbpath, sizeof(dbpath), "test_commit_rejects_renamed_database");
+  sqlite3_snprintf(sizeof(renamedPath), renamedPath, "%s-renamed", dbpath);
+  removeDbFiles(dbpath);
+  removeDbFiles(renamedPath);
+
+  check("renamed_commit_open", open_db(dbpath, &db)==SQLITE_OK);
+  check("renamed_commit_setup", execSql(db,
+    "CREATE TABLE t1(a,b,c);"
+    "INSERT INTO t1 VALUES(673,'stone','philips');"
+    "SELECT dolt_commit('-A','-m','base');")==SQLITE_OK);
+  check("renamed_commit_stage", execSql(db,
+    "BEGIN;"
+    "UPDATE t1 SET b='staged';")==SQLITE_OK);
+  check("renamed_commit_rename", rename(dbpath, renamedPath)==0);
+
+  rc = execSqlSilent(db, "COMMIT;");
+  check("renamed_commit_readonly", rc==SQLITE_READONLY);
+  check("renamed_commit_autocommit_restored", sqlite3_get_autocommit(db)==1);
+  check("renamed_commit_connection_rolled_back",
+        strcmp(queryScalarText(db, "SELECT b FROM t1 WHERE a=673"), "stone")==0);
+  sqlite3_close(db);
+  db = 0;
+
+  check("renamed_commit_reopen", open_db(renamedPath, &db)==SQLITE_OK);
+  check("renamed_commit_row_not_durable",
+        strcmp(queryScalarText(db, "SELECT b FROM t1 WHERE a=673"), "stone")==0);
+  check("renamed_commit_status_not_durable",
+        strcmp(queryScalarText(db, "SELECT count(*) FROM dolt_status"), "0")==0);
+  sqlite3_close(db);
+  removeDbFiles(dbpath);
+  removeDbFiles(renamedPath);
+#endif
+}
+
 static void run_savepoint_restores_session_metadata(void){
   sqlite3 *db = 0;
   char dbpath[256];
@@ -8766,6 +8808,7 @@ static const RegressionCase aCases[] = {
   { "table_moveto_mutmap_exact_keeps_iteration_aligned", "Table Moveto MutMap Exact Keeps Iteration Aligned Test", run_table_moveto_mutmap_exact_keeps_iteration_aligned },
   { "index_moveto_mutmap_exact_keeps_iteration_aligned", "Index Moveto MutMap Exact Keeps Iteration Aligned Test", run_index_moveto_mutmap_exact_keeps_iteration_aligned },
   { "btree_commit_failure_transactional", "Btree Commit Failure Transaction Test", run_btree_commit_failure_transactional },
+  { "commit_rejects_renamed_database", "Commit Rejects Renamed Database Test", run_commit_rejects_renamed_database },
   { "savepoint_restores_session_metadata", "Savepoint Restores Session Metadata Test", run_savepoint_restores_session_metadata },
   { "savepoint_flush_snapshot_rollback_reopen", "Savepoint Flush Snapshot Rollback Reopen Test", run_savepoint_flush_snapshot_rollback_reopen },
   { "savepoint_flush_snapshot_release_reopen", "Savepoint Flush Snapshot Release Reopen Test", run_savepoint_flush_snapshot_release_reopen },


### PR DESCRIPTION
## Summary

- check the open chunk-store handle for a moved backing file immediately before persistence
- cover transactions that already hold the graph lock and therefore do not run the lock-acquisition refresh path during commit
- add a regression that verifies `COMMIT` returns `SQLITE_READONLY` and neither the row update nor working-set status becomes durable

## Finding verification

On unmodified master, renaming the database after `BEGIN`/`UPDATE` allowed `COMMIT` to succeed. Reopening the renamed file returned `673|staged|philips`. The final regression failed 4 of 10 assertions before the fix and passes all 10 after it.

A `movedReadOnly` re-check only after `chunkStoreLockAndRefresh` is insufficient: explicit write transactions inherit an already-held graph lock and skip that refresh. The check therefore also calls `csMovedFileIsGone` at the final pre-write boundary.

## Validation

- focused regression: 10 passed
- full C regression: 309,990 passed
- native shell suites: 93/93 passed
- gated C harnesses: 24/24 passed
- `pager4` unchanged at its three known divergences
- lint

Follow-up to #1855.

Co-Authored-By: OpenAI Codex <noreply@openai.com>