### PR TITLE
Avoid graph lock upgrade livelock

### DIFF
--- a/src/chunk_store_int.h
+++ b/src/chunk_store_int.h
@@ -24,6 +24,7 @@ typedef sqlite3_file *CsFileLock;
 int csFileLockHeld(sqlite3_file *pFile);
 int csFileLock(sqlite3_vfs *pVfs, const char *path,
                sqlite3_file **ppFile, char **pzName);
+int csFileLockPromote(sqlite3_file *pFile);
 void csFileUnlock(sqlite3_file *pFile, char **pzName);
 int csFileLockNB(sqlite3_vfs *pVfs, const char *path,
                  sqlite3_file **ppFile, char **pzName);
@@ -39,4 +40,3 @@ void csFillChunkHdr(u8 *p, const ProllyHash *pHash, u32 size);
 void csSerializeManifest(const ChunkStore *cs, u8 *aBuf);
 
 #endif /* CHUNK_STORE_INT_H */
-

--- a/src/chunk_store_lock.c
+++ b/src/chunk_store_lock.c
@@ -12,6 +12,10 @@ int csFileLockHeld(sqlite3_file *pFile){
   return pFile!=0;
 }
 
+int csFileLockPromote(sqlite3_file *pFile){
+  return sqlite3OsLock(pFile, SQLITE_LOCK_RESERVED);
+}
+
 static char *csLockPath(const char *path){
   const char *zBase = strrchr(path, '/');
   int nDir = 0;
@@ -110,7 +114,7 @@ int csFileLock(sqlite3_vfs *pVfs, const char *path,
   ** smoke in development-builds). */
   rc = sqlite3OsLock(pFile, SQLITE_LOCK_SHARED);
   if( rc==SQLITE_OK ){
-    rc = sqlite3OsLock(pFile, SQLITE_LOCK_EXCLUSIVE);
+    rc = csFileLockPromote(pFile);
   }
   if( rc!=SQLITE_OK ){
     sqlite3OsUnlock(pFile, SQLITE_LOCK_NONE);

--- a/test/chunk_store_fork_lock_test.c
+++ b/test/chunk_store_fork_lock_test.c
@@ -2,7 +2,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "sqlite3.h"
-#include "chunk_store.h"
+#include "chunk_store_int.h"
 
 #ifndef _WIN32
 # include <unistd.h>
@@ -119,8 +119,58 @@ static void test_fork_child_does_not_keep_parent_lock(void){
 #endif
 }
 
+static void test_graph_lock_promotion_has_one_winner(void){
+#ifdef _WIN32
+  check("graph_lock_promotion_skipped_on_windows", 1);
+#else
+  char zPath[] = "/tmp/test_chunk_store_lock_promotion\0";
+  sqlite3_vfs *pVfs = sqlite3_vfs_find(0);
+  sqlite3_file *pFile1 = 0;
+  sqlite3_file *pFile2 = 0;
+  int flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE
+            | SQLITE_OPEN_MAIN_DB;
+  int rc1;
+  int rc2;
+
+  printf("--- graph lock promotion has one winner ---\n");
+  check("graph_lock_promotion_has_vfs", pVfs!=0);
+  if( !pVfs ) return;
+  sqlite3OsDelete(pVfs, zPath, 0);
+
+  rc1 = sqlite3OsOpenMalloc(pVfs, zPath, &pFile1, flags, 0);
+  rc2 = sqlite3OsOpenMalloc(pVfs, zPath, &pFile2, flags, 0);
+  check("graph_lock_promotion_open_first", rc1==SQLITE_OK);
+  check("graph_lock_promotion_open_second", rc2==SQLITE_OK);
+  if( rc1!=SQLITE_OK || rc2!=SQLITE_OK ) goto done;
+
+  rc1 = sqlite3OsLock(pFile1, SQLITE_LOCK_SHARED);
+  rc2 = sqlite3OsLock(pFile2, SQLITE_LOCK_SHARED);
+  check("graph_lock_promotion_share_first", rc1==SQLITE_OK);
+  check("graph_lock_promotion_share_second", rc2==SQLITE_OK);
+  if( rc1!=SQLITE_OK || rc2!=SQLITE_OK ) goto done;
+
+  rc1 = csFileLockPromote(pFile1);
+  rc2 = csFileLockPromote(pFile2);
+  check("graph_lock_promotion_single_winner",
+        (rc1==SQLITE_OK && rc2==SQLITE_BUSY)
+     || (rc1==SQLITE_BUSY && rc2==SQLITE_OK));
+
+done:
+  if( pFile1 ){
+    sqlite3OsUnlock(pFile1, SQLITE_LOCK_NONE);
+    sqlite3OsCloseFree(pFile1);
+  }
+  if( pFile2 ){
+    sqlite3OsUnlock(pFile2, SQLITE_LOCK_NONE);
+    sqlite3OsCloseFree(pFile2);
+  }
+  sqlite3OsDelete(pVfs, zPath, 0);
+#endif
+}
+
 int main(void){
   test_fork_child_does_not_keep_parent_lock();
+  test_graph_lock_promotion_has_one_winner();
 
   printf("\n");
   printf("chunk_store_fork_lock_test: %d passed, %d failed\n", nPass, nFail);


### PR DESCRIPTION
## Summary

- promote graph-lock sidecars from shared to reserved instead of shared to exclusive
- guarantee one winner when two processes contend after both obtain shared locks
- add a deterministic VFS-level regression for the collision behind nightly failure #1860

## Validation

- fail-before: chunk_store_fork_lock_test reports 13 passed, 1 failed with exclusive promotion
- pass-after: chunk_store_fork_lock_test reports 14 passed, 0 failed
- multi_process_gc_test reports 101 passed, 0 failed
- assert-enabled chunk_store_fork_lock_test reports 14 passed, 0 failed
- make lint

Closes #1860

Co-Authored-By: OpenAI Codex <noreply@openai.com>