### PR TITLE
fix: credential empty-list hint includes SELECT

### DIFF
--- a/src/doltlite_remote_sql.c
+++ b/src/doltlite_remote_sql.c
@@ -912,7 +912,7 @@ static void doltCredsFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
       return;
     }
     if( n==0 ){
-      sqlite3_result_text(ctx, "no credentials; run dolt_creds_new()", -1,
+      sqlite3_result_text(ctx, "no credentials; run SELECT dolt_creds_new()", -1,
                           SQLITE_STATIC);
       doltliteCredsFreeList(kids, n);
       return;
@@ -950,7 +950,7 @@ static void doltCredsFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
     }
   }else{
     doltliteVcResultError(ctx, db,
-        "usage: dolt_creds(['list'] | 'rm', <kid>); use dolt_creds_new() to create");
+        "usage: dolt_creds(['list'] | 'rm', <kid>); use SELECT dolt_creds_new() to create");
   }
 }
 #endif /* DOLTLITE_HAVE_AUTH */


### PR DESCRIPTION
## Summary

- Empty `dolt_creds('list')` message now says `run SELECT dolt_creds_new()` so the CLI does not invite a bare function call (parse error).
- Same wording in the bad-args usage string.
- Fixes #1866.

## Test plan

- [ ] `SELECT dolt_creds('list');` with empty creds dir shows the new hint
- [ ] CI