### PR TITLE
Seed every database, and prove a replaced file is ours by its head commit (#1853, #1873)

### DIFF
--- a/src/attach.c
+++ b/src/attach.c
@@ -245,6 +245,18 @@ static void attachFunc(
 #endif
     if( !REOPEN_AS_MEMDB(db) ){
       rc = sqlite3Init(db, &zErrDyn);
+#ifdef DOLTLITE_PROLLY
+      /* Seed the newly attached database. doltliteMaybeSeedRepo only ever reaches
+      ** aDb[0], so without this the attached database's default branch is created
+      ** by its first working-set persist pointing at the empty hash: data with no
+      ** history, and no later chance to repair it. Reported through rc so a
+      ** failure runs the same teardown as a failed sqlite3Init instead of leaving
+      ** the database attached behind an error. */
+      if( rc==SQLITE_OK ){
+        extern int doltliteSeedAttachedDb(sqlite3*, int);
+        rc = doltliteSeedAttachedDb(db, db->nDb - 1);
+      }
+#endif
     }
     sqlite3BtreeLeaveAll(db);
     assert( zErrDyn==0 || rc!=SQLITE_OK );
@@ -270,7 +282,7 @@ static void attachFunc(
     }
     goto attach_error;
   }
-  
+
   return;
 
 attach_error:

--- a/src/chunk_store.h
+++ b/src/chunk_store.h
@@ -164,13 +164,17 @@ struct ChunkStore {
 
   u8 readOnly;
 
-  /* Set while the file this handle opened has been renamed or unlinked away and
-
-  ** nothing replaced it: writes are refused, reads keep serving the open handle.
-
-  ** Re-evaluated on every refresh, so restoring the file restores writability. */
-
+  /* Set while the file this handle opened is no longer the file at its path and
+  ** the one there cannot be shown to be this database: writes are refused, reads
+  ** keep serving the open handle. Re-evaluated on every refresh, so restoring the
+  ** file restores writability. */
   u8 movedReadOnly;
+
+  /* One-shot: adopt whatever file is now at the path on the next refresh. Only an
+  ** operation that installed a database there itself may set this -- a backup
+  ** destination is replaced with unrelated content on purpose, which the
+  ** moved-file check would otherwise refuse as a foreign file. */
+  u8 adoptReplacement;
   u8 isMemory;
   u8 fullFsync;           /* PRAGMA fullfsync: syncs use SQLITE_SYNC_FULL */
   u8 noSync;              /* PRAGMA synchronous=OFF: skip durability syncs */

--- a/src/chunk_store_lock.c
+++ b/src/chunk_store_lock.c
@@ -239,33 +239,61 @@ void chunkStoreUnlock(ChunkStore *cs){
   }
 }
 
-/* Whether the file this handle opened has been renamed or unlinked away with
-** nothing taking its place. The caller has already established that the VFS
-** reports it moved; GC replaces the store atomically, which keeps the path
-** populated throughout, so a vacant path is what separates "moved out from under
-** us" from "upgraded beneath us".
+static int csStoreHasAnyBranchTip(ChunkStore *pCand, const RefsTable *rt,
+                                  int *pHas){
+  int i;
+  *pHas = 0;
+  for(i=0; i<rt->nBranches; i++){
+    const ProllyHash *pTip = &rt->aBranches[i].commitHash;
+    int rc, has = 0;
+    if( prollyHashIsEmpty(pTip) ) continue;
+    rc = chunkStoreHas(pCand, pTip, &has);
+    if( rc!=SQLITE_OK ) return rc;
+    if( has ){
+      *pHas = 1;
+      return SQLITE_OK;
+    }
+  }
+  return SQLITE_OK;
+}
+
+/* Whether the file now at this handle's path is provably the database this handle
+** opened. Upstream makes any moved file read-only for good; GC is DoltLite's one
+** legitimate reason for the path to hold a different file, and a GC replacement,
+** a rename and a vacant path are indistinguishable from the outside. So require
+** proof: the candidate holds a branch tip of ours. GC preserves every commit
+** reachable from the refs it sweeps under, and our tip stays an ancestor of
+** whatever the branch has since become, so this survives an arbitrarily stale
+** handle. No proof leaves the upstream verdict in place.
 **
-** Never written means never moved: the VFS reports moved whenever it cannot
-** resolve the path at all, so a store whose file is still to be created -- a fresh
-** database, or a backup target before its first write -- is indistinguishable
-** from one renamed away unless this handle has already seen the file on disk.
-**
-** Returns an error rather than a verdict when the existence check itself fails:
-** an I/O error is not evidence about where the database went. */
-static int csMovedFileGone(ChunkStore *cs, int *pGone){
-  int exists = 0;
+** Working-set roots cannot be the proof: a peer advancing the working set makes
+** GC sweep the one we remember, so a live database fails its own test. */
+static int csMovedFileIsOurs(ChunkStore *cs, int *pIsOurs){
+  ChunkStore cand;
   int rc;
 
-  *pGone = 0;
+  *pIsOurs = 0;
   if( cs->isMemory || cs->file.pFile==0 ) return SQLITE_OK;
   if( cs->file.zFilename==0 || cs->file.zFilename[0]==0 ) return SQLITE_OK;
+  /* Never written means never moved: the VFS reports moved whenever it cannot
+  ** resolve the path at all, so a store whose file is still to be created -- a
+  ** fresh database, or a backup target before its first write -- is
+  ** indistinguishable from one renamed away. */
   if( cs->file.iFileSize<=0 ) return SQLITE_OK;
 
-  rc = sqlite3OsAccess(cs->file.pVfs, cs->file.zFilename,
-                       SQLITE_ACCESS_EXISTS, &exists);
-  if( rc!=SQLITE_OK ) return rc;
-  *pGone = !exists;
-  return SQLITE_OK;
+  rc = chunkStoreOpen(&cand, cs->file.pVfs, cs->file.zFilename,
+                      SQLITE_OPEN_READONLY | SQLITE_OPEN_MAIN_DB);
+  if( rc==SQLITE_OK ){
+    rc = csStoreHasAnyBranchTip(&cand, &cs->refs, pIsOurs);
+    chunkStoreClose(&cand);
+  }
+  if( rc!=SQLITE_OK ){
+    /* Only OOM is inconclusive; every other failure to read the candidate --
+    ** vacant path, unreadable, not a database -- is simply a failed proof. */
+    *pIsOurs = 0;
+    if( rc!=SQLITE_NOMEM && rc!=SQLITE_IOERR_NOMEM ) rc = SQLITE_OK;
+  }
+  return rc;
 }
 
 static int csDetectExternalChanges(ChunkStore *cs, int *pChanged){
@@ -295,14 +323,13 @@ static int csDetectExternalChanges(ChunkStore *cs, int *pChanged){
   rc = sqlite3OsFileControl(cs->file.pFile, SQLITE_FCNTL_HAS_MOVED, &bMoved);
   if( rc!=SQLITE_OK ) return rc;
   if( bMoved ){
-    /* Nothing at the path means renamed or unlinked away, not GC's atomic
-    ** replace. Reporting a change would reload by path; keep the handle we hold
-    ** so reads continue to see the database. Nothing is latched, so renaming the
-    ** file back resumes normal operation. */
-    int bGone = 0;
-    rc = csMovedFileGone(cs, &bGone);
+    int bOurs = 0;
+    rc = csMovedFileIsOurs(cs, &bOurs);
     if( rc!=SQLITE_OK ) return rc;
-    if( bGone ){
+    if( !bOurs ){
+      /* Reporting a change would reload by path and adopt whatever is there.
+      ** Reads keep serving the open handle; nothing is latched, so moving the
+      ** file back resumes normal operation. */
       cs->movedReadOnly = 1;
       *pChanged = 0;
       return SQLITE_OK;
@@ -336,6 +363,17 @@ int chunkStoreRefreshIfChanged(ChunkStore *cs, int *pChanged){
     return SQLITE_OK;
   }
   *pChanged = 0;
+  /* The caller installed a database at this path itself, so adopt it whatever it
+  ** holds -- the moved-file check would refuse it as foreign, and a pinned
+  ** snapshot has nothing left to pin. */
+  if( cs->adoptReplacement ){
+    cs->adoptReplacement = 0;
+    cs->movedReadOnly = 0;
+    rc = csReloadFromDisk(cs);
+    if( rc!=SQLITE_OK ) return rc;
+    *pChanged = 1;
+    return SQLITE_OK;
+  }
   if( cs->snapshotPinned ) return SQLITE_OK;
   rc = csDetectExternalChanges(cs, &bChanged);
   if( rc!=SQLITE_OK ) return rc;

--- a/src/doltlite_config.c
+++ b/src/doltlite_config.c
@@ -173,25 +173,97 @@ static void doltliteInternalMaterializeDefaultColumnFunc(
   sqlite3_result_int(ctx, 0);
 }
 
+/* Write the seed commit into cs and point its default branch at it.
+**
+** Deliberately store-scoped rather than going through doltliteCreateAndStoreCommit
+** and doltliteAdvanceBranch: those resolve the store from aDb[0], so they can only
+** ever seed the connection's main database. */
+static int doltliteSeedStore(sqlite3 *db, ChunkStore *cs, const char *zBranch){
+  DoltliteCommit c;
+  ProllyHash seedHash;
+  u8 *aData = 0;
+  int nData = 0;
+  int rc;
+
+  memset(&c, 0, sizeof(c));
+  c.timestamp = (i64)time(0);
+  c.zName = sqlite3_mprintf("%s", doltliteGetAuthorName(db));
+  c.zEmail = sqlite3_mprintf("%s", doltliteGetAuthorEmail(db));
+  c.zMessage = sqlite3_mprintf("Initialize data repository");
+  if( c.zName==0 || c.zEmail==0 || c.zMessage==0 ){
+    doltliteCommitClear(&c);
+    return SQLITE_NOMEM;
+  }
+
+  rc = doltliteCommitSerialize(&c, &aData, &nData);
+  if( rc==SQLITE_OK ) rc = chunkStorePut(cs, aData, nData, &seedHash);
+  sqlite3_free(aData);
+  doltliteCommitClear(&c);
+  if( rc!=SQLITE_OK ) return rc;
+
+  if( chunkStoreFindBranch(cs, zBranch, 0)==SQLITE_OK ){
+    return chunkStoreUpdateBranch(cs, zBranch, &seedHash);
+  }
+  rc = chunkStoreAddBranch(cs, zBranch, &seedHash);
+  if( rc==SQLITE_OK ) rc = chunkStoreSetDefaultBranch(cs, zBranch);
+  return rc;
+}
+
+/* Whether cs still needs a seed: either it has no branches at all, or its default
+** branch exists while naming no commit. The second case is the repair — the
+** working-set persist path creates a missing default branch pointing at the empty
+** hash, leaving a database holding data with no history, and the old
+** any-branch-at-all test then declined to fix it for the rest of its life. Any
+** other populated repo is left alone, so a database whose branches simply don't
+** include the recorded default is never handed a fabricated one. */
+static int doltliteStoreNeedsSeed(ChunkStore *cs, const char **pzBranch){
+  const char *zBranch = chunkStoreGetDefaultBranch(cs);
+  ProllyHash tip;
+
+  *pzBranch = zBranch;
+  if( zBranch==0 || zBranch[0]==0 ) return 0;
+  if( refsTableBranchCount(&cs->refs)==0 ) return 1;
+  return chunkStoreFindBranch(cs, zBranch, &tip)==SQLITE_OK
+      && prollyHashIsEmpty(&tip);
+}
+
 int doltliteMaybeSeedRepo(sqlite3 *db){
   ChunkStore *cs = doltliteGetChunkStore(db);
+  const char *zBranch;
   ProllyHash emptyParent;
   ProllyHash emptyCatalog;
   ProllyHash seedHash;
   int rc;
 
   if( !cs ) return SQLITE_OK;
-  if( refsTableBranchCount(&cs->refs) > 0 ) return SQLITE_OK;
   if( sqlite3_db_readonly(db, "main")==1 ) return SQLITE_OK;
+  if( !doltliteStoreNeedsSeed(cs, &zBranch) ) return SQLITE_OK;
 
   memset(&emptyParent, 0, sizeof(emptyParent));
   memset(&emptyCatalog, 0, sizeof(emptyCatalog));
 
+  /* The main database seeds through AdvanceBranch, which also sets the session
+  ** head and staged hashes, switches the catalog and persists the working set. */
   rc = doltliteCreateAndStoreCommit(db, &emptyParent, &emptyCatalog,
       "Initialize data repository", NULL, NULL, 0, 0, &seedHash);
   if( rc!=SQLITE_OK ) return rc;
 
   return doltliteAdvanceBranch(db, &seedHash, &emptyCatalog, 0);
+}
+
+/* An attached database has no session head, staged hash or catalog of its own, so
+** it cannot go through AdvanceBranch; its working set is still created by the
+** first persist, which now finds the branch already naming a commit. */
+int doltliteSeedAttachedDb(sqlite3 *db, int iDb){
+  ChunkStore *cs;
+  const char *zBranch;
+
+  if( db==0 || iDb<=0 || iDb>=db->nDb ) return SQLITE_OK;
+  cs = doltliteGetChunkStoreForDb(db, iDb);
+  if( cs==0 || cs->readOnly ) return SQLITE_OK;
+  if( sqlite3_db_readonly(db, db->aDb[iDb].zDbSName)==1 ) return SQLITE_OK;
+  if( !doltliteStoreNeedsSeed(cs, &zBranch) ) return SQLITE_OK;
+  return doltliteSeedStore(db, cs, zBranch);
 }
 
 int doltliteConfigRegister(sqlite3 *db){

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -805,6 +805,7 @@ static SQLITE_INLINE int dlReadFramedHeader(DlByteReader *r, u8 m0, u8 m1,
 }
 
 ChunkStore *doltliteGetChunkStore(sqlite3 *db);
+ChunkStore *doltliteGetChunkStoreForDb(sqlite3 *db, int iDb);
 BtShared *doltliteGetBtShared(sqlite3 *db);
 int doltliteIsStockSqliteDb(sqlite3 *db);
 void doltliteInvalidateWorkingState(sqlite3 *db);
@@ -961,6 +962,7 @@ int doltliteRevertRegister(sqlite3 *db);
 int doltliteRebaseRegister(sqlite3 *db);
 int doltliteConfigRegister(sqlite3 *db);
 int doltliteMaybeSeedRepo(sqlite3 *db);
+int doltliteSeedAttachedDb(sqlite3 *db, int iDb);
 
 int doltliteRegisterConflictTables(sqlite3 *db);
 int doltliteRegisterDiffTables(sqlite3 *db);

--- a/src/pager_shim.c
+++ b/src/pager_shim.c
@@ -1134,7 +1134,7 @@ backup_step_done:
   }
 
   if( rc == SQLITE_OK ){
-    destCs->file.iFileSize = -1;
+    destCs->adoptReplacement = 1;
     rc = chunkStoreLockAndRefresh(destCs);
     if( rc==SQLITE_OK ){
       /* The chunk store now reflects the renamed file. Force the

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -1974,13 +1974,17 @@ static void doltiteEngineFunc(
   sqlite3_result_text(context, zEngine, -1, SQLITE_STATIC);
 }
 
-ChunkStore *doltliteGetChunkStore(sqlite3 *db){
-  if( db && db->nDb>0 && db->aDb[0].pBt ){
-    Btree *pBt = db->aDb[0].pBt;
+ChunkStore *doltliteGetChunkStoreForDb(sqlite3 *db, int iDb){
+  if( db && iDb>=0 && iDb<db->nDb && db->aDb[iDb].pBt ){
+    Btree *pBt = db->aDb[iDb].pBt;
     if( sqlite3BtreeUsesOrig(pBt) ) return 0;
     return &pBt->pBt->store;
   }
   return 0;
+}
+
+ChunkStore *doltliteGetChunkStore(sqlite3 *db){
+  return doltliteGetChunkStoreForDb(db, 0);
 }
 
 BtShared *doltliteGetBtShared(sqlite3 *db){

--- a/src/prolly_btree_int.h
+++ b/src/prolly_btree_int.h
@@ -739,6 +739,7 @@ int unpackedRecordCanUseIntSortKey(BtCursor*, UnpackedRecord*, int);
 int sortKeyFromUnpackedIntRecordBuffer(UnpackedRecord*, int, u8**, int*, int*);
 int prollyInvokeBusyHandler(BtShared*);
 ChunkStore *doltliteGetChunkStore(sqlite3*);
+ChunkStore *doltliteGetChunkStoreForDb(sqlite3*, int);
 BtShared *doltliteGetBtShared(sqlite3*);
 ProllyCache *doltliteGetCache(sqlite3*);
 int doltliteRegister(sqlite3*);

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -4549,6 +4549,62 @@ static void run_commit_rejects_renamed_database(void){
 #endif
 }
 
+static void run_write_rejects_foreign_database_at_path(void){
+#ifndef _WIN32
+  sqlite3 *db = 0;
+  sqlite3 *foreign = 0;
+  char dbpath[256];
+  char renamedPath[320];
+  int rc;
+
+  printf("=== Write Rejects Foreign Database At Path Test ===\n\n");
+  make_dbpath(dbpath, sizeof(dbpath), "test_write_rejects_foreign_database");
+  sqlite3_snprintf(sizeof(renamedPath), renamedPath, "%s-renamed", dbpath);
+  removeDbFiles(dbpath);
+  removeDbFiles(renamedPath);
+
+  check("foreign_path_open", open_db(dbpath, &db)==SQLITE_OK);
+  check("foreign_path_setup", execSql(db,
+    "CREATE TABLE t1(a,b,c);"
+    "INSERT INTO t1 VALUES(673,'stone','philips');"
+    "SELECT dolt_commit('-A','-m','base');"
+    "UPDATE t1 SET b='dirty';")==SQLITE_OK);
+  check("foreign_path_rename", rename(dbpath, renamedPath)==0);
+
+  check("foreign_path_open_stranger", open_db(dbpath, &foreign)==SQLITE_OK);
+  check("foreign_path_seed_stranger",
+        execSql(foreign, "CREATE TABLE t2(x,y,z);")==SQLITE_OK);
+  sqlite3_close(foreign);
+  foreign = 0;
+
+  check("foreign_path_read_keeps_own_store",
+        strcmp(queryScalarText(db, "SELECT b FROM t1 WHERE a=673"), "dirty")==0);
+  rc = execSqlSilent(db, "UPDATE t1 SET b='after';");
+  check("foreign_path_write_readonly", rc==SQLITE_READONLY);
+  check("foreign_path_read_survives_refusal",
+        strcmp(queryScalarText(db, "SELECT b FROM t1 WHERE a=673"), "dirty")==0);
+  check("foreign_path_own_schema_retained",
+        strcmp(queryScalarText(db,
+          "SELECT count(*) FROM sqlite_master WHERE name='t2'"), "0")==0);
+  sqlite3_close(db);
+  db = 0;
+
+  check("foreign_path_reopen_own_store", open_db(renamedPath, &db)==SQLITE_OK);
+  check("foreign_path_own_store_unmodified",
+        strcmp(queryScalarText(db, "SELECT b FROM t1 WHERE a=673"), "dirty")==0);
+  sqlite3_close(db);
+  db = 0;
+
+  check("foreign_path_reopen_stranger", open_db(dbpath, &foreign)==SQLITE_OK);
+  check("foreign_path_stranger_unmodified",
+        strcmp(queryScalarText(foreign,
+          "SELECT count(*) FROM sqlite_master WHERE name='t1'"), "0")==0);
+  sqlite3_close(foreign);
+  removeDbFiles(dbpath);
+  removeDbFiles(renamedPath);
+#endif
+}
+
 static void run_savepoint_restores_session_metadata(void){
   sqlite3 *db = 0;
   char dbpath[256];
@@ -8809,6 +8865,7 @@ static const RegressionCase aCases[] = {
   { "index_moveto_mutmap_exact_keeps_iteration_aligned", "Index Moveto MutMap Exact Keeps Iteration Aligned Test", run_index_moveto_mutmap_exact_keeps_iteration_aligned },
   { "btree_commit_failure_transactional", "Btree Commit Failure Transaction Test", run_btree_commit_failure_transactional },
   { "commit_rejects_renamed_database", "Commit Rejects Renamed Database Test", run_commit_rejects_renamed_database },
+  { "write_rejects_foreign_database_at_path", "Write Rejects Foreign Database At Path Test", run_write_rejects_foreign_database_at_path },
   { "savepoint_restores_session_metadata", "Savepoint Restores Session Metadata Test", run_savepoint_restores_session_metadata },
   { "savepoint_flush_snapshot_rollback_reopen", "Savepoint Flush Snapshot Rollback Reopen Test", run_savepoint_flush_snapshot_rollback_reopen },
   { "savepoint_flush_snapshot_release_reopen", "Savepoint Flush Snapshot Release Reopen Test", run_savepoint_flush_snapshot_release_reopen },

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -2405,9 +2405,9 @@ nolock nolock-3.2  # VFS xLock call counts differ under chunk-store locking
 nolock nolock-3.12  # VFS xLock call counts differ under chunk-store locking
 nolock nolock-4.1  # VFS xLock call counts differ under chunk-store locking
 nolock nolock-4.3  # VFS xLock call counts differ under chunk-store locking
-pager4 pager4-1.4  # rename-while-open: commit goes BY PATH, creating a fresh db at the original path (silent fork)
-pager4 pager4-1.7  # journal_mode rejection aborts the catchsql batch; rename behavior never reached
-pager4 pager4-1.8  # journal_mode rejection aborts the catchsql batch; rename behavior never reached
+pager4 pager4-1.4  # two databases created in the same second are byte-identical, so a same-second stranger at the vacated path carries our seed commit and cannot be told from our own store
+pager4 pager4-1.7  # journal_mode is fixed at wal and the PRAGMA is a no-op, so OFF/MEMORY cannot grant stock's write exception for a moved file
+pager4 pager4-1.8  # journal_mode is fixed at wal and the PRAGMA is a no-op, so OFF/MEMORY cannot grant stock's write exception for a moved file
 resetdb resetdb-100  # sqlite_dbpage writes rejected; page counts/journal-mode reporting differ
 resetdb resetdb-110  # sqlite_dbpage writes rejected; page counts/journal-mode reporting differ
 resetdb resetdb-200  # sqlite_dbpage writes rejected; page counts/journal-mode reporting differ


### PR DESCRIPTION
Fixes #1873 and the remaining half of #1853. **Force-pushed over the earlier
working-set-probe approach, which CI proved wrong — see the comment above.**

You were right that no extra metadata was needed: the head commit is the correct
thing to probe. It only looked unusable because of a real bug underneath.

## #1873 — attached databases never got a seed commit

`doltliteMaybeSeedRepo` runs once per connection from `doltliteInit` and resolves
its store from `aDb[0]`, so it only ever seeded **main**. An attached database
instead got its default branch created by the first working-set persist, pointing at
the empty hash, and the old "has any branch" early-out then declined to repair it for
the rest of the database's life:

```
main db:      main tip=6e00e5bfd100
ATTACHED db:  main tip=000000000000    dolt_log rows: 0   (rows in table: 1)
```

ATTACH now seeds through a store-scoped path, and the guard tests whether the
default branch *names a commit* rather than whether any branch exists, so an
already-damaged database is repaired on open. Any other populated repo is left
alone — a database whose branches don't include the recorded default is never handed
a fabricated one.

Main keeps seeding through `doltliteAdvanceBranch`, which also sets the session head
and staged hashes, switches the catalog and persists the working set. Replacing that
with a bare `chunkStoreAddBranch` is what broke `gc_vs_merge` and `stale_session` on
my first attempt.

## #1853 — prove ownership by the head commit

Read-only on `HAS_MOVED` unless the connection can prove the file now at its path is
its own database. The proof: the candidate — opened read-only, no `OPEN_CREATE` —
holds one of our branch tips. GC preserves everything reachable from the refs it
sweeps under, and our tip stays an ancestor of whatever the branch became, so this
survives an arbitrarily stale handle.

Working-set roots cannot be the proof (my first attempt): a peer advancing the
working set makes GC sweep the one we remember, so a live database fails its own
test. `threadtest4 --serialized 6` caught that — **`VACUUM` *is* GC** in DoltLite
(`sqlite3RunVacuum` → `doltliteGcCompactWithPhase`), so concurrent writers plus a
store-replacing GC is an everyday workload.

**Backup** is a second sanctioned replacer that can never be proved by content, since
it installs unrelated content at the destination on purpose. It now declares the
replace with a one-shot `adoptReplacement`, consumed in `chunkStoreRefreshIfChanged`
where the reload happens — deliberately not in `csDetectExternalChanges`, because the
read-to-write upgrade path calls `chunkStoreHasExternalChanges` as a pure probe and
must not consume it, and a sanctioned replacement must be adopted even under a
pinned snapshot whose file is gone.

## Measured blast radius

| our database's history | stranger appears at the vacated path | result |
| --- | --- | --- |
| ≥1 `dolt_commit` | write refused, matches stock; our store untouched | fixed |
| seed-only (never committed) | still adopts the stranger | `pager4-1.4`, gated |

## Gates

- `pager4-1.4` stays gated, reason corrected to the true one: two databases created
  in the same second are byte-identical, so a same-second stranger carries our own
  seed commit and no content hash can separate them.
- `pager4-1.7`/`1.8` keep their gates (#1846) but also had a wrong reason —
  `journal_mode` is not "rejected", the PRAGMA is a no-op reporting `wal`, and the
  write is refused because there is no journal mode for OFF/MEMORY to switch off.
- `backup_malloc-1.transient.66`/`.67` need no action here: #1867 removed them on
  master after its own OOM re-sweep, and rebasing onto that keeps `backup_malloc`
  clean with this change too (2184 iterations, 15 known divergences, no entry
  reported fixed). Rebase resolution notes are below.

## Verification

- `threadtest4 --serialized 6`: clean 3/3 (master clean 4/4; previous attempt failed 3/3)
- `multi_process_gc_test`: 101/101 ×3
- `pager4`: down to its three gates
- C tests: 24/24 on freshly built binaries
- shell suites: 95/95
- `doltlite_regression_test_c`: 309990/309990
- `backup_malloc`, `backup2`, `backup4`, `backup5`: clean
- `make lint`, gate inventory and ratchet: clean

New regression `write_rejects_foreign_database_at_path` fails four assertions on the
unfixed engine and passes with the fix.

## Open question

Closing the `pager4-1.4` residual needs the seed commit to be unique per database.
My earlier claim that this needs no format change was too glib: the only spare
non-user-visible slot is a new commit format field (`DOLTLITE_COMMIT_V3`), i.e.
exactly the #1547 area #1864 declined. The alternatives put a random token in
`author`/`email`/`message`, which is user-visible in `dolt_log` forever and diverges
from Dolt (also second-resolution, no nonce). Given the residual loses no data and
only affects a never-committed database whose path is taken over within the same
second, my recommendation is to leave it gated. Easy to add if you'd rather close it.

## Rebase notes (onto #1867)

#1867 landed in the same code and this was rebased onto it rather than stacked.
Resolutions:

- `csMovedFileGone` → `csMovedFileIsOurs`: this replaces the predicate outright, and
  already carries #1867's substance — rc returned with the verdict as an
  out-parameter, no redundant `HAS_MOVED` re-query, helper `static` with the
  declaration out of `chunk_store_int.h` (that last one auto-resolved, master had
  already removed it).
- #1867's `iFileSize<=0` early-out is **kept**, with its reasoning: the VFS reports
  moved whenever it cannot resolve the path at all, so a store whose file is still to
  be created — a fresh database, or a backup target before its first write — must not
  read as moved.
- `backup_malloc` 66/67: took master's removal over this branch's `@linux`
  qualification, then re-ran the sweep to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
