### PR TITLE
Correct the three pager4 gate reasons

### DIFF
--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -2405,9 +2405,9 @@ nolock nolock-3.2  # VFS xLock call counts differ under chunk-store locking
 nolock nolock-3.12  # VFS xLock call counts differ under chunk-store locking
 nolock nolock-4.1  # VFS xLock call counts differ under chunk-store locking
 nolock nolock-4.3  # VFS xLock call counts differ under chunk-store locking
-pager4 pager4-1.4  # rename-while-open: commit goes BY PATH, creating a fresh db at the original path (silent fork)
-pager4 pager4-1.7  # journal_mode rejection aborts the catchsql batch; rename behavior never reached
-pager4 pager4-1.8  # journal_mode rejection aborts the catchsql batch; rename behavior never reached
+pager4 pager4-1.4  # a different database already at the vacated path is adopted, so the write is not refused: it fails 'no such table: t1' against the stranger's schema
+pager4 pager4-1.7  # journal_mode is fixed at wal and the PRAGMA is a no-op reporting 'wal', so OFF cannot grant stock's moved-file write exception; the write is refused
+pager4 pager4-1.8  # journal_mode is fixed at wal and the PRAGMA is a no-op reporting 'wal', so MEMORY cannot grant stock's moved-file write exception; the write is refused
 resetdb resetdb-100  # sqlite_dbpage writes rejected; page counts/journal-mode reporting differ
 resetdb resetdb-110  # sqlite_dbpage writes rejected; page counts/journal-mode reporting differ
 resetdb resetdb-200  # sqlite_dbpage writes rejected; page counts/journal-mode reporting differ


### PR DESCRIPTION
Comment strings only in `known_testfixture_divergences.txt` — no gate added or
removed, no counts moved. All three reasons described mechanisms that are no longer,
or never were, what actually happens, which would mislead whoever picks up #1853.

### pager4-1.4

Said the commit goes *by path* and creates a fresh database at the original path.
That was true once and was fixed by #1855/#1862 — a reload no longer passes
`OPEN_CREATE`, so nothing fabricates a database at a vacated path and the write is
refused there.

What still fails is the case the test actually sets up: a **different** database
already sitting at the path, which gets adopted, so the write is never refused:

```
expected: [1 {attempt to write a readonly database}]
got:      [1 {no such table: t1}]
```

That message is the stranger's schema showing through, not a read-only refusal.

### pager4-1.7 / 1.8

Said the `journal_mode` PRAGMA is rejected and the rename behaviour is never
reached. Neither half holds. The PRAGMA is not rejected — it is a no-op reporting the
fixed mode:

```
$ doltlite a.db ".shell mv a.db b.db" "PRAGMA journal_mode=OFF;"
wal
```

and the rename behaviour is very much reached — the write is refused, which is the
whole divergence. Stock permits writing a moved database when no rollback journal is
needed; DoltLite has no journal mode for OFF/MEMORY to switch off, so there is no
exception to grant.

### Verification

Measured against master (2ab5b7be) rather than written from memory. `pager4` still
reports exactly 3 known divergences, and `check_testfixture_exception_inventory.sh`,
its self-test, and `check_testfixture_inventory_issues_alive_test.sh` all pass
unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)