### PR TITLE
Backup declares its destination replace instead of leaning on change detection

### DIFF
--- a/src/chunk_store.h
+++ b/src/chunk_store.h
@@ -171,6 +171,12 @@ struct ChunkStore {
   ** Re-evaluated on every refresh, so restoring the file restores writability. */
 
   u8 movedReadOnly;
+
+  /* One-shot: adopt whatever file is now at the path on the next refresh. Only an
+  ** operation that installed a database there itself may set this -- a backup
+  ** destination is replaced with unrelated content on purpose, which no external
+  ** change detection can be expected to bless. */
+  u8 adoptReplacement;
   u8 isMemory;
   u8 fullFsync;           /* PRAGMA fullfsync: syncs use SQLITE_SYNC_FULL */
   u8 noSync;              /* PRAGMA synchronous=OFF: skip durability syncs */

--- a/src/chunk_store_lock.c
+++ b/src/chunk_store_lock.c
@@ -336,6 +336,17 @@ int chunkStoreRefreshIfChanged(ChunkStore *cs, int *pChanged){
     return SQLITE_OK;
   }
   *pChanged = 0;
+  /* The caller installed a database at this path itself, so adopt it whatever it
+  ** holds -- external-change detection has no basis to bless foreign content, and
+  ** a pinned snapshot has nothing left to pin. */
+  if( cs->adoptReplacement ){
+    cs->adoptReplacement = 0;
+    cs->movedReadOnly = 0;
+    rc = csReloadFromDisk(cs);
+    if( rc!=SQLITE_OK ) return rc;
+    *pChanged = 1;
+    return SQLITE_OK;
+  }
   if( cs->snapshotPinned ) return SQLITE_OK;
   rc = csDetectExternalChanges(cs, &bChanged);
   if( rc!=SQLITE_OK ) return rc;

--- a/src/pager_shim.c
+++ b/src/pager_shim.c
@@ -1134,7 +1134,7 @@ backup_step_done:
   }
 
   if( rc == SQLITE_OK ){
-    destCs->file.iFileSize = -1;
+    destCs->adoptReplacement = 1;
     rc = chunkStoreLockAndRefresh(destCs);
     if( rc==SQLITE_OK ){
       /* The chunk store now reflects the renamed file. Force the


### PR DESCRIPTION
First of the #1853 sequence — standalone, one fix.

`sqlite3_backup_step` installs the copied store at the destination path with
`sqlite3OsReplaceFile`, then set `iFileSize = -1` so the next refresh's
external-change heuristics would notice something changed and reload. That works
today only because the moved-file path happens to bless any occupied path — but the
backup destination now holds content *unrelated* to what the handle had open, which
is exactly what that detection exists to be suspicious of. When the moved-file check
tightens (next PR in the sequence), backup must not depend on a heuristic blessing
foreign content.

Backup knows it performed the replace, so it now says so: a one-shot
`adoptReplacement` on the destination store, consumed in `chunkStoreRefreshIfChanged`
where the reload happens. The consume clears `movedReadOnly` (a sanctioned replace
supersedes any earlier moved verdict) and runs before the `snapshotPinned`
early-return — a pinned snapshot of the pre-backup store has nothing left to pin.
Kept out of `csDetectExternalChanges` deliberately: `chunkStoreHasExternalChanges` is
used as a pure probe on the read-to-write upgrade path and must not consume the flag.
The `iFileSize = -1` trick had exactly one user; it is gone.

No behavior change intended today — this is the backup path stating its own semantics
rather than borrowing them.

## Verification

- `backup_safety` 18/18, `doltlite_regression_test_c` 309990/309990
- 24/24 C tests (fresh binaries), 95/95 shell suites, lint + inventory + ratchet clean
- **Full fault-fuzz and storage buckets run locally, isolated**: this change adds
  zero OOM-sweep shifts — the 12 unexpected positions the run surfaced reproduce
  identically on unmodified master (pre-existing macos gate drift from the attach
  seeding; filed as #1877 with the full shifted-pair table)
- `bigfile`/`bigfile2` "no summary line" is upstream's Darwin self-skip before
  `tester.tcl` loads — those two can never satisfy the local runner on macos; CI runs
  them on linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)