### PR TITLE
Refuse to adopt a file at our path unless it holds one of our branch tips (#1853)

### DIFF
--- a/src/chunk_store_lock.c
+++ b/src/chunk_store_lock.c
@@ -239,33 +239,66 @@ void chunkStoreUnlock(ChunkStore *cs){
   }
 }
 
-/* Whether the file this handle opened has been renamed or unlinked away with
-** nothing taking its place. The caller has already established that the VFS
-** reports it moved; GC replaces the store atomically, which keeps the path
-** populated throughout, so a vacant path is what separates "moved out from under
-** us" from "upgraded beneath us".
+static int csStoreHasAnyBranchTip(ChunkStore *pCand, const RefsTable *rt,
+                                  int *pHas){
+  int i;
+  *pHas = 0;
+  for(i=0; i<rt->nBranches; i++){
+    const ProllyHash *pTip = &rt->aBranches[i].commitHash;
+    int rc, has = 0;
+    if( prollyHashIsEmpty(pTip) ) continue;
+    rc = chunkStoreHas(pCand, pTip, &has);
+    if( rc!=SQLITE_OK ) return rc;
+    if( has ){
+      *pHas = 1;
+      return SQLITE_OK;
+    }
+  }
+  return SQLITE_OK;
+}
+
+/* Whether the file now at this handle's path is provably the database this handle
+** opened. Upstream makes any moved file read-only for good; GC is DoltLite's one
+** legitimate reason for the path to hold a different file, and a GC replacement,
+** a rename and a vacant path are indistinguishable from the outside. So require
+** proof: the candidate holds a branch tip of ours. GC preserves every commit
+** reachable from the refs it sweeps under and our tip stays an ancestor of
+** whatever the branch has since become, so this survives an arbitrarily stale
+** handle -- the contract gc_tip_survival_test pins. No proof leaves the upstream
+** verdict in place.
+**
+** Working-set roots cannot be the proof: a peer advancing the working set makes
+** GC sweep the one we remember, so a live database fails its own test.
 **
 ** Never written means never moved: the VFS reports moved whenever it cannot
-** resolve the path at all, so a store whose file is still to be created -- a fresh
-** database, or a backup target before its first write -- is indistinguishable
-** from one renamed away unless this handle has already seen the file on disk.
-**
-** Returns an error rather than a verdict when the existence check itself fails:
-** an I/O error is not evidence about where the database went. */
-static int csMovedFileGone(ChunkStore *cs, int *pGone){
-  int exists = 0;
+** resolve the path at all, so a store whose file is still to be created -- a
+** fresh database, or a backup target before its first write -- is
+** indistinguishable from one renamed away. */
+static int csMovedFileIsOurs(ChunkStore *cs, int *pIsOurs){
+  ChunkStore cand;
   int rc;
 
-  *pGone = 0;
+  *pIsOurs = 0;
   if( cs->isMemory || cs->file.pFile==0 ) return SQLITE_OK;
   if( cs->file.zFilename==0 || cs->file.zFilename[0]==0 ) return SQLITE_OK;
-  if( cs->file.iFileSize<=0 ) return SQLITE_OK;
+  if( cs->file.iFileSize<=0 ){
+    *pIsOurs = 1;
+    return SQLITE_OK;
+  }
 
-  rc = sqlite3OsAccess(cs->file.pVfs, cs->file.zFilename,
-                       SQLITE_ACCESS_EXISTS, &exists);
-  if( rc!=SQLITE_OK ) return rc;
-  *pGone = !exists;
-  return SQLITE_OK;
+  rc = chunkStoreOpen(&cand, cs->file.pVfs, cs->file.zFilename,
+                      SQLITE_OPEN_READONLY | SQLITE_OPEN_MAIN_DB);
+  if( rc==SQLITE_OK ){
+    rc = csStoreHasAnyBranchTip(&cand, &cs->refs, pIsOurs);
+    chunkStoreClose(&cand);
+  }
+  if( rc!=SQLITE_OK ){
+    /* Only OOM is inconclusive; every other failure to read the candidate --
+    ** vacant path, unreadable, not a database -- is simply a failed proof. */
+    *pIsOurs = 0;
+    if( rc!=SQLITE_NOMEM && rc!=SQLITE_IOERR_NOMEM ) rc = SQLITE_OK;
+  }
+  return rc;
 }
 
 static int csDetectExternalChanges(ChunkStore *cs, int *pChanged){
@@ -295,14 +328,13 @@ static int csDetectExternalChanges(ChunkStore *cs, int *pChanged){
   rc = sqlite3OsFileControl(cs->file.pFile, SQLITE_FCNTL_HAS_MOVED, &bMoved);
   if( rc!=SQLITE_OK ) return rc;
   if( bMoved ){
-    /* Nothing at the path means renamed or unlinked away, not GC's atomic
-    ** replace. Reporting a change would reload by path; keep the handle we hold
-    ** so reads continue to see the database. Nothing is latched, so renaming the
-    ** file back resumes normal operation. */
-    int bGone = 0;
-    rc = csMovedFileGone(cs, &bGone);
+    int bOurs = 0;
+    rc = csMovedFileIsOurs(cs, &bOurs);
     if( rc!=SQLITE_OK ) return rc;
-    if( bGone ){
+    if( !bOurs ){
+      /* Reporting a change would reload by path and adopt whatever is there.
+      ** Reads keep serving the open handle; nothing is latched, so moving the
+      ** file back resumes normal operation. */
       cs->movedReadOnly = 1;
       *pChanged = 0;
       return SQLITE_OK;
@@ -362,6 +394,12 @@ int chunkStoreForceRefresh(ChunkStore *cs){
   int rc;
   int wasPinned;
   if( cs->isMemory ) return SQLITE_OK;
+  /* The refresh the moved-file check declined, refused for the reason it
+  ** declined it: reloading by path here would adopt the foreign store while the
+  ** caller's catalog stays ours, and every caller is on a write path. A peer's
+  ** gc never latches this -- our tips survive its sweep -- so the only handles
+  ** refused are ones whose file genuinely is not at their path. */
+  if( cs->movedReadOnly ) return SQLITE_READONLY;
   /* Only the outermost lock holder reloads; a reentrant (inner) holder runs
   ** under the outer scope's already-current view, so a multi-step VC op that
   ** holds the lock across sub-operations keeps the in-memory state it builds. */

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -4619,6 +4619,66 @@ static void run_attached_database_seed_and_repair(void){
   removeDbFiles(auxPath);
 }
 
+static void run_write_rejects_foreign_database_at_path(void){
+#ifndef _WIN32
+  sqlite3 *db = 0;
+  sqlite3 *foreign = 0;
+  char dbpath[256];
+  char renamedPath[320];
+  int rc;
+
+  printf("=== Write Rejects Foreign Database At Path Test ===\n\n");
+  make_dbpath(dbpath, sizeof(dbpath), "test_write_rejects_foreign_database");
+  sqlite3_snprintf(sizeof(renamedPath), renamedPath, "%s-renamed", dbpath);
+  removeDbFiles(dbpath);
+  removeDbFiles(renamedPath);
+
+  check("foreign_path_open", open_db(dbpath, &db)==SQLITE_OK);
+  check("foreign_path_setup", execSql(db,
+    "CREATE TABLE t1(a,b,c);"
+    "INSERT INTO t1 VALUES(673,'stone','philips');"
+    "SELECT dolt_commit('-A','-m','base');"
+    "UPDATE t1 SET b='dirty';")==SQLITE_OK);
+  check("foreign_path_rename", rename(dbpath, renamedPath)==0);
+
+  check("foreign_path_open_stranger", open_db(dbpath, &foreign)==SQLITE_OK);
+  check("foreign_path_seed_stranger",
+        execSql(foreign, "CREATE TABLE t2(x,y,z);")==SQLITE_OK);
+  sqlite3_close(foreign);
+  foreign = 0;
+
+  check("foreign_path_read_keeps_own_store",
+        strcmp(queryScalarText(db, "SELECT b FROM t1 WHERE a=673"), "dirty")==0);
+  rc = execSqlSilent(db, "UPDATE t1 SET b='after';");
+  check("foreign_path_write_readonly", rc==SQLITE_READONLY);
+  /* The VC write path force-refreshes before advancing the ref; it must refuse
+  ** the same way instead of reloading by path and adopting the stranger. */
+  rc = execSqlSilent(db, "SELECT dolt_commit('-A','-m','vc');");
+  check("foreign_path_vc_commit_readonly", rc==SQLITE_READONLY);
+  check("foreign_path_read_survives_refusals",
+        strcmp(queryScalarText(db, "SELECT b FROM t1 WHERE a=673"), "dirty")==0);
+  check("foreign_path_own_schema_retained",
+        strcmp(queryScalarText(db,
+          "SELECT count(*) FROM sqlite_master WHERE name='t2'"), "0")==0);
+  sqlite3_close(db);
+  db = 0;
+
+  check("foreign_path_reopen_own_store", open_db(renamedPath, &db)==SQLITE_OK);
+  check("foreign_path_own_store_unmodified",
+        strcmp(queryScalarText(db, "SELECT b FROM t1 WHERE a=673"), "dirty")==0);
+  sqlite3_close(db);
+  db = 0;
+
+  check("foreign_path_reopen_stranger", open_db(dbpath, &foreign)==SQLITE_OK);
+  check("foreign_path_stranger_unmodified",
+        strcmp(queryScalarText(foreign,
+          "SELECT count(*) FROM sqlite_master WHERE name='t1'"), "0")==0);
+  sqlite3_close(foreign);
+  removeDbFiles(dbpath);
+  removeDbFiles(renamedPath);
+#endif
+}
+
 static void run_savepoint_restores_session_metadata(void){
   sqlite3 *db = 0;
   char dbpath[256];
@@ -8879,6 +8939,7 @@ static const RegressionCase aCases[] = {
   { "index_moveto_mutmap_exact_keeps_iteration_aligned", "Index Moveto MutMap Exact Keeps Iteration Aligned Test", run_index_moveto_mutmap_exact_keeps_iteration_aligned },
   { "btree_commit_failure_transactional", "Btree Commit Failure Transaction Test", run_btree_commit_failure_transactional },
   { "commit_rejects_renamed_database", "Commit Rejects Renamed Database Test", run_commit_rejects_renamed_database },
+  { "write_rejects_foreign_database_at_path", "Write Rejects Foreign Database At Path Test", run_write_rejects_foreign_database_at_path },
   { "attached_database_seed_and_repair", "Attached Database Seed And Repair Test", run_attached_database_seed_and_repair },
   { "savepoint_restores_session_metadata", "Savepoint Restores Session Metadata Test", run_savepoint_restores_session_metadata },
   { "savepoint_flush_snapshot_rollback_reopen", "Savepoint Flush Snapshot Rollback Reopen Test", run_savepoint_flush_snapshot_rollback_reopen },

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -2464,7 +2464,7 @@ nolock nolock-3.2  # VFS xLock call counts differ under chunk-store locking
 nolock nolock-3.12  # VFS xLock call counts differ under chunk-store locking
 nolock nolock-4.1  # VFS xLock call counts differ under chunk-store locking
 nolock nolock-4.3  # VFS xLock call counts differ under chunk-store locking
-pager4 pager4-1.4  # a different database already at the vacated path is adopted, so the write is not refused: it fails 'no such table: t1' against the stranger's schema
+pager4 pager4-1.4  # two databases created in the same second are byte-identical, so a same-second stranger at the vacated path carries our own seed commit and passes the tip proof; any database with a real commit is protected
 pager4 pager4-1.7  # journal_mode is fixed at wal and the PRAGMA is a no-op reporting 'wal', so OFF cannot grant stock's moved-file write exception; the write is refused
 pager4 pager4-1.8  # journal_mode is fixed at wal and the PRAGMA is a no-op reporting 'wal', so MEMORY cannot grant stock's moved-file write exception; the write is refused
 resetdb resetdb-100  # sqlite_dbpage writes rejected; page counts/journal-mode reporting differ


### PR DESCRIPTION
Third and last of the #1853 sequence, on top of #1878 (backup `adoptReplacement`)
and #1879 (GC tip-survival contract test), both merged.

## The fix

A vacated path already goes read-only, but any file *occupying* the path was adopted
wholesale — an unrelated database created there silently swapped the live connection
onto it (`"no such table: t1"`, our real store untouched at its new path).

Default back to upstream (`HAS_MOVED` ⇒ read-only) and make GC the positive
exception: the connection stays writable only if it can prove the file now at its
path is its own database. The proof: the candidate — opened read-only, no
`OPEN_CREATE` — holds one of our **branch tips**. GC preserves every commit
reachable from the refs it sweeps under, and our tip stays an ancestor of whatever
the branch has since become, so the proof survives an arbitrarily stale handle.
**That contract is pinned by `gc_tip_survival_test` (#1879)**, including both
negative spaces: working-set roots are swept on peer advance (so they can never be
the proof), and a deleted branch's unique tip is collected (a handle that only
remembers deleted branches goes read-only by design). Vacant, unreadable, and
not-a-database all fail the proof; only OOM is inconclusive and propagates. A
never-written store keeps its adopt-on-first-sight behavior.

`chunkStoreForceRefresh` now refuses while `movedReadOnly` is latched instead of
reloading by path underneath a VC write, which previously produced a torn handle
(foreign chunk store, our catalog — phantom "commit conflict", then "unknown
operation"). With the tip proof this guard is safe where the earlier working-set
attempt was not: a peer's `reset --hard` + `gc` keeps our tips, so `movedReadOnly`
never latches on live databases — `multi_process_gc_test` stays 101/101 — and a
genuinely foreign path now gets a clean `SQLITE_READONLY` from `dolt_commit`.

## Residual (gated, deliberate)

`pager4-1.4`: two databases created in the same second are byte-identical, so a
same-second stranger carries our own seed commit and passes the proof. Closing that
needs a per-database-unique seed, which is a format question deliberately not taken
here. Any database with a real commit is protected.

## Verification

- `write_rejects_foreign_database_at_path`: **5 assertions fail on the unfixed
  engine, 14/14 with the fix**, including the clean READONLY from `dolt_commit`
- `multi_process_gc_test` 101/101 ×3
- `threadtest4 --serialized 6` clean ×3 on a force-regenerated amalgamation (the
  scenario that killed the working-set approach)
- `pager4` at exactly its three gates; 1.4's reason updated to the true residual
- Full fault-fuzz + storage buckets, isolated: zero shifts — the only unexpected
  entries are the pre-existing macos gate-drift dozen (#1877) and the two Darwin
  self-skip `bigfile` artifacts, byte-identical to unmodified master
- 24/24 C tests, 95/95 shell suites, lint + inventory + ratchet clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)