### PR TITLE
Stabilize OOM fault-sweep gates

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -314,6 +314,7 @@ jobs:
         bash test/check_testfixture_crash_coverage_test.sh
         bash test/check_testfixture_exception_inventory.sh
         bash test/check_testfixture_exception_inventory_test.sh
+        bash test/run_testfixture_test.sh
         bash test/check_testfixture_inventory_issues_alive_test.sh
 
     - name: SQLite regression tests - ${{ matrix.bucket }}

--- a/test/check_testfixture_exception_inventory.sh
+++ b/test/check_testfixture_exception_inventory.sh
@@ -44,7 +44,9 @@ if ! awk '
       printf "%s:%d: invalid suite name: %s\n", FILENAME, NR, $1
       bad = 1
     }
-    if ($2 != "*" && $2 !~ /^[A-Za-z0-9_.()-]+$/) {
+    exact = ($2 ~ /^[A-Za-z0-9_.()-]+$/)
+    counted = ($2 ~ /^[A-Za-z0-9_.()-]+[.][*][{][1-9][0-9]*[}]$/)
+    if ($2 != "*" && !exact && !counted) {
       printf "%s:%d: invalid gate: %s\n", FILENAME, NR, $2
       bad = 1
     }
@@ -68,6 +70,67 @@ if ! awk '
   }
   END { exit bad }
 ' "$INVENTORY_FILE"; then
+  exit 1
+fi
+
+if ! awk '
+  function is_counted(g) {
+    return g ~ /^[A-Za-z0-9_.()-]+[.][*][{][1-9][0-9]*[}]$/
+  }
+  function counted_prefix(g, p) {
+    p = g
+    sub(/[.][*][{][1-9][0-9]*[}]$/, "", p)
+    return p "."
+  }
+  {
+    sub(/#.*/, "")
+    if (NF == 0) next
+    if (NF < 2) {
+      printf "%s:%d: expected at least 2 fields\n", FILENAME, NR
+      bad = 1
+      next
+    }
+    exact = ($2 ~ /^[A-Za-z0-9_.()-]+$/)
+    counted = is_counted($2)
+    if (!exact && !counted) {
+      printf "%s:%d: invalid gate: %s\n", FILENAME, NR, $2
+      bad = 1
+    }
+    for (i = 3; i <= NF; i++) {
+      if ($i != "@linux" && $i != "@darwin" && $i != "@windows" &&
+          $i != "@coverage" && $i != "@no-coverage") {
+        printf "%s:%d: invalid qualifier: %s\n", FILENAME, NR, $i
+        bad = 1
+      }
+    }
+    suite[++n] = $1
+    gate[n] = $2
+    if (counted) counted_gate[++n_counted] = n
+  }
+  END {
+    for (k = 1; k <= n_counted; k++) {
+      i = counted_gate[k]
+      p = counted_prefix(gate[i])
+      for (j = 1; j <= n; j++) {
+        if (i == j) continue
+        if (suite[i] != suite[j]) continue
+        if (is_counted(gate[j])) {
+          if (j < i) continue
+          q = counted_prefix(gate[j])
+          overlap = (index(p, q) == 1 || index(q, p) == 1)
+        } else {
+          overlap = (index(gate[j], p) == 1)
+        }
+        if (overlap) {
+          printf "%s: overlapping gates for %s: %s and %s\n",
+                 FILENAME, suite[i], gate[i], gate[j]
+          bad = 1
+        }
+      }
+    }
+    exit bad
+  }
+' "$DIVERGENCE_FILE"; then
   exit 1
 fi
 
@@ -107,10 +170,31 @@ report_set "stale inventory entries" "$TMP_DIR/stale"
 
 [ "$FAIL" -eq 0 ] || exit 1
 
-TOTAL=$(wc -l < "$TMP_DIR/inventory" | tr -d ' ')
+TOTAL=$(awk '
+  function weight(g, n) {
+    if (g ~ /[.][*][{][1-9][0-9]*[}]$/) {
+      n = g
+      sub(/^.*[.][*][{]/, "", n)
+      sub(/[}]$/, "", n)
+      return n + 0
+    }
+    return 1
+  }
+  { sub(/#.*/, ""); if (NF) n += weight($2) }
+  END { print n + 0 }
+' "$INVENTORY_FILE")
 counts_for() {
   awk -v want="$1" '
-    { sub(/#.*/, ""); if (NF && $3 == want) n++ }
+    function weight(g, n) {
+      if (g ~ /[.][*][{][1-9][0-9]*[}]$/) {
+        n = g
+        sub(/^.*[.][*][{]/, "", n)
+        sub(/[}]$/, "", n)
+        return n + 0
+      }
+      return 1
+    }
+    { sub(/#.*/, ""); if (NF && $3 == want) n += weight($2) }
     END { print n + 0 }
   ' "$INVENTORY_FILE"
 }

--- a/test/check_testfixture_exception_inventory_test.sh
+++ b/test/check_testfixture_exception_inventory_test.sh
@@ -122,6 +122,37 @@ printf '%s\n' \
   'gamma * harness -' > "$INVENTORY"
 expect_failure "one gate of a suite left without a disposition"
 
+# Counted patterns retain their represented assertion count in the ratchet.
+printf '%s\n' \
+  'alpha alpha-1.transient.*{2}' \
+  'beta beta-1 @linux # platform case' > "$DIVERGENCES"
+printf '%s\n' \
+  'alpha alpha-1.transient.*{2} intentional -' \
+  'beta beta-1 unsupported https://github.com/dolthub/doltlite/issues/42' \
+  'gamma * harness -' > "$INVENTORY"
+write_ratchet 4 2 1 1 0
+run_check
+
+printf '%s\n' \
+  'alpha alpha-1.transient.*{0}' \
+  'beta beta-1 @linux # platform case' > "$DIVERGENCES"
+printf '%s\n' \
+  'alpha alpha-1.transient.*{0} intentional -' \
+  'beta beta-1 unsupported https://github.com/dolthub/doltlite/issues/42' \
+  'gamma * harness -' > "$INVENTORY"
+expect_failure "a zero-count pattern"
+
+printf '%s\n' \
+  'alpha alpha-1.transient.*{2}' \
+  'alpha alpha-1.transient.7' \
+  'beta beta-1 @linux # platform case' > "$DIVERGENCES"
+printf '%s\n' \
+  'alpha alpha-1.transient.*{2} intentional -' \
+  'alpha alpha-1.transient.7 intentional -' \
+  'beta beta-1 unsupported https://github.com/dolthub/doltlite/issues/42' \
+  'gamma * harness -' > "$INVENTORY"
+expect_failure "overlapping exact and counted gates"
+
 # Back to the 3-gate fixture for the ratchet cases.
 printf '%s\n' \
   'alpha alpha-1' \

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -2,6 +2,8 @@
 #
 # Format: <test_file> <test_name> [qualifiers...]  # reason (optional)
 # Qualifiers: @linux, @darwin, @windows, @coverage, @no-coverage
+# A counted gate ending in .*{N} matches exactly N failures with that prefix.
+# Index movement passes; adding or resolving a failure does not.
 #
 # These tests fail when run by run_testfixture.sh against doltlite's
 # testfixture build, but the failures are not bugs — they're cases
@@ -2087,28 +2089,12 @@ backup4 backup4-2.4  # chunk-store file sizes; in-memory doltlite backup rejecte
 backup4 backup4-3.2  # chunk-store file sizes; in-memory doltlite backup rejected
 backup4 backup4-3.3  # chunk-store file sizes; in-memory doltlite backup rejected
 backup4 backup4-3.4  # chunk-store file sizes; in-memory doltlite backup rejected
-# backup_malloc: the indices below are fault-sweep positions, not stable
-# identities. Any change to the allocation sequence moves them, so this block
-# has to be re-derived rather than trusted -- tracked as #1859.
 # backup_malloc: raw sqlite3_backup_step page-copy fault points do not line up
 # with DoltLite's supported Tcl backup path. Native coverage in
 # doltlite_recover_backup_fault asserts clean OOM failure at the Tcl backup
 # entry point, source usability, and absent/valid target state.
-backup_malloc backup_malloc-1.transient.0  # OOM fault-point shift + harness cascade
-backup_malloc backup_malloc-1.transient.1  # OOM fault-point shift + harness cascade
-backup_malloc backup_malloc-1.transient.2  # OOM fault-point shift + harness cascade
-backup_malloc backup_malloc-1.transient.3  # OOM fault-point shift + harness cascade
-backup_malloc backup_malloc-1.transient.4  # OOM fault-point shift + harness cascade
-backup_malloc backup_malloc-1.transient.5  # OOM fault-point shift + harness cascade
-backup_malloc backup_malloc-1.transient.6  # OOM fault-point shift + harness cascade
-backup_malloc backup_malloc-1.transient.35  # OOM fault-point shift + harness cascade (+SHARED graph lock)
-backup_malloc backup_malloc-1.persistent.0  # OOM fault-point shift + harness cascade
-backup_malloc backup_malloc-1.persistent.1  # OOM fault-point shift + harness cascade
-backup_malloc backup_malloc-1.persistent.2  # OOM fault-point shift + harness cascade
-backup_malloc backup_malloc-1.persistent.3  # OOM fault-point shift + harness cascade
-backup_malloc backup_malloc-1.persistent.4  # OOM fault-point shift + harness cascade
-backup_malloc backup_malloc-1.persistent.5  # OOM fault-point shift + harness cascade
-backup_malloc backup_malloc-1.persistent.6  # OOM fault-point shift + harness cascade
+backup_malloc backup_malloc-1.transient.*{8}  # OOM fault-point shift + harness cascade
+backup_malloc backup_malloc-1.persistent.*{7}  # OOM fault-point shift + harness cascade
 busy2 busy2-2.1.2  # wal_checkpoint counters zero; checkpoint mode rejected
 busy2 busy2-2.1.3  # wal_checkpoint counters zero; checkpoint mode rejected
 busy2 busy2-2.1.4  # wal_checkpoint counters zero; checkpoint mode rejected

--- a/test/known_testfixture_exception_inventory.txt
+++ b/test/known_testfixture_exception_inventory.txt
@@ -1,9 +1,10 @@
 # Per-gate disposition for every testfixture divergence and expected crash.
 # Format: <test_file> <gate> <intentional|unsupported|harness|engine-gap> <issue-url|->
 #
-# <gate> is the divergence's test name, or * for a crash row, where the gate is
-# the whole file. unsupported and engine-gap require a DoltLite issue URL;
-# intentional and harness may cite the issue that documents the limitation.
+# <gate> is the divergence's test name, a counted prefix ending in .*{N}, or
+# * for a crash row, where the gate is the whole file. unsupported and
+# engine-gap require a DoltLite issue URL; intentional and harness may cite the
+# issue that documents the limitation.
 #
 # Per gate rather than per suite: a suite-level label blankets every assertion
 # in the file, and real bugs have hidden behind a plausible one (#1155, #1156,
@@ -190,21 +191,8 @@ backup4 backup4-3.4 unsupported https://github.com/dolthub/doltlite/issues/1839
 backup5 backup5-1.3 unsupported https://github.com/dolthub/doltlite/issues/1839
 backup5 backup5-1.4 unsupported https://github.com/dolthub/doltlite/issues/1839
 backup_ioerr * harness -
-backup_malloc backup_malloc-1.persistent.0 unsupported https://github.com/dolthub/doltlite/issues/1839
-backup_malloc backup_malloc-1.persistent.1 unsupported https://github.com/dolthub/doltlite/issues/1839
-backup_malloc backup_malloc-1.persistent.2 unsupported https://github.com/dolthub/doltlite/issues/1839
-backup_malloc backup_malloc-1.persistent.3 unsupported https://github.com/dolthub/doltlite/issues/1839
-backup_malloc backup_malloc-1.persistent.4 unsupported https://github.com/dolthub/doltlite/issues/1839
-backup_malloc backup_malloc-1.persistent.5 unsupported https://github.com/dolthub/doltlite/issues/1839
-backup_malloc backup_malloc-1.persistent.6 unsupported https://github.com/dolthub/doltlite/issues/1839
-backup_malloc backup_malloc-1.transient.0 unsupported https://github.com/dolthub/doltlite/issues/1839
-backup_malloc backup_malloc-1.transient.1 unsupported https://github.com/dolthub/doltlite/issues/1839
-backup_malloc backup_malloc-1.transient.2 unsupported https://github.com/dolthub/doltlite/issues/1839
-backup_malloc backup_malloc-1.transient.3 unsupported https://github.com/dolthub/doltlite/issues/1839
-backup_malloc backup_malloc-1.transient.35 unsupported https://github.com/dolthub/doltlite/issues/1839
-backup_malloc backup_malloc-1.transient.4 unsupported https://github.com/dolthub/doltlite/issues/1839
-backup_malloc backup_malloc-1.transient.5 unsupported https://github.com/dolthub/doltlite/issues/1839
-backup_malloc backup_malloc-1.transient.6 unsupported https://github.com/dolthub/doltlite/issues/1839
+backup_malloc backup_malloc-1.persistent.*{7} unsupported https://github.com/dolthub/doltlite/issues/1839
+backup_malloc backup_malloc-1.transient.*{8} unsupported https://github.com/dolthub/doltlite/issues/1839
 badutf badutf-1.10 unsupported https://github.com/dolthub/doltlite/issues/1838
 badutf badutf-1.11 unsupported https://github.com/dolthub/doltlite/issues/1838
 badutf badutf-1.12 unsupported https://github.com/dolthub/doltlite/issues/1838

--- a/test/run_testfixture.sh
+++ b/test/run_testfixture.sh
@@ -88,6 +88,17 @@ count_lines() {
   fi
 }
 
+parse_counted_pattern() {
+  COUNTED_PREFIX=""
+  COUNTED_EXPECTED=0
+  if [[ "$1" =~ ^(.+)\.\*\{([1-9][0-9]*)\}$ ]]; then
+    COUNTED_PREFIX="${BASH_REMATCH[1]}."
+    COUNTED_EXPECTED="${BASH_REMATCH[2]}"
+    return 0
+  fi
+  return 1
+}
+
 total_pass=0
 total_fail_known=0
 total_fail_unexpected=0
@@ -98,7 +109,7 @@ unexpected_failure_lines=""
 unused_lines=""
 
 for test in "$@"; do
-  expected="$(expected_for "$test")"
+  expected_specs="$(expected_for "$test")"
   out=$(run_with_timeout "$TIMEOUT" ./testfixture ../test/${test}.test 2>&1) || true
 
   done_line=$(echo "$out" | grep "errors out of" | head -1)
@@ -115,7 +126,7 @@ for test in "$@"; do
     continue
   fi
 
-  if is_crash_expected "$test" && [ -z "$expected" ]; then
+  if is_crash_expected "$test" && [ -z "$expected_specs" ]; then
     echo "FIXED CRASH: $test (was on crash list, now produces summary — remove from $CRASH_FILE)"
     total_unexpected_clean=$((total_unexpected_clean + 1))
     unused_lines="$unused_lines"$'\n'"  $test (crash list)"
@@ -124,6 +135,45 @@ for test in "$@"; do
   actual=""
   if [ -n "$fail_line" ]; then
     actual=$(echo "$fail_line" | sed 's/^!Failures on these tests://' | tr ' ' '\n' | grep -v '^$' || true)
+  fi
+
+  expected=""
+  exact_expected=""
+  fixed=""
+  n_expected_total=0
+  if [ -n "$expected_specs" ]; then
+    while IFS= read -r spec; do
+      [ -z "$spec" ] && continue
+      if parse_counted_pattern "$spec"; then
+        matches=""
+        while IFS= read -r name; do
+          [ -z "$name" ] && continue
+          if [[ "$name" == "$COUNTED_PREFIX"* ]]; then
+            matches="$matches"$'\n'"$name"
+          fi
+        done <<< "$actual"
+        matches="$(echo "$matches" | grep -v '^$' || true)"
+        n_matches=$(count_lines "$matches")
+        n_expected_total=$((n_expected_total + COUNTED_EXPECTED))
+        if [ "$n_matches" -eq "$COUNTED_EXPECTED" ]; then
+          expected="$expected"$'\n'"$matches"
+        else
+          fixed="$fixed"$'\n'"$spec (expected $COUNTED_EXPECTED matches, got $n_matches)"
+        fi
+      else
+        n_expected_total=$((n_expected_total + 1))
+        expected="$expected"$'\n'"$spec"
+        exact_expected="$exact_expected"$'\n'"$spec"
+      fi
+    done <<< "$expected_specs"
+  fi
+  expected="$(echo "$expected" | grep -v '^$' || true)"
+  exact_expected="$(echo "$exact_expected" | grep -v '^$' || true)"
+  duplicate_expected=$(echo "$expected" | sort | uniq -d | grep -v '^$' || true)
+  if [ -n "$duplicate_expected" ]; then
+    while IFS= read -r name; do
+      fixed="$fixed"$'\n'"overlapping expected gates: $name"
+    done <<< "$duplicate_expected"
   fi
 
   unexpected=""
@@ -137,18 +187,16 @@ for test in "$@"; do
   fi
   unexpected="$(echo "$unexpected" | grep -v '^$' || true)"
 
-  fixed=""
-  if [ -n "$expected" ]; then
+  if [ -n "$exact_expected" ]; then
     while IFS= read -r name; do
       [ -z "$name" ] && continue
       if ! is_in_set "$name" "$actual"; then
         fixed="$fixed"$'\n'"$name"
       fi
-    done <<< "$expected"
+    done <<< "$exact_expected"
   fi
   fixed="$(echo "$fixed" | grep -v '^$' || true)"
 
-  n_expected_total=$(count_lines "$expected")
   n_actual_total=$(count_lines "$actual")
   n_unexpected=$(count_lines "$unexpected")
   n_fixed=$(count_lines "$fixed")
@@ -178,7 +226,7 @@ for test in "$@"; do
       done <<< "$unexpected"
     fi
     if [ "$n_fixed" -gt 0 ]; then
-      echo "FIXED: $test — these entries no longer fail and should be removed from $DIVERGENCE_FILE:"
+      echo "MISMATCH: $test — these entries no longer match and should be updated in $DIVERGENCE_FILE:"
       echo "$fixed" | sed 's/^/    /'
       while IFS= read -r name; do
         [ -z "$name" ] && continue
@@ -200,9 +248,9 @@ if [ "$total_fail_unexpected" -gt 0 ] || [ "$total_unexpected_crashes" -gt 0 ]; 
   exit 1
 fi
 if [ "$total_unused" -gt 0 ] || [ "$total_unexpected_clean" -gt 0 ]; then
-  echo "  fixed entries (remove from list):  $((total_unused + total_unexpected_clean))"
-  echo "  fixed entry list:$unused_lines"
-  echo "::error::$LABEL: $((total_unused + total_unexpected_clean)) entry/entries should be removed from divergence/crash list"
+  echo "  stale/mismatched entries:          $((total_unused + total_unexpected_clean))"
+  echo "  stale/mismatched entry list:$unused_lines"
+  echo "::error::$LABEL: $((total_unused + total_unexpected_clean)) entry/entries should be updated or removed from divergence/crash list"
   exit 1
 fi
 exit 0

--- a/test/run_testfixture_test.sh
+++ b/test/run_testfixture_test.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+RUNNER="$SCRIPT_DIR/run_testfixture.sh"
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+mkdir "$TMP_DIR/build"
+touch "$TMP_DIR/crashes"
+
+cat > "$TMP_DIR/build/testfixture" <<'EOF'
+#!/usr/bin/env bash
+case "$1" in
+  *two.test)
+    names="two-1.transient.41 two-1.transient.99"
+    ;;
+  *shifted.test)
+    names="shifted-1.transient.52 shifted-1.transient.104"
+    ;;
+  *three.test)
+    names="three-1.transient.41 three-1.transient.99 three-1.transient.120"
+    ;;
+  *one.test)
+    names="one-1.transient.41"
+    ;;
+  *extra.test)
+    names="extra-1.transient.41 extra-1.transient.99 extra-2.1"
+    ;;
+esac
+count=$(wc -w <<< "$names" | tr -d ' ')
+echo "$count errors out of 10 tests"
+echo "!Failures on these tests: $names"
+EOF
+chmod +x "$TMP_DIR/build/testfixture"
+
+run_case() {
+  (
+    cd "$TMP_DIR/build"
+    DIVERGENCE_FILE="$TMP_DIR/divergences" \
+      CRASH_FILE="$TMP_DIR/crashes" \
+      bash "$RUNNER" self-test 10 "$1"
+  ) >/dev/null 2>&1
+}
+
+expect_pass() {
+  if ! run_case "$1"; then
+    echo "ERROR: runner rejected $2"
+    exit 1
+  fi
+}
+
+expect_failure() {
+  if run_case "$1"; then
+    echo "ERROR: runner accepted $2"
+    exit 1
+  fi
+}
+
+printf '%s\n' \
+  'two two-1.transient.41' \
+  'two two-1.transient.99' > "$TMP_DIR/divergences"
+expect_pass two "exact gates"
+
+printf '%s\n' 'shifted shifted-1.transient.*{2}' > "$TMP_DIR/divergences"
+expect_pass shifted "a counted index shift"
+
+printf '%s\n' 'three three-1.transient.*{2}' > "$TMP_DIR/divergences"
+expect_failure three "a counted pattern with an added failure"
+
+printf '%s\n' 'one one-1.transient.*{2}' > "$TMP_DIR/divergences"
+expect_failure one "a counted pattern with a resolved failure"
+
+printf '%s\n' 'extra extra-1.transient.*{2}' > "$TMP_DIR/divergences"
+expect_failure extra "an unrelated failure beside a satisfied pattern"
+
+printf '%s\n' \
+  'two two-1.transient.*{2}' \
+  'two two-1.transient.41' > "$TMP_DIR/divergences"
+expect_failure two "overlapping exact and counted gates"
+
+printf '%s\n' \
+  'shifted shifted-1.transient.41' \
+  'shifted shifted-1.transient.99' > "$TMP_DIR/divergences"
+expect_failure shifted "shifted exact gates"
+
+echo "OK: testfixture runner self-test"


### PR DESCRIPTION
## Summary

- add counted prefix gates (`prefix.*{N}`) for fault sweeps whose iteration numbers are allocation positions rather than stable identities
- accept index movement only when exactly `N` failures remain; added, resolved, unrelated, and overlapping failures still fail the runner
- keep counted assertions weighted in the inventory and ratchet, preserving the 5,360-gate ceiling and every category total
- migrate `backup_malloc` from 15 positional entries to two stable transient/persistent identities
- add runner and inventory self-tests to the regression manifest checks

## Validation

- runner self-test: exact, shifted, added, resolved, unrelated, and overlapping cases
- inventory checker self-test: counted weighting, zero-count rejection, and overlap rejection
- inventory: 5,360 classified gates; category totals unchanged; ratchet holds
- full fault-fuzz bucket: 247,485 passing tests and 436 classified divergences, no mismatches
- fresh post-#1881 `backup_malloc`: 2,169 passing tests and 15 classified divergences
- shell syntax checks and `git diff --check`

Closes #1859

Co-Authored-By: OpenAI Codex <noreply@openai.com>