### PR TITLE
test: fix nightly publish report unit test for --merge

### DIFF
--- a/test/publish_performance_report_test.py
+++ b/test/publish_performance_report_test.py
@@ -96,6 +96,8 @@ class PublishPerformanceReportTest(unittest.TestCase):
             "dolthub/doltlite", "report-bot"
         )
         self.assertEqual(merged, 42)
+        # Repo merge policy forbids squash; publisher uses a regular merge
+        # commit (see 42e9d4fed). Do not re-assert --squash here.
         command.assert_called_once_with(
             [
                 "gh",
@@ -104,7 +106,7 @@ class PublishPerformanceReportTest(unittest.TestCase):
                 "42",
                 "--repo",
                 "dolthub/doltlite",
-                "--squash",
+                "--merge",
                 "--delete-branch",
                 "--match-head-commit",
                 "abcdef123456",


### PR DESCRIPTION
## Summary

Nightly performance report job failed on [run 30623213751](https://github.com/dolthub/doltlite/actions/runs/30623213751/job/91150674627):

```
Expected: ... gh pr merge 42 ... --squash ...
  Actual: ... gh pr merge 42 ... --merge ...
```

### Root cause

- [42e9d4fed](https://github.com/dolthub/doltlite/commit/42e9d4fed5faee8b87b64b0fd961727c6c0db4fd) correctly changed the publisher to `gh pr merge --merge` (repo forbids squash).
- `test/publish_performance_report_test.py` still expected `--squash`, so the report job’s unit tests fail and publication aborts even when benchmarks succeed.

### Fix

Update the test to expect `--merge`, with a short comment so it is not re-“fixed” back to squash.

## Test plan

- [x] `python3 test/publish_performance_report_test.py -v`
- [x] `python3 test/nightly_performance_report_test.py -v`