### PR TITLE
Point the pager4-1.4 gate at its successor issue

### DIFF
--- a/test/known_testfixture_exception_inventory.txt
+++ b/test/known_testfixture_exception_inventory.txt
@@ -3599,7 +3599,7 @@ pager2 pager2-3.1 intentional -
 pager3 pager3-1.1.1 intentional https://github.com/dolthub/doltlite/issues/1846
 pager3 pager3-1.4.2 intentional https://github.com/dolthub/doltlite/issues/1846
 pager3 pager3-1.5.2 intentional https://github.com/dolthub/doltlite/issues/1846
-pager4 pager4-1.4 engine-gap https://github.com/dolthub/doltlite/issues/1853
+pager4 pager4-1.4 engine-gap https://github.com/dolthub/doltlite/issues/1884
 pager4 pager4-1.7 intentional https://github.com/dolthub/doltlite/issues/1846
 pager4 pager4-1.8 intentional https://github.com/dolthub/doltlite/issues/1846
 pagerfault * harness -


### PR DESCRIPTION
One-line inventory update: the gate cited #1853, closed by the landed #1878/#1879/#1881 sequence. The remaining same-second seed-collision residual is tracked as #1884, and the issues-alive check requires gates to cite open issues. Ratchet and inventory checkers pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)