### PR TITLE
Pin the compat consumer to the tag list the producer built

### DIFF
--- a/test/doltlite_compat_test.sh
+++ b/test/doltlite_compat_test.sh
@@ -204,6 +204,16 @@ if [ -z "$cur_csv" ] || [ -z "$cur_series" ]; then
   exit 1
 fi
 
+# The tag list is resolved from repo state, not commit state, so a tag pushed
+# while a run is in flight makes a prebuilt consumer demand a binary the
+# producer never saw -- and rerunning only the failed job can never recover,
+# because the artifact is frozen. The producer therefore records the list it
+# built, and a prebuilt consumer tests exactly that list.
+if [ "$MODE" = "test" ] && [ "${DOLTLITE_COMPAT_PREBUILT:-0}" = "1" ] \
+   && [ -z "${DOLTLITE_COMPAT_TAGS:-}" ] && [ -s "$CACHE_DIR/TAGS" ]; then
+  DOLTLITE_COMPAT_TAGS=$(cat "$CACHE_DIR/TAGS")
+fi
+
 TAGS="${DOLTLITE_COMPAT_TAGS:-$(compute_default_tags "$cur_series")}"
 if [ -z "${TAGS// }" ]; then
   echo "ERROR: no historical tags to test against"
@@ -221,6 +231,8 @@ if [ "$MODE" = "build-only" ]; then
       exit 1
     fi
   done
+  mkdir -p "$CACHE_DIR"
+  printf '%s\n' "$TAGS" > "$CACHE_DIR/TAGS"
   echo "Built all compatibility binaries."
   exit 0
 fi


### PR DESCRIPTION
Fixes the recurring `Test Suite / compat` failure on #1885, and the class of failure behind it.

## Diagnosis

The compat suite resolves its tag list from **repo state** (`git tag --list`), not commit state, in two jobs that check out at different times. `v0.11.39` was pushed while #1885's run was in flight:

```
compat-build (16:52 UTC):  tags:  v0.10.11 v0.9.3 v0.11.38 v0.11.0   ← built .38
compat test  (17:34 UTC):  tags:  v0.10.11 v0.9.3 v0.11.39 v0.11.0   ← demanded .39
ERROR: prebuilt compatibility binary missing: .../v0.11.39/doltlite
```

With `DOLTLITE_COMPAT_PREBUILT=1` a missing binary is (correctly) a hard failure — but "re-run failed jobs" reruns only the consumer against the frozen artifact, so it can **never** recover. This will recur on any run in flight when a tag lands.

## Fix

The producer records the list it actually built in `.compat-cache/TAGS` (written only after every binary built, so a failed build never publishes a list), and a prebuilt consumer tests exactly that list. `DOLTLITE_COMPAT_TAGS` still overrides everything; a missing `TAGS` file (pre-change artifact) falls back to computing the list — today's behavior. New tags are covered on the next run, when their binary exists.

## Verification (local, end to end)

- `--build-only` writes the file; full prebuilt run: **18/18**
- Race simulated (file carries the pre-tag list, computation would demand the new tag): **11/11**, consumer follows the file
- File deleted: reproduces CI's failure **verbatim** (`11 passed, 1 failed`, same ERROR line)

#1885 itself is unblocked separately by a full-workflow rerun, which regenerates the artifact against the post-tag list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)