### PR TITLE
fix: unify secondary-index row deltas with KeyInfo-aware encoding

### DIFF
--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -1089,12 +1089,6 @@ int doltliteSerializeConflicts(ChunkStore *cs,
 void doltliteIpkSerialType(i64 v, u32 *pType, u32 *pLen);
 void doltliteIpkWriteBE(u8 *p, i64 v, int n);
 KeyInfo *doltliteKeyInfoOfIndex(sqlite3 *db, Index *pIdx);
-int doltliteBuildIndexSortKey(const u8 *pRec, int nRec,
-                              const i16 *aiColumn, int nIdxCol,
-                              KeyInfo *pKeyInfo,
-                              int iPKey, i64 intKey,
-                              const u8 *pTreeKey, int nTreeKey,
-                              u8 **ppKey, int *pnKey);
 int doltliteIndexMutMapRowDelta(
   ProllyMutMap *pMap,
   const i16 *aiColumn, int nIdxCol,

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -15,6 +15,7 @@
 
 typedef struct BtShared BtShared;
 typedef struct ProllyCache ProllyCache;
+typedef struct ProllyMutMap ProllyMutMap;
 typedef struct DoltliteTxnState DoltliteTxnState;
 typedef struct DoltlitePkRange DoltlitePkRange;
 typedef struct DoltliteCommitQueue DoltliteCommitQueue;
@@ -1082,17 +1083,39 @@ int doltliteSerializeConflicts(ChunkStore *cs,
                                DoltliteConflictTable *aTables,
                                int nTables, ProllyHash *pHash);
 
-/* Index key construction helpers (see doltlite_merge_rows.c). Exposed for
-** dolt_conflicts_resolve --theirs to maintain secondary indexes when
-** writing theirs's row directly via the raw-row mutation path. */
+/* Index key construction helpers (see doltlite_merge_rows.c). Shared by
+** merge, dolt_conflicts_resolve, and workspace so secondary indexes stay
+** consistent with VDBE (including NOCASE/RTRIM/DESC). */
 void doltliteIpkSerialType(i64 v, u32 *pType, u32 *pLen);
 void doltliteIpkWriteBE(u8 *p, i64 v, int n);
+KeyInfo *doltliteKeyInfoOfIndex(sqlite3 *db, Index *pIdx);
 int doltliteBuildIndexSortKey(const u8 *pRec, int nRec,
                               const i16 *aiColumn, int nIdxCol,
                               KeyInfo *pKeyInfo,
                               int iPKey, i64 intKey,
                               const u8 *pTreeKey, int nTreeKey,
                               u8 **ppKey, int *pnKey);
+int doltliteIndexMutMapRowDelta(
+  ProllyMutMap *pMap,
+  const i16 *aiColumn, int nIdxCol,
+  KeyInfo *pKeyInfo,
+  int iPKey, i64 intKey,
+  const u8 *pTreeKey, int nTreeKey,
+  const u8 *pOldVal, int nOldVal,
+  const u8 *pNewVal, int nNewVal
+);
+int doltliteIndexApplyRowDelta(
+  sqlite3 *db,
+  ChunkStore *cs,
+  ProllyCache *cache,
+  ProllyHash *pIdxRoot,
+  u8 idxFlags,
+  Index *pIdx,
+  int iPKey, i64 intKey,
+  const u8 *pTreeKey, int nTreeKey,
+  const u8 *pOldVal, int nOldVal,
+  const u8 *pNewVal, int nNewVal
+);
 int doltliteEnsureWriteTxnAndSavepoints(sqlite3 *db);
 int doltliteSwitchCatalog(sqlite3 *db, const ProllyHash *catHash);
 int doltliteHardReset(sqlite3 *db, const ProllyHash *catHash);

--- a/src/doltlite_merge_pass1.c
+++ b/src/doltlite_merge_pass1.c
@@ -18,26 +18,6 @@ int mergeAppendReindexName(char ***paz, int *pn, const char *zName){
   return SQLITE_OK;
 }
 
-/* Inline row-merge index maintenance encodes sort keys with a BINARY/ASC
-** KeyInfo. Indexes whose key columns fold case/space (NOCASE, RTRIM) or sort
-** DESC need the real collation and order, so rebuild them canonically over the
-** merged table via the post-merge REINDEX instead. */
-static int mergeIndexNeedsRebuild(Index *pIdx){
-  int k;
-  for(k=0; k<pIdx->nKeyCol; k++){
-    const char *zColl = pIdx->azColl ? pIdx->azColl[k] : 0;
-    if( zColl
-     && (sqlite3StrICmp(zColl,"NOCASE")==0 || sqlite3StrICmp(zColl,"RTRIM")==0) ){
-      return 1;
-    }
-    if( pIdx->aSortOrder && (pIdx->aSortOrder[k] & KEYINFO_ORDER_DESC) ){
-      return 1;
-    }
-  }
-  return 0;
-}
-
-
 typedef struct IndexMergePatch IndexMergePatch;
 struct IndexMergePatch {
   Pgno iTable;
@@ -91,8 +71,21 @@ static int mergePass1NoteSchemaConflict(
   return SQLITE_OK;
 }
 
-/* Build secondary-index merge descriptors for a named table. Indexes that
-** need real collation/order go on the reindex list instead. */
+/* Free KeyInfo refs owned by collectIndexes before freeing the array. */
+static void mergePass1FreeIdxInfo(MergeIndexInfo *aIdxInfo, int nIdxInfo){
+  int i;
+  if( !aIdxInfo ) return;
+  for(i=0; i<nIdxInfo; i++){
+    if( aIdxInfo[i].pKeyInfo ){
+      sqlite3KeyInfoUnref(aIdxInfo[i].pKeyInfo);
+      aIdxInfo[i].pKeyInfo = 0;
+    }
+  }
+  sqlite3_free(aIdxInfo);
+}
+
+/* Build secondary-index merge descriptors for a named table. Every secondary
+** index is patched inline with a real KeyInfo (NOCASE/RTRIM/DESC included). */
 static int mergePass1CollectIndexes(
   MergePass1Ctx *c,
   const char *zName,
@@ -126,14 +119,6 @@ static int mergePass1CollectIndexes(
   for(pIdx=pTab->pIndex; pIdx; pIdx=pIdx->pNext){
     struct TableEntry *oursIdx;
     if( pIdx->idxType==SQLITE_IDXTYPE_PRIMARYKEY ) continue;
-    if( mergeIndexNeedsRebuild(pIdx) ){
-      rc = mergeAppendReindexName(c->pazReindex, c->pnReindex, pIdx->zName);
-      if( rc!=SQLITE_OK ){
-        sqlite3_free(aIdxInfo);
-        return rc;
-      }
-      continue;
-    }
     oursIdx = doltliteFindTableByNumber(c->aOurs, c->nOurs, pIdx->tnum);
     if( oursIdx ){
       MergeIndexInfo *mi = &aIdxInfo[nIdxInfo];
@@ -141,7 +126,11 @@ static int mergePass1CollectIndexes(
       memcpy(&mi->oursRoot, &oursIdx->root, sizeof(ProllyHash));
       mi->nColumn = pIdx->nKeyCol;
       mi->aiColumn = pIdx->aiColumn;
-      mi->pKeyInfo = 0;
+      mi->pKeyInfo = doltliteKeyInfoOfIndex(c->db, pIdx);
+      if( !mi->pKeyInfo ){
+        mergePass1FreeIdxInfo(aIdxInfo, nIdxInfo);
+        return SQLITE_NOMEM;
+      }
       mi->iPKey = pTab->iPKey;
       nIdxInfo++;
     }
@@ -149,7 +138,7 @@ static int mergePass1CollectIndexes(
 
   *paIdxInfo = aIdxInfo;
   *pnIdxInfo = nIdxInfo;
-  return SQLITE_OK;
+  return rc;
 }
 
 static int mergePass1RecordIndexPatches(
@@ -205,7 +194,7 @@ static int mergePass1MergeTableData(
       &pAnc->root, &pOurs->root, pTheirsRoot,
       pOurs->flags, &mergedTableRoot, &handled);
     if( rc!=SQLITE_OK ){
-      sqlite3_free(aIdxInfo);
+      mergePass1FreeIdxInfo(aIdxInfo, nIdxInfo);
       return rc;
     }
   }
@@ -216,13 +205,13 @@ static int mergePass1MergeTableData(
                         &mergedTableRoot, &nConflicts, &aConflictRows,
                         aIdxInfo, nIdxInfo);
     if( rc!=SQLITE_OK ){
-      sqlite3_free(aIdxInfo);
+      mergePass1FreeIdxInfo(aIdxInfo, nIdxInfo);
       return rc;
     }
   }
 
   rc = mergePass1RecordIndexPatches(c, aIdxInfo, nIdxInfo);
-  sqlite3_free(aIdxInfo);
+  mergePass1FreeIdxInfo(aIdxInfo, nIdxInfo);
   if( rc!=SQLITE_OK ) return rc;
 
   {

--- a/src/doltlite_merge_rows.c
+++ b/src/doltlite_merge_rows.c
@@ -231,20 +231,6 @@ static int doltliteBuildIndexEntry(
   return SQLITE_OK;
 }
 
-/* Build index keys from row records; substitute intkey for IPK ghosts. */
-int doltliteBuildIndexSortKey(
-  const u8 *pRec, int nRec,
-  const i16 *aiColumn, int nIdxCol,
-  KeyInfo *pKeyInfo,
-  int iPKey, i64 intKey,
-  const u8 *pTreeKey, int nTreeKey,
-  u8 **ppKey, int *pnKey
-){
-  return doltliteBuildIndexEntry(
-      pRec, nRec, aiColumn, nIdxCol, pKeyInfo, iPKey, intKey,
-      pTreeKey, nTreeKey, ppKey, pnKey, 0, 0, 0);
-}
-
 /* Apply old/new table-row values to one secondary-index mutmap. Shared by
 ** merge, conflicts resolve, and workspace so NOCASE/RTRIM/DESC match VDBE. */
 int doltliteIndexMutMapRowDelta(

--- a/src/doltlite_merge_rows.c
+++ b/src/doltlite_merge_rows.c
@@ -22,14 +22,66 @@ void doltliteIpkWriteBE(u8 *p, i64 v, int n){
   for(i=n-1; i>=0; i--){ p[i] = (u8)(v & 0xff); v >>= 8; }
 }
 
-/* Build index keys from row records; substitute intkey for IPK ghosts. */
-int doltliteBuildIndexSortKey(
+/* KeyInfo for Index without a Parse context. Matches sqlite3KeyInfoOfIndex
+** collations/sort flags so VC raw-row paths encode the same sort keys as VDBE. */
+KeyInfo *doltliteKeyInfoOfIndex(sqlite3 *db, Index *pIdx){
+  int i;
+  int nCol;
+  int nKey;
+  KeyInfo *pKey;
+
+  if( !db || !pIdx ) return 0;
+  nCol = pIdx->nColumn;
+  nKey = pIdx->nKeyCol;
+  if( pIdx->uniqNotNull ){
+    pKey = sqlite3KeyInfoAlloc(db, nKey, nCol - nKey);
+  }else{
+    pKey = sqlite3KeyInfoAlloc(db, nCol, 0);
+  }
+  if( !pKey ) return 0;
+  for(i=0; i<nCol; i++){
+    const char *zColl = pIdx->azColl ? pIdx->azColl[i] : 0;
+    if( !zColl || zColl==sqlite3StrBINARY
+     || sqlite3StrICmp(zColl, "BINARY")==0 ){
+      pKey->aColl[i] = 0;
+    }else{
+      pKey->aColl[i] = sqlite3FindCollSeq(db, ENC(db), zColl, 0);
+    }
+    pKey->aSortFlags[i] = pIdx->aSortOrder ? pIdx->aSortOrder[i] : 0;
+  }
+  return pKey;
+}
+
+static int indexKeyInfoNeedsPayload(
+  const KeyInfo *pKeyInfo,
+  const u8 *pIdxRec,
+  int nIdxRec
+){
+  int i;
+  if( pKeyInfo ){
+    if( pKeyInfo->nKeyField < pKeyInfo->nAllField ) return 1;
+    for(i=0; i<pKeyInfo->nAllField; i++){
+      const CollSeq *pColl = pKeyInfo->aColl[i];
+      if( pColl && pColl->zName
+       && (sqlite3StrICmp(pColl->zName, "NOCASE")==0
+        || sqlite3StrICmp(pColl->zName, "RTRIM")==0) ){
+        return 1;
+      }
+    }
+  }
+  return sortKeyRecordNeedsPayload(pIdxRec, nIdxRec, 0);
+}
+
+/* Build index sort key (+ optional index-record payload) from a table row. */
+static int doltliteBuildIndexEntry(
   const u8 *pRec, int nRec,
   const i16 *aiColumn, int nIdxCol,
   KeyInfo *pKeyInfo,
   int iPKey, i64 intKey,
   const u8 *pTreeKey, int nTreeKey,
-  u8 **ppKey, int *pnKey
+  u8 **ppSortKey, int *pnSortKey,
+  u8 **ppIdxRec, int *pnIdxRec,
+  int *pStorePayload
 ){
   DoltliteRecordInfo info;
   u8 *pIdxRec = 0;
@@ -37,7 +89,14 @@ int doltliteBuildIndexSortKey(
   u32 ipkType = 0;
   u32 ipkLen = 0;
   int useIpk = 0;
+  int storePayload = 0;
   int rc;
+
+  if( ppSortKey ) *ppSortKey = 0;
+  if( pnSortKey ) *pnSortKey = 0;
+  if( ppIdxRec ) *ppIdxRec = 0;
+  if( pnIdxRec ) *pnIdxRec = 0;
+  if( pStorePayload ) *pStorePayload = 0;
 
   doltliteParseRecord(pRec, nRec, &info);
   if( info.nField==0 ) return SQLITE_CORRUPT;
@@ -141,22 +200,145 @@ int doltliteBuildIndexSortKey(
     sqlite3_free(aUsed);
   }
 
+  storePayload = indexKeyInfoNeedsPayload(pKeyInfo, pIdxRec, nIdxRec);
   rc = sortKeyFromRecordPrefixColl(pIdxRec, nIdxRec, 0, pKeyInfo,
-                                    ppKey, pnKey);
-  sqlite3_free(pIdxRec);
+                                    ppSortKey, pnSortKey);
   /* WITHOUT ROWID secondary indexes suffix the table-tree key. */
   if( rc==SQLITE_OK && iPKey<0 && pTreeKey && nTreeKey>0 ){
-    u8 *pCombined = sqlite3_realloc(*ppKey, *pnKey + nTreeKey);
+    u8 *pCombined = sqlite3_realloc(*ppSortKey, *pnSortKey + nTreeKey);
     if( !pCombined ){
-      sqlite3_free(*ppKey);
-      *ppKey = 0;
-      *pnKey = 0;
+      sqlite3_free(*ppSortKey);
+      *ppSortKey = 0;
+      *pnSortKey = 0;
+      sqlite3_free(pIdxRec);
       return SQLITE_NOMEM;
     }
-    memcpy(pCombined + *pnKey, pTreeKey, nTreeKey);
-    *ppKey = pCombined;
-    *pnKey += nTreeKey;
+    memcpy(pCombined + *pnSortKey, pTreeKey, nTreeKey);
+    *ppSortKey = pCombined;
+    *pnSortKey += nTreeKey;
   }
+  if( rc!=SQLITE_OK ){
+    sqlite3_free(pIdxRec);
+    return rc;
+  }
+  if( pStorePayload ) *pStorePayload = storePayload;
+  if( storePayload && ppIdxRec ){
+    *ppIdxRec = pIdxRec;
+    if( pnIdxRec ) *pnIdxRec = nIdxRec;
+  }else{
+    sqlite3_free(pIdxRec);
+  }
+  return SQLITE_OK;
+}
+
+/* Build index keys from row records; substitute intkey for IPK ghosts. */
+int doltliteBuildIndexSortKey(
+  const u8 *pRec, int nRec,
+  const i16 *aiColumn, int nIdxCol,
+  KeyInfo *pKeyInfo,
+  int iPKey, i64 intKey,
+  const u8 *pTreeKey, int nTreeKey,
+  u8 **ppKey, int *pnKey
+){
+  return doltliteBuildIndexEntry(
+      pRec, nRec, aiColumn, nIdxCol, pKeyInfo, iPKey, intKey,
+      pTreeKey, nTreeKey, ppKey, pnKey, 0, 0, 0);
+}
+
+/* Apply old/new table-row values to one secondary-index mutmap. Shared by
+** merge, conflicts resolve, and workspace so NOCASE/RTRIM/DESC match VDBE. */
+int doltliteIndexMutMapRowDelta(
+  ProllyMutMap *pMap,
+  const i16 *aiColumn, int nIdxCol,
+  KeyInfo *pKeyInfo,
+  int iPKey, i64 intKey,
+  const u8 *pTreeKey, int nTreeKey,
+  const u8 *pOldVal, int nOldVal,
+  const u8 *pNewVal, int nNewVal
+){
+  int rc = SQLITE_OK;
+
+  if( !pMap ) return SQLITE_MISUSE;
+
+  if( pOldVal && nOldVal>0 ){
+    u8 *pSK = 0;
+    int nSK = 0;
+    rc = doltliteBuildIndexEntry(
+        pOldVal, nOldVal, aiColumn, nIdxCol, pKeyInfo, iPKey, intKey,
+        pTreeKey, nTreeKey, &pSK, &nSK, 0, 0, 0);
+    if( rc==SQLITE_OK ){
+      rc = prollyMutMapDelete(pMap, pSK, nSK, 0);
+    }
+    sqlite3_free(pSK);
+    if( rc!=SQLITE_OK ) return rc;
+  }
+
+  if( pNewVal && nNewVal>0 ){
+    u8 *pSK = 0;
+    u8 *pRec = 0;
+    int nSK = 0, nRec = 0, store = 0;
+    rc = doltliteBuildIndexEntry(
+        pNewVal, nNewVal, aiColumn, nIdxCol, pKeyInfo, iPKey, intKey,
+        pTreeKey, nTreeKey, &pSK, &nSK, &pRec, &nRec, &store);
+    if( rc==SQLITE_OK ){
+      if( store ){
+        rc = prollyMutMapInsert(pMap, pSK, nSK, 0, pRec, nRec);
+      }else{
+        rc = prollyMutMapInsert(pMap, pSK, nSK, 0, 0, 0);
+      }
+    }
+    sqlite3_free(pSK);
+    sqlite3_free(pRec);
+  }
+  return rc;
+}
+
+int doltliteIndexApplyRowDelta(
+  sqlite3 *db,
+  ChunkStore *cs,
+  ProllyCache *cache,
+  ProllyHash *pIdxRoot,
+  u8 idxFlags,
+  Index *pIdx,
+  int iPKey, i64 intKey,
+  const u8 *pTreeKey, int nTreeKey,
+  const u8 *pOldVal, int nOldVal,
+  const u8 *pNewVal, int nNewVal
+){
+  KeyInfo *pKeyInfo = 0;
+  ProllyMutMap mm;
+  ProllyMutator mut;
+  int rc;
+
+  if( !cs || !cache || !pIdxRoot || !pIdx ) return SQLITE_MISUSE;
+  if( (!pOldVal || nOldVal<=0) && (!pNewVal || nNewVal<=0) ) return SQLITE_OK;
+
+  pKeyInfo = doltliteKeyInfoOfIndex(db, pIdx);
+  if( !pKeyInfo ) return SQLITE_NOMEM;
+
+  rc = prollyMutMapInit(&mm, 0);
+  if( rc!=SQLITE_OK ){
+    sqlite3KeyInfoUnref(pKeyInfo);
+    return rc;
+  }
+
+  rc = doltliteIndexMutMapRowDelta(
+      &mm, pIdx->aiColumn, pIdx->nKeyCol, pKeyInfo,
+      iPKey, intKey, pTreeKey, nTreeKey,
+      pOldVal, nOldVal, pNewVal, nNewVal);
+  if( rc==SQLITE_OK && !prollyMutMapIsEmpty(&mm) ){
+    memset(&mut, 0, sizeof(mut));
+    mut.pStore = cs;
+    mut.pCache = cache;
+    mut.oldRoot = *pIdxRoot;
+    mut.pEdits = &mm;
+    mut.flags = idxFlags ? idxFlags : (u8)PROLLY_NODE_BLOBKEY;
+    rc = prollyMutateFlush(&mut);
+    if( rc==SQLITE_OK ) *pIdxRoot = mut.newRoot;
+  }
+
+  prollyMutMapFree(&mm);
+  sqlite3KeyInfoUnref(pKeyInfo);
   return rc;
 }
 
@@ -400,16 +582,11 @@ static int rowMergeCallback(void *pCtx, const ThreeWayChange *pChange){
        && pChange->pTheirVal && pChange->nTheirVal>0 ){
         int ix;
         for(ix=0; ix<ctx->nIndexes && rc==SQLITE_OK; ix++){
-          u8 *pIK = 0; int nIK = 0;
           MergeIndexInfo *mi = &ctx->aIndexes[ix];
-          rc = doltliteBuildIndexSortKey(pChange->pTheirVal, pChange->nTheirVal,
-                                 mi->aiColumn, mi->nColumn, mi->pKeyInfo,
-                                 mi->iPKey, pChange->intKey, pChange->pKey, pChange->nKey,
-                                 &pIK, &nIK);
-          if( rc==SQLITE_OK ){
-            rc = prollyMutMapInsert(mi->pEdits, pIK, nIK, 0, 0, 0);
-            sqlite3_free(pIK);
-          }
+          rc = doltliteIndexMutMapRowDelta(
+              mi->pEdits, mi->aiColumn, mi->nColumn, mi->pKeyInfo,
+              mi->iPKey, pChange->intKey, pChange->pKey, pChange->nKey,
+              0, 0, pChange->pTheirVal, pChange->nTheirVal);
         }
       }
       break;
@@ -423,29 +600,11 @@ static int rowMergeCallback(void *pCtx, const ThreeWayChange *pChange){
         int ix;
         for(ix=0; ix<ctx->nIndexes && rc==SQLITE_OK; ix++){
           MergeIndexInfo *mi = &ctx->aIndexes[ix];
-          if( pChange->pBaseVal && pChange->nBaseVal>0 ){
-            u8 *pOK = 0; int nOK = 0;
-            rc = doltliteBuildIndexSortKey(pChange->pBaseVal, pChange->nBaseVal,
-                                   mi->aiColumn, mi->nColumn, mi->pKeyInfo,
-                                   mi->iPKey, pChange->intKey, pChange->pKey, pChange->nKey,
-                                   &pOK, &nOK);
-            if( rc==SQLITE_OK ){
-              rc = prollyMutMapDelete(mi->pEdits, pOK, nOK, 0);
-              sqlite3_free(pOK);
-            }
-          }
-          if( rc==SQLITE_OK
-           && pChange->pTheirVal && pChange->nTheirVal>0 ){
-            u8 *pNK = 0; int nNK = 0;
-            rc = doltliteBuildIndexSortKey(pChange->pTheirVal, pChange->nTheirVal,
-                                   mi->aiColumn, mi->nColumn, mi->pKeyInfo,
-                                   mi->iPKey, pChange->intKey, pChange->pKey, pChange->nKey,
-                                   &pNK, &nNK);
-            if( rc==SQLITE_OK ){
-              rc = prollyMutMapInsert(mi->pEdits, pNK, nNK, 0, 0, 0);
-              sqlite3_free(pNK);
-            }
-          }
+          rc = doltliteIndexMutMapRowDelta(
+              mi->pEdits, mi->aiColumn, mi->nColumn, mi->pKeyInfo,
+              mi->iPKey, pChange->intKey, pChange->pKey, pChange->nKey,
+              pChange->pBaseVal, pChange->nBaseVal,
+              pChange->pTheirVal, pChange->nTheirVal);
         }
       }
       break;
@@ -458,16 +617,11 @@ static int rowMergeCallback(void *pCtx, const ThreeWayChange *pChange){
        && pChange->pBaseVal && pChange->nBaseVal>0 ){
         int ix;
         for(ix=0; ix<ctx->nIndexes && rc==SQLITE_OK; ix++){
-          u8 *pIK = 0; int nIK = 0;
           MergeIndexInfo *mi = &ctx->aIndexes[ix];
-          rc = doltliteBuildIndexSortKey(pChange->pBaseVal, pChange->nBaseVal,
-                                 mi->aiColumn, mi->nColumn, mi->pKeyInfo,
-                                 mi->iPKey, pChange->intKey, pChange->pKey, pChange->nKey,
-                                 &pIK, &nIK);
-          if( rc==SQLITE_OK ){
-            rc = prollyMutMapDelete(mi->pEdits, pIK, nIK, 0);
-            sqlite3_free(pIK);
-          }
+          rc = doltliteIndexMutMapRowDelta(
+              mi->pEdits, mi->aiColumn, mi->nColumn, mi->pKeyInfo,
+              mi->iPKey, pChange->intKey, pChange->pKey, pChange->nKey,
+              pChange->pBaseVal, pChange->nBaseVal, 0, 0);
         }
       }
       break;
@@ -499,28 +653,10 @@ static int rowMergeCallback(void *pCtx, const ThreeWayChange *pChange){
           int ix;
           for(ix=0; ix<ctx->nIndexes && rc==SQLITE_OK; ix++){
             MergeIndexInfo *mi = &ctx->aIndexes[ix];
-            if( pChange->pBaseVal && pChange->nBaseVal>0 ){
-              u8 *pOK = 0; int nOK = 0;
-              rc = doltliteBuildIndexSortKey(pChange->pBaseVal, pChange->nBaseVal,
-                                     mi->aiColumn, mi->nColumn, mi->pKeyInfo,
-                                     mi->iPKey, pChange->intKey, pChange->pKey, pChange->nKey,
-                                     &pOK, &nOK);
-              if( rc==SQLITE_OK ){
-                rc = prollyMutMapDelete(mi->pEdits, pOK, nOK, 0);
-                sqlite3_free(pOK);
-              }
-            }
-            if( rc==SQLITE_OK ){
-              u8 *pNK = 0; int nNK = 0;
-              rc = doltliteBuildIndexSortKey(pMerged, nMerged,
-                                     mi->aiColumn, mi->nColumn, mi->pKeyInfo,
-                                     mi->iPKey, pChange->intKey, pChange->pKey, pChange->nKey,
-                                     &pNK, &nNK);
-              if( rc==SQLITE_OK ){
-                rc = prollyMutMapInsert(mi->pEdits, pNK, nNK, 0, 0, 0);
-                sqlite3_free(pNK);
-              }
-            }
+            rc = doltliteIndexMutMapRowDelta(
+                mi->pEdits, mi->aiColumn, mi->nColumn, mi->pKeyInfo,
+                mi->iPKey, pChange->intKey, pChange->pKey, pChange->nKey,
+                pChange->pBaseVal, pChange->nBaseVal, pMerged, nMerged);
           }
         }
         sqlite3_free(pMerged);

--- a/src/doltlite_workspace.c
+++ b/src/doltlite_workspace.c
@@ -441,41 +441,15 @@ static WorkspaceRow *wsFindCachedRow(WorkspaceVtab *p, i64 rowid){
 
 /* Apply one row's old/new records to one secondary-index root. */
 static int wsApplyRowToIndex(
+  sqlite3 *db,
   ChunkStore *cs, ProllyCache *pCache,
   struct TableEntry *idxEntry, Index *pIdx, int iPKey,
   const u8 *pKey, int nKey, i64 intKey,
   const u8 *pSrc, int nSrc, const u8 *pTgt, int nTgt
 ){
-  ProllyHash root = idxEntry->root;
-  int rc = SQLITE_OK;
-  if( pSrc ){
-    u8 *pIK = 0; int nIK = 0;
-    ProllyHash next;
-    rc = doltliteBuildIndexSortKey(pSrc, nSrc, pIdx->aiColumn, pIdx->nKeyCol,
-                                   0, iPKey, intKey, pKey, nKey, &pIK, &nIK);
-    if( rc==SQLITE_OK ){
-      rc = prollyMutateDelete(cs, pCache, &root, idxEntry->flags,
-                              pIK, nIK, 0, &next);
-      sqlite3_free(pIK);
-      if( rc==SQLITE_OK ) root = next;
-    }
-    if( rc!=SQLITE_OK ) return rc;
-  }
-  if( pTgt ){
-    u8 *pIK = 0; int nIK = 0;
-    ProllyHash next;
-    rc = doltliteBuildIndexSortKey(pTgt, nTgt, pIdx->aiColumn, pIdx->nKeyCol,
-                                   0, iPKey, intKey, pKey, nKey, &pIK, &nIK);
-    if( rc==SQLITE_OK ){
-      rc = prollyMutateInsert(cs, pCache, &root, idxEntry->flags,
-                              pIK, nIK, 0, 0, 0, &next);
-      sqlite3_free(pIK);
-      if( rc==SQLITE_OK ) root = next;
-    }
-    if( rc!=SQLITE_OK ) return rc;
-  }
-  idxEntry->root = root;
-  return SQLITE_OK;
+  return doltliteIndexApplyRowDelta(
+      db, cs, pCache, &idxEntry->root, idxEntry->flags, pIdx,
+      iPKey, intKey, pKey, nKey, pSrc, nSrc, pTgt, nTgt);
 }
 
 static int wsApplyRowToStaged(WorkspaceVtab *p, WorkspaceRow *r, int makeStaged){
@@ -556,7 +530,7 @@ static int wsApplyRowToStaged(WorkspaceVtab *p, WorkspaceRow *r, int makeStaged)
       if( pIdx->idxType==SQLITE_IDXTYPE_PRIMARYKEY ) continue;
       idxEntry = doltliteFindTableByNumber(aTables, nTables, pIdx->tnum);
       if( !idxEntry ) continue;
-      rc = wsApplyRowToIndex(cs, pCache, idxEntry, pIdx, pTab->iPKey,
+      rc = wsApplyRowToIndex(db, cs, pCache, idxEntry, pIdx, pTab->iPKey,
                              r->pKey, r->nKey, r->intKey,
                              pSrc, nSrc, pTgt, nTgt);
     }

--- a/src/prolly_btree_mutation.c
+++ b/src/prolly_btree_mutation.c
@@ -1547,13 +1547,17 @@ int doltliteSetTableSchemaHash(sqlite3 *db, Pgno iTable, const ProllyHash *pH){
 /* Declared in doltlite_internal.h. Forward-declared here because that
 ** header redefines TableEntry/SchemaEntry in a shape incompatible with
 ** this file's local definitions, so we can't just include it. */
-extern int doltliteBuildIndexSortKey(
-  const u8 *pRec, int nRec,
-  const i16 *aiColumn, int nIdxCol,
-  KeyInfo *pKeyInfo,
+extern int doltliteIndexApplyRowDelta(
+  sqlite3 *db,
+  ChunkStore *cs,
+  ProllyCache *cache,
+  ProllyHash *pIdxRoot,
+  u8 idxFlags,
+  Index *pIdx,
   int iPKey, i64 intKey,
   const u8 *pTreeKey, int nTreeKey,
-  u8 **ppKey, int *pnKey
+  const u8 *pOldVal, int nOldVal,
+  const u8 *pNewVal, int nNewVal
 );
 
 /* Read the current value bytes at (pKey/intKey) in the table's prolly
@@ -1591,75 +1595,6 @@ static int readRowValue(
     }
   }
   prollyCursorClose(&cur);
-  return rc;
-}
-
-/* Mutate one secondary index: delete the old key (if pOldVal is set)
-** and insert the new key (if pNewVal is set). Used by the raw-row
-** mutation path so dolt_conflicts_resolve --theirs (and any future
-** caller) keeps secondary indexes consistent with the table. */
-static int mutateSecondaryIndex(
-  BtShared *pBt,
-  struct TableEntry *pIdxTE,
-  Index *pIdx,
-  int iPKey,
-  i64 intKey,
-  const u8 *pTreeKey, int nTreeKey,
-  const u8 *pOldVal, int nOldVal,
-  const u8 *pNewVal, int nNewVal
-){
-  ProllyMutMap mm;
-  ProllyMutator mut;
-  u8 *pOldKey = 0, *pNewKey = 0;
-  int nOldKey = 0, nNewKey = 0;
-  int rc;
-
-  rc = prollyMutMapInit(&mm, 0);
-  if( rc!=SQLITE_OK ) return rc;
-
-  if( pOldVal && nOldVal>0 ){
-    rc = doltliteBuildIndexSortKey(pOldVal, nOldVal,
-                                   pIdx->aiColumn, pIdx->nKeyCol, 0,
-                                   iPKey, intKey,
-                                   pTreeKey, nTreeKey,
-                                   &pOldKey, &nOldKey);
-    if( rc==SQLITE_OK ){
-      rc = prollyMutMapDelete(&mm, pOldKey, nOldKey, 0);
-    }
-    sqlite3_free(pOldKey);
-    if( rc!=SQLITE_OK ){
-      prollyMutMapFree(&mm);
-      return rc;
-    }
-  }
-  if( pNewVal && nNewVal>0 ){
-    rc = doltliteBuildIndexSortKey(pNewVal, nNewVal,
-                                   pIdx->aiColumn, pIdx->nKeyCol, 0,
-                                   iPKey, intKey,
-                                   pTreeKey, nTreeKey,
-                                   &pNewKey, &nNewKey);
-    if( rc==SQLITE_OK ){
-      rc = prollyMutMapInsert(&mm, pNewKey, nNewKey, 0, 0, 0);
-    }
-    sqlite3_free(pNewKey);
-    if( rc!=SQLITE_OK ){
-      prollyMutMapFree(&mm);
-      return rc;
-    }
-  }
-
-  memset(&mut, 0, sizeof(mut));
-  mut.pStore = &pBt->store;
-  mut.pCache = &pBt->cache;
-  memcpy(&mut.oldRoot, &pIdxTE->root, sizeof(ProllyHash));
-  mut.pEdits = &mm;
-  mut.flags = pIdxTE->flags;
-
-  rc = prollyMutateFlush(&mut);
-  if( rc==SQLITE_OK ){
-    memcpy(&pIdxTE->root, &mut.newRoot, sizeof(ProllyHash));
-  }
-  prollyMutMapFree(&mm);
   return rc;
 }
 
@@ -1748,7 +1683,8 @@ int doltliteApplyRawRowMutation(
 
   /* Update secondary indexes (delete old key, insert new). pOldVal can
   ** be NULL when this is an insert of a fresh PK; pVal is NULL when
-  ** this is a delete. */
+  ** this is a delete. Uses the shared KeyInfo-aware path so NOCASE/RTRIM
+  ** match VDBE-encoded index trees. */
   if( rc==SQLITE_OK && pTab && pTab->pIndex
    && (pOldVal || (pVal && nVal>0)) ){
     Index *pIdx;
@@ -1767,9 +1703,10 @@ int doltliteApplyRawRowMutation(
         }
       }
       if( !pIdxTE ) continue;
-      rc = mutateSecondaryIndex(pBt, pIdxTE, pIdx, iPKey, intKey,
-                                pKey, nKey,
-                                pOldVal, nOldVal, pVal, nVal);
+      rc = doltliteIndexApplyRowDelta(
+          db, &pBt->store, &pBt->cache, &pIdxTE->root, pIdxTE->flags,
+          pIdx, iPKey, intKey, pKey, nKey,
+          pOldVal, nOldVal, pVal, nVal);
     }
   }
 

--- a/test/doltlite_index_row_delta.sh
+++ b/test/doltlite_index_row_delta.sh
@@ -1,0 +1,159 @@
+#!/bin/bash
+# Secondary-index row-delta paths (conflicts resolve, merge, workspace) must
+# use the same KeyInfo-aware encoding as VDBE. BINARY-only sort keys leave
+# ghost entries on NOCASE/RTRIM/DESC indexes and fail integrity_check.
+. "$(dirname "$0")/lib/doltlite_test_common.sh"
+
+echo "=== Doltlite Index Row-Delta Unification ==="
+echo ""
+
+# --- NOCASE: conflicts_resolve --theirs renames the indexed column -----------
+DB=/tmp/test_idx_delta_nocase_resolve_$$.db
+rm -f "$DB"
+cat <<'EOF' | $DOLTLITE "$DB" > /dev/null 2>&1
+CREATE TABLE t(id INTEGER PRIMARY KEY, name TEXT COLLATE NOCASE, v INT);
+CREATE UNIQUE INDEX idx_name ON t(name COLLATE NOCASE);
+INSERT INTO t VALUES (1, 'Alpha', 10), (2, 'Beta', 20);
+SELECT dolt_commit('-Am', 'init');
+SELECT dolt_checkout('-b', 'feat');
+UPDATE t SET name = 'Gamma', v = 21 WHERE id = 1;
+SELECT dolt_commit('-Am', 'feat');
+SELECT dolt_checkout('main');
+UPDATE t SET name = 'Delta', v = 31 WHERE id = 1;
+SELECT dolt_commit('-Am', 'main');
+BEGIN;
+SELECT dolt_merge('feat');
+SELECT dolt_conflicts_resolve('--theirs', 't');
+COMMIT;
+EOF
+
+run_test "nocase_resolve_row" \
+  "SELECT id || ':' || name || ':' || v FROM t WHERE id=1;" "1:Gamma:21" "$DB"
+run_test "nocase_resolve_seek_gamma" \
+  "SELECT id FROM t INDEXED BY idx_name WHERE name = 'gamma';" "1" "$DB"
+run_test "nocase_resolve_seek_delta_gone" \
+  "SELECT count(*) FROM t INDEXED BY idx_name WHERE name = 'delta';" "0" "$DB"
+run_test "nocase_resolve_seek_alpha_gone" \
+  "SELECT count(*) FROM t INDEXED BY idx_name WHERE name = 'alpha';" "0" "$DB"
+run_test_lastline "nocase_resolve_integrity" "PRAGMA integrity_check;" "ok" "$DB"
+
+PRE=$(echo "SELECT group_concat(id || ':' || name, ',') FROM (SELECT id, name FROM t INDEXED BY idx_name ORDER BY name, id);" | $DOLTLITE "$DB" 2>/dev/null | tail -1)
+echo "REINDEX idx_name;" | $DOLTLITE "$DB" > /dev/null 2>&1
+POST=$(echo "SELECT group_concat(id || ':' || name, ',') FROM (SELECT id, name FROM t INDEXED BY idx_name ORDER BY name, id);" | $DOLTLITE "$DB" 2>/dev/null | tail -1)
+if [ -n "$PRE" ] && [ "$PRE" = "$POST" ]; then
+  PASS=$((PASS+1))
+else
+  FAIL=$((FAIL+1))
+  ERRORS="$ERRORS\nFAIL: nocase_resolve_reindex_idempotent\n  pre:  $PRE\n  post: $POST"
+fi
+rm -f "$DB"
+
+# --- RTRIM: conflict resolve ------------------------------------------------
+DB=/tmp/test_idx_delta_rtrim_$$.db
+rm -f "$DB"
+cat <<'EOF' | $DOLTLITE "$DB" > /dev/null 2>&1
+CREATE TABLE t(id INTEGER PRIMARY KEY, tag TEXT COLLATE RTRIM, v INT);
+CREATE INDEX idx_tag ON t(tag COLLATE RTRIM);
+INSERT INTO t VALUES (1, 'x', 1);
+SELECT dolt_commit('-Am', 'init');
+SELECT dolt_checkout('-b', 'feat');
+UPDATE t SET tag = 'y  ', v = 2 WHERE id = 1;
+SELECT dolt_commit('-Am', 'feat');
+SELECT dolt_checkout('main');
+UPDATE t SET tag = 'z', v = 3 WHERE id = 1;
+SELECT dolt_commit('-Am', 'main');
+BEGIN;
+SELECT dolt_merge('feat');
+SELECT dolt_conflicts_resolve('--theirs', 't');
+COMMIT;
+EOF
+
+run_test "rtrim_resolve_row" \
+  "SELECT id || ':' || quote(tag) || ':' || v FROM t WHERE id=1;" "1:'y  ':2" "$DB"
+run_test "rtrim_resolve_seek" \
+  "SELECT id FROM t INDEXED BY idx_tag WHERE tag = 'y';" "1" "$DB"
+run_test_lastline "rtrim_resolve_integrity" "PRAGMA integrity_check;" "ok" "$DB"
+rm -f "$DB"
+
+# --- DESC + NOCASE merge (inline patch, not post-merge REINDEX-only) --------
+DB=/tmp/test_idx_delta_desc_merge_$$.db
+rm -f "$DB"
+cat <<'EOF' | $DOLTLITE "$DB" > /dev/null 2>&1
+CREATE TABLE t(id INTEGER PRIMARY KEY, name TEXT COLLATE NOCASE, v INT);
+CREATE INDEX idx_nd ON t(name COLLATE NOCASE DESC, v);
+INSERT INTO t VALUES (1, 'a', 1), (2, 'B', 2);
+SELECT dolt_commit('-Am', 'init');
+SELECT dolt_checkout('-b', 'feat');
+INSERT INTO t VALUES (3, 'c', 3);
+UPDATE t SET v = 20 WHERE id = 2;
+SELECT dolt_commit('-Am', 'feat');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES (4, 'D', 4);
+SELECT dolt_commit('-Am', 'main');
+SELECT dolt_merge('feat');
+EOF
+
+run_test "desc_merge_count" "SELECT count(*) FROM t;" "4" "$DB"
+run_test "desc_merge_seek_b" \
+  "SELECT id || ':' || v FROM t INDEXED BY idx_nd WHERE name = 'b';" "2:20" "$DB"
+run_test_lastline "desc_merge_integrity" "PRAGMA integrity_check;" "ok" "$DB"
+PRE=$(echo "SELECT group_concat(id, ',') FROM (SELECT id FROM t INDEXED BY idx_nd WHERE name >= 'a' ORDER BY name DESC, v, id);" | $DOLTLITE "$DB" 2>/dev/null | tail -1)
+echo "REINDEX idx_nd;" | $DOLTLITE "$DB" > /dev/null 2>&1
+POST=$(echo "SELECT group_concat(id, ',') FROM (SELECT id FROM t INDEXED BY idx_nd WHERE name >= 'a' ORDER BY name DESC, v, id);" | $DOLTLITE "$DB" 2>/dev/null | tail -1)
+if [ -n "$PRE" ] && [ "$PRE" = "$POST" ]; then
+  PASS=$((PASS+1))
+else
+  FAIL=$((FAIL+1))
+  ERRORS="$ERRORS\nFAIL: desc_merge_reindex_idempotent\n  pre:  $PRE\n  post: $POST"
+fi
+rm -f "$DB"
+
+# --- Workspace stage of NOCASE index row ------------------------------------
+DB=/tmp/test_idx_delta_ws_nocase_$$.db
+rm -f "$DB"
+cat <<'EOF' | $DOLTLITE "$DB" > /dev/null 2>&1
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT COLLATE NOCASE);
+CREATE INDEX idx_t_v ON t(v);
+INSERT INTO t VALUES(1,'Abc'),(2,'Def');
+SELECT dolt_commit('-A','-m','seed');
+INSERT INTO t VALUES(3,'GHI');
+UPDATE t SET v = 'xyz' WHERE id = 1;
+UPDATE dolt_workspace_t SET staged=TRUE WHERE to_id IN (1, 3);
+SELECT dolt_commit('-m','stage nocase rows');
+EOF
+
+run_test "ws_nocase_seek_xyz" \
+  "SELECT id FROM t INDEXED BY idx_t_v WHERE v = 'XYZ';" "1" "$DB"
+run_test "ws_nocase_seek_ghi" \
+  "SELECT id FROM t INDEXED BY idx_t_v WHERE v = 'ghi';" "3" "$DB"
+run_test "ws_nocase_seek_abc_gone" \
+  "SELECT count(*) FROM t INDEXED BY idx_t_v WHERE v = 'abc';" "0" "$DB"
+run_test_lastline "ws_nocase_integrity" "PRAGMA integrity_check;" "ok" "$DB"
+rm -f "$DB"
+
+# --- BINARY unique index still works on resolve (regression) ----------------
+DB=/tmp/test_idx_delta_binary_$$.db
+rm -f "$DB"
+cat <<'EOF' | $DOLTLITE "$DB" > /dev/null 2>&1
+CREATE TABLE t(id INTEGER PRIMARY KEY, name TEXT, v INT);
+CREATE UNIQUE INDEX idx_name ON t(name);
+INSERT INTO t VALUES (1, 'Alpha', 10);
+SELECT dolt_commit('-Am', 'init');
+SELECT dolt_checkout('-b', 'feat');
+UPDATE t SET name = 'Gamma', v = 21 WHERE id = 1;
+SELECT dolt_commit('-Am', 'feat');
+SELECT dolt_checkout('main');
+UPDATE t SET name = 'Delta', v = 31 WHERE id = 1;
+SELECT dolt_commit('-Am', 'main');
+BEGIN;
+SELECT dolt_merge('feat');
+SELECT dolt_conflicts_resolve('--theirs', 't');
+COMMIT;
+EOF
+
+run_test "binary_resolve_seek" \
+  "SELECT id FROM t INDEXED BY idx_name WHERE name = 'Gamma';" "1" "$DB"
+run_test_lastline "binary_resolve_integrity" "PRAGMA integrity_check;" "ok" "$DB"
+rm -f "$DB"
+
+dltest_finish

--- a/test/doltlite_merge_nocase_reindex.sh
+++ b/test/doltlite_merge_nocase_reindex.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
-# NOCASE secondary indexes skip inline mutmap patching during three-way row
-# merge (mergeIndexNeedsRebuild) and are rebuilt via REINDEX after the merged
-# catalog is live. This suite checks that the post-merge index matches a full
-# rebuild: same INDEXED BY results before/after REINDEX, and after drop+recreate.
+# NOCASE secondary indexes are patched inline during three-way merge with a
+# real KeyInfo (same path as conflicts resolve / workspace). This suite checks
+# that the post-merge index matches a full rebuild: same INDEXED BY results
+# before/after REINDEX, and after drop+recreate.
 . "$(dirname "$0")/lib/doltlite_test_common.sh"
 
 echo "=== Doltlite Merge NOCASE Index Reindex Property ==="
@@ -75,7 +75,7 @@ fi
 
 run_test_lastline "nocase_merge_integrity" "PRAGMA integrity_check;" "ok" "$DB"
 
-# DESC + NOCASE also takes the rebuild path (mergeIndexNeedsRebuild).
+# DESC + NOCASE also uses KeyInfo-aware inline index patching.
 DB2=/tmp/test_merge_nocase_desc_$$.db
 rm -f "$DB2"
 cat <<'EOF' | $DOLTLITE "$DB2" > /dev/null 2>&1

--- a/test/lib/doltlite_suite_manifest.sh
+++ b/test/lib/doltlite_suite_manifest.sh
@@ -17,6 +17,7 @@ doltlite_merge.sh
 doltlite_merge_status.sh
 doltlite_merge_index_conflict.sh
 doltlite_merge_nocase_reindex.sh
+doltlite_index_row_delta.sh
 doltlite_index_vc_matrix.sh
 doltlite_stats_merge.sh
 large_merge_test.sh


### PR DESCRIPTION
## Summary

Non-VDBE writers (`dolt_conflicts_resolve`, workspace staging, three-way merge) maintained secondary indexes with **BINARY** sort keys (`pKeyInfo = 0`) and never stored lossy payloads. That diverged from VDBE `OP_IdxInsert`, so NOCASE/RTRIM/DESC indexes could be corrupted after VC operations.

Reproduced before the fix: resolve a NOCASE rename conflict with `--theirs` → `PRAGMA integrity_check` reports `row 1 missing from index`, stale seeks still hit the old key, and the index scan shows ghost entries.

### Changes

- Add shared helpers in `doltlite_merge_rows.c`:
  - `doltliteKeyInfoOfIndex` — KeyInfo without a Parse context
  - `doltliteIndexMutMapRowDelta` — old/new row → mutmap (merge batching)
  - `doltliteIndexApplyRowDelta` — mutmap + flush to an index root
- Wire them from merge pass1, raw-row mutation, and workspace
- Drop the merge dual path that skipped inline patches for NOCASE/RTRIM/DESC and relied on post-merge `REINDEX`; patch all secondary indexes inline with real KeyInfo
- Store index-record payloads for lossy collations (and other VDBE-matching cases)

## Test plan

- [x] `test/doltlite_index_row_delta.sh` (new, 19 cases): NOCASE resolve, RTRIM resolve, DESC+NOCASE merge, workspace NOCASE rename/insert, BINARY regression
- [x] `doltlite_merge_nocase_reindex.sh`
- [x] `doltlite_conflicts.sh`, `doltlite_conflict_rows.sh`
- [x] `doltlite_merge_index_conflict.sh`, `doltlite_index_vc_matrix.sh`
- [x] `doltlite_workspace.sh`, `doltlite_nocase_index.sh`
- [ ] CI full suite on this PR