### PR TITLE
Make ref mutations atomic

### DIFF
--- a/src/chunk_store.h
+++ b/src/chunk_store.h
@@ -255,6 +255,19 @@ int chunkStoreInstallRefsBlob(ChunkStore *cs, const u8 *data, int nData);
 
 int chunkStoreSerializeRefsToBlob(ChunkStore *cs, u8 **ppOut, int *pnOut);
 
+typedef struct ChunkStoreRefsSnapshot ChunkStoreRefsSnapshot;
+struct ChunkStoreRefsSnapshot {
+  SavedRefsState state;
+  ProllyHash refsHash;
+  ProllyHash committedRefsHash;
+};
+int chunkStoreSnapshotRefs(ChunkStore *cs, ChunkStoreRefsSnapshot *pSnapshot);
+void chunkStoreRestoreRefsSnapshot(
+  ChunkStore *cs,
+  ChunkStoreRefsSnapshot *pSnapshot
+);
+void chunkStoreDiscardRefsSnapshot(ChunkStoreRefsSnapshot *pSnapshot);
+
 int chunkStoreHasMany(ChunkStore *cs, const ProllyHash *aHash, int nHash, u8 *aResult);
 
 int chunkStoreHas(ChunkStore *cs, const ProllyHash *hash, int *pHas);

--- a/src/chunk_store_refs_api.c
+++ b/src/chunk_store_refs_api.c
@@ -488,5 +488,51 @@ int chunkStoreSerializeRefsToBlob(ChunkStore *cs, u8 **ppOut, int *pnOut){
   return csSerializeRefsBlob(cs, ppOut, pnOut);
 }
 
+int chunkStoreSnapshotRefs(ChunkStore *cs, ChunkStoreRefsSnapshot *pSnapshot){
+  u8 *pRefs = 0;
+  int nRefs = 0;
+  int rc;
+
+  memset(pSnapshot, 0, sizeof(*pSnapshot));
+  rc = csSerializeRefsBlob(cs, &pRefs, &nRefs);
+  if( rc!=SQLITE_OK ) return rc;
+  pSnapshot->refsHash = cs->refs.refsHash;
+  pSnapshot->committedRefsHash = cs->refs.committedRefsHash;
+  csDetachSavedRefsState(cs, &pSnapshot->state);
+  rc = csReplaceRefsStateFromBlob(cs, pRefs, nRefs, 0);
+  sqlite3_free(pRefs);
+  if( rc!=SQLITE_OK ){
+    csRestoreSavedRefsState(cs, &pSnapshot->state);
+    REFS_OWNED_CLEAR(pSnapshot->state);
+    cs->refs.refsHash = pSnapshot->refsHash;
+    cs->refs.committedRefsHash = pSnapshot->committedRefsHash;
+    cs->bRefsStale = 0;
+    memset(pSnapshot, 0, sizeof(*pSnapshot));
+    return rc;
+  }
+  cs->refs.refsHash = pSnapshot->refsHash;
+  cs->refs.committedRefsHash = pSnapshot->committedRefsHash;
+  cs->bRefsStale = 0;
+  return SQLITE_OK;
+}
+
+void chunkStoreRestoreRefsSnapshot(
+  ChunkStore *cs,
+  ChunkStoreRefsSnapshot *pSnapshot
+){
+  csFreeRefsState(cs);
+  csRestoreSavedRefsState(cs, &pSnapshot->state);
+  REFS_OWNED_CLEAR(pSnapshot->state);
+  cs->refs.refsHash = pSnapshot->refsHash;
+  cs->refs.committedRefsHash = pSnapshot->committedRefsHash;
+  cs->bRefsStale = 0;
+  memset(pSnapshot, 0, sizeof(*pSnapshot));
+}
+
+void chunkStoreDiscardRefsSnapshot(ChunkStoreRefsSnapshot *pSnapshot){
+  csFreeSavedRefsState(&pSnapshot->state);
+  memset(pSnapshot, 0, sizeof(*pSnapshot));
+}
+
 
 #endif

--- a/src/doltlite_cherry_pick.c
+++ b/src/doltlite_cherry_pick.c
@@ -254,13 +254,8 @@ int applyMergedCatalogAndCommit(
       zMessage, NULL, NULL, NULL, 0, &commitHash);
   if( rc!=SQLITE_OK ) goto apply_rollback;
 
-  /* Re-confirm under the lock right before advancing; the first confirm is
-  ** staled by intervening lock-cycling SQL. */
-  rc = doltliteRefreshAndConfirmHead(db, cs, ourHead);
-  if( rc!=SQLITE_OK ) goto apply_rollback;
-  graphLocked = 1;
-
-  rc = doltliteAdvanceBranch(db, &commitHash, &liveMergedCatHash, 0);
+  rc = doltliteCompareAndAdvanceBranch(
+      db, ourHead, &commitHash, &liveMergedCatHash, 0);
   if( rc!=SQLITE_OK ) goto apply_rollback;
 
   rc = doltliteVcSealActiveSavepoints(db);

--- a/src/doltlite_commit_cmd.c
+++ b/src/doltlite_commit_cmd.c
@@ -589,6 +589,7 @@ static void doltliteCommitFunc(
   sqlite3 *db = sqlite3_context_db_handle(context);
   ChunkStore *cs = doltliteGetChunkStore(db);
   DoltliteCommitOptions opts;
+  DoltliteTxnState mutationState;
   const char *zMessage, *zDate;
   int addAll, addModifiedOnly, amend, allowEmpty, skipEmpty, force;
   ProllyHash commitHash;
@@ -597,6 +598,8 @@ static void doltliteCommitFunc(
   char hexBuf[PROLLY_HASH_SIZE*2+1];
   int sealTopLevel = doltliteSavepointIsTopLevelTxn(db);
   int rc;
+
+  memset(&mutationState, 0, sizeof(mutationState));
 
   if( !cs ){
     sqlite3_result_error(context, doltliteVcUnavailableMessage(db), -1);
@@ -787,12 +790,7 @@ static void doltliteCommitFunc(
   if( rc!=SQLITE_OK ) return;
 
   doltliteGetSessionHead(db, &sessionHeadBeforeLock);
-
-  rc = doltliteRefreshAndConfirmHead(db, cs, &sessionHeadBeforeLock);
-  if( rc==SQLITE_BUSY ){
-    doltliteCmdResultPeerBranchBusy(context, "commit");
-    return;
-  }
+  rc = doltliteSaveTxnState(db, &mutationState);
   if( rc!=SQLITE_OK ){
     sqlite3_result_error_code(context, rc);
     return;
@@ -804,7 +802,8 @@ static void doltliteCommitFunc(
     if( wasMerging ){
       rc = doltliteClearSessionMergeState(db);
       if( rc!=SQLITE_OK ){
-        sqlite3_result_error_code(context, rc);
+        sqlite3_result_error_code(context,
+            doltliteRestoreTxnStateOnFailure(db, &mutationState, rc));
         return;
       }
     }
@@ -821,14 +820,22 @@ static void doltliteCommitFunc(
     ProllyHash workingCatHash;
     rc = doltliteFlushCatalogToHash(db, &workingCatHash);
     if( rc==SQLITE_OK ){
-      rc = doltliteAdvanceBranch(db, &commitHash, &catalogHash, &workingCatHash);
+      rc = doltliteCompareAndAdvanceBranch(
+          db, &sessionHeadBeforeLock, &commitHash, &catalogHash,
+          &workingCatHash);
     }
   }
-  chunkStoreUnlock(cs);
-  if( rc!=SQLITE_OK ){
-    sqlite3_result_error_code(context, rc);
+  if( rc==SQLITE_BUSY ){
+    rc = doltliteRestoreTxnStateOnFailure(db, &mutationState, rc);
+    doltliteCmdResultPeerBranchBusy(context, "commit");
     return;
   }
+  if( rc!=SQLITE_OK ){
+    sqlite3_result_error_code(context,
+        doltliteRestoreTxnStateOnFailure(db, &mutationState, rc));
+    return;
+  }
+  doltliteTxnStateClear(&mutationState);
 
   doltliteHashToHex(&commitHash, hexBuf);
 

--- a/src/doltlite_core.c
+++ b/src/doltlite_core.c
@@ -311,11 +311,24 @@ int doltliteLoadLiveSchemaSql(
   return rc;
 }
 
-int doltliteMutateRefs(sqlite3 *db, DoltliteRefsMutation xMutate, void *pArg){
+int doltliteMutateRefsExpected(
+  sqlite3 *db,
+  const DoltliteBranchExpectation *aExpected,
+  int nExpected,
+  DoltliteRefsMutation xMutate,
+  void *pArg
+){
   ChunkStore *cs = doltliteGetChunkStore(db);
+  ChunkStoreRefsSnapshot snapshot;
+  int haveSnapshot = 0;
+  int i;
   int rc;
 
-  if( !cs ) return SQLITE_ERROR;
+  memset(&snapshot, 0, sizeof(snapshot));
+
+  if( !cs || !xMutate || nExpected<0 || (nExpected>0 && !aExpected) ){
+    return SQLITE_MISUSE;
+  }
 
   rc = chunkStoreLockAndRefresh(cs);
   if( rc!=SQLITE_OK ) return rc;
@@ -330,14 +343,43 @@ int doltliteMutateRefs(sqlite3 *db, DoltliteRefsMutation xMutate, void *pArg){
     return rc;
   }
 
-  rc = xMutate(db, cs, pArg);
+  rc = chunkStoreSnapshotRefs(cs, &snapshot);
+  if( rc==SQLITE_OK ) haveSnapshot = 1;
+  for(i=0; rc==SQLITE_OK && i<nExpected; i++){
+    ProllyHash tip;
+    int found = 0;
+    rc = chunkStoreReadDiskBranchTip(
+        cs, aExpected[i].zBranch, &tip, &found);
+    if( rc==SQLITE_OK ){
+      if( aExpected[i].pTip ){
+        if( !found || prollyHashCompare(&tip, aExpected[i].pTip)!=0 ){
+          rc = SQLITE_BUSY;
+        }
+      }else if( found ){
+        rc = SQLITE_BUSY;
+      }
+    }
+  }
+
+  if( rc==SQLITE_OK ) rc = xMutate(db, cs, pArg);
   if( rc==SQLITE_OK ){
     rc = chunkStoreSerializeRefs(cs);
     if( rc==SQLITE_OK ) rc = chunkStoreCommit(cs);
   }
+  if( haveSnapshot ){
+    if( rc==SQLITE_OK ){
+      chunkStoreDiscardRefsSnapshot(&snapshot);
+    }else{
+      chunkStoreRestoreRefsSnapshot(cs, &snapshot);
+    }
+  }
 
   chunkStoreUnlock(cs);
   return rc;
+}
+
+int doltliteMutateRefs(sqlite3 *db, DoltliteRefsMutation xMutate, void *pArg){
+  return doltliteMutateRefsExpected(db, 0, 0, xMutate, pArg);
 }
 
 int doltliteFlushCatalogToHash(sqlite3 *db, ProllyHash *pHash){
@@ -587,6 +629,25 @@ int doltliteAdvanceBranch(
 
   doltliteTxnStateClear(&saved);
   return SQLITE_OK;
+}
+
+int doltliteCompareAndAdvanceBranch(
+  sqlite3 *db,
+  const ProllyHash *pExpectedHead,
+  const ProllyHash *pNewHead,
+  const ProllyHash *pCatalogHash,
+  const ProllyHash *pWorkingCatHash
+){
+  ChunkStore *cs = doltliteGetChunkStore(db);
+  int rc;
+  if( !cs ) return SQLITE_ERROR;
+  rc = doltliteRefreshAndConfirmHead(db, cs, pExpectedHead);
+  if( rc==SQLITE_OK ){
+    rc = doltliteAdvanceBranch(
+        db, pNewHead, pCatalogHash, pWorkingCatHash);
+    chunkStoreUnlock(cs);
+  }
+  return rc;
 }
 
 int doltlitePersistOrSaveWorkingSet(sqlite3 *db){

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -853,6 +853,13 @@ int doltliteAdvanceBranch(
   const ProllyHash *pCatalogHash,
   const ProllyHash *pWorkingCatHash
 );
+int doltliteCompareAndAdvanceBranch(
+  sqlite3 *db,
+  const ProllyHash *pExpectedHead,
+  const ProllyHash *pNewHead,
+  const ProllyHash *pCatalogHash,
+  const ProllyHash *pWorkingCatHash
+);
 int doltlitePersistOrSaveWorkingSet(sqlite3 *db);
 /* Shared dolt_* command scaffolding (doltlite_cmd.c). */
 void doltliteCmdResultUnknownOption(sqlite3_context *ctx, const char *zOpt);
@@ -1165,6 +1172,18 @@ void doltliteVcResultError(sqlite3_context *ctx, sqlite3 *db, const char *zMsg);
 int doltliteVcSealBranchStyleTxn(sqlite3 *db);
 
 typedef int (*DoltliteRefsMutation)(sqlite3 *db, ChunkStore *cs, void *pArg);
+typedef struct DoltliteBranchExpectation DoltliteBranchExpectation;
+struct DoltliteBranchExpectation {
+  const char *zBranch;
+  const ProllyHash *pTip;
+};
+int doltliteMutateRefsExpected(
+  sqlite3 *db,
+  const DoltliteBranchExpectation *aExpected,
+  int nExpected,
+  DoltliteRefsMutation xMutate,
+  void *pArg
+);
 int doltliteMutateRefs(sqlite3 *db, DoltliteRefsMutation xMutate, void *pArg);
 
 const char *doltliteGetAuthorName(sqlite3 *db);

--- a/src/doltlite_merge_cmd.c
+++ b/src/doltlite_merge_cmd.c
@@ -46,7 +46,6 @@ int mergeFastForward(
 ){
   DoltliteCommit theirCommit;
   DoltliteTxnState savedState;
-  int graphLocked = 0;
   int rc;
   char hx[PROLLY_HASH_SIZE*2+1];
 
@@ -65,31 +64,18 @@ int mergeFastForward(
     sqlite3_result_error_code(context, rc);
     return rc;
   }
-  rc = doltliteRefreshAndConfirmHead(db, cs, pOurHead);
-  if( rc==SQLITE_BUSY ){
-    doltliteTxnStateClear(&savedState);
-    doltliteCommitClear(&theirCommit);
-    doltliteCmdResultPeerBranchBusy(context, "merge");
-    return rc;
-  }
-  if( rc!=SQLITE_OK ){
-    doltliteTxnStateClear(&savedState);
-    doltliteCommitClear(&theirCommit);
-    sqlite3_result_error_code(context, rc);
-    return rc;
-  }
-  graphLocked = 1;
   rc = doltliteSwitchCatalog(db, &theirCommit.catalogHash);
   if( rc==SQLITE_OK ){
     rc = doltliteUpdateBranchWorkingState(db, doltliteGetSessionBranch(db),
                                           &theirCommit.catalogHash, NULL);
   }
   if( rc==SQLITE_OK ){
-    rc = doltliteAdvanceBranch(db, pTheirHead, &theirCommit.catalogHash, 0);
+    rc = doltliteCompareAndAdvanceBranch(
+        db, pOurHead, pTheirHead, &theirCommit.catalogHash, 0);
   }
-  if( graphLocked ) chunkStoreUnlock(cs);
   if( rc!=SQLITE_OK ){
     doltliteCommitClear(&theirCommit);
+    if( rc==SQLITE_BUSY ) doltliteCmdResultPeerBranchBusy(context, "merge");
     sqlite3_result_error_code(context,
         doltliteRestoreTxnStateOnFailure(db, &savedState, rc));
     return rc;
@@ -509,25 +495,12 @@ int doltliteMergeRef(
       return SQLITE_ERROR;
     }
 
-    /* Re-confirm under the lock right before advancing; the merge's first
-    ** confirm is staled by intervening lock-cycling SQL (ANALYZE, etc.). */
-    rc = doltliteRefreshAndConfirmHead(db, cs, &ourHead);
+    rc = doltliteCompareAndAdvanceBranch(
+        db, &ourHead, &commitHash, &mergedCatHash, 0);
     if( rc==SQLITE_BUSY ){
       doltliteCmdResultPeerBranchBusy(context, "merge");
       doltliteRestoreTxnStateOnFailure(db, &savedState, rc);
       return SQLITE_ERROR;
-    }
-    if( rc!=SQLITE_OK ){
-      sqlite3_result_error_code(context,
-          doltliteRestoreTxnStateOnFailure(db, &savedState, rc));
-      return SQLITE_ERROR;
-    }
-    graphLocked = 1;
-
-    rc = doltliteAdvanceBranch(db, &commitHash, &mergedCatHash, 0);
-    if( graphLocked ){
-      chunkStoreUnlock(cs);
-      graphLocked = 0;
     }
     if( rc!=SQLITE_OK ){
       sqlite3_result_error_code(context,

--- a/src/doltlite_rebase.c
+++ b/src/doltlite_rebase.c
@@ -386,7 +386,13 @@ static int doltliteRebaseLinearReplay(
   createCtx.zWorkingBranch = zWorking;
   createCtx.pHead = &upstreamHash;
   createCtx.pCatalog = &upstreamCommit.catalogHash;
-  rc = doltliteMutateRefs(db, rebaseCreateWorkingBranchRefs, &createCtx);
+  {
+    DoltliteBranchExpectation expected;
+    expected.zBranch = zWorking;
+    expected.pTip = 0;
+    rc = doltliteMutateRefsExpected(
+        db, &expected, 1, rebaseCreateWorkingBranchRefs, &createCtx);
+  }
   if( rc==SQLITE_OK ) workingCreated = 1;
   doltliteCommitClear(&upstreamCommit);
   memset(&upstreamCommit, 0, sizeof(upstreamCommit));
@@ -460,7 +466,15 @@ static int doltliteRebaseLinearReplay(
   refsCtx.pExpectedOrigHead = &headHash;
   refsCtx.pCurHead = &curHead;
   refsCtx.pCurCat = &curCat;
-  rc = doltliteMutateRefs(db, rebaseFinalizeLinearRefs, &refsCtx);
+  {
+    DoltliteBranchExpectation expected[2];
+    expected[0].zBranch = zOrig;
+    expected[0].pTip = &headHash;
+    expected[1].zBranch = zWorking;
+    expected[1].pTip = &curHead;
+    rc = doltliteMutateRefsExpected(
+        db, expected, 2, rebaseFinalizeLinearRefs, &refsCtx);
+  }
   if( rc!=SQLITE_OK ) goto rollback;
   workingCreated = 0;
 
@@ -1389,7 +1403,15 @@ static void doltliteRebaseInteractiveContinue(
   refsCtx.pExpectedOrigHead = &expectedOrigHead;
   refsCtx.pCurHead = &curHead;
   refsCtx.pCurCat = &curCat;
-  rc = doltliteMutateRefs(db, rebaseFinalizeContinueRefs, &refsCtx);
+  {
+    DoltliteBranchExpectation expected[2];
+    expected[0].zBranch = zOrigBranch;
+    expected[0].pTip = &expectedOrigHead;
+    expected[1].zBranch = zWorking;
+    expected[1].pTip = &curHead;
+    rc = doltliteMutateRefsExpected(
+        db, expected, 2, rebaseFinalizeContinueRefs, &refsCtx);
+  }
   if( rc!=SQLITE_OK ) goto abort_err;
 
   rc = doltliteClearSessionRebaseState(db);

--- a/test/lint_layers.sh
+++ b/test/lint_layers.sh
@@ -185,6 +185,15 @@ for f in "$SRCDIR"/doltlite_*.c; do
   fi
 done
 
+for f in "$SRCDIR"/doltlite_*.c; do
+  case "$f" in
+    "$SRCDIR/doltlite_core.c"|"$SRCDIR/doltlite_config.c") continue ;;
+  esac
+  while IFS= read -r line; do
+    lint "$f:$line — branch advances must use doltliteCompareAndAdvanceBranch()"
+  done < <(grep -n 'doltliteAdvanceBranch[[:space:]]*(' "$f")
+done
+
 NFAIL=$(wc -l < "$TMPFILE" | tr -d ' ')
 if [ "$NFAIL" -eq 0 ]; then
   echo "lint_layers: all checks passed"

--- a/test/vc_ref_mutation_stress_test.c
+++ b/test/vc_ref_mutation_stress_test.c
@@ -5,6 +5,7 @@
 #include <sys/wait.h>
 #include <unistd.h>
 #include "sqlite3.h"
+#include "doltlite_internal.h"
 
 #define N_WORKERS 3
 #define N_ROUNDS 4
@@ -434,6 +435,77 @@ static void runDefaultRenameStress(void){
   cleanupDb(path);
 }
 
+typedef struct FailingMutationCtx FailingMutationCtx;
+struct FailingMutationCtx {
+  const char *zBranch;
+  ProllyHash head;
+};
+
+static int failAfterBranchAdd(sqlite3 *db, ChunkStore *cs, void *pArg){
+  FailingMutationCtx *p = (FailingMutationCtx*)pArg;
+  int rc;
+  (void)db;
+  rc = chunkStoreAddBranch(cs, p->zBranch, &p->head);
+  return rc==SQLITE_OK ? SQLITE_IOERR : rc;
+}
+
+static int addMutationBranch(sqlite3 *db, ChunkStore *cs, void *pArg){
+  FailingMutationCtx *p = (FailingMutationCtx*)pArg;
+  (void)db;
+  return chunkStoreAddBranch(cs, p->zBranch, &p->head);
+}
+
+static void runAtomicMutationTests(void){
+  const char *path = "/tmp/test_vc_atomic_mutation.db";
+  sqlite3 *db1 = 0;
+  sqlite3 *db2 = 0;
+  FailingMutationCtx mutation;
+  DoltliteBranchExpectation expected;
+  int count = 0;
+  int rc;
+
+  check("atomic_mutation_setup", setupDb(path)==SQLITE_OK);
+  check("atomic_mutation_open_first", sqlite3_open(path, &db1)==SQLITE_OK);
+  sqlite3_busy_timeout(db1, 5000);
+  doltliteGetSessionHead(db1, &mutation.head);
+  mutation.zBranch = "rollback_probe";
+  rc = doltliteMutateRefs(db1, failAfterBranchAdd, &mutation);
+  check("atomic_mutation_surfaces_callback_failure", rc==SQLITE_IOERR);
+  check("atomic_mutation_restores_in_memory_refs",
+        queryIntWithRetry(db1,
+          "SELECT count(*) FROM dolt_branches WHERE name='rollback_probe'",
+          &count)==SQLITE_OK && count==0);
+  sqlite3_close(db1);
+  db1 = 0;
+  check("atomic_mutation_reopen_first", sqlite3_open(path, &db1)==SQLITE_OK);
+  check("atomic_mutation_failure_not_persisted",
+        queryIntWithRetry(db1,
+          "SELECT count(*) FROM dolt_branches WHERE name='rollback_probe'",
+          &count)==SQLITE_OK && count==0);
+
+  check("atomic_mutation_open_peer", sqlite3_open(path, &db2)==SQLITE_OK);
+  sqlite3_busy_timeout(db1, 5000);
+  sqlite3_busy_timeout(db2, 5000);
+  doltliteGetSessionHead(db1, &mutation.head);
+  check("atomic_mutation_peer_insert",
+        execSql(db2, "INSERT INTO ref_rows VALUES(99, 99, 99)")==SQLITE_OK);
+  check("atomic_mutation_peer_commit",
+        execSql(db2, "SELECT dolt_commit('-A','-m','peer advance')")==SQLITE_OK);
+  mutation.zBranch = "cas_probe";
+  expected.zBranch = "main";
+  expected.pTip = &mutation.head;
+  rc = doltliteMutateRefsExpected(
+      db1, &expected, 1, addMutationBranch, &mutation);
+  check("atomic_mutation_rejects_stale_expected_tip", rc==SQLITE_BUSY);
+  check("atomic_mutation_rejected_ref_absent",
+        queryIntWithRetry(db1,
+          "SELECT count(*) FROM dolt_branches WHERE name='cas_probe'",
+          &count)==SQLITE_OK && count==0);
+  sqlite3_close(db2);
+  sqlite3_close(db1);
+  cleanupDb(path);
+}
+
 int main(void){
   const char *path = "/tmp/test_vc_ref_mutation_stress.db";
   pid_t pids[N_WORKERS];
@@ -461,6 +533,7 @@ int main(void){
   verifyFinalState(path);
   cleanupDb(path);
   runDefaultRenameStress();
+  runAtomicMutationTests();
 
   printf("\nResults: %d passed, %d failed out of %d tests\n",
          nPass, nFail, nPass+nFail);


### PR DESCRIPTION
## Summary

- make ref callbacks transactional by mutating a cloned refs state while retaining an allocation-free rollback snapshot
- validate declared branch tips from authoritative storage under the graph lock, and centralize final branch CAS plus persistence in `doltliteCompareAndAdvanceBranch`
- migrate commit, merge, cherry-pick, and rebase advancement paths; add lint enforcement and deterministic rollback/stale-tip coverage

## Correctness

A callback, refs serialization, or chunk-store commit failure now restores the exact prior owned ref arrays, refs hash, committed refs hash, and freshness state. Rebase finalization declares both the original and working branch tips. A losing commit race restores its full transaction snapshot instead of leaving prepared merge or constraint state behind.

The new callback-failure assertion fails on the previous implementation because the partially added branch remains visible in memory. The stale-peer test proves an expected-tip mismatch returns `SQLITE_BUSY` without installing any requested ref.

## Validation

- `make -C build -j4 doltlite doltlite-c-tests-build`
- `make -C build lint`
- `vc_ref_mutation_stress_test`: 282/282
- `vc_concurrency_test`: 37/37
- `multi_process_merge_rebase_test`: 20/20
- branch, default-branch, merge, cherry-pick, rebase, and rebase-schema shell suites
- 1,500 targeted OOM fault points across branch creation, checkout, and linear rebase
- full native run during implementation: 95/95 shell suites, including 310,021 regression assertions

Co-Authored-By: OpenAI Codex <noreply@openai.com>