### PR TITLE
Scan the whole WAL tail when classifying damage

### DIFF
--- a/src/chunk_wal.c
+++ b/src/chunk_wal.c
@@ -131,7 +131,8 @@ void csFreeReloadState(ChunkStoreReloadState *pSaved){
   memset(pSaved, 0, sizeof(*pSaved));
 }
 
-/* Cap recovery scans; valid writer gaps are sector-bounded. */
+/* Cap the zero-tail probe; valid writer gaps are sector-bounded, so a
+** legitimate preallocated tail never hides data past this window. */
 #define CS_WAL_SCAN_MAX (64*1024*1024)
 
 /* True if the WAL region from pos to walSize is zero as far as the scan
@@ -169,7 +170,11 @@ static int csWalResolveDamage(
   i64 q = damagePos + 1;
   i64 last = walSize - 5;
   i64 damageAbs = cs->wal.iWalOffset + damagePos;
-  if( last > damagePos + CS_WAL_SCAN_MAX ) last = damagePos + CS_WAL_SCAN_MAX;
+  /* The scan must reach the end of the WAL: a single batch can span far
+  ** more than any fixed window (drains plus large chunks), and a sealed
+  ** root past a capped window proves the damaged region was committed.
+  ** Stopping early would default that case to TORN, silently rewinding
+  ** committed batches that the next append then overwrites. */
   *pAction = CS_DAMAGE_TORN;
   *pResume = 0;
   while( q <= last ){

--- a/test/corruption_test.c
+++ b/test/corruption_test.c
@@ -908,6 +908,106 @@ static void test_corrupt_index_order(void){
 }
 
 
+/* Body offset of the first WAL chunk record whose declared length matches. */
+static off_t wal_chunk_body_offset_by_len(const char *path, unsigned int want){
+  long long walOffset = read_i64_le_at(path, 84);
+  off_t sz = file_size(path);
+  off_t pos;
+  if( walOffset < MANIFEST_SIZE || sz <= (off_t)walOffset ) return -1;
+  pos = (off_t)walOffset;
+  while( pos < sz ){
+    unsigned char tag = 0;
+    if( read_bytes(path, pos, &tag, 1)!=0 ) return -1;
+    pos++;
+    if( tag==0x01 ){
+      unsigned int len;
+      if( pos + 24 > sz ) return -1;
+      len = read_u32_le_at(path, pos + 20);
+      if( len==0xffffffffu || pos + 24 + (off_t)len > sz ) return -1;
+      if( len==want ) return pos + 24;
+      pos += 24 + (off_t)len;
+    }else if( tag==0x02 ){
+      if( pos + MANIFEST_SIZE > sz ) return -1;
+      pos += MANIFEST_SIZE;
+    }else{
+      return -1;
+    }
+  }
+  return -1;
+}
+
+static void test_damage_far_before_sealing_root_poisons(void){
+  const char *dbpath = "/tmp/test_corr_scan_window.db";
+  ChunkStore cs;
+  ProllyHash h1, h2, h3;
+  unsigned char small1[32], small3[32];
+  unsigned char bad = 0xA5;
+  /* Larger than any bounded damage-scan window, so this batch's sealing
+  ** root — and the next batch's — lie more than 64MB past the damage. */
+  const unsigned int bigLen = 70u*1024u*1024u;
+  unsigned char *big;
+  off_t bodyOff;
+  int rc;
+
+  printf("--- Test 23: Damage far before its sealing root poisons ---\n");
+
+  removeDb(dbpath);
+  memset(small1, 0x11, sizeof(small1));
+  memset(small3, 0x33, sizeof(small3));
+  big = sqlite3_malloc64(bigLen);
+  check("scan_window_alloc", big!=0);
+  if( !big ) return;
+  {
+    unsigned int x = 0x9e3779b9u, i;
+    for(i=0; i<bigLen; i++){
+      x ^= x<<13; x ^= x>>17; x ^= x<<5;
+      big[i] = (unsigned char)x;
+    }
+  }
+
+  rc = chunkStoreOpen(&cs, sqlite3_vfs_find(0), dbpath,
+      SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_MAIN_DB);
+  check("scan_window_open", rc==SQLITE_OK);
+  if( rc!=SQLITE_OK ){ sqlite3_free(big); return; }
+
+  check("scan_window_put1",
+    chunkStorePut(&cs, small1, sizeof(small1), &h1)==SQLITE_OK);
+  check("scan_window_commit1", chunkStoreCommit(&cs)==SQLITE_OK);
+  check("scan_window_put_big",
+    chunkStorePut(&cs, big, (int)bigLen, &h2)==SQLITE_OK);
+  check("scan_window_commit2", chunkStoreCommit(&cs)==SQLITE_OK);
+  check("scan_window_put3",
+    chunkStorePut(&cs, small3, sizeof(small3), &h3)==SQLITE_OK);
+  check("scan_window_commit3", chunkStoreCommit(&cs)==SQLITE_OK);
+  chunkStoreClose(&cs);
+  sqlite3_free(big);
+
+  bodyOff = wal_chunk_body_offset_by_len(dbpath, bigLen);
+  check("scan_window_find_big_body", bodyOff > 0);
+  if( bodyOff > 0 ){
+    check("scan_window_corrupt", corrupt_bytes(dbpath, bodyOff, &bad, 1)==0);
+  }
+
+  /* The sealed roots of batches 2 and 3 prove the damaged bytes sit below
+  ** committed data. A bounded scan that misses them would call this a torn
+  ** tail and silently rewind both committed batches; the store must be
+  ** poisoned instead. */
+  rc = chunkStoreOpen(&cs, sqlite3_vfs_find(0), dbpath,
+      SQLITE_OPEN_READWRITE | SQLITE_OPEN_MAIN_DB);
+  check("scan_window_reopen", rc==SQLITE_OK);
+  if( rc==SQLITE_OK ){
+    u8 *pData = 0;
+    int nData = 0;
+    check("scan_window_poisoned", cs.corruptMidStream);
+    rc = chunkStoreGet(&cs, &h1, &pData, &nData);
+    check("scan_window_no_silent_rewind", rc==SQLITE_CORRUPT);
+    sqlite3_free(pData);
+    chunkStoreClose(&cs);
+  }
+
+  removeDb(dbpath);
+}
+
 int main(void){
   printf("=== DoltLite Corruption Detection Tests ===\n\n");
 
@@ -932,6 +1032,7 @@ int main(void){
   test_corrupt_index_offset();
   test_corrupt_index_entry_offset();
   test_corrupt_index_order();
+  test_damage_far_before_sealing_root_poisons();
 
   printf("\n=== Results: %d passed, %d failed out of %d tests ===\n",
     nPass, nFail, nPass+nFail);


### PR DESCRIPTION
## Problem

`csWalResolveDamage` scans forward from a damage point looking for a later sealed root record, but capped the scan at 64MB (`CS_WAL_SCAN_MAX`) and defaulted to `CS_DAMAGE_TORN` when the window ran out. A single batch routinely spans more than 64MB — mid-transaction drains and large chunks all share one sealing root — so damage early in a large *committed* batch found no root inside the window and was classified as an uncommitted torn tail.

The consequences of that misclassification: replay rewinds `nWalData`/`iFileSize` to the last boundary before the damage, dropping the committed batch **and every committed batch after it**, refs revert to the older root, and the next commit appends over the "reclaimed" region, physically destroying committed transactions. Silent data loss, where the `durableTo` contract calls for poisoning the store and refusing.

## Fix

The root scan now runs to the end of the WAL. The classification logic is unchanged — a sealed root with `durableTo`/`batchStart` above the damage still yields MIDSTREAM/RESUME, a root of the damaged batch itself still keeps scanning — but TORN is now only reachable by scanning to EOF without finding a sealing root, which is the actual proof of a torn tail. Cost is bounded by WAL size and paid only on the (rare) damage path, which already reads and hashes the full tail during replay.

`csWalTailIsZero` keeps its 64MB cap: writer gaps are sector-bounded, so a legitimate preallocated zero tail can't hide data past the window. The macro comment now says that's its only consumer's rationale.

## Test

New `corruption_test` case builds a store with three committed batches — small, one 70MB chunk (sealing root >64MB past the batch start), small — corrupts one byte early in the big chunk's body, reopens, and asserts the store is poisoned (`corruptMidStream`, `chunkStoreGet` → `SQLITE_CORRUPT`) instead of silently serving the rewound commit-1 view.

Fail-before/pass-after verified locally:
- unfixed: `FAIL: scan_window_poisoned`, `FAIL: scan_window_no_silent_rewind` (93/95)
- fixed: 95/95

## Local validation

- `corruption_test`: 95/95
- `doltlite_regression_test_c`: 310,021/310,021
- `crash_recovery_test_sqlite_test`: 119/119
- `test/crash_injection_test.sh`: 104/104
- `test/run_c_tests.sh` coverage set: 16/16 suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)