### PR TITLE
refactor: split mega-functions on commit, chunk store, and index seek

### DIFF
--- a/src/chunk_store_commit.c
+++ b/src/chunk_store_commit.c
@@ -109,11 +109,234 @@ static int csCommitToMemory(ChunkStore *cs){
   return SQLITE_OK;
 }
 
+/* Open/lock the store file, resolve logical EOF, and sector-align the
+** next commit batch. On entry *pLockFd / *pzLockName are zeroed by the
+** caller when the graph lock is already held. */
+static int csCommitResolveAppendPoint(
+  ChunkStore *cs,
+  int hadFile,
+  int lockHeld,
+  CsFileLock *pLockFd,
+  char **pzLockName,
+  i64 *pFileSize,
+  i64 *pOrigFileSize,
+  i64 *pDurableTo,
+  i64 *pBatchStart,
+  int *pSectorSize
+){
+  int rc = SQLITE_OK;
+  i64 fileSize = 0;
+  i64 physFileSize = -1;
+  int sectorSize = 1;
+
+  if( cs->file.pFile == 0 ){
+    int openFlags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE
+                  | SQLITE_OPEN_MAIN_DB;
+    rc = csOpenFile(cs->file.pVfs, cs->file.zFilename, &cs->file.pFile, openFlags, 0);
+    if( rc != SQLITE_OK ){
+      return (rc==SQLITE_NOMEM || rc==SQLITE_IOERR_NOMEM) ? rc : SQLITE_CANTOPEN;
+    }
+  }
+
+  if( !lockHeld ){
+    rc = csFileLock(cs->file.pVfs, cs->file.zFilename, pLockFd, pzLockName);
+    if( rc!=SQLITE_OK ) return rc;
+  }
+
+  if( lockHeld && hadFile ){
+    fileSize = cs->file.iFileSize;
+  }else{
+    rc = cs->file.pFile->pMethods->xFileSize(cs->file.pFile, &fileSize);
+    if( rc != SQLITE_OK ) return rc;
+    physFileSize = fileSize;
+  }
+
+  if( hadFile && !lockHeld ){
+    int bMoved = 0;
+    int rc2 = sqlite3OsFileControl(cs->file.pFile, SQLITE_FCNTL_HAS_MOVED,
+                                   &bMoved);
+    if( rc2==SQLITE_OK && bMoved ){
+      rc = csReloadFromDiskPreservingLocalRefs(cs);
+      if( rc != SQLITE_OK ) return rc;
+      fileSize = cs->file.iFileSize;
+    }
+  }
+
+  if( fileSize > cs->file.iFileSize && hadFile ){
+    rc = csReloadFromDiskPreservingLocalRefs(cs);
+    if( rc != SQLITE_OK ) return rc;
+    fileSize = cs->file.iFileSize;
+  }
+#if defined(SQLITE_TEST) || defined(DOLTLITE_MECH_REPRO)
+  if( hadFile && cs->staging.nRecentUncommitted>0 && csReloadInjectionActive() ){
+    static int csReloadInjected = 0;
+    if( !csReloadInjected ){
+      csReloadInjected = 1;
+      rc = csReloadFromDiskPreservingLocalRefs(cs);
+      if( rc != SQLITE_OK ) return rc;
+      fileSize = cs->file.iFileSize;
+    }
+  }
+#endif
+  /* Append at logical EOF and truncate crash garbage beyond it. */
+  if( hadFile && cs->file.iFileSize > fileSize ){
+    fileSize = cs->file.iFileSize;
+  }
+  if( physFileSize > fileSize ){
+    (void)sqlite3OsTruncate(cs->file.pFile, fileSize);
+  }
+
+  /* On non-atomic media, isolate commit batches on fresh sectors. */
+  if( (cs->file.pFile->pMethods->xDeviceCharacteristics(cs->file.pFile)
+       & (SQLITE_IOCAP_POWERSAFE_OVERWRITE|SQLITE_IOCAP_ATOMIC))==0 ){
+    sectorSize = cs->file.pFile->pMethods->xSectorSize(cs->file.pFile);
+    if( sectorSize < 512 ) sectorSize = 512;
+    if( sectorSize > 65536 ) sectorSize = 65536;
+  }
+  *pFileSize = fileSize;
+  *pOrigFileSize = fileSize;
+  *pDurableTo = fileSize > 0 ? fileSize : (i64)CHUNK_MANIFEST_SIZE;
+  *pBatchStart = *pDurableTo;
+  if( fileSize > 0 && sectorSize > 1 && (*pBatchStart % sectorSize)!=0 ){
+    *pBatchStart += sectorSize - 1;
+    *pBatchStart -= *pBatchStart % sectorSize;
+  }
+  *pSectorSize = sectorSize;
+  return SQLITE_OK;
+}
+
+/* Build the on-disk index plan for pending chunks (offsets + merge/recent). */
+static int csCommitPlanPendingIndex(
+  ChunkStore *cs,
+  i64 batchStart,
+  int crashWriteActive,
+  ChunkIndexEntry *aSmallCommittedPending,
+  int nSmallCommittedPending,
+  ChunkIndexEntry **paCommittedPending,
+  ChunkIndexEntry **paMergePending,
+  ChunkIndexEntry **paMerged,
+  int *pnMerged,
+  int *pUseRecent
+){
+  ChunkStore mergeView;
+  i64 filePos = batchStart;
+  i64 appendBytes = 0;
+  int i;
+  int rc = SQLITE_OK;
+
+  *paCommittedPending = 0;
+  *paMergePending = 0;
+  *paMerged = 0;
+  *pnMerged = 0;
+  *pUseRecent = 0;
+  if( cs->staging.nPending <= 0 ) return SQLITE_OK;
+
+  for( i = 0; i < cs->staging.nPending; i++ ){
+    i64 recBytes = (i64)CS_WAL_CHUNK_HDR_SIZE
+                 + (i64)cs->staging.aPending[i].size;
+    if( appendBytes > LARGEST_INT64 - recBytes ) return SQLITE_TOOBIG;
+    appendBytes += recBytes;
+  }
+  if( cs->wal.nWalData > LARGEST_INT64 - appendBytes ) return SQLITE_TOOBIG;
+
+  if( cs->staging.nPending <= nSmallCommittedPending ){
+    *paCommittedPending = aSmallCommittedPending;
+  }else{
+    *paCommittedPending = (ChunkIndexEntry*)sqlite3_malloc(
+      cs->staging.nPending * (int)sizeof(ChunkIndexEntry)
+    );
+    if( !*paCommittedPending ) return SQLITE_NOMEM;
+  }
+
+  for( i = 0; i < cs->staging.nPending; i++ ){
+    ChunkIndexEntry *pSrc = &cs->staging.aPending[i];
+    (*paCommittedPending)[i] = *pSrc;
+    (*paCommittedPending)[i].offset = filePos + CS_WAL_CHUNK_LEN_OFF;
+    filePos += (i64)CS_WAL_CHUNK_HDR_SIZE + (i64)pSrc->size;
+  }
+
+  *pUseRecent = !crashWriteActive
+             && cs->staging.nPending <= 32
+             && cs->staging.nRecent + cs->staging.nPending
+                  <= CS_RECENT_FAST_PATH_MAX;
+  if( *pUseRecent ){
+    return csGrowRecent(cs, cs->staging.nPending);
+  }
+
+  if( cs->staging.nRecent > 0 ){
+    *paMergePending = (ChunkIndexEntry*)sqlite3_malloc(
+      (cs->staging.nRecent + cs->staging.nPending) * (int)sizeof(ChunkIndexEntry)
+    );
+    if( !*paMergePending ) return SQLITE_NOMEM;
+    memcpy(*paMergePending, cs->staging.aRecent,
+           cs->staging.nRecent * sizeof(ChunkIndexEntry));
+    memcpy(*paMergePending + cs->staging.nRecent, *paCommittedPending,
+           cs->staging.nPending * sizeof(ChunkIndexEntry));
+    mergeView = *cs;
+    mergeView.staging.aPending = *paMergePending;
+    mergeView.staging.nPending = cs->staging.nRecent + cs->staging.nPending;
+  }else{
+    mergeView = *cs;
+    mergeView.staging.aPending = *paCommittedPending;
+    mergeView.staging.nPending = cs->staging.nPending;
+  }
+  return csMergeIndex(&mergeView, paMerged, pnMerged);
+}
+
+/* Install the committed index view and clear staging after a successful sync. */
+static void csCommitPublishStaging(
+  ChunkStore *cs,
+  int useRecent,
+  ChunkIndexEntry *aCommittedPending,
+  ChunkIndexEntry *aMerged,
+  int nMerged
+){
+  int i;
+
+  if( cs->staging.nPending > 0 ){
+    if( useRecent ){
+      memcpy(cs->staging.aRecent + cs->staging.nRecent, aCommittedPending,
+             cs->staging.nPending * sizeof(ChunkIndexEntry));
+      for( i=0; i<cs->staging.nPending; i++ ){
+        cs->staging.aRecentZeroTail[cs->staging.nRecent+i] =
+          cs->staging.aPendingZeroTail[i];
+      }
+      cs->staging.nRecent += cs->staging.nPending;
+      sqlite3_free(aMerged);
+    }else{
+      csReleaseIndexBuf(cs->index.aIndex, cs->index.aIndexMmapBase, cs->index.aIndexMmapSize);
+      cs->index.aIndex = aMerged;
+      cs->index.nIndex = nMerged;
+      cs->index.aIndexMmapBase = 0;
+      cs->index.aIndexMmapSize = 0;
+      cs->staging.nRecent = 0;
+      if( cs->staging.aRecentZeroTail ){
+        memset(cs->staging.aRecentZeroTail, 0,
+               cs->staging.nRecentAlloc * sizeof(i64));
+      }
+      csRecentHTClear(cs);
+    }
+  }else{
+    sqlite3_free(aMerged);
+  }
+
+  cs->staging.nRecentUncommitted = 0;
+  cs->staging.iUncommittedStart = 0;
+  cs->staging.nWriteBuf = 0;
+  if( cs->staging.nWriteBufAlloc > CS_WRITEBUF_RETAIN_MAX ){
+    sqlite3_free(cs->staging.pWriteBuf);
+    cs->staging.pWriteBuf = 0;
+    cs->staging.nWriteBufAlloc = 0;
+  }
+  cs->staging.nPending = 0;
+  csPendHTReset(cs);
+  csMarkRefsCommitted(cs);
+}
+
 static int csCommitToFile(ChunkStore *cs){
   int rc;
   int i;
   i64 fileSize = 0;
-  i64 physFileSize = -1;
   i64 origFileSize = 0;
   i64 writeOff = 0;
   i64 durableTo = 0;
@@ -132,151 +355,22 @@ static int csCommitToFile(ChunkStore *cs){
   int useRecent = 0;
   int crashWriteActive = csCrashWriteInjectionActive();
 
-  if( cs->file.pFile == 0 ){
-    int openFlags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE
-                  | SQLITE_OPEN_MAIN_DB;
-    rc = csOpenFile(cs->file.pVfs, cs->file.zFilename, &cs->file.pFile, openFlags, 0);
-    if( rc != SQLITE_OK ){
-      return (rc==SQLITE_NOMEM || rc==SQLITE_IOERR_NOMEM) ? rc : SQLITE_CANTOPEN;
-    }
+  rc = csCommitResolveAppendPoint(
+      cs, hadFile, lockHeld, &lockFd, &lockName,
+      &fileSize, &origFileSize, &durableTo, &batchStart, &sectorSize);
+  if( rc!=SQLITE_OK ){
+    /* Open-before-lock failures never held a commit lock; unlock is a no-op
+    ** when lockHeld or when the lock was never acquired. */
+    if( !lockHeld ) csFileUnlock(lockFd, &lockName);
+    return rc;
   }
 
-  if( lockHeld ){
-    lockFd = CS_FILE_LOCK_INIT;
-  }else{
-    rc = csFileLock(cs->file.pVfs, cs->file.zFilename, &lockFd, &lockName);
-    if( rc!=SQLITE_OK ) return rc;
-  }
-
-  if( lockHeld && hadFile ){
-    fileSize = cs->file.iFileSize;
-  }else{
-    rc = cs->file.pFile->pMethods->xFileSize(cs->file.pFile, &fileSize);
-    if( rc != SQLITE_OK ) goto commit_done;
-    physFileSize = fileSize;
-  }
-
-  if( hadFile && !lockHeld ){
-    int bMoved = 0;
-    int rc2 = sqlite3OsFileControl(cs->file.pFile, SQLITE_FCNTL_HAS_MOVED,
-                                   &bMoved);
-    if( rc2==SQLITE_OK && bMoved ){
-      rc = csReloadFromDiskPreservingLocalRefs(cs);
-      if( rc != SQLITE_OK ) goto commit_done;
-      fileSize = cs->file.iFileSize;
-    }
-  }
-
-  if( fileSize > cs->file.iFileSize && hadFile ){
-    rc = csReloadFromDiskPreservingLocalRefs(cs);
-    if( rc != SQLITE_OK ) goto commit_done;
-    fileSize = cs->file.iFileSize;
-  }
-#if defined(SQLITE_TEST) || defined(DOLTLITE_MECH_REPRO)
-  if( hadFile && cs->staging.nRecentUncommitted>0 && csReloadInjectionActive() ){
-    static int csReloadInjected = 0;
-    if( !csReloadInjected ){
-      csReloadInjected = 1;
-      rc = csReloadFromDiskPreservingLocalRefs(cs);
-      if( rc != SQLITE_OK ) goto commit_done;
-      fileSize = cs->file.iFileSize;
-    }
-  }
-#endif
-  /* Append at logical EOF and truncate crash garbage beyond it. */
-  if( hadFile && cs->file.iFileSize > fileSize ){
-    fileSize = cs->file.iFileSize;
-  }
-  if( physFileSize > fileSize ){
-    (void)sqlite3OsTruncate(cs->file.pFile, fileSize);
-  }
-  origFileSize = fileSize;
-
-  /* On non-atomic media, isolate commit batches on fresh sectors. */
-  if( (cs->file.pFile->pMethods->xDeviceCharacteristics(cs->file.pFile)
-       & (SQLITE_IOCAP_POWERSAFE_OVERWRITE|SQLITE_IOCAP_ATOMIC))==0 ){
-    sectorSize = cs->file.pFile->pMethods->xSectorSize(cs->file.pFile);
-    if( sectorSize < 512 ) sectorSize = 512;
-    if( sectorSize > 65536 ) sectorSize = 65536;
-  }
-  durableTo = fileSize > 0 ? fileSize : (i64)CHUNK_MANIFEST_SIZE;
-  batchStart = durableTo;
-  if( fileSize > 0 && sectorSize > 1 && (batchStart % sectorSize)!=0 ){
-    batchStart += sectorSize - 1;
-    batchStart -= batchStart % sectorSize;
-  }
-
-  if( cs->staging.nPending > 0 ){
-    ChunkStore mergeView;
-    i64 filePos = batchStart;
-    i64 appendBytes = 0;
-
-    for( i = 0; i < cs->staging.nPending; i++ ){
-      i64 recBytes = (i64)CS_WAL_CHUNK_HDR_SIZE
-                   + (i64)cs->staging.aPending[i].size;
-      if( appendBytes > LARGEST_INT64 - recBytes ){
-        rc = SQLITE_TOOBIG;
-        goto commit_done;
-      }
-      appendBytes += recBytes;
-    }
-    if( cs->wal.nWalData > LARGEST_INT64 - appendBytes ){
-      rc = SQLITE_TOOBIG;
-      goto commit_done;
-    }
-
-    if( cs->staging.nPending <= (int)(sizeof(aSmallCommittedPending)
-                                    / sizeof(aSmallCommittedPending[0])) ){
-      aCommittedPending = aSmallCommittedPending;
-    }else{
-      aCommittedPending = (ChunkIndexEntry*)sqlite3_malloc(
-        cs->staging.nPending * (int)sizeof(ChunkIndexEntry)
-      );
-      if( !aCommittedPending ){
-        rc = SQLITE_NOMEM;
-        goto commit_done;
-      }
-    }
-
-    for( i = 0; i < cs->staging.nPending; i++ ){
-      ChunkIndexEntry *pSrc = &cs->staging.aPending[i];
-      aCommittedPending[i] = *pSrc;
-      aCommittedPending[i].offset = filePos + CS_WAL_CHUNK_LEN_OFF;
-      filePos += (i64)CS_WAL_CHUNK_HDR_SIZE + (i64)pSrc->size;
-    }
-
-    useRecent = !crashWriteActive
-             && cs->staging.nPending <= 32
-             && cs->staging.nRecent + cs->staging.nPending
-                  <= CS_RECENT_FAST_PATH_MAX;
-    if( useRecent ){
-      rc = csGrowRecent(cs, cs->staging.nPending);
-      if( rc!=SQLITE_OK ) goto commit_done;
-    }else{
-      if( cs->staging.nRecent > 0 ){
-        aMergePending = (ChunkIndexEntry*)sqlite3_malloc(
-          (cs->staging.nRecent + cs->staging.nPending) * (int)sizeof(ChunkIndexEntry)
-        );
-        if( !aMergePending ){
-          rc = SQLITE_NOMEM;
-          goto commit_done;
-        }
-        memcpy(aMergePending, cs->staging.aRecent,
-               cs->staging.nRecent * sizeof(ChunkIndexEntry));
-        memcpy(aMergePending + cs->staging.nRecent, aCommittedPending,
-               cs->staging.nPending * sizeof(ChunkIndexEntry));
-        mergeView = *cs;
-        mergeView.staging.aPending = aMergePending;
-        mergeView.staging.nPending = cs->staging.nRecent + cs->staging.nPending;
-      }else{
-        mergeView = *cs;
-        mergeView.staging.aPending = aCommittedPending;
-        mergeView.staging.nPending = cs->staging.nPending;
-      }
-      rc = csMergeIndex(&mergeView, &aMerged, &nMerged);
-      if( rc!=SQLITE_OK ) goto commit_done;
-    }
-  }
+  rc = csCommitPlanPendingIndex(
+      cs, batchStart, crashWriteActive,
+      aSmallCommittedPending,
+      (int)(sizeof(aSmallCommittedPending)/sizeof(aSmallCommittedPending[0])),
+      &aCommittedPending, &aMergePending, &aMerged, &nMerged, &useRecent);
+  if( rc!=SQLITE_OK ) goto commit_done;
 
 #ifdef SQLITE_TEST
   {
@@ -448,49 +542,11 @@ commit_done:
     return rc;
   }
 
-  if( cs->staging.nPending > 0 ){
-    if( useRecent ){
-      memcpy(cs->staging.aRecent + cs->staging.nRecent, aCommittedPending,
-             cs->staging.nPending * sizeof(ChunkIndexEntry));
-      for( i=0; i<cs->staging.nPending; i++ ){
-        cs->staging.aRecentZeroTail[cs->staging.nRecent+i] =
-          cs->staging.aPendingZeroTail[i];
-      }
-      cs->staging.nRecent += cs->staging.nPending;
-      sqlite3_free(aMerged);
-    }else{
-      csReleaseIndexBuf(cs->index.aIndex, cs->index.aIndexMmapBase, cs->index.aIndexMmapSize);
-      cs->index.aIndex = aMerged;
-      cs->index.nIndex = nMerged;
-      cs->index.aIndexMmapBase = 0;
-      cs->index.aIndexMmapSize = 0;
-      cs->staging.nRecent = 0;
-      if( cs->staging.aRecentZeroTail ){
-        memset(cs->staging.aRecentZeroTail, 0,
-               cs->staging.nRecentAlloc * sizeof(i64));
-      }
-      csRecentHTClear(cs);
-    }
-  }else{
-    sqlite3_free(aMerged);
-  }
+  csCommitPublishStaging(cs, useRecent, aCommittedPending, aMerged, nMerged);
   if( aCommittedPending!=aSmallCommittedPending ){
     sqlite3_free(aCommittedPending);
   }
   sqlite3_free(aMergePending);
-
-  cs->staging.nRecentUncommitted = 0;
-  cs->staging.iUncommittedStart = 0;
-  cs->staging.nWriteBuf = 0;
-  if( cs->staging.nWriteBufAlloc > CS_WRITEBUF_RETAIN_MAX ){
-    sqlite3_free(cs->staging.pWriteBuf);
-    cs->staging.pWriteBuf = 0;
-    cs->staging.nWriteBufAlloc = 0;
-  }
-  cs->staging.nPending = 0;
-  csPendHTReset(cs);
-  csMarkRefsCommitted(cs);
-
   return SQLITE_OK;
 }
 

--- a/src/chunk_store_commit.c
+++ b/src/chunk_store_commit.c
@@ -222,7 +222,6 @@ static int csCommitPlanPendingIndex(
   i64 filePos = batchStart;
   i64 appendBytes = 0;
   int i;
-  int rc = SQLITE_OK;
 
   *paCommittedPending = 0;
   *paMergePending = 0;

--- a/src/prolly_btree_cursor_seek.c
+++ b/src/prolly_btree_cursor_seek.c
@@ -416,12 +416,401 @@ static int scanTreeForCustomCollation(
   return rc;
 }
 
+/* Build the sort-key probe for an index moveto; caches on pCur. */
+static int indexMovetoBuildSeekKey(
+  BtCursor *pCur,
+  UnpackedRecord *pIdxKey,
+  int *pnSeekKeyField,
+  int *pnSortKey,
+  u8 **ppSortKey,
+  int *pExactMutMapKey
+){
+  int nSeekKeyField = 0;
+  int nSortKey = 0;
+  int nSerKey = 0;
+  int rc;
+
+  *pExactMutMapKey = 0;
+  if( pCur->pKeyInfo && pIdxKey->nField < pCur->pKeyInfo->nAllField ){
+    nSeekKeyField = (int)pIdxKey->nField;
+  }
+  /* Table-root range seeks must ignore probe fields beyond the PK. */
+  if( pCur->isTableRoot && pCur->pKeyInfo
+   && pIdxKey->default_rc != 0
+   && pIdxKey->nField > pCur->pKeyInfo->nKeyField
+   && (nSeekKeyField==0 || nSeekKeyField > pCur->pKeyInfo->nKeyField) ){
+    nSeekKeyField = pCur->pKeyInfo->nKeyField;
+  }
+  if( unpackedRecordCanUseIntSortKey(
+          pCur, pIdxKey,
+          nSeekKeyField>0 ? nSeekKeyField : (int)pIdxKey->nField) ){
+    rc = sortKeyFromUnpackedIntRecordBuffer(
+        pIdxKey, nSeekKeyField>0 ? nSeekKeyField : (int)pIdxKey->nField,
+        &pCur->pSeekSortKey, &pCur->nSeekSortKeyAlloc, &nSortKey);
+  }else{
+    rc = sortKeyFromMemPrefixCollBuffer(
+        pIdxKey->aMem, (int)pIdxKey->nField, nSeekKeyField,
+        pCur->pKeyInfo,
+        &pCur->pSeekSortKey, &pCur->nSeekSortKeyAlloc, &nSortKey);
+    if( rc==SQLITE_NOTFOUND ){
+      rc = serializeUnpackedRecordBuffer(
+          pIdxKey, &pCur->pSeekRecord, &pCur->nSeekRecordAlloc, &nSerKey);
+      if( rc!=SQLITE_OK ) return rc;
+      rc = sortKeyFromRecordPrefixCollBuffer(
+          pCur->pSeekRecord, nSerKey, nSeekKeyField, pCur->pKeyInfo,
+          &pCur->pSeekSortKey, &pCur->nSeekSortKeyAlloc, &nSortKey);
+    }
+  }
+  if( rc!=SQLITE_OK ) return rc;
+  *ppSortKey = pCur->pSeekSortKey;
+  *pnSortKey = nSortKey;
+  *pnSeekKeyField = nSeekKeyField;
+  pCur->nSeekSortKey = nSortKey;
+  pCur->nSeekKeyField = nSeekKeyField;
+  if( pCur->pKeyInfo
+   && nSeekKeyField == pCur->pKeyInfo->nKeyField
+   && pCur->isTableRoot ){
+    *pExactMutMapKey = 1;
+  }
+  return SQLITE_OK;
+}
+
+/* Exact full-key probe against cursor + pending mutmaps. *pDone is set when
+** the seek is fully resolved (hit or hard error already returned). */
+static int indexMovetoExactMutMap(
+  BtCursor *pCur,
+  UnpackedRecord *pIdxKey,
+  const u8 *pSortKey,
+  int nSortKey,
+  int exactMutMapKey,
+  int *pRes,
+  int *pDone
+){
+  struct TableEntry *pTE;
+  ProllyMutMap *pPending;
+  ProllyMutMapEntry *pEntry = 0;
+  int rc;
+
+  *pDone = 0;
+  if( !pCur->pKeyInfo
+   || !(exactMutMapKey || pIdxKey->nField >= pCur->pKeyInfo->nAllField) ){
+    return SQLITE_OK;
+  }
+  pTE = findTable(pCur->pBtree, pCur->pgnoRoot);
+  pPending = pTE ? (ProllyMutMap*)pTE->pPending : 0;
+  if( pCur->pMutMap && !prollyMutMapIsEmpty(pCur->pMutMap) ){
+    rc = prollyMutMapFindRc(pCur->pMutMap, pSortKey, nSortKey, 0, &pEntry);
+    if( rc!=SQLITE_OK ) return rc;
+    if( pEntry && pEntry->op==PROLLY_EDIT_INSERT ){
+      if( pCur->isPinned ) return SQLITE_CONSTRAINT_PINNED;
+      setCursorToMutMapEntryPhys(
+          pCur, (int)(pEntry - pCur->pMutMap->aEntries));
+      /* The tree side is still wherever the last operation left it. A
+      ** later step must re-seek it to this key before merging, or it
+      ** feeds stale entries into the merge scan. */
+      pCur->deferredTreeSeek = 1;
+      *pRes = 0;
+      pIdxKey->eqSeen = 1;
+      *pDone = 1;
+      return SQLITE_OK;
+    }
+  }
+  if( pPending && pPending!=pCur->pMutMap
+   && !prollyMutMapIsEmpty(pPending) ){
+    rc = prollyMutMapFindRc(pPending, pSortKey, nSortKey, 0, &pEntry);
+    if( rc!=SQLITE_OK ) return rc;
+    if( pEntry && pEntry->op==PROLLY_EDIT_INSERT ){
+      if( pCur->isPinned ) return SQLITE_CONSTRAINT_PINNED;
+      pCur->pMutMap = pPending;
+      setCursorToMutMapEntryPhys(
+          pCur, (int)(pEntry - pPending->aEntries));
+      pCur->deferredTreeSeek = 1;
+      *pRes = 0;
+      pIdxKey->eqSeen = 1;
+      *pDone = 1;
+      return SQLITE_OK;
+    }
+  }
+  return SQLITE_OK;
+}
+
+/* Unsupported-collation full scan of mutmaps + tree. *pDone when resolved. */
+static int indexMovetoCustomCollation(
+  BtCursor *pCur,
+  UnpackedRecord *pIdxKey,
+  int nSeekKeyField,
+  int exactMutMapKey,
+  int *pRes,
+  int *pDone
+){
+  struct TableEntry *pTE;
+  ProllyMutMap *pPending;
+  ProllyMutMapEntry *pEntry = 0;
+  int cmp = 0;
+  int treeFound = 0;
+  int rc;
+
+  *pDone = 0;
+  if( !pCur->pKeyInfo
+   || !(exactMutMapKey || pIdxKey->nField >= pCur->pKeyInfo->nAllField)
+   || !keyInfoHasUnsupportedCollation(
+          pCur->pKeyInfo,
+          nSeekKeyField>0 ? nSeekKeyField : (int)pIdxKey->nField) ){
+    return SQLITE_OK;
+  }
+  pTE = findTable(pCur->pBtree, pCur->pgnoRoot);
+  pPending = pTE ? (ProllyMutMap*)pTE->pPending : 0;
+
+  rc = scanMutMapForCustomCollation(
+      pCur, (ProllyMutMap*)pCur->pMutMap, pIdxKey, &pEntry, &cmp);
+  if( rc!=SQLITE_OK ) return rc;
+  if( pEntry ){
+    setCursorToMutMapEntryPhys(
+        pCur, (int)(pEntry - pCur->pMutMap->aEntries));
+    *pRes = cmp;
+    pIdxKey->eqSeen = 1;
+    *pDone = 1;
+    return SQLITE_OK;
+  }
+
+  if( pPending && pPending!=pCur->pMutMap ){
+    rc = scanMutMapForCustomCollation(
+        pCur, pPending, pIdxKey, &pEntry, &cmp);
+    if( rc!=SQLITE_OK ) return rc;
+    if( pEntry ){
+      const u8 *pVal = pEntry->pVal;
+      int nVal = pEntry->nVal;
+      if( nVal==0 ){
+        rc = cacheCursorPayloadReconstructed(
+            pCur, pEntry->pKey, pEntry->nKey);
+      }else{
+        rc = cacheCursorPayloadCopy(pCur, pVal, nVal);
+      }
+      if( rc!=SQLITE_OK ) return rc;
+      pCur->eState = CURSOR_VALID;
+      *pRes = cmp;
+      pIdxKey->eqSeen = 1;
+      *pDone = 1;
+      return SQLITE_OK;
+    }
+  }
+
+  rc = scanTreeForCustomCollation(pCur, pIdxKey, &treeFound, &cmp);
+  if( rc!=SQLITE_OK ) return rc;
+  if( treeFound ){
+    pCur->eState = CURSOR_VALID;
+    cacheCurrentTreeStoredPayloadNonIntKey(pCur);
+    *pRes = cmp;
+    pIdxKey->eqSeen = 1;
+    *pDone = 1;
+  }
+  return SQLITE_OK;
+}
+
+/* After a non-exact tree seek, scan forward for the first live match /
+** successor, skipping mutmap-delete-masked rows. */
+static int indexMovetoScanTreeLeaf(
+  BtCursor *pCur,
+  UnpackedRecord *pIdxKey,
+  const u8 *pSortKey,
+  int nSortKey,
+  int nSeekKeyField,
+  int *pTreeFound,
+  int *pTreeCmp
+){
+  int rc = SQLITE_OK;
+  int iLevel;
+  ProllyCacheEntry *pLeaf;
+  int lo;
+  int nItems;
+  int bestIdx = -1;
+  int bestCmp = 0;
+  u8 *pRecBuf;
+  int nRecBufAlloc;
+  int i;
+
+  if( pCur->pCur.eState!=PROLLY_CURSOR_VALID ) return SQLITE_OK;
+
+  iLevel = pCur->pCur.iLevel;
+  pLeaf = pCur->pCur.aLevel[iLevel].pEntry;
+  lo = pCur->pCur.aLevel[iLevel].idx;
+  nItems = pLeaf->node.nItems;
+  pRecBuf = pCur->pMovetoRec;
+  nRecBufAlloc = pCur->nMovetoRecAlloc;
+
+  for(;;){
+    for( i = lo; i < nItems; i++ ){
+      const u8 *pSK; int nSK;
+      const u8 *pVal; int nVal;
+      int recCmp;
+      prollyNodeKey(&pLeaf->node, i, &pSK, &nSK);
+
+      {
+        int cmpLen = nSK < nSortKey ? nSK : nSortKey;
+        int prefixCmp = memcmp(pSK, pSortKey, cmpLen);
+        if( prefixCmp > 0 ){
+          if( bestIdx < 0 ){
+            if( pCur->pMutMap && !prollyMutMapIsEmpty(pCur->pMutMap) ){
+              ProllyMutMapEntry *mmE = 0;
+              rc = prollyMutMapFindRc(pCur->pMutMap, pSK, nSK, 0, &mmE);
+              if( rc!=SQLITE_OK ) break;
+              if( mmE && mmE->op==PROLLY_EDIT_DELETE ){
+                /* Delete-masked row past the seek key: the next live row
+                ** is still the positioning answer, so keep scanning. */
+                continue;
+              }
+            }
+            bestIdx = i;
+            if( nSeekKeyField>0 ){
+              pIdxKey->eqSeen = 0;
+              bestCmp = 1;
+            }else{
+              const u8 *pVal2; int nVal2;
+              prollyNodeValue(&pLeaf->node, i, &pVal2, &nVal2);
+              if( nVal2==0 ){
+                rc = recordFromSortKeyBufferColl(
+                    pSK, nSK, pCur->pKeyInfo,
+                    &pRecBuf, &nRecBufAlloc, &nVal2);
+                if( rc!=SQLITE_OK ) break;
+                pVal2 = pRecBuf;
+              }
+              pIdxKey->eqSeen = 0;
+              bestCmp = sqlite3VdbeRecordCompare(nVal2, pVal2, pIdxKey);
+            }
+          }
+          break;
+        }
+        if( nSeekKeyField>0 && prefixCmp==0 && nSK>=nSortKey ){
+          if( pCur->pMutMap && !prollyMutMapIsEmpty(pCur->pMutMap) ){
+            ProllyMutMapEntry *mmE = 0;
+            rc = prollyMutMapFindRc(pCur->pMutMap, pSK, nSK, 0, &mmE);
+            if( rc!=SQLITE_OK ) break;
+            if( mmE && mmE->op==PROLLY_EDIT_DELETE ){
+              continue;
+            }
+          }
+          pIdxKey->eqSeen = 1;
+          bestIdx = i;
+          bestCmp = pIdxKey->default_rc;
+          *pTreeFound = 1;
+          *pTreeCmp = bestCmp;
+          if( pIdxKey->default_rc < 0 ){
+            continue;
+          }
+          break;
+        }
+      }
+      prollyNodeValue(&pLeaf->node, i, &pVal, &nVal);
+      if( nVal==0 ){
+        rc = recordFromSortKeyBufferColl(
+            pSK, nSK, pCur->pKeyInfo, &pRecBuf, &nRecBufAlloc, &nVal);
+        if( rc!=SQLITE_OK ) break;
+        pVal = pRecBuf;
+      }
+      pIdxKey->eqSeen = 0;
+      recCmp = sqlite3VdbeRecordCompare(nVal, pVal, pIdxKey);
+
+      if( recCmp==0 || pIdxKey->eqSeen ){
+        if( pCur->pMutMap && !prollyMutMapIsEmpty(pCur->pMutMap) ){
+          ProllyMutMapEntry *mmE = 0;
+          rc = prollyMutMapFindRc(pCur->pMutMap, pSK, nSK, 0, &mmE);
+          if( rc!=SQLITE_OK ) break;
+          if( mmE && mmE->op==PROLLY_EDIT_DELETE ){
+            continue;
+          }
+        }
+        bestIdx = i;
+        bestCmp = recCmp;
+        *pTreeFound = 1;
+        *pTreeCmp = recCmp;
+        break;
+      }else if( recCmp > 0 ){
+        if( pCur->pMutMap && !prollyMutMapIsEmpty(pCur->pMutMap) ){
+          ProllyMutMapEntry *mmE = 0;
+          rc = prollyMutMapFindRc(pCur->pMutMap, pSK, nSK, 0, &mmE);
+          if( rc!=SQLITE_OK ) break;
+          if( mmE && mmE->op==PROLLY_EDIT_DELETE ){
+            continue;
+          }
+        }
+        if( bestIdx < 0 ){
+          bestIdx = i;
+          bestCmp = recCmp;
+        }
+      }
+    }
+    if( rc!=SQLITE_OK || *pTreeFound || bestIdx>=0 ) break;
+    if( !(pCur->pMutMap && !prollyMutMapIsEmpty(pCur->pMutMap)) ) break;
+    /* Everything from the seek point through the end of this leaf was
+    ** delete-masked; the first live row may sit in a later leaf. */
+    if( nItems>0 ) pCur->pCur.aLevel[pCur->pCur.iLevel].idx = nItems-1;
+    rc = prollyCursorNext(&pCur->pCur);
+    if( rc!=SQLITE_OK ) break;
+    if( pCur->pCur.eState!=PROLLY_CURSOR_VALID ) break;
+    iLevel = pCur->pCur.iLevel;
+    pLeaf = pCur->pCur.aLevel[iLevel].pEntry;
+    nItems = pLeaf->node.nItems;
+    lo = 0;
+  }
+  pCur->pMovetoRec = pRecBuf;
+  pCur->nMovetoRecAlloc = nRecBufAlloc;
+  if( rc!=SQLITE_OK ) return rc;
+
+  if( *pTreeFound ){
+    pCur->pCur.aLevel[iLevel].idx = bestIdx;
+  }else if( bestIdx >= 0 ){
+    pCur->pCur.aLevel[iLevel].idx = bestIdx;
+    *pTreeCmp = bestCmp;
+    *pTreeFound = 1;
+  }
+  return SQLITE_OK;
+}
+
+/* Exact tree hit (not delete-masked). *pDone when resolved. */
+static int indexMovetoExactTreeHit(
+  BtCursor *pCur,
+  UnpackedRecord *pIdxKey,
+  const u8 *pSortKey,
+  int nSortKey,
+  int exactMutMapKey,
+  int *pRes,
+  int *pDone
+){
+  int seekRes = 0;
+  int rc;
+
+  *pDone = 0;
+  rc = prollyCursorSeekBlob(&pCur->pCur, pSortKey, nSortKey, &seekRes);
+  if( rc!=SQLITE_OK ) return rc;
+  if( seekRes==0
+   && pCur->pCur.eState==PROLLY_CURSOR_VALID
+   && pCur->pKeyInfo
+   && (exactMutMapKey || pIdxKey->nField >= pCur->pKeyInfo->nAllField) ){
+    int isDeleted = 0;
+    if( pCur->pMutMap && !prollyMutMapIsEmpty(pCur->pMutMap) ){
+      ProllyMutMapEntry *mmE = 0;
+      rc = prollyMutMapFindRc(pCur->pMutMap, pSortKey, nSortKey, 0, &mmE);
+      if( rc!=SQLITE_OK ) return rc;
+      if( mmE && mmE->op==PROLLY_EDIT_DELETE ) isDeleted = 1;
+    }
+    if( !isDeleted ){
+      *pRes = 0;
+      pIdxKey->eqSeen = 1;
+      pCur->eState = CURSOR_VALID;
+      cacheCurrentTreeStoredPayloadNonIntKey(pCur);
+      *pDone = 1;
+    }
+  }
+  return SQLITE_OK;
+}
+
 int prollyBtCursorIndexMoveto(
   BtCursor *pCur,
   UnpackedRecord *pIdxKey,
   int *pRes
 ){
   int rc;
+  int done = 0;
 
   assert( !pCur->curIntKey );
 
@@ -442,322 +831,32 @@ int prollyBtCursorIndexMoveto(
     ProllyMutMapEntry *mutE = 0;
     int mutFromCursorMap = 0;
     int exactMutMapKey = 0;
-
-    u8 *pSerKey = 0;
-    int nSerKey = 0;
     u8 *pSortKey = 0;
     int nSortKey = 0;
     int nSeekKeyField = 0;
-    if( pCur->pKeyInfo && pIdxKey->nField < pCur->pKeyInfo->nAllField ){
-      nSeekKeyField = (int)pIdxKey->nField;
-    }
-    /* Table-root range seeks must ignore probe fields beyond the PK. */
-    if( pCur->isTableRoot && pCur->pKeyInfo
-     && pIdxKey->default_rc != 0
-     && pIdxKey->nField > pCur->pKeyInfo->nKeyField
-     && (nSeekKeyField==0 || nSeekKeyField > pCur->pKeyInfo->nKeyField) ){
-      nSeekKeyField = pCur->pKeyInfo->nKeyField;
-    }
-    if( unpackedRecordCanUseIntSortKey(
-            pCur, pIdxKey,
-            nSeekKeyField>0 ? nSeekKeyField : (int)pIdxKey->nField) ){
-      rc = sortKeyFromUnpackedIntRecordBuffer(
-          pIdxKey, nSeekKeyField>0 ? nSeekKeyField : (int)pIdxKey->nField,
-          &pCur->pSeekSortKey, &pCur->nSeekSortKeyAlloc, &nSortKey);
-    }else{
-      rc = sortKeyFromMemPrefixCollBuffer(
-          pIdxKey->aMem, (int)pIdxKey->nField, nSeekKeyField,
-          pCur->pKeyInfo,
-          &pCur->pSeekSortKey, &pCur->nSeekSortKeyAlloc, &nSortKey);
-      if( rc==SQLITE_NOTFOUND ){
-        rc = serializeUnpackedRecordBuffer(
-            pIdxKey, &pCur->pSeekRecord, &pCur->nSeekRecordAlloc, &nSerKey);
-        if( rc!=SQLITE_OK ) return rc;
-        pSerKey = pCur->pSeekRecord;
-        rc = sortKeyFromRecordPrefixCollBuffer(
-            pSerKey, nSerKey, nSeekKeyField, pCur->pKeyInfo,
-            &pCur->pSeekSortKey, &pCur->nSeekSortKeyAlloc, &nSortKey);
-      }
-    }
+
+    rc = indexMovetoBuildSeekKey(
+        pCur, pIdxKey, &nSeekKeyField, &nSortKey, &pSortKey, &exactMutMapKey);
     if( rc!=SQLITE_OK ) return rc;
-    pSortKey = pCur->pSeekSortKey;
-    pCur->nSeekSortKey = nSortKey;
-    pCur->nSeekKeyField = nSeekKeyField;
 
-    if( pCur->pKeyInfo
-     && nSeekKeyField == pCur->pKeyInfo->nKeyField ){
-      if( pCur->isTableRoot ){
-        exactMutMapKey = 1;
-      }
-    }
+    rc = indexMovetoCustomCollation(
+        pCur, pIdxKey, nSeekKeyField, exactMutMapKey, pRes, &done);
+    if( rc!=SQLITE_OK || done ) return rc;
 
-    if( pCur->pKeyInfo
-     && (exactMutMapKey || pIdxKey->nField >= pCur->pKeyInfo->nAllField)
-     && keyInfoHasUnsupportedCollation(
-          pCur->pKeyInfo,
-          nSeekKeyField>0 ? nSeekKeyField : (int)pIdxKey->nField) ){
-      struct TableEntry *pTE = findTable(pCur->pBtree, pCur->pgnoRoot);
-      ProllyMutMap *pPending = pTE ? (ProllyMutMap*)pTE->pPending : 0;
-      ProllyMutMapEntry *pEntry = 0;
-      int cmp = 0;
-      int treeFound = 0;
+    rc = indexMovetoExactMutMap(
+        pCur, pIdxKey, pSortKey, nSortKey, exactMutMapKey, pRes, &done);
+    if( rc!=SQLITE_OK || done ) return rc;
 
-      rc = scanMutMapForCustomCollation(
-          pCur, (ProllyMutMap*)pCur->pMutMap, pIdxKey, &pEntry, &cmp);
-      if( rc!=SQLITE_OK ) return rc;
-      if( pEntry ){
-        setCursorToMutMapEntryPhys(
-            pCur, (int)(pEntry - pCur->pMutMap->aEntries));
-        *pRes = cmp;
-        pIdxKey->eqSeen = 1;
-        return SQLITE_OK;
-      }
-
-      if( pPending && pPending!=pCur->pMutMap ){
-        rc = scanMutMapForCustomCollation(
-            pCur, pPending, pIdxKey, &pEntry, &cmp);
-        if( rc!=SQLITE_OK ) return rc;
-        if( pEntry ){
-          const u8 *pVal = pEntry->pVal;
-          int nVal = pEntry->nVal;
-          if( nVal==0 ){
-            rc = cacheCursorPayloadReconstructed(
-                pCur, pEntry->pKey, pEntry->nKey);
-          }else{
-            rc = cacheCursorPayloadCopy(pCur, pVal, nVal);
-          }
-          if( rc!=SQLITE_OK ) return rc;
-          pCur->eState = CURSOR_VALID;
-          *pRes = cmp;
-          pIdxKey->eqSeen = 1;
-          return SQLITE_OK;
-        }
-      }
-
-      rc = scanTreeForCustomCollation(pCur, pIdxKey, &treeFound, &cmp);
-      if( rc!=SQLITE_OK ) return rc;
-      if( treeFound ){
-        pCur->eState = CURSOR_VALID;
-        cacheCurrentTreeStoredPayloadNonIntKey(pCur);
-        *pRes = cmp;
-        pIdxKey->eqSeen = 1;
-        return SQLITE_OK;
-      }
-    }
-
-    if( pCur->pKeyInfo
-     && (exactMutMapKey || pIdxKey->nField >= pCur->pKeyInfo->nAllField) ){
-      struct TableEntry *pTE = findTable(pCur->pBtree, pCur->pgnoRoot);
-      ProllyMutMap *pPending = pTE ? (ProllyMutMap*)pTE->pPending : 0;
-      ProllyMutMapEntry *pEntry = 0;
-      if( pCur->pMutMap && !prollyMutMapIsEmpty(pCur->pMutMap) ){
-        rc = prollyMutMapFindRc(pCur->pMutMap, pSortKey, nSortKey, 0, &pEntry);
-        if( rc!=SQLITE_OK ) return rc;
-        if( pEntry && pEntry->op==PROLLY_EDIT_INSERT ){
-          if( pCur->isPinned ){
-            return SQLITE_CONSTRAINT_PINNED;
-          }
-          setCursorToMutMapEntryPhys(
-              pCur, (int)(pEntry - pCur->pMutMap->aEntries));
-          /* The tree side is still wherever the last operation left it. A
-          ** later step must re-seek it to this key before merging, or it
-          ** feeds stale entries into the merge scan. */
-          pCur->deferredTreeSeek = 1;
-          *pRes = 0;
-          pIdxKey->eqSeen = 1;
-          return SQLITE_OK;
-        }
-      }
-      if( pPending && pPending!=pCur->pMutMap
-       && !prollyMutMapIsEmpty(pPending) ){
-        rc = prollyMutMapFindRc(pPending, pSortKey, nSortKey, 0, &pEntry);
-        if( rc!=SQLITE_OK ) return rc;
-        if( pEntry && pEntry->op==PROLLY_EDIT_INSERT ){
-          if( pCur->isPinned ){
-            return SQLITE_CONSTRAINT_PINNED;
-          }
-          pCur->pMutMap = pPending;
-          setCursorToMutMapEntryPhys(
-              pCur, (int)(pEntry - pPending->aEntries));
-          pCur->deferredTreeSeek = 1;
-          *pRes = 0;
-          pIdxKey->eqSeen = 1;
-          return SQLITE_OK;
-        }
-      }
-    }
-
-    {
-      int seekRes = 0;
-      rc = prollyCursorSeekBlob(&pCur->pCur, pSortKey, nSortKey, &seekRes);
-      if( rc==SQLITE_OK
-       && seekRes==0
-       && pCur->pCur.eState==PROLLY_CURSOR_VALID
-       && pCur->pKeyInfo
-       && (exactMutMapKey || pIdxKey->nField >= pCur->pKeyInfo->nAllField) ){
-        int isDeleted = 0;
-        if( pCur->pMutMap && !prollyMutMapIsEmpty(pCur->pMutMap) ){
-          ProllyMutMapEntry *mmE = 0;
-          rc = prollyMutMapFindRc(pCur->pMutMap, pSortKey, nSortKey, 0, &mmE);
-          if( rc!=SQLITE_OK ) return rc;
-          if( mmE && mmE->op==PROLLY_EDIT_DELETE ) isDeleted = 1;
-        }
-        if( !isDeleted ){
-          *pRes = 0;
-          pIdxKey->eqSeen = 1;
-          pCur->eState = CURSOR_VALID;
-          cacheCurrentTreeStoredPayloadNonIntKey(pCur);
-          return SQLITE_OK;
-        }
-      }
-    }
+    rc = indexMovetoExactTreeHit(
+        pCur, pIdxKey, pSortKey, nSortKey, exactMutMapKey, pRes, &done);
+    if( rc!=SQLITE_OK || done ) return rc;
     /* A failed tree seek must not fall through to the mut-map merge below:
     ** that path resets rc and reports "row not found" for what was really
     ** an I/O or allocation failure. */
+    rc = indexMovetoScanTreeLeaf(
+        pCur, pIdxKey, pSortKey, nSortKey, nSeekKeyField,
+        &treeFound, &treeCmp);
     if( rc!=SQLITE_OK ) return rc;
-    if( pCur->pCur.eState==PROLLY_CURSOR_VALID ){
-      int iLevel = pCur->pCur.iLevel;
-      ProllyCacheEntry *pLeaf = pCur->pCur.aLevel[iLevel].pEntry;
-      int lo = pCur->pCur.aLevel[iLevel].idx;
-      int nItems = pLeaf->node.nItems;
-
-      int bestIdx = -1;
-      int bestCmp = 0;
-      {
-        u8 *pRecBuf = pCur->pMovetoRec;
-        int nRecBufAlloc = pCur->nMovetoRecAlloc;
-        int i;
-
-       for(;;){
-        for( i = lo; i < nItems; i++ ){
-          const u8 *pSK; int nSK;
-          const u8 *pVal; int nVal;
-          int recCmp;
-          prollyNodeKey(&pLeaf->node, i, &pSK, &nSK);
-
-          {
-            int cmpLen = nSK < nSortKey ? nSK : nSortKey;
-            int prefixCmp = memcmp(pSK, pSortKey, cmpLen);
-            if( prefixCmp > 0 ){
-              if( bestIdx < 0 ){
-                if( pCur->pMutMap && !prollyMutMapIsEmpty(pCur->pMutMap) ){
-                  ProllyMutMapEntry *mmE = 0;
-                  rc = prollyMutMapFindRc(pCur->pMutMap, pSK, nSK, 0, &mmE);
-                  if( rc!=SQLITE_OK ) break;
-                  if( mmE && mmE->op==PROLLY_EDIT_DELETE ){
-                    /* Delete-masked row past the seek key: the next live row
-                    ** is still the positioning answer, so keep scanning. */
-                    continue;
-                  }
-                }
-                bestIdx = i;
-                if( nSeekKeyField>0 ){
-                  pIdxKey->eqSeen = 0;
-                  bestCmp = 1;
-                }else{
-                  const u8 *pVal2; int nVal2;
-                  prollyNodeValue(&pLeaf->node, i, &pVal2, &nVal2);
-                  if( nVal2==0 ){
-                    rc = recordFromSortKeyBufferColl(
-                        pSK, nSK, pCur->pKeyInfo,
-                        &pRecBuf, &nRecBufAlloc, &nVal2);
-                    if( rc!=SQLITE_OK ) break;
-                    pVal2 = pRecBuf;
-                  }
-                  pIdxKey->eqSeen = 0;
-                  bestCmp = sqlite3VdbeRecordCompare(nVal2, pVal2, pIdxKey);
-                }
-              }
-              break;
-            }
-            if( nSeekKeyField>0 && prefixCmp==0 && nSK>=nSortKey ){
-              if( pCur->pMutMap && !prollyMutMapIsEmpty(pCur->pMutMap) ){
-                ProllyMutMapEntry *mmE = 0;
-                rc = prollyMutMapFindRc(pCur->pMutMap, pSK, nSK, 0, &mmE);
-                if( rc!=SQLITE_OK ) break;
-                if( mmE && mmE->op==PROLLY_EDIT_DELETE ){
-                  continue;
-                }
-              }
-              pIdxKey->eqSeen = 1;
-              bestIdx = i;
-              bestCmp = pIdxKey->default_rc;
-              treeFound = 1;
-              treeCmp = bestCmp;
-              if( pIdxKey->default_rc < 0 ){
-                continue;
-              }
-              break;
-            }
-          }
-          prollyNodeValue(&pLeaf->node, i, &pVal, &nVal);
-          if( nVal==0 ){
-            rc = recordFromSortKeyBufferColl(
-                pSK, nSK, pCur->pKeyInfo, &pRecBuf, &nRecBufAlloc, &nVal);
-            if( rc!=SQLITE_OK ) break;
-            pVal = pRecBuf;
-          }
-          pIdxKey->eqSeen = 0;
-          recCmp = sqlite3VdbeRecordCompare(nVal, pVal, pIdxKey);
-
-          if( recCmp==0 || pIdxKey->eqSeen ){
-            if( pCur->pMutMap && !prollyMutMapIsEmpty(pCur->pMutMap) ){
-              ProllyMutMapEntry *mmE = 0;
-              rc = prollyMutMapFindRc(pCur->pMutMap, pSK, nSK, 0, &mmE);
-              if( rc!=SQLITE_OK ) break;
-              if( mmE && mmE->op==PROLLY_EDIT_DELETE ){
-                continue;
-              }
-            }
-            bestIdx = i;
-            bestCmp = recCmp;
-            treeFound = 1;
-            treeCmp = recCmp;
-            break;
-          } else if( recCmp > 0 ){
-            if( pCur->pMutMap && !prollyMutMapIsEmpty(pCur->pMutMap) ){
-              ProllyMutMapEntry *mmE = 0;
-              rc = prollyMutMapFindRc(pCur->pMutMap, pSK, nSK, 0, &mmE);
-              if( rc!=SQLITE_OK ) break;
-              if( mmE && mmE->op==PROLLY_EDIT_DELETE ){
-                continue;
-              }
-            }
-            if( bestIdx < 0 ){
-              bestIdx = i;
-              bestCmp = recCmp;
-            }
-          }
-        }
-        if( rc!=SQLITE_OK || treeFound || bestIdx>=0 ) break;
-        if( !(pCur->pMutMap && !prollyMutMapIsEmpty(pCur->pMutMap)) ) break;
-        /* Everything from the seek point through the end of this leaf was
-        ** delete-masked; the first live row may sit in a later leaf. */
-        if( nItems>0 ) pCur->pCur.aLevel[pCur->pCur.iLevel].idx = nItems-1;
-        rc = prollyCursorNext(&pCur->pCur);
-        if( rc!=SQLITE_OK ) break;
-        if( pCur->pCur.eState!=PROLLY_CURSOR_VALID ) break;
-        iLevel = pCur->pCur.iLevel;
-        pLeaf = pCur->pCur.aLevel[iLevel].pEntry;
-        nItems = pLeaf->node.nItems;
-        lo = 0;
-       }
-        pCur->pMovetoRec = pRecBuf;
-        pCur->nMovetoRecAlloc = nRecBufAlloc;
-        if( rc!=SQLITE_OK ) return rc;
-      }
-
-      if( treeFound ){
-
-        pCur->pCur.aLevel[iLevel].idx = bestIdx;
-      } else if( bestIdx >= 0 ){
-
-        pCur->pCur.aLevel[iLevel].idx = bestIdx;
-        treeCmp = bestCmp;
-        treeFound = 1;
-      }
-
-    }
 
     {
       struct TableEntry *pTE = findTable(pCur->pBtree, pCur->pgnoRoot);

--- a/src/prolly_btree_txn.c
+++ b/src/prolly_btree_txn.c
@@ -825,6 +825,206 @@ int sqlite3BtreeCommitPhaseOne(Btree *p, const char *zSuperJrnl){
   return p->pOps->xCommitPhaseOne(p, zSuperJrnl);
 }
 
+/* Drop graph lock + snapshot pin after a write-txn commit attempt. */
+static void commitPhaseTwoReleaseGraph(BtShared *pBt){
+  chunkStoreUnlock(&pBt->store);
+  pBt->store.snapshotPinned = 0;
+}
+
+/* Abort a write commit that has not yet published: free catalog bytes,
+** roll back the store, release the graph. Optional reload catalog is freed. */
+static void commitPhaseTwoAbort(
+  BtShared *pBt,
+  u8 **ppCatData,
+  Btree *pReload,
+  int *pbHaveReload
+){
+  if( pbHaveReload && *pbHaveReload && pReload ){
+    catFree(&pReload->cat);
+    *pbHaveReload = 0;
+  }
+  if( ppCatData ){
+    sqlite3_free(*ppCatData);
+    *ppCatData = 0;
+  }
+  chunkStoreRollback(&pBt->store);
+  commitPhaseTwoReleaseGraph(pBt);
+}
+
+/* Serialize working catalog + working-set blob + refs for a write commit. */
+static int commitPhaseTwoStageCatalog(
+  Btree *p,
+  BtShared *pBt,
+  u8 **ppCatData,
+  int *pnCatData,
+  ProllyHash *pCatHash
+){
+  int rc;
+  const char *zBr;
+
+  pBt->inCatalogSerialize = 1;
+  rc = serializeCatalogForCommit(p, ppCatData, pnCatData);
+  pBt->inCatalogSerialize = 0;
+  if( rc==SQLITE_OK ){
+    rc = chunkStorePut(&pBt->store, *ppCatData, *pnCatData, pCatHash);
+  }
+  if( rc!=SQLITE_OK ) return rc;
+
+  zBr = p->zBranch ? p->zBranch : "main";
+  rc = btreeStoreWorkingSetBlob(&pBt->store, zBr, pCatHash,
+                                &p->headCommit,
+                                &p->vc.stagedCatalog, p->vc.isMerging,
+                                &p->vc.mergeCommitHash,
+                                &p->vc.conflictsCatalogHash,
+                                p->isRebasing,
+                                &p->preRebaseWorkingCat,
+                                &p->rebaseOntoCommit,
+                                p->zRebaseOrigBranch,
+                                p->zRebaseReturnBranch,
+                                &p->vc.constraintViolationsHash);
+  if( rc!=SQLITE_OK ) return rc;
+  return chunkStoreSerializeRefs(&pBt->store);
+}
+
+/* Deserialize the about-to-commit catalog and freeze peer cursors before
+** a schema-changing publish. */
+static int commitPhaseTwoPrepSchemaReload(
+  Btree *p,
+  BtShared *pBt,
+  const u8 *catData,
+  int nCatData,
+  Btree *pReload,
+  u32 *pNativeSchemaCookie
+){
+  BtCursor *pC;
+  int rc;
+
+  *pNativeSchemaCookie = p->aMeta[BTREE_SCHEMA_VERSION];
+  memcpy(pReload->aMeta, p->aMeta, sizeof(pReload->aMeta));
+  rc = deserializeCatalog(pReload, catData, nCatData);
+  if( rc!=SQLITE_OK ){
+    catFree(&pReload->cat);
+    return rc;
+  }
+  /* Save this handle's live cursors before refreshing the schema root. */
+  for(pC = pBt->pCursor; pC; pC = pC->pNext){
+    if( pC->pBtree==p ){
+      if( (pC->eState==CURSOR_VALID || pC->eState==CURSOR_SKIPNEXT)
+       && saveCursorPosition(pC)!=SQLITE_OK ){
+        pC->eState = CURSOR_FAULT;
+        pC->skipNext = SQLITE_ABORT;
+        prollyCursorReleaseAll(&pC->pCur);
+      }
+      pC->pMutMap = 0;
+      pC->mmActive = 0;
+      pC->mmPhysActive = 0;
+      pC->deferredTreeSeek = 0;
+      pC->mmIdx = -1;
+      pC->mmPhysIdx = -1;
+    }else{
+      pC->eState = CURSOR_FAULT;
+      pC->skipNext = SQLITE_ABORT;
+      pC->mmActive = 0;
+      prollyCursorReleaseAll(&pC->pCur);
+    }
+  }
+  return SQLITE_OK;
+}
+
+static void commitPhaseTwoAdoptReloadedCatalog(
+  Btree *p,
+  BtShared *pBt,
+  Btree *pReload,
+  int *pbHaveReload,
+  u32 nativeSchemaCookie
+){
+  BtCursor *pC;
+
+  if( *pbHaveReload ){
+    btreeFreeCatalogTables(p);
+    p->cat = pReload->cat;
+    memcpy(p->aMeta, pReload->aMeta, sizeof(p->aMeta));
+    /* sqlite already bumped its cookie for this DDL; keep the stock
+    ** value instead of the reload's hash-derived one so in-session
+    ** cookie semantics stay stock (writes stick, DDL increments). */
+    p->aMeta[BTREE_SCHEMA_VERSION] = nativeSchemaCookie;
+    memset(&pReload->cat, 0, sizeof(pReload->cat));
+    *pbHaveReload = 0;
+  }
+  /* A saved cursor whose table vanished in the reload would re-seek a
+  ** stale root; fault it. */
+  for(pC = pBt->pCursor; pC; pC = pC->pNext){
+    if( pC->pBtree==p && pC->eState==CURSOR_REQUIRESEEK
+     && findTable(p, pC->pgnoRoot)==0 ){
+      pC->eState = CURSOR_FAULT;
+      pC->skipNext = SQLITE_ABORT;
+    }
+  }
+  invalidateSchema(p);
+  if( p->db ){
+    /* Hard expiry: canonical renumbering can move rootpages compiled
+    ** into running statements (tkt-c694113d5). */
+    sqlite3ExpirePreparedStatements(p->db, 1);
+    sqlite3ResetAllSchemasOfConnection(p->db);
+  }
+}
+
+static void commitPhaseTwoEndWriteTxn(Btree *p){
+  p->inTrans = TRANS_NONE;
+  p->inTransaction = TRANS_NONE;
+  btreeDiscardAllSavepoints(p);
+  p->bSchemaChangedTxn = 0;
+  p->bMasterRootChangedTxn = 0;
+}
+
+/* After chunkStoreCommit failed: restore pre-commit state or drop the
+** catalog if restore itself fails. Always releases the graph. */
+static int commitPhaseTwoFailRestore(
+  Btree *p,
+  BtShared *pBt,
+  int commitRc,
+  u8 **ppCatData,
+  Btree *pReload,
+  int *pbHaveReload
+){
+  int rc2;
+
+  if( *pbHaveReload ){
+    catFree(&pReload->cat);
+    *pbHaveReload = 0;
+  }
+  sqlite3_free(*ppCatData);
+  *ppCatData = 0;
+  rc2 = restoreFromCommitted(p);
+  if( rc2!=SQLITE_OK ){
+    /* Same shape as the rollback path: the restore OOM'd, but the
+    ** transaction must end with the partial state discarded, or the
+    ** next statement's autocommit publishes it. */
+    btreeFreeCatalogTables(p);
+    memset(&p->committedCatalogHash, 0, sizeof(p->committedCatalogHash));
+    p->bCatalogDropped = 1;
+    p->iLoadedWorkingStateVersion = pBt->iWorkingStateVersion - 1;
+    resetConnectionSchema(p);
+    chunkStoreRollback(&pBt->store);
+    commitPhaseTwoEndWriteTxn(p);
+    commitPhaseTwoReleaseGraph(pBt);
+    /* Preserve the original commit error; restore failure is secondary. */
+    return commitRc;
+  }
+  {
+    BtCursor *pC;
+    for(pC = pBt->pCursor; pC; pC = pC->pNext){
+      if( pC->pBtree==p && pC->pMutMap ) prollyMutMapClear(pC->pMutMap);
+    }
+  }
+  invalidateCursors(pBt, 0, commitRc);
+  resetConnectionSchema(p);
+  chunkStoreRollback(&pBt->store);
+  commitPhaseTwoEndWriteTxn(p);
+  commitPhaseTwoReleaseGraph(pBt);
+  return commitRc;
+}
+
 int prollyBtreeCommitPhaseTwo(Btree *p, int bCleanup){
   BtShared *pBt = p->pBt;
   int rc = SQLITE_OK;
@@ -843,224 +1043,81 @@ int prollyBtreeCommitPhaseTwo(Btree *p, int bCleanup){
   ** recursing into a stack overflow. */
   if( pBt->inCatalogSerialize ) return SQLITE_OK;
 
-  if( p->inTrans==TRANS_WRITE ){
-    PROLLY_ASSERT_GRAPH_LOCKED(pBt);
-    rc = flushAllPending(p, pBt, 0);
-    if( rc!=SQLITE_OK ){
-      chunkStoreRollback(&pBt->store);
-      chunkStoreUnlock(&pBt->store);
-      pBt->store.snapshotPinned = 0;
-      return rc;
-    }
-
-    {
-      pBt->inCatalogSerialize = 1;
-      rc = serializeCatalogForCommit(p, &catData, &nCatData);
-      pBt->inCatalogSerialize = 0;
-      if( rc==SQLITE_OK ){
-        rc = chunkStorePut(&pBt->store, catData, nCatData, &catHash);
-      }
-      if( rc!=SQLITE_OK ){
-        sqlite3_free(catData);
-        chunkStoreRollback(&pBt->store);
-        chunkStoreUnlock(&pBt->store);
-        pBt->store.snapshotPinned = 0;
-        return rc;
-      }
-
-      {
-        const char *zBr = p->zBranch ? p->zBranch : "main";
-        rc = btreeStoreWorkingSetBlob(&pBt->store, zBr, &catHash,
-                                      &p->headCommit,
-                                      &p->vc.stagedCatalog, p->vc.isMerging,
-                                      &p->vc.mergeCommitHash,
-                                      &p->vc.conflictsCatalogHash,
-                                      p->isRebasing,
-                                      &p->preRebaseWorkingCat,
-                                      &p->rebaseOntoCommit,
-                                      p->zRebaseOrigBranch,
-                                      p->zRebaseReturnBranch,
-                                      &p->vc.constraintViolationsHash);
-        if( rc!=SQLITE_OK ){
-          sqlite3_free(catData);
-          chunkStoreRollback(&pBt->store);
-          chunkStoreUnlock(&pBt->store);
-          pBt->store.snapshotPinned = 0;
-          return rc;
-        }
-        rc = chunkStoreSerializeRefs(&pBt->store);
-        if( rc!=SQLITE_OK ){
-          sqlite3_free(catData);
-          chunkStoreRollback(&pBt->store);
-          chunkStoreUnlock(&pBt->store);
-          pBt->store.snapshotPinned = 0;
-          return rc;
-        }
-      }
-    }
-
-    /* A schema-changing commit adopts the canonical catalog wholesale --
-    ** including the canonical master root, so the live view and the
-    ** persisted form never diverge (rowid bindings, rootpages, and row
-    ** order all match what any reload would see). */
-    bReloadSchema = p->bSchemaChangedTxn;
-    if( bReloadSchema ){
-      BtCursor *pC;
-      nativeSchemaCookie = p->aMeta[BTREE_SCHEMA_VERSION];
-      memcpy(reloadBtree.aMeta, p->aMeta, sizeof(reloadBtree.aMeta));
-      rc = deserializeCatalog(&reloadBtree, catData, nCatData);
-      if( rc!=SQLITE_OK ){
-        catFree(&reloadBtree.cat);
-        sqlite3_free(catData);
-        chunkStoreRollback(&pBt->store);
-        chunkStoreUnlock(&pBt->store);
-        pBt->store.snapshotPinned = 0;
-        return rc;
-      }
-      bHaveReloadCatalog = 1;
-      /* Save this handle's live cursors before refreshing the schema root. */
-      for(pC = pBt->pCursor; pC; pC = pC->pNext){
-        if( pC->pBtree==p ){
-          if( (pC->eState==CURSOR_VALID || pC->eState==CURSOR_SKIPNEXT)
-           && saveCursorPosition(pC)!=SQLITE_OK ){
-            pC->eState = CURSOR_FAULT;
-            pC->skipNext = SQLITE_ABORT;
-            prollyCursorReleaseAll(&pC->pCur);
-          }
-          pC->pMutMap = 0;
-          pC->mmActive = 0;
-          pC->mmPhysActive = 0;
-          pC->deferredTreeSeek = 0;
-          pC->mmIdx = -1;
-          pC->mmPhysIdx = -1;
-        }else{
-          pC->eState = CURSOR_FAULT;
-          pC->skipNext = SQLITE_ABORT;
-          pC->mmActive = 0;
-          prollyCursorReleaseAll(&pC->pCur);
-        }
-      }
-    }
-
-    /* Phase one already refused the caller's own commit when conflicts are
-    ** unresolved, so reaching here with a non-empty conflicts catalog means this
-    ** is a statement commit nested inside a dolt_* command -- dolt_commit's
-    ** staging, typically. Those must not be failed, or the command's own
-    ** diagnosis is replaced by a bare "constraint failed", but they must not
-    ** make the conflict durable either. Leaving the batch pending satisfies
-    ** both: the chunks stay in the pending set exactly as an in-transaction save
-    ** leaves them, and only a later conflict-free commit flushes them. */
-    if( !prollyHashIsEmpty(&p->vc.conflictsCatalogHash) ){
-      chunkStoreUnlock(&pBt->store);
-      pBt->store.snapshotPinned = 0;
-      p->inTrans = TRANS_READ;
-      return SQLITE_OK;
-    }
-
-    rc = chunkStoreCommit(&pBt->store);
-    if( rc==SQLITE_OK ){
-      p->committedCatalogHash = catHash;
-      p->committedVc = p->vc;
-      memcpy(p->committedAMeta, p->aMeta, sizeof(p->committedAMeta));
-      btreeMarkWorkingStateChanged(p, 1);
-      if( bReloadSchema ){
-        BtCursor *pC;
-        if( bHaveReloadCatalog ){
-          btreeFreeCatalogTables(p);
-          p->cat = reloadBtree.cat;
-          memcpy(p->aMeta, reloadBtree.aMeta, sizeof(p->aMeta));
-          /* sqlite already bumped its cookie for this DDL; keep the stock
-          ** value instead of the reload's hash-derived one so in-session
-          ** cookie semantics stay stock (writes stick, DDL increments). */
-          p->aMeta[BTREE_SCHEMA_VERSION] = nativeSchemaCookie;
-          memset(&reloadBtree.cat, 0, sizeof(reloadBtree.cat));
-          bHaveReloadCatalog = 0;
-        }
-        /* A saved cursor whose table vanished in the reload would re-seek a
-        ** stale root; fault it. */
-        for(pC = pBt->pCursor; pC; pC = pC->pNext){
-          if( pC->pBtree==p && pC->eState==CURSOR_REQUIRESEEK
-           && findTable(p, pC->pgnoRoot)==0 ){
-            pC->eState = CURSOR_FAULT;
-            pC->skipNext = SQLITE_ABORT;
-          }
-        }
-        invalidateSchema(p);
-        if( p->db ){
-          /* Hard expiry: canonical renumbering can move rootpages compiled
-          ** into running statements (tkt-c694113d5). */
-          sqlite3ExpirePreparedStatements(p->db, 1);
-          sqlite3ResetAllSchemasOfConnection(p->db);
-        }
-      }
-      p->inTrans = TRANS_NONE;
-      p->inTransaction = TRANS_NONE;
-      btreeDiscardAllSavepoints(p);
-      p->bSchemaChangedTxn = 0;
-      p->bMasterRootChangedTxn = 0;
-
-      btreeTakeCatalogCache(p, &catData, nCatData, &catHash);
-      assert( p->nCatalogCache==nCatData );
-      assert( prollyHashCompare(&p->catalogCacheHash, &catHash)==0 );
-      sqlite3_free(catData);
-      chunkStoreUnlock(&pBt->store);
-      pBt->store.snapshotPinned = 0;
-    }else{
-      int rc2;
-      if( bHaveReloadCatalog ){
-        catFree(&reloadBtree.cat);
-        bHaveReloadCatalog = 0;
-      }
-      sqlite3_free(catData);
-      rc2 = restoreFromCommitted(p);
-      if( rc2!=SQLITE_OK ){
-        /* Same shape as the rollback path: the restore OOM'd, but the
-        ** transaction must end with the partial state discarded, or the
-        ** next statement's autocommit publishes it. */
-        btreeFreeCatalogTables(p);
-        memset(&p->committedCatalogHash, 0, sizeof(p->committedCatalogHash));
-        p->bCatalogDropped = 1;
-        p->iLoadedWorkingStateVersion = pBt->iWorkingStateVersion - 1;
-        resetConnectionSchema(p);
-        chunkStoreRollback(&pBt->store);
-        p->inTrans = TRANS_NONE;
-        p->inTransaction = TRANS_NONE;
-        btreeDiscardAllSavepoints(p);
-        chunkStoreUnlock(&pBt->store);
-        pBt->store.snapshotPinned = 0;
-        /* Preserve the original commit error; restore failure is secondary. */
-        return rc;
-      }
-      {
-        BtCursor *pC;
-        for(pC = pBt->pCursor; pC; pC = pC->pNext){
-          if( pC->pBtree==p && pC->pMutMap ) prollyMutMapClear(pC->pMutMap);
-        }
-      }
-      invalidateCursors(pBt, 0, rc);
-      resetConnectionSchema(p);
-      chunkStoreRollback(&pBt->store);
-      p->inTrans = TRANS_NONE;
-      p->inTransaction = TRANS_NONE;
-      btreeDiscardAllSavepoints(p);
-      p->bSchemaChangedTxn = 0;
-      p->bMasterRootChangedTxn = 0;
-      chunkStoreUnlock(&pBt->store);
-      pBt->store.snapshotPinned = 0;
-    }
+  if( p->inTrans!=TRANS_WRITE ){
+    commitPhaseTwoEndWriteTxn(p);
+    commitPhaseTwoReleaseGraph(pBt);
     return rc;
   }
 
-  p->inTrans = TRANS_NONE;
-  p->inTransaction = TRANS_NONE;
-  p->bSchemaChangedTxn = 0;
-  p->bMasterRootChangedTxn = 0;
-  btreeDiscardAllSavepoints(p);
+  PROLLY_ASSERT_GRAPH_LOCKED(pBt);
+  rc = flushAllPending(p, pBt, 0);
+  if( rc!=SQLITE_OK ){
+    commitPhaseTwoAbort(pBt, 0, 0, 0);
+    return rc;
+  }
 
-  chunkStoreUnlock(&pBt->store);
-  pBt->store.snapshotPinned = 0;
+  rc = commitPhaseTwoStageCatalog(p, pBt, &catData, &nCatData, &catHash);
+  if( rc!=SQLITE_OK ){
+    commitPhaseTwoAbort(pBt, &catData, 0, 0);
+    return rc;
+  }
 
-  return rc;
+  /* A schema-changing commit adopts the canonical catalog wholesale --
+  ** including the canonical master root, so the live view and the
+  ** persisted form never diverge (rowid bindings, rootpages, and row
+  ** order all match what any reload would see). */
+  bReloadSchema = p->bSchemaChangedTxn;
+  if( bReloadSchema ){
+    rc = commitPhaseTwoPrepSchemaReload(
+        p, pBt, catData, nCatData, &reloadBtree, &nativeSchemaCookie);
+    if( rc!=SQLITE_OK ){
+      commitPhaseTwoAbort(pBt, &catData, 0, 0);
+      return rc;
+    }
+    bHaveReloadCatalog = 1;
+  }
+
+  /* Phase one already refused the caller's own commit when conflicts are
+  ** unresolved, so reaching here with a non-empty conflicts catalog means this
+  ** is a statement commit nested inside a dolt_* command -- dolt_commit's
+  ** staging, typically. Those must not be failed, or the command's own
+  ** diagnosis is replaced by a bare "constraint failed", but they must not
+  ** make the conflict durable either. Leaving the batch pending satisfies
+  ** both: the chunks stay in the pending set exactly as an in-transaction save
+  ** leaves them, and only a later conflict-free commit flushes them. */
+  if( !prollyHashIsEmpty(&p->vc.conflictsCatalogHash) ){
+    if( bHaveReloadCatalog ){
+      catFree(&reloadBtree.cat);
+      bHaveReloadCatalog = 0;
+    }
+    sqlite3_free(catData);
+    commitPhaseTwoReleaseGraph(pBt);
+    p->inTrans = TRANS_READ;
+    return SQLITE_OK;
+  }
+
+  rc = chunkStoreCommit(&pBt->store);
+  if( rc!=SQLITE_OK ){
+    return commitPhaseTwoFailRestore(
+        p, pBt, rc, &catData, &reloadBtree, &bHaveReloadCatalog);
+  }
+
+  p->committedCatalogHash = catHash;
+  p->committedVc = p->vc;
+  memcpy(p->committedAMeta, p->aMeta, sizeof(p->committedAMeta));
+  btreeMarkWorkingStateChanged(p, 1);
+  if( bReloadSchema ){
+    commitPhaseTwoAdoptReloadedCatalog(
+        p, pBt, &reloadBtree, &bHaveReloadCatalog, nativeSchemaCookie);
+  }
+  commitPhaseTwoEndWriteTxn(p);
+
+  btreeTakeCatalogCache(p, &catData, nCatData, &catHash);
+  assert( p->nCatalogCache==nCatData );
+  assert( prollyHashCompare(&p->catalogCacheHash, &catHash)==0 );
+  sqlite3_free(catData);
+  commitPhaseTwoReleaseGraph(pBt);
+  return SQLITE_OK;
 }
 int sqlite3BtreeCommitPhaseTwo(Btree *p, int bCleanup){
   if( !p ) return SQLITE_OK;


### PR DESCRIPTION
## Summary

P1 large-function cleanup from the code review: decompose the highest-risk mega-functions so commit/rollback cleanup and seek paths are reviewable and less bug-prone.

### Changes (behavior-preserving)

| Function | Before | After |
|---|---:|---:|
| `prollyBtreeCommitPhaseTwo` | ~237 | ~94 |
| `csCommitToFile` | ~375 | ~217 |
| `prollyBtCursorIndexMoveto` | ~475 | ~186 |

- **Commit phase two** (`prolly_btree_txn.c`): extract `commitPhaseTwoStageCatalog`, schema reload prep/adopt, fail-restore, and a shared abort that always rolls back + unlocks + clears the snapshot pin. Also free `catData` on the leave-pending conflict path (prior code leaked it).
- **Chunk store commit** (`chunk_store_commit.c`): `csCommitResolveAppendPoint`, `csCommitPlanPendingIndex`, `csCommitPublishStaging`; keep the existing `commit_done` single exit.
- **Index moveto** (`prolly_btree_cursor_seek.c`): seek-key build, custom-collation scan, exact mutmap/tree hits, and leaf scan as helpers.

## Test plan

- [x] `doltlite_commit.sh` (62)
- [x] `doltlite_savepoint.sh` (128)
- [x] `doltlite_merge.sh` (99)
- [x] `doltlite_conflicts.sh` (40)
- [x] `doltlite_index_row_delta.sh` (19)
- [x] `doltlite_merge_nocase_reindex.sh`, `doltlite_nocase_index.sh`, `doltlite_workspace.sh`, `doltlite_rollback_durability.sh`
- [ ] CI full suite