### PR TITLE
Propagate OOM and IO failures in backup init and step

### DIFF
--- a/src/pager_shim.c
+++ b/src/pager_shim.c
@@ -888,24 +888,35 @@ static int doltliteBackupSameFile(
   sqlite3_vfs *pSrcVfs,
   const char *zSrcFile,
   sqlite3_vfs *pDestVfs,
-  const char *zDestFile
+  const char *zDestFile,
+  int *pRc
 ){
   char *zSrcFull = 0;
   char *zDestFull = 0;
   int nSrc;
   int nDest;
+  int rc;
   int same = strcmp(zSrcFile, zDestFile)==0;
 
+  *pRc = SQLITE_OK;
   if( pSrcVfs!=pDestVfs ) return same;
   nSrc = pSrcVfs->mxPathname + 1;
   nDest = pDestVfs->mxPathname + 1;
   zSrcFull = sqlite3_malloc(nSrc);
   zDestFull = sqlite3_malloc(nDest);
-  if( !zSrcFull || !zDestFull ) goto backup_same_file_done;
-  if( sqlite3OsFullPathname(pSrcVfs, zSrcFile, nSrc, zSrcFull)!=SQLITE_OK ){
+  if( !zSrcFull || !zDestFull ){
+    *pRc = SQLITE_NOMEM;
     goto backup_same_file_done;
   }
-  if( sqlite3OsFullPathname(pDestVfs, zDestFile, nDest, zDestFull)!=SQLITE_OK ){
+  rc = sqlite3OsFullPathname(pSrcVfs, zSrcFile, nSrc, zSrcFull);
+  if( rc==SQLITE_OK ){
+    rc = sqlite3OsFullPathname(pDestVfs, zDestFile, nDest, zDestFull);
+  }
+  if( rc!=SQLITE_OK ){
+    /* Answering from the raw names would let an allocation or path failure
+    ** silently misclassify two spellings of one file as distinct databases
+    ** and start a self-overwriting backup. */
+    *pRc = rc;
     goto backup_same_file_done;
   }
   same = strcmp(zSrcFull, zDestFull)==0;
@@ -985,17 +996,32 @@ sqlite3_backup *sqlite3_backup_init(sqlite3 *pDest, const char *zDestDb,
     sqlite3ErrorWithMsg(pDest, SQLITE_NOTADB, "file is not a database");
     return 0;
   }
-  if( doltliteBackupSameFile(chunkFileGetVfs(&srcCs->file),
-                             chunkFileGetFilename(&srcCs->file),
-                             chunkFileGetVfs(&destCs->file),
-                             chunkFileGetFilename(&destCs->file)) ){
-    sqlite3ErrorWithMsg(pDest, SQLITE_ERROR,
-                        "source and destination are the same database");
-    return 0;
+  {
+    int sameRc = SQLITE_OK;
+    int same = doltliteBackupSameFile(chunkFileGetVfs(&srcCs->file),
+                                      chunkFileGetFilename(&srcCs->file),
+                                      chunkFileGetVfs(&destCs->file),
+                                      chunkFileGetFilename(&destCs->file),
+                                      &sameRc);
+    if( sameRc!=SQLITE_OK ){
+      /* Stock backup_init surfaces OOM as plain SQLITE_NOMEM; keep that
+      ** contract when the allocation failed inside the OS layer. */
+      if( sameRc==SQLITE_IOERR_NOMEM ) sameRc = SQLITE_NOMEM;
+      sqlite3Error(pDest, sameRc);
+      return 0;
+    }
+    if( same ){
+      sqlite3ErrorWithMsg(pDest, SQLITE_ERROR,
+                          "source and destination are the same database");
+      return 0;
+    }
   }
 
   p = (DoltliteBackup*)sqlite3_malloc(sizeof(DoltliteBackup));
-  if( !p ) return 0;
+  if( !p ){
+    sqlite3Error(pDest, SQLITE_NOMEM);
+    return 0;
+  }
   memset(p, 0, sizeof(*p));
 
   p->pSrcDb = pSrc;
@@ -1008,6 +1034,7 @@ sqlite3_backup *sqlite3_backup_init(sqlite3 *pDest, const char *zDestDb,
   if( chunkStoreDupFilenameDoubleNul(chunkFileGetFilename(&srcCs->file),
                                      &p->zSrcFile)!=SQLITE_OK ){
     sqlite3_free(p);
+    sqlite3Error(pDest, SQLITE_NOMEM);
     return 0;
   }
   p->zDestFile = sqlite3_mprintf("%s", chunkFileGetFilename(&destCs->file));
@@ -1015,6 +1042,7 @@ sqlite3_backup *sqlite3_backup_init(sqlite3 *pDest, const char *zDestDb,
     sqlite3_free(p->zSrcFile);
     sqlite3_free(p->zDestFile);
     sqlite3_free(p);
+    sqlite3Error(pDest, SQLITE_NOMEM);
     return 0;
   }
 
@@ -1080,7 +1108,12 @@ int sqlite3_backup_step(sqlite3_backup *pBackup, int nPage){
     sqlite3_free(zTmpRaw);
     if( rc!=SQLITE_OK ) goto backup_step_done;
   }
-  (void)sqlite3OsDelete(p->pDestVfs, zTmpFile, 0);
+  /* Clearing a stale tmp file may legitimately find nothing to delete, but
+  ** any other failure would surface as a confusing EXCLUSIVE-open error (or
+  ** silently consume an injected fault), so propagate it here. */
+  rc = sqlite3OsDelete(p->pDestVfs, zTmpFile, 0);
+  if( rc==SQLITE_IOERR_DELETE_NOENT ) rc = SQLITE_OK;
+  if( rc!=SQLITE_OK ) goto backup_step_done;
 
   openFlags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_EXCLUSIVE
             | SQLITE_OPEN_MAIN_DB;


### PR DESCRIPTION
## Problem

This is the root cause of the `sqlite-regression-fault-fuzz` failure on #1891 (`backup_malloc` transient/persistent iterations 0-6, 35, 270) — and it is a master bug, not #1891's: the failing iterations reproduce on unmodified master on macOS, where the fault-fuzz bucket never runs. #1891's file-geometry change merely shifted allocation counts enough for the ubuntu sweep to reach the same swallow sites.

Three swallowed-failure classes in the doltlite backup path (`src/pager_shim.c`), pinpointed with the faultsim backtrace hook:

1. **`doltliteBackupSameFile` answered from raw filenames on failure.** When its full-path buffers failed to allocate or `xFullPathname` failed, it silently fell back to `strcmp` of the unresolved names — so `./x.db` vs `x.db` could pass the same-database check under memory pressure and start a backup of a file onto itself.
2. **`sqlite3_backup_init` OOM exits set no error code.** The `DoltliteBackup` allocation and its filename copies returned NULL bare, unlike stock init which reports `SQLITE_NOMEM` on the destination handle — callers checking `sqlite3_errcode` for OOM (including the inherited test) saw `SQLITE_OK`.
3. **`backup_step` voided the stale-tmp pre-delete.** A real delete failure only surfaced later as a confusing EXCLUSIVE-open error, and an injected fault vanished entirely (`[0 SQLITE_OK]`).

## Fix

- Same-file check failures propagate; OS-layer `SQLITE_IOERR_NOMEM` (from the SQLITE_TEST OS fault shim) is mapped to plain `SQLITE_NOMEM` to keep stock's init OOM contract.
- Every init OOM exit sets `SQLITE_NOMEM` on `pDest`.
- The tmp pre-delete propagates everything except `SQLITE_IOERR_DELETE_NOENT` (nothing to delete is the expected case).

## Fail-before/pass-after

`backup_malloc` (macOS, where it reproduces deterministically): 15-16 errors unfixed → **0 errors** fixed. Each swallow site was confirmed with a temporary backtrace hook at the faultsim injection point before fixing.

## Local validation

- `backup_malloc`: 0/2184 errors (first clean run on macOS)
- `backup2/4/5`, `backup_ioerr`: identical results on fixed and unfixed builds (pre-existing macOS-local noise; the linux storage bucket gates these)
- `doltlite_regression_test_c`: 310,021/310,021
- `test/run_c_tests.sh` coverage set: 16/16 suites

Once this merges, #1891 should be rebased/re-run — its fault-fuzz failure was this bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)