### PR TITLE
Snapshot refs in dolt_tags and dolt_branches cursors

### DIFF
--- a/src/chunk_refs.c
+++ b/src/chunk_refs.c
@@ -83,10 +83,6 @@ int refsTableBranchCount(const RefsTable *rt){
   return rt->nBranches;
 }
 
-int refsTableTagCount(const RefsTable *rt){
-  return rt->nTags;
-}
-
 int refsTableRemoteCount(const RefsTable *rt){
   return rt->nRemotes;
 }

--- a/src/chunk_refs.h
+++ b/src/chunk_refs.h
@@ -73,7 +73,6 @@ int csFindNamedRef(const void *aBase, int n, int stride, const char *zName);
 int csRefArrayGrow(void **paBase, int n, int stride);
 
 int refsTableBranchCount(const RefsTable *rt);
-int refsTableTagCount(const RefsTable *rt);
 int refsTableRemoteCount(const RefsTable *rt);
 
 /* Return the stored sequence for zTableName, or 0 if absent. */

--- a/src/doltlite_branches.c
+++ b/src/doltlite_branches.c
@@ -15,8 +15,13 @@ typedef struct BrCur BrCur;
 struct BrCur {
   sqlite3_vtab_cursor base;
   int iRow;
-  int bSingle;
-  int iSingle;
+  /* Cursor-owned copy of the branches visible at xFilter time. A VC
+  ** function evaluated in the same statement mutates and reallocates the
+  ** live cs->refs arrays mid-scan, so rows must never be served from
+  ** them. Commit metadata is still loaded lazily by hash; commits are
+  ** immutable, so those lookups cannot go stale. */
+  int nRows;
+  BranchRef *aSnap;
   int iCommitRow;
   DoltliteCommit commit;
 };
@@ -24,6 +29,37 @@ struct BrCur {
 static void brClearCommit(BrCur *c){
   doltliteCommitClear(&c->commit);
   c->iCommitRow = -1;
+}
+
+static void brCurClearSnapshot(BrCur *c){
+  int i;
+  for(i=0; i<c->nRows; i++){
+    sqlite3_free(c->aSnap[i].zName);
+  }
+  sqlite3_free(c->aSnap);
+  c->aSnap = 0;
+  c->nRows = 0;
+  c->iRow = 0;
+}
+
+static int brCurSnapshot(BrCur *c, const BranchRef *aBr, int nBr){
+  int i;
+  brCurClearSnapshot(c);
+  if( nBr<=0 ) return SQLITE_OK;
+  c->aSnap = (BranchRef*)sqlite3_malloc64(
+      (sqlite3_uint64)nBr*sizeof(BranchRef));
+  if( !c->aSnap ) return SQLITE_NOMEM;
+  memset(c->aSnap, 0, (size_t)nBr*sizeof(BranchRef));
+  for(i=0; i<nBr; i++){
+    c->nRows = i+1;
+    c->aSnap[i] = aBr[i];
+    c->aSnap[i].zName = sqlite3_mprintf("%s", aBr[i].zName ? aBr[i].zName : "");
+    if( !c->aSnap[i].zName ){
+      brCurClearSnapshot(c);
+      return SQLITE_NOMEM;
+    }
+  }
+  return SQLITE_OK;
 }
 
 static int brConnect(sqlite3 *db, void *pAux, int argc,
@@ -61,27 +97,31 @@ static int brOpen(sqlite3_vtab *v, sqlite3_vtab_cursor **pp){
 static int brClose(sqlite3_vtab_cursor *cur){
   BrCur *c = (BrCur*)cur;
   brClearCommit(c);
+  brCurClearSnapshot(c);
   sqlite3_free(c);
   return SQLITE_OK;
 }
 static int brFilter(sqlite3_vtab_cursor *c, int n, const char *s, int a, sqlite3_value **v){
   BrVtab *pVtab = (BrVtab*)c->pVtab;
   BrCur *pCur = (BrCur*)c;
+  ChunkStore *cs = doltliteGetChunkStore(pVtab->db);
+  int nBr = 0;
+  const BranchRef *aBr = 0;
   (void)s;
   (void)a;
   brClearCommit(pCur);
-  pCur->iRow = 0;
-  pCur->bSingle = 0;
-  pCur->iSingle = -1;
+  brCurClearSnapshot(pCur);
+  if( !cs ) return SQLITE_OK;
+  refsTableGetBranches(&cs->refs, &nBr, &aBr);
   if( n==1 ){
-    ChunkStore *cs = doltliteGetChunkStore(pVtab->db);
     const char *zName = (const char*)sqlite3_value_text(v[0]);
-    pCur->bSingle = 1;
-    pCur->iSingle = cs ? csFindNamedRef(cs->refs.aBranches, cs->refs.nBranches,
-                                        (int)sizeof(BranchRef), zName) : -1;
-    pCur->iRow = pCur->iSingle;
+    int i = csFindNamedRef(cs->refs.aBranches, cs->refs.nBranches,
+                           (int)sizeof(BranchRef), zName);
+    if( i<0 ) return SQLITE_OK;
+    aBr += i;
+    nBr = 1;
   }
-  return SQLITE_OK;
+  return brCurSnapshot(pCur, aBr, nBr);
 }
 static int brNext(sqlite3_vtab_cursor *c){
   brClearCommit((BrCur*)c);
@@ -89,12 +129,8 @@ static int brNext(sqlite3_vtab_cursor *c){
   return SQLITE_OK;
 }
 static int brEof(sqlite3_vtab_cursor *c){
-  BrVtab *v = (BrVtab*)c->pVtab;
   BrCur *pCur = (BrCur*)c;
-  ChunkStore *cs = doltliteGetChunkStore(v->db);
-  if( !cs ) return 1;
-  if( pCur->bSingle ) return pCur->iSingle<0 || pCur->iRow!=pCur->iSingle;
-  return pCur->iRow >= refsTableBranchCount(&cs->refs);
+  return pCur->iRow >= pCur->nRows;
 }
 
 static int brIsDirty(
@@ -168,11 +204,9 @@ static int brColumn(sqlite3_vtab_cursor *c, sqlite3_context *ctx, int col){
   BrCur *pCur = (BrCur*)c;
   ChunkStore *cs = doltliteGetChunkStore(v->db);
   const BranchRef *br;
-  int nBr;
-  const BranchRef *aBr;
   if(!cs) return SQLITE_OK;
-  refsTableGetBranches(&cs->refs, &nBr, &aBr);
-  br = &aBr[((BrCur*)c)->iRow];
+  if( pCur->iRow >= pCur->nRows ) return SQLITE_OK;
+  br = &pCur->aSnap[pCur->iRow];
 
   switch(col){
     case 0:

--- a/src/doltlite_tag.c
+++ b/src/doltlite_tag.c
@@ -165,7 +165,64 @@ static void doltTagFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
 typedef struct TagVtab TagVtab;
 struct TagVtab { sqlite3_vtab base; sqlite3 *db; };
 typedef struct TagCur TagCur;
-struct TagCur { sqlite3_vtab_cursor base; int iRow; int bSingle; int iSingle; };
+struct TagCur {
+  sqlite3_vtab_cursor base;
+  int iRow;
+  /* Cursor-owned copy of the tags visible at xFilter time. A dolt_tag()
+  ** call evaluated in the same statement mutates and reallocates the live
+  ** cs->refs arrays mid-scan, so rows must never be served from them. */
+  int nRows;
+  TagRef *aSnap;
+};
+
+static void tagCurClearSnapshot(TagCur *pCur){
+  int i;
+  for(i=0; i<pCur->nRows; i++){
+    sqlite3_free(pCur->aSnap[i].zName);
+    sqlite3_free(pCur->aSnap[i].zTagger);
+    sqlite3_free(pCur->aSnap[i].zEmail);
+    sqlite3_free(pCur->aSnap[i].zMessage);
+  }
+  sqlite3_free(pCur->aSnap);
+  pCur->aSnap = 0;
+  pCur->nRows = 0;
+  pCur->iRow = 0;
+}
+
+static int tagCurSnapshot(TagCur *pCur, const TagRef *aTg, int nTg){
+  int i;
+  tagCurClearSnapshot(pCur);
+  if( nTg<=0 ) return SQLITE_OK;
+  pCur->aSnap = (TagRef*)sqlite3_malloc64((sqlite3_uint64)nTg*sizeof(TagRef));
+  if( !pCur->aSnap ) return SQLITE_NOMEM;
+  memset(pCur->aSnap, 0, (size_t)nTg*sizeof(TagRef));
+  for(i=0; i<nTg; i++){
+    TagRef *pDst = &pCur->aSnap[i];
+    const TagRef *pSrc = &aTg[i];
+    pCur->nRows = i+1;
+    pDst->commitHash = pSrc->commitHash;
+    pDst->timestamp = pSrc->timestamp;
+    pDst->zName = sqlite3_mprintf("%s", pSrc->zName ? pSrc->zName : "");
+    pDst->zTagger = pSrc->zTagger ? sqlite3_mprintf("%s", pSrc->zTagger) : 0;
+    pDst->zEmail = pSrc->zEmail ? sqlite3_mprintf("%s", pSrc->zEmail) : 0;
+    pDst->zMessage = pSrc->zMessage ? sqlite3_mprintf("%s", pSrc->zMessage) : 0;
+    if( !pDst->zName
+     || (pSrc->zTagger && !pDst->zTagger)
+     || (pSrc->zEmail && !pDst->zEmail)
+     || (pSrc->zMessage && !pDst->zMessage) ){
+      tagCurClearSnapshot(pCur);
+      return SQLITE_NOMEM;
+    }
+  }
+  return SQLITE_OK;
+}
+
+static int tagClose(sqlite3_vtab_cursor *pCursor){
+  TagCur *pCur = (TagCur*)pCursor;
+  tagCurClearSnapshot(pCur);
+  sqlite3_free(pCur);
+  return SQLITE_OK;
+}
 
 static int tagConnect(sqlite3 *db, void *pAux, int argc,
     const char *const*argv, sqlite3_vtab **ppVtab, char **pzErr){
@@ -198,41 +255,36 @@ static int tagFilter(sqlite3_vtab_cursor *pCursor, int idxNum,
     const char *idxStr, int argc, sqlite3_value **argv){
   TagVtab *pVtab = (TagVtab*)pCursor->pVtab;
   TagCur *pCur = (TagCur*)pCursor;
+  ChunkStore *cs = doltliteGetChunkStore(pVtab->db);
+  int nTg = 0;
+  const TagRef *aTg = 0;
   (void)idxStr;
-  pCur->iRow = 0;
-  pCur->bSingle = 0;
-  pCur->iSingle = -1;
+  tagCurClearSnapshot(pCur);
+  if( !cs ) return SQLITE_OK;
+  refsTableGetTags(&cs->refs, &nTg, &aTg);
   if( idxNum==1 && argc==1 ){
-    ChunkStore *cs = doltliteGetChunkStore(pVtab->db);
     const char *zName = (const char*)sqlite3_value_text(argv[0]);
-    pCur->bSingle = 1;
-    pCur->iSingle = cs ? csFindNamedRef(cs->refs.aTags, cs->refs.nTags,
-                                        (int)sizeof(TagRef), zName) : -1;
-    pCur->iRow = pCur->iSingle;
+    int i = csFindNamedRef(cs->refs.aTags, cs->refs.nTags,
+                           (int)sizeof(TagRef), zName);
+    if( i<0 ) return SQLITE_OK;
+    aTg += i;
+    nTg = 1;
   }
-  return SQLITE_OK;
+  return tagCurSnapshot(pCur, aTg, nTg);
 }
 static int tagNext(sqlite3_vtab_cursor *pCursor){
   ((TagCur*)pCursor)->iRow++;
   return SQLITE_OK;
 }
 static int tagEof(sqlite3_vtab_cursor *pCursor){
-  TagVtab *pVtab = (TagVtab*)pCursor->pVtab;
   TagCur *pCur = (TagCur*)pCursor;
-  ChunkStore *cs = doltliteGetChunkStore(pVtab->db);
-  if( !cs ) return 1;
-  if( pCur->bSingle ) return pCur->iSingle<0 || pCur->iRow!=pCur->iSingle;
-  return pCur->iRow >= refsTableTagCount(&cs->refs);
+  return pCur->iRow >= pCur->nRows;
 }
 static int tagColumn(sqlite3_vtab_cursor *pCursor, sqlite3_context *ctx, int col){
-  TagVtab *pVtab = (TagVtab*)pCursor->pVtab;
-  ChunkStore *cs = doltliteGetChunkStore(pVtab->db);
+  TagCur *pCur = (TagCur*)pCursor;
   const TagRef *t;
-  int nTg;
-  const TagRef *aTg;
-  if( !cs ) return SQLITE_OK;
-  refsTableGetTags(&cs->refs, &nTg, &aTg);
-  t = &aTg[((TagCur*)pCursor)->iRow];
+  if( pCur->iRow >= pCur->nRows ) return SQLITE_OK;
+  t = &pCur->aSnap[pCur->iRow];
   switch(col){
     case 0:
       sqlite3_result_text(ctx, t->zName, -1, SQLITE_TRANSIENT);
@@ -275,7 +327,7 @@ static int tagBestIndex(sqlite3_vtab *pVtab, sqlite3_index_info *pInfo){
 
 static sqlite3_module tagModule = {
   0,0,tagConnect,tagBestIndex,doltliteVtabDisconnect,0,
-  tagOpen,doltliteVtabClose,tagFilter,tagNext,tagEof,tagColumn,tagRowid,
+  tagOpen,tagClose,tagFilter,tagNext,tagEof,tagColumn,tagRowid,
   0,0,0,0,0,0,0,0,0,0,0,0
 };
 

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -8861,7 +8861,75 @@ static void run_directonly_dolt_functions(void){
   removeDbFiles(dbpath);
 }
 
+/* A VC function evaluated in the same statement as a dolt_tags or
+** dolt_branches scan mutates and reallocates the live refs arrays the
+** cursors used to read rows from — the scan ended early against the
+** shrinking live count and the stale index read freed memory. The cursors
+** must serve rows from a snapshot taken at xFilter. */
+static void run_refs_vtab_snapshot_stability(void){
+  sqlite3 *db = 0;
+  char dbpath[256];
+  int rc;
+
+  printf("=== Refs Vtab Snapshot Stability Test ===\n\n");
+  make_dbpath(dbpath, sizeof(dbpath), "test_refs_vtab_snapshot");
+  removeDbFiles(dbpath);
+  check("snapshot_open", open_db(dbpath, &db)==SQLITE_OK);
+  if( !db ) return;
+
+  rc = execSql(db,
+    "SELECT dolt_config('user.name','snap'),"
+    "       dolt_config('user.email','snap@example.com');"
+    "CREATE TABLE t(a INTEGER PRIMARY KEY);"
+    "INSERT INTO t VALUES(1);"
+    "SELECT dolt_add('-A');"
+    "SELECT dolt_commit('-m','base');"
+    "SELECT dolt_tag('tag_a'), dolt_tag('tag_b'), dolt_tag('tag_c');");
+  check("snapshot_setup", rc==SQLITE_OK);
+
+  /* Deleting each tag while scanning must still visit every tag that was
+  ** visible when the scan started, and delete all of them. A subquery
+  ** would let the planner prune the side-effecting column, so step the
+  ** scan directly. */
+  {
+    sqlite3_stmt *pStmt = 0;
+    int nRows = 0;
+    rc = sqlite3_prepare_v2(db,
+        "SELECT tag_name, dolt_tag('-d', tag_name) FROM dolt_tags",
+        -1, &pStmt, 0);
+    check("tags_scan_prepared", rc==SQLITE_OK);
+    while( sqlite3_step(pStmt)==SQLITE_ROW ) nRows++;
+    check("tags_scan_finalized", sqlite3_finalize(pStmt)==SQLITE_OK);
+    check("tags_scan_sees_snapshot", nRows==3);
+  }
+  check("tags_all_deleted",
+        strcmp(queryScalarText(db, "SELECT count(*) FROM dolt_tags"), "0")==0);
+
+  rc = execSql(db,
+    "SELECT dolt_branch('br_a'), dolt_branch('br_b'), dolt_branch('br_c')");
+  check("snapshot_branches_created", rc==SQLITE_OK);
+  {
+    sqlite3_stmt *pStmt = 0;
+    int nRows = 0;
+    rc = sqlite3_prepare_v2(db,
+        "SELECT name, CASE WHEN name<>'main'"
+        " THEN dolt_branch('-D', name) END FROM dolt_branches",
+        -1, &pStmt, 0);
+    check("branches_scan_prepared", rc==SQLITE_OK);
+    while( sqlite3_step(pStmt)==SQLITE_ROW ) nRows++;
+    check("branches_scan_finalized", sqlite3_finalize(pStmt)==SQLITE_OK);
+    check("branches_scan_sees_snapshot", nRows==4);
+  }
+  check("branches_all_deleted",
+        strcmp(queryScalarText(db, "SELECT count(*) FROM dolt_branches"),
+               "1")==0);
+
+  sqlite3_close(db);
+  removeDbFiles(dbpath);
+}
+
 static const RegressionCase aCases[] = {
+  { "refs_vtab_snapshot_stability", "Refs Vtab Snapshot Stability Test", run_refs_vtab_snapshot_stability },
   { "directonly_dolt_functions", "Direct-Only Dolt Functions Test", run_directonly_dolt_functions },
   { "refs_deserialize_overflow_guard", "Refs Deserialize Overflow Guard Test", run_refs_deserialize_overflow_guard },
   { "backup_safety", "Backup Safety Test", run_backup_safety },


### PR DESCRIPTION
## Problem

`dolt_tags` and `dolt_branches` cursors served rows straight out of the live `cs->refs` arrays: `xEof` bounded the row index against the live count, and `xColumn` re-fetched the live array and indexed it with the cursor's saved position (src/doltlite_tag.c, src/doltlite_branches.c). Nothing pinned a snapshot, so a VC function evaluated in the same statement —

```sql
SELECT tag_name, dolt_tag('-d', tag_name) FROM dolt_tags;
```

— goes through `doltliteMutateRefs`, whose force-refresh frees and reallocates the refs arrays between rows. Consequences on unfixed code (all reproduced):

- the scan ends early against the shrinking live count: 2 of 3 tags visited, the third **silently left undeleted**;
- `xColumn` indexes the reallocated array with a stale position — heap read of freed memory (ASAN-visible) and wrong-row results;
- the single-lookup path (`WHERE name = ?`) cached an index into the same live array.

## Fix

Both cursors deep-copy the refs visible at `xFilter` into cursor-owned memory and serve every row from the snapshot (freed in a new `xClose`). The equality-lookup path snapshots just the matching row. Branch commit metadata is still loaded lazily by hash — commits are immutable, so those lookups can't go stale.

## Test

New regression case (`refs_vtab_snapshot_stability`) scans `dolt_tags` deleting every tag mid-scan, and `dolt_branches` deleting every non-main branch mid-scan, asserting the scan visits every row visible at start and every mutation landed. (The scan is stepped directly — wrapping it in a subquery lets the planner prune the side-effecting column, which is how the first draft of this test silently tested nothing.)

Fail-before/pass-after:
- unfixed: 4 assertion failures (scans visit 2/3 and 3/4 rows, survivors remain)
- fixed: 11/11

## Local validation

- `doltlite_regression_test_c`: 310,032/310,032 (includes the new case)
- `test/run_c_tests.sh` coverage set: 16/16
- `test/run_doltlite_tests.sh` shell battery: 90/90 suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)