### PR TITLE
Route pull's ref writes through the atomic ref-mutation helper

### DIFF
--- a/src/doltlite_remote_sql.c
+++ b/src/doltlite_remote_sql.c
@@ -432,6 +432,20 @@ static void doltFetchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   sqlite3_result_int(ctx, 0);
 }
 
+typedef struct PullAdvanceCtx PullAdvanceCtx;
+struct PullAdvanceCtx {
+  const char *zBranch;
+  ProllyHash newTip;
+  int isCreate;
+};
+
+static int mutatePullAdvance(sqlite3 *db, ChunkStore *cs, void *pArg){
+  PullAdvanceCtx *p = (PullAdvanceCtx*)pArg;
+  (void)db;
+  if( p->isCreate ) return chunkStoreAddBranch(cs, p->zBranch, &p->newTip);
+  return chunkStoreUpdateBranch(cs, p->zBranch, &p->newTip);
+}
+
 static void doltPullFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   sqlite3 *db = sqlite3_context_db_handle(ctx);
   ChunkStore *cs = doltliteGetChunkStore(db);
@@ -489,14 +503,29 @@ static void doltPullFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
 
   rc = chunkStoreFindBranch(cs, zBranch, &localCommit);
   if( rc!=SQLITE_OK ){
-
-    rc = chunkStoreAddBranch(cs, zBranch, &trackingCommit);
+    /* Create and persist the local branch atomically: mutating the
+    ** in-memory refs outside the lock would either be clobbered by the
+    ** lock-time refresh of a later ref write or linger unpersisted. */
+    DoltliteBranchExpectation exp;
+    PullAdvanceCtx adv;
+    exp.zBranch = zBranch;
+    exp.pTip = 0;
+    adv.zBranch = zBranch;
+    adv.newTip = trackingCommit;
+    adv.isCreate = 1;
+    rc = doltliteMutateRefsExpected(db, &exp, 1, mutatePullAdvance, &adv);
+    if( rc==SQLITE_BUSY ){
+      doltliteCmdResultPeerBranchBusy(ctx, "pull");
+      (void)doltliteRestoreTxnStateOnFailure(db, &savedState, rc);
+      return;
+    }
     if( rc!=SQLITE_OK ){
       remoteSqlRestoreAndReport(ctx, db, cs, &savedState, SQLITE_ERROR,
                                 "failed to create local branch");
       return;
     }
-    localCommit = trackingCommit;
+    remoteSqlClearAndSucceed(ctx, &savedState);
+    return;
   }
 
   if( prollyHashCompare(&localCommit, &trackingCommit)==0 ){
@@ -551,27 +580,22 @@ static void doltPullFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
     }
   }
 
-  /* Advance and persist the branch under the graph lock, first re-confirming
-  ** the branch's authoritative on-disk tip still matches the one the
-  ** fast-forward was computed from. Holding the lock across the confirm and
-  ** the persist keeps a peer from committing to zBranch in between, which
-  ** would otherwise be clobbered (lost update). */
-  rc = chunkStoreLockAndRefresh(cs);
-  if( rc!=SQLITE_OK ){
-    remoteSqlRestoreAndReport(ctx, db, cs, &savedState, rc, 0);
-    return;
-  }
+  /* Advance and persist the branch through the atomic ref-mutation helper:
+  ** it force-refreshes under the graph lock before serializing the whole
+  ** refs blob (the lock-time size heuristic can miss a peer commit, and a
+  ** stale view here would clobber the peer's ref change), CAS-checks the
+  ** branch's authoritative on-disk tip against the one the fast-forward
+  ** was computed from, and restores the refs snapshot on failure. */
   {
-    ProllyHash diskTip;
-    int found = 0;
-    rc = chunkStoreReadDiskBranchTip(cs, zBranch, &diskTip, &found);
-    if( rc==SQLITE_OK && found && prollyHashCompare(&diskTip, &localCommit)!=0 ){
-      rc = SQLITE_BUSY;
-    }
+    DoltliteBranchExpectation exp;
+    PullAdvanceCtx adv;
+    exp.zBranch = zBranch;
+    exp.pTip = &localCommit;
+    adv.zBranch = zBranch;
+    adv.newTip = trackingCommit;
+    adv.isCreate = 0;
+    rc = doltliteMutateRefsExpected(db, &exp, 1, mutatePullAdvance, &adv);
   }
-  if( rc==SQLITE_OK ) rc = chunkStoreUpdateBranch(cs, zBranch, &trackingCommit);
-  if( rc==SQLITE_OK ) rc = doltliteRemotePersistRefs(cs);
-  chunkStoreUnlock(cs);
   if( rc!=SQLITE_OK ){
     if( rc==SQLITE_BUSY ){
       doltliteCmdResultPeerBranchBusy(ctx, "pull");

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -1844,6 +1844,80 @@ static void run_pull_persist_failure(void){
   removeDbFiles(remoteClientPath);
 }
 
+/* Pulling a branch that does not exist locally used to add it to the
+** in-memory refs outside the graph lock and never serialize it: the
+** branch answered queries for the rest of the session and silently
+** vanished on reopen (a later unrelated ref write could also clobber or
+** accidentally persist it). The create must go through the atomic
+** ref-mutation helper like every other ref write. */
+static void run_pull_new_branch_persists(void){
+  sqlite3 *localDb = 0;
+  sqlite3 *remoteDb = 0;
+  sqlite3 *remoteClientDb = 0;
+  char localPath[256];
+  char remotePath[256];
+  char remoteClientPath[256];
+  char sql[1024];
+  const char *res;
+
+  printf("=== Pull New Branch Persists Test ===\n\n");
+  make_dbpath(localPath, sizeof(localPath), "test_pull_new_branch_local");
+  make_dbpath(remotePath, sizeof(remotePath), "test_pull_new_branch_remote");
+  make_dbpath(remoteClientPath, sizeof(remoteClientPath),
+              "test_pull_new_branch_client");
+  removeDbFiles(localPath);
+  removeDbFiles(remotePath);
+  removeDbFiles(remoteClientPath);
+
+  check("open_local_db", open_db(localPath, &localDb)==SQLITE_OK);
+  check("open_remote_db", open_db(remotePath, &remoteDb)==SQLITE_OK);
+
+  snprintf(sql, sizeof(sql),
+    "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
+    "INSERT INTO t VALUES(1,'a');"
+    "SELECT dolt_commit('-A', '-m', 'init');"
+    "SELECT dolt_remote('add','origin','file://%s');"
+    "SELECT dolt_push('origin','main','--force');",
+    remotePath);
+  check("setup_local_and_push", execSql(localDb, sql)==SQLITE_OK);
+
+  check("open_remote_client_db",
+        open_db(remoteClientPath, &remoteClientDb)==SQLITE_OK);
+  snprintf(sql, sizeof(sql), "SELECT dolt_clone('file://%s')", remotePath);
+  check("clone_remote_into_client", execSql(remoteClientDb, sql)==SQLITE_OK);
+  check("client_creates_feature", execSql(remoteClientDb,
+    "SELECT dolt_branch('feature');"
+    "SELECT dolt_checkout('feature');"
+    "INSERT INTO t VALUES(2,'b');"
+    "SELECT dolt_add('-A');"
+    "SELECT dolt_commit('-m','feature work');"
+    "SELECT dolt_push('origin','feature');")==SQLITE_OK);
+
+  res = queryScalarText(localDb, "SELECT dolt_pull('origin','feature')");
+  check("pull_new_branch_succeeds", strstr(res, "ERROR:")==0);
+  check("pulled_branch_visible_in_session",
+    strcmp(queryScalarText(localDb,
+      "SELECT count(*) FROM dolt_branches WHERE name='feature'"), "1")==0);
+
+  sqlite3_close(localDb);
+  localDb = 0;
+  check("reopen_local_after_pull", open_db(localPath, &localDb)==SQLITE_OK);
+  check("pulled_branch_persisted_across_reopen",
+    strcmp(queryScalarText(localDb,
+      "SELECT count(*) FROM dolt_branches WHERE name='feature'"), "1")==0);
+  check("pulled_branch_checkout_works", execSql(localDb,
+    "SELECT dolt_checkout('feature')")==SQLITE_OK);
+  check("pulled_branch_rows_present",
+    strcmp(queryScalarText(localDb, "SELECT count(*) FROM t"), "2")==0);
+
+  sqlite3_close(remoteClientDb);
+  sqlite3_close(remoteDb);
+  sqlite3_close(localDb);
+  removeDbFiles(localPath);
+  removeDbFiles(remotePath);
+  removeDbFiles(remoteClientPath);
+}
+
 static void run_pull_dirty_working_set_fails(void){
   sqlite3 *localDb = 0;
   sqlite3 *remoteDb = 0;
@@ -8887,6 +8961,7 @@ static const RegressionCase aCases[] = {
   { "ancestor_missing_start", "Ancestor Missing Start Test", run_ancestor_missing_start },
   { "pull_persist_failure", "Pull Persist Failure Test", run_pull_persist_failure },
   { "push_persist_failure", "Push Persist Failure Test", run_push_persist_failure },
+  { "pull_new_branch_persists", "Pull New Branch Persists Test", run_pull_new_branch_persists },
   { "pull_dirty_working_set_fails", "Pull Dirty Working Set Fails Test", run_pull_dirty_working_set_fails },
   { "pull_staged_changes_fails", "Pull Staged Changes Fails Test", run_pull_staged_changes_fails },
   { "push_persist_failure", "Push Persist Failure Test", run_push_persist_failure },


### PR DESCRIPTION
## Problem

`dolt_pull` wrote refs through two hand-rolled paths that predate `doltliteMutateRefsExpected` (src/doltlite_remote_sql.c):

1. **Creating a missing local branch** called `chunkStoreAddBranch` on the in-memory refs *outside the graph lock* and never serialized them. The pulled branch answered queries for the rest of the session and **silently vanished on reopen**; any later ref write would either clobber it (the lock-time force-refresh reloads persisted refs) or accidentally persist it as a side effect.
2. **The fast-forward advance** took `chunkStoreLockAndRefresh` (heuristic refresh only) before rewriting the whole refs blob, with a hand-rolled disk-tip CAS and no rollback of in-memory refs on failure. `doltliteMutateRefsExpected`'s own comment documents why whole-refs serializers must force-refresh under the lock: the size heuristic can miss a peer commit, and a stale view drops the peer's concurrent ref change. Pull was the last whole-refs writer not using the helper.

## Fix

Both writes go through `doltliteMutateRefsExpected`: force-refresh under the lock, authoritative disk-tip expectation (branch still at the fast-forward base; must-not-exist for the create), refs-snapshot rollback on failure, and serialize+commit in one place. The BUSY-on-stale-tip surface is preserved (`peer branch busy`), and the create path now reports BUSY if a peer created the same branch concurrently.

## Test

New regression case `pull_new_branch_persists`: a remote client pushes a `feature` branch; the local database pulls it (branch absent locally), is closed, and reopened.

Fail-before/pass-after:
- unfixed: `FAIL: pulled_branch_persisted_across_reopen` (branch visible in the pulling session, gone after reopen — 11/12)
- fixed: 12/12, and the pulled branch checks out with its data

The force-refresh half of the change has no deterministic single-process repro (the lost-update window needs a peer commit the size heuristic misses, between fetch's unlock and the advance's lock); it is the same invariant the helper enforces for every other ref writer, now including this one.

## Local validation

- `doltlite_regression_test_c`: 310,033/310,033 (includes the new case)
- `test/run_c_tests.sh` coverage set: 16/16
- `test/run_doltlite_tests.sh` shell battery: 90/90 suites (includes pull/remote oracle suites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)