### PR TITLE
Update pull_reconfirm contract evidence for the atomic ref helper

### DIFF
--- a/test/concurrency_contract.tsv
+++ b/test/concurrency_contract.tsv
@@ -13,7 +13,7 @@ process.forked_writers	adapted	test/multi_process_test.c#mp_commit_final_rows,te
 vc.merge_reconfirm	adapted	src/doltlite_merge_cmd.c#doltliteRefreshAndConfirmHead,test/multi_process_merge_rebase_test.c#merge_race_feat_rows_present	Merge re-confirms its planned HEAD under the graph lock before advancing the branch
 vc.cherry_pick_reconfirm	adapted	src/doltlite_cherry_pick.c#doltliteRefreshAndConfirmHead	Cherry-pick re-confirms its planned HEAD under the graph lock before advancing the branch
 vc.revert_reconfirm	adapted	src/doltlite_revert.c#applyMergedCatalogAndCommit,src/doltlite_cherry_pick.c#doltliteCompareAndAdvanceBranch	Revert advances its planned result through the locked compare-and-advance path
-vc.pull_reconfirm	adapted	src/doltlite_remote_sql.c#chunkStoreReadDiskBranchTip	Pull re-reads and compares the on-disk branch tip while holding the graph lock
+vc.pull_reconfirm	adapted	src/doltlite_remote_sql.c#doltliteMutateRefsExpected,src/doltlite_core.c#chunkStoreReadDiskBranchTip	Pull re-reads and compares the on-disk branch tip while holding the graph lock
 vc.rebase_reconfirm	adapted	src/doltlite_rebase.c#doltliteMutateRefsExpected,test/doltlite_regression_test_c.c#rebase_rejects_concurrent_peer_commit	Rebase uses locked branch expectations and rejects a concurrent peer commit
 vc.peer_commit_rejected	adapted	test/concurrent_commit_test.c#commit_add_two_rejected,test/concurrent_commit_test.c#latest_commit_is_add_one	A second connection that commits without refreshing loses to the first tip and does not overwrite it
 gc.blocked_by_writer	adapted	test/multi_process_test.c#mp_gc_blocked,test/multi_process_gc_test.c#gc_blocked_first_attempt	GC reports busy or defers while a concurrent writer holds the graph lock


### PR DESCRIPTION
The concurrency contract (#1898) pinned `src/doltlite_remote_sql.c#chunkStoreReadDiskBranchTip` as evidence for `vc.pull_reconfirm`, and #1900 (merged after) replaced that inline call with `doltliteMutateRefsExpected` — so the selector is stale **on master** and every PR's merge-ref now fails `concurrency_contract_test.sh` in three jobs (Build-Test macos/windows, coverage-native-shell). This is what's currently blocking #1891.

The contract row itself is still true — pull re-reads and compares the on-disk branch tip under the graph lock — the evidence now points at the `doltliteMutateRefsExpected` call in the pull path plus the `chunkStoreReadDiskBranchTip` expectation check inside the helper (`src/doltlite_core.c`).

Local: `concurrency_contract_test.sh` 6/6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)