### PR TITLE
storage: bind root seals to file offsets

### DIFF
--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -146,16 +146,27 @@ void csSerializeManifest(const ChunkStore *cs, u8 *aBuf){
   memcpy(aBuf + CS_MANIFEST_REFS_HASH_OFF, cs->refs.refsHash.data, PROLLY_HASH_SIZE);
 }
 
-void csManifestSeal(u8 *aBuf){
+static void csManifestHashOffset(blake3_hasher *pHasher, i64 iOffset){
+  u8 aOffset[8];
+  CS_WRITE_I64(aOffset, iOffset);
+  blake3_hasher_update(pHasher, aOffset, sizeof(aOffset));
+}
+
+void csManifestSeal(u8 *aBuf, i64 iOffset){
   blake3_hasher hasher;
   memset(aBuf + CS_MANIFEST_SELF_HASH_OFF, 0, PROLLY_HASH_SIZE);
   blake3_hasher_init(&hasher);
   blake3_hasher_update(&hasher, aBuf, CHUNK_MANIFEST_SIZE);
+  csManifestHashOffset(&hasher, iOffset);
   blake3_hasher_finalize(&hasher, aBuf + CS_MANIFEST_SELF_HASH_OFF,
                          PROLLY_HASH_SIZE);
 }
 
-int csManifestHashState(const u8 *aBuf){
+static int csManifestHashStateImpl(
+  const u8 *aBuf,
+  i64 iOffset,
+  int bindOffset
+){
   blake3_hasher hasher;
   u8 aCopy[CHUNK_MANIFEST_SIZE];
   u8 aHash[PROLLY_HASH_SIZE];
@@ -168,9 +179,18 @@ int csManifestHashState(const u8 *aBuf){
   memset(aCopy + CS_MANIFEST_SELF_HASH_OFF, 0, PROLLY_HASH_SIZE);
   blake3_hasher_init(&hasher);
   blake3_hasher_update(&hasher, aCopy, CHUNK_MANIFEST_SIZE);
+  if( bindOffset ) csManifestHashOffset(&hasher, iOffset);
   blake3_hasher_finalize(&hasher, aHash, PROLLY_HASH_SIZE);
   return memcmp(aHash, aBuf + CS_MANIFEST_SELF_HASH_OFF, PROLLY_HASH_SIZE)==0
        ? CS_MANIFEST_HASH_OK : CS_MANIFEST_HASH_BAD;
+}
+
+int csManifestHashState(const u8 *aBuf, i64 iOffset){
+  return csManifestHashStateImpl(aBuf, iOffset, 1);
+}
+
+int csManifestHashStateOffsetless(const u8 *aBuf){
+  return csManifestHashStateImpl(aBuf, 0, 0);
 }
 
 static int csReadManifest(ChunkStore *cs){
@@ -232,11 +252,7 @@ static int csScanForCommittedRoot(ChunkStore *cs, int *pEverCommitted,
         if( q + i + 1 + CHUNK_MANIFEST_SIZE > fileSize ) continue;
         rc = sqlite3OsRead(cs->file.pFile, m, CHUNK_MANIFEST_SIZE, q + i + 1);
         if( rc != SQLITE_OK ) return rc;
-        state = csManifestHashState(m);
-        if( state==CS_MANIFEST_HASH_LEGACY ){
-          *pEverCommitted = 1;
-          return SQLITE_OK;
-        }
+        state = csManifestHashState(m, q + i);
         if( state==CS_MANIFEST_HASH_OK ){
           if( CS_READ_I64(m + CS_MANIFEST_DURABLE_TO_OFF) > CHUNK_MANIFEST_SIZE ){
             *pEverCommitted = 1;
@@ -590,7 +606,7 @@ static void csWriteCleanCloseMarker(ChunkStore *cs){
   CS_WRITE_I64(rootRec + 1 + CS_MANIFEST_DURABLE_TO_OFF, markerStart);
   CS_WRITE_I64(rootRec + 1 + CS_MANIFEST_NEXT_OFF_OFF, markerNext);
   CS_WRITE_I64(rootRec + 1 + CS_MANIFEST_BATCH_START_OFF, markerStart);
-  csManifestSeal(rootRec + 1);
+  csManifestSeal(rootRec + 1, markerStart);
 
   rc = sqlite3OsWrite(cs->file.pFile, rootRec, sizeof(rootRec), markerStart);
   if( rc==SQLITE_OK ){
@@ -933,7 +949,7 @@ static int csDrainPendingToWal(ChunkStore *cs){
     u8 manifest[CHUNK_MANIFEST_SIZE];
     cs->wal.iWalOffset = CHUNK_MANIFEST_SIZE;
     csSerializeManifest(cs, manifest);
-    csManifestSeal(manifest);
+    csManifestSeal(manifest, 0);
     rc = sqlite3OsWrite(cs->file.pFile, manifest, CHUNK_MANIFEST_SIZE, 0);
     if( rc!=SQLITE_OK ) return rc;
     writeOff = CHUNK_MANIFEST_SIZE;

--- a/src/chunk_store.h
+++ b/src/chunk_store.h
@@ -71,8 +71,9 @@
 **     between are an unwritten gap that replay resumes across.
 **   NEXT_OFF: absolute offset where the writer puts the next batch (the
 **     sector-aligned end of this one). Replay skips the gap unread.
-**   SELF_HASH: hash of the manifest with this field zeroed. A root whose
-**     stored hash is nonzero and wrong is damage, not a commit point. */
+**   SELF_HASH: hash of the manifest with this field zeroed, followed by the
+**     root record's absolute file offset. A root whose stored hash is nonzero
+**     and wrong is damage, not a commit point. */
 #define CS_MANIFEST_DURABLE_TO_OFF   44
 #define CS_MANIFEST_NEXT_OFF_OFF     52
 #define CS_MANIFEST_BATCH_START_OFF  60
@@ -198,8 +199,8 @@ struct ChunkStore {
   int checkpointActive;
 };
 
-void csManifestSeal(u8 *aBuf);
-int csManifestHashState(const u8 *aBuf);
+void csManifestSeal(u8 *aBuf, i64 iOffset);
+int csManifestHashState(const u8 *aBuf, i64 iOffset);
 
 int chunkStoreOpen(ChunkStore *cs, sqlite3_vfs *pVfs,
                    const char *zFilename, int flags);

--- a/src/chunk_store_commit.c
+++ b/src/chunk_store_commit.c
@@ -393,7 +393,7 @@ static int csCommitToFile(ChunkStore *cs){
     u8 manifest[CHUNK_MANIFEST_SIZE];
     cs->wal.iWalOffset = CHUNK_MANIFEST_SIZE;
     csSerializeManifest(cs, manifest);
-    csManifestSeal(manifest);
+    csManifestSeal(manifest, 0);
     CRASH_CHECK_WRITE();
     rc = sqlite3OsWrite(cs->file.pFile, manifest, CHUNK_MANIFEST_SIZE, 0);
     if( rc != SQLITE_OK ) goto commit_done;
@@ -502,7 +502,7 @@ static int csCommitToFile(ChunkStore *cs){
     CS_WRITE_I64(rootRec + 1 + CS_MANIFEST_DURABLE_TO_OFF, durableTo);
     CS_WRITE_I64(rootRec + 1 + CS_MANIFEST_NEXT_OFF_OFF, nextOff);
     CS_WRITE_I64(rootRec + 1 + CS_MANIFEST_BATCH_START_OFF, batchStart);
-    csManifestSeal(rootRec + 1);
+    csManifestSeal(rootRec + 1, writeOff);
     CRASH_CHECK_WRITE();
     rc = sqlite3OsWrite(cs->file.pFile, rootRec, sizeof(rootRec), writeOff);
     if( rc != SQLITE_OK ) goto commit_done;

--- a/src/chunk_store_int.h
+++ b/src/chunk_store_int.h
@@ -37,5 +37,6 @@ int csOpenFile(sqlite3_vfs *pVfs, const char *zPath, sqlite3_file **ppFile,
 int csSyncFile(ChunkStore *cs);
 void csFillChunkHdr(u8 *p, const ProllyHash *pHash, u32 size);
 void csSerializeManifest(const ChunkStore *cs, u8 *aBuf);
+int csManifestHashStateOffsetless(const u8 *aBuf);
 
 #endif /* CHUNK_STORE_INT_H */

--- a/src/chunk_store_refs_api.c
+++ b/src/chunk_store_refs_api.c
@@ -53,6 +53,7 @@ int chunkStoreFindBranch(ChunkStore *cs, const char *zName, ProllyHash *pCommit)
 ** size-coincident rewrite, force the slow path). */
 int csDiskStateMatchesMemory(ChunkStore *cs){
   int bMoved = 0;
+  int hashState;
   i64 contentEnd;
   i64 physSize = 0;
   u8 aRoot[1 + CHUNK_MANIFEST_SIZE];
@@ -71,8 +72,13 @@ int csDiskStateMatchesMemory(ChunkStore *cs){
                     contentEnd - (i64)sizeof(aRoot))!=SQLITE_OK ){
     return 0;
   }
+  hashState = csManifestHashState(aRoot+1,
+                                  contentEnd - (i64)sizeof(aRoot));
+  if( hashState==CS_MANIFEST_HASH_BAD ){
+    hashState = csManifestHashStateOffsetless(aRoot+1);
+  }
   return aRoot[0]==CS_WAL_TAG_ROOT
-      && csManifestHashState(aRoot+1)==CS_MANIFEST_HASH_OK
+      && hashState==CS_MANIFEST_HASH_OK
       && memcmp(aRoot + 1 + CS_MANIFEST_REFS_HASH_OFF,
                 cs->refs.refsHash.data, PROLLY_HASH_SIZE)==0;
 }

--- a/src/chunk_wal.c
+++ b/src/chunk_wal.c
@@ -3,6 +3,7 @@
 
 #include "chunk_wal.h"
 #include "chunk_store.h"
+#include "chunk_store_int.h"
 #include "chunk_staging.h"
 #include "chunk_file.h"
 #include "../ext/blake3/blake3.h"
@@ -192,7 +193,7 @@ static int csWalResolveDamage(
         rc = sqlite3OsRead(cs->file.pFile, m, CHUNK_MANIFEST_SIZE,
                            cs->wal.iWalOffset + cand + 1);
         if( rc != SQLITE_OK ) return rc;
-        state = csManifestHashState(m);
+        state = csManifestHashState(m, cs->wal.iWalOffset + cand);
         if( state==CS_MANIFEST_HASH_OK ){
           i64 durableTo = CS_READ_I64(m + CS_MANIFEST_DURABLE_TO_OFF);
           i64 batchStart = CS_READ_I64(m + CS_MANIFEST_BATCH_START_OFF);
@@ -207,11 +208,6 @@ static int csWalResolveDamage(
             return SQLITE_OK;
           }
           /* A root of the damaged batch itself; keep scanning. */
-        }else if( state==CS_MANIFEST_HASH_LEGACY
-               && cand + 1 + CHUNK_MANIFEST_SIZE < walSize ){
-          cs->wal.recoveredMidStream = 1;
-          *pAction = CS_DAMAGE_MIDSTREAM;
-          return SQLITE_OK;
         }
       }
     }
@@ -385,7 +381,13 @@ int csReplayWal(ChunkStore *cs){
                          CHUNK_MANIFEST_SIZE - (CS_WAL_CHUNK_HDR_SIZE - 1),
                          cs->wal.iWalOffset + pos);
       if( rc != SQLITE_OK ) goto replay_error;
-      hashState = csManifestHashState(m);
+      hashState = csManifestHashState(m, cs->wal.iWalOffset + recPos);
+      /* Offsetless v12 seals are safe only at a sequentially parsed boundary;
+      ** damage scans must require an offset-bound seal. */
+      if( hashState==CS_MANIFEST_HASH_BAD
+       && csManifestHashStateOffsetless(m)==CS_MANIFEST_HASH_OK ){
+        hashState = CS_MANIFEST_HASH_OK;
+      }
       if( CS_READ_U32(m) != CHUNK_STORE_MAGIC
        || hashState == CS_MANIFEST_HASH_BAD ){
         sqlite3_log(SQLITE_NOTICE,

--- a/src/doltlite_gc.c
+++ b/src/doltlite_gc.c
@@ -641,7 +641,7 @@ static int gcRewriteFile(
                         CHUNK_MANIFEST_SIZE + nDataBytes, indexSize);
   walStateSetOffset(&manifestCs.wal, finalSize);
   csSerializeManifest(&manifestCs, manifest);
-  csManifestSeal(manifest);
+  csManifestSeal(manifest, 0);
 
   {
     i64 nEntries = kept ? (i64)kept : 1;

--- a/test/corruption_test.c
+++ b/test/corruption_test.c
@@ -1069,6 +1069,23 @@ static void test_damage_far_before_sealing_root_poisons(void){
   removeDb(dbpath);
 }
 
+static void test_root_seal_binds_file_offset(void){
+  unsigned char manifest[CHUNK_MANIFEST_SIZE];
+  const long long rootOffset = 4096;
+
+  printf("--- Test 25: Root seal binds file offset ---\n");
+
+  memset(manifest, 0, sizeof(manifest));
+  CS_WRITE_U32(manifest + CS_MANIFEST_MAGIC_OFF, CHUNK_STORE_MAGIC);
+  CS_WRITE_U32(manifest + CS_MANIFEST_VERSION_OFF, CHUNK_STORE_VERSION);
+  csManifestSeal(manifest, rootOffset);
+
+  check("root_seal_valid_at_record_offset",
+        csManifestHashState(manifest, rootOffset)==CS_MANIFEST_HASH_OK);
+  check("root_seal_rejects_root_shaped_blob",
+        csManifestHashState(manifest, rootOffset + 1)==CS_MANIFEST_HASH_BAD);
+}
+
 int main(void){
   printf("=== DoltLite Corruption Detection Tests ===\n\n");
 
@@ -1095,6 +1112,7 @@ int main(void){
   test_corrupt_index_order();
   test_damage_far_before_sealing_root_poisons();
   test_crash_garbage_truncated_on_write();
+  test_root_seal_binds_file_offset();
 
   printf("\n=== Results: %d passed, %d failed out of %d tests ===\n",
     nPass, nFail, nPass+nFail);


### PR DESCRIPTION
## Summary

- include each root record’s absolute file offset in its self-seal
- accept existing offsetless version-12 seals only at sequentially parsed WAL boundaries and the already-known physical tail root
- require offset-bound seals during arbitrary damage scans so root-shaped user bytes cannot steer recovery classification
- preserve the disk-state fast path for version-12 databases written by earlier releases

## Tests

- `build/corruption_test` (106 passed)
- `DOLTLITE_COMPAT_TAGS=v0.11.39 bash test/doltlite_compat_test.sh build/doltlite` (7 passed)
- paired `test/vc_perf_ceiling.sh`: clean status 1.031x, dirty status 1.004x, checkout 1.015x vs master
- `make lint`

Co-Authored-By: OpenAI Codex <noreply@openai.com>