### PR TITLE
Gate history-growth scaling in PR CI

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -210,6 +210,17 @@ jobs:
       run: cd build && bash ../test/large_scale_test.sh ./doltlite --quick
       timeout-minutes: 5
 
+    - name: Growth-axis scaling gates
+      if: matrix.platform != 'windows'
+      # Ratio gates: per-operation cost vs history size (multi-writer
+      # refresh, open latency, commit depth). Ratios, not absolute times,
+      # so runner load moves both sides of each gate.
+      run: |
+        cd build
+        make libdoltlite.a
+        bash ../test/growth_axis_test.sh . --quick
+      timeout-minutes: 10
+
     - name: Chunk size distribution
       if: matrix.platform != 'windows'
       run: cd build && bash ../test/chunk_distribution_test.sh ./doltlite

--- a/test/growth_axis_driver.c
+++ b/test/growth_axis_driver.c
@@ -1,0 +1,210 @@
+/* Growth-axis benchmark driver: measures how per-operation cost scales
+** with history size and gates the growth RATIO rather than absolute wall
+** time, so runner load shifts both sides of each ratio and the gates stay
+** meaningful on shared CI hosts.
+**
+**   A. multi-writer refresh: two connections on separate branches
+**      alternate single-row commits after a seeded history; each commit
+**      makes the peer's next refresh see a grown file. Cost must not
+**      scale with the seeded WAL (the incremental tail replay axis).
+**   B. open latency: fresh open + first query against the same seeded
+**      histories. Replay is linear in WAL today, so linear growth is
+**      tolerated and superlinear growth fails; after dolt_gc the WAL is
+**      gone and open must not be slower than the pre-gc open.
+**   C. commit depth: one connection makes a long chain of single-row
+**      commits; the last window must not cost more than the first.
+**
+** Usage: growth_axis_driver DIR SEED ROUNDS DEPTH
+** Gate thresholds are fixed here so CI and local runs agree.
+*/
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/time.h>
+#include "sqlite3.h"
+
+#define RATIO_A_MAX 3.0   /* refresh cost vs 5x seeded history */
+#define RATIO_B_MAX 12.0  /* open cost vs 5x seeded history (linear ~5x) */
+#define RATIO_B_GC_MAX 1.5 /* post-gc open vs pre-gc open */
+#define RATIO_C_MAX 3.0   /* late commits vs early commits */
+
+static int nPass = 0;
+static int nFail = 0;
+
+static void gate(const char *name, double ratio, double max){
+  if( ratio <= max ){
+    printf("  PASS: %s ratio %.2f <= %.2f\n", name, ratio, max);
+    nPass++;
+  }else{
+    printf("  FAIL: %s ratio %.2f > %.2f\n", name, ratio, max);
+    nFail++;
+  }
+}
+
+static double now_ms(void){
+  struct timeval tv;
+  gettimeofday(&tv, 0);
+  return tv.tv_sec*1000.0 + tv.tv_usec/1000.0;
+}
+
+static void die(const char *what, const char *detail){
+  fprintf(stderr, "FATAL %s: %s\n", what, detail ? detail : "");
+  exit(2);
+}
+
+static void x(sqlite3 *db, const char *sql){
+  char *err = 0;
+  if( sqlite3_exec(db, sql, 0, 0, &err)!=SQLITE_OK ){
+    fprintf(stderr, "SQL failed: %s\n", err ? err : "?");
+    die("exec", sql);
+  }
+}
+
+static sqlite3 *openDb(const char *path){
+  sqlite3 *db = 0;
+  if( sqlite3_open(path, &db)!=SQLITE_OK ) die("open", path);
+  sqlite3_busy_timeout(db, 30000);
+  return db;
+}
+
+static void seedDb(const char *path, int nRows){
+  sqlite3 *db = openDb(path);
+  char sql[256];
+  x(db, "SELECT dolt_config('user.name','growth'),"
+        "dolt_config('user.email','g@e.com')");
+  x(db, "CREATE TABLE t(id INTEGER PRIMARY KEY, v BLOB)");
+  x(db, "BEGIN");
+  snprintf(sql, sizeof(sql),
+    "WITH RECURSIVE c(x) AS (SELECT 1 UNION ALL SELECT x+1 FROM c WHERE x<%d) "
+    "INSERT INTO t SELECT x, randomblob(200) FROM c", nRows);
+  x(db, sql);
+  x(db, "COMMIT");
+  x(db, "SELECT dolt_commit('-Am','seed')");
+  x(db, "SELECT dolt_branch('side')");
+  sqlite3_close(db);
+}
+
+/* ms per commit for two connections alternating on separate branches. */
+static double alternatingCost(const char *path, int seedRows, int nRounds){
+  sqlite3 *a = openDb(path);
+  sqlite3 *b = openDb(path);
+  char sql[256];
+  double t0;
+  int i;
+  x(b, "SELECT dolt_checkout('side')");
+  t0 = now_ms();
+  for(i=0; i<nRounds; i++){
+    snprintf(sql, sizeof(sql),
+      "INSERT INTO t VALUES(%d, randomblob(64));"
+      "SELECT dolt_commit('-Am','a%d');", seedRows+1+i*2, i);
+    x(a, sql);
+    snprintf(sql, sizeof(sql),
+      "INSERT INTO t VALUES(%d, randomblob(64));"
+      "SELECT dolt_commit('-Am','b%d');", seedRows+2+i*2, i);
+    x(b, sql);
+  }
+  t0 = now_ms() - t0;
+  sqlite3_close(a);
+  sqlite3_close(b);
+  return t0 / (nRounds*2);
+}
+
+/* Fresh open + first query, which forces the store open and replay. */
+static double openCost(const char *path){
+  double t0 = now_ms();
+  sqlite3 *db = openDb(path);
+  sqlite3_stmt *stmt = 0;
+  if( sqlite3_prepare_v2(db, "SELECT count(*) FROM t", -1, &stmt, 0)
+      !=SQLITE_OK ) die("prepare", sqlite3_errmsg(db));
+  if( sqlite3_step(stmt)!=SQLITE_ROW ) die("step", sqlite3_errmsg(db));
+  sqlite3_finalize(stmt);
+  t0 = now_ms() - t0;
+  sqlite3_close(db);
+  return t0;
+}
+
+/* Median-of-3 to keep one cold-cache or scheduler blip from gating. */
+static double openCost3(const char *path){
+  double a = openCost(path);
+  double b = openCost(path);
+  double c = openCost(path);
+  if( (a<=b && b<=c) || (c<=b && b<=a) ) return b;
+  if( (b<=a && a<=c) || (c<=a && a<=b) ) return a;
+  return c;
+}
+
+static double commitWindow(sqlite3 *db, int idFrom, int n){
+  char sql[256];
+  double t0 = now_ms();
+  int i;
+  for(i=0; i<n; i++){
+    snprintf(sql, sizeof(sql),
+      "INSERT INTO t VALUES(%d, randomblob(64));"
+      "SELECT dolt_commit('-Am','d%d');", idFrom+i, idFrom+i);
+    x(db, sql);
+  }
+  return (now_ms() - t0) / n;
+}
+
+int main(int argc, char **argv){
+  const char *dir = argc>1 ? argv[1] : "/tmp";
+  int seed = argc>2 ? atoi(argv[2]) : 200000;
+  int rounds = argc>3 ? atoi(argv[3]) : 40;
+  int depth = argc>4 ? atoi(argv[4]) : 1000;
+  char small[512], large[512], deep[512], sql[600];
+  double aS, aL, oS, oL, oGc, cEarly, cLate;
+  int window = depth/5;
+  sqlite3 *db;
+
+  snprintf(small, sizeof(small), "%s/growth_small.db", dir);
+  snprintf(large, sizeof(large), "%s/growth_large.db", dir);
+  snprintf(deep, sizeof(deep), "%s/growth_deep.db", dir);
+  remove(small); remove(large); remove(deep);
+  snprintf(sql, sizeof(sql), "%s/.growth_small.db-lock", dir); remove(sql);
+  snprintf(sql, sizeof(sql), "%s/.growth_large.db-lock", dir); remove(sql);
+  snprintf(sql, sizeof(sql), "%s/.growth_deep.db-lock", dir); remove(sql);
+
+  printf("=== Growth-axis benchmarks (seed=%d rounds=%d depth=%d) ===\n\n",
+         seed, rounds, depth);
+
+  seedDb(small, seed);
+  seedDb(large, seed*5);
+
+  /* A: multi-writer refresh */
+  aS = alternatingCost(small, seed, rounds);
+  aL = alternatingCost(large, seed*5, rounds);
+  printf("A multi-writer refresh: %.1f ms/commit @%d rows, "
+         "%.1f ms/commit @%d rows\n", aS, seed, aL, seed*5);
+  gate("refresh_cost_flat_vs_history", aL/(aS>0.05?aS:0.05), RATIO_A_MAX);
+
+  /* B: open latency, pre- and post-gc (on the large db) */
+  oS = openCost3(small);
+  oL = openCost3(large);
+  printf("B open+first-query: %.1f ms @%d rows, %.1f ms @%d rows\n",
+         oS, seed, oL, seed*5);
+  gate("open_cost_at_most_linear", oL/(oS>0.5?oS:0.5), RATIO_B_MAX);
+  db = openDb(large);
+  x(db, "SELECT dolt_gc()");
+  sqlite3_close(db);
+  oGc = openCost3(large);
+  printf("B open after gc: %.1f ms (pre-gc %.1f ms)\n", oGc, oL);
+  gate("open_after_gc_not_slower", oGc/(oL>0.5?oL:0.5), RATIO_B_GC_MAX);
+
+  /* C: commit latency vs history depth (single connection, no gc) */
+  seedDb(deep, 1000);
+  db = openDb(deep);
+  cEarly = commitWindow(db, 2000, window);
+  commitWindow(db, 4000, depth - 2*window);
+  cLate = commitWindow(db, 4000+depth, window);
+  sqlite3_close(db);
+  printf("C commit depth: %.1f ms/commit early, %.1f ms/commit late "
+         "(%d deep)\n", cEarly, cLate, depth);
+  gate("commit_cost_flat_vs_depth", cLate/(cEarly>0.05?cEarly:0.05),
+       RATIO_C_MAX);
+
+  remove(small); remove(large); remove(deep);
+
+  printf("\nResults: %d passed, %d failed out of %d gates\n",
+         nPass, nFail, nPass+nFail);
+  return nFail>0 ? 1 : 0;
+}

--- a/test/growth_axis_test.sh
+++ b/test/growth_axis_test.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Growth-axis benchmark gates: how per-operation cost scales with history
+# size (multi-writer refresh, open latency, commit depth). Gates are growth
+# RATIOS, not absolute times, so shared-runner load does not flake them.
+# See test/growth_axis_driver.c for the axes and thresholds.
+#
+# Usage: growth_axis_test.sh [build-dir] [--quick]
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+BUILD_DIR="${1:-$REPO_ROOT/build}"
+
+SEED=200000
+ROUNDS=40
+DEPTH=1000
+if [ "${2:-}" = "--quick" ]; then
+  SEED=20000
+  ROUNDS=25
+  DEPTH=250
+fi
+
+if [ ! -f "$BUILD_DIR/libdoltlite.a" ]; then
+  echo "ERROR: $BUILD_DIR/libdoltlite.a not found (make libdoltlite.a first)"
+  exit 2
+fi
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+link_libs=(-lz -lpthread -lm)
+case "$(uname -s 2>/dev/null || echo unknown)" in
+  MINGW*|MSYS*|CYGWIN*) link_libs+=(-lws2_32 -lbcrypt -lcrypt32) ;;
+esac
+
+"${CC:-cc}" ${CFLAGS:-"-O2"} -I"$BUILD_DIR" -I"$REPO_ROOT/src" \
+  -o "$TMP/growth_axis_driver" "$SCRIPT_DIR/growth_axis_driver.c" \
+  "$BUILD_DIR/libdoltlite.a" ${LDFLAGS:-} "${link_libs[@]}" || exit 2
+
+"$TMP/growth_axis_driver" "$TMP" "$SEED" "$ROUNDS" "$DEPTH"


### PR DESCRIPTION
## Why

Perf CI measures steady state only (sysbench ratios, absolute wall-clock ceilings). The store's real exposure is the **scaling axis** — how per-operation cost grows with history since the last gc — and nothing gates it. #1904 just improved that axis by ~355×; without a gate the next refactor could quietly give it back.

## What

`test/growth_axis_test.sh` compiles `test/growth_axis_driver.c` against `libdoltlite.a` and gates three growth **ratios** between a seeded history and 5× that history. Runs in the Build-Test job (macos + ubuntu) right next to the quick large-scale test — the quick profile is a few seconds of work. Ratios rather than absolute times, so runner load moves both sides of each gate and it shouldn't flake the way absolute perf ceilings do.

| axis | gate | pre-#1904 | post-#1904 |
|---|---|---|---|
| A: multi-writer refresh (alternating commits, two connections) | ≤ 3× | **4.4× FAIL** | 1.0–1.3× |
| B: open + first query | ≤ 12× (linear tolerated, superlinear fails) | ~4.9× | ~4.9× |
| B': open after `dolt_gc` vs before | ≤ 1.5× | ~0.01× | ~0.01× |
| C: commit cost, last window of a deep chain vs first | ≤ 3× | ~1.0× | ~1.0× |

Axis B intentionally tolerates linear growth — open replays the whole WAL by design today. When the clean-open fast path (review item 3.2) lands, that gate should tighten to flat.

Local repro: `bash test/growth_axis_test.sh build --quick` (or no `--quick` for the 1M-row profile, ~5s).

## Ordering

**Merge #1904 first.** Axis A is calibrated to the tail-replay engine and correctly fails on current master (that's the fail-before evidence above, verified against both builds locally) — including this PR's own Build-Test run until #1904 is in; I'll rerun CI here once it merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)