### PR TITLE
docs: trim README and fix outdated claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,18 +6,15 @@
 
 A SQLite fork that replaces the B-tree storage engine with a content-addressed
 [prolly tree](https://docs.dolthub.com/architecture/storage-engine/prolly-tree),
-enabling Git-like version control on a SQL database. SQLite's `btree.h`
-interface is the architectural seam: the parser, query planner, and VDBE remain
-upstream-derived and are kept close to upstream, while a DoltLite-format
-primary database replaces SQLite's B-tree, pager, and on-disk format with a
-prolly-tree engine backed by a single-file, content-addressed chunk store.
+giving Git-like version control on a SQL database. The parser, planner, and
+VDBE stay upstream-derived above SQLite's `btree.h` seam; below it, a
+single-file chunk store backs prolly trees instead of SQLite pages.
 
-[Why DoltLite?](https://www.dolthub.com/blog/2026-04-27-why-doltlite/) DoltLite
-can be embedded in any language enabling local-first use cases for [Dolt](https://github.com/dolthub/dolt/).
-
-You can read more about DoltLite, including its 
-[origin story](https://www.dolthub.com/blog/2026-03-24-a-week-in-gas-town/), 
-on the [DoltHub blog](https://www.dolthub.com/blog/?tags=doltlite).
+[Why DoltLite?](https://www.dolthub.com/blog/2026-04-27-why-doltlite/) Embeds
+in any language for local-first [Dolt](https://github.com/dolthub/dolt/) use
+cases. More on the
+[DoltHub blog](https://www.dolthub.com/blog/?tags=doltlite)
+([origin story](https://www.dolthub.com/blog/2026-03-24-a-week-in-gas-town/)).
 
 ## Install
 
@@ -26,7 +23,7 @@ Prebuilt binaries: [github.com/dolthub/doltlite/releases](https://github.com/dol
 Each install method places the same set of files (paths shown for `/usr/local`):
 
 - `bin/doltlite`, `bin/doltlite-remotesrv` — the CLI shell and remote sync server
-- `include/doltlite.h` — embedding header (the SQLite C API, under our name; `#include <doltlite.h>`)
+- `include/doltlite.h` — embedding header (`sqlite3_*` C API; `#include <doltlite.h>`)
 - `include/doltlite_remotesrv.h` — in-process remote server API
 - `lib/libdoltlite.a` — static library
 - `lib/libdoltlite.{so,dylib}` — shared library
@@ -107,101 +104,53 @@ make DOLTLITE_PROLLY=0 sqlite3
 
 ### WebAssembly (`ext/wasm`)
 
-Doltlite vendors SQLite's `ext/wasm` build and defaults it to the Doltlite
-engine path in this repo. Build the top-level generated SQLite files first,
-then build the wasm package:
+Vendored SQLite `ext/wasm`, defaulting to the Doltlite engine. Build generated
+SQLite sources first, then wasm:
 
 ```bash
 ./configure
 make sqlite3.c sqlite3.h sqlite3ext.h
 make -C ext/wasm
-```
-
-That produces the browser-consumable artifacts under
-[`ext/wasm/jswasm`](ext/wasm/jswasm), including:
-
-- `sqlite3.js`
-- `sqlite3.mjs`
-- `sqlite3.wasm`
-
-To build the upstream SQLite wasm path instead of Doltlite's split build:
-
-```bash
-make -C ext/wasm DOLTLITE_WASM=0
-```
-
-To package the generated wasm distribution as a zip:
-
-```bash
-make -C ext/wasm dist
+# → ext/wasm/jswasm/{sqlite3.js,sqlite3.mjs,sqlite3.wasm}
+make -C ext/wasm DOLTLITE_WASM=0   # upstream SQLite wasm instead
+make -C ext/wasm dist             # zip package
 ```
 
 ## Using as a C Library
 
-Doltlite exposes the bundled SQLite version's public C API declarations
-(`sqlite3_open`, `sqlite3_exec`, `sqlite3_prepare_v2`, ...) through
-`doltlite.h`, and exports the same `sqlite3_*` symbol names. C programs using
-supported interfaces generally port by changing `#include "sqlite3.h"` to
-`#include <doltlite.h>` and linking against `libdoltlite` instead of
-`libsqlite3`. APIs coupled to SQLite's pager, page format, or journaling have
-documented differences. The build produces `libdoltlite.a` (static) and
-`libdoltlite.dylib`/`.so` (shared) with the prolly-tree engine and all Dolt
-functions included.
+Public C API is the bundled SQLite declarations under `sqlite3_*` names via
+`doltlite.h`. Port supported programs by switching the include/link to
+`libdoltlite`; APIs tied to SQLite's pager, page format, or journaling differ
+(see [SQLite Compatibility](#sqlite-compatibility)). Dolt features are SQL
+functions (`dolt_commit`, `dolt_branch`, …) and virtual tables
+(`dolt_log`, `dolt_diff_<table>`, …).
 
-Loadable-extension authors use `doltliteext.h` (the rebranded `sqlite3ext.h`,
-shipped in the amalgamation zip alongside `doltlite.c`/`doltlite.h`).
-
-The shared library exports only `sqlite3_*` and the `doltliteServe*` entry
-points from `doltlite_remotesrv.h`. Everything else — the prolly, chunk-store
-and `doltlite*` internals, and statically linked mbedtls, BLAKE3 and ed25519 —
-is hidden, so linking `libdoltlite` cannot collide with a host's own copy of
-those libraries. The static archive is deliberately unfiltered for tests and
-tooling that need the internals.
+Loadable extensions use `doltliteext.h` (rebranded `sqlite3ext.h`, shipped in
+the amalgamation zip). The shared library exports only `sqlite3_*` and
+`doltliteServe*` (`doltlite_remotesrv.h`); prolly/chunk-store/`doltlite*`
+internals and vendored crypto are hidden. The static archive is unfiltered for
+tests and tooling.
 
 ```bash
 cd build
 ../configure
-make doltlite-lib   # builds libdoltlite.a and libdoltlite.dylib/.so
-```
+make doltlite-lib   # libdoltlite.a and libdoltlite.dylib/.so
 
-Compile and link your program:
-
-```bash
-# Static link (recommended — single binary, no runtime deps)
+# Static (recommended) or dynamic
 gcc -o myapp myapp.c -I/path/to/build libdoltlite.a -lpthread -lz
-
-# Dynamic link
 gcc -o myapp myapp.c -I/path/to/build -L/path/to/build -ldoltlite -lpthread -lz
-```
 
-`make install` places the same `doltlite.h`, `doltlite_remotesrv.h`,
-`libdoltlite.a`, `libdoltlite.{so,dylib}`, `doltlite` and `doltlite-remotesrv`
-that the release packages do. Installed under the default `/usr/local` prefix,
-those are already on the compiler's search path:
-
-```bash
-sudo make install                       # honours --prefix and DESTDIR
+sudo make install   # honours --prefix / DESTDIR; then:
 gcc -o myapp myapp.c -ldoltlite -lpthread -lz
 ```
 
-Being a SQLite fork, `make install` additionally installs SQLite's own
-`sqlite3.h`, `libsqlite3.*`, `sqlite3.pc` and man page — built from this tree,
-so they are DoltLite under SQLite's name. The release packages deliberately
-ship none of those, to avoid colliding with a system SQLite. Pass
-`--prefix` somewhere private if that matters to you.
-
-The API uses the standard [SQLite C API](https://sqlite.org/cintro.html) names —
-`sqlite3_open`, `sqlite3_exec`, `sqlite3_prepare_v2`, etc. Dolt features are
-called as SQL functions (`dolt_commit`, `dolt_branch`, `dolt_merge`, ...) and
-virtual tables (`dolt_log`, `dolt_diff_<table>`, `dolt_workspace_<table>`,
-`dolt_history_<table>`, ...). Storage-specific differences are listed under
-[SQLite Compatibility](#sqlite-compatibility).
+`make install` also installs SQLite-named artifacts (`sqlite3.h`,
+`libsqlite3.*`, …) from this tree — release packages omit those so they do not
+collide with system SQLite. Use a private `--prefix` if that matters.
 
 ### Quickstart Examples
 
-Complete working examples that demonstrate commits, branches, merges,
-point-in-time queries, diffs, and tags. Each example does the same thing
-in a different language.
+Same flow (commits, branches, merges, diffs, tags) in each language.
 
 **C** ([`examples/quickstart.c`](examples/quickstart.c)) — based on the
 [SQLite quickstart](https://sqlite.org/quickstart.html):
@@ -212,47 +161,21 @@ gcc -o quickstart ../examples/quickstart.c -I. libdoltlite.a -lpthread -lz
 ./quickstart
 ```
 
-**Python** ([`examples/quickstart.py`](examples/quickstart.py)) — uses the
-standard `sqlite3` module, zero code changes. The
-[`doltlite`](https://github.com/dolthub/doltlite-python) package bundles a
-precompiled libdoltlite and handles loading it ahead of the stdlib SQLite:
+**Python** ([`examples/quickstart.py`](examples/quickstart.py)) — stdlib
+`sqlite3` with the [`doltlite`](https://github.com/dolthub/doltlite-python)
+package (bundles libdoltlite):
 
 ```bash
 pip install doltlite
 python3 examples/quickstart.py
 ```
 
-If you'd rather wire up the preload yourself (e.g. against a libdoltlite
-you just built locally):
-
-```bash
-cd build
-# Linux:
-LD_PRELOAD=./libdoltlite.so python3 ../examples/quickstart.py
-# macOS: see https://github.com/dolthub/doltlite-python for the
-# install_name-shim + DYLD_INSERT_LIBRARIES recipe — macOS's two-level
-# namespace means a plain LD_PRELOAD / ctypes preload won't redirect
-# _sqlite3's symbol lookups.
-```
-
-All of the above paths require a Python whose `_sqlite3` module is loaded
-as a shared extension that links to a separate `libsqlite3`. The
-following Pythons do **not** qualify, regardless of which loading recipe
-you use:
-
-- **python-build-standalone** interpreters — the default for `uv python
-  install`, `mise`, and Rye; `_sqlite3` is built into the interpreter.
-- **python.org installer (macOS framework build)** — `_sqlite3` is built
-  with SQLite statically linked in; only `/usr/lib/libSystem.B.dylib`
-  shows as a dependency.
-- **Apple's system Python** — same framework-style static link.
-
-Use distro Python, Homebrew Python, pyenv-built Python, or conda Python
-instead. For `uv`:
-
-```bash
-uv venv --python /opt/homebrew/bin/python3   # or /usr/bin/python3, etc.
-```
+Needs a Python whose `_sqlite3` links a shared `libsqlite3` (distro,
+Homebrew, pyenv, or conda). Avoid python-build-standalone (`uv python install`
+defaults), the python.org macOS installer, and Apple system Python — they
+static-link SQLite and cannot preload libdoltlite. Local-build preload
+recipes (including macOS) are in the
+[doltlite-python](https://github.com/dolthub/doltlite-python) README.
 
 **Go** ([`examples/go/main.go`](examples/go/main.go)) — uses
 [mattn/go-sqlite3](https://github.com/mattn/go-sqlite3) with the `libsqlite3`
@@ -273,45 +196,30 @@ Version control operations are exposed as SQL functions and virtual tables.
 
 #### Configuration
 
+Per-connection, not persisted. Used by `dolt_commit`, `dolt_merge`,
+`dolt_cherry_pick`, and `dolt_revert`. `dolt_commit --author` overrides once.
+
 ```sql
--- Set committer name and email (per-session)
 SELECT dolt_config('user.name', 'Tim Sehn');
 SELECT dolt_config('user.email', 'tim@dolthub.com');
-
--- Read current config
 SELECT dolt_config('user.name');
 -- Tim Sehn
 ```
 
-All commit-creating operations (`dolt_commit`, `dolt_merge`, `dolt_cherry_pick`,
-`dolt_revert`) use these values. The `--author` flag on `dolt_commit` overrides
-the session config for a single commit. Config is per-connection and not
-persisted — set it at the start of each session.
-
 #### Staging and Committing
 
 ```sql
--- Stage specific tables or all changes
 SELECT dolt_add('users');
 SELECT dolt_add('-A');
-
--- Commit staged changes
 SELECT dolt_commit('-m', 'Add users table');
-
--- Stage and commit in one step
 SELECT dolt_commit('-A', '-m', 'Initial commit');
-
--- Shorthand (compound flags, like git commit -am)
-SELECT dolt_commit('-am', 'Initial commit');
-
--- Commit with author
+SELECT dolt_commit('-am', 'Initial commit');   -- like git commit -am
 SELECT dolt_commit('-m', 'Fix data', '--author', 'Alice <alice@example.com>');
 ```
 
 #### Status
 
 ```sql
--- Working/staged changes
 SELECT * FROM dolt_status;
 -- table_name | staged | status
 -- users      | 1      | modified
@@ -320,8 +228,8 @@ SELECT * FROM dolt_status;
 
 #### Workspace Tables
 
-`dolt_workspace_<table>` exposes row-level working/staged changes and lets
-you stage or unstage individual edits by updating `staged`:
+Row-level working/staged edits; set `staged` to stage/unstage. `DELETE`
+discards unstaged rows (staged rows must be unstaged first).
 
 ```sql
 SELECT id, staged, diff_type, to_id, to_rating, to_confidence,
@@ -335,15 +243,12 @@ UPDATE dolt_workspace_ratings
 SELECT dolt_commit('-m', 'accept higher-confidence edits');
 ```
 
-`DELETE FROM dolt_workspace_<table>` discards unstaged working-set edits
-(restores the staged/HEAD side of those rows). Staged workspace rows cannot
-be deleted; unstage them first.
-
 #### Ignoring Tables (`dolt_ignore`)
 
-Tables matching a pattern in `dolt_ignore` stay in the working set
-but are skipped by `dolt_add` and hidden from `dolt_status`. Create
-the table once per repo, then `INSERT` patterns:
+Patterns skipped by `dolt_add` and hidden from `dolt_status` (tables stay in
+the working set). Create once per repo, then insert patterns (`*`/`%` =
+any; `?` = one char). Most-specific match wins; equal-specificity conflicts
+error.
 
 ```sql
 CREATE TABLE dolt_ignore(
@@ -351,79 +256,50 @@ CREATE TABLE dolt_ignore(
   ignored TINYINT NOT NULL,
   PRIMARY KEY(pattern)
 );
-INSERT INTO dolt_ignore VALUES ('tmp_*', 1);    -- ignore tmp_* tables
-INSERT INTO dolt_ignore VALUES ('tmp_keep', 0); -- un-ignore a specific name
+INSERT INTO dolt_ignore VALUES ('tmp_*', 1);
+INSERT INTO dolt_ignore VALUES ('tmp_keep', 0);  -- un-ignore
 ```
-
-Patterns use `*` / `%` for zero-or-more and `?` for exactly one;
-everything else is literal. Most-specific pattern wins (longest
-literal count); equal-specificity disagreements error out.
 
 ### Inspecting what's there
 
 #### Diff
 
-Several ways to ask what changed:
-
 ```sql
--- Which tables changed across the commit history?
+-- Tables changed across commit history
 SELECT * FROM dolt_diff WHERE table_name = 'users';
 
--- Row- and cell-level change counts between two refs (commits, branches, tags)
+-- Row/cell counts between refs
 SELECT * FROM dolt_diff_stat('v1.0', 'HEAD');
-SELECT * FROM dolt_diff_stat('v1.0', 'HEAD', 'users');  -- narrow to one table
+SELECT * FROM dolt_diff_stat('v1.0', 'HEAD', 'users');
 
--- High-level per-table classification: added / dropped / renamed / modified
+-- Per-table added / dropped / renamed / modified
 SELECT * FROM dolt_diff_summary('v1.0', 'HEAD');
 
--- Schema-level diff (tables, views, indexes)
+-- Schema-level (tables, views, indexes)
 SELECT * FROM dolt_schema_diff('v1.0', 'v2.0');
 
--- Turn a diff into ordered, executable SQLite statements. The result has
--- Dolt's statement_order, from_commit_hash, to_commit_hash, table_name,
--- diff_type, and statement columns. Schema changes that SQLite cannot express
--- with ALTER TABLE are emitted as an ordered table rebuild.
+-- Ordered, executable SQLite statements (schema rebuilds when ALTER cannot express)
 SELECT * FROM dolt_patch('v1.0', 'v2.0');
 SELECT * FROM dolt_patch('v1.0', 'v2.0', 'users');
 SELECT * FROM dolt_patch('v1.0..v2.0');
 SELECT * FROM dolt_patch('main...feature', 'users');
-
--- Generate only data statements; numbering is compacted just as in Dolt.
 SELECT statement FROM dolt_patch('HEAD', 'WORKING')
  WHERE diff_type = 'data'
  ORDER BY statement_order;
 
--- Row-level history for a single table: every INSERT / UPDATE / DELETE
--- that was ever committed, with real per-column to_/from_ pairs plus
--- commit metadata and a diff_type. One virtual table per user table,
--- auto-registered on each commit. Filter by to_commit (including the
--- special 'WORKING' value for staged + working changes) or from_commit
--- to narrow to a specific slice.
+-- Per-table row history (to_/from_ columns + commit metadata + diff_type).
+-- One vtable per user table. to_commit = 'WORKING' is staged + working.
 SELECT * FROM dolt_diff_users;
--- to_id | to_name | to_email | to_commit | to_commit_date |
---   from_id | from_name | from_email | from_commit | from_commit_date |
---   diff_type
+SELECT * FROM dolt_diff_users WHERE to_id = 42;
+SELECT * FROM dolt_diff_users WHERE to_commit = 'WORKING';
 
-SELECT diff_type, to_name, to_email, to_commit
-  FROM dolt_diff_users
-  WHERE to_id = 42;
-
-SELECT * FROM dolt_diff_users WHERE to_commit = 'WORKING';  -- staged+working
-
--- TVF form: compare the table snapshots at two refs. Equivalent to
--- Dolt's dolt_diff(from_ref, to_ref, table) TVF — the table name
--- rides in the module name (SQLite TVFs declare a static schema at
--- xConnect, so the per-table column list can't move into the
--- argument list) and the two refs come through as positional args.
+-- TVF form: snapshots at two refs (table name is in the module, like Dolt).
+-- Two dots = endpoints; three dots = merge base to right endpoint.
 SELECT * FROM dolt_diff_users('HEAD~1', 'HEAD');
 SELECT * FROM dolt_diff_users('v1.0', 'WORKING');
-
--- Two dots also compare the endpoint snapshots. Three dots compare the
--- merge base to the right endpoint.
 SELECT * FROM dolt_diff_users('main..feature');
 SELECT * FROM dolt_diff_users('main...feature');
 
--- Restrict the commit-attributed system table to a history range.
 SELECT d.*
   FROM dolt_diff_users AS d
   JOIN dolt_log('v1.0..HEAD') AS l ON l.commit_hash = d.to_commit;
@@ -451,28 +327,23 @@ SELECT * FROM dolt_at_users('feature');
 SELECT * FROM dolt_at_users('v1.0');
 ```
 
-#### Blame (dolt_blame\_&lt;table&gt;)
+#### Blame (`dolt_blame_<table>`)
 
-For each live row, the most recent commit that introduced its current
-value:
+Most recent commit that set each live row's current value:
 
 ```sql
 SELECT * FROM dolt_blame_users;
 -- id | commit | commit_date | committer | email | message
 ```
 
-Walks history first-parent from HEAD; at linear commits a row is
-blamed if it differs from first-parent, at merge commits if it
-differs from the merge base. Schema-only changes (`ALTER TABLE ADD
-COLUMN`) don't update blame.
+First-parent walk from HEAD: blame updates when a row differs from the
+first parent (or from the merge base at merges). Schema-only changes
+(`ALTER TABLE ADD COLUMN`) do not update blame.
 
-#### Schema History (dolt_schemas)
+#### Schema History (`dolt_schemas`)
 
-Projection of views and triggers from `sqlite_schema`. This is the Dolt-style
-surface for browsing non-table schema objects. Because `sqlite_schema` lives
-in the branch-scoped catalog, `dolt_schemas` is version-controlled per branch
-just like user tables — switching branches with `dolt_checkout` will show the
-views and triggers defined on that branch:
+Views and triggers from the branch-scoped `sqlite_schema` (not ordinary
+tables/indexes). Switches with `dolt_checkout`:
 
 ```sql
 CREATE VIEW active_users AS SELECT * FROM users WHERE active = 1;
@@ -486,9 +357,7 @@ SELECT * FROM dolt_schemas;
 -- trigger | audit_users  | CREATE TRIGGER audit_users AFTER UPDATE...|       |
 ```
 
-Rows are filtered to `type IN ('view','trigger')` — ordinary tables and
-indexes are not reported here. Use `sqlite_schema` directly (or
-`dolt_schema_diff`) if you need the full schema surface.
+Use `sqlite_schema` or `dolt_schema_diff` for the full schema surface.
 
 ### Undoing on one branch
 
@@ -501,86 +370,54 @@ SELECT dolt_reset('--hard');   -- discard all uncommitted changes
 
 #### Revert
 
-Create a new commit that undoes the changes from a specific commit:
+New commit that applies the inverse of a target commit onto HEAD
+(message `Revert '<original message>'`). Cannot revert the initial commit.
 
 ```sql
 SELECT dolt_revert('abc123...');
 -- Returns new commit hash, or "Revert completed with N conflict(s)"
 ```
 
-Revert computes the inverse of the target commit's changes and applies
-them to the current HEAD. The new commit message is
-`Revert '<original message>'`. Cannot revert the initial commit.
-
 ### Parallel development
 
 #### Branching (Per-Session)
 
-Each connection tracks its own active branch. Branch state (active branch
-name, HEAD commit, staged catalog hash) lives in the `Btree` struct
-(per-connection). Each connection gets its own `BtShared` and chunk store.
+Each connection tracks its own active branch (and session view of HEAD /
+staging). Uncommitted work belongs to the **branch**, not the connection —
+see [Concurrency](#concurrency).
 
 ```sql
--- Create a branch at current HEAD
 SELECT dolt_branch('feature');
-
--- Switch to it (fails if uncommitted changes exist)
 SELECT dolt_checkout('feature');
-
--- See current branch
 SELECT active_branch();
-
--- List all branches
 SELECT * FROM dolt_branches;
--- name | hash | latest_committer | latest_committer_email
--- | latest_commit_date | latest_commit_message | remote | branch | dirty
-
--- Delete a branch
 SELECT dolt_branch('-d', 'feature');
 ```
 
-##### Opening a Specific Branch
-
-By default, Doltlite opens a database on the `main` branch. To connect
-directly to another branch, put the branch name in the database target:
+Open a branch at connect time via the database path (CLI, C API, or bindings):
 
 ```bash
 ./doltlite my.db@feature
 ./doltlite my.db/feature
 ```
 
-The same syntax works through the SQLite C API and language bindings, since
-the branch is parsed from the database filename passed to `sqlite3_open()`:
-
 ```c
 sqlite3_open("my.db@feature", &db);
-sqlite3_open("my.db/feature", &db);
-```
-
-After opening, `active_branch()` reflects the selected branch:
-
-```sql
-SELECT active_branch();
--- feature
 ```
 
 #### Tags
 
-Immutable named pointers to commits:
-
 ```sql
 SELECT dolt_tag('v1.0');                  -- tag HEAD
-SELECT dolt_tag('v1.0', 'abc123...');     -- tag specific commit
-SELECT dolt_tag('-d', 'v1.0');            -- delete tag
-SELECT * FROM dolt_tags;                  -- list tags
+SELECT dolt_tag('v1.0', 'abc123...');     -- tag a commit
+SELECT dolt_tag('-d', 'v1.0');
+SELECT * FROM dolt_tags;
 ```
 
 #### Merge
 
-Three-way merge of another branch into the current branch. Merges at the
-**row level** — non-conflicting changes to different rows of the same table
-are auto-merged. Conflicts (same row modified on both branches) are detected
-and stored for resolution.
+Three-way, **row-level** merge into the current branch. Non-conflicting row
+edits auto-merge; same-row edits become conflicts (see below).
 
 ```sql
 SELECT dolt_merge('feature');
@@ -589,7 +426,7 @@ SELECT dolt_merge('feature');
 
 #### Merge Status
 
-Always one row. When nothing is merging, `is_merging` is 0 and the rest is NULL.
+Always one row (`is_merging = 0` and other columns NULL when idle):
 
 ```sql
 SELECT * FROM dolt_merge_status;
@@ -598,124 +435,90 @@ SELECT * FROM dolt_merge_status;
 ```
 
 `unmerged_tables` is the name-ordered union of tables with data conflicts,
-constraint violations, or schema conflicts. Merge state lives in the working
-set, so a connection that did not run the merge still reports it — but it
-recovers `source` from the branch pointing at the merge commit, falling back to
-the hash when none matches.
+constraint violations, or schema conflicts. Merge state is in the working set,
+so other connections see it too; `source` is recovered from the branch at the
+merge commit when possible, otherwise the commit hash.
 
 #### Conflicts
 
-View and resolve merge conflicts:
-
 ```sql
--- View which tables have conflicts (summary)
 SELECT * FROM dolt_conflicts;
 -- table | num_conflicts
 -- users | 2
 
--- View individual conflict rows for a table. Columns are
--- (from_root_ish, base_<col>..., our_<col>..., our_diff_type,
---  their_<col>..., their_diff_type, dolt_conflict_id) — one base/our/their
--- triple per user column, plus per-side diff_type and a stable
--- dolt_conflict_id for resolution.
+-- Per-table rows: base_/our_/their_ columns, diff_types, dolt_conflict_id
 SELECT * FROM dolt_conflicts_users;
 
--- Resolve individual conflicts by deleting them (keeps current working value)
-DELETE FROM dolt_conflicts_users WHERE dolt_conflict_id = 5;
+DELETE FROM dolt_conflicts_users WHERE dolt_conflict_id = 5;  -- keep working value
+SELECT dolt_conflicts_resolve('--ours', 'users');
+SELECT dolt_conflicts_resolve('--theirs', 'users');
 
--- Or resolve all conflicts for a table at once
-SELECT dolt_conflicts_resolve('--ours', 'users');   -- keep our values
-SELECT dolt_conflicts_resolve('--theirs', 'users'); -- take their values
-
--- Commit is blocked while conflicts exist
 SELECT dolt_commit('-A', '-m', 'msg');
 -- Error: "cannot commit: unresolved merge conflicts"
 ```
 
-Conflicts are never persisted as conflicts. They live only in the transaction
-that produced them, so inspect and resolve them there; `COMMIT` is refused while
-any remain, and an autocommit merge that conflicts is rolled back whole. Either
-way nothing conflicted reaches disk, and no later connection inherits a merge to
-finish. Dolt differs here — it can commit a working set holding conflicts — so
-this is a deliberate divergence, not a gap.
+Conflicts are never durable: they exist only in the transaction that produced
+them. Resolve there; `COMMIT` is refused while any remain, and an autocommit
+merge that conflicts is rolled back whole. Nothing conflicted is left on disk
+for a later connection. Dolt can commit a conflicted working set — this is a
+deliberate divergence.
 
 #### Constraint Violations on Merge
 
-Merges apply cell-by-cell at the prolly layer and don't run
-referential actions inline. After the merge, doltlite walks the
-merged state and records any row that violates a foreign key,
-unique index, or CHECK constraint into per-table
-`dolt_constraint_violations_<table>` vtables. A summary vtable
-`dolt_constraint_violations` reports `(table, num_violations)`.
+Merges apply cell-by-cell and do not run referential actions inline.
+Post-merge, violating rows land in `dolt_constraint_violations_<table>`
+(summary: `dolt_constraint_violations`).
 
 ```sql
--- Summary of post-merge violations
 SELECT * FROM dolt_constraint_violations;
 -- table | num_violations
 -- child | 1
 
--- Inspect violations for a specific table
 SELECT violation_type, pk, violation_info
   FROM dolt_constraint_violations_child;
 -- foreign key | 2 | {"Columns":["v1"],"ReferencedTable":"parent",...}
 
--- Resolve by deleting the offending rows from the base table,
--- or clear the violation entry directly:
 DELETE FROM dolt_constraint_violations_child WHERE pk = 2;
 ```
 
-`violation_type` values match Dolt: `foreign key`, `unique index`,
-`check constraint`. For foreign-key and CHECK violations the
-offending row remains in the base table; for unique-index
-violations the loser (highest rowid) is evicted from the base
-table into the violations vtable so the remaining value
-stays unique. `dolt_commit` refuses to proceed while any row
-remains in `dolt_constraint_violations_*`; pass `--force` to
-bypass the guard. Re-scan anytime with `SELECT dolt_verify_constraints([--all] [--output-only] [table...]);` (returns 0 or 1).
+Types match Dolt: `foreign key`, `unique index`, `check constraint`. FK/CHECK
+violators stay in the base table; unique-index losers (highest rowid) are
+evicted into the violations vtable. `dolt_commit` refuses while any remain
+(`--force` bypasses). Re-scan:
+`SELECT dolt_verify_constraints([--all] [--output-only] [table...]);`.
 
 #### Cherry-Pick
 
-Apply the changes from a specific commit onto the current branch:
+Apply one commit's changes onto the current branch (parent→commit diff as a
+three-way merge; conflicts like `dolt_merge`). Ranges / multi-commit are not
+supported.
 
 ```sql
 SELECT dolt_cherry_pick('abc123...');
 -- Returns new commit hash, or "Cherry-pick completed with N conflict(s)"
 ```
 
-Cherry-pick works by computing the diff between the target commit and its
-parent, then applying that diff to the current HEAD as a three-way merge.
-Conflicts are handled the same way as `dolt_merge`. Each call accepts exactly
-one commit; commit ranges and multi-commit cherry-picks are not supported.
-
 #### Rebase
 
-Replay the current branch's commits on top of an upstream:
+Replay this branch onto an upstream. Atomic: conflict/error restores the
+pre-rebase branch. Interactive (`-i`) edits a plan table before apply:
 
 ```sql
 SELECT dolt_rebase('main');
 -- "Successfully rebased and updated refs/heads/feat"
-```
 
-Atomic: any conflict or error during the replay restores the branch
-to its pre-rebase state. Interactive mode lets you edit the plan
-before applying it:
-
-```sql
 SELECT dolt_rebase('-i', 'main');
--- Creates a working branch dolt_rebase_<orig> and a dolt_rebase
--- table with one row per commit (default action: pick). Edit with
--- normal SQL: action in ('pick','drop','reword','squash','fixup'),
--- change commit_message, or reorder with fractional rebase_order.
+-- Working branch dolt_rebase_<orig> + dolt_rebase plan rows (default pick).
+-- action: pick | drop | reword | squash | fixup; edit commit_message /
+-- rebase_order with normal SQL.
 
 UPDATE dolt_rebase SET action='drop'   WHERE commit_message='debug';
 UPDATE dolt_rebase SET action='squash' WHERE commit_message='fixup';
-SELECT dolt_rebase('--continue');  -- apply the edited plan
-SELECT dolt_rebase('--abort');     -- throw the working branch away
+SELECT dolt_rebase('--continue');
+SELECT dolt_rebase('--abort');
 ```
 
 #### Merge Base
-
-Find the common ancestor of two commits:
 
 ```sql
 SELECT dolt_merge_base('abc123...', 'def456...');
@@ -725,84 +528,57 @@ SELECT dolt_merge_base('abc123...', 'def456...');
 
 #### Content-Addressed Hashes
 
-Doltlite exposes the content-address of any ref, table, or the whole
-database as a scalar SQL function. The decentralized use case is
-simple: two peers that compute the same hash are at the exact same
-state — no row-level diff required, no metadata roundtrip.
-
 ```sql
--- Commit hash for a branch, tag, raw hash, HEAD, or HEAD~N / HEAD^N
+-- Commit hash (branch, tag, raw hash, HEAD, HEAD~N / HEAD^N)
 SELECT dolt_hashof('main');
 SELECT dolt_hashof('HEAD~2');
 
--- Table root hash. One-arg form reflects uncommitted working edits.
+-- Table root (one-arg form includes uncommitted working edits)
 SELECT dolt_hashof_table('users');
 SELECT dolt_hashof_table('users', 'main');
 
--- Whole-catalog hash — changes iff any table root moves or a table
--- is created/dropped.
+-- Whole catalog (moves when any table root or membership changes)
 SELECT dolt_hashof_db();
 SELECT dolt_hashof_db('HEAD');
 ```
 
-All results are 40-char lowercase hex (20-byte prolly hash).
-
-The `_table` and `_db` variants are history-independent: any two
-rowsets that reduce to the same `(key, value)` set hash identically
-regardless of insert order, transient deletions, commit chain, or
-branch. See `test/vc_oracle_hashof_test.sh` for the property tests.
+Results are 40-char lowercase hex. `_table` / `_db` are history-independent:
+identical `(key, value)` sets hash the same regardless of insert order or
+branch. Property tests: `test/vc_oracle_hashof_test.sh`.
 
 #### Garbage Collection
 
-Remove unreachable chunks from the store to reclaim space:
+Stop-the-world mark-and-sweep over branches, tags, history, catalogs, and
+prolly nodes; rewrites the file with only live chunks. Safe and idempotent.
 
 ```sql
 SELECT dolt_gc();
 -- "12 chunks removed, 45 chunks kept"
 ```
 
-Stop-the-world mark-and-sweep: walks all branches, tags, commit
-history, catalogs, and prolly tree nodes to find reachable chunks,
-then rewrites the file with only live data. Safe and idempotent.
-
 #### Remotes
 
-Doltlite supports Git-like remotes for pushing, fetching, pulling, and cloning
-between databases.
+Git-like push / fetch / pull / clone between databases.
 
 ##### Filesystem Remotes
 
 ```sql
--- Add a remote
 SELECT dolt_remote('add', 'origin', 'file:///path/to/remote.doltlite');
-
--- Push a branch
 SELECT dolt_push('origin', 'main');
-
--- Clone a remote database
 SELECT dolt_clone('file:///path/to/source.doltlite');
-
--- Fetch updates
 SELECT dolt_fetch('origin', 'main');
-
--- Pull (fetch + fast-forward)
-SELECT dolt_pull('origin', 'main');
-
--- List remotes
+SELECT dolt_pull('origin', 'main');   -- fetch + fast-forward
 SELECT * FROM dolt_remotes;
 ```
 
 ##### HTTP Remotes
 
-```sql
--- Add an HTTP remote (URL includes database name)
-SELECT dolt_remote('add', 'origin', 'http://myserver:8080/mydb.db');
+Same ops as filesystem remotes; the URL includes the database name:
 
--- All operations work identically to file:// remotes
+```sql
+SELECT dolt_remote('add', 'origin', 'http://myserver:8080/mydb.db');
 SELECT dolt_push('origin', 'main');
 SELECT dolt_clone('http://myserver:8080/mydb.db');
-SELECT dolt_fetch('origin', 'main');
-SELECT dolt_pull('origin', 'main');
 ```
 
 ##### Remote Server (`doltlite-remotesrv`)
@@ -815,145 +591,60 @@ SELECT dolt_pull('origin', 'main');
 > may read the served databases *and push to them*. Configure both, or place the
 > server behind a reverse proxy that provides equivalent TLS and authentication.
 
-Doltlite includes a standalone HTTP server for serving databases over the
-network. Build it alongside doltlite:
-
-```
-cd build
-make doltlite-remotesrv
-```
-
-Start serving a directory of databases:
+Standalone HTTP server for a directory of databases (`make doltlite-remotesrv`
+in `build/`):
 
 ```
 ./doltlite-remotesrv -p 8080 /path/to/databases/
-# To bind to all interfaces (e.g. behind a TLS-terminating reverse proxy):
-./doltlite-remotesrv -p 8080 --bind 0.0.0.0 /path/to/databases/
-
-# Serve HTTPS and require authorized client credentials:
+./doltlite-remotesrv -p 8080 --bind 0.0.0.0 /path/to/databases/   # all interfaces
 ./doltlite-remotesrv -p 8443 --bind 0.0.0.0 \
   --cert server.crt --key server.key \
   --auth-keys /path/to/authorized-keys --audience db.example.com \
   /path/to/databases/
 ```
 
-HTTPS clients verify the server certificate and hostname using the system
-trust store. Set `DOLTLITE_CA_FILE` for a private CA. Client credentials live
-in `~/.doltlite/creds` and can be created with `SELECT dolt_creds_new();`.
-HTTP and HTTPS requests have a 30-second deadline by default. Set
-`DOLTLITE_HTTP_TIMEOUT_MS` to a positive number of milliseconds to tune it.
-
-Every `.db` file in that directory becomes accessible at
-`http://host:8080/filename.db` or its configured HTTPS URL. The server supports
-push, fetch, pull, and clone — multiple clients can collaborate on the same
-databases.
-
-The server is also embeddable as a library (`doltliteServeAsync` in
-`doltlite_remotesrv.h`) for applications that want to host remotes in-process.
-Transfers are content-addressed — only chunks the remote doesn't already
-have are sent.
+Each `.db` is at `http://host:8080/filename.db` (or the HTTPS URL). Clients use
+the system trust store (`DOLTLITE_CA_FILE` for a private CA); credentials live
+in `~/.doltlite/creds` (`SELECT dolt_creds_new();`). Default HTTP timeout is
+30s (`DOLTLITE_HTTP_TIMEOUT_MS`). Embeddable as `doltliteServeAsync` in
+`doltlite_remotesrv.h`. Transfers are content-addressed.
 
 #### Version String
 
 ```sql
 SELECT dolt_version();
--- e.g. "v0.10.6"
+-- e.g. "v0.11.38" (from git describe at compile time)
 ```
-
-Zero-arg scalar returning the build's version string (from
-`git describe` at compile time). Useful for peer negotiation in
-decentralized setups, bug-report ergonomics, and migrations
-that branch on engine version. Matches Dolt's `DOLT_VERSION()`
-argcount contract.
 
 ## Using Existing SQLite Databases
 
-Doltlite can ATTACH standard SQLite databases alongside its own prolly-tree
-storage. This lets you keep versioned tables in doltlite and high-write
-operational tables in standard SQLite, queried through a single connection.
-
-Doltlite detects the file format automatically from the header — no
-configuration needed. Standard SQLite files route to SQLite's original B-tree
-engine; everything else uses the prolly tree.
-
-### Basic ATTACH
+Header-based auto-detect: stock SQLite files use the original B-tree engine;
+everything else is prolly. Typical hybrid: versioned tables on the DoltLite
+main DB, high-write operational tables on an attached stock SQLite file. Version
+control applies only to the DoltLite-format main database.
 
 ```sql
--- Attach a standard SQLite database
 ATTACH DATABASE '/path/to/events.sqlite' AS ops;
-
--- Query it (prefix table names with the alias)
 SELECT * FROM ops.events WHERE type='click';
-
--- Main db tables need no prefix
-SELECT * FROM threads;
-
--- Detach when done
-DETACH DATABASE ops;
-```
-
-### Cross-Database JOINs
-
-```sql
--- Join doltlite (versioned) tables with SQLite (attached) tables
+SELECT * FROM threads;   -- main DB, no prefix
 SELECT t.title, e.type
-FROM threads t
-JOIN ops.events e ON t.id = e.thread_id;
-```
+  FROM threads t
+  JOIN ops.events e ON t.id = e.thread_id;
 
-### Migrating Data Between Formats
-
-```sql
--- Copy from SQLite into doltlite (now versioned)
+-- Migrate either direction
 INSERT INTO threads SELECT * FROM ops.threads;
-
--- Copy from doltlite into SQLite (for export)
 INSERT INTO ops.archive SELECT * FROM threads WHERE archived=1;
-
--- One-step copy with CREATE TABLE...AS
 CREATE TABLE local_events AS SELECT * FROM ops.events;
-```
 
-### Hybrid Storage Pattern
-
-Use doltlite for tables that benefit from version control, and standard SQLite
-for high-throughput tables that don't need history:
-
-```sql
--- Main DB: doltlite (versioned)
-CREATE TABLE config(key TEXT PRIMARY KEY, val TEXT);
-SELECT dolt_commit('-am', 'Add config table');
-
--- Attached: standard SQLite (high-write, no versioning overhead)
-ATTACH DATABASE 'telemetry.sqlite' AS tel;
-CREATE TABLE tel.events(seq INTEGER PRIMARY KEY, kind TEXT, payload TEXT);
-
--- Hot write path goes to standard SQLite
-INSERT INTO tel.events VALUES(1, 'pageview', '{"url":"/home"}');
-
--- Analytics spans both databases
-SELECT c.val, count(e.seq)
-FROM config c
-JOIN tel.events e ON e.kind = c.key
-GROUP BY c.key;
-
--- Version control only applies to main db
-SELECT * FROM dolt_diff WHERE table_name='config';
+DETACH DATABASE ops;
 ```
 
 ## Per-Session Branching Architecture
 
-Each connection gets its own `Btree` / `BtShared` pair and independently
-tracks branch name, HEAD commit, and staged catalog hash, so different
-connections can sit on different branches at the same time. Each branch's
-working catalog lives in its own chunk, so one branch's autocommit can
-never corrupt another branch's reads. Writes and commit-graph mutations
-are serialized through an exclusive file-level lock (matching SQLite's
-standard behavior); reads are concurrent.
-
-Uncommitted work belongs to the branch, not the connection: checking out a
-dirty branch neither refuses nor carries changes over. Hence no `dolt_stash` —
-there is no single working tree to free up.
+Each connection selects a branch independently and recovers that branch's
+working set when it checks it out. There is no `dolt_stash`: checkout does not
+shelve uncommitted work between branches. Writer serialization, snapshot pins,
+and multiproc rules are spelled out under [Concurrency](#concurrency).
 
 ## SQLite Compatibility
 
@@ -1041,7 +732,7 @@ For a DoltLite-format main database, the concurrency contract is:
 - **Conflicts are never durable.** A conflicted merge exists only inside the
   transaction that produced it. Commit is refused while conflicts remain;
   nothing conflicted is left on disk for a later connection to inherit.
-  Constraint violations still persist (see Conflicts under Dolt Features).
+  Constraint violations still persist (see Constraint Violations on Merge).
 
 The machine-readable contract and its test mapping live in
 [`test/concurrency_contract.tsv`](test/concurrency_contract.tsv). Multiproc and
@@ -1096,269 +787,66 @@ and keep evidence needles live.
 
 ## Performance
 
-The latest automated DoltLite-versus-SQLite measurements are published in the
-[nightly performance report](performance-report.md).
+Nightly DoltLite-versus-SQLite numbers:
+[performance-report.md](performance-report.md). Per-release comparisons ship on
+[GitHub releases](https://github.com/dolthub/doltlite/releases).
 
-### Sysbench OLTP Benchmarks: Doltlite vs SQLite
+PR CI runs paired sysbench-style workloads (int / text / blob / composite PK)
+and a short version-control latency suite against the PR base, with automatic
+remeasurement on borderline regressions. Details live in
+[`.github/workflows/benchmark.yml`](.github/workflows/benchmark.yml).
 
-Doltlite retains SQLite's SQL engine and C API while replacing its storage
-engine, so the natural question is: what does version control cost?
+Complexity properties asserted in CI (`test/doltlite_perf.sh`,
+`test/doltlite_structural.sh`):
 
-Every PR builds the exact PR base and candidate with the same optimized
-toolchain, then runs paired sysbench-style benchmarks on the same runners. The
-int-key suite in [`test/sysbench_compare.sh`](test/sysbench_compare.sh) runs
-alongside TEXT, BLOB, and composite-primary-key variants. Baseline and candidate
-execution order alternates on each repetition to reduce host-load bias. CI
-fails when an individual workload regresses by more than 25% and 5ms, or when
-a section, suite, or overall runtime regresses by more than 15% and 5ms.
-Short, process-startup-bound version-control operations use a 50% and 25ms
-individual gate; their aggregate still uses the 15% suite gate. A suite that
-exceeds a gate is measured again automatically and only fails CI after three
-consecutive failures of the same individual, section, or suite gate. Different
-metrics failing on later attempts do not confirm the original regression.
-Command, result-format, and revision-provenance errors fail immediately instead
-of being retried. Retry logs identify the current attempt, elapsed time, and
-exact gates still eligible for confirmation. The selected result and its retry
-history carry a shared producer identity so stale artifacts cannot be paired.
-
-A scheduled workflow starts nightly at 09:30 UTC, after the nightly fuzzing
-window. Four parallel workers run 55 paired samples per SQL workload against
-stock SQLite, while the version-control latency suite runs 101 samples per
-benchmark. A regression opens or updates a
-`nightly-performance-regression` issue. Each structurally complete run also
-publishes raw samples as 30-day artifacts and opens a rolling, reviewable PR
-for `performance-report.md`; the next run safely merges the prior report before
-opening its own. The per-release SQLite comparison is still published with
-each release on the
-[GitHub releases page](https://github.com/dolthub/doltlite/releases).
-
-### Algorithmic Complexity
-
-All numbers below have automated assertions in CI (`test/doltlite_perf.sh` and `test/doltlite_structural.sh`).
-
-- **O(log n) Point Operations** -- SELECT, UPDATE, and DELETE by primary key are O(log n), essentially constant time from 1K to 1M rows. Tested and asserted at 1K, 100K, and 1M rows.
-- **O(n log n) Bulk Insert** -- Bulk INSERT inside BEGIN/COMMIT scales as O(n log n). 1M rows inserts in ~2 seconds. CTE-based inserts also scale linearly (5M rows in 11s).
-- **O(changes) Diff** -- `dolt_diff` between two commits is proportional to the number of changed rows, not the table size. A single-row diff on a 1M-row table takes the same time as on a 1K-row table (~30ms).
-- **Structural Sharing** -- The prolly tree provides structural sharing between versions. Changing 1 row in a 10K-row table adds only 1.9% to the file size (5.2KB on 273KB). Branch creation with 1 new row adds ~10% overhead.
-- **Garbage Collection** -- `dolt_gc()` reclaims orphaned chunks. Deleting a branch with 1000 unique rows and running GC reclaims 53% of file size. GC is idempotent and preserves all reachable data.
+- **O(log n)** point SELECT / UPDATE / DELETE by primary key
+- **O(n log n)** bulk INSERT inside an explicit transaction
+- **O(changes)** `dolt_diff` between commits (not proportional to table size)
+- **Structural sharing** between versions (small edits add little file growth)
+- **GC** reclaims unreachable chunks without dropping reachable data
 
 ## Running Tests
 
-### SQLite Tcl Test Suite
-
-`testfixture` is built from real doltlite (the prolly + version-control engine,
-not stock SQLite) and runs the upstream SQLite TCL suite.
-
-The TCL suite is gated in two layers:
-
-- Passing upstream files are split into five CI buckets under
-  [`test/regression-buckets`](test/regression-buckets): `core-sql`,
-  `ddl-schema`, `storage`, `fault-fuzz`, and `ported`. The `ported` bucket holds
-  doltlite-native rewrites of upstream tests whose original synchronization or
-  raw-file assumptions do not apply to prolly storage.
-- Remaining inherited-file gaps are tracked in
-  [`test/known_testfixture_divergences.txt`](test/known_testfixture_divergences.txt)
-  and [`test/known_testfixture_crashes.txt`](test/known_testfixture_crashes.txt).
-  Every affected suite has a disposition in
-  [`test/known_testfixture_exception_inventory.txt`](test/known_testfixture_exception_inventory.txt):
-  `intentional` storage-model behavior, an `unsupported` SQLite surface, a
-  test-`harness` incompatibility, or an unresolved `engine-gap`. Unsupported
-  surfaces and engine gaps must carry a DoltLite issue URL.
-  The dominant classes are doltlite's **rowid / primary-key identity** semantics
-  (non-INTEGER primary key tables are stored as PK-keyed WITHOUT ROWID tables),
-  raw SQLite page-format probes (`hexio_write`, file-format bytes,
-  rootpage/page-count assertions), unsupported non-UTF-8 database encodings,
-  custom-collation indexes, pager/WAL/rollback-journal lock-state expectations,
-  VACUUM/page-layout behavior, planner counters such as `sqlite_search_count`,
-  and a small number of diagnostic text differences.
-
-`test/run_testfixture.sh` enforces these lists **bidirectionally**: every actual
-failure/crash must be listed, and every listed entry must still fail/crash. That
-catches both new regressions and stale allowlist entries. The lists are still an
-audit backlog rather than proof of correctness: per-assertion comments retain
-the detailed rationale, while
-`test/check_testfixture_exception_inventory.sh` rejects missing, duplicate, or
-stale suite dispositions and missing issue links for potentially fixable
-categories. CI runs both checks and the bucket sweep on every PR in
-[`.github/workflows/test.yml`](.github/workflows/test.yml).
-
-To rerun the gated buckets locally:
-
 ```bash
 cd build
-bash ../test/run_testfixture.sh "SQLite regression core-sql" 300 \
-  $(tr '\n' ' ' < ../test/regression-buckets/core-sql.txt)
-bash ../test/run_testfixture.sh "SQLite regression ddl-schema" 300 \
-  $(tr '\n' ' ' < ../test/regression-buckets/ddl-schema.txt)
-bash ../test/run_testfixture.sh "SQLite regression storage" 300 \
-  $(tr '\n' ' ' < ../test/regression-buckets/storage.txt)
-bash ../test/run_testfixture.sh "SQLite regression fault-fuzz" 300 \
-  $(tr '\n' ' ' < ../test/regression-buckets/fault-fuzz.txt)
-bash ../test/run_testfixture.sh "SQLite regression ported" 300 \
-  $(tr '\n' ' ' < ../test/regression-buckets/ported.txt)
-```
+../configure && make
 
-To audit only the known-divergence and expected-crash files:
-
-```bash
-cd build
-awk 'BEGIN{n=0} /^[[:space:]]*#/ || /^[[:space:]]*$/ {next} {print $1}' \
-  ../test/known_testfixture_divergences.txt \
-  ../test/known_testfixture_crashes.txt | sort -u > /tmp/doltlite-known-tests.txt
-DIVERGENCE_FILE=$PWD/../test/known_testfixture_divergences.txt \
-CRASH_FILE=$PWD/../test/known_testfixture_crashes.txt \
-  bash ../test/run_testfixture.sh known-audit 120 $(cat /tmp/doltlite-known-tests.txt)
-```
-
-### Doltlite Shell Tests
-
-60+ test suites covering all features:
-
-```bash
-# Run all suites
-cd build
+# DoltLite shell suites (branch / commit / merge / remotes / …)
 bash ../test/run_doltlite_tests.sh
 
-# Run individual suites
-bash ../test/doltlite_parity.sh          # SQLite compatibility (119 tests)
-bash ../test/doltlite_commit.sh          # Commits and log
-bash ../test/doltlite_staging.sh         # Add, status, staging
-bash ../test/doltlite_workspace.sh       # Workspace tables and partial row staging
-bash ../test/doltlite_branch.sh          # Branching and checkout
-bash ../test/doltlite_merge.sh           # Three-way merge
-bash ../test/doltlite_attach_sqlite.sh   # ATTACH standard SQLite databases
-```
+# C unit / multiproc / stress harnesses
+bash ../test/run_c_tests.sh
 
-### Source Coverage
+# Upstream SQLite TCL suite (prolly engine) — one CI bucket
+bash ../test/run_testfixture.sh "SQLite regression core-sql" 300 \
+  $(tr '\n' ' ' < ../test/regression-buckets/core-sql.txt)
 
-Pull-request CI has two global phases. The first phase builds every binary and
-generated source needed by the suite, rejects compiler warnings, and publishes
-short-lived artifacts. It includes checked Linux, macOS, and Windows builds;
-LLVM coverage; optimized benchmarks; ASan/UBSan and TSan; crash-test and
-libFuzzer targets; WebAssembly; historical compatibility references; and
-assert-enabled development configurations. The second phase starts only after
-every build is green and runs all tests against those immutable artifacts.
-This avoids recompiling the same engine in each test shard and prevents test
-jobs from consuming a partially successful build set.
-Independent development configurations and sanitizer surfaces are sharded by
-purpose so the complete pull-request workflow remains within its 20-minute
-wall-clock budget without reducing coverage.
-
-The LLVM job builds the non-amalgamated engine once with source-coverage
-instrumentation. The existing Linux correctness jobs consume that artifact and
-run the complete SQLite Tcl regression buckets, differential oracles,
-deterministic shell and C suites, and the credential/TLS/HTTP remote
-integration suites. Each parallel job uploads a small pool of raw profiles; a
-final job merges them and publishes line, branch, and function coverage for
-the DoltLite-owned `src/` implementation files. The workflow fails if an owned
-source file with executable lines receives zero line coverage.
-
-Timing and scale gates, concurrency and fault stress, sanitizers, and
-platform-specific jobs consume their optimized or specialized phase-one
-artifacts. They do not contribute profiles. macOS and Windows still run their
-platform checks, but deterministic Linux correctness tests are not repeated
-outside the instrumented jobs.
-
-CI requires aggregate line coverage of at least 80%. Aggregate branch and
-function coverage remain informational. CI updates a single coverage comment
-on the pull request. Its linked artifact contains an HTML report, aggregate
-summary, per-file TSV, merged LLVM profile, and LCOV data. To produce a local
-report with Clang, LLVM tools, and Dolt:
-
-```bash
-mkdir build-coverage
-cd build-coverage
-CC=clang \
-  CFLAGS="-O1 -g -fprofile-instr-generate -fcoverage-mapping" \
-  LDFLAGS="-fprofile-instr-generate" \
-  ../configure
-make -j2 DOLTLITE_PROLLY_CHECK=1 \
-  doltlite doltlite-remotesrv doltlite-lib testfixture \
-  doltlite-c-tests-build doltlite-regression-test-c-build
-make DOLTLITE_PROLLY=0 sqlite3
-cd ..
-mkdir -p coverage-profiles
-export LLVM_PROFILE_FILE="$PWD/coverage-profiles/%8m.profraw"
-export DOLTLITE_REGRESSION_PREBUILT=1
-DOLTLITE_BUILD_DIR="$PWD/build-coverage" \
-  DOLTLITE_SUITE_SET=coverage \
-  bash test/run_doltlite_tests.sh
-bash test/run_c_tests.sh build-coverage coverage
-# Run the Tcl regression buckets and differential oracles as in test.yml.
-bash test/source_coverage_report.sh \
-  build-coverage coverage-profiles coverage-report
-```
-
-The report command accepts optional percentage floors through
-`DOLTLITE_COVERAGE_MIN_LINES`, `DOLTLITE_COVERAGE_MIN_BRANCHES`, and
-`DOLTLITE_COVERAGE_MIN_FUNCTIONS`. Pull-request CI sets the line floor to 80;
-the other floors remain unset.
-
-### Differential Oracle Tests
-
-Doltlite ships a suite of differential oracle tests that run the same SQL
-through doltlite and stock sqlite3, or through doltlite and Dolt for
-version-control behavior, and compare results byte-for-byte. Each
-script is focused on a SQL feature surface: savepoints, foreign keys, UPSERT,
-generated columns, WITHOUT ROWID, large BLOBs at chunk boundaries, ATTACH
-cross-engine queries, TEMP tables, triggers, dot-commands, FTS5, workspace
-staging, or version-control operations. Scenarios are written to hit
-storage-layer edge cases.
-
-```bash
-cd build
+# Differential oracles (need stock sqlite3 and/or dolt on PATH)
 bash ../test/sql_oracle_test.sh ./doltlite ./sqlite3
-bash ../test/oracle_savepoints_test.sh ./doltlite ./sqlite3
-bash ../test/oracle_foreign_keys_test.sh ./doltlite ./sqlite3
-bash ../test/oracle_upsert_test.sh ./doltlite ./sqlite3
-bash ../test/oracle_generated_columns_test.sh ./doltlite ./sqlite3
-bash ../test/oracle_without_rowid_test.sh ./doltlite ./sqlite3
-bash ../test/oracle_large_blobs_test.sh ./doltlite ./sqlite3
-bash ../test/oracle_attach_test.sh ./doltlite ./sqlite3
-bash ../test/oracle_temp_tables_test.sh ./doltlite ./sqlite3
-bash ../test/oracle_triggers_test.sh ./doltlite ./sqlite3
-bash ../test/oracle_fts5_test.sh ./doltlite ./sqlite3
 bash ../test/vc_oracle_workspace_test.sh ./doltlite dolt
+
+# sqllogictest corpus (needs Fossil + corpus checkout)
+bash ../test/run_sqllogictest.sh ./doltlite ./sqlite3 /path/to/sqllogictest
 ```
 
-A separate CI job builds the same suite with
-`-fsanitize=address,undefined` and runs every oracle under ASan/UBSan to
-catch memory and undefined-behavior bugs before they reach master.
-The sanitizer workflow also runs SQLite's shared-connection and
-shared-database thread tests plus Doltlite's concurrent HTTP remote suite
-under TSan.
+CI wiring, coverage floors, and full bucket lists are in
+[`.github/workflows/test.yml`](.github/workflows/test.yml) and
+[AGENTS.md](AGENTS.md). Contract suites
+(`sqlite_compatibility_contract_test.sh`, `concurrency_contract_test.sh`,
+`storage_format_contract_test.sh`) gate the README contracts above.
 
-### SQL Logic Test Suite
-
-doltlite runs the full [sqllogictest](https://www.sqlite.org/sqllogictest/)
-corpus — the same 5.7M-statement set SQLite uses — against **real doltlite** and
-stock SQLite. `test/run_sqllogictest.sh` compares doltlite-only divergences
-against `test/known_sqllogictest_divergences.txt`.
-Run `bash test/run_sqllogictest.sh <doltlite-runner> <stock-runner> <corpus-dir>`
-locally (requires Fossil for the upstream corpus).
-
-### Concurrent Branch Tests
-
-C tests that verify cross-branch isolation — two connections on different
-branches both write and read without corrupting each other:
-
-```bash
-cd build
-gcc -o cross_branch_test ../test/cross_branch_test.c \
-    -I. -I../src libdoltlite.a -lz -lpthread
-./cross_branch_test
-```
+Inherited TCL allowlists:
+[`test/known_testfixture_divergences.txt`](test/known_testfixture_divergences.txt),
+[`test/known_testfixture_crashes.txt`](test/known_testfixture_crashes.txt),
+[`test/known_testfixture_exception_inventory.txt`](test/known_testfixture_exception_inventory.txt).
 
 ## Architecture
 
-Doltlite implements the same prolly tree design as
-[Dolt](https://github.com/dolthub/dolt) — content-addressed immutable
-nodes with rolling-hash-determined boundaries — adapted for SQLite's
-constraints and C implementation. The prolly tree engine lives in
-`src/prolly_*.c`, the feature-level implementations of `dolt_*` SQL
-functions and vtables live in `src/doltlite_*.c`, and `src/prolly_btree.c`
-is the integration point where prolly dispatches against SQLite's
-`btree.h` API.
+Same prolly-tree design as [Dolt](https://github.com/dolthub/dolt) —
+content-addressed immutable nodes with rolling-hash boundaries — in C under
+SQLite's `btree.h` seam. Engine code is `src/prolly_*.c` and `src/chunk_*.c`;
+`dolt_*` SQL surfaces are `src/doltlite_*.c`; `src/prolly_btree.c` dispatches
+the btree API.
 
-For a deeper side-by-side of Dolt and DoltLite storage internals, see
-[Dolt vs DoltLite Storage Comparison](https://www.dolthub.com/blog/2026-07-08-dolt-doltlite-storage-comp/).
+Deeper comparison:
+[Dolt vs DoltLite Storage](https://www.dolthub.com/blog/2026-07-08-dolt-doltlite-storage-comp/).

--- a/README.md
+++ b/README.md
@@ -10,11 +10,12 @@ giving Git-like version control on a SQL database. The parser, planner, and
 VDBE stay upstream-derived above SQLite's `btree.h` seam; below it, a
 single-file chunk store backs prolly trees instead of SQLite pages.
 
-[Why DoltLite?](https://www.dolthub.com/blog/2026-04-27-why-doltlite/) Embeds
-in any language for local-first [Dolt](https://github.com/dolthub/dolt/) use
-cases. More on the
-[DoltHub blog](https://www.dolthub.com/blog/?tags=doltlite)
-([origin story](https://www.dolthub.com/blog/2026-03-24-a-week-in-gas-town/)).
+[Why DoltLite?](https://www.dolthub.com/blog/2026-04-27-why-doltlite/) DoltLite
+can be embedded in any language enabling local-first use cases for [Dolt](https://github.com/dolthub/dolt/).
+
+You can read more about DoltLite, including its 
+[origin story](https://www.dolthub.com/blog/2026-03-24-a-week-in-gas-town/), 
+on the [DoltHub blog](https://www.dolthub.com/blog/?tags=doltlite).
 
 ## Install
 


### PR DESCRIPTION
## Summary
- Trim excess README fat: long CI gate prose, coverage recipes, per-suite test lists, hybrid-storage demo, and redundant feature commentary → point at workflows, AGENTS, and contract TSVs instead.
- Fix outdated claims: checkout no longer fails on uncommitted work; C/bindings API is public `sqlite3_*` surface with storage-coupled exceptions; working sets belong to the branch; conflicts are txn-only / never durable; version example updated.
- Leave the SQLite compatibility, concurrency, and frozen storage-format v12 contracts as the authoritative behavior sections.

## Test plan
- [ ] Skim rendered README on GitHub for broken anchors and section flow
- [ ] Spot-check claims against `test/sqlite_compatibility_contract.tsv`, `test/concurrency_contract.tsv`, and `test/storage_format_contract.tsv`