### PR TITLE
ci: run VC concurrency tests under TSan

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -616,7 +616,8 @@ jobs:
             -o threadtest5 ../test/threadtest5.c sqlite3.c \
             $TSAN_LDFLAGS -ldl -lpthread -lm -lz
           make CC=clang CFLAGS="$TSAN_CFLAGS" LDFLAGS="$TSAN_LDFLAGS" \
-            doltlite doltlite-remotesrv
+            doltlite doltlite-remotesrv vc_concurrency_test \
+            vc_ref_mutation_stress_test
         } 2>&1 | tee build.log
         if grep -E "warning:" build.log; then
           echo "::error::compiler warnings in TSan build"

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -227,6 +227,12 @@ jobs:
         rm -f /tmp/doltlite-threadtest5.db
         ./threadtest5 'file:/tmp/doltlite-threadtest5.db?mode=rwc' -num-workers 8
 
+    - name: Run version-control concurrency under TSan
+      run: |
+        cd build
+        ./vc_concurrency_test
+        ./vc_ref_mutation_stress_test
+
     - name: Run HTTP remote concurrency under TSan
       run: |
         cd build


### PR DESCRIPTION
## Summary

- include `vc_concurrency_test` and `vc_ref_mutation_stress_test` in the existing TSan build artifact
- execute both with the sanitizer job's existing fail-fast TSan configuration

## Testing

- built both targets with `-fsanitize=thread` and the CI compiler flags
- `vc_concurrency_test` (37 passed)
- `vc_ref_mutation_stress_test` (282 passed)
- parsed both modified workflow files as YAML

Co-Authored-By: OpenAI Codex <noreply@openai.com>