### PR TITLE
test: fuzz remote wire responses

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -716,7 +716,7 @@ jobs:
         {
           make CC=clang CFLAGS="$FUZZ_CFLAGS" LDFLAGS="$FUZZ_LDFLAGS" \
             libdoltlite.a
-          for target in fuzz_replaywal fuzz_prolly_node fuzz_deserialize_refs fuzz_read_index fuzz_deserialize_catalog; do
+          for target in fuzz_replaywal fuzz_prolly_node fuzz_deserialize_refs fuzz_read_index fuzz_deserialize_catalog fuzz_wire_response; do
             clang -O1 -g -Werror \
               -fsanitize=fuzzer,address -fno-omit-frame-pointer \
               -fno-sanitize-recover=address \

--- a/.github/workflows/nightly-fuzz.yml
+++ b/.github/workflows/nightly-fuzz.yml
@@ -7,7 +7,7 @@ name: Nightly fuzz
 # report-failure-issue action (GitHub then emails repo watchers).
 #
 # One matrix job per target so each gets its own time budget (a single job
-# caps at GitHub's 6-hour limit, so the five can't be serialized). Starts at
+# caps at GitHub's 6-hour limit, so the six can't be serialized). Starts at
 # 1 hour per target and can be raised later. The discovered corpus is cached
 # per target, so each night compounds on the inputs earlier runs found instead
 # of restarting from the committed seeds.
@@ -42,6 +42,7 @@ jobs:
           - deserialize_refs
           - read_index
           - deserialize_catalog
+          - wire_response
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -137,6 +137,17 @@ jobs:
           -rss_limit_mb=2048 \
           -print_final_stats=1
 
+    - name: Run wire response fuzzer (1m)
+      env:
+        ASAN_OPTIONS: abort_on_error=1:halt_on_error=1:print_stacktrace=1:detect_leaks=0
+      run: |
+        "$GITHUB_WORKSPACE/build-fuzz/fuzz_wire_response" \
+          "$GITHUB_WORKSPACE/test/fuzz-corpus/wire_response" \
+          -max_total_time=60 \
+          -timeout=10 \
+          -rss_limit_mb=2048 \
+          -print_final_stats=1
+
     - name: Upload fuzz crash artifacts
       if: failure()
       uses: actions/upload-artifact@v4

--- a/src/doltlite_http_remote.c
+++ b/src/doltlite_http_remote.c
@@ -185,6 +185,110 @@ static int readUntilEof(HttpConn *conn, u8 **ppOut, int *pnOut){
   return SQLITE_OK;
 }
 
+static int httpParseResponse(
+  const u8 *pRaw,
+  int nRaw,
+  int *pStatus,
+  u8 **ppResp,
+  int *pnResp
+){
+  int i = 0;
+  int bodyStart = -1;
+  int contentLength = -1;
+  int seenContentLength = 0;
+  int seenTransferEncoding = 0;
+  int statusStart;
+  int statusEnd;
+  uint64_t value;
+
+  *pStatus = 0;
+  *ppResp = 0;
+  *pnResp = 0;
+
+  while( i<nRaw && pRaw[i]!=' ' && pRaw[i]!='\r' && pRaw[i]!='\n' ) i++;
+  if( i>=nRaw || pRaw[i]!=' ' ) return SQLITE_PROTOCOL;
+  statusStart = ++i;
+  while( i<nRaw && pRaw[i]!=' ' && pRaw[i]!='\r' && pRaw[i]!='\n' ) i++;
+  statusEnd = i;
+  if( statusEnd-statusStart!=3
+   || doltliteParseDecimal(
+        (const char*)pRaw+statusStart, (const char*)pRaw+statusEnd,
+        999, &value)!=DOLTLITE_DECIMAL_OK
+   || value<100 ){
+    return SQLITE_PROTOCOL;
+  }
+  *pStatus = (int)value;
+
+  while( i+1<nRaw && !(pRaw[i]=='\r' && pRaw[i+1]=='\n') ) i++;
+  if( i+1>=nRaw ) return SQLITE_PROTOCOL;
+  i += 2;
+  while( i<nRaw ){
+    int lineStart = i;
+    int lineEnd;
+    int colon;
+    int valueStart;
+    int valueEnd;
+    int parseRc;
+
+    if( i+1<nRaw && pRaw[i]=='\r' && pRaw[i+1]=='\n' ){
+      bodyStart = i + 2;
+      break;
+    }
+    while( i+1<nRaw && !(pRaw[i]=='\r' && pRaw[i+1]=='\n') ) i++;
+    if( i+1>=nRaw ) return SQLITE_PROTOCOL;
+    lineEnd = i;
+    i += 2;
+
+    colon = lineStart;
+    while( colon<lineEnd && pRaw[colon]!=':' ) colon++;
+    if( colon==lineStart || colon==lineEnd ) continue;
+
+    valueStart = colon + 1;
+    while( valueStart<lineEnd
+        && (pRaw[valueStart]==' ' || pRaw[valueStart]=='\t') ){
+      valueStart++;
+    }
+    valueEnd = lineEnd;
+    while( valueEnd>valueStart
+        && (pRaw[valueEnd-1]==' ' || pRaw[valueEnd-1]=='\t') ){
+      valueEnd--;
+    }
+
+    if( httpHeaderNameEquals(
+          pRaw+lineStart, colon-lineStart, "Content-Length") ){
+      if( seenContentLength ) return SQLITE_PROTOCOL;
+      seenContentLength = 1;
+      parseRc = doltliteParseDecimal(
+          (const char*)pRaw+valueStart, (const char*)pRaw+valueEnd,
+          (uint64_t)HTTP_RESP_MAX_BYTES, &value);
+      if( parseRc!=DOLTLITE_DECIMAL_OK ){
+        return parseRc==DOLTLITE_DECIMAL_RANGE
+             ? SQLITE_TOOBIG : SQLITE_PROTOCOL;
+      }
+      contentLength = (int)value;
+    }else if( httpHeaderNameEquals(
+                 pRaw+lineStart, colon-lineStart, "Transfer-Encoding") ){
+      seenTransferEncoding = 1;
+    }
+  }
+
+  if( bodyStart<0 || seenTransferEncoding ) return SQLITE_PROTOCOL;
+
+  {
+    int nAvail = nRaw - bodyStart;
+    int nCopy = contentLength>=0 ? contentLength : nAvail;
+    if( contentLength>=0 && contentLength!=nAvail ) return SQLITE_PROTOCOL;
+    if( nCopy>0 ){
+      *ppResp = sqlite3_malloc(nCopy);
+      if( !*ppResp ) return SQLITE_NOMEM;
+      memcpy(*ppResp, pRaw + bodyStart, nCopy);
+      *pnResp = nCopy;
+    }
+  }
+
+  return SQLITE_OK;
+}
+
 static int httpRequest(
   HttpRemote *p,
   const char *zMethod,
@@ -254,124 +358,9 @@ static int httpRequest(
   rc = readUntilEof(conn, &pRaw, &nRaw);
   httpConnClose(conn);
   if( rc != SQLITE_OK ) return rc;
-
-  {
-    int i = 0;
-    int bodyStart = -1;
-    int contentLength = -1;
-    int seenContentLength = 0;
-    int seenTransferEncoding = 0;
-    int statusStart;
-    int statusEnd;
-    uint64_t value;
-
-    while( i<nRaw && pRaw[i]!=' ' && pRaw[i]!='\r' && pRaw[i]!='\n' ) i++;
-    if( i>=nRaw || pRaw[i]!=' ' ){
-      sqlite3_free(pRaw);
-      return SQLITE_PROTOCOL;
-    }
-    statusStart = ++i;
-    while( i<nRaw && pRaw[i]!=' ' && pRaw[i]!='\r' && pRaw[i]!='\n' ) i++;
-    statusEnd = i;
-    if( statusEnd-statusStart!=3
-     || doltliteParseDecimal(
-          (const char*)pRaw+statusStart, (const char*)pRaw+statusEnd,
-          999, &value)!=DOLTLITE_DECIMAL_OK
-     || value<100 ){
-      sqlite3_free(pRaw);
-      return SQLITE_PROTOCOL;
-    }
-    *pStatus = (int)value;
-
-    while( i+1<nRaw && !(pRaw[i]=='\r' && pRaw[i+1]=='\n') ) i++;
-    if( i+1>=nRaw ){
-      sqlite3_free(pRaw);
-      return SQLITE_PROTOCOL;
-    }
-    i += 2;
-    while( i<nRaw ){
-      int lineStart = i;
-      int lineEnd;
-      int colon;
-      int valueStart;
-      int valueEnd;
-      int parseRc;
-
-      if( i+1<nRaw && pRaw[i]=='\r' && pRaw[i+1]=='\n' ){
-        bodyStart = i + 2;
-        break;
-      }
-      while( i+1<nRaw && !(pRaw[i]=='\r' && pRaw[i+1]=='\n') ) i++;
-      if( i+1>=nRaw ){
-        sqlite3_free(pRaw);
-        return SQLITE_PROTOCOL;
-      }
-      lineEnd = i;
-      i += 2;
-
-      colon = lineStart;
-      while( colon<lineEnd && pRaw[colon]!=':' ) colon++;
-      if( colon==lineStart || colon==lineEnd ) continue;
-
-      valueStart = colon + 1;
-      while( valueStart<lineEnd
-          && (pRaw[valueStart]==' ' || pRaw[valueStart]=='\t') ){
-        valueStart++;
-      }
-      valueEnd = lineEnd;
-      while( valueEnd>valueStart
-          && (pRaw[valueEnd-1]==' ' || pRaw[valueEnd-1]=='\t') ){
-        valueEnd--;
-      }
-
-      if( httpHeaderNameEquals(
-            pRaw+lineStart, colon-lineStart, "Content-Length") ){
-        if( seenContentLength ){
-          sqlite3_free(pRaw);
-          return SQLITE_PROTOCOL;
-        }
-        seenContentLength = 1;
-        parseRc = doltliteParseDecimal(
-            (const char*)pRaw+valueStart, (const char*)pRaw+valueEnd,
-            (uint64_t)HTTP_RESP_MAX_BYTES, &value);
-        if( parseRc!=DOLTLITE_DECIMAL_OK ){
-          sqlite3_free(pRaw);
-          return parseRc==DOLTLITE_DECIMAL_RANGE
-               ? SQLITE_TOOBIG : SQLITE_PROTOCOL;
-        }
-        contentLength = (int)value;
-      }else if( httpHeaderNameEquals(
-                   pRaw+lineStart, colon-lineStart, "Transfer-Encoding") ){
-        seenTransferEncoding = 1;
-      }
-    }
-
-    if( bodyStart<0 || seenTransferEncoding ){
-      sqlite3_free(pRaw);
-      return SQLITE_PROTOCOL;
-    }
-
-    {
-      int nAvail = nRaw - bodyStart;
-      int nCopy = contentLength>=0 ? contentLength : nAvail;
-      if( contentLength>=0 && contentLength!=nAvail ){
-        sqlite3_free(pRaw);
-        return SQLITE_PROTOCOL;
-      }
-      if( nCopy>0 ){
-        *ppResp = sqlite3_malloc(nCopy);
-        if( !*ppResp ){
-          sqlite3_free(pRaw);
-          return SQLITE_NOMEM;
-        }
-        memcpy(*ppResp, pRaw + bodyStart, nCopy);
-        *pnResp = nCopy;
-      }
-    }
-    sqlite3_free(pRaw);
-  }
-
-  return SQLITE_OK;
+  rc = httpParseResponse(pRaw, nRaw, pStatus, ppResp, pnResp);
+  sqlite3_free(pRaw);
+  return rc;
 }
 
 static int uploadBufAppend(HttpRemote *p, const u8 *pData, int nData){
@@ -508,6 +497,58 @@ static int httpPutChunk(DoltliteRemote *pRemote, const ProllyHash *pHash,
   return rc;
 }
 
+static int httpParseChunkBatch(
+  const u8 *pResp,
+  int nResp,
+  int nHash,
+  u8 **apData,
+  int *anData
+){
+  i64 poff = 0;
+  int rc = SQLITE_OK;
+  int i;
+
+  for(i=0; i<nHash; i++){ apData[i] = 0; anData[i] = 0; }
+  for(i=0; i<nHash; i++){
+    u32 len;
+    if( poff + 4 > nResp ){ rc = SQLITE_ERROR; break; }
+    len = ((u32)pResp[poff] << 24) | ((u32)pResp[poff+1] << 16)
+        | ((u32)pResp[poff+2] << 8) | (u32)pResp[poff+3];
+    poff += 4;
+    if( len == 0xFFFFFFFFu ) continue;
+    if( poff + (i64)len > nResp ){ rc = SQLITE_ERROR; break; }
+    apData[i] = sqlite3_malloc(len ? (int)len : 1);
+    if( !apData[i] ){ rc = SQLITE_NOMEM; break; }
+    memcpy(apData[i], pResp + poff, len);
+    anData[i] = (int)len;
+    poff += len;
+  }
+  return rc;
+}
+
+int doltliteHttpParseResponseForTest(
+  const u8 *pRaw,
+  int nRaw,
+  int nHash
+){
+  u8 *apData[64];
+  int anData[64];
+  u8 *pResp = 0;
+  int nResp = 0;
+  int status = 0;
+  int rc;
+  int i;
+
+  if( nHash<0 || nHash>64 ) return SQLITE_MISUSE;
+  rc = httpParseResponse(pRaw, nRaw, &status, &pResp, &nResp);
+  if( rc==SQLITE_OK && status==200 ){
+    rc = httpParseChunkBatch(pResp, nResp, nHash, apData, anData);
+    for(i=0; i<nHash; i++) sqlite3_free(apData[i]);
+  }
+  sqlite3_free(pResp);
+  return rc;
+}
+
 /* Batched fetch: POST the concatenated hashes to /get-chunks and parse the
 ** framed reply (per requested hash: a 4-byte big-endian length then that many
 ** payload bytes; length 0xFFFFFFFF marks an absent chunk). One round trip
@@ -522,7 +563,6 @@ static int httpGetChunks(DoltliteRemote *pRemote, const ProllyHash *aHash,
   int status = 0;
   int rc;
   int i;
-  i64 poff;
 
   for(i=0; i<nHash; i++){ apData[i] = 0; anData[i] = 0; }
   if( nHash <= 0 ) return SQLITE_OK;
@@ -542,23 +582,7 @@ static int httpGetChunks(DoltliteRemote *pRemote, const ProllyHash *aHash,
   sqlite3_free(pReq);
   if( rc != SQLITE_OK ){ sqlite3_free(pResp); return rc; }
   if( status != 200 ){ sqlite3_free(pResp); return SQLITE_ERROR; }
-
-  poff = 0;
-  for(i=0; i<nHash; i++){
-    u32 len;
-    if( poff + 4 > nResp ){ rc = SQLITE_ERROR; break; }
-    len = ((u32)pResp[poff] << 24) | ((u32)pResp[poff+1] << 16)
-        | ((u32)pResp[poff+2] << 8) | (u32)pResp[poff+3];
-    poff += 4;
-    if( len == 0xFFFFFFFFu ) continue;            /* absent */
-    if( poff + (i64)len > nResp ){ rc = SQLITE_ERROR; break; }
-    apData[i] = sqlite3_malloc(len ? (int)len : 1);
-    if( !apData[i] ){ rc = SQLITE_NOMEM; break; }
-    memcpy(apData[i], pResp + poff, len);
-    anData[i] = (int)len;
-    poff += len;
-  }
-
+  rc = httpParseChunkBatch(pResp, nResp, nHash, apData, anData);
   sqlite3_free(pResp);
   return rc;   /* caller frees any apData[i] set before an error */
 }

--- a/src/doltlite_remote.h
+++ b/src/doltlite_remote.h
@@ -60,4 +60,6 @@ DoltliteRemote *doltliteLocalAsRemote(ChunkStore *pLocal);
 
 DoltliteRemote *doltliteHttpRemoteOpen(const char *zUrl);
 
+int doltliteHttpParseResponseForTest(const u8 *pRaw, int nRaw, int nHash);
+
 #endif

--- a/test/fuzz-corpus/wire_response/http_batch
+++ b/test/fuzz-corpus/wire_response/http_batch
@@ -1,0 +1,4 @@
+BHTTP/1.1 200 OK
+Content-Length: 6
+
+AAAA

--- a/test/fuzz_wire_response.c
+++ b/test/fuzz_wire_response.c
@@ -1,0 +1,43 @@
+#include <stdint.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include "sqlite3.h"
+
+extern int doltliteHttpParseResponseForTest(
+  const unsigned char *pRaw,
+  int nRaw,
+  int nHash
+);
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  static int initialized = 0;
+  uint8_t *normalized;
+  size_t i;
+  size_t nNormalized;
+  int nHash;
+
+  if (size < 1 || size > 1024 * 1024) return 0;
+  if (size - 1 > (size_t)0x7fffffff) return 0;
+  if (!initialized) {
+    sqlite3_initialize();
+    initialized = 1;
+  }
+
+  nHash = data[0] % 65;
+  (void)doltliteHttpParseResponseForTest(
+      data + 1, (int)(size - 1), nHash);
+
+  normalized = (uint8_t *)malloc((size - 1) * 2);
+  if (!normalized) return 0;
+  nNormalized = 0;
+  for (i = 1; i < size; i++) {
+    if (data[i] == '\n' && (i == 1 || data[i - 1] != '\r')) {
+      normalized[nNormalized++] = '\r';
+    }
+    normalized[nNormalized++] = data[i];
+  }
+  (void)doltliteHttpParseResponseForTest(
+      normalized, (int)nNormalized, nHash);
+  free(normalized);
+  return 0;
+}

--- a/test/run_fuzz.sh
+++ b/test/run_fuzz.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 if [ $# -lt 1 ]; then
   echo "usage: $0 <target> [libFuzzer args...]" >&2
-  echo "  target: replaywal | prolly_node | deserialize_refs | read_index | deserialize_catalog" >&2
+  echo "  target: replaywal | prolly_node | deserialize_refs | read_index | deserialize_catalog | wire_response" >&2
   exit 2
 fi
 
@@ -31,8 +31,12 @@ case "$target" in
     src="fuzz_deserialize_catalog.c"
     corpus="deserialize_catalog"
     ;;
+  wire_response)
+    src="fuzz_wire_response.c"
+    corpus="wire_response"
+    ;;
   *)
-    echo "ERROR: unknown target '$target' (expected: replaywal | prolly_node | deserialize_refs | read_index | deserialize_catalog)" >&2
+    echo "ERROR: unknown target '$target' (expected: replaywal | prolly_node | deserialize_refs | read_index | deserialize_catalog | wire_response)" >&2
     exit 2
     ;;
 esac


### PR DESCRIPTION
## Summary

- extract bounded HTTP response parsing and batched chunk-frame decoding into reusable parser boundaries
- add a corpus-backed `fuzz_wire_response` ASan/libFuzzer target that exercises raw and normalized wire inputs
- run the target for one minute in PR smoke and as an independent nightly soak with persistent corpus growth
- expose it through `test/run_fuzz.sh wire_response`

## Testing

- ASan-instrumented standalone driver: valid framed response plus 100,000 randomized inputs
- `http_remote_content_length_test.sh`
- `remotesrv_http_test.sh` (29 passed)
- `remotesrv_http_partial_failure_test.sh` (9 passed)
- `make lint`
- parsed all modified workflow files as YAML

The local Apple clang installation does not ship `libclang_rt.fuzzer_osx.a`; the Ubuntu CI build supplies libFuzzer and runs the corpus target directly.

Co-Authored-By: OpenAI Codex <noreply@openai.com>