### PR TITLE
merge: conflict index changes with parent table drops

### DIFF
--- a/src/doltlite_merge.c
+++ b/src/doltlite_merge.c
@@ -350,6 +350,9 @@ static int preDetectIndexSchemaConflicts(
       SchemaEntry *pAnc;
       SchemaEntry *pOurs;
       SchemaEntry *pTheirs;
+      SchemaEntry *pAncTable;
+      SchemaEntry *pOursTable;
+      SchemaEntry *pTheirsTable;
       const char *zTable;
       int oursChanged;
       int theirsChanged;
@@ -373,6 +376,25 @@ static int preDetectIndexSchemaConflicts(
       pTheirs = findSchemaEntry(aTheirs, nTheirs, a[i].zName);
       oursChanged = !mergeSchemaEntriesSame(pAnc, pOurs);
       theirsChanged = !mergeSchemaEntriesSame(pAnc, pTheirs);
+      zTable = pOurs && pOurs->zTblName ? pOurs->zTblName
+             : (pTheirs && pTheirs->zTblName ? pTheirs->zTblName
+             : (pAnc && pAnc->zTblName ? pAnc->zTblName : a[i].zName));
+      pAncTable = findSchemaEntry(aAnc, nAnc, zTable);
+      pOursTable = findSchemaEntry(aOurs, nOurs, zTable);
+      pTheirsTable = findSchemaEntry(aTheirs, nTheirs, zTable);
+      if( pAncTable && pAncTable->zType
+       && strcmp(pAncTable->zType, "table")==0
+       && ((pOursTable && !pTheirsTable && oursChanged)
+        || (!pOursTable && pTheirsTable && theirsChanged)) ){
+        rc = appendSchemaConflict(ppConflictTables, pnConflictTables,
+                                  zTable, zTable, &addedSchemaTable);
+        if( rc!=SQLITE_OK ) return rc;
+        if( addedSchemaTable ) (*pTotalConflicts)++;
+        rc = appendSchemaConflict(ppConflictTables, pnConflictTables,
+                                  zTable, a[i].zName, &addedSchemaTable);
+        if( rc!=SQLITE_OK ) return rc;
+        continue;
+      }
       if( !oursChanged || !theirsChanged
        || mergeSchemaEntriesSame(pOurs, pTheirs) ){
         continue;
@@ -380,9 +402,6 @@ static int preDetectIndexSchemaConflicts(
       /* Dolt keeps the modified index definition when the other branch
       ** drops that index. Only competing surviving definitions conflict. */
       if( pAnc && (!pOurs || !pTheirs) ) continue;
-      zTable = pOurs && pOurs->zTblName ? pOurs->zTblName
-             : (pTheirs && pTheirs->zTblName ? pTheirs->zTblName
-                                             : a[i].zName);
       rc = appendSchemaConflict(ppConflictTables, pnConflictTables,
                                 zTable, a[i].zName, &addedSchemaTable);
       if( rc!=SQLITE_OK ) return rc;
@@ -811,6 +830,11 @@ static int rebuildDisjointSchemaRows(
     Pgno iRootpage;
     if( !pSe->zName || !pSe->zType ) continue;
     if( strcmp(pSe->zType, "index")!=0 ) continue;
+    if( hasSchemaConflictObject(aConflictTables, nConflictTables, pSe->zName)
+     || hasSchemaConflictTable(aConflictTables, nConflictTables,
+                               pSe->zTblName) ){
+      continue;
+    }
     if( !schemaEntryChangedByName(aAncSchema, nAncSchema,
                                   aTheirsSchema, nTheirsSchema,
                                   pSe->zName) ){

--- a/test/doltlite_merge_index_conflict.sh
+++ b/test/doltlite_merge_index_conflict.sh
@@ -152,6 +152,61 @@ EOF
 out=$("$DOLTLITE" "$DB" "SELECT id || '|' || v FROM t INDEXED BY iv WHERE v > 0 ORDER BY v;")
 check "delmod_iv_one_row" "1|3" "$out"
 
+DB="$TMPROOT/index_vs_table_drop.db"
+"$DOLTLITE" "$DB" <<'EOF' >/dev/null 2>&1
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+CREATE TABLE keep(id INTEGER PRIMARY KEY);
+SELECT dolt_commit('-A','-m','init');
+SELECT dolt_branch('feat');
+CREATE INDEX iv ON t(v);
+SELECT dolt_commit('-A','-m','main-index');
+EOF
+"$DOLTLITE" "$DB/feat" <<'EOF' >/dev/null 2>&1
+DROP TABLE t;
+CREATE TABLE added(id INTEGER PRIMARY KEY);
+SELECT dolt_commit('-A','-m','feat-drop');
+EOF
+out=$("$DOLTLITE" "$DB" <<'EOF' 2>/dev/null | tail -1
+BEGIN;
+SELECT dolt_merge('feat');
+SELECT (SELECT count(*) FROM dolt_schema_conflicts) || '|' ||
+       (SELECT count(*) FROM dolt_status WHERE status='schema conflict') || '|' ||
+       (SELECT count(*) FROM sqlite_schema WHERE name='t') || '|' ||
+       (SELECT count(*) FROM sqlite_schema WHERE name='added');
+ROLLBACK;
+EOF
+)
+check "added_index_vs_table_drop_conflicts" "1|1|1|1" "$out"
+
+DB="$TMPROOT/table_drop_vs_index.db"
+"$DOLTLITE" "$DB" <<'EOF' >/dev/null 2>&1
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+CREATE TABLE keep(id INTEGER PRIMARY KEY);
+CREATE TABLE obsolete(id INTEGER PRIMARY KEY);
+SELECT dolt_commit('-A','-m','init');
+SELECT dolt_branch('feat');
+DROP TABLE t;
+CREATE TABLE added(id INTEGER PRIMARY KEY);
+SELECT dolt_commit('-A','-m','main-drop');
+EOF
+"$DOLTLITE" "$DB/feat" <<'EOF' >/dev/null 2>&1
+DROP TABLE obsolete;
+CREATE INDEX iv ON t(v);
+SELECT dolt_commit('-A','-m','feat-index');
+EOF
+out=$("$DOLTLITE" "$DB" <<'EOF' 2>/dev/null | tail -1
+BEGIN;
+SELECT dolt_merge('feat');
+SELECT (SELECT count(*) FROM dolt_schema_conflicts) || '|' ||
+       (SELECT count(*) FROM dolt_status WHERE status='schema conflict') || '|' ||
+       (SELECT count(*) FROM sqlite_schema WHERE name='t') || '|' ||
+       (SELECT count(*) FROM sqlite_schema WHERE name='added') || '|' ||
+       (SELECT count(*) FROM sqlite_schema WHERE name='obsolete');
+ROLLBACK;
+EOF
+)
+check "table_drop_vs_added_index_conflicts" "1|1|0|1|0" "$out"
+
 echo
 echo "doltlite_merge_index_conflict: $pass passed, $fail failed"
 if [ "$fail" -gt 0 ]; then


### PR DESCRIPTION
## Summary
- classify an index change against deletion of its parent table as a schema conflict
- retain the target side of both the table and index while the conflict is unresolved
- prevent a conflicting source index from being resurrected during schema-row rebuilding
- cover both merge directions and concurrent root renumbering

## Validation
- fail-before: `doltlite_merge_index_conflict.sh` reports 2 failures on master
- pass-after: `doltlite_merge_index_conflict.sh` passes 11/11
- deterministic CI seed `1785540977` passes 435 steps, including the former step-373 corruption
- 97 runnable native suites passed; the two unavailable suites require `sqlite3` and `libdoltlite.a` artifacts not built in this worktree
- layering and raw-I/O lint passed
- behavior checked against Dolt 2.2.2, which reports a schema conflict

Co-Authored-By: OpenAI Codex <noreply@openai.com>