### PR TITLE
Fix staged state after branch reconnect

### DIFF
--- a/src/doltlite_checkout.c
+++ b/src/doltlite_checkout.c
@@ -452,13 +452,6 @@ void doltConnectBranchFunc(
     doltliteSetSessionHead(db, &targetCommit);
     rc = doltliteLoadWorkingSet(db, zBranch);
   }
-  if( rc==SQLITE_OK ){
-    ProllyHash staged;
-    doltliteGetSessionStaged(db, &staged);
-    if( prollyHashIsEmpty(&staged) ){
-      rc = doltliteSetSessionStaged(db, &targetCatHash);
-    }
-  }
   if( rc!=SQLITE_OK ){
     int restoreRc = checkoutRestoreSession(db, &m);
     if( restoreRc!=SQLITE_OK ) rc = restoreRc;

--- a/test/doltlite_connect_branch.sh
+++ b/test/doltlite_connect_branch.sh
@@ -105,6 +105,11 @@ setup_db "$DB"
 res=$("$DOLTLITE" "$DB" "SELECT dolt_connect_branch('feat'); SELECT dolt_branch('-d','feat');" 2>&1)
 check_match "connect_then_delete_current_branch_errors" "cannot delete" "$res"
 
+setup_db "$DB"
+"$DOLTLITE" "$DB" "SELECT dolt_connect_branch('feat'); INSERT INTO t VALUES(3,'unstaged');" >/dev/null
+res=$("$DOLTLITE" "$DB" "SELECT dolt_connect_branch('feat'); SELECT staged FROM dolt_status WHERE table_name='t';")
+check_eq "reconnect_preserves_unstaged_state" $'0\n0' "$res"
+
 rm -f "$DB"
 
 echo ""


### PR DESCRIPTION
## Summary

- preserve an empty staged hash when loading a branch working set
- stop replacing the staged baseline with the working catalog during checkout and explicit branch connection
- cover reconnecting to a branch with persisted unstaged edits

The expanded stateful VC fuzzer in #1906 exposed this: reopening a branch could make an unstaged row eligible for `dolt_commit` without `dolt_add`.

## Tests

- fail-before/pass-after reconnect regression
- `doltlite_connect_branch.sh`: 21 passed
- `doltlite_branch.sh`: 63 passed
- `make lint`
- native suite: all runnable suites passed; parity and C-regression wrappers required unbuilt optional `sqlite3` / `libdoltlite.a` artifacts

Co-Authored-By: OpenAI Codex <noreply@openai.com>