### PR TITLE
Regenerate the amalgamation when doltlite sources change

### DIFF
--- a/main.mk
+++ b/main.mk
@@ -1288,8 +1288,12 @@ T.link.tcl = $(T.tcl.env.source); $(T.link)
 # files are automatically generated.  This target takes care of
 # all that automatic generation.
 #
-.target_source: $(MAKE_SANITY_CHECK) $(SRC) $(TOP)/tool/vdbe-compress.tcl \
-    fts5.c $(B.tclsh)
+# DOLTLITE_EXTRA_TSRC is copied into tsrc below, so it must also be a
+# prerequisite: without it, editing a doltlite/prolly/chunk source leaves
+# the amalgamation stale, and every amalgamation consumer (testfixture
+# above all) silently tests the previously generated engine.
+.target_source: $(MAKE_SANITY_CHECK) $(SRC) $(DOLTLITE_EXTRA_TSRC) \
+    $(TOP)/tool/vdbe-compress.tcl fts5.c $(B.tclsh)
 	rm -rf tsrc
 	mkdir tsrc
 	cp -f $(SRC) tsrc


### PR DESCRIPTION
## The bug

`.target_source` copies `$(DOLTLITE_EXTRA_TSRC)` into `tsrc/` but does not list it as a prerequisite. So editing **any** doltlite/prolly/chunk source leaves `sqlite3.c` stale, and every amalgamation consumer silently builds the previously generated engine — `testfixture` above all, since the entire inherited tcl suite compiles from `sqlite3.c`.

The failure mode is the nasty kind: the build succeeds, the tests run, and the results say nothing about the code in your tree.

## Proof

Before, with `src/chunk_wal.c` timestamped an hour *ahead* of `sqlite3.c`:

```
$ make testfixture          # relinks, regenerates nothing
$ stat sqlite3.c            # 07:58:52  (unchanged, older than the edit)
```

After:

```
$ make testfixture          # runs mksqlite3c.tcl
$ stat sqlite3.c            # 08:00:29  (regenerated)
$ make testfixture          # no edit → no regeneration (idempotent)
```

## Why it matters

This cost me most of a debugging session yesterday, twice: container test runs that "proved" a branch was clean were built from a stale amalgamation, which sent a root-cause investigation down a wrong path (blaming a master regression that didn't exist). Anyone bisecting engine behavior through `testfixture` is exposed to the same trap, and nothing warns you.

`DOLTLITE_EXTRA_TSRC` is empty unless `DOLTLITE_PROLLY=1`, so the prerequisite is a no-op for stock builds.

## Validation

- `corruption_test` 106/106, `doltlite_regression_test_c` 310,064/310,064, growth-axis gates 3/3
- `testfixture` rebuilt from the regenerated amalgamation: `atomic` clean; `avtrans` shows the same single pre-existing macOS-local failure as before the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)