### PR TITLE
Fix cherry-pick of rename over dropped table

### DIFF
--- a/src/doltlite_merge.c
+++ b/src/doltlite_merge.c
@@ -498,6 +498,110 @@ SchemaEntry *findSchemaEntryByRootpage(
   return 0;
 }
 
+static int mergeTableSchemaBodiesSame(
+  const SchemaEntry *pA,
+  const SchemaEntry *pB
+){
+  const char *zA;
+  const char *zB;
+  if( !pA || !pA->zType || !pA->zSql
+   || !pB || !pB->zType || !pB->zSql
+   || strcmp(pA->zType, "table")!=0
+   || strcmp(pB->zType, "table")!=0 ){
+    return 0;
+  }
+  zA = strchr(pA->zSql, '(');
+  zB = strchr(pB->zSql, '(');
+  return zA && zB && strcmp(zA, zB)==0;
+}
+
+static int mergeRenameNamesExclusive(
+  struct TableEntry *aAnc, int nAnc,
+  struct TableEntry *aDropped, int nDropped,
+  struct TableEntry *aRenamed, int nRenamed,
+  const char *zOld,
+  const char *zNew
+){
+  return !doltliteFindTableByName(aRenamed, nRenamed, zOld)
+      && !doltliteFindTableByName(aAnc, nAnc, zNew)
+      && !doltliteFindTableByName(aDropped, nDropped, zOld)
+      && !doltliteFindTableByName(aDropped, nDropped, zNew);
+}
+
+int mergeTableRenameOtherDrop(
+  struct TableEntry *aAnc, int nAnc,
+  struct TableEntry *aDropped, int nDropped,
+  struct TableEntry *aRenamed, int nRenamed,
+  SchemaEntry *aAncSchema, int nAncSchema,
+  SchemaEntry *aRenamedSchema, int nRenamedSchema,
+  struct TableEntry *pRenamed
+){
+  struct TableEntry *pAnc;
+  SchemaEntry *pAncSe;
+  SchemaEntry *pRenamedSe;
+  int i;
+
+  if( !pRenamed || !pRenamed->zName || pRenamed->iTable<=1 ) return 0;
+  pAnc = doltliteFindTableByNumber(aAnc, nAnc, pRenamed->iTable);
+  pAncSe = pAnc ? findSchemaEntryByRootpage(
+      aAncSchema, nAncSchema, pAnc->iTable) : 0;
+  pRenamedSe = findSchemaEntryByRootpage(
+      aRenamedSchema, nRenamedSchema, pRenamed->iTable);
+  if( !pRenamedSe || !pRenamedSe->zType
+   || strcmp(pRenamedSe->zType, "table")!=0 ) return 0;
+  if( !pAnc || !pAnc->zName
+   || strcmp(pAnc->zName, pRenamed->zName)==0
+   || prollyHashCompare(&pAnc->root, &pRenamed->root)!=0
+   || !mergeTableSchemaBodiesSame(pAncSe, pRenamedSe) ){
+    pAnc = 0;
+    pAncSe = 0;
+  }
+  if( pAnc && !mergeRenameNamesExclusive(
+        aAnc, nAnc, aDropped, nDropped, aRenamed, nRenamed,
+        pAnc->zName, pRenamed->zName) ){
+    pAnc = 0;
+    pAncSe = 0;
+  }
+  if( !pAnc ){
+    for(i=0; i<nRenamedSchema; i++){
+      SchemaEntry *pAncIdx;
+      SchemaEntry *pCandidate;
+      struct TableEntry *pCandidateEntry;
+      if( !aRenamedSchema[i].zType || !aRenamedSchema[i].zName
+       || !aRenamedSchema[i].zTblName
+       || strcmp(aRenamedSchema[i].zType, "index")!=0
+       || sqlite3_stricmp(aRenamedSchema[i].zTblName,
+                          pRenamed->zName)!=0 ){
+        continue;
+      }
+      pAncIdx = findSchemaEntry(
+          aAncSchema, nAncSchema, aRenamedSchema[i].zName);
+      if( !pAncIdx || !pAncIdx->zType || !pAncIdx->zTblName
+       || strcmp(pAncIdx->zType, "index")!=0
+       || sqlite3_stricmp(pAncIdx->zTblName, pRenamed->zName)==0 ){
+        continue;
+      }
+      pCandidate = findSchemaEntry(
+          aAncSchema, nAncSchema, pAncIdx->zTblName);
+      if( !mergeTableSchemaBodiesSame(pCandidate, pRenamedSe) ){
+        continue;
+      }
+      pCandidateEntry = doltliteFindTableByName(
+          aAnc, nAnc, pCandidate->zName);
+      if( pCandidateEntry
+       && mergeRenameNamesExclusive(
+            aAnc, nAnc, aDropped, nDropped, aRenamed, nRenamed,
+            pCandidate->zName, pRenamed->zName) ){
+        pAnc = pCandidateEntry;
+        pAncSe = pCandidate;
+        break;
+      }
+    }
+  }
+  if( !pAnc || !pAncSe ) return 0;
+  return 1;
+}
+
 struct TableEntry *findCatalogEntryBySchemaObject(
   struct TableEntry *aCat,
   int nCat,
@@ -830,6 +934,10 @@ static int rebuildDisjointSchemaRows(
     Pgno iRootpage;
     if( !pSe->zName || !pSe->zType ) continue;
     if( strcmp(pSe->zType, "index")!=0 ) continue;
+    if( !pSe->zTblName
+     || !doltliteFindTableByName(aMerged, nMerged, pSe->zTblName) ){
+      continue;
+    }
     if( hasSchemaConflictObject(aConflictTables, nConflictTables, pSe->zName)
      || hasSchemaConflictTable(aConflictTables, nConflictTables,
                                pSe->zTblName) ){

--- a/src/doltlite_merge_int.h
+++ b/src/doltlite_merge_int.h
@@ -162,6 +162,15 @@ SchemaEntry *findSchemaEntryByRootpage(
   Pgno iRootpage
 );
 
+int mergeTableRenameOtherDrop(
+  struct TableEntry *aAnc, int nAnc,
+  struct TableEntry *aDropped, int nDropped,
+  struct TableEntry *aRenamed, int nRenamed,
+  SchemaEntry *aAncSchema, int nAncSchema,
+  SchemaEntry *aRenamedSchema, int nRenamedSchema,
+  struct TableEntry *pRenamed
+);
+
 struct TableEntry *findCatalogEntryBySchemaObject(
   struct TableEntry *aCat,
   int nCat,

--- a/src/doltlite_merge_pass1.c
+++ b/src/doltlite_merge_pass1.c
@@ -45,6 +45,7 @@ struct MergePass1Ctx {
   SchemaMergeAction **ppSchemaActions; int *pnSchemaActions;
   int bDisjointSchemaChanges;
   int bPreferOurMaster;
+  int bTheirsRenameOursDrop;
   char ***pazReindex; int *pnReindex;
   IndexMergePatch *aPatches;
   int nPatches;
@@ -538,6 +539,14 @@ static int mergePass1TheirsModifyDelete(MergePass1Ctx *c){
 
     if( c->aTheirs[i].iTable<=1 ) continue;
     if( zObject ){
+      if( mergeTableRenameOtherDrop(
+            c->aAnc, c->nAnc, c->aOurs, c->nOurs,
+            c->aTheirs, c->nTheirs,
+            c->aAncSchema, c->nAncSchema,
+            c->aTheirsSchema, c->nTheirsSchema, &c->aTheirs[i]) ){
+        c->bTheirsRenameOursDrop = 1;
+        continue;
+      }
       pAncEntry = doltliteFindTableByName(c->aAnc, c->nAnc, zObject);
       pOurEntry = doltliteFindTableByName(c->aOurs, c->nOurs, zObject);
       if( pAncEntry ){
@@ -596,7 +605,8 @@ static int mergePass1MergeMaster(MergePass1Ctx *c, int iTable1Idx){
   hasSchemaActions = (c->ppSchemaActions && c->pnSchemaActions
                       && *c->pnSchemaActions > 0);
   bPreferOurMasterHere = hasAnySchemaConflict(
-      *c->ppConflictTables, *c->pnConflictTables) || (c->bPreferOurMaster
+      *c->ppConflictTables, *c->pnConflictTables)
+      || c->bTheirsRenameOursDrop || (c->bPreferOurMaster
       && replayDropsDisjointSchemaObject(c->aAncSchema, c->nAncSchema,
                                          c->aTheirsSchema, c->nTheirsSchema));
 

--- a/src/doltlite_merge_pass2.c
+++ b/src/doltlite_merge_pass2.c
@@ -34,10 +34,17 @@ int mergeCatalogPass2(
           aTheirsSchema, nTheirsSchema, aTheirs[i].iTable);
       if( pTheirSe && pTheirSe->zName && pTheirSe->zType
        && strcmp(pTheirSe->zType, "index")==0 ){
+        struct TableEntry *pTheirTable = doltliteFindTableByName(
+            aTheirs, nTheirs, pTheirSe->zTblName);
         if( hasSchemaConflictObject(aConflictTables, nConflictTables,
                                     pTheirSe->zName)
          || hasSchemaConflictTable(aConflictTables, nConflictTables,
-                                   pTheirSe->zTblName) ){
+                                   pTheirSe->zTblName)
+         || !pTheirTable
+         || mergeTableRenameOtherDrop(
+              aAnc, nAnc, aOurs, nOurs, aTheirs, nTheirs,
+              aAncSchema, nAncSchema, aTheirsSchema, nTheirsSchema,
+              pTheirTable) ){
           continue;
         }
         oursEntry = findCatalogEntryBySchemaObject(
@@ -170,6 +177,12 @@ int mergeCatalogPass2(
     }
 
     if( hasSchemaConflictObject(aConflictTables, nConflictTables, zName) ){
+      continue;
+    }
+    if( mergeTableRenameOtherDrop(
+          aAnc, nAnc, aOurs, nOurs, aTheirs, nTheirs,
+          aAncSchema, nAncSchema, aTheirsSchema, nTheirsSchema,
+          &aTheirs[i]) ){
       continue;
     }
     oursEntry = doltliteFindTableByName(aOurs, nOurs, zName);

--- a/test/doltlite_merge_index_conflict.sh
+++ b/test/doltlite_merge_index_conflict.sh
@@ -238,6 +238,33 @@ EOF
 )
 check "source_index_on_conflicted_table_is_not_adopted" "2|0|1" "$out"
 
+DB="$TMPROOT/rename_vs_drop.db"
+"$DOLTLITE" "$DB" <<'EOF' >/dev/null 2>&1
+CREATE TABLE first(id INTEGER PRIMARY KEY);
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+CREATE INDEX iv ON t(v);
+INSERT INTO t VALUES(1,1);
+SELECT dolt_commit('-A','-m','init');
+SELECT dolt_branch('feat');
+DROP TABLE first;
+ALTER TABLE t RENAME TO renamed;
+SELECT dolt_commit('-A','-m','rename');
+EOF
+"$DOLTLITE" "$DB/feat" <<'EOF' >/dev/null 2>&1
+DROP TABLE t;
+CREATE TABLE replacement(id INTEGER PRIMARY KEY);
+SELECT dolt_commit('-A','-m','drop-add');
+EOF
+out=$("$DOLTLITE" "$DB/feat" "SELECT dolt_cherry_pick('main');" 2>/dev/null)
+rc=$?
+check "rename_vs_drop_cherry_pick_succeeds" "0" "$rc"
+out=$("$DOLTLITE" "$DB/feat" \
+  "SELECT group_concat(name, ',') FROM sqlite_schema WHERE name IN ('first','t','renamed','iv','replacement') ORDER BY name;")
+check "rename_vs_drop_keeps_current_schema" "replacement" "$out"
+out=$("$DOLTLITE" "$DB/feat" \
+  "SELECT (SELECT count(*) FROM dolt_status) || '|' || (SELECT message FROM dolt_log LIMIT 1);")
+check "rename_vs_drop_is_clean_commit" "0|rename" "$out"
+
 echo
 echo "doltlite_merge_index_conflict: $pass passed, $fail failed"
 if [ "$fail" -gt 0 ]; then


### PR DESCRIPTION
## Summary

- recognize a source-side table rename when the current branch dropped the ancestor table
- keep the current branch drop even when another table reused the ancestor catalog number
- exclude indexes whose renamed parent is absent from the merged catalog

The expanded stateful VC fuzzer in #1906 exposed an invariant abort while cherry-picking a rename onto a drop. Dolt keeps the current branch schema in this direction and creates an empty cherry-picked commit.

## Tests

- exact retained #1906 failure database: invariant abort before, successful clean cherry-pick after
- `doltlite_merge_index_conflict.sh`: 15 passed
- `doltlite_cherry_pick.sh`: 98 passed
- fail-before/pass-after rename/drop regression with catalog-number reuse
- `make lint`

Co-Authored-By: OpenAI Codex <noreply@openai.com>