### PR TITLE
Conflict index drop with parent table rename

### DIFF
--- a/src/doltlite_merge.c
+++ b/src/doltlite_merge.c
@@ -353,6 +353,7 @@ static int preDetectIndexSchemaConflicts(
       SchemaEntry *pAncTable;
       SchemaEntry *pOursTable;
       SchemaEntry *pTheirsTable;
+      SchemaEntry *pRenamedTable;
       const char *zTable;
       int oursChanged;
       int theirsChanged;
@@ -376,6 +377,36 @@ static int preDetectIndexSchemaConflicts(
       pTheirs = findSchemaEntry(aTheirs, nTheirs, a[i].zName);
       oursChanged = !mergeSchemaEntriesSame(pAnc, pOurs);
       theirsChanged = !mergeSchemaEntriesSame(pAnc, pTheirs);
+      if( pAnc && pAnc->zTblName && !pOurs
+       && pTheirs && pTheirs->zTblName
+       && sqlite3_stricmp(pAnc->zTblName, pTheirs->zTblName)!=0 ){
+        pAncTable = findSchemaEntry(aAnc, nAnc, pAnc->zTblName);
+        pOursTable = findSchemaEntry(aOurs, nOurs, pAnc->zTblName);
+        pTheirsTable = findSchemaEntry(aTheirs, nTheirs, pAnc->zTblName);
+        pRenamedTable = findSchemaEntry(aTheirs, nTheirs,
+                                        pTheirs->zTblName);
+        if( pAncTable && pAncTable->zType
+         && strcmp(pAncTable->zType, "table")==0
+         && pOursTable && !pTheirsTable
+         && pRenamedTable && pRenamedTable->zType
+         && strcmp(pRenamedTable->zType, "table")==0
+         && !findSchemaEntry(aAnc, nAnc, pTheirs->zTblName) ){
+          rc = appendSchemaConflict(ppConflictTables, pnConflictTables,
+                                    pAnc->zTblName, pAnc->zTblName,
+                                    &addedSchemaTable);
+          if( rc!=SQLITE_OK ) return rc;
+          if( addedSchemaTable ) (*pTotalConflicts)++;
+          rc = appendSchemaConflict(ppConflictTables, pnConflictTables,
+                                    pAnc->zTblName, pTheirs->zTblName,
+                                    &addedSchemaTable);
+          if( rc!=SQLITE_OK ) return rc;
+          rc = appendSchemaConflict(ppConflictTables, pnConflictTables,
+                                    pAnc->zTblName, a[i].zName,
+                                    &addedSchemaTable);
+          if( rc!=SQLITE_OK ) return rc;
+          continue;
+        }
+      }
       zTable = pOurs && pOurs->zTblName ? pOurs->zTblName
              : (pTheirs && pTheirs->zTblName ? pTheirs->zTblName
              : (pAnc && pAnc->zTblName ? pAnc->zTblName : a[i].zName));

--- a/test/doltlite_merge_index_conflict.sh
+++ b/test/doltlite_merge_index_conflict.sh
@@ -265,6 +265,34 @@ out=$("$DOLTLITE" "$DB/feat" \
   "SELECT (SELECT count(*) FROM dolt_status) || '|' || (SELECT message FROM dolt_log LIMIT 1);")
 check "rename_vs_drop_is_clean_commit" "0|rename" "$out"
 
+DB="$TMPROOT/index_drop_vs_parent_rename.db"
+"$DOLTLITE" "$DB" <<'EOF' >/dev/null 2>&1
+CREATE TABLE dropme(id INTEGER PRIMARY KEY);
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+CREATE INDEX iv ON t(v);
+INSERT INTO t VALUES(1,1);
+SELECT dolt_commit('-A','-m','init');
+SELECT dolt_branch('feat');
+DROP TABLE dropme;
+ALTER TABLE t RENAME TO renamed;
+SELECT dolt_commit('-A','-m','drop-and-rename');
+EOF
+"$DOLTLITE" "$DB/feat" <<'EOF' >/dev/null 2>&1
+DROP INDEX iv;
+SELECT dolt_commit('-A','-m','drop-index');
+EOF
+out=$("$DOLTLITE" "$DB/feat" <<'EOF' 2>/dev/null | tail -1
+BEGIN;
+SELECT dolt_cherry_pick('main');
+SELECT (SELECT count(*) FROM dolt_status WHERE status='schema conflict') || '|' ||
+       (SELECT count(*) FROM sqlite_schema WHERE name='t') || '|' ||
+       (SELECT count(*) FROM sqlite_schema WHERE name='renamed') || '|' ||
+       (SELECT count(*) FROM sqlite_schema WHERE name='iv');
+ROLLBACK;
+EOF
+)
+check "index_drop_vs_parent_rename_conflicts" "1|1|0|0" "$out"
+
 echo
 echo "doltlite_merge_index_conflict: $pass passed, $fail failed"
 if [ "$fail" -gt 0 ]; then


### PR DESCRIPTION
## Summary

- detect when the source renames a table while the current branch drops one of that table's indexes
- report one schema conflict on the original table, matching Dolt
- prevent merge pass 2 from installing the renamed table or an index entry without its schema row

The expanded stateful VC fuzzer in #1906 exposed this during rebase after the earlier rename/drop fix let the soak advance to step 1679.

## Tests

- reduced fail-before invariant abort / pass-after schema-conflict regression
- exact retained #1906 rebase database: invariant abort before, clean rebase abort with branch restoration after
- `doltlite_merge_index_conflict.sh`: 13 passed
- `make lint`
- behavior checked against Dolt 1.86.3

Co-Authored-By: OpenAI Codex <noreply@openai.com>