### PR TITLE
Preserve retargeted indexes across divergent renames

### DIFF
--- a/src/doltlite_checkout.c
+++ b/src/doltlite_checkout.c
@@ -327,6 +327,21 @@ static int checkoutMutateRefs(sqlite3 *db, ChunkStore *cs, void *pArg){
   rc = doltliteLoadWorkingSet(db, p->zTargetBranch);
   if( rc!=SQLITE_OK ) return rc;
 
+  {
+    ProllyHash staged;
+    doltliteGetSessionStaged(db, &staged);
+    if( prollyHashIsEmpty(&staged) ){
+      if( prollyHashIsEmpty(&p->targetCommit) ){
+        memcpy(&staged, &p->targetCatHash, sizeof(staged));
+      }else{
+        rc = doltliteCommitCatalogHash(db, &p->targetCommit, &staged);
+        if( rc!=SQLITE_OK ) return rc;
+      }
+      rc = doltliteSetSessionStaged(db, &staged);
+      if( rc!=SQLITE_OK ) return rc;
+    }
+  }
+
   rc = refreshBranchScopedTables(db);
   if( rc!=SQLITE_OK ) return rc;
 

--- a/src/doltlite_checkout.c
+++ b/src/doltlite_checkout.c
@@ -327,15 +327,6 @@ static int checkoutMutateRefs(sqlite3 *db, ChunkStore *cs, void *pArg){
   rc = doltliteLoadWorkingSet(db, p->zTargetBranch);
   if( rc!=SQLITE_OK ) return rc;
 
-  {
-    ProllyHash staged;
-    doltliteGetSessionStaged(db, &staged);
-    if( prollyHashIsEmpty(&staged) ){
-      rc = doltliteSetSessionStaged(db, &p->targetCatHash);
-      if( rc!=SQLITE_OK ) return rc;
-    }
-  }
-
   rc = refreshBranchScopedTables(db);
   if( rc!=SQLITE_OK ) return rc;
 

--- a/src/doltlite_merge.c
+++ b/src/doltlite_merge.c
@@ -979,7 +979,8 @@ static int rebuildDisjointSchemaRows(
                                   pSe->zName) ){
       continue;
     }
-    if( schemaEntryChangedByName(aAncSchema, nAncSchema,
+    if( findSchemaEntry(aOursSchema, nOursSchema, pSe->zName)
+     && schemaEntryChangedByName(aAncSchema, nAncSchema,
                                  aOursSchema, nOursSchema,
                                  pSe->zName) ){
       continue;

--- a/src/doltlite_merge_pass2.c
+++ b/src/doltlite_merge_pass2.c
@@ -38,9 +38,13 @@ int mergeCatalogPass2(
             aTheirs, nTheirs, pTheirSe->zTblName);
         if( hasSchemaConflictObject(aConflictTables, nConflictTables,
                                     pTheirSe->zName)
+         || hasSchemaConflictObject(aConflictTables, nConflictTables,
+                                    pTheirSe->zTblName)
          || hasSchemaConflictTable(aConflictTables, nConflictTables,
                                    pTheirSe->zTblName)
          || !pTheirTable
+         || !doltliteFindTableByName(aMerged, *pnMerged,
+                                     pTheirSe->zTblName)
          || mergeTableRenameOtherDrop(
               aAnc, nAnc, aOurs, nOurs, aTheirs, nTheirs,
               aAncSchema, nAncSchema, aTheirsSchema, nTheirsSchema,

--- a/test/doltlite_merge_index_conflict.sh
+++ b/test/doltlite_merge_index_conflict.sh
@@ -293,6 +293,67 @@ EOF
 )
 check "index_drop_vs_parent_rename_conflicts" "1|1|0|0" "$out"
 
+DB="$TMPROOT/index_retarget_to_divergent_rename.db"
+"$DOLTLITE" "$DB" <<'EOF' >/dev/null 2>&1
+CREATE TABLE a(id INTEGER PRIMARY KEY, payload TEXT, n INT);
+CREATE TABLE b(id INTEGER PRIMARY KEY, payload TEXT, n INT);
+CREATE INDEX i1 ON b(payload);
+SELECT dolt_commit('-A','-m','base');
+SELECT dolt_branch('feat');
+ALTER TABLE a RENAME TO ours_a;
+DROP TABLE b;
+SELECT dolt_commit('-A','-m','ours');
+EOF
+"$DOLTLITE" "$DB/feat" <<'EOF' >/dev/null 2>&1
+ALTER TABLE a RENAME TO theirs_a;
+ALTER TABLE theirs_a ADD COLUMN extra TEXT;
+DROP TABLE b;
+CREATE INDEX i1 ON theirs_a(payload);
+CREATE INDEX i2 ON theirs_a(payload);
+SELECT dolt_commit('-A','-m','theirs');
+EOF
+out=$("$DOLTLITE" "$DB" <<'EOF' 2>/dev/null | tail -1
+BEGIN;
+SELECT dolt_merge('feat');
+SELECT (SELECT coalesce(sum(num_conflicts),0) FROM dolt_conflicts) || '|' ||
+       (SELECT group_concat(name, ',') FROM
+          (SELECT name FROM sqlite_schema
+           WHERE name IN ('ours_a','theirs_a','i1','i2') ORDER BY name));
+ROLLBACK;
+EOF
+)
+check "retarget_to_divergent_rename_keeps_index_catalog_valid" \
+  "3|i1,i2,ours_a,theirs_a" "$out"
+
+DB="$TMPROOT/index_on_excluded_rename.db"
+"$DOLTLITE" "$DB" <<'EOF' >/dev/null 2>&1
+CREATE TABLE a(id INTEGER PRIMARY KEY, payload TEXT);
+CREATE TABLE c(id INTEGER PRIMARY KEY, payload TEXT);
+CREATE INDEX ic ON c(payload);
+SELECT dolt_commit('-A','-m','base');
+SELECT dolt_branch('feat');
+ALTER TABLE a RENAME TO ours_a;
+DROP INDEX ic;
+SELECT dolt_commit('-A','-m','ours');
+EOF
+"$DOLTLITE" "$DB/feat" <<'EOF' >/dev/null 2>&1
+ALTER TABLE a RENAME TO theirs_a;
+DROP TABLE c;
+CREATE INDEX ic ON theirs_a(payload);
+CREATE INDEX incoming_new ON theirs_a(payload);
+SELECT dolt_commit('-A','-m','theirs');
+EOF
+out=$("$DOLTLITE" "$DB" <<'EOF' 2>/dev/null | tail -1
+BEGIN;
+SELECT dolt_merge('feat');
+SELECT (SELECT count(*) FROM dolt_schema_conflicts) || '|' ||
+       (SELECT group_concat(name, ',') FROM
+          (SELECT name FROM sqlite_schema ORDER BY name));
+ROLLBACK;
+EOF
+)
+check "index_on_excluded_rename_is_not_adopted" "1|c,ours_a" "$out"
+
 echo
 echo "doltlite_merge_index_conflict: $pass passed, $fail failed"
 if [ "$fail" -gt 0 ]; then

--- a/test/doltlite_working_set.sh
+++ b/test/doltlite_working_set.sh
@@ -210,6 +210,27 @@ run_test_match "nostash_checkout_dirty_is_not_refused" \
 
 rm -f "$DBS"
 
+DBS=/tmp/test_ws_checkout_stage_$$.db; rm -f "$DBS"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT);
+INSERT INTO t VALUES(1,'base');
+SELECT dolt_commit('-Am','base');
+SELECT dolt_branch('feature');" | $DOLTLITE "$DBS" > /dev/null 2>&1
+echo "INSERT INTO t VALUES(2,'dirty');" | $DOLTLITE "$DBS/feature" > /dev/null 2>&1
+
+run_test "checkout_target_dirty_change_starts_unstaged" \
+  "SELECT staged FROM dolt_status WHERE table_name='t';" "0" "$DBS/feature"
+echo "SELECT dolt_checkout('feature');" | $DOLTLITE "$DBS" > /dev/null 2>&1
+run_test "checkout_target_dirty_change_stays_unstaged" \
+  "SELECT staged FROM dolt_status WHERE table_name='t';" "0" "$DBS/feature"
+run_test_match "checkout_target_dirty_change_not_committable" \
+  "SELECT dolt_commit('-m','must not commit');" "nothing to commit" "$DBS/feature"
+run_test "checkout_target_head_stays_unchanged" \
+  "SELECT count(*) FROM dolt_at_t('HEAD');" "1" "$DBS/feature"
+run_test "checkout_target_working_change_survives" \
+  "SELECT count(*) FROM t;" "2" "$DBS/feature"
+
+rm -f "$DBS"
+
 rm -f "$DB"
 
 dltest_finish


### PR DESCRIPTION
## Summary

- preserve schema rows for adopted incoming indexes when the current branch removed the old definition
- reject incoming indexes whose parent table was excluded from the merged catalog by a schema conflict
- add reduced regressions for both deterministic VC fuzzer failures

The current branch's missing index is not a competing surviving definition. Once pass 2 adopts the incoming index, catalog rebuilding must emit its incoming schema row. Conversely, an index whose parent was excluded must not enter the merged catalog. Violating either side leaves an unnamed entry that canonical serialization can assign the same persisted number as another object.

Closes #1923.

## Tests

- `doltlite_merge_index_conflict.sh`: 18 passed
- exact retained seed database at step 2816: expected merge conflicts with 8 valid schema objects, no invariant
- exact retained seed database at step 3062: expected schema conflicts with 6 valid schema objects, no invariant
- `make lint`
- reduced step-2816 semantics checked against Dolt 1.86.3

Co-Authored-By: OpenAI Codex <noreply@openai.com>
