### PR TITLE
Preserve unstaged changes across branch checkout

### DIFF
--- a/src/doltlite_checkout.c
+++ b/src/doltlite_checkout.c
@@ -327,6 +327,21 @@ static int checkoutMutateRefs(sqlite3 *db, ChunkStore *cs, void *pArg){
   rc = doltliteLoadWorkingSet(db, p->zTargetBranch);
   if( rc!=SQLITE_OK ) return rc;
 
+  {
+    ProllyHash staged;
+    doltliteGetSessionStaged(db, &staged);
+    if( prollyHashIsEmpty(&staged) ){
+      if( prollyHashIsEmpty(&p->targetCommit) ){
+        memcpy(&staged, &p->targetCatHash, sizeof(staged));
+      }else{
+        rc = doltliteCommitCatalogHash(db, &p->targetCommit, &staged);
+        if( rc!=SQLITE_OK ) return rc;
+      }
+      rc = doltliteSetSessionStaged(db, &staged);
+      if( rc!=SQLITE_OK ) return rc;
+    }
+  }
+
   rc = refreshBranchScopedTables(db);
   if( rc!=SQLITE_OK ) return rc;
 

--- a/src/doltlite_checkout.c
+++ b/src/doltlite_checkout.c
@@ -327,15 +327,6 @@ static int checkoutMutateRefs(sqlite3 *db, ChunkStore *cs, void *pArg){
   rc = doltliteLoadWorkingSet(db, p->zTargetBranch);
   if( rc!=SQLITE_OK ) return rc;
 
-  {
-    ProllyHash staged;
-    doltliteGetSessionStaged(db, &staged);
-    if( prollyHashIsEmpty(&staged) ){
-      rc = doltliteSetSessionStaged(db, &p->targetCatHash);
-      if( rc!=SQLITE_OK ) return rc;
-    }
-  }
-
   rc = refreshBranchScopedTables(db);
   if( rc!=SQLITE_OK ) return rc;
 

--- a/test/doltlite_working_set.sh
+++ b/test/doltlite_working_set.sh
@@ -210,6 +210,27 @@ run_test_match "nostash_checkout_dirty_is_not_refused" \
 
 rm -f "$DBS"
 
+DBS=/tmp/test_ws_checkout_stage_$$.db; rm -f "$DBS"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT);
+INSERT INTO t VALUES(1,'base');
+SELECT dolt_commit('-Am','base');
+SELECT dolt_branch('feature');" | $DOLTLITE "$DBS" > /dev/null 2>&1
+echo "INSERT INTO t VALUES(2,'dirty');" | $DOLTLITE "$DBS/feature" > /dev/null 2>&1
+
+run_test "checkout_target_dirty_change_starts_unstaged" \
+  "SELECT staged FROM dolt_status WHERE table_name='t';" "0" "$DBS/feature"
+echo "SELECT dolt_checkout('feature');" | $DOLTLITE "$DBS" > /dev/null 2>&1
+run_test "checkout_target_dirty_change_stays_unstaged" \
+  "SELECT staged FROM dolt_status WHERE table_name='t';" "0" "$DBS/feature"
+run_test_match "checkout_target_dirty_change_not_committable" \
+  "SELECT dolt_commit('-m','must not commit');" "nothing to commit" "$DBS/feature"
+run_test "checkout_target_head_stays_unchanged" \
+  "SELECT count(*) FROM dolt_at_t('HEAD');" "1" "$DBS/feature"
+run_test "checkout_target_working_change_survives" \
+  "SELECT count(*) FROM t;" "2" "$DBS/feature"
+
+rm -f "$DBS"
+
 rm -f "$DB"
 
 dltest_finish


### PR DESCRIPTION
## Summary

- preserve unstaged changes when checking out a dirty branch
- materialize an empty staged slot from the target HEAD catalog, never its dirty working catalog
- retain the existing unborn-branch fallback, where no committed catalog exists
- prove checkout keeps dirty rows unstaged and a staged-only commit cannot include them

The stateful VC fuzzer exposed this on two independent CI seeds after #1906 merged. A branch checkout loaded the target working set correctly, then replaced its empty staged root with the dirty working catalog. The next staged-only `dolt_commit` committed rows that had never passed through `dolt_add`.

Closes #1927.

## Tests

- full DoltLite-native suite: 99 suites passed, 0 failed
- C regression coverage within that suite: 310,064 passed, 0 failed
- checked unborn-branch regression: 15 passed, 0 failed
- OOM fault sweep: 13 operations / 6,500 iterations, 0 bugs
- exact failed seed `1785611755`: 418 steps across all 26 VC operations, passed
- `doltlite_working_set.sh`: 30 passed, 0 failed
- reduced fail-before/pass-after checkout and staged-only commit regression
- `make lint`

Co-Authored-By: OpenAI Codex <noreply@openai.com>