### PR TITLE
Checkpoint the database it was given, not aDb[0]

### DIFF
--- a/src/doltlite_gc.c
+++ b/src/doltlite_gc.c
@@ -1058,8 +1058,15 @@ static void doltliteGcFunc(
   sqlite3_result_text(context, result, -1, SQLITE_TRANSIENT);
 }
 
-int doltliteGcCompactWithPhase(sqlite3 *db, const char **pzPhase){
-  ChunkStore *cs = doltliteGetChunkStore(db);
+/* Compaction is always aimed at one specific store. gcMarkReachable seeds
+** every root from cs itself, and doltliteSeedSessionHashes walks all of db's
+** btrees but keeps only those sharing cs, so a store reached through an
+** ATTACH is marked from its own refs and its own session state. */
+int doltliteGcCompactStoreWithPhase(
+  sqlite3 *db,
+  ChunkStore *cs,
+  const char **pzPhase
+){
   int nKept = 0, nRemoved = 0;
 
   if( !cs ) return SQLITE_OK;
@@ -1075,9 +1082,13 @@ int doltliteGcCompactWithPhase(sqlite3 *db, const char **pzPhase){
   return gcRun(db, cs, &nKept, &nRemoved, pzPhase, 0, 0, 0, 0, 0);
 }
 
-int doltliteGcCompact(sqlite3 *db){
+int doltliteGcCompactStore(sqlite3 *db, ChunkStore *cs){
   const char *zPhase = 0;
-  return doltliteGcCompactWithPhase(db, &zPhase);
+  return doltliteGcCompactStoreWithPhase(db, cs, &zPhase);
+}
+
+int doltliteGcCompactWithPhase(sqlite3 *db, const char **pzPhase){
+  return doltliteGcCompactStoreWithPhase(db, doltliteGetChunkStore(db), pzPhase);
 }
 
 int doltliteGcRegister(sqlite3 *db){

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -806,6 +806,8 @@ static SQLITE_INLINE int dlReadFramedHeader(DlByteReader *r, u8 m0, u8 m1,
 }
 
 ChunkStore *doltliteGetChunkStore(sqlite3 *db);
+int doltliteGcCompactStoreWithPhase(sqlite3 *db, ChunkStore *cs, const char **pzPhase);
+int doltliteGcCompactStore(sqlite3 *db, ChunkStore *cs);
 BtShared *doltliteGetBtShared(sqlite3 *db);
 int doltliteIsStockSqliteDb(sqlite3 *db);
 void doltliteInvalidateWorkingState(sqlite3 *db);

--- a/src/pager_shim.c
+++ b/src/pager_shim.c
@@ -321,8 +321,7 @@ static DbPage *shimPagerLookup(Pager *p, Pgno pgno){
 }
 
 #ifndef SQLITE_OMIT_WAL
-extern int doltliteGcCompact(sqlite3 *db);
-extern ChunkStore *doltliteGetChunkStore(sqlite3 *db);
+extern int doltliteGcCompactStore(sqlite3 *db, ChunkStore *cs);
 
 #ifdef SQLITE_TEST
 static int shimPagerCheckpointTestWrites(Pager *p, sqlite3 *db){
@@ -355,7 +354,7 @@ static int shimPagerCheckpointTestWrites(Pager *p, sqlite3 *db){
 
 static int shimPagerCheckpoint(Pager *p, sqlite3 *db, int eMode,
                                int *pnLog, int *pnCkpt){
-  ChunkStore *pCs = db ? doltliteGetChunkStore(db) : 0;
+  ChunkStore *pCs = (ChunkStore*)SHIM(p)->pStore;
   int rc = SQLITE_OK;
   (void)eMode;
   if( pnLog ) *pnLog = 0;
@@ -370,8 +369,8 @@ static int shimPagerCheckpoint(Pager *p, sqlite3 *db, int eMode,
 #else
   (void)p;
 #endif
-  if( rc==SQLITE_OK && db ){
-    rc = doltliteGcCompact(db);
+  if( rc==SQLITE_OK && db && pCs ){
+    rc = doltliteGcCompactStore(db, pCs);
   }
   if( pCs ) pCs->checkpointActive = 0;
   if( rc!=SQLITE_OK ) return rc;

--- a/test/doltlite_pragma_wal_checkpoint.sh
+++ b/test/doltlite_pragma_wal_checkpoint.sh
@@ -46,6 +46,54 @@ done
 
 db_rm "$DB"
 
+echo ""
+echo "--- checkpoint compacts the named database only ---"
+
+# Checkpoint bridges to GC, so aiming it at the wrong store rewrites a file the
+# caller never named. Both databases carry reclaimable chunks so either one
+# shrinking is visible.
+MAIN=/tmp/test_wc_main_$$.db; db_rm "$MAIN"
+AUX=/tmp/test_wc_aux_$$.db;  db_rm "$AUX"
+for D in "$MAIN" "$AUX"; do
+  $DOLTLITE "$D" "CREATE TABLE big(a INTEGER PRIMARY KEY, b TEXT);
+WITH RECURSIVE c(i) AS (SELECT 1 UNION ALL SELECT i+1 FROM c WHERE i<4000)
+  INSERT INTO big SELECT i, 'padding-data-'||i FROM c;
+DELETE FROM big WHERE a%2=0;" > /dev/null 2>&1
+done
+
+main_before=$(wc -c < "$MAIN"); aux_before=$(wc -c < "$AUX")
+$DOLTLITE "$MAIN" "ATTACH '$AUX' AS aux; PRAGMA aux.wal_checkpoint;" > /dev/null 2>&1
+main_after=$(wc -c < "$MAIN"); aux_after=$(wc -c < "$AUX")
+
+run_test_eq "wc_aux_leaves_main_untouched" "$main_after" "$main_before"
+if [ "$aux_after" -lt "$aux_before" ]; then
+  PASS=$((PASS+1))
+else
+  FAIL=$((FAIL+1))
+  ERRORS="$ERRORS\nFAIL: wc_aux_compacts_aux\n  aux size $aux_before -> $aux_after (expected shrink)"
+fi
+run_test_eq "wc_aux_rows_intact" \
+  "$($DOLTLITE "$AUX" "SELECT count(*) FROM big;" 2>&1)" "2000"
+
+db_rm "$MAIN"; db_rm "$AUX"
+
+# The main-named form must still compact main.
+DB=/tmp/test_wc_selfmain_$$.db; db_rm "$DB"
+$DOLTLITE "$DB" "CREATE TABLE big(a INTEGER PRIMARY KEY, b TEXT);
+WITH RECURSIVE c(i) AS (SELECT 1 UNION ALL SELECT i+1 FROM c WHERE i<4000)
+  INSERT INTO big SELECT i, 'padding-data-'||i FROM c;
+DELETE FROM big WHERE a%2=0;" > /dev/null 2>&1
+before=$(wc -c < "$DB")
+$DOLTLITE "$DB" "PRAGMA main.wal_checkpoint;" > /dev/null 2>&1
+after=$(wc -c < "$DB")
+if [ "$after" -lt "$before" ]; then
+  PASS=$((PASS+1))
+else
+  FAIL=$((FAIL+1))
+  ERRORS="$ERRORS\nFAIL: wc_main_still_compacts\n  main size $before -> $after (expected shrink)"
+fi
+db_rm "$DB"
+
 if [ -x "$SQLITE3" ]; then
   echo ""
   echo "--- stock-SQLite file via orig route ---"

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -2856,10 +2856,6 @@ tkt-fc62af4523 tkt-fc62af4523.4
 # not produce; checkpoint itself matches the documented contract (BUSY
 # parity is partial: the C-API variant returns OK where stock returns BUSY
 # under a concurrent checkpoint).
-e_walckpt e_walckpt-1.1.2
-e_walckpt e_walckpt-1.1.3
-e_walckpt e_walckpt-1.1.4
-e_walckpt e_walckpt-1.1.5
 e_walckpt e_walckpt-1.2.2.b
 e_walckpt e_walckpt-1.3.1
 e_walckpt e_walckpt-1.3.2.1
@@ -2891,10 +2887,6 @@ e_walckpt e_walckpt-1.truncate.3.11
 e_walckpt e_walckpt-1.truncate.3.12
 e_walckpt e_walckpt-1.truncate.3.7
 e_walckpt e_walckpt-1.truncate.3.9
-e_walckpt e_walckpt-2.1.2
-e_walckpt e_walckpt-2.1.3
-e_walckpt e_walckpt-2.1.4
-e_walckpt e_walckpt-2.1.5
 e_walckpt e_walckpt-2.2.2.b
 e_walckpt e_walckpt-2.3.1
 e_walckpt e_walckpt-2.3.2.1
@@ -2942,10 +2934,6 @@ e_walckpt e_walckpt-2.truncate.3.12
 e_walckpt e_walckpt-2.truncate.3.3
 e_walckpt e_walckpt-2.truncate.3.7
 e_walckpt e_walckpt-2.truncate.3.9
-e_walckpt e_walckpt-3.1.2
-e_walckpt e_walckpt-3.1.3
-e_walckpt e_walckpt-3.1.4
-e_walckpt e_walckpt-3.1.5
 e_walckpt e_walckpt-3.3.1
 e_walckpt e_walckpt-3.3.2.1
 e_walckpt e_walckpt-3.3.2.2
@@ -2983,7 +2971,6 @@ e_walckpt e_walckpt-4.4
 e_walckpt e_walckpt-4.5
 e_walckpt e_walckpt-4.6
 e_walckpt e_walckpt-5.1.2
-e_walckpt e_walckpt-5.2.1
 e_walckpt e_walckpt-5.2.2
 e_walckpt e_walckpt-5.3.2
 e_walckpt e_walckpt-6.1

--- a/test/known_testfixture_exception_inventory.txt
+++ b/test/known_testfixture_exception_inventory.txt
@@ -1024,10 +1024,6 @@ e_wal e_wal-4.1.4 unsupported https://github.com/dolthub/doltlite/issues/1836
 e_wal e_wal-4.2.2 unsupported https://github.com/dolthub/doltlite/issues/1836
 e_wal e_wal-4.2.3 unsupported https://github.com/dolthub/doltlite/issues/1836
 e_wal e_wal-4.3 unsupported https://github.com/dolthub/doltlite/issues/1836
-e_walckpt e_walckpt-1.1.2 unsupported https://github.com/dolthub/doltlite/issues/1836
-e_walckpt e_walckpt-1.1.3 unsupported https://github.com/dolthub/doltlite/issues/1836
-e_walckpt e_walckpt-1.1.4 unsupported https://github.com/dolthub/doltlite/issues/1836
-e_walckpt e_walckpt-1.1.5 unsupported https://github.com/dolthub/doltlite/issues/1836
 e_walckpt e_walckpt-1.2.2.b unsupported https://github.com/dolthub/doltlite/issues/1836
 e_walckpt e_walckpt-1.3.1 unsupported https://github.com/dolthub/doltlite/issues/1836
 e_walckpt e_walckpt-1.3.2.1 unsupported https://github.com/dolthub/doltlite/issues/1836
@@ -1059,10 +1055,6 @@ e_walckpt e_walckpt-1.truncate.3.11 unsupported https://github.com/dolthub/doltl
 e_walckpt e_walckpt-1.truncate.3.12 unsupported https://github.com/dolthub/doltlite/issues/1836
 e_walckpt e_walckpt-1.truncate.3.7 unsupported https://github.com/dolthub/doltlite/issues/1836
 e_walckpt e_walckpt-1.truncate.3.9 unsupported https://github.com/dolthub/doltlite/issues/1836
-e_walckpt e_walckpt-2.1.2 unsupported https://github.com/dolthub/doltlite/issues/1836
-e_walckpt e_walckpt-2.1.3 unsupported https://github.com/dolthub/doltlite/issues/1836
-e_walckpt e_walckpt-2.1.4 unsupported https://github.com/dolthub/doltlite/issues/1836
-e_walckpt e_walckpt-2.1.5 unsupported https://github.com/dolthub/doltlite/issues/1836
 e_walckpt e_walckpt-2.2.2.b unsupported https://github.com/dolthub/doltlite/issues/1836
 e_walckpt e_walckpt-2.3.1 unsupported https://github.com/dolthub/doltlite/issues/1836
 e_walckpt e_walckpt-2.3.2.1 unsupported https://github.com/dolthub/doltlite/issues/1836
@@ -1110,10 +1102,6 @@ e_walckpt e_walckpt-2.truncate.3.12 unsupported https://github.com/dolthub/doltl
 e_walckpt e_walckpt-2.truncate.3.3 unsupported https://github.com/dolthub/doltlite/issues/1836
 e_walckpt e_walckpt-2.truncate.3.7 unsupported https://github.com/dolthub/doltlite/issues/1836
 e_walckpt e_walckpt-2.truncate.3.9 unsupported https://github.com/dolthub/doltlite/issues/1836
-e_walckpt e_walckpt-3.1.2 unsupported https://github.com/dolthub/doltlite/issues/1836
-e_walckpt e_walckpt-3.1.3 unsupported https://github.com/dolthub/doltlite/issues/1836
-e_walckpt e_walckpt-3.1.4 unsupported https://github.com/dolthub/doltlite/issues/1836
-e_walckpt e_walckpt-3.1.5 unsupported https://github.com/dolthub/doltlite/issues/1836
 e_walckpt e_walckpt-3.3.1 unsupported https://github.com/dolthub/doltlite/issues/1836
 e_walckpt e_walckpt-3.3.2.1 unsupported https://github.com/dolthub/doltlite/issues/1836
 e_walckpt e_walckpt-3.3.2.2 unsupported https://github.com/dolthub/doltlite/issues/1836
@@ -1151,7 +1139,6 @@ e_walckpt e_walckpt-4.4 unsupported https://github.com/dolthub/doltlite/issues/1
 e_walckpt e_walckpt-4.5 unsupported https://github.com/dolthub/doltlite/issues/1836
 e_walckpt e_walckpt-4.6 unsupported https://github.com/dolthub/doltlite/issues/1836
 e_walckpt e_walckpt-5.1.2 unsupported https://github.com/dolthub/doltlite/issues/1836
-e_walckpt e_walckpt-5.2.1 unsupported https://github.com/dolthub/doltlite/issues/1836
 e_walckpt e_walckpt-5.2.2 unsupported https://github.com/dolthub/doltlite/issues/1836
 e_walckpt e_walckpt-5.3.2 unsupported https://github.com/dolthub/doltlite/issues/1836
 e_walckpt e_walckpt-6.1 unsupported https://github.com/dolthub/doltlite/issues/1836

--- a/test/known_testfixture_exception_ratchet.txt
+++ b/test/known_testfixture_exception_ratchet.txt
@@ -6,8 +6,8 @@
 # Counts are per gate -- one divergent assertion, or one expected crash.
 # Lowering a number is the point. Raising one is a deliberate act that belongs
 # in a PR description.
-gates 4968
+gates 4955
 intentional 3613
-unsupported 1282
+unsupported 1269
 harness 8
 engine-gap 65


### PR DESCRIPTION
## Problem

`shimPagerCheckpoint` received the target database's `Pager` but resolved the chunk store from the `sqlite3*` handle, which always means `aDb[0]`:

```c
ChunkStore *pCs = db ? doltliteGetChunkStore(db) : 0;
...
rc = doltliteGcCompact(db);
```

Since checkpoint bridges to GC, and GC is VACUUM in this engine, checkpointing an attached database ran a destructive chunk sweep against `main` instead:

```
before: main=677727 aux=2113
$ ATTACH 'auxA.db' AS aux; PRAGMA aux.wal_checkpoint;   -> 0|0|0
after:  main=226498 aux=2113
```

`main` lost 450 KB; the database the user actually named was untouched. The mirror case failed the other way — with an orig-format `main`, `PRAGMA aux.wal_checkpoint` on a doltlite `aux` silently no-opped.

## Fix

Resolve the store from the shim itself. `pagerShimSetStore` already points `PagerShim.pStore` at the owning btree's store (prolly_btree.c), so the correct target was already in hand.

Compaction splits into a store-targeted entry point. GC's reachability contract already supports this: `gcMarkReachable` seeds every root from `cs` itself (refs, branches, tags, tracking, pending), and the one `db`-dependent seed, `doltliteSeedSessionHashes`, already walks all of `db`'s btrees and keeps only those whose `&pBt->pBt->store == cs`. `gcLockAndRefresh` uses `db` only for the mutex assert and busy handler. So a store reached through ATTACH is marked from its own refs and its own session state.

`doltliteGcCompact` loses its last caller and is removed (the dead-code gate flagged it).

## Tests

Extended `test/doltlite_pragma_wal_checkpoint.sh` with a section asserting the checkpoint compacts only the database named, plus that the `main`-named form still compacts `main`.

Fail-before / pass-after, same rig:

| | master | this branch |
|---|---|---|
| `doltlite_pragma_wal_checkpoint.sh` | 8 passed, **2 failed** | **10 passed, 0 failed** |

Master's failures are `wc_aux_leaves_main_untouched` (main shrank 223102 -> 74466) and `wc_aux_compacts_aux` (aux unchanged).

## Validation

- `test/run_doltlite_tests.sh`: **99/99 suites**
- `doltlite_regression_test_c`: **310064/310064**
- `test/dead_code_check.sh`: PASS
- testfixture (amalgamation) builds clean
- tcl `vacuum{,2,4,5}`, `e_vacuum`, `backup{,2,4}`, `attach{,2,3}`, `wal{,2}`, `walmode`, `walro`, `pager1`, `savepoint`: failing-assertion sets **byte-identical to a master control build in the same rig** (pre-existing intentional divergences)

## Not in this PR

The review that found this also found that legacy stock-format databases silently no-op on `VACUUM`, get a false "not supported for doltlite databases" on `VACUUM INTO`, and fail `sqlite3_backup_*`. Those share the same root cause but cannot be fixed alongside it: the page-copy path needs `orig_sqlite3BtreeCopyFile`, and `tool/mksqlite3c.tcl` deliberately excludes stock `backup.c` from the amalgamation because it reaches into `struct Db.pBt` expecting the stock `Btree` layout. Fixing them in the object build only would make the same SQL behave differently in the single-file build. That needs its own PR and its own decision about `backup.c`.

Separately, checkpoint-driven GC passes `bForceRefresh=0` while explicit `dolt_gc()` passes `1`. GC is the one consumer of the freshness heuristic whose failure mode is deleting a peer's committed chunks, so it should carry the strongest proof — also left for its own change, since it needs a multi-process test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)