### PR TITLE
Fix unique constraint detection during merge

### DIFF
--- a/src/doltlite_merge_constraints_unique.c
+++ b/src/doltlite_merge_constraints_unique.c
@@ -119,7 +119,6 @@ static KeyInfo *uniqueIndexKeyInfo(sqlite3 *db, Index *pIdx, int *pRc){
 
   sqlite3ParseObjectInit(&sParse, db);
   pKeyInfo = sqlite3KeyInfoOfIndex(&sParse, pIdx);
-  if( pKeyInfo ) pKeyInfo->nKeyField = pKeyInfo->nAllField;
   *pRc = sParse.rc;
   if( !pKeyInfo && *pRc==SQLITE_OK ) *pRc = SQLITE_NOMEM;
   sqlite3ParseObjectReset(&sParse);
@@ -132,6 +131,7 @@ struct UniqueIndexEntry {
   int nKey;
   u8 *pPk;
   int nPk;
+  sqlite3_int64 rowid;
   UnpackedRecord *pUnpacked;
 };
 
@@ -303,131 +303,109 @@ static int detectUniqueViolationsForIndex(
   const char *zCols,
   int *pnFound
 ){
+  sqlite3_stmt *pScan = 0;
   KeyInfo *pKeyInfo = 0;
-  UnpackedRecord *pRecord = 0;
-  BtCursor *pCursor = 0;
-  u8 *pRecordBuf = 0;
-  u8 *pPrevBuf = 0;
-  int nRecordAlloc = 0;
-  int nPrevAlloc = 0;
-  int nPrev = 0;
-  sqlite3_int64 winnerRowid = 0;
+  UniqueIndexEntry *aEntry = 0;
+  char *zQuery = 0;
+  int nEntry = 0;
+  int nAlloc = 0;
   int winnerHandled = 0;
-  int havePrev = 0;
-  int cursorOpen = 0;
   int rc;
-  int atEnd = 0;
+  int i;
 
   pKeyInfo = uniqueIndexKeyInfo(db, pIdx, &rc);
   if( !pKeyInfo ) goto unique_done;
-  pRecord = sqlite3VdbeAllocUnpackedRecord(pKeyInfo);
-  if( !pRecord ){ rc = SQLITE_NOMEM; goto unique_done; }
-  memset(pRecord->aMem, 0,
-         sizeof(Mem) * (size_t)(pKeyInfo->nKeyField + 1));
-  pCursor = sqlite3_malloc(sqlite3BtreeCursorSize());
-  if( !pCursor ){ rc = SQLITE_NOMEM; goto unique_done; }
-  sqlite3BtreeCursorZero(pCursor);
-  rc = sqlite3BtreeCursor(db->aDb[0].pBt, pIdx->tnum, 0,
-                          pKeyInfo, pCursor);
+  zQuery = sqlite3_mprintf(
+      "SELECT rowid, %s FROM main.\"%w\" NOT INDEXED", zCols, zTable);
+  if( !zQuery ){ rc = SQLITE_NOMEM; goto unique_done; }
+  rc = sqlite3_prepare_v2(db, zQuery, -1, &pScan, 0);
   if( rc!=SQLITE_OK ) goto unique_done;
-  cursorOpen = 1;
-  rc = sqlite3BtreeFirst(pCursor, &atEnd);
 
-  while( rc==SQLITE_OK && !atEnd ){
-    u32 nRecordU32 = sqlite3BtreePayloadSize(pCursor);
-    int nRecord;
-    int isDup = 0;
-    sqlite3_int64 rowid = 0;
+  while( (rc = sqlite3_step(pScan))==SQLITE_ROW ){
+    UniqueIndexEntry entry;
 
-    if( nRecordU32==0 || nRecordU32>0x7fffffff ){
+    memset(&entry, 0, sizeof(entry));
+    entry.rowid = sqlite3_column_int64(pScan, 0);
+    entry.pKey = buildRecordFromStmtCols(
+        pScan, 1, pIdx->nKeyCol, &entry.nKey);
+    if( !entry.pKey ){ rc = SQLITE_NOMEM; break; }
+    entry.pUnpacked = sqlite3VdbeAllocUnpackedRecord(pKeyInfo);
+    if( !entry.pUnpacked ){
+      sqlite3_free(entry.pKey);
+      rc = SQLITE_NOMEM;
+      break;
+    }
+    memset(entry.pUnpacked->aMem, 0,
+           sizeof(Mem) * (size_t)(pKeyInfo->nKeyField + 1));
+    sqlite3VdbeRecordUnpack(entry.nKey, entry.pKey, entry.pUnpacked);
+    if( entry.pUnpacked->nField < pIdx->nKeyCol ){
+      sqlite3_free(entry.pKey);
+      sqlite3DbFree(db, entry.pUnpacked);
       rc = SQLITE_CORRUPT;
       break;
     }
-    nRecord = (int)nRecordU32;
-    if( nRecord>nRecordAlloc ){
-      u8 *pNew = sqlite3_realloc(pRecordBuf, nRecord);
-      if( !pNew ){ rc = SQLITE_NOMEM; break; }
-      pRecordBuf = pNew;
-      nRecordAlloc = nRecord;
+    entry.pUnpacked->nField = pIdx->nKeyCol;
+    if( uniqueIndexRecordHasNull(entry.pUnpacked, pIdx->nKeyCol) ){
+      sqlite3_free(entry.pKey);
+      sqlite3DbFree(db, entry.pUnpacked);
+      continue;
     }
-    rc = sqlite3BtreePayload(pCursor, 0, nRecordU32, pRecordBuf);
-    if( rc!=SQLITE_OK ) break;
-    pRecord->nField = pKeyInfo->nKeyField + 1;
-    sqlite3VdbeRecordUnpack(nRecord, pRecordBuf, pRecord);
-    if( pRecord->nField < pIdx->nKeyCol ){
-      rc = SQLITE_CORRUPT;
-      break;
-    }
-    if( uniqueIndexRecordHasNull(pRecord, pIdx->nKeyCol) ){
-      havePrev = 0;
-      winnerHandled = 0;
-      goto unique_next;
-    }
-
-    rc = sqlite3VdbeIdxRowid(db, pCursor, &rowid);
-    if( rc!=SQLITE_OK ) break;
-
-    if( havePrev ){
-      pRecord->nField = pIdx->nKeyCol;
-      pRecord->errCode = 0;
-      isDup = sqlite3VdbeRecordCompare(nPrev, pPrevBuf, pRecord)==0;
-      if( pRecord->errCode ){
-        rc = pRecord->errCode;
+    if( nEntry==nAlloc ){
+      int nNew = nAlloc ? nAlloc*2 : 64;
+      UniqueIndexEntry *aNew;
+      if( nNew<nAlloc || nNew>0x7fffffff/(int)sizeof(UniqueIndexEntry) ){
+        sqlite3_free(entry.pKey);
+        sqlite3DbFree(db, entry.pUnpacked);
+        rc = SQLITE_TOOBIG;
         break;
       }
+      aNew = sqlite3_realloc64(
+          aEntry, (sqlite3_int64)nNew * sizeof(UniqueIndexEntry));
+      if( !aNew ){
+        sqlite3_free(entry.pKey);
+        sqlite3DbFree(db, entry.pUnpacked);
+        rc = SQLITE_NOMEM;
+        break;
+      }
+      aEntry = aNew;
+      nAlloc = nNew;
     }
-    if( !isDup ){
-      winnerRowid = rowid;
-      winnerHandled = 0;
-    }else{
+    aEntry[nEntry++] = entry;
+  }
+  if( rc==SQLITE_DONE ) rc = SQLITE_OK;
+  if( rc!=SQLITE_OK ) goto unique_done;
+  rc = uniqueIndexEntriesSort(aEntry, nEntry);
+  if( rc!=SQLITE_OK ) goto unique_done;
+
+  for(i=1; i<nEntry && rc==SQLITE_OK; i++){
+    int cmp;
+    rc = uniqueIndexEntryCompare(&aEntry[i-1], &aEntry[i], &cmp);
+    if( rc==SQLITE_OK && cmp==0 ){
+      int appended = 0;
       if( !winnerHandled ){
-        int appended = 0;
         rc = appendUniqueViolationByRowid(
             db, aAnc, nAnc, zTable, pIdx->zName, zCols,
-            winnerRowid, &appended);
+            aEntry[i-1].rowid, &appended);
         if( rc!=SQLITE_OK ) break;
         if( appended && pnFound ) (*pnFound)++;
         winnerHandled = 1;
       }
-      {
-        int appended = 0;
-        rc = appendUniqueViolationByRowid(
-            db, aAnc, nAnc, zTable, pIdx->zName, zCols,
-            rowid, &appended);
-        if( rc!=SQLITE_OK ) break;
-        if( appended && pnFound ) (*pnFound)++;
-      }
-    }
-
-    {
-      u8 *pSwap = pPrevBuf;
-      int nSwap = nPrevAlloc;
-      pPrevBuf = pRecordBuf;
-      nPrevAlloc = nRecordAlloc;
-      pRecordBuf = pSwap;
-      nRecordAlloc = nSwap;
-      nPrev = nRecord;
-      havePrev = 1;
-    }
-
-unique_next:
-    rc = sqlite3BtreeNext(pCursor, 0);
-    if( rc==SQLITE_DONE ){
-      rc = SQLITE_OK;
-      atEnd = 1;
+      appended = 0;
+      rc = appendUniqueViolationByRowid(
+          db, aAnc, nAnc, zTable, pIdx->zName, zCols,
+          aEntry[i].rowid, &appended);
+      if( rc!=SQLITE_OK ) break;
+      if( appended && pnFound ) (*pnFound)++;
+    }else{
+      winnerHandled = 0;
     }
   }
 
 unique_done:
-  if( cursorOpen ){
-    int closeRc = sqlite3BtreeCloseCursor(pCursor);
-    if( rc==SQLITE_OK ) rc = closeRc;
-  }
-  sqlite3_free(pCursor);
-  sqlite3DbFree(db, pRecord);
+  sqlite3_finalize(pScan);
+  sqlite3_free(zQuery);
+  uniqueIndexEntriesFree(db, aEntry, nEntry);
   sqlite3KeyInfoUnref(pKeyInfo);
-  sqlite3_free(pRecordBuf);
-  sqlite3_free(pPrevBuf);
   return rc;
 }
 

--- a/src/doltlite_merge_constraints_unique.c
+++ b/src/doltlite_merge_constraints_unique.c
@@ -1,6 +1,7 @@
 #ifdef DOLTLITE_PROLLY
 
 #include "doltlite_merge_constraints_int.h"
+#include "vdbeInt.h"
 
 static int appendUniqueViolationByRowid(
   sqlite3 *db,
@@ -102,186 +103,492 @@ static int appendUniqueViolationByPk(
   return rc;
 }
 
-static int uniqueIndexRowHasNull(sqlite3_stmt *pScan, int colFirst, int colLast){
+static int uniqueIndexRecordHasNull(UnpackedRecord *pRecord, int nKeyCol){
   int i;
-  for(i=colFirst; i<colLast; i++){
-    if( sqlite3_column_type(pScan, i) == SQLITE_NULL ) return 1;
+  for(i=0; i<nKeyCol; i++){
+    if( sqlite3_value_type((sqlite3_value*)&pRecord->aMem[i])==SQLITE_NULL ){
+      return 1;
+    }
   }
   return 0;
+}
+
+static KeyInfo *uniqueIndexKeyInfo(sqlite3 *db, Index *pIdx, int *pRc){
+  Parse sParse;
+  KeyInfo *pKeyInfo;
+
+  sqlite3ParseObjectInit(&sParse, db);
+  pKeyInfo = sqlite3KeyInfoOfIndex(&sParse, pIdx);
+  if( pKeyInfo ) pKeyInfo->nKeyField = pKeyInfo->nAllField;
+  *pRc = sParse.rc;
+  if( !pKeyInfo && *pRc==SQLITE_OK ) *pRc = SQLITE_NOMEM;
+  sqlite3ParseObjectReset(&sParse);
+  return pKeyInfo;
+}
+
+typedef struct UniqueIndexEntry UniqueIndexEntry;
+struct UniqueIndexEntry {
+  u8 *pKey;
+  int nKey;
+  u8 *pPk;
+  int nPk;
+  UnpackedRecord *pUnpacked;
+};
+
+static int uniqueValueFromRecord(
+  const u8 *pRecord,
+  int nRecord,
+  const DoltliteRecordInfo *pInfo,
+  int iField,
+  DoltliteSerialValue *pValue
+){
+  int st;
+  int off;
+  int n;
+
+  memset(pValue, 0, sizeof(*pValue));
+  if( iField<0 || iField>=pInfo->nField ) return SQLITE_CORRUPT;
+  st = pInfo->aType[iField];
+  off = pInfo->aOffset[iField];
+  n = dlSerialTypeLen((u64)st);
+  if( n<0 || off<0 || off>nRecord-n ) return SQLITE_CORRUPT;
+  if( st==0 ){
+    pValue->eType = SQLITE_NULL;
+  }else if( st==8 || st==9 || (st>=1 && st<=6) ){
+    pValue->eType = SQLITE_INTEGER;
+    pValue->i = st==8 ? 0 : st==9 ? 1 : dlReadIntBytes(pRecord + off, n);
+  }else if( st==7 ){
+    u64 bits = 0;
+    int i;
+    pValue->eType = SQLITE_FLOAT;
+    for(i=0; i<8; i++) bits = (bits<<8) | pRecord[off+i];
+    memcpy(&pValue->r, &bits, 8);
+  }else if( st>=13 && (st&1)==1 ){
+    pValue->eType = SQLITE_TEXT;
+    pValue->p = pRecord + off;
+    pValue->n = n;
+  }else if( st>=12 && (st&1)==0 ){
+    pValue->eType = SQLITE_BLOB;
+    pValue->p = pRecord + off;
+    pValue->n = n;
+  }else{
+    return SQLITE_CORRUPT;
+  }
+  return SQLITE_OK;
+}
+
+static int uniqueRecordFromTableRow(
+  const u8 *pRecord,
+  int nRecord,
+  const DoltliteRecordInfo *pInfo,
+  const DoltliteColInfo *pCols,
+  Index *pIdx,
+  int nField,
+  u8 **ppOut,
+  int *pnOut,
+  int *pHasNull
+){
+  DoltliteSerialValue *aValue;
+  int i;
+  int rc = SQLITE_OK;
+
+  *ppOut = 0;
+  *pnOut = 0;
+  if( pHasNull ) *pHasNull = 0;
+  aValue = sqlite3_malloc64(
+      (sqlite3_int64)nField * sizeof(DoltliteSerialValue));
+  if( !aValue ) return SQLITE_NOMEM;
+  memset(aValue, 0, (size_t)nField * sizeof(DoltliteSerialValue));
+  for(i=0; i<nField; i++){
+    int iColumn = pIdx->aiColumn[i];
+    int iRecord;
+    if( iColumn<0 || iColumn>=pCols->nCol ){
+      rc = SQLITE_NOTFOUND;
+      break;
+    }
+    iRecord = pCols->aColToRec[iColumn];
+    rc = uniqueValueFromRecord(
+        pRecord, nRecord, pInfo, iRecord, &aValue[i]);
+    if( rc!=SQLITE_OK ) break;
+    if( pHasNull && aValue[i].eType==SQLITE_NULL ) *pHasNull = 1;
+  }
+  if( rc==SQLITE_OK ){
+    *ppOut = doltliteBuildRecord(aValue, nField, pnOut);
+    if( !*ppOut ) rc = SQLITE_NOMEM;
+  }
+  sqlite3_free(aValue);
+  return rc;
+}
+
+static void uniqueIndexEntriesFree(
+  sqlite3 *db,
+  UniqueIndexEntry *aEntry,
+  int nEntry
+){
+  int i;
+  for(i=0; i<nEntry; i++){
+    sqlite3_free(aEntry[i].pKey);
+    sqlite3_free(aEntry[i].pPk);
+    sqlite3DbFree(db, aEntry[i].pUnpacked);
+  }
+  sqlite3_free(aEntry);
+}
+
+static int uniqueIndexEntryCompare(
+  UniqueIndexEntry *pLeft,
+  UniqueIndexEntry *pRight,
+  int *pCmp
+){
+  pRight->pUnpacked->errCode = 0;
+  *pCmp = sqlite3VdbeRecordCompare(
+      pLeft->nKey, pLeft->pKey, pRight->pUnpacked);
+  return pRight->pUnpacked->errCode;
+}
+
+static int uniqueIndexEntriesSort(
+  UniqueIndexEntry *aEntry,
+  int nEntry
+){
+  UniqueIndexEntry *aTmp;
+  UniqueIndexEntry *aSrc = aEntry;
+  UniqueIndexEntry *aDst;
+  int width;
+  int rc = SQLITE_OK;
+
+  if( nEntry<2 ) return SQLITE_OK;
+  aTmp = sqlite3_malloc64(
+      (sqlite3_int64)nEntry * sizeof(UniqueIndexEntry));
+  if( !aTmp ) return SQLITE_NOMEM;
+  aDst = aTmp;
+  for(width=1; width<nEntry && rc==SQLITE_OK; width*=2){
+    int left;
+    for(left=0; left<nEntry; left+=width*2){
+      int mid = left + width;
+      int right = mid + width;
+      int i = left;
+      int j;
+      int out = left;
+      if( mid>nEntry ) mid = nEntry;
+      if( right>nEntry ) right = nEntry;
+      j = mid;
+      while( i<mid && j<right ){
+        int cmp;
+        rc = uniqueIndexEntryCompare(&aSrc[i], &aSrc[j], &cmp);
+        if( rc!=SQLITE_OK ) break;
+        aDst[out++] = cmp<=0 ? aSrc[i++] : aSrc[j++];
+      }
+      while( rc==SQLITE_OK && i<mid ) aDst[out++] = aSrc[i++];
+      while( rc==SQLITE_OK && j<right ) aDst[out++] = aSrc[j++];
+      if( rc!=SQLITE_OK ) break;
+    }
+    if( rc==SQLITE_OK ){
+      UniqueIndexEntry *aSwap = aSrc;
+      aSrc = aDst;
+      aDst = aSwap;
+    }
+    if( width>nEntry/2 ) break;
+  }
+  if( rc==SQLITE_OK && aSrc!=aEntry ){
+    memcpy(aEntry, aSrc, (size_t)nEntry * sizeof(UniqueIndexEntry));
+  }
+  sqlite3_free(aTmp);
+  return rc;
 }
 
 static int detectUniqueViolationsForIndex(
   sqlite3 *db,
   struct TableEntry *aAnc, int nAnc,
   const char *zTable,
-  const char *zIndexName,
+  Index *pIdx,
   const char *zCols,
-  char **pzErrMsg,
   int *pnFound
 ){
-  sqlite3_stmt *pScan = 0;
-  char *zQuery;
-  char *zWinnerKey = 0;
+  KeyInfo *pKeyInfo = 0;
+  UnpackedRecord *pRecord = 0;
+  BtCursor *pCursor = 0;
+  u8 *pRecordBuf = 0;
+  u8 *pPrevBuf = 0;
+  int nRecordAlloc = 0;
+  int nPrevAlloc = 0;
+  int nPrev = 0;
   sqlite3_int64 winnerRowid = 0;
   int winnerHandled = 0;
+  int havePrev = 0;
+  int cursorOpen = 0;
   int rc;
-  (void)pzErrMsg;
+  int atEnd = 0;
 
-  zQuery = sqlite3_mprintf(
-    "SELECT rowid, %s FROM main.\"%w\" NOT INDEXED ORDER BY %s, rowid",
-    zCols, zTable, zCols);
-  if( !zQuery ) return SQLITE_NOMEM;
-  rc = sqlite3_prepare_v2(db, zQuery, -1, &pScan, 0);
-  sqlite3_free(zQuery);
-  if( rc != SQLITE_OK ) return rc;
+  pKeyInfo = uniqueIndexKeyInfo(db, pIdx, &rc);
+  if( !pKeyInfo ) goto unique_done;
+  pRecord = sqlite3VdbeAllocUnpackedRecord(pKeyInfo);
+  if( !pRecord ){ rc = SQLITE_NOMEM; goto unique_done; }
+  memset(pRecord->aMem, 0,
+         sizeof(Mem) * (size_t)(pKeyInfo->nKeyField + 1));
+  pCursor = sqlite3_malloc(sqlite3BtreeCursorSize());
+  if( !pCursor ){ rc = SQLITE_NOMEM; goto unique_done; }
+  sqlite3BtreeCursorZero(pCursor);
+  rc = sqlite3BtreeCursor(db->aDb[0].pBt, pIdx->tnum, 0,
+                          pKeyInfo, pCursor);
+  if( rc!=SQLITE_OK ) goto unique_done;
+  cursorOpen = 1;
+  rc = sqlite3BtreeFirst(pCursor, &atEnd);
 
-  while( (rc = sqlite3_step(pScan)) == SQLITE_ROW ){
-    sqlite3_int64 rowid = sqlite3_column_int64(pScan, 0);
-    int nc = sqlite3_column_count(pScan);
-    int i;
-    sqlite3_str *pS;
-    char *zRowKey;
-    int isDup;
+  while( rc==SQLITE_OK && !atEnd ){
+    u32 nRecordU32 = sqlite3BtreePayloadSize(pCursor);
+    int nRecord;
+    int isDup = 0;
+    sqlite3_int64 rowid = 0;
 
-    if( uniqueIndexRowHasNull(pScan, 1, nc) ) continue;
-
-    pS = sqlite3_str_new(0);
-    for(i=1; i<nc; i++){
-      const char *zV = (const char*)sqlite3_column_text(pScan, i);
-      sqlite3_str_appendf(pS, "%s%Q", i>1?"|":"", zV ? zV : "");
+    if( nRecordU32==0 || nRecordU32>0x7fffffff ){
+      rc = SQLITE_CORRUPT;
+      break;
     }
-    zRowKey = sqlite3_str_finish(pS);
-    if( !zRowKey ){ rc = SQLITE_NOMEM; break; }
+    nRecord = (int)nRecordU32;
+    if( nRecord>nRecordAlloc ){
+      u8 *pNew = sqlite3_realloc(pRecordBuf, nRecord);
+      if( !pNew ){ rc = SQLITE_NOMEM; break; }
+      pRecordBuf = pNew;
+      nRecordAlloc = nRecord;
+    }
+    rc = sqlite3BtreePayload(pCursor, 0, nRecordU32, pRecordBuf);
+    if( rc!=SQLITE_OK ) break;
+    pRecord->nField = pKeyInfo->nKeyField + 1;
+    sqlite3VdbeRecordUnpack(nRecord, pRecordBuf, pRecord);
+    if( pRecord->nField < pIdx->nKeyCol ){
+      rc = SQLITE_CORRUPT;
+      break;
+    }
+    if( uniqueIndexRecordHasNull(pRecord, pIdx->nKeyCol) ){
+      havePrev = 0;
+      winnerHandled = 0;
+      goto unique_next;
+    }
 
-    isDup = zWinnerKey && strcmp(zWinnerKey, zRowKey)==0;
+    rc = sqlite3VdbeIdxRowid(db, pCursor, &rowid);
+    if( rc!=SQLITE_OK ) break;
+
+    if( havePrev ){
+      pRecord->nField = pIdx->nKeyCol;
+      pRecord->errCode = 0;
+      isDup = sqlite3VdbeRecordCompare(nPrev, pPrevBuf, pRecord)==0;
+      if( pRecord->errCode ){
+        rc = pRecord->errCode;
+        break;
+      }
+    }
     if( !isDup ){
-      sqlite3_free(zWinnerKey);
-      zWinnerKey = zRowKey;
       winnerRowid = rowid;
       winnerHandled = 0;
-      continue;
-    }
-    sqlite3_free(zRowKey);
-
-    if( !winnerHandled ){
-      int appended = 0;
-      rc = appendUniqueViolationByRowid(db, aAnc, nAnc, zTable, zIndexName,
-                                        zCols, winnerRowid, &appended);
-      if( rc != SQLITE_OK ) break;
-      if( appended && pnFound ) (*pnFound)++;
-      winnerHandled = 1;
+    }else{
+      if( !winnerHandled ){
+        int appended = 0;
+        rc = appendUniqueViolationByRowid(
+            db, aAnc, nAnc, zTable, pIdx->zName, zCols,
+            winnerRowid, &appended);
+        if( rc!=SQLITE_OK ) break;
+        if( appended && pnFound ) (*pnFound)++;
+        winnerHandled = 1;
+      }
+      {
+        int appended = 0;
+        rc = appendUniqueViolationByRowid(
+            db, aAnc, nAnc, zTable, pIdx->zName, zCols,
+            rowid, &appended);
+        if( rc!=SQLITE_OK ) break;
+        if( appended && pnFound ) (*pnFound)++;
+      }
     }
 
     {
-      int appended = 0;
-      rc = appendUniqueViolationByRowid(db, aAnc, nAnc, zTable, zIndexName,
-                                        zCols, rowid, &appended);
-      if( rc != SQLITE_OK ) break;
-      if( appended && pnFound ) (*pnFound)++;
+      u8 *pSwap = pPrevBuf;
+      int nSwap = nPrevAlloc;
+      pPrevBuf = pRecordBuf;
+      nPrevAlloc = nRecordAlloc;
+      pRecordBuf = pSwap;
+      nRecordAlloc = nSwap;
+      nPrev = nRecord;
+      havePrev = 1;
+    }
+
+unique_next:
+    rc = sqlite3BtreeNext(pCursor, 0);
+    if( rc==SQLITE_DONE ){
+      rc = SQLITE_OK;
+      atEnd = 1;
     }
   }
-  sqlite3_free(zWinnerKey);
-  if( rc == SQLITE_DONE ) rc = SQLITE_OK;
-  sqlite3_finalize(pScan);
+
+unique_done:
+  if( cursorOpen ){
+    int closeRc = sqlite3BtreeCloseCursor(pCursor);
+    if( rc==SQLITE_OK ) rc = closeRc;
+  }
+  sqlite3_free(pCursor);
+  sqlite3DbFree(db, pRecord);
+  sqlite3KeyInfoUnref(pKeyInfo);
+  sqlite3_free(pRecordBuf);
+  sqlite3_free(pPrevBuf);
   return rc;
 }
 
 static int detectUniqueViolationsForIndexWithoutRowid(
   sqlite3 *db,
   struct TableEntry *aAnc, int nAnc,
+  struct TableEntry *pCurrent,
   const char *zTable,
-  const char *zIndexName,
+  Index *pIdx,
   const char *zCols,
   const MergePkInfo *pPk,
   int *pnFound
 ){
-  sqlite3_stmt *pScan = 0;
-  sqlite3_str *pSql = 0;
-  char *zQuery = 0;
-  char *zWinnerKey = 0;
-  u8 *pWinnerPkRec = 0;
-  int nWinnerPkRec = 0;
+  ChunkStore *cs = doltliteGetChunkStore(db);
+  ProllyCache *pCache = doltliteGetCache(db);
+  Index *pPkIdx = sqlite3PrimaryKeyIndex(pIdx->pTable);
+  KeyInfo *pKeyInfo = 0;
+  DoltliteColInfo cols;
+  ProllyCursor cursor;
+  UniqueIndexEntry *aEntry = 0;
+  int nEntry = 0;
+  int nAlloc = 0;
+  int cursorOpen = 0;
   int winnerHandled = 0;
   int rc;
+  int res = 0;
+  int i;
 
-  pSql = sqlite3_str_new(0);
-  sqlite3_str_appendf(pSql,
-      "SELECT %s, %s FROM main.\"%w\" NOT INDEXED ORDER BY %s, %s",
-      zCols, pPk->zPkCols, zTable, zCols, pPk->zPkCols);
-  zQuery = sqlite3_str_finish(pSql);
-  if( !zQuery ) return SQLITE_NOMEM;
-  rc = sqlite3_prepare_v2(db, zQuery, -1, &pScan, 0);
-  sqlite3_free(zQuery);
-  if( rc!=SQLITE_OK ) return rc;
+  memset(&cols, 0, sizeof(cols));
+  if( !cs || !pCache || !pCurrent || !pPkIdx ) return SQLITE_ERROR;
+  rc = doltliteGetColumnNames(db, zTable, &cols);
+  if( rc!=SQLITE_OK ) goto without_rowid_done;
+  pKeyInfo = uniqueIndexKeyInfo(db, pIdx, &rc);
+  if( !pKeyInfo ) goto without_rowid_done;
+  if( prollyHashIsEmpty(&pCurrent->root) ) goto without_rowid_done;
 
-  while( (rc = sqlite3_step(pScan)) == SQLITE_ROW ){
-    int nc = sqlite3_column_count(pScan);
-    int nDupKeyCol = nc - pPk->nPk;
-    sqlite3_str *pS;
-    char *zRowKey = 0;
-    int i, isDup;
+  prollyCursorInit(
+      &cursor, cs, pCache, &pCurrent->root, pCurrent->flags);
+  cursorOpen = 1;
+  rc = prollyCursorFirst(&cursor, &res);
+  while( rc==SQLITE_OK && res==0 && prollyCursorIsValid(&cursor) ){
+    const u8 *pKey = 0;
+    const u8 *pValue = 0;
+    const u8 *pRecord;
+    u8 *pOwnedRecord = 0;
+    int nKey = 0;
+    int nValue = 0;
+    int nRecord;
+    DoltliteRecordInfo info;
+    UniqueIndexEntry entry;
+    int hasNull = 0;
 
-    if( uniqueIndexRowHasNull(pScan, 0, nDupKeyCol) ) continue;
-
-    pS = sqlite3_str_new(0);
-    for(i=0; i<nDupKeyCol; i++){
-      const char *zV = (const char*)sqlite3_column_text(pScan, i);
-      sqlite3_str_appendf(pS, "%s%Q", i>0?"|":"", zV ? zV : "");
+    memset(&entry, 0, sizeof(entry));
+    prollyCursorKey(&cursor, &pKey, &nKey);
+    prollyCursorValue(&cursor, &pValue, &nValue);
+    pRecord = pValue;
+    nRecord = nValue;
+    if( nRecord<=0 ){
+      rc = doltliteRecordFromClusteredKey(
+          db, zTable, pKey, nKey, &pOwnedRecord, &nRecord);
+      if( rc!=SQLITE_OK ) break;
+      pRecord = pOwnedRecord;
     }
-    zRowKey = sqlite3_str_finish(pS);
-    if( !zRowKey ){ rc = SQLITE_NOMEM; break; }
-
-    isDup = zWinnerKey && strcmp(zWinnerKey, zRowKey)==0;
-    if( !isDup ){
-      u8 *pPkRec = 0;
-      int nPkRec = 0;
-      pPkRec = buildRecordFromStmtCols(pScan, nDupKeyCol, pPk->nPk, &nPkRec);
-      if( !pPkRec ){
-        sqlite3_free(zRowKey);
+    rc = doltliteParseRecordStrict(pRecord, nRecord, &info);
+    if( rc==SQLITE_OK ){
+      rc = uniqueRecordFromTableRow(
+          pRecord, nRecord, &info, &cols, pIdx, pIdx->nKeyCol,
+          &entry.pKey, &entry.nKey, &hasNull);
+    }
+    if( rc==SQLITE_OK && !hasNull ){
+      rc = uniqueRecordFromTableRow(
+          pRecord, nRecord, &info, &cols, pPkIdx, pPkIdx->nKeyCol,
+          &entry.pPk, &entry.nPk, 0);
+    }
+    sqlite3_free(pOwnedRecord);
+    if( rc!=SQLITE_OK ){
+      sqlite3_free(entry.pKey);
+      sqlite3_free(entry.pPk);
+      break;
+    }
+    if( !hasNull ){
+      entry.pUnpacked = sqlite3VdbeAllocUnpackedRecord(pKeyInfo);
+      if( !entry.pUnpacked ){
+        sqlite3_free(entry.pKey);
+        sqlite3_free(entry.pPk);
         rc = SQLITE_NOMEM;
         break;
       }
-      sqlite3_free(zWinnerKey);
-      sqlite3_free(pWinnerPkRec);
-      zWinnerKey = zRowKey;
-      pWinnerPkRec = pPkRec;
-      nWinnerPkRec = nPkRec;
-      winnerHandled = 0;
-      continue;
-    }
-    sqlite3_free(zRowKey);
-
-    {
-      u8 *pPkRec = 0; int nPkRec = 0;
-      pPkRec = buildRecordFromStmtCols(pScan, nDupKeyCol, pPk->nPk, &nPkRec);
-      if( !pPkRec ){ rc = SQLITE_NOMEM; break; }
-      if( !winnerHandled ){
-        int appended = 0;
-        rc = appendUniqueViolationByPk(db, aAnc, nAnc, zTable, zIndexName,
-                                       zCols, pPk, pWinnerPkRec, nWinnerPkRec,
-                                       &appended);
-        if( rc != SQLITE_OK ){
-          sqlite3_free(pPkRec);
+      memset(entry.pUnpacked->aMem, 0,
+             sizeof(Mem) * (size_t)(pKeyInfo->nKeyField + 1));
+      sqlite3VdbeRecordUnpack(entry.nKey, entry.pKey, entry.pUnpacked);
+      if( entry.pUnpacked->nField<pIdx->nKeyCol ){
+        sqlite3_free(entry.pKey);
+        sqlite3_free(entry.pPk);
+        sqlite3DbFree(db, entry.pUnpacked);
+        rc = SQLITE_CORRUPT;
+        break;
+      }
+      entry.pUnpacked->nField = pIdx->nKeyCol;
+      if( nEntry==nAlloc ){
+        int nNew = nAlloc ? nAlloc*2 : 64;
+        UniqueIndexEntry *aNew;
+        if( nNew<nAlloc || nNew>0x7fffffff/(int)sizeof(UniqueIndexEntry) ){
+          sqlite3_free(entry.pKey);
+          sqlite3_free(entry.pPk);
+          sqlite3DbFree(db, entry.pUnpacked);
+          rc = SQLITE_TOOBIG;
           break;
         }
+        aNew = sqlite3_realloc64(
+            aEntry, (sqlite3_int64)nNew * sizeof(UniqueIndexEntry));
+        if( !aNew ){
+          sqlite3_free(entry.pKey);
+          sqlite3_free(entry.pPk);
+          sqlite3DbFree(db, entry.pUnpacked);
+          rc = SQLITE_NOMEM;
+          break;
+        }
+        aEntry = aNew;
+        nAlloc = nNew;
+      }
+      aEntry[nEntry++] = entry;
+    }else{
+      sqlite3_free(entry.pKey);
+    }
+    rc = prollyCursorNext(&cursor);
+  }
+  if( rc==SQLITE_DONE ) rc = SQLITE_OK;
+  if( rc!=SQLITE_OK ) goto without_rowid_done;
+  rc = uniqueIndexEntriesSort(aEntry, nEntry);
+  if( rc!=SQLITE_OK ) goto without_rowid_done;
+
+  for(i=1; i<nEntry && rc==SQLITE_OK; i++){
+    int cmp;
+    rc = uniqueIndexEntryCompare(&aEntry[i-1], &aEntry[i], &cmp);
+    if( rc==SQLITE_OK && cmp==0 ){
+      int appended = 0;
+      if( !winnerHandled ){
+        rc = appendUniqueViolationByPk(
+            db, aAnc, nAnc, zTable, pIdx->zName, zCols, pPk,
+            aEntry[i-1].pPk, aEntry[i-1].nPk, &appended);
+        if( rc!=SQLITE_OK ) break;
         if( appended && pnFound ) (*pnFound)++;
         winnerHandled = 1;
       }
-      {
-        int appended = 0;
-        rc = appendUniqueViolationByPk(db, aAnc, nAnc, zTable, zIndexName,
-                                       zCols, pPk, pPkRec, nPkRec, &appended);
-        sqlite3_free(pPkRec);
-        if( rc != SQLITE_OK ) break;
-        if( appended && pnFound ) (*pnFound)++;
-      }
+      appended = 0;
+      rc = appendUniqueViolationByPk(
+          db, aAnc, nAnc, zTable, pIdx->zName, zCols, pPk,
+          aEntry[i].pPk, aEntry[i].nPk, &appended);
+      if( rc!=SQLITE_OK ) break;
+      if( appended && pnFound ) (*pnFound)++;
+    }else{
+      winnerHandled = 0;
     }
   }
 
-  sqlite3_free(zWinnerKey);
-  sqlite3_free(pWinnerPkRec);
-  if( rc == SQLITE_DONE ) rc = SQLITE_OK;
-  sqlite3_finalize(pScan);
+without_rowid_done:
+  if( cursorOpen ) prollyCursorClose(&cursor);
+  uniqueIndexEntriesFree(db, aEntry, nEntry);
+  doltliteFreeColInfo(&cols);
+  sqlite3KeyInfoUnref(pKeyInfo);
   return rc;
 }
 
@@ -300,6 +607,7 @@ int doltliteDetectMergeUniqueViolations(
   int nCur = 0;
   int rc;
 
+  (void)pzErrMsg;
   if( pnFound ) *pnFound = 0;
 
   rc = loadAncestorAndCurrentCatalogs(db, pAncCatHash, &aAnc, &nAnc,
@@ -360,11 +668,11 @@ int doltliteDetectMergeUniqueViolations(
       const char *zIdxRaw;
       const char *zOrigin;
       char *zIdx;
-      char *zColsQ;
-      sqlite3_stmt *pCols = 0;
+      Index *pIdx;
       sqlite3_str *pColList;
       char *zColList;
-      int idxRc;
+      int i;
+      int supported = 1;
 
       if( !unique ) continue;
       zIdxRaw = (const char*)sqlite3_column_text(pIdxList, 1);
@@ -375,33 +683,35 @@ int doltliteDetectMergeUniqueViolations(
 
       zIdx = sqlite3_mprintf("%s", zIdxRaw);
       if( !zIdx ) break;
-      zColsQ = sqlite3_mprintf("PRAGMA main.index_xinfo(%Q)", zIdx);
-      if( !zColsQ ){ sqlite3_free(zIdx); break; }
-      idxRc = sqlite3_prepare_v2(db, zColsQ, -1, &pCols, 0);
-      sqlite3_free(zColsQ);
-      if( idxRc != SQLITE_OK ){ sqlite3_free(zIdx); continue; }
+      pIdx = sqlite3FindIndex(db, zIdx, "main");
+      if( !pIdx ){
+        sqlite3_free(zIdx);
+        rc = SQLITE_CORRUPT;
+        break;
+      }
 
       pColList = sqlite3_str_new(0);
-      while( sqlite3_step(pCols) == SQLITE_ROW ){
-        int cno = sqlite3_column_int(pCols, 1);
-        int isKey = sqlite3_column_int(pCols, 5);
-        const char *zCol = (const char*)sqlite3_column_text(pCols, 2);
-        if( cno < 0 || !zCol || !isKey ) continue;
-        if( sqlite3_str_length(pColList) > 0 ){
-          sqlite3_str_appendall(pColList, ", ");
+      for(i=0; i<pIdx->nKeyCol; i++){
+        int cno = pIdx->aiColumn[i];
+        if( i>0 ) sqlite3_str_appendall(pColList, ", ");
+        if( cno>=0 && cno<pIdx->pTable->nCol ){
+          sqlite3_str_appendf(
+              pColList, "\"%w\"", pIdx->pTable->aCol[cno].zCnName);
+        }else{
+          supported = 0;
+          sqlite3_str_appendall(pColList, "null");
         }
-        sqlite3_str_appendf(pColList, "\"%w\"", zCol);
       }
-      sqlite3_finalize(pCols);
       zColList = sqlite3_str_finish(pColList);
-      if( zColList && *zColList ){
+      if( supported && zColList && *zColList ){
         if( hasRowid ){
-          rc = detectUniqueViolationsForIndex(db, aAnc, nAnc, zTable,
-                                               zIdx, zColList, pzErrMsg,
-                                               pnFound);
+          rc = detectUniqueViolationsForIndex(
+              db, aAnc, nAnc, zTable, pIdx, zColList, pnFound);
         }else{
           rc = detectUniqueViolationsForIndexWithoutRowid(
-              db, aAnc, nAnc, zTable, zIdx, zColList, &pkInfo, pnFound);
+              db, aAnc, nAnc,
+              doltliteFindTableByName(aCur, nCur, zTable),
+              zTable, pIdx, zColList, &pkInfo, pnFound);
         }
       }
       sqlite3_free(zColList);

--- a/test/doltlite_merge.sh
+++ b/test/doltlite_merge.sh
@@ -246,6 +246,59 @@ else
   ERRORS="$ERRORS\nFAIL: constraint_violation_merge_tx_persists\n  expected: TX|0|1|1:9:main1,2:9:feat2\n  got:      $TX_OUT"
 fi
 
+DB11D=/tmp/test_merge11d_$$.db; rm -f "$DB11D"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, u TEXT COLLATE NOCASE UNIQUE);
+SELECT dolt_commit('-A','-m','init');
+SELECT dolt_branch('feat'); SELECT dolt_checkout('feat');
+INSERT INTO t VALUES(2,'a'); SELECT dolt_commit('-A','-m','feat');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES(1,'A'); SELECT dolt_commit('-A','-m','main');" | $DOLTLITE "$DB11D" > /dev/null 2>&1
+TX_OUT=$(echo "BEGIN;
+SELECT dolt_merge('feat');
+SELECT 'TX|' || (SELECT count(*) FROM dolt_constraint_violations) || '|' ||
+       COALESCE((SELECT num_violations FROM dolt_constraint_violations WHERE \"table\"='t'),0) || '|' ||
+       COALESCE((SELECT group_concat(id, ',') FROM (SELECT id FROM dolt_constraint_violations_t ORDER BY id)),'');
+ROLLBACK;" | $DOLTLITE "$DB11D" 2>&1 | grep '^TX|')
+if [ "$TX_OUT" = "TX|1|2|1,2" ]; then
+  PASS=$((PASS+1))
+else
+  FAIL=$((FAIL+1))
+  ERRORS="$ERRORS\nFAIL: constraint_violation_nocase_unique\n  expected: TX|1|2|1,2\n  got:      $TX_OUT"
+fi
+
+DB11E=/tmp/test_merge11e_$$.db; rm -f "$DB11E"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, u BLOB UNIQUE);
+SELECT dolt_commit('-A','-m','init');
+SELECT dolt_branch('feat'); SELECT dolt_checkout('feat');
+INSERT INTO t VALUES(2,x'410042'); SELECT dolt_commit('-A','-m','feat');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES(1,x'4100'); SELECT dolt_commit('-A','-m','main');" | $DOLTLITE "$DB11E" > /dev/null 2>&1
+run_test_match "constraint_violation_blob_prefix_merge" \
+  "SELECT dolt_merge('feat');" "^[0-9a-f]{40}$" "$DB11E"
+run_test "constraint_violation_blob_prefix_rows" \
+  "SELECT group_concat(hex(u), ',') FROM (SELECT u FROM t ORDER BY id);" \
+  "4100,410042" "$DB11E"
+
+DB11F=/tmp/test_merge11f_$$.db; rm -f "$DB11F"
+echo "CREATE TABLE t(pk TEXT PRIMARY KEY, u TEXT COLLATE NOCASE UNIQUE) WITHOUT ROWID;
+SELECT dolt_commit('-A','-m','init');
+SELECT dolt_branch('feat'); SELECT dolt_checkout('feat');
+INSERT INTO t VALUES('two','a'); SELECT dolt_commit('-A','-m','feat');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES('one','A'); SELECT dolt_commit('-A','-m','main');" | $DOLTLITE "$DB11F" > /dev/null 2>&1
+TX_OUT=$(echo "BEGIN;
+SELECT dolt_merge('feat');
+SELECT 'TX|' || (SELECT count(*) FROM dolt_constraint_violations) || '|' ||
+       COALESCE((SELECT num_violations FROM dolt_constraint_violations WHERE \"table\"='t'),0) || '|' ||
+       COALESCE((SELECT group_concat(pk, ',') FROM (SELECT pk FROM dolt_constraint_violations_t ORDER BY pk)),'');
+ROLLBACK;" | $DOLTLITE "$DB11F" 2>&1 | grep '^TX|')
+if [ "$TX_OUT" = "TX|1|2|one,two" ]; then
+  PASS=$((PASS+1))
+else
+  FAIL=$((FAIL+1))
+  ERRORS="$ERRORS\nFAIL: constraint_violation_nocase_unique_without_rowid\n  expected: TX|1|2|one,two\n  got:      $TX_OUT"
+fi
+
 DB13=/tmp/test_merge13_$$.db; rm -f "$DB13"
 echo "CREATE TABLE anchor(id INTEGER PRIMARY KEY); INSERT INTO anchor VALUES(1); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB13" > /dev/null 2>&1
 echo "SELECT dolt_branch('feat'); SELECT dolt_checkout('feat'); CREATE TABLE feat_tbl(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO feat_tbl VALUES(1,'f'); SELECT dolt_commit('-A','-m','feat_add_table');" | $DOLTLITE "$DB13" > /dev/null 2>&1
@@ -379,5 +432,5 @@ run_test "many_fk_violations_autocommit_rolled_back" \
 run_test "many_fk_violations_parent_restored" \
   "SELECT count(*) FROM parent;" "0" "$DB23"
 
-rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8" "$DB8B" "$DB9" "$DB10" "$DB11" "$DB12" "$DB13" "$DB14" "$DB15" "$DB16" "$DB17" "$DB18" "$DB19" "$DB20" "$DB20B" "$DB21" "$DB22" "$DB23"
+rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8" "$DB8B" "$DB9" "$DB10" "$DB11" "$DB11D" "$DB11E" "$DB11F" "$DB12" "$DB13" "$DB14" "$DB15" "$DB16" "$DB17" "$DB18" "$DB19" "$DB20" "$DB20B" "$DB21" "$DB22" "$DB23"
 dltest_finish


### PR DESCRIPTION
## Summary

- scan merged table rows and compare typed unique keys with SQLite `KeyInfo` semantics instead of formatting values as SQL text
- reconstruct typed unique and primary keys for `WITHOUT ROWID` tables before detecting duplicate groups
- avoid trusting secondary-index roots that may be stale or duplicated while schema replay is in progress
- preserve collation, BLOB length, composite-key, and NULL semantics during post-merge constraint verification

The previous detector could miss real collation conflicts such as `A` versus `a` under `NOCASE`, and could report distinct BLOBs with embedded NUL bytes as duplicates. The initial direct-index implementation also exposed a replay edge where temporary duplicate index catalog entries caused a violating cherry-pick to be accepted. Building typed keys from table rows handles both cases.

## Tests

- fail-before/pass-after rowid-table `NOCASE` merge conflict
- fail-before/pass-after `WITHOUT ROWID` `NOCASE` merge conflict
- regression for distinct embedded-NUL BLOB keys
- `vc_oracle_constraints_triggers_replay_test.sh`: 17/17
- `doltlite_merge.sh`: 103/103
- `vc_oracle_constraint_violations_test.sh`: 5/5
- `doltlite_merge_nocase_reindex.sh`: 11/11
- `make lint`
- `run_doltlite_tests.sh`: 99/99 suites, including 310,064/310,064 C regression assertions

Co-Authored-By: OpenAI Codex <noreply@openai.com>