### PR TITLE
Name every file a recovered assertion has to be removed from

### DIFF
--- a/test/run_testfixture.sh
+++ b/test/run_testfixture.sh
@@ -11,6 +11,9 @@ ulimit -Sn 1024 2>/dev/null || true
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 DIVERGENCE_FILE="${DIVERGENCE_FILE:-$SCRIPT_DIR/known_testfixture_divergences.txt}"
 TERMINATION_FILE="${TERMINATION_FILE:-$SCRIPT_DIR/known_testfixture_terminations.txt}"
+# Only used to point at the other gates when an entry goes stale.
+INVENTORY_FILE="${INVENTORY_FILE:-$SCRIPT_DIR/known_testfixture_exception_inventory.txt}"
+RATCHET_FILE="${RATCHET_FILE:-$SCRIPT_DIR/known_testfixture_exception_ratchet.txt}"
 HOST_OS="$(uname -s 2>/dev/null | tr '[:upper:]' '[:lower:]')"
 TEST_VARIANT="${TESTFIXTURE_VARIANT:-default}"
 case "$HOST_OS" in
@@ -462,7 +465,28 @@ fi
 if [ "$total_unused" -gt 0 ] || [ "$total_unexpected_clean" -gt 0 ]; then
   echo "  stale/mismatched entries:          $((total_unused + total_unexpected_clean))"
   echo "  stale/mismatched entry list:$unused_lines"
-  echo "::error::$LABEL: $((total_unused + total_unexpected_clean)) entry/entries should be updated or removed from divergence/termination list"
+  echo
+  echo "  A recovered assertion is recorded in three places, and each is gated"
+  echo "  separately -- fixing only this one just moves the failure to \`make lint\`."
+  echo "  For every entry listed above:"
+  echo
+  echo "    1. test/$(basename "$DIVERGENCE_FILE")"
+  echo "       (or test/$(basename "$TERMINATION_FILE") for one that terminated)"
+  echo "       Delete the entry. Match on the first two fields: lines may carry a"
+  echo "       trailing '# comment' that a whole-line match will miss."
+  echo "    2. test/$(basename "$INVENTORY_FILE")"
+  echo "       Delete the same entry, which additionally carries a classification."
+  echo "    3. test/$(basename "$RATCHET_FILE")"
+  echo "       Lower the affected counts. Re-run the command in step 4; it prints"
+  echo "       the exact numbers to use."
+  echo "    4. Confirm with: make lint"
+  echo
+  echo "  Before deleting, check the entry genuinely passes now. An assertion that"
+  echo "  errored out or never ran is absent from the failure list without passing,"
+  echo "  and belongs in the termination list instead. The per-test 'Ok' line is the"
+  echo "  proof; this run's authoritative failure set is the '!Failures on these"
+  echo "  tests:' line for each test."
+  echo "::error::$LABEL: $((total_unused + total_unexpected_clean)) entry/entries should be updated or removed -- see the three files listed above"
   exit 1
 fi
 exit 0


### PR DESCRIPTION
## Problem

When an assertion stops diverging, the fix is spread across three files, each gated separately — and the first gate to fail named only one of them:

```
::error::SQLite regression storage: 13 entry/entries should be updated or
         removed from divergence/termination list
```

Remove the entries from the divergence list and the failure moves to `make lint` (the exception inventory). Fix that and it moves again to the ratchet. That is three CI round trips to retire one recovered assertion, which is how #1934 actually went.

## Change

The bucket runner's stale-entry error now lists all three files and what to do in each, and points at `make lint` for the ratchet numbers rather than duplicating them:

```
  A recovered assertion is recorded in three places, and each is gated
  separately -- fixing only this one just moves the failure to `make lint`.
  For every entry listed above:

    1. test/known_testfixture_divergences.txt
       (or test/known_testfixture_terminations.txt for one that terminated)
       Delete the entry. Match on the first two fields: lines may carry a
       trailing '# comment' that a whole-line match will miss.
    2. test/known_testfixture_exception_inventory.txt
       Delete the same entry, which additionally carries a classification.
    3. test/known_testfixture_exception_ratchet.txt
       Lower the affected counts. Re-run the command in step 4; it prints
       the exact numbers to use.
    4. Confirm with: make lint

  Before deleting, check the entry genuinely passes now. An assertion that
  errored out or never ran is absent from the failure list without passing,
  and belongs in the termination list instead. The per-test 'Ok' line is the
  proof; this run's authoritative failure set is the '!Failures on these
  tests:' line for each test.
```

The last two paragraphs are the parts that cost real time to rediscover:

- Entries can carry a trailing `# comment` (`vacuum5 vacuum5-1.3.4  # VACUUM size metric`), so a whole-line match silently removes nothing.
- An assertion that raised a tcl error or never ran is absent from the failure list **without passing**. Diffing the list against `grep '^! '` output made 38 entries look stale when only 13 were — the other 25 had errored. It belongs in the termination list, not deleted.

## Tests

Verified both paths by appending a deliberately stale entry for an assertion that passes (`vacuum4-1.1`):

- stale entry present → guidance printed, exit 1
- entry removed → exit 0, no extra output
- `test/run_testfixture_test.sh` (the runner's own self-test) passes

No behavior change and no change to which entries are considered stale — output text only. Nothing else in the tree or in `.github/workflows` matches on the old wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)