### PR TITLE
Model dolt_reset('--soft') as the no-op it is

### DIFF
--- a/test/vc_oracle_reset_test.sh
+++ b/test/vc_oracle_reset_test.sh
@@ -171,7 +171,7 @@ SELECT dolt_add('-A');
 SELECT dolt_reset();
 "
 
-oracle "reset_soft_no_ref_unstages_all" "
+oracle "reset_soft_no_ref_keeps_staged" "
 $SEED
 INSERT INTO t VALUES (2, 20);
 SELECT dolt_add('-A');

--- a/test/vc_stateful_fuzzer.py
+++ b/test/vc_stateful_fuzzer.py
@@ -305,7 +305,10 @@ def reset_branch(doltlite, db_path, branch, model, hard):
                 % (branch, committed, working)
             )
         model[branch]["working"] = dict(committed)
-    model[branch]["staged"] = dict(committed)
+        model[branch]["staged"] = dict(committed)
+    # --soft without a ref moves nothing: Dolt leaves the working set AND the
+    # staged set exactly as they were, so the model must too. Only a mixed reset
+    # (no flag) unstages, and this fuzzer does not exercise that form.
 
 
 def create_branch(doltlite, db_path, branches, model, rng, name, via_checkout):


### PR DESCRIPTION
The stateful VC fuzzer went red with a `commit model mismatch`, claiming a staged-only commit had picked up a row that was never staged. **The engine is right; the model was wrong.** This is a harness fix, not an engine fix.

## Reduction

From the reported seed (`1785790693`, step 4271, `op=commit_staged`) the divergence was a single row:

```
expected 79 rows, HEAD has 80
in HEAD but NOT expected:  2820051: ('b282_04254_8196', 853247)
nothing missing, nothing with a wrong value
```

The value encodes its own provenance — branch `b282`, written at step 4254 — and a trace of the run gave the exact four operations on that branch:

```
mutate_b282   INSERT ... 2820051, 'b282_04254_8196' ...
add_b282      SELECT dolt_add('-A');
reset_b282    SELECT dolt_reset('--soft');
commit_b282   SELECT dolt_commit('-m', ...);
```

Which reproduces standalone in four statements, one process each:

```sql
INSERT INTO kv VALUES(555,'WITNESS',555);
SELECT dolt_add('-A');
SELECT dolt_reset('--soft');
SELECT dolt_commit('-m','staged only');   -- 555 lands in HEAD
```

## Ground truth

`--soft` without a ref moves nothing: it leaves the working set **and the staged set** exactly as they were. Only a *mixed* reset unstages, and this fuzzer never issues that form. Verified against `dolt 2.2.2` — doltlite matches it exactly:

| | dolt 2.2.2 | doltlite |
|---|---|---|
| after `add -A` | staged=1 | staged=1 |
| after `reset --soft` | staged=1 | staged=1 |
| after `reset` (mixed) | staged=0 | staged=0 |

`reset_branch()` was setting `staged = committed` for both flags, so every soft reset silently dropped the pending mutation from the model's staged set, and the next staged-only commit looked like it had over-committed. Fixed by moving that assignment inside the `hard` branch.

## Also: an oracle name that asserts the opposite of what it pins

`test/vc_oracle_reset_test.sh` had `reset_soft_no_ref_unstages_all` — which says `--soft` unstages, when neither dolt nor doltlite does. It passes precisely *because* both agree, so the misleading name was invisible. It cost me real time while triaging this (I went looking for an engine bug in the reset path on the strength of that name), so it is now `reset_soft_no_ref_keeps_staged`.

## Validation

- `test/vc_oracle_reset_test.sh` against real `dolt`: **43 passed, 0 failed** (the renamed case included)
- The reported seed re-run with the fixed model is in flight past the old failure point; the parity table above is the substantive proof, and I will confirm the clean run on this PR.

## Note for triage

Worth recording that a red vc-fuzz is not automatically an engine bug — this one was the model. The tell was that the oracle suite, which compares `dolt_status` including the `staged` column against real dolt, was green on exactly this sequence. When the fuzzer and the oracle disagree, the oracle is the one holding dolt's actual behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)