### PR TITLE
Return structured JSON errors from remotesrv

### DIFF
--- a/src/doltlite_http_remote.c
+++ b/src/doltlite_http_remote.c
@@ -171,11 +171,15 @@ static int httpMapError(
     if( !p->zLastError ){
       httpSetLastError(p, "remote refs changed; pull and retry");
     }
-  }else if( status==401
-         || (zCode && strcmp(zCode, "unauthorized")==0)
+  }else if( status==401 || status==403
+         || (zCode && (strcmp(zCode, "unauthorized")==0
+                    || strcmp(zCode, "forbidden")==0))
          || (hasSqlite && sqliteRc==SQLITE_AUTH) ){
+    /* 403 (forbidden) is an auth failure too; SQLite has no separate authz code. */
     rc = SQLITE_AUTH;
-    if( !p->zLastError ) httpSetLastError(p, "unauthorized");
+    if( !p->zLastError ){
+      httpSetLastError(p, status==403 ? "forbidden" : "unauthorized");
+    }
   }else if( status==404
          || (zCode && strcmp(zCode, "not_found")==0)
          || (hasSqlite && sqliteRc==SQLITE_NOTFOUND) ){

--- a/src/doltlite_http_remote.c
+++ b/src/doltlite_http_remote.c
@@ -40,10 +40,173 @@ struct HttpRemote {
   u8 hasExpectedRefsHash;
   char *zPushBranch;
   int bPushForce;
+  char *zLastError;
 };
 
 #define HTTP_RESP_MAX_BYTES ((i64)128 * 1024 * 1024)
 #define HTTP_TIMEOUT_MS 30000
+
+static void httpClearLastError(HttpRemote *p){
+  sqlite3_free(p->zLastError);
+  p->zLastError = 0;
+}
+
+static void httpSetLastError(HttpRemote *p, const char *zMsg){
+  httpClearLastError(p);
+  if( zMsg && zMsg[0] ){
+    p->zLastError = sqlite3_mprintf("%s", zMsg);
+  }
+}
+
+/* Extract a JSON string value for "key" from a flat object body. */
+static char *httpJsonStringField(const u8 *p, int n, const char *zKey){
+  char zNeedle[64];
+  int nNeedle;
+  int i;
+  if( !p || n<=0 || !zKey ) return 0;
+  sqlite3_snprintf(sizeof(zNeedle), zNeedle, "\"%s\"", zKey);
+  nNeedle = (int)strlen(zNeedle);
+  for(i=0; i+nNeedle<n; i++){
+    int j, k, start, end;
+    if( memcmp(p+i, zNeedle, (size_t)nNeedle)!=0 ) continue;
+    j = i + nNeedle;
+    while( j<n && (p[j]==' ' || p[j]=='\t' || p[j]=='\r' || p[j]=='\n') ) j++;
+    if( j>=n || p[j]!=':' ) continue;
+    j++;
+    while( j<n && (p[j]==' ' || p[j]=='\t' || p[j]=='\r' || p[j]=='\n') ) j++;
+    if( j>=n || p[j]!='"' ) continue;
+    start = ++j;
+    while( j<n && p[j]!='"' ){
+      if( p[j]=='\\' ) j++;
+      j++;
+    }
+    if( j>=n ) return 0;
+    end = j;
+    {
+      char *z = sqlite3_malloc(end - start + 1);
+      if( !z ) return 0;
+      /* Bodies we emit are plain ASCII without escapes. */
+      for(k=0; k<end-start; k++) z[k] = (char)p[start+k];
+      z[end-start] = 0;
+      return z;
+    }
+  }
+  return 0;
+}
+
+static int httpJsonIntField(const u8 *p, int n, const char *zKey, int *pOut){
+  char zNeedle[64];
+  int nNeedle;
+  int i;
+  if( !p || n<=0 || !zKey || !pOut ) return 0;
+  sqlite3_snprintf(sizeof(zNeedle), zNeedle, "\"%s\"", zKey);
+  nNeedle = (int)strlen(zNeedle);
+  for(i=0; i+nNeedle<n; i++){
+    int j;
+    uint64_t value;
+    int neg = 0;
+    if( memcmp(p+i, zNeedle, (size_t)nNeedle)!=0 ) continue;
+    j = i + nNeedle;
+    while( j<n && (p[j]==' ' || p[j]=='\t' || p[j]=='\r' || p[j]=='\n') ) j++;
+    if( j>=n || p[j]!=':' ) continue;
+    j++;
+    while( j<n && (p[j]==' ' || p[j]=='\t' || p[j]=='\r' || p[j]=='\n') ) j++;
+    if( j<n && p[j]=='-' ){ neg = 1; j++; }
+    if( j>=n || p[j]<'0' || p[j]>'9' ) continue;
+    {
+      int k = j;
+      while( k<n && p[k]>='0' && p[k]<='9' ) k++;
+      if( doltliteParseDecimal((const char*)p+j, (const char*)p+k,
+                              0x7fffffff, &value)!=DOLTLITE_DECIMAL_OK ){
+        return 0;
+      }
+      *pOut = neg ? -(int)value : (int)value;
+      return 1;
+    }
+  }
+  return 0;
+}
+
+/* Map HTTP status (+ optional structured body) to an SQLite result code and
+** stash a message for xErrMsg. */
+static int httpMapError(
+  HttpRemote *p,
+  int status,
+  const u8 *pResp,
+  int nResp
+){
+  char *zCode = 0;
+  char *zMsg = 0;
+  int sqliteRc = 0;
+  int hasSqlite = 0;
+  int rc;
+
+  httpClearLastError(p);
+  if( pResp && nResp>0 && pResp[0]=='{' ){
+    zCode = httpJsonStringField(pResp, nResp, "code");
+    zMsg = httpJsonStringField(pResp, nResp, "message");
+    hasSqlite = httpJsonIntField(pResp, nResp, "sqlite", &sqliteRc);
+  }
+
+  if( zMsg ){
+    httpSetLastError(p, zMsg);
+  }else if( pResp && nResp>0 && pResp[0]!='{' ){
+    /* Plain-text body from older servers. */
+    char *zPlain = sqlite3_malloc(nResp + 1);
+    if( zPlain ){
+      memcpy(zPlain, pResp, (size_t)nResp);
+      zPlain[nResp] = 0;
+      while( nResp>0 && (zPlain[nResp-1]=='\n' || zPlain[nResp-1]=='\r') ){
+        zPlain[--nResp] = 0;
+      }
+      if( zPlain[0] ) httpSetLastError(p, zPlain);
+      sqlite3_free(zPlain);
+    }
+  }
+
+  if( status==409
+   || (zCode && strcmp(zCode, "refs_changed")==0)
+   || (hasSqlite && sqliteRc==SQLITE_BUSY) ){
+    rc = SQLITE_BUSY;
+    if( !p->zLastError ){
+      httpSetLastError(p, "remote refs changed; pull and retry");
+    }
+  }else if( status==401
+         || (zCode && strcmp(zCode, "unauthorized")==0)
+         || (hasSqlite && sqliteRc==SQLITE_AUTH) ){
+    rc = SQLITE_AUTH;
+    if( !p->zLastError ) httpSetLastError(p, "unauthorized");
+  }else if( status==404
+         || (zCode && strcmp(zCode, "not_found")==0)
+         || (hasSqlite && sqliteRc==SQLITE_NOTFOUND) ){
+    rc = SQLITE_NOTFOUND;
+    if( !p->zLastError ) httpSetLastError(p, "not found");
+  }else if( status==413
+         || (zCode && strcmp(zCode, "toobig")==0)
+         || (hasSqlite && sqliteRc==SQLITE_TOOBIG) ){
+    rc = SQLITE_TOOBIG;
+    if( !p->zLastError ) httpSetLastError(p, "payload too large");
+  }else if( (zCode && strcmp(zCode, "non_ff")==0)
+         || (hasSqlite && sqliteRc==SQLITE_CONSTRAINT) ){
+    rc = SQLITE_CONSTRAINT;
+    if( !p->zLastError ){
+      httpSetLastError(p,
+        "not a fast-forward of the remote branch (use force to overwrite)");
+    }
+  }else if( hasSqlite && sqliteRc!=0 ){
+    rc = sqliteRc;
+  }else if( status>=500 ){
+    rc = SQLITE_IOERR;
+    if( !p->zLastError ) httpSetLastError(p, "remote server error");
+  }else{
+    rc = SQLITE_ERROR;
+    if( !p->zLastError ) httpSetLastError(p, "remote request failed");
+  }
+
+  sqlite3_free(zCode);
+  sqlite3_free(zMsg);
+  return rc;
+}
 
 static int httpHeaderNameEquals(
   const u8 *zName,
@@ -307,9 +470,13 @@ static int httpRequest(
   *pStatus = 0;
   *ppResp = 0;
   *pnResp = 0;
+  httpClearLastError(p);
 
   conn = httpConnOpen(p->zHost, p->port, p->useTls, p->timeoutMs);
-  if( !conn ) return SQLITE_ERROR;
+  if( !conn ){
+    httpSetLastError(p, "could not connect to remote");
+    return SQLITE_ERROR;
+  }
 
 #ifdef DOLTLITE_HAVE_AUTH
   if( p->useTls && p->cred ){
@@ -418,10 +585,14 @@ static int httpHasChunks(DoltliteRemote *pRemote, const ProllyHash *aHash,
   sqlite3_free(pReqBody);
   sqlite3_free(zPath);
 
-  if( rc != SQLITE_OK ) return rc;
-  if( status != 200 ){
+  if( rc != SQLITE_OK ){
     sqlite3_free(pResp);
-    return SQLITE_ERROR;
+    return rc;
+  }
+  if( status != 200 ){
+    rc = httpMapError(p, status, pResp, nResp);
+    sqlite3_free(pResp);
+    return rc;
   }
 
   if( nResp >= nHash ){
@@ -463,13 +634,10 @@ static int httpGetChunk(DoltliteRemote *pRemote, const ProllyHash *pHash,
     sqlite3_free(pResp);
     return rc;
   }
-  if( status == 404 ){
-    sqlite3_free(pResp);
-    return SQLITE_NOTFOUND;
-  }
   if( status != 200 ){
+    rc = httpMapError(p, status, pResp, nResp);
     sqlite3_free(pResp);
-    return SQLITE_ERROR;
+    return rc;
   }
 
   *ppData = pResp;
@@ -581,7 +749,11 @@ static int httpGetChunks(DoltliteRemote *pRemote, const ProllyHash *aHash,
   sqlite3_free(zPath);
   sqlite3_free(pReq);
   if( rc != SQLITE_OK ){ sqlite3_free(pResp); return rc; }
-  if( status != 200 ){ sqlite3_free(pResp); return SQLITE_ERROR; }
+  if( status != 200 ){
+    rc = httpMapError(p, status, pResp, nResp);
+    sqlite3_free(pResp);
+    return rc;
+  }
   rc = httpParseChunkBatch(pResp, nResp, nHash, apData, anData);
   sqlite3_free(pResp);
   return rc;   /* caller frees any apData[i] set before an error */
@@ -609,13 +781,10 @@ static int httpGetRefs(DoltliteRemote *pRemote, u8 **ppData, int *pnData){
     sqlite3_free(pResp);
     return rc;
   }
-  if( status == 404 ){
-    sqlite3_free(pResp);
-    return SQLITE_NOTFOUND;
-  }
   if( status != 200 ){
+    rc = httpMapError(p, status, pResp, nResp);
     sqlite3_free(pResp);
-    return SQLITE_ERROR;
+    return rc;
   }
 
   *ppData = pResp;
@@ -681,9 +850,16 @@ static int httpCommit(DoltliteRemote *pRemote){
                      p->pUploadBuf, (int)p->nUploadBuf,
                      &status, &pResp, &nResp);
     sqlite3_free(zPath);
+    if( rc != SQLITE_OK ){
+      sqlite3_free(pResp);
+      return rc;
+    }
+    if( status != 200 && status != 204 ){
+      rc = httpMapError(p, status, pResp, nResp);
+      sqlite3_free(pResp);
+      return rc;
+    }
     sqlite3_free(pResp);
-    if( rc != SQLITE_OK ) return rc;
-    if( status != 200 && status != 204 ) return SQLITE_ERROR;
   }
 
   if( p->pPendingRefs && p->nPendingRefs > 0 ){
@@ -716,10 +892,16 @@ static int httpCommit(DoltliteRemote *pRemote){
     rc = httpRequest(p, "PUT", zPath, pReq, nReq, &status, &pResp, &nResp);
     sqlite3_free(pReq);
     sqlite3_free(zPath);
+    if( rc != SQLITE_OK ){
+      sqlite3_free(pResp);
+      return rc;
+    }
+    if( status != 200 && status != 204 ){
+      rc = httpMapError(p, status, pResp, nResp);
+      sqlite3_free(pResp);
+      return rc;
+    }
     sqlite3_free(pResp);
-    if( rc != SQLITE_OK ) return rc;
-    if( status == 409 ) return SQLITE_BUSY;
-    if( status != 200 && status != 204 ) return SQLITE_ERROR;
   }
 
   {
@@ -730,9 +912,16 @@ static int httpCommit(DoltliteRemote *pRemote){
     rc = httpRequest(p, "POST", zPath,
                      0, 0, &status, &pResp, &nResp);
     sqlite3_free(zPath);
+    if( rc != SQLITE_OK ){
+      sqlite3_free(pResp);
+      return rc;
+    }
+    if( status != 200 && status != 204 ){
+      rc = httpMapError(p, status, pResp, nResp);
+      sqlite3_free(pResp);
+      return rc;
+    }
     sqlite3_free(pResp);
-    if( rc != SQLITE_OK ) return rc;
-    if( status != 200 && status != 204 ) return SQLITE_ERROR;
   }
 
   sqlite3_free(p->pUploadBuf);
@@ -750,6 +939,11 @@ static int httpCommit(DoltliteRemote *pRemote){
   return SQLITE_OK;
 }
 
+static const char *httpErrMsg(DoltliteRemote *pRemote){
+  HttpRemote *p = (HttpRemote*)pRemote;
+  return p->zLastError;
+}
+
 static void httpClose(DoltliteRemote *pRemote){
   HttpRemote *p = (HttpRemote*)pRemote;
 #ifdef DOLTLITE_HAVE_AUTH
@@ -761,6 +955,7 @@ static void httpClose(DoltliteRemote *pRemote){
   sqlite3_free(p->pUploadBuf);
   sqlite3_free(p->pPendingRefs);
   sqlite3_free(p->zPushBranch);
+  httpClearLastError(p);
   sqlite3_free(p);
 }
 
@@ -921,6 +1116,7 @@ DoltliteRemote *doltliteHttpRemoteOpen(const char *zUrl){
   p->base.xSetRefsIf = httpSetRefsIf;
   p->base.xCommit = httpCommit;
   p->base.xClose = httpClose;
+  p->base.xErrMsg = httpErrMsg;
 
   return &p->base;
 }

--- a/src/doltlite_remote.c
+++ b/src/doltlite_remote.c
@@ -783,7 +783,7 @@ int doltlitePush(
         int isAnc = syncIsAncestor(pLocal, &remoteCommit, &localCommit);
         if( isAnc <= 0 ){
           sqlite3_free(refsData);
-          return isAnc<0 ? SQLITE_NOMEM : SQLITE_ERROR;
+          return isAnc<0 ? SQLITE_NOMEM : SQLITE_CONSTRAINT;
         }
       }
     }

--- a/src/doltlite_remote.h
+++ b/src/doltlite_remote.h
@@ -23,6 +23,9 @@ struct DoltliteRemote {
                     int bForce, const u8*, int);
   int (*xCommit)(DoltliteRemote*);
   void (*xClose)(DoltliteRemote*);
+  /* Optional. Last human-readable error from a remote op, or NULL. Lifetime
+  ** is until the next op or xClose. */
+  const char *(*xErrMsg)(DoltliteRemote*);
 };
 
 static inline int doltliteRemotePersistRefs(ChunkStore *cs){

--- a/src/doltlite_remote_sql.c
+++ b/src/doltlite_remote_sql.c
@@ -280,12 +280,14 @@ static void doltPushFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   rc = doltlitePush(cs, pRemote, zBranch, bForce);
   if( rc!=SQLITE_OK ){
     const char *zMsg = remoteSqlRemoteMsg(pRemote, rc);
-    char *zOwned = zMsg ? sqlite3_mprintf("%s", zMsg) : 0;
+    char *zOwned;
+    if( !zMsg && rc==SQLITE_ERROR ){
+      zMsg = "push failed (not a fast-forward?)";
+    }
+    zOwned = zMsg ? sqlite3_mprintf("%s", zMsg) : 0;
     pRemote->xClose(pRemote);
     (void)doltliteVcSealSavepointError(db);
-    remoteSqlResultError(ctx, rc,
-      zOwned ? zOwned
-      : (rc==SQLITE_ERROR ? "push failed" : 0));
+    remoteSqlResultError(ctx, rc, zOwned);
     sqlite3_free(zOwned);
     return;
   }

--- a/src/doltlite_remote_sql.c
+++ b/src/doltlite_remote_sql.c
@@ -51,6 +51,21 @@ static void remoteSqlResultError(
   }
 }
 
+static const char *remoteSqlRemoteMsg(DoltliteRemote *pRemote, int rc){
+  const char *z;
+  if( pRemote && pRemote->xErrMsg ){
+    z = pRemote->xErrMsg(pRemote);
+    if( z && z[0] ) return z;
+  }
+  if( rc==SQLITE_BUSY ) return "push failed (remote refs changed)";
+  if( rc==SQLITE_CONSTRAINT ){
+    return "not a fast-forward of the remote branch (use force to overwrite)";
+  }
+  if( rc==SQLITE_AUTH ) return "remote unauthorized";
+  if( rc==SQLITE_TOOBIG ) return "remote payload too large";
+  return 0;
+}
+
 static void remoteSqlRestoreAndReport(
   sqlite3_context *ctx,
   sqlite3 *db,
@@ -263,15 +278,18 @@ static void doltPushFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   if( remoteSqlReportOpenError(ctx, db, rc, 0) ) return;
 
   rc = doltlitePush(cs, pRemote, zBranch, bForce);
-  pRemote->xClose(pRemote);
-
   if( rc!=SQLITE_OK ){
+    const char *zMsg = remoteSqlRemoteMsg(pRemote, rc);
+    char *zOwned = zMsg ? sqlite3_mprintf("%s", zMsg) : 0;
+    pRemote->xClose(pRemote);
     (void)doltliteVcSealSavepointError(db);
     remoteSqlResultError(ctx, rc,
-      rc==SQLITE_BUSY ? "push failed (remote refs changed)"
-      : rc==SQLITE_ERROR ? "push failed (not a fast-forward?)" : 0);
+      zOwned ? zOwned
+      : (rc==SQLITE_ERROR ? "push failed" : 0));
+    sqlite3_free(zOwned);
     return;
   }
+  pRemote->xClose(pRemote);
   sqlite3_result_int(ctx, 0);
 }
 
@@ -374,10 +392,14 @@ static void doltFetchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
     }
     rc = doltliteFetch(cs, pRemote, zRemoteName, zBranch);
     if( rc!=SQLITE_OK ){
+      const char *zMsg = remoteSqlRemoteMsg(pRemote, rc);
+      char *zOwned = zMsg ? sqlite3_mprintf("%s", zMsg) : 0;
       pRemote->xClose(pRemote);
       (void)doltliteVcSealSavepointError(db);
       remoteSqlResultError(ctx, rc,
-        rc==SQLITE_NOTFOUND ? "fetch failed: branch not found on remote" : 0);
+        zOwned ? zOwned
+        : (rc==SQLITE_NOTFOUND ? "fetch failed: branch not found on remote" : 0));
+      sqlite3_free(zOwned);
       return;
     }
   }else{
@@ -415,14 +437,18 @@ static void doltFetchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
         return;
       }
       rc = doltliteFetch(cs, pBrRemote, zRemoteName, azNames[i]);
-      pBrRemote->xClose(pBrRemote);
       if( rc!=SQLITE_OK ){
+        const char *zMsg = remoteSqlRemoteMsg(pBrRemote, rc);
+        char *zOwned = zMsg ? sqlite3_mprintf("%s", zMsg) : 0;
+        pBrRemote->xClose(pBrRemote);
         doltliteFreeStringArray(azNames, nNames);
         sqlite3_free(zUrlOwned);
         (void)doltliteVcSealSavepointError(db);
-        remoteSqlResultError(ctx, rc, "fetch failed");
+        remoteSqlResultError(ctx, rc, zOwned ? zOwned : "fetch failed");
+        sqlite3_free(zOwned);
         return;
       }
+      pBrRemote->xClose(pBrRemote);
     }
     doltliteFreeStringArray(azNames, nNames);
     sqlite3_free(zUrlOwned);
@@ -712,11 +738,16 @@ static void doltCloneFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   }
 
   rc = doltliteClone(cs, pRemote);
-  pRemote->xClose(pRemote);
   if( rc!=SQLITE_OK ){
-    remoteSqlRestoreAndReport(ctx, db, cs, &savedState, rc, "clone failed");
+    const char *zMsg = remoteSqlRemoteMsg(pRemote, rc);
+    char *zOwned = zMsg ? sqlite3_mprintf("%s", zMsg) : 0;
+    pRemote->xClose(pRemote);
+    remoteSqlRestoreAndReport(ctx, db, cs, &savedState, rc,
+                              zOwned ? zOwned : "clone failed");
+    sqlite3_free(zOwned);
     return;
   }
+  pRemote->xClose(pRemote);
 
   rc = chunkStoreAddRemote(cs, "origin", zUrl);
   if( rc!=SQLITE_OK ){

--- a/src/doltlite_remotesrv.c
+++ b/src/doltlite_remotesrv.c
@@ -153,11 +153,6 @@ static void sendBadRequest(DoltliteConn *fd){
                       "bad request");
 }
 
-static void sendError(DoltliteConn *fd){
-  sendStructuredError(fd, 500, "Internal Server Error", "error", SQLITE_ERROR,
-                      "internal error");
-}
-
 static void sendSqliteError(DoltliteConn *fd, int rc){
   switch( rc ){
     case SQLITE_BUSY:
@@ -210,10 +205,6 @@ static void sendSqliteError(DoltliteConn *fd, int rc){
 static void sendPayloadTooLarge(DoltliteConn *fd){
   sendStructuredError(fd, 413, "Payload Too Large", "toobig", SQLITE_TOOBIG,
                       "payload too large");
-}
-
-static void sendConflict(DoltliteConn *fd){
-  sendSqliteError(fd, SQLITE_BUSY);
 }
 
 static void sendUnauthorized(DoltliteConn *fd){

--- a/src/doltlite_remotesrv.c
+++ b/src/doltlite_remotesrv.c
@@ -78,16 +78,32 @@ struct DoltliteServer {
   int nDbCache;
 };
 
-static void sendResponse(DoltliteConn *fd, int status, const char *zStatus,
-                         const u8 *pBody, int nBody){
-  char zHeader[256];
+static void sendResponseEx(
+  DoltliteConn *fd,
+  int status,
+  const char *zStatus,
+  const char *zContentType,
+  const u8 *pBody,
+  int nBody
+){
+  char zHeader[384];
   int nHeader;
-  sqlite3_snprintf(sizeof(zHeader), zHeader,
-    "HTTP/1.1 %d %s\r\n"
-    "Content-Length: %d\r\n"
-    "Connection: close\r\n"
-    "\r\n",
-    status, zStatus, nBody);
+  if( zContentType && zContentType[0] ){
+    sqlite3_snprintf(sizeof(zHeader), zHeader,
+      "HTTP/1.1 %d %s\r\n"
+      "Content-Type: %s\r\n"
+      "Content-Length: %d\r\n"
+      "Connection: close\r\n"
+      "\r\n",
+      status, zStatus, zContentType, nBody);
+  }else{
+    sqlite3_snprintf(sizeof(zHeader), zHeader,
+      "HTTP/1.1 %d %s\r\n"
+      "Content-Length: %d\r\n"
+      "Connection: close\r\n"
+      "\r\n",
+      status, zStatus, nBody);
+  }
   nHeader = (int)strlen(zHeader);
   if( doltliteConnWriteAll(fd, zHeader, nHeader)!=0 ) return;
   if( pBody && nBody>0 ){
@@ -95,34 +111,114 @@ static void sendResponse(DoltliteConn *fd, int status, const char *zStatus,
   }
 }
 
+static void sendResponse(DoltliteConn *fd, int status, const char *zStatus,
+                         const u8 *pBody, int nBody){
+  sendResponseEx(fd, status, zStatus, 0, pBody, nBody);
+}
+
 static void sendOk(DoltliteConn *fd, const u8 *pBody, int nBody){
   sendResponse(fd, 200, "OK", pBody, nBody);
 }
 
+/* Structured error body: {"code":"...","sqlite":N,"message":"..."}.
+** Clients parse "message" for humans and "code"/"sqlite" for recovery. */
+static void sendStructuredError(
+  DoltliteConn *fd,
+  int httpStatus,
+  const char *zHttpReason,
+  const char *zCode,
+  int sqliteRc,
+  const char *zMessage
+){
+  char zBody[512];
+  int nBody;
+  const char *zMsg = zMessage && zMessage[0] ? zMessage : "error";
+  const char *zC = zCode && zCode[0] ? zCode : "error";
+  /* Keep body simple ASCII so no JSON escaping is required for known strings. */
+  sqlite3_snprintf(sizeof(zBody), zBody,
+    "{\"code\":\"%s\",\"sqlite\":%d,\"message\":\"%s\"}",
+    zC, sqliteRc, zMsg);
+  nBody = (int)strlen(zBody);
+  sendResponseEx(fd, httpStatus, zHttpReason, "application/json",
+                 (const u8*)zBody, nBody);
+}
+
 static void sendNotFound(DoltliteConn *fd){
-  sendResponse(fd, 404, "Not Found", (const u8*)"Not Found", 9);
+  sendStructuredError(fd, 404, "Not Found", "not_found", SQLITE_NOTFOUND,
+                      "not found");
 }
 
 static void sendBadRequest(DoltliteConn *fd){
-  sendResponse(fd, 400, "Bad Request", (const u8*)"Bad Request", 11);
+  sendStructuredError(fd, 400, "Bad Request", "bad_request", SQLITE_ERROR,
+                      "bad request");
 }
 
 static void sendError(DoltliteConn *fd){
-  sendResponse(fd, 500, "Internal Server Error",
-               (const u8*)"Internal Server Error", 21);
+  sendStructuredError(fd, 500, "Internal Server Error", "error", SQLITE_ERROR,
+                      "internal error");
+}
+
+static void sendSqliteError(DoltliteConn *fd, int rc){
+  switch( rc ){
+    case SQLITE_BUSY:
+      sendStructuredError(fd, 409, "Conflict", "refs_changed", rc,
+                          "remote refs changed; pull and retry");
+      return;
+    case SQLITE_CONSTRAINT:
+      sendStructuredError(fd, 400, "Bad Request", "non_ff", rc,
+                          "not a fast-forward of the remote branch "
+                          "(use force to overwrite)");
+      return;
+    case SQLITE_NOMEM:
+      sendStructuredError(fd, 500, "Internal Server Error", "nomem", rc,
+                          "out of memory");
+      return;
+    case SQLITE_READONLY:
+      sendStructuredError(fd, 500, "Internal Server Error", "readonly", rc,
+                          "database is read-only");
+      return;
+    case SQLITE_CORRUPT:
+      sendStructuredError(fd, 500, "Internal Server Error", "corrupt", rc,
+                          "database is corrupt");
+      return;
+    case SQLITE_NOTADB:
+      sendStructuredError(fd, 500, "Internal Server Error", "notadb", rc,
+                          "file is not a database");
+      return;
+    case SQLITE_IOERR:
+      sendStructuredError(fd, 500, "Internal Server Error", "io", rc,
+                          "I/O error");
+      return;
+    case SQLITE_TOOBIG:
+      sendStructuredError(fd, 413, "Payload Too Large", "toobig", rc,
+                          "payload too large");
+      return;
+    case SQLITE_AUTH:
+      sendStructuredError(fd, 401, "Unauthorized", "unauthorized", rc,
+                          "unauthorized");
+      return;
+    case SQLITE_NOTFOUND:
+      sendNotFound(fd);
+      return;
+    default:
+      sendStructuredError(fd, 500, "Internal Server Error", "error",
+                          rc ? rc : SQLITE_ERROR, "internal error");
+      return;
+  }
 }
 
 static void sendPayloadTooLarge(DoltliteConn *fd){
-  sendResponse(fd, 413, "Payload Too Large",
-               (const u8*)"Payload Too Large", 17);
+  sendStructuredError(fd, 413, "Payload Too Large", "toobig", SQLITE_TOOBIG,
+                      "payload too large");
 }
 
 static void sendConflict(DoltliteConn *fd){
-  sendResponse(fd, 409, "Conflict", (const u8*)"Conflict", 8);
+  sendSqliteError(fd, SQLITE_BUSY);
 }
 
 static void sendUnauthorized(DoltliteConn *fd){
-  sendResponse(fd, 401, "Unauthorized", (const u8*)"Unauthorized", 12);
+  sendStructuredError(fd, 401, "Unauthorized", "unauthorized", SQLITE_AUTH,
+                      "unauthorized");
 }
 
 static int remoteSrvCommitPending(ChunkStore *pStore){
@@ -427,7 +523,7 @@ static void handleHasChunks(ChunkStore *pStore, DoltliteConn *fd,
   /* nHashes is bounded by MAX_REQUEST_BYTES / PROLLY_HASH_SIZE. */
   aResult = (u8*)sqlite3_malloc64((sqlite3_uint64)nHashes);
   if( !aResult ){
-    sendError(fd);
+    sendSqliteError(fd, SQLITE_NOMEM);
     return;
   }
   memset(aResult, 0, (size_t)nHashes);
@@ -441,7 +537,7 @@ static void handleHasChunks(ChunkStore *pStore, DoltliteConn *fd,
                          nHashes, aResult);
   if( rc!=SQLITE_OK ){
     sqlite3_free(aResult);
-    sendError(fd);
+    sendSqliteError(fd, rc);
     return;
   }
   sendOk(fd, aResult, nHashes);
@@ -478,7 +574,7 @@ static void handleGetChunks(ChunkStore *pStore, DoltliteConn *fd,
     if( rc!=SQLITE_OK && rc!=SQLITE_NOTFOUND ){
       sqlite3_free(pData);
       sqlite3_free(pOut);
-      sendError(fd);
+      sendSqliteError(fd, rc);
       return;
     }
     bPresent = (rc==SQLITE_OK);
@@ -502,7 +598,7 @@ static void handleGetChunks(ChunkStore *pStore, DoltliteConn *fd,
     if( growRc!=SQLITE_OK ){
       sqlite3_free(pData);
       sqlite3_free(pOut);
-      sendError(fd);
+      sendSqliteError(fd, growRc);
       return;
     }
 
@@ -544,7 +640,7 @@ static void handleGetChunk(ChunkStore *pStore, DoltliteConn *fd, const char *zHe
     return;
   }
   if( rc!=SQLITE_OK ){
-    sendError(fd);
+    sendSqliteError(fd, rc);
     return;
   }
   if( nData<0 || (i64)nData>MAX_RESPONSE_BYTES ){
@@ -584,7 +680,7 @@ static void handlePostChunks(ChunkStore *pStore, DoltliteConn *fd,
     rc = chunkStorePut(pStore, pBody + offset, (int)len, &hash);
     if( rc!=SQLITE_OK ){
       chunkStoreRollback(pStore);
-      sendError(fd);
+      sendSqliteError(fd, rc);
       return;
     }
     offset += (int)len;
@@ -592,7 +688,7 @@ static void handlePostChunks(ChunkStore *pStore, DoltliteConn *fd,
 
   rc = remoteSrvCommitPending(pStore);
   if( rc!=SQLITE_OK ){
-    sendError(fd);
+    sendSqliteError(fd, rc);
     return;
   }
 
@@ -615,7 +711,7 @@ static void handleGetRefs(ChunkStore *pStore, DoltliteConn *fd){
     return;
   }
   if( rc!=SQLITE_OK ){
-    sendError(fd);
+    sendSqliteError(fd, rc);
     return;
   }
 
@@ -708,7 +804,7 @@ static void handlePutRefs(ChunkStore *pStore, DoltliteConn *fd,
   rc = remoteSrvApplyRefs(pStore, zBranch, bForce, pRest, nRest);
   sqlite3_free(zBranch);
   if( rc!=SQLITE_OK ){
-    sendError(fd);
+    sendSqliteError(fd, rc);
     return;
   }
 
@@ -737,12 +833,8 @@ static void handlePutRefsIf(ChunkStore *pStore, DoltliteConn *fd,
                             pRest + PROLLY_HASH_SIZE,
                             nRest - PROLLY_HASH_SIZE);
   sqlite3_free(zBranch);
-  if( rc==SQLITE_BUSY ){
-    sendConflict(fd);
-    return;
-  }
   if( rc!=SQLITE_OK ){
-    sendError(fd);
+    sendSqliteError(fd, rc);
     return;
   }
 
@@ -773,7 +865,7 @@ static void handleCommit(ChunkStore *pStore, DoltliteConn *fd){
 
   rc = remoteSrvPersistRefs(pStore);
   if( rc!=SQLITE_OK ){
-    sendError(fd);
+    sendSqliteError(fd, rc);
     return;
   }
 
@@ -1014,7 +1106,7 @@ static void handleRequest(DoltliteServer *pSrv, DoltliteConn *fd){
   pVfs = sqlite3_vfs_find(0);
   rc = pVfs->xAccess(pVfs, zDbPath, SQLITE_ACCESS_EXISTS, &exists);
   if( rc!=SQLITE_OK ){
-    sendError(fd);
+    sendSqliteError(fd, rc);
     sqlite3_free(pBody);
     return;
   }
@@ -1031,7 +1123,7 @@ static void handleRequest(DoltliteServer *pSrv, DoltliteConn *fd){
 
   rc = remoteDbAcquire(pSrv, zDbPath, !isReadOnlyEndpoint, &pHandle);
   if( rc!=SQLITE_OK ){
-    sendError(fd);
+    sendSqliteError(fd, rc);
     sqlite3_free(pBody);
     return;
   }


### PR DESCRIPTION
## Summary

- Remotesrv error responses use a small JSON body: `{"code","sqlite","message"}` with matching HTTP status (e.g. `non_ff` → 400, `refs_changed` → 409, `unauthorized` → 401).
- Map SQLite result codes from handlers (`SQLITE_CONSTRAINT`, `SQLITE_BUSY`, etc.) instead of collapsing almost everything to a generic 500.
- HTTP client parses the body (or plain-text fallback), maps status/code to SQLite codes, and exposes the message via optional `xErrMsg` for `dolt_push` / `dolt_fetch` / `dolt_clone`.

Based on latest `origin/master` (includes remotesrv handle reuse #1944).

## Test plan

- [x] `bash test/remotesrv_http_test.sh build/doltlite build/doltlite-remotesrv`
- [x] `bash test/remotesrv_http_force_push_test.sh build/doltlite build/doltlite-remotesrv`
- [x] Rebased onto current master and rebuilt
- [ ] CI full suite