### PR TITLE
Support wide primary keys in dolt_blame

### DIFF
--- a/src/doltlite_blame.c
+++ b/src/doltlite_blame.c
@@ -19,6 +19,7 @@
 #define BLAME_IDX_PK_GT 0x08
 #define BLAME_IDX_PK_LT 0x10
 #define BLAME_IDX_PK_ANY (BLAME_IDX_PK_EQ|BLAME_IDX_PK_GE|BLAME_IDX_PK_LE|BLAME_IDX_PK_GT|BLAME_IDX_PK_LT)
+#define BLAME_METADATA_COLUMNS 5
 
 typedef struct BlameRow BlameRow;
 struct BlameRow {
@@ -69,6 +70,23 @@ struct BlamePkTmp {
   int isIntegerType;
 };
 
+static int blameGrowPkTmp(
+  BlamePkTmp **paTmp,
+  int *pnAlloc,
+  int nLimit
+){
+  BlamePkTmp *aNew;
+  int nNew;
+  if( *pnAlloc>=nLimit ) return SQLITE_TOOBIG;
+  nNew = *pnAlloc ? *pnAlloc * 2 : 8;
+  if( nNew>nLimit ) nNew = nLimit;
+  aNew = sqlite3_realloc64(*paTmp, (sqlite3_uint64)nNew * sizeof(*aNew));
+  if( !aNew ) return SQLITE_NOMEM;
+  *paTmp = aNew;
+  *pnAlloc = nNew;
+  return SQLITE_OK;
+}
+
 static int blameLoadPkColumns(
   sqlite3 *db,
   const char *zTable,
@@ -84,8 +102,11 @@ static int blameLoadPkColumns(
   char **azNames = 0;
   int *aCid = 0;
   int intPkCid = -1;
-  BlamePkTmp tmp[64];
+  BlamePkTmp *aTmp = 0;
   int nTmp = 0;
+  int nTmpAlloc = 0;
+  int nColumnLimit;
+  int finalizeRc;
   int i, j;
 
   *pazNames = 0;
@@ -99,35 +120,47 @@ static int blameLoadPkColumns(
   sqlite3_free(zSql);
   if( rc!=SQLITE_OK ) return rc;
 
-  while( sqlite3_step(pStmt)==SQLITE_ROW ){
+  nColumnLimit = sqlite3_limit(db, SQLITE_LIMIT_COLUMN, -1);
+  while( (rc = sqlite3_step(pStmt))==SQLITE_ROW ){
     int cid = sqlite3_column_int(pStmt, 0);
     const char *zName = (const char*)sqlite3_column_text(pStmt, 1);
     const char *zType = (const char*)sqlite3_column_text(pStmt, 2);
     int pkPos = sqlite3_column_int(pStmt, 5);
     if( pkPos <= 0 ) continue;
-    if( nTmp >= (int)(sizeof(tmp)/sizeof(tmp[0])) ) continue;
-    tmp[nTmp].cid = cid;
-    tmp[nTmp].zName = sqlite3_mprintf("%s", zName ? zName : "");
-    tmp[nTmp].pkPos = pkPos;
-    tmp[nTmp].isIntegerType =
+    if( nTmp>=nTmpAlloc ){
+      rc = blameGrowPkTmp(&aTmp, &nTmpAlloc, nColumnLimit);
+      if( rc!=SQLITE_OK ) break;
+    }
+    aTmp[nTmp].cid = cid;
+    aTmp[nTmp].zName = sqlite3_mprintf("%s", zName ? zName : "");
+    aTmp[nTmp].pkPos = pkPos;
+    aTmp[nTmp].isIntegerType =
         zType && sqlite3_stricmp(zType, "INTEGER")==0;
-    if( !tmp[nTmp].zName ){ rc = SQLITE_NOMEM; break; }
+    if( !aTmp[nTmp].zName ){ rc = SQLITE_NOMEM; break; }
     nTmp++;
   }
-  sqlite3_finalize(pStmt);
+  if( rc==SQLITE_DONE ) rc = SQLITE_OK;
+  finalizeRc = sqlite3_finalize(pStmt);
+  if( rc==SQLITE_OK ) rc = finalizeRc;
+  if( rc==SQLITE_OK
+   && (nColumnLimit<BLAME_METADATA_COLUMNS
+       || nTmp>nColumnLimit-BLAME_METADATA_COLUMNS) ){
+    rc = SQLITE_TOOBIG;
+  }
   if( rc!=SQLITE_OK ){
-    for(i=0; i<nTmp; i++) sqlite3_free(tmp[i].zName);
+    for(i=0; i<nTmp; i++) sqlite3_free(aTmp[i].zName);
+    sqlite3_free(aTmp);
     return rc;
   }
 
   for(i=1; i<nTmp; i++){
-    BlamePkTmp t = tmp[i];
+    BlamePkTmp t = aTmp[i];
     j = i - 1;
-    while( j>=0 && tmp[j].pkPos > t.pkPos ){
-      tmp[j+1] = tmp[j];
+    while( j>=0 && aTmp[j].pkPos > t.pkPos ){
+      aTmp[j+1] = aTmp[j];
       j--;
     }
-    tmp[j+1] = t;
+    aTmp[j+1] = t;
   }
 
   if( nTmp > 0 ){
@@ -136,19 +169,21 @@ static int blameLoadPkColumns(
     if( !azNames || !aCid ){
       sqlite3_free(azNames);
       sqlite3_free(aCid);
-      for(i=0; i<nTmp; i++) sqlite3_free(tmp[i].zName);
+      for(i=0; i<nTmp; i++) sqlite3_free(aTmp[i].zName);
+      sqlite3_free(aTmp);
       return SQLITE_NOMEM;
     }
   }
   for(i=0; i<nTmp; i++){
-    azNames[i] = tmp[i].zName;
-    aCid[i] = tmp[i].cid;
+    azNames[i] = aTmp[i].zName;
+    aCid[i] = aTmp[i].cid;
     n++;
   }
 
-  if( nTmp == 1 && tmp[0].isIntegerType ){
-    intPkCid = tmp[0].cid;
+  if( nTmp == 1 && aTmp[0].isIntegerType ){
+    intPkCid = aTmp[0].cid;
   }
+  sqlite3_free(aTmp);
 
   *pazNames = azNames;
   *paColIdx = aCid;
@@ -666,7 +701,14 @@ static int bmConnect(sqlite3 *db, void *pAux, int argc,
                           &v->intPkCid);
   if( rc!=SQLITE_OK ){
     if( pzErr ){
-      *pzErr = sqlite3_mprintf("dolt_blame_%s: failed to read schema", v->zTableName);
+      if( rc==SQLITE_TOOBIG ){
+        *pzErr = sqlite3_mprintf(
+            "dolt_blame_%s: output schema exceeds column limit",
+            v->zTableName);
+      }else{
+        *pzErr = sqlite3_mprintf(
+            "dolt_blame_%s: failed to read schema", v->zTableName);
+      }
     }
     sqlite3_free(v->zTableName);
     sqlite3_free(v);

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -2518,6 +2518,90 @@ static void run_blame_deep_history_scan(void){
   removeDbFiles(dbpath);
 }
 
+static char *blameWidePkSql(
+  sqlite3 *db,
+  const char *zTable,
+  int nCols,
+  int insertRow
+){
+  sqlite3_str *pSql = sqlite3_str_new(db);
+  int i;
+  if( !pSql ) return 0;
+  sqlite3_str_appendf(pSql, "CREATE TABLE \"%w\"(", zTable);
+  for(i=1; i<=nCols; i++){
+    sqlite3_str_appendf(pSql, "%sc%d INTEGER", i==1 ? "" : ",", i);
+  }
+  sqlite3_str_appendall(pSql, ",PRIMARY KEY(");
+  for(i=1; i<=nCols; i++){
+    sqlite3_str_appendf(pSql, "%sc%d", i==1 ? "" : ",", i);
+  }
+  sqlite3_str_appendall(pSql, "));");
+  if( insertRow ){
+    sqlite3_str_appendf(pSql, "INSERT INTO \"%w\" VALUES(", zTable);
+    for(i=1; i<=nCols; i++){
+      sqlite3_str_appendf(pSql, "%s%d", i==1 ? "" : ",", i);
+    }
+    sqlite3_str_appendall(pSql, ");");
+  }
+  return sqlite3_str_finish(pSql);
+}
+
+static void run_blame_wide_primary_key(void){
+  sqlite3 *db = 0;
+  sqlite3_stmt *pStmt = 0;
+  char dbpath[256];
+  char *zSql;
+  int nLimit;
+  int rc;
+
+  printf("=== Blame Wide Primary Key Test ===\n\n");
+  make_dbpath(dbpath, sizeof(dbpath), "test_blame_wide_primary_key");
+  removeDbFiles(dbpath);
+
+  check("open_db_for_blame_wide_primary_key",
+        open_db(dbpath, &db)==SQLITE_OK);
+  if( !db ) return;
+
+  zSql = blameWidePkSql(db, "wide65", 65, 1);
+  check("build_65_column_primary_key_sql", zSql!=0);
+  if( zSql ){
+    check("create_65_column_primary_key", execSql(db, zSql)==SQLITE_OK);
+    sqlite3_free(zSql);
+  }
+  check("commit_65_column_primary_key", execSql(db,
+        "SELECT dolt_commit('-Am', 'wide primary key');")==SQLITE_OK);
+  check("blame_65_column_schema_complete",
+        strcmp(queryScalarText(db,
+          "SELECT count(*) FROM pragma_table_info('dolt_blame_wide65');"),
+          "70")==0);
+  check("blame_65_column_row_complete",
+        strcmp(queryScalarText(db,
+          "SELECT c65 || '|' || message FROM dolt_blame_wide65;"),
+          "65|wide primary key")==0);
+
+  nLimit = sqlite3_limit(db, SQLITE_LIMIT_COLUMN, -1);
+  zSql = blameWidePkSql(db, "widemax", nLimit, 0);
+  check("build_max_column_primary_key_sql", zSql!=0);
+  if( zSql ){
+    check("create_max_column_primary_key", execSql(db, zSql)==SQLITE_OK);
+    sqlite3_free(zSql);
+  }
+  check("commit_max_column_primary_key", execSql(db,
+        "SELECT dolt_commit('-Am', 'maximum primary key');")==SQLITE_OK);
+  check("max_column_primary_key_is_complete",
+        atoi(queryScalarText(db,
+          "SELECT count(*) FROM pragma_table_info('widemax');"))==nLimit);
+  rc = sqlite3_prepare_v2(db,
+      "SELECT count(*) FROM dolt_blame_widemax;", -1, &pStmt, 0);
+  check("blame_max_column_primary_key_fails_explicitly", rc==SQLITE_TOOBIG);
+  check("blame_max_column_primary_key_reports_limit",
+        strstr(sqlite3_errmsg(db), "column limit")!=0);
+  sqlite3_finalize(pStmt);
+
+  sqlite3_close(db);
+  removeDbFiles(dbpath);
+}
+
 static void run_merge_persist_failure(void){
   sqlite3 *db = 0;
   char dbpath[256];
@@ -9228,6 +9312,7 @@ static const RegressionCase aCases[] = {
   { "commit_am_many_tables", "Commit -am Many Tables Test", run_commit_am_many_tables },
   { "blame_all_parents_merge_base", "Blame All-Parents Merge Base Test", run_blame_all_parents_merge_base },
   { "blame_deep_history_scan", "Blame Deep History Scan Test", run_blame_deep_history_scan },
+  { "blame_wide_primary_key", "Blame Wide Primary Key Test", run_blame_wide_primary_key },
   { "merge_persist_failure", "Merge Persist Failure Test", run_merge_persist_failure },
   { "merge_conflict_persist_failure", "Merge Conflict Persist Failure Test", run_merge_conflict_persist_failure },
   { "conflict_serializer_bounds", "Conflict Serializer Bounds Test", run_conflict_serializer_bounds },


### PR DESCRIPTION
## Summary

- replace the fixed 64-entry blame PK descriptor array with bounded geometric growth up to the connection column limit
- preserve terminal `sqlite3_step()` and `sqlite3_finalize()` errors while reading `table_info`
- reject blame output schemas that cannot fit their five metadata columns with an explicit `SQLITE_TOOBIG` error
- cover a working 65-column composite PK and a PK at SQLite's configured maximum

## Fail-before evidence

The new regression failed on master because the 65th PK column was absent from both schema and rows, while the maximum-width PK silently exposed only 64 key columns instead of reporting the output-column limit.

## Validation

- `make doltlite`
- `make testfixture`
- `make lint`
- `bash test/vc_oracle_blame_test.sh build/doltlite dolt` — 25/25
- focused blame regressions — 217/217
- `bash test/run_doltlite_tests.sh` — 99/99 suites
- `bash test/run_c_tests.sh build` — 25/25 gated binaries
- post-rebase latest-master rebuild and focused wide-PK regression — 12/12

Co-Authored-By: OpenAI Codex <noreply@openai.com>