### PR TITLE
Count pending edits when answering whether a table is empty

### DIFF
--- a/src/prolly_btree_cursor.c
+++ b/src/prolly_btree_cursor.c
@@ -691,9 +691,19 @@ int prollyBtCursorIsEmpty(BtCursor *pCur, int *pRes){
   pTE = findTable(pCur->pBtree, pCur->pgnoRoot);
   if( !pTE ){
     *pRes = 1;
-  } else {
-    *pRes = prollyHashIsEmpty(&pTE->root) ? 1 : 0;
+    return SQLITE_OK;
   }
+  /* Rows written in this transaction sit in the pending map until it drains,
+  ** so a table whose persisted root is still empty is not necessarily empty.
+  ** Answering from the root alone made OP_IfEmpty break out of a join over a
+  ** table that had rows.
+  **
+  ** A non-empty map counts as non-empty even if every entry is a tombstone.
+  ** Erring that way only forgoes the optimization, while erring the other way
+  ** drops rows, and it keeps this O(1): OP_IfEmpty sits inside the enclosing
+  ** loops, so it re-runs per outer row and cannot afford to scan the map. */
+  *pRes = (prollyHashIsEmpty(&pTE->root)
+        && (pTE->pPending==0 || prollyMutMapIsEmpty(pTE->pPending))) ? 1 : 0;
   return SQLITE_OK;
 }
 int sqlite3BtreeIsEmpty(BtCursor *pCur, int *pRes){

--- a/test/doltlite_txn_seek_visibility.sh
+++ b/test/doltlite_txn_seek_visibility.sh
@@ -169,4 +169,57 @@ run_test "fts4_langid_rebuild_preserves_partitions" \
 
 db_rm "$DB"
 
+# A join of three or more tables emits OP_IfEmpty for the third and later
+# loops, which breaks out of the whole join when the table is empty. Answering
+# that from the persisted root alone dropped rows written earlier in the same
+# transaction, because they are still in the pending map.
+DB=/tmp/test_txn_ifempty_$$.db; db_rm "$DB"
+
+run_test "join_sees_table_populated_only_in_this_txn" \
+  "CREATE TABLE t1(a INTEGER PRIMARY KEY);
+   CREATE TABLE t2(a INTEGER PRIMARY KEY);
+   CREATE TABLE t3(a INTEGER PRIMARY KEY);
+   INSERT INTO t1 VALUES (1);
+   INSERT INTO t2 VALUES (1);
+   BEGIN;
+   INSERT INTO t3 VALUES (1);
+   SELECT count(*) FROM t1, t2, t3;
+   SELECT count(*) FROM t3, t1, t2;
+   COMMIT;
+   SELECT count(*) FROM t1, t2, t3;" \
+  "1
+1
+1" \
+  "$DB"
+
+db_rm "$DB"
+
+# The optimization must still fire for a table that really is empty, and a
+# table emptied inside the transaction must still join to nothing.
+DB=/tmp/test_txn_ifempty_neg_$$.db; db_rm "$DB"
+
+run_test "join_still_empty_for_empty_and_emptied_tables" \
+  "CREATE TABLE t1(a INTEGER PRIMARY KEY);
+   CREATE TABLE t2(a INTEGER PRIMARY KEY);
+   CREATE TABLE e(a INTEGER PRIMARY KEY);
+   CREATE TABLE d(a INTEGER PRIMARY KEY);
+   INSERT INTO t1 VALUES (1);
+   INSERT INTO t2 VALUES (1);
+   INSERT INTO d VALUES (1);
+   SELECT count(*) FROM t1, t2, e;
+   BEGIN;
+   DELETE FROM d;
+   SELECT count(*) FROM t1, t2, d;
+   INSERT INTO e VALUES (9);
+   SELECT count(*) FROM t1, t2, e;
+   ROLLBACK;
+   SELECT count(*) FROM t1, t2, e;" \
+  "0
+0
+1
+0" \
+  "$DB"
+
+db_rm "$DB"
+
 dltest_finish


### PR DESCRIPTION
Recommendation 2 from the review. Wrong query results, no error, on ordinary SQL.

## Problem

`prollyBtCursorIsEmpty()` answered from the persisted tree root alone:

```c
*pRes = prollyHashIsEmpty(&pTE->root) ? 1 : 0;
```

Rows written in the current transaction sit in the pending map until it drains, so a table that *has* rows can still have an empty root. `where.c` emits `OP_IfEmpty` for the third and later loops of a join, and that instruction breaks out of the whole join — so a three-way join over a table populated earlier in the same transaction silently returned nothing:

```sql
BEGIN;
INSERT INTO t3 VALUES(1);
SELECT count(*) FROM t1, t2, t3;   -- 0, should be 1
SELECT count(*) FROM t3, t1, t2;   -- 1, t3 is no longer the third loop
COMMIT;
SELECT count(*) FROM t1, t2, t3;   -- 1
```

The reordered and post-commit forms returning 1 isolate it to the optimization rather than to the join or the data.

## Fix

A non-empty pending map counts as non-empty, even when every entry is a tombstone. Two reasons for that asymmetry:

- **Direction of the error.** Saying "non-empty" when the table is really empty only forgoes an optimization. Saying "empty" when it isn't drops rows.
- **Cost.** `OP_IfEmpty` sits inside the enclosing loops and re-runs per outer row, so scanning the map for a live insert would turn the join into O(n·m). `prollyMutMapIsEmpty()` is a field read, and unlike `prollyMutMapEntryAt()` it does not touch the sort order — worth avoiding here, since that ordering path silently discards `ensureOrder()`'s return code.

## Tests

Added to `doltlite_txn_seek_visibility.sh`, which already owns in-transaction visibility over mut-map edits:

- the join seeing a table populated only in this transaction, in both loop positions and after commit;
- a negative case pinning that the optimization still fires for a genuinely empty table, that a table emptied inside the transaction still joins to nothing, and that a rollback restores that.

Both fail on the unfixed engine and pass with the fix:

```
unfixed:  10 passed, 2 failed out of 12
fixed:    12 passed, 0 failed out of 12
```

## Validation

- `run_doltlite_tests.sh`: **99/99 suites**
- `doltlite_regression_test_c`: **310085/310085**
- `doltlite_parity.sh` against stock sqlite3: **119/119**
- tcl `join`, `join2`, `join3`, `join5`, `where`, `where2`, `select1`, `trans`, `trans2`: zero failing assertions
- dead-code gate: pass

## Not in this PR

The review grouped three more pending-map issues with this one; they are separate bugs in separate functions and get their own PRs: the use-after-free when `chunkStoreCommit` fails (`prolly_btree_txn.c` writes through cursor mut-map aliases after `restoreFromCommitted` frees them, where the rollback path already detaches and documents the hazard), the payload/rowid accessors discarding `materializeDeferredMergedSeekBackward()`'s error without faulting the cursor, and `prollyMutMapEntryAt()` swallowing `ensureOrder()`'s return code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)