### PR TITLE
Fix staged commits with untracked schemas

### DIFF
--- a/src/doltlite_add.c
+++ b/src/doltlite_add.c
@@ -737,6 +737,7 @@ static int addStageNamedTables(
       if( aWorking[j].iTable==iTable ){
         int k;
         int updated = 0;
+        updateMaster = 1;
         for(k=0; k<nStaged; k++){
           int nameMatch = aStaged[k].zName && aWorking[j].zName
             && strcmp(aStaged[k].zName, aWorking[j].zName)==0;
@@ -765,8 +766,6 @@ static int addStageNamedTables(
             }
           }
           if( nameMatch || unnamedRootMatch || renameRootMatch ){
-            int schemaChanged =
-              prollyHashCompare(&aStaged[k].schemaHash, &aWorking[j].schemaHash)!=0;
             int nameChanged =
               (!aStaged[k].zName) != (!aWorking[j].zName)
               || (aStaged[k].zName && aWorking[j].zName
@@ -788,15 +787,11 @@ static int addStageNamedTables(
             sqlite3_free(aStaged[k].zName);
             aStaged[k] = aWorking[j];
             aStaged[k].zName = zDup;
-            if( schemaChanged || nameChanged ){
-              updateMaster = 1;
-            }
             updated = 1;
             break;
           }
         }
         if( !updated ){
-          updateMaster = 1;
           rc = addAppendTableEntry(context, &aStaged, &nStaged, &aWorking[j]);
           if( rc!=SQLITE_OK ){
             ADDNAMED_FREE_ALL();

--- a/test/doltlite_commit.sh
+++ b/test/doltlite_commit.sh
@@ -415,7 +415,28 @@ PRAGMA integrity_check;"   "0
 0
 ok" "$DB13"
 
-rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8" "$DB9" "$DB10" "$DB11" "$DB12" "$DB13"
+DB14=/tmp/test_dolt_staged_untracked_$$.db; rm -f "$DB14"
+
+run_test_match "staged_untracked_setup"   "CREATE TABLE kv(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO kv VALUES(1,'base');
+SELECT dolt_commit('-Am','base');"   "^[0-9a-f]{40}$" "$DB14"
+
+run_test_match "staged_untracked_commit"   "CREATE TABLE aux(id INTEGER PRIMARY KEY);
+INSERT INTO kv VALUES(2,'next');
+SELECT dolt_add('kv');
+SELECT dolt_commit('-m','staged');"   "[0-9a-f]{40}$" "$DB14"
+
+run_test "staged_untracked_head_reopens"   "SELECT dolt_reset('--hard');
+SELECT group_concat(id) FROM kv;
+SELECT group_concat(name,'|') FROM (
+  SELECT name FROM sqlite_schema WHERE name NOT LIKE 'sqlite_%' ORDER BY name
+);
+PRAGMA integrity_check;"   "0
+1,2
+aux|kv
+ok" "$DB14"
+
+rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8" "$DB9" "$DB10" "$DB11" "$DB12" "$DB13" "$DB14"
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"


### PR DESCRIPTION
## Summary

- compose the named-stage master for data-only table staging so schema rows and entries share the working catalog numbering domain
- prevent duplicate schema rows when an untracked table shifts live catalog numbers
- add a regression covering staged-only commit, hard reset, reopen, and integrity check

This is an unrelated correctness bug surfaced by the tightened `vc-fuzz` gate on #1936. Seed `1785800828` previously created a malformed HEAD at step 1722 and failed at step 1731.

## Validation

- fail-before/pass-after `test/doltlite_commit.sh` regression
- `bash test/doltlite_commit.sh build/doltlite` (65/65)
- `bash test/run_doltlite_tests.sh build/doltlite` (99/99 suites; 310,085 C regression assertions)
- `make lint`
- separate `DOLTLITE_PROLLY_CHECK=1` build + commit suite (65/65)
- exact stateful fuzzer seed passed the former failure and continued through step 1925

Co-Authored-By: OpenAI Codex <noreply@openai.com>