### PR TITLE
Detach cursor pending-map aliases before a failed commit frees them

### DIFF
--- a/src/prolly_btree_txn.c
+++ b/src/prolly_btree_txn.c
@@ -995,6 +995,24 @@ static int commitPhaseTwoFailRestore(
   }
   sqlite3_free(*ppCatData);
   *ppCatData = 0;
+  /* Detach the cursors' pending-edit map aliases before restoreFromCommitted()
+  ** frees the maps -- explicitly on the catalog-cache path, and via catFree on
+  ** the reload path. Only null the alias: catFree owns the map, so touching it
+  ** after the free is the use-after-free being avoided, and a prior savepoint
+  ** rollback may already have freed the one a cursor points at. ensureMutMap
+  ** re-aliases on reuse. Same shape as prollyBtreeRollback(). */
+  {
+    BtCursor *pC;
+    for(pC = pBt->pCursor; pC; pC = pC->pNext){
+      if( pC->pBtree!=p || pC->pMutMap==0 ) continue;
+      pC->pMutMap = 0;
+      pC->mmActive = 0;
+      pC->mmPhysActive = 0;
+      pC->deferredTreeSeek = 0;
+      pC->mmIdx = -1;
+      pC->mmPhysIdx = -1;
+    }
+  }
   rc2 = restoreFromCommitted(p);
   if( rc2!=SQLITE_OK ){
     /* Same shape as the rollback path: the restore OOM'd, but the
@@ -1010,12 +1028,6 @@ static int commitPhaseTwoFailRestore(
     commitPhaseTwoReleaseGraph(pBt);
     /* Preserve the original commit error; restore failure is secondary. */
     return commitRc;
-  }
-  {
-    BtCursor *pC;
-    for(pC = pBt->pCursor; pC; pC = pC->pNext){
-      if( pC->pBtree==p && pC->pMutMap ) prollyMutMapClear(pC->pMutMap);
-    }
   }
   invalidateCursors(pBt, 0, commitRc);
   resetConnectionSchema(p);

--- a/test/doltlite_recover_commit_fail_cursor.test
+++ b/test/doltlite_recover_commit_fail_cursor.test
@@ -1,0 +1,51 @@
+# A failed commit must not touch a cursor's pending-edit map after freeing it.
+#
+# commitPhaseTwoFailRestore() called restoreFromCommitted(), which frees the
+# per-table pending maps, and then cleared each cursor's pMutMap -- an alias of
+# the map just freed. Flushing leaves the map allocated (flushMutMap ends with
+# prollyMutMapClear, and flushPendingForTable returns early once it is empty),
+# so any write transaction holding an open cursor reached the failure path with
+# a live alias. AddressSanitizer reported heap-use-after-free in
+# prollyMutMapClear, freed one call earlier in the same function.
+#
+# The cursor here is a partially stepped SELECT, which is what keeps an entry on
+# pBt->pCursor across the COMMIT. Without an ASan build this exercises the path
+# and asserts the database stays usable; under ASan it is the actual detector.
+
+set testdir [file dirname $argv0]
+source $testdir/tester.tcl
+
+set testprefix doltlite_recover_commit_fail_cursor
+
+do_execsql_test 1.0 {
+  CREATE TABLE t(a INTEGER PRIMARY KEY, b TEXT);
+  INSERT INTO t VALUES(1,'one');
+  INSERT INTO t VALUES(2,'two');
+}
+
+do_test 1.1 {
+  set errors [list]
+  for {set iFail 1} {$iFail <= 400} {incr iFail} {
+    catchsql ROLLBACK
+    execsql BEGIN
+    catchsql {INSERT INTO t VALUES(3,'three')}
+    catchsql {UPDATE t SET b='mut' WHERE a=1}
+
+    # Leave a cursor open over the pending edits across the COMMIT.
+    set stmt [sqlite3_prepare_v2 db {SELECT a, b FROM t ORDER BY a} -1 tail]
+    sqlite3_step $stmt
+
+    sqlite3_memdebug_fail $iFail -repeat 0
+    catchsql COMMIT
+    sqlite3_memdebug_fail -1
+    catch { sqlite3_finalize $stmt }
+    catchsql ROLLBACK
+
+    # Whatever the injected failure did, the row set must still be readable.
+    set rc [catchsql {SELECT count(*) FROM t}]
+    if {[lindex $rc 0]!=0} { lappend errors "iFail=$iFail read failed: $rc" }
+  }
+  set errors
+} {}
+
+finish_test

--- a/test/regression-buckets/fault-fuzz.txt
+++ b/test/regression-buckets/fault-fuzz.txt
@@ -88,3 +88,4 @@ wherelfault
 windowfault
 zeroblobfault
 zipfilefault
+doltlite_recover_commit_fail_cursor


### PR DESCRIPTION
Step 2 of recommendation 2, following #1948. A use-after-free on the commit-failure path, confirmed by AddressSanitizer.

## The bug

`commitPhaseTwoFailRestore()` called `restoreFromCommitted()` — which frees the per-table pending maps — and then walked the cursor list clearing each cursor's `pMutMap`, an alias of a map freed **one call earlier in the same function**. ASan on the unfixed tree:

```
ERROR: AddressSanitizer: heap-use-after-free
  #0 prollyMutMapClear
  #1 commitPhaseTwoFailRestore        <- sqlite3.c:299396
  ...
freed by thread T0 here:
  #1 sqlite3_free
  #2 restoreFromCommitted
  #3 commitPhaseTwoFailRestore        <- sqlite3.c:299377
```

Reachable from any write transaction holding an open cursor. Flushing does not free the map — `flushMutMap` ends with `prollyMutMapClear`, and `flushPendingForTable` returns early once the map is empty — so the alias is still live when the commit fails.

## Fix

Exactly what `prollyBtreeRollback()` already does, and its comment describes this hazard verbatim:

> Either way detach the cursor's pending-edit map alias before `restoreFromCommitted()` (via catFree) frees it … We only null the alias — catFree owns the map, and a prior savepoint rollback may already have freed the one this cursor points at, so clearing it would be a use-after-free.

So the clear has to *stop*, not merely move: `catFree` owns the map, and a prior savepoint rollback may already have freed the one a given cursor points at. `ensureMutMap` re-aliases on reuse. The commit-failure path now nulls the alias and its dependent cursor state before the restore, the same as rollback.

## Test

`test/doltlite_recover_commit_fail_cursor.test` sweeps an injected OOM through `COMMIT` while a partially stepped `SELECT` holds the alias — that is what keeps an entry on `pBt->pCursor` across the commit, which a completed statement would not.

Under an ASan build it is the detector; without ASan the case still exercises the path and asserts the database stays readable. **Fails on the unfixed tree, passes with the fix.** Registered in the `fault-fuzz` bucket, where the other `doltlite_recover_*` fault tests live.

## Validation

- `run_doltlite_tests.sh`: **99/99 suites**
- `doltlite_regression_test_c`: **310085/310085**
- ASan `testfixture` on the new test: clean, 0 errors
- dead-code gate, crash-coverage gate, exception/ratchet gates: pass
- no duplicate bucket entries

## Remaining in recommendation 2

Two more, each getting its own PR: the payload/rowid accessors discarding `materializeDeferredMergedSeekBackward()`'s error without faulting the cursor, and `prollyMutMapEntryAt()` swallowing `ensureOrder()`'s return code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)