### PR TITLE
Fault the cursor when a deferred seek fails in the payload accessors

### DIFF
--- a/src/prolly_btree_cursor_payload.c
+++ b/src/prolly_btree_cursor_payload.c
@@ -45,11 +45,21 @@ int prollyBtreeCursorCurrentTreeValueCopy(
   return SQLITE_OK;
 }
 
+/* These accessors have no error channel, so a failed deferred-seek
+** materialization has to be recorded on the cursor instead: fault it and stash
+** the code in skipNext, the way prollyBtCursorEof() does, so the next cursor
+** operation returns the real error. Returning a zero key or an empty payload
+** without faulting reports a row that was never read -- an OOM or interrupt
+** during positioning became wrong data under SQLITE_OK. */
 i64 prollyBtCursorIntegerKey(BtCursor *pCur){
-  if( pCur->deferredMergedSeek
-   && (materializeDeferredMergedSeekBackward(pCur)
-       || pCur->eState!=CURSOR_VALID) ){
-    return 0;
+  if( pCur->deferredMergedSeek ){
+    int rc = materializeDeferredMergedSeekBackward(pCur);
+    if( rc!=SQLITE_OK ){
+      pCur->eState = CURSOR_FAULT;
+      pCur->skipNext = rc;
+      return 0;
+    }
+    if( pCur->eState!=CURSOR_VALID ) return 0;
   }
   assert( pCur->eState==CURSOR_VALID );
   assert( pCur->curIntKey );
@@ -185,10 +195,14 @@ int getCursorPayload(BtCursor *pCur, const u8 **ppData, int *pnData){
 u32 prollyBtCursorPayloadSize(BtCursor *pCur){
   const u8 *pData;
   int nData;
-  if( pCur->deferredMergedSeek
-   && (materializeDeferredMergedSeekBackward(pCur)
-       || pCur->eState!=CURSOR_VALID) ){
-    return 0;
+  if( pCur->deferredMergedSeek ){
+    int rc = materializeDeferredMergedSeekBackward(pCur);
+    if( rc!=SQLITE_OK ){
+      pCur->eState = CURSOR_FAULT;
+      pCur->skipNext = rc;
+      return 0;
+    }
+    if( pCur->eState!=CURSOR_VALID ) return 0;
   }
   assert( pCur->eState==CURSOR_VALID );
   if( pCur->pCachedPayload && pCur->nCachedPayload > 0 ){
@@ -297,11 +311,18 @@ const void *prollyBtCursorPayloadFetch(BtCursor *pCur, u32 *pAmt){
   const u8 *pData;
   int nData;
 
-  if( pCur->deferredMergedSeek
-   && (materializeDeferredMergedSeekBackward(pCur)
-       || pCur->eState!=CURSOR_VALID) ){
-    if( pAmt ) *pAmt = 0;
-    return 0;
+  if( pCur->deferredMergedSeek ){
+    int rc = materializeDeferredMergedSeekBackward(pCur);
+    if( rc!=SQLITE_OK ){
+      pCur->eState = CURSOR_FAULT;
+      pCur->skipNext = rc;
+      if( pAmt ) *pAmt = 0;
+      return 0;
+    }
+    if( pCur->eState!=CURSOR_VALID ){
+      if( pAmt ) *pAmt = 0;
+      return 0;
+    }
   }
   assert( pCur->eState==CURSOR_VALID );
   if( pCur->pCachedPayload && pCur->nCachedPayload > 0 ){


### PR DESCRIPTION
Part 3 of recommendation 2, after #1948 and #1952. Touches only `prolly_btree_cursor_payload.c`, so it is independent of #1952 (`prolly_btree_txn.c`).

## Problem

A moveto miss defers positioning the merged base-map+mutmap cursor and leaves the work to whichever accessor runs next. Three of those threw away the result:

```c
if( pCur->deferredMergedSeek
 && (materializeDeferredMergedSeekBackward(pCur)
     || pCur->eState!=CURSOR_VALID) ){
  return 0;
}
```

`materializeDeferredMergedSeekBackward()` re-seeks the tree and walks the mut map, so it can fail with `SQLITE_NOMEM`, `SQLITE_INTERRUPT` or an I/O error. None of `prollyBtCursorIntegerKey`, `prollyBtCursorPayloadSize` or `prollyBtCursorPayloadFetch` has an error channel, so the failure was reported **as data** — a zero key or an empty payload, with the statement completing `SQLITE_OK` describing a row it never read.

`prollyBtCursorPayload()` already propagated its code and is unchanged.

## Fix

Record the failure on the cursor — `CURSOR_FAULT` plus the code in `skipNext` — so the next cursor operation returns the real error instead of the caller consuming a phantom row. Same shape `prollyBtCursorEof()` already uses.

## Why there is no test, and a second bug found while trying to write one

I attempted an OOM sweep over a backward seek and it exposed a **different, pre-existing** defect that swallows the fault before these accessors are reached, which makes the two indistinguishable in a sweep:

`prollyBtCursorEof()` faults the cursor and then returns **1**. The VDBE reads that as end-of-scan, so the statement ends cleanly and nothing ever consults `skipNext`. An injected OOM there produces an **empty result set with `rc=0`** — the same wrong-data-under-OOM class this PR is closing, one layer up.

Verified identical before and after this change (iteration 33 of the sweep, byte-for-byte the same output on both), so it is not a regression and not something this PR can claim to fix. Reporting it separately rather than bundling. The repro is a backward seek (`WHERE a <= 35 ORDER BY a DESC`) over a mutmap holding an insert and a delete, under `-faults oom-transient`; I have the test file and will attach it to that follow-up.

Worth flagging that the "correct model" cited for this fix turns out to be insufficient on its own — faulting the cursor only helps if something later reads the fault.

## Validation

- `run_doltlite_tests.sh`: **99/99 suites**
- `doltlite_regression_test_c`: **310085/310085**
- `doltlite_recover_cacheflush_oom` (the sibling deferred-seek OOM suite): 0 errors of 62
- `doltlite_recover_postcommit_oom`: 0 errors of 4
- `incrblob`, `incrblob2`, `select1` through the gate-aware runner: only their existing gated divergences, no stale or unexpected entries
- dead-code gate: pass

## Remaining in recommendation 2

`prollyMutMapEntryAt()` swallowing `ensureOrder()`'s return code — plus the `Eof` truncation above, now a known follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)