### PR TITLE
Surface a failed deferred seek instead of reporting end of data

### DIFF
--- a/src/btree.h
+++ b/src/btree.h
@@ -343,6 +343,9 @@ int sqlite3BtreeIsEmpty(BtCursor *pCur, int *pRes);
 int sqlite3BtreeLast(BtCursor*, int *pRes);
 int sqlite3BtreeNext(BtCursor*, int flags);
 int sqlite3BtreeEof(BtCursor*);
+#ifdef DOLTLITE_PROLLY
+int doltliteBtreeCursorFaultCode(BtCursor*);
+#endif
 int sqlite3BtreePrevious(BtCursor*, int flags);
 i64 sqlite3BtreeIntegerKey(BtCursor*);
 void sqlite3BtreeCursorPin(BtCursor*);

--- a/src/btree_orig_prefix.h
+++ b/src/btree_orig_prefix.h
@@ -4,6 +4,7 @@
 #define BTREE_ORIG_PREFIX_H
 
 #define sqlite3SchemaMutexHeld orig_sqlite3SchemaMutexHeld
+#define doltliteBtreeCursorFaultCode orig_doltliteBtreeCursorFaultCode
 
 #define sqlite3BtreeBeginStmt orig_sqlite3BtreeBeginStmt
 #define sqlite3BtreeBeginTrans orig_sqlite3BtreeBeginTrans

--- a/src/prolly_btree_cursor.c
+++ b/src/prolly_btree_cursor.c
@@ -697,6 +697,16 @@ int prollyBtCursorEof(BtCursor *pCur){
   }
   return (pCur->eState!=CURSOR_VALID);
 }
+
+/* Whether the EOF just reported means end-of-data or a failed deferred seek.
+** Orig cursors surface their own faults through the stock paths, so they
+** always answer SQLITE_OK. */
+int doltliteBtreeCursorFaultCode(BtCursor *pCur){
+  if( !pCur || pCur->pCurOps!=&prollyCursorOps ) return SQLITE_OK;
+  if( pCur->eState!=CURSOR_FAULT ) return SQLITE_OK;
+  return pCur->skipNext ? pCur->skipNext : SQLITE_ERROR;
+}
+
 int sqlite3BtreeEof(BtCursor *pCur){
   if( !pCur ) return 1;
   return pCur->pCurOps->xEof(pCur);

--- a/src/vdbe.c
+++ b/src/vdbe.c
@@ -3023,6 +3023,10 @@ case OP_Offset: {          /* out3 */
       if( rc ) goto abort_due_to_error;
     }
     if( sqlite3BtreeEof(pC->uc.pCursor) ){
+#ifdef DOLTLITE_PROLLY
+      rc = doltliteBtreeCursorFaultCode(pC->uc.pCursor);
+      if( rc ) goto abort_due_to_error;
+#endif
       sqlite3VdbeMemSetNull(pOut);
     }else{
       sqlite3VdbeMemSetInt64(pOut, sqlite3BtreeOffset(pC->uc.pCursor));
@@ -4109,6 +4113,11 @@ case OP_CountIndexRange: {    /* out2 */
       }
       if( rc ) goto abort_due_to_error;
     }
+#ifdef DOLTLITE_PROLLY
+    /* Leaving the loop on a faulted cursor would undercount silently. */
+    rc = doltliteBtreeCursorFaultCode(pCrsr);
+    if( rc ) goto abort_due_to_error;
+#endif
   }else if( rc ){
     goto abort_due_to_error;
   }
@@ -5376,6 +5385,13 @@ case OP_SeekGT: {       /* jump0, in3, group, ncycle */
       ** see if this is the case.
       */
       res = sqlite3BtreeEof(pC->uc.pCursor);
+#ifdef DOLTLITE_PROLLY
+      /* A deferred merged-seek that failed reports EOF, so without this the
+      ** seek would read the failure as an empty table and the statement would
+      ** end cleanly with no rows. */
+      rc = doltliteBtreeCursorFaultCode(pC->uc.pCursor);
+      if( rc ) goto abort_due_to_error;
+#endif
     }
   }
 seek_not_found:

--- a/test/doltlite_recover_deferred_seek_oom.test
+++ b/test/doltlite_recover_deferred_seek_oom.test
@@ -1,0 +1,72 @@
+# A failed deferred merged-seek must not be reported as end of data.
+#
+# A moveto miss defers positioning the merged base-map+mutmap cursor, leaving
+# the work to whichever accessor runs next. prollyBtCursorEof() is one of them,
+# and it has no error channel: when positioning fails it faults the cursor and
+# answers 1. OP_SeekLT and friends call it only to distinguish a negative
+# comparison result from an empty table, so the fault read as "no rows" and the
+# statement ended with SQLITE_OK having returned nothing.
+#
+# Each fault iteration below must either fail cleanly or return exactly the
+# correct rows. An empty or short result counts as a failure.
+
+set testdir [file dirname $argv0]
+source $testdir/tester.tcl
+source $testdir/malloc_common.tcl
+
+set testprefix doltlite_recover_deferred_seek_oom
+
+do_execsql_test 1.0 {
+  CREATE TABLE k(a INTEGER PRIMARY KEY, b TEXT);
+  INSERT INTO k VALUES(10, 'ten');
+  INSERT INTO k VALUES(20, 'twenty');
+  INSERT INTO k VALUES(30, 'thirty');
+  INSERT INTO k VALUES(40, 'forty');
+}
+faultsim_save_and_close
+
+# Backward seek whose target key is absent, over a mutmap holding an insert and
+# a delete, so the seek misses and positioning is deferred to the accessors.
+do_faultsim_test 1.1 -faults oom-transient -prep {
+  faultsim_restore_and_reopen
+  db eval {
+    BEGIN;
+      DELETE FROM k WHERE a=30;
+      INSERT INTO k VALUES(25, 'twentyfive');
+  }
+} -body {
+  set out [list]
+  db eval { SELECT a, b FROM k WHERE a <= 35 ORDER BY a DESC } {
+    lappend out $a $b
+  }
+  set out
+} -test {
+  faultsim_test_result {0 {25 twentyfive 20 twenty 10 ten}} \
+      {1 {out of memory}} {1 {disk I/O error}}
+  catchsql ROLLBACK
+  faultsim_integrity_check
+}
+
+# Same shape reaching the payload accessors through a blob value, so a
+# truncated fetch is visible as a wrong length rather than a wrong key.
+do_faultsim_test 1.2 -faults oom-transient -prep {
+  faultsim_restore_and_reopen
+  db eval {
+    BEGIN;
+      UPDATE k SET b = 'x' WHERE a=20;
+      INSERT INTO k VALUES(35, 'thirtyfive');
+  }
+} -body {
+  set out [list]
+  db eval { SELECT a, length(b) FROM k WHERE a <= 38 ORDER BY a DESC } {
+    lappend out $a [set {} $length(b)]
+  }
+  set out
+} -test {
+  faultsim_test_result {0 {35 10 30 6 20 1 10 3}} \
+      {1 {out of memory}} {1 {disk I/O error}}
+  catchsql ROLLBACK
+  faultsim_integrity_check
+}
+
+finish_test

--- a/test/regression-buckets/fault-fuzz.txt
+++ b/test/regression-buckets/fault-fuzz.txt
@@ -90,3 +90,4 @@ zeroblobfault
 zipfilefault
 doltlite_recover_commit_fail_cursor
 doltlite_recover_mutmap_order_oom
+doltlite_recover_deferred_seek_oom


### PR DESCRIPTION
`prollyBtCursorEof()` materializes a deferred merged-seek, and when that fails it faults the cursor and returns 1. `Eof` has no error channel, so every caller reads that 1 as end of data.

`OP_SeekLT` and friends call `Eof` only to tell a negative comparison result apart from an empty table, so the fault became "the table is empty": the seek jumped to P2 and the statement ended with `SQLITE_OK` having produced no rows. An OOM while positioning silently truncated a result set — wrong data, reported as success. `OP_Offset` turns the same fault into a NULL offset and `OP_CountIndexRange` leaves its loop early and undercounts; both are fixed here too.

`doltliteBtreeCursorFaultCode()` answers whether the EOF just reported was end of data or a failure, so the three sites can abort. It reports OK for orig cursors, which surface their own faults through the stock paths. A faulted cursor with no stored error answers `SQLITE_ERROR` rather than OK, so the hole cannot reopen.

`btree.h` declares the accessor, and the amalgamation compiles `btree.h` a second time inside the `orig_*` rename scope where `BtCursor` is `orig_BtCursor` — so the prototype needs the same rename entry every other `btree.h` prototype has.

## Proof

`test/doltlite_recover_deferred_seek_oom.test` drives a backward seek whose target key is absent, over a mutmap holding an insert and a delete, under `-faults oom-transient`. On the unpatched engine:

```
! doltlite_recover_deferred_seek_oom-1.1-oom-transient.33 expected: [0 ok]
! ...                                       got: [1 {nfail=1 rc=0 result= ...}]
```

`rc=0` with an empty result where `{25 twentyfive 20 twenty 10 ten}` is due. With the fix, 0 errors out of 73. Both runs were done in one directory, patch applied and reverted in place.

## Testing

- New test: fails before, passes after (73 assertions).
- `fkey_malloc` A/B in a single clean build directory: identical failure sets before and after the patch, so the fix shifts no OOM iteration indices.
- c-tests with `DOLTLITE_PROLLY_CHECK=1`: all 25 gated tests pass.
- doltlite shell battery: 98/99 suites (`doltlite_parity.sh` needs a stock `./sqlite3` that a fresh worktree does not have).
- fault-fuzz bucket running locally alongside CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)