### PR TITLE
Harden HTTP remote transfers and cached handles

### DIFF
--- a/src/doltlite_http_remote.c
+++ b/src/doltlite_http_remote.c
@@ -44,6 +44,7 @@ struct HttpRemote {
 };
 
 #define HTTP_RESP_MAX_BYTES ((i64)128 * 1024 * 1024)
+#define HTTP_UPLOAD_BATCH_MAX ((i64)32 * 1024 * 1024)
 #define HTTP_TIMEOUT_MS 30000
 
 static void httpClearLastError(HttpRemote *p){
@@ -460,7 +461,7 @@ static int httpRequest(
   HttpRemote *p,
   const char *zMethod,
   const char *zPath,
-  const u8 *pBody, int nBody,
+  const u8 *pBody, i64 nBody,
   int *pStatus,
   u8 **ppResp, int *pnResp
 ){
@@ -497,7 +498,7 @@ static int httpRequest(
       "%s %s HTTP/1.1\r\n"
       "Host: %s\r\n"
       "%s"
-      "Content-Length: %d\r\n"
+      "Content-Length: %lld\r\n"
       "Content-Type: application/octet-stream\r\n"
       "Connection: close\r\n"
       "\r\n",
@@ -520,9 +521,15 @@ static int httpRequest(
   sqlite3_free(zHdr);
   if( rc != SQLITE_OK ){ httpConnClose(conn); return rc; }
   if( pBody && nBody > 0 ){
-    if( httpConnWriteAll(conn, pBody, nBody) ){
-      httpConnClose(conn);
-      return SQLITE_IOERR;
+    i64 off = 0;
+    while( off<nBody ){
+      i64 nRemain = nBody - off;
+      int nWrite = nRemain>0x7fffffff ? 0x7fffffff : (int)nRemain;
+      if( httpConnWriteAll(conn, pBody+off, nWrite) ){
+        httpConnClose(conn);
+        return SQLITE_IOERR;
+      }
+      off += nWrite;
     }
   }
 
@@ -558,6 +565,27 @@ static char *buildPath(HttpRemote *p, const char *zSuffix){
     memcpy(z + nBase, zSuffix, nSuffix + 1);
   }
   return z;
+}
+
+static int httpFlushUploadBatch(HttpRemote *p){
+  char *zPath;
+  int status = 0;
+  u8 *pResp = 0;
+  int nResp = 0;
+  int rc;
+
+  if( p->nUploadBuf==0 ) return SQLITE_OK;
+  zPath = buildPath(p, "/chunks");
+  if( !zPath ) return SQLITE_NOMEM;
+  rc = httpRequest(p, "POST", zPath, p->pUploadBuf, p->nUploadBuf,
+                   &status, &pResp, &nResp);
+  sqlite3_free(zPath);
+  if( rc==SQLITE_OK && status!=200 && status!=204 ){
+    rc = httpMapError(p, status, pResp, nResp);
+  }
+  sqlite3_free(pResp);
+  if( rc==SQLITE_OK ) p->nUploadBuf = 0;
+  return rc;
 }
 
 static int httpHasChunks(DoltliteRemote *pRemote, const ProllyHash *aHash,
@@ -653,19 +681,35 @@ static int httpPutChunk(DoltliteRemote *pRemote, const ProllyHash *pHash,
                         const u8 *pData, int nData){
   HttpRemote *p = (HttpRemote*)pRemote;
   u8 aLen[4];
+  i64 nRecord;
+  i64 nSaved;
   int rc;
 
+  if( nData<0 ) return SQLITE_CORRUPT;
+  nRecord = PROLLY_HASH_SIZE + 4 + (i64)nData;
+  if( p->nUploadBuf>0
+   && p->nUploadBuf + nRecord > HTTP_UPLOAD_BATCH_MAX ){
+    rc = httpFlushUploadBatch(p);
+    if( rc!=SQLITE_OK ) return rc;
+  }
+  nSaved = p->nUploadBuf;
+
   rc = uploadBufAppend(p, pHash->data, PROLLY_HASH_SIZE);
-  if( rc != SQLITE_OK ) return rc;
+  if( rc != SQLITE_OK ) goto put_error;
 
   aLen[0] = (u8)(nData & 0xff);
   aLen[1] = (u8)((nData >> 8) & 0xff);
   aLen[2] = (u8)((nData >> 16) & 0xff);
   aLen[3] = (u8)((nData >> 24) & 0xff);
   rc = uploadBufAppend(p, aLen, 4);
-  if( rc != SQLITE_OK ) return rc;
+  if( rc != SQLITE_OK ) goto put_error;
 
   rc = uploadBufAppend(p, pData, nData);
+  if( rc != SQLITE_OK ) goto put_error;
+  return SQLITE_OK;
+
+put_error:
+  p->nUploadBuf = nSaved;
   return rc;
 }
 
@@ -846,25 +890,8 @@ static int httpCommit(DoltliteRemote *pRemote){
   int rc;
   char *zPath;
 
-  if( p->pUploadBuf && p->nUploadBuf > 0 ){
-    zPath = buildPath(p, "/chunks");
-    if( !zPath ) return SQLITE_NOMEM;
-
-    rc = httpRequest(p, "POST", zPath,
-                     p->pUploadBuf, (int)p->nUploadBuf,
-                     &status, &pResp, &nResp);
-    sqlite3_free(zPath);
-    if( rc != SQLITE_OK ){
-      sqlite3_free(pResp);
-      return rc;
-    }
-    if( status != 200 && status != 204 ){
-      rc = httpMapError(p, status, pResp, nResp);
-      sqlite3_free(pResp);
-      return rc;
-    }
-    sqlite3_free(pResp);
-  }
+  rc = httpFlushUploadBatch(p);
+  if( rc!=SQLITE_OK ) return rc;
 
   if( p->pPendingRefs && p->nPendingRefs > 0 ){
     /* Body: [u16 branchLen][branch][u8 force] then, for refs-if, the expected
@@ -1121,6 +1148,7 @@ DoltliteRemote *doltliteHttpRemoteOpen(const char *zUrl){
   p->base.xCommit = httpCommit;
   p->base.xClose = httpClose;
   p->base.xErrMsg = httpErrMsg;
+  p->base.bResumePartialPuts = 1;
 
   return &p->base;
 }

--- a/src/doltlite_remote.c
+++ b/src/doltlite_remote.c
@@ -197,6 +197,8 @@ int doltliteSyncChunks(
   ProllyHashSet seen;
   ProllyHash aBatch[SYNC_BATCH_SIZE];
   u8 aPresent[SYNC_BATCH_SIZE];
+  int bFirstBatch = 1;
+  int bResumeScan = 0;
   int rc, i;
 
   rc = syncQueueInit(&queue);
@@ -225,40 +227,58 @@ int doltliteSyncChunks(
 
     rc = pDst->xHasChunks(pDst, aBatch, nBatch, aPresent);
     if( rc!=SQLITE_OK ) break;
+    if( bFirstBatch && pDst->bResumePartialPuts ){
+      bResumeScan = 1;
+      for(i=0; i<nBatch; i++){
+        if( !aPresent[i] ){
+          bResumeScan = 0;
+          break;
+        }
+      }
+    }
+    bFirstBatch = 0;
 
-    /* Collect the chunks the destination is missing, then fetch them from the
-    ** source. A source that provides xGetChunks pulls the whole batch in one
-    ** round trip; otherwise fall back to one fetch per chunk. */
+    /* A resumed partial put may have persisted a parent before its missing
+    ** descendants. Scan below present roots in that case. */
     {
-      ProllyHash aMissing[SYNC_BATCH_SIZE];
-      int nMissing = 0;
+      ProllyHash aFetch[SYNC_BATCH_SIZE];
+      u8 aPut[SYNC_BATCH_SIZE];
+      int nFetch = 0;
 
       for(i=0; i<nBatch; i++){
-        if( !aPresent[i] ) aMissing[nMissing++] = aBatch[i];
+        if( !aPresent[i] || bResumeScan ){
+          aFetch[nFetch] = aBatch[i];
+          aPut[nFetch] = !aPresent[i];
+          nFetch++;
+        }
       }
-      if( nMissing==0 ) continue;
+      if( nFetch==0 ) continue;
 
       if( pSrc->xGetChunks ){
         u8 *apData[SYNC_BATCH_SIZE];
         int anData[SYNC_BATCH_SIZE];
 
-        memset(apData, 0, sizeof(apData[0]) * nMissing);
-        rc = pSrc->xGetChunks(pSrc, aMissing, nMissing, apData, anData);
-        for(i=0; i<nMissing && rc==SQLITE_OK; i++){
+        memset(apData, 0, sizeof(apData[0]) * nFetch);
+        rc = pSrc->xGetChunks(pSrc, aFetch, nFetch, apData, anData);
+        for(i=0; i<nFetch && rc==SQLITE_OK; i++){
           if( !apData[i] ){ rc = SQLITE_NOTFOUND; break; }
-          rc = pDst->xPutChunk(pDst, &aMissing[i], apData[i], anData[i]);
+          if( aPut[i] ){
+            rc = pDst->xPutChunk(pDst, &aFetch[i], apData[i], anData[i]);
+          }
           if( rc==SQLITE_OK ){
             rc = syncEnqueueChildren(apData[i], anData[i], &queue, &seen);
           }
         }
-        for(i=0; i<nMissing; i++) sqlite3_free(apData[i]);
+        for(i=0; i<nFetch; i++) sqlite3_free(apData[i]);
       }else{
-        for(i=0; i<nMissing && rc==SQLITE_OK; i++){
+        for(i=0; i<nFetch && rc==SQLITE_OK; i++){
           u8 *data = 0;
           int nData = 0;
-          rc = pSrc->xGetChunk(pSrc, &aMissing[i], &data, &nData);
+          rc = pSrc->xGetChunk(pSrc, &aFetch[i], &data, &nData);
           if( rc!=SQLITE_OK ) break;
-          rc = pDst->xPutChunk(pDst, &aMissing[i], data, nData);
+          if( aPut[i] ){
+            rc = pDst->xPutChunk(pDst, &aFetch[i], data, nData);
+          }
           if( rc==SQLITE_OK ){
             rc = syncEnqueueChildren(data, nData, &queue, &seen);
           }

--- a/src/doltlite_remote.h
+++ b/src/doltlite_remote.h
@@ -26,6 +26,7 @@ struct DoltliteRemote {
   /* Optional. Last human-readable error from a remote op, or NULL. Lifetime
   ** is until the next op or xClose. */
   const char *(*xErrMsg)(DoltliteRemote*);
+  int bResumePartialPuts;
 };
 
 static inline int doltliteRemotePersistRefs(ChunkStore *cs){

--- a/src/doltlite_remotesrv.c
+++ b/src/doltlite_remotesrv.c
@@ -45,6 +45,7 @@ struct RemoteDbHandle {
   ChunkStore store;
   int bOpen;
   int bWritable;
+  int nReservations;
   i64 lastUseMs;
   pthread_mutex_t mu;
   int muInit;
@@ -487,11 +488,14 @@ static int isSafeDbName(const char *zDbName){
 static void handleGetRoot(ChunkStore *pStore, DoltliteConn *fd){
   ProllyHash root;
   const char *zDef = chunkStoreGetDefaultBranch(pStore);
-  if( zDef && chunkStoreFindBranch(pStore, zDef, &root)==SQLITE_OK ){
+  int rc = zDef ? chunkStoreFindBranch(pStore, zDef, &root) : SQLITE_NOTFOUND;
+  if( rc==SQLITE_OK ){
     sendOk(fd, root.data, PROLLY_HASH_SIZE);
-  }else{
+  }else if( rc==SQLITE_NOTFOUND ){
     memset(&root, 0, sizeof(root));
     sendOk(fd, root.data, PROLLY_HASH_SIZE);
+  }else{
+    sendSqliteError(fd, rc);
   }
 }
 
@@ -872,6 +876,28 @@ static void remoteDbHandleCloseStore(RemoteDbHandle *h){
   }
 }
 
+static int remoteDbHandleOpenStore(
+  RemoteDbHandle *h,
+  const char *zPath,
+  int bWritable
+){
+  sqlite3_vfs *pVfs = sqlite3_vfs_find(0);
+  int flags;
+  int rc;
+
+  if( !pVfs ) return SQLITE_ERROR;
+  flags = bWritable
+        ? (SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_MAIN_DB)
+        : (SQLITE_OPEN_READONLY | SQLITE_OPEN_MAIN_DB);
+  memset(&h->store, 0, sizeof(h->store));
+  rc = chunkStoreOpen(&h->store, pVfs, zPath, flags);
+  if( rc==SQLITE_OK ){
+    h->bOpen = 1;
+    h->bWritable = bWritable ? 1 : 0;
+  }
+  return rc;
+}
+
 static void remoteDbHandleFree(RemoteDbHandle *h){
   if( !h ) return;
   remoteDbHandleCloseStore(h);
@@ -904,6 +930,7 @@ static void remoteDbCacheEvictOne(DoltliteServer *pSrv){
   i64 bestAge = 0;
 
   for(h=pSrv->pDbCache; h; pPrev=h, h=h->pNext){
+    if( h->nReservations>0 ) continue;
     if( pthread_mutex_trylock(&h->mu)!=0 ) continue;
     if( !pBest || h->lastUseMs < bestAge ){
       if( pBest ) pthread_mutex_unlock(&pBest->mu);
@@ -931,8 +958,6 @@ static int remoteDbAcquire(
   RemoteDbHandle **ppOut
 ){
   RemoteDbHandle *h = 0;
-  sqlite3_vfs *pVfs;
-  int flags;
   int rc;
 
   *ppOut = 0;
@@ -964,6 +989,7 @@ static int remoteDbAcquire(
     pSrv->pDbCache = h;
     pSrv->nDbCache++;
   }
+  h->nReservations++;
   pthread_mutex_unlock(&pSrv->mutex);
 
   pthread_mutex_lock(&h->mu);
@@ -980,52 +1006,30 @@ static int remoteDbAcquire(
   }
 
   if( !h->bOpen ){
-    pVfs = sqlite3_vfs_find(0);
-    if( !pVfs ){
-      pthread_mutex_unlock(&h->mu);
-      return SQLITE_ERROR;
-    }
-    flags = bWritable
-          ? (SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_MAIN_DB)
-          : (SQLITE_OPEN_READONLY | SQLITE_OPEN_MAIN_DB);
-    memset(&h->store, 0, sizeof(h->store));
-    rc = chunkStoreOpen(&h->store, pVfs, zPath, flags);
-    if( rc!=SQLITE_OK ){
-      pthread_mutex_unlock(&h->mu);
-      return rc;
-    }
-    h->bOpen = 1;
-    h->bWritable = bWritable ? 1 : 0;
+    rc = remoteDbHandleOpenStore(h, zPath, bWritable);
+    if( rc!=SQLITE_OK ) goto acquire_error;
   }else{
     int changed = 0;
     rc = chunkStoreRefreshIfChanged(&h->store, &changed);
-    if( rc!=SQLITE_OK ){
-      /* Stale open handle (e.g. replaced file): reopen once. */
+    if( rc!=SQLITE_OK || h->store.movedReadOnly ){
       remoteDbHandleCloseStore(h);
-      pVfs = sqlite3_vfs_find(0);
-      if( !pVfs ){
-        pthread_mutex_unlock(&h->mu);
-        return SQLITE_ERROR;
-      }
-      flags = bWritable
-            ? (SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_MAIN_DB)
-            : (SQLITE_OPEN_READONLY | SQLITE_OPEN_MAIN_DB);
-      memset(&h->store, 0, sizeof(h->store));
-      rc = chunkStoreOpen(&h->store, pVfs, zPath, flags);
-      if( rc!=SQLITE_OK ){
-        pthread_mutex_unlock(&h->mu);
-        return rc;
-      }
-      h->bOpen = 1;
-      h->bWritable = bWritable ? 1 : 0;
+      rc = remoteDbHandleOpenStore(h, zPath, bWritable);
+      if( rc!=SQLITE_OK ) goto acquire_error;
     }
   }
 
   *ppOut = h;
   return SQLITE_OK;
+
+acquire_error:
+  pthread_mutex_unlock(&h->mu);
+  pthread_mutex_lock(&pSrv->mutex);
+  h->nReservations--;
+  pthread_mutex_unlock(&pSrv->mutex);
+  return rc;
 }
 
-static void remoteDbRelease(RemoteDbHandle *h){
+static void remoteDbRelease(DoltliteServer *pSrv, RemoteDbHandle *h){
   if( !h ) return;
   /* Leave the store open for the next request; only drop the exclusive lock. */
   if( h->bOpen
@@ -1033,6 +1037,9 @@ static void remoteDbRelease(RemoteDbHandle *h){
     chunkStoreRollback(&h->store);
   }
   pthread_mutex_unlock(&h->mu);
+  pthread_mutex_lock(&pSrv->mutex);
+  h->nReservations--;
+  pthread_mutex_unlock(&pSrv->mutex);
 }
 
 static void handleRequest(DoltliteServer *pSrv, DoltliteConn *fd){
@@ -1154,7 +1161,7 @@ static void handleRequest(DoltliteServer *pSrv, DoltliteConn *fd){
     sendBadRequest(fd);
   }
 
-  remoteDbRelease(pHandle);
+  remoteDbRelease(pSrv, pHandle);
   sqlite3_free(pBody);
 }
 

--- a/test/remotesrv_http_concurrency_test.sh
+++ b/test/remotesrv_http_concurrency_test.sh
@@ -217,6 +217,35 @@ check "branch_b fetch and checkout sees its row" "0
 0
 1" "$("$DOLTLITE" "$TMP/check_branches.db" "SELECT dolt_checkout('main'); SELECT dolt_fetch('origin','branch_b'); SELECT dolt_checkout('-b','local_b','origin/branch_b'); SELECT count(*) FROM t WHERE id=200;" 2>&1 | tail -3)"
 
+case "$(uname -s)" in
+  MINGW*|MSYS*|CYGWIN*) ;;
+  *)
+    echo "=== live replacement and recovery ==="
+    "$DOLTLITE" "$TMP/replacement.db" <<'SQL' >/dev/null
+CREATE TABLE replacement(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO replacement VALUES(1,'new generation');
+SELECT dolt_commit('-A','-m','replacement');
+SQL
+    mv "$TMP/replacement.db" "$TMP/srv/repo.db"
+    result=$("$DOLTLITE" "$TMP/replacement_clone.db" \
+      "SELECT dolt_clone('$URL'); SELECT v FROM replacement;" 2>&1)
+    check "cached server adopts a valid replacement" "0
+new generation" "$result"
+
+    mv "$TMP/srv/repo.db" "$TMP/restored.db"
+    printf 'damaged' >"$TMP/srv/repo.db"
+    result=$("$DOLTLITE" "$TMP/damaged_clone.db" \
+      "SELECT dolt_clone('$URL');" 2>&1 || true)
+    check_match "damaged replacement returns an error" \
+      "ERROR|Error|error|malformed|format|failed" "$result"
+    mv "$TMP/restored.db" "$TMP/srv/repo.db"
+    result=$("$DOLTLITE" "$TMP/recovered_clone.db" \
+      "SELECT dolt_clone('$URL'); SELECT v FROM replacement;" 2>&1)
+    check "cached server recovers after file restoration" "0
+new generation" "$result"
+    ;;
+esac
+
 echo ""
 echo "======================================="
 echo "Results: $pass passed, $fail failed"

--- a/test/remotesrv_http_partial_failure_test.sh
+++ b/test/remotesrv_http_partial_failure_test.sh
@@ -65,9 +65,14 @@ cat >"$TMP/proxy.py" <<'PY'
 import socket
 import socketserver
 import sys
+import threading
 
 upstream_port = int(sys.argv[1])
 fail_path_file = sys.argv[2]
+forwarded_path = sys.argv[3]
+failure_lock = threading.Lock()
+failure_control = ""
+failure_count = 0
 
 def current_fail_path():
     try:
@@ -75,6 +80,28 @@ def current_fail_path():
             return f.read().strip()
     except OSError:
         return ""
+
+def should_fail(path):
+    global failure_control, failure_count
+    control = current_fail_path()
+    with failure_lock:
+        if control != failure_control:
+            failure_control = control
+            failure_count = 0
+        if not control:
+            return False
+        target, separator, ordinal = control.rpartition("|")
+        if not separator or not ordinal.isdigit():
+            return path.endswith(control)
+        if not path.endswith(target):
+            return False
+        failure_count += 1
+        return failure_count == int(ordinal)
+
+def record_forward(method, path):
+    with failure_lock:
+        with open(forwarded_path, "a") as f:
+            f.write(f"{method} {path}\n")
 
 class Handler(socketserver.BaseRequestHandler):
     def handle(self):
@@ -105,15 +132,15 @@ class Handler(socketserver.BaseRequestHandler):
                 return
             body += chunk
 
-        fail_path = current_fail_path()
-        if fail_path and path.endswith(fail_path):
+        if should_fail(path):
             self.request.sendall(
                 b"HTTP/1.1 503 Service Unavailable\r\n"
                 b"Content-Length: 0\r\nConnection: close\r\n\r\n"
             )
             return
 
-        with socket.create_connection(("127.0.0.1", upstream_port), timeout=10) as s:
+        record_forward(method, path)
+        with socket.create_connection(("127.0.0.1", upstream_port), timeout=60) as s:
             s.sendall(head + b"\r\n\r\n" + body)
             s.shutdown(socket.SHUT_WR)
             while True:
@@ -132,7 +159,8 @@ with Server(("127.0.0.1", 0), Handler) as srv:
 PY
 
 : >"$TMP/fail_path"
-python3 "$TMP/proxy.py" "$SRV_PORT" "$TMP/fail_path" >"$TMP/proxy.log" 2>"$TMP/proxy.err" &
+: >"$TMP/forwarded.log"
+python3 "$TMP/proxy.py" "$SRV_PORT" "$TMP/fail_path" "$TMP/forwarded.log" >"$TMP/proxy.log" 2>"$TMP/proxy.err" &
 PROXY_PID=$!
 PROXY_PORT=""
 for _ in $(seq 1 50); do
@@ -200,6 +228,29 @@ result=$("$DB" "$TMP/clone_after_commit_retry.db" "SELECT dolt_clone('$URL'); SE
 check "remote publishes retried commit push" "0
 $commit_fail_head
 3" "$result"
+
+echo "=== push more than 128 MiB with a failed second chunk batch ==="
+"$DB" "$A" <<'SQL' >/dev/null
+CREATE TABLE large_payload(id INTEGER PRIMARY KEY, payload BLOB);
+WITH RECURSIVE seq(i) AS (
+  VALUES(1) UNION ALL SELECT i+1 FROM seq WHERE i<8704
+) INSERT INTO large_payload SELECT i, randomblob(16384) FROM seq;
+SELECT dolt_commit('-A','-m','large payload');
+SQL
+before=$(grep -c 'POST .*/chunks' "$TMP/forwarded.log" || true)
+printf '/chunks|2\n' >"$TMP/fail_path"
+result=$("$DB" "$A" "SELECT dolt_push('origin','main');" 2>&1)
+check_match "push reports second chunk batch failure" "ERROR|Error|error|failed" "$result"
+after=$(grep -c 'POST .*/chunks' "$TMP/forwarded.log" || true)
+check "first chunk batch was acknowledged before failure" "1" "$((after-before))"
+printf '\n' >"$TMP/fail_path"
+result=$("$DB" "$A" "SELECT dolt_push('origin','main');" 2>&1)
+check "retry after partial chunk upload succeeds" "0" "$result"
+after_retry=$(grep -c 'POST .*/chunks' "$TMP/forwarded.log" || true)
+check_match "retry uses multiple bounded chunk batches" "^[4-9]$|^[1-9][0-9]+$" "$((after_retry-after))"
+result=$("$DB" "$TMP/clone_large.db" "SELECT dolt_clone('$URL'); SELECT count(*),sum(length(payload)) FROM large_payload;" 2>&1)
+check "clone reads the greater-than-128-MiB push" "0
+8704|142606336" "$result"
 
 echo ""
 echo "======================================="


### PR DESCRIPTION
## Summary

- stream HTTP chunk uploads in acknowledged 32 MiB batches while keeping the refs CAS as the final publication step
- make retries after a partially durable upload scan beneath an already-present root for missing descendants
- reserve cached server handles across lookup and per-database lock acquisition so cache eviction cannot free an in-flight handle
- reopen moved database files before serving endpoints and return root lookup failures consistently
- cover a failed second batch across a 136 MiB push and clone, plus live replacement, damage, and recovery

## Validation

- `bash test/remotesrv_http_partial_failure_test.sh build/doltlite build/doltlite-remotesrv` (14/14)
- `bash test/remotesrv_http_concurrency_test.sh build/doltlite build/doltlite-remotesrv` (16/16)
- `bash test/remotesrv_http_test.sh build/doltlite build/doltlite-remotesrv` (29/29)
- `bash test/remotesrv_http_force_push_test.sh build/doltlite build/doltlite-remotesrv` (11/11)
- `bash test/run_doltlite_tests.sh` (99/99 suites; 310,085 C regression assertions)
- gated C-test build with `-Werror`; isolated `multi_process_test` (49/49) and `multi_process_merge_rebase_test` (30/30)
- `make lint`

Co-Authored-By: OpenAI Codex <noreply@openai.com>
