### PR TITLE
Propagate a failed mutmap sort out of the entry accessors

### DIFF
--- a/src/prolly_btree_cursor.c
+++ b/src/prolly_btree_cursor.c
@@ -139,7 +139,8 @@ static int mergeScan(BtCursor *pCur, int dir, int *pRes){
       if( pRes ) *pRes = 0;
       return SQLITE_OK;
     }
-    e = orderedMutMapEntryAt(pCur->pMutMap, pCur->mmIdx);
+    rc = orderedMutMapEntryAt(pCur->pMutMap, pCur->mmIdx, &e);
+    if( rc!=SQLITE_OK ) return rc;
     if( !treeOk ){
       if( e->op==PROLLY_EDIT_DELETE ){ pCur->mmIdx += dir; continue; }
       pCur->mergeSrc = MERGE_SRC_MUT;
@@ -205,7 +206,9 @@ static int materializeDeferredTreeSeek(BtCursor *pCur, int dir){
   if( pCur->curIntKey ){
     rc = prollyCursorSeekInt(&pCur->pCur, pCur->cachedIntKey, &res);
   }else{
-    ProllyMutMapEntry *e = orderedMutMapEntryAt(pCur->pMutMap, pCur->mmIdx);
+    ProllyMutMapEntry *e;
+    rc = orderedMutMapEntryAt(pCur->pMutMap, pCur->mmIdx, &e);
+    if( rc!=SQLITE_OK ) return rc;
     rc = prollyCursorSeekBlob(&pCur->pCur, e->pKey, e->nKey, &res);
   }
   if( rc!=SQLITE_OK ) return rc;
@@ -507,16 +510,23 @@ static int prollyBtCursorStepPrologue(BtCursor *pCur, int dir, int *pImmediate){
   return SQLITE_OK;
 }
 
-static void prollyCursorClassifyMergeSrc(BtCursor *pCur, int idx){
+static int prollyCursorClassifyMergeSrc(BtCursor *pCur, int idx){
+  int both = 0;
   if( idx >= 0 && idx < pCur->pMutMap->nEntries
-   && prollyCursorIsValid(&pCur->pCur)
-   && mergeCompare(pCur, prollyMutMapEntryAt(pCur->pMutMap, idx))==0 ){
+   && prollyCursorIsValid(&pCur->pCur) ){
+    ProllyMutMapEntry *e;
+    int rc = prollyMutMapEntryAt(pCur->pMutMap, idx, &e);
+    if( rc!=SQLITE_OK ) return rc;
+    both = mergeCompare(pCur, e)==0;
+  }
+  if( both ){
     pCur->mergeSrc = MERGE_SRC_BOTH;
   }else if( !prollyCursorIsValid(&pCur->pCur) ){
     pCur->mergeSrc = MERGE_SRC_MUT;
   }else{
     pCur->mergeSrc = MERGE_SRC_TREE;
   }
+  return SQLITE_OK;
 }
 
 static int prollyCursorApplyMergeStep(BtCursor *pCur, int dir){
@@ -586,7 +596,8 @@ int prollyBtCursorNext(BtCursor *pCur, int flags){
     if( rc!=SQLITE_OK ) return rc;
     pCur->mmIdx = it.idx;
     pCur->mmActive = 1;
-    prollyCursorClassifyMergeSrc(pCur, it.idx);
+    rc = prollyCursorClassifyMergeSrc(pCur, it.idx);
+    if( rc!=SQLITE_OK ) return rc;
     rc = prollyCursorApplyMergeStep(pCur, 1);
   }else{
     rc = prollyCursorFinishTreeStep(pCur, prollyCursorNextFastLeaf(&pCur->pCur));
@@ -623,22 +634,26 @@ int prollyBtCursorPrevious(BtCursor *pCur, int flags){
       rc = prollyMutMapIterSeek(&it, pCur->pMutMap, 0, 0,
                                 prollyCursorIntKey(&pCur->pCur));
       if( rc!=SQLITE_OK ) return rc;
-      if( it.idx >= pCur->pMutMap->nEntries
-       || mergeCompare(pCur, orderedMutMapEntryAt(pCur->pMutMap, it.idx))>=0
-       || orderedMutMapEntryAt(pCur->pMutMap, it.idx)->op==PROLLY_EDIT_DELETE
-      ){
+      if( it.idx >= pCur->pMutMap->nEntries ){
         it.idx--;
+      }else{
+        ProllyMutMapEntry *e;
+        rc = orderedMutMapEntryAt(pCur->pMutMap, it.idx, &e);
+        if( rc!=SQLITE_OK ) return rc;
+        if( mergeCompare(pCur, e)>=0 || e->op==PROLLY_EDIT_DELETE ) it.idx--;
       }
     }else if( !pCur->curIntKey && prollyCursorIsValid(&pCur->pCur) ){
       const u8 *pK; int nK;
       prollyCursorKey(&pCur->pCur, &pK, &nK);
       rc = prollyMutMapIterSeek(&it, pCur->pMutMap, pK, nK, 0);
       if( rc!=SQLITE_OK ) return rc;
-      if( it.idx >= pCur->pMutMap->nEntries
-       || mergeCompare(pCur, orderedMutMapEntryAt(pCur->pMutMap, it.idx))>=0
-       || orderedMutMapEntryAt(pCur->pMutMap, it.idx)->op==PROLLY_EDIT_DELETE
-      ){
+      if( it.idx >= pCur->pMutMap->nEntries ){
         it.idx--;
+      }else{
+        ProllyMutMapEntry *e;
+        rc = orderedMutMapEntryAt(pCur->pMutMap, it.idx, &e);
+        if( rc!=SQLITE_OK ) return rc;
+        if( mergeCompare(pCur, e)>=0 || e->op==PROLLY_EDIT_DELETE ) it.idx--;
       }
     }else if( pCur->eState==CURSOR_VALID ){
       rc = seedMutMapIterFromCursor(pCur, &it);
@@ -653,7 +668,8 @@ int prollyBtCursorPrevious(BtCursor *pCur, int flags){
     if( rc!=SQLITE_OK ) return rc;
     pCur->mmIdx = it.idx;
     pCur->mmActive = 1;
-    prollyCursorClassifyMergeSrc(pCur, it.idx);
+    rc = prollyCursorClassifyMergeSrc(pCur, it.idx);
+    if( rc!=SQLITE_OK ) return rc;
     rc = prollyCursorApplyMergeStep(pCur, -1);
   }else{
     rc = prollyCursorFinishTreeStep(pCur, prollyCursorPrev(&pCur->pCur));
@@ -733,7 +749,9 @@ int sqlite3BtreeProllyIndexRowid(BtCursor *pCur, i64 *pRowid){
 
   if( pCur->mmActive
    && (pCur->mergeSrc==MERGE_SRC_MUT || pCur->mergeSrc==MERGE_SRC_BOTH) ){
-    ProllyMutMapEntry *e = currentMutMapEntry(pCur);
+    ProllyMutMapEntry *e;
+    int rc = currentMutMapEntry(pCur, &e);
+    if( rc!=SQLITE_OK ) return rc;
     if( !e ) return SQLITE_NOTFOUND;
     pKey = e->pKey;
     nKey = e->nKey;

--- a/src/prolly_btree_cursor_payload.c
+++ b/src/prolly_btree_cursor_payload.c
@@ -66,7 +66,14 @@ i64 prollyBtCursorIntegerKey(BtCursor *pCur){
 
   if( pCur->mmActive
    && (pCur->mergeSrc==MERGE_SRC_MUT || pCur->mergeSrc==MERGE_SRC_BOTH) ){
-    return prollyMutMapEntryIntKey(currentMutMapEntry(pCur));
+    ProllyMutMapEntry *e;
+    int rc = currentMutMapEntry(pCur, &e);
+    if( rc!=SQLITE_OK ){
+      pCur->eState = CURSOR_FAULT;
+      pCur->skipNext = rc;
+      return 0;
+    }
+    return prollyMutMapEntryIntKey(e);
   }
   if( pCur->pCur.eState!=PROLLY_CURSOR_VALID
    && (pCur->curFlags & BTCF_ValidNKey) ){
@@ -114,7 +121,11 @@ int getCursorPayload(BtCursor *pCur, const u8 **ppData, int *pnData){
 
   if( pCur->mmActive
    && (pCur->mergeSrc==MERGE_SRC_MUT || pCur->mergeSrc==MERGE_SRC_BOTH) ){
-    ProllyMutMapEntry *e = currentMutMapEntry(pCur);
+    ProllyMutMapEntry *e;
+    int rcEntry = currentMutMapEntry(pCur, &e);
+    if( rcEntry!=SQLITE_OK ){
+      return cursorPayloadFault(pCur, rcEntry, ppData, pnData);
+    }
     if( pCur->curIntKey ){
       if( e->nZeroTail > 0 ){
         int rc = cacheCursorPayloadZeroTail(pCur, e->pVal, e->nVal,
@@ -210,7 +221,13 @@ u32 prollyBtCursorPayloadSize(BtCursor *pCur){
   }
   if( pCur->curIntKey && pCur->mmActive
    && (pCur->mergeSrc==MERGE_SRC_MUT || pCur->mergeSrc==MERGE_SRC_BOTH) ){
-    ProllyMutMapEntry *e = currentMutMapEntry(pCur);
+    ProllyMutMapEntry *e;
+    int rc = currentMutMapEntry(pCur, &e);
+    if( rc!=SQLITE_OK ){
+      pCur->eState = CURSOR_FAULT;
+      pCur->skipNext = rc;
+      return 0;
+    }
     /* Answer from the pending row before consulting the tree. The tree cursor
     ** may still be valid for MERGE_SRC_BOTH, but its value is stale. */
     return (u32)((i64)e->nVal + e->nZeroTail);
@@ -269,7 +286,9 @@ int prollyBtCursorPayload(BtCursor *pCur, u32 offset, u32 amt, void *pBuf){
   if( pCur->curIntKey
    && pCur->mmActive
    && (pCur->mergeSrc==MERGE_SRC_MUT || pCur->mergeSrc==MERGE_SRC_BOTH) ){
-    ProllyMutMapEntry *e = currentMutMapEntry(pCur);
+    ProllyMutMapEntry *e;
+    rc = currentMutMapEntry(pCur, &e);
+    if( rc!=SQLITE_OK ) return rc;
     if( e && e->nZeroTail>0 ){
       return copyZeroTailPayload(e, offset, amt, pBuf);
     }
@@ -332,7 +351,13 @@ const void *prollyBtCursorPayloadFetch(BtCursor *pCur, u32 *pAmt){
   if( pCur->curIntKey
    && pCur->mmActive
    && (pCur->mergeSrc==MERGE_SRC_MUT || pCur->mergeSrc==MERGE_SRC_BOTH) ){
-    ProllyMutMapEntry *e = currentMutMapEntry(pCur);
+    ProllyMutMapEntry *e;
+    int rc = currentMutMapEntry(pCur, &e);
+    if( rc!=SQLITE_OK ){
+      pCur->eState = CURSOR_FAULT;
+      pCur->skipNext = rc;
+      return 0;
+    }
     if( e && e->nZeroTail>0 && e->nVal>0 ){
       if( pAmt ) *pAmt = (u32)e->nVal;
       return (const void*)e->pVal;

--- a/src/prolly_btree_cursor_seek.c
+++ b/src/prolly_btree_cursor_seek.c
@@ -259,11 +259,16 @@ static int findMatchingMutMapEntry(
                                     &lo, &found);
 
   while( rc==SQLITE_OK && lo < pMap->nEntries ){
-    ProllyMutMapEntry *pEntry = prollyMutMapEntryAt(pMap, lo);
-    const u8 *pRec = pEntry->pVal;
-    int nRec = pEntry->nVal;
+    ProllyMutMapEntry *pEntry;
+    const u8 *pRec;
+    int nRec;
     int cmpLen;
     int prefixCmp;
+
+    rc = prollyMutMapEntryAt(pMap, lo, &pEntry);
+    if( rc!=SQLITE_OK ) break;
+    pRec = pEntry->pVal;
+    nRec = pEntry->nVal;
 
     if( pMap->isIntKey ){
       lo++;
@@ -1008,8 +1013,8 @@ int cachedSeekKeyMatchesCurrent(BtCursor *pCur){
   }
   if( pCur->mmActive
    && (pCur->mergeSrc==MERGE_SRC_MUT || pCur->mergeSrc==MERGE_SRC_BOTH) ){
-    ProllyMutMapEntry *e = currentMutMapEntry(pCur);
-    if( !e ) return 0;
+    ProllyMutMapEntry *e;
+    if( currentMutMapEntry(pCur, &e)!=SQLITE_OK || !e ) return 0;
     pKey = e->pKey;
     nKey = e->nKey;
   }else if( prollyCursorIsValid(&pCur->pCur) ){
@@ -1038,7 +1043,9 @@ int sqlite3BtreeProllyCachedIndexKeyCompare(
 
   if( pCur->mmActive
    && (pCur->mergeSrc==MERGE_SRC_MUT || pCur->mergeSrc==MERGE_SRC_BOTH) ){
-    ProllyMutMapEntry *e = currentMutMapEntry(pCur);
+    ProllyMutMapEntry *e;
+    int rc = currentMutMapEntry(pCur, &e);
+    if( rc!=SQLITE_OK ) return rc;
     if( !e ) return SQLITE_NOTFOUND;
     pKey = e->pKey;
     nKey = e->nKey;

--- a/src/prolly_btree_int.h
+++ b/src/prolly_btree_int.h
@@ -474,7 +474,7 @@ int prollyBtreeCheckMaxPageCount(Btree *p);
 int cacheCursorPayloadZeroTail(BtCursor *pCur, const u8 *pData,
                                int nData, i64 nZeroTail);
 u32 prollySerialTypeLen(u32 serialType);
-ProllyMutMapEntry *currentMutMapEntry(BtCursor *pCur);
+int currentMutMapEntry(BtCursor *pCur, ProllyMutMapEntry **ppEntry);
 void setCursorToMutMapEntryPhys(BtCursor *pCur, int physIdx);
 const char *findTableNumberName(sqlite3 *db, Pgno iTable);
 int cachedSeekKeyMatchesCurrent(BtCursor *pCur);
@@ -734,7 +734,7 @@ void clearMergeCursorState(BtCursor*);
 int mergeLast(BtCursor *pCur, int *pRes);
 int prollyCursorCheckInterrupt(BtCursor*);
 int advanceTreeCursor(BtCursor*, int);
-ProllyMutMapEntry *orderedMutMapEntryAt(ProllyMutMap*, int);
+int orderedMutMapEntryAt(ProllyMutMap*, int, ProllyMutMapEntry**);
 int unpackedRecordCanUseIntSortKey(BtCursor*, UnpackedRecord*, int);
 int sortKeyFromUnpackedIntRecordBuffer(UnpackedRecord*, int, u8**, int*, int*);
 int prollyInvokeBusyHandler(BtShared*);

--- a/src/prolly_btree_mutation.c
+++ b/src/prolly_btree_mutation.c
@@ -329,26 +329,29 @@ void clearMergeCursorState(BtCursor *pCur){
   pCur->mergeSrc = MERGE_SRC_TREE;
 }
 
-ProllyMutMapEntry *currentMutMapEntry(BtCursor *pCur){
+int currentMutMapEntry(BtCursor *pCur, ProllyMutMapEntry **ppEntry){
   assert( pCur!=0 );
   assert( pCur->mmActive );
   assert( pCur->pMutMap!=0 );
   if( pCur->mmPhysActive ){
     assert( pCur->mmPhysIdx>=0 && pCur->mmPhysIdx<pCur->pMutMap->nEntries );
-    return &pCur->pMutMap->aEntries[pCur->mmPhysIdx];
+    *ppEntry = &pCur->pMutMap->aEntries[pCur->mmPhysIdx];
+    return SQLITE_OK;
   }
   assert( pCur->mmIdx>=0 );
-  return prollyMutMapEntryAt(pCur->pMutMap, pCur->mmIdx);
+  return prollyMutMapEntryAt(pCur->pMutMap, pCur->mmIdx, ppEntry);
 }
 
-SQLITE_INLINE ProllyMutMapEntry *orderedMutMapEntryAt(
+SQLITE_INLINE int orderedMutMapEntryAt(
   ProllyMutMap *pMap,
-  int idx
+  int idx,
+  ProllyMutMapEntry **ppEntry
 ){
   if( pMap->keepSorted || !pMap->orderDirty ){
-    return &pMap->aEntries[pMap->aOrder[idx]];
+    *ppEntry = &pMap->aEntries[pMap->aOrder[idx]];
+    return SQLITE_OK;
   }
-  return prollyMutMapEntryAt(pMap, idx);
+  return prollyMutMapEntryAt(pMap, idx, ppEntry);
 }
 
 void setCursorToMutMapEntryPhys(BtCursor *pCur, int physIdx){
@@ -598,7 +601,10 @@ int saveCursorPosition(BtCursor *pCur){
   if( pCur->curIntKey ){
     if( pCur->mmActive
      && (pCur->mergeSrc==MERGE_SRC_MUT || pCur->mergeSrc==MERGE_SRC_BOTH) ){
-      pCur->nKey = prollyMutMapEntryIntKey(currentMutMapEntry(pCur));
+      ProllyMutMapEntry *pEntry;
+      int rcEntry = currentMutMapEntry(pCur, &pEntry);
+      if( rcEntry!=SQLITE_OK ) return rcEntry;
+      pCur->nKey = prollyMutMapEntryIntKey(pEntry);
     }else{
       pCur->nKey = prollyCursorIntKey(&pCur->pCur);
     }
@@ -608,7 +614,9 @@ int saveCursorPosition(BtCursor *pCur){
     int nKey = 0;
     if( pCur->mmActive
      && (pCur->mergeSrc==MERGE_SRC_MUT || pCur->mergeSrc==MERGE_SRC_BOTH) ){
-      ProllyMutMapEntry *pEntry = currentMutMapEntry(pCur);
+      ProllyMutMapEntry *pEntry;
+      int rcEntry = currentMutMapEntry(pCur, &pEntry);
+      if( rcEntry!=SQLITE_OK ) return rcEntry;
       pKey = pEntry->pKey;
       nKey = pEntry->nKey;
     }else{
@@ -816,7 +824,9 @@ int prollyBtCursorInsert(
      && (pCur->mergeSrc==MERGE_SRC_MUT || pCur->mergeSrc==MERGE_SRC_BOTH)
      && (pCur->curFlags & BTCF_ValidNKey)
      && pCur->cachedIntKey==pPayload->nKey ){
-      ProllyMutMapEntry *pEntry = currentMutMapEntry(pCur);
+      ProllyMutMapEntry *pEntry;
+      int rcEntry = currentMutMapEntry(pCur, &pEntry);
+      if( rcEntry!=SQLITE_OK ) return rcEntry;
       if( pEntry->op==PROLLY_EDIT_INSERT ){
         rc = prollyMutMapReplaceEntry(pCur->pMutMap, pEntry, pData, nData);
       }else{
@@ -1132,7 +1142,10 @@ int prollyBtCursorDelete(BtCursor *pCur, u8 flags){
     if( pCur->curIntKey ){
       if( pCur->mmActive
        && (pCur->mergeSrc==MERGE_SRC_MUT || pCur->mergeSrc==MERGE_SRC_BOTH) ){
-        savedIntKey = prollyMutMapEntryIntKey(currentMutMapEntry(pCur));
+        ProllyMutMapEntry *pEntry;
+        int rcEntry = currentMutMapEntry(pCur, &pEntry);
+        if( rcEntry!=SQLITE_OK ) return rcEntry;
+        savedIntKey = prollyMutMapEntryIntKey(pEntry);
         hasSavedKey = 1;
       }else if( !prollyCursorIsValid(&pCur->pCur)
        && (pCur->curFlags & BTCF_ValidNKey) ){
@@ -1151,7 +1164,9 @@ int prollyBtCursorDelete(BtCursor *pCur, u8 flags){
         hasSavedKey = 1;
       }else if( pCur->mmActive
        && (pCur->mergeSrc==MERGE_SRC_MUT || pCur->mergeSrc==MERGE_SRC_BOTH) ){
-        ProllyMutMapEntry *e = currentMutMapEntry(pCur);
+        ProllyMutMapEntry *e;
+        int rcEntry = currentMutMapEntry(pCur, &e);
+        if( rcEntry!=SQLITE_OK ) return rcEntry;
         pSavedDelKey = sqlite3_malloc(e->nKey);
         if( !pSavedDelKey ) return SQLITE_NOMEM;
         memcpy(pSavedDelKey, e->pKey, e->nKey);
@@ -1222,7 +1237,9 @@ int prollyBtCursorDelete(BtCursor *pCur, u8 flags){
      && pCur->mmPhysActive
      && pCur->pMutMap
      && (pCur->mergeSrc==MERGE_SRC_MUT || pCur->mergeSrc==MERGE_SRC_BOTH) ){
-      ProllyMutMapEntry *pEntry = currentMutMapEntry(pCur);
+      ProllyMutMapEntry *pEntry;
+      int rcEntry = currentMutMapEntry(pCur, &pEntry);
+      if( rcEntry!=SQLITE_OK ) return rcEntry;
       if( pEntry->op==PROLLY_EDIT_INSERT
        && prollyMutMapEntryIntKey(pEntry)==iKey ){
         rc = prollyMutMapDeleteEntry(pCur->pMutMap, pEntry);
@@ -1239,7 +1256,9 @@ int prollyBtCursorDelete(BtCursor *pCur, u8 flags){
      && pCur->mmPhysActive
      && pCur->pMutMap
      && (pCur->mergeSrc==MERGE_SRC_MUT || pCur->mergeSrc==MERGE_SRC_BOTH) ){
-      ProllyMutMapEntry *pEntry = currentMutMapEntry(pCur);
+      ProllyMutMapEntry *pEntry;
+      int rcEntry = currentMutMapEntry(pCur, &pEntry);
+      if( rcEntry!=SQLITE_OK ) return rcEntry;
       if( pEntry->op==PROLLY_EDIT_INSERT
        && pEntry->nKey==nKey
        && nKey>0
@@ -1369,7 +1388,9 @@ int prollyBtCursorTransferRow(BtCursor *pDest, BtCursor *pSrc, i64 iKey){
     int nKey;
     if( pSrc->mmActive
      && (pSrc->mergeSrc==MERGE_SRC_MUT || pSrc->mergeSrc==MERGE_SRC_BOTH) ){
-      ProllyMutMapEntry *pEntry = currentMutMapEntry(pSrc);
+      ProllyMutMapEntry *pEntry;
+      int rcEntry = currentMutMapEntry(pSrc, &pEntry);
+      if( rcEntry!=SQLITE_OK ) return rcEntry;
       pKey = pEntry->pKey;
       nKey = pEntry->nKey;
     }else{
@@ -1398,7 +1419,9 @@ int prollyBtCursorPayloadChecked(BtCursor *pCur, u32 offset, u32 amt, void *pBuf
   if( pCur->curIntKey
    && pCur->mmActive
    && (pCur->mergeSrc==MERGE_SRC_MUT || pCur->mergeSrc==MERGE_SRC_BOTH) ){
-    ProllyMutMapEntry *e = currentMutMapEntry(pCur);
+    ProllyMutMapEntry *e;
+    int rcEntry = currentMutMapEntry(pCur, &e);
+    if( rcEntry!=SQLITE_OK ) return rcEntry;
     if( e && e->nZeroTail>0 ){
       return copyZeroTailPayload(e, offset, amt, pBuf);
     }
@@ -1475,7 +1498,10 @@ int prollyBtCursorPutData(BtCursor *pCur, u32 offset, u32 amt, void *pBuf){
     /* A row pending in the mutmap may have no positioned tree cursor. */
     if( pCur->mmActive
      && (pCur->mergeSrc==MERGE_SRC_MUT || pCur->mergeSrc==MERGE_SRC_BOTH) ){
-      payload.nKey = prollyMutMapEntryIntKey(currentMutMapEntry(pCur));
+      ProllyMutMapEntry *pEntry;
+      int rcEntry = currentMutMapEntry(pCur, &pEntry);
+      if( rcEntry!=SQLITE_OK ) return rcEntry;
+      payload.nKey = prollyMutMapEntryIntKey(pEntry);
     }else{
       payload.nKey = prollyCursorIntKey(&pCur->pCur);
     }

--- a/src/prolly_mutmap.c
+++ b/src/prolly_mutmap.c
@@ -991,11 +991,18 @@ int prollyMutMapFindRc(
   return SQLITE_OK;
 }
 
-ProllyMutMapEntry *prollyMutMapEntryAt(ProllyMutMap *mm, int idx){
+int prollyMutMapEntryAt(
+  ProllyMutMap *mm,
+  int idx,
+  ProllyMutMapEntry **ppEntry
+){
+  int rc;
   assert( mm!=0 );
   assert( idx>=0 && idx<mm->nEntries );
-  ensureOrder(mm);
-  return entryAtOrder(mm, idx);
+  rc = ensureOrder(mm);
+  if( rc!=SQLITE_OK ) return rc;
+  *ppEntry = entryAtOrder(mm, idx);
+  return SQLITE_OK;
 }
 
 int prollyMutMapResolveSortedPos(
@@ -1029,6 +1036,7 @@ int prollyMutMapOrderIndexFromEntry(ProllyMutMap *mm, ProllyMutMapEntry *pEntry)
   if( !mm->keepSorted && mm->orderDirty ){
     return rankEntryWithoutOrder(mm, phys);
   }
+  /* Both branches that can fail returned above, so this only refreshes aPos. */
   ensureOrder(mm);
   return mm->aPos[phys];
 }

--- a/src/prolly_mutmap.h
+++ b/src/prolly_mutmap.h
@@ -107,7 +107,7 @@ int prollyMutMapResolveSortedPos(
   int *pIdx, int *pFound
 );
 
-ProllyMutMapEntry *prollyMutMapEntryAt(ProllyMutMap *mm, int idx);
+int prollyMutMapEntryAt(ProllyMutMap *mm, int idx, ProllyMutMapEntry **ppEntry);
 
 int prollyMutMapOrderIndexFromEntry(ProllyMutMap *mm, ProllyMutMapEntry *pEntry);
 

--- a/test/doltlite_recover_mutmap_order_oom.test
+++ b/test/doltlite_recover_mutmap_order_oom.test
@@ -1,0 +1,74 @@
+# Pending edits that arrived out of key order must sort or fail, never both.
+#
+# An unsorted pending set has to be sorted before it can be read in key order,
+# and that sort allocates, so it can fail under memory pressure. This drives
+# both shapes -- an ordered scan and a keyed seek -- so the sort runs and, on
+# the iterations where it fails, the failure has to reach the caller instead of
+# resolving indexes through the pre-sort ordering.
+#
+# Each fault iteration must either fail cleanly or return exactly the correct
+# rows. A right-sized result carrying wrong pairings counts as a failure.
+
+set testdir [file dirname $argv0]
+source $testdir/tester.tcl
+source $testdir/malloc_common.tcl
+
+set testprefix doltlite_recover_mutmap_order_oom
+
+do_execsql_test 1.0 {
+  CREATE TABLE t(a INTEGER PRIMARY KEY, b TEXT);
+  INSERT INTO t VALUES(100, 'hundred');
+  INSERT INTO t VALUES(200, 'twohundred');
+}
+faultsim_save_and_close
+
+# Descending inserts leave appendSorted clear and orderDirty set, so the first
+# ordered read has to sort, and the sort has to allocate.
+do_faultsim_test 1.1 -faults oom-transient -prep {
+  faultsim_restore_and_reopen
+  db eval {
+    BEGIN;
+      INSERT INTO t VALUES(90, 'ninety');
+      INSERT INTO t VALUES(70, 'seventy');
+      INSERT INTO t VALUES(80, 'eighty');
+      INSERT INTO t VALUES(60, 'sixty');
+      INSERT INTO t VALUES(50, 'fifty');
+  }
+} -body {
+  set out [list]
+  db eval { SELECT a, b FROM t ORDER BY a } { lappend out $a $b }
+  set out
+} -test {
+  faultsim_test_result {0 {50 fifty 60 sixty 70 seventy 80 eighty 90 ninety 100 hundred 200 twohundred}} \
+      {1 {out of memory}} {1 {disk I/O error}}
+  catchsql ROLLBACK
+  faultsim_integrity_check
+}
+
+# Same unsorted pending set, reached through a keyed seek rather than a scan,
+# so a stale mapping shows up as the wrong value for a known key.
+do_faultsim_test 1.2 -faults oom-transient -prep {
+  faultsim_restore_and_reopen
+  db eval {
+    BEGIN;
+      INSERT INTO t VALUES(95, 'ninetyfive');
+      INSERT INTO t VALUES(75, 'seventyfive');
+      INSERT INTO t VALUES(85, 'eightyfive');
+      INSERT INTO t VALUES(65, 'sixtyfive');
+  }
+} -body {
+  set out [list]
+  db eval { SELECT b FROM t WHERE a=75 } { lappend out $b }
+  db eval { SELECT b FROM t WHERE a=85 } { lappend out $b }
+  db eval { SELECT a FROM t WHERE a>=65 AND a<=95 ORDER BY a DESC } {
+    lappend out $a
+  }
+  set out
+} -test {
+  faultsim_test_result {0 {seventyfive eightyfive 95 85 75 65}} \
+      {1 {out of memory}} {1 {disk I/O error}}
+  catchsql ROLLBACK
+  faultsim_integrity_check
+}
+
+finish_test

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -7539,7 +7539,10 @@ static int mutmapAssertMatchesModel(
     ok = ok && pEntry->op==pModel->a[i].op;
     ok = ok && ((pEntry->op==PROLLY_EDIT_DELETE)
              || (pEntry->nVal==(int)sizeof(int) && memcmp(pEntry->pVal, &pModel->a[i].val, sizeof(int))==0));
-    ok = ok && prollyMutMapEntryAt(pMap, i)==pEntry;
+    {
+      ProllyMutMapEntry *pAt = 0;
+      ok = ok && prollyMutMapEntryAt(pMap, i, &pAt)==SQLITE_OK && pAt==pEntry;
+    }
     ok = ok && prollyMutMapOrderIndexFromEntry(pMap, pEntry)==i;
     rc = prollyMutMapFindRc(pMap, 0, 0, pModel->a[i].key, &pFind);
     ok = ok && rc==SQLITE_OK;

--- a/test/regression-buckets/fault-fuzz.txt
+++ b/test/regression-buckets/fault-fuzz.txt
@@ -89,3 +89,4 @@ windowfault
 zeroblobfault
 zipfilefault
 doltlite_recover_commit_fail_cursor
+doltlite_recover_mutmap_order_oom


### PR DESCRIPTION
`prollyMutMapEntryAt()` maps a sorted index to an entry, building the ordering first when pending edits arrived out of key order. That sort allocates a scratch buffer, so `ensureOrder()` can return `SQLITE_NOMEM` or `SQLITE_TOOBIG`. The code discarded the return code and indexed through the stale `aOrder` anyway, resolving every index to whichever entry it named before the pending rows were added.

## This one is latent, not observable

I could not build a test that fails before and passes after, and I want to be upfront that the obvious one is misleading. `test/doltlite_recover_mutmap_order_oom.test` drives out-of-order pending inserts under `-faults oom-transient` — and it passes on the **unfixed** engine too.

So I instrumented both the sort's failure path and the discarded-rc branch:

| suite | sort failed | `prollyMutMapEntryAt` saw it |
|---|---|---|
| the new test | 2 | 0 |
| `malloc` | 2 | 0 |
| `mallocA`, `fkey_malloc`, `oomfault` | 0 | 0 |

The sort really does fail under injected OOM. The accessor never observes it, because `mmIdx` is a *sorted-order* index — it cannot exist unless the ordering was already built successfully. Every path that builds it (`ensureCursorMutMapOrder()`, the iterators, `prollyMutMapResolveSortedPos()`) already checks the code.

Nothing guarantees that stays true, which is the argument for this change; but it is footgun-removal, not a live-bug fix, and it costs ~190 lines across 7 source files. Reasonable to weigh that trade before merging.

## The change

`prollyMutMapEntryAt()`, `currentMutMapEntry()` and `orderedMutMapEntryAt()` take the entry as an out-parameter and return `int`. Callers with no error channel — the integer-key, payload-size and payload-fetch accessors — fault the cursor and return their sentinel, matching how they already handle a failed deferred seek.

`prollyMutMapOrderIndexFromEntry()` keeps its bare `ensureOrder()` call. The two branches that can fail have returned by then, so it only refreshes `aPos`; that is now stated in a comment rather than left looking like the same bug.

Two `prollyBtCursorPrevious()` conditions called `orderedMutMapEntryAt()` twice on the same index; they now look it up once.

## Testing

- Gated testfixture spot-check: `select1 where index rowid delete insert update trans` — all OK, 18 known divergences, no new ones.
- c-tests: 310,085 pass. One caller lived in `test/doltlite_regression_test_c.c` and is updated for the new signature.
- doltlite shell battery: 98/99 (`doltlite_parity.sh` needs a stock `./sqlite3` a fresh worktree does not have).
- fault-fuzz bucket running; `attachmalloc`/`fkey_malloc`/`vtab_err` fail identically on pristine master on this machine (a rig offset against the CI-calibrated `@no-coverage` gates), so they are read as pre-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)