### PR TITLE
Reject refs with a missing default branch

### DIFF
--- a/src/chunk_refs.c
+++ b/src/chunk_refs.c
@@ -283,20 +283,32 @@ static int refsReadCount(CsRefsReader *pReader, int nMin, int *pCount){
   return SQLITE_OK;
 }
 
-static int refsReadString(CsRefsReader *pReader, char **pzOut){
+static int refsReadStringView(
+  CsRefsReader *pReader,
+  char **pzOut,
+  const u8 **ppView,
+  int *pnView
+){
   const u8 *p;
   char *z;
   int n;
   int rc = refsReadU32(pReader, &n);
   if( rc!=SQLITE_OK ) return rc;
   rc = refsTake(pReader, n, &p);
-  if( rc!=SQLITE_OK || !pzOut ) return rc;
+  if( rc!=SQLITE_OK ) return rc;
+  if( ppView ) *ppView = p;
+  if( pnView ) *pnView = n;
+  if( !pzOut ) return SQLITE_OK;
   z = sqlite3_malloc64((sqlite3_uint64)n + 1);
   if( !z ) return SQLITE_NOMEM;
   memcpy(z, p, n);
   z[n] = 0;
   *pzOut = z;
   return SQLITE_OK;
+}
+
+static int refsReadString(CsRefsReader *pReader, char **pzOut){
+  return refsReadStringView(pReader, pzOut, 0, 0);
 }
 
 static int refsReadHash(
@@ -341,11 +353,14 @@ int csDecodeRefsV7(
 ){
   CsRefsReader reader;
   const u8 *pVersion;
+  const u8 *pDefaultBranch;
+  int nDefaultBranch;
   int nBranches;
   int nTags;
   int nRemotes;
   int nTracking;
   int nSequences;
+  int hasDefaultBranch = 0;
   int i;
   int rc;
 
@@ -354,7 +369,9 @@ int csDecodeRefsV7(
   reader.n = nData;
   rc = refsTake(&reader, 1, &pVersion);
   if( rc!=SQLITE_OK || pVersion[0]!=7 ) return SQLITE_CORRUPT;
-  rc = refsReadString(&reader, pRefs ? &pRefs->zDefaultBranch : 0);
+  rc = refsReadStringView(&reader,
+      pRefs ? &pRefs->zDefaultBranch : 0,
+      &pDefaultBranch, &nDefaultBranch);
   if( rc!=SQLITE_OK ) return rc;
 
   rc = refsReadCount(&reader, 4 + 2*PROLLY_HASH_SIZE, &nBranches);
@@ -367,7 +384,15 @@ int csDecodeRefsV7(
   }
   for(i=0; i<nBranches; i++){
     BranchRef *pBranch = pRefs ? &pRefs->aBranches[i] : 0;
-    rc = refsReadString(&reader, pBranch ? &pBranch->zName : 0);
+    const u8 *pBranchName;
+    int nBranchName;
+    rc = refsReadStringView(&reader, pBranch ? &pBranch->zName : 0,
+                            &pBranchName, &nBranchName);
+    if( rc==SQLITE_OK
+     && nBranchName==nDefaultBranch
+     && memcmp(pBranchName, pDefaultBranch, nBranchName)==0 ){
+      hasDefaultBranch = 1;
+    }
     if( rc==SQLITE_OK ){
       rc = refsReadHash(&reader, pBranch ? &pBranch->commitHash : 0,
                         xHash, pCtx);
@@ -378,6 +403,7 @@ int csDecodeRefsV7(
     }
     if( rc!=SQLITE_OK ) return rc;
   }
+  if( nBranches>0 && !hasDefaultBranch ) return SQLITE_CORRUPT;
 
   rc = refsReadCount(&reader, 24 + PROLLY_HASH_SIZE, &nTags);
   if( rc!=SQLITE_OK ) return rc;

--- a/src/doltlite_remotesrv.c
+++ b/src/doltlite_remotesrv.c
@@ -485,18 +485,28 @@ static int isSafeDbName(const char *zDbName){
   return 1;
 }
 
+static int remoteSrvResolveRoot(ChunkStore *pStore, ProllyHash *pRoot){
+  const char *zDef = chunkStoreGetDefaultBranch(pStore);
+  int rc = zDef ? chunkStoreFindBranch(pStore, zDef, pRoot) : SQLITE_NOTFOUND;
+  if( rc==SQLITE_NOTFOUND && refsTableBranchCount(&pStore->refs)==0 ){
+    memset(pRoot, 0, sizeof(*pRoot));
+    return SQLITE_OK;
+  }
+  return rc==SQLITE_NOTFOUND ? SQLITE_CORRUPT : rc;
+}
+
+int doltliteRemoteSrvResolveRootForTest(
+  ChunkStore *pStore,
+  ProllyHash *pRoot
+){
+  return remoteSrvResolveRoot(pStore, pRoot);
+}
+
 static void handleGetRoot(ChunkStore *pStore, DoltliteConn *fd){
   ProllyHash root;
-  const char *zDef = chunkStoreGetDefaultBranch(pStore);
-  int rc = zDef ? chunkStoreFindBranch(pStore, zDef, &root) : SQLITE_NOTFOUND;
-  if( rc==SQLITE_OK ){
-    sendOk(fd, root.data, PROLLY_HASH_SIZE);
-  }else if( rc==SQLITE_NOTFOUND ){
-    memset(&root, 0, sizeof(root));
-    sendOk(fd, root.data, PROLLY_HASH_SIZE);
-  }else{
-    sendSqliteError(fd, rc);
-  }
+  int rc = remoteSrvResolveRoot(pStore, &root);
+  if( rc==SQLITE_OK ) sendOk(fd, root.data, PROLLY_HASH_SIZE);
+  else sendSqliteError(fd, rc);
 }
 
 static void handleHasChunks(ChunkStore *pStore, DoltliteConn *fd,

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -31,6 +31,9 @@ extern int doltliteRemoteSrvCommitPendingForTest(ChunkStore *pStore);
 extern int doltliteRemoteSrvApplyRefsForTest(
   ChunkStore *pStore, const u8 *pBody, int nBody
 );
+extern int doltliteRemoteSrvResolveRootForTest(
+  ChunkStore *pStore, ProllyHash *pRoot
+);
 
 static int nPass = 0;
 static int nFail = 0;
@@ -1269,12 +1272,18 @@ static int countChunkChild(void *pCtx, const ProllyHash *pHash){
 static void run_refs_blob_corruption(void){
   ChunkStore cs;
   ChunkStore cs2;
+  ChunkStore branchless;
   ProllyHash commitHash;
+  ProllyHash rootHash;
   ProllyHash workingSetHash;
   u8 *pBlob = 0;
+  u8 *pMissingDefault = 0;
+  u8 *pBranchless = 0;
   u8 *pTrailing = 0;
   u8 shortBlob[13];
   int nBlob = 0;
+  int nMissingDefault = 0;
+  int nBranchless = 0;
   int allTruncationsCorrupt = 1;
   int nChildren = 0;
   int i;
@@ -1287,6 +1296,8 @@ static void run_refs_blob_corruption(void){
         chunkStoreOpen(&cs, sqlite3_vfs_find(0), ":memory:", 0)==SQLITE_OK);
   check("open_mem_store_2",
         chunkStoreOpen(&cs2, sqlite3_vfs_find(0), ":memory:", 0)==SQLITE_OK);
+  check("open_mem_store_branchless",
+        chunkStoreOpen(&branchless, sqlite3_vfs_find(0), ":memory:", 0)==SQLITE_OK);
 
   check("set_default_branch",
         chunkStoreSetDefaultBranch(&cs, "main")==SQLITE_OK);
@@ -1325,6 +1336,32 @@ static void run_refs_blob_corruption(void){
   check("refs_walker_uses_complete_decoder",
         rc==SQLITE_OK && nChildren==4);
 
+  check("set_missing_default_branch",
+        chunkStoreSetDefaultBranch(&cs, "missing")==SQLITE_OK);
+  rc = doltliteRemoteSrvResolveRootForTest(&cs, &rootHash);
+  check("missing_default_branch_root_returns_corrupt", rc==SQLITE_CORRUPT);
+  check("serialize_missing_default_branch",
+        chunkStoreSerializeRefsToBlob(
+          &cs, &pMissingDefault, &nMissingDefault)==SQLITE_OK);
+  check("restore_default_branch",
+        chunkStoreSetDefaultBranch(&cs, "main")==SQLITE_OK);
+  rc = chunkStoreLoadRefsFromBlob(
+      &cs2, pMissingDefault, nMissingDefault);
+  check("missing_default_branch_returns_corrupt", rc==SQLITE_CORRUPT);
+  rc = doltliteEnumerateChunkChildren(
+      pMissingDefault, nMissingDefault, 0, 0);
+  check("refs_walker_rejects_missing_default_branch", rc==SQLITE_CORRUPT);
+
+  check("serialize_branchless_refs",
+        chunkStoreSerializeRefsToBlob(
+          &branchless, &pBranchless, &nBranchless)==SQLITE_OK);
+  rc = doltliteRemoteSrvResolveRootForTest(&branchless, &rootHash);
+  check("branchless_root_is_empty",
+        rc==SQLITE_OK && prollyHashIsEmpty(&rootHash));
+  rc = chunkStoreLoadRefsFromBlob(&cs2, pBranchless, nBranchless);
+  check("branchless_refs_blob_loads",
+        rc==SQLITE_OK && refsTableBranchCount(&cs2.refs)==0);
+
   for(i=0; i<nBlob; i++){
     rc = chunkStoreLoadRefsFromBlob(&cs2, pBlob, i);
     if( rc!=SQLITE_CORRUPT ) allTruncationsCorrupt = 0;
@@ -1348,7 +1385,10 @@ static void run_refs_blob_corruption(void){
   }
 
   sqlite3_free(pTrailing);
+  sqlite3_free(pBranchless);
+  sqlite3_free(pMissingDefault);
   sqlite3_free(pBlob);
+  chunkStoreClose(&branchless);
   chunkStoreClose(&cs2);
   chunkStoreClose(&cs);
 }
@@ -8927,7 +8967,7 @@ static void run_refs_deserialize_overflow_guard(void){
     memcpy(p, "main", 4); p += 4;
     CS_WRITE_U32(p, 1); p += 4;               /* nBranches */
     CS_WRITE_U32(p, 4); p += 4;               /* branch name length */
-    memcpy(p, "feat", 4); p += 4;
+    memcpy(p, "main", 4); p += 4;
     memset(p, 0xAB, PROLLY_HASH_SIZE); p += PROLLY_HASH_SIZE;  /* commit hash */
     memset(p, 0xCD, PROLLY_HASH_SIZE); p += PROLLY_HASH_SIZE;  /* working set */
     CS_WRITE_U32(p, 0); p += 4;               /* nTags */
@@ -8944,7 +8984,7 @@ static void run_refs_deserialize_overflow_guard(void){
     check("refs_roundtrip_branch_count", cs.refs.nBranches==1);
     check("refs_roundtrip_branch_name",
           cs.refs.nBranches==1 && cs.refs.aBranches[0].zName
-          && strcmp(cs.refs.aBranches[0].zName, "feat")==0);
+          && strcmp(cs.refs.aBranches[0].zName, "main")==0);
     csFreeRefsState(&cs);
   }
 


### PR DESCRIPTION
## Summary

- require every non-empty v7 refs table to contain its declared default branch
- apply the invariant in the shared decoder used by refs loading and GC traversal
- return structured corruption from the legacy root endpoint for inconsistent refs while preserving the zero root for branchless repositories
- cover malformed and branchless refs blobs, GC traversal, and root resolution

## Validation

- fail-before: the refs loader and GC walker both accepted a blob whose default branch was absent
- `./doltlite_regression_test_c refs_blob_corruption` (29/29)
- `./doltlite_regression_test_c refs_deserialize_overflow_guard` (6/6)
- `bash test/remotesrv_http_test.sh build/doltlite build/doltlite-remotesrv` (29/29)
- `bash test/run_doltlite_tests.sh` (99/99 suites; 310,093 C regression assertions)
- `make lint`

Co-Authored-By: OpenAI Codex <noreply@openai.com>
