### PR TITLE
Don't mirror a rebase over another branch's uncommitted work

### DIFF
--- a/src/doltlite_rebase.c
+++ b/src/doltlite_rebase.c
@@ -104,6 +104,43 @@ static int rebaseRestoreReturnBranchWorkingState(
   doltliteCommitClear(&c);
   return rc;
 }
+/* True if zBranch holds working-set changes its head commit does not. An
+** interactive rebase mirrors its working set onto the return branch so a
+** reopen can resume, and clears that branch at the end -- both of which
+** destroy uncommitted work, so a dirty branch must not be adopted as the
+** mirror target. Rebase already refuses to start with a dirty current branch;
+** the return branch is a different one and has no such guarantee. */
+static int rebaseBranchHasUncommittedWork(
+  sqlite3 *db,
+  const char *zBranch,
+  int *pDirty
+){
+  ChunkStore *cs = doltliteGetChunkStore(db);
+  DoltliteCommit c;
+  ProllyHash headHash, wsCat, wsCommit;
+  int rc;
+
+  *pDirty = 0;
+  if( !cs || !zBranch || !zBranch[0] ) return SQLITE_OK;
+  rc = chunkStoreFindBranch(cs, zBranch, &headHash);
+  if( rc!=SQLITE_OK ) return rc==SQLITE_NOTFOUND ? SQLITE_OK : rc;
+  memset(&wsCat, 0, sizeof(wsCat));
+  memset(&wsCommit, 0, sizeof(wsCommit));
+  if( chunkStoreReadBranchWorkingCatalog(cs, zBranch, &wsCat, &wsCommit)
+        !=SQLITE_OK ){
+    return SQLITE_OK;
+  }
+  memset(&c, 0, sizeof(c));
+  rc = doltliteLoadCommit(db, &headHash, &c);
+  if( rc==SQLITE_OK
+   && prollyHashCompare(&wsCommit, &headHash)==0
+   && prollyHashCompare(&wsCat, &c.catalogHash)!=0 ){
+    *pDirty = 1;
+  }
+  doltliteCommitClear(&c);
+  return rc;
+}
+
 static int doltliteRebaseCollectReplaySet(
   sqlite3 *db,
   const ProllyHash *pHeadHash,
@@ -1169,6 +1206,17 @@ static void doltliteRebaseInteractiveStart(
       sqlite3_result_error(context,
         "rebase working branch already exists", -1);
       return;
+    }
+  }
+
+  {
+    int dirty = 0;
+    rc = rebaseBranchHasUncommittedWork(db, zReturnBranch, &dirty);
+    if( rc!=SQLITE_OK ) goto fail;
+    if( dirty ){
+      /* Empty disables both the mirror and the end-of-rebase clear. The rebase
+      ** still runs; only resuming it after a reopen is given up. */
+      zReturnBranch[0] = 0;
     }
   }
 

--- a/test/doltlite_rebase.sh
+++ b/test/doltlite_rebase.sh
@@ -99,7 +99,70 @@ run_test "start_failure_temp_branch_removed" \
   "0" \
   "$DB2"
 
-rm -f "$DB" "$DB2"
+# An interactive rebase mirrors its working set onto the branch a reopen would
+# land on, and clears that branch when it finishes. Rebase only refuses to
+# start over a dirty *current* branch, so uncommitted work on the other branch
+# used to be destroyed. The two controls establish that neither a plain
+# checkout roundtrip nor a non-interactive rebase ever did this.
+seed_dirty_main() {
+  rm -f "$1"
+  cat <<'SQL' | "$DOLTLITE" "$1" >/dev/null 2>&1
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'one');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','init');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO t VALUES(10,'f1');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','f1');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES(2,'m1');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','m1');
+INSERT INTO t VALUES(99,'row99');
+SQL
+}
+
+DB3=/tmp/test_rebase_dirty_$$.db
+seed_dirty_main "$DB3"
+run_test "interactive_rebase_keeps_other_branch_uncommitted_work" \
+  "SELECT dolt_checkout('feat');
+   SELECT dolt_rebase('-i','main');
+   SELECT dolt_rebase('--continue');
+   SELECT dolt_checkout('main');
+   SELECT count(*) FROM t WHERE v='row99';" \
+  "0
+interactive rebase started on branch dolt_rebase_feat; adjust the rebase plan in the dolt_rebase table, then continue rebasing by calling dolt_rebase('--continue')
+Successfully rebased and updated refs/heads/feat
+0
+1" \
+  "$DB3"
+
+seed_dirty_main "$DB3"
+run_test_match "interactive_rebase_abort_keeps_other_branch_uncommitted_work" \
+  "SELECT dolt_checkout('feat');
+   SELECT dolt_rebase('-i','main');
+   SELECT dolt_rebase('--abort');
+   SELECT dolt_checkout('main');
+   SELECT count(*) FROM t WHERE v='row99';" \
+  "^1$" \
+  "$DB3"
+
+seed_dirty_main "$DB3"
+run_test_match "checkout_roundtrip_keeps_uncommitted_work" \
+  "SELECT dolt_checkout('feat');
+   SELECT dolt_checkout('main');
+   SELECT count(*) FROM t WHERE v='row99';" \
+  "^1$" \
+  "$DB3"
+
+seed_dirty_main "$DB3"
+run_test_match "noninteractive_rebase_keeps_other_branch_uncommitted_work" \
+  "SELECT dolt_checkout('feat');
+   SELECT dolt_rebase('main');
+   SELECT dolt_checkout('main');
+   SELECT count(*) FROM t WHERE v='row99';" \
+  "^1$" \
+  "$DB3"
+
+rm -f "$DB" "$DB2" "$DB3"
 echo ""
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"
 if [ $FAIL -gt 0 ]; then echo -e "$ERRORS"; exit 1; fi


### PR DESCRIPTION
Recommendation 4 from the code review, and the most serious bug in it: **silent loss of uncommitted user data on a branch the operation was never asked to touch.**

## The bug

An interactive rebase mirrors every working-set save from its working branch onto `zRebaseReturnBranch` (`prolly_btree_state.c:949-956`), and clears that branch to a clean state when it finishes (`rebaseRestoreReturnBranchWorkingState`). That return branch is the store's *default* branch (`doltlite_rebase.c:1152`) — not the branch being rebased.

Rebase refuses to start over a dirty *current* branch, so the branch you are rebasing is protected. Nothing protected the other one.

```
main dirty before:|1
rebase:|interactive rebase started on branch dolt_rebase_feature...
Successfully rebased and updated refs/heads/feature
main row99 after:|0        <- uncommitted row silently gone
```

Both `--continue` and `--abort` destroy it. Two controls confirm the scope:

| scenario | `row99` on `main` |
|---|---|
| interactive rebase `--continue` | **destroyed** |
| interactive rebase `--abort` | **destroyed** |
| plain checkout roundtrip | survives |
| non-interactive rebase | survives |

## Why not just retarget the mirror

`zReturnBranch` looks misnamed, and the obvious fix is to point it at the branch being rebased. That is wrong. `0b8dc2bd3d` ("Fix interactive rebase reopen working-set mirroring") *removed* an earlier `chunkStoreSetDefaultBranch(cs, zWorking)` and replaced it with this mirror precisely so a reopen mid-rebase lands on the default branch rather than being stranded on `dolt_rebase_*` — `doltlite_savepoint.sh` pins that with `rebase_resolve_theirs_top_savepoint_reopen_main`. Retargeting the mirror would regress it.

So instead: the return branch is adopted only when it has no uncommitted work of its own. An empty return branch already disables both the mirror and the end-of-rebase clear at every site that consults it (all guard on `zReturnBranch[0]`, and the `--continue`/`--abort` guards test for NULL, not empty), so the rebase still runs normally. The only thing given up is resuming a rebase after a reopen, and only in the case that previously lost data — strictly better than destroying it.

When the default branch is clean the new code path does not execute at all, so existing behaviour is untouched.

## Testing

- Four new tests in `doltlite_rebase.sh`. The two interactive ones fail on unfixed master; the two controls pass on unfixed master, which is what makes them controls rather than tautologies. 12/12 with the fix, 10/12 without.
- `doltlite_rebase.sh` 12/12, `doltlite_rebase_schema.sh` 23/23, `doltlite_savepoint.sh` 128/128 — the last includes the reopen assertion above.
- Full shell battery 98/99 (`doltlite_parity.sh` needs a stock `./sqlite3` a fresh worktree does not have).
- c-tests with `DOLTLITE_PROLLY_CHECK=1`: 310,085 pass.
- Verified separately that reopen-then-`--continue` is already broken on unfixed master in the same way, so that is pre-existing and not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)