### PR TITLE
Ignore stale working sets after branch advancement

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -699,31 +699,12 @@ int sqlite3BtreeOpen(
   p->aMeta[BTREE_APPLICATION_ID] = 0;
 
   {
-    ProllyHash catHash;
-    ProllyHash workingCommit;
-    ProllyHash stagedCatalog;
-    ProllyHash mergeCommitHash;
-    ProllyHash conflictsCatalogHash;
+    BtreeBranchState state;
     ProllyHash branchCommit;
-    ProllyHash preRebaseCat;
-    ProllyHash rebaseOnto;
-    ProllyHash constraintViolationsHash;
-    char *zRebaseOrigBranch = 0;
-    char *zRebaseReturnBranch = 0;
-    u8 isRebasing = 0;
     const char *zDef = zBranchFromPath ? zBranchFromPath :
       chunkStoreGetDefaultBranch(&pBt->store);
-    u8 isMerging = 0;
     if( !zDef ) zDef = "main";
-    memset(&catHash, 0, sizeof(catHash));
-    memset(&workingCommit, 0, sizeof(workingCommit));
-    memset(&stagedCatalog, 0, sizeof(stagedCatalog));
-    memset(&mergeCommitHash, 0, sizeof(mergeCommitHash));
-    memset(&conflictsCatalogHash, 0, sizeof(conflictsCatalogHash));
     memset(&branchCommit, 0, sizeof(branchCommit));
-    memset(&preRebaseCat, 0, sizeof(preRebaseCat));
-    memset(&rebaseOnto, 0, sizeof(rebaseOnto));
-    memset(&constraintViolationsHash, 0, sizeof(constraintViolationsHash));
     if( zBranchFromPath
      && chunkStoreFindBranch(&pBt->store, zDef, &branchCommit)!=SQLITE_OK ){
       sqlite3ErrorWithMsg(db, SQLITE_ERROR, "unable to select branch \"%s\"",
@@ -736,15 +717,7 @@ int sqlite3BtreeOpen(
       sqlite3_free(p);
       return SQLITE_ERROR;
     }
-    rc = btreeLoadWorkingSetBlob(&pBt->store, zDef, &catHash, &workingCommit,
-                                 &stagedCatalog, &isMerging,
-                                 &mergeCommitHash, &conflictsCatalogHash,
-                                 &isRebasing, &preRebaseCat, &rebaseOnto,
-                                 &zRebaseOrigBranch, &zRebaseReturnBranch,
-                                 &constraintViolationsHash);
-    if( rc==SQLITE_NOTFOUND ){
-      rc = SQLITE_OK;
-    }
+    rc = btreeLoadBranchState(&pBt->store, zDef, 1, &state);
     if( rc!=SQLITE_OK ){
       pagerShimDestroy(pBt->pPagerShim);
       prollyCacheFree(&pBt->cache);
@@ -754,29 +727,15 @@ int sqlite3BtreeOpen(
       sqlite3_free(p);
       return rc;
     }
-    if( prollyHashIsEmpty(&catHash) ){
-      rc = btreeLoadBranchHeadCatalog(&pBt->store, zDef, &catHash, 0);
-      if( rc==SQLITE_NOTFOUND ){
-        rc = SQLITE_OK;
-      }
-      if( rc!=SQLITE_OK ){
-        pagerShimDestroy(pBt->pPagerShim);
-        prollyCacheFree(&pBt->cache);
-        chunkStoreClose(&pBt->store);
-        sqlite3_free(zStoreFilename);
-        sqlite3_free(pBt);
-        sqlite3_free(p);
-        return rc;
-      }
-    }
-    if( !prollyHashIsEmpty(&catHash) ){
+    if( !prollyHashIsEmpty(&state.catalog) ){
       u8 *catData = 0;
       int nCatData = 0;
-      rc = chunkStoreGet(&pBt->store, &catHash, &catData, &nCatData);
+      rc = chunkStoreGet(&pBt->store, &state.catalog, &catData, &nCatData);
       if( rc==SQLITE_OK && catData ){
         rc = deserializeCatalog(p, catData, nCatData);
         sqlite3_free(catData);
         if( rc!=SQLITE_OK ){
+          btreeClearBranchState(&state);
           pagerShimDestroy(pBt->pPagerShim);
           prollyCacheFree(&pBt->cache);
           chunkStoreClose(&pBt->store);
@@ -788,6 +747,7 @@ int sqlite3BtreeOpen(
       }else{
         sqlite3_free(catData);
         if( rc!=SQLITE_OK ){
+          btreeClearBranchState(&state);
           pagerShimDestroy(pBt->pPagerShim);
           prollyCacheFree(&pBt->cache);
           chunkStoreClose(&pBt->store);
@@ -799,23 +759,17 @@ int sqlite3BtreeOpen(
       }
     }
 
-    if( chunkStoreFindBranch(&pBt->store, zDef, &branchCommit)==SQLITE_OK ){
-      memcpy(&p->headCommit, &branchCommit, sizeof(ProllyHash));
-    }else if( !prollyHashIsEmpty(&workingCommit) ){
-      memcpy(&p->headCommit, &workingCommit, sizeof(ProllyHash));
-    }else{
-      memset(&p->headCommit, 0, sizeof(ProllyHash));
-    }
-    p->vc.stagedCatalog = stagedCatalog;
-    p->vc.isMerging = isMerging;
-    p->vc.mergeCommitHash = mergeCommitHash;
-    p->vc.conflictsCatalogHash = conflictsCatalogHash;
-    p->isRebasing = isRebasing;
-    p->preRebaseWorkingCat = preRebaseCat;
-    p->rebaseOntoCommit = rebaseOnto;
-    p->zRebaseOrigBranch = zRebaseOrigBranch;
-    p->zRebaseReturnBranch = zRebaseReturnBranch;
-    p->vc.constraintViolationsHash = constraintViolationsHash;
+    p->headCommit = state.headCommit;
+    p->vc.stagedCatalog = state.stagedCatalog;
+    p->vc.isMerging = state.isMerging;
+    p->vc.mergeCommitHash = state.mergeCommit;
+    p->vc.conflictsCatalogHash = state.conflictsCatalog;
+    p->isRebasing = state.isRebasing;
+    p->preRebaseWorkingCat = state.preRebaseCatalog;
+    p->rebaseOntoCommit = state.rebaseOnto;
+    p->zRebaseOrigBranch = state.zRebaseOrigBranch;
+    p->zRebaseReturnBranch = state.zRebaseReturnBranch;
+    p->vc.constraintViolationsHash = state.constraintViolations;
   }
 
   p->cat.iNextTable = 2;

--- a/src/prolly_btree_int.h
+++ b/src/prolly_btree_int.h
@@ -691,6 +691,23 @@ extern const struct BtCursorOps prollyCursorOps;
 extern const struct BtCursorOps origCursorVtOps;
 
 int btreeLoadBranchHeadCatalog(ChunkStore*, const char*, ProllyHash*, ProllyHash*);
+typedef struct BtreeBranchState BtreeBranchState;
+struct BtreeBranchState {
+  ProllyHash catalog;
+  ProllyHash headCommit;
+  ProllyHash stagedCatalog;
+  ProllyHash mergeCommit;
+  ProllyHash conflictsCatalog;
+  ProllyHash preRebaseCatalog;
+  ProllyHash rebaseOnto;
+  ProllyHash constraintViolations;
+  char *zRebaseOrigBranch;
+  char *zRebaseReturnBranch;
+  u8 isMerging;
+  u8 isRebasing;
+};
+int btreeLoadBranchState(ChunkStore*, const char*, int, BtreeBranchState*);
+void btreeClearBranchState(BtreeBranchState*);
 int btreeLoadWorkingSetBlob(ChunkStore*, const char*, ProllyHash*, ProllyHash*,
                             ProllyHash*, u8*, ProllyHash*, ProllyHash*, u8*,
                             ProllyHash*, ProllyHash*, char**, char**, ProllyHash*);

--- a/src/prolly_btree_state.c
+++ b/src/prolly_btree_state.c
@@ -165,6 +165,7 @@ int btreeLoadBranchState(
   ProllyHash committedCatalog;
   ProllyHash headCommit;
   ProllyHash workingCommit;
+  int useWorkingState;
   int rc;
 
   assert( cs!=0 && zBranch!=0 && pState!=0 );
@@ -173,7 +174,7 @@ int btreeLoadBranchState(
   memset(&headCommit, 0, sizeof(headCommit));
   memset(&workingCommit, 0, sizeof(workingCommit));
 
-  rc = btreeLoadBranchHeadCatalog(cs, zBranch, &committedCatalog, &headCommit);
+  rc = chunkStoreFindBranch(cs, zBranch, &headCommit);
   if( rc==SQLITE_NOTFOUND ) rc = SQLITE_OK;
   if( rc!=SQLITE_OK ) return rc;
 
@@ -188,12 +189,17 @@ int btreeLoadBranchState(
     btreeClearBranchState(pState);
     return rc;
   }
-  if( rc==SQLITE_NOTFOUND
-   || (prollyHashCompare(&workingCommit, &headCommit)!=0
-       && !(bSeedRepair && prollyHashIsEmpty(&headCommit))) ){
+  useWorkingState = rc==SQLITE_OK
+    && (prollyHashCompare(&workingCommit, &headCommit)==0
+        || (bSeedRepair && prollyHashIsEmpty(&headCommit)));
+  if( !useWorkingState ){
     btreeClearBranchState(pState);
-    pState->catalog = committedCatalog;
-  }else if( prollyHashIsEmpty(&pState->catalog) ){
+  }
+  if( !useWorkingState || prollyHashIsEmpty(&pState->catalog) ){
+    if( !prollyHashIsEmpty(&headCommit) ){
+      rc = btreeLoadBranchHeadCatalog(cs, zBranch, &committedCatalog, 0);
+      if( rc!=SQLITE_OK ) return rc;
+    }
     pState->catalog = committedCatalog;
   }
   pState->headCommit = headCommit;

--- a/src/prolly_btree_state.c
+++ b/src/prolly_btree_state.c
@@ -149,6 +149,57 @@ int btreeLoadBranchHeadCatalog(
   return SQLITE_OK;
 }
 
+void btreeClearBranchState(BtreeBranchState *pState){
+  if( !pState ) return;
+  sqlite3_free(pState->zRebaseOrigBranch);
+  sqlite3_free(pState->zRebaseReturnBranch);
+  memset(pState, 0, sizeof(*pState));
+}
+
+int btreeLoadBranchState(
+  ChunkStore *cs,
+  const char *zBranch,
+  int bSeedRepair,
+  BtreeBranchState *pState
+){
+  ProllyHash committedCatalog;
+  ProllyHash headCommit;
+  ProllyHash workingCommit;
+  int rc;
+
+  assert( cs!=0 && zBranch!=0 && pState!=0 );
+  memset(pState, 0, sizeof(*pState));
+  memset(&committedCatalog, 0, sizeof(committedCatalog));
+  memset(&headCommit, 0, sizeof(headCommit));
+  memset(&workingCommit, 0, sizeof(workingCommit));
+
+  rc = btreeLoadBranchHeadCatalog(cs, zBranch, &committedCatalog, &headCommit);
+  if( rc==SQLITE_NOTFOUND ) rc = SQLITE_OK;
+  if( rc!=SQLITE_OK ) return rc;
+
+  rc = btreeLoadWorkingSetBlob(
+      cs, zBranch, &pState->catalog, &workingCommit,
+      &pState->stagedCatalog, &pState->isMerging,
+      &pState->mergeCommit, &pState->conflictsCatalog,
+      &pState->isRebasing, &pState->preRebaseCatalog,
+      &pState->rebaseOnto, &pState->zRebaseOrigBranch,
+      &pState->zRebaseReturnBranch, &pState->constraintViolations);
+  if( rc!=SQLITE_OK && rc!=SQLITE_NOTFOUND ){
+    btreeClearBranchState(pState);
+    return rc;
+  }
+  if( rc==SQLITE_NOTFOUND
+   || (prollyHashCompare(&workingCommit, &headCommit)!=0
+       && !(bSeedRepair && prollyHashIsEmpty(&headCommit))) ){
+    btreeClearBranchState(pState);
+    pState->catalog = committedCatalog;
+  }else if( prollyHashIsEmpty(&pState->catalog) ){
+    pState->catalog = committedCatalog;
+  }
+  pState->headCommit = headCommit;
+  return SQLITE_OK;
+}
+
 void btreeFillWorkingSetBlob(
   u8 *buf,
   const ProllyHash *pWorkingCat,
@@ -304,19 +355,8 @@ int btreeReloadBranchWorkingStateInto(
   ProllyHash *pLoadedCatHash
 ){
   BtShared *pBt;
-  ProllyHash catHash;
-  ProllyHash workingCommitHash;
-  ProllyHash stagedCatalog;
-  ProllyHash mergeCommitHash;
-  ProllyHash conflictsCatalogHash;
-  ProllyHash preRebaseCat;
-  ProllyHash rebaseOnto;
-  ProllyHash constraintViolationsHash;
-  char *zRebaseOrigBranch = 0;
-  char *zRebaseReturnBranch = 0;
+  BtreeBranchState state;
   const char *zBr;
-  u8 isMerging = 0;
-  u8 isRebasing = 0;
   int hadUserCatalog;
   int rc;
 
@@ -324,87 +364,53 @@ int btreeReloadBranchWorkingStateInto(
   pBt = p->pBt;
   zBr = p->zBranch ? p->zBranch : "main";
   hadUserCatalog = p->cat.n > 1;
-  memset(&catHash, 0, sizeof(catHash));
-  memset(&workingCommitHash, 0, sizeof(workingCommitHash));
-  memset(&stagedCatalog, 0, sizeof(stagedCatalog));
-  memset(&mergeCommitHash, 0, sizeof(mergeCommitHash));
-  memset(&conflictsCatalogHash, 0, sizeof(conflictsCatalogHash));
-  memset(&preRebaseCat, 0, sizeof(preRebaseCat));
-  memset(&rebaseOnto, 0, sizeof(rebaseOnto));
-  memset(&constraintViolationsHash, 0, sizeof(constraintViolationsHash));
 
   rc = chunkStoreEnsureRefsFresh(&pBt->store);
   if( rc!=SQLITE_OK ) return rc;
-  rc = btreeLoadWorkingSetBlob(
-      &pBt->store, zBr, &catHash, &workingCommitHash, &stagedCatalog, &isMerging,
-      &mergeCommitHash, &conflictsCatalogHash,
-      &isRebasing, &preRebaseCat, &rebaseOnto, &zRebaseOrigBranch,
-      &zRebaseReturnBranch,
-      &constraintViolationsHash);
-  if( rc==SQLITE_NOTFOUND ){
-    rc = SQLITE_OK;
-  }
-  if( rc!=SQLITE_OK ){
-    sqlite3_free(zRebaseOrigBranch);
-    sqlite3_free(zRebaseReturnBranch);
-    return rc;
-  }
-  if( prollyHashIsEmpty(&catHash) ){
-    rc = btreeLoadBranchHeadCatalog(&pBt->store, zBr, &catHash,
-                                    &workingCommitHash);
-    if( rc==SQLITE_NOTFOUND ){
-      rc = SQLITE_OK;
-    }
-    if( rc!=SQLITE_OK ){
-      sqlite3_free(zRebaseOrigBranch);
-      sqlite3_free(zRebaseReturnBranch);
-      return rc;
-    }
-  }
+  rc = btreeLoadBranchState(&pBt->store, zBr, 0, &state);
+  if( rc!=SQLITE_OK ) return rc;
 
   if( bLoadCatalog
-   && !prollyHashIsEmpty(&catHash)
+   && !prollyHashIsEmpty(&state.catalog)
    && (prollyHashIsEmpty(&p->committedCatalogHash)
-       || prollyHashCompare(&catHash, &p->committedCatalogHash)!=0) ){
+       || prollyHashCompare(&state.catalog, &p->committedCatalogHash)!=0) ){
     u8 *catData = 0;
     int nCatData = 0;
-    rc = chunkStoreGet(&pBt->store, &catHash, &catData, &nCatData);
+    rc = chunkStoreGet(&pBt->store, &state.catalog, &catData, &nCatData);
     if( rc==SQLITE_OK && catData ){
       rc = deserializeCatalog(p, catData, nCatData);
       sqlite3_free(catData);
       if( rc!=SQLITE_OK ){
-        sqlite3_free(zRebaseOrigBranch);
-        sqlite3_free(zRebaseReturnBranch);
+        btreeClearBranchState(&state);
         return rc;
       }
     }else{
       sqlite3_free(catData);
       if( rc!=SQLITE_OK ){
-        sqlite3_free(zRebaseOrigBranch);
-        sqlite3_free(zRebaseReturnBranch);
+        btreeClearBranchState(&state);
         return rc;
       }
     }
   }
   if( prollyHashIsEmpty(&p->headCommit) || !hadUserCatalog ){
-    p->headCommit = workingCommitHash;
+    p->headCommit = state.headCommit;
   }
   if( pLoadedCatHash ){
-    *pLoadedCatHash = catHash;
+    *pLoadedCatHash = state.catalog;
   }
 
-  p->vc.stagedCatalog = stagedCatalog;
-  p->vc.isMerging = isMerging;
-  p->vc.mergeCommitHash = mergeCommitHash;
-  p->vc.conflictsCatalogHash = conflictsCatalogHash;
-  p->isRebasing = isRebasing;
-  p->preRebaseWorkingCat = preRebaseCat;
-  p->rebaseOntoCommit = rebaseOnto;
+  p->vc.stagedCatalog = state.stagedCatalog;
+  p->vc.isMerging = state.isMerging;
+  p->vc.mergeCommitHash = state.mergeCommit;
+  p->vc.conflictsCatalogHash = state.conflictsCatalog;
+  p->isRebasing = state.isRebasing;
+  p->preRebaseWorkingCat = state.preRebaseCatalog;
+  p->rebaseOntoCommit = state.rebaseOnto;
   sqlite3_free(p->zRebaseOrigBranch);
-  p->zRebaseOrigBranch = zRebaseOrigBranch;
+  p->zRebaseOrigBranch = state.zRebaseOrigBranch;
   sqlite3_free(p->zRebaseReturnBranch);
-  p->zRebaseReturnBranch = zRebaseReturnBranch;
-  p->vc.constraintViolationsHash = constraintViolationsHash;
+  p->zRebaseReturnBranch = state.zRebaseReturnBranch;
+  p->vc.constraintViolationsHash = state.constraintViolations;
   return SQLITE_OK;
 }
 

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -4100,6 +4100,58 @@ static void run_open_rejects_corrupt_working_set(void){
   removeDbFiles(dbpath);
 }
 
+static void run_open_ignores_stale_working_set(void){
+  sqlite3 *db = 0;
+  sqlite3 *db2 = 0;
+  sqlite3 *db3 = 0;
+  ChunkStore cs;
+  ProllyHash staleWorkingSet;
+  char dbpath[256];
+
+  printf("=== Open Ignores Stale Working Set Test ===\n\n");
+  make_dbpath(dbpath, sizeof(dbpath), "test_open_ignores_stale_working_set");
+  removeDbFiles(dbpath);
+
+  check("open_db_for_stale_working_set", open_db(dbpath, &db)==SQLITE_OK);
+  check("setup_repo_for_stale_working_set", execSql(db,
+    "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
+    "INSERT INTO t VALUES(1,'one');"
+    "SELECT dolt_commit('-A', '-m', 'first');")==SQLITE_OK);
+  check("capture_stale_working_set",
+        chunkStoreGetBranchWorkingSet(doltliteGetChunkStore(db), "main",
+                                      &staleWorkingSet)==SQLITE_OK);
+  check("open_peer_before_head_advance", open_db(dbpath, &db2)==SQLITE_OK);
+  check("advance_head_past_stale_working_set", execSql(db,
+    "INSERT INTO t VALUES(2,'two');"
+    "SELECT dolt_commit('-A', '-m', 'second');")==SQLITE_OK);
+  sqlite3_close(db);
+  db = 0;
+
+  check("open_store_to_restore_stale_working_set",
+        chunkStoreOpen(&cs, sqlite3_vfs_find(0), dbpath,
+          SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_MAIN_DB)==SQLITE_OK);
+  check("restore_stale_working_set",
+        chunkStoreSetBranchWorkingSet(&cs, "main", &staleWorkingSet)==SQLITE_OK);
+  check("serialize_stale_working_set_refs",
+        chunkStoreSerializeRefs(&cs)==SQLITE_OK);
+  check("commit_stale_working_set_refs", chunkStoreCommit(&cs)==SQLITE_OK);
+  chunkStoreClose(&cs);
+
+  check("peer_refresh_follows_head_past_stale_working_set",
+        strcmp(queryScalarText(db2, "SELECT count(*) FROM t"), "2")==0);
+  sqlite3_close(db2);
+
+  check("reopen_db_with_stale_working_set", open_db(dbpath, &db3)==SQLITE_OK);
+  check("head_retains_second_commit",
+        strcmp(queryScalarText(db3, "SELECT message FROM dolt_log LIMIT 1"),
+               "second")==0);
+  check("live_catalog_follows_head_past_stale_working_set",
+        strcmp(queryScalarText(db3, "SELECT count(*) FROM t"), "2")==0);
+
+  sqlite3_close(db3);
+  removeDbFiles(dbpath);
+}
+
 static void run_diff_stat_requires_refs(void){
   sqlite3 *db = 0;
   char dbpath[256];
@@ -9390,6 +9442,7 @@ static const RegressionCase aCases[] = {
   { "begin_write_refreshes_working_set_metadata", "Begin Write Refreshes Working Set Metadata Test", run_begin_write_refreshes_working_set_metadata },
   { "begin_write_from_stale_read_snapshot", "Begin Write From Stale Read Snapshot Test", run_begin_write_from_stale_read_snapshot },
   { "open_rejects_corrupt_working_set", "Open Rejects Corrupt Working Set Test", run_open_rejects_corrupt_working_set },
+  { "open_ignores_stale_working_set", "Open Ignores Stale Working Set Test", run_open_ignores_stale_working_set },
   { "diff_stat_requires_refs", "Diff Stat Requires Refs Test", run_diff_stat_requires_refs },
   { "diff_stat_wide_modified_rows", "Diff Stat Wide Modified Rows Test", run_diff_stat_wide_modified_rows },
   { "diff_table_deep_history_map", "Diff Table Deep History Map Test", run_diff_table_deep_history_map },


### PR DESCRIPTION
Closes #1959.

## Root cause

The merge and concurrent writer both preserved the committed graph, but a stale branch working-set ref could survive with a catalog recorded against an older commit. Database open and refresh trusted that catalog without checking its recorded commit against the current branch tip. The result matched the nightly failure: `HEAD` contained the merged feature rows while the live table opened from an older catalog and omitted them.

## Fix

- Resolve the branch tip and working-set blob together in one storage-engine helper.
- Use working catalog, staged state, merge state, rebase state, and constraint-violation state only when the working-set commit matches the current branch tip.
- Fall back atomically to the committed catalog and clean metadata when the working set is stale.
- Preserve the existing empty-tip seed-repair path used when repairing an attached database.
- Keep the connection's expected HEAD unchanged during refresh so stale ref mutations still fail their CAS check.

## Tests

The new regression deterministically restores an old working-set ref after advancing `main`. It fails on master because both an already-open peer and a fresh reopen see the stale catalog; both follow current HEAD with this fix.

Validated with:

- `test/doltlite_regression_test_c.sh` — 310,108 assertions passed
- `test/run_c_tests.sh build specialized --no-build` — concurrency, multiprocess, GC, merge/rebase, and OOM gates passed
- `multi_process_merge_rebase_test` — 30/30 passed
- `make lint`
- Remaining 98 suites in `test/run_doltlite_tests.sh` passed; the one regression-suite failure found during that run is the attached seed-repair case covered and passing above

🤖 Generated with [OpenAI Codex](https://openai.com/codex)