### PR TITLE
Name the offending action when a rebase plan verb is unknown

### DIFF
--- a/src/doltlite_rebase.c
+++ b/src/doltlite_rebase.c
@@ -1400,16 +1400,26 @@ static void doltliteRebaseInteractiveContinue(
   rc = doltliteEnsureWriteTxnAndSavepoints(db);
   if( rc!=SQLITE_OK ) goto abort_err;
 
-  /* Reject any unknown plan verb (e.g. a typo in dolt_rebase.action) instead
-  ** of silently treating it as a pick; abort_err restores the pre-rebase
-  ** branch and reports the failure. */
+  /* Reject any unknown plan verb (e.g. a typo in dolt_rebase.action) instead of
+  ** silently treating it as a pick. The rebase stays in progress so the plan can
+  ** be corrected and --continue retried, so name the offending action rather
+  ** than reporting a bare failure. */
   for(i=0; i<nPlan; i++){
     const char *zAct = aPlan[i].zAction;
     if( strcmp(zAct,"pick")!=0 && strcmp(zAct,"reword")!=0
      && strcmp(zAct,"squash")!=0 && strcmp(zAct,"fixup")!=0
      && strcmp(zAct,"drop")!=0 ){
+      char *zMsg = sqlite3_mprintf(
+          "unknown rebase action \"%s\": expected pick, reword, squash, "
+          "fixup or drop", zAct);
       rc = SQLITE_ERROR;
-      goto abort_err;
+      if( zMsg ){
+        sqlite3_result_error(context, zMsg, -1);
+        sqlite3_free(zMsg);
+      }else{
+        sqlite3_result_error_nomem(context);
+      }
+      goto abort_err_silent;
     }
   }
 

--- a/test/doltlite_rebase.sh
+++ b/test/doltlite_rebase.sh
@@ -162,7 +162,45 @@ run_test_match "noninteractive_rebase_keeps_other_branch_uncommitted_work" \
   "^1$" \
   "$DB3"
 
-rm -f "$DB" "$DB2" "$DB3"
+# An unrecognised plan verb used to report a bare "rebase failed", which reads
+# as though the rebase had been rolled back. It is not: the plan and working
+# branch are deliberately kept so the action can be corrected and --continue
+# retried, so the error has to name what was wrong.
+DB4=/tmp/test_rebase_verb_$$.db
+seed_verb_repo() {
+  rm -f "$1"
+  cat <<'SQL' | "$DOLTLITE" "$1" >/dev/null 2>&1
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES(1,1);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','init');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO t VALUES(2,2);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','f1');
+SELECT dolt_checkout('main');
+SQL
+}
+
+seed_verb_repo "$DB4"
+run_test_match "unknown_plan_action_names_the_action" \
+  "SELECT dolt_checkout('feat');
+   SELECT dolt_rebase('-i','main');
+   UPDATE dolt_rebase SET action='oops';
+   SELECT dolt_rebase('--continue');" \
+  'unknown rebase action "oops": expected pick, reword, squash, fixup or drop' \
+  "$DB4"
+
+seed_verb_repo "$DB4"
+run_test_match "unknown_plan_action_stays_resumable" \
+  "SELECT dolt_checkout('feat');
+   SELECT dolt_rebase('-i','main');
+   UPDATE dolt_rebase SET action='oops';
+   SELECT dolt_rebase('--continue');
+   UPDATE dolt_rebase SET action='pick';
+   SELECT dolt_rebase('--continue');" \
+  "Successfully rebased and updated refs/heads/feat" \
+  "$DB4"
+
+rm -f "$DB" "$DB2" "$DB3" "$DB4"
 echo ""
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"
 if [ $FAIL -gt 0 ]; then echo -e "$ERRORS"; exit 1; fi


### PR DESCRIPTION
Closes #1962 — though not the way the issue was written, because investigating it changed the diagnosis.

## What #1962 said, and what is actually happening

The report was that an invalid plan leaves the temporary `dolt_rebase_<branch>` branch and the plan table behind, i.e. a cleanup leak. That retained state turns out to be **correct**. The rebase is genuinely still in progress and resumable:

```
SELECT dolt_rebase('-i','main');
UPDATE dolt_rebase SET action='oops';
SELECT dolt_rebase('--continue');   -> Error: rebase failed
UPDATE dolt_rebase SET action='pick';
SELECT dolt_rebase('--continue');   -> Successfully rebased and updated refs/heads/feat
```

That is the git-like behaviour you want: fix the todo and carry on. `dolt_rebase('--abort')` also still works. So there is nothing to clean up.

The real defect is the message. The unknown-verb check at `doltlite_rebase.c` sets `rc` and jumps to `abort_err` **without** setting an error. `bPlanDropped` is still 0 at that point, so `abort_err` takes its early branch, which restores nothing and reports a bare `rebase failed`. That reads as though the rebase had been rolled back, which is why the retained branch and plan table looked like a leak. The check's own comment claimed "abort_err restores the pre-rebase branch and reports the failure" — that path does neither.

Its sibling three lines below, for a first non-drop action, already does the right thing: a specific message via `abort_err_silent`, rebase left intact.

## The change

Report which action was rejected and what was expected, and leave the rebase in progress like the neighbouring check:

```
Error: unknown rebase action "oops": expected pick, reword, squash, fixup or drop
```

The misleading comment is corrected too.

## Testing

- `unknown_plan_action_names_the_action` — fails on unfixed master (bare "rebase failed"), passes here.
- `unknown_plan_action_stays_resumable` — **passes on unfixed master**, and is included deliberately: it pins the retained plan/working branch as intended behaviour so a future reading of #1962 does not "fix" it by tearing the rebase down.
- `doltlite_rebase.sh` 14/14, `doltlite_rebase_schema.sh` 23/23, `doltlite_savepoint.sh` 128/128.
- c-tests with `DOLTLITE_PROLLY_CHECK=1`: 310,095 pass (master control: same).
- Full shell battery 98/99 — `doltlite_parity.sh` needs a stock `./sqlite3` a fresh worktree does not have.

🤖 Generated with [Claude Code](https://claude.com/claude-code)