### PR TITLE
Re-check the record header size after adding its own varint

### DIFF
--- a/src/doltlite_record.c
+++ b/src/doltlite_record.c
@@ -579,7 +579,15 @@ u8 *doltliteBuildRecord(const DoltliteSerialValue *aMem, int nField, int *pnOut)
     hdrSize += sqlite3VarintLen(aType[i]);
     bodySize += (int)aLen[i];
   }
-  hdrSize += sqlite3VarintLen(hdrSize);
+  /* Adding the header-size varint can push the size across a varint width, so
+  ** re-check: 127 one-byte type codes need a two-byte size, not one. Stock does
+  ** the same in sqlite3VdbeMakeRecord, as do the sibling encoders by reserving
+  ** the byte up front and bumping past MAX_ONEBYTE_HEADER. */
+  {
+    int nVarint = sqlite3VarintLen(hdrSize);
+    hdrSize += nVarint;
+    if( nVarint < sqlite3VarintLen(hdrSize) ) hdrSize++;
+  }
 
   pOut = sqlite3_malloc(hdrSize + bodySize);
   if( !pOut ){

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -3201,6 +3201,55 @@ static void run_gc_rewrite_failure(void){
   removeDbFiles(dbpath);
 }
 
+/* The header-size varint is part of the header it measures, so adding it can
+** push the size across a varint width. With 127 single-byte type codes the
+** header reaches 128, which no longer fits the one byte that was reserved for
+** it; the record was then built one byte short and would not parse back. */
+static void run_record_header_varint_boundary(void){
+  static const int aField[] = { 125, 126, 127, 128, 129, 253, 254, 255 };
+  int k;
+
+  for(k=0; k<(int)(sizeof(aField)/sizeof(aField[0])); k++){
+    int nField = aField[k];
+    DoltliteSerialValue *aMem;
+    DoltliteRecordInfo info;
+    u8 *pRec;
+    int nRec = 0;
+    int i;
+    int ok;
+    char zName[128];
+
+    aMem = sqlite3_malloc((int)sizeof(*aMem) * nField);
+    if( !aMem ){
+      check("record_header_boundary_alloc", 0);
+      return;
+    }
+    for(i=0; i<nField; i++){
+      memset(&aMem[i], 0, sizeof(aMem[i]));
+      aMem[i].eType = SQLITE_INTEGER;
+      /* 2..127 all encode as serial type 1: one header byte, one body byte.
+      ** 128 would need type 2, which would change the header arithmetic. */
+      aMem[i].i = (i % 126) + 2;
+    }
+
+    pRec = doltliteBuildRecord(aMem, nField, &nRec);
+    memset(&info, 0, sizeof(info));
+    ok = pRec!=0
+      && doltliteParseRecordStrict(pRec, nRec, &info)==SQLITE_OK
+      && info.nField==nField;
+    if( ok ){
+      for(i=0; i<nField; i++){
+        if( info.aType[i]!=1 ){ ok = 0; break; }
+      }
+    }
+    sqlite3_snprintf((int)sizeof(zName), zName,
+                     "record_header_varint_boundary_%d_fields", nField);
+    check(zName, ok);
+    sqlite3_free(pRec);
+    sqlite3_free(aMem);
+  }
+}
+
 static void run_record_decode_corruption(void){
   static const u8 badRecord[] = {
     0x05, 0x01
@@ -9418,6 +9467,7 @@ static const RegressionCase aCases[] = {
   { "branches_metadata_corruption", "Branches Metadata Corruption Test", run_branches_metadata_corruption },
   { "gc_rewrite_failure", "GC Rewrite Failure Test", run_gc_rewrite_failure },
   { "record_decode_corruption", "Record Decode Corruption Test", run_record_decode_corruption },
+  { "record_header_varint_boundary", "Record Header Varint Boundary Test", run_record_header_varint_boundary },
   { "sortkey_two_numeric_roundtrip", "Sortkey Two Numeric Roundtrip Test", run_sortkey_two_numeric_roundtrip },
   { "sortkey_numeric_text_roundtrip", "Sortkey Numeric Text Roundtrip Test", run_sortkey_numeric_text_roundtrip },
   { "sortkey_numeric_blob_roundtrip", "Sortkey Numeric Blob Roundtrip Test", run_sortkey_numeric_blob_roundtrip },


### PR DESCRIPTION
Half of recommendation 3 from the code review: a record-header encoding bug that makes a merge fail at exactly one table width.

## The bug

`doltliteBuildRecord` sums the serial-type varints into `hdrSize`, then does:

```c
hdrSize += sqlite3VarintLen(hdrSize);
```

The size field is part of the header it measures, so adding it can push the total across a varint width. With 127 single-byte type codes `hdrSize` reaches 127, whose varint is one byte, giving 128 — and 128 no longer fits the one byte that was just accounted for. The record is built a byte short and does not parse back.

Stock re-checks for exactly this in `sqlite3VdbeMakeRecord` (`vdbe.c`):

```c
nVarint = sqlite3VarintLen(nHdr);
nHdr += nVarint;
if( nVarint<sqlite3VarintLen(nHdr) ) nHdr++;
```

and both sibling encoders avoid it a different way — `prolly_btree_mutation.c` and `sortkey.c` reserve the byte up front and bump past `MAX_ONEBYTE_HEADER`. This copy had neither.

## Observable effect

A dual `ADD COLUMN` merge over a 124-column table emits 127 fields. Swept across the boundary on unfixed code:

```
fields=124 : ok      fields=126 : ok
fields=127 : merge failed          <- only here
fields=128 : ok      fields=129 : ok
```

The table is left without the merged column. It fails at one width and nowhere else, which is why it survived this long.

## Testing

`run_record_header_varint_boundary` builds and re-parses records at 125–129 and 253–255 fields, checking field count and every recovered type code.

- On a verified `origin/master` build: **exactly one failure, the 127-field case** (310,115/310,116). Neighbours pass, which is what makes it a boundary test rather than a smoke test.
- With the fix: 310,116/310,116.
- Full shell battery 98/99 — `doltlite_parity.sh` needs a stock `./sqlite3` a fresh worktree does not have.
- The merge-level sweep above was verified by hand; the committed guard is the unit test, since `doltliteBuildRecord` is where the defect lives and a 127-column oracle fixture would not add coverage of it.

Note while writing the test: my first version used field values `(i % 127) + 2`, which yields 128 for some fields — and 128 needs serial type 2, changing the very header arithmetic under test. Values are now held in 2..127 so every field is genuinely one header byte and one body byte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)