### PR TITLE
Mark a flaky assertion per assertion instead of quarantining its file

### DIFF
--- a/test/check_testfixture_exception_inventory.sh
+++ b/test/check_testfixture_exception_inventory.sh
@@ -59,6 +59,7 @@ validate_records() {
       issue = ""
       nclass = 0
       nissue = 0
+      nunstable = 0
       for (i = nkey + 1; i <= NF; i++) {
         if ($i ~ /^@/) {
           if ($i != "@linux" && $i != "@darwin" && $i != "@windows" &&
@@ -68,6 +69,7 @@ validate_records() {
           }
           continue
         }
+        if ($i == "unstable") { nunstable++; continue }
         if ($i ~ /^class=/) { nclass++; category = substr($i, 7); continue }
         if ($i ~ /^issue=/) { nissue++; issue = substr($i, 7); continue }
         printf "%s:%d: unrecognized field: %s\n", FILENAME, NR, $i
@@ -99,6 +101,22 @@ validate_records() {
       # limitation, but are not required to.
       if ((category == "unsupported" || category == "engine-gap") && !nissue) {
         printf "%s:%d: %s requires issue=<number>\n", FILENAME, NR, category
+        bad = 1
+      }
+      if (nunstable > 1) {
+        printf "%s:%d: expected at most one unstable, found %d\n",
+               FILENAME, NR, nunstable
+        bad = 1
+      }
+      # An entry whose outcome varies is enforced in neither direction, so it
+      # needs somewhere the investigation is tracked.
+      if (nunstable && !nissue) {
+        printf "%s:%d: unstable requires issue=<number>\n", FILENAME, NR
+        bad = 1
+      }
+      if (nunstable && nkey != 2) {
+        printf "%s:%d: unstable applies per assertion, not per file\n",
+               FILENAME, NR
         bad = 1
       }
     }

--- a/test/check_testfixture_exception_inventory_test.sh
+++ b/test/check_testfixture_exception_inventory_test.sh
@@ -154,6 +154,33 @@ printf '%s\n' \
   'beta beta-1 @linux class=unsupported issue=42' > "$DIVERGENCES"
 expect_failure "overlapping exact and counted gates"
 
+# unstable marks a gate whose assertion does not fail every run. It is enforced
+# in neither direction, so it has to cite the issue tracking the cause, and it
+# only means anything per assertion -- a whole-file marker is what it replaces.
+printf '%s\n' \
+  'alpha alpha-1 unstable class=harness issue=42' \
+  'beta beta-1 @linux class=unsupported issue=42' > "$DIVERGENCES"
+write_ratchet 3 0 1 2 0
+run_check
+write_fixture
+write_ratchet
+
+printf '%s\n' \
+  'alpha alpha-1 unstable class=harness' \
+  'beta beta-1 @linux class=unsupported issue=42' > "$DIVERGENCES"
+expect_failure "an unstable gate without an issue"
+write_fixture
+
+printf '%s\n' \
+  'alpha alpha-1 unstable unstable class=harness issue=42' \
+  'beta beta-1 @linux class=unsupported issue=42' > "$DIVERGENCES"
+expect_failure "two unstable fields on one gate"
+write_fixture
+
+printf '%s\n' 'gamma unstable class=harness issue=42' > "$CRASHES"
+expect_failure "unstable on a crash row, which is keyed per file"
+write_fixture
+
 # Back to the 3-gate fixture for the ratchet cases.
 write_fixture
 write_ratchet

--- a/test/known_testfixture_crashes.txt
+++ b/test/known_testfixture_crashes.txt
@@ -2,6 +2,15 @@
 # not authorize a passing result; run_testfixture.sh requires the exact contract
 # in known_testfixture_terminations.txt. Unbucketed suites require replacement
 # coverage in known_testfixture_crash_coverage.txt.
+#
+# This is for files that cannot produce a comparable failure list at all -- they
+# abort, time out, or their fault sweep is capped. It is NOT the place for a
+# flaky assertion: an assertion whose outcome varies between runs is marked
+# `unstable` on its own line in known_testfixture_divergences.txt, which leaves
+# the rest of the file enforced. Quarantining a whole suite to quiet one
+# assertion costs every other assertion in it. Several reasons below say
+# "unstable"; they mean the file does not complete, not that a known assertion
+# flaps -- verified for malloc3, which produces no summary line at all.
 
 alter2 class=intentional  # raw file-format setup prevents the db command from opening
 backup_ioerr class=harness  # cap-truncated page-copy fault sequence; unbucketed

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -4,6 +4,11 @@
 # Qualifiers: @linux, @darwin, @windows, @coverage, @no-coverage
 # A counted gate ending in .*{N} matches exactly N failures with that prefix.
 # Index movement passes; adding or resolving a failure does not.
+# `unstable` marks an assertion whose outcome varies between runs on the same
+# commit: it stays gated when it fails and is not reported stale when it passes.
+# It requires issue=<number> because it is enforced in neither direction, so
+# only an open investigation keeps it from becoming a permanent blind spot.
+# Prefer it to crash-listing the whole file, which drops every other assertion.
 #
 # These tests fail when run by run_testfixture.sh against doltlite's
 # testfixture build, but the failures are not bugs — they're cases
@@ -58,7 +63,7 @@
 # freelist, headers). On a chunk-store repo the same offsets hit CTLD
 # manifest/hash/journal bytes. Architectural — not a missing integrity
 # detector, and not message-parity work if the store reports differently.
-corrupt corrupt-3.3 @linux class=intentional  # hexio lands on CTLD bytes, not btree cells (architectural, as 3.4/3.5); linux-only but not variant-specific
+corrupt corrupt-3.3 @linux unstable class=harness issue=1963  # outcome varies run to run on identical commits (4 of 6 observed runs passed); fixture is deterministic, cause unknown
 corrupt corrupt-3.4 class=intentional  # hexio lands on CTLD bytes, not btree cells (architectural)
 corrupt corrupt-3.5 class=intentional  # hexio lands on CTLD bytes, not btree cells (architectural)
 corrupt corrupt-3.6 class=intentional  # hexio lands on CTLD bytes, not btree cells (architectural)

--- a/test/known_testfixture_exception_ratchet.txt
+++ b/test/known_testfixture_exception_ratchet.txt
@@ -7,7 +7,7 @@
 # Lowering a number is the point. Raising one is a deliberate act that belongs
 # in a PR description.
 gates 4953
-intentional 3611
+intentional 3610
 unsupported 1269
-harness 8
+harness 9
 engine-gap 65

--- a/test/run_testfixture.sh
+++ b/test/run_testfixture.sh
@@ -85,6 +85,36 @@ expected_for() {
   ' "$DIVERGENCE_FILE"
 }
 
+# Gates whose assertion does not fail every run. They are still gated when they
+# fail, but passing must not be reported as a stale entry: the outcome varies,
+# so neither result is news. Kept per assertion rather than per file so the rest
+# of the suite stays enforced.
+unstable_for() {
+  local file="$1"
+  [ -f "$DIVERGENCE_FILE" ] || return 0
+  awk -v f="$file" -v host_os="$HOST_OS" -v test_variant="$TEST_VARIANT" '
+    {
+      sub(/#.*/, "")
+      gsub(/^[ \t]+|[ \t]+$/, "")
+      if ($0 == "") next
+      is_unstable = 0
+      for (i = 3; i <= NF; i++) {
+        if ($i == "unstable") { is_unstable = 1; continue }
+        if ($i !~ /^@/) continue
+        qualifier = substr($i, 2)
+        if (qualifier == "coverage") {
+          if (test_variant != "coverage") next
+        } else if (qualifier == "no-coverage") {
+          if (test_variant == "coverage") next
+        } else if (qualifier != host_os) {
+          next
+        }
+      }
+      if ($1 == f && is_unstable) print $2
+    }
+  ' "$DIVERGENCE_FILE"
+}
+
 termination_contracts_for() {
   local file="$1"
   [ -f "$TERMINATION_FILE" ] || return 0
@@ -401,10 +431,12 @@ for test in "$@"; do
   fi
   unexpected="$(echo "$unexpected" | grep -v '^$' || true)"
 
+  unstable_expected="$(unstable_for "$test")"
   if [ -n "$exact_expected" ]; then
     while IFS= read -r name; do
       [ -z "$name" ] && continue
       if ! is_in_set "$name" "$actual"; then
+        is_in_set "$name" "$unstable_expected" && continue
         fixed="$fixed"$'\n'"$name"
       fi
     done <<< "$exact_expected"

--- a/test/run_testfixture_test.sh
+++ b/test/run_testfixture_test.sh
@@ -114,6 +114,30 @@ printf '%s\n' \
   'shifted shifted-1.transient.99' > "$TMP_DIR/divergences"
 expect_failure shifted "shifted exact gates"
 
+# An unstable gate is enforced in neither direction: the assertion may fail (it
+# is gated) or pass (not reported stale). one.test fails only one of the two
+# gated names, which without the marker is a stale entry.
+printf '%s\n' \
+  'one one-1.transient.41' \
+  'one one-1.transient.99' > "$TMP_DIR/divergences"
+expect_failure one "a gate whose assertion stopped failing"
+
+printf '%s\n' \
+  'one one-1.transient.41' \
+  'one one-1.transient.99 unstable class=harness issue=42' > "$TMP_DIR/divergences"
+expect_pass one "an unstable gate whose assertion passed this run"
+
+printf '%s\n' \
+  'one one-1.transient.41 unstable class=harness issue=42' > "$TMP_DIR/divergences"
+expect_pass one "an unstable gate whose assertion failed this run"
+
+# The marker suppresses staleness, not unexpected failures: an ungated failure
+# beside an unstable gate is still a red.
+printf '%s\n' \
+  'extra extra-1.transient.41 unstable class=harness issue=42' \
+  'extra extra-1.transient.99' > "$TMP_DIR/divergences"
+expect_failure extra "an ungated failure beside an unstable gate"
+
 stable_hash=$(printf '%s' 'stable failure' | {
   if command -v sha256sum >/dev/null 2>&1; then
     sha256sum


### PR DESCRIPTION
Groundwork for #1963. #1968 should rebase onto this once it lands.

## Why

An assertion whose outcome varies between runs on the same commit cannot be expressed in a ratchet that enforces both directions. Gating it goes red on the runs where it passes; removing it goes red on the runs where it fails. `corrupt-3.3` has now taken out three consecutive unrelated PRs (#1958, #1967, #1968) — 4 of 6 observed runs passed, and it flipped on a re-run of an identical commit twice.

The only mechanism available was crash-listing the whole file, which unbuckets it and drops every other assertion. For `corrupt.test` that means quarantining 16 assertions, 6 of them stable and pinned unconditionally, to quiet one.

## The flag

`unstable` on a divergence line:

```
corrupt corrupt-3.3 @linux unstable class=harness issue=1963  # outcome varies run to run...
```

- Stays gated when the assertion fails; not reported stale when it passes.
- The rest of the file stays enforced.
- Does **not** suppress unexpected failures — an ungated failure beside it is still red.
- Requires `issue=<number>`. Enforced in neither direction, it would otherwise be a permanent blind spot; an open investigation is the only thing keeping it honest.
- Still counted by the ratchet, so the population cannot grow silently.
- Rejected on crash rows, which are keyed per file.

`corrupt-3.3`'s reason is also corrected. It read "hexio lands on CTLD bytes, not btree cells (architectural, as 3.4/3.5)" — but 3.3 pokes no bytes at all; `corrupt-3.2` swaps the `rootpage` values of `t1` and `t1i1` through `writable_schema`, and 3.3 then expects the INSERT to report malformed. The comment was inherited from its siblings. Reclassified `intentional` → `harness` to match how `corrupt4` records nondeterminism; ratchet moved deliberately (`intentional` 3611→3610, `harness` 8→9, `gates` unchanged).

## On deprecating the per-file mechanism

I could not, and it is worth recording why rather than leaving it looking like an oversight. Nothing currently in `known_testfixture_crashes.txt` can move to per-assertion gating: those files abort, exceed the per-file timeout, or have a cap-truncated fault sweep, so there is no comparable failure list to gate against. Verified empirically for `malloc3`, which produces no summary line at all; `corrupt4` completes on darwin but its own record says it aborts pre-summary on ubuntu. The OOM-sweep entries additionally index by fault iteration, which must not be pinned.

So the two files serve different purposes, and the confusing part was vocabulary: several crash reasons say "unstable" meaning *the file does not complete*, not that a known assertion flaps. Its header now states the distinction and points flaky assertions at the new flag, so per-file quarantine stops being the default answer.

## Testing

Four cases in `run_testfixture_test.sh`, proving both directions:

- a gate whose assertion stopped failing → red (unchanged behaviour, the control)
- the same gate marked `unstable` → green
- an `unstable` gate whose assertion *did* fail → green
- an ungated failure beside an `unstable` gate → still red

Four in `check_testfixture_exception_inventory_test.sh`: accepted with an issue, rejected without one, rejected when doubled, rejected on a crash row.

- `run_testfixture_test.sh`, `check_testfixture_exception_inventory_test.sh`, `check_testfixture_exception_inventory.sh`, `check_testfixture_crash_coverage.sh` — all pass.
- Full `storage` bucket: 208 suites OK, `corrupt` at 9320 tests / 6 known divergences. The two reds are `bigfile`/`bigfile2` clean-exits, which reproduce identically on master here (darwin lacks the large-file support they need).

🤖 Generated with [Claude Code](https://claude.com/claude-code)