### PR TITLE
Validate chunk shape when a batch update changes value sizes

### DIFF
--- a/src/prolly_mutate.c
+++ b/src/prolly_mutate.c
@@ -1063,6 +1063,7 @@ static int replaceBatchLeafNoRechunk(
   ProllyNodeBuilder b;
   int rc = SQLITE_OK;
   int changed = 0;
+  int sizeChanged = 0;
   int i;
 
   prollyNodeBuilderInit(&b, 0, pMut->flags);
@@ -1091,6 +1092,7 @@ static int replaceBatchLeafNoRechunk(
       rc = prollyNodeBuilderAdd(&b, pCurKey, nCurKey,
                                 pEd->pVal, pEd->nVal);
       changed = 1;
+      if( pEd->nVal!=nVal ) sizeChanged = 1;
       prollyMutMapIterNext(pIter);
     }else{
       rc = prollyNodeBuilderAdd(&b, pCurKey, nCurKey, pVal, nVal);
@@ -1107,7 +1109,16 @@ static int replaceBatchLeafNoRechunk(
   }
 
   if( changed ){
-    rc = writeBuilderNode(pMut->pStore, &b, pHash);
+    if( sizeChanged ){
+      /* A replacement of a different length moves every following entry, so the
+      ** boundaries this leaf was chunked at may no longer be the ones a fresh
+      ** build would pick. Validate and let the caller rechunk if they moved,
+      ** the way the single-edit path does -- writing regardless freezes a shape
+      ** that history independence says must not depend on how we got here. */
+      rc = finishAndWriteBuilderNode(pMut->pStore, &b, !isLast, pHash);
+    }else{
+      rc = writeBuilderNode(pMut->pStore, &b, pHash);
+    }
   }
   prollyNodeBuilderFree(&b);
   if( rc!=SQLITE_OK ) return rc;


### PR DESCRIPTION
The remaining half of recommendation 3: the chunk-shape divergence, plus the `prollyCheckTree` gate that turns this class of bug into "cannot commit".

## The bug

`replaceBatchLeafNoRechunk` rebuilt a leaf in place and wrote it through the unvalidated `writeBuilderNode` even when a replacement had a different length. A different length shifts every following entry, so the boundaries the leaf was chunked at are no longer the ones a fresh build would pick.

The single-edit path already guards exactly this — it writes unvalidated only when `sameSize`, and otherwise uses `finishAndWriteBuilderNode`, which rejects a moved shape so the caller falls back to a rechunk. Only the batch path was missing the check.

So the tree's shape depended on how it was built. Same 2000 rows, same 48000 bytes of content, two routes:

| built by | `dolt_hashof_table('t')` |
|---|---|
| batch UPDATE that grows values | `e40188e6…` |
| built fresh | `74c77755…` |

`dolt_hashof_table` reported a difference where there was none, which defeats structural sharing and contradicts the history independence the catalog serializer already enforces for schema.

Two controls located it precisely — both matched before the fix:

- same-size batch update → `043b5b66…` both ways
- single-row size-changing update → `265eec83…` both ways

After the fix all four shapes are canonical: growing, shrinking, partial (`WHERE id%2=0`), and same-size.

## The gate

`prollyCheckTree` now verifies the same predicate on every node, so a non-canonical shape is an enforced invariant rather than something only a hash comparison would reveal. `isRightmost` threads down the recursion, since only the rightmost node at each level may end short of a boundary.

`nodeHasSameChunkShape` becomes `prollyNodeHasCanonicalShape` and is shared from `prolly_mutate.h`, rather than the checker growing a second copy of the rule — which is the actual point of the recommendation.

Proof the gate catches what the fix repairs. With the write fix reverted and the gate kept, the same scenario aborts:

```
doltlite: prolly tree invariant violated: non-canonical chunk shape at level=0 nItems=163 rightmost=0
```

## Testing

- c-tests with `DOLTLITE_PROLLY_CHECK=1`: **310,116 pass, 0 fail** — so the gate finds no pre-existing violations anywhere in the corpus, which was the main risk.
- Full shell battery 98/99 (`doltlite_parity.sh` needs a stock `./sqlite3` a fresh worktree does not have).
- `doltlite_perf.sh` 11/11, `doltlite_scaling.sh` 43/43.
- Cost of the rechunk fallback, three runs each: size-changing bulk update 29/30/29ms at 2000 rows and 40/39/37ms at 20000, against 28/30/30ms and 37/39/37ms for the same-size path that still writes in place. No measurable penalty.

## Deliberately not in this PR

**Subtree-count validation.** The recommendation also suggested `prollyCheckTree` verify `PROLLY_NODE_SUBTREE_COUNTS`, which it still does not. That is a separate invariant with its own chance of surfacing pre-existing violations, and keeping it out means it cannot block this fix. Worth doing next.

**`chunkBoundary` is still duplicated.** Its comment says the predicate is "shared with the chunker (`prolly_chunker.c addToLevel`)" — meaning by convention, not by code. That is another instance of the one-definition problem, but deduplicating it touches the chunker's hot path and belongs on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)