### PR TITLE
Compute the refs-array growth size in 64 bits

### DIFF
--- a/src/chunk_refs.c
+++ b/src/chunk_refs.c
@@ -21,9 +21,17 @@ int csFindNamedRef(const void *aBase, int n, int stride, const char *zName){
 
 int csRefArrayGrow(void **paBase, int n, int stride){
   void *aNew;
+  i64 nByte;
   assert( paBase!=0 );
   assert( n>=0 && stride>0 );
-  aNew = sqlite3_realloc(*paBase, (n+1)*stride);
+  /* (n+1)*stride in int wraps once n is large enough, which hands realloc a
+  ** small size and leaves the memset below writing past the allocation. The
+  ** callers append one ref at a time, so reaching that needs tens of millions
+  ** of successful appends -- but the arithmetic should not be what stands
+  ** between us and it. */
+  nByte = ((i64)n + 1) * (i64)stride;
+  if( nByte > (i64)INT_MAX ) return SQLITE_TOOBIG;
+  aNew = sqlite3_realloc(*paBase, (int)nByte);
   if( !aNew ) return SQLITE_NOMEM;
   *paBase = aNew;
   memset((char*)aNew + (size_t)n*stride, 0, stride);

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -8,6 +8,7 @@
 #include "sqlite3.h"
 #include "prolly_hash.h"
 #include "chunk_store.h"
+#include "chunk_refs.h"
 #include "doltlite_commit.h"
 #include "doltlite_chunk_walk.h"
 #include "doltlite_ancestor.h"
@@ -3249,6 +3250,32 @@ static void run_record_header_varint_boundary(void){
     sqlite3_free(pRec);
     sqlite3_free(aMem);
   }
+}
+
+/* csRefArrayGrow computed (n+1)*stride in int. At stride 72 and n 59652416 that
+** wraps to 6728 where the true size is 4294974024, so realloc succeeds with a
+** 6KB buffer and the zeroing memset writes 72 bytes at offset 4294973952. The
+** guard has to reject the request instead of allocating the wrapped size. */
+static void run_ref_array_grow_rejects_overflow(void){
+  void *aBase = 0;
+  int rc;
+
+  rc = csRefArrayGrow(&aBase, 59652416, 72);
+  check("ref_array_grow_rejects_wrapping_size", rc!=SQLITE_OK);
+  check("ref_array_grow_left_the_array_alone", aBase==0);
+
+  /* An ordinary growth still works. */
+  rc = csRefArrayGrow(&aBase, 0, 72);
+  check("ref_array_grow_still_grows", rc==SQLITE_OK && aBase!=0);
+  if( aBase ){
+    int i;
+    int allZero = 1;
+    for(i=0; i<72; i++){
+      if( ((unsigned char*)aBase)[i]!=0 ) allZero = 0;
+    }
+    check("ref_array_grow_zeroes_the_new_slot", allZero);
+  }
+  sqlite3_free(aBase);
 }
 
 static void run_record_decode_corruption(void){
@@ -9561,6 +9588,7 @@ static const RegressionCase aCases[] = {
   { "gc_rewrite_failure", "GC Rewrite Failure Test", run_gc_rewrite_failure },
   { "record_decode_corruption", "Record Decode Corruption Test", run_record_decode_corruption },
   { "sync_rejects_wrong_chunk", "Sync Chunk Address Verification Test", run_sync_rejects_wrong_chunk },
+  { "ref_array_grow_overflow", "Ref Array Grow Overflow Test", run_ref_array_grow_rejects_overflow },
   { "record_header_varint_boundary", "Record Header Varint Boundary Test", run_record_header_varint_boundary },
   { "sortkey_two_numeric_roundtrip", "Sortkey Two Numeric Roundtrip Test", run_sortkey_two_numeric_roundtrip },
   { "sortkey_numeric_text_roundtrip", "Sortkey Numeric Text Roundtrip Test", run_sortkey_numeric_text_roundtrip },


### PR DESCRIPTION
Second of the two hardening one-liners from recommendation 5.

## The arithmetic

`csRefArrayGrow` sized its realloc with `(n+1)*stride` in `int`:

```c
aNew = sqlite3_realloc(*paBase, (n+1)*stride);
if( !aNew ) return SQLITE_NOMEM;
*paBase = aNew;
memset((char*)aNew + (size_t)n*stride, 0, stride);
```

`BranchRef` is 72 bytes. At `n = 59652416`:

```
int arithmetic:  (n+1)*stride = 6728
true value:      4294974024
memset offset:   4294973952
```

So the wrap lands on a small *positive* value — realloc succeeds with a 6 KB buffer, and the zeroing `memset` writes 72 bytes at a ~4 GB offset. Note the failure mode is not a rejected allocation; it is a successful one of the wrong size.

## Reachability — not, and I would rather say so

The review described this as something "a large hostile refs blob can overflow". Having traced it, that overstates it. `n` is not a count taken from the blob: `chunkStoreAddBranch` and its siblings append **one ref at a time**, each with its own `sqlite3_mprintf` for the name and an O(n) `chunkStoreFindBranch` duplicate scan first. Reaching ~30M refs therefore needs ~30M successful appends and on the order of 10¹⁴ string comparisons, with every allocation succeeding.

So this is defensive: the arithmetic is wrong, and it is the only thing between the callers and a heap overflow, but no input reaches it today. Fixing it is a few lines and removes the question.

## The change

Compute in `i64`, reject past `INT_MAX`. Callers do `if( csRefArrayGrow(...) ) return SQLITE_NOMEM;`, so they coerce any non-zero return — `SQLITE_TOOBIG` is for the function's own contract rather than something they distinguish.

## Testing

`csRefArrayGrow` is called directly at the wrapping size and must refuse without touching the array, and an ordinary growth must still allocate and zero its new slot.

- With the fix: 310,120 c-tests pass; full battery 98/99 (`doltlite_parity.sh` needs a stock `./sqlite3` a fresh worktree does not have).
- The pre-fix behaviour is deliberately **not** committed as a test: it corrupts the heap rather than failing an assertion, so it would take the suite down rather than report. The wrap is demonstrated by the arithmetic above instead, which is checkable without running it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)