### PR TITLE
Restore merge state when a merge reports failure

### DIFF
--- a/src/doltlite_cmd.c
+++ b/src/doltlite_cmd.c
@@ -141,14 +141,19 @@ int doltliteRollbackAutocommitConflict(
   int hadTopLevelSavepoint = db->pSavepoint!=0 && db->nSavepoint==0;
   sqlite3RollbackAll(db, SQLITE_OK);
   rc = doltliteRestoreTxnState(db, pSaved);
-  if( rc==SQLITE_OK ){
-    rc = doltliteSetSessionMergeState(db, pSaved->sessionIsMerging,
-                                      &pSaved->sessionMergeCommit,
-                                      &pSaved->sessionConflictsCatalog);
-  }
-  if( rc==SQLITE_OK ){
-    rc = doltliteSetSessionConstraintViolationsCatalog(
+  /* Put the merge markers back even when the restore above failed. pSaved is
+  ** cleared below, so a skipped restore leaves isMerging set from the merge we
+  ** just told the caller was rolled back, and the next merge refuses because
+  ** one is already in progress. These are in-memory writes; keep the first
+  ** error for the return value rather than the last. */
+  {
+    int rc2 = doltliteSetSessionMergeState(db, pSaved->sessionIsMerging,
+                                          &pSaved->sessionMergeCommit,
+                                          &pSaved->sessionConflictsCatalog);
+    if( rc==SQLITE_OK ) rc = rc2;
+    rc2 = doltliteSetSessionConstraintViolationsCatalog(
         db, &pSaved->sessionConstraintViolationsCatalog);
+    if( rc==SQLITE_OK ) rc = rc2;
   }
   if( rc==SQLITE_OK ){
     rc = doltlitePersistWorkingSet(db);

--- a/src/doltlite_merge_cmd.c
+++ b/src/doltlite_merge_cmd.c
@@ -432,6 +432,12 @@ int doltliteMergeRef(
   if( nMergeConflicts>0 ){
     ProllyHash conflictsHash;
     doltliteGetSessionConflictsCatalog(db, &conflictsHash);
+    /* From here the session is marked as merging, so every later exit has to
+    ** restore the saved state rather than discard it. Discarding leaves
+    ** isMerging set with a conflicts catalog while the caller is told the merge
+    ** did not happen, and the next merge then refuses because one is already in
+    ** progress. */
+    bRestoreOnFail = 1;
     rc = doltliteSetSessionMergeState(db, 1, &theirHead, &conflictsHash);
     /* Caching the spec only sharpens dolt_merge_status.source, which falls
     ** back to the branch at theirHead, so losing it must not fail the merge. */

--- a/test/doltlite_recover_merge_state.test
+++ b/test/doltlite_recover_merge_state.test
@@ -1,0 +1,57 @@
+# A merge that reports failure must not leave a merge in progress.
+#
+# doltliteSetSessionMergeState marks the session as merging as soon as the
+# catalog merge reports conflicts, which happens before the head is
+# re-confirmed under the lock. Any failure after that point -- a peer having
+# advanced the branch, or an allocation failing -- took an exit that only
+# discarded the saved state instead of restoring it, so isMerging stayed set
+# with a conflicts catalog while the caller was told the merge did not happen.
+# The next merge then refuses because one is already in progress, leaving
+# dolt_merge('--abort') as the only way out.
+#
+# The invariant does not depend on why the merge failed: if it failed, there is
+# no merge in progress.
+
+set testdir [file dirname $argv0]
+source $testdir/tester.tcl
+source $testdir/malloc_common.tcl
+
+set testprefix doltlite_recover_merge_state
+
+do_test 1.0 {
+  execsql {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+    INSERT INTO t VALUES(1,'base');
+    SELECT dolt_commit('-A','-m','base');
+    SELECT dolt_checkout('-b','feat');
+    UPDATE t SET v='theirs' WHERE id=1;
+    SELECT dolt_commit('-A','-m','feat');
+    SELECT dolt_checkout('main');
+    UPDATE t SET v='ours' WHERE id=1;
+    SELECT dolt_commit('-A','-m','main');
+  }
+  set {} {}
+} {}
+faultsim_save_and_close
+
+# Conflicting merge in autocommit: it always reports failure and always rolls
+# back, so is_merging must read 0 on every iteration.
+do_faultsim_test 1.1 -faults oom-transient -prep {
+  faultsim_restore_and_reopen
+} -body {
+  set mrc [catch { db eval { SELECT dolt_merge('feat') } } mmsg]
+  set merging [db one {
+    SELECT count(*) FROM dolt_merge_status WHERE is_merging=1
+  }]
+  if {$mrc && $merging} {
+    error "merge reported failure but left is_merging=$merging"
+  }
+  list $mrc $merging
+} -test {
+  faultsim_test_result {0 {1 0}} \
+      {1 {out of memory}} {1 {disk I/O error}}
+  catchsql ROLLBACK
+  faultsim_integrity_check
+}
+
+finish_test

--- a/test/regression-buckets/fault-fuzz.txt
+++ b/test/regression-buckets/fault-fuzz.txt
@@ -91,3 +91,4 @@ zipfilefault
 doltlite_recover_commit_fail_cursor
 doltlite_recover_mutmap_order_oom
 doltlite_recover_deferred_seek_oom
+doltlite_recover_merge_state


### PR DESCRIPTION
Most of recommendation 4's remaining item. Two exits left the session marked as merging after telling the caller the merge did not happen; the next merge then refuses because one is already in progress, with `dolt_merge('--abort')` the only way out.

## First leak: the flag was set too late

`doltliteMergeCatalogs` reporting conflicts sets the session merge state, and that happens *before* `doltliteRefreshAndConfirmHead` re-confirms the head under the lock. Both exits after it — the `SQLITE_BUSY` one for a peer that advanced the branch, and the generic failure one — ran with `bRestoreOnFail` still 0, so `merge_fail` took the `doltliteTxnStateClear` branch instead of `doltliteRestoreTxnStateOnFailure`. `bRestoreOnFail` is now set where the state is first mutated, rather than several steps later after `doltliteSwitchCatalog`.

## Second leak: the same shape one level down

`doltliteRollbackAutocommitConflict` restores the txn state, then puts the merge markers back **only if that succeeded**, then clears `pSaved` unconditionally:

```c
rc = doltliteRestoreTxnState(db, pSaved);
if( rc==SQLITE_OK ){
  rc = doltliteSetSessionMergeState(db, pSaved->sessionIsMerging, ...);
}
...
doltliteTxnStateClear(pSaved);
```

So a failing restore dropped the only copy of the pre-merge markers while reporting the merge had rolled back. Those are in-memory writes, so they now run regardless, keeping the first error for the return value.

I only found this one because closing the first leak moved the failing OOM iterations from 545 to 1380 rather than eliminating them.

## Testing

The invariant does not depend on *why* the merge failed, so the test asserts only that: a merge that reports failure leaves no merge in progress. That makes it indifferent to whether the fault was a peer, an allocation, or a conflict.

- On unfixed master: **21 failures in two bands** — 545-555 and 1380-1389 — matching the two exits.
- With both closed: **0 errors out of 1581**.
- c-tests with `DOLTLITE_PROLLY_CHECK=1`: 310,116 pass.
- Full shell battery 98/99 (`doltlite_parity.sh` needs a stock `./sqlite3` a fresh worktree does not have).
- Registered in the `fault-fuzz` bucket.

## Why reset is not here

`doltlite_reset.c` does set the session head before moving the ref, and reordering that closes one window. But the test I wrote for it still failed afterwards, because it also catches a second divergence: reset calls `chunkStoreUpdateBranch` directly rather than going through `doltliteMutateRefsExpected`, so the in-memory refs advance and are not rolled back when a later step fails. That is the "unlike every `doltliteMutateRefsExpected` caller, which gets snapshot/restore for free" part of the review, and it is a restructure rather than a reorder — so it belongs in its own PR rather than riding along half-done here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)