### PR TITLE
Move the ref before the session head in reset --hard

### DIFF
--- a/src/doltlite_reset.c
+++ b/src/doltlite_reset.c
@@ -501,12 +501,21 @@ static void doltliteResetFunc(
     }
     graphLocked = 1;
 
-    doltliteSetSessionHead(db, &targetCommit);
+    /* Move the ref before the session head. There is no rollback on this path,
+    ** so the other order leaves the session reading a commit the branch was
+    ** never advanced to when the update fails. The update needs only the
+    ** session branch, so the order costs nothing.
+    **
+    ** This is the ordering only: reset --hard is not atomic against a failure
+    ** part way through, and dolt does not make it atomic either -- an explicit
+    ** ROLLBACK around CALL dolt_reset('--hard', ...) leaves HEAD moved -- so
+    ** there is no rollback contract here to hold up. */
     rc = chunkStoreUpdateBranch(cs, doltliteGetSessionBranch(db), &targetCommit);
     if( rc!=SQLITE_OK ){
       sqlite3_result_error_code(context, rc);
       goto reset_cleanup;
     }
+    doltliteSetSessionHead(db, &targetCommit);
 
     rc = doltliteClearSessionMergeState(db);
     if( rc!=SQLITE_OK ){


### PR DESCRIPTION
Last of recommendation 4, and smaller than the review implied — for a reason worth recording.

## The change

`dolt_reset --hard` set the session head to the target and only then advanced the branch:

```c
doltliteSetSessionHead(db, &targetCommit);
rc = chunkStoreUpdateBranch(cs, doltliteGetSessionBranch(db), &targetCommit);
if( rc!=SQLITE_OK ){ ... goto reset_cleanup; }
```

There is no rollback on this path, so a failed update left the session reading a commit the branch was never moved to. The update needs only the session *branch*, so swapping the order closes the window at no cost.

## Why that is all this does

The review described this as reset lacking the snapshot/restore that "every `doltliteMutateRefsExpected` caller gets for free", and I started building that. Two things stopped it.

First, mechanics: `doltliteRefreshAndConfirmHead` already holds the lock that `doltliteMutateRefsExpected` acquires, so reset cannot nest it — it would need the snapshot primitives applied directly.

Second, and decisive: **dolt does not make `reset --hard` atomic**, so there is no contract here to uphold.

```
SET autocommit=0; BEGIN;
CALL dolt_reset('--hard','HEAD~1');
ROLLBACK;
SELECT hashof('HEAD');
```

`hashof('HEAD')` comes back as the reset target, not the pre-reset head — an explicit `ROLLBACK` does not undo it (dolt 2.2.2). Row count stays at the reset state too.

I did implement the refs snapshot/restore and measured it: leaked ref advances after a failed reset went from **287 to 71** across an OOM sweep. Real improvement, but incomplete — the residual is the path where the reset body finishes and the *seal* then fails, so `bSucceeded` is already set and no restore runs. Closing that means reordering unlock/seal/restore. Building a partial rollback contract that the reference implementation does not offer at all is the wrong direction, so it is not here.

## No test, on purpose

The window this closes sits between two adjacent statements with no observable state in between. The property that *is* observable — refs not advancing when a reset fails — is precisely the one dolt does not promise, so asserting it would encode a divergence rather than prevent one.

## Testing

- c-tests with `DOLTLITE_PROLLY_CHECK=1`: 310,123 pass.
- Full shell battery 98/99 (`doltlite_parity.sh` needs a stock `./sqlite3` a fresh worktree does not have).

🤖 Generated with [Claude Code](https://claude.com/claude-code)