### PR TITLE
Truncate trailing 0xff when building a prefix successor

### DIFF
--- a/src/prolly_btree_cursor_count.c
+++ b/src/prolly_btree_cursor_count.c
@@ -187,20 +187,24 @@ int sortKeyFromUnpackedForCount(
   return rc;
 }
 
-static int blobPrefixSuccessor(const u8 *pKey, int nKey, u8 **ppOut){
+/* Smallest key sorting above every key that has pKey as a prefix. Trailing
+** 0xff bytes must be dropped, not carried: keeping them yields a bound above
+** the true successor, which counts keys past the end of the range. */
+static int blobPrefixSuccessor(const u8 *pKey, int nKey, u8 **ppOut, int *pnOut){
   int i;
-  u8 *pOut = sqlite3_malloc(nKey);
-  if( !pOut ) return SQLITE_NOMEM;
-  memcpy(pOut, pKey, nKey);
-  for(i=nKey-1; i>=0; i--){
-    if( pOut[i]!=0xff ){
-      pOut[i]++;
-      *ppOut = pOut;
-      return SQLITE_OK;
-    }
+  u8 *pOut;
+  for(i=nKey-1; i>=0 && pKey[i]==0xff; i--){}
+  if( i<0 ){
+    *ppOut = 0;
+    *pnOut = 0;
+    return SQLITE_OK;
   }
-  sqlite3_free(pOut);
-  *ppOut = 0;
+  pOut = sqlite3_malloc(i+1);
+  if( !pOut ) return SQLITE_NOMEM;
+  memcpy(pOut, pKey, i+1);
+  pOut[i]++;
+  *ppOut = pOut;
+  *pnOut = i+1;
   return SQLITE_OK;
 }
 
@@ -251,6 +255,7 @@ static int countTreeBlobPrefixRange(
   u8 *pUpperNext = 0;
   int nLowerKey = 0;
   int nUpperKey = 0;
+  int nUpperNext = 0;
   int nLowerAlloc = 0;
   int nUpperAlloc = 0;
   i64 nLower = 0;
@@ -267,7 +272,7 @@ static int countTreeBlobPrefixRange(
   rc = sortKeyFromUnpackedForCount(
       pCur, pUpper, &pUpperKey, &nUpperAlloc, &nUpperKey);
   if( rc!=SQLITE_OK ) goto done;
-  rc = blobPrefixSuccessor(pUpperKey, nUpperKey, &pUpperNext);
+  rc = blobPrefixSuccessor(pUpperKey, nUpperKey, &pUpperNext, &nUpperNext);
   if( rc!=SQLITE_OK ) goto done;
 
   rc = countBlobKeysBefore(pCur->pBtree, &pTE->root, pTE->flags,
@@ -275,7 +280,7 @@ static int countTreeBlobPrefixRange(
   if( rc!=SQLITE_OK ) goto done;
   if( pUpperNext ){
     rc = countBlobKeysBefore(pCur->pBtree, &pTE->root, pTE->flags,
-                             pUpperNext, nUpperKey, &nUpper);
+                             pUpperNext, nUpperNext, &nUpper);
   }else{
     rc = countTreeEntries(pCur->pBtree, pCur->pgnoRoot, &nUpper);
   }

--- a/test/sql_oracle_test.sh
+++ b/test/sql_oracle_test.sh
@@ -6002,6 +6002,91 @@ SELECT a FROM t WHERE b=3;
 "
 
 echo ""
+echo "--- Category 123: Indexed COUNT(*) over key ranges ---"
+
+oracle "cat123_count_range_negative_ints" "
+CREATE TABLE t(x);
+CREATE INDEX i ON t(x);
+INSERT INTO t VALUES(-2),(-1),(-0.97),(0),(5);
+SELECT count(*) FROM t WHERE x BETWEEN -2 AND -1;
+SELECT group_concat(x) FROM t WHERE x BETWEEN -2 AND -1;
+"
+
+oracle "cat123_count_range_negative_reals" "
+CREATE TABLE t(x);
+CREATE INDEX i ON t(x);
+INSERT INTO t VALUES(-3.5),(-2.25),(-2.0),(-1.75),(-0.5),(0.5);
+SELECT count(*) FROM t WHERE x BETWEEN -3.5 AND -2.0;
+SELECT count(*) FROM t WHERE x BETWEEN -2.25 AND -1.75;
+SELECT count(*) FROM t WHERE x >= -3.5 AND x <= -0.5;
+"
+
+oracle "cat123_count_range_spanning_zero" "
+CREATE TABLE t(x);
+CREATE INDEX i ON t(x);
+WITH RECURSIVE c(x) AS (VALUES(-50) UNION ALL SELECT x+1 FROM c WHERE x<50)
+INSERT INTO t SELECT x FROM c;
+SELECT count(*) FROM t WHERE x BETWEEN -50 AND -1;
+SELECT count(*) FROM t WHERE x BETWEEN -10 AND 10;
+SELECT count(*) FROM t WHERE x BETWEEN -1 AND 0;
+SELECT count(*) FROM t WHERE x <= -1;
+"
+
+oracle "cat123_count_range_extreme_bounds" "
+CREATE TABLE t(x);
+CREATE INDEX i ON t(x);
+INSERT INTO t VALUES(-9223372036854775808),(-1),(0),(1),(9223372036854775807);
+SELECT count(*) FROM t WHERE x BETWEEN -9223372036854775808 AND -1;
+SELECT count(*) FROM t WHERE x BETWEEN 0 AND 9223372036854775807;
+SELECT count(*) FROM t WHERE x BETWEEN -9223372036854775808 AND 9223372036854775807;
+"
+
+oracle "cat123_count_range_composite_index" "
+CREATE TABLE t(a,b);
+CREATE INDEX i ON t(a,b);
+INSERT INTO t VALUES(-2,1),(-2,2),(-1,1),(-1,2),(-0.5,1),(0,1);
+SELECT count(*) FROM t WHERE a BETWEEN -2 AND -1;
+SELECT count(*) FROM t WHERE a = -1;
+SELECT count(*) FROM t WHERE a BETWEEN -2 AND -1 AND b = 1;
+"
+
+oracle "cat123_count_range_text_keys" "
+CREATE TABLE t(s TEXT);
+CREATE INDEX i ON t(s);
+INSERT INTO t VALUES('a'),('b'),('ba'),('bz'),('c'),('ca');
+SELECT count(*) FROM t WHERE s BETWEEN 'a' AND 'b';
+SELECT count(*) FROM t WHERE s BETWEEN 'b' AND 'c';
+SELECT count(*) FROM t WHERE s >= 'b' AND s < 'c';
+"
+
+oracle "cat123_count_range_blob_keys" "
+CREATE TABLE t(k BLOB);
+CREATE INDEX i ON t(k);
+INSERT INTO t VALUES(x'41'),(x'41ff'),(x'42'),(x'4200'),(x'42ff'),(x'43');
+SELECT count(*) FROM t WHERE k BETWEEN x'41' AND x'41ff';
+SELECT count(*) FROM t WHERE k BETWEEN x'42' AND x'42ff';
+SELECT count(*) FROM t WHERE k BETWEEN x'41ff' AND x'4200';
+"
+
+oracle "cat123_count_range_without_rowid" "
+CREATE TABLE t(pk INT PRIMARY KEY, v INT) WITHOUT ROWID;
+INSERT INTO t VALUES(-3,1),(-2,2),(-1,3),(0,4),(1,5);
+SELECT count(*) FROM t WHERE pk BETWEEN -3 AND -1;
+SELECT count(*) FROM t WHERE pk BETWEEN -1 AND 1;
+"
+
+oracle "cat123_count_range_after_mutation" "
+CREATE TABLE t(x);
+CREATE INDEX i ON t(x);
+INSERT INTO t VALUES(-4),(-3),(-2),(-1),(0);
+DELETE FROM t WHERE x = -3;
+UPDATE t SET x = -5 WHERE x = 0;
+SELECT count(*) FROM t WHERE x BETWEEN -5 AND -1;
+SELECT count(*) FROM t WHERE x BETWEEN -4 AND -2;
+SELECT group_concat(x) FROM (SELECT x FROM t ORDER BY x);
+"
+
+echo ""
 echo "================================"
 echo "Results: $pass passed, $fail failed"
 echo "================================"


### PR DESCRIPTION
## Problem

`blobPrefixSuccessor` (`src/prolly_btree_cursor_count.c`) built the exclusive upper bound for an indexed `COUNT(*)` range by incrementing the last non-`0xff` byte of the sortkey, but it kept the trailing `0xff` bytes in place, and `countTreeBlobPrefixRange` then passed the *original* key length to `countBlobKeysBefore`.

For a key ending at index `i`, the correct prefix successor is `key[0..i]` with `key[i]` incremented and everything after it dropped. Carrying the trailing `0xff` bytes produces a bound that sorts strictly above that, so every key in between is counted.

The numeric sortkey encoding ends in `0xff` for negative values, which makes this reachable from ordinary SQL with no version-control feature involved:

```sql
CREATE TABLE t(x); CREATE INDEX i ON t(x);
INSERT INTO t VALUES(-2),(-1),(-0.97),(0),(5);
SELECT count(*) FROM t WHERE x BETWEEN -2 AND -1;   -- returned 3
SELECT group_concat(x) FROM t WHERE x BETWEEN -2 AND -1;  -- -2,-1
```

`DROP INDEX i` made the same count return 2, and stock sqlite returns 2. Within a single query the aggregate over the scan gave 2 while a subquery going through `OP_CountIndexRange` gave 3.

## Fix

Compute the successor length alongside the bytes and truncate at the incremented byte, then pass that length to `countBlobKeysBefore`. The all-`0xff` case still reports "no upper bound" and falls through to `countTreeEntries` as before.

## Testing

Added Category 123 to `test/sql_oracle_test.sh`, the existing differential suite against stock sqlite: nine cases covering negative integers and reals, ranges spanning zero, INT64 extremes, composite indexes, text and blob keys, `WITHOUT ROWID`, and counts after mutation.

Fail-before/pass-after on that suite:

- before the fix: **565 passed, 3 failed**
- after the fix: **568 passed, 0 failed**

Also run locally, all clean:

- `test/run_doltlite_tests.sh` — 99/99 suites
- `test/doltlite_regression_test_c.sh` — 310,123 tests, 0 failures
- testfixture `count countofview index index2 index3 index4 index5` — 197 passing, 11 known divergences, 0 unexpected
- testfixture `where{,2..9} minmax{,2,3,4}` — 5,035 passing, 57 known divergences, 0 unexpected

sqllogictest needs the separate CI build, so it is left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)