### PR TITLE
Verify remote chunks before publishing refs

### DIFF
--- a/main.mk
+++ b/main.mk
@@ -2695,6 +2695,7 @@ DOLTLITE_C_TESTS = \
 	prolly_hashset_test$(T.exe) \
 	prolly_chunker_boundary_test$(T.exe) \
 	scoped_refs_push_test$(T.exe) \
+	remote_chunk_integrity_test$(T.exe) \
 	sequence_reload_test$(T.exe) \
 	chunk_store_fork_lock_test$(T.exe) \
 	remotesrv_init_failure_test$(T.exe) \
@@ -2813,6 +2814,11 @@ prolly_chunker_boundary_test$(T.exe): $(TOP)/test/prolly_chunker_boundary_test.c
 scoped_refs_push_test$(T.exe): $(TOP)/test/scoped_refs_push_test.c libdoltlite$(T.lib)
 	$(T.link) -I. -I$(TOP)/src -DDOLTLITE_PROLLY=1 -D_HAVE_SQLITE_CONFIG_H \
 		-o $@ $(TOP)/test/scoped_refs_push_test.c \
+		libdoltlite$(T.lib) -lz -lpthread -lm
+
+remote_chunk_integrity_test$(T.exe): $(TOP)/test/remote_chunk_integrity_test.c libdoltlite$(T.lib)
+	$(T.link) -I. -I$(TOP)/src -DDOLTLITE_PROLLY=1 -D_HAVE_SQLITE_CONFIG_H \
+		-o $@ $(TOP)/test/remote_chunk_integrity_test.c \
 		libdoltlite$(T.lib) -lz -lpthread -lm
 
 # oom_dolt_fault_test installs a wrapper allocator that fails the Nth

--- a/src/doltlite_remote.c
+++ b/src/doltlite_remote.c
@@ -185,6 +185,75 @@ static int syncEnqueueChildren(
   return doltliteEnumerateChunkChildren(data, nData, syncChildCb, &ctx);
 }
 
+static int remoteValidateGraph(
+  ChunkStore *pStore,
+  const ProllyHash *aRoots,
+  int nRoots
+){
+  SyncQueue queue;
+  ProllyHashSet seen;
+  ProllyHash hash;
+  int rc;
+  int i;
+
+  rc = syncQueueInit(&queue);
+  if( rc!=SQLITE_OK ) return rc;
+  rc = prollyHashSetInit(&seen, 256);
+  if( rc!=SQLITE_OK ){
+    syncQueueFree(&queue);
+    return rc;
+  }
+  for(i=0; i<nRoots && rc==SQLITE_OK; i++){
+    if( !prollyHashIsEmpty(&aRoots[i])
+     && !prollyHashSetContains(&seen, &aRoots[i]) ){
+      rc = prollyHashSetAdd(&seen, &aRoots[i]);
+      if( rc==SQLITE_OK ) rc = syncQueuePush(&queue, &aRoots[i]);
+    }
+  }
+  while( rc==SQLITE_OK && syncQueuePop(&queue, &hash) ){
+    u8 *pData = 0;
+    int nData = 0;
+    rc = chunkStoreGet(pStore, &hash, &pData, &nData);
+    if( rc==SQLITE_NOTFOUND ) rc = SQLITE_CORRUPT;
+    if( rc==SQLITE_OK ){
+      rc = syncEnqueueChildren(pData, nData, &queue, &seen);
+    }
+    sqlite3_free(pData);
+  }
+  prollyHashSetFree(&seen);
+  syncQueueFree(&queue);
+  return rc;
+}
+
+int doltliteValidateRefsTargetGraph(
+  ChunkStore *pStore,
+  const u8 *pBlob,
+  int nBlob,
+  const char *zBranch
+){
+  ChunkStore refsView;
+  ProllyHash aRoots[2];
+  const BranchRef *aBranch;
+  int nBranch;
+  int rc;
+  int i;
+
+  rc = remoteLoadRefsView(pBlob, nBlob, &refsView);
+  if( rc!=SQLITE_OK ) return rc;
+  refsTableGetBranches(&refsView.refs, &nBranch, &aBranch);
+  rc = SQLITE_NOTFOUND;
+  for(i=0; i<nBranch; i++){
+    if( strcmp(aBranch[i].zName, zBranch)==0 ){
+      aRoots[0] = aBranch[i].commitHash;
+      aRoots[1] = aBranch[i].workingSetHash;
+      rc = remoteValidateGraph(pStore, aRoots, 2);
+      break;
+    }
+  }
+  chunkStoreClose(&refsView);
+  return rc;
+}
+
 #define SYNC_BATCH_SIZE 256
 
 /* A fetched chunk must hash to the address it was requested under. Without this
@@ -342,9 +411,9 @@ static int remoteGetChunk(DoltliteRemote *pRemote, const ProllyHash *pHash,
 static int remotePutChunk(DoltliteRemote *pRemote, const ProllyHash *pHash,
                           const u8 *pData, int nData){
   ChunkStore *pStore = ((RemoteStoreHdr*)pRemote)->pStore;
-  ProllyHash computed;
-  (void)pHash;
-  return chunkStorePut(pStore, pData, nData, &computed);
+  int rc = syncVerifyFetchedChunk(pHash, pData, nData);
+  if( rc!=SQLITE_OK ) return rc;
+  return chunkStorePut(pStore, pData, nData, 0);
 }
 
 static int remoteHasChunks(DoltliteRemote *pRemote, const ProllyHash *aHash,
@@ -404,6 +473,9 @@ static int fsSetRefs(DoltliteRemote *pRemote, const char *zBranch, int bForce,
   FsRemote *p = (FsRemote*)pRemote;
   int rc = doltliteValidateScopedRefsUpdate(&p->store, pData, nData,
                                             zBranch, bForce);
+  if( rc==SQLITE_OK ){
+    rc = doltliteValidateRefsTargetGraph(&p->store, pData, nData, zBranch);
+  }
   if( rc!=SQLITE_OK ) return rc;
   return chunkStoreInstallRefsBlob(&p->store, pData, nData);
 }
@@ -523,6 +595,9 @@ static int localSetRefs(DoltliteRemote *pRemote, const char *zBranch,
   LocalAsRemote *p = (LocalAsRemote*)pRemote;
   int rc = doltliteValidateScopedRefsUpdate(p->pStore, pData, nData,
                                             zBranch, bForce);
+  if( rc==SQLITE_OK ){
+    rc = doltliteValidateRefsTargetGraph(p->pStore, pData, nData, zBranch);
+  }
   if( rc!=SQLITE_OK ) return rc;
   return chunkStoreInstallRefsBlob(p->pStore, pData, nData);
 }

--- a/src/doltlite_remote.h
+++ b/src/doltlite_remote.h
@@ -53,6 +53,9 @@ int doltliteValidateScopedRefsUpdate(ChunkStore *pStore, const u8 *pBlob,
                                      int nBlob, const char *zBranch,
                                      int bForce);
 
+int doltliteValidateRefsTargetGraph(ChunkStore *pStore, const u8 *pBlob,
+                                    int nBlob, const char *zBranch);
+
 int doltliteFetch(ChunkStore *pLocal, DoltliteRemote *pRemote,
                   const char *zRemoteName, const char *zBranch);
 

--- a/src/doltlite_remotesrv.c
+++ b/src/doltlite_remotesrv.c
@@ -658,15 +658,24 @@ static void handleGetChunk(ChunkStore *pStore, DoltliteConn *fd, const char *zHe
   sqlite3_free(pData);
 }
 
-static void handlePostChunks(ChunkStore *pStore, DoltliteConn *fd,
-                             const u8 *pBody, int nBody){
+static int remoteSrvStoreChunkBatch(
+  ChunkStore *pStore,
+  const u8 *pBody,
+  int nBody
+){
   int offset = 0;
   int rc;
 
-  while( offset + PROLLY_HASH_SIZE + 4 <= nBody ){
+  while( offset<nBody ){
     u32 len;
-    ProllyHash hash;
+    ProllyHash declared;
+    ProllyHash computed;
 
+    if( nBody-offset < PROLLY_HASH_SIZE+4 ){
+      rc = SQLITE_PROTOCOL;
+      goto store_error;
+    }
+    memcpy(declared.data, pBody+offset, PROLLY_HASH_SIZE);
     offset += PROLLY_HASH_SIZE;
 
     len = (u32)pBody[offset]
@@ -675,23 +684,36 @@ static void handlePostChunks(ChunkStore *pStore, DoltliteConn *fd,
         | ((u32)pBody[offset+3] << 24);
     offset += 4;
 
-    /* Compare as unsigned and cap single-chunk memory use. */
     if( len > (u32)MAX_CHUNK_BYTES
      || len > (u32)(nBody - offset) ){
-      sendBadRequest(fd);
-      return;
+      rc = SQLITE_PROTOCOL;
+      goto store_error;
     }
 
-    rc = chunkStorePut(pStore, pBody + offset, (int)len, &hash);
-    if( rc!=SQLITE_OK ){
-      chunkStoreRollback(pStore);
-      sendSqliteError(fd, rc);
-      return;
+    prollyHashCompute(pBody+offset, (int)len, &computed);
+    if( prollyHashCompare(&declared, &computed)!=0 ){
+      rc = SQLITE_PROTOCOL;
+      goto store_error;
     }
+    rc = chunkStorePut(pStore, pBody+offset, (int)len, 0);
+    if( rc!=SQLITE_OK ) goto store_error;
     offset += (int)len;
   }
 
-  rc = remoteSrvCommitPending(pStore);
+  return remoteSrvCommitPending(pStore);
+
+store_error:
+  chunkStoreRollback(pStore);
+  return rc;
+}
+
+static void handlePostChunks(ChunkStore *pStore, DoltliteConn *fd,
+                             const u8 *pBody, int nBody){
+  int rc = remoteSrvStoreChunkBatch(pStore, pBody, nBody);
+  if( rc==SQLITE_PROTOCOL ){
+    sendBadRequest(fd);
+    return;
+  }
   if( rc!=SQLITE_OK ){
     sendSqliteError(fd, rc);
     return;
@@ -737,6 +759,9 @@ static int remoteSrvApplyRefs(ChunkStore *pStore, const char *zBranch,
 
   if( nBody<=0 ) return SQLITE_ERROR;
   rc = doltliteValidateScopedRefsUpdate(pStore, pBody, nBody, zBranch, bForce);
+  if( rc==SQLITE_OK ){
+    rc = doltliteValidateRefsTargetGraph(pStore, pBody, nBody, zBranch);
+  }
   if( rc!=SQLITE_OK ){
     chunkStoreRollback(pStore);
     return rc;
@@ -848,6 +873,12 @@ static void handlePutRefsIf(ChunkStore *pStore, DoltliteConn *fd,
 
 int doltliteRemoteSrvCommitPendingForTest(ChunkStore *pStore){
   return remoteSrvCommitPending(pStore);
+}
+
+int doltliteRemoteSrvStoreChunkBatchForTest(
+  ChunkStore *pStore, const u8 *pBody, int nBody
+){
+  return remoteSrvStoreChunkBatch(pStore, pBody, nBody);
 }
 
 int doltliteRemoteSrvApplyRefsForTest(

--- a/test/remote_chunk_integrity_test.c
+++ b/test/remote_chunk_integrity_test.c
@@ -1,0 +1,229 @@
+#ifdef DOLTLITE_PROLLY
+
+#include "doltlite_commit.h"
+#include "doltlite_remote.h"
+#include <stdio.h>
+#include <string.h>
+
+typedef struct FakeRemote FakeRemote;
+struct FakeRemote {
+  DoltliteRemote base;
+  const u8 *pData;
+  int nData;
+  int nPut;
+};
+
+static int failures;
+
+int doltliteRemoteSrvStoreChunkBatchForTest(
+  ChunkStore *pStore, const u8 *pBody, int nBody
+);
+
+static void check(const char *zName, int ok){
+  if( !ok ){
+    fprintf(stderr, "FAIL: %s\n", zName);
+    failures++;
+  }
+}
+
+static int fakeGetChunk(
+  DoltliteRemote *pRemote,
+  const ProllyHash *pHash,
+  u8 **ppData,
+  int *pnData
+){
+  FakeRemote *p = (FakeRemote*)pRemote;
+  (void)pHash;
+  *ppData = sqlite3_malloc(p->nData);
+  if( !*ppData ) return SQLITE_NOMEM;
+  memcpy(*ppData, p->pData, p->nData);
+  *pnData = p->nData;
+  return SQLITE_OK;
+}
+
+static int fakeGetChunks(
+  DoltliteRemote *pRemote,
+  const ProllyHash *aHash,
+  int nHash,
+  u8 **apData,
+  int *anData
+){
+  int i;
+  for(i=0; i<nHash; i++){
+    int rc = fakeGetChunk(pRemote, &aHash[i], &apData[i], &anData[i]);
+    if( rc!=SQLITE_OK ) return rc;
+  }
+  return SQLITE_OK;
+}
+
+static int fakeHasChunks(
+  DoltliteRemote *pRemote,
+  const ProllyHash *aHash,
+  int nHash,
+  u8 *aResult
+){
+  (void)pRemote;
+  (void)aHash;
+  memset(aResult, 0, nHash);
+  return SQLITE_OK;
+}
+
+static int fakePutChunk(
+  DoltliteRemote *pRemote,
+  const ProllyHash *pHash,
+  const u8 *pData,
+  int nData
+){
+  FakeRemote *p = (FakeRemote*)pRemote;
+  (void)pHash;
+  (void)pData;
+  (void)nData;
+  p->nPut++;
+  return SQLITE_OK;
+}
+
+static int syncOnce(
+  const u8 *pData,
+  int nData,
+  const ProllyHash *pRoot,
+  int bBatch,
+  int *pnPut
+){
+  FakeRemote src;
+  FakeRemote dst;
+  ProllyHash root = *pRoot;
+  int rc;
+
+  memset(&src, 0, sizeof(src));
+  memset(&dst, 0, sizeof(dst));
+  src.pData = pData;
+  src.nData = nData;
+  src.base.xGetChunk = fakeGetChunk;
+  if( bBatch ) src.base.xGetChunks = fakeGetChunks;
+  dst.base.xHasChunks = fakeHasChunks;
+  dst.base.xPutChunk = fakePutChunk;
+  rc = doltliteSyncChunks(&src.base, &dst.base, &root, 1);
+  *pnPut = dst.nPut;
+  return rc;
+}
+
+static u8 *makeRefsBlob(const ProllyHash *pCommit, int *pnBlob){
+  ChunkStore refs;
+  u8 *pBlob = 0;
+  memset(&refs, 0, sizeof(refs));
+  if( chunkStoreSetDefaultBranch(&refs, "main")!=SQLITE_OK ) return 0;
+  if( chunkStoreAddBranch(&refs, "main", pCommit)!=SQLITE_OK ){
+    chunkStoreClose(&refs);
+    return 0;
+  }
+  if( chunkStoreSerializeRefsToBlob(&refs, &pBlob, pnBlob)!=SQLITE_OK ){
+    pBlob = 0;
+  }
+  chunkStoreClose(&refs);
+  return pBlob;
+}
+
+static void putLength(u8 *p, int n){
+  p[0] = (u8)(n & 0xff);
+  p[1] = (u8)((n >> 8) & 0xff);
+  p[2] = (u8)((n >> 16) & 0xff);
+  p[3] = (u8)((n >> 24) & 0xff);
+}
+
+int main(void){
+  DoltliteCommit commit;
+  ChunkStore store;
+  ProllyHash actual;
+  ProllyHash wrong;
+  u8 *pCommit = 0;
+  u8 *pBody = 0;
+  u8 *pRefs = 0;
+  int nCommit = 0;
+  int nRecord;
+  int nRefs = 0;
+  int nPut = 0;
+  int has = 0;
+  int rc;
+
+  sqlite3_initialize();
+  memset(&commit, 0, sizeof(commit));
+  commit.timestamp = 1;
+  commit.zName = "n";
+  commit.zEmail = "e";
+  commit.zMessage = "m";
+  rc = doltliteCommitSerialize(&commit, &pCommit, &nCommit);
+  check("serialize commit", rc==SQLITE_OK);
+  if( rc!=SQLITE_OK ) return 1;
+  prollyHashCompute(pCommit, nCommit, &actual);
+  wrong = actual;
+  wrong.data[0] ^= 0xff;
+
+  rc = syncOnce(pCommit, nCommit, &wrong, 0, &nPut);
+  check("single fetch rejects mismatched hash", rc==SQLITE_CORRUPT);
+  check("single fetch stores nothing", nPut==0);
+  rc = syncOnce(pCommit, nCommit, &wrong, 1, &nPut);
+  check("batch fetch rejects mismatched hash", rc==SQLITE_CORRUPT);
+  check("batch fetch stores nothing", nPut==0);
+  rc = syncOnce(pCommit, nCommit, &actual, 1, &nPut);
+  check("batch fetch accepts matching hash", rc==SQLITE_OK);
+  check("matching batch stores chunk", nPut==1);
+
+  memset(&store, 0, sizeof(store));
+  rc = chunkStoreOpen(&store, sqlite3_vfs_find(0), ":memory:",
+      SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_MAIN_DB);
+  check("open chunk store", rc==SQLITE_OK);
+  if( rc!=SQLITE_OK ) goto done;
+
+  nRecord = PROLLY_HASH_SIZE + 4 + nCommit;
+  pBody = sqlite3_malloc64((sqlite3_uint64)nRecord * 2);
+  check("allocate upload body", pBody!=0);
+  if( !pBody ) goto close_store;
+  memcpy(pBody, actual.data, PROLLY_HASH_SIZE);
+  putLength(pBody+PROLLY_HASH_SIZE, nCommit);
+  memcpy(pBody+PROLLY_HASH_SIZE+4, pCommit, nCommit);
+  memcpy(pBody+nRecord, wrong.data, PROLLY_HASH_SIZE);
+  putLength(pBody+nRecord+PROLLY_HASH_SIZE, nCommit);
+  memcpy(pBody+nRecord+PROLLY_HASH_SIZE+4, pCommit, nCommit);
+
+  rc = doltliteRemoteSrvStoreChunkBatchForTest(&store, pBody, nRecord*2);
+  check("upload rejects mismatched declared hash", rc==SQLITE_PROTOCOL);
+  rc = chunkStoreHas(&store, &actual, &has);
+  check("rejected upload rolls back whole batch", rc==SQLITE_OK && !has);
+  rc = doltliteRemoteSrvStoreChunkBatchForTest(&store, pBody, nRecord);
+  check("upload accepts matching declared hash", rc==SQLITE_OK);
+  rc = chunkStoreHas(&store, &actual, &has);
+  check("accepted upload stores chunk", rc==SQLITE_OK && has);
+  rc = doltliteRemoteSrvStoreChunkBatchForTest(&store, pBody, nRecord-1);
+  check("upload rejects truncated record", rc==SQLITE_PROTOCOL);
+
+  pRefs = makeRefsBlob(&wrong, &nRefs);
+  check("serialize refs", pRefs!=0);
+  if( pRefs ){
+    rc = doltliteValidateRefsTargetGraph(&store, pRefs, nRefs, "main");
+    check("refs reject missing reachable graph", rc==SQLITE_CORRUPT);
+    sqlite3_free(pRefs);
+    pRefs = makeRefsBlob(&actual, &nRefs);
+    check("serialize valid refs", pRefs!=0);
+    if( pRefs ){
+      rc = doltliteValidateRefsTargetGraph(&store, pRefs, nRefs, "main");
+      check("refs accept complete reachable graph", rc==SQLITE_OK);
+    }
+  }
+
+close_store:
+  chunkStoreClose(&store);
+done:
+  sqlite3_free(pRefs);
+  sqlite3_free(pBody);
+  sqlite3_free(pCommit);
+  if( failures ){
+    fprintf(stderr, "remote_chunk_integrity_test: %d failure(s)\n", failures);
+    return 1;
+  }
+  printf("remote_chunk_integrity_test: all passed\n");
+  return 0;
+}
+
+#else
+int main(void){ return 0; }
+#endif

--- a/test/run_c_tests.sh
+++ b/test/run_c_tests.sh
@@ -27,6 +27,7 @@ COVERAGE_TESTS=(
   prolly_hashset_test
   prolly_chunker_boundary_test
   scoped_refs_push_test
+  remote_chunk_integrity_test
   cross_branch_test
   corruption_test
   gc_tip_survival_test


### PR DESCRIPTION
## Summary

- reject HTTP chunk records whose declared address does not match their payload
- roll back malformed upload batches and reject truncated framing
- verify destination puts and require the pushed commit and working-set graph to be complete before installing refs
- add focused C coverage for single and batch fetches, upload atomicity, malformed records, and incomplete graphs

## Testing

- ./build/remote_chunk_integrity_test
- bash test/run_c_tests.sh build coverage
- bash test/remote_test.sh build/doltlite
- bash test/remotesrv_http_test.sh build/doltlite build/doltlite-remotesrv
- bash test/remotesrv_http_force_push_test.sh build/doltlite build/doltlite-remotesrv
- bash test/remotesrv_http_partial_failure_test.sh build/doltlite build/doltlite-remotesrv
- make -C build lint
- bash test/run_doltlite_tests.sh

Co-Authored-By: OpenAI Codex <noreply@openai.com>