### PR TITLE
Key the cell-merge index delete on ours' row, not base

### DIFF
--- a/src/doltlite_merge_rows.c
+++ b/src/doltlite_merge_rows.c
@@ -642,7 +642,7 @@ static int rowMergeCallback(void *pCtx, const ThreeWayChange *pChange){
             rc = doltliteIndexMutMapRowDelta(
                 mi->pEdits, mi->aiColumn, mi->nColumn, mi->pKeyInfo,
                 mi->iPKey, pChange->intKey, pChange->pKey, pChange->nKey,
-                pChange->pBaseVal, pChange->nBaseVal, pMerged, nMerged);
+                pChange->pOurVal, pChange->nOurVal, pMerged, nMerged);
           }
         }
         sqlite3_free(pMerged);

--- a/test/doltlite_merge_index_conflict.sh
+++ b/test/doltlite_merge_index_conflict.sh
@@ -354,6 +354,65 @@ EOF
 )
 check "index_on_excluded_rename_is_not_adopted" "1|c,ours_a" "$out"
 
+# A modify/modify change that touches disjoint columns merges cell-wise rather
+# than conflicting. The index delta for that merged row must be taken against
+# ours' row, since the index it patches is built over ours' root. Indexes
+# spanning both an ours-changed and a theirs-changed column are what expose a
+# base-keyed delete: it misses, and ours' entry survives beside the merged one.
+DB="$TMPROOT/cellmerge.db"
+"$DOLTLITE" "$DB" <<'EOF' >/dev/null 2>&1
+CREATE TABLE t(pk INTEGER PRIMARY KEY, a TEXT, b TEXT, c TEXT);
+CREATE INDEX iab ON t(a,b);
+CREATE INDEX iabc ON t(a,b,c);
+INSERT INTO t VALUES(1,'a0','b0','c0'),(2,'p0','q0','r0');
+SELECT dolt_commit('-A','-m','init');
+SELECT dolt_checkout('-b','feat');
+UPDATE t SET b='b1' WHERE pk=1;
+UPDATE t SET b='q1' WHERE pk=2;
+SELECT dolt_commit('-A','-m','theirs');
+SELECT dolt_checkout('main');
+UPDATE t SET a='a1' WHERE pk=1;
+UPDATE t SET a='p1' WHERE pk=2;
+SELECT dolt_commit('-A','-m','ours');
+SELECT dolt_merge('feat');
+EOF
+out=$("$DOLTLITE" "$DB" "SELECT group_concat(pk||':'||a||':'||b,' ') FROM (SELECT pk,a,b FROM t NOT INDEXED ORDER BY pk);")
+check "cellmerge_table_scan_rows" "1:a1:b1 2:p1:q1" "$out"
+out=$("$DOLTLITE" "$DB" "SELECT group_concat(pk||':'||a||':'||b,' ') FROM (SELECT pk,a,b FROM t INDEXED BY iab WHERE a>='' ORDER BY a,b,pk);")
+check "cellmerge_composite_index_has_no_stale_entry" "1:a1:b1 2:p1:q1" "$out"
+out=$("$DOLTLITE" "$DB" "SELECT count(*) FROM (SELECT pk FROM t INDEXED BY iab WHERE a>='');")
+check "cellmerge_composite_index_count" "2" "$out"
+out=$("$DOLTLITE" "$DB" "SELECT group_concat(pk||':'||a||':'||b||':'||c,' ') FROM (SELECT pk,a,b,c FROM t INDEXED BY iabc WHERE a>='' ORDER BY a,b,c,pk);")
+check "cellmerge_three_col_index_has_no_stale_entry" "1:a1:b1:c0 2:p1:q1:r0" "$out"
+out=$("$DOLTLITE" "$DB" "SELECT pk||':'||a||':'||b FROM t INDEXED BY iab WHERE a='a1';")
+check "cellmerge_index_seek_serves_merged_row_only" "1:a1:b1" "$out"
+
+PRE=$("$DOLTLITE" "$DB" "SELECT group_concat(pk||':'||a||':'||b,' ') FROM (SELECT pk,a,b FROM t INDEXED BY iab WHERE a>='' ORDER BY a,b,pk);")
+"$DOLTLITE" "$DB" "REINDEX iab;" >/dev/null 2>&1
+POST=$("$DOLTLITE" "$DB" "SELECT group_concat(pk||':'||a||':'||b,' ') FROM (SELECT pk,a,b FROM t INDEXED BY iab WHERE a>='' ORDER BY a,b,pk);")
+check "cellmerge_index_matches_full_rebuild" "$POST" "$PRE"
+
+# Same shape reached through cherry-pick and revert, which replay onto ours
+# through the identical row-merge path.
+DB="$TMPROOT/cellmerge_pick.db"
+"$DOLTLITE" "$DB" <<'EOF' >/dev/null 2>&1
+CREATE TABLE t(pk INTEGER PRIMARY KEY, a TEXT, b TEXT);
+CREATE INDEX iab ON t(a,b);
+INSERT INTO t VALUES(1,'a0','b0');
+SELECT dolt_commit('-A','-m','init');
+SELECT dolt_checkout('-b','feat');
+UPDATE t SET b='b1' WHERE pk=1;
+SELECT dolt_commit('-A','-m','theirs');
+SELECT dolt_checkout('main');
+UPDATE t SET a='a1' WHERE pk=1;
+SELECT dolt_commit('-A','-m','ours');
+SELECT dolt_cherry_pick('feat');
+EOF
+out=$("$DOLTLITE" "$DB" "SELECT group_concat(pk||':'||a||':'||b,' ') FROM (SELECT pk,a,b FROM t NOT INDEXED ORDER BY pk);")
+check "cherry_pick_cellmerge_table_scan_rows" "1:a1:b1" "$out"
+out=$("$DOLTLITE" "$DB" "SELECT group_concat(pk||':'||a||':'||b,' ') FROM (SELECT pk,a,b FROM t INDEXED BY iab WHERE a>='' ORDER BY a,b,pk);")
+check "cherry_pick_cellmerge_index_has_no_stale_entry" "1:a1:b1" "$out"
+
 echo
 echo "doltlite_merge_index_conflict: $pass passed, $fail failed"
 if [ "$fail" -gt 0 ]; then


### PR DESCRIPTION
## Problem

When a modify/modify change touches disjoint columns, `rowMergeCallback` merges it cell-wise instead of raising a conflict. The secondary-index delta for that merged row was built with the **base** row as the old value (`src/doltlite_merge_rows.c:645`), but those index edits are flushed over **ours'** root (`:813`), whose entry is keyed on ours' values.

A cell merge means ours differs from base by definition, so the delete targeted a key that isn't in ours' index. It missed, and ours' entry survived beside the newly inserted merged entry.

The neighbouring `RIGHT_MODIFY` and `RIGHT_DELETE` cases pass the base row and are correct, because ours equals base in those cases.

An index has to span **both** an ours-changed and a theirs-changed column to expose this. When it covers only one side, the merged value equals ours' value for those columns, so the insert lands on exactly the key the missed delete left behind and the net result is right. That is why the existing single-column merge-index tests didn't catch it — and why the two-index case at `test/doltlite_merge_index_conflict.sh:107` doesn't either, since it changes both columns on both sides and so resolves as a genuine conflict via `--ours` rather than cell-merging.

Reproduction:

```sql
CREATE TABLE t(pk INTEGER PRIMARY KEY, a TEXT, b TEXT);
CREATE INDEX iab ON t(a,b);
INSERT INTO t VALUES(1,'a0','b0');
-- commit; branch feat sets b='b1'; main sets a='a1'; both commit; merge feat
```

After the merge the table scan correctly returned one row `1|a1|b1`, while `iab` served two: the phantom `1|a1|b0` and `1|a1|b1`. `SELECT count(*)` through the index gave 2 instead of 1.

Two things make this worse than a stale-read: `PRAGMA integrity_check` reported **ok**, and the corruption is reached through merge, cherry-pick, revert, and rebase replay, since all four go through `mergeTableRows`. `REINDEX` repairs it.

## Fix

Pass `pChange->pOurVal`/`nOurVal` as the delta's old value, matching the root the edits are applied over. One line.

## Testing

Extended `test/doltlite_merge_index_conflict.sh`, the existing merge-plus-secondary-index suite, with eight checks: composite and three-column indexes spanning both sides, an index seek, a count through the index, a rebuild-equivalence property comparing the post-merge index against the same query after `REINDEX`, and the same shape reached through `dolt_cherry_pick`. Two rows are cell-merged, not one, so the assertion isn't a single-row coincidence.

Fail-before/pass-after on that suite:

- before the fix: **20 passed, 6 failed**
- after the fix: **26 passed, 0 failed**

The two table-scan checks passed in both runs, which localizes the defect to index maintenance rather than the merged row data.

Also run locally, all clean:

- `test/run_doltlite_tests.sh` — 99/99 suites
- `test/doltlite_regression_test_c.sh` — 310,123 tests, 0 failures
- `test/sql_oracle_test.sh` vs stock sqlite — 568 passed, 0 failed
- Dolt 2.2.2 oracle suites, 301 checks total, 0 failures: `vc_oracle_merge_test` (75), `vc_oracle_schema_merge_test` (81), `vc_oracle_revert_cherrypick_test` (58), `vc_oracle_fk_merge_test` (39), `vc_oracle_merge_base_test` (32), `vc_oracle_merge_status_test` (10), `vc_oracle_revert_test` (6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)