### PR TITLE
Report inactive branch working changes as dirty

### DIFF
--- a/src/doltlite_branches.c
+++ b/src/doltlite_branches.c
@@ -139,6 +139,7 @@ static int brIsDirty(
   const BranchRef *br,
   int *pDirty
 ){
+  ProllyHash workingCat;
   ProllyHash stagedCat;
   ProllyHash commitCat;
   u8 *wsData = 0;
@@ -159,20 +160,21 @@ static int brIsDirty(
     sqlite3_free(wsData);
     return rc==SQLITE_OK ? SQLITE_CORRUPT : rc;
   }
+  memcpy(workingCat.data, wsData + WS_WORKING_CAT_OFF, PROLLY_HASH_SIZE);
   memcpy(stagedCat.data, wsData + WS_STAGED_OFF, PROLLY_HASH_SIZE);
   sqlite3_free(wsData);
 
-  if( prollyHashIsEmpty(&stagedCat) ){
-    return SQLITE_OK;
-  }
-
   if( prollyHashIsEmpty(&br->commitHash) ){
-    *pDirty = 1;
+    *pDirty = !prollyHashIsEmpty(&workingCat)
+           || !prollyHashIsEmpty(&stagedCat);
     return SQLITE_OK;
   }
   rc = doltliteCommitCatalogHash(db, &br->commitHash, &commitCat);
   if( rc==SQLITE_OK ){
-    *pDirty = prollyHashCompare(&stagedCat, &commitCat)!=0;
+    *pDirty = (!prollyHashIsEmpty(&workingCat)
+            && prollyHashCompare(&workingCat, &commitCat)!=0)
+           || (!prollyHashIsEmpty(&stagedCat)
+            && prollyHashCompare(&stagedCat, &commitCat)!=0);
   }
   return rc;
 }

--- a/test/doltlite_branch.sh
+++ b/test/doltlite_branch.sh
@@ -164,5 +164,14 @@ run_test "branch_from_first_parent_ref_persists_across_reopen" "SELECT count(*) 
 run_test "branch_from_second_parent_ref_persists_across_reopen" "SELECT count(*) FROM t;" "2" "$DB13/from_p2"
 run_test "branch_from_second_parent_hash_persists_across_reopen" "SELECT count(*) FROM t;" "2" "$DB13/from_hash"
 
-rm -f "$DB" "$DB2" "$DB2B" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8" "$DB9" "$DB10" "$DB11" "$DB12" "$DB13"
+DB14=/tmp/test_branch14_$$.db; rm -f "$DB14"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'base'); SELECT dolt_commit('-A','-m','init'); SELECT dolt_branch('feature'); SELECT dolt_checkout('feature'); UPDATE t SET v='working' WHERE id=1; SELECT dolt_checkout('main');" | $DOLTLITE "$DB14" > /dev/null 2>&1
+run_test "inactive_branch_unstaged_changes_are_dirty" "SELECT dirty FROM dolt_branches WHERE name='feature';" "1" "$DB14"
+run_test "inactive_branch_peer_remains_clean" "SELECT dirty FROM dolt_branches WHERE name='main';" "0" "$DB14"
+echo "SELECT dolt_checkout('feature'); SELECT dolt_add('-A'); SELECT dolt_checkout('main');" | $DOLTLITE "$DB14" > /dev/null 2>&1
+run_test "inactive_branch_staged_changes_are_dirty" "SELECT dirty FROM dolt_branches WHERE name='feature';" "1" "$DB14"
+echo "SELECT dolt_checkout('feature'); SELECT dolt_commit('-m','feature change'); SELECT dolt_checkout('main');" | $DOLTLITE "$DB14" > /dev/null 2>&1
+run_test "inactive_branch_committed_changes_are_clean" "SELECT dirty FROM dolt_branches WHERE name='feature';" "0" "$DB14"
+
+rm -f "$DB" "$DB2" "$DB2B" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8" "$DB9" "$DB10" "$DB11" "$DB12" "$DB13" "$DB14"
 dltest_finish


### PR DESCRIPTION
## Summary

- include the persisted working catalog when computing `dolt_branches.dirty` for inactive branches
- preserve staged-versus-HEAD detection and unborn-branch behavior
- cover unstaged, staged, and committed inactive-branch states

## Failure before

A branch with an unstaged update reported `dirty = 0` after checking out another branch.

## Testing

- `DOLTLITE=build/doltlite bash test/doltlite_branch.sh` (66/66)
- `bash test/vc_oracle_branches_test.sh build/doltlite dolt` (15/15)
- `bash test/run_doltlite_tests.sh` (99/99 suites; 310,123 C regression assertions)
- `make -C build lint`

Co-Authored-By: OpenAI Codex <noreply@openai.com>