### PR TITLE
Enforce the push scope over the whole refs blob

### DIFF
--- a/src/doltlite_remote.c
+++ b/src/doltlite_remote.c
@@ -741,6 +741,115 @@ static int syncIsAncestor(
   return found;
 }
 
+static int scopedSameText(const char *zA, const char *zB){
+  return strcmp(zA ? zA : "", zB ? zB : "")==0;
+}
+
+/* Same fallback csSerializeRefsBlob applies, so an unset default and an
+** explicit "main" compare equal rather than reading as a repoint. */
+static const char *scopedDefaultBranch(const RefsTable *rt){
+  return rt->zDefaultBranch ? rt->zDefaultBranch : "main";
+}
+
+/* Refs lookups resolve a name to its first matching slot, so a duplicate name
+** is a shadow entry: unreachable through the refs API, invisible to a scope
+** check that compares first matches, yet carried forward by every later
+** reserialization. Every named section must be a set. */
+static int scopedNamesAreUnique(const void *aBase, int n, int stride){
+  const char *p = (const char*)aBase;
+  int i, j;
+  for(i=0; i<n; i++){
+    const char *zI = *(const char *const*)(p + (size_t)i*stride);
+    if( !zI ) return 0;
+    for(j=0; j<i; j++){
+      const char *zJ = *(const char *const*)(p + (size_t)j*stride);
+      if( zJ && strcmp(zJ, zI)==0 ) return 0;
+    }
+  }
+  return 1;
+}
+
+/* Tracking entries are keyed by the remote/branch pair, not the leading name. */
+static int scopedTrackingIsUnique(const TrackingBranch *a, int n){
+  int i, j;
+  for(i=0; i<n; i++){
+    if( !a[i].zRemote || !a[i].zBranch ) return 0;
+    for(j=0; j<i; j++){
+      if( scopedSameText(a[j].zRemote, a[i].zRemote)
+       && scopedSameText(a[j].zBranch, a[i].zBranch) ){
+        return 0;
+      }
+    }
+  }
+  return 1;
+}
+
+static int scopedTagsMatch(const TagRef *aCur, int nCur,
+                           const TagRef *aInc, int nInc){
+  int i, j;
+  if( nCur!=nInc ) return 0;
+  for(i=0; i<nCur; i++){
+    for(j=0; j<nInc; j++){
+      if( scopedSameText(aInc[j].zName, aCur[i].zName) ) break;
+    }
+    if( j>=nInc ) return 0;
+    if( prollyHashCompare(&aInc[j].commitHash, &aCur[i].commitHash)!=0 ) return 0;
+    if( aInc[j].timestamp!=aCur[i].timestamp ) return 0;
+    if( !scopedSameText(aInc[j].zTagger, aCur[i].zTagger)
+     || !scopedSameText(aInc[j].zEmail, aCur[i].zEmail)
+     || !scopedSameText(aInc[j].zMessage, aCur[i].zMessage) ){
+      return 0;
+    }
+  }
+  return 1;
+}
+
+static int scopedRemotesMatch(const RemoteRef *aCur, int nCur,
+                              const RemoteRef *aInc, int nInc){
+  int i, j;
+  if( nCur!=nInc ) return 0;
+  for(i=0; i<nCur; i++){
+    for(j=0; j<nInc; j++){
+      if( scopedSameText(aInc[j].zName, aCur[i].zName) ) break;
+    }
+    if( j>=nInc || !scopedSameText(aInc[j].zUrl, aCur[i].zUrl) ) return 0;
+  }
+  return 1;
+}
+
+static int scopedTrackingMatch(const TrackingBranch *aCur, int nCur,
+                               const TrackingBranch *aInc, int nInc){
+  int i, j;
+  if( nCur!=nInc ) return 0;
+  for(i=0; i<nCur; i++){
+    for(j=0; j<nInc; j++){
+      if( scopedSameText(aInc[j].zRemote, aCur[i].zRemote)
+       && scopedSameText(aInc[j].zBranch, aCur[i].zBranch) ){
+        break;
+      }
+    }
+    if( j>=nInc
+     || prollyHashCompare(&aInc[j].commitHash, &aCur[i].commitHash)!=0 ){
+      return 0;
+    }
+  }
+  return 1;
+}
+
+/* Push bumps the shared AUTOINCREMENT counters, so these may rise and gain
+** entries. Regressing or dropping one would hand out row ids already used. */
+static int scopedSequencesOnlyAdvance(const SequenceRef *aCur, int nCur,
+                                      const SequenceRef *aInc, int nInc){
+  int i, j;
+  for(i=0; i<nCur; i++){
+    for(j=0; j<nInc; j++){
+      if( scopedSameText(aInc[j].zTableName, aCur[i].zTableName) ) break;
+    }
+    if( j>=nInc || aInc[j].iSeq < aCur[i].iSeq ) return 0;
+  }
+  return 1;
+}
+
 int doltliteValidateScopedRefsUpdate(
   ChunkStore *pStore,
   const u8 *pBlob,
@@ -751,7 +860,12 @@ int doltliteValidateScopedRefsUpdate(
   ChunkStore inc;
   const BranchRef *aCur = 0, *aInc = 0;
   const TagRef *aCurTag = 0, *aIncTag = 0;
+  const RemoteRef *aCurRem = 0, *aIncRem = 0;
+  const TrackingBranch *aCurTrk = 0, *aIncTrk = 0;
+  const SequenceRef *aCurSeq = 0, *aIncSeq = 0;
   int nCur = 0, nInc = 0, nCurTag = 0, nIncTag = 0;
+  int nCurRem = 0, nIncRem = 0, nCurTrk = 0, nIncTrk = 0;
+  int nCurSeq = 0, nIncSeq = 0;
   const BranchRef *curB = 0, *incB = 0;
   int rc;
   int i, j;
@@ -768,16 +882,33 @@ int doltliteValidateScopedRefsUpdate(
   refsTableGetBranches(&inc.refs, &nInc, &aInc);
   refsTableGetTags(&pStore->refs, &nCurTag, &aCurTag);
   refsTableGetTags(&inc.refs, &nIncTag, &aIncTag);
+  refsTableGetRemotes(&pStore->refs, &nCurRem, &aCurRem);
+  refsTableGetRemotes(&inc.refs, &nIncRem, &aIncRem);
+  refsTableGetTracking(&pStore->refs, &nCurTrk, &aCurTrk);
+  refsTableGetTracking(&inc.refs, &nIncTrk, &aIncTrk);
+  refsTableGetSequences(&pStore->refs, &nCurSeq, &aCurSeq);
+  refsTableGetSequences(&inc.refs, &nIncSeq, &aIncSeq);
+
+  if( !scopedNamesAreUnique(aInc, nInc, (int)sizeof(BranchRef))
+   || !scopedNamesAreUnique(aIncTag, nIncTag, (int)sizeof(TagRef))
+   || !scopedNamesAreUnique(aIncRem, nIncRem, (int)sizeof(RemoteRef))
+   || !scopedNamesAreUnique(aIncSeq, nIncSeq, (int)sizeof(SequenceRef))
+   || !scopedTrackingIsUnique(aIncTrk, nIncTrk) ){
+    rc = SQLITE_CONSTRAINT;
+    goto done;
+  }
 
   /* Every current branch other than the one being pushed must survive
-  ** unchanged: same name present, same commit. Blocks rewrite and delete. */
+  ** unchanged: same name present, same commit and working set. Blocks rewrite
+  ** and delete. */
   for(i=0; i<nCur; i++){
     if( strcmp(aCur[i].zName, zBranch)==0 ) continue;
     for(j=0; j<nInc; j++){
       if( strcmp(aInc[j].zName, aCur[i].zName)==0 ) break;
     }
     if( j>=nInc
-     || prollyHashCompare(&aInc[j].commitHash, &aCur[i].commitHash)!=0 ){
+     || prollyHashCompare(&aInc[j].commitHash, &aCur[i].commitHash)!=0
+     || prollyHashCompare(&aInc[j].workingSetHash, &aCur[i].workingSetHash)!=0 ){
       rc = SQLITE_CONSTRAINT;
       goto done;
     }
@@ -795,20 +926,23 @@ int doltliteValidateScopedRefsUpdate(
     }
   }
 
-  /* Tags are immutable over push: identical set, identical targets. */
-  if( nCurTag!=nIncTag ){
+  /* Tags are immutable over push: identical set, identical targets, identical
+  ** annotations. Remotes and tracking are likewise none of a push's business. */
+  if( !scopedTagsMatch(aCurTag, nCurTag, aIncTag, nIncTag)
+   || !scopedRemotesMatch(aCurRem, nCurRem, aIncRem, nIncRem)
+   || !scopedTrackingMatch(aCurTrk, nCurTrk, aIncTrk, nIncTrk)
+   || !scopedSequencesOnlyAdvance(aCurSeq, nCurSeq, aIncSeq, nIncSeq) ){
     rc = SQLITE_CONSTRAINT;
     goto done;
   }
-  for(i=0; i<nCurTag; i++){
-    for(j=0; j<nIncTag; j++){
-      if( strcmp(aCurTag[i].zName, aIncTag[j].zName)==0 ) break;
-    }
-    if( j>=nIncTag
-     || prollyHashCompare(&aIncTag[j].commitHash, &aCurTag[i].commitHash)!=0 ){
-      rc = SQLITE_CONSTRAINT;
-      goto done;
-    }
+
+  /* Whatever the default branch names is what a clone checks out and what
+  ** GET /root resolves, so a push may not repoint it. An empty target
+  ** legitimately adopts the pushed branch, the way doltlitePush seeds one. */
+  if( !scopedSameText(scopedDefaultBranch(&inc.refs),
+                      nCur==0 ? zBranch : scopedDefaultBranch(&pStore->refs)) ){
+    rc = SQLITE_CONSTRAINT;
+    goto done;
   }
 
   /* The declared branch may be created freely, but an existing branch may only
@@ -818,6 +952,12 @@ int doltliteValidateScopedRefsUpdate(
   }
   for(j=0; j<nInc; j++){
     if( strcmp(aInc[j].zName, zBranch)==0 ){ incB = &aInc[j]; break; }
+  }
+  /* A push creates or advances the declared branch, never deletes it. Omitting
+  ** it would otherwise skip the fast-forward gate below entirely. */
+  if( !incB ){
+    rc = SQLITE_CONSTRAINT;
+    goto done;
   }
   if( !bForce && curB && incB
    && prollyHashCompare(&curB->commitHash, &incB->commitHash)!=0 ){

--- a/test/scoped_refs_push_test.c
+++ b/test/scoped_refs_push_test.c
@@ -33,6 +33,46 @@ static int openStore(ChunkStore *cs, const char *path){
       SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_MAIN_DB);
 }
 
+/* chunkStoreAddBranch refuses a name it already holds, so a shadow entry can
+** only arrive over the wire. Splice one into a serialized V7 blob: bump the
+** branch count and append a second entry for zName at the end of the branch
+** section. Layout is u8 version, u32 defLen + default, u32 count, then per
+** branch u32 nameLen + name + commitHash + workingSetHash. */
+static u8 *spliceDuplicateBranch(const u8 *pBlob, int nBlob, const char *zName,
+                                 const ProllyHash *pCommit, int *pnOut){
+  int nName = (int)strlen(zName);
+  int nExtra = 4 + nName + PROLLY_HASH_SIZE*2;
+  int defLen, nBranch, off, i;
+  u8 *out;
+
+  *pnOut = 0;
+  if( nBlob < 5 || pBlob[0]!=7 ) return 0;
+  defLen = (int)CS_READ_U32(pBlob + 1);
+  off = 1 + 4 + defLen;
+  if( off + 4 > nBlob ) return 0;
+  nBranch = (int)CS_READ_U32(pBlob + off);
+  off += 4;
+  for(i=0; i<nBranch; i++){
+    int nEntryName;
+    if( off + 4 > nBlob ) return 0;
+    nEntryName = (int)CS_READ_U32(pBlob + off);
+    off += 4 + nEntryName + PROLLY_HASH_SIZE*2;
+    if( off > nBlob ) return 0;
+  }
+
+  out = sqlite3_malloc(nBlob + nExtra);
+  if( !out ) return 0;
+  memcpy(out, pBlob, off);
+  CS_WRITE_U32(out + 1 + 4 + defLen, (u32)(nBranch + 1));
+  CS_WRITE_U32(out + off, (u32)nName);
+  memcpy(out + off + 4, zName, nName);
+  memcpy(out + off + 4 + nName, pCommit, PROLLY_HASH_SIZE);
+  memset(out + off + 4 + nName + PROLLY_HASH_SIZE, 0, PROLLY_HASH_SIZE);
+  memcpy(out + off + nExtra, pBlob + off, nBlob - off);
+  *pnOut = nBlob + nExtra;
+  return out;
+}
+
 /* Build a refs blob from a fresh store carrying main@a and foo@b, then hand
 ** back that same starting blob so scenarios can mutate copies of it. */
 static u8 *seedRefs(ChunkStore *cs, const ProllyHash *a, const ProllyHash *b,
@@ -138,6 +178,200 @@ int main(void){
   /* Legitimate: an unchanged blob is always in scope. */
   rc = doltliteValidateScopedRefsUpdate(&cs, curBlob, nCur, "foo", 0);
   check("allow no-op refs update", rc==SQLITE_OK);
+
+  /* Attack: delete the branch being pushed by omitting it. The fast-forward
+  ** gate only fires when the declared branch appears on both sides, so an
+  ** omission used to slip past it with no force. */
+  {
+    ChunkStore tmp;
+    u8 *blob = 0; int n = 0;
+    memset(&tmp, 0, sizeof(tmp));
+    chunkStoreSetDefaultBranch(&tmp, "main");
+    chunkStoreAddBranch(&tmp, "main", &Ha);
+    chunkStoreSerializeRefsToBlob(&tmp, &blob, &n);
+    chunkStoreClose(&tmp);
+    rc = doltliteValidateScopedRefsUpdate(&cs, blob, n, "foo", 0);
+    check("reject deleting the declared branch by omission", rc==SQLITE_CONSTRAINT);
+    rc = doltliteValidateScopedRefsUpdate(&cs, blob, n, "foo", 1);
+    check("force does not authorize deleting the declared branch",
+          rc==SQLITE_CONSTRAINT);
+    sqlite3_free(blob);
+  }
+
+  /* Attack: a second entry for main. Every refs lookup resolves to the first
+  ** matching slot, so the shadow entry is invisible to the scope check that
+  ** compares main's commit, yet it rides along into the installed blob. */
+  {
+    u8 *blob = 0; int n = 0;
+    blob = spliceDuplicateBranch(curBlob, nCur, "main", &Hc, &n);
+    check("splice a shadow main entry", blob!=0);
+    if( blob ){
+      ChunkStore probe;
+      ProllyHash seen;
+      /* The shadow is real but invisible: the store still reports main@a. */
+      memset(&probe, 0, sizeof(probe));
+      chunkStoreLoadRefsFromBlob(&probe, blob, n);
+      check("shadow entry is unreachable through the refs API",
+            chunkStoreFindBranch(&probe, "main", &seen)==SQLITE_OK
+            && memcmp(&seen, &Ha, sizeof(seen))==0);
+      check("shadow entry still occupies a branch slot",
+            refsTableBranchCount(&probe.refs)==3);
+      chunkStoreClose(&probe);
+
+      rc = doltliteValidateScopedRefsUpdate(&cs, blob, n, "foo", 0);
+      check("reject duplicate branch entry for main", rc==SQLITE_CONSTRAINT);
+      rc = doltliteValidateScopedRefsUpdate(&cs, blob, n, "foo", 1);
+      check("force does not authorize a duplicate branch entry",
+            rc==SQLITE_CONSTRAINT);
+      sqlite3_free(blob);
+    }
+  }
+
+  /* Attack: repoint the default branch. Every clone checks out whatever this
+  ** names, so it steers readers without touching a single branch hash. */
+  {
+    ChunkStore tmp;
+    u8 *blob = 0; int n = 0;
+    memset(&tmp, 0, sizeof(tmp));
+    chunkStoreLoadRefsFromBlob(&tmp, curBlob, nCur);
+    chunkStoreSetDefaultBranch(&tmp, "foo");
+    chunkStoreSerializeRefsToBlob(&tmp, &blob, &n);
+    chunkStoreClose(&tmp);
+    rc = doltliteValidateScopedRefsUpdate(&cs, blob, n, "foo", 0);
+    check("reject repointing the default branch", rc==SQLITE_CONSTRAINT);
+    sqlite3_free(blob);
+  }
+
+  /* Attack: inject a remote URL that every later clone inherits. */
+  {
+    ChunkStore tmp;
+    u8 *blob = 0; int n = 0;
+    memset(&tmp, 0, sizeof(tmp));
+    chunkStoreLoadRefsFromBlob(&tmp, curBlob, nCur);
+    chunkStoreAddRemote(&tmp, "origin", "http://attacker.example/evil");
+    chunkStoreSerializeRefsToBlob(&tmp, &blob, &n);
+    chunkStoreClose(&tmp);
+    rc = doltliteValidateScopedRefsUpdate(&cs, blob, n, "foo", 0);
+    check("reject injecting a remote", rc==SQLITE_CONSTRAINT);
+    sqlite3_free(blob);
+  }
+
+  /* Attack: rewrite a tag's message while leaving its name and target alone. */
+  {
+    ChunkStore tmp;
+    u8 *blob = 0; int n = 0;
+    ChunkStore tagged;
+    u8 *tagBlob = 0; int nTag = 0;
+
+    check("open tagged store",
+          openStore(&tagged, "/tmp/scoped_refs_tagged.db")==SQLITE_OK);
+    chunkStoreSetDefaultBranch(&tagged, "main");
+    chunkStoreAddBranch(&tagged, "main", &Ha);
+    chunkStoreAddBranch(&tagged, "foo", &Hb);
+    chunkStoreAddTagFull(&tagged, "v1", &Ha, "t", "t@e", 1, "original");
+    chunkStoreSerializeRefs(&tagged);
+    chunkStoreCommit(&tagged);
+    chunkStoreSerializeRefsToBlob(&tagged, &tagBlob, &nTag);
+
+    memset(&tmp, 0, sizeof(tmp));
+    chunkStoreLoadRefsFromBlob(&tmp, tagBlob, nTag);
+    chunkStoreDeleteTag(&tmp, "v1");
+    chunkStoreAddTagFull(&tmp, "v1", &Ha, "t", "t@e", 1, "rewritten");
+    chunkStoreSerializeRefsToBlob(&tmp, &blob, &n);
+    chunkStoreClose(&tmp);
+
+    rc = doltliteValidateScopedRefsUpdate(&tagged, blob, n, "foo", 0);
+    check("reject rewriting a tag message", rc==SQLITE_CONSTRAINT);
+
+    /* And the same tag, untouched, stays in scope. */
+    rc = doltliteValidateScopedRefsUpdate(&tagged, tagBlob, nTag, "foo", 0);
+    check("allow push that leaves the tag alone", rc==SQLITE_OK);
+
+    sqlite3_free(blob);
+    sqlite3_free(tagBlob);
+    chunkStoreClose(&tagged);
+    remove("/tmp/scoped_refs_tagged.db");
+  }
+
+  /* Sequences are shared AUTOINCREMENT counters that a push legitimately
+  ** bumps, so they may rise and gain entries but never regress or vanish. */
+  {
+    ChunkStore seqStore;
+    u8 *seqBlob = 0; int nSeq = 0;
+
+    check("open sequence store",
+          openStore(&seqStore, "/tmp/scoped_refs_seq.db")==SQLITE_OK);
+    chunkStoreSetDefaultBranch(&seqStore, "main");
+    chunkStoreAddBranch(&seqStore, "main", &Ha);
+    chunkStoreAddBranch(&seqStore, "foo", &Hb);
+    chunkStoreBumpSequence(&seqStore, "t", 100);
+    chunkStoreSerializeRefs(&seqStore);
+    chunkStoreCommit(&seqStore);
+    chunkStoreSerializeRefsToBlob(&seqStore, &seqBlob, &nSeq);
+
+    {
+      ChunkStore tmp; u8 *blob = 0; int n = 0;
+      memset(&tmp, 0, sizeof(tmp));
+      chunkStoreLoadRefsFromBlob(&tmp, seqBlob, nSeq);
+      chunkStoreBumpSequence(&tmp, "t", 250);
+      chunkStoreBumpSequence(&tmp, "other", 7);
+      chunkStoreSerializeRefsToBlob(&tmp, &blob, &n);
+      chunkStoreClose(&tmp);
+      rc = doltliteValidateScopedRefsUpdate(&seqStore, blob, n, "foo", 0);
+      check("allow sequences to advance and appear", rc==SQLITE_OK);
+      sqlite3_free(blob);
+    }
+    {
+      ChunkStore tmp; u8 *blob = 0; int n = 0;
+      memset(&tmp, 0, sizeof(tmp));
+      chunkStoreSetDefaultBranch(&tmp, "main");
+      chunkStoreAddBranch(&tmp, "main", &Ha);
+      chunkStoreAddBranch(&tmp, "foo", &Hb);
+      chunkStoreBumpSequence(&tmp, "t", 5);
+      chunkStoreSerializeRefsToBlob(&tmp, &blob, &n);
+      chunkStoreClose(&tmp);
+      rc = doltliteValidateScopedRefsUpdate(&seqStore, blob, n, "foo", 0);
+      check("reject rewinding a sequence", rc==SQLITE_CONSTRAINT);
+      sqlite3_free(blob);
+    }
+    {
+      ChunkStore tmp; u8 *blob = 0; int n = 0;
+      memset(&tmp, 0, sizeof(tmp));
+      chunkStoreSetDefaultBranch(&tmp, "main");
+      chunkStoreAddBranch(&tmp, "main", &Ha);
+      chunkStoreAddBranch(&tmp, "foo", &Hb);
+      chunkStoreSerializeRefsToBlob(&tmp, &blob, &n);
+      chunkStoreClose(&tmp);
+      rc = doltliteValidateScopedRefsUpdate(&seqStore, blob, n, "foo", 0);
+      check("reject dropping a sequence", rc==SQLITE_CONSTRAINT);
+      sqlite3_free(blob);
+    }
+
+    sqlite3_free(seqBlob);
+    chunkStoreClose(&seqStore);
+    remove("/tmp/scoped_refs_seq.db");
+  }
+
+  /* A fresh target legitimately adopts the pushed branch as its default, the
+  ** way doltlitePush seeds an empty remote. */
+  {
+    ChunkStore fresh;
+    ChunkStore tmp;
+    u8 *blob = 0; int n = 0;
+    check("open fresh target",
+          openStore(&fresh, "/tmp/scoped_refs_fresh.db")==SQLITE_OK);
+    memset(&tmp, 0, sizeof(tmp));
+    chunkStoreSetDefaultBranch(&tmp, "foo");
+    chunkStoreAddBranch(&tmp, "foo", &Hb);
+    chunkStoreSerializeRefsToBlob(&tmp, &blob, &n);
+    chunkStoreClose(&tmp);
+    rc = doltliteValidateScopedRefsUpdate(&fresh, blob, n, "foo", 0);
+    check("allow fresh target to adopt the pushed branch as default",
+          rc==SQLITE_OK);
+    sqlite3_free(blob);
+    chunkStoreClose(&fresh);
+    remove("/tmp/scoped_refs_fresh.db");
+  }
 
   sqlite3_free(curBlob);
   chunkStoreClose(&cs);


### PR DESCRIPTION
## Problem

`doltliteValidateScopedRefsUpdate` is the only gate between a `PUT /refs` — unauthenticated by default — and the receiving store's refs. Its contract, stated in `doltlite_remote.h`, is that a push "only creates/advances zBranch and leaves every other branch and tag byte-identical." It read two of the blob's six sections, and three distinct bypasses fell out of that.

**Duplicate names.** Every refs lookup resolves a name to its *first* matching slot (`csFindNamedRef`), so a second entry for a branch is a shadow: invisible to a scope check that compares the first match, yet carried forward by every later reserialization, and `chunkStoreDeleteBranch` swaps the last element into the deleted slot. `chunkStoreAddBranch` refuses duplicates, so these can only arrive over the wire — the test splices one into a serialized blob directly, which is the actual threat model.

**Unchecked sections.** `defaultBranch`, `remotes`, `tracking`, and `sequences` rode along unvalidated. A push could repoint the branch every clone checks out and `GET /root` resolves, or inject a remote URL that every clone inherits, without touching a single branch hash.

**Deleting the declared branch.** The fast-forward gate is conditional on that branch appearing on both sides (`curB && incB`), so a blob that simply omitted it deleted the branch with no `--force`.

## Fix

Every named section must now be a set, with tracking keyed on its remote/branch pair rather than its leading name. `defaultBranch` must hold still, except on an empty target, which adopts the pushed branch the way `doltlitePush` seeds a fresh remote. Remotes and tracking must match exactly, tags gain their annotations to the comparison, and other branches gain their working set. The declared branch must be present.

Sequences needed care: they are the one section a push legitimately changes, because `doltlitePush` bumps the shared AUTOINCREMENT counters from the local store (`doltlite_remote.c:986-997`, monotonic via `chunkStoreBumpSequence`). So they may rise and gain entries, but never regress or vanish — either would hand out row ids already in use. Requiring them unchanged would have broken every real push.

## Scope

Deliberately one gate enforcing one invariant. Two related items from the same review are left for their own PRs:

- `httpHasChunks` (`doltlite_http_remote.c:630`) accepts any 200 body of at least `nHash` bytes as the presence bitmap, so one bogus 200 turns a push into a silent zero-upload.
- `PUT /refs` (`doltlite_remotesrv.c:734`) validates and installs without the store lock that `/refs-if` takes.

A fourth hole I had noted — no existence check on the pushed hashes — turned out to be **already fixed** on master by `doltliteValidateRefsTargetGraph` (commit `143d0eba15`), which landed after the commit I reviewed. No change needed.

## Testing

Extended `test/scoped_refs_push_test.c` with nine attack cases and four legitimate-flow cases. The legitimate ones matter as much as the attacks here, since the risk in tightening a validator is rejecting real pushes: sequences advancing and gaining entries, a fresh target adopting the pushed branch as its default, a push that leaves an annotated tag alone, and the existing no-op and forced-move cases. The duplicate-entry case also asserts the shadow is genuinely invisible through the refs API while still occupying a slot.

Fail-before/pass-after, same test file both runs (source fix stashed for the baseline):

- before: **19 passed, 9 failed**
- after: **28 passed, 0 failed**

Full local validation, all clean:

- All 14 remote/push/clone/fetch/pull suites, including `remote_test` (100), `vc_oracle_remotes_test` (34), `vc_oracle_fetch_pull_convergence_test` (29), `remotesrv_http_test` (29), `vc_oracle_push_default_branch_test` (19), `remote_https_auth_test` (15), `remotesrv_http_force_push_test` (11)
- `test/run_doltlite_tests.sh` — 99/99 suites
- `test/run_c_tests.sh` — 26/26 gated c-tests
- `test/doltlite_regression_test_c.sh` — 310,123 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)