### PR TITLE
Reject malformed persisted object lengths

### DIFF
--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -30,6 +30,19 @@ typedef char chunk_index_entry_size_check[
 ];
 #endif
 
+int chunkStoreValidateWorkingSetBlob(const u8 *data, int nData){
+  int nExpected;
+  if( !data || nData<1 ) return SQLITE_CORRUPT;
+  switch( data[0] ){
+    case WS_FORMAT_VERSION_V2: nExpected = WS_TOTAL_SIZE_V2; break;
+    case WS_FORMAT_VERSION_V3: nExpected = WS_TOTAL_SIZE_V3; break;
+    case WS_FORMAT_VERSION_V4: nExpected = WS_TOTAL_SIZE_V4; break;
+    case WS_FORMAT_VERSION_V5: nExpected = WS_TOTAL_SIZE; break;
+    default: return SQLITE_CORRUPT;
+  }
+  return nData==nExpected ? SQLITE_OK : SQLITE_CORRUPT;
+}
+
 
 int csOpenFile(
   sqlite3_vfs *pVfs,

--- a/src/chunk_store.h
+++ b/src/chunk_store.h
@@ -116,6 +116,8 @@
 #define WS_CONSTRAINT_VIOLATIONS_OFF (WS_REBASE_RETURN_BRANCH_OFF + WS_REBASE_BRANCH_LEN)
 #define WS_TOTAL_SIZE       (WS_CONSTRAINT_VIOLATIONS_OFF + PROLLY_HASH_SIZE)
 
+int chunkStoreValidateWorkingSetBlob(const u8 *data, int nData);
+
 #define CATALOG_FORMAT_V3       0x44
 #define CATALOG_FORMAT_V4       0x45
 #define CATALOG_FORMAT_V5       0x46

--- a/src/doltlite_branches.c
+++ b/src/doltlite_branches.c
@@ -156,9 +156,12 @@ static int brIsDirty(
   }
 
   rc = chunkStoreGet(cs, &br->workingSetHash, &wsData, &nWsData);
-  if( rc!=SQLITE_OK || !wsData || nWsData < WS_TOTAL_SIZE || wsData[0] != WS_FORMAT_VERSION ){
+  if( rc==SQLITE_OK ){
+    rc = chunkStoreValidateWorkingSetBlob(wsData, nWsData);
+  }
+  if( rc!=SQLITE_OK ){
     sqlite3_free(wsData);
-    return rc==SQLITE_OK ? SQLITE_CORRUPT : rc;
+    return rc;
   }
   memcpy(workingCat.data, wsData + WS_WORKING_CAT_OFF, PROLLY_HASH_SIZE);
   memcpy(stagedCat.data, wsData + WS_STAGED_OFF, PROLLY_HASH_SIZE);

--- a/src/doltlite_chunk_walk.c
+++ b/src/doltlite_chunk_walk.c
@@ -65,10 +65,7 @@ DoltliteChunkType doltliteClassifyChunk(const u8 *data, int nData){
     return CHUNK_CONSTRAINT_VIOLATIONS;
   }
 
-  if( (data[0] == WS_FORMAT_VERSION_V5 && nData == WS_TOTAL_SIZE)
-   || (data[0] == WS_FORMAT_VERSION_V4 && nData == WS_TOTAL_SIZE_V4)
-   || (data[0] == WS_FORMAT_VERSION_V3 && nData == WS_TOTAL_SIZE_V3)
-   || (data[0] == WS_FORMAT_VERSION_V2 && nData == WS_TOTAL_SIZE_V2) ){
+  if( chunkStoreValidateWorkingSetBlob(data, nData)==SQLITE_OK ){
     return CHUNK_WORKING_SET;
   }
 

--- a/src/doltlite_commit.c
+++ b/src/doltlite_commit.c
@@ -128,6 +128,11 @@ int doltliteCommitDeserialize(const u8 *data, int nData, DoltliteCommit *c){
   if( !c->zMessage ){ doltliteCommitClear(c); return SQLITE_NOMEM; }
   if( nMsg>0 ) memcpy(c->zMessage, p, nMsg);
   c->zMessage[nMsg] = 0;
+  p += nMsg;
+  if( p != data + nData ){
+    doltliteCommitClear(c);
+    return SQLITE_CORRUPT;
+  }
 
   return SQLITE_OK;
 }

--- a/src/prolly_btree_state.c
+++ b/src/prolly_btree_state.c
@@ -45,18 +45,12 @@ int btreeLoadWorkingSetBlob(
 
   rc = chunkStoreGet(cs, &wsHash, &data, &nData);
   if( rc!=SQLITE_OK ) return rc;
-  if( !data || nData < WS_TOTAL_SIZE_V2 ){
+  rc = chunkStoreValidateWorkingSetBlob(data, nData);
+  if( rc!=SQLITE_OK ){
     sqlite3_free(data);
-    return SQLITE_CORRUPT;
+    return rc;
   }
   version = data[0];
-  if( version != WS_FORMAT_VERSION_V2
-   && version != WS_FORMAT_VERSION_V3
-   && version != WS_FORMAT_VERSION_V4
-   && version != WS_FORMAT_VERSION_V5 ){
-    sqlite3_free(data);
-    return SQLITE_CORRUPT;
-  }
 
   if( pWorkingCat ) memcpy(pWorkingCat->data, data + WS_WORKING_CAT_OFF, PROLLY_HASH_SIZE);
   if( pWorkingCommit ) memcpy(pWorkingCommit->data, data + WS_WORKING_COMMIT_OFF, PROLLY_HASH_SIZE);

--- a/test/commit_deserialize_test.c
+++ b/test/commit_deserialize_test.c
@@ -88,6 +88,36 @@ static void testValidRoundTrip(void){
   sqlite3_free(buf);
 }
 
+static void testTrailingByte(void){
+  DoltliteCommit in;
+  u8 *buf = 0;
+  u8 *pNew;
+  int n = 0;
+  int rc;
+
+  memset(&in, 0, sizeof(in));
+  in.zName = "alice";
+  in.zEmail = "alice@example.com";
+  in.zMessage = "message";
+  rc = doltliteCommitSerialize(&in, &buf, &n);
+  if( rc!=SQLITE_OK ){
+    fprintf(stderr, "FAIL trailing_byte: serialize rc=%d\n", rc);
+    failures++;
+    return;
+  }
+  pNew = sqlite3_realloc(buf, n + 1);
+  if( !pNew ){
+    fprintf(stderr, "FAIL trailing_byte: realloc\n");
+    failures++;
+    sqlite3_free(buf);
+    return;
+  }
+  buf = pNew;
+  buf[n] = 0;
+  expectCorrupt("trailing_byte", buf, n + 1);
+  sqlite3_free(buf);
+}
+
 int main(void){
   int H = PROLLY_HASH_SIZE;
   int nData = 16 + H;               /* minimum that clears the header check */
@@ -95,6 +125,7 @@ int main(void){
   int off;
 
   testValidRoundTrip();
+  testTrailingByte();
 
   /* Truncated after a non-empty name: the email length prefix would be read
   ** at data[nData]. */

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -36,6 +36,9 @@ extern int doltliteRemoteSrvApplyRefsForTest(
 extern int doltliteRemoteSrvResolveRootForTest(
   ChunkStore *pStore, ProllyHash *pRoot
 );
+extern int btreeReadWorkingCatalog(
+  ChunkStore*, const char*, ProllyHash*, ProllyHash*
+);
 
 static int nPass = 0;
 static int nFail = 0;
@@ -4235,9 +4238,11 @@ static void run_open_rejects_corrupt_working_set(void){
   int stmtRc;
   ProllyHash badHash;
   int rc;
-  static const unsigned char badBlob[] = { 0x01, 0x02, 0x03, 0x04 };
+  unsigned char badBlob[WS_TOTAL_SIZE-1];
 
   printf("=== Open Rejects Corrupt Working Set Test ===\n\n");
+  memset(badBlob, 0, sizeof(badBlob));
+  badBlob[0] = WS_FORMAT_VERSION_V5;
   make_dbpath(dbpath, sizeof(dbpath), "test_open_rejects_corrupt_working_set");
   removeDbFiles(dbpath);
 
@@ -4267,6 +4272,59 @@ static void run_open_rejects_corrupt_working_set(void){
         rc==SQLITE_CORRUPT || stmtRc==SQLITE_CORRUPT);
   if( db2 ) sqlite3_close(db2);
   removeDbFiles(dbpath);
+}
+
+static int loadWorkingSetBytes(const u8 *data, int nData){
+  ChunkStore cs;
+  ProllyHash emptyHash;
+  ProllyHash wsHash;
+  int rc;
+
+  memset(&cs, 0, sizeof(cs));
+  memset(&emptyHash, 0, sizeof(emptyHash));
+  rc = chunkStoreOpen(&cs, sqlite3_vfs_find(0), ":memory:", 0);
+  if( rc==SQLITE_OK ) rc = chunkStorePut(&cs, data, nData, &wsHash);
+  if( rc==SQLITE_OK ) rc = chunkStoreAddBranch(&cs, "main", &emptyHash);
+  if( rc==SQLITE_OK ){
+    rc = chunkStoreSetBranchWorkingSet(&cs, "main", &wsHash);
+  }
+  if( rc==SQLITE_OK ){
+    rc = btreeReadWorkingCatalog(&cs, "main", 0, 0);
+  }
+  chunkStoreClose(&cs);
+  return rc;
+}
+
+static void run_working_set_blob_size_validation(void){
+  static const struct {
+    int version;
+    int size;
+  } aCase[] = {
+    { WS_FORMAT_VERSION_V2, WS_TOTAL_SIZE_V2 },
+    { WS_FORMAT_VERSION_V3, WS_TOTAL_SIZE_V3 },
+    { WS_FORMAT_VERSION_V4, WS_TOTAL_SIZE_V4 },
+    { WS_FORMAT_VERSION_V5, WS_TOTAL_SIZE }
+  };
+  u8 data[WS_TOTAL_SIZE+1];
+  int i;
+
+  printf("=== Working Set Blob Size Validation Test ===\n\n");
+  for(i=0; i<(int)(sizeof(aCase)/sizeof(aCase[0])); i++){
+    char zName[80];
+    memset(data, 0, sizeof(data));
+    data[0] = (u8)aCase[i].version;
+    sqlite3_snprintf(sizeof(zName), zName,
+                     "working_set_v%d_exact_size", aCase[i].version);
+    check(zName, loadWorkingSetBytes(data, aCase[i].size)==SQLITE_OK);
+    sqlite3_snprintf(sizeof(zName), zName,
+                     "working_set_v%d_short_rejected", aCase[i].version);
+    check(zName,
+          loadWorkingSetBytes(data, aCase[i].size-1)==SQLITE_CORRUPT);
+    sqlite3_snprintf(sizeof(zName), zName,
+                     "working_set_v%d_trailing_rejected", aCase[i].version);
+    check(zName,
+          loadWorkingSetBytes(data, aCase[i].size+1)==SQLITE_CORRUPT);
+  }
 }
 
 static void run_open_ignores_stale_working_set(void){
@@ -9614,6 +9672,7 @@ static const RegressionCase aCases[] = {
   { "begin_write_refreshes_working_set_metadata", "Begin Write Refreshes Working Set Metadata Test", run_begin_write_refreshes_working_set_metadata },
   { "begin_write_from_stale_read_snapshot", "Begin Write From Stale Read Snapshot Test", run_begin_write_from_stale_read_snapshot },
   { "open_rejects_corrupt_working_set", "Open Rejects Corrupt Working Set Test", run_open_rejects_corrupt_working_set },
+  { "working_set_blob_size_validation", "Working Set Blob Size Validation Test", run_working_set_blob_size_validation },
   { "open_ignores_stale_working_set", "Open Ignores Stale Working Set Test", run_open_ignores_stale_working_set },
   { "diff_stat_requires_refs", "Diff Stat Requires Refs Test", run_diff_stat_requires_refs },
   { "diff_stat_wide_modified_rows", "Diff Stat Wide Modified Rows Test", run_diff_stat_wide_modified_rows },


### PR DESCRIPTION
## Summary

- require every supported working-set version to match its exact persisted length
- share the validator across state loading, chunk classification, and branch metadata inspection
- require commit deserialization to consume the complete chunk
- cover truncated and extended V2-V5 working sets plus commit trailing bytes

## Failure before

A V3-V5 working-set blob shorter than its declared version was accepted whenever it still met the V2 minimum. The decoder silently treated the absent version-specific fields as zero. Every working-set version and commit chunk also accepted trailing bytes.

## Storage format

Writer output is unchanged. This only rejects malformed encodings, so the frozen storage format remains version 12.

## Testing

- focused commit and working-set corruption cases: 24/24 assertions
- `bash test/run_c_tests.sh build coverage`: 17/17 gated C tests
- `bash test/run_doltlite_tests.sh`: 99/99 suites; 310,135 regression assertions
- storage-format contract: 23/23
- `make lint`

Co-Authored-By: OpenAI Codex <noreply@openai.com>