### PR TITLE
Record the merged branch as a parent when a merge is committed

### DIFF
--- a/src/doltlite_commit_cmd.c
+++ b/src/doltlite_commit_cmd.c
@@ -558,6 +558,29 @@ static int doltliteCommitCreateObject(
     doltliteCommitClear(&headCommit);
   }
 
+  /* A commit concluding a merge owes the merged branch a second parent, or the
+  ** merge leaves no trace in ancestry and later merge bases are computed
+  ** against a history that never recorded it. Only a real merge records a
+  ** source commit here: cherry-pick, revert, and rebase replay leave it empty
+  ** because their result is a single-parent commit. */
+  {
+    u8 isMerging = 0;
+    ProllyHash mergeCommit;
+    doltliteGetSessionMergeState(db, &isMerging, &mergeCommit, 0);
+    if( isMerging && !prollyHashIsEmpty(&mergeCommit)
+     && prollyHashCompare(&mergeCommit, &parentHash)!=0
+     && nExtraParents < DOLTLITE_MAX_PARENTS-1 ){
+      int i;
+      for(i=0; i<nExtraParents; i++){
+        if( prollyHashCompare(&aExtraParents[i], &mergeCommit)==0 ) break;
+      }
+      if( i>=nExtraParents ){
+        memcpy(&aExtraParents[nExtraParents++], &mergeCommit,
+               sizeof(ProllyHash));
+      }
+    }
+  }
+
   if( zAuthor ){
     const char *lt = strchr(zAuthor, '<');
     const char *gt = lt ? strchr(lt, '>') : 0;

--- a/src/doltlite_conflicts.c
+++ b/src/doltlite_conflicts.c
@@ -373,7 +373,7 @@ static int storeConflictBytes(
     if( rc!=SQLITE_OK ) return rc;
     rc = doltliteSetSessionConflictsCatalog(db, &newHash);
     if( rc==SQLITE_OK ){
-      rc = doltliteSetSessionMergeState(db, 1, 0, &newHash);
+      rc = doltliteSetSessionMergeConflicts(db, &newHash);
     }
   }
   if( rc!=SQLITE_OK ) return rc;

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -1148,6 +1148,7 @@ int doltliteSetSessionMergeState(sqlite3 *db, u8 isMerging,
                                  const ProllyHash *pMergeCommit,
                                  const ProllyHash *pConflictsCatalog);
 int doltliteClearSessionMergeState(sqlite3 *db);
+int doltliteSetSessionMergeConflicts(sqlite3 *db, const ProllyHash *pConflicts);
 int doltliteSetSessionMergeSourceSpec(sqlite3 *db, const char *zSpec,
                                       const ProllyHash *pMergeCommit);
 const char *doltliteGetSessionMergeSourceSpec(sqlite3 *db,

--- a/src/doltlite_merge.c
+++ b/src/doltlite_merge.c
@@ -1242,7 +1242,7 @@ static int recordMergeConflicts(
   if( rc!=SQLITE_OK ) return rc;
   rc = doltliteSetSessionConflictsCatalog(db, &conflictsHash);
   if( rc!=SQLITE_OK ) return rc;
-  return doltliteSetSessionMergeState(db, 1, 0, &conflictsHash);
+  return doltliteSetSessionMergeConflicts(db, &conflictsHash);
 }
 
 int doltliteMergeCatalogs(

--- a/src/prolly_btree_state.c
+++ b/src/prolly_btree_state.c
@@ -696,6 +696,16 @@ int doltliteClearSessionMergeState(sqlite3 *db){
   return doltliteSetSessionMergeState(db, 0, 0, 0);
 }
 
+/* Record a new conflicts catalog without disturbing the source commit already
+** on the session. Reaching for doltliteSetSessionMergeState with a null
+** pMergeCommit zeroes it, which drops the second parent commit owes the merged
+** branch and blanks dolt_merge_status.source. */
+int doltliteSetSessionMergeConflicts(sqlite3 *db, const ProllyHash *pConflicts){
+  ProllyHash mergeCommit;
+  doltliteGetSessionMergeState(db, 0, &mergeCommit, 0);
+  return doltliteSetSessionMergeState(db, 1, &mergeCommit, pConflicts);
+}
+
 int doltliteSetSessionMergeSourceSpec(sqlite3 *db, const char *zSpec,
                                       const ProllyHash *pMergeCommit){
   Btree *p;

--- a/test/vc_oracle_merge_status_test.sh
+++ b/test/vc_oracle_merge_status_test.sh
@@ -230,6 +230,21 @@ SELECT dolt_checkout('main');
 UPDATE t SET v = 'ours' WHERE id = 1;
 SELECT dolt_commit('-Am', 'ours');" "feature"
 
+# Resolving part of a conflict must not blank the merge source. It is still the
+# same merge, status still has to name it, and the commit that concludes the
+# merge still owes the merged branch a second parent.
+oracle "source_survives_partial_conflict_resolution" "$BASE
+SELECT dolt_branch('feature');
+SELECT dolt_checkout('feature');
+UPDATE t SET v = 'theirs' WHERE id = 1;
+UPDATE t SET v = 'theirs' WHERE id = 2;
+SELECT dolt_commit('-Am', 'theirs');
+SELECT dolt_checkout('main');
+UPDATE t SET v = 'ours' WHERE id = 1;
+UPDATE t SET v = 'ours' WHERE id = 2;
+SELECT dolt_commit('-Am', 'ours');" "feature" \
+"DELETE FROM dolt_conflicts_t WHERE our_id = 1;"
+
 echo ""
 echo "=== Results: $pass passed, $fail failed ==="
 if [ $fail -gt 0 ]; then

--- a/test/vc_oracle_merge_test.sh
+++ b/test/vc_oracle_merge_test.sh
@@ -1614,6 +1614,72 @@ SELECT dolt_merge('feature');
 " "SELECT id || '|' || Name || '|' || Score || '|' || coalesce(MainNote,'~') || '|' || coalesce(FeatNote,'~') FROM t" \
 "SELECT CONCAT(id, '|', Name, '|', Score, '|', coalesce(MainNote,'~'), '|', coalesce(FeatNote,'~')) FROM t"
 
+# Concluding a conflicted merge with dolt_commit still has to record the merged
+# branch as a second parent. Without it the merged commits leave the log, and
+# every later merge base is computed against a history that never recorded the
+# merge -- so dolt_merge('feature') would replay work already merged.
+oracle "conflict_resolved_commit_keeps_merged_branch_in_log" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1, 'base');
+SELECT dolt_commit('-Am', 'init');
+SELECT dolt_checkout('-b', 'feature');
+UPDATE t SET v = 'theirs' WHERE id = 1;
+SELECT dolt_commit('-Am', 'feature edit');
+SELECT dolt_checkout('main');
+UPDATE t SET v = 'ours' WHERE id = 1;
+SELECT dolt_commit('-Am', 'main edit');
+BEGIN;
+SELECT dolt_merge('feature');
+SELECT dolt_conflicts_resolve('--ours', 't');
+SELECT dolt_commit('-Am', 'resolved');
+COMMIT;
+"
+
+# Same shape through cherry-pick, which must stay a single-parent commit: the
+# picked branch is a source to resolve against, not a parent to record.
+oracle "conflict_resolved_cherry_pick_stays_single_parent" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1, 'base');
+SELECT dolt_commit('-Am', 'init');
+SELECT dolt_checkout('-b', 'feature');
+UPDATE t SET v = 'theirs' WHERE id = 1;
+SELECT dolt_commit('-Am', 'feature edit');
+SELECT dolt_checkout('main');
+UPDATE t SET v = 'ours' WHERE id = 1;
+SELECT dolt_commit('-Am', 'main edit');
+BEGIN;
+SELECT dolt_cherry_pick('feature');
+SELECT dolt_conflicts_resolve('--ours', 't');
+SELECT dolt_commit('-Am', 'picked');
+COMMIT;
+"
+
+# The merged branch really is an ancestor afterwards, so re-merging it is a
+# no-op rather than a replay of work already merged.
+oracle_reopen_state "conflict_resolved_commit_makes_merged_branch_an_ancestor" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1, 'base');
+SELECT dolt_commit('-Am', 'init');
+SELECT dolt_checkout('-b', 'feature');
+UPDATE t SET v = 'theirs' WHERE id = 1;
+SELECT dolt_commit('-Am', 'feature edit');
+SELECT dolt_checkout('main');
+UPDATE t SET v = 'ours' WHERE id = 1;
+SELECT dolt_commit('-Am', 'main edit');
+BEGIN;
+SELECT dolt_merge('feature');
+SELECT dolt_conflicts_resolve('--ours', 't');
+SELECT dolt_commit('-Am', 'resolved');
+COMMIT;
+" "SELECT 'Q' || char(9) ||
+          (SELECT count(*) FROM dolt_log WHERE message = 'feature edit') || char(9) ||
+          (SELECT count(*) FROM dolt_commit_ancestors
+             WHERE commit_hash = dolt_hashof('HEAD'));" \
+"SELECT CONCAT('Q', char(9),
+               (SELECT COUNT(*) FROM dolt_log WHERE message = 'feature edit'), char(9),
+               (SELECT COUNT(*) FROM dolt_commit_ancestors
+                  WHERE commit_hash = HASHOF('HEAD')));"
+
 echo ""
 echo "=== Results: $pass passed, $fail failed ==="
 if [ $fail -gt 0 ]; then


### PR DESCRIPTION
## Problem

Concluding a conflicted merge with `dolt_commit` produced a **single-parent** commit, so the merged branch left the history entirely. Verified against Dolt 2.2.2:

```sql
-- base; feature sets v='theirs'; main sets v='ours'; both commit
BEGIN;
SELECT dolt_merge('feature');
SELECT dolt_conflicts_resolve('--ours','t');
SELECT dolt_commit('-Am','resolved');
COMMIT;
```

| | doltlite (before) | Dolt 2.2.2 |
|---|---|---|
| parents of the resolving commit | 1 | 2 |
| `'feature edit'` in `dolt_log` | absent | present |
| `dolt_merge_base` sees feature as ancestor | no | yes |
| re-running `dolt_merge('feature')` | replays the merge | already up to date |

This is the worst kind of defect in a version-control engine: it happens on the ordinary happy path — merge, resolve conflicts, commit — and the damage is written permanently into the commit graph. No later fix repairs commits already recorded.

For the source commit to reach commit time at all, it had to survive conflict resolution, and it did not. `recordMergeConflicts` and `storeConflictBytes` both called `doltliteSetSessionMergeState(db, 1, 0, &hash)`, and a null `pMergeCommit` **zeroes** the stored hash. So resolving part of a conflict also blanked `dolt_merge_status.source` and `source_commit`, where Dolt keeps naming the branch.

## Why this is one PR and not three

The two halves are one invariant — the merge source survives from merge start through commit — and neither is testable alone. Teaching commit to consume the source hash does nothing while partial resolution still zeroes it; preserving the hash does nothing while commit ignores it. `doltliteSetSessionMergeConflicts` now expresses "record conflicts, keep the source", so the zeroing form is harder to reach by accident.

## The cherry-pick trap

My first design would have set the source commit for cherry-pick and revert too, since Dolt's `dolt_merge_status` reports them as merging. Checking Dolt showed that a **resolved conflicted cherry-pick still commits with one parent** — `is_merging` being true does not imply a second parent. Doing that would have silently forged merge commits out of every cherry-pick.

So only a real merge records a source commit; cherry-pick, revert, and rebase replay leave it empty and are correct by construction. `conflict_resolved_cherry_pick_stays_single_parent` pins this, and it passes both before and after the fix — it is a guard, not a repair.

Making cherry-pick and revert report a source in `dolt_merge_status` for Dolt parity is a separate change that needs a merge-versus-replay distinction first. Left out deliberately.

## Testing

Extended the two existing oracle singletons rather than adding files — three cases in `vc_oracle_merge_test.sh` (log contents, ancestor/parent count, cherry-pick guard) and one in `vc_oracle_merge_status_test.sh` (source survives partial resolution). All compare against real Dolt.

Fail-before/pass-after, same test files both runs (source stashed for the baseline):

- `vc_oracle_merge_test.sh` — **76 passed, 2 failed** to **78 passed, 0 failed**
- `vc_oracle_merge_status_test.sh` — **10 passed, 1 failed** to **11 passed, 0 failed**

Full local validation, all clean:

- **51 VC oracle suites** against Dolt 2.2.2, ~2,600 checks, 0 failures — including the ones most at risk from a change to commit and merge state: `feature_interaction` (752), `error_recovery` (261), `schema_merge` (81), `merge` (78), `patch` (76), `checkout` (65), `revert_cherrypick` (58), `txn_commit` (53), `workspace` (50), `rebase` (48), `reset` (43), `commit` (39), `conflicts_resolve` (28), `pk_shapes_vc_ops` (28), `state_transitions` (19)
- `test/run_doltlite_tests.sh` — 99/99 suites
- `test/run_c_tests.sh` — 26/26 gated c-tests
- `test/doltlite_regression_test_c.sh` — 310,123 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)