### PR TITLE
Bound the chunk store WAL offset before trusting it

### DIFF
--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -231,27 +231,6 @@ static int csReadManifest(ChunkStore *cs){
     return SQLITE_NOTADB;
   }
 
-  /* Every writer seals this header, so a mismatch means its bytes changed
-  ** under us. Trusting them is not merely a bad read: a WAL offset pointing
-  ** into the data region makes replay call live chunk bytes a torn tail and
-  ** rewind the logical EOF, and the next write-lock acquisition truncates the
-  ** file there. Failing closed keeps a still-readable file readable. */
-  {
-    /* Headers written before seals were bound to file offsets hash the bytes
-    ** alone, so accept that form too -- same fallback the tail-root check in
-    ** chunk_store_refs_api.c makes. */
-    int sealState = csManifestHashState(aBuf, 0);
-    if( sealState==CS_MANIFEST_HASH_BAD ){
-      sealState = csManifestHashStateOffsetless(aBuf);
-    }
-    if( sealState==CS_MANIFEST_HASH_BAD ){
-      sqlite3_log(SQLITE_CORRUPT,
-        "doltlite: chunk store header failed its seal; refusing to open so "
-        "the file stays recoverable");
-      return SQLITE_CORRUPT;
-    }
-  }
-
   cs->index.nChunks = (int)CS_READ_U32(aBuf + CS_MANIFEST_CHUNK_COUNT_OFF);
   cs->index.iIndexOffset = CS_READ_I64(aBuf + CS_MANIFEST_INDEX_OFFSET_OFF);
   cs->index.nIndexSize = (i64)CS_READ_U32(aBuf + CS_MANIFEST_INDEX_SIZE_OFF);
@@ -259,9 +238,16 @@ static int csReadManifest(ChunkStore *cs){
   cs->wal.iWalOffset = CS_READ_I64(aBuf + CS_MANIFEST_WAL_OFFSET_OFF);
   memcpy(cs->refs.refsHash.data, aBuf + CS_MANIFEST_REFS_HASH_OFF, PROLLY_HASH_SIZE);
 
-  /* Sealing started long after the current format version, so headers with an
-  ** all-zero self hash are legitimate and reach here unverified. Bound the one
-  ** field that drives the destructive path so those files are covered too. */
+  /* A WAL offset below the data it is supposed to follow is the one header
+  ** value that turns damage into destruction: replay reads live chunk bytes as
+  ** WAL records, calls the tail torn, and rewinds the logical EOF, and the next
+  ** write-lock acquisition reclaims everything past it. Refusing the open keeps
+  ** a file whose rows are still readable readable.
+  **
+  ** The header carries a seal too, but it covers all 168 bytes including ones
+  ** no reader consults, so verifying it would reject files over damage that
+  ** cannot mislead anything. These bounds cover the harmful case on their own,
+  ** and cover pre-seal headers that no seal check could reach. */
   if( cs->index.iIndexOffset<0 || cs->index.nIndexSize<0 ) return SQLITE_CORRUPT;
   if( cs->wal.iWalOffset < CHUNK_MANIFEST_SIZE ) return SQLITE_CORRUPT;
   if( cs->index.iIndexOffset>0
@@ -424,8 +410,8 @@ int chunkStoreOpen(
     }
 
     rc = csReadManifest(cs);
-    /* NOTADB only: a header that still identifies as a chunk store but fails
-    ** its seal or bounds is damaged data, not a crashed creation, and this
+    /* NOTADB only: a header that still identifies as a chunk store but carries
+    ** impossible offsets is damaged data, not a crashed creation, and this
     ** recovery ends in truncating the file to zero. */
     if( rc==SQLITE_NOTADB
      && (flags & SQLITE_OPEN_CREATE)!=0 && !cs->readOnly ){

--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -231,13 +231,43 @@ static int csReadManifest(ChunkStore *cs){
     return SQLITE_NOTADB;
   }
 
-  /* Header seals are advisory; WAL root seals are load-bearing. */
+  /* Every writer seals this header, so a mismatch means its bytes changed
+  ** under us. Trusting them is not merely a bad read: a WAL offset pointing
+  ** into the data region makes replay call live chunk bytes a torn tail and
+  ** rewind the logical EOF, and the next write-lock acquisition truncates the
+  ** file there. Failing closed keeps a still-readable file readable. */
+  {
+    /* Headers written before seals were bound to file offsets hash the bytes
+    ** alone, so accept that form too -- same fallback the tail-root check in
+    ** chunk_store_refs_api.c makes. */
+    int sealState = csManifestHashState(aBuf, 0);
+    if( sealState==CS_MANIFEST_HASH_BAD ){
+      sealState = csManifestHashStateOffsetless(aBuf);
+    }
+    if( sealState==CS_MANIFEST_HASH_BAD ){
+      sqlite3_log(SQLITE_CORRUPT,
+        "doltlite: chunk store header failed its seal; refusing to open so "
+        "the file stays recoverable");
+      return SQLITE_CORRUPT;
+    }
+  }
+
   cs->index.nChunks = (int)CS_READ_U32(aBuf + CS_MANIFEST_CHUNK_COUNT_OFF);
   cs->index.iIndexOffset = CS_READ_I64(aBuf + CS_MANIFEST_INDEX_OFFSET_OFF);
   cs->index.nIndexSize = (i64)CS_READ_U32(aBuf + CS_MANIFEST_INDEX_SIZE_OFF);
 
   cs->wal.iWalOffset = CS_READ_I64(aBuf + CS_MANIFEST_WAL_OFFSET_OFF);
   memcpy(cs->refs.refsHash.data, aBuf + CS_MANIFEST_REFS_HASH_OFF, PROLLY_HASH_SIZE);
+
+  /* Sealing started long after the current format version, so headers with an
+  ** all-zero self hash are legitimate and reach here unverified. Bound the one
+  ** field that drives the destructive path so those files are covered too. */
+  if( cs->index.iIndexOffset<0 || cs->index.nIndexSize<0 ) return SQLITE_CORRUPT;
+  if( cs->wal.iWalOffset < CHUNK_MANIFEST_SIZE ) return SQLITE_CORRUPT;
+  if( cs->index.iIndexOffset>0
+   && cs->wal.iWalOffset < cs->index.iIndexOffset + cs->index.nIndexSize ){
+    return SQLITE_CORRUPT;
+  }
 
   return SQLITE_OK;
 }
@@ -394,7 +424,10 @@ int chunkStoreOpen(
     }
 
     rc = csReadManifest(cs);
-    if( (rc==SQLITE_NOTADB || rc==SQLITE_CORRUPT)
+    /* NOTADB only: a header that still identifies as a chunk store but fails
+    ** its seal or bounds is damaged data, not a crashed creation, and this
+    ** recovery ends in truncating the file to zero. */
+    if( rc==SQLITE_NOTADB
      && (flags & SQLITE_OPEN_CREATE)!=0 && !cs->readOnly ){
       /* Recover only proven first-commit crashes to an empty database. */
       int everCommitted = 1;

--- a/test/corruption_test.c
+++ b/test/corruption_test.c
@@ -791,10 +791,12 @@ static void test_corrupt_version(void){
 static void test_corrupt_head_commit(void){
   const char *dbpath = "/tmp/test_corr_head.db";
   unsigned char bad_hash[20];
+  off_t before;
 
   printf("--- Test 17: Corrupt former head_commit bytes (compacted) ---\n");
 
   check("create_compacted_15", create_compacted_db(dbpath)==0);
+  before = file_size(dbpath);
 
   memset(bad_hash, 0xCD, sizeof(bad_hash));
   check("corrupt_15",
@@ -815,7 +817,12 @@ static void test_corrupt_head_commit(void){
           strncmp(b, "ERROR", 5)!=0 && atoi(b) >= 1);
       }
     }else{
+      /* These bytes sit inside the sealed header, so the store now refuses the
+      ** open rather than running on fields it cannot vouch for. Refusing is
+      ** only an improvement if the file survives it. */
       check("corrupt_head_commit_no_crash", 1);
+      check("corrupt_head_refusal_leaves_file_intact",
+            file_size(dbpath)==before);
     }
     if( db ) sqlite3_close(db);
   }
@@ -1086,6 +1093,113 @@ static void test_root_seal_binds_file_offset(void){
         csManifestHashState(manifest, rootOffset + 1)==CS_MANIFEST_HASH_BAD);
 }
 
+/* Open, then write. The destructive reclaim fires on write-lock acquisition,
+** not on open, so a read-only probe would not reach it. */
+static int open_write_and_probe(const char *path){
+  sqlite3 *db = 0;
+  int errSeen = 0;
+  int rc = sqlite3_open(path, &db);
+  if( rc!=SQLITE_OK ){
+    if( db ) sqlite3_close(db);
+    return 1;
+  }
+  if( execSql(db, "INSERT INTO t1 VALUES(99, 'probe')")!=SQLITE_OK ) errSeen = 1;
+  if( execSql(db, "SELECT count(*) FROM t1")!=SQLITE_OK ) errSeen = 1;
+  sqlite3_close(db);
+  return errSeen;
+}
+
+static const char *rowCountOf(const char *path){
+  sqlite3 *db = 0;
+  static char buf[64];
+  const char *res;
+  if( sqlite3_open(path, &db)!=SQLITE_OK ){
+    if( db ) sqlite3_close(db);
+    snprintf(buf, sizeof(buf), "OPENFAIL");
+    return buf;
+  }
+  res = queryScalarText(db, "SELECT count(*) FROM t1");
+  snprintf(buf, sizeof(buf), "%s", res);
+  sqlite3_close(db);
+  return buf;
+}
+
+/* A compacted store is manifest | data | index with an empty WAL, so lowering
+** the WAL offset aims replay straight at live chunk bytes. Replay reads them
+** as WAL records, calls the tail torn, and rewinds the logical EOF; the next
+** write-lock acquisition then reclaims those "dead" bytes and takes the index
+** and the whole data region with them. The damage is one header field and the
+** rows are still readable, so failing closed keeps a recoverable file
+** recoverable instead of destroying it on the next write. */
+static void test_header_seal_detects_tampered_wal_offset(void){
+  const char *dbpath = "/tmp/test_corr_hdrseal.db";
+  unsigned char buf[8];
+  off_t before, after;
+
+  printf("--- Test 26: Header seal detects a tampered WAL offset ---\n");
+
+  check("create_compacted_26", create_compacted_db(dbpath)==0);
+  before = file_size(dbpath);
+  check("rows_before_26", strcmp(rowCountOf(dbpath), "5")==0);
+
+  CS_WRITE_I64(buf, (long long)(MANIFEST_SIZE + 32));
+  check("corrupt_26",
+        corrupt_bytes(dbpath, CS_MANIFEST_WAL_OFFSET_OFF, buf, sizeof(buf))==0);
+
+  check("tampered_wal_offset_detected", open_write_and_probe(dbpath)==1);
+
+  after = file_size(dbpath);
+  check("tampered_wal_offset_does_not_truncate", after==before);
+
+  removeDb(dbpath);
+}
+
+/* The seal only started being written well after CHUNK_STORE_VERSION reached
+** its current value, so version-current files carrying an all-zero self hash
+** are in the field and must keep opening. */
+static void test_unsealed_header_still_opens(void){
+  const char *dbpath = "/tmp/test_corr_legacyhdr.db";
+  unsigned char zeros[PROLLY_HASH_SIZE];
+
+  printf("--- Test 27: Unsealed (legacy) header still opens ---\n");
+
+  check("create_compacted_27", create_compacted_db(dbpath)==0);
+  memset(zeros, 0, sizeof(zeros));
+  check("unseal_27",
+        corrupt_bytes(dbpath, CS_MANIFEST_SELF_HASH_OFF, zeros,
+                      sizeof(zeros))==0);
+
+  check("unsealed_header_opens_clean", open_write_and_probe(dbpath)==0);
+  removeDb(dbpath);
+}
+
+/* An unsealed header has no seal to check, so its WAL offset is bounds-checked
+** on its own -- otherwise legacy files keep the destructive path. */
+static void test_unsealed_header_bounds_checks_wal_offset(void){
+  const char *dbpath = "/tmp/test_corr_legacybounds.db";
+  unsigned char zeros[PROLLY_HASH_SIZE];
+  unsigned char buf[8];
+  off_t before, after;
+
+  printf("--- Test 28: Unsealed header bounds-checks its WAL offset ---\n");
+
+  check("create_compacted_28", create_compacted_db(dbpath)==0);
+  before = file_size(dbpath);
+  memset(zeros, 0, sizeof(zeros));
+  check("unseal_28",
+        corrupt_bytes(dbpath, CS_MANIFEST_SELF_HASH_OFF, zeros,
+                      sizeof(zeros))==0);
+  CS_WRITE_I64(buf, (long long)(MANIFEST_SIZE + 32));
+  check("corrupt_28",
+        corrupt_bytes(dbpath, CS_MANIFEST_WAL_OFFSET_OFF, buf, sizeof(buf))==0);
+
+  check("unsealed_bad_wal_offset_detected", open_write_and_probe(dbpath)==1);
+  after = file_size(dbpath);
+  check("unsealed_bad_wal_offset_does_not_truncate", after==before);
+
+  removeDb(dbpath);
+}
+
 int main(void){
   printf("=== DoltLite Corruption Detection Tests ===\n\n");
 
@@ -1113,6 +1227,9 @@ int main(void){
   test_damage_far_before_sealing_root_poisons();
   test_crash_garbage_truncated_on_write();
   test_root_seal_binds_file_offset();
+  test_header_seal_detects_tampered_wal_offset();
+  test_unsealed_header_still_opens();
+  test_unsealed_header_bounds_checks_wal_offset();
 
   printf("\n=== Results: %d passed, %d failed out of %d tests ===\n",
     nPass, nFail, nPass+nFail);

--- a/test/corruption_test.c
+++ b/test/corruption_test.c
@@ -791,12 +791,10 @@ static void test_corrupt_version(void){
 static void test_corrupt_head_commit(void){
   const char *dbpath = "/tmp/test_corr_head.db";
   unsigned char bad_hash[20];
-  off_t before;
 
   printf("--- Test 17: Corrupt former head_commit bytes (compacted) ---\n");
 
   check("create_compacted_15", create_compacted_db(dbpath)==0);
-  before = file_size(dbpath);
 
   memset(bad_hash, 0xCD, sizeof(bad_hash));
   check("corrupt_15",
@@ -817,12 +815,7 @@ static void test_corrupt_head_commit(void){
           strncmp(b, "ERROR", 5)!=0 && atoi(b) >= 1);
       }
     }else{
-      /* These bytes sit inside the sealed header, so the store now refuses the
-      ** open rather than running on fields it cannot vouch for. Refusing is
-      ** only an improvement if the file survives it. */
       check("corrupt_head_commit_no_crash", 1);
-      check("corrupt_head_refusal_leaves_file_intact",
-            file_size(dbpath)==before);
     }
     if( db ) sqlite3_close(db);
   }
@@ -1136,7 +1129,7 @@ static void test_header_seal_detects_tampered_wal_offset(void){
   unsigned char buf[8];
   off_t before, after;
 
-  printf("--- Test 26: Header seal detects a tampered WAL offset ---\n");
+  printf("--- Test 26: Tampered WAL offset is refused, not truncated ---\n");
 
   check("create_compacted_26", create_compacted_db(dbpath)==0);
   before = file_size(dbpath);
@@ -1154,14 +1147,14 @@ static void test_header_seal_detects_tampered_wal_offset(void){
   removeDb(dbpath);
 }
 
-/* The seal only started being written well after CHUNK_STORE_VERSION reached
-** its current value, so version-current files carrying an all-zero self hash
-** are in the field and must keep opening. */
+/* Header sealing began well after CHUNK_STORE_VERSION reached its current
+** value, so version-current files carrying an all-zero self hash are in the
+** field and must keep opening. */
 static void test_unsealed_header_still_opens(void){
   const char *dbpath = "/tmp/test_corr_legacyhdr.db";
   unsigned char zeros[PROLLY_HASH_SIZE];
 
-  printf("--- Test 27: Unsealed (legacy) header still opens ---\n");
+  printf("--- Test 27: Pre-seal header still opens ---\n");
 
   check("create_compacted_27", create_compacted_db(dbpath)==0);
   memset(zeros, 0, sizeof(zeros));
@@ -1173,15 +1166,15 @@ static void test_unsealed_header_still_opens(void){
   removeDb(dbpath);
 }
 
-/* An unsealed header has no seal to check, so its WAL offset is bounds-checked
-** on its own -- otherwise legacy files keep the destructive path. */
+/* Pre-seal headers are covered by the same bounds check, so they do not keep
+** the destructive path to themselves. */
 static void test_unsealed_header_bounds_checks_wal_offset(void){
   const char *dbpath = "/tmp/test_corr_legacybounds.db";
   unsigned char zeros[PROLLY_HASH_SIZE];
   unsigned char buf[8];
   off_t before, after;
 
-  printf("--- Test 28: Unsealed header bounds-checks its WAL offset ---\n");
+  printf("--- Test 28: Bounds check covers pre-seal headers ---\n");
 
   check("create_compacted_28", create_compacted_db(dbpath)==0);
   before = file_size(dbpath);


### PR DESCRIPTION
## Problem

A WAL offset that points below the data it is supposed to follow does not merely produce a bad read. Replay reads live chunk bytes as WAL records, decides the tail is torn, and rewinds the logical EOF; the next write-lock acquisition then reclaims everything past it (`chunk_store_lock.c:478`, mirrored at `chunk_store_commit.c:186`). On a compacted store that is the index and the entire data region.

Demonstrated on a healthy compacted store (`manifest | data | index`, empty WAL, 1727 bytes, 5 rows), flipping only the 8-byte WAL offset:

```
size before: 1727
SELECT count(*) FROM t1   -> 5          # reads fine, the corruption is silent
INSERT ...                -> disk I/O error
size after:  200                        # index and data gone
```

Restoring the correct offset afterwards does not help — `database disk image is malformed`, permanently. One damaged header field destroys an otherwise fully readable database.

With the bounds check, the same sequence refuses the open, leaves the file at 1727 bytes, and restoring the field brings all 5 rows back.

## Fix

Reject a header whose WAL offset falls below `CHUNK_MANIFEST_SIZE`, or below `iIndexOffset + nIndexSize` when an index is present, plus negative index geometry.

A damaged header also no longer enters the creation-crash recovery at `chunkStoreOpen`. That path ends in `sqlite3OsTruncate(pFile, 0)`, and a header that still identifies as a chunk store is damaged data, not a crashed creation. `csReadManifest` could not previously return `SQLITE_CORRUPT`, so narrowing that condition to `SQLITE_NOTADB` changes nothing that happens today.

## Why not verify the header seal

My first version did, since every writer already seals the offset-0 header and nothing checked it. CI disagreed, correctly.

The seal covers all 168 bytes, including ones no reader consults. `pragma.test:274` does `hexio_write test.db 48 FFFFFF00` — offset 48 is stock's `default_cache_size` slot, and in this format the unused upper half of a root record's `DURABLE_TO`, which the offset-0 header never populates. Verifying the seal refused that database over damage that cannot mislead anything, and `sqlite-regression-ddl-schema` went red.

The bounds checks cover the harmful case on their own, and they also cover headers written before sealing existed, which no seal check could reach. Verifying the seal is still worth doing eventually, but it needs to distinguish load-bearing fields from padding, and that is a larger change than this one.

## Testing

Three cases in `test/corruption_test.c`, all on the compacted layout that actually reproduces: a tampered WAL offset, a pre-seal header that must still open cleanly, and a pre-seal header whose bad WAL offset must still be caught. Each asserts both that the damage is detected and that the file is **not** truncated.

Fail-before/pass-after, same test file both runs:

- before: **117 passed, 2 failed**
- after: **119 passed, 0 failed**

Both baseline failures are the truncation assertions — the pre-fix engine detected the corruption *and* destroyed the file anyway, which is the point.

Full local validation:

- testfixture `ddl-schema` bucket (the one that went red) — 14,980 passing, 387 known divergences, 0 unexpected; `pragma` back to its baseline 62 known divergences
- testfixture `storage` bucket — 45,265 passing, 0 unexpected failures. `bigfile`/`bigfile2` terminate without a summary, confirmed identical on a control build without the fix, so environmental and pre-existing.
- `test/run_doltlite_tests.sh` — 99/99 suites, including `storage_format_contract_test.sh` at 23/23
- `test/run_c_tests.sh` — 26/26 gated c-tests
- `test/doltlite_regression_test_c.sh` — 310,135 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)