### PR TITLE
Treat a NULL bound as matching nothing in dolt_ table filters

### DIFF
--- a/src/doltlite_at.c
+++ b/src/doltlite_at.c
@@ -333,6 +333,7 @@ static int atFilter(sqlite3_vtab_cursor *cur,
       AT_IDX_PK_EQ, AT_IDX_PK_GE, AT_IDX_PK_LE,
       AT_IDX_PK_GT, AT_IDX_PK_LT,
       argc-1, argv+1, &c->pkRange);
+  if( c->pkRange.isEmpty ) return SQLITE_OK;
 
   pBt=doltliteGetBtShared(db);
   if(!pBt) return SQLITE_OK;

--- a/src/doltlite_blame.c
+++ b/src/doltlite_blame.c
@@ -802,6 +802,7 @@ static int bmFilter(sqlite3_vtab_cursor *pCursor,
       BLAME_IDX_PK_EQ, BLAME_IDX_PK_GE, BLAME_IDX_PK_LE,
       BLAME_IDX_PK_GT, BLAME_IDX_PK_LT,
       argc, argv, &pkRange);
+  if( pkRange.isEmpty ) return SQLITE_OK;
 
   if( !cs || !pCache ) return SQLITE_OK;
 

--- a/src/doltlite_diff.c
+++ b/src/doltlite_diff.c
@@ -768,7 +768,12 @@ static int diffFilter(sqlite3_vtab_cursor *pCursor,
   }
 
   if( (idxNum & DIFF_IDX_TABLE_NAME) && argIdx<argc ){
-    const char *z = (const char*)sqlite3_value_text(argv[argIdx++]);
+    const char *z;
+    /* A NULL name matches no table. Leaving the filter unset would read as
+    ** "no filter" and return every row, and xBestIndex omits the constraint
+    ** so nothing rechecks it. */
+    if( sqlite3_value_type(argv[argIdx])==SQLITE_NULL ) return SQLITE_OK;
+    z = (const char*)sqlite3_value_text(argv[argIdx++]);
     if( z ){
       pCur->zFilterTable = sqlite3_mprintf("%s", z);
       if( !pCur->zFilterTable ) return SQLITE_NOMEM;

--- a/src/doltlite_history.c
+++ b/src/doltlite_history.c
@@ -290,6 +290,7 @@ static int htFilter(sqlite3_vtab_cursor *cur,
       HIST_IDX_PK_EQ, HIST_IDX_PK_GE, HIST_IDX_PK_LE,
       HIST_IDX_PK_GT, HIST_IDX_PK_LT,
       argc, argv, &c->pkRange);
+  if( c->pkRange.isEmpty ) return SQLITE_OK;
   if( idxNum & HIST_IDX_PK_EQ ){
     iArg = 1;
   }else{

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -74,6 +74,7 @@ struct DoltlitePkRange {
   int hasPkHi;
   int pkLoStrict;
   int pkHiStrict;
+  int isEmpty;            /* A NULL bound: the scan can match nothing. */
 };
 
 struct DoltliteCommitQueue {
@@ -397,14 +398,25 @@ static SQLITE_INLINE void doltlitePkRangeFromArgs(
   int iArg = 0;
   memset(pRange, 0, sizeof(*pRange));
 
+  /* No value compares true against NULL, so any NULL bound empties the scan.
+  ** sqlite3_value_int64 would read it as 0 and happily match the pk=0 row, and
+  ** xBestIndex omits these constraints, so nothing downstream rechecks them. */
   if( idxNum & idxEq ){
     if( iArg < argc ){
+      if( sqlite3_value_type(argv[iArg])==SQLITE_NULL ){
+        pRange->isEmpty = 1;
+        return;
+      }
       pRange->pkLo = sqlite3_value_int64(argv[iArg++]);
       pRange->hasPkLo = 1;
     }
   }else{
     if( idxNum & idxGe ){
       if( iArg < argc ){
+        if( sqlite3_value_type(argv[iArg])==SQLITE_NULL ){
+          pRange->isEmpty = 1;
+          return;
+        }
         pRange->pkLo = sqlite3_value_int64(argv[iArg++]);
         pRange->hasPkLo = 1;
         pRange->pkLoStrict = 0;
@@ -412,7 +424,12 @@ static SQLITE_INLINE void doltlitePkRangeFromArgs(
     }
     if( idxNum & idxGt ){
       if( iArg < argc ){
-        i64 v2 = sqlite3_value_int64(argv[iArg++]);
+        i64 v2;
+        if( sqlite3_value_type(argv[iArg])==SQLITE_NULL ){
+          pRange->isEmpty = 1;
+          return;
+        }
+        v2 = sqlite3_value_int64(argv[iArg++]);
         if( !pRange->hasPkLo || v2 >= pRange->pkLo ){
           pRange->pkLo = v2;
           pRange->hasPkLo = 1;
@@ -422,6 +439,10 @@ static SQLITE_INLINE void doltlitePkRangeFromArgs(
     }
     if( idxNum & idxLe ){
       if( iArg < argc ){
+        if( sqlite3_value_type(argv[iArg])==SQLITE_NULL ){
+          pRange->isEmpty = 1;
+          return;
+        }
         pRange->pkHi = sqlite3_value_int64(argv[iArg++]);
         pRange->hasPkHi = 1;
         pRange->pkHiStrict = 0;
@@ -429,7 +450,12 @@ static SQLITE_INLINE void doltlitePkRangeFromArgs(
     }
     if( idxNum & idxLt ){
       if( iArg < argc ){
-        i64 v2 = sqlite3_value_int64(argv[iArg++]);
+        i64 v2;
+        if( sqlite3_value_type(argv[iArg])==SQLITE_NULL ){
+          pRange->isEmpty = 1;
+          return;
+        }
+        v2 = sqlite3_value_int64(argv[iArg++]);
         if( !pRange->hasPkHi || v2 <= pRange->pkHi ){
           pRange->pkHi = v2;
           pRange->hasPkHi = 1;

--- a/src/doltlite_status.c
+++ b/src/doltlite_status.c
@@ -940,6 +940,9 @@ static int statusFilter(sqlite3_vtab_cursor *pCursor,
   memset(&baseCatHash, 0, sizeof(baseCatHash));
   if( idxNum & STATUS_IDX_STAGED_EQ ){
     if( iArg>=argc ) return SQLITE_OK;
+    /* NULL reads as 0 through sqlite3_value_int, which would quietly become
+    ** "staged=0" for a constraint that can never be true. */
+    if( sqlite3_value_type(argv[iArg])==SQLITE_NULL ) return SQLITE_OK;
     iStagedOnly = sqlite3_value_int(argv[iArg++]);
     if( iStagedOnly!=0 && iStagedOnly!=1 ) return SQLITE_OK;
   }

--- a/test/doltlite_dolt_table_pushdown.sh
+++ b/test/doltlite_dolt_table_pushdown.sh
@@ -161,4 +161,53 @@ run_test "nonint_history_filter_correct" \
 
 rm -f "$DB2"
 
+# A pushed-down constraint is omitted, so xFilter is the only thing standing
+# between a NULL bound and a wrong answer. Nothing compares true against NULL,
+# yet sqlite3_value_int64 reads one as 0 -- so the pk=0 row below is what makes
+# the difference between "matches nothing" and "matches by accident".
+DB3=/tmp/test_pushdown_null_$$.db
+rm -f "$DB3"
+echo "CREATE TABLE t(pk INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(0,'zero');
+INSERT INTO t VALUES(1,'one');
+SELECT dolt_commit('-A','-m','init');
+UPDATE t SET v='changed' WHERE pk=1;
+SELECT dolt_commit('-A','-m','c2');
+UPDATE t SET v='dirty' WHERE pk=0;" | $DOLTLITE "$DB3" > /dev/null 2>&1
+
+run_test "null_pk_eq_at_empty" \
+  "SELECT count(*) FROM dolt_at_t WHERE commit_ref='HEAD' AND pk=NULL;" "0" "$DB3"
+run_test "null_pk_eq_history_empty" \
+  "SELECT count(*) FROM dolt_history_t WHERE pk=NULL;" "0" "$DB3"
+run_test "null_pk_eq_blame_empty" \
+  "SELECT count(*) FROM dolt_blame_t WHERE pk=NULL;" "0" "$DB3"
+run_test "null_pk_ge_history_empty" \
+  "SELECT count(*) FROM dolt_history_t WHERE pk>=NULL;" "0" "$DB3"
+run_test "null_pk_le_history_empty" \
+  "SELECT count(*) FROM dolt_history_t WHERE pk<=NULL;" "0" "$DB3"
+run_test "null_table_name_diff_empty" \
+  "SELECT count(*) FROM dolt_diff WHERE table_name=NULL;" "0" "$DB3"
+run_test "null_staged_status_empty" \
+  "SELECT count(*) FROM dolt_status WHERE staged=NULL;" "0" "$DB3"
+
+# The same shape a join produces, which is how this reaches real queries.
+run_test "null_join_history_empty" \
+  "WITH n(k) AS (SELECT NULL) SELECT count(*) FROM n JOIN dolt_history_t h ON h.pk=n.k;" \
+  "0" "$DB3"
+
+# Non-NULL bounds must keep working, including the pk=0 row that a NULL used
+# to collide with.
+run_test "pk_eq_zero_still_matches" \
+  "SELECT count(*) FROM dolt_at_t WHERE commit_ref='HEAD' AND pk=0;" "1" "$DB3"
+run_test "pk_eq_one_still_matches" \
+  "SELECT count(*) FROM dolt_at_t WHERE commit_ref='HEAD' AND pk=1;" "1" "$DB3"
+run_test "pk_ge_zero_still_matches" \
+  "SELECT count(*) FROM dolt_history_t WHERE pk>=0;" "4" "$DB3"
+run_test "staged_zero_still_matches" \
+  "SELECT count(*) FROM dolt_status WHERE staged=0;" "1" "$DB3"
+run_test "table_name_named_still_matches" \
+  "SELECT count(*) FROM dolt_diff WHERE table_name='t';" "3" "$DB3"
+
+rm -f "$DB3"
+
 dltest_finish


### PR DESCRIPTION
## Problem

`xBestIndex` marks these constraints `omit=1`, so `xFilter` is the only thing that ever evaluates them — nothing downstream rechecks. Each filter converted its argument without asking whether it was NULL, and every conversion has a plausible-looking default:

| conversion | result on NULL | effect |
|---|---|---|
| `sqlite3_value_int64` | `0` | `pk=NULL` matched the `pk=0` row |
| `sqlite3_value_int` | `0` | `staged=NULL` read as `staged=0` |
| `sqlite3_value_text` | `NULL` | `table_name=NULL` read as *no filter*, returning every row |

Nothing compares true against NULL, so all of these must return no rows. Measured on a two-row table with a `pk=0` row and one dirty table:

```
dolt_at_t      WHERE commit_ref='HEAD' AND pk=NULL  -> 1   (want 0)
dolt_history_t WHERE pk=NULL                        -> 2   (want 0)
dolt_blame_t   WHERE pk=NULL                        -> 1   (want 0)
dolt_status    WHERE staged=NULL                    -> 1   (want 0)
dolt_diff      WHERE table_name=NULL                -> 3   (want 0)
```

The pk case only appears when the table has a row at 0 — with pks starting at 1 the wrong answer and the right answer coincide, which is why it survived. My first probe missed it for exactly that reason.

This reaches ordinary queries through joins, where a NULL-producing outer row silently pulls in unrelated history:

```sql
WITH n(k) AS (SELECT NULL) SELECT count(*) FROM n JOIN dolt_history_t h ON h.pk=n.k;  -- was 2
```

## Fix

`DoltlitePkRange` gains an `isEmpty` flag, set whenever any bound argument is `SQLITE_NULL`, and the three pk consumers (`dolt_at_`, `dolt_history_`, `dolt_blame_`) return an empty result when it is set. `dolt_diff`'s table-name filter and `dolt_status`'s `staged` filter get the same treatment inline.

`dolt_status`'s *table* filter already did the right thing (`if( !zTableFilter ) return SQLITE_OK;`) — the others now match it rather than inventing a new convention.

## Testing

All cases went into `test/doltlite_dolt_table_pushdown.sh`, the existing suite for exactly this concern, rather than being scattered across five per-surface oracle singletons. That keeps the theme in one place and leaves those oracles free for the `WITHOUT ROWID` fix that follows.

Thirteen cases: the five surfaces under `=NULL`, `>=NULL` and `<=NULL` on the range path, the join shape, and five guards that non-NULL bounds still work — including `pk=0`, the value a NULL used to collide with.

Fail-before/pass-after, same test file both runs:

- before: **27 passed, 8 failed**
- after: **35 passed, 0 failed**

All eight failures are the NULL cases; the five "still matches" guards pass in both runs, so they are guards rather than repairs.

Full local validation:

- `test/run_doltlite_tests.sh` — 99/99 suites
- Read-surface oracle suites against Dolt 2.2.2, 0 failures: `diff` (67), `status` (40), `history` (27), `at` (26), `blame` (25), `log` (20), `diff_tvf` (16)
- `test/run_c_tests.sh` — 26/26 gated c-tests
- `test/doltlite_regression_test_c.sh` — 310,135 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)