### PR TITLE
Make WAL-vs-index bounds check overflow-safe

### DIFF
--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -250,8 +250,11 @@ static int csReadManifest(ChunkStore *cs){
   ** and cover pre-seal headers that no seal check could reach. */
   if( cs->index.iIndexOffset<0 || cs->index.nIndexSize<0 ) return SQLITE_CORRUPT;
   if( cs->wal.iWalOffset < CHUNK_MANIFEST_SIZE ) return SQLITE_CORRUPT;
+  /* Compare without summing: a large iIndexOffset + nIndexSize can wrap i64
+  ** and accept a WAL offset that still sits inside live data. */
   if( cs->index.iIndexOffset>0
-   && cs->wal.iWalOffset < cs->index.iIndexOffset + cs->index.nIndexSize ){
+   && ( cs->wal.iWalOffset < cs->index.iIndexOffset
+     || cs->wal.iWalOffset - cs->index.iIndexOffset < cs->index.nIndexSize ) ){
     return SQLITE_CORRUPT;
   }
 

--- a/test/corruption_test.c
+++ b/test/corruption_test.c
@@ -1193,6 +1193,40 @@ static void test_unsealed_header_bounds_checks_wal_offset(void){
   removeDb(dbpath);
 }
 
+/* iIndexOffset + nIndexSize in i64 can wrap for a crafted large offset. A
+** subtractive bounds check must still refuse a low WAL offset that aims at
+** live data, and must not truncate the file. */
+static void test_index_end_overflow_bounds_wal_offset(void){
+  const char *dbpath = "/tmp/test_corr_idxoverflow.db";
+  unsigned char buf[8];
+  unsigned char sizeBuf[4];
+  off_t before, after;
+
+  printf("--- Test 29: Overflow-shaped index end still refuses bad WAL ---\n");
+
+  check("create_compacted_29", create_compacted_db(dbpath)==0);
+  before = file_size(dbpath);
+  check("rows_before_29", strcmp(rowCountOf(dbpath), "5")==0);
+
+  /* Near i64 max so iIndexOffset + nIndexSize wraps if added naively. */
+  CS_WRITE_I64(buf, (long long)0x7fffffffffffffffLL);
+  check("corrupt_index_offset_29",
+        corrupt_bytes(dbpath, CS_MANIFEST_INDEX_OFFSET_OFF, buf, sizeof(buf))==0);
+  CS_WRITE_U32(sizeBuf, 1u);
+  check("corrupt_index_size_29",
+        corrupt_bytes(dbpath, CS_MANIFEST_INDEX_SIZE_OFF, sizeBuf,
+                      sizeof(sizeBuf))==0);
+  CS_WRITE_I64(buf, (long long)(MANIFEST_SIZE + 32));
+  check("corrupt_wal_offset_29",
+        corrupt_bytes(dbpath, CS_MANIFEST_WAL_OFFSET_OFF, buf, sizeof(buf))==0);
+
+  check("overflow_index_end_bad_wal_detected", open_write_and_probe(dbpath)==1);
+  after = file_size(dbpath);
+  check("overflow_index_end_does_not_truncate", after==before);
+
+  removeDb(dbpath);
+}
+
 int main(void){
   printf("=== DoltLite Corruption Detection Tests ===\n\n");
 
@@ -1223,6 +1257,7 @@ int main(void){
   test_header_seal_detects_tampered_wal_offset();
   test_unsealed_header_still_opens();
   test_unsealed_header_bounds_checks_wal_offset();
+  test_index_end_overflow_bounds_wal_offset();
 
   printf("\n=== Results: %d passed, %d failed out of %d tests ===\n",
     nPass, nFail, nPass+nFail);


### PR DESCRIPTION
## Summary

Follow-up to #1987. Ito flagged that the new production bounds check can miss an overflow-shaped header:

```c
cs->wal.iWalOffset < cs->index.iIndexOffset + cs->index.nIndexSize
```

Both fields are `i64`. A crafted large `iIndexOffset` (with non-zero `nIndexSize`) can wrap the sum, so a low WAL offset that still points into live data is accepted. That is the same class of damage #1987 closed for ordinary offsets.

## Fix

Compare without summing:

- reject if `iWalOffset < iIndexOffset`
- or if `iWalOffset - iIndexOffset < nIndexSize`

Exact index-end (`iWalOffset == iIndexOffset + nIndexSize`) still accepts. The empty-index path (`iIndexOffset == 0`) is unchanged.

## Test plan

- [x] `build/corruption_test` — **126 passed, 0 failed** (includes new Test 29)
- New case: compacted DB, `iIndexOffset = INT64_MAX`, `nIndexSize = 1`, `iWalOffset = MANIFEST_SIZE + 32`; open/write refused; file size preserved

Refs Ito QA on #1987 (overflow-shaped index end).