### PR TITLE
Give each workspace cursor its own reference to the scan's rows

### DIFF
--- a/src/doltlite_workspace.c
+++ b/src/doltlite_workspace.c
@@ -22,15 +22,25 @@ struct WorkspaceRow {
   u8 *pNewVal; int nNewVal;
 };
 
+/* One scan's rows, shared between the cursor producing them and the table,
+** which keeps the latest set so xUpdate can resolve the rowids that scan
+** handed out. A plain buffer on the table could not do both: a second cursor
+** starting its own scan freed the array the first was still reading. */
+typedef struct WorkspaceRows WorkspaceRows;
+struct WorkspaceRows {
+  int nRef;
+  WorkspaceRow *a;
+  int n;
+  int nAlloc;
+};
+
 typedef struct WorkspaceVtab WorkspaceVtab;
 struct WorkspaceVtab {
   sqlite3_vtab base;
   sqlite3 *db;
   char *zTableName;
   DoltliteColInfo cols;
-  WorkspaceRow *aCache;
-  int nCache;
-  int nCacheAlloc;
+  WorkspaceRows *pLastRows;
 };
 
 typedef struct WorkspaceCursor WorkspaceCursor;
@@ -46,6 +56,7 @@ struct WorkspaceCursor {
   ProllyHash headRoot, stagedRoot, workingRoot;
   u8 stagedFlags, workingFlags;
   int stagedOnly;
+  WorkspaceRows *pRows;
 };
 
 static void wsFreeRows(WorkspaceRow *aRow, int nRow){
@@ -58,11 +69,19 @@ static void wsFreeRows(WorkspaceRow *aRow, int nRow){
   sqlite3_free(aRow);
 }
 
-static void wsClearCache(WorkspaceVtab *p){
-  wsFreeRows(p->aCache, p->nCache);
-  p->aCache = 0;
-  p->nCache = 0;
-  p->nCacheAlloc = 0;
+static WorkspaceRows *wsRowsNew(void){
+  WorkspaceRows *p = sqlite3_malloc(sizeof(*p));
+  if( !p ) return 0;
+  memset(p, 0, sizeof(*p));
+  p->nRef = 1;
+  return p;
+}
+
+static void wsRowsRelease(WorkspaceRows *p){
+  if( !p ) return;
+  if( --p->nRef > 0 ) return;
+  wsFreeRows(p->a, p->n);
+  sqlite3_free(p);
 }
 
 static char *wsBuildSchema(const DoltliteColInfo *ci){
@@ -92,17 +111,19 @@ static char *wsBuildSchema(const DoltliteColInfo *ci){
 }
 
 static int wsAppendRow(
-  WorkspaceVtab *pVtab,
+  WorkspaceCursor *c,
   int staged,
   u8 flags,
   const ProllyDiffChange *pChange
 ){
+  WorkspaceVtab *pVtab = (WorkspaceVtab*)c->base.pVtab;
+  WorkspaceRows *pRows = c->pRows;
   WorkspaceRow row;
   WorkspaceRow *aNew;
   int nNew;
 
   memset(&row, 0, sizeof(row));
-  row.rowid = pVtab->nCache + 1;
+  row.rowid = pRows->n + 1;
   row.staged = staged;
   row.diffType = pChange->type;
   row.flags = flags;
@@ -150,16 +171,15 @@ static int wsAppendRow(
       sqlite3_free(pRec);
     }
   }
-  if( pVtab->nCache>=pVtab->nCacheAlloc ){
-    nNew = pVtab->nCacheAlloc ? pVtab->nCacheAlloc*2 : 16;
-    aNew = sqlite3_realloc(pVtab->aCache,
-                           nNew*(int)sizeof(WorkspaceRow));
+  if( pRows->n>=pRows->nAlloc ){
+    nNew = pRows->nAlloc ? pRows->nAlloc*2 : 16;
+    aNew = sqlite3_realloc(pRows->a, nNew*(int)sizeof(WorkspaceRow));
     if( !aNew ) goto nomem;
-    pVtab->aCache = aNew;
-    pVtab->nCacheAlloc = nNew;
+    pRows->a = aNew;
+    pRows->nAlloc = nNew;
   }
-  pVtab->aCache[pVtab->nCache] = row;
-  pVtab->nCache++;
+  pRows->a[pRows->n] = row;
+  pRows->n++;
   return SQLITE_OK;
 
 nomem:
@@ -286,7 +306,7 @@ static int wsLoadNextRow(WorkspaceCursor *c, WorkspaceVtab *pVtab){
   ProllyDiffChange *pChange = 0;
   int rc;
 
-  if( c->iRow < pVtab->nCache ) return SQLITE_OK;
+  if( c->iRow < c->pRows->n ) return SQLITE_OK;
   while( !c->eof ){
     if( !c->iterOpen ){
       rc = wsOpenNextIter(c, pVtab);
@@ -294,7 +314,7 @@ static int wsLoadNextRow(WorkspaceCursor *c, WorkspaceVtab *pVtab){
     }
     rc = prollyDiffIterStep(&c->iter, &pChange);
     if( rc==SQLITE_ROW && pChange ){
-      return wsAppendRow(pVtab, c->iterStaged, c->iterFlags, pChange);
+      return wsAppendRow(c, c->iterStaged, c->iterFlags, pChange);
     }
     if( rc!=SQLITE_DONE && rc!=SQLITE_ROW ) return rc;
     wsCloseIter(c);
@@ -305,10 +325,8 @@ static int wsLoadNextRow(WorkspaceCursor *c, WorkspaceVtab *pVtab){
 static int wsConnect(sqlite3 *db, void *pAux, int argc,
     const char *const*argv, sqlite3_vtab **ppVtab, char **pzErr){
   (void)pAux;
-  /* WorkspaceVtab has trailing aCache/nCache fields, but they start zeroed
-  ** and only fill in during xFilter, so the shared Connect (which inits the
-  ** common prefix and cleans up via the common disconnect on failure) is
-  ** safe here; wsDisconnect still frees the cache at teardown. */
+  /* pLastRows starts null, which the shared Connect guarantees, and only gets
+  ** set in xFilter; wsDisconnect drops the reference at teardown. */
   return doltliteVtabConnectUserTable(db, argc, argv, "dolt_workspace_",
                                       sizeof(WorkspaceVtab), wsBuildSchema,
                                       ppVtab, pzErr);
@@ -316,7 +334,8 @@ static int wsConnect(sqlite3 *db, void *pAux, int argc,
 
 static int wsDisconnect(sqlite3_vtab *pBase){
   WorkspaceVtab *p = (WorkspaceVtab*)pBase;
-  wsClearCache(p);
+  wsRowsRelease(p->pLastRows);
+  p->pLastRows = 0;
   doltliteFreeColInfo(&p->cols);
   sqlite3_free(p->zTableName);
   sqlite3_free(p);
@@ -355,7 +374,9 @@ static int wsOpen(sqlite3_vtab *pVtab, sqlite3_vtab_cursor **pp){
 }
 
 static int wsClose(sqlite3_vtab_cursor *cur){
-  wsCloseIter((WorkspaceCursor*)cur);
+  WorkspaceCursor *c = (WorkspaceCursor*)cur;
+  wsCloseIter(c);
+  wsRowsRelease(c->pRows);
   sqlite3_free(cur);
   return SQLITE_OK;
 }
@@ -367,7 +388,12 @@ static int wsFilter(sqlite3_vtab_cursor *cur,
   int rc;
   (void)idxStr;
   wsCloseIter(c);
-  wsClearCache(p);
+  wsRowsRelease(c->pRows);
+  c->pRows = wsRowsNew();
+  if( !c->pRows ) return SQLITE_NOMEM;
+  wsRowsRelease(p->pLastRows);
+  p->pLastRows = c->pRows;
+  c->pRows->nRef++;
   c->iRow = 0;
   c->eof = 0;
   c->phase = 0;
@@ -396,14 +422,19 @@ static int wsNext(sqlite3_vtab_cursor *cur){
 
 static int wsEof(sqlite3_vtab_cursor *cur){
   WorkspaceCursor *c = (WorkspaceCursor*)cur;
-  return c->eof && c->iRow >= ((WorkspaceVtab*)cur->pVtab)->nCache;
+  return c->eof && (!c->pRows || c->iRow >= c->pRows->n);
 }
 
 static int wsColumn(sqlite3_vtab_cursor *cur, sqlite3_context *ctx, int col){
   WorkspaceCursor *c = (WorkspaceCursor*)cur;
   WorkspaceVtab *p = (WorkspaceVtab*)cur->pVtab;
-  WorkspaceRow *r = &p->aCache[c->iRow];
+  WorkspaceRow *r;
   int nCols = p->cols.nCol;
+  if( !c->pRows || c->iRow<0 || c->iRow>=c->pRows->n ){
+    sqlite3_result_null(ctx);
+    return SQLITE_OK;
+  }
+  r = &c->pRows->a[c->iRow];
   if( col==0 ){
     sqlite3_result_int64(ctx, r->rowid);
   }else if( col==1 ){
@@ -426,14 +457,15 @@ static int wsColumn(sqlite3_vtab_cursor *cur, sqlite3_context *ctx, int col){
 
 static int wsRowid(sqlite3_vtab_cursor *cur, sqlite3_int64 *pRowid){
   WorkspaceCursor *c = (WorkspaceCursor*)cur;
-  WorkspaceVtab *p = (WorkspaceVtab*)cur->pVtab;
-  *pRowid = p->aCache[c->iRow].rowid;
+  if( !c->pRows || c->iRow<0 || c->iRow>=c->pRows->n ) return SQLITE_ERROR;
+  *pRowid = c->pRows->a[c->iRow].rowid;
   return SQLITE_OK;
 }
 
 static WorkspaceRow *wsFindCachedRow(WorkspaceVtab *p, i64 rowid){
-  if( rowid>=1 && rowid<=p->nCache ){
-    WorkspaceRow *r = &p->aCache[rowid - 1];
+  WorkspaceRows *pRows = p->pLastRows;
+  if( pRows && rowid>=1 && rowid<=pRows->n ){
+    WorkspaceRow *r = &pRows->a[rowid - 1];
     if( r->rowid==rowid ) return r;
   }
   return 0;

--- a/test/doltlite_workspace.sh
+++ b/test/doltlite_workspace.sh
@@ -186,4 +186,47 @@ run_test "workspace_delete_index_query_old" \
 run_test "workspace_delete_index_query_new" \
   "SELECT id FROM t WHERE v=2;" "" "$DEL_DB"
 
+# Two cursors are open at once here. Rows used to accumulate on the table, so
+# the second xFilter freed the array the first was still indexing into: the
+# join returned extra rows carrying ids that were never assigned.
+MC_DB=/tmp/doltlite_workspace_multicursor_$$.db
+rm -rf "$MC_DB"
+dltest_run_sql "
+CREATE TABLE t(pk INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'a'),(2,'b'),(3,'c');
+SELECT dolt_commit('-A','-m','seed');
+UPDATE t SET v='x' WHERE pk=1;
+UPDATE t SET v='y' WHERE pk=2;
+UPDATE t SET v='z' WHERE pk=3;
+" "$MC_DB" >/dev/null
+
+run_test "workspace_single_cursor_rows" \
+  "SELECT count(*) FROM dolt_workspace_t;" "3" "$MC_DB"
+run_test "workspace_self_join_row_count" \
+  "SELECT count(*) FROM dolt_workspace_t a, dolt_workspace_t b;" "9" "$MC_DB"
+run_test "workspace_self_join_values_intact" \
+  "SELECT group_concat(a.id || ':' || coalesce(a.to_v,'~'), ' ')
+     FROM dolt_workspace_t a, dolt_workspace_t b;" \
+  "1:x 1:x 1:x 2:y 2:y 2:y 3:z 3:z 3:z" "$MC_DB"
+run_test "workspace_subquery_same_table" \
+  "SELECT count(*) FROM dolt_workspace_t
+     WHERE id IN (SELECT id FROM dolt_workspace_t);" "3" "$MC_DB"
+run_test "workspace_correlated_subquery" \
+  "SELECT count(*) FROM dolt_workspace_t a
+     WHERE EXISTS (SELECT 1 FROM dolt_workspace_t b WHERE b.id=a.id);" "3" "$MC_DB"
+
+# xUpdate has no cursor and resolves a rowid by replaying the scan, so it has
+# to replay the staged filter the rowid came from.
+run_test "workspace_stage_one_row" \
+  "UPDATE dolt_workspace_t SET staged=1 WHERE id=1;
+   SELECT group_concat(id || ':' || staged, ' ') FROM dolt_workspace_t;" \
+  "1:1 2:0 3:0" "$MC_DB"
+run_test "workspace_delete_via_filtered_rowid" \
+  "DELETE FROM dolt_workspace_t
+     WHERE id=(SELECT id FROM dolt_workspace_t WHERE staged=0 LIMIT 1);
+   SELECT group_concat(id || ':' || staged, ' ') FROM dolt_workspace_t;" \
+  "1:1 2:0" "$MC_DB"
+
+rm -rf "$MC_DB"
+
 dltest_finish


### PR DESCRIPTION
## Problem

`dolt_workspace_<table>` kept its row buffer on the **table** while cursors held indexes into it. Two cursors are live for something as ordinary as a self-join, so the second one's `xFilter` freed the array the first was still reading.

```sql
SELECT group_concat(a.id || ':' || coalesce(a.to_v,'~'), ' ')
  FROM dolt_workspace_t a, dolt_workspace_t b;
```

On a three-row dirty table that **segfaults** (exit 139). Under ASAN it does not crash but returns ids of `-4702111234474983746` — `0xBEBEBEBEBEBEBEBE`, the poison fill, i.e. reading memory it no longer owns. A plain `count(*)` over the same join returned 15 instead of 9.

This is a read of freed memory reachable from a single ordinary query, with no concurrency and no unusual schema.

## Fix

The rows become a refcounted set (`WorkspaceRows`). The cursor producing them holds a reference for as long as it reads, and the table retains the latest set so `xUpdate` can resolve the rowids that scan handed out. `xFilter` starts a fresh set rather than freeing one somebody else may be holding.

## Two wrong turns worth recording

I first moved the buffer onto the cursor outright and had `xUpdate` replay the scan to resolve a rowid, since `xUpdate` gets no cursor. That is simpler, and it was wrong twice:

1. A rowid is a *position in a scan*, and the staged filter changes which rows that scan visits. Replaying unfiltered renumbered the rows, so `DELETE ... WHERE id=(SELECT id FROM dolt_workspace_t WHERE staged=0 LIMIT 1)` resolved to a staged row and was refused. I caught this by checking the same statement on master, where it worked.
2. Even with the filter carried over, a bulk `UPDATE`/`DELETE` mutates the working set between `xUpdate` calls, so by the second row the replayed scan no longer numbers rows the same way. This showed up as two `vc_oracle_workspace_test` failures (`unstage_all_after_stage_all`, `workspace_delete_all_unstaged_modifies`).

Sharing one stable snapshot is what the original design was getting right; the only real defect was who owned its lifetime.

## Testing

Seven cases added to `test/doltlite_workspace.sh`: single-cursor count, self-join count, self-join **values** (the crashing query), `IN` subquery, correlated `EXISTS` subquery, and the two `xUpdate` paths — staging one row, then deleting via a rowid that came from a `staged=0` filtered scan, which is what caught wrong turn 1.

Fail-before/pass-after, same test file both runs:

- before: **SIGSEGV, exit 139** (the suite dies before printing a summary)
- after: **25 passed, 0 failed**

Full local validation:

- `test/vc_oracle_workspace_test.sh` against Dolt 2.2.2 — 50/50 (the two failures from wrong turn 2 are gone)
- ASAN build, crashing query — correct output, no poison, clean exit
- `test/run_doltlite_tests.sh` — 99/99 suites
- `test/run_c_tests.sh` — 26/26 gated c-tests
- `test/doltlite_regression_test_c.sh` — 310,135 tests, 0 failures
- Adjacent oracles: `diff` (67), `reset` (43), `status` (40), `add` (34), all 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)