### PR TITLE
Claim the rowid alias only for tables that have a rowid

### DIFF
--- a/src/doltlite_blame.c
+++ b/src/doltlite_blame.c
@@ -180,8 +180,11 @@ static int blameLoadPkColumns(
     n++;
   }
 
+  /* Only a rowid alias is served from the tree's integer key. A WITHOUT ROWID
+  ** table never sets intKey, so claiming the alias renders every pk as 0. */
   if( nTmp == 1 && aTmp[0].isIntegerType ){
-    intPkCid = aTmp[0].cid;
+    Table *pTab = sqlite3FindTable(db, zTable, "main");
+    if( pTab && HasRowid(pTab) ) intPkCid = aTmp[0].cid;
   }
   sqlite3_free(aTmp);
 

--- a/src/doltlite_record.c
+++ b/src/doltlite_record.c
@@ -311,8 +311,14 @@ int doltliteGetColumnNames(sqlite3 *db, const char *zTable, DoltliteColInfo *ci)
     return rc;
   }
 
+  /* iPkCol marks a rowid alias: readers render that column from the tree's
+  ** integer key and seek on it. A WITHOUT ROWID table is clustered by its
+  ** declared primary key and has no integer key to read, so treating its
+  ** INTEGER pk as an alias yields the raw key bytes as a number and silently
+  ** drops the pk constraints xBestIndex promised to apply. */
   if( nPkCols==1 && iCandidateAlias>=0 ){
-    ci->iPkCol = iCandidateAlias;
+    Table *pTab = sqlite3FindTable(db, zTable, "main");
+    if( pTab && HasRowid(pTab) ) ci->iPkCol = iCandidateAlias;
   }
 
   if( ci->nCol>0 ){

--- a/test/doltlite_dolt_table_pushdown.sh
+++ b/test/doltlite_dolt_table_pushdown.sh
@@ -210,4 +210,91 @@ run_test "table_name_named_still_matches" \
 
 rm -f "$DB3"
 
+# An INTEGER PRIMARY KEY is a rowid alias only when the table has a rowid.
+# A WITHOUT ROWID table is clustered by its declared key instead, so reading
+# that column from the tree's integer key yields the raw key bytes as a number
+# and the pk constraints xBestIndex promised to apply are silently dropped.
+DB4=/tmp/test_pushdown_worid_$$.db
+rm -f "$DB4"
+echo "CREATE TABLE t(pk INTEGER PRIMARY KEY, v TEXT) WITHOUT ROWID;
+INSERT INTO t VALUES(1,'one');
+INSERT INTO t VALUES(2,'two');
+INSERT INTO t VALUES(3,'three');
+SELECT dolt_commit('-A','-m','init');
+UPDATE t SET v='TWO' WHERE pk=2;
+SELECT dolt_commit('-A','-m','c2');" | $DOLTLITE "$DB4" > /dev/null 2>&1
+
+run_test "worid_table_rows" \
+  "SELECT group_concat(pk || ':' || v, ' ') FROM (SELECT pk,v FROM t ORDER BY pk);" \
+  "1:one 2:TWO 3:three" "$DB4"
+run_test "worid_at_renders_pk" \
+  "SELECT group_concat(pk || ':' || v, ' ')
+     FROM (SELECT pk,v FROM dolt_at_t WHERE commit_ref='HEAD' ORDER BY pk);" \
+  "1:one 2:TWO 3:three" "$DB4"
+run_test "worid_at_pk_eq_selects_that_row" \
+  "SELECT group_concat(pk || ':' || v, ' ')
+     FROM dolt_at_t WHERE commit_ref='HEAD' AND pk=2;" "2:TWO" "$DB4"
+run_test "worid_at_pk_eq_absent_is_empty" \
+  "SELECT count(*) FROM dolt_at_t WHERE commit_ref='HEAD' AND pk=99;" "0" "$DB4"
+run_test "worid_history_renders_pk" \
+  "SELECT group_concat(pk || ':' || v, ' ')
+     FROM (SELECT pk,v FROM dolt_history_t ORDER BY pk, v);" \
+  "1:one 1:one 2:TWO 2:two 3:three 3:three" "$DB4"
+run_test "worid_history_pk_eq" \
+  "SELECT count(*) FROM dolt_history_t WHERE pk=2;" "2" "$DB4"
+run_test "worid_history_pk_range" \
+  "SELECT count(*) FROM dolt_history_t WHERE pk>=2;" "4" "$DB4"
+run_test "worid_blame_renders_pk" \
+  "SELECT group_concat(pk, ' ') FROM (SELECT pk FROM dolt_blame_t ORDER BY pk);" \
+  "1 2 3" "$DB4"
+run_test "worid_blame_pk_eq" \
+  "SELECT count(*) FROM dolt_blame_t WHERE pk=2;" "1" "$DB4"
+
+rm -f "$DB4"
+
+# A composite WITHOUT ROWID key has no single INTEGER column to mistake for a
+# rowid, so it already read correctly; keep it that way.
+DB4B=/tmp/test_pushdown_worid_comp_$$.db
+rm -f "$DB4B"
+echo "CREATE TABLE t(a INTEGER, b INTEGER, v TEXT, PRIMARY KEY(a,b)) WITHOUT ROWID;
+INSERT INTO t VALUES(1,1,'x');
+INSERT INTO t VALUES(1,2,'y');
+SELECT dolt_commit('-A','-m','init');
+UPDATE t SET v='Y' WHERE a=1 AND b=2;
+SELECT dolt_commit('-A','-m','c2');" | $DOLTLITE "$DB4B" > /dev/null 2>&1
+
+run_test "worid_composite_at_renders_key" \
+  "SELECT group_concat(a || '/' || b || ':' || v, ' ')
+     FROM (SELECT a,b,v FROM dolt_at_t WHERE commit_ref='HEAD' ORDER BY a,b);" \
+  "1/1:x 1/2:Y" "$DB4B"
+run_test "worid_composite_blame_renders_key" \
+  "SELECT group_concat(a || '/' || b, ' ')
+     FROM (SELECT a,b FROM dolt_blame_t ORDER BY a,b);" "1/1 1/2" "$DB4B"
+
+rm -f "$DB4B"
+
+# The rowid table beside it must keep its pushdown: the fix narrows which
+# tables claim an alias, not whether the alias is used.
+DB5=/tmp/test_pushdown_rowid_$$.db
+rm -f "$DB5"
+echo "CREATE TABLE t(pk INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'one');
+INSERT INTO t VALUES(2,'two');
+SELECT dolt_commit('-A','-m','init');
+UPDATE t SET v='TWO' WHERE pk=2;
+SELECT dolt_commit('-A','-m','c2');" | $DOLTLITE "$DB5" > /dev/null 2>&1
+
+run_test_match "rowid_history_still_pushes_down" \
+  "EXPLAIN QUERY PLAN SELECT * FROM dolt_history_t WHERE pk=2;" \
+  "VIRTUAL TABLE INDEX [1-9]" "$DB5"
+run_test "rowid_at_renders_pk" \
+  "SELECT group_concat(pk || ':' || v, ' ')
+     FROM (SELECT pk,v FROM dolt_at_t WHERE commit_ref='HEAD' ORDER BY pk);" \
+  "1:one 2:TWO" "$DB5"
+run_test "rowid_blame_renders_pk" \
+  "SELECT group_concat(pk, ' ') FROM (SELECT pk FROM dolt_blame_t ORDER BY pk);" \
+  "1 2" "$DB5"
+
+rm -f "$DB5"
+
 dltest_finish


### PR DESCRIPTION
## Problem

An `INTEGER PRIMARY KEY` is a rowid alias only when the table **has** a rowid. A `WITHOUT ROWID` table is clustered by its declared key and never sets an integer key, so reading that column from one yields the raw key bytes interpreted as a number — and the pk constraints `xBestIndex` promised to apply get dropped with nothing rechecking them.

```sql
CREATE TABLE t(pk INTEGER PRIMARY KEY, v TEXT) WITHOUT ROWID;
-- table holds 1:one  2:TWO  3:three
```

| query | before |
|---|---|
| `dolt_at_t WHERE commit_ref='HEAD'` | `-7656136958715887616:one  -9217249956111319040:TWO  …` |
| `dolt_at_t WHERE commit_ref='HEAD' AND pk=2` | `-7656136958715887616:one` — wrong row, garbage pk |
| `dolt_history_t` | garbage pks |
| `dolt_blame_t` | pk `0` for every row |

The table itself reads correctly throughout; only the version-control views are wrong.

## Fix

Gate the alias on `HasRowid`. Two independent places decide it: `doltliteGetColumnNames` (`iPkCol`, used by `dolt_at_`, `dolt_history_`, and others) and `blameLoadPkColumns` (`intPkCid`, which `dolt_blame_` uses instead), so both needed it.

Losing the alias also loses the pushdown for these tables. That is correct rather than merely tolerable — the constraint is now rechecked by SQLite instead of silently discarded, which is the same shape a TEXT primary key already has (`nonint_history_no_index_pushdown` in this suite pins that behavior).

## What I did not change

The review that found this also suspected `dolt_diff_stat`'s cell counters of indexing records by declared column position rather than through `aColToRec`. I could not make it differ: `WITHOUT ROWID` and rowid tables return identical counts, including with the pk declared mid-table and a column added across the range. No failing case, no change.

Separately, and unrelated to this fix, `dolt_diff_stat` reports `cells_modified=1` where Dolt 2.2.2 reports `2` for a range that both modifies a cell and adds a column. That reproduces on rowid tables on master, so it is pre-existing and belongs in its own issue.

## Testing

Eleven cases added to `test/doltlite_dolt_table_pushdown.sh`, beside the existing `nonint_*` section that covers the analogous TEXT-pk case: pk rendering and pk equality/range across `dolt_at_`, `dolt_history_` and `dolt_blame_`, an absent-pk case, a composite `WITHOUT ROWID` key (which never had a single INTEGER column to mistake, so it is a guard), and a rowid table beside it asserting its pushdown still happens.

Fail-before/pass-after, same test file both runs:

- before: **42 passed, 7 failed**
- after: **49 passed, 0 failed**

The composite and rowid-control cases pass in both runs, so they are guards rather than repairs.

Full local validation — `doltliteGetColumnNames` also feeds merge constraint checking, patch and diff_table, so those were covered deliberately:

- `test/run_doltlite_tests.sh` — 99/99 suites
- Oracle suites against Dolt 2.2.2, 0 failures: `merge` (78), `patch` (76), `diff_stat` (75), `fk_merge` (39), `diff_multi_pk` (30), `pk_shapes_vc_ops` (28), `history` (27), `at` (26), `blame` (25), `diff_tvf` (16), `pk_shapes_conflicts` (16), `verify_constraints` (13), `conflicts_table` (13), `pk_edge_values` (12), `pk_only_tables` (10), `constraint_violations` (5)
- `test/run_c_tests.sh` — 26/26 gated c-tests
- `test/doltlite_regression_test_c.sh` — 310,147 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)