### PR TITLE
Match Dolt's cells_modified across schema changes

### DIFF
--- a/src/doltlite_diff_stat.c
+++ b/src/doltlite_diff_stat.c
@@ -175,38 +175,59 @@ static int dsBuildColMap(
   return SQLITE_OK;
 }
 
-static int dsCountChangedCells(
+/* Two different questions, which the same walk answers.
+**
+** *pnDiffer is whether the row changed at all, and so whether it counts toward
+** rows_modified. Gaining or losing a column that held a value counts; gaining
+** or losing one that is NULL on both sides does not.
+**
+** *pnModified is cells_modified, which is narrower: a column the range added
+** counts whatever its value, and a column the range dropped never counts.
+** Those cells are already reported by cells_added and cells_deleted. */
+static void dsCountChangedCells(
   const u8 *pFromRec, int nFromRec,
   const u8 *pToRec,   int nToRec,
-  const DsColMap *pColMap
+  const DsColMap *pColMap,
+  int *pnDiffer,
+  int *pnModified
 ){
   DoltliteRecordInfo fromRi, toRi;
-  int i, changed = 0;
-  if( !pFromRec || !pToRec ) return 0;
+  int i;
+  int nDiffer = 0;
+  int nModified = 0;
+
+  *pnDiffer = 0;
+  *pnModified = 0;
+  if( !pFromRec || !pToRec ) return;
   doltliteParseRecord(pFromRec, nFromRec, &fromRi);
   doltliteParseRecord(pToRec,   nToRec,   &toRi);
 
   for(i=0; i<pColMap->nTo; i++){
     int fromIdx = pColMap->aToFrom ? pColMap->aToFrom[i] : -1;
     if( fromIdx<0 ){
-
-      if( i<toRi.nField && toRi.aType[i]!=0 ) changed++;
+      /* A trailing NULL is not stored, so the field may be absent from the
+      ** record even though the column exists on the to side. */
+      nModified++;
+      if( i<toRi.nField && toRi.aType[i]!=0 ) nDiffer++;
       continue;
     }
     if( i>=toRi.nField || fromIdx>=fromRi.nField ) continue;
     if( !doltliteFieldValuesEqual(
             fromRi.aType[fromIdx], pFromRec, nFromRec, fromRi.aOffset[fromIdx],
             toRi.aType[i],         pToRec,   nToRec,   toRi.aOffset[i]) ){
-      changed++;
+      nDiffer++;
+      nModified++;
     }
   }
 
   for(i=0; i<pColMap->nFrom; i++){
     if( pColMap->aFromMatched && pColMap->aFromMatched[i] ) continue;
     if( i>=fromRi.nField ) continue;
-    if( fromRi.aType[i]!=0 ) changed++;
+    if( fromRi.aType[i]!=0 ) nDiffer++;
   }
-  return changed;
+
+  *pnDiffer = nDiffer;
+  *pnModified = nModified;
 }
 
 typedef struct DsStatRow DsStatRow;
@@ -380,13 +401,14 @@ static int dsComputeTableStats(
           cellsDel += nFromCols;
           break;
         case PROLLY_DIFF_MODIFY: {
-          int changed = dsCountChangedCells(
+          int nDiffer = 0, nModified = 0;
+          dsCountChangedCells(
               pChange->pOldVal, pChange->nOldVal,
               pChange->pNewVal, pChange->nNewVal,
-              &colMap);
-          if( changed>0 ){
+              &colMap, &nDiffer, &nModified);
+          if( nDiffer>0 ){
             rowsMod++;
-            cellsMod += changed;
+            cellsMod += nModified;
           }
           break;
         }

--- a/test/vc_oracle_diff_stat_test.sh
+++ b/test/vc_oracle_diff_stat_test.sh
@@ -215,6 +215,73 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'c2');
 " "HEAD~1" "HEAD"
 
+# The case above gives the added column a value on the row it edits, which is
+# what kept it agreeing. A column that stays NULL on an otherwise-modified row
+# still counts as a modified cell.
+oracle_both "add_null_column_plus_update_same_row" "
+$SEED
+ALTER TABLE t ADD COLUMN extra INT;
+UPDATE t SET v = v + 1 WHERE id = 1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c2');
+" "HEAD~1" "HEAD"
+
+oracle_both "add_null_column_plus_update_all_rows" "
+$SEED
+ALTER TABLE t ADD COLUMN extra INT;
+UPDATE t SET v = v + 1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c2');
+" "HEAD~1" "HEAD"
+
+echo "--- schema change: DROP COLUMN ---"
+
+# Dropped cells are reported by cells_deleted and must not also be counted as
+# modified, whether or not the dropped column held a value.
+# Stat only: dolt_diff_summary reports data_change=1 here where Dolt reports 0,
+# a separate pre-existing divergence in how a no-op column drop is classified.
+oracle_stat "drop_null_column_no_data_change" "
+CREATE TABLE t(id INT PRIMARY KEY, v INT, gone INT);
+INSERT INTO t VALUES(1, 10, NULL), (2, 20, NULL);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'seed');
+ALTER TABLE t DROP COLUMN gone;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c2');
+" "HEAD~1" "HEAD"
+
+oracle_both "drop_valued_column_no_data_change" "
+CREATE TABLE t(id INT PRIMARY KEY, v INT, gone INT);
+INSERT INTO t VALUES(1, 10, 7), (2, 20, 8);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'seed');
+ALTER TABLE t DROP COLUMN gone;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c2');
+" "HEAD~1" "HEAD"
+
+oracle_both "drop_valued_column_plus_update" "
+CREATE TABLE t(id INT PRIMARY KEY, v INT, gone INT);
+INSERT INTO t VALUES(1, 10, 7), (2, 20, 8);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'seed');
+ALTER TABLE t DROP COLUMN gone;
+UPDATE t SET v = v + 1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c2');
+" "HEAD~1" "HEAD"
+
+oracle_both "drop_null_column_plus_update" "
+CREATE TABLE t(id INT PRIMARY KEY, v INT, gone INT);
+INSERT INTO t VALUES(1, 10, NULL), (2, 20, NULL);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'seed');
+ALTER TABLE t DROP COLUMN gone;
+UPDATE t SET v = v + 1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c2');
+" "HEAD~1" "HEAD"
+
 echo "--- multi-table ---"
 
 oracle_both "two_tables_one_modified" "


### PR DESCRIPTION
Fixes #1995.

## Problem

`dolt_diff_stat` derived `rows_modified` and `cells_modified` from a single per-row count, and those two questions have different answers once a range changes a table's columns.

I mapped all nine add/drop/edit shapes against Dolt 2.2.2. Three disagreed — and only one of them is the case I originally filed:

| shape | doltlite | Dolt 2.2.2 | |
|---|---|---|---|
| add column left NULL, no row edits | 0 | 0 | ok |
| **add column left NULL, plus row edits** | **2** | **4** | undercount |
| add column with a value, plus row edits | 4 | 4 | ok |
| add column with a value, no other edits | 2 | 2 | ok |
| drop NULL column, no row edits | 0 | 0 | ok |
| drop NULL column, plus row edits | 2 | 2 | ok |
| **drop valued column, no row edits** | **2** | **0** | overcount |
| **drop valued column, plus row edits** | **4** | **2** | overcount |
| edit only, no schema change | 1 | 1 | ok |

So the surface was wrong in both directions. The issue only mentioned the undercount because the drop side had no oracle coverage at all to notice.

Dolt's rule: a column the range **added** counts as a modified cell on every row it reports modified, whatever the value; a column the range **dropped** never counts, because those cells are already reported by `cells_deleted`.

## Fix

The constraint that shaped this: `rows_modified` **already agreed on all nine shapes**, so whatever decides it had to stay exactly as it was. A one-line guard removal would have fixed the cells and broken the rows — dropping a valued column with no other edits reports `rows_modified=2, cells_modified=0` in Dolt, so the row must still count as modified while contributing no modified cell.

`dsCountChangedCells` now answers both questions from the same walk and returns them separately: `nDiffer` (did anything about this row change — still including added and dropped columns that held a value) decides `rows_modified`, and `nModified` (common-column differences plus added columns, never dropped ones) accumulates `cells_modified`.

Only the reported number changes, and only for ranges that add or drop columns.

## Testing

Seven cases added to `test/vc_oracle_diff_stat_test.sh`, which compares against real Dolt, so the tests *are* the parity check. The existing `add_column_plus_update` case gives the added column a value on the row it edits, which is exactly why it agreed and missed this; the new cases cover the NULL variants. `DROP COLUMN` had **no** coverage in this suite at all, so that section is new.

Fail-before/pass-after, same test file both runs:

- before: **82 passed, 4 failed**
- after: **86 passed, 0 failed**

## One case left as stat-only

`drop_null_column_no_data_change` runs through `oracle_stat` rather than `oracle_both`. Its `dolt_diff_summary` half reports `data_change=1` where Dolt reports `0` for a column drop that changes no values — that fails identically on master, is a different surface and a different invariant, and is not touched by this change. Filing separately rather than bundling; the comment in the test says so, so it does not read as an oversight.

## Validation

- `test/run_doltlite_tests.sh` — 99/99 suites
- Diff-family oracles against Dolt 2.2.2, 0 failures: `patch` (76), `diff` (67), `schema_diff` (65), `diff_multi_pk` (30), `diff_tvf` (16), `pk_shapes_scale` (12)
- `test/run_c_tests.sh` — 26/26 gated c-tests
- `test/doltlite_regression_test_c.sh` — 310,162 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)