### PR TITLE
Reject unpersistable interactive rebase names

### DIFF
--- a/src/doltlite_rebase.c
+++ b/src/doltlite_rebase.c
@@ -1201,6 +1201,16 @@ static void doltliteRebaseInteractiveStart(
     sqlite3_result_error_code(context, SQLITE_NOMEM);
     return;
   }
+  if( strlen(zOrig)>=WS_REBASE_BRANCH_LEN ){
+    sqlite3_free(zOrig);
+    sqlite3_free(zReturnBranch);
+    sqlite3_free(zWorking);
+    sqlite3_free(aReplay);
+    sqlite3_result_error(context,
+      "cannot start interactive rebase: current branch name exceeds "
+      "the 63-byte persisted-state limit", -1);
+    return;
+  }
   {
     ProllyHash probe;
     if( chunkStoreFindBranch(cs, zWorking, &probe)==SQLITE_OK ){
@@ -1223,6 +1233,16 @@ static void doltliteRebaseInteractiveStart(
       ** still runs; only resuming it after a reopen is given up. */
       zReturnBranch[0] = 0;
     }
+  }
+  if( strlen(zReturnBranch)>=WS_REBASE_BRANCH_LEN ){
+    sqlite3_free(zOrig);
+    sqlite3_free(zReturnBranch);
+    sqlite3_free(zWorking);
+    sqlite3_free(aReplay);
+    sqlite3_result_error(context,
+      "cannot start interactive rebase: default branch name exceeds "
+      "the 63-byte persisted-state limit", -1);
+    return;
   }
 
   rc = doltliteFlushCatalogToHash(db, &preRebaseCat);

--- a/src/prolly_btree_int.h
+++ b/src/prolly_btree_int.h
@@ -484,7 +484,7 @@ int copyZeroTailPayload(ProllyMutMapEntry *e, u32 offset, u32 amt, void *pBuf);
 void btreeMarkWorkingStateChanged(Btree *p, int bLocal);
 int restoreFromCommitted(Btree *p);
 int rollbackNeedsSchemaReset(Btree *pBtree);
-void btreeFillWorkingSetBlob(
+int btreeFillWorkingSetBlob(
   u8 *buf,
   const ProllyHash *pWorkingCat,
   const ProllyHash *pWorkingCommit,

--- a/src/prolly_btree_state.c
+++ b/src/prolly_btree_state.c
@@ -200,7 +200,7 @@ int btreeLoadBranchState(
   return SQLITE_OK;
 }
 
-void btreeFillWorkingSetBlob(
+int btreeFillWorkingSetBlob(
   u8 *buf,
   const ProllyHash *pWorkingCat,
   const ProllyHash *pWorkingCommit,
@@ -216,6 +216,13 @@ void btreeFillWorkingSetBlob(
   const ProllyHash *pConstraintViolations
 ){
   static const ProllyHash emptyHash = {{0}};
+  int nOrig = zRebaseOrigBranch ? (int)strlen(zRebaseOrigBranch) : 0;
+  int nReturn = zRebaseReturnBranch ? (int)strlen(zRebaseReturnBranch) : 0;
+
+  if( nOrig >= WS_REBASE_BRANCH_LEN
+   || nReturn >= WS_REBASE_BRANCH_LEN ){
+    return SQLITE_TOOBIG;
+  }
 
   memset(buf, 0, WS_TOTAL_SIZE);
   buf[0] = WS_FORMAT_VERSION;
@@ -236,18 +243,15 @@ void btreeFillWorkingSetBlob(
   memcpy(buf + WS_REBASE_ONTO_OFF,
          (pRebaseOnto ? pRebaseOnto : &emptyHash)->data, PROLLY_HASH_SIZE);
   if( zRebaseOrigBranch ){
-    int n = (int)strlen(zRebaseOrigBranch);
-    if( n > WS_REBASE_BRANCH_LEN - 1 ) n = WS_REBASE_BRANCH_LEN - 1;
-    memcpy(buf + WS_REBASE_BRANCH_OFF, zRebaseOrigBranch, n);
+    memcpy(buf + WS_REBASE_BRANCH_OFF, zRebaseOrigBranch, nOrig);
   }
   if( zRebaseReturnBranch ){
-    int n = (int)strlen(zRebaseReturnBranch);
-    if( n > WS_REBASE_BRANCH_LEN - 1 ) n = WS_REBASE_BRANCH_LEN - 1;
-    memcpy(buf + WS_REBASE_RETURN_BRANCH_OFF, zRebaseReturnBranch, n);
+    memcpy(buf + WS_REBASE_RETURN_BRANCH_OFF, zRebaseReturnBranch, nReturn);
   }
   memcpy(buf + WS_CONSTRAINT_VIOLATIONS_OFF,
          (pConstraintViolations ? pConstraintViolations : &emptyHash)->data,
          PROLLY_HASH_SIZE);
+  return SQLITE_OK;
 }
 
 int btreeStoreWorkingSetBlob(
@@ -270,11 +274,12 @@ int btreeStoreWorkingSetBlob(
   ProllyHash wsHash;
   int rc;
 
-  btreeFillWorkingSetBlob(buf, pWorkingCat, pWorkingCommit, pStaged,
-                          isMerging, pMergeCommit, pConflicts,
-                          isRebasing, pPreRebaseCat, pRebaseOnto,
-                          zRebaseOrigBranch, zRebaseReturnBranch,
-                          pConstraintViolations);
+  rc = btreeFillWorkingSetBlob(buf, pWorkingCat, pWorkingCommit, pStaged,
+                               isMerging, pMergeCommit, pConflicts,
+                               isRebasing, pPreRebaseCat, pRebaseOnto,
+                               zRebaseOrigBranch, zRebaseReturnBranch,
+                               pConstraintViolations);
+  if( rc!=SQLITE_OK ) return rc;
 
   rc = chunkStorePut(cs, buf, WS_TOTAL_SIZE, &wsHash);
   if( rc != SQLITE_OK ) return rc;
@@ -761,6 +766,10 @@ int doltliteSetSessionRebaseState(sqlite3 *db, u8 isRebasing,
     char *zNewOrigBranch = 0;
     char *zNewReturnBranch = 0;
     int rc;
+    if( (zOrigBranch && strlen(zOrigBranch)>=WS_REBASE_BRANCH_LEN)
+     || (zReturnBranch && strlen(zReturnBranch)>=WS_REBASE_BRANCH_LEN) ){
+      return SQLITE_TOOBIG;
+    }
     if( zOrigBranch ){
       zNewOrigBranch = sqlite3_mprintf("%s", zOrigBranch);
       if( !zNewOrigBranch ) return SQLITE_NOMEM;

--- a/src/prolly_btree_txn.c
+++ b/src/prolly_btree_txn.c
@@ -1354,13 +1354,21 @@ int prollyBtreeRollback(Btree *p, int tripCode, int writeOnly){
       }
       prollyHashCompute(catData, nCatData, &catHash);
 
-      btreeFillWorkingSetBlob(wsBuf, &catHash, &p->headCommit,
-                              &p->vc.stagedCatalog, p->vc.isMerging,
-                              &p->vc.mergeCommitHash, &p->vc.conflictsCatalogHash,
-                              p->isRebasing, &p->preRebaseWorkingCat,
-                              &p->rebaseOntoCommit,
-                              p->zRebaseOrigBranch, p->zRebaseReturnBranch,
-                              &p->vc.constraintViolationsHash);
+      rc = btreeFillWorkingSetBlob(wsBuf, &catHash, &p->headCommit,
+                                   &p->vc.stagedCatalog, p->vc.isMerging,
+                                   &p->vc.mergeCommitHash,
+                                   &p->vc.conflictsCatalogHash,
+                                   p->isRebasing, &p->preRebaseWorkingCat,
+                                   &p->rebaseOntoCommit,
+                                   p->zRebaseOrigBranch,
+                                   p->zRebaseReturnBranch,
+                                   &p->vc.constraintViolationsHash);
+      if( rc!=SQLITE_OK ){
+        sqlite3_free(catData);
+        chunkStoreUnlock(&pBt->store);
+        pBt->store.snapshotPinned = 0;
+        return rc;
+      }
       prollyHashCompute(wsBuf, WS_TOTAL_SIZE, &wsHashWouldBe);
 
       if( chunkStoreGetBranchWorkingSet(&pBt->store, zBr, &wsHashOnDisk)

--- a/test/doltlite_rebase.sh
+++ b/test/doltlite_rebase.sh
@@ -200,7 +200,109 @@ run_test_match "unknown_plan_action_stays_resumable" \
   "Successfully rebased and updated refs/heads/feat" \
   "$DB4"
 
-rm -f "$DB" "$DB2" "$DB3" "$DB4"
+BRANCH63=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+BRANCH64=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+
+seed_rebase_name_repo() {
+  rm -f "$1"
+  "$DOLTLITE" "$1" >/dev/null 2>&1 <<SQL
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES(1);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','init');
+SELECT dolt_checkout('-b','$2');
+INSERT INTO t VALUES(2);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','feature');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES(3);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','main');
+SQL
+}
+
+DB5=/tmp/test_rebase_name_continue_$$.db
+seed_rebase_name_repo "$DB5" "$BRANCH63"
+run_test_match "rebase_63_byte_branch_starts" \
+  "SELECT dolt_rebase('-i','main');" \
+  "interactive rebase started" \
+  "$DB5/$BRANCH63"
+run_test "rebase_63_byte_branch_continues_after_reopen" \
+  "SELECT dolt_rebase('--continue');
+   SELECT active_branch();
+   SELECT group_concat(id, ',') FROM t;" \
+  "Successfully rebased and updated refs/heads/$BRANCH63
+$BRANCH63
+1,2,3" \
+  "$DB5/dolt_rebase_$BRANCH63"
+
+DB6=/tmp/test_rebase_name_abort_$$.db
+seed_rebase_name_repo "$DB6" "$BRANCH63"
+run_test_match "rebase_63_byte_branch_starts_for_abort" \
+  "SELECT dolt_rebase('-i','main');" \
+  "interactive rebase started" \
+  "$DB6/$BRANCH63"
+run_test "rebase_63_byte_branch_aborts_after_reopen" \
+  "SELECT dolt_rebase('--abort');
+   SELECT active_branch();
+   SELECT group_concat(id, ',') FROM t;" \
+  "Interactive rebase aborted
+$BRANCH63
+1,2" \
+  "$DB6"
+
+DB7=/tmp/test_rebase_name_reject_$$.db
+seed_rebase_name_repo "$DB7" "$BRANCH64"
+run_test_match "rebase_64_byte_branch_rejected" \
+  "SELECT dolt_rebase('-i','main');" \
+  "current branch name exceeds the 63-byte persisted-state limit" \
+  "$DB7/$BRANCH64"
+run_test "rebase_64_byte_branch_rejection_is_atomic" \
+  "SELECT count(*) FROM dolt_branches WHERE name='dolt_rebase_$BRANCH64';
+   SELECT count(*) FROM sqlite_master WHERE name='dolt_rebase';" \
+  "0
+0" \
+  "$DB7"
+
+DB8=/tmp/test_rebase_return_name_$$.db
+seed_rebase_return_repo() {
+  rm -f "$1"
+  "$DOLTLITE" "$1" >/dev/null 2>&1 <<SQL
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES(1);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','init');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO t VALUES(2);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','feature');
+SELECT dolt_checkout('main');
+SELECT dolt_checkout('-b','$2');
+INSERT INTO t VALUES(3);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','upstream');
+SELECT dolt_default_branch('$2');
+SQL
+}
+
+seed_rebase_return_repo "$DB8" "$BRANCH63"
+run_test_match "rebase_63_byte_default_branch_starts" \
+  "SELECT dolt_rebase('-i','$BRANCH63');" \
+  "interactive rebase started" \
+  "$DB8/feat"
+run_test "rebase_63_byte_default_branch_aborts_after_reopen" \
+  "SELECT dolt_rebase('--abort'); SELECT active_branch();" \
+  "Interactive rebase aborted
+feat" \
+  "$DB8"
+
+seed_rebase_return_repo "$DB8" "$BRANCH64"
+run_test_match "rebase_64_byte_default_branch_rejected" \
+  "SELECT dolt_rebase('-i','$BRANCH64');" \
+  "default branch name exceeds the 63-byte persisted-state limit" \
+  "$DB8/feat"
+run_test "rebase_64_byte_default_branch_rejection_is_atomic" \
+  "SELECT count(*) FROM dolt_branches WHERE name='dolt_rebase_feat';
+   SELECT count(*) FROM sqlite_master WHERE name='dolt_rebase';" \
+  "0
+0" \
+  "$DB8"
+
+rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8"
 echo ""
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"
 if [ $FAIL -gt 0 ]; then echo -e "$ERRORS"; exit 1; fi


### PR DESCRIPTION
## Summary

- reject interactive rebase before mutation when its current or return branch name cannot fit the V5 working-set fields
- make the session-state setter and working-set serializer return `SQLITE_TOOBIG` instead of silently truncating branch names
- cover the 63-byte boundary across reopen for continue and abort, and prove 64-byte rejection leaves no temporary branch or plan table

## Failure before

Interactive rebase persisted its original and return branch names in fixed 64-byte fields. Serialization silently clipped names longer than 63 bytes, so starting a rebase appeared successful but reopening and aborting failed recovery because the truncated branch did not exist.

A 64-byte current branch reproduced this as:

`rebase recovery failed — pre-rebase state may not have been fully restored`

The fix rejects overlong names with a precise error before flushing the catalog or creating `dolt_rebase_<branch>`. The lower state and serialization layers also reject them, so future callers cannot write a truncated V5 working set.

## Validation

- fail-before reproduction on a 64-byte current branch
- `test/doltlite_rebase.sh`: 24 passed, 0 failed
- `test/run_doltlite_tests.sh build/doltlite`: 99/99 suites; 310,162 regression assertions
- `test/run_c_tests.sh build`: 26/26 gated tests rebuilt and passed
- `make lint`
- `git diff --check`

Co-Authored-By: OpenAI Codex <noreply@openai.com>
