### PR TITLE
Base diff_summary data_change on values, not the table root

### DIFF
--- a/src/doltlite_diff_stat.c
+++ b/src/doltlite_diff_stat.c
@@ -969,6 +969,77 @@ static int dssSetRow(DssCursor *c, const char *zFrom, const char *zTo,
   return SQLITE_OK;
 }
 
+/* Records carry their column values, so any schema change rewrites every row
+** and moves the table root -- a dropped column that held only NULLs included.
+** The root alone therefore cannot answer whether data changed; walk the rows
+** and ask whether any value did. Only reached when the schema also changed,
+** so the ordinary data-only diff keeps its hash comparison. */
+static int dssDataActuallyChanged(
+  sqlite3 *db,
+  const DsFilterCtx *pCtx,
+  const char *zTableName,
+  struct TableEntry *pFromEntry,
+  struct TableEntry *pToEntry,
+  int *pChanged
+){
+  char **azFromCols = 0, **azToCols = 0;
+  int nFromCols = 0, nToCols = 0;
+  DsColMap colMap;
+  ChunkStore *cs = doltliteGetChunkStore(db);
+  ProllyCache *pCache = doltliteGetCache(db);
+  ProllyDiffIter iter;
+  ProllyDiffChange *pChange = 0;
+  int changed = 0;
+  int iterOpen = 0;
+  u8 flags;
+  int rc;
+  int i;
+
+  memset(&colMap, 0, sizeof(colMap));
+  /* Anything unexpected falls back to the root comparison's answer. */
+  *pChanged = 1;
+  if( !cs || !pCache ) return SQLITE_OK;
+
+  rc = dsLoadColNames(db, &pCtx->fromCat, zTableName, &azFromCols, &nFromCols);
+  if( rc!=SQLITE_OK ) goto done;
+  rc = dsLoadColNames(db, &pCtx->toCat, zTableName, &azToCols, &nToCols);
+  if( rc!=SQLITE_OK ) goto done;
+  rc = dsBuildColMap(azFromCols, nFromCols, azToCols, nToCols, &colMap);
+  if( rc!=SQLITE_OK ) goto done;
+
+  flags = pFromEntry->flags ? pFromEntry->flags : pToEntry->flags;
+  rc = prollyDiffIterOpen(&iter, cs, pCache, &pFromEntry->root,
+                          &pToEntry->root, flags);
+  if( rc!=SQLITE_OK ) goto done;
+  iterOpen = 1;
+
+  while( (rc = prollyDiffIterStep(&iter, &pChange))==SQLITE_ROW && pChange ){
+    int nDiffer = 0, nModified = 0;
+    if( pChange->type!=PROLLY_DIFF_MODIFY ){
+      changed = 1;
+      break;
+    }
+    dsCountChangedCells(pChange->pOldVal, pChange->nOldVal,
+                        pChange->pNewVal, pChange->nNewVal,
+                        &colMap, &nDiffer, &nModified);
+    if( nDiffer>0 ){
+      changed = 1;
+      break;
+    }
+  }
+  if( rc==SQLITE_ROW || rc==SQLITE_DONE ) rc = SQLITE_OK;
+  if( rc==SQLITE_OK ) *pChanged = changed;
+
+done:
+  if( iterOpen ) prollyDiffIterClose(&iter);
+  for(i=0; i<nFromCols; i++) sqlite3_free(azFromCols[i]);
+  sqlite3_free(azFromCols);
+  for(i=0; i<nToCols; i++) sqlite3_free(azToCols[i]);
+  sqlite3_free(azToCols);
+  dsFreeColMap(&colMap);
+  return rc;
+}
+
 static int dssAppendTableChange(
   DssCursor *c,
   sqlite3 *db,
@@ -989,6 +1060,11 @@ static int dssAppendTableChange(
     int schemasDiffer = prollyHashCompare(&pFromEntry->schemaHash,
                                           &pToEntry->schemaHash)!=0;
     if( !rootsDiffer && !schemasDiffer ) return SQLITE_OK;
+    if( rootsDiffer && schemasDiffer ){
+      rc = dssDataActuallyChanged(db, &c->fctx, zTableName,
+                                  pFromEntry, pToEntry, &rootsDiffer);
+      if( rc!=SQLITE_OK ) return rc;
+    }
     return dssSetRow(c, zTableName, zTableName, "modified",
                      rootsDiffer, schemasDiffer);
   }

--- a/test/vc_oracle_diff_stat_test.sh
+++ b/test/vc_oracle_diff_stat_test.sh
@@ -238,9 +238,7 @@ echo "--- schema change: DROP COLUMN ---"
 
 # Dropped cells are reported by cells_deleted and must not also be counted as
 # modified, whether or not the dropped column held a value.
-# Stat only: dolt_diff_summary reports data_change=1 here where Dolt reports 0,
-# a separate pre-existing divergence in how a no-op column drop is classified.
-oracle_stat "drop_null_column_no_data_change" "
+oracle_both "drop_null_column_no_data_change" "
 CREATE TABLE t(id INT PRIMARY KEY, v INT, gone INT);
 INSERT INTO t VALUES(1, 10, NULL), (2, 20, NULL);
 SELECT dolt_add('-A');
@@ -278,6 +276,32 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'seed');
 ALTER TABLE t DROP COLUMN gone;
 UPDATE t SET v = v + 1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c2');
+" "HEAD~1" "HEAD"
+
+# A schema change rewrites every record, so the table root moves whether or not
+# any value did. data_change has to reflect the values, not the root.
+# Summary only: dolt_diff_stat emits an all-zero row for an in-place column
+# rename where Dolt emits none. Narrowing the emission gate to "no counters, no
+# row" is not the fix -- Dolt does emit that row when the table was recreated,
+# which diff_stat_revert_schema_change_with_later_added_table pins.
+oracle_summary "rename_column_no_data_change" "
+CREATE TABLE t(id INT PRIMARY KEY, v INT);
+INSERT INTO t VALUES(1, 10), (2, 20);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'seed');
+ALTER TABLE t RENAME COLUMN v TO w;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c2');
+" "HEAD~1" "HEAD"
+
+oracle_both "drop_valued_column_is_a_data_change" "
+CREATE TABLE t(id INT PRIMARY KEY, v INT, gone INT);
+INSERT INTO t VALUES(1, 10, 7), (2, 20, 8);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'seed');
+ALTER TABLE t DROP COLUMN gone;
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'c2');
 " "HEAD~1" "HEAD"


### PR DESCRIPTION
## Problem

Records carry their column values, so any schema change rewrites every row and moves the table root. `dolt_diff_summary` read `data_change` straight off that hash comparison, and so reported a data change for schema edits that touched no value. Against Dolt 2.2.2:

| range | doltlite | Dolt 2.2.2 |
|---|---|---|
| drop a column holding only NULLs | `data_change=1` | `0` |
| rename a column | `data_change=1` | `0` |
| drop a column holding values | `1` | `1` |
| add a column, plus a real edit | `1` | `1` |

This is the divergence #1996 deferred: its `drop_null_column_no_data_change` case had to run stat-only because the summary half failed on master.

## Fix

When the root **and** the schema both moved, the hash can no longer answer the question, so ask the rows: walk the diff and stop at the first one that really differs.

A data-only change still answers from the hash, so the common path is untouched, and the walk short-circuits on the first differing row rather than scanning the table. Dropping a column that held values is still a data change — the walk reports it and a test pins it — so this narrows the answer rather than suppressing it.

`drop_null_column_no_data_change` goes back to `oracle_both` now that both halves agree.

## The dolt_diff_stat rename divergence: attempted and backed out

You asked me to fold in the other divergence I hit here — `dolt_diff_stat` emitting an all-zero row for a bare column rename where Dolt emits none. I implemented it and backed it out, because the obvious rule is wrong.

The natural fix is to drop the `schemaChanged` exception from the emission gate, so a table with no counters gets no row. That made the rename case pass and **broke `diff_stat_revert_schema_change_with_later_added_table`**, an existing pinned case where Dolt *does* emit an all-zero row.

Probing further:

| schema-only change | Dolt |
|---|---|
| `ALTER TABLE t RENAME COLUMN v TO w` | no row |
| `ALTER TABLE t MODIFY COLUMN v VARCHAR(50)` | no row |
| recreate table with a CHECK, `DROP`, `RENAME TO t` | all-zero row |

So Dolt emits the row when the table was *recreated*, and not for in-place column changes. Matching that needs table-identity reasoning rather than a counter test, which is more than I can justify bolting on here. The test carries a comment recording why the tempting one-line fix is wrong, so the next person does not repeat it.

That leaves `rename_column_no_data_change` as summary-only. Its summary half is exactly what this PR fixes, so it still earns its place.

## Testing

Fail-before/pass-after on `test/vc_oracle_diff_stat_test.sh`, same file both runs:

- before: **89 passed, 2 failed**
- after: **90 passed, 0 failed**

(The second baseline failure was the stat rename case, now scoped to summary.)

Also verified directly against Dolt across four schema-change shapes — drop-NULL-column, drop-valued-column, add-NULL-column, and schema-change-plus-edit — all matching.

- `test/run_doltlite_tests.sh` — 99/99 suites
- Diff-family oracles: `patch` (76), `diff` (67), `schema_diff` (65), `diff_tvf` (16), 0 failures
- `test/run_c_tests.sh` — 26/26 gated c-tests
- `test/doltlite_regression_test_c.sh` — 310,162 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)