### PR TITLE
Validate user refs and reset forced branch targets

### DIFF
--- a/src/doltlite_branch.c
+++ b/src/doltlite_branch.c
@@ -51,6 +51,17 @@ static void branchNamedResultError(
   doltliteRefResultError(ctx, rc, zNotFound, zExists);
 }
 
+static int resetBranchRef(sqlite3 *db, ChunkStore *cs, const char *zName,
+                          const ProllyHash *pCommit){
+  ProllyHash catalog;
+  int rc = doltliteCommitCatalogHash(db, pCommit, &catalog);
+  if( rc==SQLITE_OK ) rc = chunkStoreUpdateBranch(cs, zName, pCommit);
+  if( rc==SQLITE_OK ){
+    rc = doltliteWriteBranchCleanWorkingState(db, zName, &catalog, pCommit);
+  }
+  return rc;
+}
+
 int mutateBranchRef(sqlite3 *db, ChunkStore *cs, void *pArg){
   BranchMutationCtx *p = (BranchMutationCtx*)pArg;
 
@@ -61,8 +72,9 @@ int mutateBranchRef(sqlite3 *db, ChunkStore *cs, void *pArg){
     return chunkStoreDeleteBranch(cs, p->zName);
   }
 
+  if( !doltliteUserRefNameIsValid(p->zName) ) return SQLITE_CONSTRAINT;
   if( p->force && chunkStoreFindBranch(cs, p->zName, 0)==SQLITE_OK ){
-    return chunkStoreUpdateBranch(cs, p->zName, &p->head);
+    return resetBranchRef(db, cs, p->zName, &p->head);
   }
   return chunkStoreAddBranch(cs, p->zName, &p->head);
 }
@@ -82,10 +94,10 @@ static int mutateBranchCopy(sqlite3 *db, ChunkStore *cs, void *pArg){
 
   rc = chunkStoreFindBranch(cs, p->zSrc, &srcCommit);
   if( rc!=SQLITE_OK ) return rc;
+  if( !doltliteUserRefNameIsValid(p->zDest) ) return SQLITE_CONSTRAINT;
   if( p->force ){
-
     if( chunkStoreFindBranch(cs, p->zDest, 0)==SQLITE_OK ){
-      return chunkStoreUpdateBranch(cs, p->zDest, &srcCommit);
+      return resetBranchRef(db, cs, p->zDest, &srcCommit);
     }
   }
   return chunkStoreAddBranch(cs, p->zDest, &srcCommit);
@@ -95,6 +107,7 @@ typedef struct BranchMoveCtx BranchMoveCtx;
 struct BranchMoveCtx {
   const char *zSrc;
   const char *zDest;
+  int force;
 };
 
 static int mutateBranchMove(sqlite3 *db, ChunkStore *cs, void *pArg){
@@ -104,33 +117,33 @@ static int mutateBranchMove(sqlite3 *db, ChunkStore *cs, void *pArg){
   int srcIsDefault;
   int rc;
   (void)db;
-
+  if( strcmp(p->zSrc, p->zDest)==0 ) return SQLITE_ERROR;
+  if( !doltliteUserRefNameIsValid(p->zDest) ) return SQLITE_CONSTRAINT;
   rc = chunkStoreFindBranch(cs, p->zSrc, &srcCommit);
   if( rc!=SQLITE_OK ) return rc;
   zDefault = chunkStoreGetDefaultBranch(cs);
   srcIsDefault = zDefault && strcmp(p->zSrc, zDefault)==0;
   rc = chunkStoreGetBranchWorkingSet(cs, p->zSrc, &srcWorkingSet);
   if( rc!=SQLITE_OK ) memset(&srcWorkingSet, 0, sizeof(srcWorkingSet));
-  rc = chunkStoreAddBranch(cs, p->zDest, &srcCommit);
+  rc = chunkStoreFindBranch(cs, p->zDest, 0);
+  if( rc==SQLITE_OK ){
+    if( !p->force ) return SQLITE_ERROR;
+    rc = chunkStoreUpdateBranch(cs, p->zDest, &srcCommit);
+  }else if( rc==SQLITE_NOTFOUND ){
+    rc = chunkStoreAddBranch(cs, p->zDest, &srcCommit);
+  }
   if( rc!=SQLITE_OK ) return rc;
-  if( !prollyHashIsEmpty(&srcWorkingSet) ){
-    rc = chunkStoreSetBranchWorkingSet(cs, p->zDest, &srcWorkingSet);
-    if( rc!=SQLITE_OK ){
-      chunkStoreDeleteBranch(cs, p->zDest);
-      return rc;
-    }
+  rc = chunkStoreSetBranchWorkingSet(cs, p->zDest, &srcWorkingSet);
+  if( rc!=SQLITE_OK ){
+    return rc;
   }
   if( srcIsDefault ){
     rc = chunkStoreSetDefaultBranch(cs, p->zDest);
     if( rc!=SQLITE_OK ){
-      chunkStoreDeleteBranch(cs, p->zDest);
       return rc;
     }
   }
   rc = chunkStoreDeleteBranch(cs, p->zSrc);
-  if( rc!=SQLITE_OK ){
-    chunkStoreDeleteBranch(cs, p->zDest);
-  }
   return rc;
 }
 
@@ -254,6 +267,16 @@ static void doltBranchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv)
         branchError(ctx, hadSavepoint, "branch name required");
         return;
       }
+      if( !doltliteUserRefNameIsValid(aPositional[1]) ){
+        branchError(ctx, hadSavepoint, "invalid branch name");
+        return;
+      }
+      if( force
+       && strcmp(aPositional[1], doltliteGetSessionBranch(db))==0 ){
+        branchError(ctx, hadSavepoint,
+          "cannot force-update the current branch");
+        return;
+      }
       memset(&m, 0, sizeof(m));
       m.zSrc = aPositional[0];
       m.zDest = aPositional[1];
@@ -283,9 +306,21 @@ static void doltBranchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv)
         branchError(ctx, hadSavepoint, "branch name required");
         return;
       }
+      if( !doltliteUserRefNameIsValid(aPositional[1]) ){
+        branchError(ctx, hadSavepoint, "invalid branch name");
+        return;
+      }
+      if( force
+       && strcmp(aPositional[0], doltliteGetSessionBranch(db))!=0
+       && strcmp(aPositional[1], doltliteGetSessionBranch(db))==0 ){
+        branchError(ctx, hadSavepoint,
+          "cannot force-update the current branch");
+        return;
+      }
       memset(&m, 0, sizeof(m));
       m.zSrc = aPositional[0];
       m.zDest = aPositional[1];
+      m.force = force;
       renamingCurrent = strcmp(m.zSrc, doltliteGetSessionBranch(db))==0;
       if( renamingCurrent ){
         rc = doltlitePrepareSessionBranch(db, m.zDest, &zPreparedBranch);
@@ -321,6 +356,9 @@ static void doltBranchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv)
       zName = aPositional[0];
       if( branchNameEmpty(zName) ){
         branchError(ctx, hadSavepoint, "branch name required"); return;
+      }
+      if( !doltliteUserRefNameIsValid(zName) ){
+        branchError(ctx, hadSavepoint, "invalid branch name"); return;
       }
       zStart = nPositional>=2 ? aPositional[1] : 0;
       memset(&m, 0, sizeof(m));

--- a/src/doltlite_checkout.c
+++ b/src/doltlite_checkout.c
@@ -970,6 +970,10 @@ void doltCheckoutFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
     if( argc>3 ){ doltliteVcResultError(ctx, db, "too many arguments"); return; }
     zBranch = (const char*)sqlite3_value_text(argv[1]);
     if( branchNameEmpty(zBranch) ){ doltliteVcResultError(ctx, db, "branch name required after -b"); return; }
+    if( !doltliteUserRefNameIsValid(zBranch) ){
+      doltliteVcResultError(ctx, db, "invalid branch name");
+      return;
+    }
 
     if( argc>=3 ){
       const char *zStart = (const char*)sqlite3_value_text(argv[2]);

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -1038,6 +1038,7 @@ int doltliteSaveTxnState(sqlite3 *db, DoltliteTxnState *p);
 int doltliteRestoreTxnState(sqlite3 *db, DoltliteTxnState *p);
 
 int doltliteResolveRef(sqlite3 *db, const char *zRef, ProllyHash *pCommit);
+int doltliteUserRefNameIsValid(const char *zName);
 int doltliteFindAncestor(sqlite3 *db, const ProllyHash *pCommit1,
                          const ProllyHash *pCommit2,
                          ProllyHash *pAncestor);

--- a/src/doltlite_ref.c
+++ b/src/doltlite_ref.c
@@ -8,6 +8,58 @@
 #include "doltlite_internal.h"
 #include "doltlite_parse.h"
 
+static int doltliteRefComponentEndsLock(const char *zStart, const char *zEnd){
+  return zEnd-zStart>=5 && memcmp(zEnd-5, ".lock", 5)==0;
+}
+
+int doltliteUserRefNameIsValid(const char *zName){
+  const unsigned char *z;
+  const char *zComponent;
+  int n, i;
+  int isHash = 1;
+
+  if( !zName || !zName[0] ) return 0;
+  if( strcmp(zName, "HEAD")==0 || strcmp(zName, "head")==0
+   || sqlite3_stricmp(zName, "WORKING")==0
+   || sqlite3_stricmp(zName, "STAGED")==0
+   || strcmp(zName, "-")==0 || strcmp(zName, "@")==0 ){
+    return 0;
+  }
+  n = (int)strlen(zName);
+  if( zName[0]=='/' || zName[n-1]=='/' || zName[n-1]=='.' ) return 0;
+  if( n==PROLLY_HASH_SIZE*2 ){
+    for(i=0; i<n; i++){
+      unsigned char c = (unsigned char)zName[i];
+      if( !((c>='0' && c<='9') || (c>='a' && c<='f')
+         || (c>='A' && c<='F')) ){
+        isHash = 0;
+        break;
+      }
+    }
+    if( isHash ) return 0;
+  }
+
+  zComponent = zName;
+  for(z=(const unsigned char*)zName; *z; z++){
+    unsigned char c = *z;
+    if( c<=0x20 || c>=0x7f || c==':' || c=='?' || c=='[' || c=='\\'
+     || c=='^' || c=='~' || c=='*' ){
+      return 0;
+    }
+    if( z==(const unsigned char*)zComponent && c=='.' ) return 0;
+    if( c=='.' && z[1]=='.' ) return 0;
+    if( c=='@' && z[1]=='{' ) return 0;
+    if( c=='/' ){
+      if( z==(const unsigned char*)zComponent
+       || doltliteRefComponentEndsLock(zComponent, (const char*)z) ){
+        return 0;
+      }
+      zComponent = (const char*)z + 1;
+    }
+  }
+  return !doltliteRefComponentEndsLock(zComponent, (const char*)z);
+}
+
 static int doltliteValidateCommitHash(
   sqlite3 *db,
   const ProllyHash *pHash

--- a/src/doltlite_tag.c
+++ b/src/doltlite_tag.c
@@ -29,6 +29,7 @@ static int mutateTagRef(sqlite3 *db, ChunkStore *cs, void *pArg){
   TagMutationCtx *p = (TagMutationCtx*)pArg;
   (void)db;
   if( p->isDelete ) return chunkStoreDeleteTag(cs, p->zName);
+  if( !doltliteUserRefNameIsValid(p->zName) ) return SQLITE_CONSTRAINT;
   return chunkStoreAddTagFull(cs, p->zName, &p->commitHash,
                               p->zTagger, p->zEmail,
                               p->timestamp, p->zMessage);
@@ -78,6 +79,11 @@ static void doltTagFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
       return;
     }
     sqlite3_result_int(ctx, 0);
+    return;
+  }
+
+  if( !doltliteUserRefNameIsValid(arg0) ){
+    doltliteVcResultError(ctx, db, "invalid tag name");
     return;
   }
 

--- a/test/doltlite_branch_edge.sh
+++ b/test/doltlite_branch_edge.sh
@@ -488,6 +488,18 @@ run_test_match "force_create_new_branch_allowed" \
   "SELECT dolt_branch('-f','brand_new');" \
   "^$|0" "$DB"
 
+run_test_match "reserved_working_branch_rejected" \
+  "SELECT dolt_branch('WORKING');" \
+  "invalid branch name" "$DB"
+
+run_test_match "reserved_staged_branch_rejected" \
+  "SELECT dolt_checkout('-b','staged');" \
+  "invalid branch name" "$DB"
+
+run_test_match "hash_branch_rejected" \
+  "SELECT dolt_branch('0123456789012345678901234567890123456789');" \
+  "invalid branch name" "$DB"
+
 db_rm "$DB"
 
 echo ""

--- a/test/doltlite_tag.sh
+++ b/test/doltlite_tag.sh
@@ -39,6 +39,12 @@ run_test_match "tag_missing_commit" \
   "SELECT dolt_tag('badtag','0123456789abcdef0123456789abcdef01234567');" \
   "commit not found" "$DB"
 
+run_test_match "tag_empty_name" "SELECT dolt_tag('');" "invalid tag name" "$DB"
+run_test_match "tag_reserved_working" "SELECT dolt_tag('WORKING');" "invalid tag name" "$DB"
+run_test_match "tag_hash_name" \
+  "SELECT dolt_tag('0123456789012345678901234567890123456789');" \
+  "invalid tag name" "$DB"
+
 run_test "delete_tag" "SELECT dolt_tag('-d','v0.9');" "0" "$DB"
 run_test "delete_and_recreate_same_name" "SELECT dolt_tag('-d','parenttilde'); SELECT dolt_tag('parenttilde');" "0
 0" "$DB"

--- a/test/vc_oracle_branch_test.sh
+++ b/test/vc_oracle_branch_test.sh
@@ -301,6 +301,38 @@ SELECT dolt_commit('-m', 'c2');
 SELECT dolt_branch('-f', 'feature');
 "
 
+oracle_with_rows "force_create_resets_destination_working_set" "
+$SEED
+SELECT dolt_branch('feature');
+SELECT dolt_checkout('feature');
+INSERT INTO t VALUES (2, 20);
+SELECT dolt_checkout('main');
+SELECT dolt_branch('-f', 'feature', 'HEAD');
+SELECT dolt_checkout('feature');
+"
+
+oracle_with_rows "force_copy_resets_destination_working_set" "
+$SEED
+SELECT dolt_branch('destination');
+SELECT dolt_checkout('destination');
+INSERT INTO t VALUES (2, 20);
+SELECT dolt_checkout('main');
+SELECT dolt_branch('-c', '-f', 'main', 'destination');
+SELECT dolt_checkout('destination');
+"
+
+oracle_with_rows "force_move_replaces_destination_working_set" "
+$SEED
+SELECT dolt_branch('destination');
+SELECT dolt_checkout('destination');
+INSERT INTO t VALUES (2, 20);
+SELECT dolt_checkout('main');
+SELECT dolt_branch('source');
+SELECT dolt_checkout('source');
+INSERT INTO t VALUES (3, 30);
+SELECT dolt_branch('-m', '-f', 'source', 'destination');
+"
+
 echo "--- explicit transaction parity ---"
 
 oracle_with_rows "branch_create_inside_txn_seals_row_state" "
@@ -368,6 +400,41 @@ $SEED
 SELECT dolt_branch('');
 "
 
+oracle_error "create_reserved_head" "
+$SEED
+SELECT dolt_branch('HEAD');
+"
+
+oracle_error "create_reserved_lower_head" "
+$SEED
+SELECT dolt_branch('head');
+"
+
+oracle_error "create_invalid_double_dot" "
+$SEED
+SELECT dolt_branch('bad..name');
+"
+
+oracle_error "create_invalid_dot_component" "
+$SEED
+SELECT dolt_branch('feature/.hidden');
+"
+
+oracle_error "create_invalid_lock_suffix" "
+$SEED
+SELECT dolt_branch('feature.lock');
+"
+
+oracle_error "create_invalid_space" "
+$SEED
+SELECT dolt_branch('bad name');
+"
+
+oracle_error "create_invalid_reflog_syntax" "
+$SEED
+SELECT dolt_branch('bad@{name}');
+"
+
 oracle_error "copy_empty_source" "
 $SEED
 SELECT dolt_branch('-c', '', 'dest');
@@ -378,6 +445,11 @@ $SEED
 SELECT dolt_branch('-c', 'main', '');
 "
 
+oracle_error "copy_invalid_dest" "
+$SEED
+SELECT dolt_branch('-c', 'main', 'bad..copy');
+"
+
 oracle_error "move_empty_source" "
 $SEED
 SELECT dolt_branch('-m', '', 'dest');
@@ -386,6 +458,12 @@ SELECT dolt_branch('-m', '', 'dest');
 oracle_error "move_empty_dest" "
 $SEED
 SELECT dolt_branch('-m', 'main', '');
+"
+
+oracle_error "move_invalid_dest" "
+$SEED
+SELECT dolt_branch('source');
+SELECT dolt_branch('-m', 'source', 'bad..move');
 "
 
 oracle_error "create_extra_arg" "

--- a/test/vc_oracle_tags_test.sh
+++ b/test/vc_oracle_tags_test.sh
@@ -58,6 +58,32 @@ oracle() {
   fi
 }
 
+oracle_error() {
+  local name="$1" setup="$2"
+  local dir="$TMPROOT/${name}_err"
+  mkdir -p "$dir/dl" "$dir/dt"
+
+  local dl_rc
+  vc_oracle_run_doltlite_script "$dir/dl/db" "$dir/dl.out" "$dir/dl.err" "$setup"
+  dl_rc=$?
+
+  local dolt_setup
+  dolt_setup=$(vc_oracle_translate_for_dolt "$setup")
+  local dt_rc
+  vc_oracle_run_dolt_script_for_error "$dir/dt" "$dir/dt.out" "$dir/dt.err" "$dolt_setup"
+  dt_rc=$?
+
+  if vc_oracle_is_clean_error "$dl_rc" && vc_oracle_is_clean_error "$dt_rc"; then
+    pass=$((pass+1))
+  else
+    fail=$((fail+1))
+    FAILED_NAMES="$FAILED_NAMES $name"
+    echo "  FAIL: $name (expected both to error)"
+    echo "    doltlite rc: $dl_rc"
+    echo "    dolt rc:     $dt_rc"
+  fi
+}
+
 oracle_savepoint_tag_poststate() {
   local name="$1" setup="$2"
   local dir="$TMPROOT/${name}_sp"
@@ -226,6 +252,36 @@ SELECT dolt_commit('-m', 'first');
 SELECT dolt_tag('temp');
 SELECT dolt_tag('-d', 'temp');
 SELECT dolt_tag('temp');
+"
+
+echo "--- invalid names ---"
+
+oracle_error "tag_empty_name" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'first');
+SELECT dolt_tag('');
+"
+
+oracle_error "tag_reserved_head" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'first');
+SELECT dolt_tag('HEAD');
+"
+
+oracle_error "tag_invalid_double_dot" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'first');
+SELECT dolt_tag('bad..name');
+"
+
+oracle_error "tag_invalid_space" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'first');
+SELECT dolt_tag('bad name');
 "
 
 echo "--- savepoint parity ---"


### PR DESCRIPTION
## Summary

- validate branch and tag names with shared Git-style rules, including DoltLite pseudo-ref and 40-hex commit-hash collisions
- reset an overwritten destination to a clean working set for forced branch create and copy
- honor `-f` for branch rename, replacing the destination ref and carrying the source working set across the rename

## Failure before

DoltLite accepted ambiguous refs such as `HEAD`, `WORKING`, `bad..name`, and empty tag names. A forced create or copy updated only the destination tip, leaving its previous dirty working set attached. Forced rename ignored `-f` and failed whenever the destination existed.

The force bug was visible even when both branches pointed at the same commit: after dirtying `victim`, `dolt_branch('-f', 'victim', 'HEAD')` returned success, but reopening `victim` still exposed the dirty row and a nonempty `dolt_status`.

## Validation

- fail-before reproductions for stale forced-update working sets, ignored forced rename, and accepted malformed refs
- `test/vc_oracle_branch_test.sh`: 45 passed, 0 failed
- `test/vc_oracle_tags_test.sh`: 19 passed, 0 failed
- `test/run_doltlite_tests.sh build/doltlite`: 99/99 suites; 310,162 regression assertions
- `make lint`
- `git diff --check`

Co-Authored-By: OpenAI Codex <noreply@openai.com>
