### PR TITLE
Error when dolt_diff_stat filter names a missing table

### DIFF
--- a/src/doltlite_diff_stat.c
+++ b/src/doltlite_diff_stat.c
@@ -803,6 +803,16 @@ static int dstFilter(sqlite3_vtab_cursor *cur,
   if( rc!=SQLITE_OK ) goto done;
   rc = doltliteLoadCatalog(db, &c->fctx.toCat, &c->aToCat, &c->nToCat, 0);
   if( rc!=SQLITE_OK ) goto done;
+  /* Match Dolt: a table filter must name a table present on at least one
+  ** side. Absent from both is "table not found", not an empty result. */
+  if( c->fctx.zTblFilter
+   && !doltliteFindTableByName(c->aFromCat, c->nFromCat, c->fctx.zTblFilter)
+   && !doltliteFindTableByName(c->aToCat, c->nToCat, c->fctx.zTblFilter) ){
+    sqlite3_free(v->base.zErrMsg);
+    v->base.zErrMsg = sqlite3_mprintf("table not found: %s", c->fctx.zTblFilter);
+    rc = SQLITE_ERROR;
+    goto done;
+  }
   if( !c->fctx.zTblFilter ){
     rc = dsNameIndexInit(&c->fromIdx, c->aFromCat, c->nFromCat);
     if( rc!=SQLITE_OK ) goto done;

--- a/test/doltlite_diff.sh
+++ b/test/doltlite_diff.sh
@@ -52,6 +52,11 @@ run_test "diff_no_such_table" \
   "SELECT count(*) FROM dolt_diff WHERE table_name='nonexistent';" \
   "0" "$DB"
 
+# Match Dolt: dolt_diff_stat errors when the filter names a table on neither side.
+run_test_match "diff_stat_no_such_table" \
+  "SELECT count(*) FROM dolt_diff_stat('main','main','nonexistent');" \
+  "table not found: nonexistent" "$DB"
+
 run_test_match "diff_bad_ref_errors" \
   "SELECT count(*) FROM dolt_diff_stat('definitely_not_a_ref', (SELECT commit_hash FROM dolt_log LIMIT 1), 't');" \
   "Error" "$DB"

--- a/test/vc_oracle_diff_stat_test.sh
+++ b/test/vc_oracle_diff_stat_test.sh
@@ -102,6 +102,35 @@ oracle_both() {
   oracle_summary "$@"
 }
 
+# Both engines must reject the script with a clean non-zero exit (not a crash).
+oracle_error() {
+  local name="$1" setup="$2"
+  local dir="$TMPROOT/${name}_err"
+  mkdir -p "$dir/dl" "$dir/dt"
+
+  local dl_rc
+  vc_oracle_run_doltlite_script "$dir/dl/db" "$dir/dl.out" "$dir/dl.err" "$setup"
+  dl_rc=$?
+
+  local dolt_setup
+  dolt_setup=$(vc_oracle_translate_for_dolt "$setup")
+  local dt_rc
+  vc_oracle_run_dolt_script_for_error "$dir/dt" "$dir/dt.out" "$dir/dt.err" "$dolt_setup"
+  dt_rc=$?
+
+  if vc_oracle_is_clean_error "$dl_rc" && vc_oracle_is_clean_error "$dt_rc"; then
+    pass=$((pass+1))
+  else
+    fail=$((fail+1))
+    FAILED_NAMES="$FAILED_NAMES $name"
+    echo "  FAIL: $name (expected both to error)"
+    echo "    doltlite rc: $dl_rc"
+    echo "    dolt rc:     $dt_rc"
+    echo "    doltlite err:"; sed 's/^/      /' "$dir/dl.err" 2>/dev/null
+    echo "    dolt err:"; sed 's/^/      /' "$dir/dt.err" 2>/dev/null
+  fi
+}
+
 SEED="
 CREATE TABLE t(id INT PRIMARY KEY, v INT, name VARCHAR(32));
 INSERT INTO t VALUES(1, 10, 'alice'), (2, 20, 'bob'), (3, 30, 'carol');
@@ -324,6 +353,54 @@ UPDATE u SET x = 'ALICE' WHERE id = 1;
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'c2');
 " "HEAD~1" "HEAD" "t"
+
+echo "--- missing table filter (match Dolt) ---"
+
+# dolt_diff_stat: filter naming a table on neither side is an error.
+oracle_error "diff_stat_missing_table" "
+$SEED
+SELECT * FROM dolt_diff_stat('HEAD', 'HEAD', 'doesnotexist');
+"
+
+oracle_error "diff_stat_missing_table_over_real_change" "
+$SEED
+UPDATE t SET v = 99 WHERE id = 1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c2');
+SELECT * FROM dolt_diff_stat('HEAD~1', 'HEAD', 'doesnotexist');
+"
+
+# After drop + empty commit, neither side has t under that name.
+oracle_error "diff_stat_filter_absent_on_both_sides" "
+$SEED
+DROP TABLE t;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'drop');
+SELECT dolt_commit('--allow-empty', '-m', 'empty after drop');
+SELECT * FROM dolt_diff_stat('HEAD~1', 'HEAD', 't');
+"
+
+oracle_error "diff_stat_bad_from_ref" "
+$SEED
+SELECT * FROM dolt_diff_stat('definitely_not_a_ref', 'HEAD', 't');
+"
+
+oracle_error "diff_stat_bad_to_ref" "
+$SEED
+SELECT * FROM dolt_diff_stat('HEAD', 'definitely_not_a_ref', 't');
+"
+
+# dolt_diff_summary: missing filter is empty success on both engines.
+oracle_summary "diff_summary_missing_table" "
+$SEED
+" "HEAD" "HEAD" "doesnotexist" "EXPECT_EMPTY"
+
+oracle_summary "diff_summary_missing_table_over_real_change" "
+$SEED
+UPDATE t SET v = 99 WHERE id = 1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c2');
+" "HEAD~1" "HEAD" "doesnotexist" "EXPECT_EMPTY"
 
 echo "--- ranges spanning multiple commits ---"
 


### PR DESCRIPTION
## Summary

Match Dolt's `dolt_diff_stat` behavior for an unknown table filter.

Dolt (`getDiffStatNodeFromDelta` in `dolt_diff_stat.go`):

```go
if !fromTableExists && !toTableExists {
    return ..., sql.ErrTableNotFound.New(tableName) // "table not found: %s"
}
```

DoltLite previously accepted the filter blindly, then produced no rows when both catalog lookups missed — status 0, empty result. That looked like a valid empty diff.

## Fix

After loading both catalogs in `dstFilter`, if a table filter is set and the name is absent from both sides, set `zErrMsg` to `table not found: %s` and return `SQLITE_ERROR`.

**Not changed:** `dolt_diff_summary` still returns empty for a missing filter name (matches live Dolt).

## Test plan

- [x] `test/doltlite_diff.sh` — 42/42, including new `diff_stat_no_such_table`
- [x] Dropped table still reports `rows_deleted` (exists on from side only)
- [x] Live Dolt check: `dolt_diff_stat(..., 'doesnotexist')` → `table not found: doesnotexist`