### PR TITLE
End the write transaction when rollback fails to persist

### DIFF
--- a/src/prolly_btree_txn.c
+++ b/src/prolly_btree_txn.c
@@ -1261,6 +1261,20 @@ int restoreFromCommitted(Btree *p){
   return SQLITE_OK;
 }
 
+/* Releasing the graph lock while inTrans still says TRANS_WRITE leaves the
+** connection believing it holds a write transaction it no longer has: the next
+** write short-circuits prollyBtreeBeginTrans and mutates the store with no
+** cross-process lock, so a concurrent peer's commit can be clobbered.
+** sqlite3RollbackAll discards the return code, so the state has to be sound
+** before returning it. Mirrors the restoreFromCommitted failure path. */
+static void rollbackAbandonWriteTxn(Btree *p, BtShared *pBt){
+  p->inTrans = TRANS_NONE;
+  p->inTransaction = TRANS_NONE;
+  btreeDiscardAllSavepoints(p);
+  chunkStoreUnlock(&pBt->store);
+  pBt->store.snapshotPinned = 0;
+}
+
 int prollyBtreeRollback(Btree *p, int tripCode, int writeOnly){
   BtShared *pBt = p->pBt;
   int rc = SQLITE_OK;
@@ -1345,11 +1359,11 @@ int prollyBtreeRollback(Btree *p, int tripCode, int writeOnly){
       const char *zBr = p->zBranch ? p->zBranch : "main";
 
       pBt->inCatalogSerialize = 1;
-      rc = serializeCatalog(p, &catData, &nCatData);
+      rc = sqlite3FaultSim(957) ? SQLITE_NOMEM
+                                : serializeCatalog(p, &catData, &nCatData);
       pBt->inCatalogSerialize = 0;
       if( rc!=SQLITE_OK ){
-        chunkStoreUnlock(&pBt->store);
-        pBt->store.snapshotPinned = 0;
+        rollbackAbandonWriteTxn(p, pBt);
         return rc;
       }
       prollyHashCompute(catData, nCatData, &catHash);
@@ -1392,8 +1406,7 @@ int prollyBtreeRollback(Btree *p, int tripCode, int writeOnly){
       }
       sqlite3_free(catData);
       if( rc!=SQLITE_OK ){
-        chunkStoreUnlock(&pBt->store);
-        pBt->store.snapshotPinned = 0;
+        rollbackAbandonWriteTxn(p, pBt);
         return rc;
       }
     }

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -1067,6 +1067,71 @@ static void run_savepoint_catalog_restore(void){
   sqlite3_close(db);
 }
 
+static void checkLabeled(const char *zLabel, const char *zWhat, int cond){
+  char zName[192];
+  snprintf(zName, sizeof(zName), "%s_%s", zLabel, zWhat);
+  check(zName, cond);
+}
+
+/* A rollback that fails while persisting the restored working set still has to
+** end the write transaction. It releases the graph lock on the way out, and
+** sqlite3RollbackAll throws the return code away, so a connection left at
+** TRANS_WRITE would let the next write short-circuit prollyBtreeBeginTrans and
+** mutate the store unlocked. */
+static void rollbackPersistFaultCase(int iFault, const char *zLabel){
+  sqlite3 *db = 0;
+  char dbpath[256];
+  char zName[128];
+  int rc;
+
+  snprintf(zName, sizeof(zName), "test_rollback_persist_%d", iFault);
+  make_dbpath(dbpath, sizeof(dbpath), zName);
+  removeDbFiles(dbpath);
+  check("rollback_persist_open", sqlite3_open(dbpath, &db)==SQLITE_OK);
+  if( !db ) return;
+
+  check("rollback_persist_seed", execSql(db,
+      "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
+      "INSERT INTO t VALUES(1, 'base');")==SQLITE_OK);
+  check("rollback_persist_commit",
+      strlen(queryScalarText(db, "SELECT dolt_commit('-A','-m','base')"))==40);
+
+  check("rollback_persist_begin", execSql(db, "BEGIN")==SQLITE_OK);
+  check("rollback_persist_write",
+      execSql(db, "INSERT INTO t VALUES(2, 'pending')")==SQLITE_OK);
+
+  gRegressionFaultCode = iFault;
+  gRegressionFaultHits = 0;
+  sqlite3_test_control(SQLITE_TESTCTRL_FAULT_INSTALL, regressionFaultCallback);
+  rc = execSqlSilent(db, "ROLLBACK");
+  sqlite3_test_control(SQLITE_TESTCTRL_FAULT_INSTALL, 0);
+  gRegressionFaultCode = 0;
+  (void)rc;
+
+  checkLabeled(zLabel, "fault_injected", gRegressionFaultHits>0);
+
+  /* The rolled-back row must not reappear, and the connection must still be
+  ** usable rather than wedged in a phantom transaction. */
+  checkLabeled(zLabel, "pending_row_discarded",
+      strcmp(queryScalarText(db, "SELECT count(*) FROM t WHERE id=2"), "0")==0);
+  checkLabeled(zLabel, "writes_work_after_failed_rollback",
+      execSql(db, "INSERT INTO t VALUES(3, 'after')")==SQLITE_OK);
+  checkLabeled(zLabel, "post_rollback_commit_ok",
+      strlen(queryScalarText(db, "SELECT dolt_commit('-A','-m','after')"))==40);
+
+  sqlite3_close(db);
+  removeDbFiles(dbpath);
+}
+
+static void run_rollback_persist_failure_ends_txn(void){
+  printf("=== Rollback Persist Failure Ends Write Txn Test ===\n\n");
+  /* Only the serialize failure is reachable from a test: the persist chain
+  ** below it is skipped whenever the restored working set already matches the
+  ** one on disk, which it does after an ordinary rollback. Both failures leave
+  ** through the same teardown. */
+  rollbackPersistFaultCase(957, "rollback_serialize_fault");
+}
+
 static void run_session_string_setter_oom(void){
   sqlite3 *db = 0;
   char dbpath[256];
@@ -9922,7 +9987,8 @@ static const RegressionCase aCases[] = {
   { "prolly_cursor_corrupt_node", "Prolly Cursor Corrupt Node Test", run_prolly_cursor_surfaces_corrupt_node },
   { "prolly_diff_iter_copies_blob_keys", "Prolly Diff Iterator Blob Key Copy Test", run_prolly_diff_iter_copies_blob_keys },
   { "prolly_diff_leaf_record_corruption", "Prolly Diff Leaf Corruption Test", run_prolly_diff_leaf_surfaces_record_corruption },
-  { "incrblob_chunked_and_multihandle", "Incrblob Chunked Record And Multi-Handle Test", run_incrblob_chunked_and_multihandle }
+  { "incrblob_chunked_and_multihandle", "Incrblob Chunked Record And Multi-Handle Test", run_incrblob_chunked_and_multihandle },
+  { "rollback_persist_failure_ends_txn", "Rollback Persist Failure Ends Write Txn Test", run_rollback_persist_failure_ends_txn }
 };
 
 static int run_case_by_name(const char *zName){


### PR DESCRIPTION
First of the three prolly-core items from the deep review.

## Problem

`prollyBtreeRollback` releases the graph lock on its way out of a failed persist, but left `inTrans` at `TRANS_WRITE`:

```c
      if( rc!=SQLITE_OK ){
        chunkStoreUnlock(&pBt->store);
        pBt->store.snapshotPinned = 0;
        return rc;                     /* inTrans still TRANS_WRITE */
      }
```

`sqlite3RollbackAll` discards that return code, so the connection goes on believing it holds a write transaction it no longer has. The next write short-circuits `prollyBtreeBeginTrans`, which returns OK immediately when `inTrans==TRANS_WRITE`, and mutates the store **with no cross-process lock** — so a concurrent peer's commit can be clobbered.

The `restoreFromCommitted` failure path a few lines above already does the right thing (clears the transaction, discards savepoints, then unlocks). These two returns were the odd ones out.

## Fix

Both persist-failure returns now leave through that same teardown, factored into `rollbackAbandonWriteTxn`.

## Testing

The invariant is one the code already asserts, which makes the failure sharp rather than subtle. Without the fix, faulting the catalog serialize during `ROLLBACK` and then writing again aborts an assert build:

```
Assertion failed: (pBt)->store.isMemory
  || ((pBt)->store.pGraphLockFile!=0 && (pBt)->store.lockDepth>0),
  function prollyBtreeCommitPhaseTwo, prolly_btree_txn.c:1064
```

That is the unlocked write reaching commit. With the fix, the same case passes 9/9.

Worth knowing: **a release build does not catch this.** All nine behavioural assertions pass with and without the fix; only `--with-debug` surfaces it. CI's `assert-enabled` job is what would catch a regression here.

Fault site 957 makes the serialize failure reachable. I deliberately did **not** add one to the persist chain below it: that block is skipped whenever the restored working set already matches the one on disk, which it does after an ordinary rollback, so the hook would be dead code. Both paths share the teardown, so the tested one exercises the fix.

## Validation

- New `rollback_persist_failure_ends_txn` c-test — assert build: **abort → 9/9**
- `test/doltlite_regression_test_c.sh` — 310,171 tests, 0 failures
- `test/run_c_tests.sh` — 26/26 gated c-tests
- `test/run_doltlite_tests.sh` — 99/99 suites

One thing I hit while validating: running the whole regression binary under `--with-debug` aborts on an unrelated pre-existing assertion (`sqlite3_mutex_held(db->mutex)` in `sqlite3DbMallocRawNN`, during `refs_deserialize_overflow_guard`). I confirmed it reproduces identically with my change stashed, so it is not from this PR — but it does mean that binary cannot currently be run end-to-end under assertions. Happy to file it separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)