### PR TITLE
Propagate dolt_diff read failures

### DIFF
--- a/src/doltlite_diff.c
+++ b/src/doltlite_diff.c
@@ -36,55 +36,68 @@ static int schemaRecordIsViewOrTrigger(const u8 *pRec, int nRec){
 static int schemaHasViewOrTriggerDiff(sqlite3 *db,
                                       const ProllyHash *pOldRoot,
                                       const ProllyHash *pNewRoot,
-                                      u8 flags){
+                                      u8 flags,
+                                      int *pFound){
   ChunkStore *cs = doltliteGetChunkStore(db);
   ProllyCache *pCache = doltliteGetCache(db);
   ProllyDiffIter iter;
   ProllyDiffChange *pChange = 0;
   int rc;
-  int found = 0;
-  if( !cs || !pCache ) return 0;
-  if( prollyHashCompare(pOldRoot, pNewRoot)==0 ) return 0;
-  rc = prollyDiffIterOpen(&iter, cs, pCache, pOldRoot, pNewRoot, flags);
-  if( rc!=SQLITE_OK ) return 0;
-  while( (rc = prollyDiffIterStep(&iter, &pChange))==SQLITE_ROW && pChange ){
+  *pFound = 0;
+  if( !cs || !pCache ) return SQLITE_ERROR;
+  if( prollyHashCompare(pOldRoot, pNewRoot)==0 ) return SQLITE_OK;
+  memset(&iter, 0, sizeof(iter));
+  rc = sqlite3FaultSim(957) ? SQLITE_IOERR :
+       prollyDiffIterOpen(&iter, cs, pCache, pOldRoot, pNewRoot, flags);
+  if( rc!=SQLITE_OK ){
+    prollyDiffIterClose(&iter);
+    return rc;
+  }
+  while( (rc = prollyDiffIterStep(&iter, &pChange))==SQLITE_ROW ){
+    if( !pChange ){
+      rc = SQLITE_CORRUPT;
+      break;
+    }
     if( schemaRecordIsViewOrTrigger(pChange->pNewVal, pChange->nNewVal)
      || schemaRecordIsViewOrTrigger(pChange->pOldVal, pChange->nOldVal) ){
-      found = 1;
+      *pFound = 1;
+      rc = SQLITE_OK;
       break;
     }
   }
   prollyDiffIterClose(&iter);
-  return found;
+  return rc==SQLITE_DONE ? SQLITE_OK : rc;
 }
 
 static int schemaHasAnyViewOrTrigger(sqlite3 *db,
                                      const ProllyHash *pRoot,
-                                     u8 flags){
+                                     u8 flags,
+                                     int *pFound){
   ChunkStore *cs = doltliteGetChunkStore(db);
   ProllyCache *pCache = doltliteGetCache(db);
   ProllyCursor cur;
   int rc, res;
-  int found = 0;
-  if( !cs || !pCache ) return 0;
-  if( prollyHashIsEmpty(pRoot) ) return 0;
+  *pFound = 0;
+  if( !cs || !pCache ) return SQLITE_ERROR;
+  if( prollyHashIsEmpty(pRoot) ) return SQLITE_OK;
   prollyCursorInit(&cur, cs, pCache, pRoot, flags);
-  rc = prollyCursorFirst(&cur, &res);
+  rc = sqlite3FaultSim(958) ? SQLITE_IOERR : prollyCursorFirst(&cur, &res);
   if( rc!=SQLITE_OK || res ){
     prollyCursorClose(&cur);
-    return 0;
+    return rc;
   }
   while( prollyCursorIsValid(&cur) ){
     const u8 *pVal; int nVal;
     prollyCursorValue(&cur, &pVal, &nVal);
     if( schemaRecordIsViewOrTrigger(pVal, nVal) ){
-      found = 1;
+      *pFound = 1;
       break;
     }
-    if( prollyCursorNext(&cur)!=SQLITE_OK ) break;
+    rc = prollyCursorNext(&cur);
+    if( rc!=SQLITE_OK ) break;
   }
   prollyCursorClose(&cur);
-  return found;
+  return rc;
 }
 
 typedef struct DiffSummaryRow DiffSummaryRow;
@@ -321,6 +334,9 @@ static int diffCatalogPairOne(
     const ProllyHash *pOldRoot;
     struct TableEntry *pNewMaster;
     struct TableEntry *pOldMaster;
+    int hasDiff;
+    int oldHas;
+    int rc;
 
     memset(&emptyRoot, 0, sizeof(emptyRoot));
     pNewMaster = doltliteFindTableByNumber(aChild, nChild, 1);
@@ -328,12 +344,14 @@ static int diffCatalogPairOne(
     if( !pNewMaster ) return SQLITE_OK;
 
     pOldRoot = pOldMaster ? &pOldMaster->root : &emptyRoot;
-    if( schemaHasViewOrTriggerDiff(db, pOldRoot, &pNewMaster->root,
-                                   pNewMaster->flags) ){
-      u8 schemaChangeFlag =
-        schemaHasAnyViewOrTrigger(db, pOldRoot, pNewMaster->flags) ? 0 : 1;
+    rc = schemaHasViewOrTriggerDiff(db, pOldRoot, &pNewMaster->root,
+                                    pNewMaster->flags, &hasDiff);
+    if( rc!=SQLITE_OK ) return rc;
+    if( hasDiff ){
+      rc = schemaHasAnyViewOrTrigger(db, pOldRoot, pNewMaster->flags, &oldHas);
+      if( rc!=SQLITE_OK ) return rc;
       return batchAppend(pCur, zHex, "dolt_schemas", pCommit,
-                         1, schemaChangeFlag);
+                         1, oldHas ? 0 : 1);
     }
     return SQLITE_OK;
   }
@@ -391,17 +409,22 @@ static int diffCatalogPair(
       ProllyHash emptyRoot;
       const ProllyHash *pOldRoot;
       struct TableEntry *pOldMaster;
+      int hasDiff;
+      int oldHas;
       /* Only the master entry carries schema rows; unnamed index entries
       ** are attributed to their tables through the row comparison below. */
       if( e->iTable!=1 ) continue;
       memset(&emptyRoot, 0, sizeof(emptyRoot));
       pOldMaster = doltliteFindTableByNumber(aParent, nParent, 1);
       pOldRoot = pOldMaster ? &pOldMaster->root : &emptyRoot;
-      if( schemaHasViewOrTriggerDiff(db, pOldRoot, &e->root, e->flags) ){
-        u8 schemaChangeFlag =
-          schemaHasAnyViewOrTrigger(db, pOldRoot, e->flags) ? 0 : 1;
+      rc = schemaHasViewOrTriggerDiff(db, pOldRoot, &e->root, e->flags,
+                                      &hasDiff);
+      if( rc!=SQLITE_OK ) goto diff_done;
+      if( hasDiff ){
+        rc = schemaHasAnyViewOrTrigger(db, pOldRoot, e->flags, &oldHas);
+        if( rc!=SQLITE_OK ) goto diff_done;
         rc = batchAppend(pCur, zHex, "dolt_schemas", pCommit,
-                         1, schemaChangeFlag);
+                         1, oldHas ? 0 : 1);
         if( rc!=SQLITE_OK ) goto diff_done;
       }
       continue;
@@ -499,7 +522,7 @@ static int computeWorkingBatch(DoltliteDiffCursor *pCur, sqlite3 *db){
   memset(&workCat, 0, sizeof(workCat));
 
   rc = doltliteGetHeadCatalogHash(db, &headCat);
-  if( rc!=SQLITE_OK ) return SQLITE_OK;
+  if( rc!=SQLITE_OK ) return rc;
   doltliteGetSessionStaged(db, &stagedCat);
   if( prollyHashIsEmpty(&stagedCat) ) stagedCat = headCat;
   rc = doltliteFlushCatalogToHash(db, &workCat);

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -4604,6 +4604,64 @@ static void run_diff_stat_surfaces_corrupt_root(void){
   removeDbFiles(dbpath);
 }
 
+static void run_diff_surfaces_read_errors(void){
+  sqlite3 *db = 0;
+  char dbpath[256];
+  ProllyHash realHead;
+  ProllyHash missingHead;
+  const char *res;
+
+  printf("=== Diff Surfaces Read Errors Test ===\n\n");
+  make_dbpath(dbpath, sizeof(dbpath), "test_diff_surfaces_read_errors");
+  removeDbFiles(dbpath);
+
+  check("open_db_for_diff_read_errors", open_db(dbpath, &db)==SQLITE_OK);
+  check("setup_repo_for_diff_read_errors", execSql(db,
+    "CREATE TABLE t(id INTEGER PRIMARY KEY);"
+    "INSERT INTO t VALUES(1);"
+    "SELECT dolt_commit('-A', '-m', 'base');"
+    "CREATE VIEW v AS SELECT id FROM t;")==SQLITE_OK);
+
+  doltliteGetSessionHead(db, &realHead);
+  memset(&missingHead, 0x5a, sizeof(missingHead));
+  doltliteSetSessionHead(db, &missingHead);
+  res = queryScalarText(db,
+    "SELECT count(*) FROM dolt_diff WHERE commit_hash='WORKING'");
+  check("diff_missing_head_returns_error", strstr(res, "ERROR:")!=0);
+  doltliteSetSessionHead(db, &realHead);
+
+  gRegressionFaultCode = 957;
+  gRegressionFaultHits = 0;
+  sqlite3_test_control(SQLITE_TESTCTRL_FAULT_INSTALL, regressionFaultCallback);
+  res = queryScalarText(db,
+    "SELECT count(*) FROM dolt_diff "
+    "WHERE commit_hash='WORKING' AND table_name='dolt_schemas'");
+  sqlite3_test_control(SQLITE_TESTCTRL_FAULT_INSTALL, 0);
+  gRegressionFaultCode = 0;
+  check("diff_schema_diff_read_failure_injected", gRegressionFaultHits==1);
+  check("diff_schema_diff_read_failure_returned", strstr(res, "ERROR:")!=0);
+
+  gRegressionFaultCode = 958;
+  gRegressionFaultHits = 0;
+  sqlite3_test_control(SQLITE_TESTCTRL_FAULT_INSTALL, regressionFaultCallback);
+  res = queryScalarText(db,
+    "SELECT count(*) FROM dolt_diff "
+    "WHERE commit_hash='WORKING' AND table_name='dolt_schemas'");
+  sqlite3_test_control(SQLITE_TESTCTRL_FAULT_INSTALL, 0);
+  gRegressionFaultCode = 0;
+  check("diff_schema_scan_failure_injected", gRegressionFaultHits==1);
+  check("diff_schema_scan_failure_returned", strstr(res, "ERROR:")!=0);
+
+  check("diff_schema_scan_retry_succeeds",
+    strcmp(queryScalarText(db,
+      "SELECT count(*) FROM dolt_diff "
+      "WHERE commit_hash='WORKING' AND table_name='dolt_schemas'"),
+      "1")==0);
+
+  sqlite3_close(db);
+  removeDbFiles(dbpath);
+}
+
 static void run_truncated_wal_is_rejected(void){
   sqlite3 *db = 0;
   ChunkStore cs;
@@ -9849,6 +9907,7 @@ static const RegressionCase aCases[] = {
   { "diff_stat_wide_modified_rows", "Diff Stat Wide Modified Rows Test", run_diff_stat_wide_modified_rows },
   { "diff_table_deep_history_map", "Diff Table Deep History Map Test", run_diff_table_deep_history_map },
   { "diff_stat_surfaces_corrupt_root", "Diff Stat Surfaces Corrupt Root Test", run_diff_stat_surfaces_corrupt_root },
+  { "diff_surfaces_read_errors", "Diff Surfaces Read Errors Test", run_diff_surfaces_read_errors },
   { "table_moveto_mutmap_delete_preserves_neighbors", "Table Moveto MutMap Delete Preserves Neighbors Test", run_table_moveto_mutmap_delete_preserves_neighbors },
   { "table_moveto_mutmap_exact_keeps_iteration_aligned", "Table Moveto MutMap Exact Keeps Iteration Aligned Test", run_table_moveto_mutmap_exact_keeps_iteration_aligned },
   { "index_moveto_mutmap_exact_keeps_iteration_aligned", "Index Moveto MutMap Exact Keeps Iteration Aligned Test", run_index_moveto_mutmap_exact_keeps_iteration_aligned },


### PR DESCRIPTION
## Summary

- return failed HEAD catalog reads from `dolt_diff` working and staged scans instead of treating them as an empty diff
- separate schema-scan status from the found/not-found result so prolly iterator and cursor failures reach the virtual-table caller
- release partially opened diff iterators when their initial tree read fails

## Failure before

`computeWorkingBatch()` returned `SQLITE_OK` whenever loading the HEAD commit failed. A `commit_hash='WORKING'` query therefore reported zero rows for a missing or unreadable HEAD instead of reporting corruption or I/O failure.

The special `dolt_schemas` scanners had the same ambiguity: their integer return value represented only whether a view or trigger was found, so iterator-open, iterator-step, cursor-first, and cursor-next failures all became “no schema change.”

## Validation

- new fault-backed regression: 8 passed, 0 failed
- full C regression: 310,170 passed, 0 failed
- `test/doltlite_diff.sh`: 41 passed, 0 failed
- `test/vc_oracle_diff_test.sh`: 67 passed, 0 failed
- `test/run_doltlite_tests.sh build/doltlite`: 99/99 suites
- `make lint`
- `git diff --check`

Co-Authored-By: OpenAI Codex <noreply@openai.com>
