### PR TITLE
Forward incremental blob writes to the legacy btree

### DIFF
--- a/src/btree_orig_api.c
+++ b/src/btree_orig_api.c
@@ -119,6 +119,14 @@ i64 origBtreeIntegerKey(void *pCur){ return orig_sqlite3BtreeIntegerKey(C(pCur))
 u32 origBtreePayloadChecked(void *pCur, u32 off, u32 amt, void *pBuf){
   return orig_sqlite3BtreePayloadChecked(C(pCur), off, amt, pBuf);
 }
+#ifndef SQLITE_OMIT_INCRBLOB
+int origBtreePutData(void *pCur, u32 off, u32 amt, void *pBuf){
+  return orig_sqlite3BtreePutData(C(pCur), off, amt, pBuf);
+}
+void origBtreeIncrblobCursor(void *pCur){
+  orig_sqlite3BtreeIncrblobCursor(C(pCur));
+}
+#endif
 int origBtreeCount(sqlite3 *db, void *pCur, i64 *pn){
   return orig_sqlite3BtreeCount(db, C(pCur), pn);
 }

--- a/src/btree_orig_api.h
+++ b/src/btree_orig_api.h
@@ -63,6 +63,10 @@ int origBtreePayload(void *pCur, u32 offset, u32 amt, void *pBuf);
 const void *origBtreePayloadFetch(void *pCur, u32 *pAmt);
 i64 origBtreeIntegerKey(void *pCur);
 u32 origBtreePayloadChecked(void *pCur, u32 offset, u32 amt, void *pBuf);
+#ifndef SQLITE_OMIT_INCRBLOB
+int origBtreePutData(void *pCur, u32 offset, u32 amt, void *pBuf);
+void origBtreeIncrblobCursor(void *pCur);
+#endif
 int origBtreeCount(sqlite3 *db, void *pCur, i64 *pnEntry);
 int origBtreeCountIndexRange(sqlite3 *db, void *pCur, UnpackedRecord *pLower,
                              UnpackedRecord *pUpper, i64 *pnEntry);

--- a/src/prolly_btree_orig.c
+++ b/src/prolly_btree_orig.c
@@ -328,12 +328,13 @@ int origCursorPayloadCheckedVt(BtCursor *pCur, u32 offset, u32 amt, void *pBuf){
   return origBtreePayloadChecked(pCur->pOrigCursor, offset, amt, pBuf);
 }
 int origCursorPutDataVt(BtCursor *pCur, u32 offset, u32 amt, void *pBuf){
-  (void)pCur; (void)offset; (void)amt; (void)pBuf;
-  return SQLITE_OK;
+  return origBtreePutData(pCur->pOrigCursor, offset, amt, pBuf);
 }
 void origCursorIncrblobCursorVt(BtCursor *pCur){
-  (void)pCur;
-
+  /* Marks the stock cursor as an incremental-blob cursor, which is how the
+  ** stock btree knows to reseek it rather than invalidate it when the row is
+  ** written. Dropping it left blob handles stale across writes. */
+  origBtreeIncrblobCursor(pCur->pOrigCursor);
 }
 #endif
 #ifndef NDEBUG

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -9406,6 +9406,81 @@ static void run_prolly_diff_leaf_surfaces_record_corruption(void){
   chunkStoreClose(&cs);
 }
 
+/* Incremental blob writes against a stock-format database. The wrapper
+** dispatches xPutData per cursor kind, and the legacy arm was a stub that
+** returned SQLITE_OK without touching the row, so sqlite3_blob_write reported
+** success and threw the bytes away. */
+static void run_incrblob_legacy_engine_write(void){
+  char dbpath[512];
+  char zUri[640];
+  sqlite3 *db = 0;
+  sqlite3_blob *pBlob = 0;
+  char buf[16];
+  int rc;
+
+  printf("=== Incrblob Legacy Engine Write Test ===\n\n");
+  make_dbpath(dbpath, sizeof(dbpath), "test_incrblob_legacy");
+  removeDbFiles(dbpath);
+
+  snprintf(zUri, sizeof(zUri), "file:%s?doltlite_engine=sqlite", dbpath);
+  rc = sqlite3_open_v2(zUri, &db,
+                       SQLITE_OPEN_READWRITE|SQLITE_OPEN_CREATE|SQLITE_OPEN_URI,
+                       0);
+  check("incrblob_legacy_open", rc==SQLITE_OK);
+  if( !db ) return;
+  check("incrblob_legacy_engine_is_orig",
+        strcmp(queryScalarText(db, "SELECT doltlite_engine()"), "orig")==0);
+  check("incrblob_legacy_setup", execSql(db,
+      "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
+      "INSERT INTO t VALUES(1, '0123456789');")==SQLITE_OK);
+
+  check("incrblob_legacy_blob_open",
+        sqlite3_blob_open(db, "main", "t", "v", 1, 1, &pBlob)==SQLITE_OK);
+  if( pBlob ){
+    check("incrblob_legacy_write_ok",
+          sqlite3_blob_write(pBlob, "WRITTEN!!!", 10, 0)==SQLITE_OK);
+    check("incrblob_legacy_blob_close", sqlite3_blob_close(pBlob)==SQLITE_OK);
+  }
+
+  check("incrblob_legacy_write_landed",
+        strcmp(queryScalarText(db, "SELECT v FROM t WHERE id=1"),
+               "WRITTEN!!!")==0);
+
+  /* And it is durable, not just visible to the writing connection. */
+  sqlite3_close(db);
+  db = 0;
+  rc = sqlite3_open_v2(zUri, &db, SQLITE_OPEN_READWRITE|SQLITE_OPEN_URI, 0);
+  check("incrblob_legacy_reopen", rc==SQLITE_OK);
+  if( db ){
+    check("incrblob_legacy_write_persisted",
+          strcmp(queryScalarText(db, "SELECT v FROM t WHERE id=1"),
+                 "WRITTEN!!!")==0);
+  }
+
+  /* A partial overwrite must leave the rest of the value alone. */
+  pBlob = 0;
+  if( db && sqlite3_blob_open(db, "main", "t", "v", 1, 1, &pBlob)==SQLITE_OK ){
+    check("incrblob_legacy_partial_write",
+          sqlite3_blob_write(pBlob, "ZZ", 2, 4)==SQLITE_OK);
+    sqlite3_blob_close(pBlob);
+    check("incrblob_legacy_partial_result",
+          strcmp(queryScalarText(db, "SELECT v FROM t WHERE id=1"),
+                 "WRITZZN!!!")==0);
+  }
+
+  memset(buf, 0, sizeof(buf));
+  pBlob = 0;
+  if( db && sqlite3_blob_open(db, "main", "t", "v", 1, 0, &pBlob)==SQLITE_OK ){
+    check("incrblob_legacy_readback",
+          sqlite3_blob_read(pBlob, buf, 10, 0)==SQLITE_OK
+          && memcmp(buf, "WRITZZN!!!", 10)==0);
+    sqlite3_blob_close(pBlob);
+  }
+
+  sqlite3_close(db);
+  removeDbFiles(dbpath);
+}
+
 static void run_incrblob_chunked_and_multihandle(void){
   char dbpath[512];
   sqlite3 *db = 0;
@@ -10046,6 +10121,7 @@ static const RegressionCase aCases[] = {
   { "prolly_cursor_corrupt_node", "Prolly Cursor Corrupt Node Test", run_prolly_cursor_surfaces_corrupt_node },
   { "prolly_diff_iter_copies_blob_keys", "Prolly Diff Iterator Blob Key Copy Test", run_prolly_diff_iter_copies_blob_keys },
   { "prolly_diff_leaf_record_corruption", "Prolly Diff Leaf Corruption Test", run_prolly_diff_leaf_surfaces_record_corruption },
+  { "incrblob_legacy_engine_write", "Incrblob Legacy Engine Write Test", run_incrblob_legacy_engine_write },
   { "incrblob_chunked_and_multihandle", "Incrblob Chunked Record And Multi-Handle Test", run_incrblob_chunked_and_multihandle },
   { "rollback_persist_failure_ends_txn", "Rollback Persist Failure Ends Write Txn Test", run_rollback_persist_failure_ends_txn }
 };


### PR DESCRIPTION
Independent of #2007 — verified the two branches merge cleanly (different regions of the same test file), so they can land in either order.

## Problem

`sqlite3_blob_write` against a **stock-format** database opened through doltlite reported success and threw the bytes away. The wrapper dispatches `xPutData` per cursor kind, and the legacy arm was a stub:

```c
int origCursorPutDataVt(BtCursor *pCur, u32 offset, u32 amt, void *pBuf){
  (void)pCur; (void)offset; (void)amt; (void)pBuf;
  return SQLITE_OK;
}
```

There was no `origBtreePutData` to call — the forwarder simply did not exist. Reads were wired correctly, which is why nothing surfaced. Measured against a file created with `doltlite_engine=sqlite`:

```
engine: orig
blob_open  rc=0
blob_write rc=0
value after write: [0123456789]     <- unchanged
```

`origCursorIncrblobCursorVt` was empty for the same reason. That call is what marks the stock cursor as an incremental-blob cursor, which is how the stock btree knows to reseek it rather than invalidate it when the row is written, so a blob handle also went stale across a write.

## Fix

Both forward through the orig API, alongside the payload readers already sitting beside them (`origBtreePayload`, `origBtreePayloadChecked`). Guarded with `SQLITE_OMIT_INCRBLOB` to match the call sites.

## Testing

`incrblob_legacy_engine_write` in `test/doltlite_regression_test_c.c`, beside the existing `incrblob_chunked_and_multihandle` case. It builds a stock-format file via the `doltlite_engine=sqlite` URI knob, asserts the engine really is `orig`, then checks the write lands, **persists across a reopen**, that a partial overwrite leaves the surrounding bytes alone, and that a subsequent `blob_read` agrees.

Fail-before/pass-after, same test file both runs:

- before: **8 passed, 4 failed**
- after: **12 passed, 0 failed**

The four baseline failures are exactly the ones that read the value back; `blob_open` and `blob_write` themselves report success in both runs, which is the point.

## Validation

- `test/doltlite_regression_test_c.sh` — 310,191 tests, 0 failures
- `test/run_c_tests.sh` — 26/26 gated c-tests
- `test/run_doltlite_tests.sh` — 99/99 suites
- testfixture incrblob family (`incrblob`, `incrblob2..4`, `incrblob_err`, `incrblobfault`, `incrcorrupt`) — 1,252 passing, 0 unexpected failures
- Legacy-format suites: `doltlite_attach_write_matrix` (96), `doltlite_compat_test` (18), `doltlite_attach_sqlite` (13), 0 failures

## Also checked

While re-verifying the remaining review items against master, `httpHasChunks` is **already fixed** — it now requires `nResp==nHash` and rejects any byte above 1. No work needed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)