### PR TITLE
Invalidate the cursor when a prolly descent hits an empty child

### DIFF
--- a/src/prolly_cursor.c
+++ b/src/prolly_cursor.c
@@ -160,7 +160,15 @@ static int descendToExtremeLeaf(ProllyCursor *cur, int bRight){
     ** on to mark the cursor valid over a node that has no key array at all.
     ** An empty root leaf is a different thing -- an empty table -- and never
     ** reaches here, because the loop only runs once we descend. */
-    if( pChild->node.nItems==0 ) return SQLITE_CORRUPT;
+    if( pChild->node.nItems==0 ){
+      /* Returning the error is not enough on its own. prollyCursorNext/Prev
+      ** propagate it without touching eState, so a cursor that was VALID
+      ** before the step stays VALID, and the accessors only assert on eState
+      ** -- a later key or value read would land on this empty child. Drop the
+      ** half-built descent and mark the cursor unusable. */
+      prollyCursorReleaseAll(cur);
+      return SQLITE_CORRUPT;
+    }
     cur->aLevel[cur->iLevel].idx = bRight ? pChild->node.nItems - 1 : 0;
   }
   return SQLITE_OK;

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -9294,11 +9294,34 @@ static void run_prolly_cursor_empty_leaf_under_internal(void){
   check("empty_leaf_internal_first_valid", res==0 && prollyCursorIsValid(&cur));
   rc = prollyCursorNext(&cur);
   check("empty_leaf_internal_next_reports_corrupt", rc==SQLITE_CORRUPT);
+  /* The error alone is not enough: the accessors gate on eState, so a cursor
+  ** left VALID here would happily read the empty child. */
+  check("empty_leaf_internal_next_leaves_cursor_unusable",
+        !prollyCursorIsValid(&cur));
   prollyCursorClose(&cur);
 
   prollyCursorInit(&cur, &cs, &cache, &rootHash, PROLLY_NODE_BLOBKEY);
   rc = prollyCursorLast(&cur, &res);
   check("empty_leaf_internal_last_reports_corrupt", rc==SQLITE_CORRUPT);
+  check("empty_leaf_internal_last_leaves_cursor_unusable",
+        !prollyCursorIsValid(&cur));
+  prollyCursorClose(&cur);
+
+  /* Walking forward from the populated leaf must not expose a row from the
+  ** empty child, however the caller drives it. */
+  prollyCursorInit(&cur, &cs, &cache, &rootHash, PROLLY_NODE_BLOBKEY);
+  rc = prollyCursorFirst(&cur, &res);
+  check("empty_leaf_internal_first_still_valid",
+        rc==SQLITE_OK && res==0 && prollyCursorIsValid(&cur));
+  if( prollyCursorIsValid(&cur) ){
+    const u8 *pKey = 0;
+    int nKey = 0;
+    prollyCursorKey(&cur, &pKey, &nKey);
+    check("empty_leaf_internal_first_key_is_the_real_row",
+          nKey==1 && pKey && pKey[0]=='a');
+  }
+  check("empty_leaf_internal_step_corrupts", prollyCursorNext(&cur)==SQLITE_CORRUPT);
+  check("empty_leaf_internal_no_row_after_step", !prollyCursorIsValid(&cur));
   prollyCursorClose(&cur);
 
   prollyCacheFree(&cache);


### PR DESCRIPTION
Follow-up to #2007, from Ito's review of that PR.

#2007 made `descendToExtremeLeaf` return `SQLITE_CORRUPT` when it lands on
an empty child under an internal node. Ito pointed out that returning the
error is not enough on its own:

- `prollyCursorNext`/`prollyCursorPrev` propagate the return without
  touching `eState`, so a cursor that was `VALID` before the step stays
  `VALID` after it.
- The accessors only assert on `eState`, so a caller that steps, sees the
  error, and then reads a key or value lands on the half-built descent --
  pointing straight at the empty child.

This releases the descent and marks the cursor `INVALID` before returning.
`prollyCursorReleaseAll` is idempotent, nulls every `aLevel[i].pEntry`, and
sets `eState = PROLLY_CURSOR_INVALID`, which covers both halves of Ito's
requirement (set the state *and* clear the failed descent state).

The level-zero empty-root path is untouched: that is ordinary EOF, and it
never reaches this loop, because the loop body only runs once a descent has
actually happened.

## Testing

`prolly_cursor_empty_leaf_under_internal` regains the state assertion I
should not have dropped from #2007, and adds a forward walk that steps off
a good leaf into the empty child and confirms no row stays exposed.

Fail-before / pass-after, same test file both runs:

| | baseline (#2007 code, no fix) | with fix |
|---|---|---|
| `..._next_leaves_cursor_unusable` | FAIL | pass |
| `..._no_row_after_step` | FAIL | pass |
| `..._last_leaves_cursor_unusable` | pass | pass |

The `Last` assertion passes in both because `prollyCursorLast` re-inits the
cursor to `INVALID` before descending; it is kept as a regression guard.
`Next` is the path that leaves the stale `VALID`.

Also run green:

- `doltlite_regression_test_c all` -- 310,199 passed, 0 failed
- the same binary built `--with-debug` (asserts on) -- 16/16 on the cursor test
- `test/run_c_tests.sh` -- 26/26
- `test/run_doltlite_tests.sh` -- 99/99 suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)