### PR TITLE
fix: clean failed rebase working branch

### DIFF
--- a/src/doltlite_rebase.c
+++ b/src/doltlite_rebase.c
@@ -1230,11 +1230,8 @@ static int rebaseDiscardWorkingBranch(
   int rc;
 
   rc = rebaseClaimActiveEndRetry(db, zWorkingBranch);
-  if( rc==SQLITE_DONE ){
-    return SQLITE_OK;
-  }
-  if( rc!=SQLITE_OK ) return rc;
-  rc = rebaseDropPlan(db);
+  if( rc!=SQLITE_OK && rc!=SQLITE_DONE ) return rc;
+  rc = rebaseRetryDbOp(db, rebaseDropPlan);
   if( rc!=SQLITE_OK ) return rc;
   return rebaseCleanupAfterClaim(db, zOrigBranch, zWorkingBranch);
 }
@@ -1412,6 +1409,7 @@ static void doltliteRebaseInteractiveStart(
   ** Committing it makes the reload re-read it instead. */
   rc = chunkStoreSerializeRefs(cs);
   if( rc==SQLITE_OK ) rc = chunkStoreCommit(cs);
+  if( rc==SQLITE_OK && sqlite3FaultSim(960) ) rc = SQLITE_BUSY;
   if( rc!=SQLITE_OK ) goto fail;
   rc = doltliteCheckoutBranchForRebase(db, zWorking);
   if( rc!=SQLITE_OK ) goto fail;

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -7018,6 +7018,70 @@ static void run_rebase_upstream_history_failure_is_atomic(void){
   removeDbFiles(dbpath);
 }
 
+static void run_rebase_start_failure_cleans_working_branch(void){
+  sqlite3 *db = 0;
+  char dbpath[256];
+  const char *res;
+  u8 isRebasing = 0;
+
+  printf("=== Rebase Start Failure Cleans Working Branch Test ===\n\n");
+  make_dbpath(dbpath, sizeof(dbpath),
+              "test_rebase_start_failure_cleans_working_branch");
+  removeDbFiles(dbpath);
+
+  check("open_db_for_rebase_start_failure", open_db(dbpath, &db)==SQLITE_OK);
+  check("setup_repo_for_rebase_start_failure", execSql(db,
+    "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
+    "INSERT INTO t VALUES(1,'base');"
+    "SELECT dolt_commit('-A','-m','base');"
+    "SELECT dolt_checkout('-b','feat');"
+    "INSERT INTO t VALUES(2,'feat');"
+    "SELECT dolt_commit('-A','-m','feat');"
+    "SELECT dolt_checkout('main');"
+    "INSERT INTO t VALUES(3,'main');"
+    "SELECT dolt_commit('-A','-m','main');"
+    "SELECT dolt_checkout('feat');")==SQLITE_OK);
+
+  gRegressionFaultCode = 960;
+  gRegressionFaultHits = 0;
+  sqlite3_test_control(SQLITE_TESTCTRL_FAULT_INSTALL, regressionFaultCallback);
+  res = queryScalarText(db, "SELECT dolt_rebase('-i','main')");
+  sqlite3_test_control(SQLITE_TESTCTRL_FAULT_INSTALL, 0);
+  gRegressionFaultCode = 0;
+
+  check("rebase_start_failure_was_injected", gRegressionFaultHits==1);
+  check("rebase_start_failure_is_returned", strstr(res, "ERROR:")!=0);
+  check("rebase_start_failure_restores_branch",
+        strcmp(queryScalarText(db, "SELECT active_branch()"), "feat")==0);
+  check("rebase_start_failure_removes_working_branch",
+        strcmp(queryScalarText(db,
+          "SELECT count(*) FROM dolt_branches "
+          "WHERE name='dolt_rebase_feat'"), "0")==0);
+  check("rebase_start_failure_leaves_no_plan",
+        strcmp(queryScalarText(db,
+          "SELECT count(*) FROM sqlite_master "
+          "WHERE type='table' AND name='dolt_rebase'"), "0")==0);
+  doltliteGetSessionRebaseState(db, &isRebasing, 0, 0, 0, 0);
+  check("rebase_start_failure_clears_rebase_state", isRebasing==0);
+  check("rebase_start_failure_allows_retry",
+        strstr(queryScalarText(db, "SELECT dolt_rebase('-i','main')"),
+               "interactive rebase started")!=0);
+  check("rebase_start_failure_retry_can_abort",
+        strcmp(queryScalarText(db, "SELECT dolt_rebase('--abort')"),
+               "Interactive rebase aborted")==0);
+
+  sqlite3_close(db);
+  db = 0;
+  check("reopen_db_after_rebase_start_failure", open_db(dbpath, &db)==SQLITE_OK);
+  check("rebase_start_failure_persists_no_working_branch",
+        strcmp(queryScalarText(db,
+          "SELECT count(*) FROM dolt_branches "
+          "WHERE name='dolt_rebase_feat'"), "0")==0);
+
+  sqlite3_close(db);
+  removeDbFiles(dbpath);
+}
+
 static void run_rebase_recovery_failure_is_reported(void){
   sqlite3 *db = 0;
   char dbpath[256];
@@ -10265,6 +10329,7 @@ static const RegressionCase aCases[] = {
   { "rebase_abort_after_reopen_restores_durable_state", "Rebase Abort After Reopen Restores Durable State Test", run_rebase_abort_after_reopen_restores_durable_state },
   { "rebase_plan_read_error_is_not_partial", "Rebase Plan Read Error Is Not Partial Test", run_rebase_plan_read_error_is_not_partial },
   { "rebase_upstream_history_failure_is_atomic", "Rebase Upstream History Failure Is Atomic Test", run_rebase_upstream_history_failure_is_atomic },
+  { "rebase_start_failure_cleans_working_branch", "Rebase Start Failure Cleans Working Branch Test", run_rebase_start_failure_cleans_working_branch },
   { "rebase_recovery_failure_is_reported", "Rebase Recovery Failure Is Reported Test", run_rebase_recovery_failure_is_reported },
   { "rebase_continue_conflict_abort_restores_durable_state", "Rebase Continue Conflict Abort Restores Durable State Test", run_rebase_continue_conflict_abort_restores_durable_state },
   { "rebase_concurrent_peer_commit_is_preserved", "Rebase Concurrent Peer Commit Preservation Test", run_rebase_concurrent_peer_commit_is_preserved },


### PR DESCRIPTION
## Summary

- finish interactive-rebase cleanup when startup fails before the durable rebase flag is written
- remove the persisted temporary branch and plan instead of treating a missing active flag as completed cleanup
- retry the plan drop under lock contention
- add a deterministic fault-injection regression for the checkout-race window that failed before the fix

## Root cause

Interactive rebase persists `dolt_rebase_<branch>` before checking it out, but writes the durable rebase flag later. If a concurrent checkout makes that middle step fail, recovery reads the still-clear flag and used to return without deleting the already-persisted branch. Every subsequent retry then failed with `rebase working branch already exists`.

## Tests

- fail-before/pass-after `rebase_start_failure_cleans_working_branch` (12 assertions)
- 25 consecutive `multi_process_merge_rebase_test` runs
- `bash test/run_doltlite_tests.sh build/doltlite` (99/99 suites)
- `./build/doltlite_regression_test_c all` (310,223 assertions)
- `bash test/run_c_tests.sh build` (26/26 gated binaries)
- `make -C build lint`

Closes #2013

Co-Authored-By: OpenAI Codex <noreply@openai.com>