### PR TITLE
Say why the chunk classifier's order is load-bearing

### DIFF
--- a/src/doltlite_chunk_walk.c
+++ b/src/doltlite_chunk_walk.c
@@ -11,6 +11,9 @@
 
 #include <string.h>
 
+/* Strict on purpose: every length prefix is bounds-checked and the record has
+** to end exactly at nData. A V2 working set leads with the same tag byte, and
+** at one size the two are otherwise indistinguishable. */
 static int isCommitChunk(const u8 *data, int nData){
   const u8 *p = data;
   const u8 *pEnd = data + nData;
@@ -36,6 +39,21 @@ static int isCommitChunk(const u8 *data, int nData){
   return p == pEnd;
 }
 
+/* Chunk formats are told apart by a leading tag and a length, and two formats
+** can share both at some size: DOLTLITE_COMMIT_V2 and WS_FORMAT_VERSION_V2 are
+** each the byte 2, and a commit whose author, email and message total 46 bytes
+** serializes to exactly WS_TOTAL_SIZE_V2. The order below is therefore
+** load-bearing -- a check that can alias another has to either run first or be
+** strict enough to reject the impostor itself.
+**
+** Getting it wrong does not surface as a parse error. The walker keeps going
+** and reads the misread bytes as child hashes, so a healthy store reports
+** chunks it holds as missing, and the damage is permanent because the chunk is
+** history. Onset scales with commit rate, which makes it read as a concurrency
+** bug rather than a classification one.
+**
+** A new chunk format has to be checked against every existing tag and size,
+** not just the neighbouring ones. */
 DoltliteChunkType doltliteClassifyChunk(const u8 *data, int nData){
   u32 m;
 


### PR DESCRIPTION
Comment only, no behaviour change.

The `'D'` collision between the conflicts/constraint-violations blobs and
`CATALOG_FORMAT_V3` was already documented at the check that handles it. The
collision that actually cost a multi-week phantom-corruption hunt was not
written down anywhere in the source:

- `DOLTLITE_COMMIT_V2` and `WS_FORMAT_VERSION_V2` are both the byte `2`
- a commit whose author, email and message total 46 bytes serializes to exactly
  `WS_TOTAL_SIZE_V2`

so the working-set check claimed commits, and the walker went on to read commit
bytes as child hashes — a healthy store reporting chunks it holds as missing,
permanently, at a rate that scales with commit frequency and therefore reads as
a concurrency bug rather than a classification one.

`test/doltlite_gc_commit_classify.sh` proves the formats we have today do not
alias. What a test cannot do is tell whoever adds the *next* format to check
theirs against every existing tag and size — that is what this comment is for.
It also records why `isCommitChunk` bounds-checks every length prefix and
insists the record end exactly at `nData`, which otherwise looks like
belt-and-braces.

Per house style there are no issue numbers in the comment; the history is
`#1547` / PR #1559.

## Testing

- builds clean with `-Werror`
- `test/doltlite_gc_commit_classify.sh` — 9/9

🤖 Generated with [Claude Code](https://claude.com/claude-code)