### PR TITLE
Keep tables with a single PRIMARY KEY column named rowid in rowid form

### DIFF
--- a/src/build.c
+++ b/src/build.c
@@ -2796,6 +2796,11 @@ void sqlite3EndTable(
   **     bookkeeping etc. and don't have user PKs.
   **   - Stock SQLite btrees: their on-disk rowid table layout must be
   **     replayed exactly.
+  **   - A single-column PRIMARY KEY named "rowid": stock keeps such
+  **     tables in rowid form (the column shadows the alias), and
+  **     extensions like sqlite-vec rely on that shape for
+  **     sqlite3_blob_open, which refuses WITHOUT ROWID tables. The
+  **     cross-branch merge caveats of keyless tables apply.
   **
   ** Runs during sqlite_master replay (db->init.busy) as well as
   ** user-issued CREATE TABLE, because the stored CREATE TABLE statement
@@ -2814,7 +2819,11 @@ void sqlite3EndTable(
    && (p->tabFlags & TF_HasPrimaryKey)!=0
    && p->iPKey<0
    && (tabOpts & TF_WithoutRowid)==0 ){
-    tabOpts |= TF_WithoutRowid;
+    Index *pPk = sqlite3PrimaryKeyIndex(p);
+    if( !(pPk && pPk->nKeyCol==1 && pPk->aiColumn[0]>=0
+       && sqlite3StrICmp(p->aCol[pPk->aiColumn[0]].zCnName, "rowid")==0) ){
+      tabOpts |= TF_WithoutRowid;
+    }
   }
 
   /* Doltlite: dolt_ignore is a user-created system table whose

--- a/src/doltlite_merge_pass1.c
+++ b/src/doltlite_merge_pass1.c
@@ -119,7 +119,9 @@ static int mergePass1CollectIndexes(
 
   for(pIdx=pTab->pIndex; pIdx; pIdx=pIdx->pNext){
     struct TableEntry *oursIdx;
-    if( pIdx->idxType==SQLITE_IDXTYPE_PRIMARYKEY ) continue;
+    /* On WITHOUT ROWID tables the PK pseudo-index is the table tree itself;
+    ** on rowid tables it is a real unique index that merges like any other. */
+    if( pIdx->idxType==SQLITE_IDXTYPE_PRIMARYKEY && !HasRowid(pTab) ) continue;
     oursIdx = doltliteFindTableByNumber(c->aOurs, c->nOurs, pIdx->tnum);
     if( oursIdx ){
       MergeIndexInfo *mi = &aIdxInfo[nIdxInfo];

--- a/src/doltlite_workspace.c
+++ b/src/doltlite_workspace.c
@@ -558,8 +558,9 @@ static int wsApplyRowToStaged(WorkspaceVtab *p, WorkspaceRow *r, int makeStaged)
     for(pIdx=pTab->pIndex; pIdx && rc==SQLITE_OK; pIdx=pIdx->pNext){
       struct TableEntry *idxEntry;
       /* For WITHOUT ROWID tables the PK is exposed as a pseudo-index whose
-      ** root is the table tree itself; it is not a separate secondary index. */
-      if( pIdx->idxType==SQLITE_IDXTYPE_PRIMARYKEY ) continue;
+      ** root is the table tree itself; it is not a separate secondary index.
+      ** On rowid tables the PK is a real unique index and must be applied. */
+      if( pIdx->idxType==SQLITE_IDXTYPE_PRIMARYKEY && !HasRowid(pTab) ) continue;
       idxEntry = doltliteFindTableByNumber(aTables, nTables, pIdx->tnum);
       if( !idxEntry ) continue;
       rc = wsApplyRowToIndex(db, cs, pCache, idxEntry, pIdx, pTab->iPKey,

--- a/src/prolly_btree_mutation.c
+++ b/src/prolly_btree_mutation.c
@@ -1720,8 +1720,9 @@ int doltliteApplyRawRowMutation(
       int j;
       /* WITHOUT ROWID tables expose the PK as a pseudo-INDEX whose
       ** tnum equals the table's own root. Mutating it like a
-      ** secondary index would overwrite the table tree. Skip. */
-      if( pIdx->idxType==SQLITE_IDXTYPE_PRIMARYKEY ) continue;
+      ** secondary index would overwrite the table tree. Skip. On rowid
+      ** tables the PK is a real unique index and must be maintained. */
+      if( pIdx->idxType==SQLITE_IDXTYPE_PRIMARYKEY && !HasRowid(pTab) ) continue;
       for(j=0; j<pBtree->cat.n; j++){
         if( pBtree->cat.a[j].iTable==(Pgno)pIdx->tnum ){
           pIdxTE = &pBtree->cat.a[j];

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -9909,6 +9909,93 @@ static void run_incrblob_chunked_and_multihandle(void){
   removeDbFiles(dbpath);
 }
 
+/* A single-column PRIMARY KEY named "rowid" keeps stock rowid-table form
+** instead of the usual conversion to WITHOUT ROWID storage. sqlite-vec
+** declares its vector-chunk shadow tables exactly this way and then writes
+** them through sqlite3_blob_open, which refuses WITHOUT ROWID tables. The
+** PK becomes a real unique index on a rowid table — a shape prolly-side
+** index maintenance never saw before this exemption — so this also pins
+** uniqueness enforcement and index consistency across updates and commits. */
+static void run_rowid_named_pk_keeps_rowid_table(void){
+  char dbpath[512];
+  sqlite3 *db = 0;
+  sqlite3_blob *pBlob = 0;
+  char buf[32];
+  int rc;
+
+  printf("=== Rowid-Named PK Keeps Rowid Table Test ===\n\n");
+  make_dbpath(dbpath, sizeof(dbpath), "test_rowid_named_pk");
+  removeDbFiles(dbpath);
+
+  rc = sqlite3_open(dbpath, &db);
+  check("rowid_pk_open", rc==SQLITE_OK);
+  if( !db ) return;
+  check("rowid_pk_setup", execSql(db,
+      "CREATE TABLE vc(rowid PRIMARY KEY, vectors BLOB NOT NULL);"
+      "INSERT INTO vc VALUES(1, zeroblob(16384));")==SQLITE_OK);
+
+  check("rowid_pk_blob_open",
+        sqlite3_blob_open(db, "main", "vc", "vectors", 1, 1, &pBlob)==SQLITE_OK);
+  if( pBlob ){
+    check("rowid_pk_blob_write",
+          sqlite3_blob_write(pBlob, "VECTORDATA", 10, 4096)==SQLITE_OK);
+    check("rowid_pk_blob_close", sqlite3_blob_close(pBlob)==SQLITE_OK);
+    pBlob = 0;
+  }
+  check("rowid_pk_write_landed",
+        strcmp(queryScalarText(db,
+            "SELECT substr(vectors, 4097, 10) FROM vc WHERE rowid=1"),
+            "VECTORDATA")==0);
+
+  /* The PK is enforced through a real unique index, and that index is
+  ** maintained when the key column changes. */
+  check("rowid_pk_unique_enforced",
+        execSqlSilent(db, "INSERT INTO vc VALUES(1, x'00')")!=SQLITE_OK);
+  check("rowid_pk_index_exists",
+        strcmp(queryScalarText(db,
+            "SELECT count(*) FROM sqlite_master"
+            " WHERE name LIKE 'sqlite_autoindex_vc%'"), "1")==0);
+  check("rowid_pk_update_key", execSql(db,
+      "INSERT INTO vc VALUES(2, x'bb');"
+      "UPDATE vc SET rowid=7 WHERE rowid=2;")==SQLITE_OK);
+  check("rowid_pk_index_lookup",
+        strcmp(queryScalarText(db, "SELECT hex(vectors) FROM vc WHERE rowid=7"),
+               "BB")==0);
+  check("rowid_pk_integrity",
+        strcmp(queryScalarText(db, "PRAGMA integrity_check"), "ok")==0);
+
+  /* The shape survives version control: commit, branch, and read the blob
+  ** back on the old branch. */
+  check("rowid_pk_commit",
+        execSql(db, "SELECT dolt_commit('-A','-m','vc rows')")==SQLITE_OK);
+  check("rowid_pk_branch",
+        execSql(db, "SELECT dolt_checkout('-b','old')")==SQLITE_OK);
+  check("rowid_pk_back_to_main",
+        execSql(db, "SELECT dolt_checkout('main')")==SQLITE_OK);
+  check("rowid_pk_mutate_main",
+        execSql(db, "DELETE FROM vc WHERE rowid=7;"
+                    "SELECT dolt_commit('-A','-m','drop 7')")==SQLITE_OK);
+  check("rowid_pk_old_branch",
+        execSql(db, "SELECT dolt_checkout('old')")==SQLITE_OK);
+  memset(buf, 0, sizeof(buf));
+  rc = sqlite3_blob_open(db, "main", "vc", "vectors", 1, 0, &pBlob);
+  check("rowid_pk_old_branch_blob_open", rc==SQLITE_OK);
+  if( pBlob ){
+    check("rowid_pk_old_branch_blob_read",
+          sqlite3_blob_read(pBlob, buf, 10, 4096)==SQLITE_OK
+          && memcmp(buf, "VECTORDATA", 10)==0);
+    sqlite3_blob_close(pBlob);
+    pBlob = 0;
+  }
+  check("rowid_pk_old_branch_rows",
+        strcmp(queryScalarText(db, "SELECT count(*) FROM vc"), "2")==0);
+  check("rowid_pk_old_branch_integrity",
+        strcmp(queryScalarText(db, "PRAGMA integrity_check"), "ok")==0);
+
+  sqlite3_close(db);
+  removeDbFiles(dbpath);
+}
+
 /* The refs blob is untrusted (it comes from a .db file or a remote fetch).
 ** Each section reads a u32 count and allocates count*sizeof(struct); the count
 ** must be bounded by the smallest possible on-disk entry and the allocation
@@ -10442,6 +10529,7 @@ static const RegressionCase aCases[] = {
   { "prolly_diff_leaf_record_corruption", "Prolly Diff Leaf Corruption Test", run_prolly_diff_leaf_surfaces_record_corruption },
   { "incrblob_legacy_engine_write", "Incrblob Legacy Engine Write Test", run_incrblob_legacy_engine_write },
   { "incrblob_chunked_and_multihandle", "Incrblob Chunked Record And Multi-Handle Test", run_incrblob_chunked_and_multihandle },
+  { "rowid_named_pk_keeps_rowid_table", "Rowid-Named PK Keeps Rowid Table Test", run_rowid_named_pk_keeps_rowid_table },
   { "rollback_persist_failure_ends_txn", "Rollback Persist Failure Ends Write Txn Test", run_rollback_persist_failure_ends_txn }
 };
 


### PR DESCRIPTION
## Why

sqlite-vec's `vec0` virtual table declares its vector-chunk shadow tables as `CREATE TABLE ...(rowid PRIMARY KEY, vectors BLOB NOT NULL)` and writes vector data through `sqlite3_blob_open`. Doltlite converts every non-`INTEGER PRIMARY KEY` table to WITHOUT ROWID storage, and `sqlite3_blob_open` refuses WITHOUT ROWID tables, so every vec0 insert failed with `Error opening vector blob`. Stock SQLite keeps this shape in rowid form (the column shadows the alias), so any incrblob-using extension hits the same wall.

## What

- `sqlite3EndTable`: skip the WITHOUT ROWID conversion when the table's PRIMARY KEY is a single column named `rowid`. The decision is purely syntactic, so sqlite_master replay reaches the same classification. Such tables keep stock rowid semantics, including the keyless-table cross-branch caveats already documented at the conversion site.
- The exemption makes a `SQLITE_IDXTYPE_PRIMARYKEY` index possible on a rowid-backed prolly table (a real unique index, not the WITHOUT ROWID pseudo-index). Three loops skipped PK indexes unconditionally; they now skip only when the table is actually WITHOUT ROWID, so the PK index is maintained through row mutation (`prolly_btree_mutation.c`), catalog merge (`doltlite_merge_pass1.c`), and workspace application (`doltlite_workspace.c`).

## Testing

- New regression case `rowid_named_pk_keeps_rowid_table`: blob_open + write + readback on the sqlite-vec shadow shape, uniqueness enforcement, autoindex existence and lookup after a key update, integrity_check, and a commit/branch/checkout roundtrip reading the blob on the old branch. Fails 4/17 on unfixed code (blob_open, write landing, autoindex existence — the exempted behaviors), passes 20/20 with the fix.
- Full regression c-test suite: 310250/310250.
- Shell battery: 99/99 suites.
- Manually verified stock sqlite-vec v0.1.6 (unpatched) end to end: create/insert/KNN/update/delete, dolt_commit, branch, checkout, historical KNN, `PRAGMA integrity_check` ok under `DOLTLITE_PROLLY_CHECK=1`, and vec0 KNN results identical to brute-force distance ranking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)