### PR TITLE
Carry virtual-table schema rows through the merged catalog rebuild

### DIFF
--- a/src/doltlite_merge.c
+++ b/src/doltlite_merge.c
@@ -897,7 +897,12 @@ static int appendMergedAuxSchemaRow(
                            aConflictTables, nConflictTables,
                            zName);
   if( !pSe || !pSe->zType || !pSe->zName ) return SQLITE_OK;
-  if( strcmp(pSe->zType, "table")==0 || strcmp(pSe->zType, "index")==0 ){
+  /* Storage-backed tables are appended from the merged catalog entries and
+  ** indexes from the index passes. Virtual tables have no catalog entry —
+  ** their storage is the shadow tables — so their schema rows (type "table",
+  ** rootpage 0) ride with the storage-free objects here. */
+  if( strcmp(pSe->zType, "index")==0 ) return SQLITE_OK;
+  if( strcmp(pSe->zType, "table")==0 && pSe->iRootpage!=0 ){
     return SQLITE_OK;
   }
 

--- a/test/doltlite_index_vc_matrix.sh
+++ b/test/doltlite_index_vc_matrix.sh
@@ -335,6 +335,77 @@ check "vtab_clone" "0
 2
 ok" "$result"
 
+# ── vtab schema rows through three-way merge ─────────────────────
+# Virtual tables have no catalog entry (their storage is the shadow
+# tables), so the merged sqlite_master rebuild must carry their schema
+# rows explicitly or every real merge silently drops the vtab.
+scenario "vtab survives clean three-way merge"
+newdb
+run_sql "CREATE VIRTUAL TABLE ft USING fts5(body); INSERT INTO ft VALUES('base doc');
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'a');
+SELECT dolt_commit('-Am','base');
+SELECT dolt_checkout('-b','side'); INSERT INTO t VALUES(2,'s'); SELECT dolt_commit('-am','side');
+SELECT dolt_checkout('main'); INSERT INTO t VALUES(3,'m'); SELECT dolt_commit('-am','main');
+SELECT dolt_merge('side');" "$DB" > /dev/null
+result=$(run_sql "SELECT count(*) FROM sqlite_master WHERE name='ft';
+SELECT count(*) FROM ft WHERE ft MATCH 'doc';
+SELECT count(*) FROM t; PRAGMA integrity_check;" "$DB")
+check "vtab_clean_merge" "1
+1
+3
+ok" "$result"
+
+scenario "vtab survives conflicted merge and resolve"
+newdb
+run_sql "CREATE VIRTUAL TABLE ft USING fts5(body); INSERT INTO ft VALUES('base doc');
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'a');
+SELECT dolt_commit('-Am','base');
+SELECT dolt_checkout('-b','side'); UPDATE t SET v='s' WHERE id=1; SELECT dolt_commit('-am','side');
+SELECT dolt_checkout('main'); UPDATE t SET v='m' WHERE id=1; SELECT dolt_commit('-am','main');" "$DB" > /dev/null
+result=$(run_sql "BEGIN;
+SELECT dolt_merge('side');
+SELECT count(*) FROM sqlite_master WHERE name='ft';
+SELECT dolt_conflicts_resolve('--theirs','t');
+SELECT length(dolt_commit('-Am','resolved'))=40;
+SELECT count(*) FROM sqlite_master WHERE name='ft';" "$DB" | grep -v "^Error")
+check "vtab_conflicted_merge" "1
+0
+1
+1" "$result"
+result=$(run_sql "SELECT count(*) FROM sqlite_master WHERE name='ft';
+SELECT count(*) FROM ft WHERE ft MATCH 'doc'; PRAGMA integrity_check;" "$DB")
+check "vtab_conflicted_merge_reopen" "1
+1
+ok" "$result"
+
+scenario "vtab added on a branch is adopted by merge"
+newdb
+run_sql "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'a');
+SELECT dolt_commit('-Am','base');
+SELECT dolt_checkout('-b','side');
+CREATE VIRTUAL TABLE ft USING fts5(body); INSERT INTO ft VALUES('side doc');
+SELECT dolt_commit('-Am','side adds ft');
+SELECT dolt_checkout('main'); INSERT INTO t VALUES(2,'m'); SELECT dolt_commit('-am','main');
+SELECT dolt_merge('side');" "$DB" > /dev/null
+result=$(run_sql "SELECT count(*) FROM sqlite_master WHERE name='ft';
+SELECT count(*) FROM ft WHERE ft MATCH 'doc'; PRAGMA integrity_check;" "$DB")
+check "vtab_merge_adopt" "1
+1
+ok" "$result"
+
+scenario "vtab dropped on a branch stays dropped after merge"
+newdb
+run_sql "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'a');
+CREATE VIRTUAL TABLE ft USING fts5(body); INSERT INTO ft VALUES('doomed doc');
+SELECT dolt_commit('-Am','base');
+SELECT dolt_checkout('-b','side'); DROP TABLE ft; SELECT dolt_commit('-Am','side drops ft');
+SELECT dolt_checkout('main'); INSERT INTO t VALUES(2,'m'); SELECT dolt_commit('-am','main');
+SELECT dolt_merge('side');" "$DB" > /dev/null
+result=$(run_sql "SELECT count(*) FROM sqlite_master WHERE name LIKE 'ft%';
+PRAGMA integrity_check;" "$DB")
+check "vtab_merge_drop_wins" "0
+ok" "$result"
+
 echo ""
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"
 if [ $FAIL -gt 0 ]; then


### PR DESCRIPTION
## Why

Any true three-way merge in a database containing a virtual table (fts3/4/5, rtree, or an extension vtab like sqlite-vec) silently dropped the `CREATE VIRTUAL TABLE` row from the merged schema while keeping the shadow tables. A clean merge lost the vtab permanently in the merge commit; a conflicted merge lost it from the live schema, and resolving + committing persisted the loss. Found while testing sqlite-vec vector-index versioning; reproduces with plain fts5 and no extensions.

## What

The merged sqlite_master rebuild emits rows from three sources: merged catalog entries (storage-backed tables), the index passes, and the aux-object passes (views, triggers). Virtual tables fell through every net: no catalog entry (their storage is the shadow tables), and schema type "table" excluded them from the aux pass. The aux pass now accepts storage-free table rows — type "table" with rootpage 0, the virtual-table signature — while still excluding storage-backed tables (rootpage ≥ 3) that the catalog pass covers.

The existing anc/ours/theirs union enumeration gives the right semantics for free: a vtab created on one branch is adopted (its shadow tables already arrive through catalog pass 2), and a vtab dropped on one branch stays dropped.

## Testing

- Four new scenarios in `test/doltlite_index_vc_matrix.sh` (which had vtab staging/checkout/clone coverage but no vtab-under-merge scenario): clean merge, conflicted merge + resolve + reopen, branch-added adoption, branch-drop-wins. All four fail on unfixed code (41/45), all pass with the fix (45/45).
- Full regression c-test suite: 310230/310230.
- Shell battery: 99/99 suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)