### PR TITLE
Seal the enclosing transaction when a clean merge advances the ref

### DIFF
--- a/src/doltlite_core.c
+++ b/src/doltlite_core.c
@@ -800,6 +800,19 @@ int doltliteVcSealActiveSavepoints(sqlite3 *db){
   return rc;
 }
 
+/* End the enclosing SQL transaction after a ref advance, the same boundary
+** dolt_commit draws. Releasing savepoints alone leaves a plain BEGIN open,
+** and a later ROLLBACK then reverts the working set while the advanced ref
+** stays, splitting HEAD from the data. */
+int doltliteVcSealEnclosingTxn(sqlite3 *db){
+  if( !db->autoCommit
+   || sqlite3_txn_state(db, "main")!=SQLITE_TXN_NONE
+   || db->pSavepoint ){
+    return sqlite3_exec(db, "COMMIT", 0, 0, 0);
+  }
+  return SQLITE_OK;
+}
+
 int doltliteVcSealSavepointError(sqlite3 *db){
   if( db->pSavepoint ){
     return doltliteVcSealActiveSavepoints(db);

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -1220,6 +1220,7 @@ int doltliteCheckoutBranchForRebaseWithOldCatalog(
 );
 DoltliteVcTxnMode doltliteVcTxnMode(sqlite3 *db);
 int doltliteVcSealActiveSavepoints(sqlite3 *db);
+int doltliteVcSealEnclosingTxn(sqlite3 *db);
 int doltliteVcSealSavepointError(sqlite3 *db);
 void doltliteVcResultError(sqlite3_context *ctx, sqlite3 *db, const char *zMsg);
 int doltliteVcSealBranchStyleTxn(sqlite3 *db);

--- a/src/doltlite_merge_cmd.c
+++ b/src/doltlite_merge_cmd.c
@@ -80,7 +80,7 @@ int mergeFastForward(
         doltliteRestoreTxnStateOnFailure(db, &savedState, rc));
     return rc;
   }
-  rc = doltliteVcSealActiveSavepoints(db);
+  rc = doltliteVcSealEnclosingTxn(db);
   if( rc!=SQLITE_OK ){
     doltliteCommitClear(&theirCommit);
     sqlite3_result_error_code(context, rc);
@@ -310,7 +310,7 @@ static int mergeRefCreateMergeCommit(
         doltliteRestoreTxnStateOnFailure(db, pSaved, rc));
     return SQLITE_ERROR;
   }
-  rc = doltliteVcSealActiveSavepoints(db);
+  rc = doltliteVcSealEnclosingTxn(db);
   if( rc!=SQLITE_OK ){
     sqlite3_result_error_code(context, rc);
     return SQLITE_ERROR;

--- a/test/doltlite_merge.sh
+++ b/test/doltlite_merge.sh
@@ -432,5 +432,57 @@ run_test "many_fk_violations_autocommit_rolled_back" \
 run_test "many_fk_violations_parent_restored" \
   "SELECT count(*) FROM parent;" "0" "$DB23"
 
-rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8" "$DB8B" "$DB9" "$DB10" "$DB11" "$DB11D" "$DB11E" "$DB11F" "$DB12" "$DB13" "$DB14" "$DB15" "$DB16" "$DB17" "$DB18" "$DB19" "$DB20" "$DB20B" "$DB21" "$DB22" "$DB23"
+# A clean merge is a transaction boundary like dolt_commit: it seals the
+# enclosing BEGIN when it advances the ref. Leaving the transaction open let
+# a later ROLLBACK revert the working set while the advanced ref stayed,
+# splitting HEAD from the data.
+DB24=/tmp/test_merge24_$$.db; rm -f "$DB24"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'a');
+SELECT dolt_commit('-A','-m','base');
+SELECT dolt_checkout('-b','feat'); INSERT INTO t VALUES(2,'b'); SELECT dolt_commit('-A','-m','feat');
+SELECT dolt_checkout('main'); INSERT INTO t VALUES(3,'c'); SELECT dolt_commit('-A','-m','main');" | $DOLTLITE "$DB24" > /dev/null 2>&1
+TX_OUT=$(echo "BEGIN;
+SELECT dolt_merge('feat');
+ROLLBACK;
+SELECT 'TX|' || (SELECT message FROM dolt_log LIMIT 1) || '|' || (SELECT count(*) FROM t) || '|' || (SELECT count(*) FROM dolt_status);" | $DOLTLITE "$DB24" 2>&1)
+TX_LINE=$(echo "$TX_OUT" | grep '^TX|')
+if [ "$TX_LINE" = "TX|Merge branch 'feat' into main|3|0" ]; then
+  PASS=$((PASS+1))
+else
+  FAIL=$((FAIL+1))
+  ERRORS="$ERRORS\nFAIL: clean_merge_in_txn_seals\n  expected: TX|Merge branch 'feat' into main|3|0\n  got:      $TX_LINE"
+fi
+echo "$TX_OUT" | grep -q "cannot rollback - no transaction is active"
+if [ $? -eq 0 ]; then
+  PASS=$((PASS+1))
+else
+  FAIL=$((FAIL+1))
+  ERRORS="$ERRORS\nFAIL: clean_merge_in_txn_rollback_refused\n  expected the post-merge ROLLBACK to find no open transaction"
+fi
+
+DB25=/tmp/test_merge25_$$.db; rm -f "$DB25"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'a');
+SELECT dolt_commit('-A','-m','base');
+SELECT dolt_checkout('-b','feat'); INSERT INTO t VALUES(2,'b'); SELECT dolt_commit('-A','-m','feat');
+SELECT dolt_checkout('main');" | $DOLTLITE "$DB25" > /dev/null 2>&1
+TX_OUT=$(echo "BEGIN;
+SELECT dolt_merge('feat');
+ROLLBACK;
+SELECT 'TX|' || (SELECT message FROM dolt_log LIMIT 1) || '|' || (SELECT count(*) FROM t) || '|' || (SELECT count(*) FROM dolt_status);" | $DOLTLITE "$DB25" 2>&1)
+TX_LINE=$(echo "$TX_OUT" | grep '^TX|')
+if [ "$TX_LINE" = "TX|feat|2|0" ]; then
+  PASS=$((PASS+1))
+else
+  FAIL=$((FAIL+1))
+  ERRORS="$ERRORS\nFAIL: ff_merge_in_txn_seals\n  expected: TX|feat|2|0\n  got:      $TX_LINE"
+fi
+echo "$TX_OUT" | grep -q "cannot rollback - no transaction is active"
+if [ $? -eq 0 ]; then
+  PASS=$((PASS+1))
+else
+  FAIL=$((FAIL+1))
+  ERRORS="$ERRORS\nFAIL: ff_merge_in_txn_rollback_refused\n  expected the post-merge ROLLBACK to find no open transaction"
+fi
+
+rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8" "$DB8B" "$DB9" "$DB10" "$DB11" "$DB11D" "$DB11E" "$DB11F" "$DB12" "$DB13" "$DB14" "$DB15" "$DB16" "$DB17" "$DB18" "$DB19" "$DB20" "$DB20B" "$DB21" "$DB22" "$DB23" "$DB24" "$DB25"
 dltest_finish


### PR DESCRIPTION
## Why

`BEGIN; SELECT dolt_merge('feat'); ROLLBACK;` left the database split: the branch ref stayed advanced (ref updates are durable) while the working set rolled back to its pre-merge contents, so HEAD and the data silently disagreed and `dolt_status` reported phantom changes. Both the fast-forward and clean three-way paths were affected.

Dolt establishes the contract empirically: `DOLT_MERGE`, like `DOLT_COMMIT`, implicitly commits the enclosing transaction, ending with ref and data consistent. doltlite's `dolt_commit` already does this (it runs `COMMIT` before advancing the ref); the merge success paths only released savepoints and never committed a plain `BEGIN`.

## What

New helper `doltliteVcSealEnclosingTxn` ends the enclosing SQL transaction using the same condition `dolt_commit` uses, and both merge success paths (`mergeFastForward`, `mergeRefCreateMergeCommit`) call it after advancing the ref, replacing the savepoint-only seal. After a clean merge, a subsequent `ROLLBACK` now reports "cannot rollback - no transaction is active" — identical to the behavior after `dolt_commit`.

Unchanged by design:
- Conflicted and constraint-violation merges keep the transaction open so the caller can inspect `dolt_conflicts`, resolve, and `dolt_commit`; `ROLLBACK` still restores the pre-merge state (covered by existing suite scenarios).
- `dolt_pull`'s fast-forward path already seals via `doltliteVcSealBranchStyleTxn`; its true-merge path delegates to `doltliteMergeRef` and inherits this fix.

## Testing

- Two new scenarios in `test/doltlite_merge.sh`: clean three-way and fast-forward merge inside `BEGIN`, asserting the post-merge `ROLLBACK` finds no open transaction, HEAD is the merged commit, table contents match HEAD, and `dolt_status` is clean. 3 of the 4 checks fail on unfixed code (104/107), all pass with the fix (107/107).
- Full regression c-test suite: 310230/310230.
- Shell battery: 99/99 suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)