### PR TITLE
Support table-level checkout of virtual tables

### DIFF
--- a/src/doltlite_checkout.c
+++ b/src/doltlite_checkout.c
@@ -661,6 +661,93 @@ static void checkoutAdoptSourceIndexRoots(
   }
 }
 
+/* Virtual tables persist through their shadow tables: a table-level
+** checkout of a vtab must swap the shadows' catalog entries, the same way
+** staging carries them. The vtab's own master row is schema-only and is
+** handled by the schema pass; when that pass rebuilt the vtab, the live
+** shadows are fresh trees whose table numbers must be kept while their
+** content roots adopt the source. */
+static int checkoutAdoptVtabShadows(
+  sqlite3 *db,
+  struct TableEntry **paWorking, int *pnWorking,
+  struct TableEntry *aSource, int nSource,
+  SchemaEntry *aWorkSchema, int nWorkSchema,
+  SchemaEntry *aSourceSchema, int nSourceSchema,
+  const char *zVtab,
+  int vtabRebuilt
+){
+  Table *pTab = sqlite3FindTable(db, zVtab, "main");
+  SchemaEntry *aList[2];
+  int aN[2];
+  int pass, i, j;
+
+  if( !pTab || !IsVirtual(pTab) ) return SQLITE_OK;
+  aList[0] = aSourceSchema; aN[0] = nSourceSchema;
+  aList[1] = aWorkSchema;   aN[1] = nWorkSchema;
+
+  for(pass=0; pass<2; pass++){
+    for(i=0; i<aN[pass]; i++){
+      const char *zName = aList[pass][i].zName;
+      int srcIdx = -1, workIdx = -1;
+      if( !zName || !aList[pass][i].zType
+       || strcmp(aList[pass][i].zType, "table")!=0
+       || strcmp(zName, zVtab)==0
+       || !sqlite3IsShadowTableOf(db, pTab, zName) ){
+        continue;
+      }
+      if( pass==1 && findSchemaEntry(aSourceSchema, nSourceSchema, zName) ){
+        continue;  /* already handled from the source list */
+      }
+      for(j=0; j<nSource; j++){
+        if( aSource[j].zName && strcmp(aSource[j].zName, zName)==0 ){
+          srcIdx = j; break;
+        }
+      }
+      for(j=0; j<*pnWorking; j++){
+        if( (*paWorking)[j].zName && strcmp((*paWorking)[j].zName, zName)==0 ){
+          workIdx = j; break;
+        }
+      }
+      if( srcIdx<0 && workIdx<0 ) continue;
+
+      if( srcIdx<0 ){
+        sqlite3_free((*paWorking)[workIdx].zName);
+        if( workIdx+1<*pnWorking ){
+          memmove(&(*paWorking)[workIdx], &(*paWorking)[workIdx+1],
+                  (*pnWorking-workIdx-1)*(int)sizeof(struct TableEntry));
+        }
+        (*pnWorking)--;
+      }else if( workIdx<0 ){
+        struct TableEntry *aNew = sqlite3_realloc(*paWorking,
+            (*pnWorking+1)*(int)sizeof(struct TableEntry));
+        char *zDup;
+        if( !aNew ) return SQLITE_NOMEM;
+        *paWorking = aNew;
+        zDup = sqlite3_mprintf("%s", zName);
+        if( !zDup ) return SQLITE_NOMEM;
+        (*paWorking)[*pnWorking] = aSource[srcIdx];
+        (*paWorking)[*pnWorking].zName = zDup;
+        (*pnWorking)++;
+      }else{
+        char *zDup = sqlite3_mprintf("%s", zName);
+        Pgno iCurrentTable = (*paWorking)[workIdx].iTable;
+        if( !zDup ) return SQLITE_NOMEM;
+        sqlite3_free((*paWorking)[workIdx].zName);
+        (*paWorking)[workIdx] = aSource[srcIdx];
+        if( vtabRebuilt ){
+          (*paWorking)[workIdx].iTable = iCurrentTable;
+        }
+        (*paWorking)[workIdx].zName = zDup;
+      }
+      checkoutAdoptSourceIndexRoots(*paWorking, *pnWorking,
+                                    aWorkSchema, nWorkSchema,
+                                    aSource, nSource,
+                                    aSourceSchema, nSourceSchema, zName);
+    }
+  }
+  return SQLITE_OK;
+}
+
 static int doltliteCheckoutTables(
   sqlite3 *db,
   const char *zSourceRef,
@@ -718,8 +805,26 @@ static int doltliteCheckoutTables(
         }
       }
       if( srcIdx<0 ){
-        doltliteFreeCatalog(aSource, nSource);
-        return SQLITE_NOTFOUND;
+        /* Virtual tables have no catalog entry — their storage is the
+        ** shadow tables — so a vtab name is validated against the source
+        ** schema instead. */
+        int hasVtab = 0;
+        char *zSql = 0;
+        rc = checkoutLoadSourceTableSql(db, aSource, nSource, zName,
+                                        &hasVtab, &zSql);
+        if( rc==SQLITE_OK && hasVtab && zSql
+         && sqlite3_strnicmp(zSql, "CREATE VIRTUAL", 14)!=0 ){
+          hasVtab = 0;
+        }
+        sqlite3_free(zSql);
+        if( rc!=SQLITE_OK ){
+          doltliteFreeCatalog(aSource, nSource);
+          return rc;
+        }
+        if( !hasVtab ){
+          doltliteFreeCatalog(aSource, nSource);
+          return SQLITE_NOTFOUND;
+        }
       }
     }
   }
@@ -832,6 +937,15 @@ static int doltliteCheckoutTables(
       if( aSchema[i].rebuilt && !aSchema[i].hasSource ){
         continue;
       }
+      /* A virtual table never has a catalog entry of its own; its schema
+      ** row was handled by the schema pass above and its content rides in
+      ** the shadow entries adopted below. */
+      if( (aSchema[i].hasSource && aSchema[i].zSourceSql
+           && sqlite3_strnicmp(aSchema[i].zSourceSql, "CREATE VIRTUAL", 14)==0)
+       || (aSchema[i].hasCurrent && aSchema[i].zCurrentSql
+           && sqlite3_strnicmp(aSchema[i].zCurrentSql, "CREATE VIRTUAL", 14)==0) ){
+        continue;
+      }
       freeSchemaEntries(aSourceSchema, nSourceSchema);
       checkoutSchemaInfoClear(aSchema, nNames);
       doltliteFreeCatalog(aWorking, nWorking);
@@ -908,6 +1022,19 @@ static int doltliteCheckoutTables(
                                   aWorkSchema, nWorkSchema,
                                   aSource, nSource,
                                   aSourceSchema, nSourceSchema, zName);
+    rc = checkoutAdoptVtabShadows(db, &aWorking, &nWorking,
+                                  aSource, nSource,
+                                  aWorkSchema, nWorkSchema,
+                                  aSourceSchema, nSourceSchema,
+                                  zName, aSchema[i].rebuilt);
+    if( rc!=SQLITE_OK ){
+      freeSchemaEntries(aSourceSchema, nSourceSchema);
+      freeSchemaEntries(aWorkSchema, nWorkSchema);
+      checkoutSchemaInfoClear(aSchema, nNames);
+      doltliteFreeCatalog(aWorking, nWorking);
+      doltliteFreeCatalog(aSource, nSource);
+      return rc;
+    }
   }
 
   {

--- a/test/doltlite_index_vc_matrix.sh
+++ b/test/doltlite_index_vc_matrix.sh
@@ -406,6 +406,56 @@ PRAGMA integrity_check;" "$DB")
 check "vtab_merge_drop_wins" "0
 ok" "$result"
 
+# ── table-level checkout of virtual tables ───────────────────────
+# Vtabs have no catalog entry (their storage is the shadow tables), so
+# name-based checkout must accept the vtab through its schema row and
+# swap the shadow entries the way staging carries them.
+scenario "table checkout discards working vtab changes"
+newdb
+run_sql "CREATE VIRTUAL TABLE ft USING fts5(body); INSERT INTO ft VALUES('one doc');
+SELECT dolt_commit('-Am','base');" "$DB" > /dev/null
+result=$(run_sql "INSERT INTO ft VALUES('two doc'); SELECT dolt_checkout('ft');
+SELECT count(*) FROM ft WHERE ft MATCH 'doc';
+INSERT INTO ft(ft) VALUES('integrity-check'); SELECT 'ftok'; PRAGMA integrity_check;" "$DB")
+check "vtab_table_checkout_discard" "0
+1
+ftok
+ok" "$result"
+
+scenario "table checkout of a vtab from another branch"
+newdb
+run_sql "CREATE VIRTUAL TABLE ft USING fts5(body); INSERT INTO ft VALUES('one doc');
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'a');
+SELECT dolt_commit('-Am','base');
+SELECT dolt_checkout('-b','side');
+INSERT INTO ft VALUES('two doc'); INSERT INTO t VALUES(2,'s');
+SELECT dolt_commit('-am','side');
+SELECT dolt_checkout('main');
+SELECT dolt_checkout('side','ft');" "$DB" > /dev/null
+result=$(run_sql "SELECT count(*) FROM ft WHERE ft MATCH 'doc';
+SELECT count(*) FROM t;
+INSERT INTO ft(ft) VALUES('integrity-check'); SELECT 'ftok'; PRAGMA integrity_check;" "$DB")
+check "vtab_table_checkout_from_branch" "2
+1
+ftok
+ok" "$result"
+
+scenario "table checkout restores a dropped vtab from history"
+newdb
+run_sql "CREATE VIRTUAL TABLE ft USING fts5(body); INSERT INTO ft VALUES('one doc');
+CREATE VIRTUAL TABLE rt USING rtree(id, x1, x2); INSERT INTO rt VALUES(1, 0.0, 1.0);
+SELECT dolt_commit('-Am','base');
+DROP TABLE ft; DROP TABLE rt;
+SELECT dolt_commit('-Am','drop both');
+SELECT dolt_checkout('HEAD~1','ft','rt');" "$DB" > /dev/null
+result=$(run_sql "SELECT count(*) FROM ft WHERE ft MATCH 'doc';
+SELECT rtreecheck('main','rt');
+INSERT INTO ft(ft) VALUES('integrity-check'); SELECT 'ftok'; PRAGMA integrity_check;" "$DB")
+check "vtab_table_checkout_restore_dropped" "1
+ok
+ftok
+ok" "$result"
+
 echo ""
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"
 if [ $FAIL -gt 0 ]; then


### PR DESCRIPTION
## Why

Every table-level `dolt_checkout` form failed on a virtual table with "no such branch or table":

- `SELECT dolt_checkout('ft')` — discard working changes to an fts table
- `SELECT dolt_checkout('side','ft')` — pull one table's state from another branch
- `SELECT dolt_checkout('HEAD~1','ft')` — restore a dropped vtab from history

Found by the new vtab×VC battery (separate PR). Loud failure, no corruption — but these workflows were impossible for fts3/4/5, rtree, and extension vtabs.

## What

`doltliteCheckoutTables` resolves names against catalog `TableEntry`s, and virtual tables have none — their schema row is storage-free (rootpage 0) and their content lives in the shadow tables. Three changes in `src/doltlite_checkout.c`:

- Validation accepts a name whose source schema row is a `CREATE VIRTUAL TABLE` statement.
- The catalog-entry swap skips the vtab's own name — the existing schema pass already handles the drop/recreate of the vtab row itself.
- New `checkoutAdoptVtabShadows` swaps the shadow tables' catalog entries from the source, mirroring how staging carries shadows (`sqlite3IsShadowTableOf` over the source and working schema lists). When the schema pass rebuilt the vtab, the live shadows are fresh trees, so their table numbers are kept while the content roots adopt the source — the same discipline the plain-table rebuilt path uses.

## Testing

- Three new scenarios in `test/doltlite_index_vc_matrix.sh` (discard, cross-branch, restore-dropped; fts5 + rtree with module self-checks). All three fail on unfixed master (40/43), all pass with the fix (43/43).
- Full regression c-test suite: 310230/310230.
- Shell battery: 99/99 suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)