### PR TITLE
Reconcile named indexes on shadow tables through vtab checkout

### DIFF
--- a/src/doltlite_checkout.c
+++ b/src/doltlite_checkout.c
@@ -636,18 +636,39 @@ static int checkoutReconcileVtabShadowIndexes(
   const char *zVtab
 ){
   Table *pTab = sqlite3FindTable(db, zVtab, "main");
+  char **azShadow = 0;
+  int nShadow = 0;
   int i, rc = SQLITE_OK;
+
   if( !pTab || !IsVirtual(pTab) ) return SQLITE_OK;
-  for(i=0; i<nSourceSchema && rc==SQLITE_OK; i++){
+
+  /* Collect the shadow names before reconciling anything: the reconcile
+  ** below runs DROP/CREATE INDEX, and that schema reset frees pTab out
+  ** from under sqlite3IsShadowTableOf. */
+  for(i=0; i<nSourceSchema; i++){
+    char **azNew;
+    char *zDup;
     if( !aSourceSchema[i].zName || !aSourceSchema[i].zType
      || strcmp(aSourceSchema[i].zType, "table")!=0
      || strcmp(aSourceSchema[i].zName, zVtab)==0
      || !sqlite3IsShadowTableOf(db, pTab, aSourceSchema[i].zName) ){
       continue;
     }
-    rc = checkoutReconcileTableIndexes(db, aSourceSchema, nSourceSchema,
-                                       aSourceSchema[i].zName);
+    azNew = sqlite3_realloc(azShadow, (nShadow+1)*(int)sizeof(char*));
+    zDup = azNew ? sqlite3_mprintf("%s", aSourceSchema[i].zName) : 0;
+    if( azNew ) azShadow = azNew;
+    if( !azNew || !zDup ){
+      doltliteFreeNameList(azShadow, nShadow);
+      return SQLITE_NOMEM;
+    }
+    azShadow[nShadow++] = zDup;
   }
+
+  for(i=0; i<nShadow && rc==SQLITE_OK; i++){
+    rc = checkoutReconcileTableIndexes(db, aSourceSchema, nSourceSchema,
+                                       azShadow[i]);
+  }
+  doltliteFreeNameList(azShadow, nShadow);
   return rc;
 }
 

--- a/src/doltlite_checkout.c
+++ b/src/doltlite_checkout.c
@@ -624,6 +624,33 @@ static int checkoutReconcileTableIndexes(
   return SQLITE_OK;
 }
 
+/* Named indexes on a virtual table's shadow tables need the same DDL
+** reconcile as the requested table's own indexes: the shadow-entry
+** adoption below only swaps storage roots, so a working-only index would
+** survive pointing at a tree that no longer matches the adopted rows, and
+** a source-only index would never be created. */
+static int checkoutReconcileVtabShadowIndexes(
+  sqlite3 *db,
+  SchemaEntry *aSourceSchema,
+  int nSourceSchema,
+  const char *zVtab
+){
+  Table *pTab = sqlite3FindTable(db, zVtab, "main");
+  int i, rc = SQLITE_OK;
+  if( !pTab || !IsVirtual(pTab) ) return SQLITE_OK;
+  for(i=0; i<nSourceSchema && rc==SQLITE_OK; i++){
+    if( !aSourceSchema[i].zName || !aSourceSchema[i].zType
+     || strcmp(aSourceSchema[i].zType, "table")!=0
+     || strcmp(aSourceSchema[i].zName, zVtab)==0
+     || !sqlite3IsShadowTableOf(db, pTab, aSourceSchema[i].zName) ){
+      continue;
+    }
+    rc = checkoutReconcileTableIndexes(db, aSourceSchema, nSourceSchema,
+                                       aSourceSchema[i].zName);
+  }
+  return rc;
+}
+
 /* Point the freshly flushed working catalog's index entries for zTable at
 ** the source's trees. Each side is resolved through its OWN schema rows
 ** (index entries are unnamed, so name-keyed overlays cannot see them), and
@@ -891,6 +918,9 @@ static int doltliteCheckoutTables(
     }
     if( aSchema[i].hasSource ){
       rc = checkoutReconcileTableIndexes(db, aSourceSchema, nSourceSchema, zName);
+      if( rc!=SQLITE_OK ) break;
+      rc = checkoutReconcileVtabShadowIndexes(db, aSourceSchema, nSourceSchema,
+                                              zName);
       if( rc!=SQLITE_OK ) break;
     }
   }

--- a/test/doltlite_index_vc_matrix.sh
+++ b/test/doltlite_index_vc_matrix.sh
@@ -440,6 +440,24 @@ check "vtab_table_checkout_from_branch" "2
 ftok
 ok" "$result"
 
+scenario "named indexes on shadow tables reconcile through vtab checkout"
+newdb
+run_sql "CREATE VIRTUAL TABLE ft USING fts5(body); INSERT INTO ft VALUES('one doc');
+CREATE INDEX live_only ON ft_content(c0);
+SELECT dolt_commit('-Am','base');
+SELECT dolt_checkout('-b','source');
+DROP INDEX live_only; CREATE INDEX source_only ON ft_content(c0);
+INSERT INTO ft VALUES('two doc');
+SELECT dolt_commit('-Am','source reindexed');
+SELECT dolt_checkout('main');
+SELECT dolt_checkout('source','ft');" "$DB" > /dev/null
+result=$(run_sql "SELECT group_concat(name) FROM (SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='ft_content' ORDER BY name);
+SELECT count(*) FROM ft WHERE ft MATCH 'doc';
+PRAGMA integrity_check;" "$DB")
+check "vtab_shadow_index_reconcile" "source_only
+2
+ok" "$result"
+
 scenario "table checkout restores a dropped vtab from history"
 newdb
 run_sql "CREATE VIRTUAL TABLE ft USING fts5(body); INSERT INTO ft VALUES('one doc');


### PR DESCRIPTION
## Why

Ito's post-merge testing of #2023 found that a table-level checkout of a virtual table leaves named indexes **on its shadow tables** unreconciled (CATALOG-3). Reproduced exactly: `CREATE INDEX live_only ON ft_content(...)`, branch swaps it for `source_only`, then `dolt_checkout('source','ft')` → `live_only` survives pointing at a tree that no longer matches the adopted rows, `source_only` is missing, and reopening reports `row N missing from index live_only` from `integrity_check`.

## What

The #2023 shadow-adoption pass swaps shadow storage roots but never reconciled index *DDL* on shadow tables — `checkoutReconcileTableIndexes` only ran for the requested name. New `checkoutReconcileVtabShadowIndexes` runs the existing per-table reconcile for every source-side shadow of a requested virtual table during the schema pass (drop working-only, create source-only); the existing root-adoption then points the reconciled indexes at the source trees, exactly as it already does for the shadows themselves. Ordinary-table checkout is unchanged.

## Ito's second finding (CHECKOUT-5, savepoint sealing) — not a #2023 regression

The savepoint-releasing seal is the pre-existing shared table-checkout path; #2023 only made vtab names reach it. Verified two ways:
- Plain-table checkout (untouched by #2023) behaves identically on master: `SAVEPOINT sp; SELECT dolt_checkout('t'); ROLLBACK TO sp` → "no such savepoint", outer rollback does not restore.
- **Dolt behaves identically**: the same script against Dolt reports `SAVEPOINT sp does not exist` after `CALL DOLT_CHECKOUT('t')`. Sealing the enclosing transaction is the platform contract for ref/working-set VC ops (same family as `dolt_commit`/`dolt_merge`).

## Testing

- New `vtab_shadow_index_reconcile` scenario in `test/doltlite_index_vc_matrix.sh` (Ito's fixture). Fails on unfixed master (48/49), passes with the fix (49/49).
- Full regression c-test suite: 310258/310258.
- Shell battery: 99/99 suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)