### PR TITLE
Require the stored model before absorbing vec1 shadow conflicts

### DIFF
--- a/src/doltlite_merge_pass2.c
+++ b/src/doltlite_merge_pass2.c
@@ -247,18 +247,26 @@ static char *mergeVec1DerivedShadowOwner(sqlite3 *db, const char *zTable){
      && pTab->u.vtab.nArg>0
      && sqlite3_stricmp(pTab->u.vtab.azArg[0], "vec1")==0
      && sqlite3IsShadowTableOf(db, pTab, zTable) ){
+      /* Eligible only when %_base still holds raw vectors AND the stored
+      ** model the rebuild depends on is present: vec1 treats a NULL
+      ** rebuild argument as "keep the current model" and proceeds on
+      ** cached state, so a missing model row would let the merge commit
+      ** a stale index instead of failing. */
       char *zQry = sqlite3_mprintf(
-          "SELECT count(*) FROM \"%w_base\" WHERE typeof(vector)!='blob'",
-          zOwner);
+          "SELECT (SELECT count(*) FROM \"%w_base\""
+          "         WHERE typeof(vector)!='blob')=0"
+          " AND EXISTS(SELECT 1 FROM \"%w_model\""
+          "             WHERE id=1 AND typeof(val)='blob' AND length(val)>0)",
+          zOwner, zOwner);
       sqlite3_stmt *pStmt = 0;
-      int bRaw = 0;
+      int bEligible = 0;
       if( zQry && sqlite3_prepare_v2(db, zQry, -1, &pStmt, 0)==SQLITE_OK ){
-        bRaw = sqlite3_step(pStmt)==SQLITE_ROW
-            && sqlite3_column_int64(pStmt, 0)==0;
+        bEligible = sqlite3_step(pStmt)==SQLITE_ROW
+                 && sqlite3_column_int(pStmt, 0)==1;
       }
       sqlite3_finalize(pStmt);
       sqlite3_free(zQry);
-      if( bRaw ) return zOwner;
+      if( bEligible ) return zOwner;
     }
     sqlite3_free(zOwner);
     return 0;

--- a/test/doltlite_vec1_vc.sh
+++ b/test/doltlite_vec1_vc.sh
@@ -209,6 +209,36 @@ SELECT dolt_commit('-am','right');" "$DB" > /dev/null
 result=$(run_sql "SELECT dolt_checkout('left'); SELECT dolt_merge('right');" "$DB" | grep -c "conflict")
 check "vec1_flat_guard_stays_loud" "1" "$result"
 
+scenario "a missing stored model disables the automation"
+newdb
+python3 -c "
+import struct, random
+random.seed(3)
+with open('$TDIR/gate600.sql','w') as f:
+    for i in range(1, 601):
+        v = [random.uniform(-1,1) for _ in range(8)]
+        blob = ''.join(f'{b:02x}' for b in struct.pack('<8f', *v))
+        f.write(f\"INSERT INTO t(rowid, vector) VALUES ({i}, x'{blob}');\n\")
+"
+# vec1 treats a NULL rebuild argument as keep-the-current-model, so an
+# owner whose stored model row is gone must stay in the manual-conflict
+# path rather than let the merge commit a stale index.
+run_sql "CREATE VIRTUAL TABLE t USING vec1(vector);
+.read $TDIR/gate600.sql
+CREATE TABLE m(id INTEGER PRIMARY KEY, v BLOB);
+INSERT INTO m SELECT 1, vec1_train(vector, '{nbucket: 8, codesize: 4, distance: \"l2\"}') FROM t_base;
+INSERT INTO t(cmd, arg) VALUES ('rebuild', (SELECT v FROM m));
+SELECT dolt_commit('-Am','built');
+SELECT dolt_checkout('-b','left');
+INSERT INTO t(rowid, vector) VALUES (7001, x'0000803f0000803f0000803f0000803f0000803f0000803f0000803f0000803f');
+DELETE FROM t_model WHERE id=1;
+SELECT dolt_commit('-am','left, model removed');
+SELECT dolt_checkout('main'); SELECT dolt_checkout('-b','right');
+INSERT INTO t(rowid, vector) VALUES (8001, x'0ad7a33f0ad7a33f0ad7a33f0ad7a33f0ad7a33f0ad7a33f0ad7a33f0ad7a33f');
+SELECT dolt_commit('-am','right');" "$DB" > /dev/null
+result=$(run_sql "SELECT dolt_checkout('left'); SELECT dolt_merge('right');" "$DB" | grep -c "conflict")
+check "vec1_missing_model_stays_loud" "1" "$result"
+
 scenario "a user-table conflict keeps every conflict manual"
 newdb
 run_sql "CREATE VIRTUAL TABLE t USING vec1(vector);


### PR DESCRIPTION
## Why

Ito's testing of #2030 (CATALOG-2) found the automation's blind spot: the rebuild statement's `(SELECT val FROM "%_model" WHERE id=1)` yields **NULL** when the model row is missing, and vec1 documents a NULL rebuild argument as *keep the current model* — proceeding on cached state. A merge could therefore commit with an index rebuilt against stale model data instead of failing. (Malformed model *blobs* were already safe: vec1's decoder errors, the merge fails, and the transaction state restores.)

## What

The eligibility gate in `mergeVec1DerivedShadowOwner` now also requires a present, non-empty blob model at `%_model` id=1. An owner without one is ineligible for automation, so the merge keeps its conflicts loud for manual resolution — the same conservative fallback as uncompressed builds and mixed conflicts. One combined query checks both conditions (raw-vector base + stored model).

## Testing

- New `vec1_missing_model_stays_loud` scenario: build a PQ index, delete the model row on ours, diverge both branches, merge → must report conflicts. On unfixed code the merge **silently auto-completes** (18/19); with the fix it stays loud (19/19).
- Full regression c-test suite: 310258/310258. Shell battery: 101/101 suites. Layer lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)