### PR TITLE
Fix vec1's NEON vector types for gcc

### DIFF
--- a/ext/vec1/vec1.c
+++ b/ext/vec1/vec1.c
@@ -6617,9 +6617,12 @@ static void vec1MetaFilterScan4ByteArray(
     switch( op ){
       case VEC1_OP_IN: {
         int ii;
+        /* doltlite: strict NEON vector types for gcc — equality compares
+        ** are sign-agnostic and vorr is bitwise, so behavior is
+        ** unchanged. Worth upstreaming. */
         for(ii=0; ii<rval; ii++){
-          uint32x4_t rhs2 = vdupq_n_s32(aRval[ii]);
-          cmp = vorrq_s32(cmp, vceqq_u32(lhs, rhs2));
+          int32x4_t rhs2 = vdupq_n_s32(aRval[ii]);
+          cmp = vorrq_u32(cmp, vceqq_s32(lhs, rhs2));
         }
         break;
       }
@@ -6629,7 +6632,7 @@ static void vec1MetaFilterScan4ByteArray(
       }
       case VEC1_OP_GT: {
         cmp = vcgtq_s32(lhs, rhs);
-        cmp = vbicq_u32(cmp, vceqq_u32(lhs, null));
+        cmp = vbicq_u32(cmp, vceqq_s32(lhs, null));
         break;
       }
       case VEC1_OP_LT: {
@@ -6638,7 +6641,7 @@ static void vec1MetaFilterScan4ByteArray(
       }
       case VEC1_OP_GE: {
         cmp = vcgeq_s32(lhs, rhs);
-        cmp = vbicq_u32(cmp, vceqq_u32(lhs, null));
+        cmp = vbicq_u32(cmp, vceqq_s32(lhs, null));
         break;
       }
       case VEC1_OP_LE: {


### PR DESCRIPTION
## Why

The v0.11.42 release workflow's **linux-arm64** artifact build failed compiling vec1: gcc enforces strict NEON vector typing that Apple clang (where all local validation ran) does not. Three spots in the metadata-filter SIMD path mixed `int32x4_t`/`uint32x4_t`: the `IN` loop dup'd a signed lane into an unsigned vector and used `vorrq_s32`/`vceqq_u32` on the wrong types, and the `GT`/`GE` null-masks called `vceqq_u32` on signed lanes.

## What

Typed the intrinsics correctly (`int32x4_t rhs2`, `vorrq_u32` + `vceqq_s32`, `vceqq_s32(lhs, null)`). Equality compares are sign-agnostic and `vorr` is bitwise, so generated semantics are unchanged — clang builds produce the same results as before. Marked as a doltlite block in the vendored file; worth upstreaming.

## Testing

- Local strict compile with `-Wvector-conversion -Werror`: clean.
- Full doltlite build warning-free; vec1 suite 19/19 (NEON path exercised on this arm64 machine).
- The real proof is the linux-arm64 release job, which will be re-run once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)