### PR TITLE
Resume merged scans from the recorded key after a deferred write

### DIFF
--- a/src/prolly_btree_cursor.c
+++ b/src/prolly_btree_cursor.c
@@ -633,7 +633,11 @@ int prollyBtCursorNext(BtCursor *pCur, int flags){
     rc = prollyCursorApplyMergeStep(pCur, 1);
   }else if( pCur->pMutMap && !prollyMutMapIsEmpty(pCur->pMutMap)
          && pCur->curIntKey
-         && (pCur->curFlags & (BTCF_ValidNKey|BTCF_DeleteKey)) ){
+         && (pCur->curFlags & (BTCF_ValidNKey|BTCF_DeleteKey))
+         && !(prollyCursorIsValid(&pCur->pCur)
+              && prollyCursorIntKey(&pCur->pCur)==pCur->cachedIntKey) ){
+    /* A tree cursor parked on the logical key seeds the fast branch below;
+    ** parked anywhere else it would skip the pending rows in between. */
     rc = ensureCursorMutMapOrder(pCur);
     if( rc!=SQLITE_OK ) return rc;
     rc = resumeDeactivatedMergedScan(pCur, 1);
@@ -691,7 +695,9 @@ int prollyBtCursorPrevious(BtCursor *pCur, int flags){
     rc = prollyCursorApplyMergeStep(pCur, -1);
   }else if( pCur->pMutMap && !prollyMutMapIsEmpty(pCur->pMutMap)
          && pCur->curIntKey
-         && (pCur->curFlags & (BTCF_ValidNKey|BTCF_DeleteKey)) ){
+         && (pCur->curFlags & (BTCF_ValidNKey|BTCF_DeleteKey))
+         && !(prollyCursorIsValid(&pCur->pCur)
+              && prollyCursorIntKey(&pCur->pCur)==pCur->cachedIntKey) ){
     rc = ensureCursorMutMapOrder(pCur);
     if( rc!=SQLITE_OK ) return rc;
     rc = resumeDeactivatedMergedScan(pCur, -1);

--- a/src/prolly_btree_cursor.c
+++ b/src/prolly_btree_cursor.c
@@ -392,6 +392,60 @@ static int seedMutMapIterFromCursor(
   return SQLITE_NOTFOUND;
 }
 
+/* Resume a merged scan whose merge state a deferred write deactivated.
+** cachedIntKey is the logical position: the row the cursor sat on
+** (BTCF_ValidNKey) or the hole a delete left there (BTCF_DeleteKey). The
+** tree cursor is only a parking spot -- when the departed row was
+** mut-map-sourced it sits past every pending row between the key and the
+** next tree row, so seeding the step from it skips them. Re-seed both
+** sides strictly past the key and let mergeScan pick the next live row. */
+static int resumeDeactivatedMergedScan(BtCursor *pCur, int dir){
+  ProllyMutMapIter it;
+  i64 intKey = pCur->cachedIntKey;
+  int res = 0;
+  int rc;
+
+  refreshCursorRoot(pCur);
+  rc = prollyCursorCheckInterrupt(pCur);
+  if( rc!=SQLITE_OK ) return rc;
+  rc = prollyCursorSeekInt(&pCur->pCur, intKey, &res);
+  if( rc!=SQLITE_OK ) return rc;
+  if( prollyCursorIsValid(&pCur->pCur) && res*dir<=0 ){
+    rc = dir>0 ? prollyCursorNext(&pCur->pCur) : prollyCursorPrev(&pCur->pCur);
+    if( rc!=SQLITE_OK ) return rc;
+  }
+  rc = prollyMutMapIterSeek(&it, pCur->pMutMap, 0, 0, intKey);
+  if( rc!=SQLITE_OK ) return rc;
+  if( dir>0 ){
+    if( it.idx < pCur->pMutMap->nEntries ){
+      ProllyMutMapEntry *e;
+      rc = orderedMutMapEntryAt(pCur->pMutMap, it.idx, &e);
+      if( rc!=SQLITE_OK ) return rc;
+      if( prollyMutMapEntryIntKey(e)==intKey ) it.idx++;
+    }
+  }else{
+    it.idx--;
+  }
+  pCur->mmIdx = it.idx;
+  pCur->mmPhysIdx = -1;
+  pCur->mmPhysActive = 0;
+  pCur->mmActive = 1;
+  rc = mergeScan(pCur, dir, &res);
+  if( rc!=SQLITE_OK ) return rc;
+  if( res ){
+    pCur->eState = CURSOR_INVALID;
+    return SQLITE_DONE;
+  }
+  pCur->eState = CURSOR_VALID;
+  /* Only a pure tree row may serve the tree payload: on a BOTH landing the
+  ** mut-map entry shadows the tree row, and getCursorPayload consults the
+  ** cached payload before the merge source. */
+  if( pCur->mergeSrc==MERGE_SRC_TREE ){
+    cacheCurrentTreePayloadIfIntKey(pCur);
+  }
+  return SQLITE_OK;
+}
+
 static int mergeFirst(BtCursor *pCur, int *pRes){
   int rc = ensureCursorMutMapOrder(pCur);
   if( rc!=SQLITE_OK ) return rc;
@@ -577,6 +631,12 @@ int prollyBtCursorNext(BtCursor *pCur, int flags){
 
   if( pCur->mmActive ){
     rc = prollyCursorApplyMergeStep(pCur, 1);
+  }else if( pCur->pMutMap && !prollyMutMapIsEmpty(pCur->pMutMap)
+         && pCur->curIntKey
+         && (pCur->curFlags & (BTCF_ValidNKey|BTCF_DeleteKey)) ){
+    rc = ensureCursorMutMapOrder(pCur);
+    if( rc!=SQLITE_OK ) return rc;
+    rc = resumeDeactivatedMergedScan(pCur, 1);
   }else if( pCur->pMutMap && !prollyMutMapIsEmpty(pCur->pMutMap) ){
     ProllyMutMapIter it;
     rc = ensureCursorMutMapOrder(pCur);
@@ -629,6 +689,12 @@ int prollyBtCursorPrevious(BtCursor *pCur, int flags){
 
   if( pCur->mmActive ){
     rc = prollyCursorApplyMergeStep(pCur, -1);
+  }else if( pCur->pMutMap && !prollyMutMapIsEmpty(pCur->pMutMap)
+         && pCur->curIntKey
+         && (pCur->curFlags & (BTCF_ValidNKey|BTCF_DeleteKey)) ){
+    rc = ensureCursorMutMapOrder(pCur);
+    if( rc!=SQLITE_OK ) return rc;
+    rc = resumeDeactivatedMergedScan(pCur, -1);
   }else if( pCur->pMutMap && !prollyMutMapIsEmpty(pCur->pMutMap) ){
     ProllyMutMapIter it;
     rc = ensureCursorMutMapOrder(pCur);

--- a/src/prolly_btree_mutation.c
+++ b/src/prolly_btree_mutation.c
@@ -692,14 +692,6 @@ int tableEntryIsTableRoot(Btree *pBtree, struct TableEntry *pTE,
   return pTE->isTableRoot ? 1 : 0;
 }
 
-static int cursorIsShadowTableRoot(BtCursor *pCur, int *pRc){
-  struct TableEntry *pTE;
-  if( !pCur || !pCur->pBtree || !pCur->pBtree->db ) return 0;
-  pTE = findTable(pCur->pBtree, pCur->pgnoRoot);
-  if( !tableEntryIsTableRoot(pCur->pBtree, pTE, pRc) || !pTE->zName ) return 0;
-  return sqlite3ShadowTableName(pCur->pBtree->db, pTE->zName);
-}
-
 int restoreCursorPosition(BtCursor *pCur, int *pDifferentRow){
   int rc = SQLITE_OK;
   int res = 0;
@@ -1285,16 +1277,13 @@ int prollyBtCursorDelete(BtCursor *pCur, u8 flags){
       pCur->curFlags &= ~(BTCF_ValidNKey|BTCF_AtLast);
       pCur->mmActive = 0;
       if( flags & (BTREE_SAVEPOSITION | BTREE_AUXDELETE) ){
-        int rcRoot = SQLITE_OK;
         pCur->flushSeekEdits = 1;
-        if( pCur->curIntKey && hasSavedKey
-         && ((flags & BTREE_AUXDELETE)
-             || cursorIsShadowTableRoot(pCur, &rcRoot)) ){
+        if( pCur->curIntKey && hasSavedKey ){
+          /* Record the hole so the next step resumes from the deleted key;
+          ** the tree cursor may be parked past pending rows the scan still
+          ** owes (see resumeDeactivatedMergedScan). */
           pCur->cachedIntKey = iKey;
           pCur->curFlags |= BTCF_DeleteKey;
-        }else if( rcRoot!=SQLITE_OK ){
-          rc = rcRoot;
-          goto delete_cleanup;
         }else if( !pCur->curIntKey && hasSavedKey && nKey>0 ){
           /* Park the cursor on the mut-map tombstone of the deleted key so
           ** the next step resumes the scan from there. Re-seeding from a

--- a/test/doltlite_txn_seek_visibility.sh
+++ b/test/doltlite_txn_seek_visibility.sh
@@ -253,4 +253,51 @@ run_test "join_still_empty_for_empty_and_emptied_tables" \
 
 db_rm "$DB"
 
+# A one-pass DELETE/UPDATE scan steps off each row it just wrote. When the
+# departed row was mut-map-sourced, the step must resume from that row's key:
+# the tree cursor is parked at the next committed row, and a step seeded from
+# it skips every pending row in between.
+DB=/tmp/test_txn_onepass_resume_$$.db; db_rm "$DB"
+
+run_test "onepass_delete_covers_pending_rows" \
+  "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+   INSERT INTO t VALUES (10,'ten'),(20,'twenty');
+   BEGIN;
+   INSERT INTO t VALUES (1,'a'),(2,'b'),(3,'c'),(4,'d'),(5,'e');
+   DELETE FROM t WHERE id < 3;
+   COMMIT;
+   SELECT group_concat(id) FROM t;" \
+  "3,4,5,10,20" \
+  "$DB"
+
+db_rm "$DB"
+
+run_test "onepass_update_covers_pending_rows" \
+  "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+   INSERT INTO t VALUES (10,'ten'),(20,'twenty');
+   BEGIN;
+   INSERT INTO t VALUES (1,'a'),(2,'b'),(3,'c');
+   UPDATE t SET v='UPD' WHERE id < 4;
+   COMMIT;
+   SELECT group_concat(id||'='||v) FROM t;" \
+  "1=UPD,2=UPD,3=UPD,10=ten,20=twenty" \
+  "$DB"
+
+db_rm "$DB"
+
+# The step lands merged: pending rows interleave committed ones, and a
+# pending update shadowing a committed row must survive as the merged value.
+run_test "onepass_update_resume_lands_merged" \
+  "CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+   INSERT INTO t VALUES (13,130),(27,270);
+   BEGIN;
+   INSERT INTO t VALUES (10,1000);
+   UPDATE t SET v=v+1 WHERE id BETWEEN 7 AND 14;
+   COMMIT;
+   SELECT group_concat(id||'='||v) FROM t;" \
+  "10=1001,13=131,27=270" \
+  "$DB"
+
+db_rm "$DB"
+
 dltest_finish


### PR DESCRIPTION
## Bug

A one-pass DELETE or UPDATE silently skips rows whenever the row it just wrote was pending (mut-map-sourced). Both repros fail on master and commit the wrong result:

```sql
CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
INSERT INTO t VALUES (10,'ten'),(20,'twenty');
BEGIN;
INSERT INTO t VALUES (1,'a'),(2,'b'),(3,'c'),(4,'d'),(5,'e');
DELETE FROM t WHERE id < 3;      -- row 2 survives
UPDATE t SET v='UPD' WHERE id < 4;  -- only row 1 updated (analogous shape)
COMMIT;
```

## Cause

The deferred write paths deactivate the merged scan state (`mmActive = 0`). The Next/Prev re-seed then trusted a still-valid tree cursor as the logical position — but when the departed row was mut-map-sourced, the tree side is legitimately parked at the *next committed row*, so the step skipped every pending row between the departed key and the parking spot. The `cachedIntKey` breadcrumbs that record the true position were unreachable because the tree-valid seed branch took precedence, and the plain-intkey deferred delete recorded no breadcrumb at all (only AUXDELETE/shadow roots did).

## Fix

- The deferred intkey delete now always records the hole (`cachedIntKey` + `BTCF_DeleteKey`), mirroring the tombstone-parking the non-intkey path already does. The AUXDELETE/shadow gate (and the now-unused `cursorIsShadowTableRoot`) go away.
- `prollyBtCursorNext`/`Previous` consult the breadcrumb before the tree cursor: `resumeDeactivatedMergedScan` re-seeks both sides strictly past `cachedIntKey` and lets `mergeScan` pick the next live row. The tree payload is cached only for pure tree landings — on a BOTH landing the mut-map entry shadows the tree row and must serve the pending value.

## Validation

- 3 new tests in `test/doltlite_txn_seek_visibility.sh` fail on a master-built control binary and pass with the fix (suite 15/15).
- Full shell battery: 101/101 suites. Regression c-test: 310,258/310,258.
- 300-seed randomized differential sweep (mixed pending INSERT/DELETE/UPDATE + forward/backward scans) vs stock SQLite 3.54: 0 regressions vs master, 24 seeds newly correct. 7 seeds still mismatch identically on master and this branch — that is a distinct pre-existing defect (`materializeDeferredMergedSeek`/`Backward` cache the stale tree payload on BOTH landings), fix coming in its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)