### PR TITLE
Serve the pending value when a deferred seek lands on a shadowed row

### DIFF
--- a/src/prolly_btree_cursor.c
+++ b/src/prolly_btree_cursor.c
@@ -265,7 +265,10 @@ static int materializeDeferredMergedSeek(BtCursor *pCur){
   if( rc!=SQLITE_OK ) return rc;
   if( res==0 ){
     pCur->eState = CURSOR_VALID;
-    if( pCur->mergeSrc!=MERGE_SRC_MUT ){
+    /* Only a pure tree landing may serve the tree payload: on a BOTH
+    ** landing the mut-map entry shadows the tree row, and getCursorPayload
+    ** consults the cached payload before the merge source. */
+    if( pCur->mergeSrc==MERGE_SRC_TREE ){
       cacheCurrentTreePayloadIfIntKey(pCur);
     }
   }else{
@@ -300,7 +303,7 @@ int materializeDeferredMergedSeekBackward(BtCursor *pCur){
   if( rc!=SQLITE_OK ) return rc;
   if( res==0 ){
     pCur->eState = CURSOR_VALID;
-    if( pCur->mergeSrc!=MERGE_SRC_MUT ){
+    if( pCur->mergeSrc==MERGE_SRC_TREE ){
       cacheCurrentTreePayloadIfIntKey(pCur);
     }
   }else{

--- a/test/doltlite_txn_seek_visibility.sh
+++ b/test/doltlite_txn_seek_visibility.sh
@@ -157,6 +157,37 @@ run_test "prefix_seek_sees_updated_row_value" \
 
 db_rm "$DB"
 
+# A deferred merged seek that lands on a row present in both the tree and
+# the pending mut map must serve the pending value: the mut-map entry
+# shadows the committed row.
+run_test "deferred_seek_lands_on_shadowed_row_reads_pending_value" \
+  "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+   INSERT INTO t VALUES (12,'old'),(27,'far');
+   BEGIN;
+   UPDATE t SET v='new' WHERE id=12;
+   SELECT v FROM t WHERE id>5 AND id<20;
+   SELECT v FROM t WHERE id<20 ORDER BY id DESC LIMIT 1;
+   ROLLBACK;" \
+  "new
+new" \
+  "$DB"
+
+db_rm "$DB"
+
+run_test "second_range_update_sees_first_updates_value" \
+  "CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+   INSERT INTO t VALUES (12,120),(27,270);
+   BEGIN;
+   UPDATE t SET v=v+1 WHERE id>=6 AND id<=15;
+   UPDATE t SET v=v+1 WHERE id>=10 AND id<=17;
+   COMMIT;
+   SELECT id||'='||v FROM t;" \
+  "12=122
+27=270" \
+  "$DB"
+
+db_rm "$DB"
+
 run_test "fts4_langid_rebuild_preserves_partitions" \
   "CREATE VIRTUAL TABLE t2 USING fts4(x, languageid=l);
    INSERT INTO t2(docid, x, l) SELECT value, 'w' || value || ' common', value % 2 FROM generate_series(0,39);


### PR DESCRIPTION
## Bug

When a deferred merged seek materializes onto a row that exists in both the tree and the pending mut map (a pending UPDATE shadowing a committed row), the cursor served the stale committed value. Both fail on master:

```sql
CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
INSERT INTO t VALUES (12,'old'),(27,'far');
BEGIN;
UPDATE t SET v='new' WHERE id=12;
SELECT v FROM t WHERE id>5 AND id<20;   -- returns 'old'
```

```sql
CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
INSERT INTO t VALUES (12,120),(27,270);
BEGIN;
UPDATE t SET v=v+1 WHERE id>=6 AND id<=15;
UPDATE t SET v=v+1 WHERE id>=10 AND id<=17;
COMMIT;                                  -- 12 ends at 121, not 122:
```
the second UPDATE applies to the stale value and silently discards the first update from the committed result.

## Cause

`materializeDeferredMergedSeek` and `materializeDeferredMergedSeekBackward` cached the tree payload for any non-MUT landing. On a BOTH landing the mut-map entry shadows the tree row, but `getCursorPayload` consults the cached payload before the merge source, so readers got the committed bytes.

## Fix

Cache the tree payload only for pure `MERGE_SRC_TREE` landings; BOTH landings read the mut-map entry lazily like every other merged step. The exact-hit paths in `prollyBtCursorTableMoveto` are unaffected — they only cache after proving the key has no mut-map entry.

## Validation

- 2 new tests in `test/doltlite_txn_seek_visibility.sh` (forward + backward materializer, and the committed-result shape) fail on a master-built control binary and pass with the fix (suite 14/14).
- Full shell battery: 101/101 suites. Regression c-test: 310,258/310,258.
- Randomized differential sweep vs stock SQLite 3.54 (pending INSERT/DELETE/UPDATE mixes, forward/backward reads): 0 regressions vs master; this fix and #2041 are exactly complementary — with both applied, all 1,300 seeds match stock (this fix alone clears the 7 seeds #2041 leaves, and vice versa for its 24).

Found while validating #2041 (same review finding family, separate root cause — filed as its own PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)