### PR TITLE
Keep unrelated uncommitted changes out of the revert commit

### DIFF
--- a/src/doltlite_cherry_pick.c
+++ b/src/doltlite_cherry_pick.c
@@ -101,6 +101,7 @@ int applyMergedCatalogAndCommit(
   const ProllyHash *ourCatHash,
   const ProllyHash *theirCatHash,
   const ProllyHash *ourHead,
+  const ProllyHash *pCommitOurCatHash,
   const char *zMessage,
   int *pnConflicts,
   char *hexBuf
@@ -109,6 +110,8 @@ int applyMergedCatalogAndCommit(
   DoltliteTxnState savedState;
   ProllyHash mergedCatHash;
   ProllyHash liveMergedCatHash;
+  ProllyHash commitCatHash;
+  int commitSplit = 0;
   ProllyHash commitHash;
   char *zMergeErr = 0;
   int graphLocked = 0;
@@ -250,12 +253,41 @@ int applyMergedCatalogAndCommit(
         db, context, &savedState, *pnConflicts, zOpLabel, 1);
   }
 
-  rc = doltliteCreateAndStoreCommit(db, ourHead, &liveMergedCatHash,
+  /* The session merge folded the caller's uncommitted delta into
+  ** liveMergedCatHash so the working set keeps it. When the commit must be
+  ** based on pCommitOurCatHash instead (revert with unrelated dirty
+  ** changes), un-apply the delta for the commit only: a three-way with the
+  ** pre-op working catalog as base takes the dirty tables back to their
+  ** pCommitOurCatHash state and keeps the merge result everywhere else.
+  ** The caller's overlap gate keeps those table sets disjoint, so this
+  ** merge has nothing to conflict or reindex over. */
+  commitCatHash = liveMergedCatHash;
+  if( pCommitOurCatHash
+   && prollyHashCompare(pCommitOurCatHash, ourCatHash)!=0 ){
+    char **azReindexC = 0;
+    int nReindexC = 0;
+    int nCommitConflicts = 0;
+    char *zCErr = 0;
+    rc = doltliteMergeCatalogs(db, ourCatHash, &liveMergedCatHash,
+                               pCommitOurCatHash, &commitCatHash,
+                               &nCommitConflicts, &zCErr, 0, 0, 0,
+                               &azReindexC, &nReindexC, 0, 0);
+    sqlite3_free(zCErr);
+    doltliteFreeNameList(azReindexC, nReindexC);
+    if( rc==SQLITE_OK && (nCommitConflicts>0 || nReindexC>0) ){
+      rc = SQLITE_CONSTRAINT;
+    }
+    if( rc!=SQLITE_OK ) goto apply_rollback;
+    commitSplit = 1;
+  }
+
+  rc = doltliteCreateAndStoreCommit(db, ourHead, &commitCatHash,
       zMessage, NULL, NULL, NULL, 0, &commitHash);
   if( rc!=SQLITE_OK ) goto apply_rollback;
 
   rc = doltliteCompareAndAdvanceBranch(
-      db, ourHead, &commitHash, &liveMergedCatHash, 0);
+      db, ourHead, &commitHash, &commitCatHash,
+      commitSplit ? &liveMergedCatHash : 0);
   if( rc!=SQLITE_OK ) goto apply_rollback;
 
   rc = doltliteVcSealActiveSavepoints(db);
@@ -367,7 +399,7 @@ static void doltliteCherryPickFunc(
 
     rc = applyMergedCatalogAndCommit(db, context,
         &parentCommit.catalogHash, &ourCommit.catalogHash,
-        &pickCommit.catalogHash, &ourHead, zMsg, &nConflicts, hexBuf);
+        &pickCommit.catalogHash, &ourHead, 0, zMsg, &nConflicts, hexBuf);
   }
 
   doltliteCommitClear(&pickCommit);

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -1068,6 +1068,7 @@ int applyMergedCatalogAndCommit(
   const ProllyHash *ourCatHash,
   const ProllyHash *theirCatHash,
   const ProllyHash *ourHead,
+  const ProllyHash *pCommitOurCatHash,
   const char *zMessage,
   int *pnConflicts,
   char *hexBuf

--- a/src/doltlite_rebase.c
+++ b/src/doltlite_rebase.c
@@ -483,7 +483,7 @@ static int doltliteRebaseLinearReplay(
         &parentCommit.catalogHash,
         &curHeadCommit.catalogHash,
         &replayCommit.catalogHash,
-        &curHead,
+        &curHead, 0,
         replayCommit.zMessage ? replayCommit.zMessage : "",
         &nConflicts, hexBuf);
 

--- a/src/doltlite_revert.c
+++ b/src/doltlite_revert.c
@@ -206,12 +206,20 @@ static void doltliteRevertFunc(
 
   {
     char msg[512];
+    /* Base the commit on HEAD, not the working catalog: the revert commit
+    ** must contain only the revert, while unrelated uncommitted changes
+    ** (the overlap gate above rejects related ones) stay in the working
+    ** set, matching Dolt. */
+    const ProllyHash *pCommitOurs =
+        prollyHashCompare(&liveOurCatalog, &ourCommit.catalogHash)!=0
+          ? &ourCommit.catalogHash : 0;
     sqlite3_snprintf(sizeof(msg), msg, "Revert \"%s\"",
                      revertCommit.zMessage ? revertCommit.zMessage : zRef);
 
     rc = applyMergedCatalogAndCommit(db, context,
         &revertCommit.catalogHash, &liveOurCatalog,
-        &parentCommit.catalogHash, &ourHead, msg, &nConflicts, hexBuf);
+        &parentCommit.catalogHash, &ourHead, pCommitOurs, msg,
+        &nConflicts, hexBuf);
   }
 
   doltliteCommitClear(&revertCommit);

--- a/test/doltlite_revert_dirty.sh
+++ b/test/doltlite_revert_dirty.sh
@@ -15,13 +15,19 @@ INSERT INTO t VALUES(1,'a');
 SELECT dolt_commit('-Am','add row');
 INSERT INTO meta VALUES(1,'side');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
+# Unstaged change to an unrelated table: revert succeeds, commits only the
+# revert, and the change stays in the working set (Dolt 2.2.2: dolt_status
+# keeps the table modified and no commit contains it).
 run_test_match "rv_dirty_unrelated_hash" \
   "SELECT dolt_revert((SELECT commit_hash FROM dolt_log LIMIT 1));" \
   "^[0-9a-f]{40}$" "$DB"
 run_test "rv_dirty_unrelated_t_reverted" "SELECT count(*) FROM t;" "0" "$DB"
 run_test "rv_dirty_unrelated_meta_kept" "SELECT note FROM meta WHERE id=1;" "side" "$DB"
-run_test "rv_dirty_unrelated_status_clean" \
-  "SELECT count(*) FROM dolt_status WHERE table_name='meta';" \
+run_test "rv_dirty_unrelated_meta_still_dirty" \
+  "SELECT count(*) FROM dolt_status WHERE table_name='meta' AND staged=0;" \
+  "1" "$DB"
+run_test "rv_dirty_unrelated_commit_excludes_meta" \
+  "SELECT count(*) FROM dolt_at_meta WHERE commit_ref='HEAD';" \
   "0" "$DB"
 run_test "rv_dirty_unrelated_log_has_revert" \
   "SELECT count(*) FROM dolt_log WHERE message LIKE 'Revert%';" \


### PR DESCRIPTION
Fixes finding 3 from the deep review: `dolt_revert` silently committed unrelated uncommitted changes.

## Bug

Revert passed the flushed **working** catalog as "ours" to the merge and committed the result wholesale. The dirty gate only rejects uncommitted changes to tables the reverted commit touched, so changes to *unrelated* tables rode into the revert commit — `dolt_status` came back clean and the user's in-flight work was permanently inside a commit titled `Revert "..."`:

```sql
INSERT INTO t VALUES(1,'from-c2');
SELECT dolt_commit('-am','c2');
INSERT INTO u VALUES(2,99);          -- uncommitted, unrelated
SELECT dolt_revert('HEAD');          -- u's row is now inside the revert commit
SELECT count(*) FROM dolt_status;    -- 0
```

**Dolt 2.2.2 (verified first-hand, single session):** revert succeeds, `u` stays `modified` in `dolt_status`, and no commit contains it — including for uncommitted new tables.

## Fix

The session merge stays exactly as it was — ours remains the working catalog, so the session never drops uncommitted tables mid-operation (a first attempt that merged from HEAD broke `doltlitePrimeSchemaCache` whenever an uncommitted table existed) and the conflict workflow still carries the dirty delta. The **commit** catalog is derived at the end by un-applying that delta: a second three-way merge with the pre-op working catalog as base takes the dirty tables back to their HEAD state and keeps the merge result everywhere else; disjointness from the overlap gate means it cannot conflict (guarded anyway). `doltliteCompareAndAdvanceBranch` already supports the split — commit/staged get the un-applied catalog, the working set keeps the folded one. Cherry-pick and rebase pass no commit-side catalog and are byte-for-byte unchanged.

`doltlite_revert_dirty.sh`'s unstaged-unrelated case asserted the fold (status clean); those expectations predate Dolt 2.2.2 — updated to the verified oracle behavior and extended with a commit-content assertion.

## Validation

- `doltlite_revert_dirty.sh`: 15/15 with the fix; the 2 updated/new assertions fail on a master-built control binary.
- Dolt oracle suites: `vc_oracle_revert_test.sh` 6/6, `vc_oracle_revert_cherrypick_test.sh` 58/58, `oracle_schema_change_cherry_pick_revert_test.sh` 23/23 against dolt 2.2.2.
- Full shell battery 101/101; regression c-test 310,258/310,258 (fresh archive).
- Edge probes under `DOLTLITE_PROLLY_CHECK=1`: dirty new table, dirty dropped table, revert inside BEGIN/COMMIT, and conflicted revert with unrelated dirt (autocommit rollback and in-transaction persisted-conflicts paths) — the dirty state survives every shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)