### PR TITLE
Run rebase constraint detection in every transaction mode

### DIFF
--- a/src/doltlite_core.c
+++ b/src/doltlite_core.c
@@ -836,13 +836,6 @@ int doltliteVcSealBranchStyleTxn(sqlite3 *db){
   return sqlite3_exec(db, "BEGIN", 0, 0, 0);
 }
 
-int doltliteVcSealBranchStyleTxnMaybeKeepTopLevelSavepoint(sqlite3 *db){
-  if( doltliteSavepointIsTopLevelTxn(db) ){
-    return SQLITE_OK;
-  }
-  return doltliteVcSealBranchStyleTxn(db);
-}
-
 int doltlitePrimeSchemaCache(sqlite3 *db){
   sqlite3_stmt *pStmt = 0;
   int rc = sqlite3_prepare_v2(

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -953,7 +953,6 @@ int doltliteRollbackAutocommitConflict(
 );
 int doltliteSavepointIsTopLevelTxn(sqlite3 *db);
 int doltliteVcSealTopLevelSavepointTxn(sqlite3 *db);
-int doltliteVcSealBranchStyleTxnMaybeKeepTopLevelSavepoint(sqlite3 *db);
 
 typedef DoltliteNameIndex AddNameIndex;
 int addNameIndexInit(

--- a/src/doltlite_rebase.c
+++ b/src/doltlite_rebase.c
@@ -848,8 +848,7 @@ static int rebaseApplyPlanRowCatalog(
   sqlite3 *db,
   const RebasePlanRow *pRow,
   const ProllyHash *pCurCat,
-  ProllyHash *pMergedCat,
-  int bSkipConstraintDetect
+  ProllyHash *pMergedCat
 ){
   DoltliteCommit parentC, replayC;
   int nConflicts = 0;
@@ -888,7 +887,7 @@ static int rebaseApplyPlanRowCatalog(
     }
     doltliteFreeNameList(azReindex, nReindex);
   }
-  if( rc==SQLITE_OK && nConflicts==0 && !bSkipConstraintDetect ){
+  if( rc==SQLITE_OK && nConflicts==0 ){
     rc = doltliteDetectPostMergeConstraintViolations(db,
                                                      &parentC.catalogHash,
                                                      &nViolations);
@@ -933,15 +932,13 @@ static int rebaseReplayPlanGroup(
   int iStart,
   ProllyHash *pCurCat,
   ProllyHash *pCurHead,
-  int *piNext,
-  int bSkipConstraintDetect
+  int *piNext
 ){
   char *combinedMsg = 0;
   int rc;
   int j;
 
-  rc = rebaseApplyPlanRowCatalog(db, &aPlan[iStart], pCurCat, pCurCat,
-                                 bSkipConstraintDetect);
+  rc = rebaseApplyPlanRowCatalog(db, &aPlan[iStart], pCurCat, pCurCat);
   if( rc!=SQLITE_OK ) return rc;
 
   combinedMsg = sqlite3_mprintf("%s",
@@ -958,8 +955,7 @@ static int rebaseReplayPlanGroup(
       continue;
     }
 
-    rc = rebaseApplyPlanRowCatalog(db, &aPlan[j], pCurCat, pCurCat,
-                                   bSkipConstraintDetect);
+    rc = rebaseApplyPlanRowCatalog(db, &aPlan[j], pCurCat, pCurCat);
     if( rc!=SQLITE_OK ){
       sqlite3_free(combinedMsg);
       return rc;
@@ -1569,7 +1565,6 @@ static void doltliteRebaseInteractiveContinue(
   int rebaseActive = 1;
   int i;
   int bPlanDropped = 0;
-  int bSkipConstraintDetect = (!db->autoCommit || db->pSavepoint!=0);
   ProllyHash curCat;
   ProllyHash curHead;
   ProllyHash expectedOrigHead;
@@ -1650,7 +1645,12 @@ static void doltliteRebaseInteractiveContinue(
   rc = rebaseDropPlan(db);
   if( rc!=SQLITE_OK ) goto abort_err;
 
-  rc = doltliteVcSealBranchStyleTxnMaybeKeepTopLevelSavepoint(db);
+  /* Seal savepoints AND the enclosing transaction: constraint detection
+  ** during the replay re-prepares against the switched catalog, which needs
+  ** the claim and plan-drop schema changes committed, not pending in an
+  ** open transaction. Releasing savepoints alone leaves that BEGIN open. */
+  rc = doltliteVcSealActiveSavepoints(db);
+  if( rc==SQLITE_OK ) rc = doltliteVcSealBranchStyleTxn(db);
   if( rc!=SQLITE_OK ) goto abort_err;
 
   rc = doltliteEnsureWriteTxnAndSavepoints(db);
@@ -1667,8 +1667,7 @@ static void doltliteRebaseInteractiveContinue(
     while( i < nPlan && strcmp(aPlan[i].zAction, "drop")==0 ) i++;
     if( i >= nPlan ) break;
 
-    rc = rebaseReplayPlanGroup(db, aPlan, nPlan, i, &curCat, &curHead, &j,
-                               bSkipConstraintDetect);
+    rc = rebaseReplayPlanGroup(db, aPlan, nPlan, i, &curCat, &curHead, &j);
     if( rc==SQLITE_CONSTRAINT ) goto abort_err_conflict;
     if( rc!=SQLITE_OK ) goto abort_err;
     i = j;
@@ -1703,9 +1702,9 @@ static void doltliteRebaseInteractiveContinue(
   if( rc!=SQLITE_OK ) goto abort_err;
 
   /* curCat is already the exact flushed catalog installed by the replay and
-  ** persisted above. Under a caller savepoint, the live SQLite schema is
-  ** transitional until checkout completes, so do not re-prepare and
-  ** re-serialize it merely to capture the branch being discarded. */
+  ** persisted above; the live SQLite schema is transitional until checkout
+  ** completes, so do not re-prepare and re-serialize it merely to capture
+  ** the branch being discarded. */
   db->busyHandler.nBusy = 0;
   do {
     rc = doltliteCheckoutBranchForRebaseWithOldCatalog(
@@ -1724,8 +1723,7 @@ static void doltliteRebaseInteractiveContinue(
   if( rc!=SQLITE_OK ) goto abort_err;
   rc = rebaseRetryDbOp(db, doltlitePersistWorkingSet);
   if( rc!=SQLITE_OK ) goto abort_err;
-  rc = rebaseRetryDbOp(
-      db, doltliteVcSealBranchStyleTxnMaybeKeepTopLevelSavepoint);
+  rc = rebaseRetryDbOp(db, doltliteVcSealBranchStyleTxn);
   if( rc!=SQLITE_OK ) goto abort_err;
 
   rebaseFreePlan(aPlan, nPlan);

--- a/test/doltlite_rebase.sh
+++ b/test/doltlite_rebase.sh
@@ -319,7 +319,61 @@ run_test "rebase_64_byte_default_branch_rejection_is_atomic" \
 0" \
   "$DB8"
 
-rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB5_SHORT" "$DB6" "$DB7" "$DB8"
+# Constraint detection must run for --continue regardless of the enclosing
+# transaction shape: a replayed commit that orphans an FK row has to abort
+# the rebase in every mode, never advance the branch with the violation.
+seed_fk_conflict_repo() {
+  local d="$1"
+  rm -f "$d"
+  cat <<'SQL' | "$DOLTLITE" "$d" >/dev/null 2>&1
+CREATE TABLE parent(id INTEGER PRIMARY KEY);
+CREATE TABLE child(id INTEGER PRIMARY KEY, pid INT REFERENCES parent(id));
+INSERT INTO parent VALUES(1);
+SELECT dolt_commit('-Am','base');
+SELECT dolt_branch('feat');
+DELETE FROM parent WHERE id=1;
+SELECT dolt_commit('-am','main deletes parent');
+SELECT dolt_checkout('feat');
+INSERT INTO child VALUES(1,1);
+SELECT dolt_commit('-am','feat adds child');
+SQL
+}
+
+DB9=/tmp/test_rebase_fk_txn_$$.db
+seed_fk_conflict_repo "$DB9"
+run_test_match "continue_in_txn_detects_fk_violation" \
+  "SELECT dolt_checkout('feat');
+   SELECT dolt_rebase('-i','main');
+   UPDATE dolt_rebase SET action='pick';
+   BEGIN;
+   SELECT dolt_rebase('--continue');
+   COMMIT;" \
+  "data conflicts from rebase" \
+  "$DB9"
+run_test "continue_in_txn_no_orphans" \
+  "SELECT count(*) FROM pragma_foreign_key_check;
+   SELECT message FROM dolt_log('feat') LIMIT 1;" \
+  "0
+feat adds child" \
+  "$DB9"
+
+seed_fk_conflict_repo "$DB9"
+run_test_match "continue_in_savepoint_detects_fk_violation" \
+  "SELECT dolt_checkout('feat');
+   SELECT dolt_rebase('-i','main');
+   UPDATE dolt_rebase SET action='pick';
+   SAVEPOINT s1;
+   SELECT dolt_rebase('--continue');" \
+  "data conflicts from rebase" \
+  "$DB9"
+run_test "continue_in_savepoint_no_orphans" \
+  "SELECT count(*) FROM pragma_foreign_key_check;
+   SELECT message FROM dolt_log('feat') LIMIT 1;" \
+  "0
+feat adds child" \
+  "$DB9"
+
+rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB5_SHORT" "$DB6" "$DB7" "$DB8" "$DB9"
 echo ""
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"
 if [ $FAIL -gt 0 ]; then echo -e "$ERRORS"; exit 1; fi


### PR DESCRIPTION
Fixes finding 4 from the deep review: `dolt_rebase('--continue')` inside a transaction or savepoint skipped all constraint detection.

## Bug

`bSkipConstraintDetect = (!db->autoCommit || db->pSavepoint!=0)` disabled post-merge FK/unique/CHECK detection for the whole replay. Reproduced: an FK-violating rebase aborts with "data conflicts" in autocommit, but inside `BEGIN…COMMIT` it *succeeded*, advanced the branch with an FK orphan (`pragma_foreign_key_check` = 1) and recorded nothing in `dolt_constraint_violations`. Merge and cherry-pick detect correctly under the same shapes — rebase was the only hole (introduced by `5ec9db9c7c` as a savepoint-regression workaround).

## Root cause of what the skip papered over

Detection re-prepares SQL against the catalog the replay just switched in. The `--continue` entry seal (`…MaybeKeepTopLevelSavepoint`) only RELEASEd savepoints, leaving the enclosing `BEGIN` open — so the claim and plan-drop schema changes were still uncommitted when the re-prepare forced a schema reload, which failed with `malformed database schema (t)`. The plain-BEGIN path never hit this because its seal is COMMIT+BEGIN.

## Fix

- Seal the enclosing transaction at `--continue` entry in every mode (release savepoints, then the same COMMIT+BEGIN boundary the plain-BEGIN path already drew — and the boundary `doltliteVcSealEnclosingTxn`'s own comment argues for, since a later ROLLBACK against an advanced ref splits HEAD from the data).
- Delete `bSkipConstraintDetect` and all its plumbing; detection now always runs per replayed commit.
- Delete the now-unused `doltliteVcSealBranchStyleTxnMaybeKeepTopLevelSavepoint`.

Net −15 lines of source.

## Validation

- 2 new tests in `test/doltlite_rebase.sh` (txn and savepoint modes): fail on a current-master build, pass with the fix (suite 30/30). Manual verification of all four shapes (autocommit / BEGIN / savepoint / BEGIN+nested savepoint): violating rebases abort with the standard "data conflicts" message and zero orphans; clean rebases succeed in all four.
- `vc_oracle_rebase_test.sh` vs dolt 2.2.2: 48/48 — including `interactive_continue_nested_savepoint_success_reopen`, which caught an intermediate version of this fix that sealed savepoints without the enclosing transaction.
- `doltlite_savepoint.sh` 128/128, full shell battery 101/101, regression c-test 310,258/310,258 (includes the rebase durable-state cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)