### PR TITLE
Keep history joins within the selected ref

### DIFF
--- a/src/doltlite_history.c
+++ b/src/doltlite_history.c
@@ -248,7 +248,8 @@ static int htBestIndex(sqlite3_vtab *v, sqlite3_index_info *p){
     const struct sqlite3_index_constraint *pC = &p->aConstraint[i];
     if( !pC->usable ) continue;
     if( pC->iColumn==iCommitCol
-     && pC->op==SQLITE_INDEX_CONSTRAINT_EQ ){
+     && pC->op==SQLITE_INDEX_CONSTRAINT_EQ
+     && !sqlite3DoltliteVtabConstraintIsCorrelated(p, i) ){
       iCommitEq = i;
     }else if( pC->iColumn==iStartRefCol
            && pC->op==SQLITE_INDEX_CONSTRAINT_EQ ){

--- a/src/doltlite_vtab_util.h
+++ b/src/doltlite_vtab_util.h
@@ -8,6 +8,9 @@
 #include "chunk_store.h"
 #include "doltlite_record.h"
 
+int sqlite3DoltliteVtabConstraintIsCorrelated(sqlite3_index_info *pIdxInfo,
+                                              int iConstraint);
+
 /*
  * Shared prefix for virtual table instances whose per-table metadata
  * consist of (db, zTableName, cols) immediately after the base vtab.

--- a/src/where.c
+++ b/src/where.c
@@ -4622,6 +4622,20 @@ int sqlite3_vtab_rhs_value(
   return rc;
 }
 
+#ifdef DOLTLITE_PROLLY
+int sqlite3DoltliteVtabConstraintIsCorrelated(
+  sqlite3_index_info *pIdxInfo,
+  int iCons
+){
+  HiddenIndexInfo *pH = (HiddenIndexInfo*)&pIdxInfo[1];
+  WhereTerm *pTerm;
+  if( iCons<0 || iCons>=pIdxInfo->nConstraint ) return 0;
+  pTerm = termFromWhereClause(pH->pWC,
+                              pIdxInfo->aConstraint[iCons].iTermOffset);
+  return pTerm->prereqRight!=0;
+}
+#endif
+
 /*
 ** Return true if ORDER BY clause may be handled as DISTINCT.
 */

--- a/test/doltlite_history.sh
+++ b/test/doltlite_history.sh
@@ -157,6 +157,44 @@ run_test "noncurrent_exact_commit" "SELECT count(*) FROM dolt_history_feature_on
 
 rm -f "$DB"
 
+DB=/tmp/test_hist_join_order_$$.db; rm -f "$DB"
+echo "CREATE TABLE items(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO items VALUES(1,'main');
+SELECT dolt_commit('-A','-m','main');
+SELECT dolt_checkout('-b','feature');
+INSERT INTO items VALUES(2,'feature-transient');
+SELECT dolt_commit('-A','-m','feature first');
+DELETE FROM items WHERE id=2;
+INSERT INTO items VALUES(3,'feature-head');
+SELECT dolt_commit('-A','-m','feature head');
+SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+ANCESTRY="WITH RECURSIVE ancestry(commit_hash) AS (
+  SELECT dolt_hashof('feature')
+  UNION ALL
+  SELECT parents.parent_hash
+  FROM ancestry
+  JOIN dolt_commit_ancestors parents
+    ON parents.commit_hash=ancestry.commit_hash
+   AND parents.parent_index=0
+  WHERE parents.parent_hash IS NOT NULL
+)"
+
+run_test "history_join_noncurrent_uses_session_head" \
+  "$ANCESTRY SELECT count(*) FROM ancestry JOIN dolt_history_items history ON history.commit_hash=ancestry.commit_hash;" \
+  "1" "$DB"
+run_test "history_cross_join_noncurrent_uses_session_head" \
+  "$ANCESTRY SELECT count(*) FROM ancestry CROSS JOIN dolt_history_items history WHERE history.commit_hash=ancestry.commit_hash;" \
+  "1" "$DB"
+run_test "history_join_explicit_ref" \
+  "$ANCESTRY SELECT count(*) FROM ancestry JOIN dolt_history_items('feature') history ON history.commit_hash=ancestry.commit_hash;" \
+  "5" "$DB"
+run_test "history_cross_join_explicit_ref" \
+  "$ANCESTRY SELECT count(*) FROM ancestry CROSS JOIN dolt_history_items('feature') history WHERE history.commit_hash=ancestry.commit_hash;" \
+  "5" "$DB"
+
+rm -f "$DB"
+
 DB=/tmp/test_hist_merge_replay_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'base');

--- a/test/vc_oracle_history_test.sh
+++ b/test/vc_oracle_history_test.sh
@@ -218,6 +218,40 @@ noncurrent_oracle "history_start_ref_on_sibling_branch_after_reopen" \
   "SELECT CONCAT('H|', id, '|', v) FROM dolt_history_feature_only('feature');" \
   "SELECT CONCAT('H|', id, '|', v) FROM dolt_history_feature_only AS OF 'feature';"
 
+JOIN_ORDER_SETUP="
+CREATE TABLE items(id INTEGER PRIMARY KEY, v TEXT NOT NULL);
+INSERT INTO items VALUES(1, 'main');
+SELECT dolt_commit('-A', '-m', 'main');
+SELECT dolt_checkout('-b', 'feature');
+INSERT INTO items VALUES(2, 'feature-transient');
+SELECT dolt_commit('-A', '-m', 'feature first');
+DELETE FROM items WHERE id = 2;
+INSERT INTO items VALUES(3, 'feature-head');
+SELECT dolt_commit('-A', '-m', 'feature head');
+SELECT dolt_checkout('main');
+"
+
+JOIN_ANCESTRY="WITH RECURSIVE ancestry(commit_hash) AS (
+  SELECT dolt_hashof('feature')
+  UNION ALL
+  SELECT parents.parent_hash
+  FROM ancestry
+  JOIN dolt_commit_ancestors parents
+    ON parents.commit_hash = ancestry.commit_hash
+   AND parents.parent_index = 0
+  WHERE parents.parent_hash IS NOT NULL
+)"
+
+noncurrent_oracle "history_noncurrent_ordinary_join_uses_session_head" \
+  "$JOIN_ORDER_SETUP" \
+  "$JOIN_ANCESTRY SELECT CONCAT('H|', count(*)) FROM ancestry JOIN dolt_history_items history ON history.commit_hash = ancestry.commit_hash;" \
+  "$JOIN_ANCESTRY SELECT CONCAT('H|', count(*)) FROM ancestry JOIN dolt_history_items history ON history.commit_hash = ancestry.commit_hash;"
+
+noncurrent_oracle "history_noncurrent_cross_join_uses_session_head" \
+  "$JOIN_ORDER_SETUP" \
+  "$JOIN_ANCESTRY SELECT CONCAT('H|', count(*)) FROM ancestry CROSS JOIN dolt_history_items history WHERE history.commit_hash = ancestry.commit_hash;" \
+  "$JOIN_ANCESTRY SELECT CONCAT('H|', count(*)) FROM ancestry CROSS JOIN dolt_history_items history WHERE history.commit_hash = ancestry.commit_hash;"
+
 oracle "history_on_feature_branch" "
 $SEED
 SELECT dolt_branch('feature');


### PR DESCRIPTION
## Summary

- keep correlated `commit_hash` predicates within the history table's session HEAD or explicit start ref
- preserve exact-commit pushdown for literals, parameters, and scalar expressions
- add native and Dolt-oracle coverage for ordinary and forced join orders

## Semantics

The issue reproducer returned 1 row with the ordinary join and 5 with the forced `CROSS JOIN`. Dolt returns 1 for both: plain `dolt_history_items` is scoped to the current branch. After this change DoltLite also returns 1 for both plans. The explicit `dolt_history_items('feature')` surface added by #2046 returns 5 with either join order.

Direct non-current exact lookup remains optimized: `commit_hash=dolt_hashof('feature')` still uses virtual-table index 32 and returns the two rows at that commit.

## Validation

- fail-before/pass-after: `doltlite_history.sh` (46/47 before; 47/47 after)
- `vc_oracle_history_test.sh`: 31/31
- full native run: all engine suites passed; the parity harness initially lacked its expected stock `build/sqlite3`
- parity rerun with a clean `DOLTLITE_PROLLY=0` binary: 119/119
- `make lint`
- clean stock SQLite build

Closes #2040

Co-Authored-By: OpenAI Codex <noreply@openai.com>