### PR TITLE
Working sets do not push or pull

### DIFF
--- a/src/chunk_store.h
+++ b/src/chunk_store.h
@@ -214,9 +214,6 @@ int chunkStoreLockAndRefreshChanged(ChunkStore *cs, int *pChanged);
 void chunkStoreUnlock(ChunkStore *cs);
 int chunkStoreHasExternalChanges(ChunkStore *cs, int *pChanged);
 
-int chunkStoreWriteBranchWorkingCatalog(ChunkStore *cs, const char *zBranch,
-                                        const ProllyHash *pCatHash,
-                                        const ProllyHash *pCommitHash);
 int chunkStoreReadBranchWorkingCatalog(ChunkStore *cs, const char *zBranch,
                                        ProllyHash *pCatHash,
                                        ProllyHash *pCommitHash);

--- a/src/doltlite_remote.c
+++ b/src/doltlite_remote.c
@@ -126,37 +126,6 @@ static int remoteCollectRootsFromRefsBlob(
   return SQLITE_OK;
 }
 
-static int remoteLoadCommitCatalogHash(
-  ChunkStore *cs,
-  const ProllyHash *pCommitHash,
-  ProllyHash *pCatalogHash
-){
-  u8 *pData = 0;
-  int nData = 0;
-  DoltliteCommit c;
-  int rc;
-
-  if( pCatalogHash ) memset(pCatalogHash, 0, sizeof(*pCatalogHash));
-  if( !cs || !pCommitHash || prollyHashIsEmpty(pCommitHash) || !pCatalogHash ){
-    return SQLITE_ERROR;
-  }
-
-  rc = chunkStoreGet(cs, pCommitHash, &pData, &nData);
-  if( rc!=SQLITE_OK ) return rc;
-
-  memset(&c, 0, sizeof(c));
-  rc = doltliteCommitDeserialize(pData, nData, &c);
-  sqlite3_free(pData);
-  if( rc!=SQLITE_OK ){
-    doltliteCommitClear(&c);
-    return rc;
-  }
-
-  memcpy(pCatalogHash, &c.catalogHash, sizeof(*pCatalogHash));
-  doltliteCommitClear(&c);
-  return SQLITE_OK;
-}
-
 typedef struct SyncEnqCtx SyncEnqCtx;
 struct SyncEnqCtx {
   SyncQueue *q;
@@ -1002,7 +971,6 @@ int doltlitePush(
   int bForce
 ){
   ProllyHash localCommit;
-  ProllyHash localCatalog;
   ProllyHash remoteCommit;
   ProllyHash expectedRefsHash;
   u8 *refsData = 0;
@@ -1014,9 +982,6 @@ int doltlitePush(
   if( rc!=SQLITE_OK ){
     return SQLITE_ERROR;
   }
-
-  rc = remoteLoadCommitCatalogHash(pLocal, &localCommit, &localCatalog);
-  if( rc!=SQLITE_OK ) return rc;
 
   rc = pRemote->xGetRefs(pRemote, &refsData, &nRefsData);
   if( rc==SQLITE_OK && refsData ){
@@ -1073,8 +1038,6 @@ int doltlitePush(
     {
       ChunkStore tmpCs;
       u8 *newRefs = 0; int nNewRefs = 0;
-      u8 *wsData = 0; int nWsData = 0;
-      ProllyHash wsHash;
       memset(&tmpCs, 0, sizeof(tmpCs));
       if( refsData2 && nRefsData2 > 0 ){
         rc = chunkStoreLoadRefsFromBlob(&tmpCs, refsData2, nRefsData2);
@@ -1100,27 +1063,17 @@ int doltlitePush(
         return rc;
       }
 
-      rc = chunkStoreWriteBranchWorkingCatalog(
-        &tmpCs, zBranch, &localCatalog, &localCommit);
-      if( rc!=SQLITE_OK ){
-        chunkStoreClose(&tmpCs);
-        return rc;
-      }
-      rc = chunkStoreGetBranchWorkingSet(&tmpCs, zBranch, &wsHash);
-      if( rc!=SQLITE_OK ){
-        chunkStoreClose(&tmpCs);
-        return rc;
-      }
-      rc = chunkStoreGet(&tmpCs, &wsHash, &wsData, &nWsData);
-      if( rc!=SQLITE_OK ){
-        chunkStoreClose(&tmpCs);
-        return rc;
-      }
-      rc = pRemote->xPutChunk(pRemote, &wsHash, wsData, nWsData);
-      sqlite3_free(wsData);
-      if( rc!=SQLITE_OK ){
-        chunkStoreClose(&tmpCs);
-        return rc;
+      /* Working sets do not push: the remote carries commits and refs only,
+      ** so clear any working-set hash an older client left on this branch
+      ** rather than declare a chunk no cloner fetches. */
+      {
+        ProllyHash emptyWs;
+        memset(&emptyWs, 0, sizeof(emptyWs));
+        rc = chunkStoreSetBranchWorkingSet(&tmpCs, zBranch, &emptyWs);
+        if( rc!=SQLITE_OK ){
+          chunkStoreClose(&tmpCs);
+          return rc;
+        }
       }
 
       {
@@ -1376,6 +1329,28 @@ int doltliteClone(ChunkStore *pLocal, DoltliteRemote *pRemote){
   sqlite3_free(refsData);
   refsData = 0;
   if( rc!=SQLITE_OK ) goto clone_restore_refs;
+
+  /* Working sets do not pull: cloned branches start clean at their heads.
+  ** Clear any working-set hashes in the installed refs (older clients
+  ** pushed them) -- the commit-graph sync above never fetches those
+  ** chunks, so a kept hash would dangle. */
+  {
+    int nBr = 0;
+    int i;
+    const BranchRef *aBr = 0;
+    ProllyHash emptyWs;
+    memset(&emptyWs, 0, sizeof(emptyWs));
+    refsTableGetBranches(&pLocal->refs, &nBr, &aBr);
+    for(i=0; i<nBr && rc==SQLITE_OK; i++){
+      if( !prollyHashIsEmpty(&aBr[i].workingSetHash) ){
+        rc = chunkStoreSetBranchWorkingSet(pLocal, aBr[i].zName, &emptyWs);
+      }
+    }
+    if( rc==SQLITE_OK ){
+      rc = chunkStoreSerializeRefs(pLocal);
+    }
+    if( rc!=SQLITE_OK ) goto clone_restore_refs;
+  }
 
   rc = chunkStoreCommit(pLocal);
   if( rc!=SQLITE_OK ){

--- a/src/prolly_btree_catalog.c
+++ b/src/prolly_btree_catalog.c
@@ -2364,12 +2364,6 @@ int doltliteWriteBranchCleanWorkingState(sqlite3 *db, const char *zBranch,
                                   0, 0, &emptyHash);
 }
 
-int chunkStoreWriteBranchWorkingCatalog(ChunkStore *cs, const char *zBranch,
-                                        const ProllyHash *pCatHash,
-                                        const ProllyHash *pCommitHash){
-  return btreeWriteWorkingState(cs, zBranch, pCatHash, pCommitHash);
-}
-
 int chunkStoreReadBranchWorkingCatalog(ChunkStore *cs, const char *zBranch,
                                        ProllyHash *pCatHash,
                                        ProllyHash *pCommitHash){

--- a/test/remote_test.sh
+++ b/test/remote_test.sh
@@ -689,6 +689,43 @@ check_match "non-ff push rejected" "not a fast-forward" "$result"
 result=$("$DB" "$TMPDIR/nff_b.db" "SELECT dolt_push('origin','main','--force');")
 check "force push succeeds" "0" "$result"
 
+echo "=== Working sets do not push/pull (Dolt 2.2.2 semantics) ==="
+# A push carries commits and refs only. A dirty working set stays local, and
+# every branch on a clone starts clean at its head -- a kept working-set hash
+# would name a chunk the commit-graph sync never fetches, wedging
+# dolt_branches and dolt_checkout on the clone.
+
+"$DB" "$TMPDIR/ws_src.db" <<ENDSQL
+CREATE TABLE t(a INTEGER PRIMARY KEY, b TEXT);
+INSERT INTO t VALUES(1,'main-row');
+SELECT dolt_commit('-Am','init');
+SELECT dolt_remote('add','origin','$R/ws_remote.db');
+SELECT dolt_push('origin','main');
+SELECT dolt_checkout('-b','feature');
+INSERT INTO t VALUES(2,'feat-row');
+SELECT dolt_commit('-am','feat commit');
+INSERT INTO t VALUES(3,'dirty-uncommitted');
+SELECT dolt_push('origin','feature');
+.quit
+ENDSQL
+
+result=$("$DB" "$TMPDIR/ws_clone.db" "SELECT dolt_clone('$R/ws_remote.db');" 2>&1)
+check_match "multi-branch clone succeeds" "^0$" "$result"
+
+result=$("$DB" "$TMPDIR/ws_clone.db" "SELECT name, dirty FROM dolt_branches ORDER BY name;" 2>&1)
+check "cloned branches are listable and clean" "feature|0
+main|0" "$result"
+
+result=$("$DB" "$TMPDIR/ws_clone.db" "SELECT dolt_checkout('feature'); SELECT count(*) FROM t; SELECT count(*) FROM dolt_status;" 2>&1)
+check "cloned branch checks out clean at its head" "0
+2
+0" "$result"
+
+result=$("$DB" "$TMPDIR/ws_src.db" "SELECT dolt_checkout('feature'); SELECT b FROM t WHERE a=3; SELECT count(*) FROM dolt_status;")
+check "dirty row stays in the source working set" "0
+dirty-uncommitted
+1" "$result"
+
 echo ""
 echo "======================================="
 echo "Results: $pass passed, $fail failed"


### PR DESCRIPTION
Fixes finding 5 from the deep review: any multi-branch clone was broken because branch refs pointed at working-set chunks the clone never fetched.

## Bug

Push wrote the pushed branch's working catalog into the remote refs blob (`workingSetHash`) and uploaded the working-set chunk; clone installed the refs blob verbatim but seeds its sync from commit/tag hashes only — the working-set blob is not part of the commit graph. Result: after cloning a multi-branch remote, every non-current branch's `workingSetHash` dangled, wedging `dolt_branches` (the dirty probe reads the chunk) and `dolt_checkout`:

```
SELECT dolt_clone('file://…/remote.db');     -- ok
SELECT name, dirty FROM dolt_branches;       -- error
SELECT dolt_checkout('feature');             -- error
```

## Oracle

Dolt 2.2.2, verified directly: **working sets do not push or pull.** Pushing a branch with a dirty working set transfers only the commit (the dirty row never reaches the remote), and a cloned branch checks out clean at its head ("working tree clean"). The original review suggested making clone fetch the working-set chunks — that would have preserved a divergence; the correct fix removes working sets from the remote protocol.

## Fix

- **Push**: no working-set chunk upload, no `workingSetHash` in the pushed refs blob; the declared branch's hash is explicitly cleared so old-format remotes converge as they are pushed to. Net −30 lines (the now-unused commit-catalog loader goes too).
- **Clone**: clears every branch's `workingSetHash` while installing remote refs, so refs from old-format remotes never dangle; the commit-only root collection is now correct by design.
- **Fetch/pull**: fetch already rebuilt tracking refs commit-only; pull inherits both fixes.

Ref scoping is unaffected: clearing the declared branch's hash is a declared-branch change under `doltliteValidateScopedRefsUpdate`, and the publish-time graph validation already skips empty working-set roots (old clients pushing full blobs still validate).

## Validation

- 4 new oracle-derived tests in `test/remote_test.sh` (dirty push → multi-branch clone → listable clean branches → clean checkout → dirty row stays local); the clone-side assertions fail on a master build. Suite 104/104.
- Back-compat both directions against an old-format remote (refs carrying working-set hashes): clone works with clean branches; pushing over it and re-cloning works.
- `remotesrv_http_test.sh` 37/37 with zero HTTP protocol violations across 150 requests; force-push 11/11; partial-failure 14/14; `vc_oracle_remotes_test.sh` 35/35 against dolt 2.2.2.
- Full shell battery 101/101; regression c-test 310,258/310,258 (includes the scoped-refs push, clone/push/pull persist-failure, and fetch-preserves-concurrent-refs cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)