### PR TITLE
Read historical roots by their own key shape in dolt_at and dolt_history

### DIFF
--- a/src/doltlite_at.c
+++ b/src/doltlite_at.c
@@ -287,29 +287,27 @@ static int atBestIndex(sqlite3_vtab *pVtab, sqlite3_index_info *pInfo){
     pInfo->aConstraintUsage[iRef].argvIndex=argvIdx++;
     pInfo->aConstraintUsage[iRef].omit=1;
     idxNum |= AT_IDX_REF;
+    /* Historical roots may not share the declared schema's key shape, so
+    ** PK constraints are never omitted: the values still push down for the
+    ** seek fast path, and SQLite re-checks them against the rendered row. */
     if( iEq>=0 ){
       pInfo->aConstraintUsage[iEq].argvIndex=argvIdx++;
-      pInfo->aConstraintUsage[iEq].omit=1;
       idxNum |= AT_IDX_PK_EQ;
     }else{
       if( iGe>=0 ){
         pInfo->aConstraintUsage[iGe].argvIndex=argvIdx++;
-        pInfo->aConstraintUsage[iGe].omit=1;
         idxNum |= AT_IDX_PK_GE;
       }
       if( iGt>=0 ){
         pInfo->aConstraintUsage[iGt].argvIndex=argvIdx++;
-        pInfo->aConstraintUsage[iGt].omit=1;
         idxNum |= AT_IDX_PK_GT;
       }
       if( iLe>=0 ){
         pInfo->aConstraintUsage[iLe].argvIndex=argvIdx++;
-        pInfo->aConstraintUsage[iLe].omit=1;
         idxNum |= AT_IDX_PK_LE;
       }
       if( iLt>=0 ){
         pInfo->aConstraintUsage[iLt].argvIndex=argvIdx++;
-        pInfo->aConstraintUsage[iLt].omit=1;
         idxNum |= AT_IDX_PK_LT;
       }
     }
@@ -390,8 +388,9 @@ static int atFilter(sqlite3_vtab_cursor *cur,
   if( prollyHashIsEmpty(&tableRoot) ) return SQLITE_OK;
 
   prollyCursorInit(&c->common.tblCur, cs, pCache, &tableRoot, flags);
+  c->common.rootIntKey = (flags & PROLLY_NODE_INTKEY) != 0;
 
-  seekable = (flags & PROLLY_NODE_INTKEY) != 0
+  seekable = c->common.rootIntKey
           && (idxNum & AT_IDX_PK_ANY) != 0;
 
   if( seekable && (idxNum & AT_IDX_PK_EQ) ){
@@ -457,7 +456,9 @@ static int atNext(sqlite3_vtab_cursor *cur){
     c->common.hasRow = 0;
     return SQLITE_OK;
   }
-  if( c->idxNum & AT_IDX_PK_EQ ){
+  /* The EQ probe positioned the cursor only on an intkey root; a
+  ** shape-mismatched root is scanning and must keep stepping. */
+  if( (c->idxNum & AT_IDX_PK_EQ) && c->common.rootIntKey ){
     prollyCursorClose(&c->common.tblCur);
     c->common.tblCurOpen = 0;
     c->common.hasRow = 0;
@@ -476,7 +477,8 @@ static int atNext(sqlite3_vtab_cursor *cur){
     c->common.hasRow = 0;
     return SQLITE_OK;
   }
-  if( (c->idxNum & AT_IDX_PK_ANY) && !atRowMatchesUpper(c) ){
+  if( (c->idxNum & AT_IDX_PK_ANY) && c->common.rootIntKey
+   && !atRowMatchesUpper(c) ){
     prollyCursorClose(&c->common.tblCur);
     c->common.tblCurOpen = 0;
     c->common.hasRow = 0;
@@ -497,7 +499,7 @@ static int atColumn(sqlite3_vtab_cursor *cur, sqlite3_context *ctx, int col){
                         -1, SQLITE_TRANSIENT);
   }else if(nCols>0 && col<nCols){
     doltliteResultUserCol(ctx, &v->cols, c->common.pVal, c->common.nVal,
-                          c->common.intKey, col);
+                          c->common.intKey, c->common.rootIntKey, col);
   }
 
   return SQLITE_OK;

--- a/src/doltlite_conflicts.c
+++ b/src/doltlite_conflicts.c
@@ -1198,7 +1198,7 @@ static void cfrEmitRecordCol(
   const DoltliteColInfo *pCols,
   i64 intKey
 ){
-  doltliteResultUserCol(ctx, pCols, pRec, nRec, intKey, iUserCol);
+  doltliteResultUserCol(ctx, pCols, pRec, nRec, intKey, 1, iUserCol);
 }
 
 static const char *cfrDiffType(const u8 *pBase, int nBase,

--- a/src/doltlite_constraint_violations.c
+++ b/src/doltlite_constraint_violations.c
@@ -859,7 +859,7 @@ static int cvrColumn(sqlite3_vtab_cursor *cur, sqlite3_context *ctx, int col){
         r->nVal = nRec;
       }
     }
-    doltliteResultUserCol(ctx, &v->cols, r->pVal, r->nVal, r->intKey, col - 1);
+    doltliteResultUserCol(ctx, &v->cols, r->pVal, r->nVal, r->intKey, 1, col - 1);
   }else if( col == nUserCols + 1 ){
     sqlite3_result_text(ctx, r->zInfo ? r->zInfo : "", -1, SQLITE_TRANSIENT);
   }else{

--- a/src/doltlite_diff_table.c
+++ b/src/doltlite_diff_table.c
@@ -1120,7 +1120,7 @@ static int dtColumn(sqlite3_vtab_cursor *cur, sqlite3_context *ctx, int col){
 
   if( nCols > 0 && col < nCols ){
     doltliteResultUserCol(ctx, &pVtab->cols, r->pNewVal, r->nNewVal,
-                          r->intKey, col);
+                          r->intKey, 1, col);
   }else if( nCols > 0 && col == nCols ){
 
     sqlite3_result_text(ctx, r->zToCommit, -1, SQLITE_TRANSIENT);
@@ -1129,7 +1129,7 @@ static int dtColumn(sqlite3_vtab_cursor *cur, sqlite3_context *ctx, int col){
   }else if( nCols > 0 && col < 2*nCols+2 ){
     int colIdx = col - nCols - 2;
     doltliteResultUserCol(ctx, &pVtab->cols, r->pOldVal, r->nOldVal,
-                          r->intKey, colIdx);
+                          r->intKey, 1, colIdx);
   }else if( nCols > 0 && col == 2*nCols+2 ){
 
     sqlite3_result_text(ctx, r->zFromCommit, -1, SQLITE_TRANSIENT);

--- a/src/doltlite_history.c
+++ b/src/doltlite_history.c
@@ -109,8 +109,9 @@ static int htOpenTableAtCommit(HistCursor *c, sqlite3 *db,
   }
 
   prollyCursorInit(&c->common.tblCur, cs, pCache, &tableRoot, flags);
+  c->common.rootIntKey = (flags & PROLLY_NODE_INTKEY) != 0;
 
-  seekable = (flags & PROLLY_NODE_INTKEY) != 0
+  seekable = c->common.rootIntKey
           && (c->idxNum & HIST_IDX_PK_ANY) != 0;
 
   if( seekable && (c->idxNum & HIST_IDX_PK_EQ) ){
@@ -171,7 +172,7 @@ static int htAdvance(HistCursor *c, sqlite3 *db, const char *zTableName){
   int rc;
 
   if( c->common.tblCurOpen ){
-    if( c->idxNum & HIST_IDX_PK_EQ ){
+    if( (c->idxNum & HIST_IDX_PK_EQ) && c->common.rootIntKey ){
       prollyCursorClose(&c->common.tblCur);
       c->common.tblCurOpen = 0;
     }else{
@@ -181,7 +182,8 @@ static int htAdvance(HistCursor *c, sqlite3 *db, const char *zTableName){
         c->common.tblCurOpen = 0;
         return rc;
       }
-      if( prollyCursorIsValid(&c->common.tblCur) && htRowMatchesUpper(c) ){
+      if( prollyCursorIsValid(&c->common.tblCur)
+       && (!c->common.rootIntKey || htRowMatchesUpper(c)) ){
         return doltliteVtabCommonCaptureRow(&c->common, db, zTableName);
       }
       prollyCursorClose(&c->common.tblCur);
@@ -367,7 +369,7 @@ static int htColumn(sqlite3_vtab_cursor *cur, sqlite3_context *ctx, int col){
 
   if(nCols>0 && col<nCols){
     doltliteResultUserCol(ctx, &v->cols, c->common.pVal, c->common.nVal,
-                          c->common.intKey, col);
+                          c->common.intKey, c->common.rootIntKey, col);
   }else{
     int fixedCol=col-nCols;
     switch(fixedCol){

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -349,29 +349,32 @@ static SQLITE_INLINE int doltliteBestIndexIntPkRange(
 
   if( iEq >= 0 ){
     pInfo->aConstraintUsage[iEq].argvIndex = ++nArg;
-    pInfo->aConstraintUsage[iEq].omit = 1;
+    /* The visited root's key shape may not match the declared schema's
+    ** rowid alias, so the constraint is applied against the rendered
+    ** values rather than omitted; the seek stays a pushdown fast path. */
+    pInfo->aConstraintUsage[iEq].omit = 0;
     idxNum |= idxEq;
     pInfo->estimatedCost = eqCost;
     pInfo->estimatedRows = eqRows;
   }else{
     if( iGe >= 0 ){
       pInfo->aConstraintUsage[iGe].argvIndex = ++nArg;
-      pInfo->aConstraintUsage[iGe].omit = 1;
+      pInfo->aConstraintUsage[iGe].omit = 0;
       idxNum |= idxGe;
     }
     if( iGt >= 0 ){
       pInfo->aConstraintUsage[iGt].argvIndex = ++nArg;
-      pInfo->aConstraintUsage[iGt].omit = 1;
+      pInfo->aConstraintUsage[iGt].omit = 0;
       idxNum |= idxGt;
     }
     if( iLe >= 0 ){
       pInfo->aConstraintUsage[iLe].argvIndex = ++nArg;
-      pInfo->aConstraintUsage[iLe].omit = 1;
+      pInfo->aConstraintUsage[iLe].omit = 0;
       idxNum |= idxLe;
     }
     if( iLt >= 0 ){
       pInfo->aConstraintUsage[iLt].argvIndex = ++nArg;
-      pInfo->aConstraintUsage[iLt].omit = 1;
+      pInfo->aConstraintUsage[iLt].omit = 0;
       idxNum |= idxLt;
     }
     if( idxNum != 0 ){

--- a/src/doltlite_record.c
+++ b/src/doltlite_record.c
@@ -490,6 +490,7 @@ void doltliteResultUserCol(
   const DoltliteColInfo *ci,
   const u8 *pRec, int nRec,
   i64 intKey,
+  int bRootIntKey,
   int iDeclaredCol
 ){
   int iRecField;
@@ -500,7 +501,10 @@ void doltliteResultUserCol(
     return;
   }
 
-  if( iDeclaredCol==ci->iPkCol && ci->iPkCol>=0 ){
+  /* intKey is the row's key only when the visited root is an intkey tree.
+  ** A historical root with a different key shape stores the whole row in
+  ** the record, so the declared rowid-alias column reads from there. */
+  if( iDeclaredCol==ci->iPkCol && ci->iPkCol>=0 && bRootIntKey ){
     sqlite3_result_int64(ctx, intKey);
     return;
   }

--- a/src/doltlite_vtab_util.h
+++ b/src/doltlite_vtab_util.h
@@ -34,6 +34,7 @@ struct DoltliteVtabCursorCommon {
   sqlite3_vtab_cursor base;
   ProllyCursor tblCur;
   int tblCurOpen;
+  u8 rootIntKey;
   i64 intKey;
   u8 *pVal;
   int nVal;
@@ -53,6 +54,7 @@ static SQLITE_INLINE void doltliteVtabCommonReset(
   c->nVal = 0;
   c->hasRow = 0;
   c->iRowid = 0;
+  c->rootIntKey = 0;
 }
 
 static SQLITE_INLINE int doltliteVtabCommonCaptureRow(

--- a/src/doltlite_workspace.c
+++ b/src/doltlite_workspace.c
@@ -445,10 +445,10 @@ static int wsColumn(sqlite3_vtab_cursor *cur, sqlite3_context *ctx, int col){
     else sqlite3_result_null(ctx);
   }else if( col>=3 && col<3+nCols ){
     doltliteResultUserCol(ctx, &p->cols, r->pNewVal, r->nNewVal,
-                          r->intKey, col-3);
+                          r->intKey, 1, col-3);
   }else if( col>=3+nCols && col<3+2*nCols ){
     doltliteResultUserCol(ctx, &p->cols, r->pOldVal, r->nOldVal,
-                          r->intKey, col-3-nCols);
+                          r->intKey, 1, col-3-nCols);
   }else{
     sqlite3_result_null(ctx);
   }

--- a/src/record_codec.h
+++ b/src/record_codec.h
@@ -53,6 +53,7 @@ void doltliteResultUserCol(sqlite3_context *ctx,
                            const DoltliteColInfo *ci,
                            const u8 *pRec, int nRec,
                            i64 intKey,
+                           int bRootIntKey,
                            int iDeclaredCol);
 
 int doltliteFieldValuesEqual(int aType, const u8 *pA, int nA, int aOff,

--- a/test/doltlite_at.sh
+++ b/test/doltlite_at.sh
@@ -328,4 +328,37 @@ run_test "empty_at_c2" \
 
 rm -f "$DB"
 
+# A historical root whose key shape differs from the declared schema (table
+# dropped and recreated across a rowid/WITHOUT ROWID boundary) must render
+# the historical row values -- matching Dolt's AS OF -- and pushed-down PK
+# constraints must still filter (they were silently dropped for such roots).
+DB=/tmp/test_at_keyshape_$$.db; rm -f "$DB"
+echo "CREATE TABLE s(a TEXT PRIMARY KEY, b TEXT) WITHOUT ROWID;
+INSERT INTO s VALUES('x','one'),('y','two');
+SELECT dolt_commit('-Am','v1');
+SELECT dolt_tag('oldtag');
+DROP TABLE s;
+CREATE TABLE s(a INTEGER PRIMARY KEY, b TEXT);
+INSERT INTO s VALUES(1,'one'),(2,'two'),(7,'seven');
+SELECT dolt_commit('-Am','v2');" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+run_test "keyshape_values_render" \
+  "SELECT a, b FROM dolt_at_s WHERE commit_ref='oldtag' ORDER BY a;" \
+  "x|one
+y|two" "$DB"
+run_test "keyshape_eq_filters" \
+  "SELECT count(*) FROM dolt_at_s WHERE commit_ref='oldtag' AND a=7;" \
+  "0" "$DB"
+run_test "keyshape_eq_matches_text" \
+  "SELECT b FROM dolt_at_s WHERE commit_ref='oldtag' AND a='y';" \
+  "two" "$DB"
+run_test "keyshape_current_seek_intact" \
+  "SELECT b FROM dolt_at_s WHERE commit_ref='HEAD' AND a=7;" \
+  "seven" "$DB"
+run_test "keyshape_upper_bound_scans_all" \
+  "SELECT count(*) FROM dolt_at_s WHERE commit_ref='oldtag' AND a<'z';" \
+  "2" "$DB"
+
+rm -f "$DB"
+
 dltest_finish

--- a/test/doltlite_history.sh
+++ b/test/doltlite_history.sh
@@ -306,4 +306,33 @@ run_test_match "filter_commit" \
 
 rm -f "$DB"
 
+# Rows from a historical root whose key shape differs from the declared
+# schema must render their real values and honor PK constraints; the old
+# code returned raw sort-key bytes for the key column and dropped the
+# pushed-down filter entirely.
+DB=/tmp/test_hist_keyshape_$$.db; rm -f "$DB"
+echo "CREATE TABLE s(a TEXT PRIMARY KEY, b TEXT) WITHOUT ROWID;
+INSERT INTO s VALUES('x','one'),('y','two');
+SELECT dolt_commit('-Am','v1');
+DROP TABLE s;
+CREATE TABLE s(a INTEGER PRIMARY KEY, b TEXT);
+INSERT INTO s VALUES(1,'one'),(2,'two'),(7,'seven');
+SELECT dolt_commit('-Am','v2');" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+run_test "keyshape_history_eq_filters" \
+  "SELECT a, b FROM dolt_history_s WHERE a=7;" \
+  "7|seven" "$DB"
+run_test "keyshape_history_upper_bound" \
+  "SELECT count(*) FROM dolt_history_s WHERE a<'z';" \
+  "2" "$DB"
+run_test "keyshape_history_values_render" \
+  "SELECT a FROM dolt_history_s ORDER BY a;" \
+  "1
+2
+7
+x
+y" "$DB"
+
+rm -f "$DB"
+
 dltest_finish


### PR DESCRIPTION
Fixes finding 2 from the deep review (the last of the five): `dolt_at_*` and `dolt_history_*` misread historical tables whose key shape differs from the current schema.

## Bug

`xBestIndex` decided PK pushdown from the *current* schema's rowid alias with `omit=1`, but `xFilter` walks table roots at *other* commits. For a root that isn't an intkey tree (table recreated across a rowid/WITHOUT ROWID boundary), the omitted filter was silently dropped and the key column rendered raw clustered sort-key bytes:

```sql
-- s committed as (a TEXT PRIMARY KEY) WITHOUT ROWID with 'x','y'; recreated as (a INTEGER PRIMARY KEY)
SELECT a,b FROM dolt_at_s WHERE commit_ref='oldtag' AND a=7;    -- returned a spurious row
SELECT a,b FROM dolt_at_s WHERE commit_ref='oldtag';            -- a = -5370542554742194176
SELECT a,b FROM dolt_history_s WHERE a=7;                       -- historical junk rows
```

## Oracle (Dolt 2.2.2, verified directly)

`SELECT … AS OF 'oldtag'` returns the historical values (`x|one`, `y|two`) and its WHERE evaluates against them (`a=7` → empty). `dolt_history_s` maps non-key columns by name (`b` shows `one`,`two`) and renders NULL for the type-incompatible key column. **One deliberate divergence, flagged for review:** Dolt's NULL is a strong-typing artifact (a VARCHAR value cannot inhabit an INTEGER column in MySQL); doltlite is dynamically typed and renders the actual historical value (`x`) instead — no information destroyed, consistent with `dolt_at`/AS OF, and the same class as the documented type divergences. Non-key columns match Dolt exactly.

## Fix

- **Filtering:** PK constraints are no longer omitted in `atBestIndex` and the shared `doltliteBestIndexIntPkRange` (history and blame). The values still push down, so the intkey seek fast path is untouched (`WHERE commit_ref='HEAD' AND a=7` still probes); SQLite now re-checks each row against the rendered values, which filters correctly for every root shape.
- **Rendering:** the cursor captures each visited root's key shape, and `doltliteResultUserCol` serves `intKey` for the rowid-alias column only when the root really is an intkey tree. Clustered roots store the full row in the record, so the key column reads the genuine historical value. Other callers (diff/conflicts/constraint-violations/workspace) pass a compatibility flag and are behaviorally unchanged.
- **Two exposed scan-termination bugs, same root cause:** the PK_EQ single-row shortcut and the upper-bound range checks consumed `intKey` on scans of non-seekable roots — `WHERE a='y'` terminated after one unmatched row, and `a<'z'` only survived because the garbage key happened to be negative. Both are now gated on the root shape.

## Validation

- 7 new tests across `test/doltlite_at.sh` (51/51) and `test/doltlite_history.sh` (46/46); five fail on a master-built control binary (values render, EQ filters, text-EQ matches, history EQ, history values).
- Full shell battery 101/101; regression c-test 310,258/310,258.
- Manual: original review repro produces exact AS OF-oracle results; current-shape seek path verified intact.

Known remaining approximation (pre-existing, unchanged): cross-schema column mapping is positional (doltlite has no column tags), so a historical schema whose PK wasn't the first declared column maps columns by position, and a PK-covering clustered root under a mismatched current schema renders NULL (its row lives in the sort key, which needs the historical KeyInfo to decode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)