### PR TITLE
Speed up integer prolly node searches

### DIFF
--- a/src/prolly_node.c
+++ b/src/prolly_node.c
@@ -194,9 +194,15 @@ void prollyEncodeIntKey(i64 v, u8 buf[8]){
   buf[7] = (u8)u;
 }
 
+static SQLITE_INLINE u64 prollyReadEncodedIntKey(const u8 *p){
+  return ((u64)p[0]<<56) | ((u64)p[1]<<48)
+       | ((u64)p[2]<<40) | ((u64)p[3]<<32)
+       | ((u64)p[4]<<24) | ((u64)p[5]<<16)
+       | ((u64)p[6]<<8) | (u64)p[7];
+}
+
 i64 prollyDecodeIntKey(const u8 *p){
-  u64 u = ((u64)p[0]<<56) | ((u64)p[1]<<48) | ((u64)p[2]<<40) | ((u64)p[3]<<32)
-        | ((u64)p[4]<<24) | ((u64)p[5]<<16) | ((u64)p[6]<<8) | (u64)p[7];
+  u64 u = prollyReadEncodedIntKey(p);
   return (i64)(u ^ ((u64)1 << 63));
 }
 
@@ -310,36 +316,39 @@ int prollyNodeSearchBlob(
 
 int prollyNodeSearchInt(const ProllyNode *pNode, i64 intKey, int *pRes){
   int lo = 0;
-  int hi = pNode->nItems - 1;
+  int hi = pNode->nItems;
   int mid;
-  i64 midKey;
+  u64 key = ((u64)intKey) ^ ((u64)1 << 63);
+  u64 midKey;
 
   if( pNode->nItems==0 ){
     *pRes = -1;
     return 0;
   }
 
-  while( lo<=hi ){
+  while( lo<hi ){
+    const u8 *p;
     mid = lo + (hi - lo) / 2;
-    midKey = prollyNodeIntKey(pNode, mid);
+    p = pNode->pKeyData + mid*8;
+    midKey = prollyReadEncodedIntKey(p);
 
-    if( intKey==midKey ){
-      *pRes = 0;
-      return mid;
-    }else if( intKey<midKey ){
-      hi = mid - 1;
-    }else{
+    if( midKey<key ){
       lo = mid + 1;
+    }else{
+      hi = mid;
     }
   }
 
   if( lo>=pNode->nItems ){
     *pRes = 1;
     return pNode->nItems - 1;
-  }else{
-    *pRes = -1;
-    return lo;
   }
+  {
+    const u8 *p = pNode->pKeyData + lo*8;
+    midKey = prollyReadEncodedIntKey(p);
+  }
+  *pRes = key==midKey ? 0 : -1;
+  return lo;
 }
 
 #define PROLLY_BUILDER_INIT_CAP  64


### PR DESCRIPTION
## Summary

- compare stored sign-normalized integer keys directly instead of decoding every midpoint
- use a branchless lower-bound search with one ordering comparison per iteration
- preserve exact-hit and before/after miss positioning semantics for all integer-key cursors

This is a general prolly-tree lookup optimization used by INTEGER PRIMARY KEY reads and write-side seeks; sysbench is only the measurement workload.

## Profile and performance

A sampled in-memory point-select profile identified prollyNodeSearchInt as roughly 16% of workload CPU. The optimized profile reduced samples in that function from 489 to 413.

An isolated mixed hit/miss benchmark over 4,096-key nodes ran 30 million searches per trial:

| Trial | Master | Candidate | Improvement |
|---|---:|---:|---:|
| Median of 4 | 0.930 s | 0.600 s | 35.5% |

Paired sysbench-style results at the nightly 100,000-row size, median of 5 alternating invocations per test:

| Section | Master/Candidate average |
|---|---:|
| In-memory reads | 0.98x |
| In-memory writes | 0.99x |
| File-backed reads | 1.00x |
| File-backed writes | 1.00x |

In-memory oltp_point_select improved from 16,441 us to 16,088 us. All benchmark tests stayed within their ceilings.

## Validation

- make lint
- 101/101 DoltLite native suites
- doltlite_parity.sh: 119/119
- focused prolly cursor, batch replacement, and node corruption C tests
- boundary1-4, intpkey, and rowid testfixture suites
- explicit INT64_MIN through INT64_MAX rowid comparison against stock behavior

Co-Authored-By: OpenAI Codex <noreply@openai.com>