### PR TITLE
Avoid duplicate pending-map probes on mutations

### DIFF
--- a/src/prolly_btree_cursor_seek.c
+++ b/src/prolly_btree_cursor_seek.c
@@ -78,6 +78,11 @@ int prollyBtCursorTableMoveto(
     }
     rc = prollyMutMapFindRc(pCur->pMutMap, 0, 0, intKey, &pEntry);
     if( rc!=SQLITE_OK ) return rc;
+    if( !pEntry ){
+      pCur->mmExactMiss = 1;
+      pCur->mmMissGeneration = pCur->pMutMap->generation;
+      pCur->mmMissIntKey = intKey;
+    }
     if( pEntry && pEntry->op==PROLLY_EDIT_INSERT ){
       if( pCur->isPinned ){
         return SQLITE_CONSTRAINT_PINNED;
@@ -494,6 +499,7 @@ static int indexMovetoExactMutMap(
   struct TableEntry *pTE;
   ProllyMutMap *pPending;
   ProllyMutMapEntry *pEntry = 0;
+  int cursorMapMiss = 0;
   int rc;
 
   *pDone = 0;
@@ -506,6 +512,7 @@ static int indexMovetoExactMutMap(
   if( pCur->pMutMap && !prollyMutMapIsEmpty(pCur->pMutMap) ){
     rc = prollyMutMapFindRc(pCur->pMutMap, pSortKey, nSortKey, 0, &pEntry);
     if( rc!=SQLITE_OK ) return rc;
+    cursorMapMiss = pEntry==0;
     if( pEntry && pEntry->op==PROLLY_EDIT_INSERT ){
       if( pCur->isPinned ) return SQLITE_CONSTRAINT_PINNED;
       setCursorToMutMapEntryPhys(
@@ -535,6 +542,14 @@ static int indexMovetoExactMutMap(
       *pDone = 1;
       return SQLITE_OK;
     }
+  }
+  if( cursorMapMiss
+   && (!pPending || pPending==pCur->pMutMap)
+   && nSortKey<=(int)sizeof(pCur->aMmMissKey) ){
+    pCur->mmExactMiss = 1;
+    pCur->mmMissGeneration = pCur->pMutMap->generation;
+    pCur->nMmMissKey = nSortKey;
+    memcpy(pCur->aMmMissKey, pSortKey, nSortKey);
   }
   return SQLITE_OK;
 }

--- a/src/prolly_btree_int.h
+++ b/src/prolly_btree_int.h
@@ -416,8 +416,13 @@ struct BtCursor {
 
   int mmIdx;
   int mmPhysIdx;
+  int nMmMissKey;
+  i64 mmMissIntKey;
+  u32 mmMissGeneration;
+  u8 aMmMissKey[40];
   u8 mmActive;
   u8 mmPhysActive;
+  u8 mmExactMiss;
   u8 deferredTreeSeek;
   u8 deferredMergedSeek;
 #define MERGE_SRC_TREE  0

--- a/src/prolly_btree_mutation.c
+++ b/src/prolly_btree_mutation.c
@@ -324,6 +324,7 @@ void clearMergeCursorState(BtCursor *pCur){
   pCur->mmPhysIdx = -1;
   pCur->mmActive = 0;
   pCur->mmPhysActive = 0;
+  pCur->mmExactMiss = 0;
   pCur->deferredTreeSeek = 0;
   pCur->deferredMergedSeek = 0;
   pCur->mergeSrc = MERGE_SRC_TREE;
@@ -525,6 +526,7 @@ void refreshCursorMutMapAliases(Btree *pBtree, BtShared *pBt,
       p->pMutMap = pNewMap;
       p->mmActive = 0;
       p->mmPhysActive = 0;
+      p->mmExactMiss = 0;
       p->deferredTreeSeek = 0;
       p->mmIdx = -1;
       p->mmPhysIdx = -1;
@@ -810,6 +812,13 @@ int prollyBtCursorInsert(
       ** zeros are never materialized in memory. */
       rc = prollyMutMapInsertZeroTail(pCur->pMutMap, pPayload->nKey,
                                       pData, nData, (i64)pPayload->nZero);
+    }else if( pCur->mmExactMiss
+     && pCur->pMutMap
+     && pCur->mmMissGeneration==pCur->pMutMap->generation
+     && pCur->mmMissIntKey==pPayload->nKey ){
+      rc = prollyMutMapInsertAbsent(pCur->pMutMap,
+                                    NULL, 0, pPayload->nKey,
+                                    pData, nData);
     }else if( pCur->mmActive
      && pCur->mmPhysActive
      && pCur->pMutMap
@@ -874,7 +883,16 @@ int prollyBtCursorInsert(
       pSortKey = pCur->pSeekSortKey;
     }
     if( rc==SQLITE_OK ){
-      if( storePayload ){
+      if( pCur->mmExactMiss
+       && pCur->pMutMap
+       && pCur->mmMissGeneration==pCur->pMutMap->generation
+       && pCur->nMmMissKey==nSortKey
+       && memcmp(pCur->aMmMissKey, pSortKey, nSortKey)==0 ){
+        rc = prollyMutMapInsertAbsent(
+            pCur->pMutMap, pSortKey, nSortKey, 0,
+            storePayload ? (const u8*)pPayload->pKey : NULL,
+            storePayload ? (int)pPayload->nKey : 0);
+      }else if( storePayload ){
         rc = prollyMutMapInsert(pCur->pMutMap,
                                  pSortKey, nSortKey, 0,
                                  (const u8*)pPayload->pKey, (int)pPayload->nKey);
@@ -1225,7 +1243,12 @@ int prollyBtCursorDelete(BtCursor *pCur, u8 flags){
   }
   if( pCur->curIntKey ){
     iKey = savedIntKey;
-    if( pCur->mmActive
+    if( pCur->mmExactMiss
+     && pCur->pMutMap
+     && pCur->mmMissGeneration==pCur->pMutMap->generation
+     && pCur->mmMissIntKey==iKey ){
+      rc = prollyMutMapDeleteAbsent(pCur->pMutMap, NULL, 0, iKey);
+    }else if( pCur->mmActive
      && pCur->mmPhysActive
      && pCur->pMutMap
      && (pCur->mergeSrc==MERGE_SRC_MUT || pCur->mergeSrc==MERGE_SRC_BOTH) ){
@@ -1244,7 +1267,13 @@ int prollyBtCursorDelete(BtCursor *pCur, u8 flags){
   } else {
     pKey = pSavedDelKey;
     nKey = nSavedDelKey;
-    if( pCur->mmActive
+    if( pCur->mmExactMiss
+     && pCur->pMutMap
+     && pCur->mmMissGeneration==pCur->pMutMap->generation
+     && pCur->nMmMissKey==nKey
+     && memcmp(pCur->aMmMissKey, pKey, nKey)==0 ){
+      rc = prollyMutMapDeleteAbsent(pCur->pMutMap, pKey, nKey, 0);
+    }else if( pCur->mmActive
      && pCur->mmPhysActive
      && pCur->pMutMap
      && (pCur->mergeSrc==MERGE_SRC_MUT || pCur->mergeSrc==MERGE_SRC_BOTH) ){

--- a/src/prolly_mutmap.c
+++ b/src/prolly_mutmap.c
@@ -549,6 +549,44 @@ static void updateAppendSorted(ProllyMutMap *mm, int phys){
   }
 }
 
+static int appendEntry(
+  ProllyMutMap *mm,
+  const u8 *pKey, int nKey,
+  const u8 *pVal, int nVal,
+  int idx, u8 op, i64 nZeroTail
+){
+  ProllyMutMapEntry *e;
+  int phys;
+  int rc;
+
+  rc = ensureCapacity(mm);
+  if( rc!=SQLITE_OK ) return rc;
+  rc = ensureHashForInsert(mm);
+  if( rc!=SQLITE_OK ) return rc;
+
+  phys = mm->nEntries;
+  e = &mm->aEntries[phys];
+  memset(e, 0, sizeof(*e));
+  e->op = op;
+  e->bornAt = encodeLevel(mm, mm->currentSavepointLevel);
+  rc = copyEntryData(mm, e, pKey, nKey, pVal, nVal);
+  if( rc!=SQLITE_OK ) return rc;
+  e->nZeroTail = nZeroTail;
+  updateAppendSorted(mm, phys);
+  if( mm->keepSorted || (!mm->orderDirty && mm->preferSorted) ){
+    insertOrderEntry(mm, idx, phys);
+  }else{
+    mm->aOrder[phys] = phys;
+    mm->aPos[phys] = phys;
+    mm->orderDirty = 1;
+  }
+
+  mm->nEntries++;
+  if( !mm->keepSorted ) hashInsertPhys(mm, phys);
+  mm->generation++;
+  return SQLITE_OK;
+}
+
 static int appendUndoRec(ProllyMutMap *mm, int idx){
   ProllyMutMapEntry *e;
   ProllyMutMapUndoRec *rec;
@@ -616,38 +654,25 @@ int prollyMutMapInsert(
     return SQLITE_OK;
   }
 
-  rc = ensureCapacity(mm);
-  if( rc!=SQLITE_OK ) return rc;
-  rc = ensureHashForInsert(mm);
-  if( rc!=SQLITE_OK ) return rc;
+  return appendEntry(mm, pKey, nKey, pVal, nVal, idx,
+                     PROLLY_EDIT_INSERT, 0);
+}
 
-  {
-    ProllyMutMapEntry *e;
-    phys = mm->nEntries;
-    e = &mm->aEntries[phys];
-    memset(e, 0, sizeof(*e));
-    e->op = PROLLY_EDIT_INSERT;
-    e->bornAt = encodeLevel(mm, mm->currentSavepointLevel);
-    rc = copyEntryData(mm, e, pKey, nKey, pVal, nVal);
-    if( rc!=SQLITE_OK ){
-      return rc;
-    }
-    updateAppendSorted(mm, phys);
-    if( mm->keepSorted || (!mm->orderDirty && mm->preferSorted) ){
-      insertOrderEntry(mm, idx, phys);
-    }else{
-      mm->aOrder[phys] = phys;
-      mm->aPos[phys] = phys;
-      mm->orderDirty = 1;
-    }
+int prollyMutMapInsertAbsent(
+  ProllyMutMap *mm,
+  const u8 *pKey, int nKey, i64 intKey,
+  const u8 *pVal, int nVal
+){
+  int found = 0;
+  int idx = 0;
+  u8 keyBuf[8];
+  prepKey(mm, &pKey, &nKey, intKey, keyBuf);
+  if( mm->keepSorted || !mm->orderDirty ){
+    idx = bsearch_key(mm, pKey, nKey, &found);
+    if( found ) return prollyMutMapInsert(mm, pKey, nKey, intKey, pVal, nVal);
   }
-
-  mm->nEntries++;
-  if( !mm->keepSorted ){
-    hashInsertPhys(mm, phys);
-  }
-  mm->generation++;
-  return SQLITE_OK;
+  return appendEntry(mm, pKey, nKey, pVal, nVal, idx,
+                     PROLLY_EDIT_INSERT, 0);
 }
 
 /* Insert a value of pVal[0..nValPrefix) followed by nZeroTail zero bytes,
@@ -696,39 +721,8 @@ int prollyMutMapInsertZeroTail(
     return SQLITE_OK;
   }
 
-  rc = ensureCapacity(mm);
-  if( rc!=SQLITE_OK ) return rc;
-  rc = ensureHashForInsert(mm);
-  if( rc!=SQLITE_OK ) return rc;
-
-  {
-    ProllyMutMapEntry *e;
-    phys = mm->nEntries;
-    e = &mm->aEntries[phys];
-    memset(e, 0, sizeof(*e));
-    e->op = PROLLY_EDIT_INSERT;
-    e->bornAt = encodeLevel(mm, mm->currentSavepointLevel);
-    rc = copyEntryData(mm, e, pKey, nKey, pVal, nValPrefix);
-    if( rc!=SQLITE_OK ){
-      return rc;
-    }
-    e->nZeroTail = nZeroTail;
-    updateAppendSorted(mm, phys);
-    if( mm->keepSorted || (!mm->orderDirty && mm->preferSorted) ){
-      insertOrderEntry(mm, idx, phys);
-    }else{
-      mm->aOrder[phys] = phys;
-      mm->aPos[phys] = phys;
-      mm->orderDirty = 1;
-    }
-  }
-
-  mm->nEntries++;
-  if( !mm->keepSorted ){
-    hashInsertPhys(mm, phys);
-  }
-  mm->generation++;
-  return SQLITE_OK;
+  return appendEntry(mm, pKey, nKey, pVal, nValPrefix, idx,
+                     PROLLY_EDIT_INSERT, nZeroTail);
 }
 
 int prollyMutMapReplaceEntry(
@@ -790,38 +784,22 @@ int prollyMutMapDelete(
     return SQLITE_OK;
   }
 
-  rc = ensureCapacity(mm);
-  if( rc!=SQLITE_OK ) return rc;
-  rc = ensureHashForInsert(mm);
-  if( rc!=SQLITE_OK ) return rc;
+  return appendEntry(mm, pKey, nKey, 0, 0, idx, PROLLY_EDIT_DELETE, 0);
+}
 
-  {
-    ProllyMutMapEntry *e;
-    phys = mm->nEntries;
-    e = &mm->aEntries[phys];
-    memset(e, 0, sizeof(*e));
-    e->op = PROLLY_EDIT_DELETE;
-    e->bornAt = encodeLevel(mm, mm->currentSavepointLevel);
-    rc = copyEntryData(mm, e, pKey, nKey, 0, 0);
-    if( rc!=SQLITE_OK ){
-      return rc;
-    }
-    updateAppendSorted(mm, phys);
-    if( mm->keepSorted || (!mm->orderDirty && mm->preferSorted) ){
-      insertOrderEntry(mm, idx, phys);
-    }else{
-      mm->aOrder[phys] = phys;
-      mm->aPos[phys] = phys;
-      mm->orderDirty = 1;
-    }
+int prollyMutMapDeleteAbsent(
+  ProllyMutMap *mm,
+  const u8 *pKey, int nKey, i64 intKey
+){
+  int found = 0;
+  int idx = 0;
+  u8 keyBuf[8];
+  prepKey(mm, &pKey, &nKey, intKey, keyBuf);
+  if( mm->keepSorted || !mm->orderDirty ){
+    idx = bsearch_key(mm, pKey, nKey, &found);
+    if( found ) return prollyMutMapDelete(mm, pKey, nKey, intKey);
   }
-
-  mm->nEntries++;
-  if( !mm->keepSorted ){
-    hashInsertPhys(mm, phys);
-  }
-  mm->generation++;
-  return SQLITE_OK;
+  return appendEntry(mm, pKey, nKey, 0, 0, idx, PROLLY_EDIT_DELETE, 0);
 }
 
 int prollyMutMapDeleteEntry(

--- a/src/prolly_mutmap.h
+++ b/src/prolly_mutmap.h
@@ -76,6 +76,10 @@ int prollyMutMapInsert(ProllyMutMap *mm,
                        const u8 *pKey, int nKey, i64 intKey,
                        const u8 *pVal, int nVal);
 
+int prollyMutMapInsertAbsent(ProllyMutMap *mm,
+                             const u8 *pKey, int nKey, i64 intKey,
+                             const u8 *pVal, int nVal);
+
 int prollyMutMapInsertZeroTail(ProllyMutMap *mm, i64 intKey,
                                const u8 *pVal, int nValPrefix,
                                i64 nZeroTail);
@@ -89,6 +93,9 @@ int prollyMutMapReplaceEntry(
 
 int prollyMutMapDelete(ProllyMutMap *mm,
                        const u8 *pKey, int nKey, i64 intKey);
+
+int prollyMutMapDeleteAbsent(ProllyMutMap *mm,
+                             const u8 *pKey, int nKey, i64 intKey);
 
 int prollyMutMapDeleteEntry(
   ProllyMutMap *mm,

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -8413,21 +8413,34 @@ static void run_mutmap_differential_randomized(void){
     int op = (int)(r % 10);
     i64 key = (i64)(mutmapRandNext(&rng) % 64);
     int val = (int)(mutmapRandNext(&rng) % 100000);
+    int useAbsent = mutmapModelFindIndex(&model, key)<0 && (r & 0x100)!=0;
 
     if( op < 4 ){
       rc = mutmapModelSet(&model, key, PROLLY_EDIT_INSERT, val);
       check("mutmap_diff_model_insert_rc", rc==SQLITE_OK);
       check("mutmap_diff_sorted_insert_rc",
-            prollyMutMapInsert(&sorted, 0, 0, key, (const u8*)&val, sizeof(val))==SQLITE_OK);
+            (useAbsent
+              ? prollyMutMapInsertAbsent(&sorted, 0, 0, key,
+                                         (const u8*)&val, sizeof(val))
+              : prollyMutMapInsert(&sorted, 0, 0, key,
+                                   (const u8*)&val, sizeof(val)))==SQLITE_OK);
       check("mutmap_diff_lazy_insert_rc",
-            prollyMutMapInsert(&lazy, 0, 0, key, (const u8*)&val, sizeof(val))==SQLITE_OK);
+            (useAbsent
+              ? prollyMutMapInsertAbsent(&lazy, 0, 0, key,
+                                         (const u8*)&val, sizeof(val))
+              : prollyMutMapInsert(&lazy, 0, 0, key,
+                                   (const u8*)&val, sizeof(val)))==SQLITE_OK);
     }else if( op < 7 ){
       rc = mutmapModelSet(&model, key, PROLLY_EDIT_DELETE, 0);
       check("mutmap_diff_model_delete_rc", rc==SQLITE_OK);
       check("mutmap_diff_sorted_delete_rc",
-            prollyMutMapDelete(&sorted, 0, 0, key)==SQLITE_OK);
+            (useAbsent
+              ? prollyMutMapDeleteAbsent(&sorted, 0, 0, key)
+              : prollyMutMapDelete(&sorted, 0, 0, key))==SQLITE_OK);
       check("mutmap_diff_lazy_delete_rc",
-            prollyMutMapDelete(&lazy, 0, 0, key)==SQLITE_OK);
+            (useAbsent
+              ? prollyMutMapDeleteAbsent(&lazy, 0, 0, key)
+              : prollyMutMapDelete(&lazy, 0, 0, key))==SQLITE_OK);
     }else if( op == 7 ){
       level++;
       check("mutmap_diff_push_snapshot",


### PR DESCRIPTION
## Summary

- carry generation-validated pending-map misses from exact cursor seeks into the following mutation
- append proven-absent integer and short blob keys without hashing and probing the same mutation map twice
- share the existing new-entry path between ordinary and proven-absent insert/delete operations

## Profile

A sampled sustained indexed-update workload showed pending-map lookup and hashing routines on both the seek and mutation sides. The seek already establishes exact absence; the following insert or delete repeated findPhysLazy for the same key. The new path preserves that exact key plus the map generation, falling back to the normal lookup whenever either changes.

## Performance

Paired DoltLite-before vs DoltLite-after sysbench-style runs, 100,000 rows, median of 15 alternating invocations:

| Workload | Before | After | Change |
|---|---:|---:|---:|
| in-memory indexed update | 62,810 us | 60,657 us | -3.4% |
| in-memory delete/insert | 45,263 us | 44,030 us | -2.7% |
| file-backed indexed update | 89,364 us | 88,099 us | -1.4% |
| file-backed delete/insert | 63,620 us | 63,190 us | -0.7% |

A separate 31-pair mixed read/write run measured 65,928 -> 65,338 us in memory (-0.9%) and 82,983 -> 83,629 us file-backed (+0.8%, neutral at this variance).

## Tests

- test/run_c_tests.sh: 26/26 gated binaries passed
- mutation-map randomized differential: 6,516 checks passed
- transaction stress: 1,577 checks passed
- focused table/index cursor alignment and rollback tests passed
- make lint

Co-Authored-By: OpenAI Codex <noreply@openai.com>