### PR TITLE
Inline the prolly cursor scan path

### DIFF
--- a/src/prolly_btree_cursor.c
+++ b/src/prolly_btree_cursor.c
@@ -528,7 +528,11 @@ int sqlite3BtreeLast(BtCursor *pCur, int *pRes){
   return pCur->pCurOps->xLast(pCur, pRes);
 }
 
-static int prollyBtCursorStepPrologue(BtCursor *pCur, int dir, int *pImmediate){
+static SQLITE_INLINE int prollyBtCursorStepPrologue(
+  BtCursor *pCur,
+  int dir,
+  int *pImmediate
+){
   int rc;
   *pImmediate = 1;
   CLEAR_CACHED_PAYLOAD(pCur);
@@ -600,7 +604,7 @@ static int prollyCursorApplyMergeStep(BtCursor *pCur, int dir){
 ** through eState, never by returning SQLITE_DONE, so returning SQLITE_DONE here
 ** unambiguously means "went invalid" and lets callers skip the trailing
 ** curFlags clear exactly as the open-coded versions did. */
-static int prollyCursorFinishTreeStep(BtCursor *pCur, int rc){
+static SQLITE_INLINE int prollyCursorFinishTreeStep(BtCursor *pCur, int rc){
   if( rc!=SQLITE_OK ) return rc;
   if( pCur->pCur.eState==PROLLY_CURSOR_VALID ){
     pCur->eState = CURSOR_VALID;


### PR DESCRIPTION
## Summary

- force-inline cursor step setup and tree-step completion into next/previous
- remove two function-call boundaries from the per-row scan hot path
- preserve the existing cursor state, interrupt, payload-cache, and mutation-map behavior

## Profile

A sampled sustained table-scan workload placed prollyBtCursorStepPrologue among the top standalone engine frames, with prollyCursorFinishTreeStep directly beneath the common next-row path. Both helpers execute for every row. After marking these small internal helpers SQLITE_INLINE, a follow-up sample contained no standalone frames for either helper.

## Performance

Paired DoltLite-before vs DoltLite-after sysbench-style runs, 100,000 rows, median of 7 alternating invocations:

| Workload | In-memory before | In-memory after | Change | File before | File after | Change |
|---|---:|---:|---:|---:|---:|---:|
| range select | 9,109 us | 8,823 us | -3.1% | 10,482 us | 10,321 us | -1.5% |
| sum range | 7,242 us | 6,959 us | -3.9% | 8,781 us | 8,596 us | -2.1% |
| group-by scan | 23,921 us | 23,758 us | -0.7% | 24,117 us | 23,997 us | -0.5% |
| typed table scan | 1,147,344 us | 1,123,661 us | -2.1% | 1,152,267 us | 1,122,884 us | -2.6% |
| table scan | 1,423,420 us | 1,383,102 us | -2.8% | 1,411,316 us | 1,382,804 us | -2.0% |

The average workload ratio improved to 0.97 in memory and 0.98 file-backed. Every measured workload was flat-to-faster.

## Tests

- test/run_c_tests.sh: 26/26 gated binaries passed
- doltlite_regression_test_c all: 310,258 checks passed
- make lint

Co-Authored-By: OpenAI Codex <noreply@openai.com>