### PR TITLE
Avoid allocations for common integer index seeks

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -1521,11 +1521,11 @@ int prollyBtCursorCloseCursor(BtCursor *pCur){
     pCur->pSeekRecord = 0;
     pCur->nSeekRecordAlloc = 0;
   }
-  if( pCur->pSeekSortKey ){
+  if( pCur->pSeekSortKey && pCur->pSeekSortKey!=pCur->aSeekSortKey ){
     sqlite3_free(pCur->pSeekSortKey);
-    pCur->pSeekSortKey = 0;
-    pCur->nSeekSortKeyAlloc = 0;
   }
+  pCur->pSeekSortKey = 0;
+  pCur->nSeekSortKeyAlloc = 0;
   if( pCur->pCompareSortKey ){
     sqlite3_free(pCur->pCompareSortKey);
     pCur->pCompareSortKey = 0;

--- a/src/prolly_btree_cursor_seek.c
+++ b/src/prolly_btree_cursor_seek.c
@@ -454,10 +454,25 @@ static int indexMovetoBuildSeekKey(
   if( unpackedRecordCanUseIntSortKey(
           pCur, pIdxKey,
           nSeekKeyField>0 ? nSeekKeyField : (int)pIdxKey->nField) ){
+    int nIntField = nSeekKeyField>0
+      ? nSeekKeyField : (int)pIdxKey->nField;
+    if( pCur->pSeekSortKey==0
+     && nIntField <= (int)sizeof(pCur->aSeekSortKey)/18 ){
+      pCur->pSeekSortKey = pCur->aSeekSortKey;
+      pCur->nSeekSortKeyAlloc = sizeof(pCur->aSeekSortKey);
+    }else if( pCur->pSeekSortKey==pCur->aSeekSortKey
+           && nIntField > (int)sizeof(pCur->aSeekSortKey)/18 ){
+      pCur->pSeekSortKey = 0;
+      pCur->nSeekSortKeyAlloc = 0;
+    }
     rc = sortKeyFromUnpackedIntRecordBuffer(
-        pIdxKey, nSeekKeyField>0 ? nSeekKeyField : (int)pIdxKey->nField,
+        pIdxKey, nIntField,
         &pCur->pSeekSortKey, &pCur->nSeekSortKeyAlloc, &nSortKey);
   }else{
+    if( pCur->pSeekSortKey==pCur->aSeekSortKey ){
+      pCur->pSeekSortKey = 0;
+      pCur->nSeekSortKeyAlloc = 0;
+    }
     rc = sortKeyFromMemPrefixCollBuffer(
         pIdxKey->aMem, (int)pIdxKey->nField, nSeekKeyField,
         pCur->pKeyInfo,
@@ -545,11 +560,13 @@ static int indexMovetoExactMutMap(
   }
   if( cursorMapMiss
    && (!pPending || pPending==pCur->pMutMap)
-   && nSortKey<=(int)sizeof(pCur->aMmMissKey) ){
+   && nSortKey<=(int)sizeof(pCur->aSeekSortKey) ){
     pCur->mmExactMiss = 1;
     pCur->mmMissGeneration = pCur->pMutMap->generation;
     pCur->nMmMissKey = nSortKey;
-    memcpy(pCur->aMmMissKey, pSortKey, nSortKey);
+    if( pSortKey!=pCur->aSeekSortKey ){
+      memcpy(pCur->aSeekSortKey, pSortKey, nSortKey);
+    }
   }
   return SQLITE_OK;
 }

--- a/src/prolly_btree_int.h
+++ b/src/prolly_btree_int.h
@@ -419,7 +419,7 @@ struct BtCursor {
   int nMmMissKey;
   i64 mmMissIntKey;
   u32 mmMissGeneration;
-  u8 aMmMissKey[40];
+  u8 aSeekSortKey[40];
   u8 mmActive;
   u8 mmPhysActive;
   u8 mmExactMiss;

--- a/src/prolly_btree_mutation.c
+++ b/src/prolly_btree_mutation.c
@@ -875,6 +875,10 @@ int prollyBtCursorInsert(
     if( rc==SQLITE_OK ){
       pSortKey = aLocalSortKey;
     }else if( rc==SQLITE_NOTFOUND ){
+      if( pCur->pSeekSortKey==pCur->aSeekSortKey ){
+        pCur->pSeekSortKey = 0;
+        pCur->nSeekSortKeyAlloc = 0;
+      }
       rc = sortKeyFromRecordPrefixCollBuffer(
           (const u8*)pPayload->pKey, (int)pPayload->nKey,
           isIndex ? 0 : (splitKey ? nKeyField : 0),
@@ -887,7 +891,7 @@ int prollyBtCursorInsert(
        && pCur->pMutMap
        && pCur->mmMissGeneration==pCur->pMutMap->generation
        && pCur->nMmMissKey==nSortKey
-       && memcmp(pCur->aMmMissKey, pSortKey, nSortKey)==0 ){
+       && memcmp(pCur->aSeekSortKey, pSortKey, nSortKey)==0 ){
         rc = prollyMutMapInsertAbsent(
             pCur->pMutMap, pSortKey, nSortKey, 0,
             storePayload ? (const u8*)pPayload->pKey : NULL,
@@ -1196,6 +1200,10 @@ int prollyBtCursorDelete(BtCursor *pCur, u8 flags){
             nDelKeyField = (int)pCur->pKeyInfo->nKeyField;
           }
         }
+        if( pCur->pSeekSortKey==pCur->aSeekSortKey ){
+          pCur->pSeekSortKey = 0;
+          pCur->nSeekSortKeyAlloc = 0;
+        }
         rc = sortKeyFromRecordPrefixCollBuffer(
             pCur->pCachedPayload, pCur->nCachedPayload,
             nDelKeyField, pCur->pKeyInfo,
@@ -1271,7 +1279,7 @@ int prollyBtCursorDelete(BtCursor *pCur, u8 flags){
      && pCur->pMutMap
      && pCur->mmMissGeneration==pCur->pMutMap->generation
      && pCur->nMmMissKey==nKey
-     && memcmp(pCur->aMmMissKey, pKey, nKey)==0 ){
+     && memcmp(pCur->aSeekSortKey, pKey, nKey)==0 ){
       rc = prollyMutMapDeleteAbsent(pCur->pMutMap, pKey, nKey, 0);
     }else if( pCur->mmActive
      && pCur->mmPhysActive

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -5922,9 +5922,9 @@ vacuum3 vacuum3-ioerr-4.29.3 @linux class=intentional
 vacuum3 vacuum3-ioerr-4.30.3 @linux class=intentional
 vacuum3 vacuum3-ioerr-4.31.3 @linux class=intentional
 
-# fkey_malloc / vtab_err: OOM fault indices, re-derived after the large-blob
-# insert path dropped two allocations (indices shift with allocation counts;
-# each list verified identical over three runs). Mechanism notes: the
+# fkey_malloc / vtab_err: OOM fault indices, re-derived after allocations were
+# removed from the large-blob insert and integer-index seek paths; indices
+# shift with allocation counts. Mechanism notes: the
 # fkey_malloc-6.*  divergent value at the terminal (no-fault) iteration is the
 # rowid-on-PK divergence surfacing, not a fault shift; the 7.* entries are
 # swallowed OOMs reported as success with final state verified intact.
@@ -5947,15 +5947,15 @@ fkey_malloc fkey_malloc-7.transient.471 @coverage class=intentional
 fkey_malloc fkey_malloc-7.transient.472 @coverage class=intentional
 fkey_malloc fkey_malloc-7.transient.473 @coverage class=intentional
 vtab_err vtab_err-1.3.3 class=intentional
-vtab_err vtab_err-2.transient.693 @no-coverage class=intentional
-vtab_err vtab_err-2.transient.716 @no-coverage class=intentional
-vtab_err vtab_err-2.persistent.716 @no-coverage class=intentional
+vtab_err vtab_err-2.transient.685 @no-coverage class=intentional
+vtab_err vtab_err-2.transient.708 @no-coverage class=intentional
+vtab_err vtab_err-2.persistent.708 @no-coverage class=intentional
 vtab_err vtab_err-3-oom-transient.425 @no-coverage class=intentional
-vtab_err vtab_err-2.transient.708 @coverage class=intentional
+vtab_err vtab_err-2.transient.707 @coverage class=intentional
+vtab_err vtab_err-2.transient.730 @coverage class=intentional
 vtab_err vtab_err-2.transient.731 @coverage class=intentional
-vtab_err vtab_err-2.transient.732 @coverage class=intentional
+vtab_err vtab_err-2.persistent.730 @coverage class=intentional
 vtab_err vtab_err-2.persistent.731 @coverage class=intentional
-vtab_err vtab_err-2.persistent.732 @coverage class=intentional
 vtab_err vtab_err-3-oom-transient.438 @coverage class=intentional
 vtab_err vtab_err-3-oom-transient.439 @coverage class=intentional
 


### PR DESCRIPTION
## Summary

- reuse the cursor exact-miss key buffer for one- and two-column integer index probes
- retain heap-backed sort keys for wider integer probes and generic/text key paths
- avoid freeing cursor-owned inline storage at cursor close

## Profile

A macOS `sample` profile of repeated secondary-index probes attributed 23 samples to `sortKeyFromUnpackedIntRecordBuffer`, with allocator work beneath it. With this change, the same profile attributed 1 sample to the function and no allocator frame to that call path.

## Sysbench-style latency

100,000 rows, paired before/after binaries from the same master revision.

- 15 paired runs across four indexed reads, in-memory average: 0.96x (6% faster index scan, 6% faster index join)
- same indexed reads, file-backed average: 1.00x (3% faster index join)
- 15 paired runs across four indexed/write mixes: 0.99x in memory, 1.00x file-backed
- broad 15-read sweep, 7 paired runs: 1.00x in memory and file-backed

## Validation

- `bash test/doltlite_regression_test_c.sh` (310258 passed)
- `bash test/run_c_tests.sh` (26/26 gated suites)
- `make lint`
- `git diff --check`

Co-Authored-By: OpenAI Codex <noreply@openai.com>