### PR TITLE
Optimize same-leaf table cursor advancement

### DIFF
--- a/src/prolly_btree_cursor.c
+++ b/src/prolly_btree_cursor.c
@@ -90,6 +90,41 @@ static SQLITE_INLINE int prollyCursorNextFastLeaf(ProllyCursor *pCur){
   return prollyCursorNext(pCur);
 }
 
+static SQLITE_INLINE int prollyBtCursorNextFastIntLeaf(BtCursor *pCur){
+  ProllyCursor *pProllyCur = &pCur->pCur;
+  ProllyCursorLevel *pLevel;
+  ProllyNode *pNode;
+  const u8 *pVal;
+  int nVal;
+  int nAvail;
+  int rc;
+  if( pCur->eState!=CURSOR_VALID
+   || pProllyCur->eState!=PROLLY_CURSOR_VALID
+   || !pCur->curIntKey
+   || pCur->mmActive
+   || pCur->pMutMap!=0
+   || pCur->cachedPayloadOwned
+   || pCur->pCachedFrom!=0 ){
+    return SQLITE_NOTFOUND;
+  }
+  pLevel = &pProllyCur->aLevel[pProllyCur->iLevel];
+  pNode = &pLevel->pEntry->node;
+  if( pLevel->idx>=pNode->nItems-1 ) return SQLITE_NOTFOUND;
+  rc = prollyCursorCheckInterrupt(pCur);
+  if( rc!=SQLITE_OK ) return rc;
+  pLevel->idx++;
+  prollyNodeValueSpan(pNode, pLevel->idx, &pVal, &nVal, &nAvail);
+  if( nVal>0 && nAvail==nVal ){
+    pCur->pCachedPayload = (u8*)pVal;
+    pCur->nCachedPayload = nVal;
+  }else{
+    pCur->pCachedPayload = 0;
+    pCur->nCachedPayload = 0;
+  }
+  pCur->curFlags &= ~(BTCF_AtLast|BTCF_ValidNKey|BTCF_DeleteKey);
+  return SQLITE_OK;
+}
+
 
 static int mergeCompare(BtCursor *pCur, ProllyMutMapEntry *e){
   assert( pCur!=0 && e!=0 );
@@ -622,6 +657,9 @@ static SQLITE_INLINE int prollyCursorFinishTreeStep(BtCursor *pCur, int rc){
 int prollyBtCursorNext(BtCursor *pCur, int flags){
   int rc, immediate;
   (void)flags;
+
+  rc = prollyBtCursorNextFastIntLeaf(pCur);
+  if( rc!=SQLITE_NOTFOUND ) return rc;
 
   rc = prollyBtCursorStepPrologue(pCur, 1, &immediate);
   if( immediate ) return rc;


### PR DESCRIPTION
## Summary

- add a direct fast path for ordinary same-leaf integer-table cursor advances
- carry the next row's unowned payload cache forward without clearing and rebuilding cursor state
- retain interrupt checks and fall back for mutation maps, owned or pinned payloads, and leaf boundaries

## Performance

100,000-row sysbench-style SQL workloads, paired baseline/candidate invocations:

| Workload group | In-memory | File-backed | Runs |
|---|---:|---:|---:|
| Sequential scan average | 0.98x | 0.99x | 15 pairs |
| Unrelated read average | 1.00x | 1.00x | 9 pairs |
| Indexed/write rerun average | 1.00x | 1.00x | 15 pairs |

In the sequential group, range select and range sum improved 3-4% in memory and 2-3% file-backed; the mixed read-only workload improved 2% in memory. The post-change profile drops `cacheCurrentTreePayloadIfIntKey` out of the top-of-stack list and reduces `prollyNodeValueSpan` samples from 48 to 12.

## Validation

- `bash test/run_doltlite_regression_case.sh all` (310,258 passed)
- rebuilt `testfixture`; `zeroblob interrupt interrupt2 select1 where` (2,417 passed, existing known divergences only)
- `bash test/run_c_tests.sh build all` (26/26 gated binaries passed)
- `make lint`
- `git diff --check`

Co-Authored-By: OpenAI Codex <noreply@openai.com>
