### PR TITLE
Clear the deferred tree seek when resuming a deactivated merged scan

### DIFF
--- a/src/prolly_btree_cursor.c
+++ b/src/prolly_btree_cursor.c
@@ -199,6 +199,15 @@ static int materializeDeferredTreeSeek(BtCursor *pCur, int dir){
   if( !pCur->deferredTreeSeek ) return SQLITE_OK;
   assert( pCur->mmActive );
   assert( pCur->pMutMap!=0 );
+#ifdef SQLITE_DEBUG
+  /* The deferral must still describe the mut-map landing it was armed on;
+  ** anything that repositions the merge state owes a cleared flag. */
+  if( pCur->curIntKey && pCur->mmIdx>=0 && pCur->mmIdx<pCur->pMutMap->nEntries ){
+    ProllyMutMapEntry *eChk = 0;
+    assert( orderedMutMapEntryAt(pCur->pMutMap, pCur->mmIdx, &eChk)==SQLITE_OK );
+    assert( eChk && prollyMutMapEntryIntKey(eChk)==pCur->cachedIntKey );
+  }
+#endif
   pCur->deferredTreeSeek = 0;
   refreshCursorRoot(pCur);
   rc = prollyCursorCheckInterrupt(pCur);
@@ -430,6 +439,11 @@ static int resumeDeactivatedMergedScan(BtCursor *pCur, int dir){
   pCur->mmPhysIdx = -1;
   pCur->mmPhysActive = 0;
   pCur->mmActive = 1;
+  /* This re-seek supersedes any tree positioning the pre-write moveto
+  ** deferred; a surviving deferral would re-seek the tree back to the
+  ** departed key on the next step, skipping pending rows and re-serving
+  ** delete-masked ones. */
+  pCur->deferredTreeSeek = 0;
   rc = mergeScan(pCur, dir, &res);
   if( rc!=SQLITE_OK ) return rc;
   if( res ){

--- a/test/doltlite_txn_seek_visibility.sh
+++ b/test/doltlite_txn_seek_visibility.sh
@@ -300,4 +300,102 @@ run_test "onepass_update_resume_lands_merged" \
 
 db_rm "$DB"
 
+# A scan whose moveto lands on a pending row defers the tree-side seek. When
+# a deferred write then deactivates the merge state, the resume re-seeds both
+# sides past the departed key; a surviving deferral would re-seek the tree
+# back to that key on the following step, skipping pending rows or
+# resurrecting delete-masked ones.
+DB=/tmp/test_txn_onepass_deferred_$$.db; db_rm "$DB"
+
+run_test "onepass_update_from_deferred_seek_landing" \
+  "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+   INSERT INTO t VALUES (5,'a'),(8,'skip'),(13,'a'),(27,'a');
+   BEGIN;
+   INSERT INTO t VALUES (10,'a');
+   UPDATE t SET v='a2' WHERE id=5;
+   UPDATE t SET v=v||'x' WHERE id>=5 AND v<>'skip';
+   COMMIT;
+   SELECT group_concat(id||'='||v) FROM t;" \
+  "5=a2x,8=skip,10=ax,13=ax,27=ax" \
+  "$DB"
+
+db_rm "$DB"
+
+run_test "onepass_delete_from_deferred_seek_landing" \
+  "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+   INSERT INTO t VALUES (5,'a'),(8,'skip'),(13,'a'),(27,'a');
+   BEGIN;
+   INSERT INTO t VALUES (10,'a');
+   UPDATE t SET v='a2' WHERE id=5;
+   DELETE FROM t WHERE id>=5 AND v<>'skip';
+   COMMIT;
+   SELECT group_concat(id||'='||v) FROM t;" \
+  "8=skip" \
+  "$DB"
+
+db_rm "$DB"
+
+run_test "onepass_interleaved_writes_no_resurrected_delete" \
+  "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+   INSERT INTO t VALUES (12,'a'),(21,'a'),(27,'b');
+   BEGIN;
+   INSERT OR REPLACE INTO t VALUES (53,'z');
+   DELETE FROM t WHERE id>=26 AND id<=42 AND v<>'skip';
+   INSERT OR REPLACE INTO t VALUES (28,'skip');
+   INSERT OR REPLACE INTO t VALUES (40,'a');
+   INSERT OR REPLACE INTO t VALUES (31,'skip');
+   INSERT OR REPLACE INTO t VALUES (23,'b');
+   SELECT count(*), coalesce(sum(id),0) FROM t WHERE id>=25;
+   DELETE FROM t WHERE id=21;
+   UPDATE t SET v=v||'F' WHERE id>=23 AND v<>'skip';
+   COMMIT;
+   SELECT id||'='||v FROM t ORDER BY id;
+   SELECT count(*) FROM t;" \
+  "4|152
+12=a
+23=bF
+28=skip
+31=skip
+40=aF
+53=zF
+6" \
+  "$DB"
+
+db_rm "$DB"
+
+run_test "onepass_interleaved_writes_covers_late_insert" \
+  "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+   INSERT INTO t VALUES (21,'skip'),(22,'skip'),(23,'skip'),(31,'skip'),
+                        (35,'a'),(40,'skip'),(50,'a'),(52,'b'),(56,'skip');
+   BEGIN;
+   UPDATE t SET v=v||'u' WHERE id=14;
+   INSERT OR REPLACE INTO t VALUES (25,'z');
+   INSERT OR REPLACE INTO t VALUES (6,'skip');
+   INSERT OR REPLACE INTO t VALUES (1,'z');
+   DELETE FROM t WHERE id=60;
+   SELECT count(*), coalesce(sum(id),0) FROM t WHERE id>=58;
+   INSERT OR REPLACE INTO t VALUES (19,'a');
+   UPDATE t SET v=v||'F' WHERE id>=19 AND v<>'skip';
+   COMMIT;
+   SELECT id||'='||v FROM t ORDER BY id;
+   SELECT count(*) FROM t;" \
+  "0|0
+1=z
+6=skip
+19=aF
+21=skip
+22=skip
+23=skip
+25=zF
+31=skip
+35=aF
+40=skip
+50=aF
+52=bF
+56=skip
+13" \
+  "$DB"
+
+db_rm "$DB"
+
 dltest_finish


### PR DESCRIPTION
## Problem

A table moveto that lands on a pending mut-map row sets `deferredTreeSeek`: the mut-map side is positioned, the tree side is not, and `cachedIntKey`/`mmIdx` both describe that landing key.

`resumeDeactivatedMergedScan` (the #2041 fix) handles the case where a deferred write deactivates the merge state mid-scan: it re-seeks the tree itself and seeds `mmIdx` strictly *past* `cachedIntKey`. But it left `deferredTreeSeek` armed. The next `mergeStepForward`/`Backward` therefore ran `materializeDeferredTreeSeek`, which re-seeked the tree back to the now-stale `cachedIntKey` and overwrote `mergeSrc` from that re-seek:

- exact hit → `MERGE_SRC_BOTH`, so the step advances both sides and silently drops the pending mut-map row at `mmIdx`;
- miss above → `MERGE_SRC_MUT`, so the tree is not advanced and the current tree row is re-served — including delete-masked rows, which a subsequent write then resurrects by overwriting the DELETE marker in place.

Net effect: a one-pass `UPDATE`/`DELETE` whose scan *starts* on a pending row commits wrong data. The result is structurally clean, so `DOLTLITE_PROLLY_CHECK=1` does not flag it.

## Fix

`resumeDeactivatedMergedScan` fully re-establishes the tree position, so it now consumes the deferral (`deferredTreeSeek = 0`). Debug builds additionally assert that a surviving deferral still describes the mut-map landing it was armed on, so any future path that repositions merge state without clearing the flag reddens immediately rather than silently miscommitting.

## Validation

Fail-before / pass-after on `test/doltlite_txn_seek_visibility.sh` — the four new cases fail on unfixed `build/doltlite` and pass with the fix:

```
FAIL: onepass_update_from_deferred_seek_landing        # 13=a,  stock 13=ax
FAIL: onepass_delete_from_deferred_seek_landing        # 13=a survives the DELETE
FAIL: onepass_interleaved_writes_no_resurrected_delete # count 7, stock 6
FAIL: onepass_interleaved_writes_covers_late_insert    # 25=z, stock 25=zF
```

The last two are reduced from randomized differential seeds; the resurrection case is the delete-mask arm.

- `test/doltlite_txn_seek_visibility.sh`: 21/21 (was 17 + 4 failing)
- Full shell battery `test/run_doltlite_tests.sh`: **101/101 suites**
- `sql_oracle_test.sh` 568/568, `doltlite_savepoint.sh` 128/128, `oracle_savepoints_test.sh` 43/43
- `doltlite_recover_deferred_seek_oom.test` 0/73 errors, `doltlite_recover_mutmap_order_oom.test` 0/104 errors (testfixture built from an amalgamation verified to contain the change)
- 2000-seed differential sweep vs stock sqlite3 over one-pass writes with interleaved in-transaction reads: **0 divergent seeds** (3 divergences before the fix)

## Note

The descending (`Prev`) arm of the resume path shares the bug symmetrically and is fixed by the same line, but has no dedicated coverage — the new tests exercise the forward arm only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)