### PR TITLE
Inline cursor interrupt checks

### DIFF
--- a/src/prolly_btree_int.h
+++ b/src/prolly_btree_int.h
@@ -754,7 +754,13 @@ int materializeDeferredMergedSeekBackward(BtCursor *pCur);
 int tableEntryIsTableRoot(Btree*, struct TableEntry*, int*);
 void clearMergeCursorState(BtCursor*);
 int mergeLast(BtCursor *pCur, int *pRes);
-int prollyCursorCheckInterrupt(BtCursor*);
+static SQLITE_INLINE int prollyCursorCheckInterrupt(BtCursor *pCur){
+  sqlite3 *db = pCur && pCur->pBtree ? pCur->pBtree->db : 0;
+  if( db && AtomicLoad(&db->u1.isInterrupted) ){
+    return SQLITE_INTERRUPT;
+  }
+  return SQLITE_OK;
+}
 int advanceTreeCursor(BtCursor*, int);
 int orderedMutMapEntryAt(ProllyMutMap*, int, ProllyMutMapEntry**);
 int unpackedRecordCanUseIntSortKey(BtCursor*, UnpackedRecord*, int);

--- a/src/prolly_btree_mutation.c
+++ b/src/prolly_btree_mutation.c
@@ -399,14 +399,6 @@ static void setCursorToMutMapMissingEntryPhys(BtCursor *pCur, int physIdx){
   }
 }
 
-int prollyCursorCheckInterrupt(BtCursor *pCur){
-  sqlite3 *db = pCur && pCur->pBtree ? pCur->pBtree->db : 0;
-  if( db && AtomicLoad(&db->u1.isInterrupted) ){
-    return SQLITE_INTERRUPT;
-  }
-  return SQLITE_OK;
-}
-
 int advanceTreeCursor(BtCursor *pCur, int dir){
   int rc = prollyCursorCheckInterrupt(pCur);
   if( rc!=SQLITE_OK ) return rc;


### PR DESCRIPTION
## Summary

- inline the cursor interrupt check at its seek and advance call sites
- preserve the existing atomic interrupt load and return behavior
- remove the per-row external function call visible in range and scan profiles

## Performance

A macOS `sample` profile of the baseline showed `prollyCursorCheckInterrupt` as a recurring leaf in both range and full-table scans. The same profile after this change no longer contains the helper frame.

Paired before/after sysbench-style runs used binaries built from the same master commit, alternating execution order. Across 15 pairs per workload:

- in-memory range select: 8,674 us -> 8,456 us (-2.5%)
- in-memory sum range: 6,813 us -> 6,529 us (-4.2%)
- in-memory random ranges: 2,134 us -> 2,066 us (-3.2%)
- in-memory typed table scan: 1,100,948 us -> 1,089,589 us (-1.0%)
- in-memory read-only mix: 86,175 us -> 85,285 us (-1.0%)
- file range select: 10,702 us -> 10,493 us (-2.0%)
- file sum range: 8,784 us -> 8,565 us (-2.5%)
- file group-by scan: 24,751 us -> 24,240 us (-2.1%)
- file typed table scan: 1,111,297 us -> 1,099,041 us (-1.1%)

Across a separate nine-pair control run covering point reads, index scans, joins, and write mixes, the aggregate median paired change was -1.27%, with 92 of 162 pairs faster.

## Validation

- targeted testfixture suites: 2,417 passing, 10 known divergences
- complete DoltLite regression set: 310,258 passed, 0 failed
- gated C tests: 26 passed, 0 failed
- native shell suites: 101 passed, 0 failed
- `make lint`
- `git diff --check`

Co-Authored-By: OpenAI Codex <noreply@openai.com>