### PR TITLE
Inline same-leaf value span decoding

### DIFF
--- a/src/prolly_btree_cursor.c
+++ b/src/prolly_btree_cursor.c
@@ -113,7 +113,7 @@ static SQLITE_INLINE int prollyBtCursorNextFastIntLeaf(BtCursor *pCur){
   rc = prollyCursorCheckInterrupt(pCur);
   if( rc!=SQLITE_OK ) return rc;
   pLevel->idx++;
-  prollyNodeValueSpan(pNode, pLevel->idx, &pVal, &nVal, &nAvail);
+  prollyNodeValueSpanInline(pNode, pLevel->idx, &pVal, &nVal, &nAvail);
   if( nVal>0 && nAvail==nVal ){
     pCur->pCachedPayload = (u8*)pVal;
     pCur->nCachedPayload = nVal;

--- a/src/prolly_node.c
+++ b/src/prolly_node.c
@@ -163,23 +163,7 @@ void prollyNodeValue(const ProllyNode *pNode, int i, const u8 **ppVal, int *pnVa
 
 void prollyNodeValueSpan(const ProllyNode *pNode, int i, const u8 **ppVal,
                          int *pnVal, int *pnAvail){
-  u32 off0;
-  u32 off1;
-  int nValPhys;
-  assert( i >= 0 && i < (int)pNode->nItems );
-  off0 = PROLLY_GET_U32((const u8*)&pNode->aValOff[i]);
-  off1 = PROLLY_GET_U32((const u8*)&pNode->aValOff[i+1]);
-  *pnVal = (int)(off1 - off0);
-  nValPhys = pNode->nDataPhys - (int)(pNode->pValData - pNode->pData);
-  if( nValPhys<0 ) nValPhys = 0;
-  if( (int)off0 < nValPhys ){
-    *ppVal = pNode->pValData + off0;
-    *pnAvail = nValPhys - (int)off0;
-    if( *pnAvail > *pnVal ) *pnAvail = *pnVal;
-  }else{
-    *ppVal = pNode->pValData + nValPhys;
-    *pnAvail = 0;
-  }
+  prollyNodeValueSpanInline(pNode, i, ppVal, pnVal, pnAvail);
 }
 
 void prollyEncodeIntKey(i64 v, u8 buf[8]){

--- a/src/prolly_node.h
+++ b/src/prolly_node.h
@@ -3,6 +3,7 @@
 #define SQLITE_PROLLY_NODE_H
 
 #include "sqliteInt.h"
+#include "prolly_encoding.h"
 #include "prolly_hash.h"
 
 #define PROLLY_NODE_MAGIC 0x504E4F44
@@ -49,6 +50,31 @@ int prollyNodeParseSparse(ProllyNode *pNode, const u8 *pData, int nData,
 void prollyNodeKey(const ProllyNode *pNode, int i, const u8 **ppKey, int *pnKey);
 
 void prollyNodeValue(const ProllyNode *pNode, int i, const u8 **ppVal, int *pnVal);
+static SQLITE_INLINE void prollyNodeValueSpanInline(
+  const ProllyNode *pNode,
+  int i,
+  const u8 **ppVal,
+  int *pnVal,
+  int *pnAvail
+){
+  u32 off0;
+  u32 off1;
+  int nValPhys;
+  assert( i >= 0 && i < (int)pNode->nItems );
+  off0 = PROLLY_GET_U32((const u8*)&pNode->aValOff[i]);
+  off1 = PROLLY_GET_U32((const u8*)&pNode->aValOff[i+1]);
+  *pnVal = (int)(off1 - off0);
+  nValPhys = pNode->nDataPhys - (int)(pNode->pValData - pNode->pData);
+  if( nValPhys<0 ) nValPhys = 0;
+  if( (int)off0 < nValPhys ){
+    *ppVal = pNode->pValData + off0;
+    *pnAvail = nValPhys - (int)off0;
+    if( *pnAvail > *pnVal ) *pnAvail = *pnVal;
+  }else{
+    *ppVal = pNode->pValData + nValPhys;
+    *pnAvail = 0;
+  }
+}
 void prollyNodeValueSpan(const ProllyNode *pNode, int i, const u8 **ppVal,
                          int *pnVal, int *pnAvail);
 


### PR DESCRIPTION
## Summary

- inline value-span decoding in the same-leaf integer table cursor advance path
- retain the external accessor for point lookups, index cursors, and non-fast paths
- remove a per-row call visible in range and table-scan profiles without changing storage or cursor semantics

## Performance

A macOS `sample` profile of the baseline attributed 14 table-scan samples to `prollyNodeValueSpan`; after this change, the same workload had one incidental sample in that external helper.

Paired before/after sysbench-style runs used binaries built from the same master commit, alternated execution order, and ran 15 pairs per workload. Median latency changes included:

- in-memory table scan: 1,360,624 us -> 1,334,635 us (-1.9%, 15/15 pairs faster)
- file table scan: 1,362,215 us -> 1,337,495 us (-1.8%, 15/15 pairs faster)
- in-memory typed table scan: 1,079,625 us -> 1,071,896 us (-0.7%, 12/15 pairs faster)
- file typed table scan: 1,078,613 us -> 1,071,716 us (-0.6%, 15/15 pairs faster)
- file range select: 9,914 us -> 9,810 us (-1.0%, paired median -1.4%, 14/15 pairs faster)
- file sum range: 8,128 us -> 8,023 us (-1.3%, paired median -1.5%, 14/15 pairs faster)
- in-memory read-only mix: 81,821 us -> 81,260 us (-0.7%, 11/15 pairs faster)

Index-scan controls were flat. Across all 270 paired measurements, the aggregate paired median was -0.60%, with 186 pairs faster.

## Validation

- targeted testfixture suites: 746 passing, 9 known divergences
- complete DoltLite regression set: 310,258 passed, 0 failed
- gated C tests: 26 passed, 0 failed
- native shell suites: 101 passed, 0 failed
- `make lint`
- `git diff --check`

Co-Authored-By: OpenAI Codex <noreply@openai.com>
