### PR TITLE
Cache nodes built by single-edit mutations

### DIFF
--- a/src/prolly_mutate.c
+++ b/src/prolly_mutate.c
@@ -422,18 +422,24 @@ static int appendNodeEntryToBuilder(
                                        subtreeCount);
 }
 
-static int writeBuilderNode(ChunkStore *pStore, ProllyNodeBuilder *pBuilder,
-                            ProllyHash *pHash){
+static int writeBuilderNode(ChunkStore *pStore, ProllyCache *pCache,
+                            ProllyNodeBuilder *pBuilder, ProllyHash *pHash){
   u8 *pData = 0;
   int nData = 0;
   int rc = prollyNodeBuilderFinish(pBuilder, &pData, &nData);
   if( rc!=SQLITE_OK ) return rc;
   rc = chunkStorePut(pStore, pData, nData, pHash);
+  if( rc==SQLITE_OK && pCache ){
+    ProllyCacheEntry *pEntry;
+    pEntry = prollyCachePutOwned(pCache, pHash, pData, nData, &rc);
+    pData = 0;
+    if( pEntry ) prollyCacheRelease(pCache, pEntry);
+  }
   sqlite3_free(pData);
   return rc;
 }
 
-static int finishAndWriteBuilderNode(ChunkStore *pStore,
+static int finishAndWriteBuilderNode(ChunkStore *pStore, ProllyCache *pCache,
                                      ProllyNodeBuilder *pBuilder,
                                      int requireBoundary,
                                      ProllyHash *pHash){
@@ -449,6 +455,12 @@ static int finishAndWriteBuilderNode(ChunkStore *pStore,
   }
   if( rc==SQLITE_OK ){
     rc = chunkStorePut(pStore, pData, nData, pHash);
+  }
+  if( rc==SQLITE_OK && pCache ){
+    ProllyCacheEntry *pEntry;
+    pEntry = prollyCachePutOwned(pCache, pHash, pData, nData, &rc);
+    pData = 0;
+    if( pEntry ) prollyCacheRelease(pCache, pEntry);
   }
   sqlite3_free(pData);
   return rc;
@@ -516,7 +528,7 @@ static int rewriteAncestorSpine(
         return rc;
       }
     }
-    rc = writeBuilderNode(pMut->pStore, &b, &parentHash);
+    rc = writeBuilderNode(pMut->pStore, pMut->pCache, &b, &parentHash);
     prollyNodeBuilderFree(&b);
     if( rc!=SQLITE_OK ) return rc;
     *pChildHash = parentHash;
@@ -595,9 +607,9 @@ static int tryInsertOrReplaceSingleNoRechunk(ProllyMutator *pMut){
       }
     }
     if( sameSize ){
-      rc = writeBuilderNode(pMut->pStore, &b, &childHash);
+      rc = writeBuilderNode(pMut->pStore, pMut->pCache, &b, &childHash);
     }else{
-      rc = finishAndWriteBuilderNode(pMut->pStore, &b,
+      rc = finishAndWriteBuilderNode(pMut->pStore, pMut->pCache, &b,
                                      !cursorLeafIsRightmost(&cur),
                                      &childHash);
     }
@@ -661,8 +673,8 @@ static int tryInsertOrReplaceSingleNoRechunk(ProllyMutator *pMut){
       }
     }
     requireBoundary = !cursorLeafIsRightmost(&cur);
-    rc = finishAndWriteBuilderNode(pMut->pStore, &b, requireBoundary,
-                                   &childHash);
+    rc = finishAndWriteBuilderNode(pMut->pStore, pMut->pCache, &b,
+                                   requireBoundary, &childHash);
     prollyNodeBuilderFree(&b);
     if( rc!=SQLITE_OK ){
       prollyCursorClose(&cur);
@@ -739,8 +751,8 @@ static int tryDeleteSingleNoRechunk(ProllyMutator *pMut){
       }
     }
     requireBoundary = !cursorLeafIsRightmost(&cur);
-    rc = finishAndWriteBuilderNode(pMut->pStore, &b, requireBoundary,
-                                   &childHash);
+    rc = finishAndWriteBuilderNode(pMut->pStore, pMut->pCache, &b,
+                                   requireBoundary, &childHash);
     prollyNodeBuilderFree(&b);
     if( rc!=SQLITE_OK ){
       prollyCursorClose(&cur);
@@ -834,7 +846,7 @@ static int tryAppendSingleNoSplit(ProllyMutator *pMut){
         rc = prollyNodeBuilderAdd(&b, pNewKey, nNewKey,
                                   pEdit->pVal, pEdit->nVal);
         if( rc==SQLITE_OK ){
-          rc = writeBuilderNode(pMut->pStore, &b, &childHash);
+          rc = writeBuilderNode(pMut->pStore, pMut->pCache, &b, &childHash);
         }
         prollyNodeBuilderFree(&b);
         if( rc!=SQLITE_OK ){
@@ -860,7 +872,7 @@ static int tryAppendSingleNoSplit(ProllyMutator *pMut){
           prollyCursorClose(&cur);
           return rc;
         }
-        rc = writeBuilderNode(pMut->pStore, &b, &childHash);
+        rc = writeBuilderNode(pMut->pStore, pMut->pCache, &b, &childHash);
         prollyNodeBuilderFree(&b);
         if( rc!=SQLITE_OK ){
           prollyCursorClose(&cur);
@@ -895,7 +907,7 @@ static int tryAppendSingleNoSplit(ProllyMutator *pMut){
         rc = prollyNodeBuilderAddWithCount(&b, pNewKey, nNewKey,
                                            childHash.data, PROLLY_HASH_SIZE, 1);
         if( rc==SQLITE_OK ){
-          rc = writeBuilderNode(pMut->pStore, &b, &parentHash);
+          rc = writeBuilderNode(pMut->pStore, pMut->pCache, &b, &parentHash);
         }
         prollyNodeBuilderFree(&b);
         if( rc!=SQLITE_OK ){
@@ -926,7 +938,7 @@ static int tryAppendSingleNoSplit(ProllyMutator *pMut){
         rc = prollyNodeBuilderAdd(&b, pNewKey, nNewKey,
                                   pEdit->pVal, pEdit->nVal);
         if( rc==SQLITE_OK ){
-          rc = writeBuilderNode(pMut->pStore, &b, &childHash);
+          rc = writeBuilderNode(pMut->pStore, pMut->pCache, &b, &childHash);
         }
         prollyNodeBuilderFree(&b);
         if( rc!=SQLITE_OK ){
@@ -971,7 +983,7 @@ static int tryAppendSingleNoSplit(ProllyMutator *pMut){
         return rc;
       }
     }
-    rc = writeBuilderNode(pMut->pStore, &b, &parentHash);
+    rc = writeBuilderNode(pMut->pStore, pMut->pCache, &b, &parentHash);
     prollyNodeBuilderFree(&b);
     if( rc!=SQLITE_OK ){
       prollyCursorClose(&cur);
@@ -1115,9 +1127,9 @@ static int replaceBatchLeafNoRechunk(
       ** build would pick. Validate and let the caller rechunk if they moved,
       ** the way the single-edit path does -- writing regardless freezes a shape
       ** that history independence says must not depend on how we got here. */
-      rc = finishAndWriteBuilderNode(pMut->pStore, &b, !isLast, pHash);
+      rc = finishAndWriteBuilderNode(pMut->pStore, 0, &b, !isLast, pHash);
     }else{
-      rc = writeBuilderNode(pMut->pStore, &b, pHash);
+      rc = writeBuilderNode(pMut->pStore, 0, &b, pHash);
     }
   }
   prollyNodeBuilderFree(&b);
@@ -1271,7 +1283,7 @@ static int replaceBatchNodeNoRechunk(
   }
 
   if( changed ){
-    rc = writeBuilderNode(pMut->pStore, &b, pHash);
+    rc = writeBuilderNode(pMut->pStore, 0, &b, pHash);
   }
   prollyNodeBuilderFree(&b);
   if( rc!=SQLITE_OK ) return rc;

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -1198,7 +1198,6 @@ reservebytes reservebytes-1.4.4 class=intentional  # no per-page reserved-bytes 
 # page cache; DoltLite's prolly storage has no equivalent large page cache to
 # release, so the heap-drop assertion fails. Data is intact.
 shrink shrink-1.1 class=intentional  # no SQLite pager page-cache to release (memory model differs)
-shrink shrink-1.2 class=intentional  # no SQLite pager page-cache to release (memory model differs)
 shrink shrink-1.3 class=intentional  # no SQLite pager page-cache to release (memory model differs)
 
 # format4 — asserts [file size test.db] equals page-multiple totals
@@ -1464,8 +1463,8 @@ attach2 attach2-4.15 class=intentional issue=1846  # PRAGMA lock_status: doltlit
 attachmalloc attachmalloc-1.transient.488 class=unsupported issue=1839  # OOM fault-point shift (parent probe)
 attachmalloc attachmalloc-1.transient.914 @no-coverage class=unsupported issue=1839  # OOM fault-point shift (ATTACH seed)
 attachmalloc attachmalloc-1.transient.1409 @no-coverage class=unsupported issue=1839  # OOM fault-point shift (ATTACH seed)
-attachmalloc attachmalloc-1.transient.922 @coverage class=unsupported issue=1839  # OOM fault-point shift (ATTACH seed)
-attachmalloc attachmalloc-1.transient.1425 @coverage class=unsupported issue=1839  # OOM fault-point shift (ATTACH seed)
+attachmalloc attachmalloc-1.transient.921 @coverage class=unsupported issue=1839  # OOM fault-point shift (ATTACH seed)
+attachmalloc attachmalloc-1.transient.1423 @coverage class=unsupported issue=1839  # OOM fault-point shift (ATTACH seed)
 mallocD mallocD-4.transient.107 class=unsupported issue=1839  # OOM fault-point shift (parent probe)
 
 # temptable2 section 8 — page_count is a chunk-store metric, not SQLite
@@ -5934,30 +5933,20 @@ fkey_malloc fkey_malloc-7.transient.198 @no-coverage class=intentional
 fkey_malloc fkey_malloc-7.transient.199 @no-coverage class=intentional
 fkey_malloc fkey_malloc-7.transient.477 @no-coverage class=intentional
 fkey_malloc fkey_malloc-7.transient.478 @no-coverage class=intentional
-fkey_malloc fkey_malloc-6.transient.63 @coverage class=intentional
-fkey_malloc fkey_malloc-6.persistent.63 @coverage class=intentional
-# fkey_malloc-7.* coverage indices re-derived after SQLite upstream merge
-# (allocation count shift from new core paths). Terminal no-fault values still
-# surface the intentional rowid-on-PK divergence; mid-sweep hits are swallowed
-# OOMs with final state intact.
-fkey_malloc fkey_malloc-7.transient.193 @coverage class=intentional
-fkey_malloc fkey_malloc-7.transient.194 @coverage class=intentional
-fkey_malloc fkey_malloc-7.transient.195 @coverage class=intentional
-fkey_malloc fkey_malloc-7.transient.471 @coverage class=intentional
-fkey_malloc fkey_malloc-7.transient.472 @coverage class=intentional
-fkey_malloc fkey_malloc-7.transient.473 @coverage class=intentional
+fkey_malloc fkey_malloc-6.transient.62 @coverage class=intentional
+fkey_malloc fkey_malloc-6.persistent.62 @coverage class=intentional
 vtab_err vtab_err-1.3.3 class=intentional
 vtab_err vtab_err-2.transient.685 @no-coverage class=intentional
 vtab_err vtab_err-2.transient.708 @no-coverage class=intentional
 vtab_err vtab_err-2.persistent.708 @no-coverage class=intentional
 vtab_err vtab_err-3-oom-transient.425 @no-coverage class=intentional
-vtab_err vtab_err-2.transient.707 @coverage class=intentional
-vtab_err vtab_err-2.transient.730 @coverage class=intentional
-vtab_err vtab_err-2.transient.731 @coverage class=intentional
-vtab_err vtab_err-2.persistent.730 @coverage class=intentional
-vtab_err vtab_err-2.persistent.731 @coverage class=intentional
-vtab_err vtab_err-3-oom-transient.438 @coverage class=intentional
-vtab_err vtab_err-3-oom-transient.439 @coverage class=intentional
+vtab_err vtab_err-2.transient.704 @coverage class=intentional
+vtab_err vtab_err-2.transient.727 @coverage class=intentional
+vtab_err vtab_err-2.transient.728 @coverage class=intentional
+vtab_err vtab_err-2.persistent.727 @coverage class=intentional
+vtab_err vtab_err-2.persistent.728 @coverage class=intentional
+vtab_err vtab_err-3-oom-transient.436 @coverage class=intentional
+vtab_err vtab_err-3-oom-transient.437 @coverage class=intentional
 
 # ── pager2 ── (was crash-listed on the journal_mode rejection; now completes)
 pager2 pager2-2.1 class=intentional issue=1846  # journal_mode is a no-op reporting the fixed "wal", not the requested "off"
@@ -6015,17 +6004,16 @@ sysfault sysfault-2.1-vfsfault-transient.105 class=intentional
 sysfault sysfault-2.1-vfsfault-transient.106 class=intentional
 sysfault sysfault-2.1-vfsfault-transient.107 class=intentional
 sysfault sysfault-2.1-vfsfault-transient.108 class=intentional
-sysfault sysfault-2.1-vfsfault-transient.109 class=intentional
+sysfault sysfault-2.2-vfsfault-persistent.100 class=intentional
+sysfault sysfault-2.2-vfsfault-persistent.101 class=intentional
 sysfault sysfault-2.2-vfsfault-persistent.106 class=intentional
 sysfault sysfault-2.2-vfsfault-persistent.107 class=intentional
 sysfault sysfault-2.2-vfsfault-persistent.108 class=intentional
-sysfault sysfault-2.2-vfsfault-persistent.109 class=intentional
-sysfault sysfault-2.2-vfsfault-persistent.110 class=intentional
+sysfault sysfault-2.2-vfsfault-transient.100 class=intentional
+sysfault sysfault-2.2-vfsfault-transient.101 class=intentional
 sysfault sysfault-2.2-vfsfault-transient.106 class=intentional
 sysfault sysfault-2.2-vfsfault-transient.107 class=intentional
 sysfault sysfault-2.2-vfsfault-transient.108 class=intentional
-sysfault sysfault-2.2-vfsfault-transient.109 class=intentional
-sysfault sysfault-2.2-vfsfault-transient.110 class=intentional
 
 stmt stmt-1.2 class=intentional  # retained graph-lock handle raises the instrumented open-file count
 stmt stmt-1.5 class=intentional  # retained graph-lock handle raises the instrumented open-file count

--- a/test/known_testfixture_exception_ratchet.txt
+++ b/test/known_testfixture_exception_ratchet.txt
@@ -6,8 +6,8 @@
 # Counts are per gate -- one divergent assertion, or one expected crash.
 # Lowering a number is the point. Raising one is a deliberate act that belongs
 # in a PR description.
-gates 4901
-intentional 3556
+gates 4893
+intentional 3548
 unsupported 1269
 harness 11
 engine-gap 65


### PR DESCRIPTION
## Summary

- retain prolly nodes built by single-edit mutation fast paths in the existing node cache
- let the cache adopt the finished node buffer instead of freeing it and reloading the same content-addressed node on the next statement
- leave batch replacement writes uncached because those nodes are not reread during the flush

## Profile

A focused indexed-update profile on master showed the next transaction repeatedly descending from loadNode through chunkStoreGetSparse and chunkStoreGet, paying index lookup, allocation, copy, BLAKE3 verification, and parse for nodes the previous transaction had just built. In the same eight-second candidate profile, those reload branches nearly disappeared even though the candidate completed more mutations.

## Before / after

100,000-row sysbench-style database, file-backed autocommit SQL, 200 statements per invocation, median of 15 alternating baseline/candidate pairs:

| Workload | Paired median | Candidate wins |
| --- | ---: | ---: |
| insert | -7.27% | 10/15 |
| indexed update | -9.11% | 14/15 |
| non-indexed update | -7.16% | 13/15 |
| delete/insert | -9.74% | 14/15 |
| write-only mix | -8.91% | 13/15 |
| typed delete/insert | -4.47% | 10/15 |
| read/write mix | -11.66% | 14/15 |

The aggregate candidate/baseline median ratio was 0.92. The point-select control moved +1.01% by paired median. Wrapped-transaction write controls averaged 0.99x in memory and 1.01x file-backed.

## Validation

- make lint
- 310,258 regression assertions
- 26/26 gated C test binaries
- 101/101 DoltLite-native suites

Co-Authored-By: OpenAI Codex <noreply@openai.com>