### PR TITLE
Avoid redundant cursor initialization

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -1402,7 +1402,9 @@ int sqlite3BtreeCursorSize(void){
 }
 
 void sqlite3BtreeCursorZero(BtCursor *p){
-  memset(p, 0, sizeof(BtCursor));
+  memset(p, 0, offsetof(BtCursor, pCur));
+  memset(&p->pMutMap, 0,
+         sizeof(BtCursor) - offsetof(BtCursor, pMutMap));
   p->pCurOps = &prollyCursorOps;
 }
 
@@ -1418,9 +1420,6 @@ int prollyBtreeCursor(
 
   assert( p->inTrans>=TRANS_READ );
 
-  memset(pCur, 0, sizeof(BtCursor));
-  pCur->pBtree = p;
-  pCur->pBt = pBt;
   pCur->pgnoRoot = iTable;
   pCur->pKeyInfo = pKeyInfo;
   pCur->eState = CURSOR_INVALID;
@@ -1454,6 +1453,9 @@ int prollyBtreeCursor(
     pCur->isTableRoot = tableEntryIsTableRoot(p, pTE, &rcRoot) ? 1 : 0;
     if( rcRoot!=SQLITE_OK ) return rcRoot;
   }
+
+  pCur->pBtree = p;
+  pCur->pBt = pBt;
 
   if( wrFlag & BTREE_WRCSR ){
     pCur->curFlags = BTCF_WriteFlag;


### PR DESCRIPTION
## Summary

- avoid clearing the full DoltLite cursor twice during every cursor open
- leave the embedded prolly cursor for `prollyCursorInit()` to initialize once
- delay cursor ownership until fallible catalog setup finishes, keeping failed opens safely closable

This is based directly on master and touches only `src/prolly_btree.c`; it does not overlap PR #2066.

## Profile

A long point-select profile on master put `_platform_memset` at 116 top-of-stack samples and showed cursor allocation/initialization on the hot path. The after-profile reduced `_platform_memset` to 28 samples, a 76% reduction.

## Before / after

Focused 100,000-row sysbench-style harnesses, alternating baseline/candidate order:

| Workload | Baseline | Candidate | Change | Candidate wins |
| --- | ---: | ---: | ---: | ---: |
| point select | 8.51s | 8.23s | -3.3% | 5/6 |
| indexed update | 9.68s | 9.27s | -4.2% | 3/4 |

Repository sysbench matrix with 50,000 rows and median of seven paired invocations per workload:

| Section | Candidate / baseline |
| --- | ---: |
| in-memory reads | 0.99x |
| in-memory writes | 0.99x |
| file-backed reads | 1.00x |
| file-backed writes | 1.01x |

## Validation

- `make lint`
- 310,258 regression assertions
- 101/101 DoltLite-native suites
- 26/26 gated C test binaries, including OOM fault sweeps

Co-Authored-By: OpenAI Codex <noreply@openai.com>
