### PR TITLE
Stop cursor release at first empty level

### DIFF
--- a/src/prolly_cursor.c
+++ b/src/prolly_cursor.c
@@ -448,12 +448,10 @@ void prollyCursorValue(ProllyCursor *cur, const u8 **ppVal, int *pnVal){
 
 void prollyCursorReleaseAll(ProllyCursor *cur){
   int i;
-  for(i=0; i<PROLLY_CURSOR_MAX_DEPTH; i++){
-    if( cur->aLevel[i].pEntry ){
-      prollyCacheRelease(cur->pCache, cur->aLevel[i].pEntry);
-      cur->aLevel[i].pEntry = 0;
-      cur->aLevel[i].idx = 0;
-    }
+  for(i=0; i<PROLLY_CURSOR_MAX_DEPTH && cur->aLevel[i].pEntry; i++){
+    prollyCacheRelease(cur->pCache, cur->aLevel[i].pEntry);
+    cur->aLevel[i].pEntry = 0;
+    cur->aLevel[i].idx = 0;
   }
   cur->iLevel = 0;
 


### PR DESCRIPTION
## Summary

- stop cursor cleanup at the first empty level instead of scanning all 20 slots
- preserve the contiguous held-level invariant established by cursor descent and unwind paths
- reduce point-read cursor teardown without changing storage format or SQL behavior

## Profile

A six-second point-select profile on master put `prollyCursorClose` at 289 top-of-stack samples. The after-profile reduced it to 42 samples, an 85% reduction.

## Before / after

Focused 100,000-row sysbench-style point-select harness, alternating baseline/candidate order across six pairs:

| Workload | Baseline | Candidate | Change |
| --- | ---: | ---: | ---: |
| point select | 7.49s | 7.23s | -3.5% |

Repository sysbench matrix with 50,000 rows and median of seven paired invocations per workload:

| Section | Candidate / baseline |
| --- | ---: |
| in-memory reads | 0.99x |
| in-memory writes | 1.00x |
| file-backed reads | 1.00x |
| file-backed writes | 0.99x |

Selected SQL latencies:

| Workload | In-memory | File-backed |
| --- | ---: | ---: |
| point select | -3% | -1% |
| indexed update | -3% | -1% |

## Validation

- `make lint`
- 310,258 regression assertions
- 101/101 DoltLite-native suites
- 26/26 gated C test binaries, including cursor/mutmap stress, concurrency, corruption, and OOM fault sweeps

Co-Authored-By: OpenAI Codex <noreply@openai.com>
