### PR TITLE
Keep read-only commits out of write slow path

### DIFF
--- a/src/prolly_btree_txn.c
+++ b/src/prolly_btree_txn.c
@@ -1037,8 +1037,7 @@ static int commitPhaseTwoFailRestore(
   return commitRc;
 }
 
-int prollyBtreeCommitPhaseTwo(Btree *p, int bCleanup){
-  BtShared *pBt = p->pBt;
+static SQLITE_NOINLINE int commitPhaseTwoWrite(Btree *p, BtShared *pBt){
   int rc = SQLITE_OK;
   u8 *catData = 0;
   int nCatData = 0;
@@ -1047,19 +1046,7 @@ int prollyBtreeCommitPhaseTwo(Btree *p, int bCleanup){
   int bReloadSchema = 0;
   int bHaveReloadCatalog = 0;
   u32 nativeSchemaCookie = 0;
-  (void)bCleanup;
   memset(&reloadBtree, 0, sizeof(reloadBtree));
-
-  /* Catalog serialization runs a SELECT whose finalize re-enters
-  ** commit/rollback; that nested call is read-only, so no-op it instead of
-  ** recursing into a stack overflow. */
-  if( pBt->inCatalogSerialize ) return SQLITE_OK;
-
-  if( p->inTrans!=TRANS_WRITE ){
-    commitPhaseTwoEndWriteTxn(p);
-    commitPhaseTwoReleaseGraph(pBt);
-    return rc;
-  }
 
   PROLLY_ASSERT_GRAPH_LOCKED(pBt);
   rc = flushAllPending(p, pBt, 0);
@@ -1130,6 +1117,23 @@ int prollyBtreeCommitPhaseTwo(Btree *p, int bCleanup){
   sqlite3_free(catData);
   commitPhaseTwoReleaseGraph(pBt);
   return SQLITE_OK;
+}
+
+int prollyBtreeCommitPhaseTwo(Btree *p, int bCleanup){
+  BtShared *pBt = p->pBt;
+  (void)bCleanup;
+
+  /* Catalog serialization runs a SELECT whose finalize re-enters
+  ** commit/rollback; that nested call is read-only, so no-op it instead of
+  ** recursing into a stack overflow. */
+  if( pBt->inCatalogSerialize ) return SQLITE_OK;
+
+  if( p->inTrans!=TRANS_WRITE ){
+    commitPhaseTwoEndWriteTxn(p);
+    commitPhaseTwoReleaseGraph(pBt);
+    return SQLITE_OK;
+  }
+  return commitPhaseTwoWrite(p, pBt);
 }
 int sqlite3BtreeCommitPhaseTwo(Btree *p, int bCleanup){
   if( !p ) return SQLITE_OK;


### PR DESCRIPTION
## Summary

- split write-only phase-two commit work into a noinline slow path
- keep read-only statement commits out of the 736-byte write stack frame
- remove the stack canary and 632-byte zero-fill from the profiled read path

## Performance

A point-select profile on master attributed 60 samples to the unconditional zero-fill performed by phase-two commit. Generated arm64 code now gives the read-only entry point a 48-byte frame and contains no zero-fill; write commits retain the existing implementation.

Six alternating long point-select runs:

- master: 7.413 s average
- candidate: 7.215 s average
- change: -2.7%

50k-row sysbench-style matrix, median of seven paired runs:

- in-memory reads: 0.99x
- in-memory writes: 0.99x
- file reads: 1.00x
- file writes: 0.98x
- in-memory point select: 0.96x

## Validation

- `make -j8 doltlite testfixture`
- `make lint`
- `bash test/run_doltlite_tests.sh` (101 suites, 310258 regression assertions)
- `bash test/run_c_tests.sh build all` (26 gates)

Co-Authored-By: OpenAI Codex <noreply@openai.com>