### PR TITLE
Repoint the savepoint4/crash2 quarantine at a live issue

### DIFF
--- a/test/doltlite_recover_crash_commit.test
+++ b/test/doltlite_recover_crash_commit.test
@@ -1,5 +1,5 @@
 # Crash-recovery coverage replacing the bucketed savepoint4 and crash2 runs
-# (issue #2045). Those suites hard-code rollback-journal semantics: stock's
+# (issue #2072). Those suites hard-code rollback-journal semantics: stock's
 # commit point (the journal delete) lies strictly after the last main-file
 # sync, and crashsql only crashes on syncs, so any simulated crash recovers
 # the pre-transaction state. DoltLite's commit point IS a sync of the main

--- a/test/known_testfixture_crashes.txt
+++ b/test/known_testfixture_crashes.txt
@@ -16,7 +16,7 @@ alter2 class=intentional  # raw file-format setup prevents the db command from o
 backup_ioerr class=harness  # cap-truncated page-copy fault sequence; unbucketed
 btreefault class=intentional issue=1840  # rowid setup failure cascades into the fault simulator
 corrupt4 class=harness  # raw-offset outcome varies by build; unbucketed
-crash2 class=harness issue=2045  # commit is durable at a main-file sync, so a torn crash may recover the committed state; layout-dependent; unbucketed
+crash2 class=harness issue=2072  # crash2-2.* crash test.db-journal, which doltlite never writes, so the child commits instead of crashing; crash2-3.*.2 may recover the committed state because the commit point is a main-file sync; layout-dependent; unbucketed
 crash8 class=harness  # crash-simulation timing is nondeterministic; unbucketed
 dbstatus class=intentional  # echo-vtab cleanup after schema reset
 incrblob class=intentional issue=1840  # rowid assumption on a primary-key table
@@ -26,5 +26,5 @@ malloc3 class=harness  # unstable OOM fault-point set; unbucketed
 multiplex2 class=intentional  # incompatible multiplex VFS setup
 pagerfault class=harness  # unstable OOM fault-point set; unbucketed
 pagerfault2 class=harness  # unstable OOM fault-point set; unbucketed
-savepoint4 class=harness issue=2045  # commit is durable at a main-file sync, so a torn crash may recover the committed state; layout-dependent; unbucketed
+savepoint4 class=harness issue=2072  # commit is durable at a main-file sync, so a torn crash may recover the committed state; which assertion fails moves with layout; unbucketed
 vtab1 class=intentional  # echo-vtab cleanup after schema reset

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -776,9 +776,11 @@ where where-1.1.1 class=intentional issue=1840  # sqlite_search_count metric; SE
 # the test sees the committed state where stock expects a journal rollback
 # (crash3-1.odd.3 post-commit signature). The test.db crash simulations
 # themselves (crash3 even, crash4, crash6) pass clean. crash2 and savepoint4
-# are quarantined whole (known_testfixture_crashes.txt, issue #2045): their
-# failing-assertion sets move with the WAL layout because a crash torn during
-# a commit's own sync may legitimately recover the committed state.
+# are quarantined whole (known_testfixture_crashes.txt, issue #2072): crash2
+# adds the same journal-sidecar divergence across its 2.* block, and both
+# suites carry an assertion that moves with the WAL layout because a crash
+# torn during a commit's own sync may legitimately recover the committed
+# state. #2072 tracks narrowing that to per-assertion gates.
 crash3 crash3-1.41.3 class=intentional
 crash3 crash3-1.43.3 class=intentional
 crash3 crash3-1.45.3 class=intentional


### PR DESCRIPTION
Fixes #2070.

## Why the check fired

`test/known_testfixture_crashes.txt` quarantines `crash2` and `savepoint4` citing #2045. That issue asked for a policy decision and a coverage port; PR #2047 delivered both, so it was closed — leaving two gates whose justification had been closed out from under them. `check_testfixture_inventory_issues_alive.sh` exists precisely so that cannot rot quietly, and it was right to fire.

Note `class=harness` does not *require* `issue=`, so deleting the citation would also have turned the check green. That would have thrown away the traceability the check is protecting, so instead the limitation is described as it stands now in **#2072** and both gates cite it.

## The limitation still stands (verified, not assumed)

No commit-protocol change has landed since #2045 — only `9169702773`, a graph-lock handle reuse, which does not move the commit point. Both suites still fail on master `4ddd48e13b`:

| suite | result |
|---|---|
| `savepoint4` | 1 error / 195 (`savepoint4-2.8.1.2`) |
| `crash2` | 60 errors / 84 |

`test/doltlite_recover_crash_commit.test`, the replacement coverage, is 0 errors / 111, and `check_testfixture_crash_coverage.sh` still maps both quarantined suites to it.

## The gate reasons were also wrong for crash2

Both gates said "layout-dependent". That is true of `savepoint4`, whose `2.*` loop falls through to crashing `test.db` on its own once the journal-phase child fails to crash — so its single failure really is the commit-at-sync coin flip. It is not true of `crash2`, where the breakdown is:

- **58 assertions** (`crash2-2.$i.1` and `.2`, i=1..29) — the deterministic no-rollback-journal class: they crash `-file test.db-journal`, doltlite writes no such file, so the child commits instead of crashing and both the "exited abnormally" and signature assertions fail every run. Same class already enumerated per-assertion for `crash3-1.odd.3`.
- **1** (`crash2-1.1`) — a raw page-format file-size assertion (3072 bytes).
- **1** (`crash2-3.1.2`) — the actual commit-at-sync flip. All the other `crash2-3.*` main-db crashes pass.

The comments now say which is which.

## Follow-up tracked in #2072

The crashes file's own header says it is for suites that cannot produce a comparable failure list at all, and warns that quarantining a whole suite to quiet one assertion costs every other assertion in it. Both of these *do* produce comparable lists, so the quarantine is over-broad — it silences 84 + 195 assertions for failures that are mostly enumerable. #2072 carries the plan: enumerate the deterministic ones as per-assertion `class=intentional` gates, mark only the layout-dependent ones `unstable`, and drop both suites from the quarantine. Pinning down the `unstable` set has to be done across build flavors and platforms (the corrupt4 lesson), so it needs its own PR and a full CI matrix rather than a local run.

## Validation

- `check_testfixture_inventory_issues_alive.sh` — `OK: all 14 issue(s) cited by testfixture exception gates are open` (was `ERROR: #2045 is CLOSED`)
- `check_testfixture_exception_inventory.sh` exit 0, plus both checker self-tests OK
- `check_testfixture_crash_coverage.sh` — `OK: 10 unbucketed crash tests have gated replacement coverage`, self-test OK
- `doltlite_recover_crash_commit.test` — 0 errors / 111

No engine code changes; documentation and inventory metadata only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)