### PR TITLE
Stop reading a numeric byte-prefix as an equal index key

### DIFF
--- a/src/prolly_btree_cursor_seek.c
+++ b/src/prolly_btree_cursor_seek.c
@@ -717,7 +717,8 @@ static int indexMovetoScanTreeLeaf(
           }
           break;
         }
-        if( nSeekKeyField>0 && prefixCmp==0 && nSK>=nSortKey ){
+        if( nSeekKeyField>0 && prefixCmp==0 && nSK>=nSortKey
+         && (nSK==nSortKey || sortKeyByteStartsField(pSK[nSortKey])) ){
           if( pCur->pMutMap && !prollyMutMapIsEmpty(pCur->pMutMap) ){
             ProllyMutMapEntry *mmE = 0;
             rc = prollyMutMapFindRc(pCur->pMutMap, pSK, nSK, 0, &mmE);
@@ -1098,6 +1099,12 @@ int sqlite3BtreeProllyCachedIndexKeyCompare(
       *pRes = 1;
     }else if( nKey < pCur->nSeekSortKey ){
       *pRes = -1;
+    }else if( nKey > pCur->nSeekSortKey
+           && !sortKeyByteStartsField(pKey[pCur->nSeekSortKey]) ){
+      /* The seek key stops mid-field, so the rows are not equal and their
+      ** order depends on the encoding rather than on the bytes compared
+      ** here. Decline and let the record comparator answer. */
+      return SQLITE_NOTFOUND;
     }else{
       pIdxKey->eqSeen = 1;
       *pRes = pIdxKey->default_rc;
@@ -1126,6 +1133,9 @@ int sqlite3BtreeProllyCachedIndexKeyCompare(
       *pRes = 1;
     }else if( nKey < pCur->nCompareSortKey ){
       *pRes = -1;
+    }else if( nKey > pCur->nCompareSortKey
+           && !sortKeyByteStartsField(pKey[pCur->nCompareSortKey]) ){
+      return SQLITE_NOTFOUND;
     }else{
       pIdxKey->eqSeen = 1;
       *pRes = pIdxKey->default_rc;

--- a/src/sortkey.h
+++ b/src/sortkey.h
@@ -10,6 +10,31 @@
 #define SORTKEY_TEXT    0x35
 #define SORTKEY_BLOB    0x45
 
+/* True when b could begin a field, in either sort direction (a DESC field is
+** stored with every byte inverted, tag included).
+**
+** A byte-prefix match only means the encoded fields are equal if the shorter
+** key ends on a field boundary. A numeric field carrying an integer that no
+** double represents exactly is 18 bytes -- 9 bytes of IEEE base plus a
+** continuation marker and the exact value -- so the 9-byte encoding of its
+** base is a byte-prefix of it while denoting a different, smaller number.
+** Anything that is not a tag is treated as a continuation, so an encoding
+** grown later fails safe onto the authoritative comparator. */
+static inline int sortKeyByteStartsField(u8 b){
+  switch( b ){
+    case SORTKEY_NULL:
+    case SORTKEY_NUM:
+    case SORTKEY_TEXT:
+    case SORTKEY_BLOB:
+    case (u8)~SORTKEY_NULL:
+    case (u8)~SORTKEY_NUM:
+    case (u8)~SORTKEY_TEXT:
+    case (u8)~SORTKEY_BLOB:
+      return 1;
+  }
+  return 0;
+}
+
 int sortKeyFromRecord(const u8 *pRec, int nRec, u8 **ppOut, int *pnOut);
 
 int sortKeyFromRecordPrefix(const u8 *pRec, int nRec, int nKeyField,

--- a/test/review_regression_test.sh
+++ b/test/review_regression_test.sh
@@ -1056,6 +1056,59 @@ run_test "negative_large_int_index_lookup" \
 
 rm -f "$DB"
 
+# An integer above 2^53 that no double represents exactly encodes as 9 bytes of
+# IEEE base plus the exact value, so the 9-byte key of the base is a byte-prefix
+# of it. Probing for the base must not match the larger row: the cases above
+# only ever probe the extended value, whose whole key matches.
+
+DB=/tmp/test_rg_large_int_prefix_$$.db; rm -f "$DB"
+echo "CREATE TABLE t(x NUMERIC PRIMARY KEY, y TEXT) WITHOUT ROWID;
+INSERT INTO t VALUES(9007199254740993,'keep');
+INSERT INTO t VALUES(1,'other');" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+run_test "large_int_base_probe_finds_nothing" \
+  "SELECT count(*) FROM t WHERE x=9007199254740992;" "0" "$DB"
+run_test "large_int_base_probe_real_finds_nothing" \
+  "SELECT count(*) FROM t WHERE x=9007199254740992.0;" "0" "$DB"
+run_test "large_int_extended_probe_still_hits" \
+  "SELECT y FROM t WHERE x=9007199254740993;" "keep" "$DB"
+run_test "large_int_base_update_spares_extended_row" \
+  "UPDATE t SET y='clobbered' WHERE x=9007199254740992.0;
+   SELECT group_concat(x || ':' || y, '|') FROM (SELECT x,y FROM t ORDER BY x);" \
+  "1:other|9007199254740993:keep" "$DB"
+run_test "large_int_base_delete_spares_extended_row" \
+  "DELETE FROM t WHERE x=9007199254740992;
+   SELECT count(*) FROM t;" "2" "$DB"
+
+rm -f "$DB"
+
+DB=/tmp/test_rg_large_int_prefix_uniq_$$.db; rm -f "$DB"
+echo "CREATE TABLE t(x NUMERIC UNIQUE, y TEXT);
+INSERT INTO t VALUES(9007199254740993,'keep');" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+run_test "large_int_base_not_a_unique_conflict" \
+  "INSERT INTO t VALUES(9007199254740992.0,'base');
+   SELECT group_concat(x || ':' || y, '|') FROM (SELECT x,y FROM t ORDER BY x);" \
+  "9007199254740992:base|9007199254740993:keep" "$DB"
+run_test "large_int_prefix_integrity_check" \
+  "PRAGMA integrity_check;" "ok" "$DB"
+
+rm -f "$DB"
+
+DB=/tmp/test_rg_large_int_prefix_range_$$.db; rm -f "$DB"
+echo "CREATE TABLE t(x NUMERIC PRIMARY KEY) WITHOUT ROWID;
+INSERT INTO t VALUES(9007199254740993);
+INSERT INTO t VALUES(9007199254740994);" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+run_test "large_int_range_above_base_sees_both" \
+  "SELECT count(*) FROM t WHERE x>9007199254740992.0 AND x<9007199254740995;" \
+  "2" "$DB"
+run_test "large_int_range_order" \
+  "SELECT group_concat(x, '|') FROM (SELECT x FROM t ORDER BY x);" \
+  "9007199254740993|9007199254740994" "$DB"
+
+rm -f "$DB"
+
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"


### PR DESCRIPTION
## Problem

`encodeNumeric` gives an integer past 2^53 that no double represents exactly an **18-byte** numeric field: 9 bytes of order-preserving IEEE base, a continuation marker (`0x80`), then the exact value. An integer that *is* exactly representable gets the **9-byte** form. So the 9-byte key of a base is a byte prefix of the 18-byte key of a different, larger number.

Three sites promoted "the probe is a byte prefix of the stored key" to "the encoded fields are equal", so probing for the base matched the larger row:

```sql
CREATE TABLE t(x NUMERIC PRIMARY KEY, y TEXT) WITHOUT ROWID;
INSERT INTO t VALUES(9007199254740993,'keep'), (1,'other');
UPDATE t SET y='clobbered' WHERE x = 9007199254740992.0;   -- rewrites the ...993 row
SELECT count(*) FROM t WHERE x = 9007199254740992;         -- 1, stock says 0
```

Consequences, all reproduced: `SELECT` returns a row that does not match; `UPDATE`/`DELETE` aimed at the base silently rewrite and remove the neighbouring row (data loss in plain SQL, no version control involved); inserting the base is rejected as a false `UNIQUE constraint failed`; and `PRAGMA integrity_check` reports a `PRIMARY KEY order` violation for rows that are correctly ordered.

## Fix

A byte-prefix match only implies field equality when the shorter key ends on a field boundary, so the promotion now requires the next byte to begin a field. `sortKeyByteStartsField` (in `sortkey.h`, next to the tag definitions) accepts the four tags and their DESC-inverted forms and treats **anything else** as a continuation, so an encoding extended later fails safe onto the authoritative comparator rather than silently matching.

- `indexMovetoScanTreeLeaf` falls through to the `sqlite3VdbeRecordCompare` path already below it.
- The two fast paths in `sqlite3BtreeProllyCachedIndexKeyCompare` cannot name a correct result once they know the keys differ, because the order then depends on the encoding rather than on the bytes they compared. They return `SQLITE_NOTFOUND`, the existing "fast path declined" signal, and the caller does the full compare.

`findMatchingMutMapEntry` uses its prefix compare only to bound the scan and already defers to `sqlite3VdbeRecordCompare`, so it needed no change.

## Scope: ordering was already correct, DESC is a separate bug

An extended value is always strictly greater than its base — when the nearest double rounds *above* the true integer, `encodeNumeric` nudges the base one ULP down — and `memcmp` sorts a longer key after its prefix, so ASC order is right. DESC inverts every byte of the field, which reverses the value comparison but not the prefix-vs-longer length relation, so DESC indexes and DESC `WITHOUT ROWID` PKs are mis-ordered *on disk* for these values. That is an encoding change, not a comparison change, so it is deliberately left out of this PR.

## Validation

New assertions extend Guard 23 of `review_regression_test.sh`, which previously only ever probed the *extended* value — whose full key matches — and so never exercised the failing direction. Expectations were oracled against stock. Fail-before / pass-after on the same rig:

```
unfixed: 124 passed, 5 failed        fixed: 129 passed, 0 failed
  FAIL large_int_base_probe_finds_nothing
  FAIL large_int_base_probe_real_finds_nothing
  FAIL large_int_base_update_spares_extended_row
  FAIL large_int_base_delete_spares_extended_row
  FAIL large_int_base_not_a_unique_conflict
```

- Full shell battery `test/run_doltlite_tests.sh`: **101/101 suites**
- `sql_oracle_test.sh` vs stock: **568/568**
- Randomized differential sweep vs stock, seeded around the 2^53 boundary across `NUMERIC`/`INTEGER` PKs, `WITHOUT ROWID`, `UNIQUE` and secondary indexes, with equality/range/`UPDATE`/`DELETE` and real-valued predicates: **0 divergent of 1200 seeds** with the fix, **125 divergent of 400** without it — so the sweep is a genuine detector, not a silent pass.

Two rig notes for anyone re-running these locally: `review_regression_test.sh` and `sql_oracle_test.sh` take the binaries as **positional** arguments (`$1` = doltlite, `$2` = stock), not from `$DOLTLITE`; and the repo-root `./sqlite3` reports `dolt_version`, so it is not usable as the stock oracle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)