### PR TITLE
Add a randomized SQL differential sweep against stock SQLite

### DIFF
--- a/.github/workflows/nightly-fuzz.yml
+++ b/.github/workflows/nightly-fuzz.yml
@@ -174,3 +174,112 @@ jobs:
       run: |
         echo "::error::fuzz crash in ${{ matrix.target }}"
         exit 1
+
+  # Randomized differential sweep against stock SQLite. Separate from the
+  # libFuzzer matrix above: those feed bytes to on-disk-format decoders, this
+  # one runs generated SQL through both engines and compares answers, so it
+  # covers query and transaction semantics instead of parsing.
+  #
+  # Nightly only for now. The engine currently diverges on roughly 3% of seeds
+  # (issue #2076), so a per-PR gate would block every pull request; adding the
+  # short per-PR run is the last step of that issue.
+  #
+  # Each night sweeps a different seed window derived from the run number, so
+  # coverage compounds instead of re-checking seeds earlier runs already
+  # cleared. The window is printed and every failing seed is reproducible from
+  # the generator alone.
+  differential:
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install dependencies
+      run: |
+        bash .github/scripts/install-apt-deps.sh tcl-dev build-essential zlib1g-dev
+
+    - name: Build doltlite and the stock reference
+      run: |
+        mkdir -p build-diff && cd build-diff
+        TCL_CONFIG=$(find /usr/lib -name tclConfig.sh -print -quit 2>/dev/null)
+        if [ -n "$TCL_CONFIG" ]; then
+          ../configure --with-tcl=$(dirname "$TCL_CONFIG")
+        else
+          ../configure
+        fi
+        make -j2 doltlite
+        # The reference is this tree with the prolly storage compiled out, so
+        # both binaries share a SQLite version. A packaged sqlite3 would
+        # differ in text rendering of large reals and read as a divergence.
+        make DOLTLITE_PROLLY=0 sqlite3
+        mv sqlite3 sqlite3-stock
+
+    - name: Run differential sweep
+      id: sweep
+      run: |
+        set -o pipefail
+        WINDOW=4000
+        FIRST=$(( (${{ github.run_number }} * WINDOW) % 1000000 + 1 ))
+        LAST=$(( FIRST + WINDOW - 1 ))
+        mkdir -p "$GITHUB_WORKSPACE/diff-artifacts"
+        cd build-diff
+        if DOLTLITE_DIFF_SAVE_DIR="$GITHUB_WORKSPACE/diff-artifacts" \
+           bash ../test/sql_differential_test.sh \
+             ./doltlite ./sqlite3-stock "$FIRST" "$LAST" \
+             2>&1 | tee "$GITHUB_WORKSPACE/diff-artifacts/sweep.log"; then
+          echo "diverged=0" >> "$GITHUB_OUTPUT"
+        else
+          echo "diverged=1" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Compose divergence report
+      if: steps.sweep.outputs.diverged == '1'
+      run: |
+        set -euo pipefail
+        WS="$GITHUB_WORKSPACE"
+        BODY="$RUNNER_TEMP/diff-body.md"
+        {
+          echo "The randomized SQL differential sweep found answers that differ"
+          echo "from stock SQLite."
+          echo ""
+          echo "Reproduce a failing seed locally:"
+          echo ""
+          echo '```'
+          echo "make DOLTLITE_PROLLY=0 sqlite3   # stock reference, same version"
+          echo "bash test/sql_differential_test.sh ./doltlite ./sqlite3 <seed> <seed>"
+          echo '```'
+          echo ""
+          echo "Generated scripts for the first failing seeds are attached as the"
+          echo "\`differential-cases\` artifact."
+          echo ""
+          echo '```'
+          tail -n 60 "$WS/diff-artifacts/sweep.log" 2>/dev/null || echo "(no log)"
+          echo '```'
+        } > "$BODY"
+        cat "$BODY"
+
+    - name: Upload failing cases
+      if: steps.sweep.outputs.diverged == '1'
+      uses: actions/upload-artifact@v4
+      with:
+        name: differential-cases
+        path: |
+          diff-artifacts/seed_*.sql
+          diff-artifacts/sweep.log
+        if-no-files-found: warn
+
+    - name: Report divergence as GitHub issue
+      if: steps.sweep.outputs.diverged == '1'
+      uses: ./.github/actions/report-failure-issue
+      with:
+        label: sql-differential-divergence
+        title: "Nightly SQL differential sweep diverged from stock SQLite"
+        body-file: ${{ runner.temp }}/diff-body.md
+        token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Fail the job if the sweep diverged
+      if: steps.sweep.outputs.diverged == '1'
+      run: |
+        echo "::error::SQL differential sweep diverged from stock SQLite"
+        exit 1

--- a/test/sql_differential_fuzzer.py
+++ b/test/sql_differential_fuzzer.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""Emit a randomized SQL script for differential testing against stock SQLite.
+
+The script is printed on stdout and is valid for both engines: no dolt_*
+surfaces, and nothing that depends on rowid identity or physical row order,
+both of which diverge by design. Every result is ordered by declared columns
+so a comparison only sees storage and query semantics.
+
+The axis this exists for is transaction shape. Explicit BEGIN/SAVEPOINT blocks
+with reads interleaved between writes are where the merged-cursor state machine
+lives, and the bugs found there (a one-pass scan skipping pending rows, a
+deferred seek serving a stale payload, a resumed scan re-seeking to a stale key)
+were all found by randomized differential runs rather than by any suite.
+
+Usage: sql_differential_fuzzer.py SEED [--include-large-ints] [--include-desc]
+"""
+
+import random
+import sys
+
+# Integers beyond 2^53 that no double represents exactly get a longer numeric
+# sort key, and INT64 extremes are in that class too. Off by default: see the
+# --include-desc note below and the runner's --help.
+LARGE_INTS = [
+    9007199254740992, 9007199254740993, 9007199254740994, 9007199254740995,
+    -9007199254740992, -9007199254740993, -9007199254740994,
+    18014398509481984, 18014398509481985,
+    9223372036854775807, 9223372036854775806,
+    -9223372036854775808, -9223372036854775807,
+]
+
+TEXTS = ["''", "'a'", "'A'", "'ab'", "'AB '", "'b'", "'z'", "'zz'",
+         "'a' || char(0) || 'b'", "'  pad  '", "x'00'", "x'0001'", "x'ff'"]
+
+
+class Gen:
+    def __init__(self, seed, large_ints, desc):
+        self.r = random.Random(seed)
+        self.large_ints = large_ints
+        self.desc = desc
+        self.out = []
+        self.depth = 0          # open SAVEPOINTs
+        self.in_txn = False
+        self.savepoints = []
+
+    def emit(self, s):
+        self.out.append(s)
+
+    # ---- values ---------------------------------------------------------
+    def int_val(self):
+        if self.large_ints and self.r.random() < 0.35:
+            return str(self.r.choice(LARGE_INTS))
+        return str(self.r.randint(-40, 40))
+
+    def text_val(self):
+        return self.r.choice(TEXTS)
+
+    def val(self, kind):
+        if kind == "int":
+            return self.int_val()
+        if kind == "text":
+            return self.text_val()
+        r = self.r.random()
+        if r < 0.15:
+            return "NULL"
+        if r < 0.5:
+            return self.int_val()
+        if r < 0.8:
+            return self.text_val()
+        return "%.3f" % self.r.uniform(-50, 50)
+
+    # ---- schema ---------------------------------------------------------
+    def schema(self):
+        coll = self.r.choice(["", "", " COLLATE NOCASE", " COLLATE RTRIM"])
+        shape = self.r.choice([
+            "int_pk", "int_pk", "text_pk", "numeric_pk",
+            "composite_pk", "no_pk", "unique_only",
+        ])
+        self.key_kind = "int"
+        wr = ""
+        if shape == "int_pk":
+            cols = "k INTEGER PRIMARY KEY, a, b TEXT%s" % coll
+        elif shape == "text_pk":
+            cols = "k TEXT PRIMARY KEY%s, a, b TEXT" % coll
+            self.key_kind = "text"
+            wr = " WITHOUT ROWID" if self.r.random() < 0.5 else ""
+        elif shape == "numeric_pk":
+            cols = "k NUMERIC PRIMARY KEY, a, b TEXT%s" % coll
+            wr = " WITHOUT ROWID" if self.r.random() < 0.5 else ""
+        elif shape == "composite_pk":
+            cols = "k INTEGER, j TEXT%s, a, b TEXT, PRIMARY KEY(k, j)" % coll
+            wr = " WITHOUT ROWID" if self.r.random() < 0.5 else ""
+        elif shape == "unique_only":
+            cols = "k INTEGER UNIQUE, a, b TEXT%s" % coll
+        else:
+            cols = "k INTEGER, a, b TEXT%s" % coll
+        self.shape = shape
+        self.emit("CREATE TABLE t(%s)%s;" % (cols, wr))
+        if self.r.random() < 0.7:
+            d = " DESC" if (self.desc and self.r.random() < 0.5) else ""
+            self.emit("CREATE INDEX i_a ON t(a%s);" % d)
+        if self.r.random() < 0.4:
+            self.emit("CREATE INDEX i_b ON t(b, a);")
+        if self.r.random() < 0.3 and self.shape != "unique_only":
+            self.emit("CREATE UNIQUE INDEX i_u ON t(b, k);")
+
+    def key_args(self):
+        """Return (column list, value list) for the key columns."""
+        if self.shape == "composite_pk":
+            return "k, j", "%s, %s" % (self.int_val(), self.text_val())
+        if self.key_kind == "text":
+            return "k", self.text_val()
+        return "k", self.int_val()
+
+    # ---- statements -----------------------------------------------------
+    def insert(self):
+        kc, kv = self.key_args()
+        verb = self.r.choice(["INSERT OR IGNORE", "INSERT OR REPLACE",
+                              "INSERT OR IGNORE", "INSERT OR ROLLBACK"])
+        if verb == "INSERT OR ROLLBACK" and self.in_txn:
+            verb = "INSERT OR IGNORE"
+        self.emit("%s INTO t(%s, a, b) VALUES(%s, %s, %s);"
+                  % (verb, kc, kv, self.val("any"), self.val("text")))
+
+    def update(self):
+        pred = self.pred()
+        col = self.r.choice(["a", "b"])
+        self.emit("UPDATE t SET %s = %s WHERE %s;"
+                  % (col, self.val("any" if col == "a" else "text"), pred))
+
+    def delete(self):
+        self.emit("DELETE FROM t WHERE %s;" % self.pred())
+
+    def pred(self):
+        r = self.r.random()
+        if self.shape == "composite_pk" and r < 0.25:
+            return "k = %s AND j = %s" % (self.int_val(), self.text_val())
+        if r < 0.3:
+            kv = self.text_val() if self.key_kind == "text" else self.int_val()
+            return "k = %s" % kv
+        if r < 0.5:
+            lo = self.int_val()
+            hi = self.int_val()
+            return "k > %s AND k < %s" % (lo, hi)
+        if r < 0.65:
+            return "a IS NULL"
+        if r < 0.8:
+            return "b > %s" % self.text_val()
+        if r < 0.9:
+            return "a = %s" % self.val("any")
+        return "k IN (%s, %s)" % (self.int_val(), self.int_val())
+
+    def read(self):
+        r = self.r.random()
+        if r < 0.3:
+            self.emit("SELECT count(*), count(a), count(b) FROM t WHERE %s;"
+                      % self.pred())
+        elif r < 0.5:
+            self.emit("SELECT group_concat(q, '|') FROM (SELECT "
+                      "coalesce(quote(k), 'NK') || '/' || coalesce(quote(a), 'NA')"
+                      " AS q FROM t WHERE %s ORDER BY 1);" % self.pred())
+        elif r < 0.65:
+            self.emit("SELECT min(k), max(k) FROM t;")
+        elif r < 0.8:
+            self.emit("SELECT group_concat(q, '|') FROM (SELECT quote(b) AS q "
+                      "FROM t ORDER BY b, k);")
+        else:
+            self.emit("SELECT count(*) FROM t WHERE a IN "
+                      "(SELECT a FROM t WHERE %s);" % self.pred())
+
+    def full_read(self):
+        self.emit("SELECT group_concat(q, '|') FROM (SELECT "
+                  "coalesce(quote(k), 'NK') || '/' || coalesce(quote(a), 'NA')"
+                  " || '/' || coalesce(quote(b), 'NB') AS q FROM t "
+                  "ORDER BY 1);")
+
+    # ---- transaction shaping -------------------------------------------
+    def open_txn(self):
+        self.emit("BEGIN;")
+        self.in_txn = True
+
+    def close_txn(self):
+        # A rollback must restore the pre-transaction state; that is as much
+        # of the contract as a commit is.
+        self.emit(self.r.choice(["COMMIT;", "COMMIT;", "ROLLBACK;"]))
+        self.in_txn = False
+        self.savepoints = []
+
+    def savepoint(self):
+        name = "sp%d" % (len(self.savepoints) + 1)
+        self.savepoints.append(name)
+        self.emit("SAVEPOINT %s;" % name)
+
+    def release_savepoint(self):
+        name = self.savepoints.pop()
+        if self.r.random() < 0.5:
+            self.emit("ROLLBACK TO %s;" % name)
+            self.emit("RELEASE %s;" % name)
+        else:
+            self.emit("RELEASE %s;" % name)
+
+    def body(self):
+        for _ in range(self.r.randint(6, 22)):
+            r = self.r.random()
+            if not self.in_txn and r < 0.3:
+                self.open_txn()
+            elif self.in_txn and self.savepoints and r < 0.12:
+                self.release_savepoint()
+            elif self.in_txn and r < 0.22:
+                self.savepoint()
+            elif self.in_txn and r < 0.32:
+                self.close_txn()
+            elif r < 0.55:
+                self.insert()
+            elif r < 0.68:
+                self.update()
+            elif r < 0.78:
+                self.delete()
+            else:
+                self.read()
+        while self.savepoints:
+            self.release_savepoint()
+        if self.in_txn:
+            self.close_txn()
+
+    def run(self):
+        self.schema()
+        for _ in range(self.r.randint(2, 10)):
+            self.insert()
+        self.body()
+        self.full_read()
+        self.emit("PRAGMA integrity_check;")
+        return "\n".join(self.out)
+
+
+def main():
+    if len(sys.argv) < 2:
+        sys.stderr.write("usage: %s SEED [--include-large-ints] [--include-desc]\n"
+                         % sys.argv[0])
+        return 2
+    seed = int(sys.argv[1])
+    flags = sys.argv[2:]
+    print(Gen(seed,
+              "--include-large-ints" in flags,
+              "--include-desc" in flags).run())
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/sql_differential_test.sh
+++ b/test/sql_differential_test.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+#
+# Randomized differential test: run a generated SQL script through doltlite and
+# through stock SQLite and require identical output. The generator shapes the
+# workload around explicit BEGIN/SAVEPOINT blocks with reads interleaved between
+# writes, which is the state space the merged-cursor bugs lived in and which no
+# hand-written suite covers.
+#
+# The stock reference must be built from this tree with DOLTLITE_PROLLY=0
+# (`make DOLTLITE_PROLLY=0 sqlite3`), same as the other oracle suites use. A
+# different SQLite version is not a valid reference here: text rendering of
+# large reals changed in 3.44, so version skew shows up as a false divergence.
+#
+# Usage: sql_differential_test.sh [doltlite] [stock] [first-seed] [last-seed]
+#
+# Two axes are off by default because they have known open bugs; enabling them
+# is how this suite grows once those land:
+#   DOLTLITE_DIFF_LARGE_INTS=1  integers beyond 2^53 (needs PR #2075)
+#   DOLTLITE_DIFF_DESC=1        DESC indexes (issue #2077)
+
+set -uo pipefail
+
+DOLTLITE="${1:-./doltlite}"
+SQLITE3="${2:-./sqlite3-stock}"
+FIRST="${3:-${DOLTLITE_DIFF_FIRST_SEED:-1}}"
+LAST="${4:-${DOLTLITE_DIFF_LAST_SEED:-200}}"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+GEN="$SCRIPT_DIR/sql_differential_fuzzer.py"
+
+for bin in "$DOLTLITE" "$SQLITE3"; do
+  if [ ! -x "$bin" ]; then
+    echo "ERROR: not executable: $bin"
+    exit 1
+  fi
+done
+if [ ! -f "$GEN" ]; then
+  echo "ERROR: missing generator: $GEN"
+  exit 1
+fi
+
+# A doltlite build answering as the stock reference would compare the engine
+# against itself and pass no matter what broke.
+if "$SQLITE3" :memory: \
+     "SELECT 1 FROM pragma_function_list WHERE name='dolt_version';" \
+     2>/dev/null | grep -q 1; then
+  echo "ERROR: $SQLITE3 provides dolt_version, so it is not a stock reference"
+  exit 1
+fi
+
+GENFLAGS=""
+[ "${DOLTLITE_DIFF_LARGE_INTS:-0}" = "1" ] && GENFLAGS="$GENFLAGS --include-large-ints"
+[ "${DOLTLITE_DIFF_DESC:-0}" = "1" ] && GENFLAGS="$GENFLAGS --include-desc"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+echo "=== SQL differential sweep: seeds $FIRST..$LAST ==="
+echo "    doltlite: $DOLTLITE"
+echo "    stock:    $SQLITE3"
+[ -n "$GENFLAGS" ] && echo "    axes:    $GENFLAGS"
+echo ""
+
+pass=0
+fail=0
+failed_seeds=""
+
+for seed in $(seq "$FIRST" "$LAST"); do
+  sql="$WORK/case.sql"
+  if ! python3 "$GEN" "$seed" $GENFLAGS > "$sql" 2>"$WORK/gen.err"; then
+    echo "  ERROR: generator failed for seed $seed"
+    cat "$WORK/gen.err"
+    fail=$((fail + 1))
+    continue
+  fi
+
+  rm -f "$WORK/dl.db" "$WORK/dl.db-lock" "$WORK/dl.db-wal" "$WORK/sq.db"
+  out_dl=$("$DOLTLITE" "$WORK/dl.db" < "$sql" 2>&1)
+  rc_dl=$?
+  out_sq=$("$SQLITE3" "$WORK/sq.db" < "$sql" 2>&1)
+  rc_sq=$?
+
+  if [ "$rc_dl" -eq "$rc_sq" ] && [ "$out_dl" = "$out_sq" ]; then
+    pass=$((pass + 1))
+    continue
+  fi
+
+  fail=$((fail + 1))
+  failed_seeds="$failed_seeds $seed"
+  if [ "$fail" -le 5 ]; then
+    echo "  FAIL: seed $seed (doltlite rc=$rc_dl, stock rc=$rc_sq)"
+    diff <(printf '%s\n' "$out_dl") <(printf '%s\n' "$out_sq") \
+      | head -20 | sed 's/^/    /'
+    cp "$sql" "${DOLTLITE_DIFF_SAVE_DIR:-$WORK}/seed_$seed.sql" 2>/dev/null || true
+  fi
+done
+
+echo ""
+echo "Results: $pass passed, $fail failed out of $((pass + fail)) seeds"
+if [ "$fail" -gt 0 ]; then
+  echo "Failing seeds:$failed_seeds"
+  echo "Reproduce with: python3 test/sql_differential_fuzzer.py <seed>$GENFLAGS"
+  exit 1
+fi


### PR DESCRIPTION
Closes the headline gap from the test-coverage audit: **no CI job ran a randomized differential comparison against stock SQLite**, even though that technique found every merged-cursor bug of the last few weeks — the one-pass scan skipping pending rows (#2041), the deferred seek serving a stale payload (#2042), and the resumed scan re-seeking to a stale key (#2062). The existing vs-stock comparisons are curated scenario lists, and `vc_stateful_fuzzer.py` contains **zero** `BEGIN` statements, so the in-transaction state space those bugs live in was unexercised by anything.

## What this adds

`test/sql_differential_fuzzer.py` turns a seed into a SQL script; `test/sql_differential_test.sh` runs it through both engines and requires identical output.

The axis it exists for is **transaction shape**: explicit `BEGIN`/`SAVEPOINT` blocks with reads interleaved between writes, plus `ROLLBACK` and `ROLLBACK TO` (a rollback restoring the pre-transaction state is as much of the contract as a commit). Around that it varies PK shape (integer, text, numeric, composite, none), `WITHOUT ROWID`, unique and secondary indexes, `NOCASE`/`RTRIM` collations, and value classes including NULLs, blobs, embedded NULs and reals.

It deliberately emits nothing that depends on rowid identity or physical row order, since both diverge by design, and orders every result by declared columns — so a divergence means storage or query semantics, not a known-intentional difference.

## Getting the reference right

The reference is this tree built with `make DOLTLITE_PROLLY=0 sqlite3`, matching what the other oracle suites use, so both binaries are the same SQLite version. This matters more than it looks:

- A packaged `sqlite3` is not a valid reference. On macOS `/usr/bin/sqlite3` is 3.43, which predates the 3.44 real-to-text change, so large reals render differently and read as false divergences — and its scientific rendering is only 15 significant digits, so the text cannot even be re-parsed back to the exact value.
- The runner **refuses** a reference that answers `dolt_version`, which would compare the engine against itself and pass no matter what broke. The repo-root `./sqlite3` is exactly such a binary.

## It works: 5 new bugs, filed with reproducers

First run found 5 divergent seeds of 200, then 16 of 500 on a fresh window — about 3%, so systemic. All five minimized reproducers are in **#2076**; all are in-transaction reads or writes on **non-intkey** tables (composite PK, `WITHOUT ROWID`, unique index, collated column), i.e. the blob/index-key arm of the same state machine whose intkey arm got #2041, #2042 and #2062. Two lose or corrupt data:

- a `DELETE` whose predicate matches no row deletes **every** row
- an `UPDATE` over an empty range after an in-transaction `DELETE` yields `database disk image is malformed`
- a one-pass `UPDATE` skips a committed row after an in-transaction insert (the #2041 shape on the blob-key path)
- two correlated-subquery counts over uncommitted state

Per one-fix-per-PR these are **not** fixed here.

## Why nightly-only, deliberately

At a 3% divergence rate a per-PR gate would block every pull request, so this lands as a nightly job in `nightly-fuzz.yml` alongside the libFuzzer matrix. That job uses the existing `report-failure-issue` action, which keeps one open issue per label and comments on repeats, so recurring failures append to a single triage thread rather than spamming. Each night sweeps a different seed window derived from the run number, so coverage compounds; failing scripts are uploaded as an artifact and every seed is reproducible from the generator alone.

Adding the short per-PR run is the last checkbox on #2076, once the divergences are fixed. Two axes are off by default for the same reason:

| axis | blocked on |
|---|---|
| `DOLTLITE_DIFF_LARGE_INTS=1` | the >2^53 prefix-equality fix (#2075) |
| `DOLTLITE_DIFF_DESC=1` | DESC sort-key ordering (#2077, filed from this work) |

## Validation

- Generator and engine output are deterministic across repeated runs (checked over several seeds) — a flaky harness would be worse than none in CI.
- All four runner exit paths verified: clean range 0, failing seed 1, non-stock reference 1, missing binary 1.
- `test/lint_orphaned_suites.sh` passes — the new suite is accounted for by the workflow that invokes it. It is intentionally **not** in `doltlite_suite_manifest.sh`, since the battery does not build a stock reference.
- `check_oracle_buckets.sh` still passes; no existing test or engine file is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)