### PR TITLE
Combine cached payload size and fetch

### DIFF
--- a/src/prolly_btree_cursor_payload.c
+++ b/src/prolly_btree_cursor_payload.c
@@ -51,7 +51,7 @@ int prollyBtreeCursorCurrentTreeValueCopy(
 ** operation returns the real error. Returning a zero key or an empty payload
 ** without faulting reports a row that was never read -- an OOM or interrupt
 ** during positioning became wrong data under SQLITE_OK. */
-i64 prollyBtCursorIntegerKey(BtCursor *pCur){
+static SQLITE_NOINLINE i64 prollyBtCursorIntegerKeySlow(BtCursor *pCur){
   if( pCur->deferredMergedSeek ){
     int rc = materializeDeferredMergedSeekBackward(pCur);
     if( rc!=SQLITE_OK ){
@@ -81,6 +81,19 @@ i64 prollyBtCursorIntegerKey(BtCursor *pCur){
   }
   assert( pCur->pCur.eState==PROLLY_CURSOR_VALID );
   return cursorCurrentTreeIntKey(pCur);
+}
+i64 prollyBtCursorIntegerKey(BtCursor *pCur){
+  if( !pCur->deferredMergedSeek && !pCur->mmActive ){
+    assert( pCur->eState==CURSOR_VALID );
+    assert( pCur->curIntKey );
+    if( pCur->pCur.eState!=PROLLY_CURSOR_VALID
+     && (pCur->curFlags & BTCF_ValidNKey) ){
+      return pCur->cachedIntKey;
+    }
+    assert( pCur->pCur.eState==PROLLY_CURSOR_VALID );
+    return cursorCurrentTreeIntKey(pCur);
+  }
+  return prollyBtCursorIntegerKeySlow(pCur);
 }
 i64 sqlite3BtreeIntegerKey(BtCursor *pCur){
   if( pCur->pCurOps==&prollyCursorOps ){
@@ -203,7 +216,7 @@ int getCursorPayload(BtCursor *pCur, const u8 **ppData, int *pnData){
   return SQLITE_OK;
 }
 
-u32 prollyBtCursorPayloadSize(BtCursor *pCur){
+static SQLITE_NOINLINE u32 prollyBtCursorPayloadSizeSlow(BtCursor *pCur){
   const u8 *pData;
   int nData;
   if( pCur->deferredMergedSeek ){
@@ -245,6 +258,13 @@ u32 prollyBtCursorPayloadSize(BtCursor *pCur){
     return 0;
   }
   return (u32)nData;
+}
+u32 prollyBtCursorPayloadSize(BtCursor *pCur){
+  if( !pCur->deferredMergedSeek
+   && pCur->pCachedPayload && pCur->nCachedPayload>0 ){
+    return (u32)pCur->nCachedPayload;
+  }
+  return prollyBtCursorPayloadSizeSlow(pCur);
 }
 u32 sqlite3BtreePayloadSize(BtCursor *pCur){
   if( pCur->pCurOps==&prollyCursorOps ){
@@ -326,7 +346,10 @@ int sqlite3BtreePayload(BtCursor *pCur, u32 offset, u32 amt, void *pBuf){
   return pCur->pCurOps->xPayload(pCur, offset, amt, pBuf);
 }
 
-const void *prollyBtCursorPayloadFetch(BtCursor *pCur, u32 *pAmt){
+static SQLITE_NOINLINE const void *prollyBtCursorPayloadFetchSlow(
+  BtCursor *pCur,
+  u32 *pAmt
+){
   const u8 *pData;
   int nData;
 
@@ -384,12 +407,35 @@ const void *prollyBtCursorPayloadFetch(BtCursor *pCur, u32 *pAmt){
   if( pAmt ) *pAmt = (u32)nData;
   return (const void*)pData;
 }
+const void *prollyBtCursorPayloadFetch(BtCursor *pCur, u32 *pAmt){
+  if( !pCur->deferredMergedSeek
+   && pCur->pCachedPayload && pCur->nCachedPayload>0 ){
+    if( pAmt ) *pAmt = (u32)pCur->nCachedPayload;
+    return (const void*)pCur->pCachedPayload;
+  }
+  return prollyBtCursorPayloadFetchSlow(pCur, pAmt);
+}
 const void *sqlite3BtreePayloadFetch(BtCursor *pCur, u32 *pAmt){
   if( !pCur ) return 0;
   if( pCur->pCurOps==&prollyCursorOps ){
     return prollyBtCursorPayloadFetch(pCur, pAmt);
   }
   return pCur->pCurOps->xPayloadFetch(pCur, pAmt);
+}
+const void *sqlite3BtreePayloadFetchWithSize(
+  BtCursor *pCur,
+  u32 *pAmt,
+  u32 *pSize
+){
+  if( !pCur ) return 0;
+  if( pCur->pCurOps==&prollyCursorOps
+   && !pCur->deferredMergedSeek
+   && pCur->pCachedPayload && pCur->nCachedPayload>0 ){
+    *pAmt = *pSize = (u32)pCur->nCachedPayload;
+    return (const void*)pCur->pCachedPayload;
+  }
+  *pSize = sqlite3BtreePayloadSize(pCur);
+  return sqlite3BtreePayloadFetch(pCur, pAmt);
 }
 
 sqlite3_int64 prollyBtCursorMaxRecordSize(BtCursor *pCur){

--- a/src/vdbe.c
+++ b/src/vdbe.c
@@ -20,6 +20,10 @@
 */
 #include "sqliteInt.h"
 #include "vdbeInt.h"
+
+#ifdef DOLTLITE_PROLLY
+const void *sqlite3BtreePayloadFetchWithSize(BtCursor*, u32*, u32*);
+#endif
 #if defined(DOLTLITE_PROLLY) && !defined(SQLITE_TEST)
 #include "chunk_store.h"
 struct ChunkStore *doltliteGetChunkStore(sqlite3 *db);
@@ -3125,8 +3129,13 @@ op_column_restart:
       assert( pC->eCurType==CURTYPE_BTREE );
       assert( pCrsr );
       assert( sqlite3BtreeCursorIsValid(pCrsr) );
+#ifdef DOLTLITE_PROLLY
+      pC->aRow = sqlite3BtreePayloadFetchWithSize(
+          pCrsr, &pC->szRow, &pC->payloadSize);
+#else
       pC->payloadSize = sqlite3BtreePayloadSize(pCrsr);
       pC->aRow = sqlite3BtreePayloadFetch(pCrsr, &pC->szRow);
+#endif
       if( pC->aRow==0 ){
         if( db->mallocFailed ) goto no_mem;
         goto op_column_corrupt;


### PR DESCRIPTION
## Summary

- return cached row data and its logical size through one DoltLite VDBE storage call
- keep merge, sparse-payload, and error handling out of ordinary cursor accessors
- preserve the stock SQLite VDBE path behind `DOLTLITE_PROLLY`

## Performance

Paired master vs. branch using `test/sysbench_compare.sh`, median of 7 invocations per workload:

- 10K-row in-memory reads averaged 0.988x master latency
- 10K-row file-backed reads averaged 0.994x master latency
- 50K-row in-memory reads averaged 0.994x master latency
- 50K-row file-backed reads averaged 0.997x master latency
- representative 50K file-backed results: point selects 31,639 to 30,224 us, range selects 10,438 to 10,140 us, and SUM ranges 8,473 to 8,085 us

Write results were neutral overall at 50K rows (1.002x file-backed) and improved in memory (0.989x).

## Testing

- `make -j8 testfixture doltlite`
- `make lint`
- clean `DOLTLITE_PROLLY=0` build and smoke test
- `bash test/run_doltlite_tests.sh` (101 suites, 0 failures)
- `bash test/run_c_tests.sh build all` (26 gates, 0 failures)
- `BENCH_ROWS=10000 BENCH_RUNS=7 bash test/sysbench_compare.sh ...`
- `BENCH_ROWS=50000 BENCH_RUNS=7 bash test/sysbench_compare.sh ...`

The local checkout does not contain the SQL logic corpus, so that full-corpus gate is left to CI.

Co-Authored-By: OpenAI Codex <noreply@openai.com>
