### PR TITLE
Keep the tree cursor put when a one-pass write leaves a pending row

### DIFF
--- a/src/prolly_btree_mutation.c
+++ b/src/prolly_btree_mutation.c
@@ -933,7 +933,12 @@ int prollyBtCursorInsert(
       } else if( (flags & BTREE_SAVEPOSITION) && !pCur->curIntKey ){
         ProllyMutMapEntry *pEntry = 0;
         CLEAR_CACHED_PAYLOAD(pCur);
-        if( prollyCursorIsValid(&pCur->pCur) ){
+        /* Step the tree off the row just written -- but only when the tree is
+        ** the side sitting on it. A mut-map-only row leaves the tree already
+        ** parked on the next committed row above it, so advancing here would
+        ** step over that row and drop it from the rest of the scan. */
+        if( prollyCursorIsValid(&pCur->pCur)
+         && (!pCur->mmActive || pCur->mergeSrc!=MERGE_SRC_MUT) ){
           int trc = prollyCursorNext(&pCur->pCur);
           if( trc!=SQLITE_OK ) return trc;
         }

--- a/test/doltlite_txn_seek_visibility.sh
+++ b/test/doltlite_txn_seek_visibility.sh
@@ -300,6 +300,51 @@ run_test "onepass_update_resume_lands_merged" \
 
 db_rm "$DB"
 
+# The same resume contract on blob keys. Writing a row that exists only in the
+# pending map must not step the tree cursor: the tree already sits on the next
+# committed row above it, so advancing drops that row from the rest of the scan.
+# The pending row has to sort between two committed ones for the skip to show.
+run_test "onepass_update_blobkey_covers_committed_row_after_pending" \
+  "CREATE TABLE t(k INTEGER, j TEXT, v TEXT, PRIMARY KEY(k, j)) WITHOUT ROWID;
+   INSERT INTO t VALUES (1,'a','x'),(3,'c','x');
+   BEGIN;
+   INSERT INTO t VALUES (2,'b','x');
+   UPDATE t SET v='u' WHERE k >= 1;
+   COMMIT;
+   SELECT group_concat(k||j||'='||v, ',') FROM (SELECT k,j,v FROM t ORDER BY k);" \
+  "1a=u,2b=u,3c=u" \
+  "$DB"
+
+db_rm "$DB"
+
+run_test "onepass_delete_blobkey_covers_committed_row_after_pending" \
+  "CREATE TABLE t(k INTEGER, j TEXT, v TEXT, PRIMARY KEY(k, j)) WITHOUT ROWID;
+   INSERT INTO t VALUES (1,'a','x'),(3,'c','x');
+   BEGIN;
+   INSERT INTO t VALUES (2,'b','x');
+   DELETE FROM t WHERE k >= 1;
+   COMMIT;
+   SELECT count(*) FROM t;" \
+  "0" \
+  "$DB"
+
+db_rm "$DB"
+
+# Several pending rows interleaved with several committed ones: every committed
+# row above a pending write must still be visited.
+run_test "onepass_update_blobkey_interleaved_rows" \
+  "CREATE TABLE t(k INTEGER, j TEXT, v TEXT, PRIMARY KEY(k, j)) WITHOUT ROWID;
+   INSERT INTO t VALUES (10,'a','x'),(30,'c','x'),(50,'e','x'),(70,'g','x');
+   BEGIN;
+   INSERT INTO t VALUES (20,'b','x'),(40,'d','x'),(60,'f','x');
+   UPDATE t SET v='u' WHERE k >= 10;
+   COMMIT;
+   SELECT count(*) FROM t WHERE v='u';" \
+  "7" \
+  "$DB"
+
+db_rm "$DB"
+
 # A scan whose moveto lands on a pending row defers the tree-side seek. When
 # a deferred write then deactivates the merge state, the resume re-seeds both
 # sides past the departed key; a surviving deferral would re-seek the tree


### PR DESCRIPTION
Second fix out of #2076, and independent of #2079 — different file, different root cause. Both edit `test/doltlite_txn_seek_visibility.sh`, but at different points in the file, so whichever lands second should rebase cleanly.

## Problem

Writing a row with `BTREE_SAVEPOSITION` has to step the tree cursor off the row just written. The non-intkey path did that unconditionally:

```c
if( prollyCursorIsValid(&pCur->pCur) ){
  int trc = prollyCursorNext(&pCur->pCur);
```

That is correct when the tree is the side sitting on the row. When the current row came from the **pending map only**, the tree is already parked on the next committed row above it — so the step goes one row too far and that committed row is dropped from the rest of the scan.

A one-pass `UPDATE` or `DELETE` whose range spans a pending row therefore missed every committed row after it:

```sql
CREATE TABLE t(k INTEGER, j TEXT, v TEXT, PRIMARY KEY(k, j)) WITHOUT ROWID;
INSERT INTO t VALUES (1,'a','x'),(3,'c','x');
BEGIN;
INSERT INTO t VALUES (2,'b','x');   -- sorts between the two committed rows
UPDATE t SET v='u' WHERE k >= 1;    -- should touch all three
COMMIT;
```

doltlite leaves `3c` as `x`; stock updates all three. With more interleaving the loss scales: four committed rows and three pending ones update 4 of 7.

This is the blob-key twin of #2041. The intkey arm of the same contract has now been fixed three times — the resume seeding (#2041), the payload caching (#2042), and the deferred-seek clearing (#2062) — but this arm never went through `resumeDeactivatedMergedScan` at all, so none of them covered it.

## Fix

Advance the tree only when the tree is the current row's source (`!mmActive || mergeSrc != MERGE_SRC_MUT`). This also covers a deferred landing, which sets `mergeSrc = MERGE_SRC_MUT` and has no meaningful tree position to step yet.

## Validation

Three cases added to `test/doltlite_txn_seek_visibility.sh` next to the existing intkey one-pass resume tests. Two fail before and pass after; the `DELETE` variant passes both ways deliberately — it takes the delete path with its own `BTCF_DeleteKey` bookkeeping, so it stands as a guard that this change does not disturb it:

```
unfixed: 22 passed, 2 failed        fixed: 24 passed, 0 failed
  FAIL onepass_update_blobkey_covers_committed_row_after_pending
  FAIL onepass_update_blobkey_interleaved_rows
```

Expectations oracled against stock.

- Full shell battery `test/run_doltlite_tests.sh`: **101/101 suites**
- `sql_oracle_test.sh` vs stock: **568/568**
- Differential sweep seeds 1–200: seed 194 now passes. The remaining failures on this branch are 17 and 143 (fixed by #2079) plus 124 and 138 (still-unfixed causes in #2076), so the delta is exactly this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)