### PR TITLE
fix: prevent concurrent-merge lost update under CAS (#2081)

### DIFF
--- a/src/doltlite_core.c
+++ b/src/doltlite_core.c
@@ -145,7 +145,17 @@ int doltliteRefreshAndConfirmHead(
     chunkStoreUnlock(cs);
     return rc;
   }
-  if( found && prollyHashCompare(&branchTip, pExpectedHead)!=0 ){
+  /* A non-empty expected tip means the branch must already exist on disk.
+  ** Treating a missing branch as "confirmed" would let the advance install a
+  ** tip without having compared against a peer that already created it. */
+  if( !found ){
+    if( !prollyHashIsEmpty(pExpectedHead) ){
+      chunkStoreUnlock(cs);
+      return SQLITE_BUSY;
+    }
+    return SQLITE_OK;
+  }
+  if( prollyHashCompare(&branchTip, pExpectedHead)!=0 ){
     chunkStoreUnlock(cs);
     return SQLITE_BUSY;
   }
@@ -587,12 +597,21 @@ int doltliteSeedStoreIfNeeded(
   return rc;
 }
 
+/* Advance the current branch tip and persist the working set. When
+** bSwitchBeforePersist is set, adopt the catalog into the live session before
+** persisting (the historical path used by non-CAS advances). The CAS path
+** leaves it clear so no lock-cycling SQL runs between tip confirm and the
+** durable refs commit — SwitchCatalog / nested statement commits can drop
+** lockDepth to 0, after which PersistWorkingSetWithHash may re-acquire the
+** lock, reload a peer tip, then overwrite it with the local tip (lost update).
+*/
 static int doltliteAdvanceBranchWithState(
   sqlite3 *db,
   const ProllyHash *pNewHead,
   const ProllyHash *pCatalogHash,
   const ProllyHash *pWorkingCatHash,
-  DoltliteTxnState *pSaved
+  DoltliteTxnState *pSaved,
+  int bSwitchBeforePersist
 ){
   ChunkStore *cs;
   const char *branch;
@@ -620,13 +639,15 @@ static int doltliteAdvanceBranchWithState(
   if( rc!=SQLITE_OK ){
     return doltliteRestoreTxnStateOnFailure(db, pSaved, rc);
   }
-  if( pWorkingCatHash && !prollyHashIsEmpty(pWorkingCatHash) ){
-    rc = doltliteSwitchCatalog(db, pWorkingCatHash);
-  }else{
-    rc = doltliteSwitchCatalog(db, pCatalogHash);
-  }
-  if( rc!=SQLITE_OK ){
-    return doltliteRestoreTxnStateOnFailure(db, pSaved, rc);
+  if( bSwitchBeforePersist ){
+    if( pWorkingCatHash && !prollyHashIsEmpty(pWorkingCatHash) ){
+      rc = doltliteSwitchCatalog(db, pWorkingCatHash);
+    }else{
+      rc = doltliteSwitchCatalog(db, pCatalogHash);
+    }
+    if( rc!=SQLITE_OK ){
+      return doltliteRestoreTxnStateOnFailure(db, pSaved, rc);
+    }
   }
 
   rc = doltlitePersistWorkingSetWithHash(db, pWorkingCatHash);
@@ -650,7 +671,7 @@ int doltliteAdvanceBranch(
   rc = doltliteSaveTxnState(db, &saved);
   if( rc!=SQLITE_OK ) return rc;
   return doltliteAdvanceBranchWithState(
-      db, pNewHead, pCatalogHash, pWorkingCatHash, &saved);
+      db, pNewHead, pCatalogHash, pWorkingCatHash, &saved, 1);
 }
 
 int doltliteCompareAndAdvanceBranch(
@@ -662,18 +683,55 @@ int doltliteCompareAndAdvanceBranch(
 ){
   ChunkStore *cs = doltliteGetChunkStore(db);
   DoltliteTxnState saved;
+  ProllyHash diskTip;
+  int found = 0;
   int rc;
   if( !cs ) return SQLITE_ERROR;
   rc = doltliteSaveTxnState(db, &saved);
   if( rc!=SQLITE_OK ) return rc;
   rc = doltliteRefreshAndConfirmHead(db, cs, pExpectedHead);
-  if( rc==SQLITE_OK ){
-    rc = doltliteAdvanceBranchWithState(
-        db, pNewHead, pCatalogHash, pWorkingCatHash, &saved);
-    assert( cs->lockDepth>0 );
-    chunkStoreUnlock(cs);
-  }else{
+  if( rc!=SQLITE_OK ){
     doltliteTxnStateClear(&saved);
+    return rc;
+  }
+  assert( cs->lockDepth>0 );
+
+  /* Persist the tip under the confirm lock without SwitchCatalog: any SQL that
+  ** cycles the graph lock between confirm and commit can let a peer land and
+  ** then be clobbered when this connection re-acquires and writes its tip. */
+  rc = doltliteAdvanceBranchWithState(
+      db, pNewHead, pCatalogHash, pWorkingCatHash, &saved, 0);
+  if( rc==SQLITE_OK ){
+    /* Belt-and-suspenders: the durable tip must be ours before we unlock.
+    ** PersistWorkingSetWithHash can silently skip the commit when a conflicts
+    ** catalog is present; refuse that here rather than report a successful
+    ** advance that never hit disk. */
+    rc = chunkStoreReadDiskBranchTip(
+        cs, doltliteGetSessionBranch(db), &diskTip, &found);
+    if( rc==SQLITE_OK
+     && (!found || prollyHashCompare(&diskTip, pNewHead)!=0) ){
+      rc = SQLITE_BUSY;
+    }
+    if( rc!=SQLITE_OK ){
+      /* AdvanceBranchWithState already cleared saved on success; rebuild a
+      ** restore from the pre-confirm session by re-saving is impossible here.
+      ** Surface BUSY so the caller retries on a fresh view. */
+    }
+  }
+  assert( cs->lockDepth>0 );
+  chunkStoreUnlock(cs);
+
+  if( rc==SQLITE_OK ){
+    /* Adopt the advanced catalog into the live session after the durable tip
+    ** is on disk. Failure here leaves HEAD advanced with a recoverable
+    ** working-set mismatch on reopen. */
+    if( pWorkingCatHash && !prollyHashIsEmpty(pWorkingCatHash) ){
+      int src = doltliteSwitchCatalog(db, pWorkingCatHash);
+      if( src!=SQLITE_OK ) rc = src;
+    }else{
+      int src = doltliteSwitchCatalog(db, pCatalogHash);
+      if( src!=SQLITE_OK ) rc = src;
+    }
   }
   return rc;
 }

--- a/test/multi_process_merge_rebase_test.c
+++ b/test/multi_process_merge_rebase_test.c
@@ -69,7 +69,7 @@ static int looks_like_lock_busy(const char *s){
 }
 
 static int looks_like_commit_conflict(const char *s){
-  return s!=0 && strstr(s, "commit conflict: another connection committed")!=0;
+  return s!=0 && strstr(s, "conflict: another connection committed")!=0;
 }
 
 static int is_commit_hash(const char *s){

--- a/test/vc_concurrency_test.c
+++ b/test/vc_concurrency_test.c
@@ -69,7 +69,7 @@ static int isRetryableMsg(const char *msg){
 }
 
 static int isCommitConflictMsg(const char *msg){
-  return msg!=0 && strstr(msg, "commit conflict: another connection committed")!=0;
+  return msg!=0 && strstr(msg, "conflict: another connection committed")!=0;
 }
 
 static int isCleanWorkingTreeMsg(const char *msg){

--- a/test/vc_ref_mutation_stress_test.c
+++ b/test/vc_ref_mutation_stress_test.c
@@ -46,7 +46,9 @@ static int isRetryableMsg(const char *msg){
   return msgContains(msg, "busy")
       || msgContains(msg, "locked")
       || msgContains(msg, "schema has changed")
-      || msgContains(msg, "commit conflict: another connection committed")
+      /* commit/merge/cherry-pick/revert peer-CAS wording from
+      ** doltliteCmdResultPeerBranchBusy: "<op> conflict: another connection..." */
+      || msgContains(msg, "conflict: another connection committed")
       || msgContains(msg, "failed to snapshot current branch state")
       || msgContains(msg, "unknown operation");
 }
@@ -219,9 +221,16 @@ static int mergeBranchToMain(sqlite3 **pDb, const char *path, int worker, int ro
       if( rc==SQLITE_OK && count==1 ) return SQLITE_OK;
       snprintf(sql, sizeof(sql), "SELECT dolt_merge('%s')", branch);
       rc = queryTextWithRetry(db, sql, out, sizeof(out));
-      if( rc==SQLITE_OK && strlen(out)==40 ) return SQLITE_OK;
-      if( rc==SQLITE_OK && msgContains(out, "Already up to date") ){
-        return SQLITE_OK;
+      if( rc==SQLITE_OK
+       && (strlen(out)==40 || msgContains(out, "Already up to date")) ){
+        /* Never treat a merge result as success unless the worker row is
+        ** actually on main — a lost-update CAS clobber used to return a
+        ** 40-char hash while dropping a peer's already-merged rows. */
+        count = 0;
+        snprintf(sql, sizeof(sql),
+                 "SELECT count(*) FROM ref_rows WHERE id=%d", rowid);
+        rc = queryIntWithRetry(db, sql, &count);
+        if( rc==SQLITE_OK && count==1 ) return SQLITE_OK;
       }
     }
     sqlite3_sleep(5);


### PR DESCRIPTION
## Summary

- Fix concurrent-merge lost updates where `dolt_merge` could advance main past a peer tip and drop already-merged rows (intermittent under TSan in `vc_ref_mutation_stress_test`, #2081).
- Root cause: `doltliteCompareAndAdvanceBranch` confirmed the tip under the graph lock, then ran `SwitchCatalog` before persisting. Nested SQL can drop `lockDepth` to 0; the subsequent persist re-acquires, reloads the peer tip, and overwrites it with the local advance.
- CAS path now persists the tip without pre-persist `SwitchCatalog`, re-checks the durable tip before unlock, and adopts the catalog only after the refs commit. Harden confirm when a non-empty expected tip has no on-disk branch.
- Stress/multiproc harnesses treat all peer-CAS busy messages as retryable and require the worker row on main before treating merge as success.

## Test plan

- [x] `multi_process_merge_rebase_test` (45/45)
- [x] `vc_ref_mutation_stress_test` × 10
- [ ] CI sanitizers / vc-concurrency-stress (PR checks)

Fixes #2081