### PR TITLE
Search the pending map by range, not by exact key, for range seeks

### DIFF
--- a/src/prolly_btree_cursor_seek.c
+++ b/src/prolly_btree_cursor_seek.c
@@ -492,7 +492,12 @@ static int indexMovetoBuildSeekKey(
   *pnSeekKeyField = nSeekKeyField;
   pCur->nSeekSortKey = nSortKey;
   pCur->nSeekKeyField = nSeekKeyField;
+  /* A probe covering a table root's whole primary key names one row, so the
+  ** pending map can be searched by exact key -- but only when the probe is an
+  ** equality. A range bound names no row, and an exact lookup for it finds
+  ** nothing, which would hide every pending row the range should return. */
   if( pCur->pKeyInfo
+   && pIdxKey->default_rc == 0
    && nSeekKeyField == pCur->pKeyInfo->nKeyField
    && pCur->isTableRoot ){
     *pExactMutMapKey = 1;

--- a/test/doltlite_txn_seek_visibility.sh
+++ b/test/doltlite_txn_seek_visibility.sh
@@ -64,6 +64,68 @@ run_test "intkey_uncommitted_insert_visible_to_range_seeks" \
 
 db_rm "$DB"
 
+# The same visibility on a blob-key table root. A probe covering the whole
+# primary key names one row, so the pending map can be searched by exact key --
+# but only for an equality. A range bound names no row, so that lookup found
+# nothing and every pending row the range should have returned went missing:
+# invisible to SELECT, and skipped by UPDATE and DELETE.
+run_test "blobkey_range_seek_sees_pending_row_above_tree" \
+  "CREATE TABLE t(k INTEGER PRIMARY KEY, v TEXT) WITHOUT ROWID;
+   INSERT INTO t VALUES(5,'c');
+   BEGIN;
+   INSERT INTO t VALUES(20,'p');
+   SELECT coalesce(group_concat(k),'none') FROM t WHERE k > 10;
+   SELECT coalesce(group_concat(k),'none') FROM t WHERE k >= 20;
+   SELECT coalesce(group_concat(k),'none') FROM t WHERE k > 1;
+   SELECT count(*) FROM t WHERE k = 20;
+   UPDATE t SET v='u' WHERE k > 10;
+   SELECT coalesce(group_concat(k||'='||v),'none') FROM (SELECT k,v FROM t ORDER BY k);
+   ROLLBACK;" \
+  "20
+20
+5,20
+1
+5=c,20=u" \
+  "$DB"
+
+db_rm "$DB"
+
+# With no committed rows at all there is no tree row to fall back on, so the
+# range sees nothing whatsoever.
+run_test "blobkey_range_seek_sees_pending_only_table" \
+  "CREATE TABLE t(k NUMERIC PRIMARY KEY, v TEXT) WITHOUT ROWID;
+   BEGIN;
+   INSERT INTO t VALUES(-18,'p');
+   SELECT count(*) FROM t WHERE k > -19 AND k < -2;
+   UPDATE t SET v='u' WHERE k > -19;
+   SELECT k||'='||v FROM t;
+   DELETE FROM t WHERE k > -19 AND k < -2;
+   SELECT count(*) FROM t;
+   COMMIT;" \
+  "1
+-18=u
+0" \
+  "$DB"
+
+db_rm "$DB"
+
+run_test "composite_pk_range_seek_sees_pending_row" \
+  "CREATE TABLE t(a INTEGER, b TEXT, v TEXT, PRIMARY KEY(a,b)) WITHOUT ROWID;
+   INSERT INTO t VALUES(1,'x','c');
+   BEGIN;
+   INSERT INTO t VALUES(9,'y','p');
+   SELECT coalesce(group_concat(a),'none') FROM t WHERE a > 4;
+   SELECT count(*) FROM t WHERE a = 9 AND b = 'y';
+   DELETE FROM t WHERE a > 4;
+   SELECT coalesce(group_concat(a),'none') FROM t;
+   COMMIT;" \
+  "9
+1
+1" \
+  "$DB"
+
+db_rm "$DB"
+
 run_test "intkey_seek_above_deleted_key" \
   "CREATE TABLE t(k INTEGER PRIMARY KEY, v);
    INSERT INTO t VALUES (5, 'a'), (7, 'b');


### PR DESCRIPTION
The residual tail from #2076, and the largest read bug of the set: **uncommitted rows were invisible to range queries.**

Independent of #2079 — different function, different cause. Together the two clear the differential sweep completely.

## Problem

`indexMovetoBuildSeekKey` sets `exactMutMapKey` whenever the probe covers a table root's whole primary key. The reasoning is sound for an **equality** probe: a full-PK probe names exactly one row, so the pending map can be searched by exact key instead of scanned. It is wrong for a **range bound**, which names no row — the exact lookup finds nothing, and the seek concludes there are no pending rows at all.

Every pending row the range should have returned then went missing, whenever the tree had nothing to fall back on (no committed row at or above the bound):

```sql
CREATE TABLE t(k INTEGER PRIMARY KEY, v TEXT) WITHOUT ROWID;
INSERT INTO t VALUES(5,'c');
BEGIN;
INSERT INTO t VALUES(20,'p');
SELECT count(*) FROM t WHERE k > 10;   -- doltlite 0, stock 1
```

Not just reads: `UPDATE ... WHERE k > 10` and `DELETE ... WHERE k > 10` skipped the row too. With no committed rows at all, the entire table was invisible to any lower-bounded range:

```sql
CREATE TABLE t(k NUMERIC PRIMARY KEY, v TEXT) WITHOUT ROWID;
BEGIN;
INSERT INTO t VALUES(-18,'p');
SELECT count(*) FROM t WHERE k > -19 AND k < -2;  -- doltlite 0, stock 1
```

The append-then-query shape — insert rows in a transaction, then read a range above the existing data — hits this directly. An upper bound alone is unaffected, and equality probes were always fine, which is why it survived this long.

## Fix

The exact-key search now requires `default_rc == 0`. That is already how this file distinguishes an equality probe from a range seek a few lines above, where table-root range seeks truncate the probe to the primary key.

## Validation

Three cases added to `test/doltlite_txn_seek_visibility.sh`, next to the intkey version of the same visibility contract, all oracled against stock. Two fail before and pass after; the composite-PK case passes both ways by design — its probe covers only part of the key, so it never took the exact path, which pins that the narrowing did not overreach:

```
before: 25 passed, 2 failed        after: 27 passed, 0 failed
  FAIL blobkey_range_seek_sees_pending_row_above_tree
  FAIL blobkey_range_seek_sees_pending_only_table
```

- Full shell battery `test/run_doltlite_tests.sh`: **101/101 suites**
- `sql_oracle_test.sh` vs stock: **568/568**; `review_regression_test.sh`: **129/129**
- testfixture buckets: `fts4-core` 1117 passing / 0 unexpected, `fts3` 198893 passing / 0 unexpected, `ported` 2797 passing / 0 unexpected. (`fts4-core` and `ported` are the two that caught an earlier attempt at #2079, so they are the canaries for cursor changes.) `core-sql` shows only this machine's pre-existing `avfs`/`loadext`/`shell*`/`zipfile` environment failures, same set as a master control.
- Differential sweep: this fix alone takes seeds 1–400 from 16 failures to 10, and the 10 left are all #2079's. On top of #2079 it is **400/400 clean on the default axis and 400/400 on the `DOLTLITE_DIFF_LARGE_INTS` axis**, and it resolves all five residual seeds (842, 1305, 1413, 1636, 2030) plus 257 on the large-int axis.

With this and #2079 merged, the sweep has no known divergences left, so the remaining #2076 checkboxes — flipping the large-int axis on and adding the per-PR smoke run — become unblocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)