### PR TITLE
Read the indexed column in index order in the differential sweep

### DIFF
--- a/test/sql_differential_fuzzer.py
+++ b/test/sql_differential_fuzzer.py
@@ -146,8 +146,10 @@ class Gen:
             return "a IS NULL"
         if r < 0.8:
             return "b > %s" % self.text_val()
-        if r < 0.9:
+        if r < 0.82:
             return "a = %s" % self.val("any")
+        if r < 0.9:
+            return "a > %s AND a < %s" % (self.val("any"), self.val("any"))
         return "k IN (%s, %s)" % (self.int_val(), self.int_val())
 
     def read(self):
@@ -164,9 +166,28 @@ class Gen:
         elif r < 0.8:
             self.emit("SELECT group_concat(q, '|') FROM (SELECT quote(b) AS q "
                       "FROM t ORDER BY b, k);")
+        elif r < 0.9:
+            # Ordered reads over the indexed column, in both directions. An
+            # index whose stored order is wrong only shows up here or in a
+            # range scan over it -- ordering by the key or by rendered text
+            # cannot see it. Ties break on the whole row so the output is
+            # deterministic even for the keyless shape.
+            d = "DESC" if self.r.random() < 0.5 else "ASC"
+            self.emit("SELECT group_concat(coalesce(quote(a),'NA'), '|') FROM "
+                      "(SELECT a FROM t ORDER BY a %s, "
+                      "coalesce(quote(k),'NK'), coalesce(quote(b),'NB'));" % d)
         else:
             self.emit("SELECT count(*) FROM t WHERE a IN "
                       "(SELECT a FROM t WHERE %s);" % self.pred())
+
+    def ordered_reads(self):
+        # Index order in both directions, once per script. A stored order that
+        # is wrong shows up nowhere else: ordering by the key or by rendered
+        # text is served without consulting the secondary index.
+        for d in ("ASC", "DESC"):
+            self.emit("SELECT group_concat(coalesce(quote(a),'NA'), '|') FROM "
+                      "(SELECT a FROM t ORDER BY a %s, "
+                      "coalesce(quote(k),'NK'), coalesce(quote(b),'NB'));" % d)
 
     def full_read(self):
         self.emit("SELECT group_concat(q, '|') FROM (SELECT "
@@ -228,6 +249,7 @@ class Gen:
         for _ in range(self.r.randint(2, 10)):
             self.insert()
         self.body()
+        self.ordered_reads()
         self.full_read()
         self.emit("PRAGMA integrity_check;")
         return "\n".join(self.out)


### PR DESCRIPTION
A coverage gap in the sweep from #2078, found while checking why its DESC axis reported nothing against an engine that provably mis-sorts DESC indexes.

## Problem

Every ordered read the generator emitted sorted by the primary key (`ORDER BY b, k`) or by rendered text (`ORDER BY 1` over a concatenation). Neither is answered by consulting a secondary index, so an index whose **stored order** is wrong was invisible to the sweep. The `DOLTLITE_DIFF_DESC` axis ran clean over 300 seeds while the engine mis-orders DESC indexes over integers past 2^53 (#2077, verified by hand).

Range predicates over the indexed column were also absent — the other shape that reads an index in order.

## Change

Every script now reads the indexed column in both directions once, and `a > x AND a < y` joins the predicate pool. Ties break on the whole row (`ORDER BY a <dir>, quote(k), quote(b)`) so output stays deterministic for the keyless shape, which has no unique column to order by — a nondeterministic harness would be worse than no harness.

## Validation

- With the change, the `DESC` axis finds the #2077 mis-ordering within **150 seeds** (seed 51), where 300 seeds previously found nothing. The divergence is exactly the expected shape — `9007199254740994` and `9007199254740995` swapped, in the ascending listing as well as the descending one:

```
doltlite: ...|36|9007199254740995|9007199254740994|'AB '|...
stock:    ...|36|9007199254740994|9007199254740995|'AB '|...
```

- No false positives introduced. On the axes CI actually runs, against master plus the two open cursor fixes (#2079, #2085): default axis **1000/1000 clean**, `DOLTLITE_DIFF_LARGE_INTS` axis **300/300 clean**.
- `DESC` stays off by default, so the nightly job's behaviour is unchanged by this PR; it becomes a working detector the moment that axis is enabled as part of #2077.

🤖 Generated with [Claude Code](https://claude.com/claude-code)