### PR TITLE
Terminate the short numeric sort key in descending fields

### DIFF
--- a/src/sortkey.c
+++ b/src/sortkey.c
@@ -86,7 +86,8 @@ static sqlite3_int64 encodedFieldSize(
   u32 serialType,
   const u8 *pData,
   u32 nData,
-  int coll
+  int coll,
+  int desc
 ){
   u8 tag = serialTypeTag(serialType);
   switch( tag ){
@@ -100,7 +101,7 @@ static sqlite3_int64 encodedFieldSize(
         i64 back;
         int exact;
         u32 i;
-        if( serialType == 8 || serialType == 9 ) return 9;
+        if( serialType == 8 || serialType == 9 ) return desc ? 10 : 9;
         for(i = 0; i < nData; i++){
           uv = (uv << 8) | pData[i];
         }
@@ -109,9 +110,9 @@ static sqlite3_int64 encodedFieldSize(
         exact = d>=-9223372036854775808.0
              && d<9223372036854775808.0
              && (back = (i64)d)==v;
-        return exact ? 9 : 18;
+        return exact ? (desc ? 10 : 9) : 18;
       }
-      return 9;
+      return desc ? 10 : 9;
     case SORTKEY_TEXT: {
       u32 n = collTextLen(coll, pData, nData);
       sqlite3_int64 extra = 0;
@@ -136,7 +137,15 @@ static sqlite3_int64 encodedFieldSize(
   }
 }
 
-static int encodeNumeric(u8 *pOut, u32 serialType, const u8 *pData, u32 nData){
+/* A descending field is stored with every byte inverted, so the 9-byte form
+** would remain a byte prefix of the 18-byte one and memcmp puts a prefix first
+** in either direction -- while descending order needs the longer form first,
+** since a nudged base is always strictly below the integer it stands for. The
+** terminator below breaks the prefix relation: inverted it becomes 0xFF, above
+** the inverted marker, so the extended form sorts first. No tag is 0x00, so
+** the length can still be read back from this byte. */
+static int encodeNumeric(u8 *pOut, u32 serialType, const u8 *pData, u32 nData,
+                         int desc){
   u8 buf[8];
   double d;
   i64 intVal = 0;
@@ -216,6 +225,10 @@ static int encodeNumeric(u8 *pOut, u32 serialType, const u8 *pData, u32 nData){
     pOut[17] = (u8)u;
     return 18;
   }
+  if( desc ){
+    pOut[9] = SORTKEY_NUM_DESC_END;
+    return 10;
+  }
   return 9;
 }
 
@@ -224,6 +237,7 @@ static int numericSortKeyLen(const u8 *pSortKey, int nAvail){
   if( nAvail>=18 && (pSortKey[9]==0x01 || pSortKey[9]==0x80) ){
     return 18;
   }
+  if( nAvail>=10 && pSortKey[9]==SORTKEY_NUM_DESC_END ) return 10;
   return 9;
 }
 
@@ -303,7 +317,8 @@ static int sortKeyEncode(const u8 *pRec, int nRec, u8 *pOut, int nMaxFields,
           pOut[outPos++] = SORTKEY_NULL;
           break;
         case SORTKEY_NUM:
-          outPos += encodeNumeric(pOut + outPos, serialType, pField, fieldLen);
+          outPos += encodeNumeric(pOut + outPos, serialType, pField, fieldLen,
+                                  descFromKeyInfo(pKeyInfo, nField));
           break;
         case SORTKEY_TEXT:
           outPos += encodeText(pOut + outPos, pField, fieldLen, coll);
@@ -320,7 +335,8 @@ static int sortKeyEncode(const u8 *pRec, int nRec, u8 *pOut, int nMaxFields,
       }
     }else{
       sqlite3_int64 nFieldSize =
-          encodedFieldSize(serialType, pField, fieldLen, coll);
+          encodedFieldSize(serialType, pField, fieldLen, coll,
+                           descFromKeyInfo(pKeyInfo, nField));
       if( nFieldSize > INT_MAX || outSize > INT_MAX - nFieldSize ){
         return -2;
       }
@@ -528,7 +544,8 @@ static int sortKeyEncodeMemArray(
           pOut[outPos++] = SORTKEY_NULL;
           break;
         case SORTKEY_NUM:
-          outPos += encodeNumeric(pOut + outPos, serialType, pField, fieldLen);
+          outPos += encodeNumeric(pOut + outPos, serialType, pField, fieldLen,
+                                  descFromKeyInfo(pKeyInfo, i));
           break;
         case SORTKEY_TEXT:
           outPos += encodeText(pOut + outPos, pField, fieldLen, coll);
@@ -545,7 +562,8 @@ static int sortKeyEncodeMemArray(
       }
     }else{
       sqlite3_int64 nFieldSize =
-          encodedFieldSize(serialType, pField, fieldLen, coll);
+          encodedFieldSize(serialType, pField, fieldLen, coll,
+                           descFromKeyInfo(pKeyInfo, i));
       if( nFieldSize > INT_MAX || outSize > INT_MAX - nFieldSize ){
         return -2;
       }
@@ -706,7 +724,7 @@ int sortKeyFromInt64(i64 v, u8 *pOut, int *pnOut){
 
   intSerialType(v, &serialType, &nData);
   writeIntBE(aData, v, (int)nData);
-  *pnOut = encodeNumeric(pOut, serialType, aData, nData);
+  *pnOut = encodeNumeric(pOut, serialType, aData, nData, 0);
   return SQLITE_OK;
 }
 

--- a/src/sortkey.h
+++ b/src/sortkey.h
@@ -10,6 +10,11 @@
 #define SORTKEY_TEXT    0x35
 #define SORTKEY_BLOB    0x45
 
+/* Terminates the 9-byte numeric form in a descending field so it is not a byte
+** prefix of the 18-byte one. Distinct from every tag, so a field's length is
+** still readable from this position. */
+#define SORTKEY_NUM_DESC_END 0x00
+
 /* True when b could begin a field, in either sort direction (a DESC field is
 ** stored with every byte inverted, tag included).
 **

--- a/test/review_regression_test.sh
+++ b/test/review_regression_test.sh
@@ -1109,6 +1109,65 @@ run_test "large_int_range_order" \
 
 rm -f "$DB"
 
+# A descending field is stored with every byte inverted, so the 9-byte numeric
+# form would stay a byte prefix of the 18-byte one and memcmp puts a prefix
+# first in either direction -- while descending order needs the longer form
+# first. The values below pair a base with the integer it stands for, which is
+# the only way to put both forms under one base.
+
+DB=/tmp/test_rg_desc_index_order_$$.db; rm -f "$DB"
+echo "CREATE TABLE t(a NUMERIC);
+CREATE INDEX ad ON t(a DESC);
+INSERT INTO t VALUES(9007199254740992.0),(9007199254740993),(9007199254740994),
+                    (18014398509481983),(18014398509481984);" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+run_test "desc_index_order_large_ints" \
+  "SELECT group_concat(a) FROM (SELECT a FROM t ORDER BY a DESC);" \
+  "18014398509481984,18014398509481983,9007199254740994,9007199254740993,9007199254740992" \
+  "$DB"
+# A wrong stored order shows up ascending too: the planner answers ORDER BY a by
+# walking the descending index backwards.
+run_test "desc_index_order_large_ints_ascending" \
+  "SELECT group_concat(a) FROM (SELECT a FROM t ORDER BY a);" \
+  "9007199254740992,9007199254740993,9007199254740994,18014398509481983,18014398509481984" \
+  "$DB"
+run_test "desc_index_range_large_ints" \
+  "SELECT count(*) FROM t WHERE a > 9007199254740992.0 AND a < 9007199254740995;" \
+  "2" "$DB"
+run_test "desc_index_integrity_large_ints" \
+  "PRAGMA integrity_check;" "ok" "$DB"
+
+rm -f "$DB"
+
+DB=/tmp/test_rg_desc_pk_order_$$.db; rm -f "$DB"
+echo "CREATE TABLE d(a NUMERIC PRIMARY KEY DESC, b) WITHOUT ROWID;
+INSERT INTO d VALUES(9007199254740992.0,'x'),(9007199254740993,'y'),
+                    (18014398509481983,'z');" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+run_test "desc_pk_order_large_ints" \
+  "SELECT group_concat(a) FROM (SELECT a FROM d ORDER BY a DESC);" \
+  "18014398509481983,9007199254740993,9007199254740992" "$DB"
+# A descending primary key stores the rows themselves, so a wrong order is
+# self-reported rather than just mis-answered.
+run_test "desc_pk_integrity_large_ints" \
+  "PRAGMA integrity_check;" "ok" "$DB"
+
+rm -f "$DB"
+
+DB=/tmp/test_rg_desc_negative_$$.db; rm -f "$DB"
+echo "CREATE TABLE t(a NUMERIC, b TEXT);
+CREATE INDEX ad ON t(a DESC, b);
+INSERT INTO t VALUES(-9007199254740993,'p'),(-9007199254740992,'q'),(5,'r'),
+                    (-9223372036854775808,'s');" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+run_test "desc_index_order_negative_large_ints" \
+  "SELECT group_concat(a||'/'||b) FROM (SELECT a,b FROM t ORDER BY a DESC, b);" \
+  "5/r,-9007199254740992/q,-9007199254740993/p,-9223372036854775808/s" "$DB"
+run_test "desc_index_negative_integrity" \
+  "PRAGMA integrity_check;" "ok" "$DB"
+
+rm -f "$DB"
+
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"


### PR DESCRIPTION
Fixes #2077.

## Problem

An integer that no double represents exactly encodes as **18** bytes — base, `0x80` marker, exact value — where every other numeric encodes as **9**. A descending field is stored with every byte inverted, which reverses how the base compares but *not* the fact that the 9-byte form is a byte **prefix** of the 18-byte one — and `memcmp` puts a prefix first in either direction. Descending order needs the longer form first, because the encoder's nudge guarantees an extended value is strictly above the base it shares.

So a descending index over such integers is mis-ordered **on disk**:

```sql
CREATE TABLE t(a NUMERIC);
CREATE INDEX ad ON t(a DESC);
INSERT INTO t VALUES(9007199254740992.0),(9007199254740993),(9007199254740994),
                    (18014398509481983),(18014398509481984);
```

| query | stock | doltlite (before) |
|---|---|---|
| `ORDER BY a DESC` | `…994,993,992` | `…994,992,993` |
| `ORDER BY a` | `992,993,994…` | `993,992,994…` |
| `a > 9007199254740992.0 AND a < 9007199254740995` | `2` | `0` |

Ascending reads are wrong too, because the planner answers `ORDER BY a` by walking the descending index backwards. And a descending **primary key** stores the rows themselves, so the damage is self-reported:

```sql
CREATE TABLE d(a NUMERIC PRIMARY KEY DESC, b) WITHOUT ROWID;
INSERT INTO d VALUES(9007199254740992.0,'x'),(9007199254740993,'y'),(18014398509481983,'z');
PRAGMA integrity_check;   -- "row not in PRIMARY KEY order for d"
```

This is the encoding half of the problem whose comparison half was #2075; that PR deliberately left it out because it needs a format change.

## Fix

A descending field's short form now ends with a terminator byte, so it is no longer a prefix of the long form. Inverted it becomes `0xFF`, above the inverted marker `0x7F`, so the extended form sorts first — which is what descending order wants.

Three things make this contained:

- No tag is `0x00`, so a field's length is still readable from that byte; `numericSortKeyLen` just learns one more case.
- The decode path already normalises a descending field's bytes *before* reading the length, so it needs no change.
- **Ascending fields are byte-for-byte unchanged**, so the common case has no format churn and no behaviour change.

Descending indexes over integers past 2^53 need rebuilding — which is what they need regardless, since they are mis-ordered today.

Two subtleties worth flagging for review, both of which bit during development:

- `encodedFieldSize` (the sizing pass) and `encodeNumeric` (the writing pass) must agree exactly or `sortKeyFromRecordPrefixCollBuffer` fails its own size check and reports `SQLITE_CORRUPT`. Both now take the direction.
- The record encoder and the `Mem` encoder index their key columns differently (`nField` vs `i`). Passing the wrong one silently produced an ascending encoding on the seek path while the insert path wrote the descending one, which showed up as `row 1 missing from index`. The `Mem` loop uses `i`, matching the `descFromKeyInfo` call already beside it.

The other encoders were checked and need nothing: `unpackedRecordCanUseIntSortKey` rejects descending fields, both single-field fast paths bail out on descending, and `sortKeyFromInt64` only serves rowid keys, which are never descending.

## Validation

Eight cases added to Guard 23 of `test/review_regression_test.sh`, which already covers the ascending side of this encoding. All oracled against stock; five fail before and pass after, and three pass throughout — the negative-value and multi-column cases, which pin that the change did not disturb what was already right:

```
before: 132 passed, 5 failed        after: 137 passed, 0 failed
```

- Full shell battery `test/run_doltlite_tests.sh`: **101/101 suites**
- `storage_format_contract_test.sh`: **23/23**
- `sql_oracle_test.sh` vs stock: **568/568**
- testfixture: `fts4-core` and `ported` **0 unexpected** (the two canaries for index/cursor changes); `core-sql` failure list **identical to a master control**
- Differential sweep: `DOLTLITE_DIFF_DESC` + `DOLTLITE_DIFF_LARGE_INTS` axes **400/400 clean** (this axis found the bug at seed 51 within 150 seeds after #2086; seed 51 now matches stock). Default axis 400/400, large-int axis 300/300 — unchanged.

With this in, all three sweep axes are clean, so #2076's remaining items — turning the gated axes on by default and adding the per-PR differential run — are unblocked. I'll send that as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)