### PR TITLE
Gate pull requests on the differential sweep

### DIFF
--- a/.github/workflows/nightly-fuzz.yml
+++ b/.github/workflows/nightly-fuzz.yml
@@ -180,9 +180,8 @@ jobs:
   # one runs generated SQL through both engines and compares answers, so it
   # covers query and transaction semantics instead of parsing.
   #
-  # Nightly only for now. The engine currently diverges on roughly 3% of seeds
-  # (issue #2076), so a per-PR gate would block every pull request; adding the
-  # short per-PR run is the last step of that issue.
+  # The per-PR gate lives in test.yml and sweeps a fixed seed window; this job
+  # sweeps a moving one for breadth, so the two do not re-check the same seeds.
   #
   # Each night sweeps a different seed window derived from the run number, so
   # coverage compounds instead of re-checking seeds earlier runs already

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -253,6 +253,16 @@ jobs:
         done
       timeout-minutes: 10
 
+    # A fixed seed window, so a red here is reproducible from the seed alone
+    # rather than depending on when it ran. The nightly job sweeps a moving
+    # window for breadth; this one is the per-PR gate.
+    - name: Randomized SQL differential sweep (vs stock SQLite)
+      if: matrix.bucket == 'sql'
+      run: |
+        cd build-coverage
+        bash ../test/sql_differential_test.sh ./doltlite ./sqlite3-stock 1 400 || exit 1
+      timeout-minutes: 12
+
     - name: Upload oracle coverage profiles
       if: always()
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
Closes #2076.

Rebased and reduced. The axis defaults this PR originally carried were superseded by #2090's group mechanism, and its version of the reference guard by #2095, so what is left is the thing that was actually missing: **the sweep runs on every pull request.**

## The change

One step in `test.yml`'s `oracle-tests` `sql` bucket, which already unpacks a stock reference into the same directory as the engine — so no new artifact plumbing, and it sits with the other vs-stock suites.

It sweeps a **fixed** seed window (1–400), so a red is reproducible from the seed alone rather than depending on when it ran. The nightly job keeps its moving window for breadth; the comment there now says which is which.

## Why this is safe to gate on now

When the sweep landed in #2078 it was nightly-only on purpose: the engine diverged on roughly 3% of seeds and a gate would have blocked everything. Those divergences were five distinct bugs, all since fixed:

| bug | fix |
|---|---|
| numeric byte-prefix read as an equal key | #2075 |
| non-intkey one-pass write stepped the tree off a pending row | #2082 |
| `mergeLast` landings only steppable backwards (three symptoms) | #2079 |
| range seeks searched the pending map by exact key, hiding uncommitted rows | #2085 |
| DESC numeric sort keys mis-ordered on disk | #2087 |
| a `>=` bound found no pending landing | #2092 |

And the reference it compares against is now built where it cannot inherit doltlite's storage, and asserted (#2095) — without that this gate would have passed vacuously.

## Validation

The exact window the gate runs, against the default group set, locally: **400/400 clean**. The default set is `large-ints` + `desc`; the feature groups added in #2090 stay opt-in while #2093 (`ddl` plus `triggers`) is open, so the gate does not depend on them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)