### PR TITLE
Let a >= bound see pending rows without calling them equal

### DIFF
--- a/src/prolly_btree_cursor_seek.c
+++ b/src/prolly_btree_cursor_seek.c
@@ -234,7 +234,8 @@ static int findMatchingMutMapEntry(
   int nSortKey,
   int bExactKey,
   ProllyMutMapEntry **ppMatch,
-  int *pCmp
+  int *pCmp,
+  int *pEqSeen
 ){
   int rc = SQLITE_OK;
   int cmp = 0;
@@ -245,6 +246,7 @@ static int findMatchingMutMapEntry(
 
   *ppMatch = 0;
   *pCmp = 0;
+  *pEqSeen = 0;
   if( !pMap || prollyMutMapIsEmpty(pMap) ){
     return SQLITE_OK;
   }
@@ -256,6 +258,7 @@ static int findMatchingMutMapEntry(
     if( rc!=SQLITE_OK ) return rc;
     if( pEntry && pEntry->op==PROLLY_EDIT_INSERT ){
       *ppMatch = pEntry;
+      *pEqSeen = 1;
     }
     return SQLITE_OK;
   }
@@ -281,18 +284,20 @@ static int findMatchingMutMapEntry(
     }
     cmpLen = pEntry->nKey < nSortKey ? pEntry->nKey : nSortKey;
     prefixCmp = memcmp(pEntry->pKey, pSortKey, cmpLen);
-    if( prefixCmp>0 && pIdxKey->default_rc<0 ){
+    if( prefixCmp>0 ){
+      /* The first pending row above the seek key. That is a landing for any
+      ** direction -- the caller reports it as above and its consumer steps
+      ** from there. It is emphatically not an equality, so *pEqSeen stays
+      ** clear: claiming otherwise tells an equality seek it found a row.
+      ** default_rc says how a prefix-equal row compares, which is a different
+      ** question, and gating this on it lost the landing for SeekGE. */
       if( pEntry->op==PROLLY_EDIT_INSERT ){
         pMatch = pEntry;
         cmp = 1;
-      }else{
-        lo++;
-        continue;
+        break;
       }
-      break;
-    }
-    if( prefixCmp>0 ){
-      break;
+      lo++;
+      continue;
     }
     if( prefixCmp==0 && pEntry->nKey < nSortKey ){
       break;
@@ -311,6 +316,7 @@ static int findMatchingMutMapEntry(
     }
     if( pEntry->op==PROLLY_EDIT_INSERT ){
       pMatch = pEntry;
+      *pEqSeen = (cmp==0 || pIdxKey->eqSeen);
       break;
     }
     lo++;
@@ -867,7 +873,7 @@ int prollyBtCursorIndexMoveto(
   refreshCursorRoot(pCur);
 
   {
-    int treeFound = 0, mutFound = 0;
+    int treeFound = 0, mutFound = 0, mutEqSeen = 0;
     int treeCmp = 0, mutCmp = 0;
     const u8 *mutKey = 0;
     int mutNKey = 0;
@@ -913,7 +919,7 @@ int prollyBtCursorIndexMoveto(
                                    pCur->pKeyInfo,
                                    pIdxKey, pSortKey, nSortKey,
                                    exactMutMapKey,
-                                   &mutE, &mutCmp);
+                                   &mutE, &mutCmp, &mutEqSeen);
       if( rc!=SQLITE_OK ){
         return rc;
       }
@@ -923,7 +929,7 @@ int prollyBtCursorIndexMoveto(
                                      pCur->pKeyInfo,
                                      pIdxKey, pSortKey, nSortKey,
                                      exactMutMapKey,
-                                     &mutE, &mutCmp);
+                                     &mutE, &mutCmp, &mutEqSeen);
         if( rc!=SQLITE_OK ){
           return rc;
         }
@@ -978,7 +984,9 @@ int prollyBtCursorIndexMoveto(
           pCur->eState = CURSOR_VALID;
         }
         *pRes = mutCmp;
-        pIdxKey->eqSeen = 1;
+        /* Only if the row actually compared equal. A landing above the key is
+        ** still a landing, but an equality seek must not read it as a hit. */
+        if( mutEqSeen ) pIdxKey->eqSeen = 1;
         return SQLITE_OK;
       }
     }

--- a/test/doltlite_txn_seek_visibility.sh
+++ b/test/doltlite_txn_seek_visibility.sh
@@ -109,6 +109,65 @@ run_test "blobkey_range_seek_sees_pending_only_table" \
 
 db_rm "$DB"
 
+# A >= bound is a forward seek that SQLite marks with a positive default_rc,
+# the same mark it puts on the backward <. Reading that mark as the direction
+# lost the pending landing for >=, so a range starting at or below a pending
+# row missed it while the same range written with > found it.
+run_test "ge_bound_sees_pending_row" \
+  "CREATE TABLE t(k NUMERIC PRIMARY KEY, a, b TEXT) WITHOUT ROWID;
+   BEGIN;
+   INSERT INTO t VALUES(-14, 'x', 'y');
+   SELECT count(*) FROM t WHERE k >= -18 AND k <= 33;
+   SELECT count(*) FROM t WHERE k >= -14;
+   UPDATE t SET a = 10 WHERE k >= -18;
+   SELECT quote(a) FROM t;
+   DELETE FROM t WHERE k >= -18;
+   SELECT count(*) FROM t;
+   COMMIT;" \
+  "1
+1
+10
+0" \
+  "$DB"
+
+db_rm "$DB"
+
+# A prefix GLOB or LIKE is compiled into a >= / < range, so it reaches the same
+# path through a secondary index.
+run_test "prefix_match_sees_pending_row" \
+  "CREATE TABLE t(k INTEGER, a, b TEXT);
+   CREATE INDEX i_b ON t(b, a);
+   BEGIN;
+   INSERT INTO t VALUES(-3, NULL, 'aXb');
+   SELECT count(*) FROM t WHERE b GLOB 'a*';
+   SELECT count(*) FROM t WHERE b >= 'a' AND b < 'b';
+   SELECT count(*) FROM t WHERE b LIKE 'a%';
+   COMMIT;" \
+  "1
+1
+1" \
+  "$DB"
+
+db_rm "$DB"
+
+# The other half of the contract, and the one an earlier attempt at this broke:
+# a landing above the key is not a match. An equality seek for a key that does
+# not exist must not settle for the next pending row above it.
+run_test "equality_seek_does_not_match_greater_pending_row" \
+  "CREATE TABLE t(k NUMERIC PRIMARY KEY, a, b TEXT);
+   BEGIN;
+   INSERT INTO t VALUES(26, 42.693, 'z');
+   UPDATE t SET b = 'zz' WHERE k = 20;
+   DELETE FROM t WHERE k = 20;
+   SELECT count(*) FROM t WHERE k = 20;
+   SELECT quote(k)||'/'||quote(b) FROM t;
+   COMMIT;" \
+  "0
+26/'z'" \
+  "$DB"
+
+db_rm "$DB"
+
 run_test "composite_pk_range_seek_sees_pending_row" \
   "CREATE TABLE t(a INTEGER, b TEXT, v TEXT, PRIMARY KEY(a,b)) WITHOUT ROWID;
    INSERT INTO t VALUES(1,'x','c');


### PR DESCRIPTION
Fixes #2089.

## Problem

SQLite sets `default_rc` on a seek to say how a **prefix-equal** row should compare: negative for `SeekGT` and `SeekLE`, positive for `SeekGE` and `SeekLT`. The pending-map search read that mark as if it gave the seek's *direction*, and only accepted a row above the seek key as a landing when it was negative:

```c
if( prefixCmp>0 && pIdxKey->default_rc<0 ){ ... accept ... }
if( prefixCmp>0 ){ break; }          /* no landing */
```

`SeekGE` therefore found no pending landing at all, and a range starting at or below a pending row missed it entirely — invisible to `SELECT`, skipped by `UPDATE` and `DELETE` — while the same range written with `>` found it:

```sql
CREATE TABLE t(k NUMERIC PRIMARY KEY, a, b TEXT) WITHOUT ROWID;
BEGIN;
INSERT INTO t VALUES(-14, 'x', 'y');
SELECT count(*) FROM t WHERE k >= -18 AND k <= 33;  -- doltlite 0, stock 1
UPDATE t SET a = 10 WHERE k >= -18;                 -- leaves a='x'
```

A prefix `GLOB` or `LIKE` is compiled into a `>=`/`<` range, so it reached this through a secondary index too:

```sql
CREATE INDEX i_b ON t(b, a);
BEGIN;
INSERT INTO t VALUES(-3, NULL, 'aXb');
SELECT count(*) FROM t WHERE b GLOB 'a*';   -- doltlite 0, stock 1
```

## Fix, in two halves

**A row above the seek key is a landing whichever way the seek runs** — the consumer steps from it — so accepting it no longer depends on `default_rc`.

**It is not a match, and the caller was asserting that it was.** On any pending landing the caller set `pIdxKey->eqSeen = 1`. Left that way, an equality seek for a key that does not exist settles for the next pending row above it:

```sql
INSERT INTO t VALUES(26, 42.693, 'z');
UPDATE t SET b = 'zz' WHERE k = 20;   -- rewrote the row at k=26
```

The search now reports whether the row actually compared equal, and the caller sets `eqSeen` only then.

Both halves are required. Accepting the landing on its own — which is the obvious reading of the issue — regressed the sweep's base group from 0 to **23 failures in 250 seeds**, because `default_rc>0` also covers the backward `SeekLT` and because of the false `eqSeen`. That is why the issue said the two had to be worked out together.

## Validation

Three cases added to `test/doltlite_txn_seek_visibility.sh`, oracled against stock. Two fail before and pass after; the third — the equality-seek guard — passes both ways deliberately, and exists precisely because the earlier attempt broke it:

```
before: 35 passed, 2 failed        after: 37 passed, 0 failed
  FAIL ge_bound_sees_pending_row
  FAIL prefix_match_sees_pending_row
```

- Full shell battery `test/run_doltlite_tests.sh`: **101/101 suites**
- `sql_oracle_test.sh` vs stock: **568/568**; `review_regression_test.sh`: **137/137**
- Differential sweep with both value axes: **400/400**
- With the twelve feature groups from #2090, **every group is now clean over 200 seeds each**, including `expr`, which was the only dirty one
- testfixture `fts4-core` and `ported`: 0 unexpected. `core-sql` differs from a master control only in `shell*` assertions that shift between runs on this machine, with nothing seek- or index-related in either direction

## Note on what is still open

Running all twelve groups *together* still diverges on ~9% of seeds. I isolated that by all-minus-one: it needs **`ddl` and `triggers` together** and nothing else — dropping either makes it clean, dropping any other group does not. That is a separate bug, filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)