### PR TITLE
Use power-of-two prolly cache buckets

### DIFF
--- a/src/prolly_cache.c
+++ b/src/prolly_cache.c
@@ -13,7 +13,7 @@
 static int cacheHashBucket(const ProllyCache *cache, const ProllyHash *hash){
   u32 h;
   memcpy(&h, hash->data, sizeof(u32));
-  return (int)(h % (u32)cache->nBucket);
+  return (int)(h & (u32)(cache->nBucket - 1));
 }
 
 static void lruRemove(ProllyCacheEntry *pEntry){
@@ -101,14 +101,15 @@ static ProllyCacheEntry *cacheEntryNewOwned(
 }
 
 int prollyCacheInit(ProllyCache *cache, int nCapacity){
-  int nBucket;
+  int nBucket = 16;
+  i64 nBucketMin = (i64)nCapacity * 2;
 
   memset(cache, 0, sizeof(*cache));
+  if( nBucketMin>0x40000000 ) return SQLITE_NOMEM;
   cache->nCapacity = nCapacity;
   cache->nUsed = 0;
 
-  nBucket = nCapacity * 2;
-  if( nBucket<16 ) nBucket = 16;
+  while( nBucket<nBucketMin ) nBucket *= 2;
   cache->nBucket = nBucket;
 
   cache->aBucket = (ProllyCacheEntry **)sqlite3_malloc(


### PR DESCRIPTION
## Summary

- round prolly cache bucket counts up to a power of two
- replace integer division in every cache bucket lookup with a bit mask
- keep the production cache's bucket count and lookup behavior unchanged

## Performance

Paired before/after measurements used binaries built from latest master and this one-file change. Timed regions were extended to roughly 0.7-1.0 seconds to reduce short-run noise, with alternating execution order.

- 0.79% faster time-weighted
- 0.87% faster geomean
- 8 of 9 workload families improved
- reads improved across point, random-point, random-range, covering-index, and join workloads
- writes improved 0.30% in aggregate across indexed update, non-index update, write-only, and mixed read/write workloads

## Validation

- `make lint`
- `bash test/run_c_tests.sh build all --build` (26/26 gated suites)
- `./testfixture ../test/doltlite_recover_changes.test` (56/56)
- clean `DOLTLITE_PROLLY=0` stock SQLite build
- `git diff --check`

Co-Authored-By: OpenAI Codex <noreply@openai.com>
