### PR TITLE
Stop the trigger side table from aborting the statement that fired it

### DIFF
--- a/test/sql_differential_fuzzer.py
+++ b/test/sql_differential_fuzzer.py
@@ -168,14 +168,19 @@ class Gen:
                 self.emit("INSERT INTO s(id, v, w) VALUES(%d, %s, %s);"
                           % (i, self.val(), self.text_val()))
         if self.on("triggers"):
-            self.emit("CREATE TABLE u(n INTEGER PRIMARY KEY, tag TEXT);")
+            # No unique constraint on n: inside a trigger body SQLite replaces
+            # the trigger statement's conflict policy with the outer
+            # statement's, so an OR IGNORE here still aborts under a plain
+            # INSERT. Collisions are certain because n is derived from a value,
+            # so the table records every firing instead.
+            self.emit("CREATE TABLE u(n INTEGER, tag TEXT);")
             # Trigger bodies run inside the statement that fired them, so they
             # write through the pending map while a scan of t is still open.
             self.emit("CREATE TRIGGER tr_i AFTER INSERT ON t BEGIN "
-                      "INSERT OR REPLACE INTO u(n, tag) "
+                      "INSERT INTO u(n, tag) "
                       "VALUES(length(coalesce(quote(NEW.b),'')), 'i'); END;")
             self.emit("CREATE TRIGGER tr_u AFTER UPDATE ON t BEGIN "
-                      "INSERT OR IGNORE INTO u(n, tag) "
+                      "INSERT INTO u(n, tag) "
                       "VALUES(length(coalesce(quote(NEW.a),'')) + 40, 'u'); END;")
             self.emit("CREATE TRIGGER tr_d AFTER DELETE ON t BEGIN "
                       "DELETE FROM u WHERE n = length(coalesce(quote(OLD.b),'')); "

--- a/test/sql_differential_test.sh
+++ b/test/sql_differential_test.sh
@@ -92,6 +92,7 @@ echo ""
 
 pass=0
 fail=0
+errored=0
 failed_seeds=""
 
 for seed in $(seq "$FIRST" "$LAST"); do
@@ -111,6 +112,13 @@ for seed in $(seq "$FIRST" "$LAST"); do
 
   if [ "$rc_dl" -eq "$rc_sq" ] && [ "$out_dl" = "$out_sq" ]; then
     pass=$((pass + 1))
+    # Some workloads conflict on purpose: INSERT OR ROLLBACK, or a CHECK
+    # violation from the constraints group. Both engines rejecting a statement
+    # and agreeing on how is the comparison working, not the script breaking,
+    # so count those rather than leave a nonzero exit looking accidental.
+    case "$out_dl" in
+      *Error*|*error*) errored=$((errored + 1)) ;;
+    esac
     continue
   fi
 
@@ -126,6 +134,10 @@ done
 
 echo ""
 echo "Results: $pass passed, $fail failed out of $((pass + fail)) seeds"
+if [ "$errored" -gt 0 ]; then
+  echo "          ($errored of the passing seeds had a statement both engines"
+  echo "           rejected, and they agreed on the rejection)"
+fi
 if [ "$fail" -gt 0 ]; then
   echo "Failing seeds:$failed_seeds"
   echo "Reproduce with: python3 test/sql_differential_fuzzer.py <seed>$GENFLAGS"


### PR DESCRIPTION
Addresses the review findings on #2090 (already merged), specifically "All generated workloads do not run cleanly" and "Generated key shapes fail during execution". The other two findings — a wrong-version reference passing validation, and long sweeps losing failure artifacts — are fixed in #2095, which already touches that file.

## The finding was right, and my first measurement of it was not

I initially measured 18 of 200 all-groups scripts hitting a constraint error and was inclined to treat it as minor. That measurement was taken with a stale copy of the runner that silently ignored `DOLTLITE_DIFF_GROUPS`, so it was really measuring the base workload. Measured properly: **106 of 150** all-groups scripts hit one, nearly all `UNIQUE constraint failed: u.n` — exactly what the review reported.

## Cause

A SQLite rule I had missed: inside a trigger body, the trigger statement's conflict policy is replaced by the **outer** statement's. So the `INSERT OR IGNORE` / `INSERT OR REPLACE` in those triggers were not honoured — under a plain `INSERT INTO t` they behaved as ABORT. And a collision was certain, because the side table's key is `length(quote(NEW.b))`, derived from a column value.

## Change

The side table no longer constrains that column, so trigger writes cannot conflict. It now records **every** firing rather than a deduplicated set, which is closer to what a trigger test wants to observe anyway — the earlier version silently dropped repeat firings even when it did not abort.

That takes the error-producing share from **106/150 to 38/150**. What remains is deliberate: `INSERT OR ROLLBACK` conflicting on `t.k`. Both engines reject those and must agree on the rejection, which is real error-parity coverage worth keeping — so rather than remove it, the sweep now reports how many passing seeds contained a rejected statement, so a nonzero exit no longer looks accidental. That was the substance of the finding: the generator claimed success while the script failed, with nothing saying so.

## Detection is unchanged, which I checked because it was the real risk

Reducing a fuzzer's noise can quietly reduce its power, so I verified the known bugs are still reached:

- `expr` group still finds #2089 at seeds **46 and 201** — the same two.
- All-groups still reaches the `ddl`+`triggers` divergence of #2093 at the same **twelve** seeds.
- `triggers`, `constraints` and `ddl` individually: **200/200 clean** each.

## One thing I tried and rejected

I first moved `INSERT OR ROLLBACK` to fire only *inside* transactions, reasoning that outside one it has nothing to roll back. Measured, that tripled the error rate (18→70 per 200 on the base measurement, and worse on all-groups) for speculative benefit, so I dropped it. Recording it because the reasoning looks sound and the measurement disagreed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)