### PR TITLE
fix: prevent stale refs restore during concurrent merge

### DIFF
--- a/src/doltlite_core.c
+++ b/src/doltlite_core.c
@@ -44,6 +44,8 @@ int doltliteSaveTxnState(sqlite3 *db, DoltliteTxnState *p){
   if( !cs ) return SQLITE_ERROR;
 
   memcpy(&p->refsHash, refsTableGetHash(&cs->refs), sizeof(ProllyHash));
+  memcpy(&p->committedRefsHash, &cs->refs.committedRefsHash,
+         sizeof(ProllyHash));
 
   p->zSessionBranch = sqlite3_mprintf("%s", doltliteGetSessionBranch(db));
   if( !p->zSessionBranch ){
@@ -74,8 +76,13 @@ int doltliteRestoreTxnState(sqlite3 *db, DoltliteTxnState *p){
 
   if( !cs ) return SQLITE_ERROR;
 
-  refsTableSetHash(&cs->refs, &p->refsHash);
-  if( prollyHashIsEmpty(&p->refsHash) ){
+  if( prollyHashCompare(&p->committedRefsHash,
+                        &cs->refs.committedRefsHash)==0 ){
+    refsTableSetHash(&cs->refs, &p->refsHash);
+  }else{
+    csRestoreCommittedRefsHash(cs);
+  }
+  if( prollyHashIsEmpty(&cs->refs.refsHash) ){
     chunkStoreClearRefs(cs);
   }else{
     rc = chunkStoreReloadRefs(cs);

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -214,6 +214,7 @@ static SQLITE_INLINE u64 doltliteFnv1aSep(u64 h){
 
 struct DoltliteTxnState {
   ProllyHash refsHash;
+  ProllyHash committedRefsHash;
   char *zSessionBranch;
   ProllyHash sessionHead;
   ProllyHash sessionStaged;

--- a/src/doltlite_merge_cmd.c
+++ b/src/doltlite_merge_cmd.c
@@ -391,6 +391,12 @@ int doltliteMergeRef(
     return SQLITE_ERROR;
   }
 
+  rc = doltliteEnsureWriteTxnAndSavepoints(db);
+  if( rc!=SQLITE_OK ){
+    sqlite3_result_error_code(context, rc);
+    return SQLITE_ERROR;
+  }
+
   doltliteGetSessionHead(db, &ourHead);
   if( prollyHashIsEmpty(&ourHead) ){
     sqlite3_result_error(context, "no commits on current branch", -1);
@@ -437,9 +443,6 @@ int doltliteMergeRef(
   rc = mergeRefLoadCatalogs(db, &ourHead, &theirHead, &ancestorHash,
                             &ourCommit, &theirCommit,
                             &ourCatHash, &theirCatHash, &ancCatHash, &zFail);
-  if( rc!=SQLITE_OK ) goto merge_fail;
-
-  rc = doltliteEnsureWriteTxnAndSavepoints(db);
   if( rc!=SQLITE_OK ) goto merge_fail;
 
   rc = doltliteSaveTxnState(db, &savedState);

--- a/src/prolly_btree_mutation.c
+++ b/src/prolly_btree_mutation.c
@@ -1771,6 +1771,10 @@ int doltliteEnsureWriteTxnAndSavepoints(sqlite3 *db){
 
   if( !db || db->nDb<=0 || !db->aDb[0].pBt ) return SQLITE_ERROR;
   pBtree = db->aDb[0].pBt;
+  if( pBtree->inTrans==TRANS_NONE ){
+    rc = sqlite3BtreeBeginTrans(pBtree, 0, 0);
+    if( rc!=SQLITE_OK ) return rc;
+  }
   if( pBtree->inTrans!=TRANS_WRITE ){
     rc = sqlite3BtreeBeginTrans(pBtree, 2, 0);
     if( rc!=SQLITE_OK ) return rc;


### PR DESCRIPTION
## Summary

- acquire the merge write transaction before reading HEAD, dirty state, or ancestry
- keep an adopted committed refs hash when transaction restoration holds an older saved hash
- prevent concurrent merges from losing a merged row and resurrecting its deleted temporary branch

## Reproduction

The existing `vc_ref_mutation_stress_test` reproduced the TSan CI failure locally under native Linux ARM64 TSan: all workers returned success, but final verification reported 279/282 assertions with one merged row missing and its deleted branch restored. Root-write tracing showed transaction restoration republishing an older refs hash after the handle had adopted a peer commit.

## Validation

- 50 consecutive clean-patch native Linux TSan stress runs: 14,100/14,100 assertions
- 10 additional post-rebase TSan stress runs
- exact TSan job sequence: threadtest4 serialized/multithread, threadtest5, vc_concurrency_test, and vc_ref_mutation_stress_test
- 20 native stress runs
- DoltLite VC suites: all non-parity suites passed, including 310,258 C regression assertions
- stock SQLite parity: 119/119
- make lint

Co-Authored-By: OpenAI Codex <noreply@openai.com>