### PR TITLE
Re-derive the other side of the merged cursor when a scan reverses

### DIFF
--- a/src/prolly_btree_cursor.c
+++ b/src/prolly_btree_cursor.c
@@ -392,12 +392,14 @@ static int mergeStepForward(BtCursor *pCur){
   if( pCur->mergeSrc==MERGE_SRC_MUT || pCur->mergeSrc==MERGE_SRC_BOTH )
     pCur->mmIdx++;
   rc = mergeScan(pCur, 1, 0);
+  pCur->mergeStepDir = 1;
   CLEAR_CACHED_PAYLOAD(pCur);
   return rc;
 }
 
 static int mergeStepBackward(BtCursor *pCur){
   int rc = SQLITE_OK;
+
   rc = cursorNormalizeMmPhys(pCur);
   if( rc!=SQLITE_OK ) return rc;
   if( pCur->deferredMergedSeek ){
@@ -410,6 +412,56 @@ static int mergeStepBackward(BtCursor *pCur){
   }
   rc = materializeDeferredTreeSeek(pCur, -1);
   if( rc!=SQLITE_OK ) return rc;
+  /* Reversing onto a mut-map row leaves the tree side stale the same way. The
+  ** step below does not touch the tree cursor for a MUT row, so whatever
+  ** forward travel left it on -- a row above this one, or nothing at all once
+  ** it ran off the end -- stands in for "the next tree row below", and every
+  ** tree row underneath goes unserved. Re-seek it to this key and put it below.
+  ** Only on a reversal: a backward scan already leaves it correctly placed, and
+  ** an exhausted tree side would otherwise pay a seek per row. */
+  if( pCur->mergeStepDir > 0
+   && pCur->mergeSrc==MERGE_SRC_MUT
+   && pCur->mmIdx>=0 && pCur->mmIdx<pCur->pMutMap->nEntries ){
+    ProllyMutMapEntry *e;
+    rc = orderedMutMapEntryAt(pCur->pMutMap, pCur->mmIdx, &e);
+    if( rc!=SQLITE_OK ) return rc;
+    {
+      int res = 0;
+      refreshCursorRoot(pCur);
+      if( pCur->curIntKey ){
+        rc = prollyCursorSeekInt(&pCur->pCur, prollyMutMapEntryIntKey(e), &res);
+      }else{
+        rc = prollyCursorSeekBlob(&pCur->pCur, e->pKey, e->nKey, &res);
+      }
+      if( rc!=SQLITE_OK ) return rc;
+      if( res>0 && prollyCursorIsValid(&pCur->pCur) ){
+        rc = prollyCursorPrev(&pCur->pCur);
+        if( rc!=SQLITE_OK ) return rc;
+      }else if( res==0 ){
+        /* The tree holds this key too, so the row is on both sides and the
+        ** step below has to retreat both. */
+        pCur->mergeSrc = MERGE_SRC_BOTH;
+      }
+    }
+  }
+  /* The mirror of the forward loop above. A row reached by scanning forwards
+  ** leaves the mut-map index at or above it, which is what a further forward
+  ** step wants; going backwards instead, those entries are ahead of the cursor
+  ** and the entry the step needs is below them. Left alone, an index parked past
+  ** the last entry reads as "no pending row below" and the rows under it are
+  ** never served -- which is how a reversal dropped a pending row entirely. */
+  if( pCur->mergeSrc==MERGE_SRC_TREE && prollyCursorIsValid(&pCur->pCur) ){
+    if( pCur->mmIdx >= pCur->pMutMap->nEntries ){
+      pCur->mmIdx = pCur->pMutMap->nEntries - 1;
+    }
+    while( pCur->mmIdx >= 0 ){
+      ProllyMutMapEntry *e;
+      rc = orderedMutMapEntryAt(pCur->pMutMap, pCur->mmIdx, &e);
+      if( rc!=SQLITE_OK ) return rc;
+      if( mergeCompare(pCur, e) >= 0 ) break;
+      pCur->mmIdx--;
+    }
+  }
   if( pCur->mergeSrc==MERGE_SRC_TREE || pCur->mergeSrc==MERGE_SRC_BOTH ){
     rc = advanceTreeCursor(pCur, -1);
     if( rc!=SQLITE_OK ) return rc;
@@ -417,6 +469,7 @@ static int mergeStepBackward(BtCursor *pCur){
   if( pCur->mergeSrc==MERGE_SRC_MUT || pCur->mergeSrc==MERGE_SRC_BOTH )
     pCur->mmIdx--;
   rc = mergeScan(pCur, -1, 0);
+  pCur->mergeStepDir = -1;
   CLEAR_CACHED_PAYLOAD(pCur);
   return rc;
 }

--- a/src/prolly_btree_cursor.c
+++ b/src/prolly_btree_cursor.c
@@ -785,31 +785,23 @@ int prollyBtCursorPrevious(BtCursor *pCur, int flags){
     ProllyMutMapIter it;
     rc = ensureCursorMutMapOrder(pCur);
     if( rc!=SQLITE_OK ) return rc;
+    /* The seek is a lower bound, so it lands on the first pending entry at or
+    ** above the tree row. A backward step needs the entry strictly below it,
+    ** which is always the one before that landing -- including when the landing
+    ** sorts above the tree row, which is the case a conditional decrement got
+    ** wrong: keeping it made the pending row above the cursor the candidate for
+    ** a step that has to move down, so a backward scan returned it. */
     if( pCur->curIntKey && prollyCursorIsValid(&pCur->pCur) ){
       rc = prollyMutMapIterSeek(&it, pCur->pMutMap, 0, 0,
                                 prollyCursorIntKey(&pCur->pCur));
       if( rc!=SQLITE_OK ) return rc;
-      if( it.idx >= pCur->pMutMap->nEntries ){
-        it.idx--;
-      }else{
-        ProllyMutMapEntry *e;
-        rc = orderedMutMapEntryAt(pCur->pMutMap, it.idx, &e);
-        if( rc!=SQLITE_OK ) return rc;
-        if( mergeCompare(pCur, e)>=0 || e->op==PROLLY_EDIT_DELETE ) it.idx--;
-      }
+      it.idx--;
     }else if( !pCur->curIntKey && prollyCursorIsValid(&pCur->pCur) ){
       const u8 *pK; int nK;
       prollyCursorKey(&pCur->pCur, &pK, &nK);
       rc = prollyMutMapIterSeek(&it, pCur->pMutMap, pK, nK, 0);
       if( rc!=SQLITE_OK ) return rc;
-      if( it.idx >= pCur->pMutMap->nEntries ){
-        it.idx--;
-      }else{
-        ProllyMutMapEntry *e;
-        rc = orderedMutMapEntryAt(pCur->pMutMap, it.idx, &e);
-        if( rc!=SQLITE_OK ) return rc;
-        if( mergeCompare(pCur, e)>=0 || e->op==PROLLY_EDIT_DELETE ) it.idx--;
-      }
+      it.idx--;
     }else if( pCur->eState==CURSOR_VALID ){
       rc = seedMutMapIterFromCursor(pCur, &it);
       if( rc==SQLITE_NOTFOUND ){

--- a/src/prolly_btree_int.h
+++ b/src/prolly_btree_int.h
@@ -429,6 +429,11 @@ struct BtCursor {
 #define MERGE_SRC_MUT   1
 #define MERGE_SRC_BOTH  2
   u8 mergeSrc;
+  /* Direction of the last merged step: +1, -1, or 0 when the position came
+  ** from a seek rather than a step. Each side of the merge is left primed for
+  ** the direction it was travelling, so a reversal has to re-derive the side
+  ** that did not produce the current row. */
+  i8 mergeStepDir;
 
   i64 nKey;
   void *pKey;

--- a/src/prolly_btree_mutation.c
+++ b/src/prolly_btree_mutation.c
@@ -328,6 +328,7 @@ void clearMergeCursorState(BtCursor *pCur){
   pCur->deferredTreeSeek = 0;
   pCur->deferredMergedSeek = 0;
   pCur->mergeSrc = MERGE_SRC_TREE;
+  pCur->mergeStepDir = 0;
 }
 
 int currentMutMapEntry(BtCursor *pCur, ProllyMutMapEntry **ppEntry){

--- a/test/doltlite_txn_seek_visibility.sh
+++ b/test/doltlite_txn_seek_visibility.sh
@@ -891,4 +891,62 @@ run_test "desc_nulls_first_does_not_repeat_pending_row" \
 
 db_rm "$DB"
 
+# Reversing direction mid-scan. A prefix seek walks forward past the matching
+# range so the step back can land on the last match, which leaves both sides of
+# the merge primed for forward travel: the pending index parked past its last
+# entry, and the tree cursor above the row -- or run off the end entirely. A
+# backward step that trusts either one skips every row underneath, so these
+# assert the rows on the far side of the reversal are still served.
+DB=/tmp/test_txn_reverse_$$.db; db_rm "$DB"
+
+run_test "reversal_serves_pending_null_row" \
+  "CREATE TABLE t(k TEXT PRIMARY KEY, a, b TEXT) WITHOUT ROWID;
+   CREATE INDEX i_a ON t(a);
+   INSERT INTO t VALUES('AB', -47.436, 'x');
+   BEGIN;
+   INSERT INTO t VALUES('zz', NULL, 'q');
+   SELECT group_concat(coalesce(quote(a),'N'),'|') FROM (SELECT a FROM t ORDER BY a DESC NULLS FIRST);
+   SELECT count(*) FROM t;
+   COMMIT;" \
+  "NULL|-47.436
+2" \
+  "$DB"
+
+db_rm "$DB"
+
+run_test "reversal_serves_committed_null_row" \
+  "CREATE TABLE t(k TEXT PRIMARY KEY COLLATE RTRIM, a, b TEXT COLLATE RTRIM);
+   CREATE INDEX i_a ON t(a);
+   INSERT OR REPLACE INTO t(k, a, b) VALUES('', NULL, x'00');
+   BEGIN;
+   INSERT OR IGNORE INTO t(k, a, b) VALUES(x'0001', -19, 'zz');
+   SELECT coalesce(group_concat(q,'|'),'none') FROM (SELECT coalesce(quote(a), 'N') AS q FROM t ORDER BY a DESC NULLS FIRST, coalesce(quote(k), 'N'));
+   SELECT count(*) FROM t;
+   COMMIT;" \
+  "NULL|-19
+2" \
+  "$DB"
+
+db_rm "$DB"
+
+# Three rows spanning the reversal, so the NULL region and the rows above it are
+# both crossed, and a pending row sits among them.
+run_test "reversal_across_null_region_keeps_order" \
+  "CREATE TABLE t(k TEXT PRIMARY KEY, a, b TEXT) WITHOUT ROWID;
+   CREATE INDEX i_a ON t(a);
+   INSERT INTO t VALUES('AB', -47.436, 'x');
+   INSERT INTO t VALUES('zz', NULL, 'q');
+   BEGIN;
+   INSERT INTO t VALUES('ab', 5, 'z');
+   SELECT group_concat(coalesce(quote(a),'N'),'|') FROM (SELECT a FROM t ORDER BY a DESC NULLS FIRST);
+   SELECT group_concat(coalesce(quote(a),'N'),'|') FROM (SELECT a FROM t ORDER BY a ASC NULLS LAST);
+   SELECT count(*) FROM t;
+   COMMIT;" \
+  "NULL|5|-47.436
+-47.436|5|NULL
+3" \
+  "$DB"
+
+db_rm "$DB"
+
 dltest_finish

--- a/test/doltlite_txn_seek_visibility.sh
+++ b/test/doltlite_txn_seek_visibility.sh
@@ -846,4 +846,49 @@ run_test "backward_scan_reaches_pending_extended_keys" \
 
 db_rm "$DB"
 
+# A backward seek whose bound is below every row lands above the bound, and the
+# step that follows has to move down and find nothing. The pending-row candidate
+# for that step is chosen from a lower-bound search, so it is always the entry
+# before the landing -- keeping the landing itself made a pending row above the
+# cursor the answer to a step that has to move down, and a backward scan
+# returned it.
+DB=/tmp/test_txn_backward_landing_$$.db; db_rm "$DB"
+
+run_test "backward_seek_below_all_rows_finds_nothing" \
+  "CREATE TABLE t(k TEXT PRIMARY KEY, a, b TEXT) WITHOUT ROWID;
+   CREATE INDEX i_a ON t(a);
+   INSERT INTO t VALUES('AB', -47.436, 'x');
+   BEGIN;
+   INSERT INTO t VALUES('ab', 5, 'z');
+   SELECT coalesce(quote(max(a)),'NULL') FROM t WHERE a <= -1e308;
+   SELECT coalesce(group_concat(quote(a)),'none') FROM (SELECT a FROM t WHERE a <= -1e308 ORDER BY a DESC);
+   SELECT count(*) FROM t WHERE a <= -1e308;
+   COMMIT;" \
+  "NULL
+none
+0" \
+  "$DB"
+
+db_rm "$DB"
+
+# The ordering that reaches the same step through a plan rather than a bound:
+# DESC NULLS FIRST is the one ordering an index cannot serve by walking
+# backwards, so it scans the NULL region separately and re-seeks for the rest.
+run_test "desc_nulls_first_does_not_repeat_pending_row" \
+  "CREATE TABLE t(k TEXT PRIMARY KEY, a, b TEXT) WITHOUT ROWID;
+   CREATE INDEX i_a ON t(a);
+   INSERT INTO t VALUES('AB', -47.436, 'x');
+   BEGIN;
+   INSERT INTO t VALUES('ab', 5, 'z');
+   SELECT group_concat(quote(a),'|') FROM (SELECT a FROM t ORDER BY a DESC NULLS FIRST, quote(k));
+   SELECT group_concat(quote(a),'|') FROM (SELECT a FROM t ORDER BY a DESC);
+   SELECT count(*) FROM t;
+   COMMIT;" \
+  "5|-47.436
+5|-47.436
+2" \
+  "$DB"
+
+db_rm "$DB"
+
 dltest_finish


### PR DESCRIPTION
Three bugs on one theme: **each side of the merged cursor is left primed for the direction it was travelling, so a reversal has to re-derive the side that did not produce the current row.** The forward step already repairs the pending index for exactly this reason; the backward step had neither half of it.

`ORDER BY ... DESC NULLS FIRST` is what exposed this. It is the one ordering an index cannot serve by walking backwards, so SQLite scans the NULL region separately — and a prefix seek reverses direction by design: `SeekLE` walks *forward* past the matching range so the step back can land on the last match.

## The three

**1. The backward step took the wrong pending candidate.** The search is a lower bound, so it lands at or above the tree row; a step moving down needs the entry strictly below. The decrement was conditional on the landing comparing at-or-below, so when it compared *above* — the case where the map holds nothing below the cursor — the entry above was kept:

```sql
SELECT max(a) FROM t WHERE a <= -1e308;   -- doltlite: 5, stock: NULL
```

**2. The pending index, parked past its last entry by forward travel, read as "no pending row below"** — so the entries underneath were never served and a **pending row was lost**, not duplicated:

```sql
INSERT INTO t VALUES('AB', -47.436, 'x');
BEGIN;
INSERT INTO t VALUES('zz', NULL, 'q');
SELECT ... ORDER BY a DESC NULLS FIRST;   -- doltlite: -47.436, stock: NULL|-47.436
```

**3. The tree cursor, left above the row by forward travel or run off the end,** stood in for "the next tree row below" — the backward step does not touch the tree side for a mut-sourced row — so **committed** rows underneath went unserved too:

```sql
INSERT OR REPLACE INTO t(k, a, b) VALUES('', NULL, x'00');
BEGIN;
INSERT OR IGNORE INTO t(k, a, b) VALUES(x'0001', -19, 'zz');
SELECT ... ORDER BY a DESC NULLS FIRST;   -- doltlite: -19, stock: NULL|-19
```

A lost row is worse than the duplicate originally reported in #2107, and both were reachable.

## Why a direction field

`mergeStepDir` records the last step's direction so the tree re-seek runs only on a reversal. Re-seeking whenever the tree cursor merely *looked* exhausted would also be correct, but then a scan whose tree side is exhausted — every remaining row pending — would pay a seek per row for the rest of the scan. This keeps the common path at a comparison.

## Testing

- `doltlite_txn_seek_visibility.sh`: 5 new tests, **all 5 fail on unfixed code**, 49/49 with the fix. The 44 pre-existing tests, covering every earlier merged-cursor fix, still pass.
- Expected values taken from stock. (One of mine was wrong first time round — `quote(NULL)` is the string `'NULL'`, so a `coalesce` fallback never fires. The engine was right and the test was wrong.)
- `nullsorder` group: **16 → 13 → 6 → 0** failures across the three fixes; 200/200 clean.
- 12-case matrix over ASC/DESC × NULLS FIRST/LAST × pending/committed × indexed/not: was 4 divergent, now all agree.
- Differential sweep: default axes 1..3000 clean; **all 21 groups** 1..300 clean.
- `review_regression_test.sh` 148/148; `run_doltlite_tests.sh` 101/101 suites.

Ruled out along the way rather than assumed: the doltlite-specific cached index-key compare (disabled it, bug persisted) and #2100 (reverted it locally, bug persisted — this is pre-existing, not a regression from that work).

Fixes #2107

🤖 Generated with [Claude Code](https://claude.com/claude-code)