### PR TITLE
Order the fkeys child insert so its LIMIT 1 names a row

### DIFF
--- a/test/sql_differential_fuzzer.py
+++ b/test/sql_differential_fuzzer.py
@@ -220,11 +220,18 @@ class Gen:
             self.emit("PRAGMA foreign_keys=ON;")
 
     def child_write(self):
-        """Insert or delete in the table that references t."""
+        """Insert or delete in the table that references t.
+
+        The ORDER BY is load-bearing: LIMIT 1 without one picks whichever row
+        the scan reaches first, which SQL does not define and which two engines
+        settle differently whenever they choose different plans. ch is only built
+        for shapes whose k is unique, so ordering by it is a total order.
+        """
         if self.r.random() < 0.7:
             self.emit("INSERT OR IGNORE INTO ch(cid, fk, note) "
-                      "SELECT %d, k, %s FROM t WHERE %s LIMIT 1;"
-                      % (self.r.randint(1, 60), self.text_val(), self.pred()))
+                      "SELECT %d, k, %s FROM t WHERE %s ORDER BY %s LIMIT 1;"
+                      % (self.r.randint(1, 60), self.text_val(), self.pred(),
+                         Q % "k"))
         else:
             self.emit("DELETE FROM ch WHERE cid = %d;" % self.r.randint(1, 60))
 


### PR DESCRIPTION
The `fkeys` group picked which parent row to reference with a bare `LIMIT 1`:

```sql
INSERT OR IGNORE INTO ch(cid, fk, note)
  SELECT 17, k, 'zz' FROM t WHERE <pred> LIMIT 1;
```

SQL does not define which row that is. Two engines disagree whenever they choose different plans for the same query, and **both answers are correct** — in the reduced case below, `t` holds two rows that both satisfy the predicate, doltlite takes the one first in primary-key order and stock takes the other.

Proof it is the harness and not the storage — the minimized repro, with nothing changed but an added `ORDER BY`:

| script | doltlite | stock |
|---|---|---|
| minimized repro as-is | `17/-9223372036854775807` | `17/40` |
| same repro + `ORDER BY quote(k)` | `17/-9223372036854775807` | `17/-9223372036854775807` |

`ch` is only built for shapes whose `k` is unique, so ordering by it is a total order.

## Why this matters beyond three seeds

This is the exact failure mode the generator exists to avoid. Its docstring already promises no dependence on rowid identity or physical row order, because *a harness that reports position-dependent differences would be worse than no harness* — every real divergence then has to be triaged against the possibility that the query never had one answer. An unordered `LIMIT` is that same hazard by another route, and I introduced it in #2102.

## The rest of #2110

The nightly reported fifteen seeds. All fifteen now agree:

- **twelve** were real, and #2108 fixed them — they were the index corruption from #2103 (`integrity_check` reporting rows missing from indexes, and `database disk image is malformed`). The nightly ran at the #2109 merge, which does not contain #2108.
- **three** were this.

Worth noting the sweep did its job on the first night it ran with every group and a 100,000-seed window: it independently caught #2103's corruption from the SQL surface.

## Testing

- All fifteen seeds from #2110: pass.
- `fkeys` group alone, seeds 1..200: clean.
- All groups, seeds 1..300: clean.
- All groups across the nightly's own window, seeds 4857379000..4857381000 (2,001 seeds): clean.

Closes #2110

🤖 Generated with [Claude Code](https://claude.com/claude-code)