### PR TITLE
Detect NOT NULL violations left by a merge

### DIFF
--- a/doltlite.mk
+++ b/doltlite.mk
@@ -66,6 +66,7 @@ PROLLY_OBJS = $(DOLTLITE_AUTH_OBJS) \
               doltlite_merge_constraints_unique.o \
               doltlite_merge_constraints_check.o \
               doltlite_merge_constraints_fk.o \
+              doltlite_merge_constraints_notnull.o \
               doltlite_dbpage.o \
               doltlite_remote.o doltlite_remote_sql.o \
               doltlite_http_remote.o doltlite_remotesrv.o

--- a/main.mk
+++ b/main.mk
@@ -1598,6 +1598,9 @@ doltlite_merge_constraints_check.o:	$(TOP)/src/doltlite_merge_constraints_check.
 doltlite_merge_constraints_fk.o:	$(TOP)/src/doltlite_merge_constraints_fk.c $(TOP)/src/doltlite_merge_constraints_int.h $(DEPS_OBJ_COMMON)
 	$(T.cc.sqlite) -c $(TOP)/src/doltlite_merge_constraints_fk.c
 
+doltlite_merge_constraints_notnull.o:	$(TOP)/src/doltlite_merge_constraints_notnull.c $(TOP)/src/doltlite_merge_constraints_int.h $(DEPS_OBJ_COMMON)
+	$(T.cc.sqlite) -c $(TOP)/src/doltlite_merge_constraints_notnull.c
+
 doltlite_merge.o:	$(TOP)/src/doltlite_merge.c $(TOP)/src/doltlite_merge_int.h $(DEPS_OBJ_COMMON)
 	$(T.cc.sqlite) -c $(TOP)/src/doltlite_merge.c
 

--- a/src/doltlite_cherry_pick.c
+++ b/src/doltlite_cherry_pick.c
@@ -197,6 +197,7 @@ int applyMergedCatalogAndCommit(
     int nViolations = 0;
     int nUnique = 0;
     int nCheck = 0;
+    int nNotNull = 0;
     char *zDetectErrMsg = 0;
 
     rc = doltliteConstraintViolationBatchBegin(db);
@@ -215,6 +216,11 @@ int applyMergedCatalogAndCommit(
                                               &zDetectErrMsg, &nCheck,
                                               0, 0);
     }
+    if( rc==SQLITE_OK ){
+      rc = doltliteDetectMergeNotNullViolations(db, ancCatHash,
+                                               &zDetectErrMsg, &nNotNull,
+                                               0, 0);
+    }
     {
       int erc = doltliteConstraintViolationBatchEnd(db, rc==SQLITE_OK);
       if( rc==SQLITE_OK ) rc = erc;
@@ -228,7 +234,7 @@ int applyMergedCatalogAndCommit(
     }
     sqlite3_free(zDetectErrMsg);
 
-    if( nViolations + nUnique + nCheck > 0 ){
+    if( nViolations + nUnique + nCheck + nNotNull > 0 ){
       if( *pnConflicts > 0 ){
         return doltliteCmdFinishWithConflictsAndConstraintViolations(
             db, context, &savedState, *pnConflicts, zOpLabel, 1, 0);

--- a/src/doltlite_constraint_violations.c
+++ b/src/doltlite_constraint_violations.c
@@ -829,6 +829,7 @@ static const char *violationTypeName(u8 t){
     case DOLTLITE_CV_FOREIGN_KEY: return "foreign key";
     case DOLTLITE_CV_UNIQUE_INDEX: return "unique index";
     case DOLTLITE_CV_CHECK_CONSTRAINT: return "check constraint";
+    case DOLTLITE_CV_NOT_NULL: return "not null";
     default: return "unknown";
   }
 }

--- a/src/doltlite_constraint_violations.h
+++ b/src/doltlite_constraint_violations.h
@@ -7,6 +7,7 @@
 #define DOLTLITE_CV_FOREIGN_KEY      1
 #define DOLTLITE_CV_UNIQUE_INDEX     2
 #define DOLTLITE_CV_CHECK_CONSTRAINT 3
+#define DOLTLITE_CV_NOT_NULL         4
 
 typedef struct ConstraintViolationRow ConstraintViolationRow;
 struct ConstraintViolationRow {

--- a/src/doltlite_core.c
+++ b/src/doltlite_core.c
@@ -769,6 +769,7 @@ int doltliteDetectConstraintViolationsFiltered(
   int nViolations = 0;
   int nUnique = 0;
   int nCheck = 0;
+  int nNotNull = 0;
   char *zDetectErrMsg = 0;
   int rc;
   sqlite3_stmt *pStmt = 0;
@@ -817,6 +818,11 @@ int doltliteDetectConstraintViolationsFiltered(
                                             &zDetectErrMsg, &nCheck,
                                             azTables, nTables);
   }
+  if( rc==SQLITE_OK ){
+    rc = doltliteDetectMergeNotNullViolations(db, pAncCatHash,
+                                             &zDetectErrMsg, &nNotNull,
+                                             azTables, nTables);
+  }
   {
     int erc = doltliteConstraintViolationBatchEnd(db, rc==SQLITE_OK);
     if( rc==SQLITE_OK ) rc = erc;
@@ -824,7 +830,7 @@ int doltliteDetectConstraintViolationsFiltered(
   sqlite3_free(zDetectErrMsg);
   if( rc!=SQLITE_OK ) return rc;
 
-  if( pnViolations ) *pnViolations = nViolations + nUnique + nCheck;
+  if( pnViolations ) *pnViolations = nViolations + nUnique + nCheck + nNotNull;
   return SQLITE_OK;
 }
 

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -1033,6 +1033,9 @@ int doltliteDetectMergeUniqueViolations(sqlite3 *db, const ProllyHash *pAncCatHa
 int doltliteDetectMergeCheckViolations(sqlite3 *db, const ProllyHash *pAncCatHash,
                                        char **pzErrMsg, int *pnFound,
                                        const char **azTables, int nTables);
+int doltliteDetectMergeNotNullViolations(sqlite3 *db, const ProllyHash *pAncCatHash,
+                                       char **pzErrMsg, int *pnFound,
+                                       const char **azTables, int nTables);
 
 int doltliteConstraintViolationBatchBegin(sqlite3 *db);
 int doltliteConstraintViolationBatchEnd(sqlite3 *db, int commit);

--- a/src/doltlite_merge_cmd.c
+++ b/src/doltlite_merge_cmd.c
@@ -263,7 +263,7 @@ static int mergeRefDetectConstraintViolations(
   int *pnViolations,
   char **pzErr
 ){
-  int nFk = 0, nUnique = 0, nCheck = 0;
+  int nFk = 0, nUnique = 0, nCheck = 0, nNotNull = 0;
   int vrc;
   int erc;
 
@@ -279,9 +279,13 @@ static int mergeRefDetectConstraintViolations(
   if( vrc==SQLITE_OK ){
     vrc = doltliteDetectMergeCheckViolations(db, pAncCat, pzErr, &nCheck, 0, 0);
   }
+  if( vrc==SQLITE_OK ){
+    vrc = doltliteDetectMergeNotNullViolations(db, pAncCat, pzErr, &nNotNull,
+                                              0, 0);
+  }
   erc = doltliteConstraintViolationBatchEnd(db, vrc==SQLITE_OK);
   if( vrc==SQLITE_OK ) vrc = erc;
-  if( vrc==SQLITE_OK ) *pnViolations = nFk + nUnique + nCheck;
+  if( vrc==SQLITE_OK ) *pnViolations = nFk + nUnique + nCheck + nNotNull;
   return vrc;
 }
 

--- a/src/doltlite_merge_constraints_notnull.c
+++ b/src/doltlite_merge_constraints_notnull.c
@@ -1,0 +1,264 @@
+#ifdef DOLTLITE_PROLLY
+
+#include "doltlite_merge_constraints_int.h"
+
+/* NOT NULL violations left behind by a merge.
+**
+** A merge can bring together a schema that declares a column NOT NULL and a
+** row from the other side that has NULL in it. Neither side violated anything
+** on its own, so nothing along the write path objects, and the row lands.
+**
+** The predicate has to be typeof(c)='null' rather than c IS NULL: the column is
+** declared NOT NULL, so the planner knows the test cannot be true and strength-
+** reduces it away. That is also why the row is invisible to the obvious query
+** and why this needs its own detector rather than a WHERE clause somewhere.
+*/
+
+static void freeNames(char **az, int n){
+  int i;
+  for(i=0; i<n; i++) sqlite3_free(az[i]);
+  sqlite3_free(az);
+}
+
+/* The columns a table declares NOT NULL, in declaration order. */
+static int loadNotNullColumns(
+  sqlite3 *db,
+  const char *zTable,
+  char ***pazCols,
+  int *pnCols
+){
+  sqlite3_stmt *pQ = 0;
+  char *zSql;
+  char **az = 0;
+  int n = 0;
+  int nAlloc = 0;
+  int rc;
+
+  *pazCols = 0;
+  *pnCols = 0;
+  zSql = sqlite3_mprintf(
+      "SELECT name FROM pragma_table_info(%Q) WHERE \"notnull\"=1", zTable);
+  if( !zSql ) return SQLITE_NOMEM;
+  rc = sqlite3_prepare_v2(db, zSql, -1, &pQ, 0);
+  sqlite3_free(zSql);
+  if( rc!=SQLITE_OK ) return rc;
+
+  while( sqlite3_step(pQ)==SQLITE_ROW ){
+    const char *zName = (const char*)sqlite3_column_text(pQ, 0);
+    if( !zName ) continue;
+    if( n==nAlloc ){
+      int nNew = nAlloc ? nAlloc*2 : 4;
+      char **azNew = sqlite3_realloc(az, nNew*(int)sizeof(char*));
+      if( !azNew ){ rc = SQLITE_NOMEM; break; }
+      az = azNew;
+      nAlloc = nNew;
+    }
+    az[n] = sqlite3_mprintf("%s", zName);
+    if( !az[n] ){ rc = SQLITE_NOMEM; break; }
+    n++;
+  }
+  sqlite3_finalize(pQ);
+  if( rc!=SQLITE_OK ){
+    freeNames(az, n);
+    return rc;
+  }
+  *pazCols = az;
+  *pnCols = n;
+  return SQLITE_OK;
+}
+
+int doltliteDetectMergeNotNullViolations(
+  sqlite3 *db,
+  const ProllyHash *pAncCatHash,
+  char **pzErrMsg,
+  int *pnFound,
+  const char **azTables,
+  int nTables
+){
+  sqlite3_stmt *pTbls = 0;
+  struct TableEntry *aAnc = 0;
+  int nAnc = 0;
+  struct TableEntry *aCur = 0;
+  int nCur = 0;
+  int rc;
+  int stepRc;
+
+  (void)pzErrMsg;
+  if( pnFound ) *pnFound = 0;
+
+  rc = loadAncestorAndCurrentCatalogs(db, pAncCatHash, &aAnc, &nAnc,
+                                      &aCur, &nCur);
+  if( rc!=SQLITE_OK ) return rc;
+
+  rc = sqlite3_prepare_v2(db,
+      "SELECT name FROM main.sqlite_master WHERE type='table' "
+      "AND name NOT LIKE 'sqlite_%' AND name NOT LIKE 'dolt_%'",
+      -1, &pTbls, 0);
+  if( rc!=SQLITE_OK ){
+    doltliteFreeCatalog(aAnc, nAnc);
+    doltliteFreeCatalog(aCur, nCur);
+    return rc;
+  }
+
+  while( (stepRc = sqlite3_step(pTbls))==SQLITE_ROW ){
+    const char *zTableRaw = (const char*)sqlite3_column_text(pTbls, 0);
+    char *zTable;
+    char **azCols = 0;
+    int nCols = 0;
+    int hasRowid;
+    int nKeyCol;
+    MergePkInfo pkInfo;
+    sqlite3_str *pStr;
+    char *zQuery = 0;
+    sqlite3_stmt *pQ = 0;
+    int i;
+
+    if( !zTableRaw ) continue;
+    zTable = sqlite3_mprintf("%s", zTableRaw);
+    if( !zTable ){ rc = SQLITE_NOMEM; break; }
+    if( !cvTableAllowed(zTable, azTables, nTables)
+     || !catalogTableChanged(aAnc, nAnc, aCur, nCur, zTable) ){
+      sqlite3_free(zTable);
+      continue;
+    }
+
+    rc = loadNotNullColumns(db, zTable, &azCols, &nCols);
+    if( rc!=SQLITE_OK ){
+      sqlite3_free(zTable);
+      break;
+    }
+    if( nCols==0 ){
+      sqlite3_free(zTable);
+      continue;
+    }
+
+    memset(&pkInfo, 0, sizeof(pkInfo));
+    hasRowid = tableHasRowid(db, zTable);
+    if( !hasRowid ){
+      rc = loadMergePkInfo(db, zTable, &pkInfo);
+      if( rc!=SQLITE_OK ){
+        freeNames(azCols, nCols);
+        sqlite3_free(zTable);
+        break;
+      }
+    }
+    nKeyCol = hasRowid ? 1 : pkInfo.nPk;
+
+    /* One row per offending row, carrying a flag per declared-NOT NULL column
+    ** so every column that is NULL in it is named, the way Dolt reports them. */
+    pStr = sqlite3_str_new(db);
+    sqlite3_str_appendf(pStr, "SELECT %s",
+                        hasRowid ? "rowid" : pkInfo.zPkCols);
+    for(i=0; i<nCols; i++){
+      sqlite3_str_appendf(pStr, ", typeof(\"%w\")='null'", azCols[i]);
+    }
+    sqlite3_str_appendf(pStr, " FROM main.\"%w\" NOT INDEXED WHERE 0", zTable);
+    for(i=0; i<nCols; i++){
+      sqlite3_str_appendf(pStr, " OR typeof(\"%w\")='null'", azCols[i]);
+    }
+    zQuery = sqlite3_str_finish(pStr);
+    if( !zQuery ){
+      freeNames(azCols, nCols);
+      freeMergePkInfo(&pkInfo);
+      sqlite3_free(zTable);
+      rc = SQLITE_NOMEM;
+      break;
+    }
+    rc = sqlite3_prepare_v2(db, zQuery, -1, &pQ, 0);
+    sqlite3_free(zQuery);
+    if( rc!=SQLITE_OK ){
+      /* A table the merge left unreadable is the other detectors' business. */
+      freeNames(azCols, nCols);
+      freeMergePkInfo(&pkInfo);
+      sqlite3_free(zTable);
+      rc = SQLITE_OK;
+      continue;
+    }
+
+    while( sqlite3_step(pQ)==SQLITE_ROW ){
+      u8 *pKey = 0; int nKey = 0;
+      u8 *pVal = 0; int nVal = 0;
+      i64 intKey = 0;
+      sqlite3_str *pInfo;
+      char *zInfo;
+      int nNamed = 0;
+      int appendRc;
+
+      if( hasRowid ){
+        intKey = sqlite3_column_int64(pQ, 0);
+        rc = fetchOrphanRow(db, zTable, intKey, &pKey, &nKey, &pVal, &nVal);
+      }else{
+        u8 *pPkRec = 0; int nPkRec = 0;
+        pPkRec = buildRecordFromStmtCols(pQ, 0, pkInfo.nPk, &nPkRec);
+        if( !pPkRec ){ rc = SQLITE_NOMEM; break; }
+        rc = fetchRowByPkFromTable(db, zTable, pPkRec, nPkRec, pkInfo.nPk,
+                                   &pKey, &nKey, &pVal, &nVal);
+        sqlite3_free(pPkRec);
+      }
+      if( rc==SQLITE_NOTFOUND ){ rc = SQLITE_OK; continue; }
+      if( rc!=SQLITE_OK ){
+        sqlite3_free(pKey);
+        sqlite3_free(pVal);
+        break;
+      }
+
+      /* A row that already had the NULL before the merge is not the merge's
+      ** doing, same rule the other detectors apply. */
+      if( aAnc ){
+        u8 *pAncVal = 0; int nAncVal = 0;
+        int ancRc = hasRowid
+            ? fetchAncestorRowByName(db, aAnc, nAnc, zTable,
+                                     intKey, &pAncVal, &nAncVal)
+            : fetchAncestorRowByKey(db, aAnc, nAnc, zTable,
+                                    pKey, nKey, &pAncVal, &nAncVal);
+        int preExisting = (ancRc==SQLITE_OK)
+            && isRowPreExisting(pVal, nVal, pAncVal, nAncVal);
+        sqlite3_free(pAncVal);
+        if( preExisting ){
+          sqlite3_free(pKey);
+          sqlite3_free(pVal);
+          continue;
+        }
+      }
+
+      pInfo = sqlite3_str_new(db);
+      sqlite3_str_appendall(pInfo, "{\"Columns\": [");
+      for(i=0; i<nCols; i++){
+        if( sqlite3_column_int(pQ, nKeyCol + i) ){
+          sqlite3_str_appendf(pInfo, "%s\"%w\"", nNamed ? ", " : "", azCols[i]);
+          nNamed++;
+        }
+      }
+      sqlite3_str_appendall(pInfo, "]}");
+      zInfo = sqlite3_str_finish(pInfo);
+      if( !zInfo ){
+        sqlite3_free(pKey);
+        sqlite3_free(pVal);
+        rc = SQLITE_NOMEM;
+        break;
+      }
+      appendRc = doltliteAppendConstraintViolation(
+          db, zTable, DOLTLITE_CV_NOT_NULL,
+          intKey, pKey, nKey, pVal, nVal, zInfo);
+      sqlite3_free(zInfo);
+      sqlite3_free(pKey);
+      sqlite3_free(pVal);
+      if( appendRc!=SQLITE_OK ){ rc = appendRc; break; }
+      if( pnFound ) (*pnFound)++;
+    }
+    sqlite3_finalize(pQ);
+    freeNames(azCols, nCols);
+    freeMergePkInfo(&pkInfo);
+    sqlite3_free(zTable);
+    if( rc!=SQLITE_OK ) break;
+  }
+  if( rc==SQLITE_OK && stepRc!=SQLITE_DONE && stepRc!=SQLITE_ROW ){
+    rc = stepRc;
+  }
+  sqlite3_finalize(pTbls);
+  doltliteFreeCatalog(aAnc, nAnc);
+  doltliteFreeCatalog(aCur, nCur);
+  return rc;
+}
+
+#endif

--- a/test/vc_oracle_constraint_violations_test.sh
+++ b/test/vc_oracle_constraint_violations_test.sh
@@ -185,6 +185,57 @@ SELECT CONCAT('R|AGG|', 't|', num_violations) FROM dolt_constraint_violations;" 
 "R|AGG|t|1
 R|CK|2|-5|expr=v>0"
 
+echo "--- not null: column tightened on one branch, NULL row on the other ---"
+# Same split as CHECK above, and for the same reason: tightening a column to NOT
+# NULL needs SQLite's recreate-and-rename, which Dolt reads as a primary-key
+# change and refuses. Expressed Dolt's way (ALTER TABLE t MODIFY b ... NOT NULL)
+# on Dolt 2.2.2, the merge reports one violation and
+# dolt_constraint_violations_t holds exactly the row asserted here:
+#   not null | 2 | {"Columns": ["b"]}
+# so the expectation below is Dolt's answer, not just doltlite's.
+dl_expect "not_null_tightened_other_branch_inserts_null" \
+"CREATE TABLE t(id INTEGER PRIMARY KEY, b TEXT);
+INSERT INTO t VALUES (1,'x');
+SELECT dolt_commit('-Am','init');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+INSERT INTO t VALUES (2,NULL);
+SELECT dolt_commit('-Am','feat_null');
+SELECT dolt_checkout('main');
+CREATE TABLE t2(id INTEGER PRIMARY KEY, b TEXT NOT NULL);
+INSERT INTO t2 SELECT * FROM t;
+DROP TABLE t;
+ALTER TABLE t2 RENAME TO t;
+SELECT dolt_commit('-Am','main_not_null');
+SELECT dolt_merge('feat');
+" \
+"SELECT CONCAT('R|', CASE violation_type WHEN 'foreign key' THEN 'FK' WHEN 'unique index' THEN 'UQ' WHEN 'check constraint' THEN 'CK' WHEN 'not null' THEN 'NN' ELSE '?' END, '|', id, '|cols=', JSON_EXTRACT(violation_info,'\$.Columns')) FROM dolt_constraint_violations_t ORDER BY id;
+SELECT CONCAT('R|AGG|', 't|', num_violations) FROM dolt_constraint_violations;" \
+"R|AGG|t|1
+R|NN|2|cols=[b]"
+
+# A column added NOT NULL WITH a default is not a violation on either engine:
+# the rows merged in from the other branch take the default. Asserted so the
+# detector cannot start reporting those.
+dl_expect "not_null_added_with_default_is_clean" \
+"CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1,'a');
+SELECT dolt_commit('-Am','init');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+INSERT INTO t VALUES (2,'b');
+SELECT dolt_commit('-Am','feat_row');
+SELECT dolt_checkout('main');
+ALTER TABLE t ADD COLUMN c TEXT NOT NULL DEFAULT 7;
+SELECT dolt_commit('-Am','main_addcol');
+SELECT dolt_merge('feat');
+" \
+"SELECT CONCAT('R|CV|', count(*)) FROM dolt_constraint_violations_t;
+SELECT CONCAT('R|ROW|', id, '|', quote(c)) FROM t ORDER BY id;" \
+"R|CV|0
+R|ROW|1|'7'
+R|ROW|2|'7'"
+
 echo ""
 echo "======================================="
 echo "Results: $pass passed, $fail failed"

--- a/tool/mksqlite3c.tcl
+++ b/tool/mksqlite3c.tcl
@@ -637,7 +637,7 @@ proc emit_doltlite_engine_block {} {
     doltlite_conflicts.c doltlite_gc.c doltlite_chunk_walk.c
     doltlite_history.c doltlite_at.c doltlite_blame.c doltlite_schema_diff.c doltlite_patch.c
     doltlite_schemas.c doltlite_diff_stat.c doltlite_record.c doltlite_ignore.c
-    doltlite_hashof.c doltlite_constraint_violations.c doltlite_verify_constraints.c doltlite_merge_constraints.c doltlite_merge_constraints_unique.c doltlite_merge_constraints_check.c doltlite_merge_constraints_fk.c
+    doltlite_hashof.c doltlite_constraint_violations.c doltlite_verify_constraints.c doltlite_merge_constraints.c doltlite_merge_constraints_unique.c doltlite_merge_constraints_check.c doltlite_merge_constraints_fk.c doltlite_merge_constraints_notnull.c
     doltlite_dbpage.c doltlite_remote.c doltlite_remote_sql.c doltlite_http_remote.c
     doltlite_remotesrv.c
   }


### PR DESCRIPTION
Nothing detected them. The constraint-violation machinery covers foreign keys, unique indexes and CHECK, so a merge where one side tightens a column to NOT NULL and the other inserts a NULL **committed cleanly with zero conflicts**.

Worse than committing it — the row could not be found:

```
merge:                   succeeds, 0 conflicts
SELECT count(*):         2
WHERE b IS NULL:         0            <-- invisible
PRAGMA integrity_check:  NULL value in t.b
```

`b` is declared NOT NULL, so the planner knows `b IS NULL` cannot be true and folds it away. Only `integrity_check` admitted the row existed. That is also why this needs its own detector rather than a WHERE clause bolted onto an existing one, and why the detector tests `typeof(c)='null'`, which the optimizer cannot fold. (It follows that the row *is* repairable through SQL via that predicate — my review notes claimed otherwise, which was wrong.)

## The detector

Mirrors the CHECK detector: for each table the merge changed, the columns `pragma_table_info` reports as NOT NULL, one query finding rows where any of them is NULL, and rows that already held the NULL before the merge skipped as not the merge's doing. One violation per row, naming every column that is NULL in it.

Wired into the merge and cherry-pick sequences directly; **rebase** and **`dolt_verify_constraints`** reach it through `doltliteDetectConstraintViolationsFiltered`, which both already call.

## Oracled against Dolt 2.2.2

Dolt, given the same scenario in its own dialect (`ALTER TABLE t MODIFY b VARCHAR(10) NOT NULL`):

```
CALL DOLT_MERGE('feat')  ->  conflicts: 1
Type: Null Constraint Violation, Columns: [b]
dolt_constraint_violations_t:  not null | 2 | {"Columns": ["b"]}
dolt_constraint_violations:    t | 1
```

doltlite now records `not null|2|{"Columns": ["b"]}` and `t|1` — the same violation type string, the same `violation_info` shape, the same count. Merge and cherry-pick are both refused with the working set left clean, matching Dolt's transaction refusal.

## The case that is deliberately *not* a violation

A column added `NOT NULL DEFAULT <v>` is clean on both engines — rows merged in from the other branch take the default. Verified against Dolt (merge successful, no violations) and asserted in the suite so the detector cannot grow into it.

## Testing

- `vc_oracle_constraint_violations_test.sh`: 2 new cases, 7/7. The NOT NULL case **fails without the detector wired in** (verified by reverting just the call sites). Its expectation is Dolt's output, recorded in a comment with the dialect difference explained — the same doltlite-only split the suite already uses for CHECK, because the recreate-and-rename that tightens a column reads to Dolt as a primary-key change.
- `vc_oracle_verify_constraints_test.sh` 13/13, `doltlite_merge.sh` 107/107, `doltlite_cherry_pick.sh` 98/98, `run_doltlite_tests.sh` 101/101 suites.
- Amalgamation rebuilt from scratch and `testfixture` linked, confirming the new source file is registered in `main.mk`, `doltlite.mk` and `tool/mksqlite3c.tcl`.

## Not in scope

Item 5(b) of the same review — `mergeTableRenameOtherDrop` silently deleting a renamed table where Dolt keeps it as an add — is deliberate behaviour from dc6be73825 and needs an intent call, so it is deliberately left out.

Fixes #2113

🤖 Generated with [Claude Code](https://claude.com/claude-code)