### PR TITLE
perf: optimize chunk search and single-edit node rewrites

### DIFF
--- a/src/chunk_index.c
+++ b/src/chunk_index.c
@@ -9,6 +9,9 @@
 #include <stdlib.h>
 #include <limits.h>
 
+#define CS_INDEX_WINDOW_MIN 4096
+#define CS_INDEX_WINDOW_MARGIN_DIV 64
+
 void chunkIndexGetEntries(const ChunkIndex *idx, int *pn, const ChunkIndexEntry **par){
   assert( idx!=0 && pn!=0 && par!=0 );
   assert( idx->nIndex>=0 );
@@ -57,9 +60,42 @@ int csSearchIndex(
 ){
   int lo = 0;
   int hi = nIdx - 1;
+  int outerLo = 0;
+  int outerHi = nIdx - 1;
   assert( pHash!=0 );
   assert( nIdx>=0 );
   assert( nIdx==0 || aIdx!=0 );
+  if( nIdx>=CS_INDEX_WINDOW_MIN ){
+    int margin = nIdx/CS_INDEX_WINDOW_MARGIN_DIV + 1;
+    int bucket = pHash->data[0];
+    lo = (int)(((i64)bucket * nIdx) >> 8) - margin;
+    hi = (int)(((i64)(bucket + 1) * nIdx) >> 8) + margin;
+    if( lo<0 ) lo = 0;
+    if( hi>=nIdx ) hi = nIdx - 1;
+    outerLo = lo;
+    outerHi = hi;
+  }
+  while( lo <= hi ){
+    int mid = lo + (hi - lo) / 2;
+    int cmp = prollyHashCompare(&aIdx[mid].hash, pHash);
+    if( cmp == 0 ) return mid;
+    if( cmp < 0 ){
+      lo = mid + 1;
+    }else{
+      hi = mid - 1;
+    }
+  }
+  if( nIdx<CS_INDEX_WINDOW_MIN ) return -1;
+  if( outerLo>0 && prollyHashCompare(pHash, &aIdx[outerLo].hash)<0 ){
+    lo = 0;
+    hi = outerLo - 1;
+  }else if( outerHi<nIdx-1
+         && prollyHashCompare(pHash, &aIdx[outerHi].hash)>0 ){
+    lo = outerHi + 1;
+    hi = nIdx - 1;
+  }else{
+    return -1;
+  }
   while( lo <= hi ){
     int mid = lo + (hi - lo) / 2;
     int cmp = prollyHashCompare(&aIdx[mid].hash, pHash);

--- a/src/prolly_mutate.c
+++ b/src/prolly_mutate.c
@@ -646,8 +646,10 @@ static int tryInsertOrReplaceSingleNoRechunk(ProllyMutator *pMut){
     sameSize = (nOldVal==pEdit->nVal);
     pData = sameSize ? copyNodeData(pLeaf) : 0;
     if( pData ){
-      memcpy(pData + (pOldVal - pLeaf->pData), pEdit->pVal,
-             pEdit->nVal);
+      if( pEdit->nVal ){
+        memcpy(pData + (pOldVal - pLeaf->pData), pEdit->pVal,
+               pEdit->nVal);
+      }
       rc = writeOwnedNode(pMut->pStore, pMut->pCache, pData,
                           pLeaf->nData, &childHash);
     }else{

--- a/src/prolly_mutate.c
+++ b/src/prolly_mutate.c
@@ -422,12 +422,9 @@ static int appendNodeEntryToBuilder(
                                        subtreeCount);
 }
 
-static int writeBuilderNode(ChunkStore *pStore, ProllyCache *pCache,
-                            ProllyNodeBuilder *pBuilder, ProllyHash *pHash){
-  u8 *pData = 0;
-  int nData = 0;
-  int rc = prollyNodeBuilderFinish(pBuilder, &pData, &nData);
-  if( rc!=SQLITE_OK ) return rc;
+static int writeOwnedNode(ChunkStore *pStore, ProllyCache *pCache,
+                          u8 *pData, int nData, ProllyHash *pHash){
+  int rc;
   rc = chunkStorePut(pStore, pData, nData, pHash);
   if( rc==SQLITE_OK && pCache ){
     ProllyCacheEntry *pEntry;
@@ -437,6 +434,25 @@ static int writeBuilderNode(ChunkStore *pStore, ProllyCache *pCache,
   }
   sqlite3_free(pData);
   return rc;
+}
+
+static int writeBuilderNode(ChunkStore *pStore, ProllyCache *pCache,
+                            ProllyNodeBuilder *pBuilder, ProllyHash *pHash){
+  u8 *pData = 0;
+  int nData = 0;
+  int rc = prollyNodeBuilderFinish(pBuilder, &pData, &nData);
+  if( rc!=SQLITE_OK ) return rc;
+  return writeOwnedNode(pStore, pCache, pData, nData, pHash);
+}
+
+static u8 *copyNodeData(const ProllyNode *pNode){
+  u8 *pData;
+  if( pNode->nDataPhys!=pNode->nData ) return 0;
+  sqlite3BeginBenignMalloc();
+  pData = sqlite3_malloc(pNode->nData);
+  sqlite3EndBenignMalloc();
+  if( pData ) memcpy(pData, pNode->pData, pNode->nData);
+  return pData;
 }
 
 static int finishAndWriteBuilderNode(ChunkStore *pStore, ProllyCache *pCache,
@@ -490,12 +506,48 @@ static int rewriteAncestorSpine(
     ProllyNode *pNode;
     ProllyNodeBuilder b;
     ProllyHash parentHash;
+    u8 *pData;
     int idx;
     int i;
 
     level--;
     pNode = &pCur->aLevel[level].pEntry->node;
     idx = pCur->aLevel[level].idx;
+    pData = copyNodeData(pNode);
+    if( pData && prollyNodeHasSubtreeCounts(pNode) ){
+      const u8 *pVal;
+      int nVal;
+      u64 cnt = prollyNodeChildSubtreeCount(pNode, idx);
+      u8 *pCount;
+      prollyNodeValue(pNode, idx, &pVal, &nVal);
+      if( nVal!=PROLLY_HASH_SIZE ){
+        sqlite3_free(pData);
+        return SQLITE_CORRUPT;
+      }
+      if( countDelta<0 && cnt==0 ){
+        sqlite3_free(pData);
+        return SQLITE_CORRUPT;
+      }
+      if( countDelta<0 ) cnt--;
+      if( countDelta>0 ) cnt++;
+      memcpy(pData + (pVal - pNode->pData), pChildHash->data,
+             PROLLY_HASH_SIZE);
+      pCount = pData + (pNode->pSubtreeCounts - pNode->pData) + idx*8;
+      pCount[0] = (u8)cnt;
+      pCount[1] = (u8)(cnt >> 8);
+      pCount[2] = (u8)(cnt >> 16);
+      pCount[3] = (u8)(cnt >> 24);
+      pCount[4] = (u8)(cnt >> 32);
+      pCount[5] = (u8)(cnt >> 40);
+      pCount[6] = (u8)(cnt >> 48);
+      pCount[7] = (u8)(cnt >> 56);
+      rc = writeOwnedNode(pMut->pStore, pMut->pCache, pData,
+                          pNode->nData, &parentHash);
+      if( rc!=SQLITE_OK ) return rc;
+      *pChildHash = parentHash;
+      continue;
+    }
+    sqlite3_free(pData);
     prollyNodeBuilderInit(&b, (u8)pNode->level, pMut->flags);
     for(i=0; i<(int)pNode->nItems; i++){
       u64 cnt = 0;
@@ -584,6 +636,7 @@ static int tryInsertOrReplaceSingleNoRechunk(ProllyMutator *pMut){
     ProllyNode *pLeaf = &cur.aLevel[level].pEntry->node;
     int idx = cur.aLevel[level].idx;
     const u8 *pOldVal;
+    u8 *pData;
     int nOldVal;
     ProllyNodeBuilder b;
     int sameSize;
@@ -591,29 +644,35 @@ static int tryInsertOrReplaceSingleNoRechunk(ProllyMutator *pMut){
 
     prollyNodeValue(pLeaf, idx, &pOldVal, &nOldVal);
     sameSize = (nOldVal==pEdit->nVal);
-
-    prollyNodeBuilderInit(&b, 0, pMut->flags);
-    for(i=0; i<(int)pLeaf->nItems; i++){
-      if( i==idx ){
-        rc = prollyNodeBuilderAdd(&b, pEdit->pKey, pEdit->nKey,
-                                  pEdit->pVal, pEdit->nVal);
-      }else{
-        rc = appendNodeEntryToBuilder(&b, pLeaf, i, 0);
-      }
-      if( rc!=SQLITE_OK ){
-        prollyNodeBuilderFree(&b);
-        prollyCursorClose(&cur);
-        return rc;
-      }
-    }
-    if( sameSize ){
-      rc = writeBuilderNode(pMut->pStore, pMut->pCache, &b, &childHash);
+    pData = sameSize ? copyNodeData(pLeaf) : 0;
+    if( pData ){
+      memcpy(pData + (pOldVal - pLeaf->pData), pEdit->pVal,
+             pEdit->nVal);
+      rc = writeOwnedNode(pMut->pStore, pMut->pCache, pData,
+                          pLeaf->nData, &childHash);
     }else{
-      rc = finishAndWriteBuilderNode(pMut->pStore, pMut->pCache, &b,
-                                     !cursorLeafIsRightmost(&cur),
-                                     &childHash);
+      prollyNodeBuilderInit(&b, 0, pMut->flags);
+      for(i=0; i<(int)pLeaf->nItems; i++){
+        if( i==idx ){
+          rc = prollyNodeBuilderAdd(&b, pEdit->pKey, pEdit->nKey,
+                                    pEdit->pVal, pEdit->nVal);
+        }else{
+          rc = appendNodeEntryToBuilder(&b, pLeaf, i, 0);
+        }
+        if( rc!=SQLITE_OK ) break;
+      }
+      if( rc==SQLITE_OK ){
+        if( sameSize ){
+          rc = writeBuilderNode(pMut->pStore, pMut->pCache, &b,
+                                &childHash);
+        }else{
+          rc = finishAndWriteBuilderNode(pMut->pStore, pMut->pCache, &b,
+                                         !cursorLeafIsRightmost(&cur),
+                                         &childHash);
+        }
+      }
+      prollyNodeBuilderFree(&b);
     }
-    prollyNodeBuilderFree(&b);
     if( rc!=SQLITE_OK ){
       prollyCursorClose(&cur);
       return rc;


### PR DESCRIPTION
## Summary

- narrow searches of large sorted chunk indexes using the leading hash byte, with a full binary-search fallback outside the estimated window
- copy and patch dense encoded prolly nodes for single-edit mutations instead of rebuilding every leaf and ancestor entry
- update ancestor child hashes and subtree counts directly for inserts, updates, and deletes
- retain the existing builder path for sparse nodes, allocation fallback, and edits that change node shape

## Performance

All measurements are paired before/after runs with alternating invocation order. Lower multipliers are faster.

The chunk-index search change was measured independently against master across the broad sysbench matrix. Its time-weighted aggregates were 0.983x in memory and 0.996x file-backed.

The node-rewrite change was then isolated using that chunk-index build as its baseline:

| 10k-row classic suite | Multiplier |
|---|---:|
| Wrapped in-memory reads | 1.00x |
| Wrapped in-memory writes | 1.00x |
| Wrapped file-backed reads | 1.00x |
| Wrapped file-backed writes | 1.00x |
| Autocommit reads | 0.99x |
| Autocommit writes | 0.95x |

Autocommit write matrices with TEXT, BLOB, and composite primary keys averaged 0.96x, 0.95x, and 0.96x respectively.

At 100k rows, seven paired in-memory runs produced:

| Workload | Multiplier |
|---|---:|
| Indexed update | 0.84x |
| Non-indexed update | 0.83x |
| Delete/insert | 0.89x |
| Mixed read/write | 0.90x |

## Validation

- `make doltlite`
- `make lint`
- all 26 gated C tests built and passed
- 1,699 mutation regression assertions passed with the existing divergence inventory unchanged
- `prolly_txn_stress_test`: 1,577 passed
- `corruption_test`: 126 passed
- multi-key integrity and reopen smoke test

Co-Authored-By: OpenAI Codex <noreply@openai.com>
