### PR TITLE
Reorient nightly performance summary

### DIFF
--- a/.github/workflows/nightly-performance.yml
+++ b/.github/workflows/nightly-performance.yml
@@ -246,6 +246,7 @@ jobs:
         SOURCE_RUN_ID: ${{ inputs.source_run_id }}
       run: |
         summary="$RUNNER_TEMP/performance-report.md"
+        report_result="$RUNNER_TEMP/performance-report.result"
         issue_body="$RUNNER_TEMP/nightly-performance-failure.md"
         generator_stderr="$RUNNER_TEMP/performance-report.stderr"
         suites="int textpk blobpk compositepk vc"
@@ -313,6 +314,7 @@ jobs:
           --generated-at "$generated_at" \
           --runner "${ImageOS:-ubuntu-latest} ${ImageVersion:-}" \
           --output "$summary" \
+          --result-output "$report_result" \
           2> "$generator_stderr"
         generator_rc=$?
         set -e
@@ -335,6 +337,14 @@ jobs:
             cat "$generator_stderr"
             echo '```'
           } > "$summary"
+        elif [ "$(cat "$report_result")" = "FAIL" ]; then
+          failed=1
+          {
+            echo "### Performance ceiling"
+            echo ""
+            echo "One or more performance ceilings were exceeded."
+            echo ""
+          } >> "$issue_body"
         fi
 
         cat "$summary" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/nightly-performance.yml
+++ b/.github/workflows/nightly-performance.yml
@@ -318,6 +318,10 @@ jobs:
           2> "$generator_stderr"
         generator_rc=$?
         set -e
+        report_result_value=""
+        if [ "$generator_rc" -eq 0 ] && [ -s "$report_result" ]; then
+          report_result_value=$(cat "$report_result") || report_result_value=""
+        fi
         if [ "$generator_rc" -ne 0 ]; then
           valid=0
           failed=1
@@ -337,7 +341,7 @@ jobs:
             cat "$generator_stderr"
             echo '```'
           } > "$summary"
-        elif [ "$(cat "$report_result")" = "FAIL" ]; then
+        elif [ "$report_result_value" = "FAIL" ]; then
           failed=1
           {
             echo "### Performance ceiling"
@@ -345,6 +349,20 @@ jobs:
             echo "One or more performance ceilings were exceeded."
             echo ""
           } >> "$issue_body"
+        elif [ "$report_result_value" != "PASS" ]; then
+          valid=0
+          failed=1
+          {
+            echo "### Report classification"
+            echo ""
+            echo "The machine-readable report result was missing or invalid."
+            echo ""
+          } >> "$issue_body"
+          {
+            echo "## Nightly DoltLite performance"
+            echo ""
+            echo "**FAILED:** missing or invalid report classification."
+          } > "$summary"
         fi
 
         cat "$summary" >> "$GITHUB_STEP_SUMMARY"

--- a/test/nightly_performance_report.py
+++ b/test/nightly_performance_report.py
@@ -10,6 +10,25 @@ from dataclasses import dataclass
 
 SYSBENCH_SUITES = ("int", "textpk", "blobpk", "compositepk")
 ALL_SUITES = SYSBENCH_SUITES + ("vc",)
+SQL_SUMMARY_GROUPS = (
+    ("In-memory", (("Reads", "mem_reads"), ("Writes", "mem_writes"))),
+    (
+        "File-backed",
+        (
+            ("Reads", "file_reads"),
+            ("Writes", "file_writes"),
+            ("Autocommit writes", "ac_writes"),
+        ),
+    ),
+)
+KEY_SHAPE_GROUPS = (
+    ("In-memory", "Reads", "mem_reads"),
+    ("In-memory", "Writes", "mem_writes"),
+    ("File-backed", "Reads", "file_reads"),
+    ("File-backed", "Writes", "file_writes"),
+    ("File-backed", "Autocommit reads", "ac_reads"),
+    ("File-backed", "Autocommit writes", "ac_writes"),
+)
 SAMPLE_HEADER = (
     "section",
     "test",
@@ -177,14 +196,24 @@ def workload_noise(suite, result):
     return median_relative_mad(ratios)
 
 
-def suite_noise(suite):
-    return statistics.median(
-        workload_noise(suite, result) for result in suite.results
-    )
-
-
-def sample_count_text(suite):
-    counts = sorted({len(values) for values in suite.samples.values()})
+def sample_count_text(suites, results=None):
+    if isinstance(suites, Suite):
+        suites = (suites,)
+    if results is None:
+        counts = sorted(
+            {
+                len(values)
+                for suite in suites
+                for values in suite.samples.values()
+            }
+        )
+    else:
+        counts = sorted(
+            {
+                len(suite.samples[(result.section, result.test)])
+                for suite, result in results
+            }
+        )
     if len(counts) == 1:
         return str(counts[0])
     return f"{counts[0]}–{counts[-1]}"
@@ -213,21 +242,106 @@ def escape_markdown(value):
 
 
 def individual_limit(result):
-    return 10.0 if result.section == "ac_writes" else 2.5
+    return 6.0 if result.section == "ac_writes" else 2.4
 
 
-def render_sysbench_summary(suite):
-    baseline = sum(result.baseline_us for result in suite.results)
-    candidate = sum(result.candidate_us for result in suite.results)
-    ratio = candidate / baseline
-    result = "PASS" if suite.status == 0 else "FAIL"
-    return (
-        f"| {suite.name} | {len(suite.results)} | "
-        f"{sample_count_text(suite)} | "
-        f"{format_duration(suite.duration_seconds)} | "
-        f"{format_time(baseline)} | {format_time(candidate)} | "
-        f"{ratio:.3f}× | {suite_noise(suite):.2f}% | **{result}** |"
+def average_limit(section):
+    return 5.0 if section == "ac_writes" else 1.95
+
+
+def section_results(suites, section):
+    return tuple(
+        (suite, result)
+        for suite in suites
+        for result in suite.results
+        if result.section == section
     )
+
+
+def section_passes(suites, section):
+    for suite in suites:
+        results = [
+            result for result in suite.results if result.section == section
+        ]
+        ratios = [
+            result.candidate_us / result.baseline_us for result in results
+        ]
+        if not ratios:
+            return False
+        if any(
+            ratio > individual_limit(result)
+            for ratio, result in zip(ratios, results)
+        ):
+            return False
+        average = float(f"{statistics.mean(ratios):.2f}")
+        if average > average_limit(section):
+            return False
+    return True
+
+
+def render_section_summary(suites, section, prefix):
+    results = section_results(suites, section)
+    if not results:
+        raise ValueError(f"missing results for section: {section}")
+    baseline = sum(result.baseline_us for _, result in results)
+    candidate = sum(result.candidate_us for _, result in results)
+    ratio = candidate / baseline
+    result = "PASS" if section_passes(suites, section) else "FAIL"
+    return (
+        f"| {prefix} | {len(results)} | "
+        f"{sample_count_text(suites, results)} | "
+        f"{format_time(baseline)} | {format_time(candidate)} | "
+        f"{ratio:.3f}× | "
+        f"{statistics.median(workload_noise(*item) for item in results):.2f}% "
+        f"| **{result}** |"
+    )
+
+
+def render_sql_summary(suites):
+    lines = []
+    for storage, operations in SQL_SUMMARY_GROUPS:
+        lines.extend(
+            [
+                f"### {storage}",
+                "",
+                "| Operation | Workloads | Samples/workload | "
+                "SQLite median total | DoltLite median total | Ratio | "
+                "Median paired-ratio MAD | Result |",
+                "|---|---:|---:|---:|---:|---:|---:|---|",
+            ]
+        )
+        for operation, section in operations:
+            lines.append(
+                render_section_summary(suites, section, operation)
+            )
+        lines.append("")
+    return lines
+
+
+def render_key_shape_breakdown(suites):
+    lines = [
+        "<details>",
+        "<summary>Key-shape and individual-workload breakdown</summary>",
+        "",
+        "The integer, text, blob, and composite primary-key runs verify "
+        "that performance holds across key shapes.",
+        "",
+        "| Storage | Operation | Key shape | Workloads | Samples/workload | "
+        "SQLite median total | DoltLite median total | Ratio | "
+        "Median paired-ratio MAD | Result |",
+        "|---|---|---|---:|---:|---:|---:|---:|---:|---|",
+    ]
+    for storage, operation, section in KEY_SHAPE_GROUPS:
+        for suite in suites:
+            prefix = f"{storage} | {operation} | {suite.name}"
+            lines.append(
+                render_section_summary((suite,), section, prefix)
+            )
+    lines.append("")
+    for suite in suites:
+        lines.extend(render_sysbench_details(suite))
+    lines.extend(["</details>", ""])
+    return lines
 
 
 def render_sysbench_details(suite):
@@ -302,24 +416,21 @@ def render_report(suites, commit, run_url, generated_at, runner):
         "",
         "## SQL workload summary",
         "",
-        "| Key shape | Workloads | Samples/workload | Wall time | "
-        "SQLite median total | DoltLite median total | Ratio | "
-        "Median paired-ratio MAD | Result |",
-        "|---|---:|---:|---:|---:|---:|---:|---:|---|",
+        "The primary view aggregates all key shapes and compares DoltLite "
+        "with SQLite by storage mode and operation class.",
+        "",
     ]
-    for name in SYSBENCH_SUITES:
-        lines.append(render_sysbench_summary(by_name[name]))
+    sysbench_suites = tuple(by_name[name] for name in SYSBENCH_SUITES)
+    lines.extend(render_sql_summary(sysbench_suites))
     lines.extend(
         [
-            "",
             "The absolute ceiling is 2.4× per ordinary workload and 1.95× "
             "for a section average. Durable autocommit writes use 6.0× "
             "and 5.0× ceilings respectively.",
             "",
         ]
     )
-    for name in SYSBENCH_SUITES:
-        lines.extend(render_sysbench_details(by_name[name]))
+    lines.extend(render_key_shape_breakdown(sysbench_suites))
     lines.extend(render_vc(by_name["vc"]))
     lines.extend(
         [

--- a/test/nightly_performance_report.py
+++ b/test/nightly_performance_report.py
@@ -29,6 +29,9 @@ KEY_SHAPE_GROUPS = (
     ("File-backed", "Autocommit reads", "ac_reads"),
     ("File-backed", "Autocommit writes", "ac_writes"),
 )
+SYSBENCH_SECTIONS = tuple(
+    section for _, _, section in KEY_SHAPE_GROUPS
+)
 SAMPLE_HEADER = (
     "section",
     "test",
@@ -279,6 +282,26 @@ def section_passes(suites, section):
     return True
 
 
+def report_passes(suites):
+    if any(suite.status != 0 for suite in suites):
+        return False
+    by_name = {suite.name: suite for suite in suites}
+    sysbench_suites = tuple(by_name[name] for name in SYSBENCH_SUITES)
+    if not all(
+        section_passes(sysbench_suites, section)
+        for section in SYSBENCH_SECTIONS
+    ):
+        return False
+    return vc_passes(by_name["vc"])
+
+
+def vc_passes(suite):
+    return suite.status == 0 and all(
+        result.candidate_us <= result.baseline_us
+        for result in suite.results
+    )
+
+
 def render_section_summary(suites, section, prefix):
     results = section_results(suites, section)
     if not results:
@@ -386,14 +409,13 @@ def render_vc(suite):
             f"{format_time(result.baseline_us)} | {used:.1%} | "
             f"{workload_noise(suite, result):.2f}% | {status} |"
         )
-    result = "PASS" if suite.status == 0 else "FAIL"
+    result = "PASS" if vc_passes(suite) else "FAIL"
     lines.extend(["", f"Version-control ceiling result: **{result}**.", ""])
     return lines
 
 
 def render_report(suites, commit, run_url, generated_at, runner):
-    overall_failed = any(suite.status != 0 for suite in suites)
-    overall = "FAIL" if overall_failed else "PASS"
+    overall = "PASS" if report_passes(suites) else "FAIL"
     by_name = {suite.name: suite for suite in suites}
     lines = [
         "# DoltLite Performance Report",
@@ -456,12 +478,27 @@ def parse_args(argv):
         "--runner", default="GitHub Actions ubuntu-latest"
     )
     parser.add_argument("--output", type=pathlib.Path, required=True)
+    parser.add_argument("--result-output", type=pathlib.Path)
     return parser.parse_args(argv)
+
+
+def remove_output(path):
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        pass
 
 
 def main(argv=None):
     args = parse_args(argv)
+    outputs = [args.output]
+    if args.result_output is not None:
+        outputs.append(args.result_output)
     try:
+        if len(set(outputs)) != len(outputs):
+            raise ValueError("output paths must be distinct")
+        for path in outputs:
+            remove_output(path)
         suites = [
             load_suite(args.results_dir, name) for name in ALL_SUITES
         ]
@@ -473,7 +510,15 @@ def main(argv=None):
             args.runner,
         )
         args.output.write_text(report, encoding="utf-8")
+        if args.result_output is not None:
+            result = "PASS" if report_passes(suites) else "FAIL"
+            args.result_output.write_text(f"{result}\n", encoding="utf-8")
     except (OSError, ValueError) as exc:
+        for path in outputs:
+            try:
+                remove_output(path)
+            except OSError:
+                pass
         print(f"error: {exc}", file=sys.stderr)
         return 1
     return 0

--- a/test/nightly_performance_report_test.py
+++ b/test/nightly_performance_report_test.py
@@ -102,6 +102,7 @@ class NightlyPerformanceReportTest(unittest.TestCase):
         )
         self.assertIn("Median paired-ratio MAD", report)
         summary = report.split("<details>", 1)[0]
+        self.assertNotIn("| Autocommit reads |", summary)
         self.assertNotIn("Key shape", summary)
         self.assertLess(
             summary.index("### In-memory"),
@@ -146,6 +147,73 @@ class NightlyPerformanceReportTest(unittest.TestCase):
                 "ubuntu24",
             )
         self.assertIn("Nightly result: **FAIL**", report)
+
+    def test_ceiling_failure_marks_report_and_machine_result_failed(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            directory = pathlib.Path(temporary)
+            self.write_all_suites(directory)
+            results_path = directory / "int.tsv"
+            results_path.write_text(
+                results_path.read_text(encoding="utf-8").replace(
+                    "ac_writes\tinsert_ac\t100\t500",
+                    "ac_writes\tinsert_ac\t100\t700",
+                ),
+                encoding="utf-8",
+            )
+            output = directory / "performance-report.md"
+            result_output = directory / "performance-report.result"
+            rc = nightly_report.main(
+                [
+                    "--results-dir",
+                    str(directory),
+                    "--commit",
+                    "abc123",
+                    "--run-url",
+                    "https://example.test/run",
+                    "--generated-at",
+                    "now",
+                    "--output",
+                    str(output),
+                    "--result-output",
+                    str(result_output),
+                ]
+            )
+            report = output.read_text(encoding="utf-8")
+            result = result_output.read_text(encoding="utf-8")
+        self.assertEqual(rc, 0)
+        self.assertIn("Nightly result: **FAIL**", report)
+        self.assertIn("| Autocommit writes | 4 | 3 |", report)
+        self.assertEqual(result, "FAIL\n")
+
+    def test_audit_only_section_still_gates_report(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            directory = pathlib.Path(temporary)
+            self.write_all_suites(directory)
+            results_path = directory / "int.tsv"
+            results_path.write_text(
+                results_path.read_text(encoding="utf-8").replace(
+                    "ac_reads\tpoint\t200\t210",
+                    "ac_reads\tpoint\t200\t600",
+                ),
+                encoding="utf-8",
+            )
+            suites = [
+                nightly_report.load_suite(directory, name)
+                for name in nightly_report.ALL_SUITES
+            ]
+            report = nightly_report.render_report(
+                suites,
+                "abc123",
+                "https://example.test/run",
+                "now",
+                "ubuntu24",
+            )
+        summary = report.split("<details>", 1)[0]
+        self.assertNotIn("| Autocommit reads |", summary)
+        self.assertIn("Nightly result: **FAIL**", report)
+        self.assertIn(
+            "| File-backed | Autocommit reads | int | 1 | 3 | ", report
+        )
 
     def test_rejects_result_without_matching_samples(self):
         with tempfile.TemporaryDirectory() as temporary:
@@ -197,6 +265,55 @@ class NightlyPerformanceReportTest(unittest.TestCase):
             report = output.read_text(encoding="utf-8")
         self.assertEqual(rc, 0)
         self.assertIn("# DoltLite Performance Report", report)
+
+    def test_main_removes_stale_outputs_on_generation_failure(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            directory = pathlib.Path(temporary)
+            self.write_all_suites(directory)
+            output = directory / "performance-report.md"
+            result_output = directory / "performance-report.result"
+            arguments = [
+                "--results-dir",
+                str(directory),
+                "--commit",
+                "abc123",
+                "--run-url",
+                "https://example.test/run",
+                "--generated-at",
+                "now",
+                "--output",
+                str(output),
+                "--result-output",
+                str(result_output),
+            ]
+            self.assertEqual(nightly_report.main(arguments), 0)
+            results_path = directory / "int.tsv"
+            results_path.write_text(
+                "\n".join(
+                    line
+                    for line in results_path.read_text(
+                        encoding="utf-8"
+                    ).splitlines()
+                    if not line.startswith("file_writes\t")
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            samples_path = directory / "int-samples.tsv"
+            samples_path.write_text(
+                "\n".join(
+                    line
+                    for line in samples_path.read_text(
+                        encoding="utf-8"
+                    ).splitlines()
+                    if not line.startswith("file_writes\t")
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            self.assertEqual(nightly_report.main(arguments), 1)
+            self.assertFalse(output.exists())
+            self.assertFalse(result_output.exists())
 
 
 if __name__ == "__main__":

--- a/test/nightly_performance_report_test.py
+++ b/test/nightly_performance_report_test.py
@@ -28,12 +28,28 @@ class NightlyPerformanceReportTest(unittest.TestCase):
         else:
             results = (
                 "mem_reads\tpoint\t100\t150\n"
+                "mem_writes\tinsert\t100\t175\n"
+                "file_reads\tpoint\t200\t100\n"
+                "file_writes\tinsert\t200\t250\n"
+                "ac_reads\tpoint\t200\t210\n"
                 "ac_writes\tinsert_ac\t100\t500\n"
             )
             samples = [
                 ("mem_reads", "point", 1, 100, 140),
                 ("mem_reads", "point", 2, 100, 150),
                 ("mem_reads", "point", 3, 100, 160),
+                ("mem_writes", "insert", 1, 100, 170),
+                ("mem_writes", "insert", 2, 100, 175),
+                ("mem_writes", "insert", 3, 100, 180),
+                ("file_reads", "point", 1, 200, 90),
+                ("file_reads", "point", 2, 200, 100),
+                ("file_reads", "point", 3, 200, 110),
+                ("file_writes", "insert", 1, 200, 240),
+                ("file_writes", "insert", 2, 200, 250),
+                ("file_writes", "insert", 3, 200, 260),
+                ("ac_reads", "point", 1, 200, 200),
+                ("ac_reads", "point", 2, 200, 210),
+                ("ac_reads", "point", 3, 200, 220),
                 ("ac_writes", "insert_ac", 1, 100, 480),
                 ("ac_writes", "insert_ac", 2, 100, 500),
                 ("ac_writes", "insert_ac", 3, 100, 520),
@@ -76,8 +92,34 @@ class NightlyPerformanceReportTest(unittest.TestCase):
                 "ubuntu24 20260720.1",
             )
         self.assertIn("Nightly result: **PASS**", report)
-        self.assertIn("| int | 2 | 3 | 1h 2m 3s |", report)
+        self.assertIn("aggregates all key shapes", report)
+        self.assertIn("### In-memory", report)
+        self.assertIn("| Reads | 4 | 3 | 400µs | 600µs | 1.500× |", report)
+        self.assertIn("### File-backed", report)
+        self.assertIn(
+            "| Autocommit writes | 4 | 3 | 400µs | 2.00ms | 5.000× |",
+            report,
+        )
         self.assertIn("Median paired-ratio MAD", report)
+        summary = report.split("<details>", 1)[0]
+        self.assertNotIn("Key shape", summary)
+        self.assertLess(
+            summary.index("### In-memory"),
+            summary.index("### File-backed"),
+        )
+        self.assertLess(
+            summary.index("| Reads |"),
+            summary.index("| Writes |"),
+        )
+        self.assertLess(
+            summary.index("| Writes |", summary.index("### File-backed")),
+            summary.index("| Autocommit writes |"),
+        )
+        self.assertIn(
+            "<summary>Key-shape and individual-workload breakdown</summary>",
+            report,
+        )
+        self.assertIn("| In-memory | Reads | int | 1 | 3 |", report)
         self.assertIn("Version-control latency", report)
         self.assertIn("50.0%", report)
         self.assertFalse(
@@ -104,7 +146,6 @@ class NightlyPerformanceReportTest(unittest.TestCase):
                 "ubuntu24",
             )
         self.assertIn("Nightly result: **FAIL**", report)
-        self.assertRegex(report, r"\| blobpk .* \*\*FAIL\*\* \|")
 
     def test_rejects_result_without_matching_samples(self):
         with tempfile.TemporaryDirectory() as temporary:


### PR DESCRIPTION
## Summary

- lead the SQL report with in-memory and file-backed comparisons against SQLite
- group headline results by reads, transactional writes, and autocommit writes across every key shape
- move key-shape aggregates and individual workloads into a collapsed audit view
- use one ceiling classification for section rows, the headline, and workflow regression status
- invalidate stale report artifacts when generation fails
- reject missing or malformed machine-readable results before publication

## Validation

- `python3 test/nightly_performance_report_test.py`
- `python3 test/publish_performance_report_test.py`
- `python3 -m py_compile test/nightly_performance_report.py test/nightly_performance_report_test.py`
- parsed `.github/workflows/nightly-performance.yml` with Ruby YAML
- ran `bash -n` on the extracted Compose nightly report shell
- generated and structurally validated a 400-line report from nightly run 31479299346

Co-Authored-By: OpenAI Codex <noreply@openai.com>