### PR TITLE
Reset and stage a table as one object with its indexes and rename mate

### DIFF
--- a/src/doltlite_add.c
+++ b/src/doltlite_add.c
@@ -737,6 +737,7 @@ int doltliteStageNamedTables(
       if( aWorking[j].iTable==iTable ){
         int k;
         int updated = 0;
+        int iRetired = -1;
         updateMaster = 1;
         for(k=0; k<nStaged; k++){
           int nameMatch = aStaged[k].zName && aWorking[j].zName
@@ -776,6 +777,7 @@ int doltliteStageNamedTables(
             ** where they no longer exist. */
             if( nameChanged && aStaged[k].zName ){
               ADDNAMED_TOUCH(aStaged[k].zName);
+              iRetired = nTouched-1;
             }
             zDup = aWorking[j].zName
                            ? sqlite3_mprintf("%s", aWorking[j].zName) : 0;
@@ -799,9 +801,16 @@ int doltliteStageNamedTables(
           }
         }
         /* An index travels with its table: replace whatever index entries
-        ** the staged catalog carried for this table with the working ones. */
+        ** the staged catalog carried for this table with the working ones.
+        ** A staged rename's index entries resolve through the OLD name in
+        ** the staged schema rows, so the retired name's entries go too. */
         addRemoveIndexEntriesOfTable(aStaged, &nStaged,
                                      aStagedSchema, nStagedSchema, zTable);
+        if( iRetired>=0 ){
+          addRemoveIndexEntriesOfTable(aStaged, &nStaged,
+                                       aStagedSchema, nStagedSchema,
+                                       azTouched[iRetired]);
+        }
         rc = addAppendIndexEntriesOfTable(context, &aStaged, &nStaged,
                                           aWorking, nWorking,
                                           aWorkSchema, nWorkSchema, zTable);

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -984,6 +984,14 @@ int doltliteStageNamedTables(
   sqlite3 *db, sqlite3_context *context, ChunkStore *cs,
   const ProllyHash *pWorkingHash, int argc, sqlite3_value **argv
 );
+int doltliteCatalogRenameMate(
+  sqlite3 *db,
+  struct TableEntry *aFrom, int nFrom,
+  struct TableEntry *aTo, int nTo,
+  const struct TableEntry *pKnown,
+  int bKnownIsFrom,
+  struct TableEntry **ppMate
+);
 
 int mergeAbortInPlace(sqlite3 *db);
 int mergeFastForward(

--- a/src/doltlite_reset.c
+++ b/src/doltlite_reset.c
@@ -69,7 +69,8 @@ static int resetStageNamedPaths(
 ){
   struct TableEntry *aHead = 0, *aStaged = 0;
   SchemaEntry *aHeadSchema = 0;
-  int nHead = 0, nStaged = 0, nHeadSchema = 0;
+  SchemaEntry *aStagedSchema = 0;
+  int nHead = 0, nStaged = 0, nHeadSchema = 0, nStagedSchema = 0;
   ProllyHash headCatHash, stagedHash;
   Pgno iNextFree = 2;
   int p, k;
@@ -92,6 +93,11 @@ static int resetStageNamedPaths(
   if( !prollyHashIsEmpty(&stagedHash) ){
     rc = doltliteLoadCatalog(db, &stagedHash, &aStaged, &nStaged, 0);
     if( rc!=SQLITE_OK ) goto done;
+    /* Staged index entries are unnamed and resolve to their parent table
+    ** only through the staged catalog's own schema rows. */
+    rc = loadSchemaFromCatalog(db, cs, doltliteGetCache(db), &stagedHash,
+                               &aStagedSchema, &nStagedSchema);
+    if( rc!=SQLITE_OK ) goto done;
   }
 
   for(k=0; k<nStaged; k++){
@@ -108,6 +114,19 @@ static int resetStageNamedPaths(
       goto done;
     }
     if( iH<0 ){
+      /* A staged-only name is a staged new table, or the new name of a
+      ** staged rename. Dolt keeps a staged rename fully staged when its
+      ** new name is reset; a staged new table leaves as one object, its
+      ** unnamed index entries with it, or the commit carries indexes over
+      ** a table that no longer exists. */
+      struct TableEntry *pMate = 0;
+      rc = doltliteCatalogRenameMate(db, aHead, nHead, aStaged, nStaged,
+                                     &aStaged[iS], 0, &pMate);
+      if( rc!=SQLITE_OK ) goto done;
+      if( pMate ) continue;
+      addRemoveIndexEntriesOfTable(aStaged, &nStaged,
+                                   aStagedSchema, nStagedSchema, zTable);
+      iS = resetFindTableIndex(aStaged, nStaged, zTable);
       sqlite3_free(aStaged[iS].zName);
       if( iS+1<nStaged ){
         memmove(&aStaged[iS], &aStaged[iS+1],
@@ -115,6 +134,33 @@ static int resetStageNamedPaths(
       }
       nStaged--;
     }else if( iS<0 ){
+      /* A HEAD-only name is a staged drop, or the old name of a staged
+      ** rename. A rename resets as one object: retire the staged new-name
+      ** entry and its indexes here, then restore HEAD's state below. */
+      struct TableEntry *pMate = 0;
+      rc = doltliteCatalogRenameMate(db, aHead, nHead, aStaged, nStaged,
+                                     &aHead[iH], 1, &pMate);
+      if( rc!=SQLITE_OK ) goto done;
+      if( pMate ){
+        char *zMateName = sqlite3_mprintf("%s", pMate->zName);
+        int iM;
+        if( !zMateName ){
+          rc = SQLITE_NOMEM;
+          goto done;
+        }
+        addRemoveIndexEntriesOfTable(aStaged, &nStaged,
+                                     aStagedSchema, nStagedSchema, zMateName);
+        iM = resetFindTableIndex(aStaged, nStaged, zMateName);
+        sqlite3_free(zMateName);
+        if( iM>=0 ){
+          sqlite3_free(aStaged[iM].zName);
+          if( iM+1<nStaged ){
+            memmove(&aStaged[iM], &aStaged[iM+1],
+                    (nStaged-iM-1)*(int)sizeof(struct TableEntry));
+          }
+          nStaged--;
+        }
+      }
       /* Restoring a staged-dropped table: the HEAD entry is numbered in
       ** HEAD's domain and its schema row is absent from the staged master
       ** (and from the live schema -- the table is dropped there), so it
@@ -127,7 +173,7 @@ static int resetStageNamedPaths(
       }
       aStaged = aNew;
       addRemoveIndexEntriesOfTable(aStaged, &nStaged,
-                                   aHeadSchema, nHeadSchema, zTable);
+                                   aStagedSchema, nStagedSchema, zTable);
       zDup = aHead[iH].zName ? sqlite3_mprintf("%s", aHead[iH].zName) : 0;
       if( aHead[iH].zName && !zDup ){
         rc = SQLITE_NOMEM;
@@ -144,7 +190,9 @@ static int resetStageNamedPaths(
       if( rc!=SQLITE_OK ) goto done;
     }else{
       /* Take HEAD's content under the STAGED entry's number so the entry
-      ** keeps pairing with the staged catalog's schema row. */
+      ** keeps pairing with the staged catalog's schema row. The table's
+      ** index set resets with it: replace whatever index entries staging
+      ** carried for this table with HEAD's. */
       Pgno iKeep = aStaged[iS].iTable;
       zDup = aHead[iH].zName ? sqlite3_mprintf("%s", aHead[iH].zName) : 0;
       if( aHead[iH].zName && !zDup ){
@@ -155,6 +203,13 @@ static int resetStageNamedPaths(
       aStaged[iS] = aHead[iH];
       aStaged[iS].zName = zDup;
       aStaged[iS].iTable = iKeep;
+      addRemoveIndexEntriesOfTable(aStaged, &nStaged,
+                                   aStagedSchema, nStagedSchema, zTable);
+      rc = addAppendIndexEntriesOfTable(0, &aStaged, &nStaged,
+                                        aHead, nHead,
+                                        aHeadSchema, nHeadSchema,
+                                        zTable);
+      if( rc!=SQLITE_OK ) goto done;
     }
   }
 
@@ -179,6 +234,10 @@ done:
   if( aHeadSchema ){
     for(k=0; k<nHeadSchema; k++) clearSchemaEntry(&aHeadSchema[k]);
     sqlite3_free(aHeadSchema);
+  }
+  if( aStagedSchema ){
+    for(k=0; k<nStagedSchema; k++) clearSchemaEntry(&aStagedSchema[k]);
+    sqlite3_free(aStagedSchema);
   }
   return rc;
 }

--- a/src/doltlite_reset.c
+++ b/src/doltlite_reset.c
@@ -138,6 +138,7 @@ static int resetStageNamedPaths(
       ** rename. A rename resets as one object: retire the staged new-name
       ** entry and its indexes here, then restore HEAD's state below. */
       struct TableEntry *pMate = 0;
+      struct TableEntry *aNew;
       rc = doltliteCatalogRenameMate(db, aHead, nHead, aStaged, nStaged,
                                      &aHead[iH], 1, &pMate);
       if( rc!=SQLITE_OK ) goto done;
@@ -165,7 +166,7 @@ static int resetStageNamedPaths(
       ** HEAD's domain and its schema row is absent from the staged master
       ** (and from the live schema -- the table is dropped there), so it
       ** gets a fresh number and its row comes from the HEAD fallback. */
-      struct TableEntry *aNew = sqlite3_realloc(aStaged,
+      aNew = sqlite3_realloc(aStaged,
           (nStaged+1)*(int)sizeof(struct TableEntry));
       if( !aNew ){
         rc = SQLITE_NOMEM;

--- a/src/doltlite_status.c
+++ b/src/doltlite_status.c
@@ -349,11 +349,47 @@ static int statusMaybeAddParentSchemaChange(
   return addRow(pCur, zParent, staged, "modified");
 }
 
+/* True when zTblA's indexes in aA and zTblB's in aB carry the same name
+** set. A renamed table's index rows re-key their tbl_name and SQL text to
+** the new table, so the exact-SQL comparator reads a pure rename as two
+** changes; across a rename pair the index names are the identity. */
+static int statusIndexNameSetsMatch(
+  SchemaEntry *aA, int nA, const char *zTblA,
+  SchemaEntry *aB, int nB, const char *zTblB
+){
+  int i, j, nACount = 0, nBCount = 0;
+  for(i=0; i<nA; i++){
+    if( !aA[i].zType || strcmp(aA[i].zType, "index")!=0
+     || !aA[i].zTblName || strcmp(aA[i].zTblName, zTblA)!=0 ){
+      continue;
+    }
+    nACount++;
+    for(j=0; j<nB; j++){
+      if( aB[j].zType && strcmp(aB[j].zType, "index")==0
+       && aB[j].zTblName && strcmp(aB[j].zTblName, zTblB)==0
+       && aB[j].zName && aA[i].zName
+       && strcmp(aB[j].zName, aA[i].zName)==0 ){
+        break;
+      }
+    }
+    if( j==nB ) return 0;
+  }
+  for(j=0; j<nB; j++){
+    if( aB[j].zType && strcmp(aB[j].zType, "index")==0
+     && aB[j].zTblName && strcmp(aB[j].zTblName, zTblB)==0 ){
+      nBCount++;
+    }
+  }
+  return nACount==nBCount;
+}
+
 static int statusCompareIndexSchemaObjects(
   DoltliteStatusCursor *pCur,
   sqlite3 *db,
   const ProllyHash *pFromCat,
   const ProllyHash *pToCat,
+  struct TableEntry *aFromEnt, int nFromEnt,
+  struct TableEntry *aToEnt, int nToEnt,
   int staged,
   const char *zFilter
 ){
@@ -373,10 +409,15 @@ static int statusCompareIndexSchemaObjects(
   if( rc!=SQLITE_OK ) goto index_schema_done;
 
   /* One comparison per distinct parent table across both row sets; the
-  ** shared comparator decides whether that table's index set changed. */
+  ** shared comparator decides whether that table's index set changed. A
+  ** parent participating in a rename pair compares across the pair, and
+  ** any real change attributes to the new name. */
   for(i=0; i<nFrom+nTo; i++){
     SchemaEntry *pRow = i<nFrom ? &aFrom[i] : &aTo[i-nFrom];
     int seen = 0;
+    struct TableEntry *pFromEnt;
+    struct TableEntry *pToEnt;
+    struct TableEntry *pMate = 0;
     if( !pRow->zType || strcmp(pRow->zType, "index")!=0
      || !pRow->zTblName ){
       continue;
@@ -391,6 +432,35 @@ static int statusCompareIndexSchemaObjects(
       }
     }
     if( seen ) continue;
+    pFromEnt = doltliteFindTableByName(aFromEnt, nFromEnt, pRow->zTblName);
+    pToEnt = doltliteFindTableByName(aToEnt, nToEnt, pRow->zTblName);
+    if( pFromEnt && !pToEnt ){
+      rc = doltliteCatalogRenameMate(db, aFromEnt, nFromEnt, aToEnt, nToEnt,
+                                     pFromEnt, 1, &pMate);
+      if( rc!=SQLITE_OK ) goto index_schema_done;
+      if( pMate ){
+        if( !statusIndexNameSetsMatch(aFrom, nFrom, pRow->zTblName,
+                                      aTo, nTo, pMate->zName) ){
+          rc = statusMaybeAddParentSchemaChange(pCur, pMate->zName,
+                                                staged, zFilter);
+          if( rc!=SQLITE_OK ) goto index_schema_done;
+        }
+        continue;
+      }
+    }else if( pToEnt && !pFromEnt ){
+      rc = doltliteCatalogRenameMate(db, aFromEnt, nFromEnt, aToEnt, nToEnt,
+                                     pToEnt, 0, &pMate);
+      if( rc!=SQLITE_OK ) goto index_schema_done;
+      if( pMate ){
+        if( !statusIndexNameSetsMatch(aFrom, nFrom, pMate->zName,
+                                      aTo, nTo, pRow->zTblName) ){
+          rc = statusMaybeAddParentSchemaChange(pCur, pRow->zTblName,
+                                                staged, zFilter);
+          if( rc!=SQLITE_OK ) goto index_schema_done;
+        }
+        continue;
+      }
+    }
     if( doltliteIndexSchemaRowsDifferForTable(aFrom, nFrom, aTo, nTo,
                                               pRow->zTblName) ){
       rc = statusMaybeAddParentSchemaChange(pCur, pRow->zTblName,
@@ -552,6 +622,44 @@ rename_done:
   return bMatch;
 }
 
+/* Find the rename mate of pKnown across the from/to catalogs, using the
+** same pairing dolt_status renders, so every staging surface agrees on
+** which two entries are one renamed object. bKnownIsFrom says which side
+** pKnown sits on; the mate is looked up on the other side. */
+int doltliteCatalogRenameMate(
+  sqlite3 *db,
+  struct TableEntry *aFrom, int nFrom,
+  struct TableEntry *aTo, int nTo,
+  const struct TableEntry *pKnown,
+  int bKnownIsFrom,
+  struct TableEntry **ppMate
+){
+  StatusCatalogIndex fromIdx, toIdx;
+  struct TableEntry *pMate;
+  int rc;
+
+  *ppMate = 0;
+  if( !pKnown->zName || pKnown->iTable<=1 ) return SQLITE_OK;
+  rc = statusCatalogIndexInit(&fromIdx, aFrom, nFrom);
+  if( rc!=SQLITE_OK ) return rc;
+  rc = statusCatalogIndexInit(&toIdx, aTo, nTo);
+  if( rc!=SQLITE_OK ){
+    statusCatalogIndexFree(&fromIdx);
+    return rc;
+  }
+  pMate = statusCatalogFindNumber(bKnownIsFrom ? &toIdx : &fromIdx,
+                                  pKnown->iTable);
+  if( pMate ){
+    const struct TableEntry *pA = bKnownIsFrom ? pKnown : pMate;
+    const struct TableEntry *pB = bKnownIsFrom ? pMate : pKnown;
+    if( !isRenamePair(db, &fromIdx, &toIdx, pA, pB) ) pMate = 0;
+  }
+  statusCatalogIndexFree(&fromIdx);
+  statusCatalogIndexFree(&toIdx);
+  *ppMate = pMate;
+  return SQLITE_OK;
+}
+
 static int compareCatalogs(
   DoltliteStatusCursor *pCur, sqlite3 *db,
   const ProllyHash *pFromCat, const ProllyHash *pToCat,
@@ -664,6 +772,7 @@ static int compareCatalogs(
     }
   }
   rc = statusCompareIndexSchemaObjects(pCur, db, pFromCat, pToCat,
+                                       aFrom, nFrom, aTo, nTo,
                                        staged, 0);
 
 compare_done:
@@ -873,6 +982,7 @@ check_deleted:
     }
   }
   rc = statusCompareIndexSchemaObjects(pCur, db, pFromCat, pToCat,
+                                       aFrom, nFrom, aTo, nTo,
                                        staged, zFilter);
 
 filtered_done:

--- a/src/prolly_btree_catalog.c
+++ b/src/prolly_btree_catalog.c
@@ -792,6 +792,26 @@ static int appendMissingSchemaCatalogRows(
     if( strcmp(aMeta[i].zType, "table")!=0 && strcmp(aMeta[i].zType, "index")!=0 ){
       continue;
     }
+    /* Live numbers can coincide with entries restored from another domain
+    ** (a reset rename). Adopting a live index row whose parent table is
+    ** not part of this catalog would retarget the index at a table the
+    ** catalog does not contain; its correct row comes from the fallback. */
+    if( strcmp(aMeta[i].zType, "index")==0 ){
+      int parentHere = 0;
+      for(j=0; j<nRows && !parentHere; j++){
+        if( aRows[j].zType && strcmp(aRows[j].zType, "table")==0
+         && aRows[j].zName && strcmp(aRows[j].zName, aMeta[i].zTblName)==0 ){
+          parentHere = 1;
+        }
+      }
+      for(j=0; j<nTables && !parentHere; j++){
+        if( aTables[j].zName
+         && strcmp(aTables[j].zName, aMeta[i].zTblName)==0 ){
+          parentHere = 1;
+        }
+      }
+      if( !parentHere ) continue;
+    }
     for(j=0; j<nTables; j++){
       if( aTables[j].iTable==aMeta[i].iTable ){
         wanted = 1;
@@ -1153,6 +1173,52 @@ static int doltliteSerializeCatalogEntriesForBtreeImpl(
     return rc;
   }
   filterSchemaCatalogRows(aRows, &nRows, aTables, nTables);
+  /* A retired object can leave an index row behind at a number a restored
+  ** entry now occupies: the entry filter pairs one row to one entry and
+  ** cannot see that the row's parent table is gone from the set, and a
+  ** serialized catalog whose index has no table does not load. Purge by
+  ** parent before the supplementation passes, so the freed number can
+  ** receive the correct row from live or fallback schema. A parent whose
+  ** row arrives in those passes has a named entry here, so requiring a
+  ** parent row OR a parent entry keeps every live pairing. Constructed
+  ** arrays only: the live catalog never composes rows across domains. */
+  if( aTables!=pBtree->cat.a ){
+    int nOut = 0;
+    for(i=0; i<nRows; i++){
+      int keep = 1;
+      if( aRows[i].zType && strcmp(aRows[i].zType, "index")==0
+       && aRows[i].zTblName ){
+        keep = 0;
+        for(j=0; j<nRows && !keep; j++){
+          if( aRows[j].zType && strcmp(aRows[j].zType, "table")==0
+           && aRows[j].zName
+           && strcmp(aRows[j].zName, aRows[i].zTblName)==0 ){
+            keep = 1;
+          }
+        }
+        for(j=0; j<nTables && !keep; j++){
+          if( aTables[j].zName
+           && strcmp(aTables[j].zName, aRows[i].zTblName)==0 ){
+            keep = 1;
+          }
+        }
+      }
+      if( keep ){
+        if( nOut!=i ){
+          aRows[nOut] = aRows[i];
+          memset(&aRows[i], 0, sizeof(aRows[i]));
+        }
+        nOut++;
+      }else{
+        sqlite3_free(aRows[i].zType);
+        sqlite3_free(aRows[i].zName);
+        sqlite3_free(aRows[i].zTblName);
+        sqlite3_free(aRows[i].zSql);
+        memset(&aRows[i], 0, sizeof(aRows[i]));
+      }
+    }
+    nRows = nOut;
+  }
   /* Live-schema supplementation keys rows by the CONNECTION's table
   ** numbers. Arrays numbered in a foreign domain (a reset target catalog)
   ** must not use it -- a live number there can belong to a different table

--- a/test/vc_oracle_reset_test.sh
+++ b/test/vc_oracle_reset_test.sh
@@ -899,6 +899,74 @@ SELECT dolt_commit('-m', 'c2');
 SELECT dolt_reset('HEAD~1');
 "
 
+echo "--- reset path: staged objects reset whole (indexes, renames) ---"
+
+oracle "reset_path_staged_new_indexed_table_unstages_cleanly" "
+$SEED
+CREATE TABLE t2(a INTEGER PRIMARY KEY, b INT);
+CREATE INDEX t2i ON t2(b);
+INSERT INTO t2 VALUES (1, 2);
+SELECT dolt_add('t2');
+SELECT dolt_reset('t2');
+"
+
+oracle_error "reset_path_staged_new_indexed_table_commit_errors" "
+$SEED
+CREATE TABLE t2(a INTEGER PRIMARY KEY, b INT);
+CREATE INDEX t2i ON t2(b);
+INSERT INTO t2 VALUES (1, 2);
+SELECT dolt_add('t2');
+SELECT dolt_reset('t2');
+SELECT dolt_commit('-m', 'nothing is staged');
+"
+
+RENAME_SEED="
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+CREATE INDEX tvi ON t(v);
+INSERT INTO t VALUES (1, 10);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+ALTER TABLE t RENAME TO t2;
+SELECT dolt_add('t2');
+"
+
+oracle "reset_path_staged_rename_new_name_noop" "
+$RENAME_SEED
+SELECT dolt_reset('t2');
+"
+
+oracle "reset_path_staged_rename_new_name_then_commit_clean" "
+$RENAME_SEED
+SELECT dolt_reset('t2');
+SELECT dolt_commit('-m', 'commit the still-staged rename');
+"
+
+oracle "reset_path_staged_rename_old_name_unstages_whole" "
+$RENAME_SEED
+SELECT dolt_reset('t');
+"
+
+oracle_error "reset_path_staged_rename_old_name_commit_errors" "
+$RENAME_SEED
+SELECT dolt_reset('t');
+SELECT dolt_commit('-m', 'nothing is staged');
+"
+
+oracle "reset_path_staged_index_only_change_unstages" "
+$SEED
+CREATE INDEX ti ON t(v);
+SELECT dolt_add('t');
+SELECT dolt_reset('t');
+"
+
+oracle_error "reset_path_staged_index_only_change_commit_errors" "
+$SEED
+CREATE INDEX ti ON t(v);
+SELECT dolt_add('t');
+SELECT dolt_reset('t');
+SELECT dolt_commit('-m', 'nothing is staged');
+"
+
 echo ""
 echo "=== Results: $pass passed, $fail failed ==="
 if [ $fail -gt 0 ]; then


### PR DESCRIPTION
Fixes the reset arm of the staging object-identity cluster (deep-review action item 1). dolt_reset of a path treated the named table entry as the whole object; its unnamed index entries and its rename's other half stayed staged. Confirmed consequences, each now an oracle case:

- Reset of a staged new table with an index left a dangling index entry; the next commit succeeded and checkout of it failed with `malformed database schema`, bricking the branch.
- Reset of the new name of a staged rename left a half-state the next commit turned into a bare DROP (table gone from history). Dolt treats this reset as a no-op.
- Reset of the old name left the opposite half-state, committing the table twice. Dolt unstages the whole rename atomically.
- Reset of a staged index-only change was a silent no-op; the "reset" index still committed.

**Mechanics**

- `resetStageNamedPaths` resolves the argument through the same rename pairing `dolt_status` renders (`isRenamePair`, exported as `doltliteCatalogRenameMate`), and every path carries the table's unnamed index entries with it, resolved through the staged catalog's own schema rows (the previous restore path resolved them through HEAD's rows — the wrong numbering domain).
- `dolt_add` of a renamed table retires the old name's index entries too; before, they survived as duplicates keyed to a dead name and produced phantom staged rows.
- The catalog serializer closes the remaining cross-domain hole for constructed arrays: index rows whose parent table is absent from both the row set and the entry set purge before the supplementation passes, and live supplementation refuses to adopt an index row whose parent is not part of the catalog (a live number coinciding with a HEAD-restored entry used to retarget the index at a table the catalog doesn't contain).
- `statusCompareIndexSchemaObjects` compares a renamed table's index set across the rename pair by index name instead of exact SQL, so a pure rename no longer reports phantom `modified` rows for both names.

**Validation**

- 8 new `vc_oracle_reset_test.sh` cases: all fail before, pass after, against Dolt 2.2.2; full reset suite 51/51.
- add / status / status_schema_objects / commit / checkout / merge_status oracle suites green; add / status / checkout / commit / reset also green under a `DOLTLITE_PROLLY_CHECK=1` build (the new purge does not trip the write-time catalog invariants).
- Full shell battery: 101/101 suites.

Known limitation (pre-existing, consistent with status): the rename pairing keeps the same-table-number gate, so an order-shifting rename (rename that changes canonical sort position among multiple tables) is still not paired — that is the add/commit-side numbering-domain cluster, next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)