### PR TITLE
Give a table precedence over a same-named ref in dolt_reset

### DIFF
--- a/src/doltlite_reset.c
+++ b/src/doltlite_reset.c
@@ -31,6 +31,36 @@ static int resetFindTableIndex(struct TableEntry *aTables, int nTables,
   return -1;
 }
 
+/* True when zName names a table in the live schema, the staged catalog,
+** or HEAD — the domains a path argument can act on. Used to give a table
+** precedence over a same-named ref, as Dolt does: a bare dolt_reset('x')
+** must never rewind HEAD when x is a table the caller meant to unstage. */
+static int resetNameIsTablePath(sqlite3 *db, const char *zName){
+  struct TableEntry *aCat = 0;
+  ProllyHash hash;
+  Pgno iLive = 0;
+  int nCat = 0;
+  int found = 0;
+
+  if( doltliteResolveTableName(db, zName, &iLive)==SQLITE_OK ) return 1;
+  doltliteGetSessionStaged(db, &hash);
+  if( !prollyHashIsEmpty(&hash)
+   && doltliteLoadCatalog(db, &hash, &aCat, &nCat, 0)==SQLITE_OK ){
+    found = resetFindTableIndex(aCat, nCat, zName)>=0;
+    doltliteFreeCatalog(aCat, nCat);
+    if( found ) return 1;
+    aCat = 0;
+    nCat = 0;
+  }
+  if( doltliteGetHeadCatalogHash(db, &hash)==SQLITE_OK
+   && !prollyHashIsEmpty(&hash)
+   && doltliteLoadCatalog(db, &hash, &aCat, &nCat, 0)==SQLITE_OK ){
+    found = resetFindTableIndex(aCat, nCat, zName)>=0;
+    doltliteFreeCatalog(aCat, nCat);
+  }
+  return found;
+}
+
 static int resetStageNamedPaths(
   sqlite3 *db,
   ChunkStore *cs,
@@ -398,7 +428,8 @@ static void doltliteResetFunc(
         zRef = arg;
       }else{
         ProllyHash probe;
-        if( doltliteResolveRef(db, arg, &probe)==SQLITE_OK ){
+        if( !resetNameIsTablePath(db, arg)
+         && doltliteResolveRef(db, arg, &probe)==SQLITE_OK ){
           zRef = arg;
         }else{
           azPaths[nPaths++] = arg;

--- a/test/vc_oracle_reset_test.sh
+++ b/test/vc_oracle_reset_test.sh
@@ -861,6 +861,44 @@ oracle_same_session "reset_hard_preserves_untracked_contents" "$UNTRACKED_SEED" 
 SELECT concat('Q|s|', id, '|', v) FROM s;
 SELECT concat('Q|u|', x, '|', w) FROM u;"
 
+echo "--- table takes precedence over a same-named ref ---"
+
+oracle "reset_path_prefers_table_over_same_named_branch" "
+CREATE TABLE x(a INT PRIMARY KEY);
+INSERT INTO x VALUES (1);
+SELECT dolt_add('x');
+SELECT dolt_commit('-m', 'c1');
+SELECT dolt_branch('x');
+INSERT INTO x VALUES (2);
+SELECT dolt_add('x');
+SELECT dolt_commit('-m', 'c2');
+INSERT INTO x VALUES (3);
+SELECT dolt_add('x');
+SELECT dolt_reset('x');
+"
+
+oracle "reset_path_prefers_staged_drop_over_same_named_branch" "
+CREATE TABLE x(a INT PRIMARY KEY);
+INSERT INTO x VALUES (1);
+SELECT dolt_add('x');
+SELECT dolt_commit('-m', 'c1');
+SELECT dolt_branch('x');
+CREATE TABLE y(b INT PRIMARY KEY);
+SELECT dolt_add('y');
+SELECT dolt_commit('-m', 'c2');
+DROP TABLE x;
+SELECT dolt_add('x');
+SELECT dolt_reset('x');
+"
+
+oracle "reset_bare_ref_still_moves_head" "
+$SEED
+INSERT INTO t VALUES (2, 20);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c2');
+SELECT dolt_reset('HEAD~1');
+"
+
 echo ""
 echo "=== Results: $pass passed, $fail failed ==="
 if [ $fail -gt 0 ]; then


### PR DESCRIPTION
Deep-review action item 1, staging cluster: `dolt_reset('x')` resolved `x` as a ref before trying it as a table, so a branch/table name collision turned "unstage my table" into a silent mixed reset to the branch tip — HEAD rewound, commits orphaned, no error. Dolt prefers the table.

The ref probe now runs only when the argument names no table in the live schema, the staged catalog, or HEAD (the three domains a path argument acts on — the staged-catalog probe covers resetting a staged drop whose table no longer exists live).

Oracle coverage (Dolt 2.2.2): two collision cases — staged modification and staged drop, both showing the orphaned-commit log divergence before the fix — plus a guard that bare-ref reset still moves HEAD when nothing collides. Reset oracle suite 46/46; battery reset + staging suites green.

Independent of #2124 (touches only the argument parsing; no shared hunks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)