### PR TITLE
Stage only the named tables when checking a table out of a ref

### DIFF
--- a/src/doltlite_add.c
+++ b/src/doltlite_add.c
@@ -553,7 +553,7 @@ static void addRemoveShadowEntriesOfDroppedVtab(
   }
 }
 
-static int addStageNamedTables(
+int doltliteStageNamedTables(
   sqlite3 *db,
   sqlite3_context *context,
   ChunkStore *cs,
@@ -901,7 +901,7 @@ static int doltliteStageArgsAndPersist(
   if( stageAll ){
     rc = addStageAllTables(db, context, cs, &workingHash);
   }else{
-    rc = addStageNamedTables(db, context, cs, &workingHash, argc, argv);
+    rc = doltliteStageNamedTables(db, context, cs, &workingHash, argc, argv);
   }
   if( rc!=SQLITE_OK ) return rc;
 

--- a/src/doltlite_checkout.c
+++ b/src/doltlite_checkout.c
@@ -791,6 +791,7 @@ static int checkoutAdoptVtabShadows(
 
 static int doltliteCheckoutTables(
   sqlite3 *db,
+  sqlite3_context *context,
   const char *zSourceRef,
   sqlite3_value **argv,
   int iFirstName,
@@ -1092,8 +1093,12 @@ static int doltliteCheckoutTables(
     if( rc==SQLITE_OK ){
       rc = doltliteSwitchCatalog(db, &newWorkingHash);
     }
+    /* Checking a table out of a ref stages that table from the ref, and
+    ** only that table: adopting the whole working catalog as staged would
+    ** sweep every other table's working changes into the next commit. */
     if( rc==SQLITE_OK && zSourceRef ){
-      rc = doltliteSetSessionStaged(db, &newWorkingHash);
+      rc = doltliteStageNamedTables(db, context, cs, &newWorkingHash,
+                                    nNames, argv+iFirstName);
     }
     if( rc==SQLITE_OK ){
       rc = doltlitePersistWorkingSet(db);
@@ -1182,9 +1187,9 @@ void doltCheckoutFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
     ProllyHash sourceRef;
     rc = doltliteResolveRef(db, zBranch, &sourceRef);
     if( rc==SQLITE_OK ){
-      rc = doltliteCheckoutTables(db, zBranch, argv, 1, argc-1);
+      rc = doltliteCheckoutTables(db, ctx, zBranch, argv, 1, argc-1);
     }else{
-      rc = doltliteCheckoutTables(db, 0, argv, 0, argc);
+      rc = doltliteCheckoutTables(db, ctx, 0, argv, 0, argc);
     }
     if( rc==SQLITE_NOTFOUND ){
       char *zErr = sqlite3_mprintf("no such branch or table: %s", zBranch);
@@ -1276,7 +1281,7 @@ void doltCheckoutFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
       return;
     }
 
-    rc = doltliteCheckoutTables(db, 0, argv, 0, argc);
+    rc = doltliteCheckoutTables(db, ctx, 0, argv, 0, argc);
     if( rc==SQLITE_NOTFOUND ){
       char *zErr = sqlite3_mprintf(
           "no such branch or table: %s", zBranch);

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -980,6 +980,10 @@ int addAppendIndexEntriesOfTable(
   SchemaEntry *aWorkSchema, int nWorkSchema,
   const char *zTable
 );
+int doltliteStageNamedTables(
+  sqlite3 *db, sqlite3_context *context, ChunkStore *cs,
+  const ProllyHash *pWorkingHash, int argc, sqlite3_value **argv
+);
 
 int mergeAbortInPlace(sqlite3 *db);
 int mergeFastForward(

--- a/test/vc_oracle_checkout_test.sh
+++ b/test/vc_oracle_checkout_test.sh
@@ -1129,6 +1129,36 @@ ROLLBACK;
 "
 
 
+echo "--- table checkout stages only the named table ---"
+
+CHK_TWO_TABLE_SEED="
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+CREATE TABLE u(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 1);
+INSERT INTO u VALUES (1, 1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+"
+
+oracle "checkout_ref_table_stages_only_named" "
+$CHK_TWO_TABLE_SEED
+SELECT dolt_branch('side');
+SELECT dolt_checkout('side');
+UPDATE t SET v = 50;
+SELECT dolt_commit('-am', 'side t');
+SELECT dolt_checkout('main');
+UPDATE t SET v = 99;
+UPDATE u SET v = 99;
+SELECT dolt_checkout('side', 't');
+"
+
+oracle "checkout_head_table_leaves_others_unstaged" "
+$CHK_TWO_TABLE_SEED
+UPDATE t SET v = 99;
+UPDATE u SET v = 99;
+SELECT dolt_checkout('HEAD', 't');
+"
+
 echo ""
 echo "=== Results: $pass passed, $fail failed ==="
 if [ $fail -gt 0 ]; then


### PR DESCRIPTION
Deep-review action item 1, staging cluster: `dolt_checkout(ref, table)` published the whole new working catalog as the staged catalog, so every unrelated working change got staged as a side effect — and silently committed by the next `dolt_commit`. Dolt (verified live, 2.2.2) stages the named table from the ref and leaves the bystanders unstaged: after `dolt_checkout('side','t1')` with `t2` modified, status is `t1 staged-modified / t2 unstaged-modified`.

The table-checkout path now routes through the same staging machinery as a named `dolt_add` (`addStageNamedTables`, exported as `doltliteStageNamedTables`), so the named table's index entries and vtab shadows travel with it and the staged master root composes exactly as a named add composes it.

Oracle coverage: two new `vc_oracle_checkout_test.sh` cases (cross-branch table checkout, same-ref revert; both with a modified bystander that must stay unstaged) — fail before, pass after. Checkout suite 67/67; add/status/reset/commit oracle suites and battery staging/working-set suites green.

Independent of #2124 and #2125 (no shared hunks — #2124 touches a different region of doltlite_add.c; merge order between them is conflict-free either way).

🤖 Generated with [Claude Code](https://claude.com/claude-code)