### PR TITLE
Rename paired-ratio noise metric

### DIFF
--- a/test/nightly_performance_report.py
+++ b/test/nightly_performance_report.py
@@ -314,8 +314,8 @@ def render_section_summary(suites, section, prefix):
         f"| {prefix} | {len(results)} | "
         f"{sample_count_text(suites, results)} | "
         f"{format_time(baseline)} | {format_time(candidate)} | "
-        f"{ratio:.3f}× | "
-        f"{statistics.median(workload_noise(*item) for item in results):.2f}% "
+        f"{ratio:.1f}× | "
+        f"{statistics.median(workload_noise(*item) for item in results):.1f}% "
         f"| **{result}** |"
     )
 
@@ -383,8 +383,8 @@ def render_sysbench_details(suite):
             f"| {escape_markdown(result.section)} | "
             f"`{escape_markdown(result.test)}` | "
             f"{format_time(result.baseline_us)} | "
-            f"{format_time(result.candidate_us)} | {ratio:.3f}× | "
-            f"{workload_noise(suite, result):.2f}% | {status} |"
+            f"{format_time(result.candidate_us)} | {ratio:.1f}× | "
+            f"{workload_noise(suite, result):.1f}% | {status} |"
         )
     lines.extend(["", "</details>", ""])
     return lines
@@ -407,7 +407,7 @@ def render_vc(suite):
             f"| `{escape_markdown(result.test)}` | "
             f"{format_time(result.candidate_us)} | "
             f"{format_time(result.baseline_us)} | {used:.1%} | "
-            f"{workload_noise(suite, result):.2f}% | {status} |"
+            f"{workload_noise(suite, result):.1f}% | {status} |"
         )
     result = "PASS" if vc_passes(suite) else "FAIL"
     lines.extend(["", f"Version-control ceiling result: **{result}**.", ""])

--- a/test/nightly_performance_report.py
+++ b/test/nightly_performance_report.py
@@ -302,7 +302,7 @@ def vc_passes(suite):
     )
 
 
-def render_section_summary(suites, section, prefix):
+def render_section_summary(suites, section, prefix, include_counts=True):
     results = section_results(suites, section)
     if not results:
         raise ValueError(f"missing results for section: {section}")
@@ -310,14 +310,19 @@ def render_section_summary(suites, section, prefix):
     candidate = sum(result.candidate_us for _, result in results)
     ratio = candidate / baseline
     result = "PASS" if section_passes(suites, section) else "FAIL"
-    return (
-        f"| {prefix} | {len(results)} | "
-        f"{sample_count_text(suites, results)} | "
-        f"{format_time(baseline)} | {format_time(candidate)} | "
-        f"{ratio:.1f}× | "
-        f"{statistics.median(workload_noise(*item) for item in results):.1f}% "
-        f"| **{result}** |"
+    cells = [prefix]
+    if include_counts:
+        cells.extend((str(len(results)), sample_count_text(suites, results)))
+    cells.extend(
+        (
+            format_time(baseline),
+            format_time(candidate),
+            f"{ratio:.1f}×",
+            f"{statistics.median(workload_noise(*item) for item in results):.1f}%",
+            f"**{result}**",
+        )
     )
+    return "| " + " | ".join(cells) + " |"
 
 
 def render_sql_summary(suites):
@@ -327,15 +332,17 @@ def render_sql_summary(suites):
             [
                 f"### {storage}",
                 "",
-                "| Operation | Workloads | Samples/workload | "
-                "SQLite median total | DoltLite median total | Ratio | "
+                "| Operation | SQLite median total | "
+                "DoltLite median total | Ratio | "
                 "Paired-ratio noise | Result |",
-                "|---|---:|---:|---:|---:|---:|---:|---|",
+                "|---|---:|---:|---:|---:|---|",
             ]
         )
         for operation, section in operations:
             lines.append(
-                render_section_summary(suites, section, operation)
+                render_section_summary(
+                    suites, section, operation, include_counts=False
+                )
             )
         lines.append("")
     return lines

--- a/test/nightly_performance_report.py
+++ b/test/nightly_performance_report.py
@@ -329,7 +329,7 @@ def render_sql_summary(suites):
                 "",
                 "| Operation | Workloads | Samples/workload | "
                 "SQLite median total | DoltLite median total | Ratio | "
-                "Median paired-ratio MAD | Result |",
+                "Paired-ratio noise | Result |",
                 "|---|---:|---:|---:|---:|---:|---:|---|",
             ]
         )
@@ -351,7 +351,7 @@ def render_key_shape_breakdown(suites):
         "",
         "| Storage | Operation | Key shape | Workloads | Samples/workload | "
         "SQLite median total | DoltLite median total | Ratio | "
-        "Median paired-ratio MAD | Result |",
+        "Paired-ratio noise | Result |",
         "|---|---|---|---:|---:|---:|---:|---:|---:|---|",
     ]
     for storage, operation, section in KEY_SHAPE_GROUPS:
@@ -373,7 +373,7 @@ def render_sysbench_details(suite):
         f"<summary>{suite.name} workload details</summary>",
         "",
         "| Section | Workload | SQLite median | DoltLite median | "
-        "Ratio | Paired-ratio MAD | Result |",
+        "Ratio | Paired-ratio noise | Result |",
         "|---|---|---:|---:|---:|---:|---|",
     ]
     for result in suite.results:
@@ -433,8 +433,9 @@ def render_report(suites, commit, run_url, generated_at, runner):
         "",
         "This report compares optimized DoltLite against stock SQLite on the "
         "same GitHub-hosted runner. Baseline and candidate execution order "
-        "alternates on each repetition. Reported timings are medians; MAD is "
-        "the median absolute deviation and describes run-to-run noise.",
+        "alternates on each repetition. Reported timings are medians. "
+        "Paired-ratio noise is the median absolute deviation of the paired "
+        "DoltLite/SQLite ratios, expressed as a percentage.",
         "",
         "## SQL workload summary",
         "",

--- a/test/nightly_performance_report_test.py
+++ b/test/nightly_performance_report_test.py
@@ -94,10 +94,10 @@ class NightlyPerformanceReportTest(unittest.TestCase):
         self.assertIn("Nightly result: **PASS**", report)
         self.assertIn("aggregates all key shapes", report)
         self.assertIn("### In-memory", report)
-        self.assertIn("| Reads | 4 | 3 | 400µs | 600µs | 1.500× |", report)
+        self.assertIn("| Reads | 4 | 3 | 400µs | 600µs | 1.5× |", report)
         self.assertIn("### File-backed", report)
         self.assertIn(
-            "| Autocommit writes | 4 | 3 | 400µs | 2.00ms | 5.000× |",
+            "| Autocommit writes | 4 | 3 | 400µs | 2.00ms | 5.0× |",
             report,
         )
         self.assertIn("Paired-ratio noise", report)

--- a/test/nightly_performance_report_test.py
+++ b/test/nightly_performance_report_test.py
@@ -100,7 +100,8 @@ class NightlyPerformanceReportTest(unittest.TestCase):
             "| Autocommit writes | 4 | 3 | 400µs | 2.00ms | 5.000× |",
             report,
         )
-        self.assertIn("Median paired-ratio MAD", report)
+        self.assertIn("Paired-ratio noise", report)
+        self.assertNotIn("paired-ratio MAD", report)
         summary = report.split("<details>", 1)[0]
         self.assertNotIn("| Autocommit reads |", summary)
         self.assertNotIn("Key shape", summary)

--- a/test/nightly_performance_report_test.py
+++ b/test/nightly_performance_report_test.py
@@ -94,15 +94,16 @@ class NightlyPerformanceReportTest(unittest.TestCase):
         self.assertIn("Nightly result: **PASS**", report)
         self.assertIn("aggregates all key shapes", report)
         self.assertIn("### In-memory", report)
-        self.assertIn("| Reads | 4 | 3 | 400µs | 600µs | 1.5× |", report)
+        self.assertIn("| Reads | 400µs | 600µs | 1.5× |", report)
         self.assertIn("### File-backed", report)
         self.assertIn(
-            "| Autocommit writes | 4 | 3 | 400µs | 2.00ms | 5.0× |",
+            "| Autocommit writes | 400µs | 2.00ms | 5.0× |",
             report,
         )
         self.assertIn("Paired-ratio noise", report)
         self.assertNotIn("paired-ratio MAD", report)
         summary = report.split("<details>", 1)[0]
+        self.assertNotIn("Workloads | Samples/workload", summary)
         self.assertNotIn("| Autocommit reads |", summary)
         self.assertNotIn("Key shape", summary)
         self.assertLess(
@@ -121,6 +122,7 @@ class NightlyPerformanceReportTest(unittest.TestCase):
             "<summary>Key-shape and individual-workload breakdown</summary>",
             report,
         )
+        self.assertIn("Workloads | Samples/workload", report)
         self.assertIn("| In-memory | Reads | int | 1 | 3 |", report)
         self.assertIn("Version-control latency", report)
         self.assertIn("50.0%", report)
@@ -183,7 +185,7 @@ class NightlyPerformanceReportTest(unittest.TestCase):
             result = result_output.read_text(encoding="utf-8")
         self.assertEqual(rc, 0)
         self.assertIn("Nightly result: **FAIL**", report)
-        self.assertIn("| Autocommit writes | 4 | 3 |", report)
+        self.assertIn("| Autocommit writes | 400µs | 2.20ms |", report)
         self.assertEqual(result, "FAIL\n")
 
     def test_audit_only_section_still_gates_report(self):


### PR DESCRIPTION
## Summary

- rename the SQL performance columns from paired-ratio MAD to paired-ratio noise
- define paired-ratio noise in the report introduction
- render measured ratios and noise percentages with one decimal place
- remove workload and sample counts from the visible summary while retaining them in the audit
- retain the exact configured ceiling values

## Validation

- `python3 test/nightly_performance_report_test.py`
- `python3 test/publish_performance_report_test.py`
- `python3 -m py_compile test/nightly_performance_report.py test/nightly_performance_report_test.py`

Co-Authored-By: OpenAI Codex <noreply@openai.com>