### PR TITLE
Pair staged renames by content and keep staging in one numbering domain

### DIFF
--- a/src/doltlite_add.c
+++ b/src/doltlite_add.c
@@ -158,6 +158,30 @@ static void addAlignStagedEntriesToWorking(
   addNameIndexFree(&workingIdx);
 }
 
+/* Move staged entries whose tables no longer exist in working onto fresh
+** numbers above both domains. Alignment cannot renumber them (nothing to
+** align to), and the number they hold may have been reused by the working
+** domain for a different table. Rows follow through the master composer,
+** which stamps old-sourced table rows from the final entry numbering. */
+static void addRenumberStaleStagedEntries(
+  struct TableEntry *aStaged, int nStaged,
+  struct TableEntry *aWorking, int nWorking
+){
+  Pgno iNext = 2;
+  int i;
+  for(i=0; i<nWorking; i++){
+    if( aWorking[i].iTable >= iNext ) iNext = aWorking[i].iTable + 1;
+  }
+  for(i=0; i<nStaged; i++){
+    if( aStaged[i].iTable >= iNext ) iNext = aStaged[i].iTable + 1;
+  }
+  for(i=0; i<nStaged; i++){
+    if( aStaged[i].iTable<=1 || !aStaged[i].zName ) continue;
+    if( addFindEntryByName(aWorking, nWorking, aStaged[i].zName) ) continue;
+    aStaged[i].iTable = iNext++;
+  }
+}
+
 static int addLoadWorkingAndStagedCatalogs(
   sqlite3 *db,
   const ProllyHash *pWorkingHash,
@@ -738,7 +762,21 @@ int doltliteStageNamedTables(
         int k;
         int updated = 0;
         int iRetired = -1;
+        struct TableEntry *pRenameMate = 0;
         updateMaster = 1;
+        /* A staged rename pairs by content identity, never by a bare
+        ** number match: table numbers are canonical-by-sorted-name, so a
+        ** drop reuses its number for the next table (a drop plus a create
+        ** is not a rename), and a rename that shifts the sort order
+        ** changes its number (still one object). */
+        rc = doltliteCatalogRenameMate(db, aStaged, nStaged,
+                                       aWorking, nWorking,
+                                       &aWorking[j], 0, &pRenameMate);
+        if( rc!=SQLITE_OK ){
+          ADDNAMED_FREE_ALL();
+          sqlite3_result_error_code(context, rc);
+          return rc;
+        }
         for(k=0; k<nStaged; k++){
           int nameMatch = aStaged[k].zName && aWorking[j].zName
             && strcmp(aStaged[k].zName, aWorking[j].zName)==0;
@@ -748,11 +786,7 @@ int doltliteStageNamedTables(
           ** the staged catalog's own schema rows say the entry at this
           ** number is this very table. */
           int unnamedRootMatch = 0;
-          int renameRootMatch = rootMatch
-            && aStaged[k].zName && aWorking[j].zName
-            && strcmp(aStaged[k].zName, aWorking[j].zName)!=0
-            && !addFindEntryByName(aWorking, nWorking, aStaged[k].zName)
-            && !addFindEntryByName(aStaged, nStaged, aWorking[j].zName);
+          int renameRootMatch = (pRenameMate==&aStaged[k]);
           if( rootMatch && !aStaged[k].zName && aWorking[j].zName ){
             int r;
             for(r=0; r<nStagedSchema; r++){
@@ -832,21 +866,32 @@ int doltliteStageNamedTables(
     }
   }
 
+  /* Settle the final numbering before composing the master, so the
+  ** composed rows can follow it: alignment moves same-named entries to
+  ** working numbers, and entries whose tables no longer exist in working
+  ** move off numbers the working domain may have reused for different
+  ** tables (a bare number collision makes the serialized catalog
+  ** ambiguous and can pair a table with another object's schema row). */
+  addAlignStagedEntriesToWorking(aWorking, nWorking, aStaged, nStaged);
+  addRenumberStaleStagedEntries(aStaged, nStaged, aWorking, nWorking);
+
   if( updateMaster ){
     struct TableEntry *pWorkingMaster = doltliteFindTableByNumber(aWorking, nWorking, 1);
     struct TableEntry *pStagedMaster = doltliteFindTableByNumber(aStaged, nStaged, 1);
     if( pWorkingMaster ){
-      /* The staged master must share the working numbering domain, but a
+      /* The staged master must share the entries' numbering domain, but a
       ** wholesale adoption would carry unstaged view and trigger changes
       ** into the commit (Dolt keeps them out of a named add). Compose the
       ** master: table and index rows from working, view and trigger rows
-      ** from the previously staged state. */
+      ** from the previously staged state, numbered from the final entry
+      ** list. */
       ProllyHash composedRoot;
       rc = doltliteBuildNamedStageMasterRoot(db,
               &pWorkingMaster->root, pWorkingMaster->flags,
               pStagedMaster ? &pStagedMaster->root : 0,
               pStagedMaster ? pStagedMaster->flags : 0,
               (const char**)azTouched, nTouched,
+              aStaged, nStaged,
               &composedRoot);
       if( rc!=SQLITE_OK ){
         ADDNAMED_FREE_ALL();
@@ -870,7 +915,6 @@ int doltliteStageNamedTables(
     }
   }
 
-  addAlignStagedEntriesToWorking(aWorking, nWorking, aStaged, nStaged);
   rc = addWriteStagedCatalog(db, cs, aStaged, nStaged);
   ADDNAMED_FREE_ALL();
   #undef ADDNAMED_TOUCH

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -1304,6 +1304,7 @@ int doltliteBuildNamedStageMasterRoot(sqlite3 *db,
     const ProllyHash *pWorkingMaster, u8 workingFlags,
     const ProllyHash *pOldMaster, u8 oldFlags,
     const char **azTouched, int nTouched,
+    struct TableEntry *aFinal, int nFinal,
     ProllyHash *pNewRoot);
 int doltliteReindexNamedIndexes(sqlite3 *db, char **az, int n);
 int doltliteTableSchemaConflictDetail(const char *zAncestorSql,

--- a/src/doltlite_status.c
+++ b/src/doltlite_status.c
@@ -588,7 +588,12 @@ static int statusRootsShareAnyKey(
   return rc;
 }
 
-static int isRenamePair(
+/* isRenamePair without the same-number gate, for renames that shift the
+** canonical order and therefore the table number. Row-content identity
+** carries the pairing; two EMPTY roots compare equal without being the
+** same object (a dropped empty table and a new one), so emptiness defers
+** to the rename-tolerant schema comparison instead. */
+static int isRenamePairContent(
   sqlite3 *db,
   const StatusCatalogIndex *pFromIdx,
   const StatusCatalogIndex *pToIdx,
@@ -600,26 +605,37 @@ static int isRenamePair(
   char *zLiveSql = 0;
   int bMatch = 0;
 
-  if( pA->iTable != pB->iTable ) return 0;
   if( !pA->zName || !pB->zName ) return 0;
   if( strcmp(pA->zName, pB->zName)==0 ) return 0;
   if( statusCatalogFindName(pFromIdx, pB->zName)!=0 ) return 0;
   if( statusCatalogFindName(pToIdx, pA->zName)!=0 ) return 0;
-  if( prollyHashCompare(&pA->root, &pB->root)==0 ){
-    bMatch = 1;
-    goto rename_done;
+  if( !prollyHashIsEmpty(&pA->root)
+   && prollyHashCompare(&pA->root, &pB->root)==0 ){
+    return 1;
   }
 
   rc = statusLoadLiveTableSql(db, pB->zName, &foundLive, &zLiveSql);
-  if( rc!=SQLITE_OK || !foundLive ) goto rename_done;
+  if( rc!=SQLITE_OK || !foundLive ) goto content_done;
   if( statusSchemaHashMatchesRename(&pA->schemaHash, zLiveSql, pA->zName)
-   && statusRootsShareAnyKey(db, pA, pB) ){
+   && (statusRootsShareAnyKey(db, pA, pB)
+       || (prollyHashIsEmpty(&pA->root) && prollyHashIsEmpty(&pB->root))) ){
     bMatch = 1;
   }
 
-rename_done:
+content_done:
   sqlite3_free(zLiveSql);
   return bMatch;
+}
+
+static int isRenamePair(
+  sqlite3 *db,
+  const StatusCatalogIndex *pFromIdx,
+  const StatusCatalogIndex *pToIdx,
+  const struct TableEntry *pA,
+  const struct TableEntry *pB
+){
+  if( pA->iTable != pB->iTable ) return 0;
+  return isRenamePairContent(db, pFromIdx, pToIdx, pA, pB);
 }
 
 /* Find the rename mate of pKnown across the from/to catalogs, using the
@@ -653,6 +669,25 @@ int doltliteCatalogRenameMate(
     const struct TableEntry *pA = bKnownIsFrom ? pKnown : pMate;
     const struct TableEntry *pB = bKnownIsFrom ? pMate : pKnown;
     if( !isRenamePair(db, &fromIdx, &toIdx, pA, pB) ) pMate = 0;
+  }
+  if( !pMate ){
+    /* A rename that shifts the canonical order changes the number, so
+    ** the number lookup misses it; scan by content and accept only an
+    ** unambiguous mate. */
+    struct TableEntry *aOther = bKnownIsFrom ? aTo : aFrom;
+    int nOther = bKnownIsFrom ? nTo : nFrom;
+    int i;
+    for(i=0; i<nOther; i++){
+      const struct TableEntry *pA = bKnownIsFrom ? pKnown : &aOther[i];
+      const struct TableEntry *pB = bKnownIsFrom ? &aOther[i] : pKnown;
+      if( aOther[i].iTable<=1 || !aOther[i].zName ) continue;
+      if( !isRenamePairContent(db, &fromIdx, &toIdx, pA, pB) ) continue;
+      if( pMate ){
+        pMate = 0;
+        break;
+      }
+      pMate = &aOther[i];
+    }
   }
   statusCatalogIndexFree(&fromIdx);
   statusCatalogIndexFree(&toIdx);
@@ -700,6 +735,35 @@ static int compareCatalogs(
         if( rc!=SQLITE_OK ) goto compare_done;
         fromHandled[i] = 1;
         toHandled[j] = 1;
+      }
+    }
+    /* Second pass for renames whose canonical order shifted: the number
+    ** changed, so pairing goes by content, and only an unambiguous mate
+    ** counts. */
+    for(i=0; i<nFrom; i++){
+      int jMate = -1;
+      if( aFrom[i].iTable<=1 || fromHandled[i] || !aFrom[i].zName ) continue;
+      if( statusCatalogFindName(&toIdx, aFrom[i].zName) ) continue;
+      for(j=0; j<nTo; j++){
+        if( toHandled[j] || aTo[j].iTable<=1 || !aTo[j].zName ) continue;
+        if( !isRenamePairContent(db, &fromIdx, &toIdx, &aFrom[i], &aTo[j]) ){
+          continue;
+        }
+        if( jMate>=0 ){
+          jMate = -1;
+          break;
+        }
+        jMate = j;
+      }
+      if( jMate>=0 ){
+        char *zCompound = sqlite3_mprintf("%s -> %s",
+                                          aFrom[i].zName, aTo[jMate].zName);
+        if( !zCompound ){ rc = SQLITE_NOMEM; goto compare_done; }
+        rc = addRow(pCur, zCompound, staged, "renamed");
+        sqlite3_free(zCompound);
+        if( rc!=SQLITE_OK ) goto compare_done;
+        fromHandled[i] = 1;
+        toHandled[jMate] = 1;
       }
     }
   }

--- a/src/prolly_btree_catalog.c
+++ b/src/prolly_btree_catalog.c
@@ -1030,6 +1030,7 @@ int doltliteBuildNamedStageMasterRoot(
   const ProllyHash *pWorkingMaster, u8 workingFlags,
   const ProllyHash *pOldMaster, u8 oldFlags,
   const char **azTouched, int nTouched,
+  struct TableEntry *aFinal, int nFinal,
   ProllyHash *pNewRoot
 ){
   Btree *pBtree;
@@ -1099,18 +1100,30 @@ int doltliteBuildNamedStageMasterRoot(
       }
       if( fromWorking != touched ) continue;
     }
-    /* Staged entries whose name exists in working are aligned to the
-    ** working table number, so old-sourced table rows must carry that
-    ** number too, or the composed rows collide across numbering domains
-    ** and no longer pair with their entries. Index entries are unnamed
-    ** and never aligned; their rows keep the old number. */
+    /* Old-sourced table rows must carry the number their entry holds in
+    ** the FINAL entry list, or the composed rows collide across numbering
+    ** domains and no longer pair with their entries: aligned entries hold
+    ** working numbers, and entries whose tables left the working tree
+    ** hold fresh numbers. Index entries are unnamed and never renumbered;
+    ** their rows keep the old number. */
     iPg = pRow->oldPg;
     if( !fromWorking && strcmp(pRow->zType, "table")==0 && pRow->zName ){
-      for(t=0; t<nWork; t++){
-        if( aWork[t].zType && strcmp(aWork[t].zType, "table")==0
-         && aWork[t].zName && strcmp(aWork[t].zName, pRow->zName)==0 ){
-          iPg = aWork[t].oldPg;
+      const struct TableEntry *pFinal = 0;
+      for(t=0; t<nFinal; t++){
+        if( aFinal[t].zName && strcmp(aFinal[t].zName, pRow->zName)==0 ){
+          pFinal = &aFinal[t];
           break;
+        }
+      }
+      if( pFinal ){
+        iPg = pFinal->iTable;
+      }else{
+        for(t=0; t<nWork; t++){
+          if( aWork[t].zType && strcmp(aWork[t].zType, "table")==0
+           && aWork[t].zName && strcmp(aWork[t].zName, pRow->zName)==0 ){
+            iPg = aWork[t].oldPg;
+            break;
+          }
         }
       }
     }

--- a/test/vc_oracle_add_test.sh
+++ b/test/vc_oracle_add_test.sh
@@ -581,6 +581,76 @@ SELECT dolt_add('t');
 INSERT INTO t VALUES (2, 20);
 "
 
+echo "--- rename identity: content pairing, one numbering domain ---"
+
+DROP_CREATE_SEED="
+CREATE TABLE m(a INT PRIMARY KEY, b INT);
+CREATE TABLE n(a INT PRIMARY KEY);
+INSERT INTO m VALUES (1, 100);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'base');
+DROP TABLE m;
+CREATE TABLE a(x INT PRIMARY KEY, y TEXT);
+INSERT INTO a VALUES (9, 'nine');
+"
+
+oracle "add_named_keeps_unstaged_drop_out" "
+$DROP_CREATE_SEED
+SELECT dolt_add('a');
+"
+
+oracle_reopen "add_named_then_commit_keeps_dropped_table_in_head" "
+$DROP_CREATE_SEED
+SELECT dolt_add('a');
+SELECT dolt_commit('-m', 'add a only');
+" "SELECT concat('Q|', table_name, '|', staged, '|', status) FROM dolt_status;"
+
+RENAME_SHIFT_SEED="
+CREATE TABLE t(id INT PRIMARY KEY, v INT);
+CREATE TABLE u(id INT PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 1);
+INSERT INTO u VALUES (2, 2);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'base');
+ALTER TABLE t RENAME TO z;
+"
+
+oracle "add_bystander_during_order_shifting_rename" "
+$RENAME_SHIFT_SEED
+INSERT INTO u VALUES (3, 3);
+SELECT dolt_add('u');
+"
+
+oracle_reopen "add_bystander_then_commit_preserves_rename" "
+$RENAME_SHIFT_SEED
+INSERT INTO u VALUES (3, 3);
+SELECT dolt_add('u');
+SELECT dolt_commit('-m', 'commit u only');
+" "SELECT concat('Q|', table_name, '|', staged, '|', status) FROM dolt_status;"
+
+oracle "add_renamed_table_order_shifting" "
+$RENAME_SHIFT_SEED
+SELECT dolt_add('z');
+"
+
+oracle_reopen "add_renamed_table_then_commit_renames_in_head" "
+$RENAME_SHIFT_SEED
+SELECT dolt_add('z');
+SELECT dolt_commit('-m', 'commit rename');
+" "SELECT concat('Q|z|', id, '|', v) FROM z ORDER BY id;
+SELECT concat('Q|u|', id, '|', v) FROM u ORDER BY id;
+SELECT concat('Q|nstatus|', count(*)) FROM dolt_status;"
+
+oracle "add_named_empty_drop_create_not_a_rename" "
+CREATE TABLE e1(a INT PRIMARY KEY);
+CREATE TABLE n(a INT PRIMARY KEY);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'base');
+DROP TABLE e1;
+CREATE TABLE e2(b VARCHAR(32) PRIMARY KEY, c INT);
+SELECT dolt_add('e2');
+"
+
 echo ""
 echo "=== Results: $pass passed, $fail failed ==="
 if [ $fail -gt 0 ]; then


### PR DESCRIPTION
Deep-review action item 1, staging cluster — the data-loss core. Staging paired a renamed table with its mate by **table number**, but numbers are canonical-by-sorted-name: a drop hands its number to the next table, and an order-shifting rename changes its number. Both directions were broken, confirmed against Dolt 2.2.2:

- **Silent history loss:** with an unstaged `DROP TABLE m`, `dolt_add('a')` for a new table that reused m's number staged the drop as a rename half — the next commit erased `m` from history and `dolt_status` reported clean afterwards.
- **Order-shifting renames shredded:** after `ALTER TABLE t RENAME TO z` shifts canonical order, `dolt_add('u')` (a bystander) left phantom staged rows and the commit reverted the rename in history; `dolt_add('z')` committed both `t` and `z`.

**Mechanics**

- Rename identity is now content, everywhere staging pairs tables: `isRenamePair` keeps the number gate as a fast path but delegates to a content core (row-root equality, or the rename-tolerant schema comparison; two *empty* roots are never identity on their own, so an empty drop+create no longer reads as a rename — that arm previously false-paired even in status).
- `doltliteCatalogRenameMate` falls back to a content scan when the number candidate fails, accepting only an unambiguous mate; `dolt_add` uses it in place of its number-coincidence heuristic, and `dolt_status` runs a content second pass so order-shifting renames render as `t -> z renamed` (the index-object comparison inherits this through the shared helper).
- `dolt_add` output stays in one numbering domain: after alignment, entries whose tables left the working tree move to fresh numbers above both domains, and `doltliteBuildNamedStageMasterRoot` stamps old-sourced table rows from the **final** entry list, so every row pairs with its entry by number (the write-time PROLLY_CHECK invariants watch exactly this).

**Validation**

- 7 new `vc_oracle_add_test.sh` cases vs Dolt 2.2.2: unstaged-drop sweep (status + post-commit history), both order-shifting rename shapes (status + post-commit contents), empty drop+create non-rename. All fail before, pass after.
- add 41/41, status 40/40, status_schema_objects 18/18, reset 54/54, checkout 67/67, commit 39/39, merge_status 11/11 — also green under a `DOLTLITE_PROLLY_CHECK=1` build.
- Full shell battery 101/101. Zero build warnings; strict-C90 clean.

Remaining in the cluster after this: `dolt_commit('-a')` committing an unstaged rename as a DROP (`doltliteCommitStageModifiedOnly` pairs by name only) — next PR, on top of this pairing helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)