### PR TITLE
Reject a rename mate contested by an identical new table

### DIFF
--- a/src/doltlite_status.c
+++ b/src/doltlite_status.c
@@ -638,6 +638,29 @@ static int isRenamePair(
   return isRenamePairContent(db, pFromIdx, pToIdx, pA, pB);
 }
 
+/* True when another to-side entry carries the same non-empty row content
+** as the from-side table: two candidates for one identity, and the rename
+** pairing cannot choose (Dolt's tags could; content cannot). From-side
+** duplicates do not contest — a dropped identical sibling never makes a
+** real rename ambiguous — and empty tables carry no content to contest
+** with. Staging state is ignored deliberately: a contestant staged a
+** moment ago is still a contestant, or staging one of two identical new
+** tables would hand the other the dropped table's identity. */
+static int renameMateIsContested(
+  struct TableEntry *aTo, int nTo,
+  const struct TableEntry *pFrom,
+  const struct TableEntry *pTo
+){
+  int i;
+  if( prollyHashIsEmpty(&pFrom->root) ) return 0;
+  for(i=0; i<nTo; i++){
+    if( &aTo[i]==pTo || aTo[i].iTable<=1 || !aTo[i].zName ) continue;
+    if( pFrom->zName && strcmp(aTo[i].zName, pFrom->zName)==0 ) continue;
+    if( prollyHashCompare(&aTo[i].root, &pFrom->root)==0 ) return 1;
+  }
+  return 0;
+}
+
 /* Find the rename mate of pKnown across the from/to catalogs, using the
 ** same pairing dolt_status renders, so every staging surface agrees on
 ** which two entries are one renamed object. bKnownIsFrom says which side
@@ -689,6 +712,11 @@ int doltliteCatalogRenameMate(
       pMate = &aOther[i];
     }
   }
+  if( pMate ){
+    const struct TableEntry *pF = bKnownIsFrom ? pKnown : pMate;
+    const struct TableEntry *pT = bKnownIsFrom ? pMate : pKnown;
+    if( renameMateIsContested(aTo, nTo, pF, pT) ) pMate = 0;
+  }
   statusCatalogIndexFree(&fromIdx);
   statusCatalogIndexFree(&toIdx);
   *ppMate = pMate;
@@ -727,7 +755,8 @@ static int compareCatalogs(
       if( !pTo ) continue;
       j = (int)(pTo - aTo);
       if( j<0 || j>=nTo || toHandled[j] || pTo->iTable<=1 ) continue;
-      if( isRenamePair(db, &fromIdx, &toIdx, &aFrom[i], pTo) ){
+      if( isRenamePair(db, &fromIdx, &toIdx, &aFrom[i], pTo)
+       && !renameMateIsContested(aTo, nTo, &aFrom[i], pTo) ){
         char *zCompound = sqlite3_mprintf("%s -> %s", aFrom[i].zName, pTo->zName);
         if( !zCompound ){ rc = SQLITE_NOMEM; goto compare_done; }
         rc = addRow(pCur, zCompound, staged, "renamed");
@@ -754,6 +783,10 @@ static int compareCatalogs(
           break;
         }
         jMate = j;
+      }
+      if( jMate>=0
+       && renameMateIsContested(aTo, nTo, &aFrom[i], &aTo[jMate]) ){
+        jMate = -1;
       }
       if( jMate>=0 ){
         char *zCompound = sqlite3_mprintf("%s -> %s",
@@ -868,7 +901,8 @@ static int statusMaybeAddRename(
   int rc = SQLITE_OK;
   *pIsRename = 0;
   if( !pFrom || !pTo ) return SQLITE_OK;
-  if( isRenamePair(db, pFromIdx, pToIdx, pFrom, pTo) ){
+  if( isRenamePair(db, pFromIdx, pToIdx, pFrom, pTo)
+   && !renameMateIsContested(pToIdx->aEntry, pToIdx->nEntry, pFrom, pTo) ){
     char *zCompound;
     *pIsRename = 1;
     zCompound = sqlite3_mprintf("%s -> %s", pFrom->zName, pTo->zName);

--- a/src/doltlite_status.c
+++ b/src/doltlite_status.c
@@ -643,20 +643,35 @@ static int isRenamePair(
 ** pairing cannot choose (Dolt's tags could; content cannot). From-side
 ** duplicates do not contest — a dropped identical sibling never makes a
 ** real rename ambiguous — and empty tables carry no content to contest
-** with. Staging state is ignored deliberately: a contestant staged a
-** moment ago is still a contestant, or staging one of two identical new
-** tables would hand the other the dropped table's identity. */
+** with. A candidate that is the new half of its own same-number rename is
+** spoken for and does not contest either: eighty identical tables renamed
+** together stay eighty renames. Otherwise staging state is deliberately
+** ignored: a contestant staged a moment ago is still a contestant, or
+** staging one of two identical new tables would hand the other the
+** dropped table's identity. */
 static int renameMateIsContested(
+  struct TableEntry *aFrom, int nFrom,
   struct TableEntry *aTo, int nTo,
   const struct TableEntry *pFrom,
   const struct TableEntry *pTo
 ){
-  int i;
+  int i, j;
   if( prollyHashIsEmpty(&pFrom->root) ) return 0;
   for(i=0; i<nTo; i++){
+    int spokenFor = 0;
     if( &aTo[i]==pTo || aTo[i].iTable<=1 || !aTo[i].zName ) continue;
     if( pFrom->zName && strcmp(aTo[i].zName, pFrom->zName)==0 ) continue;
-    if( prollyHashCompare(&aTo[i].root, &pFrom->root)==0 ) return 1;
+    if( prollyHashCompare(&aTo[i].root, &pFrom->root)!=0 ) continue;
+    for(j=0; j<nFrom; j++){
+      if( aFrom[j].iTable==aTo[i].iTable
+       && aFrom[j].zName
+       && strcmp(aFrom[j].zName, aTo[i].zName)!=0
+       && prollyHashCompare(&aFrom[j].root, &aTo[i].root)==0 ){
+        spokenFor = 1;
+        break;
+      }
+    }
+    if( !spokenFor ) return 1;
   }
   return 0;
 }
@@ -715,7 +730,7 @@ int doltliteCatalogRenameMate(
   if( pMate ){
     const struct TableEntry *pF = bKnownIsFrom ? pKnown : pMate;
     const struct TableEntry *pT = bKnownIsFrom ? pMate : pKnown;
-    if( renameMateIsContested(aTo, nTo, pF, pT) ) pMate = 0;
+    if( renameMateIsContested(aFrom, nFrom, aTo, nTo, pF, pT) ) pMate = 0;
   }
   statusCatalogIndexFree(&fromIdx);
   statusCatalogIndexFree(&toIdx);
@@ -756,7 +771,7 @@ static int compareCatalogs(
       j = (int)(pTo - aTo);
       if( j<0 || j>=nTo || toHandled[j] || pTo->iTable<=1 ) continue;
       if( isRenamePair(db, &fromIdx, &toIdx, &aFrom[i], pTo)
-       && !renameMateIsContested(aTo, nTo, &aFrom[i], pTo) ){
+       && !renameMateIsContested(aFrom, nFrom, aTo, nTo, &aFrom[i], pTo) ){
         char *zCompound = sqlite3_mprintf("%s -> %s", aFrom[i].zName, pTo->zName);
         if( !zCompound ){ rc = SQLITE_NOMEM; goto compare_done; }
         rc = addRow(pCur, zCompound, staged, "renamed");
@@ -785,7 +800,7 @@ static int compareCatalogs(
         jMate = j;
       }
       if( jMate>=0
-       && renameMateIsContested(aTo, nTo, &aFrom[i], &aTo[jMate]) ){
+       && renameMateIsContested(aFrom, nFrom, aTo, nTo, &aFrom[i], &aTo[jMate]) ){
         jMate = -1;
       }
       if( jMate>=0 ){
@@ -902,7 +917,8 @@ static int statusMaybeAddRename(
   *pIsRename = 0;
   if( !pFrom || !pTo ) return SQLITE_OK;
   if( isRenamePair(db, pFromIdx, pToIdx, pFrom, pTo)
-   && !renameMateIsContested(pToIdx->aEntry, pToIdx->nEntry, pFrom, pTo) ){
+   && !renameMateIsContested(pFromIdx->aEntry, pFromIdx->nEntry,
+                             pToIdx->aEntry, pToIdx->nEntry, pFrom, pTo) ){
     char *zCompound;
     *pIsRename = 1;
     zCompound = sqlite3_mprintf("%s -> %s", pFrom->zName, pTo->zName);

--- a/test/vc_oracle_add_test.sh
+++ b/test/vc_oracle_add_test.sh
@@ -651,6 +651,19 @@ CREATE TABLE e2(b VARCHAR(32) PRIMARY KEY, c INT);
 SELECT dolt_add('e2');
 "
 
+oracle "add_ambiguous_content_match_is_not_a_rename" "
+CREATE TABLE orig(id INT PRIMARY KEY, v INT);
+INSERT INTO orig VALUES (1, 10);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'base');
+DROP TABLE orig;
+CREATE TABLE alpha(id INT PRIMARY KEY, v INT);
+INSERT INTO alpha VALUES (1, 10);
+CREATE TABLE beta(id INT PRIMARY KEY, v INT);
+INSERT INTO beta VALUES (1, 10);
+SELECT dolt_add('alpha');
+"
+
 echo ""
 echo "=== Results: $pass passed, $fail failed ==="
 if [ $fail -gt 0 ]; then

--- a/test/vc_oracle_status_test.sh
+++ b/test/vc_oracle_status_test.sh
@@ -508,6 +508,18 @@ INSERT INTO d VALUES (1);
 INSERT INTO c VALUES (2, 20);
 "
 
+oracle "ambiguous_content_match_shows_no_rename" "
+CREATE TABLE orig(id INT PRIMARY KEY, v INT);
+INSERT INTO orig VALUES (1, 10);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'base');
+DROP TABLE orig;
+CREATE TABLE alpha(id INT PRIMARY KEY, v INT);
+INSERT INTO alpha VALUES (1, 10);
+CREATE TABLE beta(id INT PRIMARY KEY, v INT);
+INSERT INTO beta VALUES (1, 10);
+"
+
 echo ""
 echo "=== Results: $pass passed, $fail failed ==="
 if [ $fail -gt 0 ]; then


### PR DESCRIPTION
Follow-up to #2130, addressing ito's RENAME-3 finding on that PR (confirmed by repro): content pairing handed a dropped table's identity to whichever identical-content new table the caller examined first. `dolt_add('alpha')` with identical new tables `alpha` and `beta` reported `orig -> alpha` as a rename (attaching orig's staged identity to an arbitrary name), and status showed the same false rename before any add. Dolt (tag identity) shows `orig deleted` plus two new tables.

**The rule:** a rename mate is rejected when another **to-side** entry carries the same non-empty row content — two candidates for one identity, which tags could distinguish and content cannot. Three deliberate asymmetries, each pinned by an oracle case:

- **From-side duplicates do not contest.** A dropped identical sibling never makes a real rename ambiguous — Dolt pairs `a -> a2` even when dropped `b` had identical content (the existing `multi_table_rename_drop_create_mix` case; a symmetric contest rule regresses it, which is how the first draft of this fix failed).
- **Staging state is ignored.** After staging one of the two identical tables, the other would otherwise become the "unique" mate and adopt the dropped table's identity on the next add — a residual data-loss path (the adopted entry replaces the dropped table in staging, and the commit erases it from history).
- **Empty tables never contest.** They carry no content to contest with; empty-table renames keep pairing through the rename-tolerant schema comparison.

The check is root-hash comparison only — no SQL loads — applied at all four pairing sites (the mate helper used by add/reset/commit, both status passes, and the filtered status path).

Validation: 2 new oracle cases vs Dolt 2.2.2 (ambiguous add stages a plain new table; status shows deleted + two new), both fail before and pass after; add 42/42, status 41/41, status_schema_objects 18/18, reset 54/54, checkout 67/67, commit 39/39, merge_status 11/11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)