### PR TITLE
Keep a working-tree rename out of dolt_commit -a

### DIFF
--- a/src/doltlite_add.c
+++ b/src/doltlite_add.c
@@ -128,7 +128,7 @@ struct TableEntry *addNameIndexFind(
   return r<0 ? 0 : (struct TableEntry*)(pIdx->aBase + (size_t)r*pIdx->stride);
 }
 
-static void addAlignStagedEntriesToWorking(
+void doltliteAlignStagedEntriesToWorking(
   struct TableEntry *aWorking,
   int nWorking,
   struct TableEntry *aStaged,
@@ -163,7 +163,7 @@ static void addAlignStagedEntriesToWorking(
 ** align to), and the number they hold may have been reused by the working
 ** domain for a different table. Rows follow through the master composer,
 ** which stamps old-sourced table rows from the final entry numbering. */
-static void addRenumberStaleStagedEntries(
+void doltliteRenumberStaleStagedEntries(
   struct TableEntry *aStaged, int nStaged,
   struct TableEntry *aWorking, int nWorking
 ){
@@ -389,7 +389,7 @@ static int addStageAllTables(
   if( useWorkingHash ){
     rc = doltliteSetSessionStaged(db, pWorkingHash);
   }else{
-    addAlignStagedEntriesToWorking(aWorking, nWorking, aNew, nNew);
+    doltliteAlignStagedEntriesToWorking(aWorking, nWorking, aNew, nNew);
     rc = addWriteStagedCatalog(db, cs, aNew, nNew);
   }
   if( workingIdxInit ) addNameIndexFree(&workingIdx);
@@ -872,8 +872,8 @@ int doltliteStageNamedTables(
   ** move off numbers the working domain may have reused for different
   ** tables (a bare number collision makes the serialized catalog
   ** ambiguous and can pair a table with another object's schema row). */
-  addAlignStagedEntriesToWorking(aWorking, nWorking, aStaged, nStaged);
-  addRenumberStaleStagedEntries(aStaged, nStaged, aWorking, nWorking);
+  doltliteAlignStagedEntriesToWorking(aWorking, nWorking, aStaged, nStaged);
+  doltliteRenumberStaleStagedEntries(aStaged, nStaged, aWorking, nWorking);
 
   if( updateMaster ){
     struct TableEntry *pWorkingMaster = doltliteFindTableByNumber(aWorking, nWorking, 1);
@@ -891,7 +891,7 @@ int doltliteStageNamedTables(
               pStagedMaster ? &pStagedMaster->root : 0,
               pStagedMaster ? pStagedMaster->flags : 0,
               (const char**)azTouched, nTouched,
-              aStaged, nStaged,
+              aStaged, nStaged, 0,
               &composedRoot);
       if( rc!=SQLITE_OK ){
         ADDNAMED_FREE_ALL();

--- a/src/doltlite_commit_cmd.c
+++ b/src/doltlite_commit_cmd.c
@@ -172,12 +172,15 @@ static int doltliteCommitStageModifiedOnly(sqlite3 *db, sqlite3_context *context
   AddNameIndex headIdx;
   AddNameIndex stagedIdx;
   u8 *aRemoveStaged = 0;
+  const char **azTouched = 0;
+  int nTouched = 0;
 
   memset(&workingIdx, 0, sizeof(workingIdx));
   memset(&headIdx, 0, sizeof(headIdx));
   memset(&stagedIdx, 0, sizeof(stagedIdx));
 
   #define FREE_ADD_MODIFIED_CATALOGS() do { \
+    sqlite3_free((void*)azTouched); \
     sqlite3_free(aRemoveStaged); \
     addNameIndexFree(&workingIdx); \
     addNameIndexFree(&headIdx); \
@@ -186,6 +189,7 @@ static int doltliteCommitStageModifiedOnly(sqlite3 *db, sqlite3_context *context
     doltliteFreeCatalog(aHead, nHead); \
     doltliteFreeCatalog(aStaged, nStaged); \
   } while(0)
+
 
   rc = doltliteFlushCatalogToHash(db, &workingHash);
   if( rc!=SQLITE_OK ){
@@ -248,22 +252,15 @@ static int doltliteCommitStageModifiedOnly(sqlite3 *db, sqlite3_context *context
     return rc;
   }
 
-  /* The master entry carries no name and pairs by table number 1. The
-  ** staged catalog must use the WORKING master root so the schema rows
-  ** and the overlaid entries share one numbering domain; keeping HEAD's
-  ** master under working-numbered entries makes the serializer pair
-  ** entries with the wrong rows. */
-  for(j=0; j<nWorking; j++){
-    if( aWorking[j].iTable!=1 ) continue;
-    for(k=0; k<nStaged; k++){
-      if( aStaged[k].iTable==1 ){
-        sqlite3_free(aStaged[k].zName);
-        aStaged[k] = aWorking[j];
-        aStaged[k].zName = 0;
-        break;
-      }
-    }
-    break;
+  /* Names whose master rows follow WORKING in this operation: tables
+  ** overlaid from working and tables staged as deleted. Rename-kept and
+  ** staged-only tables keep their previous rows through the composed
+  ** master below. Names are borrowed from the catalog arrays. */
+  azTouched = sqlite3_malloc((nWorking+nHead+1)*(int)sizeof(char*));
+  if( !azTouched ){
+    sqlite3_result_error_nomem(context);
+    FREE_ADD_MODIFIED_CATALOGS();
+    return SQLITE_NOMEM;
   }
 
   for(j=0; j<nWorking; j++){
@@ -273,6 +270,7 @@ static int doltliteCommitStageModifiedOnly(sqlite3 *db, sqlite3_context *context
     struct TableEntry *pStaged;
     if( !addNameIndexFind(&headIdx, zName) ) continue;
 
+    azTouched[nTouched++] = zName;
     pStaged = addNameIndexFind(&stagedIdx, zName);
     if( pStaged ){
         k = (int)(pStaged - aStaged);
@@ -303,7 +301,22 @@ static int doltliteCommitStageModifiedOnly(sqlite3 *db, sqlite3_context *context
   for(k=0; k<nHead; k++){
     const char *zName = aHead[k].zName;
     struct TableEntry *pStaged;
+    struct TableEntry *pMate = 0;
     if( addNameIndexFind(&workingIdx, zName) ) continue;
+    /* A HEAD table missing from working is a deletion — unless it is the
+    ** old name of a working-tree rename. Dolt's -a leaves the rename in
+    ** the working tree (the new name reads as a new table, which -a never
+    ** stages); staging just this half commits the rename as a bare DROP
+    ** and the table's history is gone. */
+    rc = doltliteCatalogRenameMate(db, aHead, nHead, aWorking, nWorking,
+                                   &aHead[k], 1, &pMate);
+    if( rc!=SQLITE_OK ){
+      sqlite3_result_error_code(context, rc);
+      FREE_ADD_MODIFIED_CATALOGS();
+      return rc;
+    }
+    if( pMate ) continue;
+    azTouched[nTouched++] = zName;
     pStaged = addNameIndexFind(&stagedIdx, zName);
     if( pStaged ){
       int j2 = (int)(pStaged - aStaged);
@@ -357,14 +370,12 @@ static int doltliteCommitStageModifiedOnly(sqlite3 *db, sqlite3_context *context
 
     for(k2=0; k2<nStaged; ){
       const char *zParent = 0;
-      const char *zIdxName = 0;
       if( aStaged[k2].iTable<=1 || aStaged[k2].zName ){ k2++; continue; }
       for(i2=0; i2<nOldSchema; i2++){
         if( aOldSchema[i2].zType
          && strcmp(aOldSchema[i2].zType, "index")==0
          && aOldSchema[i2].iRootpage==aStaged[k2].iTable ){
           zParent = aOldSchema[i2].zTblName;
-          zIdxName = aOldSchema[i2].zName;
           break;
         }
       }
@@ -372,27 +383,12 @@ static int doltliteCommitStageModifiedOnly(sqlite3 *db, sqlite3_context *context
        && amTableStagedByName(aStaged, nStaged, zParent)
        && !(addNameIndexFind(&workingIdx, zParent)
             && addNameIndexFind(&headIdx, zParent)) ){
-        /* Staged-sourced index: its table was staged explicitly and is
-        ** not refreshed from working, so the entry keeps the staged data
-        ** root — but its number is from the add-time catalog's domain,
-        ** which the serializer resolves against working-domain schema
-        ** rows. Renumber by index name so the row pairs; an index that
-        ** no longer exists in working falls through to the drop. */
-        int renumbered = 0;
-        for(i2=0; i2<nWorkSchema; i2++){
-          if( aWorkSchema[i2].zType
-           && strcmp(aWorkSchema[i2].zType, "index")==0
-           && aWorkSchema[i2].zName && zIdxName
-           && strcmp(aWorkSchema[i2].zName, zIdxName)==0 ){
-            aStaged[k2].iTable = aWorkSchema[i2].iRootpage;
-            renumbered = 1;
-            break;
-          }
-        }
-        if( renumbered ){
-          k2++;
-          continue;
-        }
+        /* Staged-sourced index: its table was staged explicitly (or is a
+        ** rename kept out of -a) and is not refreshed from working. The
+        ** composed master keeps its previous rows, so the entry keeps
+        ** its previous number and pairs as stored. */
+        k2++;
+        continue;
       }
       sqlite3_free(aStaged[k2].zName);
       if( k2+1<nStaged ){
@@ -449,6 +445,38 @@ static int doltliteCommitStageModifiedOnly(sqlite3 *db, sqlite3_context *context
 
     freeSchemaEntries(aWorkSchema, nWorkSchema);
     freeSchemaEntries(aOldSchema, nOldSchema);
+  }
+
+  /* Settle the final numbering, then compose the staged master so its
+  ** rows follow it: touched tables' rows come from working, everything
+  ** else keeps its previous rows stamped to the final entry numbers.
+  ** Wholesale adoption of the working master dropped the rows of tables
+  ** deliberately kept out of -a (a working-tree rename), and the
+  ** serializer then dropped their unpairable entries from the commit. */
+  doltliteAlignStagedEntriesToWorking(aWorking, nWorking, aStaged, nStaged);
+  doltliteRenumberStaleStagedEntries(aStaged, nStaged, aWorking, nWorking);
+  {
+    struct TableEntry *pWorkingMaster =
+        doltliteFindTableByNumber(aWorking, nWorking, 1);
+    struct TableEntry *pStagedMaster =
+        doltliteFindTableByNumber(aStaged, nStaged, 1);
+    if( pWorkingMaster && pStagedMaster ){
+      ProllyHash composedRoot;
+      rc = doltliteBuildNamedStageMasterRoot(db,
+              &pWorkingMaster->root, pWorkingMaster->flags,
+              &pStagedMaster->root, pStagedMaster->flags,
+              azTouched, nTouched,
+              aStaged, nStaged, 1,
+              &composedRoot);
+      if( rc!=SQLITE_OK ){
+        sqlite3_result_error_code(context, rc);
+        FREE_ADD_MODIFIED_CATALOGS();
+        return rc;
+      }
+      pStagedMaster->root = composedRoot;
+      pStagedMaster->schemaHash = pWorkingMaster->schemaHash;
+      pStagedMaster->flags = pWorkingMaster->flags;
+    }
   }
 
   if( nStaged==0 ){

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -1305,7 +1305,14 @@ int doltliteBuildNamedStageMasterRoot(sqlite3 *db,
     const ProllyHash *pOldMaster, u8 oldFlags,
     const char **azTouched, int nTouched,
     struct TableEntry *aFinal, int nFinal,
+    int bEntrylessFromWorking,
     ProllyHash *pNewRoot);
+void doltliteRenumberStaleStagedEntries(
+    struct TableEntry *aStaged, int nStaged,
+    struct TableEntry *aWorking, int nWorking);
+void doltliteAlignStagedEntriesToWorking(
+    struct TableEntry *aWorking, int nWorking,
+    struct TableEntry *aStaged, int nStaged);
 int doltliteReindexNamedIndexes(sqlite3 *db, char **az, int n);
 int doltliteTableSchemaConflictDetail(const char *zAncestorSql,
     const char *zOurSql, const char *zTheirSql, char **pzDetail);

--- a/src/prolly_btree_catalog.c
+++ b/src/prolly_btree_catalog.c
@@ -1031,6 +1031,7 @@ int doltliteBuildNamedStageMasterRoot(
   const ProllyHash *pOldMaster, u8 oldFlags,
   const char **azTouched, int nTouched,
   struct TableEntry *aFinal, int nFinal,
+  int bEntrylessFromWorking,
   ProllyHash *pNewRoot
 ){
   Btree *pBtree;
@@ -1087,7 +1088,9 @@ int doltliteBuildNamedStageMasterRoot(
     isEntryless = strcmp(pRow->zType, "view")==0
                || strcmp(pRow->zType, "trigger")==0;
     if( isEntryless ){
-      if( fromWorking ) continue;      /* views/triggers keep staged state */
+      /* A named add keeps views and triggers at their staged state; -a
+      ** stages them from working, as Dolt does through dolt_schemas. */
+      if( fromWorking != (bEntrylessFromWorking!=0) ) continue;
     }else{
       zParent = strcmp(pRow->zType, "index")==0
                   ? pRow->zTblName : pRow->zName;

--- a/test/vc_oracle_commit_test.sh
+++ b/test/vc_oracle_commit_test.sh
@@ -599,6 +599,64 @@ SELECT dolt_merge('feature');
 SELECT dolt_commit('-m', 'force-commit-with-conflict');
 "
 
+echo "--- commit -a leaves a working-tree rename in the working tree ---"
+
+COMMIT_A_RENAME_SEED="
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+CREATE INDEX tvi ON t(v);
+INSERT INTO t VALUES (1, 10);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+ALTER TABLE t RENAME TO t2;
+"
+
+oracle "commit_a_leaves_unstaged_rename_alone" "
+$COMMIT_A_RENAME_SEED
+SELECT dolt_commit('-am', 'nothing stageable');
+"
+
+oracle_query "commit_a_unstaged_rename_head_keeps_table" "
+$COMMIT_A_RENAME_SEED
+SELECT dolt_commit('-am', 'nothing stageable');
+SELECT dolt_reset('--hard');
+" "SELECT 'R|' || id || '|' || v FROM t;" "SELECT concat('R|', id, '|', v) FROM t;"
+
+COMMIT_A_SHIFT_SEED="
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+CREATE TABLE u(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 1);
+INSERT INTO u VALUES (2, 2);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+ALTER TABLE t RENAME TO z;
+INSERT INTO u VALUES (3, 3);
+"
+
+oracle "commit_a_order_shifting_rename_stays_unstaged" "
+$COMMIT_A_SHIFT_SEED
+SELECT dolt_commit('-am', 'rename and edit');
+"
+
+oracle_query "commit_a_order_shifting_rename_head_keeps_table" "
+$COMMIT_A_SHIFT_SEED
+SELECT dolt_commit('-am', 'rename and edit');
+SELECT dolt_reset('--hard');
+" "SELECT 'R|t|' || id || '|' || v FROM t;
+SELECT 'R|u|' || id || '|' || v FROM u;" "SELECT concat('R|t|', id, '|', v) FROM t;
+SELECT concat('R|u|', id, '|', v) FROM u;"
+
+oracle "commit_a_drop_create_commits_drop_only" "
+CREATE TABLE m(a INT PRIMARY KEY, b INT);
+CREATE TABLE n(a INT PRIMARY KEY);
+INSERT INTO m VALUES (1, 100);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'base');
+DROP TABLE m;
+CREATE TABLE a(x INT PRIMARY KEY, y INT);
+INSERT INTO a VALUES (9, 9);
+SELECT dolt_commit('-am', 'drop only');
+"
+
 echo ""
 echo "=== Results: $pass passed, $fail failed ==="
 if [ $fail -gt 0 ]; then


### PR DESCRIPTION
Final piece of deep-review action item 1 (staging cluster). `dolt_commit('-a')` staged half of an unstaged rename — the old name's deletion — so the commit recorded a bare DROP and the table vanished from history with its data. Verified against Dolt 2.2.2: Dolt leaves the rename **entirely in the working tree** (`-a` stages neither half; a lone rename makes the commit fail with nothing to commit). Whether Dolt should instead stage the whole rename is now tracked as dolthub/dolt#11522 (git, verified, commits the drop half — tolerable for files, data loss for tables); if Dolt changes, doltlite follows.

**Mechanics**

- The `-a` deletion pass skips a HEAD table whose absence from working is a rename's old name, resolved through the same content pairing status renders (`doltliteCatalogRenameMate`, from #2130).
- That exposed the deeper half: the overlay adopted the **working master root wholesale**, so a kept table's schema row vanished and the serializer silently dropped its unpairable entry from the commit anyway. The overlay now settles the final entry numbering (alignment + fresh numbers for working-absent tables, both helpers shared with `dolt_add`) and composes the staged master from it: touched tables' rows (overlaid from working, staged deletions) follow working; everything else keeps its previous rows stamped to the final numbers. Views/triggers follow working under `-a` (Dolt stages them via dolt_schemas) — the composer takes the source choice as a flag, with the named-add path keeping its staged-state behavior.
- With rows pairing by final numbering, the index-entry rebuild's renumber-against-working-schema hack is gone: kept entries keep their numbers and pair as stored.

**Validation**

- 4 new `vc_oracle_commit_test.sh` cases vs Dolt 2.2.2: lone rename stages nothing + follow-up commit rejected; order-shifting rename with modified bystander commits only the bystander; both shapes keep the table at HEAD after `dolt_reset('--hard')`. All fail before, pass after.
- commit 44/44, add 41/41, status 40/40, reset 54/54, checkout 67/67; PROLLY_CHECK build green on commit/add/reset; full shell battery 101/101; strict-C90 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)