### PR TITLE
Serialize prolly node arrays in bulk

### DIFF
--- a/src/prolly_node.c
+++ b/src/prolly_node.c
@@ -615,7 +615,9 @@ int prollyNodeBuilderFinishSparse(ProllyNodeBuilder *b, u8 **ppOut, int *pnOut,
   int nPhys;
   u8 *pBuf;
   u8 *pCur;
+#if SQLITE_BYTEORDER!=1234
   int i;
+#endif
   int writeCounts;
   u8 flagsOut;
 
@@ -649,6 +651,12 @@ int prollyNodeBuilderFinishSparse(ProllyNodeBuilder *b, u8 **ppOut, int *pnOut,
 
   pCur = pBuf + PROLLY_HDR_SIZE;
 
+#if SQLITE_BYTEORDER==1234
+  memcpy(pCur, b->aKeyOff, nOff);
+  pCur += nOff;
+  memcpy(pCur, b->aValOff, nOff);
+  pCur += nOff;
+#else
   for(i=0; i<=b->nItems; i++){
     PROLLY_PUT_U32(pCur, b->aKeyOff[i]);
     pCur += 4;
@@ -658,6 +666,7 @@ int prollyNodeBuilderFinishSparse(ProllyNodeBuilder *b, u8 **ppOut, int *pnOut,
     PROLLY_PUT_U32(pCur, b->aValOff[i]);
     pCur += 4;
   }
+#endif
 
   if( b->nKeyBytes>0 ){
     memcpy(pCur, b->pKeyBuf, b->nKeyBytes);
@@ -671,6 +680,10 @@ int prollyNodeBuilderFinishSparse(ProllyNodeBuilder *b, u8 **ppOut, int *pnOut,
   }
 
   if( writeCounts ){
+#if SQLITE_BYTEORDER==1234
+    memcpy(pCur, b->aSubtreeCount, b->nItems * 8);
+    pCur += b->nItems * 8;
+#else
     for(i=0; i<b->nItems; i++){
       u64 v = b->aSubtreeCount[i];
       pCur[0] = (u8)v;
@@ -683,6 +696,7 @@ int prollyNodeBuilderFinishSparse(ProllyNodeBuilder *b, u8 **ppOut, int *pnOut,
       pCur[7] = (u8)(v >> 56);
       pCur += 8;
     }
+#endif
   }
 
   assert( pCur==pBuf+nPhys );


### PR DESCRIPTION
## Summary

- bulk-copy native little-endian key/value offset arrays when finishing prolly nodes
- bulk-copy native little-endian subtree counts
- retain the byte-wise encoder on big-endian hosts, preserving the storage format and hashes

## Performance

Measured against a clean `master` timer at 50,000 rows with 15 alternating paired runs per workload. In-memory write paired-sample geometric means:

- integer keys: **1.31% faster**
- text keys: **0.39% faster**
- blob keys: **0.18% slower** (noise)
- composite keys: **0.75% faster**

For integer file-backed writes, 7 of 8 workload medians improved and the median workload ratio was 0.993 (about 0.7% faster). The all-sample geometric mean was 1.005 because host sync outliers still dominate sub-percent CPU changes, so this PR does not claim a reliable aggregate fsync-path improvement.

## Validation

- `make lint`
- `build/prolly_chunker_boundary_test` (1,048 passed)
- `bash test/run_doltlite_regression_case.sh prolly_mutate_batch_int_replace` (101,015 passed)
- `bash test/run_c_tests.sh` (27/27 gated binaries passed)

Co-Authored-By: OpenAI Codex <noreply@openai.com>