### PR TITLE
Abort the rebase when a replayed commit leaves constraint violations

### DIFF
--- a/src/doltlite_cherry_pick.c
+++ b/src/doltlite_cherry_pick.c
@@ -104,6 +104,7 @@ int applyMergedCatalogAndCommit(
   const ProllyHash *pCommitOurCatHash,
   const char *zMessage,
   int *pnConflicts,
+  int *pnViolations,
   char *hexBuf
 ){
   ChunkStore *cs;
@@ -235,6 +236,7 @@ int applyMergedCatalogAndCommit(
     sqlite3_free(zDetectErrMsg);
 
     if( nViolations + nUnique + nCheck + nNotNull > 0 ){
+      if( pnViolations ) *pnViolations = nViolations + nUnique + nCheck + nNotNull;
       if( *pnConflicts > 0 ){
         return doltliteCmdFinishWithConflictsAndConstraintViolations(
             db, context, &savedState, *pnConflicts, zOpLabel, 1, 0);
@@ -405,7 +407,8 @@ static void doltliteCherryPickFunc(
 
     rc = applyMergedCatalogAndCommit(db, context,
         &parentCommit.catalogHash, &ourCommit.catalogHash,
-        &pickCommit.catalogHash, &ourHead, 0, zMsg, &nConflicts, hexBuf);
+        &pickCommit.catalogHash, &ourHead, 0, zMsg, &nConflicts, 0,
+        hexBuf);
   }
 
   doltliteCommitClear(&pickCommit);

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -1090,6 +1090,7 @@ int applyMergedCatalogAndCommit(
   const ProllyHash *pCommitOurCatHash,
   const char *zMessage,
   int *pnConflicts,
+  int *pnViolations,
   char *hexBuf
 );
 

--- a/src/doltlite_rebase.c
+++ b/src/doltlite_rebase.c
@@ -332,6 +332,7 @@ static int doltliteRebaseLinearReplay(
   int dirty = 0;
   char *zFailedMsg = 0;
   int bConflict = 0;
+  int bViolation = 0;
   assert( db!=0 && context!=0 && zUpstream!=0 && pzFinalMessage!=0 );
   cs = doltliteGetChunkStore(db);
   sealTopLevel = db->pSavepoint!=0 && db->nSavepoint==0;
@@ -447,6 +448,7 @@ static int doltliteRebaseLinearReplay(
     DoltliteCommit replayCommit, parentCommit, curHeadCommit;
     ProllyHash curHead;
     int nConflicts = 0;
+    int nViolations = 0;
     char hexBuf[PROLLY_HASH_SIZE*2+1];
 
     memset(&replayCommit, 0, sizeof(replayCommit));
@@ -485,7 +487,7 @@ static int doltliteRebaseLinearReplay(
         &replayCommit.catalogHash,
         &curHead, 0,
         replayCommit.zMessage ? replayCommit.zMessage : "",
-        &nConflicts, hexBuf);
+        &nConflicts, &nViolations, hexBuf);
 
     doltliteCommitClear(&replayCommit);
     doltliteCommitClear(&parentCommit);
@@ -493,6 +495,10 @@ static int doltliteRebaseLinearReplay(
 
     if( rc!=SQLITE_OK ) goto rollback;
     if( nConflicts>0 ){ bConflict = 1; rc = SQLITE_ERROR; goto rollback; }
+    /* The finish helper rolled the replay back and returned OK; without
+    ** this stop the loop would move on and the rebase would finalize
+    ** WITHOUT this commit — its rows silently gone from the branch. */
+    if( nViolations>0 ){ bViolation = 1; rc = SQLITE_ERROR; goto rollback; }
   }
 
   doltliteGetSessionHead(db, &curHead);
@@ -560,6 +566,11 @@ rollback:
     if( bConflict && zFailedMsg && zFailedMsg[0] ){
       zErr = sqlite3_mprintf(
           "conflict rebasing \"%s\"; rebase aborted, branch restored to pre-rebase state",
+          zFailedMsg);
+    }else if( bViolation && zFailedMsg && zFailedMsg[0] ){
+      zErr = sqlite3_mprintf(
+          "constraint violations rebasing \"%s\"; rebase aborted, "
+          "branch restored to pre-rebase state",
           zFailedMsg);
     }else if( zFailedMsg && zFailedMsg[0] ){
       zErr = sqlite3_mprintf(

--- a/src/doltlite_revert.c
+++ b/src/doltlite_revert.c
@@ -219,7 +219,7 @@ static void doltliteRevertFunc(
     rc = applyMergedCatalogAndCommit(db, context,
         &revertCommit.catalogHash, &liveOurCatalog,
         &parentCommit.catalogHash, &ourHead, pCommitOurs, msg,
-        &nConflicts, hexBuf);
+        &nConflicts, 0, hexBuf);
   }
 
   doltliteCommitClear(&revertCommit);

--- a/test/vc_oracle_constraints_triggers_replay_test.sh
+++ b/test/vc_oracle_constraints_triggers_replay_test.sh
@@ -254,7 +254,8 @@ ALTER TABLE t2 RENAME TO t;
 SELECT dolt_add('-A'); SELECT dolt_commit('-m','main_check');
 SELECT dolt_checkout('feat');
 " "SELECT dolt_rebase('main');" \
-  "SELECT CONCAT('R|',id,'|',v) FROM t ORDER BY id;"
+  "SELECT dolt_checkout('feat');
+SELECT CONCAT('R|',id,'|',v) FROM t ORDER BY id;"
 
 echo ""
 echo "--- Group E: FK constraint + rebase ---"
@@ -293,7 +294,8 @@ ALTER TABLE c2 RENAME TO c;
 SELECT dolt_add('-A'); SELECT dolt_commit('-m','main_fk');
 SELECT dolt_checkout('feat');
 " "SELECT dolt_rebase('main');" \
-  "SELECT CONCAT('R|',id,'|',u) FROM c ORDER BY id;"
+  "SELECT dolt_checkout('feat');
+SELECT CONCAT('R|',id,'|',u) FROM c ORDER BY id;"
 
 echo ""
 echo "--- Group F: AFTER triggers fire based on commit diff, not replay DML ---"

--- a/test/vc_oracle_rebase_test.sh
+++ b/test/vc_oracle_rebase_test.sh
@@ -915,6 +915,66 @@ oracle "merge_dissolve_log" "$MERGE_DISSOLVE_SETUP" \
 oracle "merge_dissolve_table" "$MERGE_DISSOLVE_SETUP" \
   "SELECT CONCAT('LOG|', id, '=', v) FROM t ORDER BY id;"
 
+echo "--- a replay that violates a constraint aborts the whole rebase ---"
+
+CV_REBASE_SETUP="
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1, 'x');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'init');
+SELECT dolt_checkout('-b', 'feat');
+INSERT INTO t VALUES (2, 'x'), (3, 'y');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'feat_rows');
+SELECT dolt_checkout('main');
+CREATE UNIQUE INDEX uv ON t(v);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'unique_v');
+SELECT dolt_checkout('feat');
+SELECT dolt_rebase('main');
+"
+
+oracle_error_reopen "rebase_aborts_on_unique_violation_replay" "$CV_REBASE_SETUP" \
+  "SELECT dolt_checkout('feat');
+SELECT CONCAT('LOG|', id, '=', v) FROM t ORDER BY id;
+SELECT CONCAT('LOG|msg=', message) FROM dolt_log;"
+
+FK_REBASE_SEED="
+CREATE TABLE parent(id INTEGER PRIMARY KEY);
+CREATE TABLE child(id INTEGER PRIMARY KEY, pid INTEGER,
+  FOREIGN KEY(pid) REFERENCES parent(id));
+INSERT INTO parent VALUES (1), (2);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'init');
+SELECT dolt_checkout('-b', 'feat');
+"
+
+oracle_error_reopen "rebase_aborts_on_fk_violation_replay" "
+$FK_REBASE_SEED
+INSERT INTO child VALUES (1, 2);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'feat_child');
+SELECT dolt_checkout('main');
+DELETE FROM parent WHERE id = 2;
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'drop_parent_row');
+SELECT dolt_checkout('feat');
+SELECT dolt_rebase('main');
+" "SELECT dolt_checkout('feat');
+SELECT CONCAT('LOG|child|', id, '=', pid) FROM child ORDER BY id;
+SELECT CONCAT('LOG|parent|', id) FROM parent ORDER BY id;
+SELECT CONCAT('LOG|msg=', message) FROM dolt_log;"
+
+oracle_error_reopen "rebase_fk_cv_in_second_replay_aborts_whole_rebase" "
+$FK_REBASE_SEED
+INSERT INTO parent VALUES (5);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'feat_clean');
+INSERT INTO child VALUES (1, 2);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'feat_child');
+SELECT dolt_checkout('main');
+DELETE FROM parent WHERE id = 2;
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'drop_parent_row');
+SELECT dolt_checkout('feat');
+SELECT dolt_rebase('main');
+" "SELECT dolt_checkout('feat');
+SELECT CONCAT('LOG|child|', id, '=', pid) FROM child ORDER BY id;
+SELECT CONCAT('LOG|parent|', id) FROM parent ORDER BY id;
+SELECT CONCAT('LOG|msg=', message) FROM dolt_log;"
+
 echo ""
 echo "=== Results: $pass passed, $fail failed ==="
 if [ $fail -gt 0 ]; then


### PR DESCRIPTION
Deep-review action item 2, the data-loss core: non-interactive `dolt_rebase` silently discarded any replayed commit whose merge produced constraint violations. The CV finish helper rolls the replay back and returns SQLITE_OK, so the loop read the violating commit as success, continued, and finalized — the commit and all its rows (including perfectly valid ones) left the branch, with "Successfully rebased" delivered through the error channel. Dolt 2.2.2 (verified live) aborts the entire rebase.

**Mechanics:** `applyMergedCatalogAndCommit` reports the violation count through a new out-parameter — the same pattern conflicts already use — and the replay loop aborts through the existing rollback path (branch restored to pre-rebase state) with a constraint-violation message. Cherry-pick and revert pass null: they return the finish result to the user directly and already behave correctly. The interactive plan path already stopped on violations (post-#2117).

**Testing archaeology worth flagging:** two existing `vc_oracle_constraints_triggers_replay_test.sh` cases (`check_rebase_violation`, `fk_rebase_orphan`) appeared to cover this but passed via a *double* bug — Dolt's failed rebase parks its session on the rebase working branch, and that wrong-branch state coincidentally matched doltlite's swallowed-rebase state. Their probes are now branch-explicit and both fail on the unfixed engine. Similarly, a unique-index CV replay already "aborted" pre-fix, but only because REINDEX fails on the duplicate (the still-open bare-"constraint failed" ordering bug) rather than through detection — a new case pins that outcome so the eventual REINDEX-ordering fix can't regress it.

**Validation:** 2 new FK-replay oracle cases (single violating replay; violating second-of-two — the partial-swallow shape) fail before / pass after vs Dolt 2.2.2; rebase suite 51/51; revert 6/6, revert_cherrypick 58/58, merge 78/78, constraint_violations 8/8, constraints_triggers_replay 17/17. Full battery running; strict-C90 clean.

Remaining item-2 follow-ups (separate PRs): REINDEX-before-CV ordering, missing STRICT type detector, unique CV recording only one side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)