### PR TITLE
Record both sides of a unique-index collision found by a merge

### DIFF
--- a/src/doltlite_merge_constraints_unique.c
+++ b/src/doltlite_merge_constraints_unique.c
@@ -3,9 +3,12 @@
 #include "doltlite_merge_constraints_int.h"
 #include "vdbeInt.h"
 
+/* Every member of a colliding group is recorded, including rows that
+** predate the merge: the collision names them all as one violation, and
+** Dolt records both sides. The pre-existing-row skip the other detectors
+** apply does not belong here — it silently halved the violation. */
 static int appendUniqueViolationByRowid(
   sqlite3 *db,
-  struct TableEntry *aAnc, int nAnc,
   const char *zTable,
   const char *zIndexName,
   const char *zCols,
@@ -24,21 +27,6 @@ static int appendUniqueViolationByRowid(
   if( rc==SQLITE_NOTFOUND ) return SQLITE_OK;
   if( rc!=SQLITE_OK ) return rc;
 
-  if( aAnc ){
-    u8 *pAncVal = 0;
-    int nAncVal = 0;
-    int ancRc = fetchAncestorRowByName(db, aAnc, nAnc, zTable,
-                                       rowid, &pAncVal, &nAncVal);
-    int preExisting = (ancRc==SQLITE_OK)
-        && isRowPreExisting(pVal, nVal, pAncVal, nAncVal);
-    sqlite3_free(pAncVal);
-    if( preExisting ){
-      sqlite3_free(pKey);
-      sqlite3_free(pVal);
-      return SQLITE_OK;
-    }
-  }
-
   zInfo = sqlite3_mprintf(
       "{\"Columns\": [%s], \"Name\": \"%w\"}",
       zCols, zIndexName);
@@ -54,7 +42,6 @@ static int appendUniqueViolationByRowid(
 
 static int appendUniqueViolationByPk(
   sqlite3 *db,
-  struct TableEntry *aAnc, int nAnc,
   const char *zTable,
   const char *zIndexName,
   const char *zCols,
@@ -74,21 +61,6 @@ static int appendUniqueViolationByPk(
                              &pKey, &nKey, &pVal, &nVal);
   if( rc==SQLITE_NOTFOUND ) return SQLITE_OK;
   if( rc!=SQLITE_OK ) return rc;
-
-  if( aAnc ){
-    u8 *pAncVal = 0;
-    int nAncVal = 0;
-    int ancRc = fetchAncestorRowByKey(db, aAnc, nAnc, zTable,
-                                      pKey, nKey, &pAncVal, &nAncVal);
-    int preExisting = (ancRc==SQLITE_OK)
-        && isRowPreExisting(pVal, nVal, pAncVal, nAncVal);
-    sqlite3_free(pAncVal);
-    if( preExisting ){
-      sqlite3_free(pKey);
-      sqlite3_free(pVal);
-      return SQLITE_OK;
-    }
-  }
 
   zInfo = sqlite3_mprintf(
       "{\"Columns\": [%s], \"Name\": \"%w\"}",
@@ -297,7 +269,6 @@ static int uniqueIndexEntriesSort(
 
 static int detectUniqueViolationsForIndex(
   sqlite3 *db,
-  struct TableEntry *aAnc, int nAnc,
   const char *zTable,
   Index *pIdx,
   const char *zCols,
@@ -384,7 +355,7 @@ static int detectUniqueViolationsForIndex(
       int appended = 0;
       if( !winnerHandled ){
         rc = appendUniqueViolationByRowid(
-            db, aAnc, nAnc, zTable, pIdx->zName, zCols,
+            db, zTable, pIdx->zName, zCols,
             aEntry[i-1].rowid, &appended);
         if( rc!=SQLITE_OK ) break;
         if( appended && pnFound ) (*pnFound)++;
@@ -392,7 +363,7 @@ static int detectUniqueViolationsForIndex(
       }
       appended = 0;
       rc = appendUniqueViolationByRowid(
-          db, aAnc, nAnc, zTable, pIdx->zName, zCols,
+          db, zTable, pIdx->zName, zCols,
           aEntry[i].rowid, &appended);
       if( rc!=SQLITE_OK ) break;
       if( appended && pnFound ) (*pnFound)++;
@@ -411,7 +382,6 @@ unique_done:
 
 static int detectUniqueViolationsForIndexWithoutRowid(
   sqlite3 *db,
-  struct TableEntry *aAnc, int nAnc,
   struct TableEntry *pCurrent,
   const char *zTable,
   Index *pIdx,
@@ -545,7 +515,7 @@ static int detectUniqueViolationsForIndexWithoutRowid(
       int appended = 0;
       if( !winnerHandled ){
         rc = appendUniqueViolationByPk(
-            db, aAnc, nAnc, zTable, pIdx->zName, zCols, pPk,
+            db, zTable, pIdx->zName, zCols, pPk,
             aEntry[i-1].pPk, aEntry[i-1].nPk, &appended);
         if( rc!=SQLITE_OK ) break;
         if( appended && pnFound ) (*pnFound)++;
@@ -553,7 +523,7 @@ static int detectUniqueViolationsForIndexWithoutRowid(
       }
       appended = 0;
       rc = appendUniqueViolationByPk(
-          db, aAnc, nAnc, zTable, pIdx->zName, zCols, pPk,
+          db, zTable, pIdx->zName, zCols, pPk,
           aEntry[i].pPk, aEntry[i].nPk, &appended);
       if( rc!=SQLITE_OK ) break;
       if( appended && pnFound ) (*pnFound)++;
@@ -684,11 +654,10 @@ int doltliteDetectMergeUniqueViolations(
       if( supported && zColList && *zColList ){
         if( hasRowid ){
           rc = detectUniqueViolationsForIndex(
-              db, aAnc, nAnc, zTable, pIdx, zColList, pnFound);
+              db, zTable, pIdx, zColList, pnFound);
         }else{
           rc = detectUniqueViolationsForIndexWithoutRowid(
-              db, aAnc, nAnc,
-              doltliteFindTableByName(aCur, nCur, zTable),
+              db, doltliteFindTableByName(aCur, nCur, zTable),
               zTable, pIdx, zColList, &pkInfo, pnFound);
         }
       }

--- a/test/vc_oracle_constraint_violations_test.sh
+++ b/test/vc_oracle_constraint_violations_test.sh
@@ -266,6 +266,23 @@ SELECT CONCAT('R|AGG|', count(*)) FROM dolt_constraint_violations;" \
 R|TYPE|not null
 R|VERIFY|1"
 
+echo "--- unique index: pre-existing row is half of the collision ---"
+oracle "unique_preexisting_side_recorded" \
+"CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1,7);
+SELECT dolt_commit('-Am','init');
+SELECT dolt_branch('feat');
+CREATE UNIQUE INDEX uv ON t(v);
+SELECT dolt_commit('-Am','unique_v');
+SELECT dolt_checkout('feat');
+INSERT INTO t VALUES (2,7);
+SELECT dolt_commit('-Am','dup_row');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feat');
+" \
+"SELECT CONCAT('R|', CASE violation_type WHEN 'foreign key' THEN 'FK' WHEN 'unique index' THEN 'UQ' WHEN 'check constraint' THEN 'CK' ELSE '?' END, '|', id, '|', v, '|cols=', JSON_EXTRACT(violation_info,'\$.Columns')) FROM dolt_constraint_violations_t ORDER BY id;
+SELECT CONCAT('R|AGG|', \`table\`, '|', num_violations) FROM dolt_constraint_violations ORDER BY \`table\`;"
+
 echo ""
 echo "======================================="
 echo "Results: $pass passed, $fail failed"


### PR DESCRIPTION
Deep-review action item 2 follow-up. A unique-index collision between a merged-in row and a row that predates the merge recorded only the new row: the collision-group append ran every member through the pre-existing-row skip shared with the other detectors, which pruned the old partner. Dolt (verified live, 2.2.2) records both rows — the collision names all its members as one violation, and resolving it requires seeing both.

The skip stays correct for the NOT NULL / CHECK / FK detectors (they flag individually-bad rows and must not blame rows the merge never touched); the unique append helpers drop the ancestor check and the dead plumbing that fed it.

Validation: new `unique_preexisting_side_recorded` oracle case vs Dolt 2.2.2 (index added on one branch, dup row from the other colliding with an unchanged row → both recorded, aggregate count 2) — fails before, passes after. CV suite 9/9; merge 78/78, merge_status 11/11, revert_cherrypick 58/58, constraints_triggers_replay 17/17, rebase 48/48; full c-regression 310,258/310,258; strict-C90 clean.

No file overlap with #2134.

🤖 Generated with [Claude Code](https://claude.com/claude-code)