### PR TITLE
Rebuild adopted unique indexes without enforcement so duplicates become violations

### DIFF
--- a/src/doltlite_merge.c
+++ b/src/doltlite_merge.c
@@ -1409,13 +1409,38 @@ void doltliteFreeNameList(char **az, int n){
   sqlite3_free(az);
 }
 
+/* Rebuild the named (merge-adopted) indexes over the merged rows. REINDEX
+** enforces uniqueness while rebuilding, but rows that collide under an
+** adopted unique index are exactly what the merge must SURFACE — as
+** resolvable constraint violations from the detector that runs after this
+** — not a bare "constraint failed" that aborts the merge with nothing
+** recorded. A unique index holds duplicates physically (entries carry the
+** row key), so the rebuild runs with enforcement off and the detector
+** owns the outcome, as Dolt does. Enforcement returns for ordinary DML
+** once onError is restored. */
 int doltliteReindexNamedIndexes(sqlite3 *db, char **az, int n){
   int i, rc = SQLITE_OK;
+  if( n>0 ){
+    /* The adopted indexes exist only in the just-switched catalog; the
+    ** schema reloads on this prepare, so the lookups below can see them. */
+    rc = sqlite3_exec(db, "SELECT 1 FROM sqlite_master LIMIT 1", 0, 0, 0);
+    if( rc!=SQLITE_OK ) return rc;
+  }
   for(i=0; i<n && rc==SQLITE_OK; i++){
+    Index *pIdx = sqlite3FindIndex(db, az[i], "main");
+    u8 savedOnError = pIdx ? pIdx->onError : 0;
+    int suppressed = pIdx!=0;
     char *zSql = sqlite3_mprintf("REINDEX \"%w\"", az[i]);
     if( !zSql ) return SQLITE_NOMEM;
+    if( pIdx ) pIdx->onError = OE_None;
     rc = sqlite3_exec(db, zSql, 0, 0, 0);
     sqlite3_free(zSql);
+    if( suppressed ){
+      /* Re-find rather than trust the pointer: a failed exec can reset
+      ** the schema and free the Index. */
+      pIdx = sqlite3FindIndex(db, az[i], "main");
+      if( pIdx ) pIdx->onError = savedOnError;
+    }
   }
   return rc;
 }

--- a/test/vc_oracle_constraint_violations_test.sh
+++ b/test/vc_oracle_constraint_violations_test.sh
@@ -283,6 +283,23 @@ SELECT dolt_merge('feat');
 "SELECT CONCAT('R|', CASE violation_type WHEN 'foreign key' THEN 'FK' WHEN 'unique index' THEN 'UQ' WHEN 'check constraint' THEN 'CK' ELSE '?' END, '|', id, '|', v, '|cols=', JSON_EXTRACT(violation_info,'\$.Columns')) FROM dolt_constraint_violations_t ORDER BY id;
 SELECT CONCAT('R|AGG|', \`table\`, '|', num_violations) FROM dolt_constraint_violations ORDER BY \`table\`;"
 
+echo "--- unique index adopted from the other branch over local duplicates ---"
+oracle "unique_adopted_index_over_local_dups" \
+"CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1,7);
+SELECT dolt_commit('-Am','init');
+SELECT dolt_branch('feat');
+INSERT INTO t VALUES (2,7);
+SELECT dolt_commit('-Am','dup_on_main');
+SELECT dolt_checkout('feat');
+CREATE UNIQUE INDEX uv ON t(v);
+SELECT dolt_commit('-Am','unique_on_feat');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feat');
+" \
+"SELECT CONCAT('R|', CASE violation_type WHEN 'foreign key' THEN 'FK' WHEN 'unique index' THEN 'UQ' WHEN 'check constraint' THEN 'CK' ELSE '?' END, '|', id, '|', v, '|cols=', JSON_EXTRACT(violation_info,'\$.Columns')) FROM dolt_constraint_violations_t ORDER BY id;
+SELECT CONCAT('R|AGG|', \`table\`, '|', num_violations) FROM dolt_constraint_violations ORDER BY \`table\`;"
+
 echo ""
 echo "======================================="
 echo "Results: $pass passed, $fail failed"


### PR DESCRIPTION
Deep-review action item 2, the REINDEX-before-CV ordering bug: a merge adopting a unique index from the other branch rebuilt it with `REINDEX`, which enforces uniqueness during the rebuild — rows already colliding under the new index aborted the whole merge with a bare `constraint failed` and nothing recorded. Those rows are exactly what the merge should surface. Dolt (verified live, 2.2.2) completes the merge and records both collision partners as resolvable CVs.

**Mechanics:** `doltliteReindexNamedIndexes` (shared by merge, cherry-pick, and rebase replays) rebuilds each adopted index with its conflict action temporarily suppressed. A unique index holds duplicates physically — entries carry the row key — so the rebuilt index is valid and queryable, the unique detector that runs immediately after records the collision (both rows, thanks to #2135), and enforcement returns for ordinary DML once the action is restored. One trap worth recording: the adopted indexes exist only in the just-switched catalog, so the lookup must force a schema reload first — the naive version silently found nothing and suppressed nothing.

Post-merge, `PRAGMA integrity_check` reports the duplicate entries in the unique index until the CVs are resolved — accurate, since the violations are real and recorded; resolving them (UPDATE/DELETE) maintains the index back to clean incrementally.

**Validation:** new `unique_adopted_index_over_local_dups` oracle case vs Dolt 2.2.2 (merge completes, both rows recorded, aggregate 2) — fails before, passes after. CV suite 10/10 (including #2135's case), merge 78/78, rebase 51/51 (the #2134 unique-replay abort case now aborts via detection rather than the rebuild failure — pinned for exactly this change), revert_cherrypick 58/58, full c-regression 310,258/310,258, strict-C90 clean.

Remaining in item 2: the missing STRICT type detector (last piece).

🤖 Generated with [Claude Code](https://claude.com/claude-code)