### PR TITLE
Detect STRICT type violations left by a merge

### DIFF
--- a/doltlite.mk
+++ b/doltlite.mk
@@ -67,6 +67,7 @@ PROLLY_OBJS = $(DOLTLITE_AUTH_OBJS) \
               doltlite_merge_constraints_check.o \
               doltlite_merge_constraints_fk.o \
               doltlite_merge_constraints_notnull.o \
+              doltlite_merge_constraints_strict.o \
               doltlite_dbpage.o \
               doltlite_remote.o doltlite_remote_sql.o \
               doltlite_http_remote.o doltlite_remotesrv.o

--- a/main.mk
+++ b/main.mk
@@ -1601,6 +1601,9 @@ doltlite_merge_constraints_fk.o:	$(TOP)/src/doltlite_merge_constraints_fk.c $(TO
 doltlite_merge_constraints_notnull.o:	$(TOP)/src/doltlite_merge_constraints_notnull.c $(TOP)/src/doltlite_merge_constraints_int.h $(DEPS_OBJ_COMMON)
 	$(T.cc.sqlite) -c $(TOP)/src/doltlite_merge_constraints_notnull.c
 
+doltlite_merge_constraints_strict.o:	$(TOP)/src/doltlite_merge_constraints_strict.c $(TOP)/src/doltlite_merge_constraints_int.h $(DEPS_OBJ_COMMON)
+	$(T.cc.sqlite) -c $(TOP)/src/doltlite_merge_constraints_strict.c
+
 doltlite_merge.o:	$(TOP)/src/doltlite_merge.c $(TOP)/src/doltlite_merge_int.h $(DEPS_OBJ_COMMON)
 	$(T.cc.sqlite) -c $(TOP)/src/doltlite_merge.c
 

--- a/src/doltlite_cherry_pick.c
+++ b/src/doltlite_cherry_pick.c
@@ -199,6 +199,7 @@ int applyMergedCatalogAndCommit(
     int nUnique = 0;
     int nCheck = 0;
     int nNotNull = 0;
+    int nStrict = 0;
     char *zDetectErrMsg = 0;
 
     rc = doltliteConstraintViolationBatchBegin(db);
@@ -222,6 +223,11 @@ int applyMergedCatalogAndCommit(
                                                &zDetectErrMsg, &nNotNull,
                                                0, 0);
     }
+    if( rc==SQLITE_OK ){
+      rc = doltliteDetectMergeStrictViolations(db, ancCatHash,
+                                              &zDetectErrMsg, &nStrict,
+                                              0, 0);
+    }
     {
       int erc = doltliteConstraintViolationBatchEnd(db, rc==SQLITE_OK);
       if( rc==SQLITE_OK ) rc = erc;
@@ -235,8 +241,10 @@ int applyMergedCatalogAndCommit(
     }
     sqlite3_free(zDetectErrMsg);
 
-    if( nViolations + nUnique + nCheck + nNotNull > 0 ){
-      if( pnViolations ) *pnViolations = nViolations + nUnique + nCheck + nNotNull;
+    if( nViolations + nUnique + nCheck + nNotNull + nStrict > 0 ){
+      if( pnViolations ){
+        *pnViolations = nViolations + nUnique + nCheck + nNotNull + nStrict;
+      }
       if( *pnConflicts > 0 ){
         return doltliteCmdFinishWithConflictsAndConstraintViolations(
             db, context, &savedState, *pnConflicts, zOpLabel, 1, 0);

--- a/src/doltlite_constraint_violations.c
+++ b/src/doltlite_constraint_violations.c
@@ -830,6 +830,7 @@ static const char *violationTypeName(u8 t){
     case DOLTLITE_CV_UNIQUE_INDEX: return "unique index";
     case DOLTLITE_CV_CHECK_CONSTRAINT: return "check constraint";
     case DOLTLITE_CV_NOT_NULL: return "not null";
+    case DOLTLITE_CV_STRICT_TYPE: return "strict type";
     default: return "unknown";
   }
 }

--- a/src/doltlite_constraint_violations.h
+++ b/src/doltlite_constraint_violations.h
@@ -8,6 +8,7 @@
 #define DOLTLITE_CV_UNIQUE_INDEX     2
 #define DOLTLITE_CV_CHECK_CONSTRAINT 3
 #define DOLTLITE_CV_NOT_NULL         4
+#define DOLTLITE_CV_STRICT_TYPE      5
 
 typedef struct ConstraintViolationRow ConstraintViolationRow;
 struct ConstraintViolationRow {

--- a/src/doltlite_core.c
+++ b/src/doltlite_core.c
@@ -770,6 +770,7 @@ int doltliteDetectConstraintViolationsFiltered(
   int nUnique = 0;
   int nCheck = 0;
   int nNotNull = 0;
+  int nStrict = 0;
   char *zDetectErrMsg = 0;
   int rc;
   sqlite3_stmt *pStmt = 0;
@@ -788,7 +789,10 @@ int doltliteDetectConstraintViolationsFiltered(
       ** dolt_verify_constraints could not see a violating row at all. Matching
       ** a column merely named like the keyword only costs a scan the detectors
       ** find nothing in; missing one reports a clean database that is not. */
-      "            OR instr(upper(sql), 'NOT NULL')>0)) "
+      "            OR instr(upper(sql), 'NOT NULL')>0 "
+      /* STRICT tables have a type detector; the keyword sits at the tail
+      ** of the CREATE statement. */
+      "            OR instr(upper(sql), 'STRICT')>0)) "
       "   OR (type='index' AND sql IS NOT NULL "
       "       AND instr(upper(sql), 'CREATE UNIQUE INDEX')>0) "
       "LIMIT 1",
@@ -829,6 +833,11 @@ int doltliteDetectConstraintViolationsFiltered(
                                              &zDetectErrMsg, &nNotNull,
                                              azTables, nTables);
   }
+  if( rc==SQLITE_OK ){
+    rc = doltliteDetectMergeStrictViolations(db, pAncCatHash,
+                                            &zDetectErrMsg, &nStrict,
+                                            azTables, nTables);
+  }
   {
     int erc = doltliteConstraintViolationBatchEnd(db, rc==SQLITE_OK);
     if( rc==SQLITE_OK ) rc = erc;
@@ -836,7 +845,9 @@ int doltliteDetectConstraintViolationsFiltered(
   sqlite3_free(zDetectErrMsg);
   if( rc!=SQLITE_OK ) return rc;
 
-  if( pnViolations ) *pnViolations = nViolations + nUnique + nCheck + nNotNull;
+  if( pnViolations ){
+    *pnViolations = nViolations + nUnique + nCheck + nNotNull + nStrict;
+  }
   return SQLITE_OK;
 }
 

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -1048,6 +1048,9 @@ int doltliteDetectMergeCheckViolations(sqlite3 *db, const ProllyHash *pAncCatHas
 int doltliteDetectMergeNotNullViolations(sqlite3 *db, const ProllyHash *pAncCatHash,
                                        char **pzErrMsg, int *pnFound,
                                        const char **azTables, int nTables);
+int doltliteDetectMergeStrictViolations(sqlite3 *db, const ProllyHash *pAncCatHash,
+                                       char **pzErrMsg, int *pnFound,
+                                       const char **azTables, int nTables);
 
 int doltliteConstraintViolationBatchBegin(sqlite3 *db);
 int doltliteConstraintViolationBatchEnd(sqlite3 *db, int commit);

--- a/src/doltlite_merge_cmd.c
+++ b/src/doltlite_merge_cmd.c
@@ -263,7 +263,7 @@ static int mergeRefDetectConstraintViolations(
   int *pnViolations,
   char **pzErr
 ){
-  int nFk = 0, nUnique = 0, nCheck = 0, nNotNull = 0;
+  int nFk = 0, nUnique = 0, nCheck = 0, nNotNull = 0, nStrict = 0;
   int vrc;
   int erc;
 
@@ -283,9 +283,15 @@ static int mergeRefDetectConstraintViolations(
     vrc = doltliteDetectMergeNotNullViolations(db, pAncCat, pzErr, &nNotNull,
                                               0, 0);
   }
+  if( vrc==SQLITE_OK ){
+    vrc = doltliteDetectMergeStrictViolations(db, pAncCat, pzErr, &nStrict,
+                                             0, 0);
+  }
   erc = doltliteConstraintViolationBatchEnd(db, vrc==SQLITE_OK);
   if( vrc==SQLITE_OK ) vrc = erc;
-  if( vrc==SQLITE_OK ) *pnViolations = nFk + nUnique + nCheck + nNotNull;
+  if( vrc==SQLITE_OK ){
+    *pnViolations = nFk + nUnique + nCheck + nNotNull + nStrict;
+  }
   return vrc;
 }
 

--- a/src/doltlite_merge_constraints_strict.c
+++ b/src/doltlite_merge_constraints_strict.c
@@ -1,0 +1,324 @@
+#ifdef DOLTLITE_PROLLY
+
+#include "doltlite_merge_constraints_int.h"
+
+/* STRICT type violations left behind by a merge.
+**
+** A merge can bring together a STRICT table schema and a row from the other
+** side whose stored type the declared column type forbids. Neither side
+** violated anything on its own, so nothing along the write path objects, and
+** the row lands: integrity_check reports it, but nothing records a violation
+** and the commit is clean.
+**
+** The predicate is typeof(c) against the declared type's allowed storage
+** class. NULL passes here — the NOT NULL detector owns missing values — and
+** ANY columns allow everything, so neither generates a term.
+*/
+
+static void freeNames(char **az, int n){
+  int i;
+  for(i=0; i<n; i++) sqlite3_free(az[i]);
+  sqlite3_free(az);
+}
+
+/* The storage class a STRICT column admits, or 0 for ANY. Declared types in
+** a STRICT table are exactly INT, INTEGER, TEXT, REAL, BLOB, ANY. */
+static const char *strictAllowedTypeof(const char *zDecl){
+  if( sqlite3_stricmp(zDecl, "INT")==0
+   || sqlite3_stricmp(zDecl, "INTEGER")==0 ){
+    return "integer";
+  }
+  if( sqlite3_stricmp(zDecl, "TEXT")==0 ) return "text";
+  if( sqlite3_stricmp(zDecl, "REAL")==0 ) return "real";
+  if( sqlite3_stricmp(zDecl, "BLOB")==0 ) return "blob";
+  return 0;
+}
+
+/* True when zTable is declared STRICT. */
+static int tableIsStrict(sqlite3 *db, const char *zTable){
+  sqlite3_stmt *pQ = 0;
+  char *zSql;
+  int strict = 0;
+
+  zSql = sqlite3_mprintf(
+      "SELECT strict FROM pragma_table_list WHERE schema='main' AND name=%Q",
+      zTable);
+  if( !zSql ) return 0;
+  if( sqlite3_prepare_v2(db, zSql, -1, &pQ, 0)==SQLITE_OK
+   && sqlite3_step(pQ)==SQLITE_ROW ){
+    strict = sqlite3_column_int(pQ, 0);
+  }
+  sqlite3_free(zSql);
+  sqlite3_finalize(pQ);
+  return strict;
+}
+
+/* The typed columns of a STRICT table with the storage class each admits. */
+static int loadStrictColumns(
+  sqlite3 *db,
+  const char *zTable,
+  char ***pazCols,
+  char ***pazAllowed,
+  int *pnCols
+){
+  sqlite3_stmt *pQ = 0;
+  char *zSql;
+  char **azCols = 0;
+  char **azAllowed = 0;
+  int n = 0;
+  int nAlloc = 0;
+  int rc;
+
+  *pazCols = 0;
+  *pazAllowed = 0;
+  *pnCols = 0;
+  zSql = sqlite3_mprintf(
+      "SELECT name, type FROM pragma_table_info(%Q)", zTable);
+  if( !zSql ) return SQLITE_NOMEM;
+  rc = sqlite3_prepare_v2(db, zSql, -1, &pQ, 0);
+  sqlite3_free(zSql);
+  if( rc!=SQLITE_OK ) return rc;
+
+  while( sqlite3_step(pQ)==SQLITE_ROW ){
+    const char *zName = (const char*)sqlite3_column_text(pQ, 0);
+    const char *zType = (const char*)sqlite3_column_text(pQ, 1);
+    const char *zAllowed;
+    if( !zName || !zType ) continue;
+    zAllowed = strictAllowedTypeof(zType);
+    if( !zAllowed ) continue;
+    if( n==nAlloc ){
+      int nNew = nAlloc ? nAlloc*2 : 4;
+      char **azNew = sqlite3_realloc(azCols, nNew*(int)sizeof(char*));
+      char **azNew2 = azNew
+          ? sqlite3_realloc(azAllowed, nNew*(int)sizeof(char*)) : 0;
+      if( azNew ) azCols = azNew;
+      if( !azNew2 ){ rc = SQLITE_NOMEM; break; }
+      azAllowed = azNew2;
+      nAlloc = nNew;
+    }
+    azCols[n] = sqlite3_mprintf("%s", zName);
+    azAllowed[n] = sqlite3_mprintf("%s", zAllowed);
+    if( !azCols[n] || !azAllowed[n] ){
+      sqlite3_free(azCols[n]);
+      sqlite3_free(azAllowed[n]);
+      rc = SQLITE_NOMEM;
+      break;
+    }
+    n++;
+  }
+  sqlite3_finalize(pQ);
+  if( rc!=SQLITE_OK ){
+    freeNames(azCols, n);
+    freeNames(azAllowed, n);
+    return rc;
+  }
+  *pazCols = azCols;
+  *pazAllowed = azAllowed;
+  *pnCols = n;
+  return SQLITE_OK;
+}
+
+int doltliteDetectMergeStrictViolations(
+  sqlite3 *db,
+  const ProllyHash *pAncCatHash,
+  char **pzErrMsg,
+  int *pnFound,
+  const char **azTables,
+  int nTables
+){
+  sqlite3_stmt *pTbls = 0;
+  struct TableEntry *aAnc = 0;
+  int nAnc = 0;
+  struct TableEntry *aCur = 0;
+  int nCur = 0;
+  int rc;
+  int stepRc;
+
+  (void)pzErrMsg;
+  if( pnFound ) *pnFound = 0;
+
+  rc = loadAncestorAndCurrentCatalogs(db, pAncCatHash, &aAnc, &nAnc,
+                                      &aCur, &nCur);
+  if( rc!=SQLITE_OK ) return rc;
+
+  rc = sqlite3_prepare_v2(db,
+      "SELECT name FROM main.sqlite_master WHERE type='table' "
+      "AND name NOT LIKE 'sqlite_%' AND name NOT LIKE 'dolt_%'",
+      -1, &pTbls, 0);
+  if( rc!=SQLITE_OK ){
+    doltliteFreeCatalog(aAnc, nAnc);
+    doltliteFreeCatalog(aCur, nCur);
+    return rc;
+  }
+
+  while( (stepRc = sqlite3_step(pTbls))==SQLITE_ROW ){
+    const char *zTableRaw = (const char*)sqlite3_column_text(pTbls, 0);
+    char *zTable;
+    char **azCols = 0;
+    char **azAllowed = 0;
+    int nCols = 0;
+    int hasRowid;
+    int nKeyCol;
+    MergePkInfo pkInfo;
+    sqlite3_str *pStr;
+    char *zQuery = 0;
+    sqlite3_stmt *pQ = 0;
+    int i;
+
+    if( !zTableRaw ) continue;
+    zTable = sqlite3_mprintf("%s", zTableRaw);
+    if( !zTable ){ rc = SQLITE_NOMEM; break; }
+    if( !cvTableAllowed(zTable, azTables, nTables)
+     || !catalogTableChanged(aAnc, nAnc, aCur, nCur, zTable)
+     || !tableIsStrict(db, zTable) ){
+      sqlite3_free(zTable);
+      continue;
+    }
+
+    rc = loadStrictColumns(db, zTable, &azCols, &azAllowed, &nCols);
+    if( rc!=SQLITE_OK ){
+      sqlite3_free(zTable);
+      break;
+    }
+    if( nCols==0 ){
+      sqlite3_free(zTable);
+      continue;
+    }
+
+    memset(&pkInfo, 0, sizeof(pkInfo));
+    hasRowid = tableHasRowid(db, zTable);
+    if( !hasRowid ){
+      rc = loadMergePkInfo(db, zTable, &pkInfo);
+      if( rc!=SQLITE_OK ){
+        freeNames(azCols, nCols);
+        freeNames(azAllowed, nCols);
+        sqlite3_free(zTable);
+        break;
+      }
+    }
+    nKeyCol = hasRowid ? 1 : pkInfo.nPk;
+
+    /* One row per offending row, carrying a flag per typed column so every
+    ** column holding a forbidden storage class is named. */
+    pStr = sqlite3_str_new(db);
+    sqlite3_str_appendf(pStr, "SELECT %s",
+                        hasRowid ? "rowid" : pkInfo.zPkCols);
+    for(i=0; i<nCols; i++){
+      sqlite3_str_appendf(pStr, ", typeof(\"%w\") NOT IN ('null','%s')",
+                          azCols[i], azAllowed[i]);
+    }
+    sqlite3_str_appendf(pStr, " FROM main.\"%w\" NOT INDEXED WHERE 0", zTable);
+    for(i=0; i<nCols; i++){
+      sqlite3_str_appendf(pStr, " OR typeof(\"%w\") NOT IN ('null','%s')",
+                          azCols[i], azAllowed[i]);
+    }
+    zQuery = sqlite3_str_finish(pStr);
+    if( !zQuery ){
+      freeNames(azCols, nCols);
+      freeNames(azAllowed, nCols);
+      freeMergePkInfo(&pkInfo);
+      sqlite3_free(zTable);
+      rc = SQLITE_NOMEM;
+      break;
+    }
+    rc = sqlite3_prepare_v2(db, zQuery, -1, &pQ, 0);
+    sqlite3_free(zQuery);
+    if( rc!=SQLITE_OK ){
+      /* A table the merge left unreadable is the other detectors' business. */
+      freeNames(azCols, nCols);
+      freeNames(azAllowed, nCols);
+      freeMergePkInfo(&pkInfo);
+      sqlite3_free(zTable);
+      rc = SQLITE_OK;
+      continue;
+    }
+
+    while( sqlite3_step(pQ)==SQLITE_ROW ){
+      u8 *pKey = 0; int nKey = 0;
+      u8 *pVal = 0; int nVal = 0;
+      i64 intKey = 0;
+      sqlite3_str *pInfo;
+      char *zInfo;
+      int nNamed = 0;
+      int appendRc;
+
+      if( hasRowid ){
+        intKey = sqlite3_column_int64(pQ, 0);
+        rc = fetchOrphanRow(db, zTable, intKey, &pKey, &nKey, &pVal, &nVal);
+      }else{
+        u8 *pPkRec = 0; int nPkRec = 0;
+        pPkRec = buildRecordFromStmtCols(pQ, 0, pkInfo.nPk, &nPkRec);
+        if( !pPkRec ){ rc = SQLITE_NOMEM; break; }
+        rc = fetchRowByPkFromTable(db, zTable, pPkRec, nPkRec, pkInfo.nPk,
+                                   &pKey, &nKey, &pVal, &nVal);
+        sqlite3_free(pPkRec);
+      }
+      if( rc==SQLITE_NOTFOUND ){ rc = SQLITE_OK; continue; }
+      if( rc!=SQLITE_OK ){
+        sqlite3_free(pKey);
+        sqlite3_free(pVal);
+        break;
+      }
+
+      /* A row that already held the forbidden type before the merge is not
+      ** the merge's doing, same rule the other detectors apply. */
+      if( aAnc ){
+        u8 *pAncVal = 0; int nAncVal = 0;
+        int ancRc = hasRowid
+            ? fetchAncestorRowByName(db, aAnc, nAnc, zTable,
+                                     intKey, &pAncVal, &nAncVal)
+            : fetchAncestorRowByKey(db, aAnc, nAnc, zTable,
+                                    pKey, nKey, &pAncVal, &nAncVal);
+        int preExisting = (ancRc==SQLITE_OK)
+            && isRowPreExisting(pVal, nVal, pAncVal, nAncVal);
+        sqlite3_free(pAncVal);
+        if( preExisting ){
+          sqlite3_free(pKey);
+          sqlite3_free(pVal);
+          continue;
+        }
+      }
+
+      pInfo = sqlite3_str_new(db);
+      sqlite3_str_appendall(pInfo, "{\"Columns\": [");
+      for(i=0; i<nCols; i++){
+        if( sqlite3_column_int(pQ, nKeyCol + i) ){
+          sqlite3_str_appendf(pInfo, "%s\"%w\"", nNamed ? ", " : "", azCols[i]);
+          nNamed++;
+        }
+      }
+      sqlite3_str_appendall(pInfo, "]}");
+      zInfo = sqlite3_str_finish(pInfo);
+      if( !zInfo ){
+        sqlite3_free(pKey);
+        sqlite3_free(pVal);
+        rc = SQLITE_NOMEM;
+        break;
+      }
+      appendRc = doltliteAppendConstraintViolation(
+          db, zTable, DOLTLITE_CV_STRICT_TYPE,
+          intKey, pKey, nKey, pVal, nVal, zInfo);
+      sqlite3_free(zInfo);
+      sqlite3_free(pKey);
+      sqlite3_free(pVal);
+      if( appendRc!=SQLITE_OK ){ rc = appendRc; break; }
+      if( pnFound ) (*pnFound)++;
+    }
+
+    sqlite3_finalize(pQ);
+    freeNames(azCols, nCols);
+    freeNames(azAllowed, nCols);
+    freeMergePkInfo(&pkInfo);
+    sqlite3_free(zTable);
+    if( rc!=SQLITE_OK ) break;
+  }
+  if( rc==SQLITE_OK && stepRc!=SQLITE_DONE && stepRc!=SQLITE_ROW ){
+    rc = stepRc;
+  }
+  sqlite3_finalize(pTbls);
+  doltliteFreeCatalog(aAnc, nAnc);
+  doltliteFreeCatalog(aCur, nCur);
+  return rc;
+}
+
+#endif

--- a/src/doltlite_merge_constraints_strict.c
+++ b/src/doltlite_merge_constraints_strict.c
@@ -15,7 +15,7 @@
 ** ANY columns allow everything, so neither generates a term.
 */
 
-static void freeNames(char **az, int n){
+static void strictFreeNames(char **az, int n){
   int i;
   for(i=0; i<n; i++) sqlite3_free(az[i]);
   sqlite3_free(az);
@@ -108,8 +108,8 @@ static int loadStrictColumns(
   }
   sqlite3_finalize(pQ);
   if( rc!=SQLITE_OK ){
-    freeNames(azCols, n);
-    freeNames(azAllowed, n);
+    strictFreeNames(azCols, n);
+    strictFreeNames(azAllowed, n);
     return rc;
   }
   *pazCols = azCols;
@@ -190,8 +190,8 @@ int doltliteDetectMergeStrictViolations(
     if( !hasRowid ){
       rc = loadMergePkInfo(db, zTable, &pkInfo);
       if( rc!=SQLITE_OK ){
-        freeNames(azCols, nCols);
-        freeNames(azAllowed, nCols);
+        strictFreeNames(azCols, nCols);
+        strictFreeNames(azAllowed, nCols);
         sqlite3_free(zTable);
         break;
       }
@@ -214,8 +214,8 @@ int doltliteDetectMergeStrictViolations(
     }
     zQuery = sqlite3_str_finish(pStr);
     if( !zQuery ){
-      freeNames(azCols, nCols);
-      freeNames(azAllowed, nCols);
+      strictFreeNames(azCols, nCols);
+      strictFreeNames(azAllowed, nCols);
       freeMergePkInfo(&pkInfo);
       sqlite3_free(zTable);
       rc = SQLITE_NOMEM;
@@ -225,8 +225,8 @@ int doltliteDetectMergeStrictViolations(
     sqlite3_free(zQuery);
     if( rc!=SQLITE_OK ){
       /* A table the merge left unreadable is the other detectors' business. */
-      freeNames(azCols, nCols);
-      freeNames(azAllowed, nCols);
+      strictFreeNames(azCols, nCols);
+      strictFreeNames(azAllowed, nCols);
       freeMergePkInfo(&pkInfo);
       sqlite3_free(zTable);
       rc = SQLITE_OK;
@@ -306,8 +306,8 @@ int doltliteDetectMergeStrictViolations(
     }
 
     sqlite3_finalize(pQ);
-    freeNames(azCols, nCols);
-    freeNames(azAllowed, nCols);
+    strictFreeNames(azCols, nCols);
+    strictFreeNames(azAllowed, nCols);
     freeMergePkInfo(&pkInfo);
     sqlite3_free(zTable);
     if( rc!=SQLITE_OK ) break;

--- a/test/vc_oracle_constraint_violations_test.sh
+++ b/test/vc_oracle_constraint_violations_test.sh
@@ -300,6 +300,33 @@ SELECT dolt_merge('feat');
 "SELECT CONCAT('R|', CASE violation_type WHEN 'foreign key' THEN 'FK' WHEN 'unique index' THEN 'UQ' WHEN 'check constraint' THEN 'CK' ELSE '?' END, '|', id, '|', v, '|cols=', JSON_EXTRACT(violation_info,'\$.Columns')) FROM dolt_constraint_violations_t ORDER BY id;
 SELECT CONCAT('R|AGG|', \`table\`, '|', num_violations) FROM dolt_constraint_violations ORDER BY \`table\`;"
 
+echo "--- strict table: forbidden storage class arrives on merge (doltlite-only) ---"
+# Same split as CHECK: Dolt has no STRICT/flexible distinction (every table is
+# typed, so the violating row cannot exist on the source branch), and the
+# recreate-and-rename tighten reads as a primary-key change there. The closest
+# Dolt behavior is a type conflict; doltlite records a violation naming the
+# column, in the shape the other detectors use.
+dl_expect "strict_type_violating_row_arrives_on_merge" \
+"CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1,10);
+SELECT dolt_commit('-Am','init');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+INSERT INTO t VALUES (2,'hello');
+SELECT dolt_commit('-Am','feat_text');
+SELECT dolt_checkout('main');
+CREATE TABLE t2(id INTEGER PRIMARY KEY, v INT) STRICT;
+INSERT INTO t2 SELECT id, CAST(v AS INT) FROM t;
+DROP TABLE t;
+ALTER TABLE t2 RENAME TO t;
+SELECT dolt_commit('-Am','main_strict');
+SELECT dolt_merge('feat');
+" \
+"SELECT CONCAT('R|', CASE violation_type WHEN 'foreign key' THEN 'FK' WHEN 'unique index' THEN 'UQ' WHEN 'check constraint' THEN 'CK' WHEN 'strict type' THEN 'ST' ELSE '?' END, '|', id, '|', v, '|', typeof(v), '|cols=', JSON_EXTRACT(violation_info,'\$.Columns')) FROM dolt_constraint_violations_t ORDER BY id;
+SELECT CONCAT('R|AGG|', 't|', num_violations) FROM dolt_constraint_violations;" \
+"R|AGG|t|1
+R|ST|2|hello|text|cols=[v]"
+
 echo ""
 echo "======================================="
 echo "Results: $pass passed, $fail failed"

--- a/tool/mksqlite3c.tcl
+++ b/tool/mksqlite3c.tcl
@@ -637,7 +637,7 @@ proc emit_doltlite_engine_block {} {
     doltlite_conflicts.c doltlite_gc.c doltlite_chunk_walk.c
     doltlite_history.c doltlite_at.c doltlite_blame.c doltlite_schema_diff.c doltlite_patch.c
     doltlite_schemas.c doltlite_diff_stat.c doltlite_record.c doltlite_ignore.c
-    doltlite_hashof.c doltlite_constraint_violations.c doltlite_verify_constraints.c doltlite_merge_constraints.c doltlite_merge_constraints_unique.c doltlite_merge_constraints_check.c doltlite_merge_constraints_fk.c doltlite_merge_constraints_notnull.c
+    doltlite_hashof.c doltlite_constraint_violations.c doltlite_verify_constraints.c doltlite_merge_constraints.c doltlite_merge_constraints_unique.c doltlite_merge_constraints_check.c doltlite_merge_constraints_fk.c doltlite_merge_constraints_notnull.c doltlite_merge_constraints_strict.c
     doltlite_dbpage.c doltlite_remote.c doltlite_remote_sql.c doltlite_http_remote.c
     doltlite_remotesrv.c
   }


### PR DESCRIPTION
Deep-review action item 2, final piece: a merge could commit rows into a STRICT table whose stored types the declared columns forbid — cleanly, with zero violations recorded. `PRAGMA integrity_check` reported the rows, but nothing refused the commit and nothing made them resolvable. Same "clean merge, corrupt table" class as the NOT NULL hole (#2113/#2114).

**Mechanics:** a new detector modeled directly on the NOT NULL one (`doltlite_merge_constraints_strict.c`): per changed STRICT table, the typed columns and the storage class each admits, one `typeof()`-based scan the planner can't fold, the shared pre-existing-row skip, and violations recorded as `strict type` naming the offending columns. NULL passes (NOT NULL owns it), `ANY` columns generate no term. Wired into the merge and cherry-pick batches and the filtered entry that rebase and `dolt_verify_constraints` share; the #2117 precheck now also matches `STRICT`. With #2134 in, a rebase replay producing a strict-type violation aborts the whole rebase like any other CV.

**Oracle:** doltlite-only fixed expectation, same split and same reason as the CHECK case (Dolt has no flexible→STRICT transition to express — every Dolt table is typed, so the violating row can't exist on the source branch). Fails before (clean commit, nothing recorded), passes after (`strict type | 2 | hello | text`, columns `[v]`, aggregate 1).

**Validation:** CV suite 10/10; merge 78/78, merge_status 11/11, revert_cherrypick 58/58, constraints_triggers_replay 17/17, rebase 51/51; full c-regression 310,258/310,258; amalgamation regenerates with the new file; strict-C90 clean.

This completes deep-review item 2: #2117 (detection gate), #2134 (rebase abort), #2135 (unique both sides), #2137 (REINDEX ordering, in CI), and this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)