### PR TITLE
Cache the tree payload only on a pure tree landing in the seek fallback

### DIFF
--- a/src/prolly_btree_cursor_seek.c
+++ b/src/prolly_btree_cursor_seek.c
@@ -1040,9 +1040,15 @@ int prollyBtCursorIndexMoveto(
     if( lastRes==0 ){
       pCur->eState = CURSOR_VALID;
       *pRes = -1;
-      if( !pCur->mmActive || pCur->mergeSrc!=MERGE_SRC_MUT ){
+      if( !pCur->mmActive || pCur->mergeSrc==MERGE_SRC_TREE ){
+        /* Cache only on a pure tree landing: getCursorPayload serves the
+        ** cache before the merge source, so caching on a BOTH landing
+        ** serves the shadowed committed value instead of the pending one
+        ** written in this transaction. A BOTH landing needs no deferral
+        ** either -- mergeLast leaves the tree cursor ON the row, valid
+        ** for a step in either direction. */
         cacheCurrentTreeStoredPayloadNonIntKey(pCur);
-      }else{
+      }else if( pCur->mergeSrc==MERGE_SRC_MUT ){
         /* mergeLast scanned backwards to get here, so the tree side sits
         ** below this mut-map row -- it was retreated past any delete-masked
         ** row at the same key. Stepping forward from that would serve a tree

--- a/test/review_regression_test.sh
+++ b/test/review_regression_test.sh
@@ -1282,6 +1282,41 @@ run_test "sp_returning_analyze_integrity" "PRAGMA integrity_check;" "ok" "$DB"
 rm -f "$DB"
 
 
+echo "--- Guard: BOTH-landing keeps the pending value (in-txn UPDATE vs descending bounded scans) ---"
+
+# The IndexMoveto past-end fallback lands on the merged last row; caching the
+# tree payload there on a BOTH landing served the shadowed committed value
+# instead of the one this transaction wrote. Expected values verified against
+# stock SQLite 3.54.
+DB=/tmp/test_rg_both_landing_$$.db; rm -f "$DB"
+echo "CREATE TABLE t(k TEXT PRIMARY KEY, v) WITHOUT ROWID;
+INSERT INTO t VALUES('a','old');
+INSERT INTO t VALUES('m','mid');
+CREATE TABLE t2(k TEXT PRIMARY KEY DESC, v) WITHOUT ROWID;
+INSERT INTO t2 VALUES('a','old');
+INSERT INTO t2 VALUES('m','mid');
+CREATE TABLE t3(k TEXT PRIMARY KEY, v) WITHOUT ROWID;
+INSERT INTO t3 VALUES('a','old');
+INSERT INTO t3 VALUES('m','mid');
+INSERT INTO t3 VALUES('z','top');" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+run_test "both_landing_desc_lt" \
+  "BEGIN; UPDATE t SET v='new' WHERE k='m'; SELECT group_concat(v,'|') FROM (SELECT v FROM t WHERE k < 'q' ORDER BY k DESC); ROLLBACK;" \
+  "new|old" "$DB"
+run_test "both_landing_desc_le" \
+  "BEGIN; UPDATE t SET v='new' WHERE k='m'; SELECT group_concat(v,'|') FROM (SELECT v FROM t WHERE k <= 'm' ORDER BY k DESC); ROLLBACK;" \
+  "new|old" "$DB"
+run_test "both_landing_scalar_last" \
+  "BEGIN; UPDATE t SET v='new' WHERE k='m'; SELECT (SELECT v FROM t WHERE k < 'z' ORDER BY k DESC LIMIT 1); ROLLBACK;" \
+  "new" "$DB"
+run_test "both_landing_desc_pk_asc_scan" \
+  "BEGIN; UPDATE t2 SET v='new' WHERE k='m'; SELECT group_concat(v,'|') FROM (SELECT v FROM t2 WHERE k > '' ORDER BY k); ROLLBACK;" \
+  "old|new" "$DB"
+run_test "both_landing_tombstone_reroute" \
+  "BEGIN; DELETE FROM t3 WHERE k='z'; UPDATE t3 SET v='new' WHERE k='m'; SELECT group_concat(v,'|') FROM (SELECT v FROM t3 WHERE k < 'y' ORDER BY k DESC); ROLLBACK;" \
+  "new|old" "$DB"
+rm -f "$DB"
+
 echo ""
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"
 if [ $FAIL -gt 0 ]; then echo -e "$ERRORS"; exit 1; fi


### PR DESCRIPTION
Deep-review action item 3 (HIGH, confirmed by repro): inside a transaction, an UPDATE on a WITHOUT ROWID table followed by a descending bounded scan returned the **pre-update** value:

```sql
CREATE TABLE t(k TEXT PRIMARY KEY, v) WITHOUT ROWID;
INSERT INTO t VALUES('a','old'); INSERT INTO t VALUES('m','mid');
BEGIN;
UPDATE t SET v='new' WHERE k='m';
SELECT group_concat(v,'|') FROM (SELECT v FROM t WHERE k < 'q' ORDER BY k DESC);
-- doltlite: mid|old      stock: new|old
```

The IndexMoveto past-end fallback cached the tree payload under `mergeSrc != MERGE_SRC_MUT`, which admits a `MERGE_SRC_BOTH` landing (committed row shadowed by this transaction's pending insert — an in-txn UPDATE), and `getCursorPayload` serves the cache before consulting the merge source. Of the 13 payload-caching sites in the merged cursor, this was the single one with the inverted guard; 12 of 450 random differential seeds collapsed to it. It survived the suites because the existing past-end tests use rowid tables, whose key-derived payloads can't go stale. A BOTH landing needs no `deferredTreeSeek` either — `mergeLast` leaves the tree cursor on the row, valid for either step direction.

**Validation:** 5 new `review_regression_test.sh` guards with stock-3.54-verified expectations (`<` and `<=` descending scans, LIMIT 1 scalar, DESC primary key walked ascending, tombstone rerouting into the fallback) — 3 reproduce the bug on the unfixed engine, 2 pin adjacent shapes; suite 158/158. Differential sweep 400/400 seeds all-groups. FTS4 canary buckets (reverse-scan sentinels for cursor changes) 115/115. Full c-regression 310,258/310,258.

Not included (deliberately, per one-fix-per-PR): three LOW hardening items from the same review — a forward-step mirror of the reversal re-seek, `mergeStepDir` reseeding on scan resume, and the custom-collation landing's missing deferral — all analyzed unreachable today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)