### PR TITLE
Merge a session's ref changes onto peer refs instead of restoring wholesale

### DIFF
--- a/src/chunk_refs.c
+++ b/src/chunk_refs.c
@@ -548,3 +548,318 @@ int csReplaceRefsStateFromBlob(
 }
 
 #endif
+
+/* Three-way merge of the session's uncommitted ref changes onto a refs
+** table peers have advanced. cs->refs holds the DISK state just reloaded;
+** pLocal holds this session's arrays, derived from pBase (the blob at the
+** committedRefsHash the session last adopted). Refs the session did not
+** touch keep their disk value — that is the whole point: a wholesale
+** restore of pLocal silently reverted every peer change except the one
+** tip the branch CAS happened to check. Refs the session changed apply
+** onto disk unless a peer changed the same ref differently, which is a
+** real race and fails SQLITE_BUSY_SNAPSHOT rather than picking a winner.
+** Sequences are AUTOINCREMENT high-water marks and merge by max. The
+** scan runs conflict-detection first so the disk arrays are untouched
+** unless the whole merge applies. */
+
+static int refsHashesEqual(const ProllyHash *a, const ProllyHash *b){
+  return prollyHashCompare(a, b)==0;
+}
+
+static int refsStrEqual(const char *a, const char *b){
+  if( a==0 && b==0 ) return 1;
+  if( a==0 || b==0 ) return 0;
+  return strcmp(a, b)==0;
+}
+
+static int branchRefsEqual(const BranchRef *a, const BranchRef *b){
+  return refsHashesEqual(&a->commitHash, &b->commitHash)
+      && refsHashesEqual(&a->workingSetHash, &b->workingSetHash);
+}
+
+static int tagRefsEqual(const TagRef *a, const TagRef *b){
+  return refsHashesEqual(&a->commitHash, &b->commitHash)
+      && a->timestamp==b->timestamp
+      && refsStrEqual(a->zTagger, b->zTagger)
+      && refsStrEqual(a->zEmail, b->zEmail)
+      && refsStrEqual(a->zMessage, b->zMessage);
+}
+
+static int remoteRefsEqual(const RemoteRef *a, const RemoteRef *b){
+  return refsStrEqual(a->zUrl, b->zUrl);
+}
+
+static int trackingRefsEqual(const TrackingBranch *a, const TrackingBranch *b){
+  return refsHashesEqual(&a->commitHash, &b->commitHash);
+}
+
+static int findTrackingIdx(
+  const TrackingBranch *a, int n,
+  const char *zRemote, const char *zBranch
+){
+  int i;
+  for(i=0; i<n; i++){
+    if( refsStrEqual(a[i].zRemote, zRemote)
+     && refsStrEqual(a[i].zBranch, zBranch) ){
+      return i;
+    }
+  }
+  return -1;
+}
+
+/* One name-keyed category: detect conflicts when checkOnly, else apply.
+** The callbacks localize the per-type field handling; iteration and the
+** three-way decisions live here once. */
+typedef struct RefsMergeCat RefsMergeCat;
+struct RefsMergeCat {
+  const void *aLocal; int nLocal;
+  const void *aBase;  int nBase;
+  void **paDisk;      int *pnDisk;
+  int stride;
+  int (*xEqual)(const void*, const void*);
+  int (*xCopyInto)(void *pDst, const void *pSrc);
+  void (*xFreeEntry)(void*);
+  int (*xFind)(const void *aBase, int n, const void *pEntry);
+};
+
+static int refsMergeCategory(RefsMergeCat *p, int checkOnly){
+  int i;
+  const u8 *aLocal = (const u8*)p->aLocal;
+  const u8 *aBase = (const u8*)p->aBase;
+
+  for(i=0; i<p->nLocal; i++){
+    const void *pL = aLocal + (size_t)i*p->stride;
+    int iB = p->xFind(p->aBase, p->nBase, pL);
+    const void *pB = iB<0 ? 0 : (const void*)(aBase + (size_t)iB*p->stride);
+    int iD;
+    void *pD;
+    if( pB && p->xEqual(pL, pB) ) continue;     /* not locally changed */
+    iD = p->xFind(*p->paDisk, *p->pnDisk, pL);
+    pD = iD<0 ? 0 : (void*)((u8*)(*p->paDisk) + (size_t)iD*p->stride);
+    if( pD ){
+      if( pB && !p->xEqual(pD, pB) && !p->xEqual(pD, pL) ){
+        return SQLITE_BUSY_SNAPSHOT;            /* both sides moved it */
+      }
+      if( !pB && !p->xEqual(pD, pL) ){
+        return SQLITE_BUSY_SNAPSHOT;            /* both sides created it */
+      }
+      if( !checkOnly ){
+        p->xFreeEntry(pD);
+        if( p->xCopyInto(pD, pL) ) return SQLITE_NOMEM;
+      }
+    }else{
+      if( pB ){
+        return SQLITE_BUSY_SNAPSHOT;   /* peer deleted what we changed */
+      }
+      if( !checkOnly ){
+        int rc = csRefArrayGrow(p->paDisk, *p->pnDisk, p->stride);
+        if( rc!=SQLITE_OK ) return rc;
+        pD = (void*)((u8*)(*p->paDisk) + (size_t)(*p->pnDisk)*p->stride);
+        if( p->xCopyInto(pD, pL) ) return SQLITE_NOMEM;
+        (*p->pnDisk)++;
+      }
+    }
+  }
+  for(i=0; i<p->nBase; i++){
+    const void *pB = aBase + (size_t)i*p->stride;
+    int iL = p->xFind(p->aLocal, p->nLocal, pB);
+    int iD;
+    if( iL>=0 ) continue;                       /* still present locally */
+    iD = p->xFind(*p->paDisk, *p->pnDisk, pB);  /* locally deleted */
+    if( iD>=0 ){
+      void *pD = (void*)((u8*)(*p->paDisk) + (size_t)iD*p->stride);
+      if( !p->xEqual(pD, pB) ){
+        return SQLITE_BUSY_SNAPSHOT;   /* peer changed what we deleted */
+      }
+      if( !checkOnly ){
+        p->xFreeEntry(pD);
+        memmove(pD, (u8*)pD + p->stride,
+                (size_t)(*p->pnDisk - iD - 1)*p->stride);
+        (*p->pnDisk)--;
+      }
+    }
+  }
+  return SQLITE_OK;
+}
+
+static int branchFind(const void *aBase, int n, const void *pEntry){
+  return csFindNamedRef(aBase, n, sizeof(BranchRef), *(char* const*)pEntry);
+}
+
+static int tagFind(const void *aBase, int n, const void *pEntry){
+  return csFindNamedRef(aBase, n, sizeof(TagRef), *(char* const*)pEntry);
+}
+
+static int remoteFind(const void *aBase, int n, const void *pEntry){
+  return csFindNamedRef(aBase, n, sizeof(RemoteRef), *(char* const*)pEntry);
+}
+
+static int trackingFind(const void *aBase, int n, const void *pEntry){
+  const TrackingBranch *e = (const TrackingBranch*)pEntry;
+  return findTrackingIdx((const TrackingBranch*)aBase, n,
+                         e->zRemote, e->zBranch);
+}
+
+static int branchCopyInto(void *pDst, const void *pSrc){
+  const BranchRef *s = (const BranchRef*)pSrc;
+  BranchRef *d = (BranchRef*)pDst;
+  memset(d, 0, sizeof(*d));
+  d->zName = sqlite3_mprintf("%s", s->zName);
+  d->commitHash = s->commitHash;
+  d->workingSetHash = s->workingSetHash;
+  return d->zName==0;
+}
+
+static void branchFreeEntry(void *pEntry){
+  sqlite3_free(((BranchRef*)pEntry)->zName);
+}
+
+static int tagCopyInto(void *pDst, const void *pSrc){
+  const TagRef *s = (const TagRef*)pSrc;
+  TagRef *d = (TagRef*)pDst;
+  memset(d, 0, sizeof(*d));
+  d->zName = sqlite3_mprintf("%s", s->zName);
+  d->commitHash = s->commitHash;
+  d->timestamp = s->timestamp;
+  d->zTagger = s->zTagger ? sqlite3_mprintf("%s", s->zTagger) : 0;
+  d->zEmail = s->zEmail ? sqlite3_mprintf("%s", s->zEmail) : 0;
+  d->zMessage = s->zMessage ? sqlite3_mprintf("%s", s->zMessage) : 0;
+  return d->zName==0
+      || (s->zTagger && !d->zTagger)
+      || (s->zEmail && !d->zEmail)
+      || (s->zMessage && !d->zMessage);
+}
+
+static void tagFreeEntry(void *pEntry){
+  TagRef *t = (TagRef*)pEntry;
+  sqlite3_free(t->zName);
+  sqlite3_free(t->zTagger);
+  sqlite3_free(t->zEmail);
+  sqlite3_free(t->zMessage);
+}
+
+static int remoteCopyInto(void *pDst, const void *pSrc){
+  const RemoteRef *s = (const RemoteRef*)pSrc;
+  RemoteRef *d = (RemoteRef*)pDst;
+  memset(d, 0, sizeof(*d));
+  d->zName = sqlite3_mprintf("%s", s->zName);
+  d->zUrl = s->zUrl ? sqlite3_mprintf("%s", s->zUrl) : 0;
+  return d->zName==0 || (s->zUrl && !d->zUrl);
+}
+
+static void remoteFreeEntry(void *pEntry){
+  RemoteRef *r = (RemoteRef*)pEntry;
+  sqlite3_free(r->zName);
+  sqlite3_free(r->zUrl);
+}
+
+static int trackingCopyInto(void *pDst, const void *pSrc){
+  const TrackingBranch *s = (const TrackingBranch*)pSrc;
+  TrackingBranch *d = (TrackingBranch*)pDst;
+  memset(d, 0, sizeof(*d));
+  d->zRemote = sqlite3_mprintf("%s", s->zRemote);
+  d->zBranch = sqlite3_mprintf("%s", s->zBranch);
+  d->commitHash = s->commitHash;
+  return d->zRemote==0 || d->zBranch==0;
+}
+
+static void trackingFreeEntry(void *pEntry){
+  TrackingBranch *t = (TrackingBranch*)pEntry;
+  sqlite3_free(t->zRemote);
+  sqlite3_free(t->zBranch);
+}
+
+int csMergeSavedRefsOntoDisk(
+  ChunkStore *cs,
+  const SavedRefsState *pLocal,
+  const RefsTable *pBase
+){
+  RefsMergeCat aCat[4];
+  int pass, i, rc;
+
+  memset(aCat, 0, sizeof(aCat));
+  aCat[0].aLocal = pLocal->aBranches; aCat[0].nLocal = pLocal->nBranches;
+  aCat[0].aBase = pBase->aBranches;   aCat[0].nBase = pBase->nBranches;
+  aCat[0].paDisk = (void**)&cs->refs.aBranches;
+  aCat[0].pnDisk = &cs->refs.nBranches;
+  aCat[0].stride = (int)sizeof(BranchRef);
+  aCat[0].xEqual = (int(*)(const void*,const void*))branchRefsEqual;
+  aCat[0].xCopyInto = branchCopyInto;
+  aCat[0].xFreeEntry = branchFreeEntry;
+  aCat[0].xFind = branchFind;
+
+  aCat[1].aLocal = pLocal->aTags; aCat[1].nLocal = pLocal->nTags;
+  aCat[1].aBase = pBase->aTags;   aCat[1].nBase = pBase->nTags;
+  aCat[1].paDisk = (void**)&cs->refs.aTags;
+  aCat[1].pnDisk = &cs->refs.nTags;
+  aCat[1].stride = (int)sizeof(TagRef);
+  aCat[1].xEqual = (int(*)(const void*,const void*))tagRefsEqual;
+  aCat[1].xCopyInto = tagCopyInto;
+  aCat[1].xFreeEntry = tagFreeEntry;
+  aCat[1].xFind = tagFind;
+
+  aCat[2].aLocal = pLocal->aRemotes; aCat[2].nLocal = pLocal->nRemotes;
+  aCat[2].aBase = pBase->aRemotes;   aCat[2].nBase = pBase->nRemotes;
+  aCat[2].paDisk = (void**)&cs->refs.aRemotes;
+  aCat[2].pnDisk = &cs->refs.nRemotes;
+  aCat[2].stride = (int)sizeof(RemoteRef);
+  aCat[2].xEqual = (int(*)(const void*,const void*))remoteRefsEqual;
+  aCat[2].xCopyInto = remoteCopyInto;
+  aCat[2].xFreeEntry = remoteFreeEntry;
+  aCat[2].xFind = remoteFind;
+
+  aCat[3].aLocal = pLocal->aTracking; aCat[3].nLocal = pLocal->nTracking;
+  aCat[3].aBase = pBase->aTracking;   aCat[3].nBase = pBase->nTracking;
+  aCat[3].paDisk = (void**)&cs->refs.aTracking;
+  aCat[3].pnDisk = &cs->refs.nTracking;
+  aCat[3].stride = (int)sizeof(TrackingBranch);
+  aCat[3].xEqual = (int(*)(const void*,const void*))trackingRefsEqual;
+  aCat[3].xCopyInto = trackingCopyInto;
+  aCat[3].xFreeEntry = trackingFreeEntry;
+  aCat[3].xFind = trackingFind;
+
+  /* The default branch is a scalar three-way. */
+  {
+    const char *zL = pLocal->zDefaultBranch;
+    const char *zB = pBase->zDefaultBranch;
+    const char *zD = cs->refs.zDefaultBranch;
+    if( !refsStrEqual(zL, zB)
+     && !refsStrEqual(zD, zB)
+     && !refsStrEqual(zD, zL) ){
+      return SQLITE_BUSY_SNAPSHOT;
+    }
+  }
+
+  for(pass=0; pass<2; pass++){
+    for(i=0; i<4; i++){
+      rc = refsMergeCategory(&aCat[i], pass==0);
+      if( rc!=SQLITE_OK ) return rc;
+    }
+  }
+
+  if( pLocal->zDefaultBranch
+   && !refsStrEqual(pLocal->zDefaultBranch, pBase->zDefaultBranch) ){
+    char *zDup = sqlite3_mprintf("%s", pLocal->zDefaultBranch);
+    if( !zDup ) return SQLITE_NOMEM;
+    sqlite3_free(cs->refs.zDefaultBranch);
+    cs->refs.zDefaultBranch = zDup;
+  }
+
+  /* AUTOINCREMENT counters are high-water marks shared across branches:
+  ** the merged value is the max of both sides, never a conflict, and a
+  ** counter the session dropped (DROP TABLE) goes away. */
+  for(i=0; i<pLocal->nSequences; i++){
+    const SequenceRef *pL = &pLocal->aSequences[i];
+    int rc2 = chunkStoreBumpSequence(cs, pL->zTableName, pL->iSeq);
+    if( rc2!=SQLITE_OK ) return rc2;
+  }
+  for(i=0; i<pBase->nSequences; i++){
+    const SequenceRef *pB = &pBase->aSequences[i];
+    if( csFindNamedRef(pLocal->aSequences, pLocal->nSequences,
+                       (int)sizeof(SequenceRef), pB->zTableName)<0 ){
+      chunkStoreDropSequence(cs, pB->zTableName);
+    }
+  }
+
+  return SQLITE_OK;
+}

--- a/src/chunk_refs.c
+++ b/src/chunk_refs.c
@@ -562,45 +562,45 @@ int csReplaceRefsStateFromBlob(
 ** scan runs conflict-detection first so the disk arrays are untouched
 ** unless the whole merge applies. */
 
-static int refsHashesEqual(const ProllyHash *a, const ProllyHash *b){
+static int refsMergeHashEqual(const ProllyHash *a, const ProllyHash *b){
   return prollyHashCompare(a, b)==0;
 }
 
-static int refsStrEqual(const char *a, const char *b){
+static int refsMergeStrEqual(const char *a, const char *b){
   if( a==0 && b==0 ) return 1;
   if( a==0 || b==0 ) return 0;
   return strcmp(a, b)==0;
 }
 
-static int branchRefsEqual(const BranchRef *a, const BranchRef *b){
-  return refsHashesEqual(&a->commitHash, &b->commitHash)
-      && refsHashesEqual(&a->workingSetHash, &b->workingSetHash);
+static int refsMergeBranchEqual(const BranchRef *a, const BranchRef *b){
+  return refsMergeHashEqual(&a->commitHash, &b->commitHash)
+      && refsMergeHashEqual(&a->workingSetHash, &b->workingSetHash);
 }
 
-static int tagRefsEqual(const TagRef *a, const TagRef *b){
-  return refsHashesEqual(&a->commitHash, &b->commitHash)
+static int refsMergeTagEqual(const TagRef *a, const TagRef *b){
+  return refsMergeHashEqual(&a->commitHash, &b->commitHash)
       && a->timestamp==b->timestamp
-      && refsStrEqual(a->zTagger, b->zTagger)
-      && refsStrEqual(a->zEmail, b->zEmail)
-      && refsStrEqual(a->zMessage, b->zMessage);
+      && refsMergeStrEqual(a->zTagger, b->zTagger)
+      && refsMergeStrEqual(a->zEmail, b->zEmail)
+      && refsMergeStrEqual(a->zMessage, b->zMessage);
 }
 
-static int remoteRefsEqual(const RemoteRef *a, const RemoteRef *b){
-  return refsStrEqual(a->zUrl, b->zUrl);
+static int refsMergeRemoteEqual(const RemoteRef *a, const RemoteRef *b){
+  return refsMergeStrEqual(a->zUrl, b->zUrl);
 }
 
-static int trackingRefsEqual(const TrackingBranch *a, const TrackingBranch *b){
-  return refsHashesEqual(&a->commitHash, &b->commitHash);
+static int refsMergeTrackingEqual(const TrackingBranch *a, const TrackingBranch *b){
+  return refsMergeHashEqual(&a->commitHash, &b->commitHash);
 }
 
-static int findTrackingIdx(
+static int refsMergeFindTrackingIdx(
   const TrackingBranch *a, int n,
   const char *zRemote, const char *zBranch
 ){
   int i;
   for(i=0; i<n; i++){
-    if( refsStrEqual(a[i].zRemote, zRemote)
-     && refsStrEqual(a[i].zBranch, zBranch) ){
+    if( refsMergeStrEqual(a[i].zRemote, zRemote)
+     && refsMergeStrEqual(a[i].zBranch, zBranch) ){
       return i;
     }
   }
@@ -682,25 +682,25 @@ static int refsMergeCategory(RefsMergeCat *p, int checkOnly){
   return SQLITE_OK;
 }
 
-static int branchFind(const void *aBase, int n, const void *pEntry){
+static int refsMergeBranchFind(const void *aBase, int n, const void *pEntry){
   return csFindNamedRef(aBase, n, sizeof(BranchRef), *(char* const*)pEntry);
 }
 
-static int tagFind(const void *aBase, int n, const void *pEntry){
+static int refsMergeTagFind(const void *aBase, int n, const void *pEntry){
   return csFindNamedRef(aBase, n, sizeof(TagRef), *(char* const*)pEntry);
 }
 
-static int remoteFind(const void *aBase, int n, const void *pEntry){
+static int refsMergeRemoteFind(const void *aBase, int n, const void *pEntry){
   return csFindNamedRef(aBase, n, sizeof(RemoteRef), *(char* const*)pEntry);
 }
 
-static int trackingFind(const void *aBase, int n, const void *pEntry){
+static int refsMergeTrackingFind(const void *aBase, int n, const void *pEntry){
   const TrackingBranch *e = (const TrackingBranch*)pEntry;
-  return findTrackingIdx((const TrackingBranch*)aBase, n,
+  return refsMergeFindTrackingIdx((const TrackingBranch*)aBase, n,
                          e->zRemote, e->zBranch);
 }
 
-static int branchCopyInto(void *pDst, const void *pSrc){
+static int refsMergeBranchCopy(void *pDst, const void *pSrc){
   const BranchRef *s = (const BranchRef*)pSrc;
   BranchRef *d = (BranchRef*)pDst;
   memset(d, 0, sizeof(*d));
@@ -710,11 +710,11 @@ static int branchCopyInto(void *pDst, const void *pSrc){
   return d->zName==0;
 }
 
-static void branchFreeEntry(void *pEntry){
+static void refsMergeBranchFree(void *pEntry){
   sqlite3_free(((BranchRef*)pEntry)->zName);
 }
 
-static int tagCopyInto(void *pDst, const void *pSrc){
+static int refsMergeTagCopy(void *pDst, const void *pSrc){
   const TagRef *s = (const TagRef*)pSrc;
   TagRef *d = (TagRef*)pDst;
   memset(d, 0, sizeof(*d));
@@ -730,7 +730,7 @@ static int tagCopyInto(void *pDst, const void *pSrc){
       || (s->zMessage && !d->zMessage);
 }
 
-static void tagFreeEntry(void *pEntry){
+static void refsMergeTagFree(void *pEntry){
   TagRef *t = (TagRef*)pEntry;
   sqlite3_free(t->zName);
   sqlite3_free(t->zTagger);
@@ -738,7 +738,7 @@ static void tagFreeEntry(void *pEntry){
   sqlite3_free(t->zMessage);
 }
 
-static int remoteCopyInto(void *pDst, const void *pSrc){
+static int refsMergeRemoteCopy(void *pDst, const void *pSrc){
   const RemoteRef *s = (const RemoteRef*)pSrc;
   RemoteRef *d = (RemoteRef*)pDst;
   memset(d, 0, sizeof(*d));
@@ -747,13 +747,13 @@ static int remoteCopyInto(void *pDst, const void *pSrc){
   return d->zName==0 || (s->zUrl && !d->zUrl);
 }
 
-static void remoteFreeEntry(void *pEntry){
+static void refsMergeRemoteFree(void *pEntry){
   RemoteRef *r = (RemoteRef*)pEntry;
   sqlite3_free(r->zName);
   sqlite3_free(r->zUrl);
 }
 
-static int trackingCopyInto(void *pDst, const void *pSrc){
+static int refsMergeTrackingCopy(void *pDst, const void *pSrc){
   const TrackingBranch *s = (const TrackingBranch*)pSrc;
   TrackingBranch *d = (TrackingBranch*)pDst;
   memset(d, 0, sizeof(*d));
@@ -763,7 +763,7 @@ static int trackingCopyInto(void *pDst, const void *pSrc){
   return d->zRemote==0 || d->zBranch==0;
 }
 
-static void trackingFreeEntry(void *pEntry){
+static void refsMergeTrackingFree(void *pEntry){
   TrackingBranch *t = (TrackingBranch*)pEntry;
   sqlite3_free(t->zRemote);
   sqlite3_free(t->zBranch);
@@ -783,49 +783,49 @@ int csMergeSavedRefsOntoDisk(
   aCat[0].paDisk = (void**)&cs->refs.aBranches;
   aCat[0].pnDisk = &cs->refs.nBranches;
   aCat[0].stride = (int)sizeof(BranchRef);
-  aCat[0].xEqual = (int(*)(const void*,const void*))branchRefsEqual;
-  aCat[0].xCopyInto = branchCopyInto;
-  aCat[0].xFreeEntry = branchFreeEntry;
-  aCat[0].xFind = branchFind;
+  aCat[0].xEqual = (int(*)(const void*,const void*))refsMergeBranchEqual;
+  aCat[0].xCopyInto = refsMergeBranchCopy;
+  aCat[0].xFreeEntry = refsMergeBranchFree;
+  aCat[0].xFind = refsMergeBranchFind;
 
   aCat[1].aLocal = pLocal->aTags; aCat[1].nLocal = pLocal->nTags;
   aCat[1].aBase = pBase->aTags;   aCat[1].nBase = pBase->nTags;
   aCat[1].paDisk = (void**)&cs->refs.aTags;
   aCat[1].pnDisk = &cs->refs.nTags;
   aCat[1].stride = (int)sizeof(TagRef);
-  aCat[1].xEqual = (int(*)(const void*,const void*))tagRefsEqual;
-  aCat[1].xCopyInto = tagCopyInto;
-  aCat[1].xFreeEntry = tagFreeEntry;
-  aCat[1].xFind = tagFind;
+  aCat[1].xEqual = (int(*)(const void*,const void*))refsMergeTagEqual;
+  aCat[1].xCopyInto = refsMergeTagCopy;
+  aCat[1].xFreeEntry = refsMergeTagFree;
+  aCat[1].xFind = refsMergeTagFind;
 
   aCat[2].aLocal = pLocal->aRemotes; aCat[2].nLocal = pLocal->nRemotes;
   aCat[2].aBase = pBase->aRemotes;   aCat[2].nBase = pBase->nRemotes;
   aCat[2].paDisk = (void**)&cs->refs.aRemotes;
   aCat[2].pnDisk = &cs->refs.nRemotes;
   aCat[2].stride = (int)sizeof(RemoteRef);
-  aCat[2].xEqual = (int(*)(const void*,const void*))remoteRefsEqual;
-  aCat[2].xCopyInto = remoteCopyInto;
-  aCat[2].xFreeEntry = remoteFreeEntry;
-  aCat[2].xFind = remoteFind;
+  aCat[2].xEqual = (int(*)(const void*,const void*))refsMergeRemoteEqual;
+  aCat[2].xCopyInto = refsMergeRemoteCopy;
+  aCat[2].xFreeEntry = refsMergeRemoteFree;
+  aCat[2].xFind = refsMergeRemoteFind;
 
   aCat[3].aLocal = pLocal->aTracking; aCat[3].nLocal = pLocal->nTracking;
   aCat[3].aBase = pBase->aTracking;   aCat[3].nBase = pBase->nTracking;
   aCat[3].paDisk = (void**)&cs->refs.aTracking;
   aCat[3].pnDisk = &cs->refs.nTracking;
   aCat[3].stride = (int)sizeof(TrackingBranch);
-  aCat[3].xEqual = (int(*)(const void*,const void*))trackingRefsEqual;
-  aCat[3].xCopyInto = trackingCopyInto;
-  aCat[3].xFreeEntry = trackingFreeEntry;
-  aCat[3].xFind = trackingFind;
+  aCat[3].xEqual = (int(*)(const void*,const void*))refsMergeTrackingEqual;
+  aCat[3].xCopyInto = refsMergeTrackingCopy;
+  aCat[3].xFreeEntry = refsMergeTrackingFree;
+  aCat[3].xFind = refsMergeTrackingFind;
 
   /* The default branch is a scalar three-way. */
   {
     const char *zL = pLocal->zDefaultBranch;
     const char *zB = pBase->zDefaultBranch;
     const char *zD = cs->refs.zDefaultBranch;
-    if( !refsStrEqual(zL, zB)
-     && !refsStrEqual(zD, zB)
-     && !refsStrEqual(zD, zL) ){
+    if( !refsMergeStrEqual(zL, zB)
+     && !refsMergeStrEqual(zD, zB)
+     && !refsMergeStrEqual(zD, zL) ){
       return SQLITE_BUSY_SNAPSHOT;
     }
   }
@@ -838,7 +838,7 @@ int csMergeSavedRefsOntoDisk(
   }
 
   if( pLocal->zDefaultBranch
-   && !refsStrEqual(pLocal->zDefaultBranch, pBase->zDefaultBranch) ){
+   && !refsMergeStrEqual(pLocal->zDefaultBranch, pBase->zDefaultBranch) ){
     char *zDup = sqlite3_mprintf("%s", pLocal->zDefaultBranch);
     if( !zDup ) return SQLITE_NOMEM;
     sqlite3_free(cs->refs.zDefaultBranch);

--- a/src/chunk_refs.h
+++ b/src/chunk_refs.h
@@ -134,6 +134,9 @@ int csReplaceRefsStateFromBlob(struct ChunkStore *cs, const u8 *data, int nData,
                                int adopt);
 void csFreeRefsState(struct ChunkStore *cs);
 void csAdoptRefsState(struct ChunkStore *pDst, struct ChunkStore *pSrc);
+int csMergeSavedRefsOntoDisk(struct ChunkStore *cs,
+                             const SavedRefsState *pLocal,
+                             const RefsTable *pBase);
 int csEnsureDefaultBranch(struct ChunkStore *cs);
 
 void csFreeBranches(struct ChunkStore *cs);

--- a/src/chunk_store_commit.c
+++ b/src/chunk_store_commit.c
@@ -562,11 +562,13 @@ int chunkStoreCommit(ChunkStore *cs){
   if( cs->readOnly || cs->movedReadOnly ) return SQLITE_READONLY;
   if( cs->isMemory ) return csCommitToMemory(cs);
   if( cs->lockDepth<=0 && cs->file.zFilename ){
+    ProllyHash baseRefsHash;
     preserveRefs = cs->staging.nPending > 0
                 && prollyHashCompare(&cs->refs.refsHash,
                                      &cs->refs.committedRefsHash)!=0;
     if( preserveRefs ){
       savedRefsHash = cs->refs.refsHash;
+      baseRefsHash = cs->refs.committedRefsHash;
       csDetachSavedRefsState(cs, &savedRefs);
     }
     rc = chunkStoreLockAndRefresh(cs);
@@ -578,9 +580,12 @@ int chunkStoreCommit(ChunkStore *cs){
       return rc;
     }
     if( preserveRefs ){
-      csFreeRefsState(cs);
-      csRestoreSavedRefsState(cs, &savedRefs);
-      cs->refs.refsHash = savedRefsHash;
+      rc = csRestoreOrMergeLocalRefs(cs, &savedRefs,
+                                     &savedRefsHash, &baseRefsHash);
+      if( rc!=SQLITE_OK ){
+        chunkStoreUnlock(cs);
+        return rc;
+      }
     }
     acquiredLock = 1;
   }

--- a/src/chunk_store_int.h
+++ b/src/chunk_store_int.h
@@ -30,6 +30,9 @@ int csFileLockNB(sqlite3_vfs *pVfs, const char *path,
                  sqlite3_file **ppFile, char **pzName);
 int csReloadFromDisk(ChunkStore *cs);
 int csReloadFromDiskPreservingLocalRefs(ChunkStore *cs);
+int csRestoreOrMergeLocalRefs(ChunkStore *cs, SavedRefsState *pSaved,
+                              const ProllyHash *pSavedRefsHash,
+                              const ProllyHash *pBaseRefsHash);
 int csFileSizeByName(sqlite3_vfs *pVfs, const char *zPath, i64 *pSize);
 int csDiskStateMatchesMemory(ChunkStore *cs);
 int csOpenFile(sqlite3_vfs *pVfs, const char *zPath, sqlite3_file **ppFile,

--- a/src/chunk_store_lock.c
+++ b/src/chunk_store_lock.c
@@ -164,10 +164,67 @@ int chunkStoreEnsureRefsFresh(ChunkStore *cs){
   return rc;
 }
 
+/* Reinstate a session's uncommitted ref changes after the store adopted
+** the on-disk state. When no peer committed refs since the base the
+** local arrays were derived from, the wholesale restore is exact. When
+** peers moved, restoring wholesale would publish the stale snapshot at
+** the next commit, silently reverting every peer change except the one
+** tip the branch CAS checks — the lost merged rows and resurrected temp
+** branches of the stress failures — so the local delta merges onto the
+** peers' table instead, and a ref both sides changed fails the operation
+** rather than picking a winner. On success pSaved is consumed; on
+** failure the local view is reinstated so the failing operation unwinds
+** over known state. */
+int csRestoreOrMergeLocalRefs(
+  ChunkStore *cs,
+  SavedRefsState *pSaved,
+  const ProllyHash *pSavedRefsHash,
+  const ProllyHash *pBaseRefsHash
+){
+  int rc;
+  if( prollyHashCompare(&cs->refs.committedRefsHash, pBaseRefsHash)==0 ){
+    csFreeRefsState(cs);
+    csRestoreSavedRefsState(cs, pSaved);
+    cs->refs.refsHash = *pSavedRefsHash;
+    return SQLITE_OK;
+  }
+  {
+    u8 *baseData = 0;
+    int nBaseData = 0;
+    ChunkStore baseView;
+    memset(&baseView, 0, sizeof(baseView));
+    rc = chunkStoreGet(cs, pBaseRefsHash, &baseData, &nBaseData);
+    if( rc==SQLITE_OK ){
+      rc = csDeserializeRefsIntoTemp(&baseView, baseData, nBaseData);
+    }
+    if( rc==SQLITE_OK ){
+      rc = csMergeSavedRefsOntoDisk(cs, pSaved, &baseView.refs);
+    }
+    sqlite3_free(baseData);
+    csFreeRefsState(&baseView);
+  }
+  if( rc==SQLITE_OK ){
+    /* The commit publishes the blob refsHash names, and the blob staged
+    ** before the merge holds only the local view; serialize the merged
+    ** table so the commit publishes it. */
+    rc = chunkStoreSerializeRefs(cs);
+  }
+  if( rc==SQLITE_OK ){
+    csFreeSavedRefsState(pSaved);
+    return SQLITE_OK;
+  }
+  rc = rc==SQLITE_NOMEM ? SQLITE_NOMEM : SQLITE_BUSY_SNAPSHOT;
+  csFreeRefsState(cs);
+  csRestoreSavedRefsState(cs, pSaved);
+  cs->refs.refsHash = *pSavedRefsHash;
+  return rc;
+}
+
 int csReloadFromDiskPreservingLocalRefs(ChunkStore *cs){
   int rc;
   int preserveRefs;
   ProllyHash savedRefsHash;
+  ProllyHash baseRefsHash;
   SavedRefsState savedRefs;
 
   /* Reloading drops aRecent; never do that with uncommitted refs to it. */
@@ -181,6 +238,7 @@ int csReloadFromDiskPreservingLocalRefs(ChunkStore *cs){
   memset(&savedRefs, 0, sizeof(savedRefs));
   if( preserveRefs ){
     savedRefsHash = cs->refs.refsHash;
+    baseRefsHash = cs->refs.committedRefsHash;
     csDetachSavedRefsState(cs, &savedRefs);
   }
 
@@ -188,7 +246,8 @@ int csReloadFromDiskPreservingLocalRefs(ChunkStore *cs){
 
   if( preserveRefs ){
     if( rc==SQLITE_OK ){
-      csFreeRefsState(cs);
+      return csRestoreOrMergeLocalRefs(cs, &savedRefs,
+                                       &savedRefsHash, &baseRefsHash);
     }
     csRestoreSavedRefsState(cs, &savedRefs);
     cs->refs.refsHash = savedRefsHash;

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -1620,6 +1620,139 @@ static void run_status_many_table_renames(void){
   removeDbFiles(dbpath);
 }
 
+
+static void run_refs_commit_merges_concurrent_peer_refs(void){
+  ChunkStore csA, csB, csC;
+  ProllyHash h1, h2, h3, hB, chunkHash;
+  ProllyHash found;
+  static const u8 payload[] = "refs-merge-pending-chunk";
+  char dbpath[256];
+
+  printf("=== Refs Commit Merges Concurrent Peer Refs Test ===\n\n");
+  make_dbpath(dbpath, sizeof(dbpath), "test_refs_commit_merges_peer");
+  removeDbFiles(dbpath);
+  memset(&csA, 0, sizeof(csA));
+  memset(&csB, 0, sizeof(csB));
+  memset(&csC, 0, sizeof(csC));
+
+  prollyHashCompute("one", 3, &h1);
+  prollyHashCompute("two", 3, &h2);
+  prollyHashCompute("three", 5, &h3);
+  prollyHashCompute("peer", 4, &hB);
+
+  /* Seed the store with a branch. */
+  check("rm_open_A",
+        chunkStoreOpen(&csA, sqlite3_vfs_find(0), dbpath,
+                      SQLITE_OPEN_READWRITE|SQLITE_OPEN_CREATE|SQLITE_OPEN_MAIN_DB)==SQLITE_OK);
+  check("rm_seed_branch",
+        chunkStoreAddBranch(&csA, "seed", &h1)==SQLITE_OK);
+  check("rm_seed_default",
+        chunkStoreSetDefaultBranch(&csA, "seed")==SQLITE_OK);
+  check("rm_seed_serialize", chunkStoreSerializeRefs(&csA)==SQLITE_OK);
+  check("rm_seed_commit", chunkStoreCommit(&csA)==SQLITE_OK);
+
+  /* A peer advances the refs on disk; A's view stays at the old base. */
+  check("rm_open_B",
+        chunkStoreOpen(&csB, sqlite3_vfs_find(0), dbpath,
+                      SQLITE_OPEN_READWRITE|SQLITE_OPEN_MAIN_DB)==SQLITE_OK);
+  check("rm_peer_branch",
+        chunkStoreAddBranch(&csB, "peer_keep", &hB)==SQLITE_OK);
+  check("rm_peer_serialize", chunkStoreSerializeRefs(&csB)==SQLITE_OK);
+  check("rm_peer_commit", chunkStoreCommit(&csB)==SQLITE_OK);
+
+  /* A stages a chunk and its own ref change over the stale view, then
+  ** commits: the resolve path adopts the peer's newer refs, and the
+  ** local delta must merge onto them instead of replacing them. */
+  check("rm_local_branch",
+        chunkStoreAddBranch(&csA, "local_new", &h3)==SQLITE_OK);
+  check("rm_local_chunk",
+        chunkStorePut(&csA, payload, (int)sizeof(payload),
+                      &chunkHash)==SQLITE_OK);
+  check("rm_local_serialize", chunkStoreSerializeRefs(&csA)==SQLITE_OK);
+  check("rm_local_commit", chunkStoreCommit(&csA)==SQLITE_OK);
+
+  /* A fresh reader sees the union: the peer's branch, the local branch,
+  ** and the seed. */
+  check("rm_open_C",
+        chunkStoreOpen(&csC, sqlite3_vfs_find(0), dbpath,
+                      SQLITE_OPEN_READWRITE|SQLITE_OPEN_MAIN_DB)==SQLITE_OK);
+  check("rm_peer_survives",
+        chunkStoreFindBranch(&csC, "peer_keep", &found)==SQLITE_OK
+        && prollyHashCompare(&found, &hB)==0);
+  check("rm_local_survives",
+        chunkStoreFindBranch(&csC, "local_new", &found)==SQLITE_OK
+        && prollyHashCompare(&found, &h3)==0);
+  check("rm_seed_survives",
+        chunkStoreFindBranch(&csC, "seed", &found)==SQLITE_OK
+        && prollyHashCompare(&found, &h1)==0);
+
+  chunkStoreClose(&csA);
+  chunkStoreClose(&csB);
+  chunkStoreClose(&csC);
+  removeDbFiles(dbpath);
+}
+
+static void run_refs_commit_conflicting_peer_ref_fails(void){
+  ChunkStore csA, csB, csC;
+  ProllyHash h1, hA, hB, chunkHash;
+  ProllyHash found;
+  static const u8 payload[] = "refs-conflict-pending-chunk";
+  char dbpath[256];
+
+  printf("=== Refs Commit Conflicting Peer Ref Fails Test ===\n\n");
+  make_dbpath(dbpath, sizeof(dbpath), "test_refs_commit_conflict_peer");
+  removeDbFiles(dbpath);
+  memset(&csA, 0, sizeof(csA));
+  memset(&csB, 0, sizeof(csB));
+  memset(&csC, 0, sizeof(csC));
+
+  prollyHashCompute("base", 4, &h1);
+  prollyHashCompute("ours", 4, &hA);
+  prollyHashCompute("theirs", 6, &hB);
+
+  check("rc_open_A",
+        chunkStoreOpen(&csA, sqlite3_vfs_find(0), dbpath,
+                      SQLITE_OPEN_READWRITE|SQLITE_OPEN_CREATE|SQLITE_OPEN_MAIN_DB)==SQLITE_OK);
+  check("rc_seed_branch",
+        chunkStoreAddBranch(&csA, "shared", &h1)==SQLITE_OK);
+  check("rc_seed_default",
+        chunkStoreSetDefaultBranch(&csA, "shared")==SQLITE_OK);
+  check("rc_seed_serialize", chunkStoreSerializeRefs(&csA)==SQLITE_OK);
+  check("rc_seed_commit", chunkStoreCommit(&csA)==SQLITE_OK);
+
+  /* Both sides move the SAME branch to different tips. */
+  check("rc_open_B",
+        chunkStoreOpen(&csB, sqlite3_vfs_find(0), dbpath,
+                      SQLITE_OPEN_READWRITE|SQLITE_OPEN_MAIN_DB)==SQLITE_OK);
+  check("rc_peer_move",
+        chunkStoreUpdateBranch(&csB, "shared", &hB)==SQLITE_OK);
+  check("rc_peer_serialize", chunkStoreSerializeRefs(&csB)==SQLITE_OK);
+  check("rc_peer_commit", chunkStoreCommit(&csB)==SQLITE_OK);
+
+  check("rc_local_move",
+        chunkStoreUpdateBranch(&csA, "shared", &hA)==SQLITE_OK);
+  check("rc_local_chunk",
+        chunkStorePut(&csA, payload, (int)sizeof(payload),
+                      &chunkHash)==SQLITE_OK);
+  check("rc_local_serialize", chunkStoreSerializeRefs(&csA)==SQLITE_OK);
+  /* A real race on one ref must fail the commit, not pick a winner. */
+  check("rc_commit_fails",
+        chunkStoreCommit(&csA)==SQLITE_BUSY_SNAPSHOT);
+
+  /* The peer's move is what disk keeps. */
+  check("rc_open_C",
+        chunkStoreOpen(&csC, sqlite3_vfs_find(0), dbpath,
+                      SQLITE_OPEN_READWRITE|SQLITE_OPEN_MAIN_DB)==SQLITE_OK);
+  check("rc_peer_tip_kept",
+        chunkStoreFindBranch(&csC, "shared", &found)==SQLITE_OK
+        && prollyHashCompare(&found, &hB)==0);
+
+  chunkStoreClose(&csA);
+  chunkStoreClose(&csB);
+  chunkStoreClose(&csC);
+  removeDbFiles(dbpath);
+}
+
 static void run_remote_refs_corruption(void){
   sqlite3 *srcDb = 0;
   sqlite3 *localDb = 0;
@@ -10457,6 +10590,8 @@ static const RegressionCase aCases[] = {
   { "conflicts_blob_corruption", "Conflicts Blob Corruption Test", run_conflicts_blob_corruption },
   { "status_error_propagation", "Status Error Propagation Test", run_status_error_propagation },
   { "status_many_table_renames", "Status Many Table Renames Test", run_status_many_table_renames },
+  { "refs_commit_merges_concurrent_peer_refs", "Refs Commit Merges Concurrent Peer Refs Test", run_refs_commit_merges_concurrent_peer_refs },
+  { "refs_commit_conflicting_peer_ref_fails", "Refs Commit Conflicting Peer Ref Fails Test", run_refs_commit_conflicting_peer_ref_fails },
   { "remote_refs_corruption", "Remote Refs Corruption Test", run_remote_refs_corruption },
   { "fetch_preserves_concurrent_local_refs", "Fetch Preserves Concurrent Local Refs Test", run_fetch_preserves_concurrent_local_refs },
   { "chunk_walk_corruption", "Chunk Walk Corruption Test", run_chunk_walk_corruption },


### PR DESCRIPTION
Deep-review action item 4 — the persist-side arm of the recurring concurrent-refs race (#2081 lineage; the restore-side arm was #2101). Every refs persist serializes the session's **entire** in-memory refs table, and two sites reinstated that table wholesale after adopting a newer on-disk state: `csReloadFromDiskPreservingLocalRefs`, and a second copy of the same pattern inside `chunkStoreCommit` around lock-and-refresh — the second would have silently defeated any fix to the first alone. Since the arrays are a full snapshot of an older base, the next commit published that snapshot and reverted every peer ref change except the single tip the branch CAS checks: exactly the lost-merged-rows and resurrected-temp-branch signatures of the TSan stress failures.

**Mechanics:** both sites share one `csRestoreOrMergeLocalRefs`:
- Base unchanged (`committedRefsHash` equal — content-addressed, so ABA-safe): the wholesale restore is exact and stands. Zero behavior change on the common path.
- Peers moved: the base blob is fetched by hash and the session's delta merges three-way onto the peers' table — untouched refs keep peer values; session-only changes apply; a ref both sides changed fails with `SQLITE_BUSY_SNAPSHOT` rather than picking a winner; sequences (AUTOINCREMENT high-water marks) merge by max; the default branch is a scalar three-way.
- The merged table is **re-serialized** before the commit proceeds — the commit publishes the blob `refsHash` names, and the blob staged before the merge holds only the local view (caught by tracing what the manifest references, not by any test).
- On merge failure the local view is reinstated so the failing operation unwinds over exactly the state the existing recovery machinery expects.

**Testing:** the race window sits inside a single statement (conflict-rollback releases the graph lock mid-call), which is why only TSan ever caught it and why it never reproduced locally. Two new deterministic store-level c-tests pin the mechanism directly instead: a commit over a stale view must keep both the peer's new branch and the session's own (`rm_peer_survives` fails on the unfixed engine — the silent deletion), and a commit racing a peer's move of the same branch must fail and leave the peer's tip (`rc_commit_fails` / `rc_peer_tip_kept` both fail unfixed — it silently won).

**Validation:** full c-regression 310,290/310,290 (includes the new tests); `vc_ref_mutation_stress_test` 10/10 runs locally; checkout/commit/merge/status/add/reset oracle suites green; full battery 101/101; strict-C90 clean. The TSan CI job is the real arbiter for the stress lineage — worth watching that bucket specifically on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)