### PR TITLE
Support detached revision database opens

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -312,6 +312,8 @@ jobs:
         SH
         chmod +x ./doltlite-no-msys-conv
         export DOLTLITE=./doltlite-no-msys-conv
+        export DOLTLITE_SYSTEM=./doltlite.exe
+        export DOLTLITE_SYSTEM_NULL=NUL
         source ../test/lib/doltlite_suite_manifest.sh
         while IFS= read -r test; do
           test="../test/$test"

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -312,7 +312,7 @@ jobs:
         SH
         chmod +x ./doltlite-no-msys-conv
         export DOLTLITE=./doltlite-no-msys-conv
-        export DOLTLITE_SYSTEM=./doltlite.exe
+        export DOLTLITE_SYSTEM="$(cygpath -w "$PWD/doltlite.exe")"
         export DOLTLITE_SYSTEM_NULL=NUL
         source ../test/lib/doltlite_suite_manifest.sh
         while IFS= read -r test; do

--- a/README.md
+++ b/README.md
@@ -415,6 +415,25 @@ Open a branch at connect time via the database path (CLI, C API, or bindings):
 sqlite3_open("my.db@feature", &db);
 ```
 
+##### Detached revisions
+
+A tag, commit hash, or ancestor spec in the same qualified database path opens
+an immutable historical snapshot:
+
+```bash
+./doltlite my.db/v1
+./doltlite my.db/0123456789abcdef0123456789abcdef01234567
+./doltlite 'my.db/main~1'
+```
+
+Detached state belongs only to that connection. `active_branch()` returns
+`NULL`, `HEAD` names the selected commit, and the database is read-only. A peer
+may advance branches or delete the selected tag without changing the open
+snapshot. `dolt_checkout()` does not enter detached state; checking out an
+existing branch from a detached connection reattaches that session and makes it
+writable again. Closing and reopening the unqualified database uses its default
+branch normally.
+
 #### Tags
 
 ```sql

--- a/main.mk
+++ b/main.mk
@@ -2698,6 +2698,7 @@ DOLTLITE_C_TESTS = \
 	invariant_test$(T.exe) \
 	corruption_test$(T.exe) \
 	gc_tip_survival_test$(T.exe) \
+	detached_head_test$(T.exe) \
 	prepared_stmt_reuse_test$(T.exe) \
 	catalog_serialize_determinism_test$(T.exe) \
 	clone_error_code_test$(T.exe) \
@@ -2790,6 +2791,10 @@ corruption_test$(T.exe): $(TOP)/test/corruption_test.c libdoltlite$(T.lib)
 
 gc_tip_survival_test$(T.exe): $(TOP)/test/gc_tip_survival_test.c libdoltlite$(T.lib)
 	$(T.link) -I. -I$(TOP)/src -o $@ $(TOP)/test/gc_tip_survival_test.c \
+		libdoltlite$(T.lib) -lz -lpthread -lm
+
+detached_head_test$(T.exe): $(TOP)/test/detached_head_test.c libdoltlite$(T.lib)
+	$(T.link) -I. -I$(TOP)/src -o $@ $(TOP)/test/detached_head_test.c \
 		libdoltlite$(T.lib) -lz -lpthread -lm
 
 prepared_stmt_reuse_test$(T.exe): $(TOP)/test/prepared_stmt_reuse_test.c libdoltlite$(T.lib)

--- a/src/doltlite_add.c
+++ b/src/doltlite_add.c
@@ -980,6 +980,7 @@ static void doltliteAddFunc(
   int stageAll = 0;
   int opRc = SQLITE_OK;
 
+  if( doltliteCmdRejectDetached(context) ) return;
   if( !cs ){
     sqlite3_result_error(context, doltliteVcUnavailableMessage(db), -1);
     goto add_cleanup;

--- a/src/doltlite_branch.c
+++ b/src/doltlite_branch.c
@@ -16,7 +16,11 @@
 static void activeBranchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   sqlite3 *db = sqlite3_context_db_handle(ctx);
   (void)argc; (void)argv;
-  sqlite3_result_text(ctx, doltliteGetSessionBranch(db), -1, SQLITE_TRANSIENT);
+  if( doltliteIsDetached(db) ){
+    sqlite3_result_null(ctx);
+  }else{
+    sqlite3_result_text(ctx, doltliteGetSessionBranch(db), -1, SQLITE_TRANSIENT);
+  }
 }
 
 int branchNameEmpty(const char *zName){
@@ -158,6 +162,7 @@ static void doltBranchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv)
   int hadSavepoint = db->pSavepoint!=0;
   int i, rc;
 
+  if( doltliteCmdRejectDetached(ctx) ) return;
   if( !cs ){ branchError(ctx, hadSavepoint, doltliteVcUnavailableMessage(db)); return; }
   if( argc<1 ){ branchError(ctx, hadSavepoint, "dolt_branch requires arguments"); return; }
 

--- a/src/doltlite_checkout.c
+++ b/src/doltlite_checkout.c
@@ -216,6 +216,7 @@ struct CheckoutMutationCtx {
   u8 savedIsRebasing;
   const char *zSavedRebaseOrigBranch;
   const char *zSavedRebaseReturnBranch;
+  u8 savedWasDetached;
   int haveOldState;
   /* Top-level branch connection checkout must persist even though SQLite has
   ** a savepoint frame; ordinary nested savepoint checkout remains rollbackable. */
@@ -228,7 +229,13 @@ struct CheckoutMutationCtx {
 static int checkoutCaptureOldCatalog(sqlite3 *db, ChunkStore *cs,
                                      ProllyHash *pOldCatHash){
   int dirty;
-  int rc = doltliteHasUncommittedChanges(db, &dirty);
+  int rc;
+  if( doltliteIsDetached(db) ){
+    ProllyHash head;
+    doltliteGetSessionHead(db, &head);
+    return doltliteCommitCatalogHash(db, &head, pOldCatHash);
+  }
+  rc = doltliteHasUncommittedChanges(db, &dirty);
   if( rc!=SQLITE_OK ) return rc;
   if( dirty ){
     u8 *oldCatData = 0;
@@ -248,6 +255,7 @@ static int checkoutCaptureOldCatalog(sqlite3 *db, ChunkStore *cs,
 /* Mirror of checkoutRestoreSession: capture the session head/staged/merge/
 ** rebase state so a failed checkout can roll back to it. */
 static void checkoutSaveSession(sqlite3 *db, CheckoutMutationCtx *p){
+  p->savedWasDetached = doltliteIsDetached(db);
   doltliteGetSessionHead(db, &p->savedSessionHead);
   doltliteGetSessionStaged(db, &p->savedSessionStaged);
   doltliteGetSessionMergeState(db, &p->savedIsMerging,
@@ -262,6 +270,7 @@ static void checkoutSaveSession(sqlite3 *db, CheckoutMutationCtx *p){
 
 static int checkoutRestoreSession(sqlite3 *db, CheckoutMutationCtx *p){
   int rc;
+  doltliteSetSessionDetached(db, 0);
   rc = doltliteSetSessionBranch(db, p->zCurrentBranch);
   if( rc==SQLITE_OK ){
     doltliteSetSessionHead(db, &p->savedSessionHead);
@@ -282,6 +291,7 @@ static int checkoutRestoreSession(sqlite3 *db, CheckoutMutationCtx *p){
   if( rc==SQLITE_OK && p->haveOldState ){
     rc = doltliteSwitchCatalog(db, &p->oldCatHash);
   }
+  doltliteSetSessionDetached(db, p->savedWasDetached);
   return rc;
 }
 
@@ -293,7 +303,7 @@ static int checkoutRestoreDurableState(
   CheckoutMutationCtx *p = (CheckoutMutationCtx*)pArg;
   int rc = SQLITE_OK;
   UNUSED_PARAMETER(cs);
-  if( p->haveOldState ){
+  if( p->haveOldState && !p->savedWasDetached ){
     rc = doltliteUpdateBranchWorkingState(db, p->zCurrentBranch,
                                           &p->oldCatHash, &p->oldCommitHash);
     if( rc!=SQLITE_OK ) return rc;
@@ -313,6 +323,7 @@ static int checkoutMutateRefs(sqlite3 *db, ChunkStore *cs, void *pArg){
                             &p->targetCommit, &p->targetCatHash);
   if( rc!=SQLITE_OK ) return rc;
 
+  doltliteSetSessionDetached(db, 0);
   rc = doltliteSetSessionBranch(db, p->zTargetBranch);
   if( rc!=SQLITE_OK ) return rc;
   doltliteSetSessionHead(db, &p->targetCommit);
@@ -343,7 +354,7 @@ static int checkoutMutateRefs(sqlite3 *db, ChunkStore *cs, void *pArg){
     if( rc!=SQLITE_OK ) return rc;
   }
 
-  if( p->haveOldState ){
+  if( p->haveOldState && !p->savedWasDetached ){
     rc = doltliteUpdateBranchWorkingState(db, p->zCurrentBranch,
                                           &p->oldCatHash, &p->oldCommitHash);
     if( rc!=SQLITE_OK ){
@@ -408,6 +419,7 @@ void doltConnectBranchFunc(
 
   (void)argc;
   memset(&m, 0, sizeof(m));
+  if( doltliteCmdRejectDetached(ctx) ) return;
   if( !cs ){
     sqlite3_result_error(ctx, doltliteVcUnavailableMessage(db), -1);
     return;
@@ -508,7 +520,7 @@ static int checkoutBranchForRebase(
   if( rc!=SQLITE_OK ){
     int restoreRc = checkoutRestoreSession(db, &m);
     if( restoreRc!=SQLITE_OK ) rc = restoreRc;
-    {
+    if( !m.savedWasDetached ){
       int durableRc = doltliteMutateRefs(db, checkoutRestoreDurableState, &m);
       if( durableRc!=SQLITE_OK ) rc = durableRc;
     }
@@ -1132,6 +1144,31 @@ void doltCheckoutFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   memset(&m, 0, sizeof(m));
   memset(&branchCreate, 0, sizeof(branchCreate));
 
+  if( doltliteIsDetached(db) ){
+    ProllyHash probe;
+    if( strcmp(zBranch, "-b")==0 ){
+      doltliteVcResultError(ctx, db,
+          "unable to create new branch in a read-only database");
+      return;
+    }
+    if( argc!=1 ){
+      doltliteVcResultError(ctx, db, "no current branch");
+      return;
+    }
+    if( chunkStoreFindBranch(cs, zBranch, &probe)!=SQLITE_OK ){
+      if( doltliteResolveRef(db, zBranch, &probe)==SQLITE_OK ){
+        doltliteVcResultError(ctx, db,
+            "dolt does not support a detached head state");
+      }else{
+        char *zErr = sqlite3_mprintf("no such branch or table: %s", zBranch);
+        doltliteVcResultError(ctx, db,
+            zErr ? zErr : "no such branch or table");
+        sqlite3_free(zErr);
+      }
+      return;
+    }
+  }
+
   {
     u8 isMerging = 0;
     doltliteGetSessionMergeState(db, &isMerging, 0, 0);
@@ -1178,7 +1215,8 @@ void doltCheckoutFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
     isCreateAndSwitch = 1;
   }
 
-  if( strcmp(zBranch, doltliteGetSessionBranch(db))==0 && argc==1 ){
+  if( !doltliteIsDetached(db)
+   && strcmp(zBranch, doltliteGetSessionBranch(db))==0 && argc==1 ){
     sqlite3_result_int(ctx, 0);
     return;
   }
@@ -1231,11 +1269,12 @@ void doltCheckoutFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
 
   m.zTargetBranch = zBranch;
   m.zCurrentBranch = zCurrentBranch;
+  doltliteSetSessionDetached(db, 0);
   rc = doltliteMutateRefs(db, checkoutMutateRefs, &m);
   if( rc!=SQLITE_OK ){
     int restoreRc = checkoutRestoreSession(db, &m);
     if( restoreRc!=SQLITE_OK ) rc = restoreRc;
-    {
+    if( !m.savedWasDetached ){
       int durableRc = doltliteMutateRefs(db, checkoutRestoreDurableState, &m);
       if( durableRc!=SQLITE_OK ) rc = durableRc;
     }
@@ -1263,11 +1302,12 @@ void doltCheckoutFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
       checkoutSaveSession(db, &m);
       m.zTargetBranch = zBranch;
       m.zCurrentBranch = zCurrentBranch;
+      doltliteSetSessionDetached(db, 0);
       rc = doltliteMutateRefs(db, checkoutMutateRefs, &m);
       if( rc!=SQLITE_OK ){
         int restoreRc = checkoutRestoreSession(db, &m);
         if( restoreRc!=SQLITE_OK ) rc = restoreRc;
-        {
+        if( !m.savedWasDetached ){
           int durableRc = doltliteMutateRefs(db, checkoutRestoreDurableState, &m);
           if( durableRc!=SQLITE_OK ) rc = durableRc;
         }

--- a/src/doltlite_cherry_pick.c
+++ b/src/doltlite_cherry_pick.c
@@ -344,6 +344,7 @@ static void doltliteCherryPickFunc(
   memset(&parentCommit, 0, sizeof(parentCommit));
   memset(&ourCommit, 0, sizeof(ourCommit));
 
+  if( doltliteCmdRejectDetached(context) ) return;
   if( !cs ){ sqlite3_result_error(context, "no database", -1); return; }
   if( argc<1 ){
     sqlite3_result_error(context, "usage: dolt_cherry_pick('commit_hash')", -1);

--- a/src/doltlite_cmd.c
+++ b/src/doltlite_cmd.c
@@ -13,6 +13,14 @@
 ** merge conflicts / constraint violations.
 */
 
+int doltliteCmdRejectDetached(sqlite3_context *ctx){
+  sqlite3 *db = sqlite3_context_db_handle(ctx);
+  if( !doltliteIsDetached(db) ) return 0;
+  sqlite3_result_error(ctx,
+      "this operation is not supported while in a detached head state", -1);
+  return 1;
+}
+
 void doltliteCmdResultUnknownOption(sqlite3_context *ctx, const char *zOpt){
   char *zErr = sqlite3_mprintf("unknown option `%s`", zOpt ? zOpt : "");
   if( zErr ){

--- a/src/doltlite_commit.c
+++ b/src/doltlite_commit.c
@@ -180,6 +180,7 @@ int doltliteResolveCatalogHashForRef(sqlite3 *db, const char *zRef,
     return doltliteGetHeadCatalogHash(db, pCatHash);
   }
   if( doltliteRefIsWorking(zRef) ){
+    if( doltliteIsDetached(db) ) return SQLITE_NOTFOUND;
     rc = doltliteHasUncommittedChanges(db, &dirty);
     if( rc!=SQLITE_OK ) return rc;
     if( dirty ){
@@ -188,6 +189,7 @@ int doltliteResolveCatalogHashForRef(sqlite3 *db, const char *zRef,
     return doltliteGetPersistedWorkingCatalogHash(db, pCatHash);
   }
   if( doltliteRefIsStaged(zRef) ){
+    if( doltliteIsDetached(db) ) return SQLITE_NOTFOUND;
     doltliteGetSessionStaged(db, pCatHash);
     if( prollyHashIsEmpty(pCatHash) ){
       return doltliteGetHeadCatalogHash(db, pCatHash);

--- a/src/doltlite_commit_cmd.c
+++ b/src/doltlite_commit_cmd.c
@@ -667,6 +667,7 @@ static void doltliteCommitFunc(
 
   memset(&mutationState, 0, sizeof(mutationState));
 
+  if( doltliteCmdRejectDetached(context) ) return;
   if( !cs ){
     sqlite3_result_error(context, doltliteVcUnavailableMessage(db), -1);
     return;

--- a/src/doltlite_conflicts.c
+++ b/src/doltlite_conflicts.c
@@ -1395,6 +1395,7 @@ static void conflictsResolveFunc(sqlite3_context *ctx, int argc, sqlite3_value *
   int found = 0;
   int j, rc;
 
+  if( doltliteCmdRejectDetached(ctx) ) return;
   if(!cs){ sqlite3_result_error(ctx,"no database",-1); return; }
   if(argc!=2){ sqlite3_result_error(ctx,"usage: dolt_conflicts_resolve('--ours'|'--theirs','table')",-1); return; }
 

--- a/src/doltlite_core.c
+++ b/src/doltlite_core.c
@@ -356,6 +356,7 @@ int doltliteMutateRefsExpected(
   if( !cs || !xMutate || nExpected<0 || (nExpected>0 && !aExpected) ){
     return SQLITE_MISUSE;
   }
+  if( doltliteIsDetached(db) ) return SQLITE_READONLY;
 
   rc = chunkStoreLockAndRefresh(cs);
   if( rc!=SQLITE_OK ) return rc;

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -901,6 +901,7 @@ int doltliteCompareAndAdvanceBranch(
 );
 int doltlitePersistOrSaveWorkingSet(sqlite3 *db);
 /* Shared dolt_* command scaffolding (doltlite_cmd.c). */
+int doltliteCmdRejectDetached(sqlite3_context *ctx);
 void doltliteCmdResultUnknownOption(sqlite3_context *ctx, const char *zOpt);
 void doltliteCmdResultMissingOptionValue(
   sqlite3_context *ctx, const char *zOptName
@@ -1188,6 +1189,8 @@ int doltliteWriteBranchCleanWorkingState(sqlite3 *db, const char *zBranch,
 int doltliteCheckRepoGraphIntegrity(Btree *p, int mxErr, int *pnErr);
 
 const char *doltliteGetSessionBranch(sqlite3 *db);
+int doltliteIsDetached(sqlite3 *db);
+void doltliteSetSessionDetached(sqlite3 *db, int isDetached);
 int doltlitePrepareSessionBranch(sqlite3 *db, const char *zBranch,
                                  char **pzPrepared);
 void doltliteInstallPreparedSessionBranch(sqlite3 *db, char *zPrepared);

--- a/src/doltlite_merge_cmd.c
+++ b/src/doltlite_merge_cmd.c
@@ -611,6 +611,7 @@ static void doltliteMergeFunc(
   u8 isMerging = 0;
   int rc, i;
 
+  if( doltliteCmdRejectDetached(context) ) return;
   if( !doltliteGetChunkStore(db) ){
     sqlite3_result_error(context, doltliteVcUnavailableMessage(db), -1);
     return;

--- a/src/doltlite_rebase.c
+++ b/src/doltlite_rebase.c
@@ -1819,6 +1819,7 @@ static void doltliteRebaseFunc(
   int sealTopLevel = db->pSavepoint!=0 && db->nSavepoint==0;
   int keepTopLevelSavepoint = 0;
 
+  if( doltliteCmdRejectDetached(context) ) return;
   if( !cs ){ sqlite3_result_error(context, "no database", -1); goto rebase_cleanup; }
   if( argc<1 ){
     sqlite3_result_error(context, "usage: dolt_rebase('upstream_branch')", -1);

--- a/src/doltlite_ref.c
+++ b/src/doltlite_ref.c
@@ -12,6 +12,136 @@ static int doltliteRefComponentEndsLock(const char *zStart, const char *zEnd){
   return zEnd-zStart>=5 && memcmp(zEnd-5, ".lock", 5)==0;
 }
 
+static int doltliteLoadCommitFromStore(
+  ChunkStore *cs,
+  const ProllyHash *pHash,
+  DoltliteCommit *pCommit
+){
+  u8 *data = 0;
+  int nData = 0;
+  int rc = chunkStoreGet(cs, pHash, &data, &nData);
+  if( rc!=SQLITE_OK ) return rc;
+  rc = doltliteCommitDeserialize(data, nData, pCommit);
+  sqlite3_free(data);
+  return rc;
+}
+
+static int doltliteOpenRevisionBase(
+  ChunkStore *cs,
+  const char *zRef,
+  ProllyHash *pCommit,
+  u8 *pIsBranch
+){
+  DoltliteCommit commit;
+  int rc;
+
+  *pIsBranch = 0;
+  rc = chunkStoreFindBranch(cs, zRef, pCommit);
+  if( rc==SQLITE_OK && !prollyHashIsEmpty(pCommit) ){
+    *pIsBranch = 1;
+  }else{
+    rc = chunkStoreFindTag(cs, zRef, pCommit);
+    if( rc!=SQLITE_OK && strlen(zRef)==PROLLY_HASH_SIZE*2 ){
+      rc = doltliteHexToHash(zRef, pCommit);
+    }
+  }
+  if( rc!=SQLITE_OK || prollyHashIsEmpty(pCommit) ) return SQLITE_NOTFOUND;
+  memset(&commit, 0, sizeof(commit));
+  rc = doltliteLoadCommitFromStore(cs, pCommit, &commit);
+  if( rc==SQLITE_OK ) doltliteCommitClear(&commit);
+  return rc;
+}
+
+static int doltliteOpenRevisionParent(
+  ChunkStore *cs,
+  ProllyHash *pCommit,
+  int iParent
+){
+  DoltliteCommit commit;
+  const ProllyHash *pParent;
+  int rc;
+
+  memset(&commit, 0, sizeof(commit));
+  rc = doltliteLoadCommitFromStore(cs, pCommit, &commit);
+  if( rc!=SQLITE_OK ) return rc;
+  pParent = doltliteCommitParentHash(&commit, iParent);
+  if( !pParent ){
+    doltliteCommitClear(&commit);
+    return SQLITE_NOTFOUND;
+  }
+  memcpy(pCommit, pParent, sizeof(*pCommit));
+  doltliteCommitClear(&commit);
+  return SQLITE_OK;
+}
+
+int doltliteResolveOpenRevision(
+  ChunkStore *cs,
+  const char *zRef,
+  ProllyHash *pCommit,
+  ProllyHash *pCatalog,
+  u8 *pIsBranch
+){
+  DoltliteCommit commit;
+  char *zBase = 0;
+  int nRef, nBase, i, rc;
+
+  if( !cs || !zRef || !pCommit || !pCatalog || !pIsBranch ){
+    return SQLITE_MISUSE;
+  }
+  nRef = (int)strlen(zRef);
+  nBase = nRef;
+  for(;;){
+    int q = nBase;
+    while( q>0 && zRef[q-1]>='0' && zRef[q-1]<='9' ) q--;
+    if( q>0 && (zRef[q-1]=='~' || zRef[q-1]=='^') ){
+      nBase = q - 1;
+    }else{
+      break;
+    }
+  }
+  if( nBase==0 ) return SQLITE_NOTFOUND;
+  if( nBase==nRef ){
+    rc = doltliteOpenRevisionBase(cs, zRef, pCommit, pIsBranch);
+  }else{
+    zBase = sqlite3_mprintf("%.*s", nBase, zRef);
+    if( !zBase ) return SQLITE_NOMEM;
+    rc = doltliteOpenRevisionBase(cs, zBase, pCommit, pIsBranch);
+    sqlite3_free(zBase);
+    *pIsBranch = 0;
+  }
+  if( rc!=SQLITE_OK ) return rc;
+
+  for(i=nBase; i<nRef; ){
+    char op = zRef[i++];
+    int d = i;
+    int n, j;
+    while( i<nRef && zRef[i]>='0' && zRef[i]<='9' ) i++;
+    if( i==d ){
+      n = 1;
+    }else{
+      uint64_t value;
+      if( doltliteParseDecimal(zRef+d, zRef+i, 0x7fffffff, &value)
+          !=DOLTLITE_DECIMAL_OK ) return SQLITE_NOTFOUND;
+      n = (int)value;
+      if( n==0 && op=='^' ) return SQLITE_NOTFOUND;
+    }
+    if( op=='~' ){
+      for(j=0; j<n && rc==SQLITE_OK; j++){
+        rc = doltliteOpenRevisionParent(cs, pCommit, 0);
+      }
+    }else{
+      rc = doltliteOpenRevisionParent(cs, pCommit, n-1);
+    }
+    if( rc!=SQLITE_OK ) return SQLITE_NOTFOUND;
+  }
+
+  memset(&commit, 0, sizeof(commit));
+  rc = doltliteLoadCommitFromStore(cs, pCommit, &commit);
+  if( rc==SQLITE_OK ) memcpy(pCatalog, &commit.catalogHash, sizeof(*pCatalog));
+  doltliteCommitClear(&commit);
+  return rc;
+}
+
 int doltliteUserRefNameIsValid(const char *zName){
   const unsigned char *z;
   const char *zComponent;

--- a/src/doltlite_reset.c
+++ b/src/doltlite_reset.c
@@ -459,6 +459,7 @@ static void doltliteResetFunc(
 
   assert( context!=0 );
   assert( argc>=0 );
+  if( doltliteCmdRejectDetached(context) ) return;
   if( !cs ){
     sqlite3_result_error(context, doltliteVcUnavailableMessage(db), -1);
     goto reset_cleanup;

--- a/src/doltlite_revert.c
+++ b/src/doltlite_revert.c
@@ -128,6 +128,7 @@ static void doltliteRevertFunc(
   memset(&parentCommit, 0, sizeof(parentCommit));
   memset(&ourCommit, 0, sizeof(ourCommit));
 
+  if( doltliteCmdRejectDetached(context) ) return;
   if( !cs ){ sqlite3_result_error(context, "no database", -1); return; }
 
   if( argc<1 ){

--- a/src/doltlite_tag.c
+++ b/src/doltlite_tag.c
@@ -47,6 +47,7 @@ static void doltTagFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   char *zParsedEmail = 0;
   int rc, i;
 
+  if( doltliteCmdRejectDetached(ctx) ) return;
   if( !cs ){ doltliteVcResultError(ctx, db, "no database"); return; }
   if( argc<1 ){ doltliteVcResultError(ctx, db, "tag name required"); return; }
 

--- a/src/doltlite_verify_constraints.c
+++ b/src/doltlite_verify_constraints.c
@@ -163,6 +163,7 @@ static void doltVerifyConstraintsFunc(
   memset(&headCommit, 0, sizeof(headCommit));
   memset(&headHash, 0, sizeof(headHash));
 
+  if( doltliteCmdRejectDetached(context) ) return;
   for(i=0; i<argc; i++){
     const char *zArg = (const char*)sqlite3_value_text(argv[i]);
     int exists;

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -711,23 +711,42 @@ int sqlite3BtreeOpen(
   {
     BtreeBranchState state;
     ProllyHash branchCommit;
+    ProllyHash revisionCatalog;
+    u8 isBranchRevision = 0;
     const char *zDef = zBranchFromPath ? zBranchFromPath :
       chunkStoreGetDefaultBranch(&pBt->store);
     if( !zDef ) zDef = "main";
     memset(&branchCommit, 0, sizeof(branchCommit));
-    if( zBranchFromPath
-     && chunkStoreFindBranch(&pBt->store, zDef, &branchCommit)!=SQLITE_OK ){
-      sqlite3ErrorWithMsg(db, SQLITE_ERROR, "unable to select branch \"%s\"",
-                          zDef);
+    memset(&revisionCatalog, 0, sizeof(revisionCatalog));
+    if( zBranchFromPath ){
+      rc = doltliteResolveOpenRevision(&pBt->store, zDef, &branchCommit,
+                                       &revisionCatalog, &isBranchRevision);
+    }
+    if( zBranchFromPath && rc!=SQLITE_OK ){
+      int openRc = rc==SQLITE_NOMEM || rc==SQLITE_IOERR_NOMEM
+                 ? rc : SQLITE_ERROR;
+      if( openRc==SQLITE_ERROR ){
+        sqlite3ErrorWithMsg(db, SQLITE_ERROR,
+                            "unable to select branch \"%s\"", zDef);
+      }
       pagerShimDestroy(pBt->pPagerShim);
       prollyCacheFree(&pBt->cache);
       chunkStoreClose(&pBt->store);
       sqlite3_free(zStoreFilename);
       sqlite3_free(pBt);
       sqlite3_free(p);
-      return SQLITE_ERROR;
+      return openRc;
     }
-    rc = btreeLoadBranchState(&pBt->store, zDef, 1, &state);
+    if( zBranchFromPath && !isBranchRevision ){
+      memset(&state, 0, sizeof(state));
+      state.catalog = revisionCatalog;
+      state.stagedCatalog = revisionCatalog;
+      state.headCommit = branchCommit;
+      p->isDetached = 1;
+      rc = SQLITE_OK;
+    }else{
+      rc = btreeLoadBranchState(&pBt->store, zDef, 1, &state);
+    }
     if( rc!=SQLITE_OK ){
       pagerShimDestroy(pBt->pPagerShim);
       prollyCacheFree(&pBt->cache);
@@ -821,6 +840,7 @@ int sqlite3BtreeOpen(
 
   pBt->store.corruptMidStream = poisonAfterOpen;
   if( hasMainBtree
+   && !p->isDetached
    && !pBt->store.notADatabase
    && !pBt->store.corruptMidStream ){
     ProllyHash seedHash;
@@ -1115,7 +1135,7 @@ const char *sqlite3BtreeGetJournalname(Btree *p){
 }
 
 int prollyBtreeIsReadonly(Btree *p){
-  return (p->pBt->btsFlags & BTS_READ_ONLY) ? 1 : 0;
+  return p->isDetached || (p->pBt->btsFlags & BTS_READ_ONLY) ? 1 : 0;
 }
 int sqlite3BtreeIsReadonly(Btree *p){
   if( !p ) return 0;

--- a/src/prolly_btree_int.h
+++ b/src/prolly_btree_int.h
@@ -48,6 +48,9 @@ int doltliteLoadLiveSchemaSql(sqlite3 *db, const char *zType,
                               const char *zDb,
                               const char *zName, const char *zTblName,
                               char **pzSql);
+int doltliteResolveOpenRevision(
+  ChunkStore*, const char*, ProllyHash*, ProllyHash*, u8*
+);
 int doltliteResolveTableName(sqlite3 *db, const char *zTable, Pgno *piTable);
 char *doltliteResolveTableNumber(sqlite3 *db, Pgno iTable);
 int doltliteSerializeCatalogEntriesWithFallbackSchema(
@@ -347,6 +350,7 @@ struct Btree {
   char *zBranch;
   char *zAuthorName;
   char *zAuthorEmail;
+  u8 isDetached;
   ProllyHash headCommit;
   DoltVcState vc;
 

--- a/src/prolly_btree_state.c
+++ b/src/prolly_btree_state.c
@@ -472,6 +472,7 @@ int btreeRefreshSharedWorkingState(Btree *p){
   ProllyHash loadedCatHash;
   int rc;
   assert( p!=0 && p->pBt!=0 );
+  if( p->isDetached ) return SQLITE_OK;
   pBt = p->pBt;
   if( p->iLoadedWorkingStateVersion==pBt->iWorkingStateVersion ){
     return SQLITE_OK;
@@ -509,6 +510,7 @@ int btreeRefreshFromDisk(Btree *p){
   }
   if( rc!=SQLITE_OK ) return rc;
   if( !bChanged ) return SQLITE_OK;
+  if( p->isDetached ) return SQLITE_OK;
 
   memset(&loadedCatHash, 0, sizeof(loadedCatHash));
   rc = btreeReloadBranchWorkingStateInto(p, 1, &loadedCatHash);
@@ -527,6 +529,17 @@ const char *doltliteGetSessionBranch(sqlite3 *db){
     return p->zBranch ? p->zBranch : "main";
   }
   return "main";
+}
+
+int doltliteIsDetached(sqlite3 *db){
+  return db && db->nDb>0 && db->aDb[0].pBt
+      && db->aDb[0].pBt->isDetached;
+}
+
+void doltliteSetSessionDetached(sqlite3 *db, int isDetached){
+  if( db && db->nDb>0 && db->aDb[0].pBt ){
+    db->aDb[0].pBt->isDetached = isDetached!=0;
+  }
 }
 
 static int replaceSessionString(char **pzDest, const char *zValue){
@@ -948,6 +961,7 @@ int doltliteSaveWorkingSetWithHash(sqlite3 *db, const ProllyHash *pWorkingCatHas
 
   if( !db || db->nDb<=0 || !db->aDb[0].pBt ) return SQLITE_ERROR;
   pBtree = db->aDb[0].pBt;
+  if( pBtree->isDetached ) return SQLITE_READONLY;
   if( !cs ) return SQLITE_ERROR;
 
   zBranch = pBtree->zBranch ? pBtree->zBranch : "main";

--- a/src/prolly_btree_txn.c
+++ b/src/prolly_btree_txn.c
@@ -716,7 +716,7 @@ int prollyBtreeBeginTrans(Btree *p, int wrFlag, int *pSchemaVersion){
   if( wrFlag ){
     int bStoreChanged = 0;
     int nSavepointStart = p->nSavepoint;
-    if( pBt->btsFlags & BTS_READ_ONLY ){
+    if( p->isDetached || (pBt->btsFlags & BTS_READ_ONLY) ){
       return SQLITE_READONLY;
     }
 
@@ -787,6 +787,10 @@ int prollyBtreeBeginTrans(Btree *p, int wrFlag, int *pSchemaVersion){
   return SQLITE_OK;
 }
 int sqlite3BtreeBeginTrans(Btree *p, int wrFlag, int *pSchemaVersion){
+  if( wrFlag && p && p->db && p->db->nDb>0 && p->db->aDb[0].pBt
+   && p->db->aDb[0].pBt->isDetached ){
+    return SQLITE_READONLY;
+  }
   if( !p ) return SQLITE_OK;
   return p->pOps->xBeginTrans(p, wrFlag, pSchemaVersion);
 }

--- a/src/shell.c.in
+++ b/src/shell.c.in
@@ -5114,7 +5114,14 @@ static void parseDoltiteDbBranch(
   {
     const char *zAt = strrchr(zInput, '@');
     if( zAt && zAt[1]!=0 && (!zSep || zAt > zSep) ){
-      *pzFilename = sqlite3_mprintf("%.*s", (int)(zAt - zInput), zInput);
+      zBase = sqlite3_mprintf("%.*s", (int)(zAt - zInput), zInput);
+      if( zBase && doltliteShellLooksLikeDbPath(zBase)
+       && (doltliteShellReadableFile(zBase) || access(zBase, 0)==0) ){
+        sqlite3_free(zBase);
+        *pzFilename = sqlite3_mprintf("%s", zInput);
+        return;
+      }
+      *pzFilename = zBase;
       *pzBranch = sqlite3_mprintf("%s", zAt + 1);
       return;
     }

--- a/src/shell.c.in
+++ b/src/shell.c.in
@@ -5131,9 +5131,9 @@ static void parseDoltiteDbBranch(
   if( zSep && zSep[1]!=0 ){
     zBase = sqlite3_mprintf("%.*s", (int)(zSep - zInput), zInput);
     if( zBase && doltliteShellLooksLikeDbPath(zBase)
-     && doltliteShellReadableFile(zBase) ){
-      *pzFilename = zBase;
-      *pzBranch = sqlite3_mprintf("%s", zSep + 1);
+     && (doltliteShellReadableFile(zBase) || access(zBase, 0)==0) ){
+      sqlite3_free(zBase);
+      *pzFilename = sqlite3_mprintf("%s", zInput);
       return;
     }
     sqlite3_free(zBase);

--- a/test/concurrency_contract.tsv
+++ b/test/concurrency_contract.tsv
@@ -1,5 +1,6 @@
 id	status	evidence	contract
 conn.per_session_branch	adapted	test/concurrent_branch_test.c#db1_still_main,test/concurrent_branch_test.c#db2_on_feature,README.md#Per-connection branch selection	Each connection holds its own active branch and session view so two connections may use different branches of the same file
+conn.detached_snapshot	adapted	test/doltlite_open_branch.sh#detached_reader_stays_on_pinned_commit,README.md#Detached revisions	A tag-, commit-, or ancestor-qualified connection remains pinned to its immutable commit while peers advance refs and is read-only until it checks out a branch
 working.branch_owned	adapted	test/vc_oracle_cross_connection_state_test.sh#main_connection_isolated_from_side_working_set,test/vc_oracle_cross_connection_state_test.sh#side_connection_recovers_its_working_set	An uncommitted working set belongs to its branch and another connection selecting that branch recovers it
 writer.graph_lock_busy	adapted	test/concurrent_write_test.c#mw_explicit_b_busy,test/multi_process_test.c#mp_parent_busy	An explicit write transaction owns the graph lock and a concurrent writer receives SQLITE_BUSY until the owner finishes
 writer.retry_after_busy	adapted	test/concurrent_write_test.c#mw_explicit_b_retry_ok,test/multi_process_test.c#mp_parent_after_child	After the lock holder commits or exits a peer write can proceed successfully

--- a/test/detached_head_test.c
+++ b/test/detached_head_test.c
@@ -1,0 +1,161 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include "sqlite3.h"
+
+static int nPass;
+static int nFail;
+
+static void check(const char *zName, int condition){
+  if( condition ){
+    nPass++;
+  }else{
+    nFail++;
+    fprintf(stderr, "FAIL: %s\n", zName);
+  }
+}
+
+static int execSql(sqlite3 *db, const char *zSql){
+  char *zErr = 0;
+  int rc = sqlite3_exec(db, zSql, 0, 0, &zErr);
+  if( rc!=SQLITE_OK ){
+    fprintf(stderr, "SQL error: %s (rc=%d)\nSQL: %s\n",
+            zErr ? zErr : "?", rc, zSql);
+  }
+  sqlite3_free(zErr);
+  return rc;
+}
+
+static int scalarInt(sqlite3 *db, const char *zSql, int *pValue){
+  sqlite3_stmt *pStmt = 0;
+  int rc = sqlite3_prepare_v2(db, zSql, -1, &pStmt, 0);
+  if( rc==SQLITE_OK ) rc = sqlite3_step(pStmt);
+  if( rc==SQLITE_ROW ){
+    *pValue = sqlite3_column_int(pStmt, 0);
+    rc = SQLITE_OK;
+  }
+  sqlite3_finalize(pStmt);
+  return rc;
+}
+
+static int scalarText(sqlite3 *db, const char *zSql, char *zOut, int nOut){
+  sqlite3_stmt *pStmt = 0;
+  int rc = sqlite3_prepare_v2(db, zSql, -1, &pStmt, 0);
+  if( rc==SQLITE_OK ) rc = sqlite3_step(pStmt);
+  if( rc==SQLITE_ROW ){
+    const unsigned char *z = sqlite3_column_text(pStmt, 0);
+    if( z ) snprintf(zOut, nOut, "%s", z);
+    rc = SQLITE_OK;
+  }
+  sqlite3_finalize(pStmt);
+  return rc;
+}
+
+static int scalarIsNull(sqlite3 *db, const char *zSql){
+  sqlite3_stmt *pStmt = 0;
+  int isNull = 0;
+  int rc = sqlite3_prepare_v2(db, zSql, -1, &pStmt, 0);
+  if( rc==SQLITE_OK && sqlite3_step(pStmt)==SQLITE_ROW ){
+    isNull = sqlite3_column_type(pStmt, 0)==SQLITE_NULL;
+  }
+  sqlite3_finalize(pStmt);
+  return isNull;
+}
+
+static void checkDetached(sqlite3 *db, const char *zName){
+  int n = 0;
+  char zCheck[128];
+  snprintf(zCheck, sizeof(zCheck), "%s: readonly", zName);
+  check(zCheck, sqlite3_db_readonly(db, "main")==1);
+  snprintf(zCheck, sizeof(zCheck), "%s: active branch null", zName);
+  check(zCheck, scalarIsNull(db, "SELECT active_branch()"));
+  snprintf(zCheck, sizeof(zCheck), "%s: historical rows", zName);
+  check(zCheck, scalarInt(db, "SELECT count(*) FROM t", &n)==SQLITE_OK && n==1);
+  snprintf(zCheck, sizeof(zCheck), "%s: rejects writes", zName);
+  check(zCheck, sqlite3_exec(db, "INSERT INTO t VALUES(3)", 0, 0, 0)==SQLITE_READONLY);
+}
+
+int main(void){
+  char zDir[] = "/tmp/doltlite-detached-head-XXXXXX";
+  char zPath[1024];
+  char zOpen[1024];
+  char zLock[1024];
+  char zHash[64] = {0};
+  sqlite3 *db = 0;
+  int rc;
+  int n = 0;
+
+  check("create temporary directory", mkdtemp(zDir)!=0);
+  snprintf(zPath, sizeof(zPath), "%s/test.db", zDir);
+
+  rc = sqlite3_open(zPath, &db);
+  check("open database", rc==SQLITE_OK);
+  check("create table", execSql(db, "CREATE TABLE t(id INTEGER PRIMARY KEY)")==SQLITE_OK);
+  check("insert first row", execSql(db, "INSERT INTO t VALUES(1)")==SQLITE_OK);
+  check("commit first row", execSql(db, "SELECT dolt_commit('-A','-m','c1')")==SQLITE_OK);
+  check("create tag", execSql(db, "SELECT dolt_tag('v1')")==SQLITE_OK);
+  check("resolve tag hash", scalarText(db, "SELECT dolt_hashof('v1')", zHash,
+                                      sizeof(zHash))==SQLITE_OK && strlen(zHash)==40);
+  check("insert second row", execSql(db, "INSERT INTO t VALUES(2)")==SQLITE_OK);
+  check("commit second row", execSql(db, "SELECT dolt_commit('-A','-m','c2')")==SQLITE_OK);
+  check("attached checkout tag rejected",
+        sqlite3_exec(db, "SELECT dolt_checkout('v1')", 0, 0, 0)!=SQLITE_OK);
+  check("rejected checkout stays attached",
+        scalarText(db, "SELECT active_branch()", zOpen, sizeof(zOpen))==SQLITE_OK
+        && strcmp(zOpen, "main")==0 && sqlite3_db_readonly(db, "main")==0);
+  snprintf(zOpen, sizeof(zOpen), "SELECT dolt_checkout('%s')", zHash);
+  check("attached checkout hash rejected", sqlite3_exec(db, zOpen, 0, 0, 0)!=SQLITE_OK);
+  sqlite3_close(db);
+  db = 0;
+
+  snprintf(zOpen, sizeof(zOpen), "%s/v1", zPath);
+  rc = sqlite3_open(zOpen, &db);
+  check("open slash tag", rc==SQLITE_OK);
+  if( rc==SQLITE_OK ){
+    checkDetached(db, "slash tag");
+    check("reattach branch", execSql(db, "SELECT dolt_checkout('main')")==SQLITE_OK);
+    check("reattached writable", sqlite3_db_readonly(db, "main")==0);
+    check("reattached active branch",
+          scalarText(db, "SELECT active_branch()", zOpen, sizeof(zOpen))==SQLITE_OK
+          && strcmp(zOpen, "main")==0);
+    check("reattached write", execSql(db, "INSERT INTO t VALUES(3)")==SQLITE_OK);
+  }
+  sqlite3_close(db);
+  db = 0;
+
+  snprintf(zOpen, sizeof(zOpen), "%s@v1", zPath);
+  rc = sqlite3_open(zOpen, &db);
+  check("open at tag", rc==SQLITE_OK);
+  if( rc==SQLITE_OK ) checkDetached(db, "at tag");
+  sqlite3_close(db);
+  db = 0;
+
+  snprintf(zOpen, sizeof(zOpen), "%s/%s", zPath, zHash);
+  rc = sqlite3_open(zOpen, &db);
+  check("open commit hash", rc==SQLITE_OK);
+  if( rc==SQLITE_OK ) checkDetached(db, "commit hash");
+  sqlite3_close(db);
+  db = 0;
+
+  rc = sqlite3_open(":memory:", &db);
+  check("open attach host", rc==SQLITE_OK);
+  if( rc==SQLITE_OK ){
+    snprintf(zOpen, sizeof(zOpen), "ATTACH DATABASE '%s/v1' AS hist", zPath);
+    check("attach detached tag", execSql(db, zOpen)==SQLITE_OK);
+    check("attached tag readonly", sqlite3_db_readonly(db, "hist")==1);
+    check("attached historical rows",
+          scalarInt(db, "SELECT count(*) FROM hist.t", &n)==SQLITE_OK && n==1);
+    check("attached tag rejects writes",
+          sqlite3_exec(db, "INSERT INTO hist.t VALUES(4)", 0, 0, 0)==SQLITE_READONLY);
+  }
+  sqlite3_close(db);
+
+  unlink(zPath);
+  snprintf(zLock, sizeof(zLock), "%s-lock", zPath);
+  unlink(zLock);
+  rmdir(zDir);
+
+  printf("%d passed, %d failed\n", nPass, nFail);
+  return nFail ? 1 : 0;
+}

--- a/test/detached_head_test.c
+++ b/test/detached_head_test.c
@@ -78,9 +78,9 @@ static void checkDetached(sqlite3 *db, const char *zName){
 
 int main(void){
   char zDir[] = "/tmp/doltlite-detached-head-XXXXXX";
-  char zPath[1024];
-  char zOpen[1024];
-  char zLock[1024];
+  char zPath[sizeof(zDir) + sizeof("/test.db")];
+  char zOpen[sizeof(zPath) + 128];
+  char zLock[sizeof(zPath) + sizeof("-lock")];
   char zHash[64] = {0};
   sqlite3 *db = 0;
   int rc;

--- a/test/doltlite_open_branch.sh
+++ b/test/doltlite_open_branch.sh
@@ -41,12 +41,16 @@ CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'main');
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','init');
+SELECT dolt_tag('v1');
 SELECT dolt_branch('side');
 SELECT dolt_checkout('side');
 UPDATE t SET v='side' WHERE id=1;
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','side');
 SELECT dolt_checkout('main');
+INSERT INTO t VALUES(2,'main2');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','main2');
 SQL
 
 res=$("$DOLTLITE" "$DB" "SELECT active_branch(); SELECT v FROM t WHERE id=1;" | normalize_output)
@@ -62,7 +66,7 @@ res=$("$DOLTLITE" "$DB" "SELECT active_branch(); SELECT v FROM t WHERE id=1;" | 
 check_eq "branch_open_does_not_change_default" $'main\nmain' "$res"
 
 res=$("$DOLTLITE" "$DB@missing" "SELECT active_branch();" 2>&1 | normalize_output || true)
-check_match "missing_branch_errors" "unable to select branch|branch.*not found|SQLITE_NOTFOUND" "$res"
+check_match "missing_branch_errors" "unable to open database|unable to select branch|branch.*not found|SQLITE_NOTFOUND" "$res"
 
 cat <<'SQL' | "$DOLTLITE" "$DB" >/dev/null 2>&1
 SELECT dolt_branch('-m','side','renamed');
@@ -84,7 +88,93 @@ SELECT dolt_branch('-D','copy');
 SQL
 
 res=$("$DOLTLITE" "$DB@copy" "SELECT active_branch();" 2>&1 | normalize_output || true)
-check_match "deleted_branch_open_errors" "unable to select branch|branch.*not found|SQLITE_NOTFOUND" "$res"
+check_match "deleted_branch_open_errors" "unable to open database|unable to select branch|branch.*not found|SQLITE_NOTFOUND" "$res"
+
+res=$("$DOLTLITE" "$DB/v1" "SELECT IFNULL(active_branch(),'NULL'); SELECT group_concat(id || ':' || v, ',') FROM t;" | normalize_output)
+check_eq "tag_open_is_detached" $'NULL\n1:main' "$res"
+
+res=$("$DOLTLITE" "$DB@v1" "SELECT IFNULL(active_branch(),'NULL'); SELECT dolt_hashof('HEAD') = (SELECT commit_hash FROM dolt_log WHERE message='init');" | normalize_output)
+check_eq "at_tag_open_is_detached" $'NULL\n1' "$res"
+
+INIT_HASH=$("$DOLTLITE" "$DB" "SELECT commit_hash FROM dolt_log WHERE message='init';" | normalize_output)
+res=$("$DOLTLITE" "$DB/$INIT_HASH" "SELECT IFNULL(active_branch(),'NULL'); SELECT group_concat(id || ':' || v, ',') FROM t;" | normalize_output)
+check_eq "hash_open_is_detached" $'NULL\n1:main' "$res"
+
+res=$("$DOLTLITE" "$DB/main~1" "SELECT IFNULL(active_branch(),'NULL'); SELECT group_concat(id || ':' || v, ',') FROM t;" | normalize_output)
+check_eq "branch_ancestor_open_is_detached" $'NULL\n1:main' "$res"
+
+res=$("$DOLTLITE" "$DB/v1~0" "SELECT IFNULL(active_branch(),'NULL'); SELECT group_concat(id || ':' || v, ',') FROM t;" | normalize_output)
+check_eq "tag_ancestor_open_is_detached" $'NULL\n1:main' "$res"
+
+res=$("$DOLTLITE" "$DB/v1" "INSERT INTO t VALUES(3,'blocked');" 2>&1 | normalize_output || true)
+check_match "detached_insert_is_readonly" "read-only|readonly" "$res"
+
+res=$("$DOLTLITE" "$DB/v1" "CREATE TABLE blocked(id INTEGER PRIMARY KEY);" 2>&1 | normalize_output || true)
+check_match "detached_ddl_is_readonly" "read-only|readonly" "$res"
+
+res=$("$DOLTLITE" "$DB/v1" "CREATE TEMPORARY TABLE blocked(id INTEGER PRIMARY KEY);" 2>&1 | normalize_output || true)
+check_match "detached_temp_ddl_is_readonly" "read-only|readonly" "$res"
+
+res=$("$DOLTLITE" "$DB/v1" "SELECT dolt_add('-A');" 2>&1 | normalize_output || true)
+check_match "detached_add_is_rejected" "detached head|read-only|readonly" "$res"
+
+res=$("$DOLTLITE" "$DB/v1" "SELECT dolt_branch('blocked');" 2>&1 | normalize_output || true)
+check_match "detached_branch_is_rejected" "detached head|read-only|readonly" "$res"
+
+for command_case in \
+  "tag|SELECT dolt_tag('blocked')" \
+  "commit|SELECT dolt_commit('-A','-m','blocked')" \
+  "reset|SELECT dolt_reset('--hard')" \
+  "merge|SELECT dolt_merge('main')" \
+  "cherry_pick|SELECT dolt_cherry_pick('$INIT_HASH')" \
+  "revert|SELECT dolt_revert('$INIT_HASH')" \
+  "rebase|SELECT dolt_rebase('main')" \
+  "verify_constraints|SELECT dolt_verify_constraints()" \
+  "connect_branch|SELECT dolt_connect_branch('main')"; do
+  command_name=${command_case%%|*}
+  command_sql=${command_case#*|}
+  res=$("$DOLTLITE" "$DB/v1" "$command_sql" 2>&1 | normalize_output || true)
+  check_match "detached_${command_name}_is_rejected" "detached head|read-only|readonly" "$res"
+done
+
+res=$("$DOLTLITE" "$DB/v1" "SELECT dolt_checkout('v1');" 2>&1 | normalize_output || true)
+check_match "checkout_tag_does_not_enter_detached" "does not support a detached head state" "$res"
+
+res=$("$DOLTLITE" "$DB" "SELECT dolt_checkout('v1');" 2>&1 | normalize_output || true)
+check_match "attached_checkout_tag_does_not_detach" "no such branch or table|does not support a detached head state" "$res"
+
+res=$("$DOLTLITE" "$DB/v1" "SELECT dolt_checkout('-b','blocked');" 2>&1 | normalize_output || true)
+check_match "checkout_new_branch_from_detached_is_rejected" "read-only database" "$res"
+
+res=$("$DOLTLITE" "$DB/v1" "SELECT dolt_hashof('WORKING');" 2>&1 | normalize_output || true)
+check_match "detached_working_ref_is_invalid" "not found|invalid|error" "$res"
+
+res=$("$DOLTLITE" "$DB/v1" "SELECT dolt_hashof('STAGED');" 2>&1 | normalize_output || true)
+check_match "detached_staged_ref_is_invalid" "not found|invalid|error" "$res"
+
+res=$("$DOLTLITE" "$DB/v1" "SELECT dolt_gc(); SELECT IFNULL(active_branch(),'NULL'); SELECT count(*) FROM t;" | normalize_output)
+check_match "detached_gc_is_allowed" "chunks removed, [0-9]+ chunks kept" "$(echo "$res" | sed -n '1p')"
+check_eq "detached_gc_preserves_snapshot" $'NULL\n1' "$(echo "$res" | tail -n 2)"
+
+res=$("$DOLTLITE" "$DB/v1" "SELECT dolt_checkout('main'); SELECT active_branch(); SELECT count(*) FROM t; INSERT INTO t VALUES(3,'reattached'); SELECT count(*) FROM t;" | normalize_output)
+check_eq "checkout_branch_reattaches_session" $'0\nmain\n2\n3' "$res"
+
+res=$("$DOLTLITE" "$DB" "SELECT active_branch(); SELECT count(*) FROM t;" | normalize_output)
+check_eq "detached_state_does_not_survive_reopen" $'main\n3' "$res"
+
+"$DOLTLITE" "$DB" "SELECT dolt_branch('same'); SELECT dolt_tag('same','v1');" >/dev/null
+res=$("$DOLTLITE" "$DB/same" "SELECT IFNULL(active_branch(),'NULL'); SELECT count(*) FROM t;" | normalize_output)
+check_eq "branch_wins_over_tag" $'same\n2' "$res"
+
+res=$("$DOLTLITE" "$DB/0000000000000000000000000000000000000000" "SELECT 1;" 2>&1 | normalize_output || true)
+check_match "missing_hash_errors" "unable to open database|unable to select branch|not found|SQLITE_NOTFOUND" "$res"
+
+res=$(printf ".headers off\nSELECT count(*) FROM t;\n.system %s %s \"INSERT INTO t VALUES(4,'peer'); SELECT dolt_commit('-A','-m','peer'); SELECT dolt_tag('-d','v1');\" >/dev/null\nSELECT IFNULL(active_branch(),'NULL');\nSELECT count(*) FROM t;\n" "$DOLTLITE" "$DB" \
+  | "$DOLTLITE" "$DB/v1" | normalize_output)
+check_eq "detached_reader_stays_on_pinned_commit" $'1\nNULL\n1' "$res"
+
+res=$("$DOLTLITE" "$DB" "SELECT count(*) FROM t; SELECT count(*) FROM dolt_tags WHERE tag_name='v1';" | normalize_output)
+check_eq "peer_advance_and_tag_delete_are_durable" $'4\n0' "$res"
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed"

--- a/test/doltlite_open_branch.sh
+++ b/test/doltlite_open_branch.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
 DOLTLITE="${1:-./doltlite}"
+DOLTLITE_SYSTEM="${DOLTLITE_SYSTEM:-$DOLTLITE}"
+DOLTLITE_SYSTEM_NULL="${DOLTLITE_SYSTEM_NULL:-/dev/null}"
 PASS=0; FAIL=0; ERRORS=""
 
 normalize_output() {
@@ -169,7 +171,7 @@ check_eq "branch_wins_over_tag" $'same\n2' "$res"
 res=$("$DOLTLITE" "$DB/0000000000000000000000000000000000000000" "SELECT 1;" 2>&1 | normalize_output || true)
 check_match "missing_hash_errors" "unable to open database|unable to select branch|not found|SQLITE_NOTFOUND" "$res"
 
-res=$(printf ".headers off\nSELECT count(*) FROM t;\n.system %s %s \"INSERT INTO t VALUES(4,'peer'); SELECT dolt_commit('-A','-m','peer'); SELECT dolt_tag('-d','v1');\" >/dev/null\nSELECT IFNULL(active_branch(),'NULL');\nSELECT count(*) FROM t;\n" "$DOLTLITE" "$DB" \
+res=$(printf ".headers off\nSELECT count(*) FROM t;\n.system %s %s \"INSERT INTO t VALUES(4,'peer'); SELECT dolt_commit('-A','-m','peer'); SELECT dolt_tag('-d','v1');\" >%s\nSELECT IFNULL(active_branch(),'NULL');\nSELECT count(*) FROM t;\n" "$DOLTLITE_SYSTEM" "$DB" "$DOLTLITE_SYSTEM_NULL" \
   | "$DOLTLITE" "$DB/v1" | normalize_output)
 check_eq "detached_reader_stays_on_pinned_commit" $'1\nNULL\n1' "$res"
 

--- a/test/run_c_tests.sh
+++ b/test/run_c_tests.sh
@@ -31,6 +31,7 @@ COVERAGE_TESTS=(
   cross_branch_test
   corruption_test
   gc_tip_survival_test
+  detached_head_test
   prepared_stmt_reuse_test
   catalog_serialize_determinism_test
   sequence_reload_test

--- a/test/vc_oracle_connection_branch_test.sh
+++ b/test/vc_oracle_connection_branch_test.sh
@@ -35,12 +35,16 @@ CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES (1, 'main');
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'init');
+SELECT dolt_tag('v1');
 SELECT dolt_branch('side');
 SELECT dolt_checkout('side');
 UPDATE t SET v='side' WHERE id=1;
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'side');
 SELECT dolt_checkout('main');
+INSERT INTO t VALUES(2,'main2');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'main2');
 SQL
   "$DOLTLITE" "$dir/dl/db.sqlite" <"$dir/setup_dl.sql" >/dev/null 2>"$dir/dl.err"
 
@@ -48,11 +52,14 @@ SQL
 CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES (1, 'main');
 CALL dolt_commit('-Am', 'init');
+CALL dolt_tag('v1');
 CALL dolt_branch('side');
 CALL dolt_checkout('side');
 UPDATE t SET v='side' WHERE id=1;
 CALL dolt_commit('-Am', 'side');
 CALL dolt_checkout('main');
+INSERT INTO t VALUES(2,'main2');
+CALL dolt_commit('-Am', 'main2');
 SQL
   (
     cd "$dir/dt" &&
@@ -113,7 +120,7 @@ oracle_with_mutation() {
 oracle_error() {
   local name="$1" setup_extra="$2" dbspec="$3" branch="$4" query="$5"
   local dir="$TMPROOT/$name"
-  local dl_rc dt_rc
+  local dl_rc dt_rc parent repo_name
 
   setup_pair "$dir"
   if [ -n "$setup_extra" ]; then
@@ -126,7 +133,14 @@ oracle_error() {
 
   run_dl "$dbspec" "$query" >/dev/null 2>>"$dir/dl.err"
   dl_rc=$?
-  run_dt "$dir/dt" "$branch" "$query" >/dev/null 2>>"$dir/dt.err"
+  parent=$(dirname "$dir/dt")
+  repo_name=$(basename "$dir/dt")
+  (
+    cd "$parent" || exit 1
+    printf "%s\n" "$query" \
+      | "$DOLT" --use-db "$repo_name/$branch" sql \
+          >"$dir/dt.out" 2>>"$dir/dt.err"
+  )
   dt_rc=$?
 
   if vc_oracle_is_clean_error "$dl_rc" && vc_oracle_is_clean_error "$dt_rc"; then
@@ -135,6 +149,107 @@ oracle_error() {
     fail=$((fail+1))
     FAILED_NAMES="$FAILED_NAMES $name"
     echo "  FAIL: $name (expected both to error)"
+    echo "    doltlite rc: $dl_rc"
+    echo "    dolt rc:     $dt_rc"
+  fi
+}
+
+oracle_hash_revision() {
+  local name="$1"
+  local dir="$TMPROOT/$name"
+  local dl_hash dt_hash dl_out dt_out
+  local query="SELECT IFNULL(active_branch(),'NULL') AS value UNION ALL SELECT CAST(COUNT(*) AS CHAR) FROM t;"
+
+  setup_pair "$dir"
+  dl_hash=$(run_dl "$dir/dl/db.sqlite" "SELECT commit_hash FROM dolt_log WHERE message='init';")
+  dt_hash=$(
+    cd "$dir/dt" || exit 1
+    "$DOLT" sql -r csv -q "SELECT commit_hash FROM dolt_log WHERE message='init';" \
+      | tail -n +2 | tr -d '"\r'
+  )
+  dl_out=$(run_dl "$dir/dl/db.sqlite/$dl_hash" "$query" 2>>"$dir/dl.err" | tr -d '\r')
+  dt_out=$(run_dt "$dir/dt" "$dt_hash" "$query" 2>>"$dir/dt.err")
+  vc_oracle_assert_match "$name" "$dl_out" "$dt_out"
+}
+
+oracle_reattach() {
+  local name="$1"
+  local dir="$TMPROOT/$name"
+  local dl_out dt_out
+
+  setup_pair "$dir"
+  dl_out=$(run_dl "$dir/dl/db.sqlite/v1" "
+SELECT 'Q0:' || IFNULL(active_branch(),'NULL') || ':' || COUNT(*) FROM t;
+SELECT dolt_checkout('main');
+SELECT 'Q1:' || active_branch() || ':' || COUNT(*) FROM t;
+INSERT INTO t VALUES(3,'reattached');
+SELECT 'Q2:' || COUNT(*) FROM t;
+" 2>>"$dir/dl.err" | tr -d '\r' | awk '/^Q[0-9]:/')
+  dt_out=$(run_dt "$dir/dt" "v1" "
+SELECT CONCAT('Q0:',IFNULL(active_branch(),'NULL'),':',COUNT(*)) FROM t;
+CALL dolt_checkout('main');
+SELECT CONCAT('Q1:',active_branch(),':',COUNT(*)) FROM t;
+INSERT INTO t VALUES(3,'reattached');
+SELECT CONCAT('Q2:',COUNT(*)) FROM t;
+" 2>>"$dir/dt.err" | awk '/^Q[0-9]:/')
+  vc_oracle_assert_match "$name" "$dl_out" "$dt_out"
+}
+
+oracle_detached_command_error() {
+  local name="$1" dl_query="$2" dt_query="$3"
+  local dir="$TMPROOT/$name"
+  local parent repo_name dl_rc dt_rc
+
+  setup_pair "$dir"
+  run_dl "$dir/dl/db.sqlite/v1" "$dl_query" \
+    >"$dir/dl.out" 2>"$dir/dl.err"
+  dl_rc=$?
+  parent=$(dirname "$dir/dt")
+  repo_name=$(basename "$dir/dt")
+  (
+    cd "$parent" || exit 1
+    printf "%s\n" "$dt_query" \
+      | "$DOLT" --use-db "$repo_name/v1" sql \
+          >"$dir/dt.out" 2>"$dir/dt.err"
+  )
+  dt_rc=$?
+
+  if vc_oracle_is_clean_error "$dl_rc" && vc_oracle_is_clean_error "$dt_rc"; then
+    pass=$((pass+1))
+  else
+    fail=$((fail+1))
+    FAILED_NAMES="$FAILED_NAMES $name"
+    echo "  FAIL: $name (expected both to error)"
+    echo "    doltlite rc: $dl_rc"
+    echo "    dolt rc:     $dt_rc"
+  fi
+}
+
+oracle_detached_command_success() {
+  local name="$1" dl_query="$2" dt_query="$3"
+  local dir="$TMPROOT/$name"
+  local parent repo_name dl_rc dt_rc
+
+  setup_pair "$dir"
+  run_dl "$dir/dl/db.sqlite/v1" "$dl_query" \
+    >"$dir/dl.out" 2>"$dir/dl.err"
+  dl_rc=$?
+  parent=$(dirname "$dir/dt")
+  repo_name=$(basename "$dir/dt")
+  (
+    cd "$parent" || exit 1
+    printf "%s\n" "$dt_query" \
+      | "$DOLT" --use-db "$repo_name/v1" sql -c \
+          >"$dir/dt.out" 2>"$dir/dt.err"
+  )
+  dt_rc=$?
+
+  if [ "$dl_rc" -eq 0 ] && [ "$dt_rc" -eq 0 ]; then
+    pass=$((pass+1))
+  else
+    fail=$((fail+1))
+    FAILED_NAMES="$FAILED_NAMES $name"
+    echo "  FAIL: $name (expected both to succeed)"
     echo "    doltlite rc: $dl_rc"
     echo "    dolt rc:     $dt_rc"
   fi
@@ -158,6 +273,92 @@ oracle_with_mutation "copied_branch_open_selects_branch" \
   "$TMPROOT/copied_branch_open_selects_branch/dl/db.sqlite/copy" \
   "copy" \
   "SELECT active_branch() AS value UNION ALL SELECT v FROM t WHERE id=1;"
+
+echo "--- detached revisions ---"
+
+oracle_with_query "tag_open_is_detached" \
+  "$TMPROOT/tag_open_is_detached/dl/db.sqlite/v1" \
+  "v1" \
+  "SELECT IFNULL(active_branch(),'NULL') AS value UNION ALL SELECT CAST(COUNT(*) AS CHAR) FROM t;"
+
+oracle_with_query "at_tag_open_is_detached" \
+  "$TMPROOT/at_tag_open_is_detached/dl/db.sqlite@v1" \
+  "v1" \
+  "SELECT IFNULL(active_branch(),'NULL') AS value UNION ALL SELECT CAST(COUNT(*) AS CHAR) FROM t;"
+
+oracle_with_query "branch_ancestor_is_detached" \
+  "$TMPROOT/branch_ancestor_is_detached/dl/db.sqlite/main~1" \
+  "main~1" \
+  "SELECT IFNULL(active_branch(),'NULL') AS value UNION ALL SELECT CAST(COUNT(*) AS CHAR) FROM t;"
+
+oracle_with_query "tag_ancestor_is_detached" \
+  "$TMPROOT/tag_ancestor_is_detached/dl/db.sqlite/v1~0" \
+  "v1~0" \
+  "SELECT IFNULL(active_branch(),'NULL') AS value UNION ALL SELECT CAST(COUNT(*) AS CHAR) FROM t;"
+
+oracle_hash_revision "raw_hash_open_is_detached"
+
+oracle_with_query "detached_read_surfaces" \
+  "$TMPROOT/detached_read_surfaces/dl/db.sqlite/v1" \
+  "v1" \
+  "SELECT IFNULL(active_branch(),'NULL') AS value UNION ALL SELECT CAST(COUNT(*) AS CHAR) FROM dolt_status UNION ALL SELECT CAST(COUNT(*) AS CHAR) FROM dolt_log UNION ALL SELECT CAST(COUNT(*) AS CHAR) FROM dolt_tags;"
+
+oracle_with_mutation "branch_wins_over_tag" \
+  "SELECT dolt_branch('same'); SELECT dolt_tag('same','v1');" \
+  "$TMPROOT/branch_wins_over_tag/dl/db.sqlite/same" \
+  "same" \
+  "SELECT active_branch() AS value UNION ALL SELECT CAST(COUNT(*) AS CHAR) FROM t;"
+
+oracle_error "detached_insert_is_readonly" "" \
+  "$TMPROOT/detached_insert_is_readonly/dl/db.sqlite/v1" \
+  "v1" \
+  "INSERT INTO t VALUES(3,'blocked');"
+
+oracle_error "detached_ddl_is_readonly" "" \
+  "$TMPROOT/detached_ddl_is_readonly/dl/db.sqlite/v1" \
+  "v1" \
+  "CREATE TABLE blocked(id INTEGER PRIMARY KEY);"
+
+oracle_error "detached_temp_table_is_readonly" "" \
+  "$TMPROOT/detached_temp_table_is_readonly/dl/db.sqlite/v1" \
+  "v1" \
+  "CREATE TEMPORARY TABLE blocked(id INTEGER PRIMARY KEY);"
+
+oracle_error "missing_revision_errors" "" \
+  "$TMPROOT/missing_revision_errors/dl/db.sqlite/missing" \
+  "missing" \
+  "SELECT COUNT(*) FROM t;"
+
+oracle_detached_command_error "detached_add_is_rejected" \
+  "SELECT dolt_add('-A');" "CALL dolt_add('-A');"
+oracle_detached_command_error "detached_commit_is_rejected" \
+  "SELECT dolt_commit('-A','-m','blocked');" \
+  "CALL dolt_commit('-Am','blocked');"
+oracle_detached_command_error "detached_branch_is_rejected" \
+  "SELECT dolt_branch('blocked');" "CALL dolt_branch('blocked');"
+oracle_detached_command_error "detached_tag_is_rejected" \
+  "SELECT dolt_tag('blocked');" "CALL dolt_tag('blocked');"
+oracle_detached_command_error "detached_reset_is_rejected" \
+  "SELECT dolt_reset('--hard');" "CALL dolt_reset('--hard');"
+oracle_detached_command_error "detached_merge_is_rejected" \
+  "SELECT dolt_merge('main');" "CALL dolt_merge('main');"
+oracle_detached_command_error "checkout_tag_does_not_detach" \
+  "SELECT dolt_checkout('v1');" "CALL dolt_checkout('v1');"
+oracle_error "attached_checkout_tag_does_not_detach" "" \
+  "$TMPROOT/attached_checkout_tag_does_not_detach/dl/db.sqlite" \
+  "main" \
+  "SELECT dolt_checkout('v1');"
+oracle_detached_command_error "checkout_new_branch_is_rejected" \
+  "SELECT dolt_checkout('-b','blocked');" \
+  "CALL dolt_checkout('-b','blocked');"
+oracle_detached_command_error "detached_working_ref_is_invalid" \
+  "SELECT dolt_hashof('WORKING');" "SELECT hashof('WORKING');"
+oracle_detached_command_error "detached_staged_ref_is_invalid" \
+  "SELECT dolt_hashof('STAGED');" "SELECT hashof('STAGED');"
+oracle_detached_command_success "detached_gc_is_allowed" \
+  "SELECT dolt_gc();" "CALL dolt_gc();"
+
+oracle_reattach "checkout_branch_reattaches"
 
 echo ""
 echo "=== Results: $pass passed, $fail failed ==="

--- a/test/vc_stateful_fuzzer.py
+++ b/test/vc_stateful_fuzzer.py
@@ -65,6 +65,25 @@ def query_rows(doltlite, db_path, branch):
     return rows
 
 
+def query_revision_rows(doltlite, db_path, revision):
+    sql = (
+        ".mode list\n"
+        ".separator |\n"
+        "SELECT id, v, n FROM dolt_at_kv(%s) ORDER BY id;\n"
+        % sql_quote(revision)
+    )
+    out = run_sql(doltlite, db_path, sql, "query_revision_rows")
+    rows = {}
+    if not out:
+        return rows
+    for line in out.splitlines():
+        parts = line.split("|")
+        if len(parts) != 3:
+            raise RuntimeError("unexpected revision row output: %r" % line)
+        rows[int(parts[0])] = (parts[1], int(parts[2]))
+    return rows
+
+
 def query_committed_rows(doltlite, db_path, branch):
     sql = (
         ".mode list\n"
@@ -551,6 +570,84 @@ def delete_tag(doltlite, db_path, tags, rng):
     tags.remove(name)
 
 
+def detached_revision(doltlite, db_path, branches, tags, model, rng, step):
+    branch = rng.choice(branches)
+    commit_branch(doltlite, db_path, branch, model, step)
+    head = query_scalar(
+        doltlite,
+        db_path,
+        "main",
+        "SELECT dolt_hashof(%s);" % sql_quote(branch),
+        "detached_head_hash",
+    )
+    revisions = [head, branch + "~0"]
+    if tags:
+        revisions.append(rng.choice(tags))
+    revision = rng.choice(revisions)
+    expected_hash = query_scalar(
+        doltlite,
+        db_path,
+        "main",
+        "SELECT dolt_hashof(%s);" % sql_quote(revision),
+        "detached_revision_hash",
+    )
+    expected_rows = query_revision_rows(doltlite, db_path, revision)
+    separator = rng.choice(("/", "@"))
+    detached_path = db_path + separator + revision
+    out = run_sql(
+        doltlite,
+        detached_path,
+        (
+            ".mode list\n"
+            ".separator |\n"
+            "SELECT 'STATE', IFNULL(active_branch(),'NULL'), dolt_hashof('HEAD');\n"
+            "SELECT 'ROW', id, v, n FROM kv ORDER BY id;\n"
+        ),
+        "detached_read_%s" % revision,
+    )
+    lines = out.splitlines()
+    if not lines or lines[0] != "STATE|NULL|" + expected_hash:
+        raise AssertionError("bad detached state for %s: %r" % (revision, out))
+    actual_rows = {}
+    for line in lines[1:]:
+        parts = line.split("|")
+        if len(parts) != 4 or parts[0] != "ROW":
+            raise AssertionError("bad detached row for %s: %r" % (revision, line))
+        actual_rows[int(parts[1])] = (parts[2], int(parts[3]))
+    if actual_rows != expected_rows:
+        raise AssertionError(
+            "detached row mismatch for %s\nexpected=%r\nactual=%r"
+            % (revision, expected_rows, actual_rows)
+        )
+
+    write = run_sql(
+        doltlite,
+        detached_path,
+        "UPDATE kv SET n=n WHERE 0;",
+        "detached_write_%s" % revision,
+        allowed_errors=("read-only", "readonly"),
+    )
+    if write is not None:
+        raise AssertionError("detached write unexpectedly succeeded for %s" % revision)
+
+    target = rng.choice(branches)
+    out = run_sql(
+        doltlite,
+        detached_path,
+        (
+            "SELECT 'BEFORE|' || IFNULL(active_branch(),'NULL');\n"
+            "SELECT dolt_checkout(%s);\n"
+            "SELECT 'AFTER|' || active_branch();\n"
+            "UPDATE kv SET n=n WHERE 0;\n"
+        )
+        % sql_quote(target),
+        "detached_reattach_%s_to_%s" % (revision, target),
+    )
+    if "BEFORE|NULL" not in out.splitlines() or "AFTER|" + target not in out.splitlines():
+        raise AssertionError("detached reattach failed for %s: %r" % (revision, out))
+    assert_rows(doltlite, db_path, target, model)
+
+
 def remote_operation(doltlite, db_path, branches, model, pushed, rng, step, op):
     if op == "pull":
         candidates = [branch for branch in branches if branch in pushed]
@@ -639,6 +736,7 @@ OPERATIONS = (
         "connect_branch",
         "tag_create",
         "tag_delete",
+        "detached_revision",
         "merge",
         "cherry_pick",
         "revert",
@@ -730,6 +828,8 @@ def main():
                 next_tag += 1
             elif op == "tag_delete":
                 delete_tag(doltlite, db_path, tags, rng)
+            elif op == "detached_revision":
+                detached_revision(doltlite, db_path, branches, tags, model, rng, step)
             elif op == "merge":
                 merge_branch(doltlite, db_path, branches, model, rng)
             elif op == "cherry_pick":


### PR DESCRIPTION
## Summary
- open tags, commit hashes, and ancestor specs as detached read-only snapshots through the existing `db/revision` and `db@revision` database-open syntax
- match Dolt session behavior: `active_branch()` is NULL, HEAD is pinned, WORKING/STAGED are unavailable, writes and mutating VC commands are rejected, and `dolt_checkout('branch')` reattaches the connection
- keep `dolt_checkout(tag-or-hash)` from entering detached state
- cover CLI, SQLite C API, ATTACH, peer ref changes, Dolt oracle parity, concurrency contracts, and stateful vc-fuzz

## Validation
- `test/doltlite_open_branch.sh`: 42 passed
- `test/vc_oracle_connection_branch_test.sh`: 29 passed
- `test/vc_oracle_checkout_test.sh`: 67 passed
- `detached_head_test`: 36 passed
- `test/concurrency_contract_test.sh`: 6 passed
- C coverage gate: 18/18
- specialized C concurrency/multiprocess gate: 10/10
- stateful vc-fuzz: 399 steps / 60 seconds, all 27 operations including detached revisions
- full native suite: all product suites passed; parity separately passed 119/119 (the aggregate runner lacked its expected `build/sqlite3` local prerequisite)
- `make lint`

Co-Authored-By: OpenAI Codex <noreply@openai.com>