### PR TITLE
Merge over an empty ancestor when the key shape changed on both branches

### DIFF
--- a/src/doltlite_merge_pass1.c
+++ b/src/doltlite_merge_pass1.c
@@ -180,6 +180,8 @@ static int mergePass1MergeTableData(
   struct TableEntry *pTheirsEntry
 ){
   ProllyHash mergedTableRoot;
+  ProllyHash emptyAnc;
+  const ProllyHash *pAncRoot = &pAnc->root;
   int nConflicts = 0;
   DoltliteConflictRow *aConflictRows = 0;
   MergeIndexInfo *aIdxInfo = 0;
@@ -187,13 +189,24 @@ static int mergePass1MergeTableData(
   int rc;
   int handled = 0;
 
+  /* A key-shape change is a recreate: the old rows are a different
+  ** object, and walking their root with the new shape's flags reads
+  ** aliased keys — an old row whose raw key collides with a new intkey
+  ** turns one side's insert into a phantom modify/delete pair and the
+  ** merge raises a conflict neither side created. Both sides' rows are
+  ** additions over an empty ancestor. */
+  if( ((pAnc->flags ^ pOurs->flags) & PROLLY_NODE_INTKEY)!=0 ){
+    memset(&emptyAnc, 0, sizeof(emptyAnc));
+    pAncRoot = &emptyAnc;
+  }
+
   rc = mergePass1CollectIndexes(c, zName, &aIdxInfo, &nIdxInfo);
   if( rc!=SQLITE_OK ) return rc;
 
   if( canFastMerge(c->db, zName, !ourSchemaChanged && !theirSchemaChanged) ){
     rc = prollyThreeWayMergeFast(
       doltliteGetChunkStore(c->db), doltliteGetCache(c->db),
-      &pAnc->root, &pOurs->root, pTheirsRoot,
+      pAncRoot, &pOurs->root, pTheirsRoot,
       pOurs->flags, &mergedTableRoot, &handled);
     if( rc!=SQLITE_OK ){
       mergePass1FreeIdxInfo(aIdxInfo, nIdxInfo);
@@ -202,7 +215,7 @@ static int mergePass1MergeTableData(
   }
 
   if( !handled ){
-    rc = mergeTableRows(c->db, &pAnc->root, &pOurs->root,
+    rc = mergeTableRows(c->db, pAncRoot, &pOurs->root,
                         pTheirsRoot, pOurs->flags,
                         &mergedTableRoot, &nConflicts, &aConflictRows,
                         aIdxInfo, nIdxInfo, 0);

--- a/test/doltlite_merge.sh
+++ b/test/doltlite_merge.sh
@@ -484,5 +484,54 @@ else
   ERRORS="$ERRORS\nFAIL: ff_merge_in_txn_rollback_refused\n  expected the post-merge ROLLBACK to find no open transaction"
 fi
 
-rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8" "$DB8B" "$DB9" "$DB10" "$DB11" "$DB11D" "$DB11E" "$DB11F" "$DB12" "$DB13" "$DB14" "$DB15" "$DB16" "$DB17" "$DB18" "$DB19" "$DB20" "$DB20B" "$DB21" "$DB22" "$DB23" "$DB24" "$DB25"
+# A key-shape recreate on both branches merges over an EMPTY ancestor: the
+# old rows are a different object, and walking their root with the new
+# shape's flags reads aliased keys. The text key 'AAAAA' aliases intkey
+# -5385951930834944000; before the fix, ours' insert at that key read as a
+# phantom modify/delete pair and the merge raised a conflict neither side
+# created.
+DB26=/tmp/test_merge_shape_recreate_$$.db; rm -f "$DB26"
+echo "CREATE TABLE t(k TEXT PRIMARY KEY, v TEXT) WITHOUT ROWID;
+INSERT INTO t VALUES('AAAAA','basev');
+SELECT dolt_commit('-Am','base');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+DROP TABLE t;
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(-5385951930834944000,'oursval');
+SELECT dolt_commit('-Am','feat recreate');
+SELECT dolt_checkout('main');
+DROP TABLE t;
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(5,'other');
+SELECT dolt_commit('-Am','main recreate');" | $DOLTLITE "$DB26" > /dev/null 2>&1
+
+run_test_match "shape_recreate_merge_clean" \
+  "SELECT dolt_merge('feat');" "^[0-9a-f]{40}$" "$DB26"
+run_test "shape_recreate_rows" \
+  "SELECT group_concat(id || '=' || v, '|') FROM (SELECT id, v FROM t ORDER BY id);" \
+  "-5385951930834944000=oursval|5=other" "$DB26"
+run_test "shape_recreate_integrity" "PRAGMA integrity_check;" "ok" "$DB26"
+
+# A true add/add collision at one key over the recreate still conflicts.
+DB27=/tmp/test_merge_shape_conflict_$$.db; rm -f "$DB27"
+echo "CREATE TABLE t(k TEXT PRIMARY KEY, v TEXT) WITHOUT ROWID;
+INSERT INTO t VALUES('AAAAA','basev');
+SELECT dolt_commit('-Am','base');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+DROP TABLE t;
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(-5385951930834944000,'oursval');
+SELECT dolt_commit('-Am','feat recreate');
+SELECT dolt_checkout('main');
+DROP TABLE t;
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(-5385951930834944000,'mainval');
+SELECT dolt_commit('-Am','main recreate');" | $DOLTLITE "$DB27" > /dev/null 2>&1
+
+run_test_match "shape_recreate_addadd_conflicts" \
+  "SELECT dolt_merge('feat');" "conflicts detected" "$DB27"
+
+rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8" "$DB8B" "$DB9" "$DB10" "$DB11" "$DB11D" "$DB11E" "$DB11F" "$DB12" "$DB13" "$DB14" "$DB15" "$DB16" "$DB17" "$DB18" "$DB19" "$DB20" "$DB20B" "$DB21" "$DB22" "$DB23" "$DB24" "$DB25" "$DB26" "$DB27"
 dltest_finish


### PR DESCRIPTION
Deep-review item 5, PR 0 — the investigation the plan called for confirmed a real **merge-correctness** bug, so it ships first and alone. When both branches drop and recreate a table with a different key shape (text PK → INTEGER PRIMARY KEY), the row merge walked the OLD ancestor root with the NEW shape's flags. Raw text keys alias intkeys (every 5-char text key is some 8-byte intkey — `'AAAAA'` is `-5385951930834944000`), so an old row read as a phantom row at a real key: one side's insert became a "modify", the other side's absence a "delete", and the merge raised a **conflict neither side created**, rolling back a perfectly clean merge.

**Fix:** in `mergePass1MergeTableData`, when `(anc->flags ^ ours->flags) & INTKEY`, the row merge runs over an empty ancestor — a key-shape change is a recreate, the recreated table is a different object, and both sides' rows are additions. Genuine add/add collisions at one key still conflict (verified); identical recreates with disjoint rows merge clean.

**Validation:** two new `doltlite_merge.sh` battery cases with the aliasing key spelled out (clean-merge shape and true-collision shape) — fail before, pass after. Merge/merge_status/CV/revert_cherrypick/replay/rebase oracle suites green; full c-regression 310,258/310,258; amalgamation compiled (the new standing gate); strict-C90 clean.

One test-harness discovery worth noting: doltlite sessions open on the **default branch** — `dolt_checkout` does not persist across processes (matching `dolt sql` semantics). The battery cases merge into main accordingly.

Remaining item-5 PRs (rendering, no shared files with this): per-side key shapes through the diff iterator, name-based column mapping, `to_commit=` ancestry gate, diff_stat cell maps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)