### PR TITLE
Give the diff iterator each root's key shape

### DIFF
--- a/src/doltlite_diff.c
+++ b/src/doltlite_diff.c
@@ -48,7 +48,8 @@ static int schemaHasViewOrTriggerDiff(sqlite3 *db,
   if( prollyHashCompare(pOldRoot, pNewRoot)==0 ) return SQLITE_OK;
   memset(&iter, 0, sizeof(iter));
   rc = sqlite3FaultSim(957) ? SQLITE_IOERR :
-       prollyDiffIterOpen(&iter, cs, pCache, pOldRoot, pNewRoot, flags);
+       prollyDiffIterOpen(&iter, cs, pCache, pOldRoot, pNewRoot, flags,
+                          flags);
   if( rc!=SQLITE_OK ){
     prollyDiffIterClose(&iter);
     return rc;

--- a/src/doltlite_diff_stat.c
+++ b/src/doltlite_diff_stat.c
@@ -383,12 +383,13 @@ static int dsComputeTableStats(
     ProllyCache *pCache = doltliteGetCache(db);
     ProllyDiffIter iter;
     ProllyDiffChange *pChange = 0;
-    u8 flags = fromFlags ? fromFlags : toFlags;
+    u8 ff = fromFlags ? fromFlags : toFlags;
+    u8 tf = toFlags ? toFlags : fromFlags;
     if( !cs || !pCache ){
       rc = SQLITE_ERROR;
       goto done;
     }
-    rc = prollyDiffIterOpen(&iter, cs, pCache, &fromRoot, &toRoot, flags);
+    rc = prollyDiffIterOpen(&iter, cs, pCache, &fromRoot, &toRoot, ff, tf);
     if( rc!=SQLITE_OK ) goto done;
     while( (rc = prollyDiffIterStep(&iter, &pChange))==SQLITE_ROW && pChange ){
       switch( pChange->type ){
@@ -1017,9 +1018,12 @@ static int dssDataActuallyChanged(
   rc = dsBuildColMap(azFromCols, nFromCols, azToCols, nToCols, &colMap);
   if( rc!=SQLITE_OK ) goto done;
 
-  flags = pFromEntry->flags ? pFromEntry->flags : pToEntry->flags;
   rc = prollyDiffIterOpen(&iter, cs, pCache, &pFromEntry->root,
-                          &pToEntry->root, flags);
+                          &pToEntry->root,
+                          pFromEntry->flags ? pFromEntry->flags
+                                            : pToEntry->flags,
+                          pToEntry->flags ? pToEntry->flags
+                                          : pFromEntry->flags);
   if( rc!=SQLITE_OK ) goto done;
   iterOpen = 1;
 

--- a/src/doltlite_diff_stat.c
+++ b/src/doltlite_diff_stat.c
@@ -1002,7 +1002,6 @@ static int dssDataActuallyChanged(
   ProllyDiffChange *pChange = 0;
   int changed = 0;
   int iterOpen = 0;
-  u8 flags;
   int rc;
   int i;
 

--- a/src/doltlite_diff_table.c
+++ b/src/doltlite_diff_table.c
@@ -43,6 +43,7 @@ typedef struct AuditRow AuditRow;
 struct AuditRow {
   u8 diffType;
   i64 intKey;
+  u8 keyIsIntKey;
   const u8 *pOldVal; int nOldVal;
   const u8 *pNewVal; int nNewVal;
   u8 *pKeyRec; int nKeyRec;   /* owned record rebuilt from a clustered key */
@@ -862,15 +863,18 @@ static int openNextPairIter(DiffTblCursor *pCur, sqlite3 *db){
 
   {
     DiffPair *p;
-    u8 flags;
+    u8 fromFlags;
+    u8 toFlags;
     p = &pCur->aPairs[pCur->iPair++];
-    flags = p->fromFlags ? p->fromFlags : p->toFlags;
+    fromFlags = p->fromFlags ? p->fromFlags : p->toFlags;
+    toFlags = p->toFlags ? p->toFlags : p->fromFlags;
     memcpy(pCur->row.zFromCommit, p->zFromCommit, PROLLY_HASH_SIZE*2+1);
     pCur->row.fromDate = p->fromDate;
     memcpy(pCur->row.zToCommit, p->zToCommit, PROLLY_HASH_SIZE*2+1);
     pCur->row.toDate = p->toDate;
     rc = prollyDiffIterOpen(&pCur->diffIter, cs, pCache,
-                            &p->fromTblRoot, &p->toTblRoot, flags);
+                            &p->fromTblRoot, &p->toTblRoot,
+                            fromFlags, toFlags);
     if( rc!=SQLITE_OK ) return rc;
     pCur->diffIterOpen = 1;
 
@@ -918,6 +922,7 @@ static int advanceToNextRow(DiffTblCursor *pCur, sqlite3 *db){
 
         pCur->row.diffType = pChange->type;
         pCur->row.intKey = pChange->intKey;
+        pCur->row.keyIsIntKey = pChange->keyIsIntKey;
 
         pCur->row.pOldVal = pChange->pOldVal;
         pCur->row.nOldVal = pChange->pOldVal ? pChange->nOldVal : 0;
@@ -1120,7 +1125,7 @@ static int dtColumn(sqlite3_vtab_cursor *cur, sqlite3_context *ctx, int col){
 
   if( nCols > 0 && col < nCols ){
     doltliteResultUserCol(ctx, &pVtab->cols, r->pNewVal, r->nNewVal,
-                          r->intKey, 1, col);
+                          r->intKey, r->keyIsIntKey, col);
   }else if( nCols > 0 && col == nCols ){
 
     sqlite3_result_text(ctx, r->zToCommit, -1, SQLITE_TRANSIENT);
@@ -1129,7 +1134,7 @@ static int dtColumn(sqlite3_vtab_cursor *cur, sqlite3_context *ctx, int col){
   }else if( nCols > 0 && col < 2*nCols+2 ){
     int colIdx = col - nCols - 2;
     doltliteResultUserCol(ctx, &pVtab->cols, r->pOldVal, r->nOldVal,
-                          r->intKey, 1, colIdx);
+                          r->intKey, r->keyIsIntKey, colIdx);
   }else if( nCols > 0 && col == 2*nCols+2 ){
 
     sqlite3_result_text(ctx, r->zFromCommit, -1, SQLITE_TRANSIENT);

--- a/src/doltlite_patch.c
+++ b/src/doltlite_patch.c
@@ -914,15 +914,18 @@ static int patchAppendData(
   ChunkStore *cs = doltliteGetChunkStore(db);
   ProllyCache *pCache = doltliteGetCache(db);
   ProllyHash oldRoot, newRoot;
-  u8 flags;
+  u8 fromFlags;
+  u8 toFlags;
   int rc;
   memset(&oldRoot,0,sizeof(oldRoot));
   memset(&newRoot,0,sizeof(newRoot));
   if( pTable->pFromTable ) oldRoot = pTable->pFromTable->root;
   if( pTable->pToTable ) newRoot = pTable->pToTable->root;
-  flags = pTable->pFromTable ? pTable->pFromTable->flags
-                             : pTable->pToTable->flags;
-  rc = prollyDiffIterOpen(&it,cs,pCache,&oldRoot,&newRoot,flags);
+  fromFlags = pTable->pFromTable ? pTable->pFromTable->flags
+                                 : pTable->pToTable->flags;
+  toFlags = pTable->pToTable ? pTable->pToTable->flags
+                             : pTable->pFromTable->flags;
+  rc = prollyDiffIterOpen(&it,cs,pCache,&oldRoot,&newRoot,fromFlags,toFlags);
   if( rc!=SQLITE_OK ) return rc;
   while( (rc=prollyDiffIterStep(&it,&pChange))==SQLITE_ROW ){
     const u8 *pOld = pChange->pOldVal;

--- a/src/doltlite_status.c
+++ b/src/doltlite_status.c
@@ -242,7 +242,8 @@ static int statusSchemaHasViewOrTriggerDiff(sqlite3 *db,
   int found = 0;
   if( !cs || !pCache ) return 0;
   if( prollyHashCompare(pOldRoot, pNewRoot)==0 ) return 0;
-  rc = prollyDiffIterOpen(&iter, cs, pCache, pOldRoot, pNewRoot, flags);
+  rc = prollyDiffIterOpen(&iter, cs, pCache, pOldRoot, pNewRoot, flags,
+                          flags);
   if( rc!=SQLITE_OK ) return 0;
   while( (rc = prollyDiffIterStep(&iter, &pChange))==SQLITE_ROW && pChange ){
     if( statusSchemaRecordIsViewOrTrigger(pChange->pNewVal, pChange->nNewVal)

--- a/src/doltlite_workspace.c
+++ b/src/doltlite_workspace.c
@@ -18,6 +18,7 @@ struct WorkspaceRow {
   u8 diffType;
   u8 flags;
   u8 *pKey; int nKey; i64 intKey;
+  u8 keyIsIntKey;
   u8 *pOldVal; int nOldVal;
   u8 *pNewVal; int nNewVal;
 };
@@ -54,7 +55,7 @@ struct WorkspaceCursor {
   u8 iterFlags;
   ProllyDiffIter iter;
   ProllyHash headRoot, stagedRoot, workingRoot;
-  u8 stagedFlags, workingFlags;
+  u8 headFlags, stagedFlags, workingFlags;
   int stagedOnly;
   WorkspaceRows *pRows;
 };
@@ -128,6 +129,7 @@ static int wsAppendRow(
   row.diffType = pChange->type;
   row.flags = flags;
   row.intKey = pChange->intKey;
+  row.keyIsIntKey = pChange->keyIsIntKey;
   if( pChange->nKey>0 ){
     row.pKey = sqlite3_malloc(pChange->nKey);
     if( !row.pKey ) goto nomem;
@@ -200,7 +202,7 @@ static int wsInitCursorRoots(WorkspaceCursor *c, WorkspaceVtab *pVtab){
   sqlite3 *db = pVtab->db;
   ProllyHash headHash, headCat, stagedCat, workingCat;
   ProllyHash schemaHash;
-  u8 headFlags = 0;
+
   int rc;
 
   memset(&headCat, 0, sizeof(headCat));
@@ -210,6 +212,7 @@ static int wsInitCursorRoots(WorkspaceCursor *c, WorkspaceVtab *pVtab){
   memset(&c->stagedRoot, 0, sizeof(c->stagedRoot));
   memset(&c->workingRoot, 0, sizeof(c->workingRoot));
   memset(&schemaHash, 0, sizeof(schemaHash));
+  c->headFlags = 0;
   c->stagedFlags = 0;
   c->workingFlags = 0;
 
@@ -233,7 +236,7 @@ static int wsInitCursorRoots(WorkspaceCursor *c, WorkspaceVtab *pVtab){
   }
 
   rc = doltliteLoadTableRootByNameOrEmpty(db, &headCat, pVtab->zTableName,
-                                          &c->headRoot, &headFlags,
+                                          &c->headRoot, &c->headFlags,
                                           &schemaHash);
   if( rc!=SQLITE_OK ) return rc;
   rc = doltliteLoadTableRootByNameOrEmpty(db, &stagedCat, pVtab->zTableName,
@@ -247,11 +250,14 @@ static int wsInitCursorRoots(WorkspaceCursor *c, WorkspaceVtab *pVtab){
     if( rc!=SQLITE_OK ) return rc;
   }
 
+  if( !c->headFlags ){
+    c->headFlags = c->stagedFlags ? c->stagedFlags : c->workingFlags;
+  }
   if( !c->stagedFlags ){
-    c->stagedFlags = headFlags ? headFlags : c->workingFlags;
+    c->stagedFlags = c->headFlags ? c->headFlags : c->workingFlags;
   }
   if( !c->workingFlags ){
-    c->workingFlags = c->stagedFlags ? c->stagedFlags : headFlags;
+    c->workingFlags = c->stagedFlags ? c->stagedFlags : c->headFlags;
   }
   return SQLITE_OK;
 }
@@ -261,7 +267,8 @@ static int wsOpenNextIter(WorkspaceCursor *c, WorkspaceVtab *pVtab){
   ProllyCache *pCache = doltliteGetCache(pVtab->db);
   const ProllyHash *pFromRoot;
   const ProllyHash *pToRoot;
-  u8 flags;
+  u8 fromFlags;
+  u8 toFlags;
   int staged;
   int rc;
 
@@ -277,7 +284,8 @@ static int wsOpenNextIter(WorkspaceCursor *c, WorkspaceVtab *pVtab){
       }
       pFromRoot = &c->headRoot;
       pToRoot = &c->stagedRoot;
-      flags = c->stagedFlags;
+      fromFlags = c->headFlags;
+      toFlags = c->stagedFlags;
       staged = 1;
     }else{
       if( c->stagedOnly==1 ){
@@ -286,16 +294,18 @@ static int wsOpenNextIter(WorkspaceCursor *c, WorkspaceVtab *pVtab){
       }
       pFromRoot = &c->stagedRoot;
       pToRoot = &c->workingRoot;
-      flags = c->workingFlags;
+      fromFlags = c->stagedFlags;
+      toFlags = c->workingFlags;
       staged = 0;
     }
     c->phase++;
     if( prollyHashCompare(pFromRoot, pToRoot)==0 ) continue;
-    rc = prollyDiffIterOpen(&c->iter, cs, pCache, pFromRoot, pToRoot, flags);
+    rc = prollyDiffIterOpen(&c->iter, cs, pCache, pFromRoot, pToRoot,
+                            fromFlags, toFlags);
     if( rc!=SQLITE_OK ) return rc;
     c->iterOpen = 1;
     c->iterStaged = staged;
-    c->iterFlags = flags;
+    c->iterFlags = toFlags;
     return SQLITE_OK;
   }
   c->eof = 1;
@@ -445,10 +455,10 @@ static int wsColumn(sqlite3_vtab_cursor *cur, sqlite3_context *ctx, int col){
     else sqlite3_result_null(ctx);
   }else if( col>=3 && col<3+nCols ){
     doltliteResultUserCol(ctx, &p->cols, r->pNewVal, r->nNewVal,
-                          r->intKey, 1, col-3);
+                          r->intKey, r->keyIsIntKey, col-3);
   }else if( col>=3+nCols && col<3+2*nCols ){
     doltliteResultUserCol(ctx, &p->cols, r->pOldVal, r->nOldVal,
-                          r->intKey, 1, col-3-nCols);
+                          r->intKey, r->keyIsIntKey, col-3-nCols);
   }else{
     sqlite3_result_null(ctx);
   }

--- a/src/prolly_diff.c
+++ b/src/prolly_diff.c
@@ -46,7 +46,8 @@ static void diffFillKey(
   prollyCursorKey(pCur, &pKey, &nKey);
   pChange->pKey   = pKey;
   pChange->nKey   = nKey;
-  pChange->intKey = (flags & PROLLY_NODE_INTKEY) ? prollyCursorIntKey(pCur) : 0;
+  pChange->keyIsIntKey = (flags & PROLLY_NODE_INTKEY)!=0;
+  pChange->intKey = pChange->keyIsIntKey ? prollyCursorIntKey(pCur) : 0;
 }
 
 static int diffIterCopyKey(
@@ -66,7 +67,8 @@ static int diffIterCopyKey(
   }
   pChange->pKey = pIter->pKeyCopy;
   pChange->nKey = pIter->nKeyCopy;
-  pChange->intKey = (flags & PROLLY_NODE_INTKEY) ? prollyCursorIntKey(pCur) : 0;
+  pChange->keyIsIntKey = (flags & PROLLY_NODE_INTKEY)!=0;
+  pChange->intKey = pChange->keyIsIntKey ? prollyCursorIntKey(pCur) : 0;
   return SQLITE_OK;
 }
 
@@ -611,7 +613,8 @@ int prollyDiffIterOpen(
   ProllyCache *pCache,
   const ProllyHash *pOldRoot,
   const ProllyHash *pNewRoot,
-  u8 flags
+  u8 oldFlags,
+  u8 newFlags
 ){
   int rc = SQLITE_OK;
   int emptyOld = 0, emptyNew = 0;
@@ -619,7 +622,11 @@ int prollyDiffIterOpen(
   memset(pIter, 0, sizeof(*pIter));
   pIter->pStore = pStore;
   pIter->pCache = pCache;
-  pIter->flags = flags;
+  pIter->flags = oldFlags;
+  pIter->oldFlags = oldFlags;
+  pIter->newFlags = newFlags;
+  pIter->shapeMismatch =
+      ((oldFlags ^ newFlags) & PROLLY_NODE_INTKEY)!=0;
 
   pIter->pCurOld = (ProllyCursor*)sqlite3_malloc(sizeof(ProllyCursor));
   pIter->pCurNew = (ProllyCursor*)sqlite3_malloc(sizeof(ProllyCursor));
@@ -633,8 +640,8 @@ int prollyDiffIterOpen(
     return SQLITE_NOMEM;
   }
 
-  prollyCursorInit(pIter->pCurOld, pStore, pCache, pOldRoot, flags);
-  prollyCursorInit(pIter->pCurNew, pStore, pCache, pNewRoot, flags);
+  prollyCursorInit(pIter->pCurOld, pStore, pCache, pOldRoot, oldFlags);
+  prollyCursorInit(pIter->pCurNew, pStore, pCache, pNewRoot, newFlags);
 
   rc = prollyCursorFirst(pIter->pCurOld, &emptyOld);
   if( rc==SQLITE_OK ) rc = prollyCursorFirst(pIter->pCurNew, &emptyNew);
@@ -681,7 +688,7 @@ int prollyDiffIterStep(ProllyDiffIter *pIter, ProllyDiffChange **ppChange){
 
     memset(pCh, 0, sizeof(*pCh));
 
-    if( validOld && validNew ){
+    if( validOld && validNew && !pIter->shapeMismatch ){
       int cmp;
       diffCompareKeys(pOld, pNew, pIter->flags, &cmp);
 
@@ -689,7 +696,7 @@ int prollyDiffIterStep(ProllyDiffIter *pIter, ProllyDiffChange **ppChange){
 
         const u8 *pVal; int nVal;
         pCh->type = PROLLY_DIFF_DELETE;
-        pIter->rc = diffIterCopyKey(pIter, pCh, pOld, pIter->flags);
+        pIter->rc = diffIterCopyKey(pIter, pCh, pOld, pIter->oldFlags);
         if( pIter->rc!=SQLITE_OK ) return pIter->rc;
         prollyCursorValue(pOld, &pVal, &nVal);
         if( diffSetChangeVal(pIter, &pIter->pOldValCopy, &pIter->nOldValCopy,
@@ -700,7 +707,7 @@ int prollyDiffIterStep(ProllyDiffIter *pIter, ProllyDiffChange **ppChange){
 
         const u8 *pVal; int nVal;
         pCh->type = PROLLY_DIFF_ADD;
-        pIter->rc = diffIterCopyKey(pIter, pCh, pNew, pIter->flags);
+        pIter->rc = diffIterCopyKey(pIter, pCh, pNew, pIter->newFlags);
         if( pIter->rc!=SQLITE_OK ) return pIter->rc;
         prollyCursorValue(pNew, &pVal, &nVal);
         if( diffSetChangeVal(pIter, &pIter->pNewValCopy, &pIter->nNewValCopy,
@@ -720,7 +727,7 @@ int prollyDiffIterStep(ProllyDiffIter *pIter, ProllyDiffChange **ppChange){
           const u8 *pOV; int nOV;
           const u8 *pNV; int nNV;
           pCh->type = PROLLY_DIFF_MODIFY;
-          pIter->rc = diffIterCopyKey(pIter, pCh, pNew, pIter->flags);
+          pIter->rc = diffIterCopyKey(pIter, pCh, pNew, pIter->newFlags);
           if( pIter->rc!=SQLITE_OK ) return pIter->rc;
           prollyCursorValue(pOld, &pOV, &nOV);
           prollyCursorValue(pNew, &pNV, &nNV);
@@ -737,7 +744,7 @@ int prollyDiffIterStep(ProllyDiffIter *pIter, ProllyDiffChange **ppChange){
 
       const u8 *pVal; int nVal;
       pCh->type = PROLLY_DIFF_DELETE;
-      pIter->rc = diffIterCopyKey(pIter, pCh, pOld, pIter->flags);
+      pIter->rc = diffIterCopyKey(pIter, pCh, pOld, pIter->oldFlags);
       if( pIter->rc!=SQLITE_OK ) return pIter->rc;
       prollyCursorValue(pOld, &pVal, &nVal);
       if( diffSetChangeVal(pIter, &pIter->pOldValCopy, &pIter->nOldValCopy,
@@ -748,7 +755,7 @@ int prollyDiffIterStep(ProllyDiffIter *pIter, ProllyDiffChange **ppChange){
 
       const u8 *pVal; int nVal;
       pCh->type = PROLLY_DIFF_ADD;
-      pIter->rc = diffIterCopyKey(pIter, pCh, pNew, pIter->flags);
+      pIter->rc = diffIterCopyKey(pIter, pCh, pNew, pIter->newFlags);
       if( pIter->rc!=SQLITE_OK ) return pIter->rc;
       prollyCursorValue(pNew, &pVal, &nVal);
       if( diffSetChangeVal(pIter, &pIter->pNewValCopy, &pIter->nNewValCopy,

--- a/src/prolly_diff.h
+++ b/src/prolly_diff.h
@@ -26,6 +26,7 @@ typedef struct ProllyDiffChange ProllyDiffChange;
 
 struct ProllyDiffChange {
   u8 type;
+  u8 keyIsIntKey;
   const u8 *pKey;
   int nKey;
   i64 intKey;
@@ -52,6 +53,12 @@ struct ProllyDiffIter {
   ChunkStore *pStore;
   ProllyCache *pCache;
   u8 flags;
+  u8 oldFlags;
+  u8 newFlags;
+  /* The roots hold different key shapes: no cross-shape order exists, so
+  ** the walk drains every old row as a delete, then every new row as an
+  ** add — a key-shape change is a drop plus a recreate. */
+  u8 shapeMismatch;
 
   ProllyCursor *pCurOld;
   ProllyCursor *pCurNew;
@@ -71,8 +78,9 @@ struct ProllyDiffIter {
 };
 
 int prollyDiffIterOpen(ProllyDiffIter *pIter, ChunkStore *pStore,
-                       ProllyCache *pCache, const ProllyHash *pOldRoot,
-                       const ProllyHash *pNewRoot, u8 flags);
+                       ProllyCache *pCache,
+                       const ProllyHash *pOldRoot, const ProllyHash *pNewRoot,
+                       u8 oldFlags, u8 newFlags);
 int prollyDiffIterStep(ProllyDiffIter *pIter, ProllyDiffChange **ppChange);
 void prollyDiffIterClose(ProllyDiffIter *pIter);
 

--- a/src/prolly_three_way_diff.c
+++ b/src/prolly_three_way_diff.c
@@ -180,13 +180,13 @@ int prollyThreeWayDiff(
   memset(&iterR, 0, sizeof(iterR));
 
   rcL = prollyDiffIterOpen(&iterL, pStore, pCache,
-                           pAncestorRoot, pOursRoot, flags);
+                           pAncestorRoot, pOursRoot, flags, flags);
   if( rcL!=SQLITE_OK ){
     rc = rcL;
     goto cleanup;
   }
   rcR = prollyDiffIterOpen(&iterR, pStore, pCache,
-                           pAncestorRoot, pTheirsRoot, flags);
+                           pAncestorRoot, pTheirsRoot, flags, flags);
   if( rcR!=SQLITE_OK ){
     rc = rcR;
     goto cleanup;

--- a/test/doltlite_diff_table.sh
+++ b/test/doltlite_diff_table.sh
@@ -212,4 +212,29 @@ run_test_match "vals_mod_to" "SELECT typeof(to_v) FROM dolt_diff_t WHERE diff_ty
 
 rm -f "$DB"
 
+# A key-shape recreate between commits renders each side under its own key
+# shape and pairs nothing across the shapes: the from row keeps its text
+# key, the to row its integer, and a raw-key collision ('AAAAA' aliases
+# intkey -5385951930834944000) is a remove plus an add, never one
+# "modified" row.
+DBS=/tmp/test_dt_shape_$$.db; rm -f "$DBS"
+echo "CREATE TABLE t(pk TEXT PRIMARY KEY, v INTEGER) WITHOUT ROWID;
+INSERT INTO t VALUES('AAAAA', 1);
+SELECT dolt_commit('-Am','c1');
+DROP TABLE t;
+CREATE TABLE t(pk INTEGER PRIMARY KEY, v INTEGER);
+INSERT INTO t VALUES(-5385951930834944000, 2);
+SELECT dolt_commit('-Am','c2');" | $DOLTLITE "$DBS" > /dev/null 2>&1
+
+run_test "shape_from_pk_text" \
+  "SELECT from_pk || '=' || from_v FROM dolt_diff_t WHERE diff_type='removed' AND to_commit=(SELECT commit_hash FROM dolt_log WHERE message='c2');" \
+  "AAAAA=1" "$DBS"
+run_test "shape_to_pk_int" \
+  "SELECT to_pk || '=' || to_v FROM dolt_diff_t WHERE diff_type='added' AND to_commit=(SELECT commit_hash FROM dolt_log WHERE message='c2');" \
+  "-5385951930834944000=2" "$DBS"
+run_test "shape_no_modified_pairing" \
+  "SELECT count(*) FROM dolt_diff_t WHERE diff_type='modified';" \
+  "0" "$DBS"
+rm -f "$DBS"
+
 dltest_finish

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -9704,7 +9704,7 @@ static void run_prolly_diff_iter_copies_blob_keys(void){
   prollyNodeBuilderFree(&b);
 
   rc = prollyDiffIterOpen(&iter, &cs, &cache, &oldRootHash, &newRootHash,
-                          PROLLY_NODE_BLOBKEY);
+                          PROLLY_NODE_BLOBKEY, PROLLY_NODE_BLOBKEY);
   check("open_diff_iter_key_copy", rc==SQLITE_OK);
   if( rc==SQLITE_OK ){
     rc = prollyDiffIterStep(&iter, &pCh);

--- a/test/doltlite_workspace.sh
+++ b/test/doltlite_workspace.sh
@@ -229,4 +229,23 @@ run_test "workspace_delete_via_filtered_rowid" \
 
 rm -rf "$MC_DB"
 
+# An uncommitted key-shape recreate renders the head row under the head
+# shape: before the per-side fix, from_pk showed the raw text sort key
+# decoded as a sign-flipped integer.
+WS_DB=/tmp/test_ws_shape_$$.db; rm -f "$WS_DB"
+echo "CREATE TABLE t(pk TEXT PRIMARY KEY, v INTEGER) WITHOUT ROWID;
+INSERT INTO t VALUES('alpha', 1);
+SELECT dolt_commit('-Am','c1');
+DROP TABLE t;
+CREATE TABLE t(pk INTEGER PRIMARY KEY, v INTEGER);
+INSERT INTO t VALUES(42, 2);" | $DOLTLITE "$WS_DB" > /dev/null 2>&1
+
+run_test "ws_shape_removed_side" \
+  "SELECT from_pk || '=' || from_v FROM dolt_workspace_t WHERE diff_type='removed';" \
+  "alpha=1" "$WS_DB"
+run_test "ws_shape_added_side" \
+  "SELECT to_pk || '=' || to_v FROM dolt_workspace_t WHERE diff_type='added';" \
+  "42=2" "$WS_DB"
+rm -f "$WS_DB"
+
 dltest_finish


### PR DESCRIPTION
Deep-review item 5, PR 1 of 4 — the core of the diff/workspace rendering cluster (all confirmed by repro at review time, files untouched since).

The diff iterator took **one** flag set for both roots, and every consumer flattened its per-side flags to pick one, so diffing across a key-shape change (drop + recreate under one name) walked one root with the other root's shape:

- `dolt_diff` / `dolt_diff_stat` rendered primary keys as garbage across a text-PK → int-PK recreate; `dolt_workspace` showed a text key's raw sort bytes as a sign-flipped integer (`-5376897250060337152` for `'alpha'`).
- A raw-key collision paired a text-keyed row with an integer-keyed row as one "modified" row — constructible, since every 5-char text key aliases some intkey.

**Mechanics:** `ProllyDiffIter` carries `oldFlags`/`newFlags`, walks each cursor under its own shape, and stamps every `ProllyDiffChange` with the emitting side's key form (`keyIsIntKey`). When the shapes differ, no cross-shape order exists, so the both-valid pairing branch is skipped and the walk drains every old row as a delete then every new row as an add — a recreate is a remove of the old table's rows plus an add of the new one's (same doctrine as #2145 on the merge side). `dolt_diff`, `dolt_workspace`, `dolt_diff_stat`, and `dolt_patch` pass per-side flags and render each side's key under its own shape, replacing the hardcoded `bRootIntKey=1` sites; master-root consumers (status, summary diff, three-way walk) pass one shape twice, which those roots always share.

**Validation:** 5 new battery cases (3 in `doltlite_diff_table.sh`, 2 in `doltlite_workspace.sh`) — from-side text key, to-side integer key, aliasing collision as remove+add, workspace head-side shape — all fail before, pass after. diff_table 44/44, workspace 27/27, merge/merge_status/status/checkout oracles green, full battery 101/101, c-regression 310,258/310,258, amalgamation compiled, strict-C90 clean.

Remaining item-5 PRs: name-based column mapping (values under wrong columns after mid-position schema changes — includes the `doltliteRecordFromClusteredKey` historical-PK decode), `to_commit=` ancestry gate, `dsCountChangedCells` field maps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)