### PR TITLE
Refuse to merge a table whose primary key changed

### DIFF
--- a/src/doltlite_merge_pass1.c
+++ b/src/doltlite_merge_pass1.c
@@ -363,6 +363,104 @@ static int mergePass1OursModifyTheirsDelete(
   return SQLITE_OK;
 }
 
+/* Ordered primary-key signature ("name type,name type") of the table zSql
+** creates, built by executing it in a scratch db. No declared PK yields the
+** empty signature, which matches SQLite treating those tables as rowid keyed
+** regardless of the rest of the schema. */
+static int mergePass1PkSignature(
+  const char *zSql,
+  const char *zTableName,
+  char **pzSig
+){
+  sqlite3 *tmp = 0;
+  sqlite3_stmt *pStmt = 0;
+  char *zQuery = 0;
+  char *zSig = 0;
+  int rc;
+
+  *pzSig = 0;
+  rc = sqlite3_open(":memory:", &tmp);
+  if( rc!=SQLITE_OK ) goto done;
+  rc = sqlite3_exec(tmp, zSql, 0, 0, 0);
+  if( rc!=SQLITE_OK ) goto done;
+  zQuery = sqlite3_mprintf(
+      "SELECT name, type FROM pragma_table_info(%Q) WHERE pk>0 ORDER BY pk",
+      zTableName);
+  if( !zQuery ){ rc = SQLITE_NOMEM; goto done; }
+  rc = sqlite3_prepare_v2(tmp, zQuery, -1, &pStmt, 0);
+  if( rc!=SQLITE_OK ) goto done;
+  while( (rc = sqlite3_step(pStmt))==SQLITE_ROW ){
+    const char *zName = (const char*)sqlite3_column_text(pStmt, 0);
+    const char *zType = (const char*)sqlite3_column_text(pStmt, 1);
+    char *zNew = sqlite3_mprintf("%s%s%s %s", zSig ? zSig : "",
+                                 zSig ? "," : "",
+                                 zName ? zName : "", zType ? zType : "");
+    sqlite3_free(zSig);
+    zSig = zNew;
+    if( !zSig ){ rc = SQLITE_NOMEM; goto done; }
+  }
+  rc = rc==SQLITE_DONE ? SQLITE_OK : rc;
+
+done:
+  if( pStmt ) sqlite3_finalize(pStmt);
+  sqlite3_free(zQuery);
+  if( tmp ) sqlite3_close(tmp);
+  if( rc!=SQLITE_OK ){
+    sqlite3_free(zSig);
+    return rc;
+  }
+  *pzSig = zSig ? zSig : sqlite3_mprintf("");
+  return *pzSig ? SQLITE_OK : SQLITE_NOMEM;
+}
+
+/* Tables whose primary keys differ never row-merge: the keys identify
+** different things, so there is no shared ancestor keyspace to merge in.
+** Refuse the merge outright, the same way Dolt does. */
+static int mergePass1CheckPrimaryKeysMatch(
+  MergePass1Ctx *c,
+  const char *zName,
+  struct TableEntry *pOurs,
+  struct TableEntry *pAnc,
+  struct TableEntry *pTheirs
+){
+  SchemaEntry *ancSE = findSchemaEntry(c->aAncSchema, c->nAncSchema, zName);
+  SchemaEntry *ourSE = findSchemaEntry(c->aOursSchema, c->nOursSchema, zName);
+  SchemaEntry *theirSE = findSchemaEntry(
+      c->aTheirsSchema, c->nTheirsSchema, zName);
+  char *zAncSig = 0, *zOursSig = 0, *zTheirsSig = 0;
+  int vsTheirs = 0, vsAncestor = 0;
+  int rc = SQLITE_OK;
+
+  if( !ancSE || !ancSE->zSql || !ourSE || !ourSE->zSql
+   || !theirSE || !theirSE->zSql ){
+    return SQLITE_OK;
+  }
+
+  rc = mergePass1PkSignature(ancSE->zSql, zName, &zAncSig);
+  if( rc==SQLITE_OK ) rc = mergePass1PkSignature(ourSE->zSql, zName, &zOursSig);
+  if( rc==SQLITE_OK ){
+    rc = mergePass1PkSignature(theirSE->zSql, zName, &zTheirsSig);
+  }
+  if( rc==SQLITE_OK ){
+    vsTheirs = sqlite3_stricmp(zOursSig, zTheirsSig)!=0
+            || ((pOurs->flags ^ pTheirs->flags) & PROLLY_NODE_INTKEY)!=0;
+    vsAncestor = sqlite3_stricmp(zOursSig, zAncSig)!=0
+              || ((pOurs->flags ^ pAnc->flags) & PROLLY_NODE_INTKEY)!=0;
+  }
+  sqlite3_free(zAncSig);
+  sqlite3_free(zOursSig);
+  sqlite3_free(zTheirsSig);
+  if( rc!=SQLITE_OK ) return rc;
+  if( !vsTheirs && !vsAncestor ) return SQLITE_OK;
+  if( c->pzErrMsg ){
+    sqlite3_free(*c->pzErrMsg);
+    *c->pzErrMsg = sqlite3_mprintf(
+        "cannot merge because table '%s' has different primary keys%s",
+        zName, vsTheirs ? "" : " in its common ancestor");
+  }
+  return SQLITE_ERROR;
+}
+
 /* Both sides still have the object. */
 static int mergePass1BothSides(
   MergePass1Ctx *c,
@@ -398,6 +496,15 @@ static int mergePass1BothSides(
     theirSchemaChanged = theirSchemaChanged || schemaEntryChangedByName(
         c->aAncSchema, c->nAncSchema, c->aTheirsSchema, c->nTheirsSchema,
         zSchemaMergeName);
+  }
+
+  /* A theirs side that never touched the table keeps ours verbatim, so no
+  ** cross-key merge can happen and the primary keys need not agree. */
+  if( zName && (ourSchemaChanged || theirSchemaChanged)
+   && (theirsChanged || theirSchemaChanged) ){
+    rc = mergePass1CheckPrimaryKeysMatch(
+        c, zName, &c->aOurs[iOurs], ancEntry, theirsEntry);
+    if( rc!=SQLITE_OK ) return rc;
   }
 
   if( ourSchemaChanged && theirSchemaChanged

--- a/test/doltlite_merge.sh
+++ b/test/doltlite_merge.sh
@@ -460,7 +460,7 @@ else
   ERRORS="$ERRORS\nFAIL: clean_merge_in_txn_rollback_refused\n  expected the post-merge ROLLBACK to find no open transaction"
 fi
 
-DB25=/tmp/test_merge25_$$.db; rm -f "$DB25"
+DB25=/tmp/test_merge25_$$.db; rm -f "$DB25" "$DB26" "$DB27" "$DB28"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'a');
 SELECT dolt_commit('-A','-m','base');
 SELECT dolt_checkout('-b','feat'); INSERT INTO t VALUES(2,'b'); SELECT dolt_commit('-A','-m','feat');
@@ -483,6 +483,31 @@ else
   FAIL=$((FAIL+1))
   ERRORS="$ERRORS\nFAIL: ff_merge_in_txn_rollback_refused\n  expected the post-merge ROLLBACK to find no open transaction"
 fi
+
+
+DB26=/tmp/test_merge26_$$.db; rm -f "$DB26"
+echo "CREATE TABLE t(pk TEXT PRIMARY KEY, v INT); INSERT INTO t VALUES('AAAAA',1); SELECT dolt_commit('-A','-m','base');" | $DOLTLITE "$DB26" > /dev/null 2>&1
+echo "SELECT dolt_branch('feature');" | $DOLTLITE "$DB26" > /dev/null 2>&1
+echo "DROP TABLE t; CREATE TABLE t(pk INTEGER PRIMARY KEY, v INT); INSERT INTO t VALUES(5,50); SELECT dolt_commit('-A','-m','feat recreate');" | $DOLTLITE "$DB26/feature" > /dev/null 2>&1
+echo "INSERT INTO t VALUES('BBBBB',2); SELECT dolt_commit('-A','-m','main rows');" | $DOLTLITE "$DB26" > /dev/null 2>&1
+run_test_match "pk_change_refused" "SELECT dolt_merge('feature');" "different primary keys" "$DB26"
+run_test "pk_change_local_intact" "SELECT count(*) FROM t;" "2" "$DB26"
+
+DB27=/tmp/test_merge27_$$.db; rm -f "$DB27"
+echo "CREATE TABLE t(pk TEXT PRIMARY KEY, v INT); INSERT INTO t VALUES('AAAAA',1); SELECT dolt_commit('-A','-m','base');" | $DOLTLITE "$DB27" > /dev/null 2>&1
+echo "SELECT dolt_branch('feature');" | $DOLTLITE "$DB27" > /dev/null 2>&1
+echo "DROP TABLE t; CREATE TABLE t(pk INTEGER PRIMARY KEY, v INT); INSERT INTO t VALUES(5,50); SELECT dolt_commit('-A','-m','feat recreate');" | $DOLTLITE "$DB27/feature" > /dev/null 2>&1
+echo "DROP TABLE t; CREATE TABLE t(pk INTEGER PRIMARY KEY, v INT); CREATE INDEX tv ON t(v); INSERT INTO t VALUES(7,70); SELECT dolt_commit('-A','-m','main recreate');" | $DOLTLITE "$DB27" > /dev/null 2>&1
+run_test_match "pk_change_ancestor_refused" "SELECT dolt_merge('feature');" "different primary keys in its common ancestor" "$DB27"
+
+DB28=/tmp/test_merge28_$$.db; rm -f "$DB28"
+echo "CREATE TABLE t(pk TEXT PRIMARY KEY, v INT); INSERT INTO t VALUES('AAAAA',1); SELECT dolt_commit('-A','-m','base');" | $DOLTLITE "$DB28" > /dev/null 2>&1
+echo "SELECT dolt_branch('feature');" | $DOLTLITE "$DB28" > /dev/null 2>&1
+echo "DROP TABLE t; CREATE TABLE t(pk TEXT PRIMARY KEY, v INT); INSERT INTO t VALUES('feat',50); SELECT dolt_commit('-A','-m','feat recreate');" | $DOLTLITE "$DB28/feature" > /dev/null 2>&1
+echo "DROP TABLE t; CREATE TABLE t(pk TEXT PRIMARY KEY, v INT); INSERT INTO t VALUES('main',7); SELECT dolt_commit('-A','-m','main recreate');" | $DOLTLITE "$DB28" > /dev/null 2>&1
+run_test_match "identical_recreate_merge_ok" "SELECT dolt_merge('feature');" "^[0-9a-f]{40}$" "$DB28"
+run_test "identical_recreate_rows" "SELECT group_concat(pk || ':' || v, ',') FROM (SELECT pk,v FROM t ORDER BY pk);" "feat:50,main:7" "$DB28"
+run_test "identical_recreate_integrity" "PRAGMA integrity_check;" "ok" "$DB28"
 
 rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8" "$DB8B" "$DB9" "$DB10" "$DB11" "$DB11D" "$DB11E" "$DB11F" "$DB12" "$DB13" "$DB14" "$DB15" "$DB16" "$DB17" "$DB18" "$DB19" "$DB20" "$DB20B" "$DB21" "$DB22" "$DB23" "$DB24" "$DB25"
 dltest_finish

--- a/test/vc_oracle_schema_merge_test.sh
+++ b/test/vc_oracle_schema_merge_test.sh
@@ -1224,6 +1224,124 @@ expect_dual_value "generated_vs_plain_ours_generated_value" "$DB" \
   "SELECT GROUP_CONCAT(CONCAT(id, ':', x) ORDER BY id SEPARATOR ',') FROM t;"
 
 echo ""
+echo "--- Primary key changes ---"
+
+DB="$TMPROOT/pk1.db"; rm -f "$DB"
+cat <<'SQL' | dl_setup "$DB" "pk1"
+CREATE TABLE t(pk VARCHAR(32) PRIMARY KEY, v INT);
+INSERT INTO t VALUES('AAAAA',1);
+SELECT dolt_commit('-Am','ancestor');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+DROP TABLE t;
+CREATE TABLE t(pk BIGINT PRIMARY KEY, v INT);
+INSERT INTO t VALUES(5,50);
+SELECT dolt_commit('-Am','feat_recreate');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES('BBBBB',2);
+SELECT dolt_commit('-Am','main_rows');
+SQL
+expect_merge_conflict "pk_change_vs_row_change" "$DB"
+expect_dual_value "pk_change_vs_row_change_local_intact" "$DB" "2" \
+  "SELECT count(*) FROM t;" "SELECT count(*) FROM t;"
+
+DB="$TMPROOT/pk2.db"; rm -f "$DB"
+cat <<'SQL' | dl_setup "$DB" "pk2"
+CREATE TABLE t(pk VARCHAR(32) PRIMARY KEY, v INT);
+INSERT INTO t VALUES('AAAAA',1);
+SELECT dolt_commit('-Am','ancestor');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+DROP TABLE t;
+CREATE TABLE t(pk BIGINT PRIMARY KEY, v INT);
+INSERT INTO t VALUES(5,50);
+SELECT dolt_commit('-Am','feat_recreate');
+SELECT dolt_checkout('main');
+CREATE TABLE other(a BIGINT PRIMARY KEY);
+SELECT dolt_commit('-Am','main_other');
+SQL
+expect_merge_conflict "pk_change_vs_untouched_table" "$DB"
+
+DB="$TMPROOT/pk3.db"; rm -f "$DB"
+cat <<'SQL' | dl_setup "$DB" "pk3"
+CREATE TABLE t(pk VARCHAR(32) PRIMARY KEY, v INT);
+INSERT INTO t VALUES('AAAAA',1);
+SELECT dolt_commit('-Am','ancestor');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+DROP TABLE t;
+CREATE TABLE t(pk BIGINT PRIMARY KEY, v INT);
+INSERT INTO t VALUES(5,50);
+SELECT dolt_commit('-Am','feat_recreate');
+SELECT dolt_checkout('main');
+DROP TABLE t;
+CREATE TABLE t(pk VARBINARY(16) PRIMARY KEY, v INT);
+INSERT INTO t VALUES(X'AB',7);
+SELECT dolt_commit('-Am','main_recreate');
+SQL
+expect_merge_conflict "pk_change_both_sides_differ" "$DB"
+
+DB="$TMPROOT/pk4.db"; rm -f "$DB"
+cat <<'SQL' | dl_setup "$DB" "pk4"
+CREATE TABLE t(pk VARCHAR(32) PRIMARY KEY, v INT);
+INSERT INTO t VALUES('AAAAA',1);
+SELECT dolt_commit('-Am','ancestor');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+DROP TABLE t;
+CREATE TABLE t(pk BIGINT PRIMARY KEY, v INT);
+INSERT INTO t VALUES(5,50);
+SELECT dolt_commit('-Am','feat_recreate');
+SELECT dolt_checkout('main');
+DROP TABLE t;
+CREATE TABLE t(pk BIGINT PRIMARY KEY, v INT);
+INSERT INTO t VALUES(7,70);
+SELECT dolt_commit('-Am','main_recreate');
+SQL
+expect_merge_conflict "pk_change_agreed_but_differs_from_ancestor" "$DB"
+
+DB="$TMPROOT/pk5.db"; rm -f "$DB"
+cat <<'SQL' | dl_setup "$DB" "pk5"
+CREATE TABLE t(pk VARCHAR(32) PRIMARY KEY, v INT);
+INSERT INTO t VALUES('AAAAA',1);
+SELECT dolt_commit('-Am','ancestor');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+DROP TABLE t;
+CREATE TABLE t(pk VARCHAR(32) PRIMARY KEY, v INT);
+INSERT INTO t VALUES('feat',50);
+SELECT dolt_commit('-Am','feat_recreate');
+SELECT dolt_checkout('main');
+DROP TABLE t;
+CREATE TABLE t(pk VARCHAR(32) PRIMARY KEY, v INT);
+INSERT INTO t VALUES('main',7);
+SELECT dolt_commit('-Am','main_recreate');
+SQL
+expect_merge_ok "identical_recreate_merges" "$DB"
+expect_dual_value "identical_recreate_rows" "$DB" "feat:50,main:7" \
+  "SELECT group_concat(pk || ':' || v, ',') FROM (SELECT pk,v FROM t ORDER BY pk);" \
+  "SELECT GROUP_CONCAT(CONCAT(pk, ':', v) ORDER BY pk SEPARATOR ',') FROM t;"
+
+DB="$TMPROOT/pk6.db"; rm -f "$DB"
+cat <<'SQL' | dl_setup "$DB" "pk6"
+CREATE TABLE t(pk VARCHAR(32) PRIMARY KEY, v INT);
+INSERT INTO t VALUES('AAAAA',1);
+SELECT dolt_commit('-Am','ancestor');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+CREATE TABLE feat_tbl(id BIGINT PRIMARY KEY);
+SELECT dolt_commit('-Am','feat_other');
+SELECT dolt_checkout('main');
+DROP TABLE t;
+CREATE TABLE t(pk BIGINT PRIMARY KEY, v INT);
+INSERT INTO t VALUES(7,70);
+SELECT dolt_commit('-Am','main_recreate');
+SQL
+expect_merge_ok "pk_change_ours_only_theirs_untouched" "$DB"
+expect_dual_value "pk_change_ours_only_kept" "$DB" "7:70" \
+  "SELECT pk || ':' || v FROM t;" "SELECT CONCAT(pk, ':', v) FROM t;"
+
+echo ""
 echo "======================================="
 echo "Results: $pass passed, $fail failed"
 echo "======================================="


### PR DESCRIPTION
## Problem

Merging a table whose primary key definition changed has no coherent semantics: the two versions key different things, so there is no shared ancestor keyspace to row-merge in. Dolt refuses these merges outright (`cannot merge because table t has different primary keys`). doltlite instead walked the old-shape ancestor with the new shape's flags, which either manufactured spurious row conflicts or — when the other side had only row changes — silently favored one side.

This replaces #2145, which went the opposite direction (merging recreates over an empty ancestor). Per review decree, doltlite should match Dolt's refusal. That also moots the ito findings on #2145: refusal fires before any secondary-index machinery runs.

## Fix

Merge pass 1 compares ordered primary-key signatures (column name and type, per `pragma_table_info`, plus the `PROLLY_NODE_INTKEY` storage bit) across ancestor/ours/theirs whenever a table's schema changed on either side. Any disagreement fails the merge with Dolt's error, including the `in its common ancestor` variant when both sides agree on a new PK.

One asymmetry, matched to live Dolt: a theirs side that never touched the table keeps ours verbatim, so recreating a PK on the current branch and merging an unrelated branch in still works. Identical recreates still merge cleanly.

## Testing

- Oracled against Dolt 2.2.2 in `vc_oracle_schema_merge_test.sh`: 8 new cases covering PK change vs row change, vs untouched table, both sides differing, both agreeing but differing from ancestor, identical recreate, and ours-only recreate (suite 90/90).
- `test/doltlite_merge.sh`: refusal-message and identical-recreate cases; the two refusal tests fail on a master build (111/113) and pass with the fix (113/113).
- Full battery: 101/101 suites. Amalgamation regenerated and compiles clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)