### PR TITLE
Render historical rows by column name, not record position

### DIFF
--- a/src/doltlite_at.c
+++ b/src/doltlite_at.c
@@ -42,6 +42,9 @@ struct AtVtab {
 typedef struct AtCursor AtCursor;
 struct AtCursor {
   DoltliteVtabCursorCommon common;
+  /* Columns as the pinned commit's schema declares them; invalid renders
+  ** with the declared layout. */
+  DoltliteSideCols side;
   char *zCommitRef;
   int idxNum;
   DoltlitePkRange pkRange;
@@ -118,6 +121,72 @@ static int atEnqueueReachableRoots(
   return rc;
 }
 
+/* Load zTable's columns as the schema at pCatHash declares them and map the
+** declared (vtab-visible) columns onto them by name. Cached by schema hash;
+** any failure leaves the side invalid, which renders with the declared
+** layout — the pre-existing behavior. */
+int doltliteSideColsLoad(
+  sqlite3 *db,
+  const ProllyHash *pCatHash,
+  const ProllyHash *pSchemaHash,
+  const char *zTable,
+  const DoltliteColInfo *pDeclared,
+  DoltliteSideCols *pSide
+){
+  ChunkStore *cs = doltliteGetChunkStore(db);
+  ProllyCache *pCache = doltliteGetCache(db);
+  SchemaEntry entry;
+  int found = 0;
+  sqlite3 *tmp = 0;
+  int i, j;
+  int rc;
+
+  if( pSide->valid
+   && prollyHashCompare(&pSide->schemaHash, pSchemaHash)==0 ){
+    return SQLITE_OK;
+  }
+  doltliteSideColsClear(pSide);
+  if( !cs || !pCache || prollyHashIsEmpty(pCatHash) ) return SQLITE_OK;
+
+  rc = loadSchemaEntryFromCatalog(db, cs, pCache, pCatHash, zTable,
+                                  &entry, &found);
+  if( rc!=SQLITE_OK ) return SQLITE_OK;
+  if( !found || !entry.zSql ){
+    clearSchemaEntry(&entry);
+    return SQLITE_OK;
+  }
+
+  rc = sqlite3_open(":memory:", &tmp);
+  if( rc==SQLITE_OK ) rc = sqlite3_exec(tmp, entry.zSql, 0, 0, 0);
+  if( rc==SQLITE_OK ) rc = doltliteGetColumnNames(tmp, zTable, &pSide->ci);
+  if( tmp ) sqlite3_close(tmp);
+  clearSchemaEntry(&entry);
+  if( rc!=SQLITE_OK || pSide->ci.nCol<=0 ){
+    doltliteSideColsClear(pSide);
+    return SQLITE_OK;
+  }
+
+  if( pDeclared->nCol>0 ){
+    pSide->aDeclToSide = sqlite3_malloc(pDeclared->nCol * (int)sizeof(int));
+    if( !pSide->aDeclToSide ){
+      doltliteSideColsClear(pSide);
+      return SQLITE_NOMEM;
+    }
+    for(i=0; i<pDeclared->nCol; i++){
+      pSide->aDeclToSide[i] = -1;
+      for(j=0; j<pSide->ci.nCol; j++){
+        if( sqlite3_stricmp(pDeclared->azName[i], pSide->ci.azName[j])==0 ){
+          pSide->aDeclToSide[i] = j;
+          break;
+        }
+      }
+    }
+  }
+  memcpy(&pSide->schemaHash, pSchemaHash, sizeof(ProllyHash));
+  pSide->valid = 1;
+  return SQLITE_OK;
+}
+
 int doltliteLoadHistoricalTableColumns(
   sqlite3 *db,
   const char *zTableName,
@@ -186,6 +255,7 @@ int doltliteLoadHistoricalTableColumns(
 }
 
 static void atCursorReset(AtCursor *c){
+  doltliteSideColsClear(&c->side);
   doltliteVtabCommonReset(&c->common);
   sqlite3_free(c->zCommitRef);
   c->zCommitRef = 0;
@@ -338,9 +408,12 @@ static int atFilter(sqlite3_vtab_cursor *cur,
   const char *zRef;
   ProllyHash catHash;
   ProllyHash tableRoot; u8 flags=0;
+  ProllyHash schemaHash;
   int rc, res;
   int seekable;
   (void)idxStr;
+
+  memset(&schemaHash, 0, sizeof(schemaHash));
 
   atCursorReset(c);
   c->idxNum = idxNum;
@@ -380,7 +453,11 @@ static int atFilter(sqlite3_vtab_cursor *cur,
       memcpy(&effCatHash, &catHash, sizeof(ProllyHash));
     }
     rc=doltliteLoadTableRootByName(db,&effCatHash,v->zTableName,&tableRoot,
-                                   &flags,0);
+                                   &flags,&schemaHash);
+    if( rc==SQLITE_OK ){
+      rc = doltliteSideColsLoad(db, &effCatHash, &schemaHash,
+                                v->zTableName, &v->cols, &c->side);
+    }
   }
   if(rc==SQLITE_NOTFOUND) return SQLITE_OK;
   if(rc!=SQLITE_OK) return rc;
@@ -404,7 +481,8 @@ static int atFilter(sqlite3_vtab_cursor *cur,
       return SQLITE_OK;
     }
     c->common.tblCurOpen = 1;
-    return doltliteVtabCommonCaptureRow(&c->common, v->db, v->zTableName);
+    return doltliteVtabCommonCaptureRowSide(&c->common, v->db, v->zTableName,
+                                            &c->side);
   }
 
   if( seekable && c->pkRange.hasPkLo ){
@@ -427,7 +505,8 @@ static int atFilter(sqlite3_vtab_cursor *cur,
       return SQLITE_OK;
     }
     c->common.tblCurOpen = 1;
-    return doltliteVtabCommonCaptureRow(&c->common, v->db, v->zTableName);
+    return doltliteVtabCommonCaptureRowSide(&c->common, v->db, v->zTableName,
+                                            &c->side);
   }
 
   rc = prollyCursorFirst(&c->common.tblCur, &res);
@@ -444,7 +523,8 @@ static int atFilter(sqlite3_vtab_cursor *cur,
     return SQLITE_OK;
   }
   c->common.tblCurOpen = 1;
-  return doltliteVtabCommonCaptureRow(&c->common, v->db, v->zTableName);
+  return doltliteVtabCommonCaptureRowSide(&c->common, v->db, v->zTableName,
+                                          &c->side);
 }
 
 static int atNext(sqlite3_vtab_cursor *cur){
@@ -484,7 +564,8 @@ static int atNext(sqlite3_vtab_cursor *cur){
     c->common.hasRow = 0;
     return SQLITE_OK;
   }
-  return doltliteVtabCommonCaptureRow(&c->common, v->db, v->zTableName);
+  return doltliteVtabCommonCaptureRowSide(&c->common, v->db, v->zTableName,
+                                          &c->side);
 }
 
 static int atColumn(sqlite3_vtab_cursor *cur, sqlite3_context *ctx, int col){
@@ -498,7 +579,8 @@ static int atColumn(sqlite3_vtab_cursor *cur, sqlite3_context *ctx, int col){
     sqlite3_result_text(ctx, c->zCommitRef ? c->zCommitRef : "",
                         -1, SQLITE_TRANSIENT);
   }else if(nCols>0 && col<nCols){
-    doltliteResultUserCol(ctx, &v->cols, c->common.pVal, c->common.nVal,
+    doltliteResultSideCol(ctx, &c->side, &v->cols,
+                          c->common.pVal, c->common.nVal,
                           c->common.intKey, c->common.rootIntKey, col);
   }
 

--- a/src/doltlite_diff_table.c
+++ b/src/doltlite_diff_table.c
@@ -46,7 +46,10 @@ struct AuditRow {
   u8 keyIsIntKey;
   const u8 *pOldVal; int nOldVal;
   const u8 *pNewVal; int nNewVal;
-  u8 *pKeyRec; int nKeyRec;   /* owned record rebuilt from a clustered key */
+  /* Owned records rebuilt from a clustered key, one per side so each is
+  ** decoded with that side's primary key definition. */
+  u8 *pKeyRec; int nKeyRec;
+  u8 *pOldKeyRec; int nOldKeyRec;
   char zFromCommit[PROLLY_HASH_SIZE*2+1];
   char zToCommit[PROLLY_HASH_SIZE*2+1];
   i64 fromDate;
@@ -92,8 +95,11 @@ struct DiffTblCursor {
   ProllyDiffIter diffIter;
   int diffIterOpen;
 
-  DoltliteColInfo fromColInfo;
-  DoltliteColInfo toColInfo;
+  /* Columns as each side's commit declares them; cached by schema hash and
+  ** reused across pairs. An invalid side renders with the vtab's declared
+  ** layout. */
+  DoltliteSideCols fromSide;
+  DoltliteSideCols toSide;
   int    needFilter;
 
   AuditRow row;
@@ -107,6 +113,7 @@ struct DiffTblCursor {
 
 static void clearAuditRow(AuditRow *r){
   sqlite3_free(r->pKeyRec);
+  sqlite3_free(r->pOldKeyRec);
   memset(r, 0, sizeof(*r));
 }
 
@@ -744,51 +751,9 @@ static int buildRangeSpecDiffPair(
 }
 
 static void freePairCols(DiffTblCursor *pCur){
-  doltliteFreeColInfo(&pCur->fromColInfo);
-  doltliteFreeColInfo(&pCur->toColInfo);
+  doltliteSideColsClear(&pCur->fromSide);
+  doltliteSideColsClear(&pCur->toSide);
   pCur->needFilter = 0;
-}
-
-static int loadColInfoAtCatalog(
-  sqlite3 *db,
-  const ProllyHash *pCatHash,
-  const char *zTableName,
-  DoltliteColInfo *pOut
-){
-  ChunkStore *cs = doltliteGetChunkStore(db);
-  ProllyCache *pCache = doltliteGetCache(db);
-  SchemaEntry entry;
-  int found = 0;
-  sqlite3 *tmp = 0;
-  int rc;
-
-  memset(pOut, 0, sizeof(*pOut));
-  if( prollyHashIsEmpty(pCatHash) ) return SQLITE_NOTFOUND;
-
-  rc = loadSchemaEntryFromCatalog(db, cs, pCache, pCatHash, zTableName,
-                                  &entry, &found);
-  if( rc!=SQLITE_OK ) return rc;
-  if( !found || !entry.zSql ){
-    clearSchemaEntry(&entry);
-    return SQLITE_NOTFOUND;
-  }
-
-  rc = sqlite3_open(":memory:", &tmp);
-  if( rc!=SQLITE_OK ) goto cleanup;
-  rc = sqlite3_exec(tmp, entry.zSql, 0, 0, 0);
-  if( rc!=SQLITE_OK ) goto cleanup;
-
-  rc = doltliteGetColumnNames(tmp, zTableName, pOut);
-  if( rc!=SQLITE_OK ) goto cleanup;
-  if( pOut->nCol<=0 ){ rc = SQLITE_NOTFOUND; goto cleanup; }
-
-cleanup:
-  if( tmp ) sqlite3_close(tmp);
-  clearSchemaEntry(&entry);
-  if( rc!=SQLITE_OK ){
-    doltliteFreeColInfo(pOut);
-  }
-  return rc;
 }
 
 static int changeIsSchemaOnly(
@@ -852,7 +817,7 @@ static int openNextPairIter(DiffTblCursor *pCur, sqlite3 *db){
   DiffTblVtab *pVtab = (DiffTblVtab*)pCur->base.pVtab;
   int rc;
 
-  freePairCols(pCur);
+  pCur->needFilter = 0;
 
   if( !cs ) return SQLITE_OK;
 
@@ -878,20 +843,18 @@ static int openNextPairIter(DiffTblCursor *pCur, sqlite3 *db){
     if( rc!=SQLITE_OK ) return rc;
     pCur->diffIterOpen = 1;
 
-    if( prollyHashCompare(&p->fromSchemaHash, &p->toSchemaHash)!=0 ){
-      int rc2;
-      rc2 = loadColInfoAtCatalog(db, &p->fromCatHash, pVtab->zTableName,
-                                 &pCur->fromColInfo);
-      if( rc2==SQLITE_OK ){
-        rc2 = loadColInfoAtCatalog(db, &p->toCatHash, pVtab->zTableName,
-                                   &pCur->toColInfo);
-      }
-      if( rc2==SQLITE_OK ){
-        pCur->needFilter = 1;
-      }else{
-        freePairCols(pCur);
-      }
+    rc = doltliteSideColsLoad(db, &p->fromCatHash, &p->fromSchemaHash,
+                              pVtab->zTableName, &pVtab->cols,
+                              &pCur->fromSide);
+    if( rc==SQLITE_OK ){
+      rc = doltliteSideColsLoad(db, &p->toCatHash, &p->toSchemaHash,
+                                pVtab->zTableName, &pVtab->cols,
+                                &pCur->toSide);
     }
+    if( rc!=SQLITE_OK ) return rc;
+
+    pCur->needFilter = pCur->fromSide.valid && pCur->toSide.valid
+        && prollyHashCompare(&p->fromSchemaHash, &p->toSchemaHash)!=0;
     return SQLITE_OK;
   }
 }
@@ -911,7 +874,7 @@ static int advanceToNextRow(DiffTblCursor *pCur, sqlite3 *db){
          && pChange->type==PROLLY_DIFF_MODIFY
          && changeIsSchemaOnly(pChange->pOldVal, pChange->nOldVal,
                                pChange->pNewVal, pChange->nNewVal,
-                               &pCur->fromColInfo, &pCur->toColInfo) ){
+                               &pCur->fromSide.ci, &pCur->toSide.ci) ){
           continue;
         }
 
@@ -930,24 +893,41 @@ static int advanceToNextRow(DiffTblCursor *pCur, sqlite3 *db){
         pCur->row.nNewVal = pChange->pNewVal ? pChange->nNewVal : 0;
 
         /* PK-only clustered rows store an empty value; both sides of the
-        ** change share one key, so rebuild the record from it once and let
-        ** each side that exists (per the diff type) present it. */
+        ** change share one key, but each is decoded with its own side's
+        ** primary key definition so historical keys read correctly. */
         if( (pCur->row.nOldVal==0 && pChange->type!=PROLLY_DIFF_ADD)
          || (pCur->row.nNewVal==0 && pChange->type!=PROLLY_DIFF_DELETE) ){
           DiffTblVtab *pV = (DiffTblVtab*)pCur->base.pVtab;
-          sqlite3_free(pCur->row.pKeyRec);
-          pCur->row.pKeyRec = 0;
-          pCur->row.nKeyRec = 0;
-          rc = doltliteRecordFromClusteredKey(db, pV->zTableName,
-                   pChange->pKey, pChange->nKey,
-                   &pCur->row.pKeyRec, &pCur->row.nKeyRec);
-          if( rc!=SQLITE_OK ) return rc;
-          if( pCur->row.pKeyRec ){
-            if( pCur->row.nOldVal==0 && pChange->type!=PROLLY_DIFF_ADD ){
-              pCur->row.pOldVal = pCur->row.pKeyRec;
-              pCur->row.nOldVal = pCur->row.nKeyRec;
+          if( pCur->row.nOldVal==0 && pChange->type!=PROLLY_DIFF_ADD ){
+            sqlite3_free(pCur->row.pOldKeyRec);
+            pCur->row.pOldKeyRec = 0;
+            pCur->row.nOldKeyRec = 0;
+            rc = pCur->fromSide.valid
+              ? doltliteRecordFromClusteredKeyCols(db, &pCur->fromSide.ci,
+                    pChange->pKey, pChange->nKey,
+                    &pCur->row.pOldKeyRec, &pCur->row.nOldKeyRec)
+              : doltliteRecordFromClusteredKey(db, pV->zTableName,
+                    pChange->pKey, pChange->nKey,
+                    &pCur->row.pOldKeyRec, &pCur->row.nOldKeyRec);
+            if( rc!=SQLITE_OK ) return rc;
+            if( pCur->row.pOldKeyRec ){
+              pCur->row.pOldVal = pCur->row.pOldKeyRec;
+              pCur->row.nOldVal = pCur->row.nOldKeyRec;
             }
-            if( pCur->row.nNewVal==0 && pChange->type!=PROLLY_DIFF_DELETE ){
+          }
+          if( pCur->row.nNewVal==0 && pChange->type!=PROLLY_DIFF_DELETE ){
+            sqlite3_free(pCur->row.pKeyRec);
+            pCur->row.pKeyRec = 0;
+            pCur->row.nKeyRec = 0;
+            rc = pCur->toSide.valid
+              ? doltliteRecordFromClusteredKeyCols(db, &pCur->toSide.ci,
+                    pChange->pKey, pChange->nKey,
+                    &pCur->row.pKeyRec, &pCur->row.nKeyRec)
+              : doltliteRecordFromClusteredKey(db, pV->zTableName,
+                    pChange->pKey, pChange->nKey,
+                    &pCur->row.pKeyRec, &pCur->row.nKeyRec);
+            if( rc!=SQLITE_OK ) return rc;
+            if( pCur->row.pKeyRec ){
               pCur->row.pNewVal = pCur->row.pKeyRec;
               pCur->row.nNewVal = pCur->row.nKeyRec;
             }
@@ -1124,7 +1104,8 @@ static int dtColumn(sqlite3_vtab_cursor *cur, sqlite3_context *ctx, int col){
   int nCols = pVtab->cols.nCol;
 
   if( nCols > 0 && col < nCols ){
-    doltliteResultUserCol(ctx, &pVtab->cols, r->pNewVal, r->nNewVal,
+    doltliteResultSideCol(ctx, &c->toSide, &pVtab->cols,
+                          r->pNewVal, r->nNewVal,
                           r->intKey, r->keyIsIntKey, col);
   }else if( nCols > 0 && col == nCols ){
 
@@ -1133,7 +1114,8 @@ static int dtColumn(sqlite3_vtab_cursor *cur, sqlite3_context *ctx, int col){
     doltliteResultTimestamp(ctx, r->toDate);
   }else if( nCols > 0 && col < 2*nCols+2 ){
     int colIdx = col - nCols - 2;
-    doltliteResultUserCol(ctx, &pVtab->cols, r->pOldVal, r->nOldVal,
+    doltliteResultSideCol(ctx, &c->fromSide, &pVtab->cols,
+                          r->pOldVal, r->nOldVal,
                           r->intKey, r->keyIsIntKey, colIdx);
   }else if( nCols > 0 && col == 2*nCols+2 ){
 

--- a/src/doltlite_history.c
+++ b/src/doltlite_history.c
@@ -42,6 +42,9 @@ struct HistVtab {
 typedef struct HistCursor HistCursor;
 struct HistCursor {
   DoltliteVtabCursorCommon common;
+  /* Columns as the visited commit's schema declares them, cached by schema
+  ** hash across commits. Invalid renders with the declared layout. */
+  DoltliteSideCols side;
   DoltliteCommitQueue queue;
   char zCommitHex[PROLLY_HASH_SIZE*2+1];
   char *zCommitter;
@@ -53,6 +56,7 @@ struct HistCursor {
 
 static void htCursorReset(HistCursor *c){
   doltliteVtabCommonReset(&c->common);
+  doltliteSideColsClear(&c->side);
   sqlite3_free(c->zCommitter);
   c->zCommitter = 0;
   doltliteCommitQueueClear(&c->queue);
@@ -74,9 +78,11 @@ static int htOpenTableAtCommit(HistCursor *c, sqlite3 *db,
   ProllyCache *pCache = doltliteGetCache(db);
   DoltliteCommit commit;
   ProllyHash tableRoot; u8 flags = 0;
+  ProllyHash schemaHash;
   int rc, res;
   int seekable;
 
+  memset(&schemaHash, 0, sizeof(schemaHash));
   memset(&commit, 0, sizeof(commit));
   rc = doltliteLoadCommit(db, pCommitHash, &commit);
   if( rc!=SQLITE_OK ) return rc;
@@ -99,7 +105,12 @@ static int htOpenTableAtCommit(HistCursor *c, sqlite3 *db,
   }
 
   rc = doltliteLoadTableRootByName(db, &commit.catalogHash, zTableName,
-                                   &tableRoot, &flags, 0);
+                                   &tableRoot, &flags, &schemaHash);
+  if( rc==SQLITE_OK ){
+    DoltliteVtabCommon *v = (DoltliteVtabCommon*)c->common.base.pVtab;
+    rc = doltliteSideColsLoad(db, &commit.catalogHash, &schemaHash,
+                              zTableName, &v->cols, &c->side);
+  }
   doltliteCommitClear(&commit);
   if( rc==SQLITE_NOTFOUND ) return SQLITE_OK;
   if( rc!=SQLITE_OK ) return rc;
@@ -184,7 +195,8 @@ static int htAdvance(HistCursor *c, sqlite3 *db, const char *zTableName){
       }
       if( prollyCursorIsValid(&c->common.tblCur)
        && (!c->common.rootIntKey || htRowMatchesUpper(c)) ){
-        return doltliteVtabCommonCaptureRow(&c->common, db, zTableName);
+        return doltliteVtabCommonCaptureRowSide(&c->common, db, zTableName,
+                                                &c->side);
       }
       prollyCursorClose(&c->common.tblCur);
       c->common.tblCurOpen = 0;
@@ -203,7 +215,8 @@ static int htAdvance(HistCursor *c, sqlite3 *db, const char *zTableName){
     if( rc!=SQLITE_OK ) return rc;
 
     if( c->common.tblCurOpen ){
-      return doltliteVtabCommonCaptureRow(&c->common, db, zTableName);
+      return doltliteVtabCommonCaptureRowSide(&c->common, db, zTableName,
+                                              &c->side);
     }
   }
 
@@ -369,7 +382,8 @@ static int htColumn(sqlite3_vtab_cursor *cur, sqlite3_context *ctx, int col){
   nCols=v->cols.nCol;
 
   if(nCols>0 && col<nCols){
-    doltliteResultUserCol(ctx, &v->cols, c->common.pVal, c->common.nVal,
+    doltliteResultSideCol(ctx, &c->side, &v->cols,
+                          c->common.pVal, c->common.nVal,
                           c->common.intKey, c->common.rootIntKey, col);
   }else{
     int fixedCol=col-nCols;

--- a/src/doltlite_record.c
+++ b/src/doltlite_record.c
@@ -239,9 +239,13 @@ void doltliteFreeColInfo(DoltliteColInfo *ci){
   for(i=0; i<ci->nCol; i++) sqlite3_free(ci->azName[i]);
   sqlite3_free(ci->azName);
   sqlite3_free(ci->aColToRec);
+  sqlite3_free(ci->aPkSortFlags);
   ci->azName = 0;
   ci->aColToRec = 0;
+  ci->aPkSortFlags = 0;
   ci->nCol = 0;
+  ci->nPk = 0;
+  ci->bHasRowid = 0;
 }
 
 int doltliteGetColumnNames(sqlite3 *db, const char *zTable, DoltliteColInfo *ci){
@@ -316,9 +320,32 @@ int doltliteGetColumnNames(sqlite3 *db, const char *zTable, DoltliteColInfo *ci)
   ** declared primary key and has no integer key to read, so treating its
   ** INTEGER pk as an alias yields the raw key bytes as a number and silently
   ** drops the pk constraints xBestIndex promised to apply. */
-  if( nPkCols==1 && iCandidateAlias>=0 ){
+  {
     Table *pTab = sqlite3FindTable(db, zTable, "main");
-    if( pTab && HasRowid(pTab) ) ci->iPkCol = iCandidateAlias;
+    if( pTab ){
+      ci->bHasRowid = HasRowid(pTab);
+      if( nPkCols==1 && iCandidateAlias>=0 && ci->bHasRowid ){
+        ci->iPkCol = iCandidateAlias;
+      }
+      if( !ci->bHasRowid ){
+        Index *pPk = sqlite3PrimaryKeyIndex(pTab);
+        if( pPk && pPk->nKeyCol>0 ){
+          ci->aPkSortFlags = sqlite3_malloc(pPk->nKeyCol);
+          if( !ci->aPkSortFlags ){
+            sqlite3_free(aPk);
+            doltliteFreeColInfo(ci);
+            sqlite3_finalize(pStmt);
+            return SQLITE_NOMEM;
+          }
+          for(i=0; i<pPk->nKeyCol; i++){
+            ci->aPkSortFlags[i] = pPk->aSortOrder[i];
+          }
+          ci->nPk = pPk->nKeyCol;
+        }
+      }
+    }else{
+      ci->bHasRowid = 1;
+    }
   }
 
   if( ci->nCol>0 ){
@@ -566,6 +593,69 @@ int doltliteRecordFromClusteredKey(
   *ppRec = pBuf;
   *pnRec = nRec;
   return SQLITE_OK;
+}
+
+/* Same reconstruction, but keyed by a DoltliteColInfo instead of the live
+** table, so a historical schema decodes keys its own primary key wrote. */
+int doltliteRecordFromClusteredKeyCols(
+  sqlite3 *db, const DoltliteColInfo *ci,
+  const u8 *pKey, int nKey,
+  u8 **ppRec, int *pnRec
+){
+  KeyInfo *pKI;
+  u8 *pBuf = 0;
+  int nAlloc = 0, nRec = 0;
+  int i, rc;
+
+  *ppRec = 0;
+  *pnRec = 0;
+  if( !pKey || nKey<=0 || !ci ) return SQLITE_OK;
+  if( ci->bHasRowid || ci->nPk<=0 || !ci->aPkSortFlags ) return SQLITE_OK;
+
+  pKI = sqlite3KeyInfoAlloc(db, ci->nPk, 0);
+  if( !pKI ) return SQLITE_NOMEM;
+  for(i=0; i<ci->nPk; i++){
+    pKI->aSortFlags[i] = ci->aPkSortFlags[i];
+  }
+  rc = recordFromSortKeyBufferColl(pKey, nKey, pKI, &pBuf, &nAlloc, &nRec);
+  sqlite3KeyInfoUnref(pKI);
+  if( rc!=SQLITE_OK ){
+    sqlite3_free(pBuf);
+    return rc;
+  }
+  *ppRec = pBuf;
+  *pnRec = nRec;
+  return SQLITE_OK;
+}
+
+void doltliteSideColsClear(DoltliteSideCols *pSide){
+  doltliteFreeColInfo(&pSide->ci);
+  sqlite3_free(pSide->aDeclToSide);
+  memset(pSide, 0, sizeof(*pSide));
+}
+
+void doltliteResultSideCol(
+  sqlite3_context *ctx,
+  const DoltliteSideCols *pSide,
+  const DoltliteColInfo *pDeclared,
+  const u8 *pRec, int nRec,
+  i64 intKey, int bRootIntKey, int iDeclaredCol
+){
+  if( pSide && pSide->valid ){
+    int iSide = -1;
+    if( iDeclaredCol>=0 && iDeclaredCol<pDeclared->nCol ){
+      iSide = pSide->aDeclToSide[iDeclaredCol];
+    }
+    if( iSide<0 ){
+      sqlite3_result_null(ctx);
+      return;
+    }
+    doltliteResultUserCol(ctx, &pSide->ci, pRec, nRec,
+                          intKey, bRootIntKey, iSide);
+    return;
+  }
+  doltliteResultUserCol(ctx, pDeclared, pRec, nRec,
+                        intKey, bRootIntKey, iDeclaredCol);
 }
 
 u8 *doltliteBuildRecord(const DoltliteSerialValue *aMem, int nField, int *pnOut){

--- a/src/doltlite_vtab_util.h
+++ b/src/doltlite_vtab_util.h
@@ -60,8 +60,9 @@ static SQLITE_INLINE void doltliteVtabCommonReset(
   c->rootIntKey = 0;
 }
 
-static SQLITE_INLINE int doltliteVtabCommonCaptureRow(
-  DoltliteVtabCursorCommon *c, sqlite3 *db, const char *zTableName
+static SQLITE_INLINE int doltliteVtabCommonCaptureRowSide(
+  DoltliteVtabCursorCommon *c, sqlite3 *db, const char *zTableName,
+  const DoltliteSideCols *pSide
 ){
   const u8 *pVal; int nVal;
   sqlite3_free(c->pVal);
@@ -76,16 +77,26 @@ static SQLITE_INLINE int doltliteVtabCommonCaptureRow(
   }else{
     /* Clustered rows whose PRIMARY KEY covers every column store an empty
     ** value; the row lives in the sort key. Rebuild the record from the key
-    ** so column reads see the PK values instead of NULLs. */
+    ** — with the visited schema's primary key when one is loaded — so
+    ** column reads see the PK values instead of NULLs. */
     const u8 *pKey; int nKey;
     int rc;
     prollyCursorKey(&c->tblCur, &pKey, &nKey);
-    rc = doltliteRecordFromClusteredKey(db, zTableName, pKey, nKey,
-                                        &c->pVal, &c->nVal);
+    rc = pSide && pSide->valid
+      ? doltliteRecordFromClusteredKeyCols(db, &pSide->ci, pKey, nKey,
+                                           &c->pVal, &c->nVal)
+      : doltliteRecordFromClusteredKey(db, zTableName, pKey, nKey,
+                                       &c->pVal, &c->nVal);
     if( rc!=SQLITE_OK ) return rc;
   }
   c->hasRow = 1;
   return SQLITE_OK;
+}
+
+static SQLITE_INLINE int doltliteVtabCommonCaptureRow(
+  DoltliteVtabCursorCommon *c, sqlite3 *db, const char *zTableName
+){
+  return doltliteVtabCommonCaptureRowSide(c, db, zTableName, 0);
 }
 
 static SQLITE_INLINE int doltliteVtabCommonDisconnect(

--- a/src/doltlite_workspace.c
+++ b/src/doltlite_workspace.c
@@ -56,6 +56,9 @@ struct WorkspaceCursor {
   ProllyDiffIter iter;
   ProllyHash headRoot, stagedRoot, workingRoot;
   u8 headFlags, stagedFlags, workingFlags;
+  /* Columns as each phase's catalog declares them; an invalid side renders
+  ** with the vtab's declared layout. */
+  DoltliteSideCols headSide, stagedSide, workingSide;
   int stagedOnly;
   WorkspaceRows *pRows;
 };
@@ -152,25 +155,33 @@ static int wsAppendRow(
   ** key for each side the diff type says exists. */
   if( (row.nOldVal==0 && pChange->type!=PROLLY_DIFF_ADD)
    || (row.nNewVal==0 && pChange->type!=PROLLY_DIFF_DELETE) ){
-    u8 *pRec = 0; int nRec = 0;
-    if( doltliteRecordFromClusteredKey(pVtab->db, pVtab->zTableName,
-            pChange->pKey, pChange->nKey, &pRec, &nRec)!=SQLITE_OK ){
-      goto nomem;
-    }
-    if( pRec ){
-      if( row.nOldVal==0 && pChange->type!=PROLLY_DIFF_ADD ){
-        row.pOldVal = sqlite3_malloc(nRec);
-        if( !row.pOldVal ){ sqlite3_free(pRec); goto nomem; }
-        memcpy(row.pOldVal, pRec, nRec);
+    const DoltliteSideCols *pFromSide = staged ? &c->headSide : &c->stagedSide;
+    const DoltliteSideCols *pToSide = staged ? &c->stagedSide : &c->workingSide;
+    if( row.nOldVal==0 && pChange->type!=PROLLY_DIFF_ADD ){
+      u8 *pRec = 0; int nRec = 0;
+      int rc2 = pFromSide->valid
+        ? doltliteRecordFromClusteredKeyCols(pVtab->db, &pFromSide->ci,
+              pChange->pKey, pChange->nKey, &pRec, &nRec)
+        : doltliteRecordFromClusteredKey(pVtab->db, pVtab->zTableName,
+              pChange->pKey, pChange->nKey, &pRec, &nRec);
+      if( rc2!=SQLITE_OK ) goto nomem;
+      if( pRec ){
+        row.pOldVal = pRec;
         row.nOldVal = nRec;
       }
-      if( row.nNewVal==0 && pChange->type!=PROLLY_DIFF_DELETE ){
-        row.pNewVal = sqlite3_malloc(nRec);
-        if( !row.pNewVal ){ sqlite3_free(pRec); goto nomem; }
-        memcpy(row.pNewVal, pRec, nRec);
+    }
+    if( row.nNewVal==0 && pChange->type!=PROLLY_DIFF_DELETE ){
+      u8 *pRec = 0; int nRec = 0;
+      int rc2 = pToSide->valid
+        ? doltliteRecordFromClusteredKeyCols(pVtab->db, &pToSide->ci,
+              pChange->pKey, pChange->nKey, &pRec, &nRec)
+        : doltliteRecordFromClusteredKey(pVtab->db, pVtab->zTableName,
+              pChange->pKey, pChange->nKey, &pRec, &nRec);
+      if( rc2!=SQLITE_OK ) goto nomem;
+      if( pRec ){
+        row.pNewVal = pRec;
         row.nNewVal = nRec;
       }
-      sqlite3_free(pRec);
     }
   }
   if( pRows->n>=pRows->nAlloc ){
@@ -201,7 +212,7 @@ static void wsCloseIter(WorkspaceCursor *c){
 static int wsInitCursorRoots(WorkspaceCursor *c, WorkspaceVtab *pVtab){
   sqlite3 *db = pVtab->db;
   ProllyHash headHash, headCat, stagedCat, workingCat;
-  ProllyHash schemaHash;
+  ProllyHash headSchema, stagedSchema, workingSchema;
 
   int rc;
 
@@ -211,7 +222,9 @@ static int wsInitCursorRoots(WorkspaceCursor *c, WorkspaceVtab *pVtab){
   memset(&c->headRoot, 0, sizeof(c->headRoot));
   memset(&c->stagedRoot, 0, sizeof(c->stagedRoot));
   memset(&c->workingRoot, 0, sizeof(c->workingRoot));
-  memset(&schemaHash, 0, sizeof(schemaHash));
+  memset(&headSchema, 0, sizeof(headSchema));
+  memset(&stagedSchema, 0, sizeof(stagedSchema));
+  memset(&workingSchema, 0, sizeof(workingSchema));
   c->headFlags = 0;
   c->stagedFlags = 0;
   c->workingFlags = 0;
@@ -237,18 +250,32 @@ static int wsInitCursorRoots(WorkspaceCursor *c, WorkspaceVtab *pVtab){
 
   rc = doltliteLoadTableRootByNameOrEmpty(db, &headCat, pVtab->zTableName,
                                           &c->headRoot, &c->headFlags,
-                                          &schemaHash);
+                                          &headSchema);
   if( rc!=SQLITE_OK ) return rc;
   rc = doltliteLoadTableRootByNameOrEmpty(db, &stagedCat, pVtab->zTableName,
                                           &c->stagedRoot, &c->stagedFlags,
-                                          &schemaHash);
+                                          &stagedSchema);
   if( rc!=SQLITE_OK ) return rc;
   if( c->stagedOnly!=1 ){
     rc = doltliteLoadTableRootByNameOrEmpty(db, &workingCat, pVtab->zTableName,
                                             &c->workingRoot, &c->workingFlags,
-                                            &schemaHash);
+                                            &workingSchema);
     if( rc!=SQLITE_OK ) return rc;
   }
+
+  rc = doltliteSideColsLoad(db, &headCat, &headSchema, pVtab->zTableName,
+                            &pVtab->cols, &c->headSide);
+  if( rc==SQLITE_OK ){
+    rc = doltliteSideColsLoad(db, &stagedCat, &stagedSchema,
+                              pVtab->zTableName, &pVtab->cols,
+                              &c->stagedSide);
+  }
+  if( rc==SQLITE_OK && c->stagedOnly!=1 ){
+    rc = doltliteSideColsLoad(db, &workingCat, &workingSchema,
+                              pVtab->zTableName, &pVtab->cols,
+                              &c->workingSide);
+  }
+  if( rc!=SQLITE_OK ) return rc;
 
   if( !c->headFlags ){
     c->headFlags = c->stagedFlags ? c->stagedFlags : c->workingFlags;
@@ -383,9 +410,16 @@ static int wsOpen(sqlite3_vtab *pVtab, sqlite3_vtab_cursor **pp){
   return doltliteVtabOpenCursor(pp, sizeof(WorkspaceCursor));
 }
 
+static void wsClearSides(WorkspaceCursor *c){
+  doltliteSideColsClear(&c->headSide);
+  doltliteSideColsClear(&c->stagedSide);
+  doltliteSideColsClear(&c->workingSide);
+}
+
 static int wsClose(sqlite3_vtab_cursor *cur){
   WorkspaceCursor *c = (WorkspaceCursor*)cur;
   wsCloseIter(c);
+  wsClearSides(c);
   wsRowsRelease(c->pRows);
   sqlite3_free(cur);
   return SQLITE_OK;
@@ -398,6 +432,7 @@ static int wsFilter(sqlite3_vtab_cursor *cur,
   int rc;
   (void)idxStr;
   wsCloseIter(c);
+  wsClearSides(c);
   wsRowsRelease(c->pRows);
   c->pRows = wsRowsNew();
   if( !c->pRows ) return SQLITE_NOMEM;
@@ -454,10 +489,12 @@ static int wsColumn(sqlite3_vtab_cursor *cur, sqlite3_context *ctx, int col){
     if( zType ) sqlite3_result_text(ctx, zType, -1, SQLITE_STATIC);
     else sqlite3_result_null(ctx);
   }else if( col>=3 && col<3+nCols ){
-    doltliteResultUserCol(ctx, &p->cols, r->pNewVal, r->nNewVal,
+    doltliteResultSideCol(ctx, r->staged ? &c->stagedSide : &c->workingSide,
+                          &p->cols, r->pNewVal, r->nNewVal,
                           r->intKey, r->keyIsIntKey, col-3);
   }else if( col>=3+nCols && col<3+2*nCols ){
-    doltliteResultUserCol(ctx, &p->cols, r->pOldVal, r->nOldVal,
+    doltliteResultSideCol(ctx, r->staged ? &c->headSide : &c->stagedSide,
+                          &p->cols, r->pOldVal, r->nOldVal,
                           r->intKey, r->keyIsIntKey, col-3-nCols);
   }else{
     sqlite3_result_null(ctx);

--- a/src/record_codec.h
+++ b/src/record_codec.h
@@ -2,6 +2,7 @@
 #define RECORD_CODEC_H
 
 #include "prolly_record.h"
+#include "prolly_hash.h"
 
 char *doltliteDecodeRecord(const u8 *pData, int nData);
 
@@ -19,6 +20,24 @@ struct DoltliteColInfo {
   ** SQLite's convertToWithoutRowidTable builds for the covering
   ** PK index. */
   int *aColToRec;
+  /* Clustered-key metadata, filled from the same table the names came
+  ** from, so a historical schema decodes its own keys. */
+  int bHasRowid;
+  int nPk;
+  u8 *aPkSortFlags;
+};
+
+/* One side of a diff-style read: the table's columns as the schema at the
+** visited commit declares them, plus a by-name projection of the vtab's
+** declared columns onto them. Cached by schema hash — adjacent commits
+** nearly always share a schema. An invalid side falls back to rendering
+** with the declared layout, which is the pre-existing behavior. */
+typedef struct DoltliteSideCols DoltliteSideCols;
+struct DoltliteSideCols {
+  DoltliteColInfo ci;
+  int *aDeclToSide;   /* declared column -> ci column, -1 when absent */
+  ProllyHash schemaHash;
+  int valid;
 };
 
 int doltliteGetColumnNames(sqlite3 *db, const char *zTable, DoltliteColInfo *ci);
@@ -49,6 +68,19 @@ void doltliteResultField(sqlite3_context *ctx, const u8 *pData, int nData,
 
 int doltliteRecordFromClusteredKey(sqlite3 *db, const char *zTable,
     const u8 *pKey, int nKey, u8 **ppRec, int *pnRec);
+int doltliteRecordFromClusteredKeyCols(sqlite3 *db,
+    const DoltliteColInfo *ci,
+    const u8 *pKey, int nKey, u8 **ppRec, int *pnRec);
+void doltliteSideColsClear(DoltliteSideCols *pSide);
+int doltliteSideColsLoad(sqlite3 *db,
+    const ProllyHash *pCatHash, const ProllyHash *pSchemaHash,
+    const char *zTable, const DoltliteColInfo *pDeclared,
+    DoltliteSideCols *pSide);
+void doltliteResultSideCol(sqlite3_context *ctx,
+    const DoltliteSideCols *pSide,
+    const DoltliteColInfo *pDeclared,
+    const u8 *pRec, int nRec,
+    i64 intKey, int bRootIntKey, int iDeclaredCol);
 void doltliteResultUserCol(sqlite3_context *ctx,
                            const DoltliteColInfo *ci,
                            const u8 *pRec, int nRec,

--- a/test/doltlite_at.sh
+++ b/test/doltlite_at.sh
@@ -361,4 +361,19 @@ run_test "keyshape_upper_bound_scans_all" \
 
 rm -f "$DB"
 
+
+# dolt_at renders the pinned commit's rows with that commit's schema.
+DBA=/tmp/test_at_namemap_$$.db; rm -f "$DBA"
+echo "CREATE TABLE t(a INTEGER PRIMARY KEY, b TEXT, c TEXT);
+INSERT INTO t VALUES(1,'BEE','CEE');
+SELECT dolt_commit('-Am','base');
+ALTER TABLE t DROP COLUMN b;
+SELECT dolt_commit('-Am','drop_b');" | $DOLTLITE "$DBA" > /dev/null 2>&1
+
+run_test "at_namemap_old_commit" \
+  "SELECT a || '=' || c FROM dolt_at_t WHERE commit_ref='HEAD~1';" \
+  "1=CEE" "$DBA"
+
+rm -f "$DBA"
+
 dltest_finish

--- a/test/doltlite_diff_table.sh
+++ b/test/doltlite_diff_table.sh
@@ -237,4 +237,60 @@ run_test "shape_no_modified_pairing" \
   "0" "$DBS"
 rm -f "$DBS"
 
+
+# Historical sides render by column NAME against the schema at their commit,
+# not by record position under the current schema: after a mid-position
+# column drop, from_c must show the old row's c, and the base commit's
+# "added" row must show its c even though the record still holds three
+# fields.
+DBN=/tmp/test_dt_namemap_$$.db; rm -f "$DBN"
+echo "CREATE TABLE t(a INTEGER PRIMARY KEY, b TEXT, c TEXT);
+INSERT INTO t VALUES(1,'BEE','CEE');
+SELECT dolt_commit('-Am','base');
+ALTER TABLE t DROP COLUMN b;
+SELECT dolt_commit('-Am','drop_b');" | $DOLTLITE "$DBN" > /dev/null 2>&1
+
+run_test "namemap_from_after_drop" \
+  "SELECT from_a || '=' || from_c FROM dolt_diff_t WHERE diff_type='modified';" \
+  "1=CEE" "$DBN"
+run_test "namemap_to_at_old_commit" \
+  "SELECT to_a || '=' || to_c FROM dolt_diff_t WHERE diff_type='added';" \
+  "1=CEE" "$DBN"
+
+# Re-adding a dropped column moves it to the end of the declared order; the
+# base commit's record still holds it at its old position, so only a name
+# walk finds it.
+DBR=/tmp/test_dt_readd_$$.db; rm -f "$DBR"
+echo "CREATE TABLE t(a INTEGER PRIMARY KEY, b TEXT, c TEXT);
+INSERT INTO t VALUES(1,'BEE','CEE');
+SELECT dolt_commit('-Am','base');
+ALTER TABLE t DROP COLUMN b;
+ALTER TABLE t ADD COLUMN b TEXT;
+UPDATE t SET b='NEWBEE';
+SELECT dolt_commit('-Am','moved_b');" | $DOLTLITE "$DBR" > /dev/null 2>&1
+
+run_test "namemap_moved_col_from" \
+  "SELECT from_b || '/' || from_c FROM dolt_diff_t WHERE diff_type='modified';" \
+  "BEE/CEE" "$DBR"
+run_test "namemap_moved_col_to" \
+  "SELECT to_b || '/' || to_c FROM dolt_diff_t WHERE diff_type='modified';" \
+  "NEWBEE/CEE" "$DBR"
+
+# A PK-only WITHOUT ROWID table whose recreate swapped the key column order
+# decodes each side's key with that side's primary key definition.
+DBK=/tmp/test_dt_pkswap_$$.db; rm -f "$DBK"
+echo "CREATE TABLE t(a TEXT, b TEXT, PRIMARY KEY(a,b)) WITHOUT ROWID;
+INSERT INTO t VALUES('k1','k2');
+SELECT dolt_commit('-Am','base');
+DROP TABLE t;
+CREATE TABLE t(b TEXT, a TEXT, PRIMARY KEY(b,a)) WITHOUT ROWID;
+INSERT INTO t VALUES('k2','k1');
+SELECT dolt_commit('-Am','swap');" | $DOLTLITE "$DBK" > /dev/null 2>&1
+
+run_test "namemap_pkswap_from" \
+  "SELECT from_a || '/' || from_b FROM dolt_diff_t WHERE diff_type='removed';" \
+  "k1/k2" "$DBK"
+
+rm -f "$DBN" "$DBR" "$DBK"
+
 dltest_finish

--- a/test/doltlite_history.sh
+++ b/test/doltlite_history.sh
@@ -373,4 +373,19 @@ y" "$DB"
 
 rm -f "$DB"
 
+
+# Rows at old commits render by column NAME against that commit's schema.
+DBH=/tmp/test_hist_namemap_$$.db; rm -f "$DBH"
+echo "CREATE TABLE t(a INTEGER PRIMARY KEY, b TEXT, c TEXT);
+INSERT INTO t VALUES(1,'BEE','CEE');
+SELECT dolt_commit('-Am','base');
+ALTER TABLE t DROP COLUMN b;
+SELECT dolt_commit('-Am','drop_b');" | $DOLTLITE "$DBH" > /dev/null 2>&1
+
+run_test "hist_namemap_old_commit" \
+  "SELECT group_concat(a || '=' || c, ',') FROM (SELECT a, c FROM dolt_history_t ORDER BY commit_date);" \
+  "1=CEE,1=CEE" "$DBH"
+
+rm -f "$DBH"
+
 dltest_finish

--- a/test/doltlite_workspace.sh
+++ b/test/doltlite_workspace.sh
@@ -248,4 +248,24 @@ run_test "ws_shape_added_side" \
   "42=2" "$WS_DB"
 rm -f "$WS_DB"
 
+
+# Uncommitted DDL: head still has column b mid-position, working does not.
+# The from side renders with head's schema by name, the to side with the
+# working schema.
+DBW=/tmp/test_ws_namemap_$$.db; rm -f "$DBW"
+echo "CREATE TABLE t(a INTEGER PRIMARY KEY, b TEXT, c TEXT);
+INSERT INTO t VALUES(1,'BEE','CEE');
+SELECT dolt_commit('-Am','base');
+ALTER TABLE t DROP COLUMN b;
+UPDATE t SET c='NEW';" | $DOLTLITE "$DBW" > /dev/null 2>&1
+
+run_test "ws_namemap_from" \
+  "SELECT from_a || '=' || from_c FROM dolt_workspace_t WHERE diff_type='modified';" \
+  "1=CEE" "$DBW"
+run_test "ws_namemap_to" \
+  "SELECT to_a || '=' || to_c FROM dolt_workspace_t WHERE diff_type='modified';" \
+  "1=NEW" "$DBW"
+
+rm -f "$DBW"
+
 dltest_finish

--- a/test/vc_oracle_diff_tvf_test.sh
+++ b/test/vc_oracle_diff_tvf_test.sh
@@ -211,6 +211,36 @@ SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'c2');
 oracle "slice_multi_col" "$SETUP_MULTI" \
   "SELECT CONCAT('R|', IFNULL(to_a,''), '|', IFNULL(to_b,''), '|', IFNULL(to_v,''), '|', IFNULL(from_a,''), '|', IFNULL(from_b,''), '|', IFNULL(from_v,''), '|', diff_type) FROM dolt_diff_m('HEAD~1', 'HEAD');"
 
+echo "--- historical sides render by column name ---"
+
+SETUP_NAMEMAP="
+CREATE TABLE t(a INT PRIMARY KEY, b VARCHAR(32), c VARCHAR(32));
+INSERT INTO t VALUES(1,'BEE','CEE');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','base');
+ALTER TABLE t DROP COLUMN b;
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','drop_b');
+"
+
+oracle "namemap_from_side_after_col_drop" "$SETUP_NAMEMAP" \
+  "SELECT CONCAT('R|', IFNULL(to_a,''), '|', IFNULL(to_c,''), '|', IFNULL(from_a,''), '|', IFNULL(from_c,''), '|', diff_type) FROM dolt_diff_t('HEAD~1','HEAD');"
+
+oracle "namemap_to_side_at_old_commit" "$SETUP_NAMEMAP" \
+  "SELECT CONCAT('R|', IFNULL(to_a,''), '|', IFNULL(to_c,''), '|', IFNULL(from_a,''), '|', IFNULL(from_c,''), '|', diff_type) FROM dolt_diff_t('HEAD~2','HEAD~1');"
+
+SETUP_READD="
+CREATE TABLE t(a INT PRIMARY KEY, b VARCHAR(32), c VARCHAR(32));
+INSERT INTO t VALUES(1,'BEE','CEE');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','base');
+ALTER TABLE t DROP COLUMN b;
+ALTER TABLE t ADD COLUMN b VARCHAR(32);
+UPDATE t SET b='NEWBEE';
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','moved_b');
+"
+
+oracle "namemap_moved_column" "$SETUP_READD" \
+  "SELECT CONCAT('R|', IFNULL(to_b,''), '|', IFNULL(to_c,''), '|', IFNULL(from_b,''), '|', IFNULL(from_c,''), '|', diff_type) FROM dolt_diff_t('HEAD~1','HEAD');"
+
+
 echo ""
 echo "=== Results: $pass passed, $fail failed ==="
 if [ $fail -gt 0 ]; then


### PR DESCRIPTION
## Problem

`dolt_diff_<t>`, `dolt_history_<t>`, `dolt_at_<t>`, and `dolt_workspace_<t>` rendered every visited commit's records with the *current* schema's column-to-record-field mapping. After a mid-position column drop, re-add, or reorder, historical records put values under the wrong columns — dropping column `b` made `from_c` return b's value. PK-only clustered rows had the same problem one level down: historical sort keys were decoded with the live table's primary key definition.

## Fix

A shared per-side column view (`DoltliteSideCols`): each visited commit's schema is parsed once (cached by schema hash, so adjacent commits sharing a schema parse nothing), the vtab's declared columns are projected onto it **by name**, and a column absent at that commit renders NULL. `DoltliteColInfo` now carries the PK definition (column count, sort flags, rowid-ness) from the same schema its names came from, so PK-only clustered keys are decoded with the visited schema's primary key — a recreate that reordered key columns reads back correctly.

All four surfaces are wired through the same helpers; an invalid side (schema unavailable) falls back to the previous behavior.

## Testing

- Oracled against Dolt 2.2.2 in `vc_oracle_diff_tvf_test.sh`: column drop (from side), old-commit to side, drop-and-re-add moved column — 20/20.
- Seven new shell cases across the four surfaces (including a WITHOUT ROWID PK-order swap); all fail on a master build, all pass with the fix.
- Full battery on a clean build: 101/101 suites. Amalgamation regenerated and compiles clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)