### PR TITLE
Gate the to_commit diff filter on head ancestry

### DIFF
--- a/src/doltlite_diff_table.c
+++ b/src/doltlite_diff_table.c
@@ -578,6 +578,23 @@ static int buildCommitDiffPair(
   rc = doltliteResolveRef(db, zToCommit, &toHash);
   if( rc!=SQLITE_OK ) return SQLITE_OK;
 
+  /* A pushed-down to_commit filter must select a subset of the full scan,
+  ** which only walks the session head's ancestry. A commit that is not
+  ** reachable from the head yields no rows, matching both the unfiltered
+  ** scan and Dolt. */
+  {
+    ProllyHash head, base;
+    memset(&head, 0, sizeof(head));
+    doltliteGetSessionHead(db, &head);
+    if( prollyHashIsEmpty(&head) ) return SQLITE_OK;
+    rc = doltliteFindAncestor(db, &head, &toHash, &base);
+    if( rc==SQLITE_NOTFOUND
+     || (rc==SQLITE_OK && prollyHashCompare(&base, &toHash)!=0) ){
+      return SQLITE_OK;
+    }
+    if( rc!=SQLITE_OK ) return rc;
+  }
+
   rc = doltliteLoadCommit(db, &toHash, &toCommit);
   if( rc!=SQLITE_OK ) return rc;
   memcpy(&toCatHash, &toCommit.catalogHash, sizeof(ProllyHash));

--- a/test/doltlite_diff_table.sh
+++ b/test/doltlite_diff_table.sh
@@ -292,5 +292,28 @@ run_test "namemap_pkswap_from" \
   "k1/k2" "$DBK"
 
 rm -f "$DBN" "$DBR" "$DBK"
+# A pushed-down to_commit filter is a SUBSET of the full scan: a commit not
+# reachable from the session head yields no rows, exactly like the
+# unfiltered scan (and Dolt). The +to_commit form blocks pushdown, so the
+# two must agree.
+DBG=/tmp/test_dt_ancgate_$$.db; rm -f "$DBG"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'base');
+SELECT dolt_commit('-Am','base');
+SELECT dolt_branch('feat');" | $DOLTLITE "$DBG" > /dev/null 2>&1
+echo "INSERT INTO t VALUES(2,'feat-only');
+SELECT dolt_commit('-Am','feat_commit');" | $DOLTLITE "$DBG/feat" > /dev/null 2>&1
+
+run_test "ancestry_gate_foreign_commit" \
+  "SELECT count(*) FROM dolt_diff_t WHERE to_commit=(SELECT commit_hash FROM dolt_log('feat') LIMIT 1);" \
+  "0" "$DBG"
+run_test "ancestry_gate_subset_of_full_scan" \
+  "SELECT (SELECT count(*) FROM dolt_diff_t WHERE to_commit=(SELECT commit_hash FROM dolt_log('feat') LIMIT 1)) = (SELECT count(*) FROM dolt_diff_t WHERE +to_commit=(SELECT commit_hash FROM dolt_log('feat') LIMIT 1));" \
+  "1" "$DBG"
+run_test "ancestry_gate_reachable_commit" \
+  "SELECT count(*) FROM dolt_diff_t WHERE to_commit=(SELECT commit_hash FROM dolt_log LIMIT 1);" \
+  "1" "$DBG"
+
+rm -f "$DBG"
 
 dltest_finish

--- a/test/vc_oracle_diff_tvf_test.sh
+++ b/test/vc_oracle_diff_tvf_test.sh
@@ -241,6 +241,19 @@ oracle "namemap_moved_column" "$SETUP_READD" \
   "SELECT CONCAT('R|', IFNULL(to_b,''), '|', IFNULL(to_c,''), '|', IFNULL(from_b,''), '|', IFNULL(from_c,''), '|', diff_type) FROM dolt_diff_t('HEAD~1','HEAD');"
 
 
+echo "--- to_commit filter is a subset of head ancestry ---"
+
+oracle "to_commit_foreign_branch_yields_nothing" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 1);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'base');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+INSERT INTO t VALUES (2, 2);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'feat_commit');
+SELECT dolt_checkout('main');
+" "SELECT CONCAT('R|', count(*)) FROM dolt_diff_t WHERE to_commit=(SELECT commit_hash FROM dolt_log('feat') LIMIT 1);"
+
 echo ""
 echo "=== Results: $pass passed, $fail failed ==="
 if [ $fail -gt 0 ]; then


### PR DESCRIPTION
## Problem

The full `dolt_diff_<t>` scan walks the session head's ancestry, but the pushed-down `to_commit=` filter resolved any commit hash and fabricated a diff pair for it. The same query returned different rows depending on the query plan: `WHERE to_commit=<foreign-branch hash>` found a row that `WHERE +to_commit=<same hash>` (pushdown blocked) did not — a violation of the virtual table contract that a constrained scan selects a subset of the full scan. Dolt returns nothing for such commits.

## Fix

`buildCommitDiffPair` verifies the resolved commit is reachable from the session head (its merge base with the head is the commit itself) and yields no rows otherwise, matching both the unfiltered scan and Dolt. Explicit two-ref slices (`dolt_diff_t('main','feat')`) still cross branches by design, and `to_commit='WORKING'` is untouched.

## Testing

- Oracle case in `vc_oracle_diff_tvf_test.sh` against Dolt 2.2.2 (foreign-branch to_commit yields zero rows in both engines).
- Shell cases assert the filtered scan equals the pushdown-blocked scan and that reachable commits still filter correctly; both new subset cases fail on master and pass with the fix.
- Full battery: 101/101 suites. Amalgamation regenerated and compiles clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)