### PR TITLE
Fail historical reads that cannot map a side's schema

### DIFF
--- a/src/doltlite_at.c
+++ b/src/doltlite_at.c
@@ -121,16 +121,60 @@ static int atEnqueueReachableRoots(
   return rc;
 }
 
+/* Whether the LIVE table's canonicalized schema hashes to pSchemaHash — when
+** it does, the declared layout is provably the visited schema's layout and
+** rendering with it cannot mislabel a value. */
+static int sideColsDeclaredSchemaMatches(
+  sqlite3 *db,
+  const char *zTable,
+  const ProllyHash *pSchemaHash,
+  int *pbMatch
+){
+  sqlite3_stmt *pStmt = 0;
+  char *zQ;
+  int rc;
+
+  *pbMatch = 0;
+  zQ = sqlite3_mprintf(
+      "SELECT sql FROM main.sqlite_master WHERE type='table' AND name=%Q",
+      zTable);
+  if( !zQ ) return SQLITE_NOMEM;
+  rc = sqlite3_prepare_v2(db, zQ, -1, &pStmt, 0);
+  sqlite3_free(zQ);
+  if( rc!=SQLITE_OK ) return rc;
+  if( sqlite3_step(pStmt)==SQLITE_ROW ){
+    const char *zSql = (const char*)sqlite3_column_text(pStmt, 0);
+    if( zSql && zSql[0] ){
+      char *zCanon = doltliteCanonicalizeSchemaSql(zSql, zTable);
+      if( zCanon ){
+        ProllyHash h;
+        prollyHashCompute((const u8*)zCanon, (int)strlen(zCanon), &h);
+        *pbMatch = prollyHashCompare(&h, pSchemaHash)==0;
+        sqlite3_free(zCanon);
+      }
+    }
+  }
+  sqlite3_finalize(pStmt);
+  return SQLITE_OK;
+}
+
 /* Load zTable's columns as the schema at pCatHash declares them and map the
-** declared (vtab-visible) columns onto them by name. Cached by schema hash;
-** any failure leaves the side invalid, which renders with the declared
-** layout — the pre-existing behavior. */
+** declared (vtab-visible) columns onto them by name. Cached by schema hash.
+**
+** A side left invalid renders with the declared layout, so that fallback is
+** allowed only when it cannot mislabel a value: the table is absent at that
+** commit (nothing to render), or the live declared schema is byte-identical
+** to the visited one. Everything else — store errors, a schema row missing
+** for a side that holds rows, a schema the scratch db cannot parse (e.g. a
+** CHECK naming an application-registered function) that drifted — fails the
+** read instead of silently decoding records with the wrong layout. */
 int doltliteSideColsLoad(
   sqlite3 *db,
   const ProllyHash *pCatHash,
   const ProllyHash *pSchemaHash,
   const char *zTable,
   const DoltliteColInfo *pDeclared,
+  int bSideHasData,
   DoltliteSideCols *pSide
 ){
   ChunkStore *cs = doltliteGetChunkStore(db);
@@ -150,10 +194,10 @@ int doltliteSideColsLoad(
 
   rc = loadSchemaEntryFromCatalog(db, cs, pCache, pCatHash, zTable,
                                   &entry, &found);
-  if( rc!=SQLITE_OK ) return SQLITE_OK;
+  if( rc!=SQLITE_OK ) return rc;
   if( !found || !entry.zSql ){
     clearSchemaEntry(&entry);
-    return SQLITE_OK;
+    return bSideHasData ? SQLITE_CORRUPT : SQLITE_OK;
   }
 
   rc = sqlite3_open(":memory:", &tmp);
@@ -162,8 +206,13 @@ int doltliteSideColsLoad(
   if( tmp ) sqlite3_close(tmp);
   clearSchemaEntry(&entry);
   if( rc!=SQLITE_OK || pSide->ci.nCol<=0 ){
+    int match = 0;
+    int rc2;
     doltliteSideColsClear(pSide);
-    return SQLITE_OK;
+    rc2 = sideColsDeclaredSchemaMatches(db, zTable, pSchemaHash, &match);
+    if( rc2==SQLITE_OK && match ) return SQLITE_OK;
+    if( rc2!=SQLITE_OK ) return rc2;
+    return rc==SQLITE_OK ? SQLITE_ERROR : rc;
   }
 
   if( pDeclared->nCol>0 ){
@@ -456,7 +505,8 @@ static int atFilter(sqlite3_vtab_cursor *cur,
                                    &flags,&schemaHash);
     if( rc==SQLITE_OK ){
       rc = doltliteSideColsLoad(db, &effCatHash, &schemaHash,
-                                v->zTableName, &v->cols, &c->side);
+                                v->zTableName, &v->cols,
+                                !prollyHashIsEmpty(&tableRoot), &c->side);
     }
   }
   if(rc==SQLITE_NOTFOUND) return SQLITE_OK;

--- a/src/doltlite_diff_table.c
+++ b/src/doltlite_diff_table.c
@@ -845,10 +845,12 @@ static int openNextPairIter(DiffTblCursor *pCur, sqlite3 *db){
 
     rc = doltliteSideColsLoad(db, &p->fromCatHash, &p->fromSchemaHash,
                               pVtab->zTableName, &pVtab->cols,
+                              !prollyHashIsEmpty(&p->fromTblRoot),
                               &pCur->fromSide);
     if( rc==SQLITE_OK ){
       rc = doltliteSideColsLoad(db, &p->toCatHash, &p->toSchemaHash,
                                 pVtab->zTableName, &pVtab->cols,
+                                !prollyHashIsEmpty(&p->toTblRoot),
                                 &pCur->toSide);
     }
     if( rc!=SQLITE_OK ) return rc;

--- a/src/doltlite_history.c
+++ b/src/doltlite_history.c
@@ -109,7 +109,8 @@ static int htOpenTableAtCommit(HistCursor *c, sqlite3 *db,
   if( rc==SQLITE_OK ){
     DoltliteVtabCommon *v = (DoltliteVtabCommon*)c->common.base.pVtab;
     rc = doltliteSideColsLoad(db, &commit.catalogHash, &schemaHash,
-                              zTableName, &v->cols, &c->side);
+                              zTableName, &v->cols,
+                              !prollyHashIsEmpty(&tableRoot), &c->side);
   }
   doltliteCommitClear(&commit);
   if( rc==SQLITE_NOTFOUND ) return SQLITE_OK;

--- a/src/doltlite_workspace.c
+++ b/src/doltlite_workspace.c
@@ -264,15 +264,18 @@ static int wsInitCursorRoots(WorkspaceCursor *c, WorkspaceVtab *pVtab){
   }
 
   rc = doltliteSideColsLoad(db, &headCat, &headSchema, pVtab->zTableName,
-                            &pVtab->cols, &c->headSide);
+                            &pVtab->cols,
+                            !prollyHashIsEmpty(&c->headRoot), &c->headSide);
   if( rc==SQLITE_OK ){
     rc = doltliteSideColsLoad(db, &stagedCat, &stagedSchema,
                               pVtab->zTableName, &pVtab->cols,
+                              !prollyHashIsEmpty(&c->stagedRoot),
                               &c->stagedSide);
   }
   if( rc==SQLITE_OK && c->stagedOnly!=1 ){
     rc = doltliteSideColsLoad(db, &workingCat, &workingSchema,
                               pVtab->zTableName, &pVtab->cols,
+                              !prollyHashIsEmpty(&c->workingRoot),
                               &c->workingSide);
   }
   if( rc!=SQLITE_OK ) return rc;

--- a/src/record_codec.h
+++ b/src/record_codec.h
@@ -75,7 +75,7 @@ void doltliteSideColsClear(DoltliteSideCols *pSide);
 int doltliteSideColsLoad(sqlite3 *db,
     const ProllyHash *pCatHash, const ProllyHash *pSchemaHash,
     const char *zTable, const DoltliteColInfo *pDeclared,
-    DoltliteSideCols *pSide);
+    int bSideHasData, DoltliteSideCols *pSide);
 void doltliteResultSideCol(sqlite3_context *ctx,
     const DoltliteSideCols *pSide,
     const DoltliteColInfo *pDeclared,

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -10111,6 +10111,64 @@ static void run_incrblob_chunked_and_multihandle(void){
   removeDbFiles(dbpath);
 }
 
+/* Historical sides whose schema the scratch db cannot parse (a CHECK naming
+** an application-registered function) must never render records with the
+** wrong layout. When the visited schema drifted from the live one, the read
+** fails; when it is identical, the declared-layout fallback is provably
+** safe and the values still come back correct. */
+static void sideCheckFn(sqlite3_context *ctx, int n, sqlite3_value **v){
+  (void)n;
+  (void)v;
+  sqlite3_result_int(ctx, 1);
+}
+
+static void run_diff_side_schema_custom_function(void){
+  char dbpath[512];
+  sqlite3 *db = 0;
+  int rc;
+
+  printf("=== Diff Side Schema Custom Function Test ===\n\n");
+  make_dbpath(dbpath, sizeof(dbpath), "test_diff_side_function");
+  removeDbFiles(dbpath);
+
+  rc = sqlite3_open(dbpath, &db);
+  check("side_fn_open", rc==SQLITE_OK);
+  if( !db ) return;
+  check("side_fn_register",
+        sqlite3_create_function(db, "side_ok", 1, SQLITE_UTF8, 0,
+                                sideCheckFn, 0, 0)==SQLITE_OK);
+
+  /* Unchanged schema: both sides fail the scratch parse, but the live
+  ** schema hashes identically, so the fallback renders real values. */
+  check("side_fn_setup_same", execSql(db,
+      "CREATE TABLE s(a TEXT CHECK(side_ok(a)), pk TEXT PRIMARY KEY, c TEXT);"
+      "INSERT INTO s VALUES('a1','k1','c1');"
+      "SELECT dolt_commit('-Am','base_s');"
+      "UPDATE s SET c='c2';"
+      "SELECT dolt_commit('-Am','update_s');")==SQLITE_OK);
+  check("side_fn_same_schema_renders",
+        strcmp(queryScalarText(db,
+            "SELECT from_c FROM dolt_diff_s WHERE diff_type='modified'"),
+            "c1")==0);
+
+  /* Drifted schema: the from side cannot be mapped and cannot fall back,
+  ** so the read fails instead of mislabeling the dropped column's value. */
+  check("side_fn_setup_drift", execSql(db,
+      "CREATE TABLE t(a TEXT CHECK(side_ok(a)), pk TEXT PRIMARY KEY, c TEXT);"
+      "INSERT INTO t VALUES('a1','k1','c1');"
+      "SELECT dolt_commit('-Am','base_t');"
+      "ALTER TABLE t DROP COLUMN a;"
+      "UPDATE t SET c='c2';"
+      "SELECT dolt_commit('-Am','drop_a');")==SQLITE_OK);
+  check("side_fn_drift_read_fails",
+        execSqlSilent(db,
+            "SELECT from_c FROM dolt_diff_t WHERE diff_type='modified'")
+        !=SQLITE_OK);
+
+  sqlite3_close(db);
+  removeDbFiles(dbpath);
+}
+
 /* A single-column PRIMARY KEY named "rowid" keeps stock rowid-table form
 ** instead of the usual conversion to WITHOUT ROWID storage. sqlite-vec
 ** declares its vector-chunk shadow tables exactly this way and then writes
@@ -10734,6 +10792,7 @@ static const RegressionCase aCases[] = {
   { "incrblob_legacy_engine_write", "Incrblob Legacy Engine Write Test", run_incrblob_legacy_engine_write },
   { "incrblob_chunked_and_multihandle", "Incrblob Chunked Record And Multi-Handle Test", run_incrblob_chunked_and_multihandle },
   { "rowid_named_pk_keeps_rowid_table", "Rowid-Named PK Keeps Rowid Table Test", run_rowid_named_pk_keeps_rowid_table },
+  { "diff_side_schema_custom_function", "Diff Side Schema Custom Function Test", run_diff_side_schema_custom_function },
   { "rollback_persist_failure_ends_txn", "Rollback Persist Failure Ends Write Txn Test", run_rollback_persist_failure_ends_txn }
 };
 


### PR DESCRIPTION
## Problem

Follow-up to #2148, addressing ito's review finding there: when a side's schema failed to load, `doltliteSideColsLoad` swallowed the error and rendered that side with the vtab's declared layout — which mislabels values whenever the visited schema drifted from the live one.

## Fix

The loader now distinguishes the cases instead of treating every failure as a benign fallback:

- Store errors (NOMEM/IOERR/CORRUPT) propagate and fail the read.
- A schema row missing for a side that holds rows returns `SQLITE_CORRUPT` — a healthy catalog can't produce that state.
- A schema the scratch db cannot parse (a CHECK naming a function only the application registers — the one reachable vector, since doltlite rejects `sqlite3_create_collation` outright) falls back only when the live table's canonicalized schema hashes identically to the visited one, making the declared layout provably correct; otherwise the read fails rather than decoding records with the wrong field positions.
- A side whose table is absent at that commit stays a benign fallback, since it has nothing to render.

## Testing

New regression case registers a CHECK function and pins both behaviors: an unchanged schema still renders real values through the fallback, and a drifted one fails the read. The drift check fails on master (it silently mislabels) and passes here. Full battery 101/101; amalgamation compiles clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)