### PR TITLE
Emit views in dolt_patch and survive parens in quoted table names

### DIFF
--- a/src/doltlite_patch.c
+++ b/src/doltlite_patch.c
@@ -252,6 +252,36 @@ static int patchRootsShareKey(
   return found;
 }
 
+/* The '(' that opens a CREATE statement's definition body: the first one
+** outside any quoted identifier or string. A quoted table name may itself
+** contain parens. */
+static const char *patchSchemaBody(const char *zSql){
+  const char *z = zSql;
+  while( *z ){
+    char c = *z;
+    if( c=='"' || c=='`' || c=='\'' ){
+      z++;
+      while( *z ){
+        if( *z==c ){
+          if( z[1]==c ){ z += 2; continue; }
+          z++;
+          break;
+        }
+        z++;
+      }
+    }else if( c=='[' ){
+      z++;
+      while( *z && *z!=']' ) z++;
+      if( *z ) z++;
+    }else if( c=='(' ){
+      return z;
+    }else{
+      z++;
+    }
+  }
+  return 0;
+}
+
 static int patchIsRenamePair(
   sqlite3 *db,
   const struct TableEntry *pFrom,
@@ -264,8 +294,8 @@ static int patchIsRenamePair(
   if( pFrom->iTable!=pTo->iTable ) return 0;
   if( prollyHashCompare(&pFrom->root,&pTo->root)==0 ) return 1;
   if( !pFromSchema || !pToSchema ) return 0;
-  zFromBody = strchr(pFromSchema->zSql,'(');
-  zToBody = strchr(pToSchema->zSql,'(');
+  zFromBody = patchSchemaBody(pFromSchema->zSql);
+  zToBody = patchSchemaBody(pToSchema->zSql);
   if( !zFromBody || !zToBody || strcmp(zFromBody,zToBody)!=0 ) return 0;
   return patchRootsShareKey(db,pFrom,pTo);
 }
@@ -517,6 +547,61 @@ static int patchAppendObjectDiffs(
   return SQLITE_OK;
 }
 
+/* Views never appear in the table walk: a view's tbl_name is the view
+** itself. Diff them by name against the other side's schema rows. Drops
+** run before any table statement so a view freeing its name (say for a
+** table that replaces it) is gone in time; creates run last, after every
+** table and trigger has reached its target state, since a view may
+** reference any of them. */
+static int patchAppendViewDrops(
+  PatchCursor *pCur, const char *zFilter,
+  SchemaEntry *aFrom, int nFrom,
+  SchemaEntry *aTo, int nTo,
+  int *pFound
+){
+  int i, rc;
+  for(i=0; i<nFrom; i++){
+    SchemaEntry *p = &aFrom[i];
+    SchemaEntry *q;
+    if( !p->zType || sqlite3_stricmp(p->zType,"view")!=0 ) continue;
+    if( !p->zName || !p->zSql ) continue;
+    if( zFilter && sqlite3_stricmp(zFilter,p->zName)!=0 ) continue;
+    q = findSchemaEntry(aTo, nTo, p->zName);
+    if( !q || !q->zSql || strcmp(p->zSql,q->zSql)!=0 ){
+      char *zSql = sqlite3_mprintf("DROP VIEW \"%w\"", p->zName);
+      if( !zSql ) return SQLITE_NOMEM;
+      rc = patchAppendRow(pCur, p->zName, "schema", zSql);
+      sqlite3_free(zSql);
+      if( rc!=SQLITE_OK ) return rc;
+      if( pFound ) *pFound = 1;
+    }
+  }
+  return SQLITE_OK;
+}
+
+static int patchAppendViewCreates(
+  PatchCursor *pCur, const char *zFilter,
+  SchemaEntry *aFrom, int nFrom,
+  SchemaEntry *aTo, int nTo,
+  int *pFound
+){
+  int i, rc;
+  for(i=0; i<nTo; i++){
+    SchemaEntry *p = &aTo[i];
+    SchemaEntry *q;
+    if( !p->zType || sqlite3_stricmp(p->zType,"view")!=0 ) continue;
+    if( !p->zName || !p->zSql ) continue;
+    if( zFilter && sqlite3_stricmp(zFilter,p->zName)!=0 ) continue;
+    q = findSchemaEntry(aFrom, nFrom, p->zName);
+    if( !q || !q->zSql || strcmp(p->zSql,q->zSql)!=0 ){
+      rc = patchAppendRow(pCur, p->zName, "schema", p->zSql);
+      if( rc!=SQLITE_OK ) return rc;
+      if( pFound ) *pFound = 1;
+    }
+  }
+  return SQLITE_OK;
+}
+
 static int patchAppendTargetTriggers(
   PatchCursor *pCur,
   const PatchTable *pTable,
@@ -578,7 +663,7 @@ static int patchAppendRebuild(
   int iTemp,
   int bCopyData
 ){
-  const char *zBody = strchr(pTable->pToSchema->zSql, '(');
+  const char *zBody = patchSchemaBody(pTable->pToSchema->zSql);
   sqlite3_str *pStr;
   char *zSql;
   char *zTemp = 0;
@@ -1195,6 +1280,10 @@ static int patchFilter(sqlite3_vtab_cursor *pCursor, int idxNum,
                                                &aToSchema,&nToSchema);
   if( rc==SQLITE_OK ) rc=patchBuildTables(pVtab->db,aFromSchema,nFromSchema,
       aToSchema,nToSchema,aFromTable,nFromTable,aToTable,nToTable,&aTable,&nTable);
+  if( rc==SQLITE_OK ){
+    rc=patchAppendViewDrops(pCur,zFilter,aFromSchema,nFromSchema,
+                            aToSchema,nToSchema,&found);
+  }
   for(i=0; rc==SQLITE_OK && i<nTable; i++){
     if( zFilter && (!aTable[i].zFromName
                  || sqlite3_stricmp(zFilter,aTable[i].zFromName)!=0)
@@ -1219,6 +1308,10 @@ static int patchFilter(sqlite3_vtab_cursor *pCursor, int idxNum,
     if( patchTableUnchanged(&aTable[i],aFromSchema,nFromSchema,
                             aToSchema,nToSchema) ) continue;
     rc=patchAppendTargetTriggers(pCur,&aTable[i],aToSchema,nToSchema);
+  }
+  if( rc==SQLITE_OK ){
+    rc=patchAppendViewCreates(pCur,zFilter,aFromSchema,nFromSchema,
+                              aToSchema,nToSchema,&found);
   }
   if( rc==SQLITE_OK && zFilter && !found ){
     patchSetError(&pVtab->base,"dolt_patch: table '%s' does not exist",zFilter);

--- a/test/vc_oracle_patch_test.sh
+++ b/test/vc_oracle_patch_test.sh
@@ -727,6 +727,45 @@ SELECT group_concat(pk||':'||v||':'||n,',') FROM t;
 SELECT group_concat(name,',') FROM (SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'dolt_%' ORDER BY name);
 "
 
+
+# Views are emitted as DDL (Dolt writes dolt_schemas rows instead — dialect
+# divergence): a changed view drops and recreates, a new one creates, and
+# creates run after all table statements since a view may reference any
+# table. Bidirectional apply covers the dropped-view direction too.
+apply_bidirectional view_redefine_and_add "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+CREATE VIEW v_old AS SELECT id FROM t;
+INSERT INTO t VALUES(1,'x');
+SELECT dolt_commit('-A','-m','base');
+SELECT dolt_tag('base');
+DROP VIEW v_old;
+CREATE VIEW v_old AS SELECT id, v FROM t;
+CREATE VIEW v_new AS SELECT count(*) AS n FROM t;
+SELECT dolt_commit('-A','-m','target');
+SELECT dolt_tag('target');
+" "
+SELECT group_concat(name||'='||replace(sql,' ',''),';') FROM (SELECT name, sql FROM sqlite_master WHERE type='view' ORDER BY name);
+SELECT group_concat(id||':'||v,',') FROM (SELECT * FROM t ORDER BY id);
+"
+
+# A quoted table name containing a paren must not split the CREATE body at
+# the wrong position: the rebuild's temp-table statement has to stay
+# executable SQL.
+apply_bidirectional quoted_paren_table_name "
+CREATE TABLE \"we (them)\"(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO \"we (them)\" VALUES(1,'x');
+SELECT dolt_commit('-A','-m','base');
+SELECT dolt_tag('base');
+ALTER TABLE \"we (them)\" ADD COLUMN w TEXT;
+UPDATE \"we (them)\" SET w='y';
+SELECT dolt_commit('-A','-m','target');
+SELECT dolt_tag('target');
+" "
+SELECT group_concat(id||':'||v,',') FROM (SELECT id, v FROM \"we (them)\" ORDER BY id);
+SELECT group_concat(name,',') FROM pragma_table_info('we (them)');
+SELECT replace(sql,' ','') FROM sqlite_master WHERE name='we (them)';
+"
+
 echo ""
 echo "=== dolt_patch oracle results: $pass passed, $fail failed ==="
 if [ "$fail" -gt 0 ]; then


### PR DESCRIPTION
## Problem

Two verified defects from #2151:

1. **Views were omitted entirely.** The patch pipeline walks table entries, and a view's `tbl_name` is the view itself, so redefined and new views alike produced zero statements.
2. **Quoted table names containing a paren emitted unexecutable SQL.** The CREATE-body scan used `strchr('(')`, splitting the statement inside the name — the rebuild produced `CREATE TABLE "__doltlite_patch_1"(them)"(...)`.

## Fix

- Views are diffed by name against the other side's schema rows. Drops run before any table statement (so a view freeing its name is gone in time), creates run last, after every table and trigger has reached its target state, since a view may reference any of them. Dolt writes `dolt_schemas` rows here instead; emitting DDL is the doltlite dialect.
- A quote-aware body scanner replaces the three `strchr('(')` sites, which also keeps rename-pair body comparison honest for such names.

## Testing

Two new bidirectional apply cases in `vc_oracle_patch_test.sh` (generate patch both directions, apply, fingerprint the result): view redefine+add and the paren-named table rebuild. Exactly those 4 checks fail on a master build (76/80); the suite is 80/80 with the fix. Full battery 101/101; amalgamation compiles clean.

Fixes #2151.

🤖 Generated with [Claude Code](https://claude.com/claude-code)