### PR TITLE
Count populated trailing NULL fields in diff stats

### DIFF
--- a/src/doltlite_diff_stat.c
+++ b/src/doltlite_diff_stat.c
@@ -185,6 +185,7 @@ static void dsCountChangedCells(
   for(i=0; i<pColMap->nTo; i++){
     int toRec = pColMap->aToRecTo ? pColMap->aToRecTo[i] : i;
     int fromRec = pColMap->aToRecFrom ? pColMap->aToRecFrom[i] : -1;
+    int fromType, fromOffset, toType, toOffset;
     if( fromRec<0 ){
       /* A trailing NULL is not stored, so the field may be absent from the
       ** record even though the column exists on the to side. */
@@ -192,10 +193,13 @@ static void dsCountChangedCells(
       if( toRec<toRi.nField && toRi.aType[toRec]!=0 ) nDiffer++;
       continue;
     }
-    if( toRec>=toRi.nField || fromRec>=fromRi.nField ) continue;
+    fromType = fromRec<fromRi.nField ? fromRi.aType[fromRec] : 0;
+    fromOffset = fromRec<fromRi.nField ? fromRi.aOffset[fromRec] : 0;
+    toType = toRec<toRi.nField ? toRi.aType[toRec] : 0;
+    toOffset = toRec<toRi.nField ? toRi.aOffset[toRec] : 0;
     if( !doltliteFieldValuesEqual(
-            fromRi.aType[fromRec], pFromRec, nFromRec, fromRi.aOffset[fromRec],
-            toRi.aType[toRec],     pToRec,   nToRec,   toRi.aOffset[toRec]) ){
+            fromType, pFromRec, nFromRec, fromOffset,
+            toType,   pToRec,   nToRec,   toOffset) ){
       nDiffer++;
       nModified++;
     }

--- a/test/vc_oracle_diff_stat_test.sh
+++ b/test/vc_oracle_diff_stat_test.sh
@@ -759,6 +759,24 @@ UPDATE t SET c='c1';
 SELECT dolt_add('-A'); SELECT dolt_commit('-m','add_c');
 " "HEAD~1" "HEAD"
 
+oracle_both "populate_omitted_trailing_null" "
+CREATE TABLE t(a VARCHAR(16), pk VARCHAR(16) PRIMARY KEY);
+INSERT INTO t VALUES('a1','k1');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','base');
+ALTER TABLE t ADD COLUMN c VARCHAR(16);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','add_c');
+UPDATE t SET c='x';
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','fill_c');
+" "HEAD~1" "HEAD"
+
+oracle_both "clear_to_omitted_trailing_null" "
+CREATE TABLE t(a VARCHAR(16), pk VARCHAR(16) PRIMARY KEY, c VARCHAR(16));
+INSERT INTO t VALUES('a1','k1','x');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','base');
+UPDATE t SET c=NULL;
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','clear_c');
+" "HEAD~1" "HEAD"
+
 echo ""
 echo "=== Results: $pass passed, $fail failed ==="
 if [ $fail -gt 0 ]; then


### PR DESCRIPTION
Fixes #2154

SQLite records may physically omit trailing NULL fields. `dolt_diff_stat` treated an omitted field as grounds to skip the comparison, so populating a previously NULL trailing column made the modified row disappear. Missing fields now participate as NULL serial values, using the existing value comparator.

The Dolt oracle covers both omitted-NULL-to-value and value-to-NULL transitions.

Validation:
- fail-before: 106/107 diff-stat oracle checks; the new population case failed
- pass-after: 107/107 diff-stat oracle checks
- C regression suite: 310296/310296
- native DoltLite shell suites: all 99 completed engine suites passed (aggregate parity prerequisite absent locally)
- `make lint`

Co-Authored-By: OpenAI Codex <noreply@openai.com>