### PR TITLE
Close three latent merged-scan direction guards

### DIFF
--- a/src/prolly_btree_cursor.c
+++ b/src/prolly_btree_cursor.c
@@ -369,6 +369,36 @@ static int mergeStepForward(BtCursor *pCur){
   }
   rc = materializeDeferredTreeSeek(pCur, 1);
   if( rc!=SQLITE_OK ) return rc;
+  /* Mirror of the reversal re-seek in mergeStepBackward: backward travel
+  ** onto a mut-map row leaves the tree cursor below it (or run off the
+  ** front), and a forward step does not touch the tree for a MUT row, so
+  ** the merge would re-serve tree rows the scan already passed. Re-seek the
+  ** tree to this key and put it above. */
+  if( pCur->mergeStepDir < 0
+   && pCur->mergeSrc==MERGE_SRC_MUT
+   && pCur->mmIdx>=0 && pCur->mmIdx<pCur->pMutMap->nEntries ){
+    ProllyMutMapEntry *e;
+    rc = orderedMutMapEntryAt(pCur->pMutMap, pCur->mmIdx, &e);
+    if( rc!=SQLITE_OK ) return rc;
+    {
+      int res = 0;
+      refreshCursorRoot(pCur);
+      if( pCur->curIntKey ){
+        rc = prollyCursorSeekInt(&pCur->pCur, prollyMutMapEntryIntKey(e), &res);
+      }else{
+        rc = prollyCursorSeekBlob(&pCur->pCur, e->pKey, e->nKey, &res);
+      }
+      if( rc!=SQLITE_OK ) return rc;
+      if( res<0 && prollyCursorIsValid(&pCur->pCur) ){
+        rc = prollyCursorNext(&pCur->pCur);
+        if( rc!=SQLITE_OK ) return rc;
+      }else if( res==0 ){
+        /* The tree holds this key too, so the row is on both sides and the
+        ** step below has to advance both. */
+        pCur->mergeSrc = MERGE_SRC_BOTH;
+      }
+    }
+  }
   /* A row reached by scanning backwards leaves the mut-map index at or below
   ** it, which is what a further backward step wants. Going forward instead,
   ** those entries are behind the cursor and must not be served again -- and one
@@ -548,6 +578,9 @@ static int resumeDeactivatedMergedScan(BtCursor *pCur, int dir){
   ** departed key on the next step, skipping pending rows and re-serving
   ** delete-masked ones. */
   pCur->deferredTreeSeek = 0;
+  /* The resume IS this scan's travel: a later reversal must compare
+  ** against it, not against whatever direction preceded the write. */
+  pCur->mergeStepDir = (i8)(dir>0 ? 1 : -1);
   rc = mergeScan(pCur, dir, &res);
   if( rc!=SQLITE_OK ) return rc;
   if( res ){

--- a/src/prolly_btree_cursor_seek.c
+++ b/src/prolly_btree_cursor_seek.c
@@ -624,6 +624,10 @@ static int indexMovetoCustomCollation(
   if( pEntry ){
     setCursorToMutMapEntryPhys(
         pCur, (int)(pEntry - pCur->pMutMap->aEntries));
+    /* The tree side is still wherever the last operation left it, the same
+    ** as every other mut-map landing after a moveto: a later step must
+    ** re-seek it to this key before merging or it feeds stale rows in. */
+    pCur->deferredTreeSeek = 1;
     *pRes = cmp;
     pIdxKey->eqSeen = 1;
     *pDone = 1;


### PR DESCRIPTION
## Problem

Fixes #2153 — the three LOW hardening items deferred from the BOTH-landing fix (#2139). None is reachable with today's callers, but each is one refactor away from the stale-payload bug class that fix closed.

## Fix

1. **`mergeStepForward`** gains the mirror of `mergeStepBackward`'s reversal re-seek: backward travel onto a mut-map row leaves the tree cursor below it, and a forward step doesn't move the tree for a MUT row, so the merge would re-serve rows the scan already passed.
2. **`resumeDeactivatedMergedScan`** records its own direction — the resume *is* that scan's travel, and a later reversal must compare against it, not whatever direction preceded the deactivating write.
3. **The custom-collation moveto's mut landing** arms `deferredTreeSeek` like every other mut landing after a moveto.

## Reachability

Per the issue, each fix lands with a test or documentation of why none can exist. Chasing a test for (3) established that the custom-collation moveto path is currently unreachable outright: persistent indexes reject custom collations wholesale, including rowid-table PK auto-indexes (the `collate1-6.5` intentional divergence). (1) and (2) require mid-scan direction reversals no SQL plan produces today. All three guards are additive and gated to reversal/resume paths.

## Validation

- 400-seed all-groups SQL differential sweep: 400/400 (this harness was built for the merged-cursor state space).
- Seek testfixture bucket (collate/index/where/descidx): 953 passing, all divergences known.
- `review_regression_test.sh` (stock-verified guards from #2139): 158/158.
- Full battery 101/101; amalgamation compiles clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)