### PR TITLE
Defer mutation-map position repairs

### DIFF
--- a/src/prolly_mutmap.c
+++ b/src/prolly_mutmap.c
@@ -422,12 +422,6 @@ static int ensureOrder(ProllyMutMap *mm){
   mm->preferSorted = 1;
   if( mm->keepSorted ) return SQLITE_OK;
   if( !mm->orderDirty ){
-    if( mm->posDirty ){
-      for(i=0; i<mm->nEntries; i++){
-        mm->aPos[mm->aOrder[i]] = i;
-      }
-      mm->posDirty = 0;
-    }
     return SQLITE_OK;
   }
   if( mm->appendSorted ){
@@ -514,7 +508,7 @@ static void insertOrderEntry(ProllyMutMap *mm, int idx, int phys){
             (mm->nEntries - idx) * sizeof(int));
   }
   mm->aOrder[idx] = phys;
-  if( !mm->isIntKey || shifted <= MUTMAP_POS_UPDATE_LIMIT ){
+  if( shifted <= MUTMAP_POS_UPDATE_LIMIT ){
     int i;
     for(i=idx; i<=mm->nEntries; i++){
       mm->aPos[mm->aOrder[i]] = i;
@@ -1010,7 +1004,7 @@ int prollyMutMapOrderIndexFromEntry(ProllyMutMap *mm, ProllyMutMapEntry *pEntry)
   assert( mm->aEntries!=0 );
   phys = (int)(pEntry - mm->aEntries);
   assert( phys>=0 && phys<mm->nEntries );
-  if( mm->keepSorted ){
+  if( mm->keepSorted || (!mm->orderDirty && mm->posDirty) ){
     int found = 0;
     int idx = bsearch_key(mm, pEntry->pKey, pEntry->nKey, &found);
     return found ? idx : mm->nEntries;
@@ -1018,8 +1012,6 @@ int prollyMutMapOrderIndexFromEntry(ProllyMutMap *mm, ProllyMutMapEntry *pEntry)
   if( !mm->keepSorted && mm->orderDirty ){
     return rankEntryWithoutOrder(mm, phys);
   }
-  /* Both branches that can fail returned above, so this only refreshes aPos. */
-  ensureOrder(mm);
   return mm->aPos[phys];
 }
 

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -8213,11 +8213,14 @@ static void run_mutmap_delete_reinsert_reuses_entry(void){
 static void run_mutmap_append_sorted_order(void){
   ProllyMutMap mm;
   ProllyMutMapIter it;
+  ProllyMutMapEntry *pEntry;
   static const u8 aVal[] = { 1 };
   static const u8 aKey1[] = { 'a', 'a' };
   static const u8 aKey2[] = { 'b', 'b' };
   static const u8 aKey3[] = { 'c', 'c' };
   static const u8 aKey0[] = { '0', '0' };
+  char zKey[8];
+  int i;
 
   printf("=== MutMap Append Sorted Order Test ===\n\n");
   check("mutmap_append_sorted_init",
@@ -8248,6 +8251,31 @@ static void run_mutmap_append_sorted_order(void){
         prollyMutMapInsert(&mm, aKey0, sizeof(aKey0), 0,
                            aVal, sizeof(aVal))==SQLITE_OK);
   check("mutmap_append_unsorted_flag_clears", !mm.appendSorted);
+  prollyMutMapFree(&mm);
+
+  check("mutmap_blob_deferred_pos_init",
+        prollyMutMapInitMode(&mm, 0, 0)==SQLITE_OK);
+  for(i=1; i<=100; i++){
+    sqlite3_snprintf(sizeof(zKey), zKey, "%04d", i);
+    check("mutmap_blob_deferred_pos_insert",
+          prollyMutMapInsert(&mm, (u8*)zKey, 4, 0,
+                             aVal, sizeof(aVal))==SQLITE_OK);
+  }
+  check("mutmap_blob_deferred_pos_order",
+        prollyMutMapEnsureOrder(&mm)==SQLITE_OK);
+  sqlite3_snprintf(sizeof(zKey), zKey, "%04d", 0);
+  check("mutmap_blob_deferred_pos_prepend",
+        prollyMutMapInsert(&mm, (u8*)zKey, 4, 0,
+                           aVal, sizeof(aVal))==SQLITE_OK);
+  sqlite3_snprintf(sizeof(zKey), zKey, "%04d", 50);
+  check("mutmap_blob_deferred_pos_find",
+        prollyMutMapFindRc(&mm, (u8*)zKey, 4, 0, &pEntry)==SQLITE_OK
+     && pEntry!=0);
+  check("mutmap_blob_deferred_pos_rank",
+        pEntry!=0 && prollyMutMapOrderIndexFromEntry(&mm, pEntry)==50);
+  check("mutmap_blob_deferred_pos_entry",
+        prollyMutMapEntryAt(&mm, 50, &pEntry)==SQLITE_OK
+     && memcmp(pEntry->pKey, zKey, 4)==0);
   prollyMutMapFree(&mm);
 }
 


### PR DESCRIPTION
## Summary

- keep sorted mutation-map order usable while its inverse position array is dirty
- use binary search for the uncommon entry-to-rank lookup instead of repairing every shifted position
- cover blob-key maps after a large ordered insertion

This removes quadratic auxiliary-position maintenance from write transactions with text, blob, composite, and secondary-index keys. It does not change the storage format, prolly nodes, hashes, or write semantics.

## Performance

Measured against the exact pre-change `master` binary at 100,000 rows with alternating paired runs. Median paired candidate/baseline ratios (lower is better):

| Workload | Memory | File-backed |
|---|---:|---:|
| integer update-index | 0.994 | 0.993 |
| text update-index | 0.938 | 0.966 |
| blob update-non-index | 0.865 | 0.889 |
| composite update-index | 0.911 | 0.915 |
| composite write-only (#2161) | 0.979 | 0.987 |

The broader five-pair matrix also improved delete/insert by 3-4% for text, blob, and composite keys. Integer-key workloads were neutral; no read-path behavior changes.

The historical #2161 master-to-master slowdown did not reproduce locally: current master was 0.7% faster than the earlier nightly commit over 15 paired runs. This PR addresses a write-path hotspot found while profiling the reported workload rather than reverting recent changes.

## Validation

- `make lint`
- `build/doltlite_regression_test_c all` (310,402 passed)
- targeted mutation-map regression tests (6,687 passed)

Fixes #2161

Co-Authored-By: OpenAI Codex <noreply@openai.com>