### PR TITLE
Keep remote clients in the amalgamation

### DIFF
--- a/doltlite.mk
+++ b/doltlite.mk
@@ -91,15 +91,11 @@ ifeq ($(DOLTLITE_PROLLY),1)
   # new source added to src/ is picked up automatically. A missed entry
   # used to leave the generated engine quietly short a file.
   #
-  # Remote transport is linked into native builds, not the single-file
-  # library.
+  # Credential/TLS and the remote server stay in the native build. The
+  # amalgamation retains the unauthenticated client and remote SQL surface.
   DOLTLITE_TSRC_EXCLUDE = \
-    $(TOP)/src/doltlite_creds.c $(TOP)/src/doltlite_creds.h \
+    $(TOP)/src/doltlite_creds.c \
     $(TOP)/src/doltlite_tls.c $(TOP)/src/doltlite_tls.h \
-    $(TOP)/src/doltlite_net.h \
-    $(TOP)/src/doltlite_remote.c $(TOP)/src/doltlite_remote.h \
-    $(TOP)/src/doltlite_remote_sql.c \
-    $(TOP)/src/doltlite_http_remote.c \
     $(TOP)/src/doltlite_remotesrv.c $(TOP)/src/doltlite_remotesrv.h
   # Files the amalgamation needs that do not match those patterns.
   DOLTLITE_EXTRA_TSRC = \

--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -19,9 +19,7 @@ extern int doltliteAncestorRegister(sqlite3 *db);
 extern int doltliteRegisterBlameTables(sqlite3 *db);
 extern int doltliteSchemaDiffRegister(sqlite3 *db);
 extern int doltlitePatchRegister(sqlite3 *db);
-#ifndef SQLITE_AMALGAMATION
 extern int doltliteRemoteSqlRegister(sqlite3 *db);
-#endif
 extern int doltliteHashofRegister(sqlite3 *db);
 extern int doltliteConstraintViolationsRegister(sqlite3 *db);
 extern int doltliteVerifyConstraintsRegister(sqlite3 *db);
@@ -53,9 +51,7 @@ int doltliteRegister(sqlite3 *db){
   if( (rc = doltlitePatchRegister(db))!=SQLITE_OK ) return rc;
   if( (rc = doltliteSchemasRegister(db))!=SQLITE_OK ) return rc;
   if( (rc = doltliteDiffStatRegister(db))!=SQLITE_OK ) return rc;
-#ifndef SQLITE_AMALGAMATION
   if( (rc = doltliteRemoteSqlRegister(db))!=SQLITE_OK ) return rc;
-#endif
   if( (rc = doltliteHashofRegister(db))!=SQLITE_OK ) return rc;
   if( (rc = doltliteConstraintViolationsRegister(db))!=SQLITE_OK ) return rc;
   if( (rc = doltliteVerifyConstraintsRegister(db))!=SQLITE_OK ) return rc;

--- a/src/doltlite_net.h
+++ b/src/doltlite_net.h
@@ -1,8 +1,8 @@
 #ifndef DOLTLITE_NET_H
 #define DOLTLITE_NET_H
 
-#include <errno.h>
-#include <string.h>
+#include <errno.h> /* amalgamator: keep */
+#include <string.h> /* amalgamator: keep */
 
 /* Thin cross-platform socket shim shared by doltlite_tls.c and
  * doltlite_remotesrv.c. Socket handles are kept as int to match
@@ -10,9 +10,9 @@
 
 #ifdef _WIN32
 
-#include <winsock2.h>
-#include <ws2tcpip.h>
-#include <windows.h>
+#include <winsock2.h> /* amalgamator: keep */
+#include <ws2tcpip.h> /* amalgamator: keep */
+#include <windows.h> /* amalgamator: keep */
 
 typedef WSAPOLLFD doltlite_pollfd;
 #define doltliteCloseSocket closesocket
@@ -45,15 +45,15 @@ static inline int doltliteNetInit(void) {
 
 #else
 
-#include <sys/socket.h>
-#include <netinet/in.h>
-#include <arpa/inet.h>
-#include <netdb.h>
-#include <fcntl.h>
-#include <poll.h>
-#include <sys/time.h>
-#include <time.h>
-#include <unistd.h>
+#include <sys/socket.h> /* amalgamator: keep */
+#include <netinet/in.h> /* amalgamator: keep */
+#include <arpa/inet.h> /* amalgamator: keep */
+#include <netdb.h> /* amalgamator: keep */
+#include <fcntl.h> /* amalgamator: keep */
+#include <poll.h> /* amalgamator: keep */
+#include <sys/time.h> /* amalgamator: keep */
+#include <time.h> /* amalgamator: keep */
+#include <unistd.h> /* amalgamator: keep */
 
 typedef struct pollfd doltlite_pollfd;
 #define doltliteCloseSocket close

--- a/test/amalgamation_http_probe.c
+++ b/test/amalgamation_http_probe.c
@@ -35,20 +35,26 @@ static int scalar_int(sqlite3 *db, const char *zSql, int *pVal){
 
 int main(int argc, char **argv){
   sqlite3 *db = 0;
-  sqlite3_stmt *pStmt = 0;
   int n = 0;
+  char *zSql;
+  const char *zSrc;
+  const char *zClone;
+  const char *zUrl;
 
-  if( argc!=2 ){
-    fprintf(stderr, "usage: %s DB\n", argv[0]);
+  if( argc!=4 ){
+    fprintf(stderr, "usage: %s SRC_DB CLONE_DB HTTP_URL\n", argv[0]);
     return 1;
   }
+  zSrc = argv[1];
+  zClone = argv[2];
+  zUrl = argv[3];
 
   if( doltliteInstallAutoExt()!=SQLITE_OK ){
     fprintf(stderr, "doltliteInstallAutoExt failed\n");
     return 1;
   }
 
-  if( sqlite3_open(argv[1], &db)!=SQLITE_OK ){
+  if( sqlite3_open(zSrc, &db)!=SQLITE_OK ){
     fprintf(stderr, "%s\n", db ? sqlite3_errmsg(db) : "sqlite3_open failed");
     return 1;
   }
@@ -60,13 +66,28 @@ int main(int argc, char **argv){
     sqlite3_close(db);
     return 1;
   }
-  if( sqlite3_prepare_v2(db, "SELECT dolt_remote('add','x','file:///x')",
-                         -1, &pStmt, 0)==SQLITE_OK ){
-    fprintf(stderr, "remote SQL is present in the amalgamation\n");
-    sqlite3_finalize(pStmt);
+  zSql = sqlite3_mprintf(
+      "SELECT dolt_remote('add','origin',%Q);"
+      "SELECT dolt_push('origin','main');", zUrl);
+  if( !zSql || exec_sql(db, zSql) ){
+    sqlite3_free(zSql);
     sqlite3_close(db);
     return 1;
   }
+  sqlite3_free(zSql);
+  sqlite3_close(db);
+
+  if( sqlite3_open(zClone, &db)!=SQLITE_OK ){
+    fprintf(stderr, "%s\n", db ? sqlite3_errmsg(db) : "sqlite3_open failed");
+    return 1;
+  }
+  zSql = sqlite3_mprintf("SELECT dolt_clone(%Q);", zUrl);
+  if( !zSql || exec_sql(db, zSql) ){
+    sqlite3_free(zSql);
+    sqlite3_close(db);
+    return 1;
+  }
+  sqlite3_free(zSql);
   if( scalar_int(db, "SELECT count(*) FROM users;", &n) ){
     sqlite3_close(db);
     return 1;
@@ -74,7 +95,37 @@ int main(int argc, char **argv){
   sqlite3_close(db);
 
   if( n!=3 ){
-    fprintf(stderr, "expected 3 users, got %d\n", n);
+    fprintf(stderr, "expected 3 cloned users, got %d\n", n);
+    return 1;
+  }
+
+  if( sqlite3_open(zSrc, &db)!=SQLITE_OK ){
+    fprintf(stderr, "%s\n", db ? sqlite3_errmsg(db) : "sqlite3_open failed");
+    return 1;
+  }
+  if( exec_sql(db,
+        "INSERT INTO users VALUES(4,'dora');"
+        "SELECT dolt_add('-A');"
+        "SELECT dolt_commit('-m','second');"
+        "SELECT dolt_push('origin','main');") ){
+    sqlite3_close(db);
+    return 1;
+  }
+  sqlite3_close(db);
+
+  if( sqlite3_open(zClone, &db)!=SQLITE_OK ){
+    fprintf(stderr, "%s\n", db ? sqlite3_errmsg(db) : "sqlite3_open failed");
+    return 1;
+  }
+  if( exec_sql(db, "SELECT dolt_pull('origin','main');")
+   || scalar_int(db, "SELECT count(*) FROM users;", &n) ){
+    sqlite3_close(db);
+    return 1;
+  }
+  sqlite3_close(db);
+
+  if( n!=4 ){
+    fprintf(stderr, "expected 4 users after pull, got %d\n", n);
     return 1;
   }
   return 0;

--- a/test/amalgamation_http_remote_test.sh
+++ b/test/amalgamation_http_remote_test.sh
@@ -5,20 +5,38 @@ build_dir="${1:-.}"
 cd "$build_dir"
 
 cc_bin="${CC:-cc}"
+remotesrv="${REMOTESRV:-./doltlite-remotesrv}"
 if [ ! -f ./sqlite3.c ] || [ ! -f ./sqlite3.h ]; then
   echo "SKIP: sqlite3.c/sqlite3.h not found in $PWD"
   exit 0
 fi
-tmp="$(mktemp -d "${TMPDIR:-/tmp}/doltlite-amalg-local.XXXXXX")"
+if [ ! -x "$remotesrv" ]; then
+  echo "SKIP: doltlite-remotesrv not found at $remotesrv"
+  exit 0
+fi
+
+tmp="$(mktemp -d "${TMPDIR:-/tmp}/doltlite-amalg-http.XXXXXX")"
+srv_pid=""
 cleanup() {
+  if [ -n "$srv_pid" ]; then
+    kill "$srv_pid" 2>/dev/null || true
+    wait "$srv_pid" 2>/dev/null || true
+    srv_pid=""
+  fi
   rm -rf "$tmp"
 }
 trap cleanup EXIT
 
-if grep -Eq 'Begin file doltlite_(remote|remote_sql|http_remote|remotesrv)\.c|DoltliteRemote|doltliteServe' ./sqlite3.c; then
-  echo "FAIL: remote implementation present in amalgamation"
+if grep -Eq 'Begin file doltlite_remotesrv\.c|doltliteServe' ./sqlite3.c; then
+  echo "FAIL: remote server implementation present in amalgamation"
   exit 1
 fi
+for source in doltlite_remote.c doltlite_remote_sql.c doltlite_http_remote.c; do
+  if ! grep -q "Begin file $source" ./sqlite3.c; then
+    echo "FAIL: remote client source missing from amalgamation: $source"
+    exit 1
+  fi
+done
 
 probe_libs=(-lz -lpthread -lm)
 case "$(uname -s)" in
@@ -33,9 +51,25 @@ if [ -z "$probe" ]; then
     ./sqlite3.c "${probe_libs[@]}" -o "$probe"
 fi
 if [ ! -x "$probe" ]; then
-  echo "FAIL: amalgamation local probe not found at $probe"
+  echo "FAIL: amalgamation HTTP probe not found at $probe"
   exit 1
 fi
 
-"$probe" "$tmp/local.db"
-echo "amalgamation excludes remote implementation: PASS"
+mkdir -p "$tmp/srv"
+"$remotesrv" -p 0 --bind 127.0.0.1 "$tmp/srv" >"$tmp/srv.log" 2>&1 &
+srv_pid=$!
+
+port=""
+for _ in $(seq 1 50); do
+  port="$(sed -n 's#.*://127.0.0.1:\([0-9][0-9]*\).*#\1#p' "$tmp/srv.log" | head -1)"
+  [ -n "$port" ] && break
+  sleep 0.1
+done
+if [ -z "$port" ]; then
+  echo "FAIL: server did not start"
+  cat "$tmp/srv.log"
+  exit 1
+fi
+
+"$probe" "$tmp/src.db" "$tmp/clone.db" "http://127.0.0.1:$port/repo.db"
+echo "amalgamation remote client without server implementation: PASS"

--- a/test/amalgamation_windows_source_test.sh
+++ b/test/amalgamation_windows_source_test.sh
@@ -8,8 +8,20 @@ if [ ! -f "$amalgamation" ]; then
   exit 1
 fi
 
-if grep -Eq '^# *include <(winsock2|ws2tcpip)\.h>' "$amalgamation"; then
-  echo "FAIL: remote networking headers present in $amalgamation"
+if grep -Eq 'Begin file doltlite_remotesrv\.c|doltliteServe' "$amalgamation"; then
+  echo "FAIL: remote server implementation present in $amalgamation"
+  exit 1
+fi
+
+winsock_line="$(grep -n -m1 '^# *include <winsock2.h>' "$amalgamation" | cut -d: -f1 || true)"
+windows_line="$(grep -n -m1 '^# *include [<\"]windows.h[>\"]' "$amalgamation" | cut -d: -f1 || true)"
+
+if [ -z "$winsock_line" ] || [ -z "$windows_line" ]; then
+  echo "FAIL: expected winsock2.h and windows.h includes in $amalgamation"
+  exit 1
+fi
+if [ "$winsock_line" -ge "$windows_line" ]; then
+  echo "FAIL: winsock2.h must precede windows.h in $amalgamation"
   exit 1
 fi
 

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -1462,12 +1462,11 @@ attach2 attach2-4.15 class=intentional issue=1846  # PRAGMA lock_status: doltlit
 # paths, shifting OOM fault indices (same #1859 brittleness as backup_malloc).
 # vec1's built-in registration adds ~25 allocations at connection open,
 # shifting every entry by +25.
-attachmalloc attachmalloc-1.transient.478 @coverage class=unsupported issue=1839  # OOM fault-point shift (parent probe)
-attachmalloc attachmalloc-1.transient.490 @no-coverage class=unsupported issue=1839  # OOM fault-point shift (parent probe)
+attachmalloc attachmalloc-1.transient.490 class=unsupported issue=1839  # OOM fault-point shift (parent probe)
 attachmalloc attachmalloc-1.transient.916 @no-coverage class=unsupported issue=1839  # OOM fault-point shift (ATTACH seed)
 attachmalloc attachmalloc-1.transient.1411 @no-coverage class=unsupported issue=1839  # OOM fault-point shift (ATTACH seed)
-attachmalloc attachmalloc-1.transient.911 @coverage class=unsupported issue=1839  # OOM fault-point shift (ATTACH seed)
-attachmalloc attachmalloc-1.transient.1413 @coverage class=unsupported issue=1839  # OOM fault-point shift (ATTACH seed)
+attachmalloc attachmalloc-1.transient.923 @coverage class=unsupported issue=1839  # OOM fault-point shift (ATTACH seed)
+attachmalloc attachmalloc-1.transient.1425 @coverage class=unsupported issue=1839  # OOM fault-point shift (ATTACH seed)
 mallocD mallocD-4.transient.107 class=unsupported issue=1839  # OOM fault-point shift (parent probe)
 
 # temptable2 section 8 — page_count is a chunk-store metric, not SQLite

--- a/test/known_testfixture_exception_ratchet.txt
+++ b/test/known_testfixture_exception_ratchet.txt
@@ -6,8 +6,8 @@
 # Counts are per gate -- one divergent assertion, or one expected crash.
 # Lowering a number is the point. Raising one is a deliberate act that belongs
 # in a PR description.
-gates 4848
+gates 4847
 intentional 3548
-unsupported 1224
+unsupported 1223
 harness 11
 engine-gap 65

--- a/tool/mksqlite3c.tcl
+++ b/tool/mksqlite3c.tcl
@@ -166,6 +166,12 @@ if {$doltlite} {
 #endif
 #ifndef DOLTLITE_VERSION
 # define DOLTLITE_VERSION "doltlite-amalgamation"
+#endif
+
+/* winsock2.h must precede SQLite's first windows.h include. */
+#ifdef _WIN32
+# include <winsock2.h>
+# include <ws2tcpip.h>
 #endif}
 }
 
@@ -242,7 +248,8 @@ if {$doltlite} {
     doltlite_constraint_violations.h doltlite_ignore.h doltlite_internal.h
     doltlite_branch_int.h doltlite_merge_int.h doltlite_merge_constraints_int.h
     doltlite_name_index.h doltlite_parse.h
-    doltlite_record.h doltlite_vtab_util.h
+    doltlite_record.h doltlite_remote.h doltlite_vtab_util.h
+    doltlite_creds.h doltlite_net.h
   } {
     set available_hdr($hdr) 1
   }
@@ -629,7 +636,8 @@ proc emit_doltlite_engine_block {} {
     doltlite_history.c doltlite_at.c doltlite_blame.c doltlite_schema_diff.c doltlite_patch.c
     doltlite_schemas.c doltlite_diff_stat.c doltlite_record.c doltlite_ignore.c
     doltlite_hashof.c doltlite_constraint_violations.c doltlite_verify_constraints.c doltlite_merge_constraints.c doltlite_merge_constraints_unique.c doltlite_merge_constraints_check.c doltlite_merge_constraints_fk.c doltlite_merge_constraints_notnull.c doltlite_merge_constraints_strict.c
-    doltlite_dbpage.c
+    doltlite_dbpage.c doltlite_remote.c doltlite_remote_sql.c
+    doltlite_http_remote.c
   }
   foreach f $doltlite_emitted {
     copy_file $srcdir/$f


### PR DESCRIPTION
## Summary

- restore `dolt_remote`, `dolt_push`, `dolt_fetch`, `dolt_pull`, `dolt_clone`, and `dolt_remotes` to the DoltLite amalgamation
- include the filesystem and plaintext HTTP client implementations
- continue excluding `doltlite_remotesrv.c` and the native credential/TLS implementation
- preserve socket headers needed by `SQLITE_OS_OTHER` and put Winsock 2 before `windows.h`

## Validation

- amalgamation client pushed over HTTP, cloned, advanced the remote, and pulled the new commit
- generated amalgamation contains all three client source units and no server implementation
- wa-sqlite-shaped Emscripten compile passes with `SQLITE_WASM`, `SQLITE_OS_OTHER=1`, and `SQLITE_THREADSAFE=0`
- Windows amalgamation source invariants pass
- `test/assert_doltlite_artifacts.sh build`
- `make lint`

Co-Authored-By: OpenAI Codex <noreply@openai.com>