### PR TITLE
Match Dolt JWT aud and require remotesrv audience

### DIFF
--- a/AUTH.md
+++ b/AUTH.md
@@ -23,6 +23,10 @@ The audience normally equals the remote host. A
 `doltliteremoteapi.<suffix>` host uses `doltremoteapi.<suffix>` to match
 DoltHub's existing audience. `DOLT_OVERRIDE_GRPC_JWT_AUDIENCE` overrides both.
 
+`doltlite-remotesrv --auth-keys` requires `--audience`. Verification accepts
+either a string `aud` or a Dolt-shaped one-element (or multi-element) array
+and rejects a missing audience rather than treating it as "any".
+
 ## Credential interface
 
 Credentials use a separate `~/.doltlite/creds/` store rather than

--- a/README.md
+++ b/README.md
@@ -615,7 +615,7 @@ SELECT dolt_clone('http://myserver:8080/mydb.db');
 > [!WARNING]
 > The server binds to `127.0.0.1` by default. Bound anywhere else, it warns at
 > startup about each protection left unconfigured: `--cert`/`--key` for TLS, and
-> `--auth-keys` for authentication. These are independent — TLS encrypts but does
+> `--auth-keys` plus `--audience` for authentication. These are independent — TLS encrypts but does
 > not authenticate, and without `--auth-keys` every client that can reach the port
 > may read the served databases *and push to them*. Configure both, or place the
 > server behind a reverse proxy that provides equivalent TLS and authentication.

--- a/src/doltlite_creds.c
+++ b/src/doltlite_creds.c
@@ -257,6 +257,9 @@ int doltliteCredsBearerTokenAt(const DoltliteCreds *c, const char *audience,
   int rc = 1;
   size_t hn, cn, need;
 
+  if( !c || !audience || !audience[0] || !jwtOut ) return 1;
+  *jwtOut = 0;
+
   kid = doltliteCredsKid(c);
   if (!kid) goto done;
 
@@ -267,11 +270,11 @@ int doltliteCredsBearerTokenAt(const DoltliteCreds *c, const char *audience,
            "{\"alg\":\"EdDSA\",\"kid\":\"%s\",\"dolt_token_version\":\"%s\"}",
            kid, JWT_TOKEN_VERSION);
 
-  cn = strlen(kid) + strlen(audience) + 160;
+  cn = strlen(kid) + strlen(audience) + 164;
   claims = (char *)sqlite3_malloc(cn);
   if (!claims) goto done;
   snprintf(claims, cn,
-           "{\"iss\":\"%s\",\"sub\":\"%s%s\",\"aud\":\"%s\",\"iat\":%ld,\"exp\":%ld}",
+           "{\"iss\":\"%s\",\"sub\":\"%s%s\",\"aud\":[\"%s\"],\"iat\":%ld,\"exp\":%ld}",
            JWT_ISSUER, JWT_SUBJECT_PREFIX, kid, audience, iat,
            iat + JWT_TTL_SECONDS);
 
@@ -332,58 +335,150 @@ char *doltliteCredsToJwk(const DoltliteCreds *c) {
   return json;
 }
 
-static char *jsonFindString(const char *json, const char *key) {
-  size_t keylen = strlen(key);
-  const char *p = json;
-  while ((p = strchr(p, '"')) != NULL) {
-    const char *kstart = p + 1;
-    if (strncmp(kstart, key, keylen) == 0 && kstart[keylen] == '"') {
-      const char *q = kstart + keylen + 1;
-      const char *vend;
-      while (*q == ' ' || *q == ':' || *q == '\t') q++;
-      if (*q != '"') return NULL;
-      q++;
-      vend = strchr(q, '"');
-      if (!vend) return NULL;
-      {
-        size_t vlen = (size_t)(vend - q);
-        char *v = (char *)sqlite3_malloc(vlen + 1);
-        if (!v) return NULL;
-        memcpy(v, q, vlen);
-        v[vlen] = '\0';
-        return v;
-      }
+static const char *jsonSkipWs(const char *p){
+  while( p && (*p==' ' || *p=='\t' || *p=='\r' || *p=='\n') ) p++;
+  return p;
+}
+
+static const char *jsonSkipString(const char *p){
+  if( !p || *p!='"' ) return 0;
+  p++;
+  while( *p && *p!='"' ){
+    if( *p=='\\' ){
+      p++;
+      if( !*p ) return 0;
     }
-    p = kstart;
+    p++;
   }
-  return NULL;
+  return *p=='"' ? p+1 : 0;
+}
+
+static const char *jsonSkipValue(const char *p){
+  p = jsonSkipWs(p);
+  if( !p || !*p ) return 0;
+  if( *p=='"' ) return jsonSkipString(p);
+  if( *p=='{' || *p=='[' ){
+    char open = *p;
+    char close = (open=='{') ? '}' : ']';
+    int depth = 1;
+    p++;
+    while( *p && depth ){
+      if( *p=='"' ){
+        p = jsonSkipString(p);
+        if( !p ) return 0;
+        continue;
+      }
+      if( *p==open ) depth++;
+      else if( *p==close ) depth--;
+      p++;
+    }
+    return depth ? 0 : p;
+  }
+  while( *p && *p!=',' && *p!='}' && *p!=']' ) p++;
+  return p;
+}
+
+static const char *jsonObjectValue(const char *json, const char *key){
+  const char *p;
+  size_t keylen;
+  if( !json || !key ) return 0;
+  keylen = strlen(key);
+  p = jsonSkipWs(json);
+  if( *p!='{' ) return 0;
+  p++;
+  for(;;){
+    const char *kstart;
+    const char *kend;
+    p = jsonSkipWs(p);
+    if( *p=='}' ) return 0;
+    if( *p!='"' ) return 0;
+    kstart = p+1;
+    p = jsonSkipString(p);
+    if( !p ) return 0;
+    kend = p-1;
+    p = jsonSkipWs(p);
+    if( *p!=':' ) return 0;
+    p = jsonSkipWs(p+1);
+    if( (size_t)(kend-kstart)==keylen && memcmp(kstart, key, keylen)==0 ){
+      return p;
+    }
+    p = jsonSkipValue(p);
+    if( !p ) return 0;
+    p = jsonSkipWs(p);
+    if( *p==',' ){ p++; continue; }
+    return 0;
+  }
+}
+
+static char *jsonDupQuoted(const char *p){
+  const char *end;
+  const char *s;
+  char *out;
+  size_t cap;
+  size_t o = 0;
+  if( !p || *p!='"' ) return 0;
+  end = jsonSkipString(p);
+  if( !end ) return 0;
+  cap = (size_t)(end - p);
+  if( cap>(size_t)0x7fffffff ) return 0;
+  out = (char*)sqlite3_malloc((int)cap);
+  if( !out ) return 0;
+  for(s=p+1; s<end-1; s++){
+    if( *s=='\\' && s+1<end-1 ) s++;
+    out[o++] = *s;
+  }
+  out[o] = 0;
+  return out;
+}
+
+static char *jsonFindString(const char *json, const char *key) {
+  return jsonDupQuoted(jsonObjectValue(json, key));
 }
 
 static int jsonFindLong(const char *json, const char *key, long *out) {
-  size_t keylen = strlen(key);
-  const char *p = json;
-  while ((p = strchr(p, '"')) != NULL) {
-    const char *kstart = p + 1;
-    if (strncmp(kstart, key, keylen) == 0 && kstart[keylen] == '"') {
-      const char *q = kstart + keylen + 1;
-      const char *end;
-      uint64_t v;
-      while (*q == ' ' || *q == ':' || *q == '\t') q++;
-      end = q;
-      while (*end >= '0' && *end <= '9') end++;
-      if (doltliteParseDecimal(q, end, LONG_MAX, &v) !=
-          DOLTLITE_DECIMAL_OK) {
-        return 0;
-      }
-      q = end;
-      while (*q == ' ' || *q == '\t' || *q == '\r' || *q == '\n') q++;
-      if (*q != ',' && *q != '}') return 0;
-      *out = (long)v;
+  const char *p = jsonObjectValue(json, key);
+  const char *end;
+  uint64_t v;
+  if( !p || !out ) return 0;
+  end = p;
+  while( *end>='0' && *end<='9' ) end++;
+  if( doltliteParseDecimal(p, end, LONG_MAX, &v)!=DOLTLITE_DECIMAL_OK ){
+    return 0;
+  }
+  end = jsonSkipWs(end);
+  if( *end!=',' && *end!='}' ) return 0;
+  *out = (long)v;
+  return 1;
+}
+
+static int jsonAudienceMatches(const char *json, const char *expected){
+  const char *p = jsonObjectValue(json, "aud");
+  if( !p || !expected || !expected[0] ) return 0;
+  if( *p=='"' ){
+    char *s = jsonDupQuoted(p);
+    int ok = s && strcmp(s, expected)==0;
+    sqlite3_free(s);
+    return ok;
+  }
+  if( *p!='[' ) return 0;
+  p++;
+  for(;;){
+    char *s;
+    p = jsonSkipWs(p);
+    if( *p==']' ) return 0;
+    if( *p!='"' ) return 0;
+    s = jsonDupQuoted(p);
+    if( s && strcmp(s, expected)==0 ){
+      sqlite3_free(s);
       return 1;
     }
-    p = kstart;
+    sqlite3_free(s);
+    p = jsonSkipString(p);
+    if( !p ) return 0;
+    p = jsonSkipWs(p);
+    if( *p==',' ){ p++; continue; }
+    return 0;
   }
-  return 0;
 }
 
 static char *decodeSegZ(const char *seg, size_t seglen) {
@@ -839,7 +934,7 @@ int doltliteCredsVerifyBearer(const char *authValue, const char *expectedAudienc
   const char *dot1, *dot2;
   char *hdr = NULL, *claims = NULL;
   char *alg = NULL, *ver = NULL, *kid = NULL;
-  char *iss = NULL, *sub = NULL, *aud = NULL, *expectSub = NULL;
+  char *iss = NULL, *sub = NULL, *expectSub = NULL;
   char *sigStr = NULL;
   unsigned char *sig = NULL;
   size_t siglen = 0;
@@ -849,6 +944,7 @@ int doltliteCredsVerifyBearer(const char *authValue, const char *expectedAudienc
 
   if (kidOut) *kidOut = NULL;
   if (!authValue) return 1;
+  if (!expectedAudience || !expectedAudience[0]) return 1;
 
   jwt = authValue;
   if (strncmp(jwt, "Bearer ", 7) == 0) jwt += 7;
@@ -883,7 +979,6 @@ int doltliteCredsVerifyBearer(const char *authValue, const char *expectedAudienc
 
   iss = jsonFindString(claims, "iss");
   sub = jsonFindString(claims, "sub");
-  aud = jsonFindString(claims, "aud");
   if (!iss || strcmp(iss, JWT_ISSUER_EXPECTED) != 0) goto done;
 
   expectSub = (char *)sqlite3_malloc(strlen(JWT_SUBJECT_PREFIX_V) + strlen(kid) + 1);
@@ -892,9 +987,7 @@ int doltliteCredsVerifyBearer(const char *authValue, const char *expectedAudienc
   strcat(expectSub, kid);
   if (!sub || strcmp(sub, expectSub) != 0) goto done;
 
-  if (expectedAudience && *expectedAudience) {
-    if (!aud || strcmp(aud, expectedAudience) != 0) goto done;
-  }
+  if (!jsonAudienceMatches(claims, expectedAudience)) goto done;
 
   if (!jsonFindLong(claims, "exp", &exp)) goto done;
   if (now >= exp) goto done;
@@ -913,7 +1006,6 @@ done:
   sqlite3_free(kid);
   sqlite3_free(iss);
   sqlite3_free(sub);
-  sqlite3_free(aud);
   sqlite3_free(expectSub);
   sqlite3_free(sigStr);
   sqlite3_free(sig);

--- a/src/doltlite_remotesrv.c
+++ b/src/doltlite_remotesrv.c
@@ -1370,6 +1370,10 @@ static int serverInit(DoltliteServer *pSrv, const DoltliteServeOpts *o){
   }
 
   if( o->authKeysDir && o->authKeysDir[0] ){
+    if( !o->audience || !o->audience[0] ){
+      serverCleanup(pSrv);
+      return SQLITE_ERROR;
+    }
     pSrv->authKeysDir = dupStr(o->authKeysDir);
     if( !pSrv->authKeysDir ){ serverCleanup(pSrv); return SQLITE_NOMEM; }
   }

--- a/src/remotesrv_main.c
+++ b/src/remotesrv_main.c
@@ -14,7 +14,7 @@
 static void usage(const char *prog){
   fprintf(stderr,
     "Usage: %s [-p PORT] [--bind ADDR] [--cert FILE --key FILE]\n"
-    "          [--auth-keys DIR] [--audience AUD] DIRECTORY\n"
+    "          [--auth-keys DIR --audience AUD] DIRECTORY\n"
     "\n"
     "Serve doltlite databases over HTTP/HTTPS.\n"
     "\n"
@@ -26,7 +26,7 @@ static void usage(const char *prog){
     "  --auth-keys DIR Require a bearer credential; authorized public keys are\n"
     "                  <kid>.jwk files in DIR. Omitted, requests are\n"
     "                  unauthenticated and may read and push.\n"
-    "  --audience AUD  Expected JWT audience (default: none)\n"
+    "  --audience AUD  Expected JWT audience (required with --auth-keys)\n"
     "  --timeout-ms MS Connection I/O timeout (default: 30000)\n"
     "  -h              Show this help\n"
     "\n"
@@ -97,6 +97,10 @@ int main(int argc, char **argv){
   }
   if( (o.certFile!=0) != (o.keyFile!=0) ){
     fprintf(stderr, "Error: --cert and --key must be given together\n");
+    return 1;
+  }
+  if( o.authKeysDir && (!o.audience || !o.audience[0]) ){
+    fprintf(stderr, "Error: --audience is required with --auth-keys\n");
     return 1;
   }
   signal(SIGINT, onSignal);

--- a/test/creds_verify_kat.c
+++ b/test/creds_verify_kat.c
@@ -32,9 +32,10 @@ static char *encodeRaw(const unsigned char *p, size_t n) {
   return z;
 }
 
-static char *tokenForKid(
+static char *tokenWithAudJson(
   const DoltliteCreds *c,
   const char *kid,
+  const char *audJson,
   const char *exp
 ) {
   char *header = NULL, *claims = NULL, *h64 = NULL, *c64 = NULL;
@@ -48,14 +49,14 @@ static char *tokenForKid(
   snprintf(header, n,
            "{\"alg\":\"EdDSA\",\"kid\":\"%s\",\"dolt_token_version\":\"2023.01\"}",
            kid);
-  n = strlen(kid) * 2 + strlen(AUD) + strlen(exp) + 160;
+  n = strlen(kid) * 2 + strlen(audJson) + strlen(exp) + 160;
   claims = (char *)malloc(n);
   if (!claims) goto done;
   snprintf(claims, n,
            "{\"iss\":\"dolt-client.dolthub.com\","
-           "\"sub\":\"doltClientCredentials/%s\",\"aud\":\"%s\","
+           "\"sub\":\"doltClientCredentials/%s\",\"aud\":%s,"
            "\"iat\":%ld,\"exp\":%s}",
-           kid, AUD, IAT, exp);
+           kid, audJson, IAT, exp);
   h64 = encodeRaw((const unsigned char *)header, strlen(header));
   c64 = encodeRaw((const unsigned char *)claims, strlen(claims));
   if (!h64 || !c64) goto done;
@@ -78,6 +79,14 @@ done:
   free(input);
   sqlite3_free(s64);
   return token;
+}
+
+static char *tokenForKid(
+  const DoltliteCreds *c,
+  const char *kid,
+  const char *exp
+) {
+  return tokenWithAudJson(c, kid, "\"" AUD "\"", exp);
 }
 
 int main(int argc, char **argv) {
@@ -119,8 +128,34 @@ int main(int argc, char **argv) {
   check("\"Bearer \" prefix accepted",
         doltliteCredsVerifyBearer(bearer, AUD, authDir, MID, NULL) == 0);
 
-  check("null expected-audience accepted",
-        doltliteCredsVerifyBearer(jwt, NULL, authDir, MID, NULL) == 0);
+  check("null expected-audience rejected",
+        doltliteCredsVerifyBearer(jwt, NULL, authDir, MID, NULL) != 0);
+  check("empty expected-audience rejected",
+        doltliteCredsVerifyBearer(jwt, "", authDir, MID, NULL) != 0);
+
+  {
+    char *arrayJwt = tokenWithAudJson(c, kid, "[\"" AUD "\"]", "1700000030");
+    char *multiJwt = tokenWithAudJson(c, kid, "[\"other\",\"" AUD "\"]",
+                                      "1700000030");
+    char *wrongArr = tokenWithAudJson(c, kid, "[\"other\"]", "1700000030");
+    char *emptyArr = tokenWithAudJson(c, kid, "[]", "1700000030");
+    check("Dolt array aud accepted",
+          arrayJwt &&
+              doltliteCredsVerifyBearer(arrayJwt, AUD, authDir, MID, NULL) == 0);
+    check("aud array containing expected accepted",
+          multiJwt &&
+              doltliteCredsVerifyBearer(multiJwt, AUD, authDir, MID, NULL) == 0);
+    check("aud array without expected rejected",
+          wrongArr &&
+              doltliteCredsVerifyBearer(wrongArr, AUD, authDir, MID, NULL) != 0);
+    check("empty aud array rejected",
+          emptyArr &&
+              doltliteCredsVerifyBearer(emptyArr, AUD, authDir, MID, NULL) != 0);
+    free(arrayJwt);
+    free(multiJwt);
+    free(wrongArr);
+    free(emptyArr);
+  }
 
   check("expired token rejected",
         doltliteCredsVerifyBearer(jwt, AUD, authDir, LATE, NULL) != 0);

--- a/test/doltlite_creds_kat.c
+++ b/test/doltlite_creds_kat.c
@@ -90,16 +90,16 @@ static const char *GOLDEN_JWT =
     "Yzl0N28zZGtkYmFycyIsImRvbHRfdG9rZW5fdmVyc2lvbiI6IjIwMjMuMDEifQ.eyJpc3Mi"
     "OiJkb2x0LWNsaWVudC5kb2x0aHViLmNvbSIsInN1YiI6ImRvbHRDbGllbnRDcmVkZW50aWFs"
     "cy83a3UxY2dkN3Vqa2NyaTV1NHNtbXJzcnBjcDNlanNtZ2M5dDdvM2RrZGJhcnMiLCJhdWQi"
-    "OiJkb2x0cmVtb3RlYXBpLmRvbHRodWIuY29tIiwiaWF0IjoxNzAwMDAwMDAwLCJleHAiOjE3"
-    "MDAwMDAwMzB9.zYNXsaON_rblUat4NuSeDYNcCkkn5V5M28BVXgTybOs4lldxD_GUxRroTTeK"
-    "xlLebVONlBZxI6ukuhbW_1hvCg";
+    "OlsiZG9sdHJlbW90ZWFwaS5kb2x0aHViLmNvbSJdLCJpYXQiOjE3MDAwMDAwMDAsImV4cCI6"
+    "MTcwMDAwMDAzMH0.BEmqWAF_yBLZu2GnOmri7caHyu2smBeyGrCH40GO8otnbV1-xokfy1l2"
+    "jF5x2nVGino6X2_EhYBFtERt5CjGDQ";
 static const char *EXP_HEADER =
     "{\"alg\":\"EdDSA\",\"kid\":\"7ku1cgd7ujkcri5u4smmrsrpcp3ejsmgc9t7o3dkdbars\","
     "\"dolt_token_version\":\"2023.01\"}";
 static const char *EXP_CLAIMS =
     "{\"iss\":\"dolt-client.dolthub.com\","
     "\"sub\":\"doltClientCredentials/7ku1cgd7ujkcri5u4smmrsrpcp3ejsmgc9t7o3dkdbars\","
-    "\"aud\":\"doltremoteapi.dolthub.com\",\"iat\":1700000000,\"exp\":1700000030}";
+    "\"aud\":[\"doltremoteapi.dolthub.com\"],\"iat\":1700000000,\"exp\":1700000030}";
 
 int main(int argc, char **argv) {
   char hexbuf[256];
@@ -193,6 +193,10 @@ int main(int argc, char **argv) {
 
   {
     char *jwt = NULL;
+    check_bool("null audience rejected at mint",
+               doltliteCredsBearerTokenAt(c, NULL, 1700000000L, &jwt) != 0);
+    check_bool("empty audience rejected at mint",
+               doltliteCredsBearerTokenAt(c, "", 1700000000L, &jwt) != 0);
     if (doltliteCredsBearerTokenAt(c, AUD, 1700000000L, &jwt) != 0 || !jwt) {
       failures++;
       printf("  FAIL  bearer token build\n");

--- a/test/remotesrv_bind_warning_test.sh
+++ b/test/remotesrv_bind_warning_test.sh
@@ -86,9 +86,24 @@ w=$(warnings_for --bind 0.0.0.0)
 check "0.0.0.0 bare: TLS warning"  "1" "$(tls_count "$w")"
 check "0.0.0.0 bare: auth warning" "1" "$(auth_count "$w")"
 
+echo "=== 3b. --auth-keys without --audience refuses to start ==="
+if [ "$HAVE_KEYS" = 1 ]; then
+  : >"$TMP/err.txt"; : >"$TMP/out.txt"
+  "$REMOTESRV" -p 0 --bind 0.0.0.0 --auth-keys "$TMP/keys" "$TMP/srv" \
+    >"$TMP/out.txt" 2>"$TMP/err.txt" || true
+  if grep -q 'audience is required' "$TMP/err.txt"; then
+    check "auth-keys without audience errors" "1" "1"
+  else
+    check "auth-keys without audience errors" "1" "0"
+    echo "    stderr: $(tr '\n' ' ' < "$TMP/err.txt")"
+  fi
+else
+  echo "  SKIP: could not generate a credential"
+fi
+
 echo "=== 4. Configured auth is not reported as unauthenticated ==="
 if [ "$HAVE_KEYS" = 1 ]; then
-  w=$(warnings_for --bind 0.0.0.0 --auth-keys "$TMP/keys")
+  w=$(warnings_for --bind 0.0.0.0 --auth-keys "$TMP/keys" --audience 0.0.0.0)
   check "0.0.0.0 with --auth-keys: still warns about TLS" "1" "$(tls_count "$w")"
   check "0.0.0.0 with --auth-keys: no auth warning"       "0" "$(auth_count "$w")"
 else
@@ -107,7 +122,7 @@ fi
 echo "=== 6. Fully configured public bind is quiet ==="
 if [ "$HAVE_TLS" = 1 ] && [ "$HAVE_KEYS" = 1 ]; then
   w=$(warnings_for --bind 0.0.0.0 --cert "$TMP/cert.pem" --key "$TMP/key.pem" \
-                   --auth-keys "$TMP/keys")
+                   --auth-keys "$TMP/keys" --audience 0.0.0.0)
   check "0.0.0.0 with TLS and auth: no TLS warning"  "0" "$(tls_count "$w")"
   check "0.0.0.0 with TLS and auth: no auth warning" "0" "$(auth_count "$w")"
 else

--- a/test/remotesrv_init_failure_test.c
+++ b/test/remotesrv_init_failure_test.c
@@ -149,6 +149,19 @@ int main(void){
   check("invalid_address_destroys_condition", condInit==0);
 
   opts.zBindAddr = "127.0.0.1";
+  opts.authKeysDir = ".";
+  opts.audience = 0;
+  setFailure(-1);
+  mutexInit = -1;
+  condInit = -1;
+  rc = doltliteRemoteSrvInitForTest(&opts, &mutexInit, &condInit);
+  check("auth_keys_without_audience_fails", rc==SQLITE_ERROR);
+  check("auth_keys_without_audience_destroys_mutex", mutexInit==0);
+  check("auth_keys_without_audience_destroys_condition", condInit==0);
+  check("auth_keys_without_audience_frees_allocations",
+        gFault.nOutstanding==nBaseline);
+  opts.authKeysDir = 0;
+
   setFailure(1);
   mutexInit = -1;
   condInit = -1;


### PR DESCRIPTION
## Summary

- emit JWT `aud` as a one-element array, matching Dolt and `AUTH.md`
- verify `aud` as either a string or an array via object-key JSON parse
- reject a missing/empty expected audience instead of treating it as any
- require `--audience` whenever `--auth-keys` is set (CLI and `doltliteServeAsyncOpts`)

Without this, Dolt-shaped tokens fail against a DoltLite remotesrv that sets `--audience`, and a remotesrv started with `--auth-keys` alone accepts any recently signed key.

## Validation

- `test/creds_kat_test.sh`
- `test/creds_verify_test.sh` (Dolt array `aud`, fail-closed audience)
- `./build/remotesrv_init_failure_test`
- `test/remotesrv_bind_warning_test.sh build/doltlite build/doltlite-remotesrv`
- `test/remote_https_auth_test.sh build/doltlite build/doltlite-remotesrv`
- `make lint`

Co-Authored-By: Grok 4.6 <noreply@x.ai>