### PR TITLE
Add the dolt_docs system table

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,6 +115,24 @@ conformance bugs. When comparing against Dolt, only **row-level semantics** must
 match; do not file conformance issues over the vtable/function shape or column
 naming.
 
+`dolt_docs` is a hybrid: an eponymous writable vtab answers reads while no
+backing table exists (always-empty scans, so `SELECT` never errors on a fresh
+repo), and the first write statement materializes a real
+`dolt_docs(doc_name TEXT NOT NULL, doc_text TEXT NOT NULL, PRIMARY KEY(doc_name))`
+table that shadows the module from then on — Dolt's lazy-creation UX without
+the open-time auto-materialization that sank the original `dolt_ignore`
+attempt (`fcb7720e00`). A default `AGENT.md` row (DoltLite's own operations
+guide, not Dolt's embedded text) is served by the module pre-materialization
+and seeded as a stored row when the table materializes. Deliberate
+divergences from Dolt: the table shows in `.tables`/`.schema` once it exists
+(same accepted divergence as `dolt_ignore`); the default `AGENT.md` text
+differs (the docs oracle compares it by name/count, or by full row after a
+test overwrites it); and because the row is stored rather than synthesized,
+deleting `AGENT.md` sticks (Dolt resurrects it on the next read) and it
+appears in row-level diffs. A `build.c` shape guard beside `dolt_ignore`'s
+keeps hand-issued `CREATE TABLE dolt_docs` on the exact schema the module
+creates.
+
 ### Surfaces deliberately not implemented
 
 Absent on purpose, so don't file them as parity gaps or implement them
@@ -145,11 +163,9 @@ unprompted:
   merges with everything else. Keeping it accurate is the user's call, same as
   `ANALYZE` anywhere else.
 
-- **`dolt_docs`, `dolt_query_catalog`** — DoltHub-specific storage, not engine
-  behavior: `dolt_docs` holds `README.md` / `LICENSE.md` and
-  `dolt_query_catalog` holds saved queries, both so DoltHub can display them.
-  Nothing local reads either. Worth revisiting if pushing to DoltHub lands, and
-  not before.
+- **`dolt_query_catalog`** — DoltHub-specific storage, not engine behavior:
+  it holds saved queries so DoltHub can display them. Nothing local reads it.
+  Worth revisiting if pushing to DoltHub lands, and not before.
 
 ### Dolt is the reference implementation
 

--- a/README.md
+++ b/README.md
@@ -261,6 +261,21 @@ INSERT INTO dolt_ignore VALUES ('tmp_*', 1);
 INSERT INTO dolt_ignore VALUES ('tmp_keep', 0);  -- un-ignore
 ```
 
+#### Repository Docs (`dolt_docs`)
+
+Versioned documents keyed by name (`README.md`, `LICENSE.md`, or any name),
+as in Dolt. `SELECT` works before any doc exists; the first write statement
+creates the backing table, which then commits, diffs, branches and merges
+like any other table. A fresh repo serves a default `AGENT.md` (a usage
+guide for AI agents); overwrite or delete it like any other doc.
+
+```sql
+SELECT * FROM dolt_docs;                       -- default AGENT.md on a fresh repo
+INSERT INTO dolt_docs VALUES ('README.md', '# my project');
+REPLACE INTO dolt_docs VALUES ('README.md', '# updated');
+SELECT dolt_commit('-A', '-m', 'update readme');
+```
+
 ### Inspecting what's there
 
 #### Diff

--- a/doltlite.mk
+++ b/doltlite.mk
@@ -60,7 +60,7 @@ PROLLY_OBJS = $(DOLTLITE_AUTH_OBJS) \
               doltlite.o doltlite_core.o doltlite_cmd.o doltlite_add.o doltlite_commit_cmd.o doltlite_reset.o doltlite_merge_cmd.o doltlite_cherry_pick.o doltlite_revert.o doltlite_rebase.o doltlite_config.o doltlite_commit.o doltlite_ref.o doltlite_log.o doltlite_commit_ancestors.o doltlite_status.o doltlite_merge_status.o \
               doltlite_diff.o doltlite_diff_table.o doltlite_workspace.o doltlite_branch.o doltlite_branches.o doltlite_checkout.o doltlite_tag.o doltlite_ancestor.o doltlite_merge.o doltlite_merge_pass1.o doltlite_merge_pass2.o doltlite_merge_rows.o doltlite_merge_schema.o doltlite_conflicts.o \
               doltlite_gc.o doltlite_chunk_walk.o doltlite_history.o doltlite_at.o doltlite_blame.o doltlite_schema_diff.o doltlite_patch.o doltlite_schemas.o doltlite_diff_stat.o doltlite_record.o \
-              doltlite_ignore.o doltlite_hashof.o \
+              doltlite_ignore.o doltlite_docs.o doltlite_hashof.o \
               doltlite_constraint_violations.o doltlite_verify_constraints.o \
               doltlite_merge_constraints.o \
               doltlite_merge_constraints_unique.o \

--- a/main.mk
+++ b/main.mk
@@ -1577,6 +1577,9 @@ doltlite_record.o:	$(TOP)/src/doltlite_record.c $(DEPS_OBJ_COMMON)
 doltlite_ignore.o:	$(TOP)/src/doltlite_ignore.c $(DEPS_OBJ_COMMON)
 	$(T.cc.sqlite) -c $(TOP)/src/doltlite_ignore.c
 
+doltlite_docs.o:	$(TOP)/src/doltlite_docs.c $(DEPS_OBJ_COMMON)
+	$(T.cc.sqlite) -c $(TOP)/src/doltlite_docs.c
+
 doltlite_hashof.o:	$(TOP)/src/doltlite_hashof.c $(DEPS_OBJ_COMMON)
 	$(T.cc.sqlite) -c $(TOP)/src/doltlite_hashof.c
 

--- a/src/build.c
+++ b/src/build.c
@@ -2870,6 +2870,46 @@ void sqlite3EndTable(
     }
   }
 
+  /* Doltlite: dolt_docs shares dolt_ignore's user-created system table
+  ** contract. The dolt_docs eponymous module materializes the table with
+  ** exactly this shape on the first write statement; a hand-issued CREATE
+  ** TABLE must match so both paths produce the same schema Dolt uses. */
+  if( !db->init.busy
+   && !db->init.imposterTable
+   && iDb!=1
+   && pParse->eParseMode!=PARSE_MODE_DECLARE_VTAB
+   && IsOrdinaryTable(p)
+   && sqlite3StrICmp(p->zName, "dolt_docs")==0 ){
+    const char *zFail = 0;
+    if( p->nCol!=2 ){
+      zFail = "dolt_docs must have exactly two columns";
+    }else if( sqlite3StrICmp(p->aCol[0].zCnName, "doc_name")!=0 ){
+      zFail = "dolt_docs.doc_name must be the first column";
+    }else if( sqlite3StrICmp(p->aCol[1].zCnName, "doc_text")!=0 ){
+      zFail = "dolt_docs.doc_text must be the second column";
+    }else if( p->aCol[0].affinity!=SQLITE_AFF_TEXT
+           && p->aCol[0].affinity!=SQLITE_AFF_BLOB ){
+      zFail = "dolt_docs.doc_name must be TEXT";
+    }else if( p->aCol[1].affinity!=SQLITE_AFF_TEXT
+           && p->aCol[1].affinity!=SQLITE_AFF_BLOB ){
+      zFail = "dolt_docs.doc_text must be TEXT";
+    }else if( p->aCol[0].notNull==OE_None ){
+      zFail = "dolt_docs.doc_name must be NOT NULL";
+    }else if( p->aCol[1].notNull==OE_None ){
+      zFail = "dolt_docs.doc_text must be NOT NULL";
+    }else if( (p->aCol[0].colFlags & COLFLAG_PRIMKEY)==0
+           || (p->aCol[1].colFlags & COLFLAG_PRIMKEY)!=0 ){
+      zFail = "dolt_docs must have PRIMARY KEY(doc_name) and no other key columns";
+    }
+    if( zFail ){
+      sqlite3ErrorMsg(pParse,
+          "%s; expected: CREATE TABLE dolt_docs("
+          "doc_name TEXT NOT NULL, doc_text TEXT NOT NULL, "
+          "PRIMARY KEY(doc_name))", zFail);
+      return;
+    }
+  }
+
   /* Special processing for WITHOUT ROWID Tables */
   if( tabOpts & TF_WithoutRowid ){
     if( (p->tabFlags & TF_Autoincrement) ){

--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -23,6 +23,7 @@ extern int doltliteRemoteSqlRegister(sqlite3 *db);
 extern int doltliteHashofRegister(sqlite3 *db);
 extern int doltliteConstraintViolationsRegister(sqlite3 *db);
 extern int doltliteVerifyConstraintsRegister(sqlite3 *db);
+extern int doltliteDocsRegister(sqlite3 *db);
 
 int doltliteRegister(sqlite3 *db){
   int rc;
@@ -55,6 +56,7 @@ int doltliteRegister(sqlite3 *db){
   if( (rc = doltliteHashofRegister(db))!=SQLITE_OK ) return rc;
   if( (rc = doltliteConstraintViolationsRegister(db))!=SQLITE_OK ) return rc;
   if( (rc = doltliteVerifyConstraintsRegister(db))!=SQLITE_OK ) return rc;
+  if( (rc = doltliteDocsRegister(db))!=SQLITE_OK ) return rc;
   return doltliteMaybeSeedRepo(db);
 }
 

--- a/src/doltlite_docs.c
+++ b/src/doltlite_docs.c
@@ -1,0 +1,286 @@
+
+#ifdef DOLTLITE_PROLLY
+
+#include "sqliteInt.h"
+#include "doltlite_internal.h"
+#include <string.h>
+
+/* Eponymous stand-in for dolt_docs while no real table exists. Reads are
+** always empty; the first write statement materializes a real dolt_docs
+** table in main, which then shadows this module in name resolution
+** (sqlite3LocateTable only reaches eponymous modules when sqlite3FindTable
+** misses), so status/diff/merge/branching treat docs as an ordinary
+** versioned table exactly like Dolt's user-space system tables. */
+
+typedef struct DocsVtab DocsVtab;
+struct DocsVtab {
+  sqlite3_vtab base;
+  sqlite3 *db;
+};
+
+typedef struct DocsCursor DocsCursor;
+struct DocsCursor {
+  sqlite3_vtab_cursor base;
+  int iRow;
+};
+
+static const char *zDocsVtabSchema =
+  "CREATE TABLE x(doc_name TEXT, doc_text TEXT)";
+
+static const char *zDocsCreate =
+  "CREATE TABLE main.dolt_docs("
+  "doc_name TEXT NOT NULL, doc_text TEXT NOT NULL, PRIMARY KEY(doc_name))";
+
+static const char *zDocsAgentName = "AGENT.md";
+
+/* Default AGENT.md, seeded when the backing table materializes and served
+** by the module before that. DoltLite's counterpart to Dolt's embedded
+** doc/AGENT.md, rewritten for this engine's SQL surface. */
+static const char *zDocsAgentDefault =
+  "# AGENT.md - DoltLite Database Operations Guide\n"
+  "\n"
+  "This database is a DoltLite database: SQLite-compatible SQL with\n"
+  "Dolt-style version control (commits, branches, diffs, merges) built in.\n"
+  "Version control operations are SQL function calls, not stored\n"
+  "procedures: use `SELECT dolt_commit(...)`, never `CALL dolt_commit(...)`.\n"
+  "\n"
+  "## Core Workflow\n"
+  "\n"
+  "```sql\n"
+  "SELECT dolt_add('-A');                    -- stage all changes\n"
+  "SELECT dolt_commit('-m', 'message');      -- commit staged changes\n"
+  "SELECT dolt_commit('-A', '-m', 'message');-- stage and commit at once\n"
+  "SELECT * FROM dolt_status;                -- what is staged / modified\n"
+  "SELECT * FROM dolt_log;                   -- commit history\n"
+  "```\n"
+  "\n"
+  "## Branches\n"
+  "\n"
+  "```sql\n"
+  "SELECT dolt_branch('feature');            -- create\n"
+  "SELECT dolt_checkout('feature');          -- switch\n"
+  "SELECT dolt_checkout('-b', 'feature2');   -- create and switch\n"
+  "SELECT active_branch();\n"
+  "SELECT * FROM dolt_branches;\n"
+  "SELECT dolt_merge('feature');\n"
+  "```\n"
+  "\n"
+  "Each branch has its own working state; uncommitted changes are\n"
+  "per-branch.\n"
+  "\n"
+  "## Diffs and History\n"
+  "\n"
+  "```sql\n"
+  "SELECT * FROM dolt_diff;                     -- tables changed per commit\n"
+  "SELECT * FROM dolt_diff_stat('v1', 'HEAD');  -- row/cell counts\n"
+  "SELECT * FROM dolt_patch('v1', 'v2');        -- executable SQL statements\n"
+  "-- Per user table <t>: dolt_diff_<t>, dolt_history_<t>, dolt_workspace_<t>\n"
+  "```\n"
+  "\n"
+  "## Merge Conflicts\n"
+  "\n"
+  "A merge that hits conflicts in autocommit mode rolls back. Run it inside\n"
+  "an explicit transaction to inspect and resolve:\n"
+  "\n"
+  "```sql\n"
+  "BEGIN;\n"
+  "SELECT dolt_merge('feature');\n"
+  "SELECT * FROM dolt_conflicts;              -- summary per table\n"
+  "SELECT * FROM dolt_conflicts_<t>;          -- base/ours/theirs rows\n"
+  "SELECT dolt_conflicts_resolve('--ours', '<t>');\n"
+  "COMMIT;\n"
+  "SELECT dolt_commit('-m', 'merged');\n"
+  "```\n"
+  "\n"
+  "## Undoing Changes\n"
+  "\n"
+  "```sql\n"
+  "SELECT dolt_reset('--hard');               -- discard working changes\n"
+  "SELECT dolt_reset('--hard', 'HEAD~1');     -- move HEAD back one commit\n"
+  "SELECT dolt_revert('HEAD');                -- new commit undoing HEAD\n"
+  "```\n"
+  "\n"
+  "## Notes\n"
+  "\n"
+  "- `dolt_docs` (this table) stores versioned documents keyed by name;\n"
+  "  `dolt_ignore` holds patterns for tables `dolt_add` should skip. Both\n"
+  "  commit, diff, branch and merge like ordinary tables.\n"
+  "- Standard SQLite applies everywhere else: `.tables`, `PRAGMA`, ATTACH,\n"
+  "  triggers, views, FTS5, R-Tree.\n";
+
+static int docsConnect(sqlite3 *db, void *pAux, int argc,
+    const char *const*argv, sqlite3_vtab **ppVtab, char **pzErr){
+  DocsVtab *pVtab;
+  int rc;
+  (void)pAux; (void)argc; (void)argv; (void)pzErr;
+  rc = doltliteVtabConnectSimple(db, zDocsVtabSchema, sizeof(*pVtab), ppVtab);
+  if( rc!=SQLITE_OK ) return rc;
+  pVtab = (DocsVtab*)*ppVtab;
+  pVtab->db = db;
+  return SQLITE_OK;
+}
+
+static int docsBestIndex(sqlite3_vtab *pVtab, sqlite3_index_info *pInfo){
+  (void)pVtab;
+  pInfo->estimatedCost = 10.0;
+  pInfo->estimatedRows = 1;
+  return SQLITE_OK;
+}
+
+static int docsOpen(sqlite3_vtab *pVtab, sqlite3_vtab_cursor **ppCursor){
+  (void)pVtab;
+  return doltliteVtabOpenCursor(ppCursor, sizeof(DocsCursor));
+}
+
+static int docsFilter(sqlite3_vtab_cursor *pCursor,
+    int idxNum, const char *idxStr, int argc, sqlite3_value **argv){
+  (void)idxNum; (void)idxStr; (void)argc; (void)argv;
+  ((DocsCursor*)pCursor)->iRow = 0;
+  return SQLITE_OK;
+}
+
+static int docsNext(sqlite3_vtab_cursor *pCursor){
+  ((DocsCursor*)pCursor)->iRow++;
+  return SQLITE_OK;
+}
+
+static int docsEof(sqlite3_vtab_cursor *pCursor){
+  return ((DocsCursor*)pCursor)->iRow >= 1;
+}
+
+static int docsColumn(sqlite3_vtab_cursor *pCursor,
+    sqlite3_context *ctx, int iCol){
+  (void)pCursor;
+  if( iCol==0 ){
+    sqlite3_result_text(ctx, zDocsAgentName, -1, SQLITE_STATIC);
+  }else{
+    sqlite3_result_text(ctx, zDocsAgentDefault, -1, SQLITE_STATIC);
+  }
+  return SQLITE_OK;
+}
+
+static int docsRowid(sqlite3_vtab_cursor *pCursor, sqlite3_int64 *pRowid){
+  (void)pCursor;
+  *pRowid = 0;
+  return SQLITE_OK;
+}
+
+static int docsSetErrMsg(DocsVtab *p, int rc){
+  sqlite3_free(p->base.zErrMsg);
+  p->base.zErrMsg = sqlite3_mprintf("%s", sqlite3_errmsg(p->db));
+  return rc;
+}
+
+static int docsExecBound(DocsVtab *p, const char *zSql,
+                         sqlite3_value *pArg1, sqlite3_value *pArg2){
+  sqlite3_stmt *pStmt = 0;
+  int rc = sqlite3_prepare_v2(p->db, zSql, -1, &pStmt, 0);
+  if( rc!=SQLITE_OK ) return docsSetErrMsg(p, rc);
+  if( pArg1 ) sqlite3_bind_value(pStmt, 1, pArg1);
+  if( pArg2 ) sqlite3_bind_value(pStmt, 2, pArg2);
+  sqlite3_step(pStmt);
+  rc = sqlite3_finalize(pStmt);
+  if( rc!=SQLITE_OK ) return docsSetErrMsg(p, rc);
+  return SQLITE_OK;
+}
+
+static int docsMaterialize(DocsVtab *p){
+  int rc;
+  char *zErr = 0;
+  sqlite3_stmt *pStmt = 0;
+  if( sqlite3FindTable(p->db, "dolt_docs", "main") ) return SQLITE_OK;
+  rc = sqlite3_exec(p->db, zDocsCreate, 0, 0, &zErr);
+  if( rc!=SQLITE_OK ){
+    sqlite3_free(p->base.zErrMsg);
+    p->base.zErrMsg = sqlite3_mprintf("%s", zErr ? zErr : sqlite3_errstr(rc));
+    sqlite3_free(zErr);
+    return rc;
+  }
+  rc = sqlite3_prepare_v2(p->db,
+      "INSERT INTO main.dolt_docs(doc_name, doc_text) VALUES('AGENT.md', ?1)",
+      -1, &pStmt, 0);
+  if( rc!=SQLITE_OK ) return docsSetErrMsg(p, rc);
+  sqlite3_bind_text(pStmt, 1, zDocsAgentDefault, -1, SQLITE_STATIC);
+  sqlite3_step(pStmt);
+  rc = sqlite3_finalize(pStmt);
+  if( rc!=SQLITE_OK ) return docsSetErrMsg(p, rc);
+  return SQLITE_OK;
+}
+
+static int docsBegin(sqlite3_vtab *pBase){
+  return docsMaterialize((DocsVtab*)pBase);
+}
+
+/* True when the stored AGENT.md row still carries the text this statement's
+** materialization seeded, so an INSERT of AGENT.md should behave as if the
+** row did not exist yet — matching Dolt, where the default row is synthetic
+** and never blocks an insert. */
+static int docsAgentSeedUntouched(DocsVtab *p){
+  sqlite3_stmt *pStmt = 0;
+  int hit = 0;
+  int rc = sqlite3_prepare_v2(p->db,
+      "SELECT 1 FROM main.dolt_docs WHERE doc_name='AGENT.md' AND doc_text=?1",
+      -1, &pStmt, 0);
+  if( rc!=SQLITE_OK ) return 0;
+  sqlite3_bind_text(pStmt, 1, zDocsAgentDefault, -1, SQLITE_STATIC);
+  hit = sqlite3_step(pStmt)==SQLITE_ROW;
+  sqlite3_finalize(pStmt);
+  return hit;
+}
+
+static int docsUpdate(sqlite3_vtab *pBase, int argc, sqlite3_value **argv,
+                      sqlite3_int64 *pRowid){
+  DocsVtab *p = (DocsVtab*)pBase;
+  const char *zSql;
+  int rc;
+
+  rc = docsMaterialize(p);
+  if( rc!=SQLITE_OK ) return rc;
+
+  if( argc==1 ){
+    return docsExecBound(p,
+        "DELETE FROM main.dolt_docs WHERE doc_name='AGENT.md'", 0, 0);
+  }
+  if( sqlite3_value_type(argv[0])!=SQLITE_NULL ){
+    return docsExecBound(p,
+        "UPDATE main.dolt_docs SET doc_name=?1, doc_text=?2 "
+        "WHERE doc_name='AGENT.md'", argv[2], argv[3]);
+  }
+
+  switch( sqlite3_vtab_on_conflict(p->db) ){
+    case SQLITE_REPLACE:
+      zSql = "INSERT OR REPLACE INTO main.dolt_docs(doc_name, doc_text) "
+             "VALUES(?1, ?2)";
+      break;
+    case SQLITE_IGNORE:
+      zSql = "INSERT OR IGNORE INTO main.dolt_docs(doc_name, doc_text) "
+             "VALUES(?1, ?2)";
+      break;
+    default:
+      zSql = "INSERT INTO main.dolt_docs(doc_name, doc_text) VALUES(?1, ?2)";
+      break;
+  }
+  if( sqlite3_value_type(argv[2])==SQLITE_TEXT
+   && strcmp((const char*)sqlite3_value_text(argv[2]), zDocsAgentName)==0
+   && docsAgentSeedUntouched(p) ){
+    zSql = "INSERT OR REPLACE INTO main.dolt_docs(doc_name, doc_text) "
+           "VALUES(?1, ?2)";
+  }
+  rc = docsExecBound(p, zSql, argv[2], argv[3]);
+  if( rc!=SQLITE_OK ) return rc;
+  if( pRowid ) *pRowid = sqlite3_last_insert_rowid(p->db);
+  return SQLITE_OK;
+}
+
+static sqlite3_module doltliteDocsModule = {
+  0, 0, docsConnect, docsBestIndex, doltliteVtabDisconnect, 0,
+  docsOpen, doltliteVtabClose, docsFilter, docsNext, docsEof,
+  docsColumn, docsRowid,
+  docsUpdate, docsBegin, 0, 0, 0, 0, 0, 0, 0, 0, 0
+};
+
+int doltliteDocsRegister(sqlite3 *db){
+  return sqlite3_create_module(db, "dolt_docs", &doltliteDocsModule, 0);
+}
+
+#endif

--- a/test/doltlite_docs.sh
+++ b/test/doltlite_docs.sh
@@ -1,0 +1,198 @@
+#!/bin/bash
+. "$(dirname "$0")/lib/doltlite_test_common.sh"
+
+echo "=== Doltlite dolt_docs Tests ==="
+
+DB=/tmp/test_docs_$$.db
+rm -f "$DB"
+
+run_test "fresh_select_shows_default_agent" \
+  "SELECT doc_name, length(doc_text) > 500 FROM dolt_docs;" \
+  "AGENT.md|1" "$DB"
+
+run_test "fresh_no_status_row" \
+  "SELECT count(*) FROM dolt_status;" \
+  "0" "$DB"
+
+run_test "fresh_not_in_sqlite_master" \
+  "SELECT count(*) FROM sqlite_master WHERE name='dolt_docs';" \
+  "0" "$DB"
+
+run_test "insert_materializes_and_seeds_agent" \
+  "INSERT INTO dolt_docs VALUES('README.md','# hello');
+   SELECT doc_name FROM dolt_docs ORDER BY doc_name;" \
+  "AGENT.md
+README.md" "$DB"
+
+run_test "status_new_table" \
+  "SELECT table_name, staged, status FROM dolt_status;" \
+  "dolt_docs|0|new table" "$DB"
+
+run_test "visible_in_sqlite_master" \
+  "SELECT count(*) FROM sqlite_master WHERE name='dolt_docs' AND type='table';" \
+  "1" "$DB"
+
+run_test "commit_docs" \
+  "SELECT dolt_add('-A') IS NOT NULL;
+   SELECT dolt_commit('-m','add docs') IS NOT NULL;
+   SELECT count(*) FROM dolt_status;" \
+  "1
+1
+0" "$DB"
+
+run_test "update_and_replace" \
+  "UPDATE dolt_docs SET doc_text='v2' WHERE doc_name='README.md';
+   REPLACE INTO dolt_docs VALUES('LICENSE.md','MIT');
+   SELECT doc_name, doc_text FROM dolt_docs WHERE doc_name != 'AGENT.md' ORDER BY doc_name;" \
+  "LICENSE.md|MIT
+README.md|v2" "$DB"
+
+run_test_match "dup_pk_rejected" \
+  "INSERT INTO dolt_docs VALUES('README.md','again');" \
+  "UNIQUE constraint failed: dolt_docs.doc_name" "$DB"
+
+run_test_match "null_doc_text_rejected" \
+  "INSERT INTO dolt_docs VALUES('x', NULL);" \
+  "NOT NULL constraint failed: dolt_docs.doc_text" "$DB"
+
+run_test "insert_or_ignore_dup" \
+  "INSERT OR IGNORE INTO dolt_docs VALUES('README.md','ignored');
+   SELECT doc_text FROM dolt_docs WHERE doc_name='README.md';" \
+  "v2" "$DB"
+
+run_test "drop_falls_back_to_module" \
+  "DROP TABLE dolt_docs;
+   SELECT doc_name FROM dolt_docs;" \
+  "AGENT.md" "$DB"
+
+rm -f "$DB"
+DB=/tmp/test_docs2_$$.db
+rm -f "$DB"
+
+run_test "zero_row_write_materializes" \
+  "DELETE FROM dolt_docs WHERE doc_name='nope';
+   SELECT table_name, status FROM dolt_status;
+   SELECT doc_name FROM dolt_docs;" \
+  "dolt_docs|new table
+AGENT.md" "$DB"
+
+rm -f "$DB"
+DB=/tmp/test_docs3_$$.db
+rm -f "$DB"
+
+run_test "rollback_undoes_materialization" \
+  "BEGIN;
+   INSERT INTO dolt_docs VALUES('a','1');
+   ROLLBACK;
+   SELECT doc_name FROM dolt_docs;
+   SELECT count(*) FROM sqlite_master WHERE name='dolt_docs';" \
+  "AGENT.md
+0" "$DB"
+
+run_test "txn_commit_keeps_docs" \
+  "BEGIN;
+   INSERT INTO dolt_docs VALUES('a','1');
+   COMMIT;
+   SELECT doc_name FROM dolt_docs ORDER BY doc_name;" \
+  "AGENT.md
+a" "$DB"
+
+run_test_match "mid_statement_failure_atomic" \
+  "DELETE FROM dolt_docs;
+   INSERT INTO dolt_docs VALUES('b','1'),('b','2');" \
+  "UNIQUE constraint failed" "$DB"
+
+run_test "mid_statement_failure_left_no_rows" \
+  "SELECT count(*) FROM dolt_docs WHERE doc_name='b';" \
+  "0" "$DB"
+
+rm -f "$DB"
+DB=/tmp/test_docs4_$$.db
+rm -f "$DB"
+
+run_test_match "drop_without_table_rejected" \
+  "DROP TABLE dolt_docs;" \
+  "may not be dropped" "$DB"
+
+run_test_match "drop_if_exists_without_table_rejected" \
+  "DROP TABLE IF EXISTS dolt_docs;" \
+  "may not be dropped" "$DB"
+
+run_test "case_insensitive_names" \
+  "INSERT INTO DOLT_DOCS VALUES('x','y');
+   SELECT count(*) FROM Dolt_Docs;" \
+  "2" "$DB"
+
+run_test "conflict_inspect_and_resolve" \
+  "DELETE FROM dolt_docs;
+   INSERT INTO dolt_docs VALUES('README.md','base');
+   SELECT dolt_commit('-A','-m','base') IS NOT NULL;
+   SELECT dolt_branch('b2') IS NOT NULL;
+   UPDATE dolt_docs SET doc_text='main edit';
+   SELECT dolt_commit('-A','-m','m') IS NOT NULL;
+   SELECT dolt_checkout('b2') IS NOT NULL;
+   UPDATE dolt_docs SET doc_text='b2 edit';
+   SELECT dolt_commit('-A','-m','b') IS NOT NULL;
+   SELECT dolt_checkout('main') IS NOT NULL;
+   BEGIN;
+   SELECT dolt_merge('b2') IS NOT NULL;
+   SELECT base_doc_text, our_doc_text, their_doc_text FROM dolt_conflicts_dolt_docs;
+   SELECT dolt_conflicts_resolve('--ours','dolt_docs') IS NOT NULL;
+   SELECT doc_text FROM dolt_docs;
+   COMMIT;" \
+  "1
+1
+1
+1
+1
+1
+Error near line 12: Merge has 1 conflict(s). Resolve and then commit with dolt_commit.
+base|main edit|b2 edit
+1
+main edit" "$DB"
+
+rm -f "$DB"
+DB=/tmp/test_docs5_$$.db
+rm -f "$DB"
+
+run_test "agent_insert_over_seed_first_write" \
+  "INSERT INTO dolt_docs VALUES('AGENT.md','mine');
+   SELECT doc_name, doc_text FROM dolt_docs;" \
+  "AGENT.md|mine" "$DB"
+
+run_test_match "agent_second_insert_rejected" \
+  "INSERT INTO dolt_docs VALUES('AGENT.md','other');" \
+  "UNIQUE constraint failed" "$DB"
+
+rm -f "$DB"
+DB=/tmp/test_docs6_$$.db
+rm -f "$DB"
+
+run_test "agent_update_pre_materialization_sticks" \
+  "UPDATE dolt_docs SET doc_text='edited' WHERE doc_name='AGENT.md';
+   SELECT doc_name, doc_text FROM dolt_docs;" \
+  "AGENT.md|edited" "$DB"
+
+rm -f "$DB"
+DB=/tmp/test_docs7_$$.db
+rm -f "$DB"
+
+run_test "agent_delete_sticks" \
+  "DELETE FROM dolt_docs WHERE doc_name='AGENT.md';
+   SELECT count(*) FROM dolt_docs;" \
+  "0" "$DB"
+
+rm -f "$DB"
+DB=/tmp/test_docs8_$$.db
+rm -f "$DB"
+
+run_test "agent_default_committable" \
+  "INSERT INTO dolt_docs VALUES('README.md','hi');
+   SELECT dolt_commit('-A','-m','docs') IS NOT NULL;
+   SELECT count(*) FROM dolt_docs WHERE doc_name='AGENT.md';" \
+  "1
+1" "$DB"
+
+rm -f "$DB"
+
+dltest_finish

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -1465,8 +1465,8 @@ attach2 attach2-4.15 class=intentional issue=1846  # PRAGMA lock_status: doltlit
 attachmalloc attachmalloc-1.transient.492 class=unsupported issue=1839  # OOM fault-point shift (parent probe)
 attachmalloc attachmalloc-1.transient.917 @no-coverage class=unsupported issue=1839  # OOM fault-point shift (ATTACH seed)
 attachmalloc attachmalloc-1.transient.1411 @no-coverage class=unsupported issue=1839  # OOM fault-point shift (ATTACH seed)
-attachmalloc attachmalloc-1.transient.924 @coverage class=unsupported issue=1839  # OOM fault-point shift (ATTACH seed)
-attachmalloc attachmalloc-1.transient.1425 @coverage class=unsupported issue=1839  # OOM fault-point shift (ATTACH seed)
+attachmalloc attachmalloc-1.transient.925 @coverage class=unsupported issue=1839  # OOM fault-point shift (ATTACH seed)
+attachmalloc attachmalloc-1.transient.1427 @coverage class=unsupported issue=1839  # OOM fault-point shift (ATTACH seed)
 mallocD mallocD-4.transient.107 class=unsupported issue=1839  # OOM fault-point shift (parent probe)
 
 # temptable2 section 8 — page_count is a chunk-store metric, not SQLite
@@ -5901,8 +5901,8 @@ vtab_err vtab_err-2.transient.727 @coverage class=intentional
 vtab_err vtab_err-2.transient.728 @coverage class=intentional
 vtab_err vtab_err-2.persistent.727 @coverage class=intentional
 vtab_err vtab_err-2.persistent.728 @coverage class=intentional
-vtab_err vtab_err-3-oom-transient.435 @coverage class=intentional
 vtab_err vtab_err-3-oom-transient.436 @coverage class=intentional
+vtab_err vtab_err-3-oom-transient.437 @coverage class=intentional
 
 # ── pager2 ── (was crash-listed on the journal_mode rejection; now completes)
 pager2 pager2-2.1 class=intentional issue=1846  # journal_mode is a no-op reporting the fixed "wal", not the requested "off"

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -5895,14 +5895,14 @@ vtab_err vtab_err-1.3.3 class=intentional
 vtab_err vtab_err-2.transient.685 @no-coverage class=intentional
 vtab_err vtab_err-2.transient.708 @no-coverage class=intentional
 vtab_err vtab_err-2.persistent.708 @no-coverage class=intentional
-vtab_err vtab_err-3-oom-transient.425 @no-coverage class=intentional
+vtab_err vtab_err-3-oom-transient.424 @no-coverage class=intentional
 vtab_err vtab_err-2.transient.704 @coverage class=intentional
 vtab_err vtab_err-2.transient.727 @coverage class=intentional
 vtab_err vtab_err-2.transient.728 @coverage class=intentional
 vtab_err vtab_err-2.persistent.727 @coverage class=intentional
 vtab_err vtab_err-2.persistent.728 @coverage class=intentional
+vtab_err vtab_err-3-oom-transient.435 @coverage class=intentional
 vtab_err vtab_err-3-oom-transient.436 @coverage class=intentional
-vtab_err vtab_err-3-oom-transient.437 @coverage class=intentional
 
 # ── pager2 ── (was crash-listed on the journal_mode rejection; now completes)
 pager2 pager2-2.1 class=intentional issue=1846  # journal_mode is a no-op reporting the fixed "wal", not the requested "off"

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -1462,10 +1462,10 @@ attach2 attach2-4.15 class=intentional issue=1846  # PRAGMA lock_status: doltlit
 # paths, shifting OOM fault indices (same #1859 brittleness as backup_malloc).
 # vec1's built-in registration adds ~25 allocations at connection open,
 # shifting every entry by +25.
-attachmalloc attachmalloc-1.transient.490 class=unsupported issue=1839  # OOM fault-point shift (parent probe)
-attachmalloc attachmalloc-1.transient.916 @no-coverage class=unsupported issue=1839  # OOM fault-point shift (ATTACH seed)
+attachmalloc attachmalloc-1.transient.492 class=unsupported issue=1839  # OOM fault-point shift (parent probe)
+attachmalloc attachmalloc-1.transient.917 @no-coverage class=unsupported issue=1839  # OOM fault-point shift (ATTACH seed)
 attachmalloc attachmalloc-1.transient.1411 @no-coverage class=unsupported issue=1839  # OOM fault-point shift (ATTACH seed)
-attachmalloc attachmalloc-1.transient.923 @coverage class=unsupported issue=1839  # OOM fault-point shift (ATTACH seed)
+attachmalloc attachmalloc-1.transient.924 @coverage class=unsupported issue=1839  # OOM fault-point shift (ATTACH seed)
 attachmalloc attachmalloc-1.transient.1425 @coverage class=unsupported issue=1839  # OOM fault-point shift (ATTACH seed)
 mallocD mallocD-4.transient.107 class=unsupported issue=1839  # OOM fault-point shift (parent probe)
 

--- a/test/lib/doltlite_suite_manifest.sh
+++ b/test/lib/doltlite_suite_manifest.sh
@@ -10,6 +10,7 @@ doltlite_parity.sh
 doltlite_commit.sh
 doltlite_staging.sh
 doltlite_workspace.sh
+doltlite_docs.sh
 doltlite_diff.sh
 doltlite_reset.sh
 doltlite_branch.sh
@@ -137,6 +138,7 @@ doltlite_parity.sh
 doltlite_commit.sh
 doltlite_staging.sh
 doltlite_workspace.sh
+doltlite_docs.sh
 doltlite_branch.sh
 doltlite_open_branch.sh
 doltlite_tag.sh

--- a/test/oracle-buckets/refs-workspace.txt
+++ b/test/oracle-buckets/refs-workspace.txt
@@ -8,6 +8,7 @@ vc_oracle_commit_ancestors_test.sh
 vc_oracle_commit_test.sh
 vc_oracle_connection_branch_test.sh
 vc_oracle_cross_connection_state_test.sh
+vc_oracle_docs_test.sh
 vc_oracle_hashof_errors_test.sh
 vc_oracle_hashof_test.sh
 vc_oracle_ignore_test.sh

--- a/test/vc_oracle_docs_test.sh
+++ b/test/vc_oracle_docs_test.sh
@@ -1,0 +1,397 @@
+#!/bin/bash
+
+set -u
+set -o pipefail
+
+DOLTLITE="${1:-./doltlite}"
+DOLT="${2:-dolt}"
+TMPROOT=$(mktemp -d)
+trap "rm -rf $TMPROOT" EXIT
+pass=0; fail=0
+FAILED_NAMES=""
+source "$(dirname "$0")/lib/vc_oracle_common.sh"
+
+# Both engines serve a default AGENT.md row on a fresh repo, but the text
+# differs (Dolt embeds its own guide, doltlite ships one for this engine)
+# and Dolt's row is synthetic while doltlite stores it on materialization.
+# Content comparisons filter AGENT.md; the agent scenarios below compare it
+# by name/count, or by full row after the test overwrote the text.
+normalize_docs() { tr -d '\r"' | grep '^D|' | grep -v '^D|AGENT\.md|' | sort; }
+normalize_status() { tr -d '\r"' | grep '^S|' | sort; }
+normalize_agent() { tr -d '\r"' | grep '^A|' | sort; }
+
+DOCS_QUERY_DL="SELECT 'D|' || doc_name || '|' || doc_text FROM dolt_docs;"
+DOCS_QUERY_DT="SELECT concat('D|', doc_name, '|', doc_text) FROM dolt_docs;"
+STATUS_QUERY_DL="SELECT 'S|' || table_name || '|' || staged || '|' || status FROM dolt_status;"
+STATUS_QUERY_DT="SELECT concat('S|', table_name, '|', staged, '|', status) FROM dolt_status;"
+AGENT_QUERY_DL="SELECT 'A|' || doc_name || '|' || doc_text FROM dolt_docs WHERE doc_name = 'AGENT.md';"
+AGENT_QUERY_DT="SELECT concat('A|', doc_name, '|', doc_text) FROM dolt_docs WHERE doc_name = 'AGENT.md';"
+AGENT_COUNT_DL="SELECT 'A|' || count(*) FROM dolt_docs WHERE doc_name = 'AGENT.md';"
+AGENT_COUNT_DT="SELECT concat('A|', count(*)) FROM dolt_docs WHERE doc_name = 'AGENT.md';"
+
+oracle() {
+  local kind="$1" name="$2" setup="$3" allow_empty="${4:-}"
+  local dir="$TMPROOT/$name"
+  local dl_query dt_query norm
+  if [ "$kind" = "docs" ]; then
+    dl_query="$DOCS_QUERY_DL"; dt_query="$DOCS_QUERY_DT"; norm=normalize_docs
+  elif [ "$kind" = "agent" ]; then
+    dl_query="$AGENT_QUERY_DL"; dt_query="$AGENT_QUERY_DT"; norm=normalize_agent
+  elif [ "$kind" = "agent_count" ]; then
+    dl_query="$AGENT_COUNT_DL"; dt_query="$AGENT_COUNT_DT"; norm=normalize_agent
+  else
+    dl_query="$STATUS_QUERY_DL"; dt_query="$STATUS_QUERY_DT"; norm=normalize_status
+  fi
+  mkdir -p "$dir/dl" "$dir/dt"
+
+  local dl_out
+  dl_out=$(printf "%s\n.headers off\n.mode list\n%s\n" "$setup" "$dl_query" \
+           | "$DOLTLITE" "$dir/dl/db" 2>"$dir/dl.err" \
+           | $norm)
+
+  local dolt_setup
+  dolt_setup=$(vc_oracle_translate_for_dolt "$setup")
+
+  (
+    cd "$dir/dt" || exit 1
+    vc_oracle_init_repo
+    printf "%s\n%s\n" "$dolt_setup" "$dt_query" \
+      | "$DOLT" sql -c -r csv 2>"$dir/dt.err"
+  ) > "$dir/dt.raw"
+
+  local dt_out
+  dt_out=$($norm < "$dir/dt.raw")
+
+  if [ "$allow_empty" = "EXPECT_EMPTY" ]; then
+    vc_oracle_assert_match_allow_empty "$name" "$dl_out" "$dt_out"
+  else
+    vc_oracle_assert_match "$name" "$dl_out" "$dt_out"
+  fi
+}
+
+oracle_docs() { oracle docs "$@"; }
+oracle_status() { oracle status "$@"; }
+oracle_agent() { oracle agent "$@"; }
+oracle_agent_count() { oracle agent_count "$@"; }
+
+oracle_error() {
+  local name="$1" setup="$2"
+  local dir="$TMPROOT/${name}_err"
+  mkdir -p "$dir/dl" "$dir/dt"
+
+  local dl_rc
+  vc_oracle_run_doltlite_script "$dir/dl/db" "$dir/dl.out" "$dir/dl.err" "$setup"
+  dl_rc=$?
+
+  local dolt_setup
+  dolt_setup=$(vc_oracle_translate_for_dolt "$setup")
+  local dt_rc
+  vc_oracle_run_dolt_script_for_error "$dir/dt" "$dir/dt.out" "$dir/dt.err" "$dolt_setup"
+  dt_rc=$?
+
+  if vc_oracle_is_clean_error "$dl_rc" && vc_oracle_is_clean_error "$dt_rc"; then
+    pass=$((pass+1))
+  else
+    fail=$((fail+1))
+    FAILED_NAMES="$FAILED_NAMES $name"
+    echo "  FAIL: $name (expected both to error)"
+    echo "    doltlite rc: $dl_rc"
+    echo "    dolt rc:     $dt_rc"
+  fi
+}
+
+echo "=== Version Control Oracle Tests: dolt_docs ==="
+echo ""
+
+echo "--- reads without a backing table ---"
+
+oracle_docs "fresh_select_empty" "
+CREATE TABLE t(x INT PRIMARY KEY);
+" "EXPECT_EMPTY"
+
+oracle_status "fresh_status_empty" "
+SELECT * FROM dolt_docs;
+" "EXPECT_EMPTY"
+
+echo "--- writes materialize the table ---"
+
+oracle_docs "insert_without_create" "
+INSERT INTO dolt_docs VALUES ('README.md', '# my project');
+INSERT INTO dolt_docs VALUES ('LICENSE.md', 'MIT License');
+"
+
+oracle_status "status_new_table_after_insert" "
+INSERT INTO dolt_docs VALUES ('README.md', '# my project');
+"
+
+oracle_status "status_new_table_zero_row_delete" "
+DELETE FROM dolt_docs WHERE doc_name = 'nope';
+"
+
+oracle_status "status_new_table_zero_row_update" "
+UPDATE dolt_docs SET doc_text = 'x' WHERE doc_name = 'nope';
+"
+
+echo "--- row operations ---"
+
+oracle_docs "update_doc" "
+INSERT INTO dolt_docs VALUES ('README.md', 'v1');
+UPDATE dolt_docs SET doc_text = 'v2' WHERE doc_name = 'README.md';
+"
+
+oracle_docs "delete_doc" "
+INSERT INTO dolt_docs VALUES ('README.md', 'v1');
+INSERT INTO dolt_docs VALUES ('LICENSE.md', 'MIT');
+DELETE FROM dolt_docs WHERE doc_name = 'README.md';
+"
+
+oracle_docs "delete_all_then_select" "
+INSERT INTO dolt_docs VALUES ('README.md', 'v1');
+DELETE FROM dolt_docs;
+" "EXPECT_EMPTY"
+
+oracle_docs "replace_upsert" "
+INSERT INTO dolt_docs VALUES ('README.md', 'v1');
+REPLACE INTO dolt_docs VALUES ('README.md', 'v2');
+REPLACE INTO dolt_docs VALUES ('LICENSE.md', 'MIT');
+"
+
+oracle_docs "arbitrary_doc_names" "
+INSERT INTO dolt_docs VALUES ('notes.txt', 'free-form names are allowed');
+INSERT INTO dolt_docs VALUES ('no-extension', 'also fine');
+"
+
+oracle_docs "case_sensitive_doc_name_values" "
+INSERT INTO dolt_docs VALUES ('README.md', 'upper');
+INSERT INTO dolt_docs VALUES ('readme.md', 'lower');
+"
+
+oracle_docs "case_insensitive_table_name" "
+INSERT INTO DOLT_DOCS VALUES ('README.md', 'v1');
+UPDATE Dolt_Docs SET doc_text = 'v2';
+"
+
+echo "--- constraints ---"
+
+oracle_error "dup_pk_rejected" "
+INSERT INTO dolt_docs VALUES ('README.md', 'v1');
+INSERT INTO dolt_docs VALUES ('README.md', 'v2');
+"
+
+oracle_error "null_doc_text_rejected" "
+INSERT INTO dolt_docs VALUES ('README.md', NULL);
+"
+
+oracle_error "null_doc_name_rejected" "
+INSERT INTO dolt_docs VALUES (NULL, 'text');
+"
+
+oracle_error "drop_without_backing_table" "
+DROP TABLE dolt_docs;
+"
+
+echo "--- version control ---"
+
+oracle_status "status_clean_after_commit" "
+INSERT INTO dolt_docs VALUES ('README.md', 'v1');
+SELECT dolt_add('dolt_docs');
+SELECT dolt_commit('-m', 'add docs');
+" "EXPECT_EMPTY"
+
+oracle_status "status_staged_after_add" "
+INSERT INTO dolt_docs VALUES ('README.md', 'v1');
+SELECT dolt_add('-A');
+"
+
+oracle_status "status_modified_after_commit" "
+INSERT INTO dolt_docs VALUES ('README.md', 'v1');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'add docs');
+UPDATE dolt_docs SET doc_text = 'v2';
+"
+
+oracle_docs "branch_isolation" "
+INSERT INTO dolt_docs VALUES ('README.md', 'main version');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'add docs');
+SELECT dolt_checkout('-b', 'feature');
+UPDATE dolt_docs SET doc_text = 'feature version';
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feature edit');
+SELECT dolt_checkout('main');
+"
+
+oracle_docs "merge_ff_brings_docs" "
+CREATE TABLE sentinel(x INT PRIMARY KEY);
+SELECT dolt_commit('-A', '-m', 'base');
+SELECT dolt_checkout('-b', 'feature');
+INSERT INTO dolt_docs VALUES ('README.md', 'from feature');
+SELECT dolt_commit('-A', '-m', 'feature adds docs');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feature');
+"
+
+oracle_docs "merge_three_way_no_conflict" "
+INSERT INTO dolt_docs VALUES ('README.md', 'base');
+SELECT dolt_commit('-A', '-m', 'base');
+SELECT dolt_checkout('-b', 'b1');
+INSERT INTO dolt_docs VALUES ('LICENSE.md', 'MIT');
+SELECT dolt_commit('-A', '-m', 'b1 adds license');
+SELECT dolt_checkout('main');
+UPDATE dolt_docs SET doc_text = 'main edit' WHERE doc_name = 'README.md';
+SELECT dolt_commit('-A', '-m', 'main edits readme');
+SELECT dolt_merge('b1');
+"
+
+oracle_error "merge_conflicting_docs" "
+INSERT INTO dolt_docs VALUES ('README.md', 'base');
+SELECT dolt_commit('-A', '-m', 'base');
+SELECT dolt_checkout('-b', 'b1');
+UPDATE dolt_docs SET doc_text = 'b1 edit';
+SELECT dolt_commit('-A', '-m', 'b1');
+SELECT dolt_checkout('main');
+UPDATE dolt_docs SET doc_text = 'main edit';
+SELECT dolt_commit('-A', '-m', 'main');
+SELECT dolt_merge('b1');
+"
+
+oracle_docs "reset_hard_restores_docs" "
+INSERT INTO dolt_docs VALUES ('README.md', 'committed');
+SELECT dolt_commit('-A', '-m', 'base');
+UPDATE dolt_docs SET doc_text = 'dirty edit';
+SELECT dolt_reset('--hard');
+"
+
+oracle_status "drop_committed_docs" "
+INSERT INTO dolt_docs VALUES ('README.md', 'v1');
+SELECT dolt_commit('-A', '-m', 'add docs');
+DROP TABLE dolt_docs;
+"
+
+oracle_docs "select_after_drop" "
+INSERT INTO dolt_docs VALUES ('README.md', 'v1');
+SELECT dolt_commit('-A', '-m', 'add docs');
+DROP TABLE dolt_docs;
+" "EXPECT_EMPTY"
+
+echo "--- default AGENT.md ---"
+
+oracle_agent_count "agent_present_on_fresh_repo" "
+SELECT 1;
+"
+
+oracle_agent_count "agent_survives_other_writes" "
+INSERT INTO dolt_docs VALUES ('README.md', 'hi');
+"
+
+oracle_agent "agent_replace_overrides_default" "
+REPLACE INTO dolt_docs VALUES ('AGENT.md', 'custom agent doc');
+"
+
+oracle_agent "agent_update_overrides_default" "
+UPDATE dolt_docs SET doc_text = 'edited agent doc' WHERE doc_name = 'AGENT.md';
+"
+
+oracle_agent "agent_insert_as_first_write" "
+INSERT INTO dolt_docs VALUES ('AGENT.md', 'inserted agent doc');
+"
+
+oracle_agent "agent_override_commits" "
+REPLACE INTO dolt_docs VALUES ('AGENT.md', 'committed agent doc');
+SELECT dolt_commit('-A', '-m', 'agent doc');
+"
+
+echo "--- large content round-trip ---"
+
+BIGDOC=$(printf 'lorem-ipsum-%.0s' $(seq 1 500))
+oracle_docs "large_doc_text" "
+INSERT INTO dolt_docs VALUES ('README.md', '$BIGDOC');
+"
+
+echo "--- doltlite-only: CREATE TABLE shape guard ---"
+
+doltlite_schema_reject() {
+  local name="$1" sql="$2"
+  local dir="$TMPROOT/${name}_rej"
+  mkdir -p "$dir/dl"
+  echo "$sql" | "$DOLTLITE" "$dir/dl/db" > "$dir/out" 2>&1
+  if grep -qi 'dolt_docs' "$dir/out" \
+     && grep -qiE 'error|fail' "$dir/out"; then
+    pass=$((pass+1))
+  else
+    fail=$((fail+1))
+    FAILED_NAMES="$FAILED_NAMES $name"
+    echo "  FAIL: $name (expected doltlite to reject)"
+    echo "    output:"; sed 's/^/      /' "$dir/out"
+  fi
+}
+
+doltlite_schema_accept() {
+  local name="$1" sql="$2"
+  local dir="$TMPROOT/${name}_acc"
+  mkdir -p "$dir/dl"
+  echo "$sql" | "$DOLTLITE" "$dir/dl/db" > "$dir/out" 2>&1
+  if ! grep -qiE 'error|fail' "$dir/out"; then
+    pass=$((pass+1))
+  else
+    fail=$((fail+1))
+    FAILED_NAMES="$FAILED_NAMES $name"
+    echo "  FAIL: $name (expected doltlite to accept)"
+    echo "    output:"; sed 's/^/      /' "$dir/out"
+  fi
+}
+
+doltlite_schema_reject "schema_one_column" "
+CREATE TABLE dolt_docs(doc_name TEXT NOT NULL PRIMARY KEY);
+"
+
+doltlite_schema_reject "schema_three_columns" "
+CREATE TABLE dolt_docs(doc_name TEXT NOT NULL, doc_text TEXT NOT NULL, extra INT, PRIMARY KEY(doc_name));
+"
+
+doltlite_schema_reject "schema_wrong_first_name" "
+CREATE TABLE dolt_docs(name TEXT NOT NULL, doc_text TEXT NOT NULL, PRIMARY KEY(name));
+"
+
+doltlite_schema_reject "schema_wrong_second_name" "
+CREATE TABLE dolt_docs(doc_name TEXT NOT NULL, body TEXT NOT NULL, PRIMARY KEY(doc_name));
+"
+
+doltlite_schema_reject "schema_wrong_name_type" "
+CREATE TABLE dolt_docs(doc_name INTEGER NOT NULL, doc_text TEXT NOT NULL, PRIMARY KEY(doc_name));
+"
+
+doltlite_schema_reject "schema_name_nullable" "
+CREATE TABLE dolt_docs(doc_name TEXT, doc_text TEXT NOT NULL, PRIMARY KEY(doc_name));
+"
+
+doltlite_schema_reject "schema_text_nullable" "
+CREATE TABLE dolt_docs(doc_name TEXT NOT NULL, doc_text TEXT, PRIMARY KEY(doc_name));
+"
+
+doltlite_schema_reject "schema_compound_pk" "
+CREATE TABLE dolt_docs(doc_name TEXT NOT NULL, doc_text TEXT NOT NULL, PRIMARY KEY(doc_name, doc_text));
+"
+
+doltlite_schema_reject "schema_no_pk" "
+CREATE TABLE dolt_docs(doc_name TEXT NOT NULL, doc_text TEXT NOT NULL);
+"
+
+doltlite_schema_accept "schema_exact" "
+CREATE TABLE dolt_docs(doc_name TEXT NOT NULL, doc_text TEXT NOT NULL, PRIMARY KEY(doc_name));
+INSERT INTO dolt_docs VALUES ('README.md', 'hand-created');
+SELECT * FROM dolt_docs;
+"
+
+doltlite_schema_accept "schema_varchar_longtext" "
+CREATE TABLE dolt_docs(doc_name VARCHAR(1023) NOT NULL, doc_text LONGTEXT NOT NULL, PRIMARY KEY(doc_name));
+INSERT INTO dolt_docs VALUES ('README.md', 'hand-created');
+SELECT * FROM dolt_docs;
+"
+
+echo ""
+echo "=== Results: $pass passed, $fail failed ==="
+if [ $fail -gt 0 ]; then
+  echo "Failed:$FAILED_NAMES"
+  exit 1
+fi

--- a/tool/mksqlite3c.tcl
+++ b/tool/mksqlite3c.tcl
@@ -635,6 +635,7 @@ proc emit_doltlite_engine_block {} {
     doltlite_conflicts.c doltlite_gc.c doltlite_chunk_walk.c
     doltlite_history.c doltlite_at.c doltlite_blame.c doltlite_schema_diff.c doltlite_patch.c
     doltlite_schemas.c doltlite_diff_stat.c doltlite_record.c doltlite_ignore.c
+    doltlite_docs.c
     doltlite_hashof.c doltlite_constraint_violations.c doltlite_verify_constraints.c doltlite_merge_constraints.c doltlite_merge_constraints_unique.c doltlite_merge_constraints_check.c doltlite_merge_constraints_fk.c doltlite_merge_constraints_notnull.c doltlite_merge_constraints_strict.c
     doltlite_dbpage.c doltlite_remote.c doltlite_remote_sql.c
     doltlite_http_remote.c


### PR DESCRIPTION
## What

Implements `dolt_docs` matching Dolt's behavior ([docs](https://www.dolthub.com/docs/sql-reference/version-control/dolt-system-tables/#dolt_docs), verified against the Dolt source):

- `SELECT * FROM dolt_docs` resolves before any doc exists — never "no such table".
- Any first write statement (including one matching zero rows, matching Dolt's `StatementBegin` semantics) materializes the backing table `dolt_docs(doc_name TEXT NOT NULL, doc_text TEXT NOT NULL, PRIMARY KEY(doc_name))` — Dolt's `varchar(1023)`/`longtext NOT NULL` schema in SQLite types.
- From then on it is an ordinary versioned table: status (`new table`/staged/`modified`), commit, branch isolation, ff and three-way merge, conflicts via `dolt_conflicts_dolt_docs` + `dolt_conflicts_resolve`, reset, drop, `dolt_diff_dolt_docs` — all with zero special cases.
- Arbitrary `doc_name` values, case-insensitive table name, binary-collated doc_name values, `REPLACE`/`INSERT OR IGNORE`, dup-PK and NULL rejections — all match Dolt.
- A fresh repo serves a default `AGENT.md` — a DoltLite operations guide (Dolt embeds its own equivalent).

## How

An eponymous **writable vtab** answers reads while no backing table exists (serving the default `AGENT.md`); the first write statement materializes the real table (seeding `AGENT.md` as a stored row) which then **shadows the module in name resolution**. This gets Dolt's lazy-creation UX without the open-time auto-materialization that was reverted for `dolt_ignore` in `fcb7720e00` — fresh repos put nothing in `sqlite_schema`, so `.tables`/`.schema`/`.dump` oracles are untouched. A `build.c` shape guard beside `dolt_ignore`'s keeps hand-issued `CREATE TABLE dolt_docs` on the exact schema the module creates.

Deliberate divergences (documented in AGENTS.md): the table is visible in `.tables` once it exists (same accepted divergence as `dolt_ignore`); the default `AGENT.md` text is DoltLite's own; and since the row is stored rather than synthesized, deleting it sticks (Dolt resurrects) and it appears in row-level diffs.

## Tests

- `test/vc_oracle_docs_test.sh` (45 scenarios, bucketed in `refs-workspace`): every compared behavior runs identically against real Dolt 2.2.1, including six AGENT.md scenarios (present on fresh repo, survives writes, replace/update/insert overrides, commits). Dolt's synthetic AGENT.md text is filtered from content comparisons; AGENT.md parity is compared by name/count or after an explicit overwrite.
- `test/doltlite_docs.sh` (26 tests): materialization, rollback atomicity, mid-statement failure atomicity, shape guard, conflict inspect/resolve flow, AGENT.md seed semantics.
- **Fault coordinates** (`known_testfixture_divergences.txt`): the module registration shifts OOM fault indices, as previous surface additions did (9aab7c5046). `attachmalloc` @no-coverage indices measured locally (`490→492`, `916→917`, `1411` unchanged); `vtab_err-3-oom-transient` shifted −1 measured branch-vs-master on identical builds. **@coverage coordinates are extrapolated** from their stable offsets to the @no-coverage twins — if the coverage CI job disagrees, they need one coordinate-fix commit like b2a9773ce8. `mallocD`, `vtab_err-2`, `fkey_malloc` measured unchanged. (`fkey_malloc`/`vtab_err-2` fail locally on darwin at identical indices on master and this branch — pre-existing platform offset, not from this change. `sortfault` only times out locally, with zero failures.)

Full sweep run locally: fault-fuzz bucket, `dolt_ignore`/`status`/`workspace` oracles, dot-command leak checks, the five `.tables`-sensitive suites, amalgamation build + compile, lint gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)