### PR TITLE
Add the dolt_tests system table and runner

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,7 +97,8 @@ make DOLTLITE_PROLLY=0 sqlite3   # stock SQLite, for oracle/perf comparison
   `doltlite_tag`, `doltlite_conflicts`, `doltlite_constraint_violations` /
   `doltlite_verify_constraints`,
   `doltlite_schemas` / `doltlite_schema_diff`, `doltlite_patch`,
-  `doltlite_status`, `doltlite_workspace`, `doltlite_ignore`, `doltlite_hashof`,
+  `doltlite_status`, `doltlite_workspace`, `doltlite_ignore`, `doltlite_docs`,
+  `doltlite_tests`, `doltlite_hashof`,
   `doltlite_gc`, `doltlite_remote` / `doltlite_http_remote` /
   `doltlite_remotesrv`. Internal header: `src/doltlite_internal.h`; surfaces are
   registered in `src/doltlite.c`.
@@ -132,6 +133,12 @@ deleting `AGENT.md` sticks (Dolt resurrects it on the next read) and it
 appears in row-level diffs. A `build.c` shape guard beside `dolt_ignore`'s
 keeps hand-issued `CREATE TABLE dolt_docs` on the exact schema the module
 creates.
+
+`dolt_tests` uses the same lazy user-space system-table pattern: empty reads
+resolve before a backing table exists, and the first write materializes the
+six-column table with Dolt's assertion checks. `dolt_test_run(...)` executes
+the versioned definitions as read-only single-statement queries and returns
+the Dolt-compatible test result rows.
 
 ### Surfaces deliberately not implemented
 

--- a/README.md
+++ b/README.md
@@ -276,6 +276,22 @@ REPLACE INTO dolt_docs VALUES ('README.md', '# updated');
 SELECT dolt_commit('-A', '-m', 'update readme');
 ```
 
+#### Repository Tests (`dolt_tests`)
+
+Versioned SQL tests live in `dolt_tests`. The first write creates the backing
+table; test definitions then commit, diff, branch and merge like ordinary
+data. Each read-only query can assert its row count, column count, or single
+result value with `==`, `!=`, `<`, `>`, `<=`, or `>=`. Run every test with no
+argument or `'*'`, or select tests by test name or group.
+
+```sql
+INSERT INTO dolt_tests VALUES (
+  'user count', 'users', 'SELECT * FROM users', 'expected_rows', '==', '10'
+);
+SELECT * FROM dolt_test_run();
+SELECT * FROM dolt_test_run('users');
+```
+
 ### Inspecting what's there
 
 #### Diff

--- a/doltlite.mk
+++ b/doltlite.mk
@@ -60,7 +60,7 @@ PROLLY_OBJS = $(DOLTLITE_AUTH_OBJS) \
               doltlite.o doltlite_core.o doltlite_cmd.o doltlite_add.o doltlite_commit_cmd.o doltlite_reset.o doltlite_merge_cmd.o doltlite_cherry_pick.o doltlite_revert.o doltlite_rebase.o doltlite_config.o doltlite_commit.o doltlite_ref.o doltlite_log.o doltlite_commit_ancestors.o doltlite_status.o doltlite_merge_status.o \
               doltlite_diff.o doltlite_diff_table.o doltlite_workspace.o doltlite_branch.o doltlite_branches.o doltlite_checkout.o doltlite_tag.o doltlite_ancestor.o doltlite_merge.o doltlite_merge_pass1.o doltlite_merge_pass2.o doltlite_merge_rows.o doltlite_merge_schema.o doltlite_conflicts.o \
               doltlite_gc.o doltlite_chunk_walk.o doltlite_history.o doltlite_at.o doltlite_blame.o doltlite_schema_diff.o doltlite_patch.o doltlite_schemas.o doltlite_diff_stat.o doltlite_record.o \
-              doltlite_ignore.o doltlite_docs.o doltlite_hashof.o \
+              doltlite_ignore.o doltlite_docs.o doltlite_tests.o doltlite_hashof.o \
               doltlite_constraint_violations.o doltlite_verify_constraints.o \
               doltlite_merge_constraints.o \
               doltlite_merge_constraints_unique.o \

--- a/main.mk
+++ b/main.mk
@@ -1580,6 +1580,9 @@ doltlite_ignore.o:	$(TOP)/src/doltlite_ignore.c $(DEPS_OBJ_COMMON)
 doltlite_docs.o:	$(TOP)/src/doltlite_docs.c $(DEPS_OBJ_COMMON)
 	$(T.cc.sqlite) -c $(TOP)/src/doltlite_docs.c
 
+doltlite_tests.o:	$(TOP)/src/doltlite_tests.c $(DEPS_OBJ_COMMON)
+	$(T.cc.sqlite) -c $(TOP)/src/doltlite_tests.c
+
 doltlite_hashof.o:	$(TOP)/src/doltlite_hashof.c $(DEPS_OBJ_COMMON)
 	$(T.cc.sqlite) -c $(TOP)/src/doltlite_hashof.c
 

--- a/src/build.c
+++ b/src/build.c
@@ -2834,6 +2834,7 @@ void sqlite3EndTable(
   ** error instead of silent mis-configuration. Skipped during
   ** schema replay (db->init.busy): a previously-validated on-disk
   ** schema is assumed correct. */
+#ifdef DOLTLITE_PROLLY
   if( !db->init.busy
    && !db->init.imposterTable
    && iDb!=1
@@ -2909,6 +2910,96 @@ void sqlite3EndTable(
       return;
     }
   }
+
+  if( !db->init.busy
+   && !db->init.imposterTable
+   && iDb!=1
+   && pParse->eParseMode!=PARSE_MODE_DECLARE_VTAB
+   && IsOrdinaryTable(p)
+   && sqlite3StrICmp(p->zName, "dolt_tests")==0 ){
+    static const char *azName[] = {
+      "test_name", "test_group", "test_query", "assertion_type",
+      "assertion_comparator", "assertion_value"
+    };
+    static const char *azCheckColumn[] = {
+      "assertion_type", "assertion_comparator"
+    };
+    static const char *aazCheckValue[2][6] = {
+      {"expected_rows", "expected_columns", "expected_single_value"},
+      {"==", "!=", "<", ">", "<=", ">="}
+    };
+    static const int anCheckValue[] = {3, 6};
+    const char *zFail = 0;
+    int i;
+    int j;
+    if( p->nCol!=6 ){
+      zFail = "dolt_tests must have exactly six columns";
+    }
+    for(i=0; !zFail && i<6; i++){
+      if( sqlite3StrICmp(p->aCol[i].zCnName, azName[i])!=0 ){
+        zFail = "dolt_tests columns have the wrong name or order";
+      }else if( p->aCol[i].affinity!=SQLITE_AFF_TEXT
+             && p->aCol[i].affinity!=SQLITE_AFF_BLOB ){
+        zFail = "dolt_tests columns must be TEXT";
+      }
+    }
+    if( !zFail && p->aCol[0].notNull==OE_None ){
+      zFail = "dolt_tests.test_name must be NOT NULL";
+    }else if( !zFail && p->aCol[1].notNull!=OE_None ){
+      zFail = "dolt_tests.test_group must be nullable";
+    }else if( !zFail && p->aCol[2].notNull==OE_None ){
+      zFail = "dolt_tests.test_query must be NOT NULL";
+    }else if( !zFail && p->aCol[3].notNull==OE_None ){
+      zFail = "dolt_tests.assertion_type must be NOT NULL";
+    }else if( !zFail && p->aCol[4].notNull==OE_None ){
+      zFail = "dolt_tests.assertion_comparator must be NOT NULL";
+    }else if( !zFail && p->aCol[5].notNull!=OE_None ){
+      zFail = "dolt_tests.assertion_value must be nullable";
+    }else if( !zFail && ((p->aCol[0].colFlags & COLFLAG_PRIMKEY)==0
+                     || (p->aCol[1].colFlags & COLFLAG_PRIMKEY)!=0
+                     || (p->aCol[2].colFlags & COLFLAG_PRIMKEY)!=0
+                     || (p->aCol[3].colFlags & COLFLAG_PRIMKEY)!=0
+                     || (p->aCol[4].colFlags & COLFLAG_PRIMKEY)!=0
+                     || (p->aCol[5].colFlags & COLFLAG_PRIMKEY)!=0)){
+      zFail = "dolt_tests must have PRIMARY KEY(test_name)";
+    }else if( !zFail && (!p->pCheck || p->pCheck->nExpr!=2) ){
+      zFail = "dolt_tests must have the assertion checks";
+    }else if( !zFail && (!p->pCheck->a[0].zEName
+                      || sqlite3StrICmp(p->pCheck->a[0].zEName,
+                           "assertion_type_check")!=0
+                      || !p->pCheck->a[1].zEName
+                      || sqlite3StrICmp(p->pCheck->a[1].zEName,
+                           "assertion_comparator_check")!=0) ){
+      zFail = "dolt_tests assertion checks have the wrong names";
+    }
+    for(i=0; !zFail && i<2; i++){
+      Expr *pExpr = p->pCheck->a[i].pExpr;
+      if( !pExpr || pExpr->op!=TK_IN || !pExpr->pLeft
+       || pExpr->pLeft->op!=TK_ID
+       || !ExprUseUToken(pExpr->pLeft)
+       || sqlite3StrICmp(pExpr->pLeft->u.zToken, azCheckColumn[i])!=0
+       || !ExprUseXList(pExpr) || !pExpr->x.pList
+       || pExpr->x.pList->nExpr!=anCheckValue[i] ){
+        zFail = "dolt_tests assertion checks have the wrong expressions";
+        break;
+      }
+      for(j=0; j<anCheckValue[i]; j++){
+        Expr *pValue = pExpr->x.pList->a[j].pExpr;
+        if( !pValue || pValue->op!=TK_STRING || !ExprUseUToken(pValue)
+         || strcmp(pValue->u.zToken, aazCheckValue[i][j])!=0 ){
+          zFail = "dolt_tests assertion checks have the wrong expressions";
+          break;
+        }
+      }
+    }
+    if( zFail ){
+      sqlite3ErrorMsg(pParse,
+          "%s; expected Dolt's six-column dolt_tests schema",
+          zFail);
+      return;
+    }
+  }
+#endif
 
   /* Special processing for WITHOUT ROWID Tables */
   if( tabOpts & TF_WithoutRowid ){

--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -24,6 +24,7 @@ extern int doltliteHashofRegister(sqlite3 *db);
 extern int doltliteConstraintViolationsRegister(sqlite3 *db);
 extern int doltliteVerifyConstraintsRegister(sqlite3 *db);
 extern int doltliteDocsRegister(sqlite3 *db);
+extern int doltliteTestsRegister(sqlite3 *db);
 
 int doltliteRegister(sqlite3 *db){
   int rc;
@@ -57,6 +58,7 @@ int doltliteRegister(sqlite3 *db){
   if( (rc = doltliteConstraintViolationsRegister(db))!=SQLITE_OK ) return rc;
   if( (rc = doltliteVerifyConstraintsRegister(db))!=SQLITE_OK ) return rc;
   if( (rc = doltliteDocsRegister(db))!=SQLITE_OK ) return rc;
+  if( (rc = doltliteTestsRegister(db))!=SQLITE_OK ) return rc;
   return doltliteMaybeSeedRepo(db);
 }
 

--- a/src/doltlite_tests.c
+++ b/src/doltlite_tests.c
@@ -2,7 +2,7 @@
 
 #include "sqliteInt.h"
 #include "doltlite_internal.h"
-#include <errno.h>
+#include <errno.h> /* amalgamator: keep */
 #include <limits.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/doltlite_tests.c
+++ b/src/doltlite_tests.c
@@ -1,0 +1,865 @@
+#ifdef DOLTLITE_PROLLY
+
+#include "sqliteInt.h"
+#include "doltlite_internal.h"
+#include <errno.h>
+#include <limits.h>
+#include <stdlib.h>
+#include <string.h>
+
+typedef struct TestsVtab TestsVtab;
+struct TestsVtab {
+  sqlite3_vtab base;
+  sqlite3 *db;
+};
+
+typedef struct TestsCursor TestsCursor;
+struct TestsCursor {
+  sqlite3_vtab_cursor base;
+};
+
+static const char *zTestsVtabSchema =
+  "CREATE TABLE x("
+  "test_name TEXT NOT NULL PRIMARY KEY,"
+  "test_group TEXT,"
+  "test_query TEXT NOT NULL,"
+  "assertion_type TEXT NOT NULL "
+    "CHECK(assertion_type IN "
+      "('expected_rows','expected_columns','expected_single_value')),"
+  "assertion_comparator TEXT NOT NULL "
+    "CHECK(assertion_comparator IN ('==','!=','<','>','<=','>=')),"
+  "assertion_value TEXT)";
+
+static const char *zTestsCreate =
+  "CREATE TABLE main.dolt_tests("
+  "test_name TEXT NOT NULL,"
+  "test_group TEXT,"
+  "test_query TEXT NOT NULL,"
+  "assertion_type TEXT NOT NULL,"
+  "assertion_comparator TEXT NOT NULL,"
+  "assertion_value TEXT,"
+  "PRIMARY KEY(test_name),"
+  "CONSTRAINT assertion_type_check CHECK(assertion_type IN "
+    "('expected_rows','expected_columns','expected_single_value')),"
+  "CONSTRAINT assertion_comparator_check CHECK(assertion_comparator IN "
+    "('==','!=','<','>','<=','>=')))";
+
+static int testsSetErr(TestsVtab *p, int rc){
+  sqlite3_free(p->base.zErrMsg);
+  p->base.zErrMsg = sqlite3_mprintf("%s", sqlite3_errmsg(p->db));
+  return rc;
+}
+
+static int testsConnect(sqlite3 *db, void *pAux, int argc,
+    const char *const*argv, sqlite3_vtab **ppVtab, char **pzErr){
+  TestsVtab *pVtab;
+  int rc;
+  (void)pAux; (void)argc; (void)argv; (void)pzErr;
+  rc = doltliteVtabConnectSimple(db, zTestsVtabSchema,
+      sizeof(*pVtab), ppVtab);
+  if( rc!=SQLITE_OK ) return rc;
+  pVtab = (TestsVtab*)*ppVtab;
+  pVtab->db = db;
+  return SQLITE_OK;
+}
+
+static int testsBestIndex(sqlite3_vtab *pVtab, sqlite3_index_info *pInfo){
+  (void)pVtab;
+  pInfo->estimatedCost = 10.0;
+  pInfo->estimatedRows = 0;
+  return SQLITE_OK;
+}
+
+static int testsOpen(sqlite3_vtab *pVtab, sqlite3_vtab_cursor **ppCursor){
+  (void)pVtab;
+  return doltliteVtabOpenCursor(ppCursor, sizeof(TestsCursor));
+}
+
+static int testsFilter(sqlite3_vtab_cursor *pCursor,
+    int idxNum, const char *idxStr, int argc, sqlite3_value **argv){
+  (void)pCursor; (void)idxNum; (void)idxStr; (void)argc; (void)argv;
+  return SQLITE_OK;
+}
+
+static int testsNext(sqlite3_vtab_cursor *pCursor){
+  (void)pCursor;
+  return SQLITE_OK;
+}
+
+static int testsEof(sqlite3_vtab_cursor *pCursor){
+  (void)pCursor;
+  return 1;
+}
+
+static int testsColumn(sqlite3_vtab_cursor *pCursor,
+    sqlite3_context *ctx, int iCol){
+  (void)pCursor; (void)ctx; (void)iCol;
+  return SQLITE_OK;
+}
+
+static int testsRowid(sqlite3_vtab_cursor *pCursor, sqlite3_int64 *pRowid){
+  (void)pCursor;
+  *pRowid = 0;
+  return SQLITE_OK;
+}
+
+static int testsMaterialize(TestsVtab *p){
+  char *zErr = 0;
+  int rc;
+  if( sqlite3FindTable(p->db, "dolt_tests", "main") ) return SQLITE_OK;
+  rc = sqlite3_exec(p->db, zTestsCreate, 0, 0, &zErr);
+  if( rc!=SQLITE_OK ){
+    sqlite3_free(p->base.zErrMsg);
+    p->base.zErrMsg = sqlite3_mprintf("%s",
+        zErr ? zErr : sqlite3_errstr(rc));
+    sqlite3_free(zErr);
+  }
+  return rc;
+}
+
+static int testsBegin(sqlite3_vtab *pBase){
+  return testsMaterialize((TestsVtab*)pBase);
+}
+
+static int testsUpdate(sqlite3_vtab *pBase, int argc, sqlite3_value **argv,
+                       sqlite3_int64 *pRowid){
+  TestsVtab *p = (TestsVtab*)pBase;
+  sqlite3_stmt *pStmt = 0;
+  const char *zSql;
+  int i;
+  int rc = testsMaterialize(p);
+  if( rc!=SQLITE_OK ) return rc;
+  if( argc==1 ) return SQLITE_OK;
+  if( sqlite3_value_type(argv[0])!=SQLITE_NULL ) return SQLITE_OK;
+  switch( sqlite3_vtab_on_conflict(p->db) ){
+    case SQLITE_REPLACE:
+      zSql = "INSERT OR REPLACE INTO main.dolt_tests VALUES(?,?,?,?,?,?)";
+      break;
+    case SQLITE_IGNORE:
+      zSql = "INSERT OR IGNORE INTO main.dolt_tests VALUES(?,?,?,?,?,?)";
+      break;
+    default:
+      zSql = "INSERT INTO main.dolt_tests VALUES(?,?,?,?,?,?)";
+      break;
+  }
+  rc = sqlite3_prepare_v2(p->db, zSql, -1, &pStmt, 0);
+  if( rc!=SQLITE_OK ) return testsSetErr(p, rc);
+  for(i=0; i<6; i++) sqlite3_bind_value(pStmt, i+1, argv[i+2]);
+  sqlite3_step(pStmt);
+  rc = sqlite3_finalize(pStmt);
+  if( rc!=SQLITE_OK ) return testsSetErr(p, rc);
+  if( pRowid ) *pRowid = sqlite3_last_insert_rowid(p->db);
+  return SQLITE_OK;
+}
+
+static sqlite3_module doltliteTestsModule = {
+  0, 0, testsConnect, testsBestIndex, doltliteVtabDisconnect, 0,
+  testsOpen, doltliteVtabClose, testsFilter, testsNext, testsEof,
+  testsColumn, testsRowid,
+  testsUpdate, testsBegin, 0, 0, 0, 0, 0, 0, 0, 0, 0
+};
+
+typedef struct TestDef TestDef;
+struct TestDef {
+  char *zName;
+  char *zGroup;
+  char *zQuery;
+  char *zAssertion;
+  char *zComparator;
+  char *zValue;
+};
+
+typedef struct TestResult TestResult;
+struct TestResult {
+  char *zName;
+  char *zGroup;
+  char *zQuery;
+  char *zStatus;
+  char *zMessage;
+};
+
+typedef struct TestRunVtab TestRunVtab;
+struct TestRunVtab {
+  sqlite3_vtab base;
+  sqlite3 *db;
+};
+
+typedef struct TestRunCursor TestRunCursor;
+struct TestRunCursor {
+  sqlite3_vtab_cursor base;
+  TestResult *aResult;
+  int nResult;
+  int iRow;
+};
+
+#define TEST_RUN_FIRST_ARG 5
+#define TEST_RUN_MAX_ARGS 127
+
+static void testDefClear(TestDef *p){
+  sqlite3_free(p->zName);
+  sqlite3_free(p->zGroup);
+  sqlite3_free(p->zQuery);
+  sqlite3_free(p->zAssertion);
+  sqlite3_free(p->zComparator);
+  sqlite3_free(p->zValue);
+  memset(p, 0, sizeof(*p));
+}
+
+static void testResultClear(TestResult *p){
+  sqlite3_free(p->zName);
+  sqlite3_free(p->zGroup);
+  sqlite3_free(p->zQuery);
+  sqlite3_free(p->zStatus);
+  sqlite3_free(p->zMessage);
+  memset(p, 0, sizeof(*p));
+}
+
+static void testRunReset(TestRunCursor *p){
+  int i;
+  for(i=0; i<p->nResult; i++) testResultClear(&p->aResult[i]);
+  sqlite3_free(p->aResult);
+  p->aResult = 0;
+  p->nResult = 0;
+  p->iRow = 0;
+}
+
+static char *testColumnDup(sqlite3_stmt *pStmt, int iCol){
+  const unsigned char *z;
+  if( sqlite3_column_type(pStmt, iCol)==SQLITE_NULL ) return 0;
+  z = sqlite3_column_text(pStmt, iCol);
+  return z ? sqlite3_mprintf("%s", z) : 0;
+}
+
+static int testDefAppend(TestDef **paDef, int *pnDef, sqlite3_stmt *pStmt){
+  TestDef *aNew;
+  TestDef *p;
+  int i;
+  aNew = sqlite3_realloc64(*paDef,
+      (sqlite3_uint64)(*pnDef + 1) * sizeof(**paDef));
+  if( !aNew ) return SQLITE_NOMEM;
+  *paDef = aNew;
+  p = &aNew[*pnDef];
+  memset(p, 0, sizeof(*p));
+  p->zName = testColumnDup(pStmt, 0);
+  p->zGroup = testColumnDup(pStmt, 1);
+  p->zQuery = testColumnDup(pStmt, 2);
+  p->zAssertion = testColumnDup(pStmt, 3);
+  p->zComparator = testColumnDup(pStmt, 4);
+  p->zValue = testColumnDup(pStmt, 5);
+  if( !p->zName || !p->zQuery || !p->zAssertion || !p->zComparator ){
+    testDefClear(p);
+    return SQLITE_NOMEM;
+  }
+  for(i=0; i<6; i++){
+    if( sqlite3_column_type(pStmt, i)!=SQLITE_NULL ){
+      char *z = i==0 ? p->zName : i==1 ? p->zGroup : i==2 ? p->zQuery
+          : i==3 ? p->zAssertion : i==4 ? p->zComparator : p->zValue;
+      if( !z ){
+        testDefClear(p);
+        return SQLITE_NOMEM;
+      }
+    }
+  }
+  (*pnDef)++;
+  return SQLITE_OK;
+}
+
+static int testLoadQuery(sqlite3 *db, const char *zSql, const char *zArg,
+    TestDef **paDef, int *pnDef, int *pnAdded){
+  sqlite3_stmt *pStmt = 0;
+  int nBefore = *pnDef;
+  int rc = sqlite3_prepare_v2(db, zSql, -1, &pStmt, 0);
+  if( rc!=SQLITE_OK ) return rc;
+  if( zArg ) sqlite3_bind_text(pStmt, 1, zArg, -1, SQLITE_TRANSIENT);
+  while( (rc = sqlite3_step(pStmt))==SQLITE_ROW ){
+    rc = testDefAppend(paDef, pnDef, pStmt);
+    if( rc!=SQLITE_OK ) break;
+  }
+  if( rc==SQLITE_DONE ) rc = SQLITE_OK;
+  if( sqlite3_finalize(pStmt)!=SQLITE_OK && rc==SQLITE_OK ){
+    rc = sqlite3_errcode(db);
+  }
+  *pnAdded = *pnDef - nBefore;
+  return rc;
+}
+
+static int testLoadArgument(sqlite3 *db, const char *zArg,
+    TestDef **paDef, int *pnDef){
+  int nAdded = 0;
+  int rc;
+  if( strcmp(zArg, "*")==0 ){
+    return testLoadQuery(db,
+        "SELECT * FROM main.dolt_tests ORDER BY test_name",
+        0, paDef, pnDef, &nAdded);
+  }
+  rc = testLoadQuery(db,
+      "SELECT * FROM main.dolt_tests WHERE test_name=?1 ORDER BY test_name",
+      zArg, paDef, pnDef, &nAdded);
+  if( rc!=SQLITE_OK || nAdded ) return rc;
+  return testLoadQuery(db,
+      "SELECT * FROM main.dolt_tests WHERE test_group=?1 ORDER BY test_name",
+      zArg, paDef, pnDef, &nAdded);
+}
+
+static const char *testComparePhrase(const char *zComparator){
+  if( strcmp(zComparator, "==")==0 ) return "equal to";
+  if( strcmp(zComparator, "!=")==0 ) return "not equal to";
+  if( strcmp(zComparator, "<")==0 ) return "less than";
+  if( strcmp(zComparator, "<=")==0 ) return "less than or equal to";
+  if( strcmp(zComparator, ">")==0 ) return "greater than";
+  if( strcmp(zComparator, ">=")==0 ) return "greater than or equal to";
+  return 0;
+}
+
+static int testComparisonPassed(const char *zComparator, int c){
+  if( strcmp(zComparator, "==")==0 ) return c==0;
+  if( strcmp(zComparator, "!=")==0 ) return c!=0;
+  if( strcmp(zComparator, "<")==0 ) return c<0;
+  if( strcmp(zComparator, "<=")==0 ) return c<=0;
+  if( strcmp(zComparator, ">")==0 ) return c>0;
+  if( strcmp(zComparator, ">=")==0 ) return c>=0;
+  return 0;
+}
+
+static char *testCompareMessage(const char *zAssertion,
+    const char *zComparator, const char *zExpected,
+    const char *zActual, int c){
+  const char *zPhrase = testComparePhrase(zComparator);
+  if( !zPhrase ){
+    return sqlite3_mprintf("%s is not a valid comparison type", zComparator);
+  }
+  if( testComparisonPassed(zComparator, c) ) return sqlite3_mprintf("");
+  return sqlite3_mprintf("Assertion failed: %s %s %s, got %s",
+      zAssertion, zPhrase, zExpected, zActual);
+}
+
+static int testParseInteger(const char *z, sqlite3_int64 *pValue){
+  char *zEnd = 0;
+  long long v;
+  if( !z || !z[0] ) return 0;
+  errno = 0;
+  v = strtoll(z, &zEnd, 10);
+  if( errno==ERANGE || zEnd==z || *zEnd!=0 ) return 0;
+  *pValue = (sqlite3_int64)v;
+  return 1;
+}
+
+static int testParseReal(const char *z, double *pValue){
+  char *zEnd = 0;
+  double v;
+  if( !z || !z[0] ) return 0;
+  errno = 0;
+  v = strtod(z, &zEnd);
+  if( errno==ERANGE || zEnd==z || *zEnd!=0 ) return 0;
+  *pValue = v;
+  return 1;
+}
+
+static int testParseBool(const char *z, int *pValue){
+  if( sqlite3StrICmp(z, "true")==0 || sqlite3StrICmp(z, "t")==0 ){
+    *pValue = 1;
+    return 1;
+  }
+  if( sqlite3StrICmp(z, "false")==0 || sqlite3StrICmp(z, "f")==0 ){
+    *pValue = 0;
+    return 1;
+  }
+  return 0;
+}
+
+static int testDecimalScale(sqlite3_stmt *pStmt){
+  const char *zType = sqlite3_column_decltype(pStmt, 0);
+  const char *zComma;
+  char *zEnd = 0;
+  long scale;
+  if( !zType || sqlite3_strnicmp(zType, "decimal(", 8)!=0 ) return -1;
+  zComma = strchr(zType+8, ',');
+  if( !zComma ) return -1;
+  scale = strtol(zComma+1, &zEnd, 10);
+  if( zEnd==zComma+1 || scale<0 || scale>30 ) return -1;
+  while( sqlite3Isspace(*zEnd) ) zEnd++;
+  return *zEnd==')' ? (int)scale : -1;
+}
+
+static char *testCompareNull(const char *zComparator,
+    sqlite3_stmt *pStmt, int iCol){
+  int isNull = sqlite3_column_type(pStmt, iCol)==SQLITE_NULL;
+  if( strcmp(zComparator, "==")==0 ){
+    if( isNull ) return sqlite3_mprintf("");
+    return sqlite3_mprintf(
+        "Assertion failed: expected_single_value equal to NULL, got %s",
+        sqlite3_column_text(pStmt, iCol));
+  }
+  if( strcmp(zComparator, "!=")==0 ){
+    if( !isNull ) return sqlite3_mprintf("");
+    return sqlite3_mprintf(
+        "Assertion failed: expected_single_value not equal to NULL, got NULL");
+  }
+  return sqlite3_mprintf(
+      "%s is not a valid comparison for NULL values", zComparator);
+}
+
+static char *testCompareSingle(sqlite3_stmt *pStmt,
+    const char *zComparator, const char *zExpected){
+  int eType = sqlite3_column_type(pStmt, 0);
+  char *zActual;
+  char *zMessage;
+  int expectedBool;
+  if( !zExpected ) return testCompareNull(zComparator, pStmt, 0);
+  if( strcmp(zExpected, "0")!=0 && strcmp(zExpected, "1")!=0
+   && testParseBool(zExpected, &expectedBool) ){
+    int actualBool;
+    if( eType==SQLITE_INTEGER ){
+      actualBool = sqlite3_column_int64(pStmt, 0)==1;
+    }else if( eType==SQLITE_TEXT ){
+      actualBool = strcmp((const char*)sqlite3_column_text(pStmt, 0), "1")==0;
+    }else{
+      return sqlite3_mprintf("Could not convert value to boolean: "
+          "unexpected SQLite type %d", eType);
+    }
+    if( strcmp(zComparator, "==")!=0 && strcmp(zComparator, "!=")!=0 ){
+      return sqlite3_mprintf("%s is not a valid comparison for boolean "
+          "values. Only '==' and '!=' are supported", zComparator);
+    }
+    if( (strcmp(zComparator, "==")==0 && expectedBool==actualBool)
+     || (strcmp(zComparator, "!=")==0 && expectedBool!=actualBool) ){
+      return sqlite3_mprintf("");
+    }
+    return sqlite3_mprintf("Assertion failed: expected_single_value %s %s, "
+        "got %s", strcmp(zComparator, "==")==0 ? "equal to" : "not equal to",
+        expectedBool ? "true" : "false", actualBool ? "true" : "false");
+  }
+  if( eType==SQLITE_NULL ){
+    return sqlite3_mprintf("Type <nil> is not supported. Open an issue at "
+        "https://github.com/dolthub/dolt/issues to see it added");
+  }
+  if( eType==SQLITE_INTEGER ){
+    sqlite3_int64 expected;
+    sqlite3_int64 actual = sqlite3_column_int64(pStmt, 0);
+    if( !testParseInteger(zExpected, &expected) ){
+      return sqlite3_mprintf("Could not compare non integer value '%s', "
+          "with %lld", zExpected, actual);
+    }
+    zActual = sqlite3_mprintf("%lld", actual);
+    zMessage = testCompareMessage("expected_single_value", zComparator,
+        zExpected, zActual, actual<expected ? -1 : actual>expected ? 1 : 0);
+    sqlite3_free(zActual);
+    return zMessage;
+  }
+  if( eType==SQLITE_FLOAT ){
+    double expected;
+    double actual = sqlite3_column_double(pStmt, 0);
+    int scale;
+    if( !testParseReal(zExpected, &expected) ){
+      return sqlite3_mprintf("Could not compare non float value '%s', "
+          "with %f", zExpected, actual);
+    }
+    scale = testDecimalScale(pStmt);
+    zActual = scale>=0 ? sqlite3_mprintf("%.*f", scale, actual)
+                       : sqlite3_mprintf("%g", actual);
+    zMessage = testCompareMessage("expected_single_value", zComparator,
+        zExpected, zActual, actual<expected ? -1 : actual>expected ? 1 : 0);
+    sqlite3_free(zActual);
+    return zMessage;
+  }
+  if( eType==SQLITE_TEXT ){
+    const char *z = (const char*)sqlite3_column_text(pStmt, 0);
+    int c = strcmp(z, zExpected);
+    return testCompareMessage("expected_single_value", zComparator,
+        zExpected, z, c<0 ? -1 : c>0 ? 1 : 0);
+  }
+  return sqlite3_mprintf("Type BLOB is not supported. Open an issue at "
+      "https://github.com/dolthub/dolt/issues to see it added");
+}
+
+static char *testAssertRows(sqlite3_stmt *pStmt, const TestDef *pDef,
+    int *pRc){
+  sqlite3_int64 expected;
+  sqlite3_int64 actual = 0;
+  int rc;
+  char *zActual;
+  char *zMessage;
+  if( !pDef->zValue ){
+    return sqlite3_mprintf("null is not a valid assertion for expected_rows");
+  }
+  if( !testParseInteger(pDef->zValue, &expected) ){
+    return sqlite3_mprintf("cannot run assertion on non integer value: %s",
+        pDef->zValue);
+  }
+  while( (rc = sqlite3_step(pStmt))==SQLITE_ROW ) actual++;
+  if( rc!=SQLITE_DONE ){
+    *pRc = rc;
+    return 0;
+  }
+  zActual = sqlite3_mprintf("%lld", actual);
+  zMessage = testCompareMessage("expected_rows", pDef->zComparator,
+      pDef->zValue, zActual, actual<expected ? -1 : actual>expected ? 1 : 0);
+  sqlite3_free(zActual);
+  return zMessage;
+}
+
+static char *testAssertColumns(sqlite3_stmt *pStmt, const TestDef *pDef,
+    int *pRc){
+  sqlite3_int64 expected;
+  sqlite3_int64 actual = 0;
+  int rc;
+  char *zActual;
+  char *zMessage;
+  if( !pDef->zValue ){
+    return sqlite3_mprintf("null is not a valid assertion for expected_rows");
+  }
+  if( !testParseInteger(pDef->zValue, &expected) ){
+    return sqlite3_mprintf("cannot run assertion on non integer value: %s",
+        pDef->zValue);
+  }
+  rc = sqlite3_step(pStmt);
+  if( rc==SQLITE_ROW ) actual = sqlite3_column_count(pStmt);
+  else if( rc!=SQLITE_DONE ){
+    *pRc = rc;
+    return 0;
+  }
+  zActual = sqlite3_mprintf("%lld", actual);
+  zMessage = testCompareMessage("expected_columns", pDef->zComparator,
+      pDef->zValue, zActual, actual<expected ? -1 : actual>expected ? 1 : 0);
+  sqlite3_free(zActual);
+  return zMessage;
+}
+
+static char *testAssertSingle(sqlite3_stmt *pStmt, const TestDef *pDef,
+    int *pRc){
+  int rc = sqlite3_step(pStmt);
+  char *zMessage;
+  if( rc==SQLITE_DONE ){
+    return sqlite3_mprintf("expected_single_value expects exactly one cell. "
+        "Received 0 rows");
+  }
+  if( rc!=SQLITE_ROW ){
+    *pRc = rc;
+    return 0;
+  }
+  if( sqlite3_column_count(pStmt)!=1 ){
+    return sqlite3_mprintf("expected_single_value expects exactly one cell. "
+        "Received multiple columns");
+  }
+  zMessage = testCompareSingle(pStmt, pDef->zComparator, pDef->zValue);
+  rc = sqlite3_step(pStmt);
+  if( rc==SQLITE_ROW ){
+    sqlite3_free(zMessage);
+    return sqlite3_mprintf("expected_single_value expects exactly one cell. "
+        "Received multiple rows");
+  }
+  if( rc!=SQLITE_DONE ){
+    sqlite3_free(zMessage);
+    *pRc = rc;
+    return 0;
+  }
+  return zMessage;
+}
+
+static char *testPrepareError(sqlite3 *db){
+  const char *z = sqlite3_errmsg(db);
+  if( sqlite3_strnicmp(z, "no such table: ", 15)==0 ){
+    return sqlite3_mprintf("query error: table not found: %s", z+15);
+  }
+  return sqlite3_mprintf("query error: %s", z);
+}
+
+typedef struct TestAuth TestAuth;
+struct TestAuth {
+  sqlite3 *db;
+  sqlite3_xauth xAuth;
+  void *pAuthArg;
+  int hasCommand;
+};
+
+static int testAuthorizer(void *pArg, int action, const char *z1,
+    const char *z2, const char *z3, const char *z4){
+  TestAuth *p = (TestAuth*)pArg;
+  int rc = SQLITE_OK;
+  if( p->xAuth ) rc = p->xAuth(p->pAuthArg, action, z1, z2, z3, z4);
+  if( rc==SQLITE_OK && action==SQLITE_FUNCTION && z2 ){
+    FuncDef *pFunc = sqlite3FindFunction(p->db, z2, -2, ENC(p->db), 0);
+    if( pFunc && (pFunc->funcFlags & SQLITE_FUNC_DIRECT)!=0 ){
+      p->hasCommand = 1;
+    }
+  }
+  return rc;
+}
+
+static int testPrepare(sqlite3 *db, const char *zQuery,
+    sqlite3_stmt **ppStmt, char **pzMessage){
+  sqlite3_stmt *pStmt = 0;
+  sqlite3_stmt *pExtra = 0;
+  TestAuth auth;
+  const char *zTail = 0;
+  const char *zNext = 0;
+  int rc;
+  auth.db = db;
+  auth.xAuth = db->xAuth;
+  auth.pAuthArg = db->pAuthArg;
+  auth.hasCommand = 0;
+  db->xAuth = testAuthorizer;
+  db->pAuthArg = &auth;
+  rc = sqlite3_prepare_v2(db, zQuery, -1, &pStmt, &zTail);
+  db->xAuth = auth.xAuth;
+  db->pAuthArg = auth.pAuthArg;
+  if( rc!=SQLITE_OK ){
+    *pzMessage = testPrepareError(db);
+    return SQLITE_OK;
+  }
+  if( !pStmt ){
+    *pzMessage = sqlite3_mprintf("Can only run exactly one query");
+    return SQLITE_OK;
+  }
+  if( auth.hasCommand ){
+    sqlite3_finalize(pStmt);
+    *pzMessage = sqlite3_mprintf("Cannot execute write queries");
+    return SQLITE_OK;
+  }
+  while( zTail && zTail[0] ){
+    rc = sqlite3_prepare_v2(db, zTail, -1, &pExtra, &zNext);
+    if( rc!=SQLITE_OK ){
+      sqlite3_finalize(pStmt);
+      *pzMessage = sqlite3_mprintf("Can only run exactly one query");
+      return SQLITE_OK;
+    }
+    if( pExtra ){
+      sqlite3_finalize(pExtra);
+      sqlite3_finalize(pStmt);
+      *pzMessage = sqlite3_mprintf("Can only run exactly one query");
+      return SQLITE_OK;
+    }
+    if( !zNext || zNext==zTail ) break;
+    zTail = zNext;
+  }
+  if( !sqlite3_stmt_readonly(pStmt) ){
+    sqlite3_finalize(pStmt);
+    *pzMessage = sqlite3_mprintf("Cannot execute write queries");
+    return SQLITE_OK;
+  }
+  if( sqlite3_strlike("%dolt_test_run(%", zQuery, 0)==0 ){
+    sqlite3_finalize(pStmt);
+    *pzMessage = sqlite3_mprintf("Cannot call dolt_test_run in dolt_tests");
+    return SQLITE_OK;
+  }
+  *ppStmt = pStmt;
+  return SQLITE_OK;
+}
+
+static int testRunOne(sqlite3 *db, const TestDef *pDef,
+    TestResult *pResult){
+  sqlite3_stmt *pStmt = 0;
+  char *zMessage = 0;
+  int rc = SQLITE_OK;
+  memset(pResult, 0, sizeof(*pResult));
+  pResult->zName = sqlite3_mprintf("%s", pDef->zName);
+  pResult->zGroup = sqlite3_mprintf("%s", pDef->zGroup ? pDef->zGroup : "");
+  pResult->zQuery = sqlite3_mprintf("%s", pDef->zQuery);
+  if( !pResult->zName || !pResult->zGroup || !pResult->zQuery ){
+    testResultClear(pResult);
+    return SQLITE_NOMEM;
+  }
+  rc = testPrepare(db, pDef->zQuery, &pStmt, &zMessage);
+  if( rc!=SQLITE_OK ) goto test_run_done;
+  if( pStmt ){
+    if( strcmp(pDef->zAssertion, "expected_rows")==0 ){
+      zMessage = testAssertRows(pStmt, pDef, &rc);
+    }else if( strcmp(pDef->zAssertion, "expected_columns")==0 ){
+      zMessage = testAssertColumns(pStmt, pDef, &rc);
+    }else if( strcmp(pDef->zAssertion, "expected_single_value")==0 ){
+      zMessage = testAssertSingle(pStmt, pDef, &rc);
+    }else{
+      zMessage = sqlite3_mprintf("%s is not a valid assertion type",
+          pDef->zAssertion);
+    }
+  }
+test_run_done:
+  if( pStmt ){
+    int rcFinal = sqlite3_finalize(pStmt);
+    if( rc==SQLITE_OK && rcFinal!=SQLITE_OK ) rc = rcFinal;
+  }
+  if( rc!=SQLITE_OK ){
+    sqlite3_free(zMessage);
+    zMessage = sqlite3_mprintf("Query error: %s", sqlite3_errmsg(db));
+    rc = zMessage ? SQLITE_OK : SQLITE_NOMEM;
+  }
+  if( rc!=SQLITE_OK ){
+    testResultClear(pResult);
+    return rc;
+  }
+  if( !zMessage ) zMessage = sqlite3_mprintf("");
+  pResult->zStatus = sqlite3_mprintf("%s", zMessage[0] ? "FAIL" : "PASS");
+  pResult->zMessage = zMessage;
+  if( !pResult->zStatus || !pResult->zMessage ){
+    testResultClear(pResult);
+    return SQLITE_NOMEM;
+  }
+  return SQLITE_OK;
+}
+
+static int testRunConnect(sqlite3 *db, void *pAux, int argc,
+    const char *const*argv, sqlite3_vtab **ppVtab, char **pzErr){
+  sqlite3_str *pSchema;
+  char *zSchema;
+  TestRunVtab *pVtab;
+  int i;
+  int rc;
+  (void)pAux; (void)argc; (void)argv; (void)pzErr;
+  pSchema = sqlite3_str_new(db);
+  sqlite3_str_appendall(pSchema,
+      "CREATE TABLE x(test_name TEXT,test_group_name TEXT,query TEXT,"
+      "status TEXT,message TEXT");
+  for(i=0; i<TEST_RUN_MAX_ARGS; i++){
+    sqlite3_str_appendf(pSchema, ",arg%d HIDDEN", i);
+  }
+  sqlite3_str_appendchar(pSchema, 1, ')');
+  zSchema = sqlite3_str_finish(pSchema);
+  if( !zSchema ) return SQLITE_NOMEM;
+  rc = doltliteVtabConnectSimple(db, zSchema, sizeof(*pVtab), ppVtab);
+  sqlite3_free(zSchema);
+  if( rc!=SQLITE_OK ) return rc;
+  pVtab = (TestRunVtab*)*ppVtab;
+  pVtab->db = db;
+  return SQLITE_OK;
+}
+
+static int testRunBestIndex(sqlite3_vtab *pVtab,
+    sqlite3_index_info *pInfo){
+  int iCol;
+  int iCons;
+  int nArg = 0;
+  (void)pVtab;
+  for(iCol=TEST_RUN_FIRST_ARG;
+      iCol<TEST_RUN_FIRST_ARG+TEST_RUN_MAX_ARGS; iCol++){
+    for(iCons=0; iCons<pInfo->nConstraint; iCons++){
+      struct sqlite3_index_constraint *p = &pInfo->aConstraint[iCons];
+      if( p->usable && p->iColumn==iCol
+       && p->op==SQLITE_INDEX_CONSTRAINT_EQ ){
+        sqlite3_value *pRhs = 0;
+        if( sqlite3_vtab_rhs_value(pInfo, iCons, &pRhs)!=SQLITE_OK || !pRhs ){
+          sqlite3_free(pVtab->zErrMsg);
+          pVtab->zErrMsg = sqlite3_mprintf(
+              "dolt_test_run requires literal arguments");
+          return SQLITE_ERROR;
+        }
+        pInfo->aConstraintUsage[iCons].argvIndex = ++nArg;
+        pInfo->aConstraintUsage[iCons].omit = 1;
+        break;
+      }
+    }
+  }
+  pInfo->idxNum = nArg;
+  pInfo->estimatedCost = 10.0;
+  pInfo->estimatedRows = 10;
+  return SQLITE_OK;
+}
+
+static int testRunOpen(sqlite3_vtab *pVtab,
+    sqlite3_vtab_cursor **ppCursor){
+  (void)pVtab;
+  return doltliteVtabOpenCursor(ppCursor, sizeof(TestRunCursor));
+}
+
+static int testRunClose(sqlite3_vtab_cursor *pCursor){
+  testRunReset((TestRunCursor*)pCursor);
+  sqlite3_free(pCursor);
+  return SQLITE_OK;
+}
+
+static int testRunFilter(sqlite3_vtab_cursor *pCursor,
+    int idxNum, const char *idxStr, int argc, sqlite3_value **argv){
+  TestRunCursor *p = (TestRunCursor*)pCursor;
+  TestRunVtab *pVtab = (TestRunVtab*)pCursor->pVtab;
+  TestDef *aDef = 0;
+  int nDef = 0;
+  int i;
+  int rc = SQLITE_OK;
+  (void)idxNum; (void)idxStr;
+  testRunReset(p);
+  if( argc==0 ){
+    rc = testLoadArgument(pVtab->db, "*", &aDef, &nDef);
+  }else{
+    for(i=0; i<argc && rc==SQLITE_OK; i++){
+      const unsigned char *z = sqlite3_value_text(argv[i]);
+      int nBefore = nDef;
+      rc = testLoadArgument(pVtab->db, z ? (const char*)z : "NULL",
+          &aDef, &nDef);
+      if( rc==SQLITE_OK && nDef==nBefore ){
+        sqlite3_free(pVtab->base.zErrMsg);
+        pVtab->base.zErrMsg = sqlite3_mprintf(
+            "could not find tests for argument: %s", z ? z : (const unsigned char*)"NULL");
+        rc = SQLITE_ERROR;
+      }
+    }
+  }
+  if( rc==SQLITE_OK && nDef==0 ){
+    sqlite3_free(pVtab->base.zErrMsg);
+    pVtab->base.zErrMsg = sqlite3_mprintf(
+        "could not find tests for argument: *");
+    rc = SQLITE_ERROR;
+  }
+  if( rc==SQLITE_OK ){
+    p->aResult = sqlite3_malloc64((sqlite3_uint64)nDef * sizeof(*p->aResult));
+    if( !p->aResult ) rc = SQLITE_NOMEM;
+  }
+  if( rc==SQLITE_OK ){
+    memset(p->aResult, 0, (size_t)nDef * sizeof(*p->aResult));
+    for(i=0; i<nDef; i++){
+      rc = testRunOne(pVtab->db, &aDef[i], &p->aResult[i]);
+      if( rc!=SQLITE_OK ) break;
+      p->nResult++;
+    }
+  }
+  for(i=0; i<nDef; i++) testDefClear(&aDef[i]);
+  sqlite3_free(aDef);
+  if( rc!=SQLITE_OK ) testRunReset(p);
+  return rc;
+}
+
+static int testRunNext(sqlite3_vtab_cursor *pCursor){
+  ((TestRunCursor*)pCursor)->iRow++;
+  return SQLITE_OK;
+}
+
+static int testRunEof(sqlite3_vtab_cursor *pCursor){
+  TestRunCursor *p = (TestRunCursor*)pCursor;
+  return p->iRow>=p->nResult;
+}
+
+static int testRunColumn(sqlite3_vtab_cursor *pCursor,
+    sqlite3_context *ctx, int iCol){
+  TestRunCursor *p = (TestRunCursor*)pCursor;
+  TestResult *pResult = &p->aResult[p->iRow];
+  const char *z = iCol==0 ? pResult->zName
+      : iCol==1 ? pResult->zGroup
+      : iCol==2 ? pResult->zQuery
+      : iCol==3 ? pResult->zStatus
+      : iCol==4 ? pResult->zMessage : 0;
+  if( z ) sqlite3_result_text(ctx, z, -1, SQLITE_TRANSIENT);
+  else sqlite3_result_null(ctx);
+  return SQLITE_OK;
+}
+
+static int testRunRowid(sqlite3_vtab_cursor *pCursor,
+    sqlite3_int64 *pRowid){
+  *pRowid = ((TestRunCursor*)pCursor)->iRow;
+  return SQLITE_OK;
+}
+
+static sqlite3_module doltliteTestRunModule = {
+  0, 0, testRunConnect, testRunBestIndex, doltliteVtabDisconnect, 0,
+  testRunOpen, testRunClose, testRunFilter, testRunNext, testRunEof,
+  testRunColumn, testRunRowid,
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+};
+
+int doltliteTestsRegister(sqlite3 *db){
+  int rc = sqlite3_create_module(db, "dolt_tests", &doltliteTestsModule, 0);
+  if( rc==SQLITE_OK ){
+    rc = sqlite3_create_module(db, "dolt_test_run",
+        &doltliteTestRunModule, 0);
+  }
+  return rc;
+}
+
+#endif

--- a/test/doltlite_tests.sh
+++ b/test/doltlite_tests.sh
@@ -1,0 +1,262 @@
+#!/bin/bash
+. "$(dirname "$0")/lib/doltlite_test_common.sh"
+
+echo "=== Doltlite dolt_tests Tests ==="
+
+DB=/tmp/test_dolt_tests_$$.db
+rm -f "$DB"
+
+run_test "fresh_select_empty" \
+  "SELECT count(*) FROM dolt_tests;" \
+  "0" "$DB"
+
+run_test "fresh_not_materialized" \
+  "SELECT count(*) FROM sqlite_master WHERE name='dolt_tests';
+   SELECT count(*) FROM dolt_status;" \
+  "0
+0" "$DB"
+
+run_test "fresh_schema" \
+  "SELECT name, type, \"notnull\", pk FROM pragma_table_info('dolt_tests');" \
+  "test_name|TEXT|1|1
+test_group|TEXT|0|0
+test_query|TEXT|1|0
+assertion_type|TEXT|1|0
+assertion_comparator|TEXT|1|0
+assertion_value|TEXT|0|0" "$DB"
+
+run_test "insert_materializes" \
+  "INSERT INTO dolt_tests VALUES('rows','group_a','SELECT 1','expected_rows','==','1');
+   SELECT * FROM dolt_tests;" \
+  "rows|group_a|SELECT 1|expected_rows|==|1" "$DB"
+
+run_test "status_new_table" \
+  "SELECT table_name, staged, status FROM dolt_status;" \
+  "dolt_tests|0|new table" "$DB"
+
+run_test_match "duplicate_name_rejected" \
+  "INSERT INTO dolt_tests VALUES('rows','x','SELECT 1','expected_rows','==','1');" \
+  "UNIQUE constraint failed: dolt_tests.test_name" "$DB"
+
+run_test_match "null_query_rejected" \
+  "INSERT INTO dolt_tests VALUES('null_query',NULL,NULL,'expected_rows','==','1');" \
+  "NOT NULL constraint failed: dolt_tests.test_query" "$DB"
+
+run_test_match "invalid_assertion_rejected" \
+  "INSERT INTO dolt_tests VALUES('bad_type',NULL,'SELECT 1','row_count','==','1');" \
+  "CHECK constraint failed" "$DB"
+
+run_test_match "invalid_comparator_rejected" \
+  "INSERT INTO dolt_tests VALUES('bad_cmp',NULL,'SELECT 1','expected_rows','=','1');" \
+  "CHECK constraint failed" "$DB"
+
+run_test "nullable_group_and_value" \
+  "INSERT INTO dolt_tests(test_name,test_query,assertion_type,assertion_comparator)
+   VALUES('null_value','SELECT NULL','expected_single_value','==');
+   SELECT test_group IS NULL, assertion_value IS NULL FROM dolt_tests WHERE test_name='null_value';" \
+  "1|1" "$DB"
+
+run_test "update_replace_delete" \
+  "UPDATE dolt_tests SET test_group='updated' WHERE test_name='rows';
+   REPLACE INTO dolt_tests VALUES('rows','replaced','SELECT 1,2','expected_columns','==','2');
+   DELETE FROM dolt_tests WHERE test_name='null_value';
+   SELECT * FROM dolt_tests;" \
+  "rows|replaced|SELECT 1,2|expected_columns|==|2" "$DB"
+
+run_test "commit_tests" \
+  "SELECT dolt_commit('-A','-m','add tests') IS NOT NULL;
+   SELECT count(*) FROM dolt_status;" \
+  "1
+0" "$DB"
+
+run_test "runner_pass_and_fail" \
+  "CREATE TABLE fixture(i INT PRIMARY KEY, s TEXT);
+   INSERT INTO fixture VALUES(1,'one'),(2,'two');
+   INSERT INTO dolt_tests VALUES
+     ('a_rows_pass','group_a','SELECT * FROM fixture','expected_rows','==','2'),
+     ('b_rows_fail','group_a','SELECT * FROM fixture','expected_rows','==','3'),
+     ('c_cols_pass','group_b','SELECT i,s FROM fixture LIMIT 1','expected_columns','==','2'),
+     ('d_value_pass','group_b','SELECT count(*) FROM fixture','expected_single_value','>=','2');
+   SELECT test_name, status, message FROM dolt_test_run() ORDER BY test_name;" \
+  "a_rows_pass|PASS|
+b_rows_fail|FAIL|Assertion failed: expected_rows equal to 3, got 2
+c_cols_pass|PASS|
+d_value_pass|PASS|
+rows|PASS|" "$DB"
+
+run_test "runner_name_group_wildcard" \
+  "SELECT test_name FROM dolt_test_run('a_rows_pass');
+   SELECT test_name FROM dolt_test_run('group_b') ORDER BY test_name;
+   SELECT count(*) FROM dolt_test_run('*');" \
+  "a_rows_pass
+c_cols_pass
+d_value_pass
+5" "$DB"
+
+run_test "runner_multiple_arguments" \
+  "SELECT test_name FROM dolt_test_run('a_rows_pass','group_b');" \
+  "a_rows_pass
+c_cols_pass
+d_value_pass" "$DB"
+
+run_test "all_comparators" \
+  "INSERT INTO dolt_tests VALUES
+     ('cmp_eq','cmp','SELECT count(*) FROM fixture','expected_single_value','==','2'),
+     ('cmp_ne','cmp','SELECT count(*) FROM fixture','expected_single_value','!=','3'),
+     ('cmp_lt','cmp','SELECT count(*) FROM fixture','expected_single_value','<','3'),
+     ('cmp_le','cmp','SELECT count(*) FROM fixture','expected_single_value','<=','2'),
+     ('cmp_gt','cmp','SELECT count(*) FROM fixture','expected_single_value','>','1'),
+     ('cmp_ge','cmp','SELECT count(*) FROM fixture','expected_single_value','>=','2');
+   SELECT count(*) FROM dolt_test_run('cmp') WHERE status='PASS';" \
+  "6" "$DB"
+
+run_test "null_assertion" \
+  "INSERT INTO dolt_tests(test_name,test_group,test_query,assertion_type,assertion_comparator)
+   VALUES('null_pass','nulls','SELECT NULL','expected_single_value','=='),
+         ('null_fail','nulls','SELECT NULL','expected_single_value','!=');
+   SELECT test_name, status, message FROM dolt_test_run('nulls');" \
+  "null_fail|FAIL|Assertion failed: expected_single_value not equal to NULL, got NULL
+null_pass|PASS|" "$DB"
+
+run_test "runner_validation_results" \
+  "INSERT INTO dolt_tests VALUES
+     ('multi_stmt','validation','SELECT 1; SELECT 2','expected_rows','==','1'),
+     ('write_stmt','validation','CREATE TABLE nope(x INT)','expected_rows','==','1'),
+     ('command_stmt','validation','SELECT dolt_branch(''side_effect'')','expected_rows','==','1'),
+     ('recursive','validation','SELECT * FROM dolt_test_run()','expected_rows','==','1'),
+     ('zero_rows','validation','SELECT i FROM fixture WHERE 0','expected_single_value','==','1'),
+     ('many_cols','validation','SELECT i,s FROM fixture LIMIT 1','expected_single_value','==','1'),
+     ('many_rows','validation','SELECT i FROM fixture','expected_single_value','==','1');
+   SELECT test_name, status, message FROM dolt_test_run('validation');
+   SELECT count(*) FROM dolt_branches WHERE name='side_effect';" \
+  "command_stmt|FAIL|Cannot execute write queries
+many_cols|FAIL|expected_single_value expects exactly one cell. Received multiple columns
+many_rows|FAIL|expected_single_value expects exactly one cell. Received multiple rows
+multi_stmt|FAIL|Can only run exactly one query
+recursive|FAIL|Cannot call dolt_test_run in dolt_tests
+write_stmt|FAIL|Cannot execute write queries
+zero_rows|FAIL|expected_single_value expects exactly one cell. Received 0 rows
+0" "$DB"
+
+run_test "runner_query_error" \
+  "INSERT INTO dolt_tests VALUES
+     ('query_error','errors','SELECT * FROM absent','expected_rows','==','0');
+   SELECT test_name, status, message FROM dolt_test_run('errors');" \
+  "query_error|FAIL|query error: table not found: absent" "$DB"
+
+run_test_match "runner_missing_argument" \
+  "SELECT * FROM dolt_test_run('missing');" \
+  "could not find tests for argument: missing" "$DB"
+
+run_test_match "runner_nonliteral_argument" \
+  "SELECT * FROM dolt_test_run(upper('errors'));" \
+  "dolt_test_run requires literal arguments" "$DB"
+
+run_test "drop_materialized_table" \
+  "DROP TABLE dolt_tests;
+   SELECT count(*) FROM dolt_tests;
+   SELECT count(*) FROM sqlite_master WHERE name='dolt_tests';" \
+  "0
+0" "$DB"
+
+rm -f "$DB"
+DB=/tmp/test_dolt_tests_zero_$$.db
+rm -f "$DB"
+
+run_test "zero_row_write_materializes" \
+  "DELETE FROM dolt_tests WHERE test_name='missing';
+   SELECT table_name, status FROM dolt_status;
+   SELECT count(*) FROM sqlite_master WHERE name='dolt_tests';" \
+  "dolt_tests|new table
+1" "$DB"
+
+rm -f "$DB"
+DB=/tmp/test_dolt_tests_txn_$$.db
+rm -f "$DB"
+
+run_test "rollback_undoes_materialization" \
+  "BEGIN;
+   INSERT INTO dolt_tests VALUES('t',NULL,'SELECT 1','expected_rows','==','1');
+   ROLLBACK;
+   SELECT count(*) FROM dolt_tests;
+   SELECT count(*) FROM sqlite_master WHERE name='dolt_tests';" \
+  "0
+0" "$DB"
+
+run_test_match "runner_without_tests_errors" \
+  "SELECT * FROM dolt_test_run();" \
+  "could not find tests for argument: *" "$DB"
+
+rm -f "$DB"
+DB=/tmp/test_dolt_tests_schema_$$.db
+rm -f "$DB"
+
+run_test "hand_created_exact_schema" \
+  "CREATE TABLE dolt_tests(
+     test_name TEXT NOT NULL,
+     test_group TEXT,
+     test_query TEXT NOT NULL,
+     assertion_type TEXT NOT NULL,
+     assertion_comparator TEXT NOT NULL,
+     assertion_value TEXT,
+     PRIMARY KEY(test_name),
+     CONSTRAINT assertion_type_check CHECK(assertion_type IN
+       ('expected_rows','expected_columns','expected_single_value')),
+     CONSTRAINT assertion_comparator_check CHECK(assertion_comparator IN
+       ('==','!=','<','>','<=','>='))
+   );
+   INSERT INTO dolt_tests VALUES('hand',NULL,'SELECT 1','expected_rows','==','1');
+   SELECT test_name, status FROM dolt_test_run();" \
+  "hand|PASS" "$DB"
+
+rm -f "$DB"
+DB=/tmp/test_dolt_tests_bad_schema_$$.db
+rm -f "$DB"
+
+run_test_match "hand_created_wrong_check_rejected" \
+  "CREATE TABLE dolt_tests(
+     test_name TEXT NOT NULL,
+     test_group TEXT,
+     test_query TEXT NOT NULL,
+     assertion_type TEXT NOT NULL,
+     assertion_comparator TEXT NOT NULL,
+     assertion_value TEXT,
+     PRIMARY KEY(test_name),
+     CONSTRAINT assertion_type_check CHECK(assertion_type IN
+       ('bad','expected_columns','expected_single_value')),
+     CONSTRAINT assertion_comparator_check CHECK(assertion_comparator IN
+       ('==','!=','<','>','<=','>='))
+   );" \
+  "wrong expressions" "$DB"
+
+rm -f "$DB"
+DB=/tmp/test_dolt_tests_branch_$$.db
+rm -f "$DB"
+
+run_test "branch_isolation" \
+  "INSERT INTO dolt_tests VALUES('base',NULL,'SELECT 1','expected_rows','==','1');
+   SELECT dolt_commit('-A','-m','base') IS NOT NULL;
+   SELECT dolt_checkout('-b','feature') IS NOT NULL;
+   INSERT INTO dolt_tests VALUES('feature',NULL,'SELECT 1','expected_rows','==','1');
+   SELECT dolt_checkout('main') IS NOT NULL;
+   SELECT group_concat(test_name, ',') FROM dolt_tests;" \
+  "1
+1
+1
+base" "$DB"
+
+run_test "merge_tests" \
+  "SELECT dolt_checkout('feature') IS NOT NULL;
+   SELECT dolt_commit('-A','-m','feature test') IS NOT NULL;
+   SELECT dolt_checkout('main') IS NOT NULL;
+   SELECT dolt_merge('feature') IS NOT NULL;
+   SELECT group_concat(test_name, ',') FROM dolt_tests;" \
+  "1
+1
+1
+1
+base,feature" "$DB"
+
+rm -f "$DB"
+
+dltest_finish

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -1461,12 +1461,13 @@ attach2 attach2-4.15 class=intentional issue=1846  # PRAGMA lock_status: doltlit
 # Parent-dir Access probe adds allocations on multi-component open/ATTACH
 # paths, shifting OOM fault indices (same #1859 brittleness as backup_malloc).
 # vec1's built-in registration adds ~25 allocations at connection open,
-# shifting every entry by +25.
-attachmalloc attachmalloc-1.transient.492 class=unsupported issue=1839  # OOM fault-point shift (parent probe)
-attachmalloc attachmalloc-1.transient.917 @no-coverage class=unsupported issue=1839  # OOM fault-point shift (ATTACH seed)
-attachmalloc attachmalloc-1.transient.1411 @no-coverage class=unsupported issue=1839  # OOM fault-point shift (ATTACH seed)
-attachmalloc attachmalloc-1.transient.925 @coverage class=unsupported issue=1839  # OOM fault-point shift (ATTACH seed)
-attachmalloc attachmalloc-1.transient.1427 @coverage class=unsupported issue=1839  # OOM fault-point shift (ATTACH seed)
+# shifting every entry by +25. The dolt_tests and dolt_test_run module
+# registrations add four more.
+attachmalloc attachmalloc-1.transient.496 class=unsupported issue=1839  # OOM fault-point shift (parent probe)
+attachmalloc attachmalloc-1.transient.921 @no-coverage class=unsupported issue=1839  # OOM fault-point shift (ATTACH seed)
+attachmalloc attachmalloc-1.transient.1415 @no-coverage class=unsupported issue=1839  # OOM fault-point shift (ATTACH seed)
+attachmalloc attachmalloc-1.transient.929 @coverage class=unsupported issue=1839  # OOM fault-point shift (ATTACH seed)
+attachmalloc attachmalloc-1.transient.1431 @coverage class=unsupported issue=1839  # OOM fault-point shift (ATTACH seed)
 mallocD mallocD-4.transient.107 class=unsupported issue=1839  # OOM fault-point shift (parent probe)
 
 # temptable2 section 8 — page_count is a chunk-store metric, not SQLite

--- a/test/lib/doltlite_suite_manifest.sh
+++ b/test/lib/doltlite_suite_manifest.sh
@@ -11,6 +11,7 @@ doltlite_commit.sh
 doltlite_staging.sh
 doltlite_workspace.sh
 doltlite_docs.sh
+doltlite_tests.sh
 doltlite_diff.sh
 doltlite_reset.sh
 doltlite_branch.sh
@@ -139,6 +140,7 @@ doltlite_commit.sh
 doltlite_staging.sh
 doltlite_workspace.sh
 doltlite_docs.sh
+doltlite_tests.sh
 doltlite_branch.sh
 doltlite_open_branch.sh
 doltlite_tag.sh

--- a/test/oracle-buckets/refs-workspace.txt
+++ b/test/oracle-buckets/refs-workspace.txt
@@ -9,6 +9,7 @@ vc_oracle_commit_test.sh
 vc_oracle_connection_branch_test.sh
 vc_oracle_cross_connection_state_test.sh
 vc_oracle_docs_test.sh
+vc_oracle_tests_test.sh
 vc_oracle_hashof_errors_test.sh
 vc_oracle_hashof_test.sh
 vc_oracle_ignore_test.sh

--- a/test/vc_oracle_tests_test.sh
+++ b/test/vc_oracle_tests_test.sh
@@ -1,0 +1,284 @@
+#!/bin/bash
+
+set -u
+set -o pipefail
+
+DOLTLITE="${1:-./doltlite}"
+DOLT="${2:-dolt}"
+TMPROOT=$(mktemp -d)
+trap "rm -rf $TMPROOT" EXIT
+pass=0; fail=0
+FAILED_NAMES=""
+source "$(dirname "$0")/lib/vc_oracle_common.sh"
+
+normalize_tests() { tr -d '\r"' | grep '^T|' | sort; }
+normalize_results() { tr -d '\r"' | grep '^R|'; }
+normalize_status() { tr -d '\r"' | grep '^S|' | sort; }
+
+TESTS_QUERY_DL="SELECT 'T|' || test_name || '|' || coalesce(test_group,'') || '|' || test_query || '|' || assertion_type || '|' || assertion_comparator || '|' || coalesce(assertion_value,'NULL') FROM dolt_tests;"
+TESTS_QUERY_DT="SELECT concat('T|', test_name, '|', coalesce(test_group,''), '|', test_query, '|', assertion_type, '|', assertion_comparator, '|', coalesce(assertion_value,'NULL')) FROM dolt_tests;"
+STATUS_QUERY_DL="SELECT 'S|' || table_name || '|' || staged || '|' || status FROM dolt_status;"
+STATUS_QUERY_DT="SELECT concat('S|', table_name, '|', staged, '|', status) FROM dolt_status;"
+
+oracle_query() {
+  local kind="$1" name="$2" setup="$3" query_dl="$4" query_dt="$5" allow_empty="${6:-}"
+  local dir="$TMPROOT/$name"
+  local norm
+  [ "$kind" = "tests" ] && norm=normalize_tests
+  [ "$kind" = "results" ] && norm=normalize_results
+  [ "$kind" = "status" ] && norm=normalize_status
+  mkdir -p "$dir/dl" "$dir/dt"
+
+  local dl_out
+  dl_out=$(printf "%s\n.headers off\n.mode list\n%s\n" "$setup" "$query_dl" \
+    | "$DOLTLITE" "$dir/dl/db" 2>"$dir/dl.err" | $norm)
+
+  local dolt_setup
+  dolt_setup=$(vc_oracle_translate_for_dolt "$setup")
+  (
+    cd "$dir/dt" || exit 1
+    vc_oracle_init_repo
+    printf "%s\n%s\n" "$dolt_setup" "$query_dt" \
+      | "$DOLT" sql -c -r csv 2>"$dir/dt.err"
+  ) >"$dir/dt.raw"
+  local dt_out
+  dt_out=$($norm < "$dir/dt.raw")
+
+  if [ "$allow_empty" = "EXPECT_EMPTY" ]; then
+    vc_oracle_assert_match_allow_empty "$name" "$dl_out" "$dt_out"
+  else
+    vc_oracle_assert_match "$name" "$dl_out" "$dt_out"
+  fi
+}
+
+oracle_tests() { oracle_query tests "$1" "$2" "$TESTS_QUERY_DL" "$TESTS_QUERY_DT" "${3:-}"; }
+oracle_status() { oracle_query status "$1" "$2" "$STATUS_QUERY_DL" "$STATUS_QUERY_DT" "${3:-}"; }
+
+oracle_results() {
+  local name="$1" setup="$2" args="${3:-}"
+  local dl="SELECT 'R|' || test_name || '|' || test_group_name || '|' || query || '|' || status || '|' || message FROM dolt_test_run($args);"
+  local dt="SELECT concat('R|', test_name, '|', test_group_name, '|', query, '|', status, '|', message) FROM dolt_test_run($args);"
+  oracle_query results "$name" "$setup" "$dl" "$dt"
+}
+
+oracle_error() {
+  local name="$1" setup="$2" query_dl="$3" query_dt="$4"
+  local dir="$TMPROOT/${name}_err"
+  mkdir -p "$dir/dl" "$dir/dt"
+  vc_oracle_run_doltlite_script "$dir/dl/db" "$dir/dl.out" "$dir/dl.err" "$setup
+$query_dl"
+  local dl_rc=$?
+  local dolt_setup
+  dolt_setup=$(vc_oracle_translate_for_dolt "$setup")
+  vc_oracle_run_dolt_script_for_error "$dir/dt" "$dir/dt.out" "$dir/dt.err" "$dolt_setup
+$query_dt"
+  local dt_rc=$?
+  if vc_oracle_is_clean_error "$dl_rc" && vc_oracle_is_clean_error "$dt_rc"; then
+    pass=$((pass+1))
+  else
+    fail=$((fail+1))
+    FAILED_NAMES="$FAILED_NAMES $name"
+    echo "  FAIL: $name (expected both to error; doltlite=$dl_rc dolt=$dt_rc)"
+  fi
+}
+
+echo "=== Version Control Oracle Tests: dolt_tests and dolt_test_run ==="
+echo ""
+
+echo "--- lazy table and writes ---"
+
+oracle_tests "fresh_select_empty" "SELECT * FROM dolt_tests;" "EXPECT_EMPTY"
+oracle_status "fresh_read_no_status" "SELECT * FROM dolt_tests;" "EXPECT_EMPTY"
+
+oracle_tests "insert_materializes" "
+INSERT INTO dolt_tests VALUES ('row_count', 'basic', 'SELECT 1', 'expected_rows', '==', '1');
+"
+
+oracle_status "zero_row_delete_materializes" "
+DELETE FROM dolt_tests WHERE test_name='missing';
+"
+
+oracle_tests "update_replace_delete" "
+INSERT INTO dolt_tests VALUES ('one', 'g', 'SELECT 1', 'expected_rows', '==', '1');
+INSERT INTO dolt_tests VALUES ('two', NULL, 'SELECT 2', 'expected_single_value', '==', '2');
+UPDATE dolt_tests SET test_group='updated' WHERE test_name='one';
+REPLACE INTO dolt_tests VALUES ('two', 'replaced', 'SELECT 3', 'expected_single_value', '==', '3');
+DELETE FROM dolt_tests WHERE test_name='one';
+"
+
+oracle_tests "nullable_group_value" "
+INSERT INTO dolt_tests(test_name,test_query,assertion_type,assertion_comparator)
+VALUES ('null_value', 'SELECT NULL', 'expected_single_value', '==');
+"
+
+oracle_error "duplicate_pk" \
+  "INSERT INTO dolt_tests VALUES ('dup',NULL,'SELECT 1','expected_rows','==','1');" \
+  "INSERT INTO dolt_tests VALUES ('dup',NULL,'SELECT 1','expected_rows','==','1');" \
+  "INSERT INTO dolt_tests VALUES ('dup',NULL,'SELECT 1','expected_rows','==','1');"
+
+oracle_error "invalid_assertion" "" \
+  "INSERT INTO dolt_tests VALUES ('bad',NULL,'SELECT 1','row_count','==','1');" \
+  "INSERT INTO dolt_tests VALUES ('bad',NULL,'SELECT 1','row_count','==','1');"
+
+oracle_error "invalid_comparator" "" \
+  "INSERT INTO dolt_tests VALUES ('bad',NULL,'SELECT 1','expected_rows','=','1');" \
+  "INSERT INTO dolt_tests VALUES ('bad',NULL,'SELECT 1','expected_rows','=','1');"
+
+echo "--- version control ---"
+
+oracle_status "clean_after_commit" "
+INSERT INTO dolt_tests VALUES ('committed',NULL,'SELECT 1','expected_rows','==','1');
+SELECT dolt_commit('-A','-m','add test');
+" "EXPECT_EMPTY"
+
+oracle_status "modified_after_commit" "
+INSERT INTO dolt_tests VALUES ('committed',NULL,'SELECT 1','expected_rows','==','1');
+SELECT dolt_commit('-A','-m','add test');
+UPDATE dolt_tests SET assertion_value='2';
+"
+
+oracle_tests "branch_isolation" "
+INSERT INTO dolt_tests VALUES ('main_test',NULL,'SELECT 1','expected_rows','==','1');
+SELECT dolt_commit('-A','-m','base');
+SELECT dolt_checkout('-b','feature');
+INSERT INTO dolt_tests VALUES ('feature_test',NULL,'SELECT 1','expected_rows','==','1');
+SELECT dolt_checkout('main');
+"
+
+oracle_tests "clean_merge" "
+INSERT INTO dolt_tests VALUES ('base',NULL,'SELECT 1','expected_rows','==','1');
+SELECT dolt_commit('-A','-m','base');
+SELECT dolt_checkout('-b','feature');
+INSERT INTO dolt_tests VALUES ('feature',NULL,'SELECT 1','expected_rows','==','1');
+SELECT dolt_commit('-A','-m','feature');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feature');
+"
+
+echo "--- runner selection and assertions ---"
+
+BASE_SETUP="
+CREATE TABLE fixture(i INT PRIMARY KEY, s TEXT);
+INSERT INTO fixture VALUES (1,'one'),(2,'two');
+INSERT INTO dolt_tests VALUES
+ ('a_rows_pass','group_a','SELECT i FROM fixture','expected_rows','==','2'),
+ ('b_rows_fail','group_a','SELECT i FROM fixture','expected_rows','==','3'),
+ ('c_cols_pass','group_b','SELECT i,s FROM fixture LIMIT 1','expected_columns','==','2'),
+ ('d_value_pass','group_b','SELECT count(*) FROM fixture','expected_single_value','>=','2'),
+ ('e_text_pass',NULL,'SELECT s FROM fixture WHERE i=1','expected_single_value','==','one');
+"
+
+oracle_results "no_args_runs_all" "$BASE_SETUP"
+oracle_results "wildcard_runs_all" "$BASE_SETUP" "'*'"
+oracle_results "individual_name" "$BASE_SETUP" "'e_text_pass'"
+oracle_results "group_name" "$BASE_SETUP" "'group_b'"
+oracle_results "multiple_arguments" "$BASE_SETUP" "'e_text_pass','group_b'"
+
+oracle_results "all_comparators" "
+INSERT INTO dolt_tests VALUES
+ ('eq','cmp','SELECT 2','expected_single_value','==','2'),
+ ('ne','cmp','SELECT 2','expected_single_value','!=','3'),
+ ('lt','cmp','SELECT 2','expected_single_value','<','3'),
+ ('le','cmp','SELECT 2','expected_single_value','<=','2'),
+ ('gt','cmp','SELECT 2','expected_single_value','>','1'),
+ ('ge','cmp','SELECT 2','expected_single_value','>=','2');
+" "'cmp'"
+
+oracle_results "null_values" "
+INSERT INTO dolt_tests(test_name,test_group,test_query,assertion_type,assertion_comparator) VALUES
+ ('null_eq','nulls','SELECT NULL','expected_single_value','=='),
+ ('null_ne','nulls','SELECT NULL','expected_single_value','!=');
+" "'nulls'"
+
+oracle_results "result_shape_errors" "
+CREATE TABLE fixture(i INT PRIMARY KEY, s TEXT);
+INSERT INTO fixture VALUES (1,'one'),(2,'two');
+INSERT INTO dolt_tests VALUES
+ ('many_cols','shape','SELECT i,s FROM fixture LIMIT 1','expected_single_value','==','1'),
+ ('many_rows','shape','SELECT i FROM fixture','expected_single_value','==','1'),
+ ('zero_rows','shape','SELECT i FROM fixture WHERE 0','expected_single_value','==','1');
+" "'shape'"
+
+oracle_results "query_validation" "
+INSERT INTO dolt_tests VALUES
+ ('multi','validation','SELECT 1; SELECT 2','expected_rows','==','1'),
+ ('recursive','validation','SELECT * FROM dolt_test_run()','expected_rows','==','1'),
+ ('write','validation','CREATE TABLE nope(x INT)','expected_rows','==','1');
+" "'validation'"
+
+oracle_results "non_integer_counts" "
+INSERT INTO dolt_tests VALUES
+ ('bad_cols','bad_int','SELECT 1','expected_columns','==','0.5'),
+ ('bad_rows','bad_int','SELECT 1','expected_rows','==','0.5');
+" "'bad_int'"
+
+oracle_results "scalar_types" "
+CREATE TABLE typed_values(d DATE, f DOUBLE, b BOOLEAN, s TEXT);
+INSERT INTO typed_values VALUES ('2025-08-22',3.14159,true,'String');
+INSERT INTO dolt_tests VALUES
+ ('boolean','types','SELECT b FROM typed_values','expected_single_value','==','true'),
+ ('date','types','SELECT d FROM typed_values','expected_single_value','<','2025-08-23'),
+ ('float','types','SELECT f FROM typed_values','expected_single_value','<','3.2'),
+ ('string','types','SELECT s FROM typed_values','expected_single_value','==','String');
+" "'types'"
+
+oracle_results "scalar_type_failures" "
+CREATE TABLE typed_failures(
+ d DATE, dt DATETIME, f DOUBLE, amount DECIMAL(10,2), b BOOLEAN, s TEXT
+);
+INSERT INTO typed_failures VALUES
+ ('2025-08-22','2025-08-22 09:00:00',3.14159,10.4,true,'String');
+INSERT INTO dolt_tests VALUES
+ ('bool_fail','type_failures','SELECT b FROM typed_failures','expected_single_value','==','false'),
+ ('date_fail','type_failures','SELECT d FROM typed_failures','expected_single_value','>','2025-08-23'),
+ ('decimal_fail','type_failures','SELECT amount FROM typed_failures','expected_single_value','>','10.5'),
+ ('datetime_fail','type_failures','SELECT dt FROM typed_failures','expected_single_value','>','2025-08-22 09:00:01'),
+ ('float_fail','type_failures','SELECT f FROM typed_failures','expected_single_value','>','3.2'),
+ ('string_fail','type_failures','SELECT s FROM typed_failures','expected_single_value','!=','String');
+" "'type_failures'"
+
+oracle_results "zero_row_columns" "
+INSERT INTO dolt_tests VALUES
+ ('zero_cols','zero','SELECT 1,2 WHERE 0','expected_columns','==','0');
+" "'zero'"
+
+oracle_results "delimiter_optional" "
+INSERT INTO dolt_tests VALUES
+ ('no_semicolon','delimiter','SELECT 1','expected_rows','==','1'),
+ ('semicolon','delimiter','SELECT 1;','expected_rows','==','1');
+" "'delimiter'"
+
+oracle_results "name_precedes_group" "
+INSERT INTO dolt_tests VALUES
+ ('chosen','other','SELECT 1','expected_rows','==','1'),
+ ('group_member','chosen','SELECT 1','expected_rows','==','1');
+" "'chosen'"
+
+oracle_results "duplicate_arguments_repeat_results" "
+INSERT INTO dolt_tests VALUES
+ ('repeat','repeats','SELECT 1','expected_rows','==','1');
+" "'repeat','repeat'"
+
+oracle_results "query_error" "
+INSERT INTO dolt_tests VALUES
+ ('missing_table','errors','SELECT * FROM absent','expected_rows','==','0');
+" "'errors'"
+
+oracle_error "missing_argument" "$BASE_SETUP" \
+  "SELECT * FROM dolt_test_run('missing');" \
+  "SELECT * FROM dolt_test_run('missing');"
+
+oracle_error "nonliteral_argument" "$BASE_SETUP" \
+  "SELECT * FROM dolt_test_run(upper('group_a'));" \
+  "SELECT * FROM dolt_test_run(upper('group_a'));"
+
+oracle_error "no_tests_wildcard" "" \
+  "SELECT * FROM dolt_test_run();" \
+  "SELECT * FROM dolt_test_run();"
+
+echo ""
+echo "=== Results: $pass passed, $fail failed ==="
+if [ $fail -gt 0 ]; then
+  echo "Failed:$FAILED_NAMES"
+  exit 1
+fi

--- a/test/vc_oracle_tests_test.sh
+++ b/test/vc_oracle_tests_test.sh
@@ -98,6 +98,27 @@ oracle_status "zero_row_delete_materializes" "
 DELETE FROM dolt_tests WHERE test_name='missing';
 "
 
+oracle_query tests "rollback_first_write" "
+BEGIN;
+INSERT INTO dolt_tests VALUES ('rolled',NULL,'SELECT 1','expected_rows','==','1');
+ROLLBACK;
+" \
+  "SELECT 'T|' || (SELECT count(*) FROM dolt_tests) || '|' ||
+      (SELECT count(*) FROM dolt_status WHERE table_name='dolt_tests');" \
+  "SELECT concat('T|', (SELECT count(*) FROM dolt_tests), '|',
+      (SELECT count(*) FROM dolt_status WHERE table_name='dolt_tests'));"
+
+oracle_query tests "rollback_after_zero_row_materialization" "
+DELETE FROM dolt_tests WHERE test_name='missing';
+BEGIN;
+INSERT INTO dolt_tests VALUES ('rolled',NULL,'SELECT 1','expected_rows','==','1');
+ROLLBACK;
+" \
+  "SELECT 'T|' || (SELECT count(*) FROM dolt_tests) || '|' ||
+      (SELECT count(*) FROM dolt_status WHERE table_name='dolt_tests');" \
+  "SELECT concat('T|', (SELECT count(*) FROM dolt_tests), '|',
+      (SELECT count(*) FROM dolt_status WHERE table_name='dolt_tests'));"
+
 oracle_tests "update_replace_delete" "
 INSERT INTO dolt_tests VALUES ('one', 'g', 'SELECT 1', 'expected_rows', '==', '1');
 INSERT INTO dolt_tests VALUES ('two', NULL, 'SELECT 2', 'expected_single_value', '==', '2');

--- a/tool/mksqlite3c.tcl
+++ b/tool/mksqlite3c.tcl
@@ -636,6 +636,7 @@ proc emit_doltlite_engine_block {} {
     doltlite_history.c doltlite_at.c doltlite_blame.c doltlite_schema_diff.c doltlite_patch.c
     doltlite_schemas.c doltlite_diff_stat.c doltlite_record.c doltlite_ignore.c
     doltlite_docs.c
+    doltlite_tests.c
     doltlite_hashof.c doltlite_constraint_violations.c doltlite_verify_constraints.c doltlite_merge_constraints.c doltlite_merge_constraints_unique.c doltlite_merge_constraints_check.c doltlite_merge_constraints_fk.c doltlite_merge_constraints_notnull.c doltlite_merge_constraints_strict.c
     doltlite_dbpage.c doltlite_remote.c doltlite_remote_sql.c
     doltlite_http_remote.c


### PR DESCRIPTION
## What

- Add a lazy writable dolt_tests system table that resolves on fresh repositories and materializes Dolt’s six-column versioned schema on the first write.
- Add the variadic dolt_test_run table function with Dolt-compatible name, group, wildcard, and multi-argument selection.
- Match Dolt assertion behavior for row counts, column counts, scalar values, comparators, NULLs, supported scalar types, result messages, and validation failures.
- Restrict test queries to one read-only statement and reject recursive runner calls and DoltLite command functions.
- Wire the surface into CLI/library/amalgamation builds, repository documentation, suite manifests, and schema guards.

## Reference behavior

The implementation follows the current Dolt dolt_tests table and dolt_test_run source, with observable behavior compared directly against Dolt 2.2.1 in the oracle suite. Like dolt_docs, an eponymous writable virtual table handles fresh reads and first-write materialization; the resulting ordinary table then commits, diffs, branches, and merges through the existing engine.

## Tests

- test/doltlite_tests.sh: 29 passed
- test/vc_oracle_tests_test.sh: 35 passed against Dolt
- make doltlite
- make lint
- test/lint_orphaned_suites.sh
- git diff --check

Co-Authored-By: OpenAI Codex <noreply@openai.com>