### PR TITLE
Fix amalgamation build with custom WAL sync

### DIFF
--- a/src/btree.c
+++ b/src/btree.c
@@ -3286,7 +3286,17 @@ static void setDefaultSyncFlag(BtShared *pBt, u8 safety_level){
   sqlite3 *db;
   Db *pDb;
   if( (db=pBt->db)!=0 && (pDb=db->aDb)!=0 ){
+#ifdef DOLTLITE_PROLLY
+    Btree *pOrig = 0;
+    while( pDb->pBt==0
+        || (pOrig=(Btree*)doltliteBtreeOrigPtr((void*)pDb->pBt))==0
+        || pOrig->pBt!=pBt
+    ){
+      pDb++;
+    }
+#else
     while( pDb->pBt==0 || pDb->pBt->pBt!=pBt ){ pDb++; }
+#endif
     if( pDb->bSyncSet==0
      && pDb->safety_level!=safety_level
      && pDb!=&db->aDb[1]

--- a/test/amalgamation_wasm_compile_test.sh
+++ b/test/amalgamation_wasm_compile_test.sh
@@ -29,6 +29,7 @@ trap 'rm -rf "$tmp"' EXIT
   -DSQLITE_ENABLE_SESSION \
   -DSQLITE_ENABLE_STMTVTAB \
   -DSQLITE_THREADSAFE=0 \
+  -DSQLITE_DEFAULT_WAL_SYNCHRONOUS=1 \
   -DSQLITE_TEMP_STORE=2 \
   -DSQLITE_ENABLE_MATH_FUNCTIONS \
   -DSQLITE_OS_OTHER=1 \
@@ -45,5 +46,26 @@ trap 'rm -rf "$tmp"' EXIT
   -DBUILD_sqlite \
   -o "$tmp/sqlite3.o"
 
+"$emcc_bin" -Werror -Wno-comment -c "$amalgamation" \
+  -Oz -flto \
+  -DSQLITE_DQS=0 \
+  -DSQLITE_THREADSAFE=0 \
+  -DSQLITE_DEFAULT_MEMSTATUS=0 \
+  -DSQLITE_DEFAULT_WAL_SYNCHRONOUS=1 \
+  -DSQLITE_LIKE_DOESNT_MATCH_BLOBS \
+  -DSQLITE_OMIT_DECLTYPE \
+  -DSQLITE_OMIT_DEPRECATED \
+  -DSQLITE_OMIT_SHARED_CACHE \
+  -DSQLITE_OMIT_AUTOINIT \
+  -DSQLITE_OMIT_UTF16 \
+  -DDOLTLITE_PROLLY=1 \
+  -DSQLITE_WASM \
+  -DSQLITE_USE_ALLOCA \
+  -DVEC1_THREADS=0 \
+  -DSQLITE_OS_OTHER=1 \
+  -DSQLITE_ENABLE_BATCH_ATOMIC_WRITE \
+  -o "$tmp/sqlite3-user-flags.o"
+
 test -s "$tmp/sqlite3.o"
+test -s "$tmp/sqlite3-user-flags.o"
 echo "amalgamation wa-sqlite compile: PASS"


### PR DESCRIPTION
## Summary

- resolve the stock btree delegate before reading its shared state in DoltLite builds
- keep stock SQLite behavior unchanged behind `DOLTLITE_PROLLY`
- compile the amalgamation in CI with the reported Emscripten feature and omit flags

## Testing

- fail-before: reported flags fail at `pDb->pBt->pBt` with incomplete `Btree`
- `test/amalgamation_wasm_compile_test.sh build/sqlite3.c`: PASS for the existing wa-sqlite profile and reported user profile
- native `cc -fsyntax-only` with the reported defines: PASS
- `make -C build doltlite doltlite-lib`: PASS
- `make -C build lint`: 14 passed, 0 failed

Co-Authored-By: OpenAI Codex <noreply@openai.com>