### PR TITLE
Keep the refs three-way merge from publishing states no open can read

### DIFF
--- a/src/chunk_refs.c
+++ b/src/chunk_refs.c
@@ -845,12 +845,30 @@ int csMergeSavedRefsOntoDisk(
     cs->refs.zDefaultBranch = zDup;
   }
 
+  /* Each category merged in isolation, so a pairing that is legal in both
+  ** views separately can still be illegal together: one side repoints the
+  ** default branch while the other deletes that branch. The decoder
+  ** requires the default to name a live branch, so publishing that pair
+  ** leaves a store no open can read. Treat it as the conflict it is. */
+  if( cs->refs.zDefaultBranch
+   && csFindNamedRef(cs->refs.aBranches, cs->refs.nBranches,
+                     (int)sizeof(BranchRef), cs->refs.zDefaultBranch)<0 ){
+    return SQLITE_BUSY_SNAPSHOT;
+  }
+
   /* AUTOINCREMENT counters are high-water marks shared across branches:
   ** the merged value is the max of both sides, never a conflict, and a
-  ** counter the session dropped (DROP TABLE) goes away. */
+  ** counter the session dropped (DROP TABLE) goes away. Counters the
+  ** session never touched are the peer's business -- bumping those back
+  ** onto disk resurrects one the peer dropped, so a recreated table would
+  ** resume from the old high-water mark. */
   for(i=0; i<pLocal->nSequences; i++){
     const SequenceRef *pL = &pLocal->aSequences[i];
-    int rc2 = chunkStoreBumpSequence(cs, pL->zTableName, pL->iSeq);
+    int iBase = csFindNamedRef(pBase->aSequences, pBase->nSequences,
+                               (int)sizeof(SequenceRef), pL->zTableName);
+    int rc2;
+    if( iBase>=0 && pBase->aSequences[iBase].iSeq==pL->iSeq ) continue;
+    rc2 = chunkStoreBumpSequence(cs, pL->zTableName, pL->iSeq);
     if( rc2!=SQLITE_OK ) return rc2;
   }
   for(i=0; i<pBase->nSequences; i++){

--- a/src/chunk_store_int.h
+++ b/src/chunk_store_int.h
@@ -41,5 +41,6 @@ int csSyncFile(ChunkStore *cs);
 void csFillChunkHdr(u8 *p, const ProllyHash *pHash, u32 size);
 void csSerializeManifest(const ChunkStore *cs, u8 *aBuf);
 int csManifestHashStateOffsetless(const u8 *aBuf);
+int csReadDiskRefsHash(ChunkStore *cs, ProllyHash *pOut);
 
 #endif /* CHUNK_STORE_INT_H */

--- a/src/chunk_store_lock.c
+++ b/src/chunk_store_lock.c
@@ -181,8 +181,22 @@ int csRestoreOrMergeLocalRefs(
   const ProllyHash *pSavedRefsHash,
   const ProllyHash *pBaseRefsHash
 ){
+  ProllyHash diskRefsHash;
+  int diskMoved = 0;
   int rc;
-  if( prollyHashCompare(&cs->refs.committedRefsHash, pBaseRefsHash)==0 ){
+  /* committedRefsHash is only a proxy for what disk holds. An operation that
+  ** lost this merge reinstates a base-derived view but leaves that field at
+  ** the disk hash, and a later lock refresh that finds the file unchanged
+  ** never re-adopts it -- so a commit retried without a rollback would read
+  ** "base unchanged" and republish the stale table, the very clobber this
+  ** merge exists to prevent. Consult the sealed manifest tail as well, and
+  ** merge whenever it proves disk has moved past the base. */
+  if( csReadDiskRefsHash(cs, &diskRefsHash)
+   && prollyHashCompare(&diskRefsHash, pBaseRefsHash)!=0 ){
+    diskMoved = 1;
+  }
+  if( !diskMoved
+   && prollyHashCompare(&cs->refs.committedRefsHash, pBaseRefsHash)==0 ){
     csFreeRefsState(cs);
     csRestoreSavedRefsState(cs, pSaved);
     cs->refs.refsHash = *pSavedRefsHash;
@@ -217,6 +231,11 @@ int csRestoreOrMergeLocalRefs(
   csFreeRefsState(cs);
   csRestoreSavedRefsState(cs, pSaved);
   cs->refs.refsHash = *pSavedRefsHash;
+  /* The reinstated tables derive from the base, so that is what they are
+  ** committed against -- leaving this at the disk hash the refresh adopted
+  ** would make the next commit capture disk as its base and see nothing to
+  ** merge. */
+  cs->refs.committedRefsHash = *pBaseRefsHash;
   return rc;
 }
 

--- a/src/chunk_store_refs_api.c
+++ b/src/chunk_store_refs_api.c
@@ -83,6 +83,35 @@ int csDiskStateMatchesMemory(ChunkStore *cs){
                 cs->refs.refsHash.data, PROLLY_HASH_SIZE)==0;
 }
 
+/* The refs hash the on-disk manifest tail records, read fresh. The
+** in-memory committedRefsHash is only a proxy for it: an operation that
+** reinstates a pre-merge view leaves the two disagreeing, and a lock
+** refresh that finds the file unchanged never re-adopts it. Returns 0 when
+** the tail cannot be read as a sealed root record, which the caller must
+** treat as "cannot prove disk is unmoved". Caller holds the store lock. */
+int csReadDiskRefsHash(ChunkStore *cs, ProllyHash *pOut){
+  i64 physSize = 0;
+  u8 aRoot[1 + CHUNK_MANIFEST_SIZE];
+
+  memset(pOut, 0, sizeof(*pOut));
+  if( cs->file.pFile==0 ) return 0;
+  /* Locate the tail from the file itself, not from this handle's WAL
+  ** bookkeeping: a peer's commit appended past where this handle believes
+  ** the content ends, and that append is exactly what must be detected. */
+  if( sqlite3OsFileSize(cs->file.pFile, &physSize)!=SQLITE_OK ) return 0;
+  if( physSize < (i64)sizeof(aRoot) ) return 0;
+  if( sqlite3OsRead(cs->file.pFile, aRoot, (int)sizeof(aRoot),
+                    physSize - (i64)sizeof(aRoot))!=SQLITE_OK ){
+    return 0;
+  }
+  /* An unsealed tail (this handle's own uncommitted append, or a torn
+  ** write) is not a published state; report "cannot prove" and let the
+  ** caller fall back to its in-memory comparison. */
+  if( aRoot[0]!=CS_WAL_TAG_ROOT ) return 0;
+  memcpy(pOut->data, aRoot + 1 + CS_MANIFEST_REFS_HASH_OFF, PROLLY_HASH_SIZE);
+  return 1;
+}
+
 /* Read zName's committed tip straight from disk into *pTip, leaving this
 ** store's in-memory state untouched. Opens a throwaway view of the file (as
 ** csReloadFromDisk does) so a commit/merge head-CAS sees a peer's advance even

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -1693,6 +1693,194 @@ static void run_refs_commit_merges_concurrent_peer_refs(void){
   removeDbFiles(dbpath);
 }
 
+/* Each ref category merges in isolation, so a pairing legal in both views
+** separately can still be illegal together: a peer repoints the default
+** branch while this session deletes that branch. The decoder requires the
+** default to name a live branch, so publishing that pair leaves a store no
+** open can read -- the merge must refuse it instead. */
+static void run_refs_merge_rejects_dangling_default(void){
+  ChunkStore csA, csB, csC;
+  ProllyHash h1, h2, chunkHash;
+  static const u8 payload[] = "refs-dangling-default-chunk";
+  char dbpath[256];
+
+  printf("=== Refs Merge Rejects Dangling Default Test ===\n\n");
+  make_dbpath(dbpath, sizeof(dbpath), "test_refs_dangling_default");
+  removeDbFiles(dbpath);
+  memset(&csA, 0, sizeof(csA));
+  memset(&csB, 0, sizeof(csB));
+  memset(&csC, 0, sizeof(csC));
+
+  prollyHashCompute("main-tip", 8, &h1);
+  prollyHashCompute("feat-tip", 8, &h2);
+
+  check("dd_open_A",
+        chunkStoreOpen(&csA, sqlite3_vfs_find(0), dbpath,
+            SQLITE_OPEN_READWRITE|SQLITE_OPEN_CREATE|SQLITE_OPEN_MAIN_DB)==SQLITE_OK);
+  check("dd_seed_main", chunkStoreAddBranch(&csA, "main", &h1)==SQLITE_OK);
+  check("dd_seed_feat", chunkStoreAddBranch(&csA, "feat", &h2)==SQLITE_OK);
+  check("dd_seed_default", chunkStoreSetDefaultBranch(&csA, "main")==SQLITE_OK);
+  check("dd_seed_serialize", chunkStoreSerializeRefs(&csA)==SQLITE_OK);
+  check("dd_seed_commit", chunkStoreCommit(&csA)==SQLITE_OK);
+
+  /* Peer repoints the default onto feat. */
+  check("dd_open_B",
+        chunkStoreOpen(&csB, sqlite3_vfs_find(0), dbpath,
+            SQLITE_OPEN_READWRITE|SQLITE_OPEN_MAIN_DB)==SQLITE_OK);
+  check("dd_peer_default",
+        chunkStoreSetDefaultBranch(&csB, "feat")==SQLITE_OK);
+  check("dd_peer_serialize", chunkStoreSerializeRefs(&csB)==SQLITE_OK);
+  check("dd_peer_commit", chunkStoreCommit(&csB)==SQLITE_OK);
+
+  /* This session, still on the base view where the default is main,
+  ** legally deletes feat and commits alongside a staged chunk. */
+  check("dd_local_delete", chunkStoreDeleteBranch(&csA, "feat")==SQLITE_OK);
+  check("dd_local_serialize", chunkStoreSerializeRefs(&csA)==SQLITE_OK);
+  check("dd_local_put",
+        chunkStorePut(&csA, payload, (int)sizeof(payload), &chunkHash)==SQLITE_OK);
+  check("dd_local_commit_refused",
+        chunkStoreCommit(&csA)==SQLITE_BUSY_SNAPSHOT);
+
+  chunkStoreClose(&csA);
+  chunkStoreClose(&csB);
+
+  /* The store must still open: a published dangling default is unreadable. */
+  check("dd_reopen",
+        chunkStoreOpen(&csC, sqlite3_vfs_find(0), dbpath,
+            SQLITE_OPEN_READWRITE|SQLITE_OPEN_MAIN_DB)==SQLITE_OK);
+  check("dd_reopen_default_live",
+        chunkStoreFindBranch(&csC, "feat", 0)==SQLITE_OK);
+  chunkStoreClose(&csC);
+  removeDbFiles(dbpath);
+}
+
+/* A commit that lost the refs merge reinstates its pre-merge view for the
+** caller to unwind over. Retrying that commit without rolling back first
+** must not republish the stale table wholesale -- that is exactly the peer
+** clobber the merge exists to prevent. */
+static void run_refs_commit_retry_after_conflict_still_fails(void){
+  ChunkStore csA, csB, csC;
+  ProllyHash h1, hA, hB, hKeep, found, chunkHash;
+  static const u8 payload[] = "refs-retry-chunk";
+  char dbpath[256];
+
+  printf("=== Refs Commit Retry After Conflict Still Fails Test ===\n\n");
+  make_dbpath(dbpath, sizeof(dbpath), "test_refs_retry_conflict");
+  removeDbFiles(dbpath);
+  memset(&csA, 0, sizeof(csA));
+  memset(&csB, 0, sizeof(csB));
+  memset(&csC, 0, sizeof(csC));
+
+  prollyHashCompute("base", 4, &h1);
+  prollyHashCompute("ours", 4, &hA);
+  prollyHashCompute("theirs", 6, &hB);
+  prollyHashCompute("keepme", 6, &hKeep);
+
+  check("rr_open_A",
+        chunkStoreOpen(&csA, sqlite3_vfs_find(0), dbpath,
+            SQLITE_OPEN_READWRITE|SQLITE_OPEN_CREATE|SQLITE_OPEN_MAIN_DB)==SQLITE_OK);
+  check("rr_seed_branch", chunkStoreAddBranch(&csA, "shared", &h1)==SQLITE_OK);
+  check("rr_seed_default",
+        chunkStoreSetDefaultBranch(&csA, "shared")==SQLITE_OK);
+  check("rr_seed_serialize", chunkStoreSerializeRefs(&csA)==SQLITE_OK);
+  check("rr_seed_commit", chunkStoreCommit(&csA)==SQLITE_OK);
+
+  /* Peer moves the shared branch and adds an unrelated one. */
+  check("rr_open_B",
+        chunkStoreOpen(&csB, sqlite3_vfs_find(0), dbpath,
+            SQLITE_OPEN_READWRITE|SQLITE_OPEN_MAIN_DB)==SQLITE_OK);
+  check("rr_peer_update",
+        chunkStoreUpdateBranch(&csB, "shared", &hB)==SQLITE_OK);
+  check("rr_peer_add", chunkStoreAddBranch(&csB, "peer_keep", &hKeep)==SQLITE_OK);
+  check("rr_peer_serialize", chunkStoreSerializeRefs(&csB)==SQLITE_OK);
+  check("rr_peer_commit", chunkStoreCommit(&csB)==SQLITE_OK);
+
+  /* This session moves the same branch from its stale base: a real
+  ** conflict, correctly refused. */
+  check("rr_local_update",
+        chunkStoreUpdateBranch(&csA, "shared", &hA)==SQLITE_OK);
+  check("rr_local_serialize", chunkStoreSerializeRefs(&csA)==SQLITE_OK);
+  check("rr_local_put",
+        chunkStorePut(&csA, payload, (int)sizeof(payload), &chunkHash)==SQLITE_OK);
+  check("rr_first_commit_conflicts",
+        chunkStoreCommit(&csA)==SQLITE_BUSY_SNAPSHOT);
+  check("rr_retry_still_conflicts",
+        chunkStoreCommit(&csA)==SQLITE_BUSY_SNAPSHOT);
+
+  chunkStoreClose(&csA);
+  chunkStoreClose(&csB);
+
+  check("rr_reopen",
+        chunkStoreOpen(&csC, sqlite3_vfs_find(0), dbpath,
+            SQLITE_OPEN_READWRITE|SQLITE_OPEN_MAIN_DB)==SQLITE_OK);
+  check("rr_peer_tip_survives",
+        chunkStoreFindBranch(&csC, "shared", &found)==SQLITE_OK
+        && prollyHashCompare(&found, &hB)==0);
+  check("rr_peer_branch_survives",
+        chunkStoreFindBranch(&csC, "peer_keep", 0)==SQLITE_OK);
+  chunkStoreClose(&csC);
+  removeDbFiles(dbpath);
+}
+
+/* AUTOINCREMENT counters merge as high-water marks, but only for counters
+** this session actually changed. Bumping an untouched one back onto disk
+** resurrects a counter a peer dropped with its table, so a recreated table
+** would resume from the old mark instead of restarting. */
+static void run_refs_merge_keeps_peer_sequence_drop(void){
+  ChunkStore csA, csB, csC;
+  ProllyHash h1, chunkHash;
+  static const u8 payload[] = "refs-seq-drop-chunk";
+  i64 seqVal = 0;
+  char dbpath[256];
+
+  printf("=== Refs Merge Keeps Peer Sequence Drop Test ===\n\n");
+  make_dbpath(dbpath, sizeof(dbpath), "test_refs_seq_drop");
+  removeDbFiles(dbpath);
+  memset(&csA, 0, sizeof(csA));
+  memset(&csB, 0, sizeof(csB));
+  memset(&csC, 0, sizeof(csC));
+
+  prollyHashCompute("main-tip", 8, &h1);
+
+  check("sd_open_A",
+        chunkStoreOpen(&csA, sqlite3_vfs_find(0), dbpath,
+            SQLITE_OPEN_READWRITE|SQLITE_OPEN_CREATE|SQLITE_OPEN_MAIN_DB)==SQLITE_OK);
+  check("sd_seed_branch", chunkStoreAddBranch(&csA, "main", &h1)==SQLITE_OK);
+  check("sd_seed_default", chunkStoreSetDefaultBranch(&csA, "main")==SQLITE_OK);
+  check("sd_seed_sequence", chunkStoreBumpSequence(&csA, "t", 5)==SQLITE_OK);
+  check("sd_seed_serialize", chunkStoreSerializeRefs(&csA)==SQLITE_OK);
+  check("sd_seed_commit", chunkStoreCommit(&csA)==SQLITE_OK);
+
+  /* Peer drops the table, taking its counter with it. */
+  check("sd_open_B",
+        chunkStoreOpen(&csB, sqlite3_vfs_find(0), dbpath,
+            SQLITE_OPEN_READWRITE|SQLITE_OPEN_MAIN_DB)==SQLITE_OK);
+  chunkStoreDropSequence(&csB, "t");
+  check("sd_peer_serialize", chunkStoreSerializeRefs(&csB)==SQLITE_OK);
+  check("sd_peer_commit", chunkStoreCommit(&csB)==SQLITE_OK);
+
+  /* This session commits something unrelated over its stale base. */
+  check("sd_local_branch",
+        chunkStoreAddBranch(&csA, "unrelated", &h1)==SQLITE_OK);
+  check("sd_local_serialize", chunkStoreSerializeRefs(&csA)==SQLITE_OK);
+  check("sd_local_put",
+        chunkStorePut(&csA, payload, (int)sizeof(payload), &chunkHash)==SQLITE_OK);
+  check("sd_local_commit", chunkStoreCommit(&csA)==SQLITE_OK);
+
+  chunkStoreClose(&csA);
+  chunkStoreClose(&csB);
+
+  check("sd_reopen",
+        chunkStoreOpen(&csC, sqlite3_vfs_find(0), dbpath,
+            SQLITE_OPEN_READWRITE|SQLITE_OPEN_MAIN_DB)==SQLITE_OK);
+  seqVal = chunkStoreGetSequenceValue(&csC, "t");
+  check("sd_dropped_sequence_stays_dropped", seqVal==0);
+  check("sd_unrelated_branch_survives",
+        chunkStoreFindBranch(&csC, "unrelated", 0)==SQLITE_OK);
+  chunkStoreClose(&csC);
+  removeDbFiles(dbpath);
+}
+
 static void run_refs_commit_conflicting_peer_ref_fails(void){
   ChunkStore csA, csB, csC;
   ProllyHash h1, hA, hB, chunkHash;
@@ -10972,6 +11160,9 @@ static const RegressionCase aCases[] = {
   { "status_error_propagation", "Status Error Propagation Test", run_status_error_propagation },
   { "status_many_table_renames", "Status Many Table Renames Test", run_status_many_table_renames },
   { "refs_commit_merges_concurrent_peer_refs", "Refs Commit Merges Concurrent Peer Refs Test", run_refs_commit_merges_concurrent_peer_refs },
+  { "refs_merge_rejects_dangling_default", "Refs Merge Rejects Dangling Default Test", run_refs_merge_rejects_dangling_default },
+  { "refs_commit_retry_after_conflict_still_fails", "Refs Commit Retry After Conflict Still Fails Test", run_refs_commit_retry_after_conflict_still_fails },
+  { "refs_merge_keeps_peer_sequence_drop", "Refs Merge Keeps Peer Sequence Drop Test", run_refs_merge_keeps_peer_sequence_drop },
   { "refs_commit_conflicting_peer_ref_fails", "Refs Commit Conflicting Peer Ref Fails Test", run_refs_commit_conflicting_peer_ref_fails },
   { "remote_refs_corruption", "Remote Refs Corruption Test", run_remote_refs_corruption },
   { "fetch_preserves_concurrent_local_refs", "Fetch Preserves Concurrent Local Refs Test", run_fetch_preserves_concurrent_local_refs },


### PR DESCRIPTION
## Problem

Three holes in the refs three-way merge added by #2143, found by the Aug 12 review and reproduced at the store level:

1. **A merged commit can publish a dangling default branch, leaving the store unopenable.** The categories merge in isolation, so a pairing that is legal in each view separately is still applied together: a peer repoints the default branch onto `feat` while this session — still on a base view where the default is `main` — legally deletes `feat`. Both halves apply, the published blob names a default with no branch behind it, and the decoder rejects that on the next open (`SQLITE_CORRUPT`). The database is bricked.
2. **A commit retried after a detected conflict silently clobbers every peer ref.** The failure path reinstates the pre-merge view for the caller to unwind over, but left `committedRefsHash` at the disk hash the refresh adopted. A caller that retried the commit without rolling back first then captured *disk* as its base, saw nothing to merge, and republished the stale table wholesale — the losing side of the conflict wins and unrelated peer branches disappear. That is exactly the clobber #2143 exists to prevent.
3. **Sequences resurrect a peer's `DROP TABLE`.** Every local counter was bumped onto disk, including ones the session never touched, so a dropped counter came back and a recreated table resumed from the old high-water mark instead of restarting.

## Fix

1. After the categories merge, verify the merged default still names a live branch; that pairing is a conflict (`SQLITE_BUSY_SNAPSHOT`), not a publishable state.
2. The failure path records the base the reinstated tables actually derive from, and the wholesale-restore fast path additionally consults the sealed manifest tail — an in-memory equality alone can no longer authorize republishing a stale table. The tail is located from the file's own size, since a peer's commit appends past where this handle believes content ends. The disk check is additive: it can only *force* the merge path, never skip it, so stores whose tail cannot be read behave exactly as before.
3. Only counters that differ from the base merge, matching how every other category decides what the session changed.

## Testing

Three store-level regression cases, all failing on master:
- `refs_merge_rejects_dangling_default` — 3 checks fail on master, including the reopen itself (the store won't open).
- `refs_commit_retry_after_conflict_still_fails` — 3 fail on master (retry succeeds; peer tip and peer branch both lost).
- `refs_merge_keeps_peer_sequence_drop` — 1 fails on master.

Full battery green (the one red suite was a missing stock `sqlite3` in my fresh worktree; 119/119 once built). Amalgamation regenerated and compiles clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)