### PR TITLE
Row-merge add/add tables with matching schema

### DIFF
--- a/src/doltlite_merge_pass1.c
+++ b/src/doltlite_merge_pass1.c
@@ -292,6 +292,25 @@ static int mergePass1ResolveOursEntry(
   return SQLITE_OK;
 }
 
+static int mergePass1AddedSchemaMatches(
+  MergePass1Ctx *c,
+  const char *zObjectName,
+  int iOurs,
+  struct TableEntry *theirsEntry
+){
+  SchemaEntry *ourSE;
+  SchemaEntry *theirSE;
+  if( prollyHashCompare(&c->aOurs[iOurs].schemaHash,
+                        &theirsEntry->schemaHash)==0 ){
+    return 1;
+  }
+  if( !zObjectName ) return 0;
+  ourSE = findSchemaEntry(c->aOursSchema, c->nOursSchema, zObjectName);
+  theirSE = findSchemaEntry(c->aTheirsSchema, c->nTheirsSchema, zObjectName);
+  if( !ourSE || !theirSE || !ourSE->zSql || !theirSE->zSql ) return 0;
+  return strcmp(ourSE->zSql, theirSE->zSql)==0;
+}
+
 /* Ours added the object (absent from ancestor). */
 static int mergePass1OursAdded(
   MergePass1Ctx *c,
@@ -307,18 +326,48 @@ static int mergePass1OursAdded(
       c->aMerged[(*c->pnMerged)++] = c->aOurs[iOurs];
       return SQLITE_OK;
     }
-    if( prollyHashCompare(&c->aOurs[iOurs].root, &theirsEntry->root)!=0
-     || prollyHashCompare(&c->aOurs[iOurs].schemaHash,
-                          &theirsEntry->schemaHash)!=0 ){
-      if( zName
-       && (strcmp(zName, "sqlite_stat1")==0
-        || strcmp(zName, "sqlite_stat4")==0) ){
+    if( zName
+     && (strcmp(zName, "sqlite_stat1")==0
+      || strcmp(zName, "sqlite_stat4")==0) ){
+      c->aMerged[(*c->pnMerged)++] = c->aOurs[iOurs];
+      return SQLITE_OK;
+    }
+    if( mergePass1AddedSchemaMatches(
+          c, zName ? zName : zSchemaMergeName, iOurs, theirsEntry) ){
+      if( prollyHashCompare(&c->aOurs[iOurs].root, &theirsEntry->root)==0 ){
         c->aMerged[(*c->pnMerged)++] = c->aOurs[iOurs];
         return SQLITE_OK;
       }
-      rc = mergePass1NoteSchemaConflict(c, zSchemaConflictTable, zSchemaMergeName);
-      if( rc!=SQLITE_OK ) return rc;
+      if( !zName ){
+        if( zSchemaMergeName && zSchemaMergeName[0] ){
+          rc = mergeAppendReindexName(
+              c->pazReindex, c->pnReindex, zSchemaMergeName);
+          if( rc!=SQLITE_OK ) return rc;
+        }
+        c->aMerged[(*c->pnMerged)++] = c->aOurs[iOurs];
+        return SQLITE_OK;
+      }
+      if( ((c->aOurs[iOurs].flags ^ theirsEntry->flags)
+           & PROLLY_NODE_INTKEY)!=0 ){
+        if( c->pzErrMsg ){
+          sqlite3_free(*c->pzErrMsg);
+          *c->pzErrMsg = sqlite3_mprintf(
+              "cannot merge because table '%s' has different primary keys",
+              zName);
+        }
+        return SQLITE_ERROR;
+      }
+      {
+        struct TableEntry ancEmpty;
+        memset(&ancEmpty, 0, sizeof(ancEmpty));
+        ancEmpty.flags = c->aOurs[iOurs].flags;
+        return mergePass1MergeTableData(
+            c, zName, zName, &c->aOurs[iOurs], &ancEmpty,
+            &theirsEntry->root, 0, 0, SCHEMA_MERGE_DEFAULT, theirsEntry);
+      }
     }
+    rc = mergePass1NoteSchemaConflict(c, zSchemaConflictTable, zSchemaMergeName);
+    if( rc!=SQLITE_OK ) return rc;
   }
   c->aMerged[(*c->pnMerged)++] = c->aOurs[iOurs];
   return SQLITE_OK;

--- a/test/vc_oracle_merge_test.sh
+++ b/test/vc_oracle_merge_test.sh
@@ -1681,6 +1681,71 @@ COMMIT;
                   WHERE commit_hash = HASHOF('HEAD')));"
 
 echo ""
+echo "--- add/add matching schema ---"
+
+oracle_error_poststate "dual_add_table_same_schema_union" "
+SELECT dolt_commit('-Am', 'init empty');
+SELECT dolt_branch('feat');
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1, 'main'), (3, 'm3');
+SELECT dolt_commit('-Am', 'main adds t');
+SELECT dolt_checkout('feat');
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (2, 'feat'), (4, 'f4');
+SELECT dolt_commit('-Am', 'feat adds t');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feat');
+" "SELECT (SELECT count(*) FROM dolt_schema_conflicts) || '|' || (SELECT count(*) FROM dolt_conflicts) || '|' || (SELECT group_concat(id || ':' || v, ',') FROM (SELECT id, v FROM t ORDER BY id))" \
+"SELECT CONCAT((SELECT COUNT(*) FROM dolt_schema_conflicts), '|', (SELECT COUNT(*) FROM dolt_conflicts), '|', (SELECT GROUP_CONCAT(CONCAT(id, ':', v) ORDER BY id SEPARATOR ',') FROM t))"
+
+oracle_same_session "dual_add_table_same_pk_is_row_conflict" "
+SELECT dolt_commit('-Am', 'init empty');
+SELECT dolt_branch('feat');
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1, 'main');
+SELECT dolt_commit('-Am', 'main adds t');
+SELECT dolt_checkout('feat');
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1, 'feat');
+SELECT dolt_commit('-Am', 'feat adds t');
+SELECT dolt_checkout('main');
+BEGIN;
+SELECT dolt_merge('feat');
+" "SELECT 'Q' || char(9) || (SELECT count(*) FROM dolt_schema_conflicts) || char(9) || (SELECT count(*) FROM dolt_conflicts) || char(9) || (SELECT coalesce(sum(num_conflicts), 0) FROM dolt_conflicts) || char(9) || (SELECT group_concat(id || ':' || v, ',') FROM (SELECT id, v FROM t ORDER BY id));" \
+"SELECT CONCAT('Q', char(9), (SELECT COUNT(*) FROM dolt_schema_conflicts), char(9), (SELECT COUNT(*) FROM dolt_conflicts), char(9), (SELECT COALESCE(SUM(num_conflicts), 0) FROM dolt_conflicts), char(9), (SELECT GROUP_CONCAT(CONCAT(id, ':', v) ORDER BY id SEPARATOR ',') FROM t));"
+
+oracle_error "dual_add_table_different_schema_refused" "
+SELECT dolt_commit('-Am', 'init empty');
+SELECT dolt_branch('feat');
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1, 'main');
+SELECT dolt_commit('-Am', 'main adds t');
+SELECT dolt_checkout('feat');
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (2, 7);
+SELECT dolt_commit('-Am', 'feat adds t');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feat');
+"
+
+oracle_error_poststate "dual_add_index_same_sql_covers_merged_rows" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, k INT, v TEXT);
+INSERT INTO t VALUES (1, 10, 'x');
+SELECT dolt_commit('-Am', 'init');
+SELECT dolt_branch('feat');
+INSERT INTO t VALUES (2, 20, 'main');
+CREATE INDEX tk ON t(k);
+SELECT dolt_commit('-Am', 'main idx');
+SELECT dolt_checkout('feat');
+INSERT INTO t VALUES (3, 30, 'feat');
+CREATE INDEX tk ON t(k);
+SELECT dolt_commit('-Am', 'feat idx');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feat');
+" "SELECT (SELECT count(*) FROM dolt_schema_conflicts) || '|' || (SELECT group_concat(id || ':' || k, ',') FROM (SELECT id, k FROM t ORDER BY id)) || '|' || (SELECT group_concat(id || ':' || k, ',') FROM (SELECT id, k FROM t INDEXED BY tk WHERE k >= 10 ORDER BY k))" \
+"SELECT CONCAT((SELECT COUNT(*) FROM dolt_schema_conflicts), '|', (SELECT GROUP_CONCAT(CONCAT(id, ':', k) ORDER BY id SEPARATOR ',') FROM t), '|', (SELECT GROUP_CONCAT(CONCAT(id, ':', k) ORDER BY k SEPARATOR ',') FROM t WHERE k >= 10))"
+
+echo ""
 echo "=== Results: $pass passed, $fail failed ==="
 if [ $fail -gt 0 ]; then
   echo "Failed:$FAILED_NAMES"


### PR DESCRIPTION
## Summary

`mergePass1OursAdded` treated any root **or** schemaHash mismatch as a schema conflict and kept ours. That is wrong when both sides add the same object:

1. Same `CREATE TABLE`, different rows — Dolt empty-ancestor row-merges. DoltLite reported "added on both branches with different definitions" and dropped theirs.
2. Same `CREATE INDEX` after a table that already existed — table rows merged, but the schema conflict skipped index-root patches, so `INDEXED BY` missed theirs rows.

## Fix

- Matching table SQL/schemaHash and different roots: `mergePass1MergeTableData` with an empty ancestor.
- Matching index SQL/schemaHash: keep ours and `REINDEX` from the merged table.
- Different definitions still schema-conflict. INTKEY mismatch still refuses as different primary keys. `sqlite_stat*` still keeps ours.

## Tests

Dolt oracle in `test/vc_oracle_merge_test.sh`:

- `dual_add_table_same_schema_union` — union of both sides, no conflicts
- `dual_add_table_same_pk_is_row_conflict` — row conflict, not schema
- `dual_add_table_different_schema_refused` — both sides error
- `dual_add_index_same_sql_covers_merged_rows` — merged table is fully indexed

Fail-before on the unfixed engine: schema conflict + missing theirs rows. Pass-after matches Dolt. Full merge oracle: 82/82. `doltlite_merge.sh`: 113/113.

Co-Authored-By: Grok 4.6 <noreply@x.ai>