### PR TITLE
Keep both tables when each side renames the same one

### DIFF
--- a/src/doltlite_merge_int.h
+++ b/src/doltlite_merge_int.h
@@ -61,18 +61,25 @@ int canFastMerge(
 
 /* Row-merge policy. Scoped by object identity, computed where both full
 ** catalogs are visible, so enabling it cannot change any conflict but the ones
-** it names -- a rename on both sides still conflicts.
+** it names.
 **
 ** azRenameOverDrop holds ancestor object names one side renamed and the other
 ** dropped. A catalog row whose base name or tbl_name is listed resolves to the
 ** surviving side instead of conflicting, matching Dolt, which keeps such a
-** table as an add. Resolving inside the row merge keeps the merged root
-** canonical, which the history-independence gate requires.
+** table as an add.
+**
+** azDualRename holds ancestor names both sides renamed to different names.
+** A modify/modify on those catalog rows is not a user conflict: pass 2 keeps
+** both tables. The row merge leaves ours in place; serialize rebuilds master.
+** Resolving inside the row merge keeps the merged root canonical, which the
+** history-independence gate requires.
 */
 typedef struct MergeRowPolicy MergeRowPolicy;
 struct MergeRowPolicy {
   const char **azRenameOverDrop;
   int nRenameOverDrop;
+  const char **azDualRename;
+  int nDualRename;
 };
 
 int mergeTableRows(

--- a/src/doltlite_merge_pass1.c
+++ b/src/doltlite_merge_pass1.c
@@ -777,6 +777,41 @@ static int mergePass1CollectRenameOverDrop(
   return SQLITE_OK;
 }
 
+static int mergePass1CollectDualRename(
+  MergePass1Ctx *c,
+  MergeRowPolicy *pPolicy
+){
+  int i;
+  for(i=0; i<c->nAnc; i++){
+    struct TableEntry *pOurs;
+    struct TableEntry *pTheirs;
+    const char **azNew;
+    if( c->aAnc[i].iTable<=1 || !c->aAnc[i].zName ) continue;
+    pOurs = doltliteFindTableByNumber(c->aOurs, c->nOurs, c->aAnc[i].iTable);
+    pTheirs = doltliteFindTableByNumber(c->aTheirs, c->nTheirs, c->aAnc[i].iTable);
+    if( !pOurs || !pTheirs || !pOurs->zName || !pTheirs->zName ) continue;
+    if( sqlite3_stricmp(pOurs->zName, c->aAnc[i].zName)==0 ) continue;
+    if( sqlite3_stricmp(pTheirs->zName, c->aAnc[i].zName)==0 ) continue;
+    if( sqlite3_stricmp(pOurs->zName, pTheirs->zName)==0 ) continue;
+    azNew = sqlite3_realloc(
+        (void*)pPolicy->azDualRename,
+        (pPolicy->nDualRename + 1) * (int)sizeof(char*));
+    if( !azNew ) return SQLITE_NOMEM;
+    pPolicy->azDualRename = azNew;
+    pPolicy->azDualRename[pPolicy->nDualRename++] = c->aAnc[i].zName;
+  }
+  return SQLITE_OK;
+}
+
+static void mergePass1FreeRowPolicy(MergeRowPolicy *pPolicy){
+  sqlite3_free((void*)pPolicy->azRenameOverDrop);
+  sqlite3_free((void*)pPolicy->azDualRename);
+  pPolicy->azRenameOverDrop = 0;
+  pPolicy->azDualRename = 0;
+  pPolicy->nRenameOverDrop = 0;
+  pPolicy->nDualRename = 0;
+}
+
 /* Merge catalog root (iTable==1). Deferred so schema actions are known. */
 static int mergePass1MergeMaster(MergePass1Ctx *c, int iTable1Idx){
   struct TableEntry *ancEntry;
@@ -839,15 +874,16 @@ static int mergePass1MergeMaster(MergePass1Ctx *c, int iTable1Idx){
       MergeRowPolicy policy;
       memset(&policy, 0, sizeof(policy));
       rc = mergePass1CollectRenameOverDrop(c, &policy);
+      if( rc==SQLITE_OK ) rc = mergePass1CollectDualRename(c, &policy);
       if( rc!=SQLITE_OK ){
-        sqlite3_free((void*)policy.azRenameOverDrop);
+        mergePass1FreeRowPolicy(&policy);
         return rc;
       }
       rc = mergeTableRows(c->db, &ancEntry->root, &c->aOurs[iTable1Idx].root,
                           &theirsEntry->root, c->aOurs[iTable1Idx].flags,
                           &mergedTableRoot, &nConflicts, &aConflictRows,
                           NULL, 0, &policy);
-      sqlite3_free((void*)policy.azRenameOverDrop);
+      mergePass1FreeRowPolicy(&policy);
       if( rc!=SQLITE_OK ) return rc;
 
       {

--- a/src/doltlite_merge_rows.c
+++ b/src/doltlite_merge_rows.c
@@ -396,12 +396,13 @@ static int parseRecordFields(const u8 *pRec, int nRec,
   return nFields;
 }
 
-/* Is this sqlite_master row one the policy names? Fields 1 and 2 are name and
-** tbl_name, so the table's own row matches by name and each of its indexes and
-** triggers matches by tbl_name. The base row is the one compared: it carries the
-** ancestor name, which is what the policy was built from. */
-static int catalogRowNamedByPolicy(
-  const MergeRowPolicy *pPolicy,
+/* Is this sqlite_master row one the listed ancestor names? Fields 1 and 2 are
+** name and tbl_name, so the table's own row matches by name and each of its
+** indexes and triggers matches by tbl_name. The base row is the one compared:
+** it carries the ancestor name, which is what the policy was built from. */
+static int catalogRowNamedInList(
+  const char **azNames,
+  int nNames,
   const u8 *pBase, int nBase
 ){
   RecField *aBase = 0;
@@ -409,14 +410,14 @@ static int catalogRowNamedByPolicy(
   int matched = 0;
   int i, f;
 
-  if( !pPolicy || pPolicy->nRenameOverDrop<=0 ) return 0;
+  if( !azNames || nNames<=0 ) return 0;
   if( !pBase || nBase<=0 ) return 0;
   /* Returns the field count, or -1; it is not an SQLITE_ code. */
   if( parseRecordFields(pBase, nBase, &aBase, &nBaseF) < 0 ) return 0;
   for(f=1; f<=2 && !matched; f++){
     if( f>=nBaseF ) break;
-    for(i=0; i<pPolicy->nRenameOverDrop && !matched; i++){
-      const char *z = pPolicy->azRenameOverDrop[i];
+    for(i=0; i<nNames && !matched; i++){
+      const char *z = azNames[i];
       int n;
       if( !z ) continue;
       n = (int)strlen(z);
@@ -428,6 +429,24 @@ static int catalogRowNamedByPolicy(
   }
   sqlite3_free(aBase);
   return matched;
+}
+
+static int catalogRowNamedByPolicy(
+  const MergeRowPolicy *pPolicy,
+  const u8 *pBase, int nBase
+){
+  if( !pPolicy ) return 0;
+  return catalogRowNamedInList(
+      pPolicy->azRenameOverDrop, pPolicy->nRenameOverDrop, pBase, nBase);
+}
+
+static int catalogRowNamedByDualRename(
+  const MergeRowPolicy *pPolicy,
+  const u8 *pBase, int nBase
+){
+  if( !pPolicy ) return 0;
+  return catalogRowNamedInList(
+      pPolicy->azDualRename, pPolicy->nDualRename, pBase, nBase);
 }
 
 static int fieldEquals(const u8 *pRecA, RecField *fA,
@@ -681,6 +700,11 @@ static int rowMergeCallback(void *pCtx, const ThreeWayChange *pChange){
           }
         }
         sqlite3_free(pMerged);
+        break;
+      }
+
+      if( catalogRowNamedByDualRename(ctx->pPolicy,
+                                      pChange->pBaseVal, pChange->nBaseVal) ){
         break;
       }
 

--- a/test/doltlite_merge_index_conflict.sh
+++ b/test/doltlite_merge_index_conflict.sh
@@ -331,7 +331,7 @@ ROLLBACK;
 EOF
 )
 check "retarget_to_divergent_rename_keeps_index_catalog_valid" \
-  "3|i1,i2,ours_a,theirs_a" "$out"
+  "2|i1,i2,ours_a,theirs_a" "$out"
 
 DB="$TMPROOT/index_on_excluded_rename.db"
 "$DOLTLITE" "$DB" <<'EOF' >/dev/null 2>&1
@@ -452,12 +452,10 @@ EOF
   check "rename_over_drop_${direction}_keeps_table" "2|i_v|ok" "$out"
 done
 
-# A rename on *both* sides now conflicts. That is not yet Dolt parity -- Dolt
-# keeps ours_t and theirs_t both, treating each rename as an add -- but it is
-# what falls out of scoping the policy to objects the other side dropped, and it
-# replaces something worse: before this change the merge reported success and
-# silently kept only ours, losing theirs_t and its rows. Conflicting is the safe
-# half-step; keeping both needs catalog-identity work, tracked separately.
+# Both sides rename the same table to different names. Dolt treats each rename
+# as delete+add and keeps both tables with no conflicts. A phantom
+# sqlite_master modify/modify used to refuse the merge (or, earlier, succeed
+# and drop theirs). Both tables stay, and autocommit can finish.
 DB="$TMPROOT/rename_vs_rename.db"; rm -rf "$DB"
 "$DOLTLITE" "$DB" <<'EOF' >/dev/null 2>&1
 CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -472,8 +470,13 @@ ALTER TABLE t RENAME TO ours_t;
 SELECT dolt_commit('-Am','ours rename');
 EOF
 out=$("$DOLTLITE" "$DB" "SELECT length(dolt_merge('feat'));" 2>/dev/null)
-rc=$?
-check "rename_vs_rename_conflicts_not_silent_loss" "1" "$rc"
+check "rename_vs_rename_merge_clean" "40" "$out"
+out=$("$DOLTLITE" "$DB" \
+  "SELECT (SELECT group_concat(name,',') FROM (SELECT name FROM sqlite_master WHERE type='table' AND name IN ('ours_t','theirs_t','t') ORDER BY name)) || '|' ||
+          (SELECT count(*) FROM ours_t) || '|' ||
+          (SELECT count(*) FROM theirs_t) || '|' ||
+          (SELECT coalesce(sum(num_conflicts),0) FROM dolt_conflicts);" 2>/dev/null)
+check "rename_vs_rename_keeps_both_tables" "ours_t,theirs_t|1|1|0" "$out"
 
 echo
 echo "doltlite_merge_index_conflict: $pass passed, $fail failed"

--- a/test/vc_oracle_merge_test.sh
+++ b/test/vc_oracle_merge_test.sh
@@ -1681,6 +1681,41 @@ COMMIT;
                   WHERE commit_hash = HASHOF('HEAD')));"
 
 echo ""
+echo "--- dual rename keeps both tables ---"
+
+oracle_error_poststate "dual_rename_keeps_both_tables" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1, 'a');
+SELECT dolt_commit('-Am', 'init');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+ALTER TABLE t RENAME TO theirs_t;
+SELECT dolt_commit('-Am', 'theirs rename');
+SELECT dolt_checkout('main');
+ALTER TABLE t RENAME TO ours_t;
+SELECT dolt_commit('-Am', 'ours rename');
+SELECT dolt_merge('feat');
+" "SELECT (SELECT count(*) FROM dolt_schema_conflicts) || '|' || (SELECT count(*) FROM dolt_conflicts) || '|' || (SELECT group_concat(name, ',') FROM (SELECT name FROM sqlite_master WHERE type='table' AND name IN ('ours_t','theirs_t','t') ORDER BY name)) || '|' || (SELECT count(*) FROM ours_t) || '|' || (SELECT count(*) FROM theirs_t)" \
+"SELECT CONCAT((SELECT COUNT(*) FROM dolt_schema_conflicts), '|', (SELECT COUNT(*) FROM dolt_conflicts), '|', (SELECT GROUP_CONCAT(TABLE_NAME ORDER BY TABLE_NAME SEPARATOR ',') FROM information_schema.tables WHERE TABLE_SCHEMA=DATABASE() AND TABLE_NAME IN ('ours_t','theirs_t','t')), '|', (SELECT COUNT(*) FROM ours_t), '|', (SELECT COUNT(*) FROM theirs_t))"
+
+oracle_error_poststate "dual_rename_with_row_edits_keeps_both" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1, 'a');
+SELECT dolt_commit('-Am', 'init');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+ALTER TABLE t RENAME TO theirs_t;
+INSERT INTO theirs_t VALUES (2, 'feat');
+SELECT dolt_commit('-Am', 'theirs');
+SELECT dolt_checkout('main');
+ALTER TABLE t RENAME TO ours_t;
+INSERT INTO ours_t VALUES (3, 'main');
+SELECT dolt_commit('-Am', 'ours');
+SELECT dolt_merge('feat');
+" "SELECT (SELECT count(*) FROM dolt_conflicts) || '|' || (SELECT group_concat(id || ':' || v, ',') FROM (SELECT id, v FROM ours_t ORDER BY id)) || '|' || (SELECT group_concat(id || ':' || v, ',') FROM (SELECT id, v FROM theirs_t ORDER BY id))" \
+"SELECT CONCAT((SELECT COUNT(*) FROM dolt_conflicts), '|', (SELECT GROUP_CONCAT(CONCAT(id, ':', v) ORDER BY id SEPARATOR ',') FROM ours_t), '|', (SELECT GROUP_CONCAT(CONCAT(id, ':', v) ORDER BY id SEPARATOR ',') FROM theirs_t))"
+
+echo ""
 echo "--- add/add matching schema ---"
 
 oracle_error_poststate "dual_add_table_same_schema_union" "


### PR DESCRIPTION
## Summary

Both branches renaming `t` → `ours_t` / `theirs_t` already built the right user catalog: pass 1 keeps ours, pass 2 adopts theirs as an add, and serialize writes both `CREATE TABLE` rows. The merge still refused because `sqlite_master` is keyed by rowid. A rename is an in-place modify of that row, so two renames were a modify/modify and showed up as `(sqlite_master)|1`. Autocommit rolled the working set back to only `ours_t`.

Dolt treats each rename as delete+add and keeps both tables with no conflicts.

## Fix

`MergeRowPolicy` now also carries ancestor names that both sides renamed to different names. A catalog-row modify/modify whose base name or `tbl_name` is on that list is not recorded as a conflict; ours stays in the merged master tree and serialize rebuilds the catalog from the merged entries plus theirs' fallback schema.

View/trigger catalog conflicts and rename-over-drop delete/modify resolution are unchanged. A general "never record `sqlite_master` conflicts" cut is **not** in this PR: it let a rename-vs-drop cherry-pick succeed that Dolt still refuses.

Closes #2118.

## Tests

Fail-before / pass-after on the unfixed engine (rollback, only `ours_t`) vs after (clean merge, both tables):

- `dual_rename_keeps_both_tables` — Dolt oracle post-state `0|0|ours_t,theirs_t|1|1`
- `dual_rename_with_row_edits_keeps_both` — each side's extra row stays on its table
- `rename_vs_rename_merge_clean` / `rename_vs_rename_keeps_both_tables` — native suite, was the "conflict rather than silent loss" half-step

Nearby: `doltlite_merge_index_conflict` 32/32, `doltlite_merge.sh` 113/113, view-conflict oracle still `Q 1 1`.

## Note

A dual rename of a table that also has a secondary index still schema-conflicts: SQLite index names are database-global, so `i_v` on both `ours_t` and `theirs_t` is not representable the way Dolt's per-table index namespace is. The issue repro (no extra index) is what this closes.

Co-Authored-By: Grok 4.6 <noreply@x.ai>