### PR TITLE
Honor partial unique WHERE when detecting merge CVs

### DIFF
--- a/src/doltlite_merge_constraints_unique.c
+++ b/src/doltlite_merge_constraints_unique.c
@@ -85,6 +85,135 @@ static int uniqueIndexRecordHasNull(UnpackedRecord *pRecord, int nKeyCol){
   return 0;
 }
 
+static int uniqueIsIdent(char c){
+  return sqlite3Isalnum(c) || c=='_';
+}
+
+/* Trailing WHERE of a CREATE INDEX statement, or NULL. */
+static char *uniqueIndexWhereFromSql(const char *zSql){
+  const char *p = zSql;
+  int depth = 0;
+  int seenOn = 0;
+  int quote = 0;
+
+  if( !zSql ) return 0;
+  while( *p ){
+    if( quote ){
+      if( *p==quote ){
+        if( p[1]==quote ){ p += 2; continue; }
+        quote = 0;
+      }
+      p++;
+      continue;
+    }
+    if( *p=='\'' || *p=='"' || *p=='`' ){ quote = *p++; continue; }
+    if( *p=='[' ){ quote = ']'; p++; continue; }
+    if( *p=='(' ){ depth++; p++; continue; }
+    if( *p==')' ){
+      if( depth>0 ) depth--;
+      p++;
+      continue;
+    }
+    if( depth==0 && (p==zSql || !uniqueIsIdent(p[-1]))
+     && (p[0]=='O' || p[0]=='o') && (p[1]=='N' || p[1]=='n')
+     && !uniqueIsIdent(p[2]) ){
+      seenOn = 1;
+      p += 2;
+      continue;
+    }
+    if( depth==0 && seenOn
+     && sqlite3_strnicmp(p, "WHERE", 5)==0 && !uniqueIsIdent(p[5]) ){
+      p += 5;
+      while( *p==' ' || *p=='\t' || *p=='\n' || *p=='\r' ) p++;
+      if( !*p ) return 0;
+      return sqlite3_mprintf("%s", p);
+    }
+    p++;
+  }
+  return 0;
+}
+
+static char *uniqueIndexWhereSql(sqlite3 *db, Index *pIdx){
+  sqlite3_stmt *pStmt = 0;
+  char *zWhere = 0;
+  int rc;
+
+  if( !pIdx || !pIdx->pPartIdxWhere || !pIdx->zName ) return 0;
+  rc = sqlite3_prepare_v2(db,
+      "SELECT sql FROM main.sqlite_master WHERE type='index' AND name=?1",
+      -1, &pStmt, 0);
+  if( rc!=SQLITE_OK ) return 0;
+  sqlite3_bind_text(pStmt, 1, pIdx->zName, -1, SQLITE_STATIC);
+  if( sqlite3_step(pStmt)==SQLITE_ROW ){
+    zWhere = uniqueIndexWhereFromSql((const char*)sqlite3_column_text(pStmt, 0));
+  }
+  sqlite3_finalize(pStmt);
+  return zWhere;
+}
+
+static int uniqueValueFromRecord(
+  const u8 *pRecord, int nRecord,
+  const DoltliteRecordInfo *pInfo, int iField,
+  DoltliteSerialValue *pValue
+);
+
+static int uniquePartialMatchesRecord(
+  sqlite3 *db,
+  Index *pIdx,
+  const char *zWhere,
+  const u8 *pRec, int nRec,
+  const DoltliteColInfo *pCols
+){
+  Table *pTab;
+  sqlite3_str *pSql;
+  char *zSql;
+  sqlite3_stmt *pStmt = 0;
+  DoltliteRecordInfo info;
+  int i, rc, match = 0;
+
+  if( !zWhere || !zWhere[0] ) return 1;
+  if( !pIdx || !pIdx->pTable || !pRec || nRec<=0 ) return 0;
+  pTab = pIdx->pTable;
+  doltliteParseRecord(pRec, nRec, &info);
+  pSql = sqlite3_str_new(0);
+  sqlite3_str_appendall(pSql, "SELECT 1 FROM (SELECT ");
+  for(i=0; i<pTab->nCol; i++){
+    if( i ) sqlite3_str_appendall(pSql, ", ");
+    sqlite3_str_appendf(pSql, "?%d AS \"%w\"", i+1, pTab->aCol[i].zCnName);
+  }
+  sqlite3_str_appendf(pSql, ") WHERE (%s)", zWhere);
+  zSql = sqlite3_str_finish(pSql);
+  if( !zSql ) return 0;
+  rc = sqlite3_prepare_v2(db, zSql, -1, &pStmt, 0);
+  sqlite3_free(zSql);
+  if( rc!=SQLITE_OK ) return 0;
+  for(i=0; i<pTab->nCol && rc==SQLITE_OK; i++){
+    int iField = (pCols && i<pCols->nCol) ? pCols->aColToRec[i] : i;
+    DoltliteSerialValue v;
+    if( iField<0 || iField>=info.nField ){
+      rc = sqlite3_bind_null(pStmt, i+1);
+      continue;
+    }
+    rc = uniqueValueFromRecord(pRec, nRec, &info, iField, &v);
+    if( rc!=SQLITE_OK ) break;
+    if( v.eType==SQLITE_NULL ){
+      rc = sqlite3_bind_null(pStmt, i+1);
+    }else if( v.eType==SQLITE_INTEGER ){
+      rc = sqlite3_bind_int64(pStmt, i+1, v.i);
+    }else if( v.eType==SQLITE_FLOAT ){
+      rc = sqlite3_bind_double(pStmt, i+1, v.r);
+    }else if( v.eType==SQLITE_TEXT ){
+      rc = sqlite3_bind_text(pStmt, i+1, (const char*)v.p, v.n, SQLITE_TRANSIENT);
+    }else{
+      rc = sqlite3_bind_blob(pStmt, i+1, v.p, v.n, SQLITE_TRANSIENT);
+    }
+  }
+  if( rc==SQLITE_OK ) rc = sqlite3_step(pStmt);
+  match = (rc==SQLITE_ROW);
+  sqlite3_finalize(pStmt);
+  return match;
+}
+
 static KeyInfo *uniqueIndexKeyInfo(sqlite3 *db, Index *pIdx, int *pRc){
   Parse sParse;
   KeyInfo *pKeyInfo;
@@ -286,8 +415,18 @@ static int detectUniqueViolationsForIndex(
 
   pKeyInfo = uniqueIndexKeyInfo(db, pIdx, &rc);
   if( !pKeyInfo ) goto unique_done;
-  zQuery = sqlite3_mprintf(
-      "SELECT rowid, %s FROM main.\"%w\" NOT INDEXED", zCols, zTable);
+  {
+    char *zWhere = uniqueIndexWhereSql(db, pIdx);
+    if( zWhere ){
+      zQuery = sqlite3_mprintf(
+          "SELECT rowid, %s FROM main.\"%w\" NOT INDEXED WHERE (%s)",
+          zCols, zTable, zWhere);
+      sqlite3_free(zWhere);
+    }else{
+      zQuery = sqlite3_mprintf(
+          "SELECT rowid, %s FROM main.\"%w\" NOT INDEXED", zCols, zTable);
+    }
+  }
   if( !zQuery ){ rc = SQLITE_NOMEM; goto unique_done; }
   rc = sqlite3_prepare_v2(db, zQuery, -1, &pScan, 0);
   if( rc!=SQLITE_OK ) goto unique_done;
@@ -400,6 +539,7 @@ static int detectUniqueViolationsForIndexWithoutRowid(
   int nAlloc = 0;
   int cursorOpen = 0;
   int winnerHandled = 0;
+  char *zPartWhere = 0;
   int rc;
   int res = 0;
   int i;
@@ -411,6 +551,7 @@ static int detectUniqueViolationsForIndexWithoutRowid(
   pKeyInfo = uniqueIndexKeyInfo(db, pIdx, &rc);
   if( !pKeyInfo ) goto without_rowid_done;
   if( prollyHashIsEmpty(&pCurrent->root) ) goto without_rowid_done;
+  zPartWhere = uniqueIndexWhereSql(db, pIdx);
 
   prollyCursorInit(
       &cursor, cs, pCache, &pCurrent->root, pCurrent->flags);
@@ -440,6 +581,13 @@ static int detectUniqueViolationsForIndexWithoutRowid(
       pRecord = pOwnedRecord;
     }
     rc = doltliteParseRecordStrict(pRecord, nRecord, &info);
+    if( rc==SQLITE_OK && zPartWhere
+     && !uniquePartialMatchesRecord(db, pIdx, zPartWhere,
+                                    pRecord, nRecord, &cols) ){
+      sqlite3_free(pOwnedRecord);
+      rc = prollyCursorNext(&cursor);
+      continue;
+    }
     if( rc==SQLITE_OK ){
       rc = uniqueRecordFromTableRow(
           pRecord, nRecord, &info, &cols, pIdx, pIdx->nKeyCol,
@@ -533,6 +681,7 @@ static int detectUniqueViolationsForIndexWithoutRowid(
   }
 
 without_rowid_done:
+  sqlite3_free(zPartWhere);
   if( cursorOpen ) prollyCursorClose(&cursor);
   uniqueIndexEntriesFree(db, aEntry, nEntry);
   doltliteFreeColInfo(&cols);

--- a/test/doltlite_index_row_delta.sh
+++ b/test/doltlite_index_row_delta.sh
@@ -145,6 +145,84 @@ else
 fi
 rm -f "$DB"
 
+# Partial unique indexes only constrain rows that match WHERE. Both
+# branches inserting v=-1 must merge cleanly; v=9 on both is a real
+# unique violation.
+DB=/tmp/test_idx_delta_partial_unique_neg_$$.db
+rm -f "$DB"
+cat <<'EOF' | $DOLTLITE "$DB" > /dev/null 2>&1
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+CREATE UNIQUE INDEX tv ON t(v) WHERE v>0;
+INSERT INTO t VALUES(1, 1);
+SELECT dolt_commit('-Am','init');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO t VALUES(3, -1);
+SELECT dolt_commit('-Am','feat');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES(2, -1);
+SELECT dolt_commit('-Am','main');
+SELECT dolt_merge('feat');
+EOF
+
+run_test_match "partial_unique_neg_merge" \
+  "SELECT length(dolt_hashof('HEAD'));" "^40$" "$DB"
+run_test "partial_unique_neg_rows" \
+  "SELECT group_concat(id||':'||v, ',') FROM (SELECT id,v FROM t ORDER BY id);" \
+  "1:1,2:-1,3:-1" "$DB"
+run_test "partial_unique_neg_no_cv" \
+  "SELECT coalesce(sum(num_violations),0) FROM dolt_constraint_violations;" \
+  "0" "$DB"
+run_test_lastline "partial_unique_neg_integrity" "PRAGMA integrity_check;" "ok" "$DB"
+rm -f "$DB"
+
+DB=/tmp/test_idx_delta_partial_unique_pos_$$.db
+rm -f "$DB"
+cat <<'EOF' | $DOLTLITE "$DB" >/dev/null 2>&1
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+CREATE UNIQUE INDEX tv ON t(v) WHERE v>0;
+INSERT INTO t VALUES(1, 1);
+SELECT dolt_commit('-Am','init');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO t VALUES(3, 9);
+SELECT dolt_commit('-Am','feat');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES(2, 9);
+SELECT dolt_commit('-Am','main');
+EOF
+out=$(echo "BEGIN; SELECT dolt_merge('feat'); SELECT coalesce(sum(num_violations),0) FROM dolt_constraint_violations; ROLLBACK;" | $DOLTLITE "$DB" 2>/dev/null | tail -1)
+if [ "$out" = "2" ]; then
+  PASS=$((PASS+1))
+else
+  FAIL=$((FAIL+1))
+  ERRORS="$ERRORS\nFAIL: partial_unique_pos_still_violates\n  expected: 2\n  got:      $out"
+fi
+rm -f "$DB"
+
+DB=/tmp/test_idx_delta_partial_unique_wr_neg_$$.db
+rm -f "$DB"
+cat <<'EOF' | $DOLTLITE "$DB" > /dev/null 2>&1
+CREATE TABLE t(k TEXT PRIMARY KEY, v INT);
+CREATE UNIQUE INDEX tv ON t(v) WHERE v>0;
+INSERT INTO t VALUES('a', 1);
+SELECT dolt_commit('-Am','init');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO t VALUES('c', -1);
+SELECT dolt_commit('-Am','feat');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES('b', -1);
+SELECT dolt_commit('-Am','main');
+SELECT dolt_merge('feat');
+EOF
+
+run_test "partial_unique_wr_neg_rows" \
+  "SELECT group_concat(k||':'||v, ',') FROM (SELECT k,v FROM t ORDER BY k);" \
+  "a:1,b:-1,c:-1" "$DB"
+run_test "partial_unique_wr_neg_no_cv" \
+  "SELECT coalesce(sum(num_violations),0) FROM dolt_constraint_violations;" \
+  "0" "$DB"
+run_test_lastline "partial_unique_wr_neg_integrity" "PRAGMA integrity_check;" "ok" "$DB"
+rm -f "$DB"
+
 # --- Workspace stage of NOCASE index row ------------------------------------
 DB=/tmp/test_idx_delta_ws_nocase_$$.db
 rm -f "$DB"


### PR DESCRIPTION
## Summary

`CREATE UNIQUE INDEX tv ON t(v) WHERE v>0` only uniqueness-checks rows with `v>0`. The merge unique detector did `SELECT rowid, v FROM t NOT INDEXED` with no predicate, so both sides inserting `v=-1` looked like a duplicate.

SQLite allows both `-1`s. A matching pair (`v=9` on both sides) is still a real violation.

## Fix

Read the index `WHERE` from `sqlite_master` and apply it:

- rowid tables: `SELECT … NOT INDEXED WHERE (<pred>)`
- WITHOUT ROWID: skip table-walk rows that do not match the predicate

## Tests

Fail-before / pass-after in `test/doltlite_index_row_delta.sh`:

| | Unfixed | After |
|---|---|---|
| both insert `v=-1` | 2 CVs, merge refused | clean merge, `1:1,2:-1,3:-1`, 0 CVs |
| both insert `v=9` | 2 CVs | still 2 CVs |
| WITHOUT ROWID `v=-1` | same false positive | clean merge |

Nearby: `doltlite_index_row_delta` 27/27, `doltlite_merge.sh` 113/113.

Oracle is SQLite uniqueness, not Dolt (Dolt has no SQLite partial-index syntax).

Co-Authored-By: Grok 4.6 <noreply@x.ai>