### PR TITLE
Include collation and sort order in the primary key signature

### DIFF
--- a/src/doltlite_merge_pass1.c
+++ b/src/doltlite_merge_pass1.c
@@ -416,6 +416,35 @@ static int mergePass1OursModifyTheirsDelete(
 ** creates, built by executing it in a scratch db. No declared PK yields the
 ** empty signature, which matches SQLite treating those tables as rowid keyed
 ** regardless of the rest of the schema. */
+/* Ordered primary-key signature of the table zSql creates, built by
+** executing it in a scratch db.
+**
+** The signature must name everything that decides where a row sorts and
+** which rows collide, because that is what makes two keyspaces mergeable:
+** the columns in key order, their types, their collations, and their sort
+** directions. A table with a real primary-key index reads all four from
+** that index. Otherwise the key is either a rowid alias, where none of it
+** applies, or absent entirely; both fall back to the declared columns, and
+** no declared PK yields the empty signature, matching SQLite treating such
+** tables as rowid keyed regardless of the rest of the schema. */
+static int mergePass1AppendSigRow(
+  char **pzSig,
+  const char *zName,
+  const char *zType,
+  const char *zColl,
+  int bDesc
+){
+  char *zNew = sqlite3_mprintf("%s%s%s %s %s %s", *pzSig ? *pzSig : "",
+                               *pzSig ? "," : "",
+                               zName ? zName : "",
+                               zType ? zType : "",
+                               zColl ? zColl : "BINARY",
+                               bDesc ? "DESC" : "ASC");
+  sqlite3_free(*pzSig);
+  *pzSig = zNew;
+  return zNew ? SQLITE_OK : SQLITE_NOMEM;
+}
+
 static int mergePass1PkSignature(
   const char *zSql,
   const char *zTableName,
@@ -432,21 +461,45 @@ static int mergePass1PkSignature(
   if( rc!=SQLITE_OK ) goto done;
   rc = sqlite3_exec(tmp, zSql, 0, 0, 0);
   if( rc!=SQLITE_OK ) goto done;
+
   zQuery = sqlite3_mprintf(
-      "SELECT name, type FROM pragma_table_info(%Q) WHERE pk>0 ORDER BY pk",
-      zTableName);
+      "SELECT x.name, i.type, x.coll, x.desc "
+      "FROM pragma_index_list(%Q) AS l "
+      "JOIN pragma_index_xinfo(l.name) AS x "
+      "LEFT JOIN pragma_table_info(%Q) AS i ON i.name = x.name "
+      "WHERE l.origin='pk' AND x.key=1 ORDER BY x.seqno",
+      zTableName, zTableName);
   if( !zQuery ){ rc = SQLITE_NOMEM; goto done; }
   rc = sqlite3_prepare_v2(tmp, zQuery, -1, &pStmt, 0);
   if( rc!=SQLITE_OK ) goto done;
   while( (rc = sqlite3_step(pStmt))==SQLITE_ROW ){
-    const char *zName = (const char*)sqlite3_column_text(pStmt, 0);
-    const char *zType = (const char*)sqlite3_column_text(pStmt, 1);
-    char *zNew = sqlite3_mprintf("%s%s%s %s", zSig ? zSig : "",
-                                 zSig ? "," : "",
-                                 zName ? zName : "", zType ? zType : "");
-    sqlite3_free(zSig);
-    zSig = zNew;
-    if( !zSig ){ rc = SQLITE_NOMEM; goto done; }
+    rc = mergePass1AppendSigRow(&zSig,
+             (const char*)sqlite3_column_text(pStmt, 0),
+             (const char*)sqlite3_column_text(pStmt, 1),
+             (const char*)sqlite3_column_text(pStmt, 2),
+             sqlite3_column_int(pStmt, 3));
+    if( rc!=SQLITE_OK ) goto done;
+  }
+  if( rc!=SQLITE_DONE ) goto done;
+  sqlite3_finalize(pStmt);
+  pStmt = 0;
+  sqlite3_free(zQuery);
+  zQuery = 0;
+
+  if( !zSig ){
+    zQuery = sqlite3_mprintf(
+        "SELECT name, type FROM pragma_table_info(%Q) WHERE pk>0 ORDER BY pk",
+        zTableName);
+    if( !zQuery ){ rc = SQLITE_NOMEM; goto done; }
+    rc = sqlite3_prepare_v2(tmp, zQuery, -1, &pStmt, 0);
+    if( rc!=SQLITE_OK ) goto done;
+    while( (rc = sqlite3_step(pStmt))==SQLITE_ROW ){
+      rc = mergePass1AppendSigRow(&zSig,
+               (const char*)sqlite3_column_text(pStmt, 0),
+               (const char*)sqlite3_column_text(pStmt, 1),
+               0, 0);
+      if( rc!=SQLITE_OK ) goto done;
+    }
   }
   rc = rc==SQLITE_DONE ? SQLITE_OK : rc;
 

--- a/test/doltlite_merge.sh
+++ b/test/doltlite_merge.sh
@@ -460,7 +460,7 @@ else
   ERRORS="$ERRORS\nFAIL: clean_merge_in_txn_rollback_refused\n  expected the post-merge ROLLBACK to find no open transaction"
 fi
 
-DB25=/tmp/test_merge25_$$.db; rm -f "$DB25" "$DB26" "$DB27" "$DB28"
+DB25=/tmp/test_merge25_$$.db; rm -f "$DB25" "$DB26" "$DB27" "$DB28" "$DB29" "$DB30" "$DB31" "$DB32"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'a');
 SELECT dolt_commit('-A','-m','base');
 SELECT dolt_checkout('-b','feat'); INSERT INTO t VALUES(2,'b'); SELECT dolt_commit('-A','-m','feat');
@@ -508,6 +508,46 @@ echo "DROP TABLE t; CREATE TABLE t(pk TEXT PRIMARY KEY, v INT); INSERT INTO t VA
 run_test_match "identical_recreate_merge_ok" "SELECT dolt_merge('feature');" "^[0-9a-f]{40}$" "$DB28"
 run_test "identical_recreate_rows" "SELECT group_concat(pk || ':' || v, ',') FROM (SELECT pk,v FROM t ORDER BY pk);" "feat:50,main:7" "$DB28"
 run_test "identical_recreate_integrity" "PRAGMA integrity_check;" "ok" "$DB28"
+
+
+# The primary key decides where a row sorts and which rows collide, so a
+# change to its collation or sort direction makes the two keyspaces
+# incomparable just as a column or type change does. Merging across one
+# produced a committed table whose rows are out of key order.
+DB29=/tmp/test_merge29_$$.db; rm -f "$DB29"
+echo "CREATE TABLE t(pk TEXT PRIMARY KEY, v INT); INSERT INTO t VALUES('a',1); SELECT dolt_commit('-A','-m','base');" | $DOLTLITE "$DB29" > /dev/null 2>&1
+echo "SELECT dolt_branch('feature');" | $DOLTLITE "$DB29" > /dev/null 2>&1
+echo "DROP TABLE t; CREATE TABLE t(pk TEXT COLLATE NOCASE PRIMARY KEY, v INT); INSERT INTO t VALUES('a',1); SELECT dolt_commit('-A','-m','feat collate');" | $DOLTLITE "$DB29/feature" > /dev/null 2>&1
+echo "INSERT INTO t VALUES('A',3); SELECT dolt_commit('-A','-m','main row');" | $DOLTLITE "$DB29" > /dev/null 2>&1
+run_test_match "pk_collation_change_refused" "SELECT dolt_merge('feature');" "different primary keys" "$DB29"
+run_test "pk_collation_change_integrity" "PRAGMA integrity_check;" "ok" "$DB29"
+
+DB30=/tmp/test_merge30_$$.db; rm -f "$DB30"
+echo "CREATE TABLE t(a INT, b INT, v TEXT, PRIMARY KEY(a,b)) WITHOUT ROWID; INSERT INTO t VALUES(1,1,'x'),(2,1,'y'); SELECT dolt_commit('-A','-m','base');" | $DOLTLITE "$DB30" > /dev/null 2>&1
+echo "SELECT dolt_branch('feature');" | $DOLTLITE "$DB30" > /dev/null 2>&1
+echo "DROP TABLE t; CREATE TABLE t(a INT, b INT, v TEXT, PRIMARY KEY(a DESC, b)) WITHOUT ROWID; INSERT INTO t VALUES(1,1,'x'),(2,1,'y'),(9,1,'f'); SELECT dolt_commit('-A','-m','feat desc');" | $DOLTLITE "$DB30/feature" > /dev/null 2>&1
+echo "INSERT INTO t VALUES(5,1,'m'); SELECT dolt_commit('-A','-m','main row');" | $DOLTLITE "$DB30" > /dev/null 2>&1
+run_test_match "pk_sort_order_change_refused" "SELECT dolt_merge('feature');" "different primary keys" "$DB30"
+run_test "pk_sort_order_change_integrity" "PRAGMA integrity_check;" "ok" "$DB30"
+
+# Matching collations must still merge: the signature names collation, so a
+# table that always had one must not start refusing its own merges.
+DB31=/tmp/test_merge31_$$.db; rm -f "$DB31"
+echo "CREATE TABLE t(pk TEXT COLLATE NOCASE PRIMARY KEY, v INT); INSERT INTO t VALUES('a',1); SELECT dolt_commit('-A','-m','base');" | $DOLTLITE "$DB31" > /dev/null 2>&1
+echo "SELECT dolt_branch('feature');" | $DOLTLITE "$DB31" > /dev/null 2>&1
+echo "INSERT INTO t VALUES('b',2); SELECT dolt_commit('-A','-m','feat row');" | $DOLTLITE "$DB31/feature" > /dev/null 2>&1
+echo "INSERT INTO t VALUES('c',3); SELECT dolt_commit('-A','-m','main row');" | $DOLTLITE "$DB31" > /dev/null 2>&1
+run_test_match "pk_same_collation_merges" "SELECT dolt_merge('feature');" "^[0-9a-f]{40}$" "$DB31"
+run_test "pk_same_collation_rows" "SELECT count(*) FROM t;" "3" "$DB31"
+
+# A DESC primary key on both sides is likewise unchanged, so it merges.
+DB32=/tmp/test_merge32_$$.db; rm -f "$DB32"
+echo "CREATE TABLE t(a INT, b INT, v TEXT, PRIMARY KEY(a DESC, b)) WITHOUT ROWID; INSERT INTO t VALUES(1,1,'x'); SELECT dolt_commit('-A','-m','base');" | $DOLTLITE "$DB32" > /dev/null 2>&1
+echo "SELECT dolt_branch('feature');" | $DOLTLITE "$DB32" > /dev/null 2>&1
+echo "INSERT INTO t VALUES(2,1,'y'); SELECT dolt_commit('-A','-m','feat row');" | $DOLTLITE "$DB32/feature" > /dev/null 2>&1
+echo "INSERT INTO t VALUES(3,1,'z'); SELECT dolt_commit('-A','-m','main row');" | $DOLTLITE "$DB32" > /dev/null 2>&1
+run_test_match "pk_same_desc_merges" "SELECT dolt_merge('feature');" "^[0-9a-f]{40}$" "$DB32"
+run_test "pk_same_desc_integrity" "PRAGMA integrity_check;" "ok" "$DB32"
 
 rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8" "$DB8B" "$DB9" "$DB10" "$DB11" "$DB11D" "$DB11E" "$DB11F" "$DB12" "$DB13" "$DB14" "$DB15" "$DB16" "$DB17" "$DB18" "$DB19" "$DB20" "$DB20B" "$DB21" "$DB22" "$DB23" "$DB24" "$DB25"
 dltest_finish


### PR DESCRIPTION
## Problem

The refusal added in #2147 for merges across a changed primary key compares only the key's column names and types. Collation and sort direction decide where a row sorts and which rows collide just as much, so changing either leaves the signature matching while the two keyspaces are no longer comparable — and the merge proceeds.

Both cases commit a broken table (found by the Aug 12 review, reproduced by hand):

```sql
-- collation: base has a BINARY text key, the branch recreates it NOCASE
--   merge succeeds; table holds both 'A' and 'a' under a NOCASE key
--   PRAGMA integrity_check -> "row not in PRIMARY KEY order for t"

-- sort order: base has PRIMARY KEY(a, b), the branch recreates it (a DESC, b)
--   merge succeeds; rows come back 5, 9, 2, 1
--   PRAGMA integrity_check -> "row not in PRIMARY KEY order for t"
```

Dolt 2.2.2 refuses the collation change with the same `cannot merge because table t has different primary keys` error this refusal already emits. (`INTEGER PRIMARY KEY` vs `INTEGER PRIMARY KEY DESC` was already caught, but only incidentally, by the intkey-flag comparison — which does nothing for WITHOUT ROWID tables.)

## Fix

The signature now reads the primary key index, which carries the columns in key order together with their collations and sort directions. A table with no such index is rowid-keyed or keyless, where none of that applies, and keeps reading the declared columns; no declared PK still yields the empty signature.

## Testing

Four cases in `doltlite_merge.sh`:

- `pk_collation_change_refused` / `pk_sort_order_change_refused` — the merges that used to produce a corrupt table.
- `pk_collation_change_integrity` / `pk_sort_order_change_integrity` — `integrity_check` stays `ok`.
- `pk_same_collation_merges` / `pk_same_desc_merges` (+ row and integrity checks) — controls proving a table that always had a NOCASE or DESC key still merges its own history, since the signature now names collation and direction.

All four of the first group fail on master; the controls pass on both. Full battery and amalgamation gate run before pushing.

Follows #2147. Two more findings from the same review cluster are queued: constraint-violation detectors are blind to PK-only clustered tables, and dual add-column merges write NULL where a column default belongs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)