### PR TITLE
Do not put sqlite_master row conflicts in dolt_conflicts

### DIFF
--- a/src/doltlite_merge_pass1.c
+++ b/src/doltlite_merge_pass1.c
@@ -814,11 +814,68 @@ static void mergePass1FreeRowPolicy(MergeRowPolicy *pPolicy){
   pPolicy->nDualRename = 0;
 }
 
+static int mergePass1IsAuxSchemaType(const char *zType){
+  return zType && (strcmp(zType, "view")==0 || strcmp(zType, "trigger")==0);
+}
+
+static int mergePass1AuxSchemaSame(const SchemaEntry *pA, const SchemaEntry *pB){
+  const char *zASql;
+  const char *zBSql;
+  const char *zATbl;
+  const char *zBTbl;
+  if( !pA || !pB ) return 0;
+  zASql = pA->zSql ? pA->zSql : "";
+  zBSql = pB->zSql ? pB->zSql : "";
+  zATbl = pA->zTblName ? pA->zTblName : "";
+  zBTbl = pB->zTblName ? pB->zTblName : "";
+  return strcmp(zASql, zBSql)==0 && sqlite3_stricmp(zATbl, zBTbl)==0;
+}
+
+/* Views and triggers live only as catalog rows. Competing definitions are
+** schema conflicts; they must not become (sqlite_master) row conflicts. */
+static int mergePass1NoteAuxSchemaConflicts(MergePass1Ctx *c){
+  int side, i, rc;
+
+  for(side=0; side<2; side++){
+    SchemaEntry *a = side==0 ? c->aOursSchema : c->aTheirsSchema;
+    int n = side==0 ? c->nOursSchema : c->nTheirsSchema;
+    for(i=0; i<n; i++){
+      SchemaEntry *pOurs;
+      SchemaEntry *pTheirs;
+      const char *zName = a[i].zName;
+      const char *zTable;
+      int oursChanged;
+      int theirsChanged;
+      if( !mergePass1IsAuxSchemaType(a[i].zType) || !zName ) continue;
+      if( side==1
+       && findSchemaEntry(c->aOursSchema, c->nOursSchema, zName) ){
+        continue;
+      }
+      pOurs = findSchemaEntry(c->aOursSchema, c->nOursSchema, zName);
+      pTheirs = findSchemaEntry(c->aTheirsSchema, c->nTheirsSchema, zName);
+      if( !pOurs && !pTheirs ) continue;
+      if( pOurs && pTheirs && mergePass1AuxSchemaSame(pOurs, pTheirs) ){
+        continue;
+      }
+      oursChanged = schemaEntryChangedByName(
+          c->aAncSchema, c->nAncSchema, c->aOursSchema, c->nOursSchema, zName);
+      theirsChanged = schemaEntryChangedByName(
+          c->aAncSchema, c->nAncSchema, c->aTheirsSchema, c->nTheirsSchema,
+          zName);
+      if( !oursChanged || !theirsChanged ) continue;
+      zTable = pOurs && pOurs->zTblName ? pOurs->zTblName
+             : (pTheirs && pTheirs->zTblName ? pTheirs->zTblName : zName);
+      rc = mergePass1NoteSchemaConflict(c, zTable, zName);
+      if( rc!=SQLITE_OK ) return rc;
+    }
+  }
+  return SQLITE_OK;
+}
+
 /* Merge catalog root (iTable==1). Deferred so schema actions are known. */
 static int mergePass1MergeMaster(MergePass1Ctx *c, int iTable1Idx){
   struct TableEntry *ancEntry;
   struct TableEntry *theirsEntry;
-  int hasSchemaActions;
   int bPreferOurMasterHere;
   int rc = SQLITE_OK;
 
@@ -826,8 +883,6 @@ static int mergePass1MergeMaster(MergePass1Ctx *c, int iTable1Idx){
 
   ancEntry = doltliteFindTableByNumber(c->aAnc, c->nAnc, 1);
   theirsEntry = doltliteFindTableByNumber(c->aTheirs, c->nTheirs, 1);
-  hasSchemaActions = (c->ppSchemaActions && c->pnSchemaActions
-                      && *c->pnSchemaActions > 0);
   bPreferOurMasterHere = hasAnySchemaConflict(
       *c->ppConflictTables, *c->pnConflictTables)
       || (c->bPreferOurMaster
@@ -857,23 +912,26 @@ static int mergePass1MergeMaster(MergePass1Ctx *c, int iTable1Idx){
         &c->aOurs[iTable1Idx].root, &ancEntry->root)!=0;
     int theirsChanged = prollyHashCompare(
         &theirsEntry->root, &ancEntry->root)!=0;
+    int hasSchemaActions = (c->ppSchemaActions && c->pnSchemaActions
+                            && *c->pnSchemaActions > 0);
     if( bPreferOurMasterHere ){
       c->aMerged[(*c->pnMerged)++] = c->aOurs[iTable1Idx];
-      /* Original pass1 returned here without applying index patches. */
+      rc = mergePass1NoteAuxSchemaConflicts(c);
+      if( rc!=SQLITE_OK ) return rc;
       return SQLITE_DONE;
     }
-    if( oursChanged && theirsChanged && hasSchemaActions ){
+    if( oursChanged && theirsChanged
+     && (hasSchemaActions || c->bDisjointSchemaChanges) ){
       c->aMerged[(*c->pnMerged)++] = c->aOurs[iTable1Idx];
-    }else if( oursChanged && theirsChanged && c->bDisjointSchemaChanges ){
-      c->aMerged[(*c->pnMerged)++] = c->aOurs[iTable1Idx];
+      rc = mergePass1NoteAuxSchemaConflicts(c);
     }else if( oursChanged && theirsChanged ){
       ProllyHash mergedTableRoot;
       int nConflicts = 0;
       DoltliteConflictRow *aConflictRows = 0;
       int theirSchemaChanged2 = prollyHashCompare(
           &theirsEntry->schemaHash, &ancEntry->schemaHash)!=0;
-
       MergeRowPolicy policy;
+
       memset(&policy, 0, sizeof(policy));
       rc = mergePass1CollectRenameOverDrop(c, &policy);
       if( rc==SQLITE_OK ) rc = mergePass1CollectDualRename(c, &policy);
@@ -902,11 +960,31 @@ static int mergePass1MergeMaster(MergePass1Ctx *c, int iTable1Idx){
         c->aMerged[(*c->pnMerged)++] = merged;
       }
 
-      if( nConflicts>0 ){
-        *c->pTotalConflicts += nConflicts;
-        rc = appendConflictTable(c->ppConflictTables, c->pnConflictTables,
-                                 "(sqlite_master)", nConflicts, aConflictRows);
-        if( rc!=SQLITE_OK ) return rc;
+      freeConflictRows(aConflictRows, nConflicts);
+      rc = mergePass1NoteAuxSchemaConflicts(c);
+      if( rc!=SQLITE_OK ) return rc;
+      if( nConflicts>0
+       && !hasAnySchemaConflict(*c->ppConflictTables, *c->pnConflictTables) ){
+        int i;
+        rc = SQLITE_OK;
+        for(i=0; i<c->nAnc && rc==SQLITE_OK; i++){
+          const char *zName = c->aAnc[i].zName;
+          if( !zName || c->aAnc[i].iTable<=1 ) continue;
+          if( !schemaEntryChangedByName(c->aAncSchema, c->nAncSchema,
+                                        c->aOursSchema, c->nOursSchema, zName) ){
+            continue;
+          }
+          if( !schemaEntryChangedByName(c->aAncSchema, c->nAncSchema,
+                                        c->aTheirsSchema, c->nTheirsSchema,
+                                        zName) ){
+            continue;
+          }
+          if( hasSchemaConflictObject(*c->ppConflictTables,
+                                      *c->pnConflictTables, zName) ){
+            continue;
+          }
+          rc = mergePass1NoteSchemaConflict(c, zName, zName);
+        }
       }
     }else if( theirsChanged ){
       struct TableEntry merged = c->aOurs[iTable1Idx];

--- a/test/doltlite_merge_index_conflict.sh
+++ b/test/doltlite_merge_index_conflict.sh
@@ -331,7 +331,7 @@ ROLLBACK;
 EOF
 )
 check "retarget_to_divergent_rename_keeps_index_catalog_valid" \
-  "2|i1,i2,ours_a,theirs_a" "$out"
+  "0|i1,i2,ours_a,theirs_a" "$out"
 
 DB="$TMPROOT/index_on_excluded_rename.db"
 "$DOLTLITE" "$DB" <<'EOF' >/dev/null 2>&1

--- a/test/vc_oracle_merge_test.sh
+++ b/test/vc_oracle_merge_test.sh
@@ -1318,8 +1318,20 @@ CREATE VIEW v AS SELECT a, b FROM t;
 SELECT dolt_commit('-Am', 'main_view');
 BEGIN;
 SELECT dolt_merge('feature');
-" "SELECT 'Q' || char(9) || (SELECT count(*) FROM dolt_conflicts) || char(9) || (SELECT sum(num_conflicts) FROM dolt_conflicts);" \
-"SELECT concat('Q', char(9), (SELECT count(*) FROM dolt_conflicts), char(9), (SELECT sum(num_conflicts) FROM dolt_conflicts));"
+" "SELECT 'Q' || char(9) || (SELECT count(*) FROM dolt_conflicts WHERE \"table\"='(sqlite_master)') || '|' || (SELECT CASE WHEN (SELECT count(*) FROM dolt_conflicts)+(SELECT count(*) FROM dolt_schema_conflicts)>0 THEN 1 ELSE 0 END);" \
+"SELECT concat('Q', char(9), (SELECT count(*) FROM dolt_conflicts WHERE \`table\`='(sqlite_master)'), '|', CASE WHEN (SELECT count(*) FROM dolt_conflicts)+(SELECT count(*) FROM dolt_schema_conflicts)>0 THEN 1 ELSE 0 END);"
+
+oracle_same_session "merge_view_both_add_different_not_master" "
+$VIEW_BASE
+CREATE VIEW v AS SELECT b FROM t;
+SELECT dolt_commit('-Am', 'feat_view');
+SELECT dolt_checkout('main');
+CREATE VIEW v AS SELECT a FROM t;
+SELECT dolt_commit('-Am', 'main_view');
+BEGIN;
+SELECT dolt_merge('feature');
+" "SELECT 'Q' || char(9) || (SELECT count(*) FROM dolt_conflicts WHERE \"table\"='(sqlite_master)') || '|' || (SELECT CASE WHEN (SELECT count(*) FROM dolt_conflicts)+(SELECT count(*) FROM dolt_schema_conflicts)>0 THEN 1 ELSE 0 END);" \
+"SELECT concat('Q', char(9), (SELECT count(*) FROM dolt_conflicts WHERE \`table\`='(sqlite_master)'), '|', CASE WHEN (SELECT count(*) FROM dolt_conflicts)+(SELECT count(*) FROM dolt_schema_conflicts)>0 THEN 1 ELSE 0 END);"
 
 TRG_DL_BASE="
 CREATE TABLE t(a INTEGER PRIMARY KEY, b INT);


### PR DESCRIPTION
## Summary

`mergePass1MergeMaster` 3-way merged `sqlite_master` as if it were a user table. That tree is keyed by rowid, so competing view definitions (and some catalog-row collisions) appeared as `(sqlite_master)` in `dolt_conflicts`. Dolt never produces that table: view/trigger disagreements are schema conflicts, and dual-rename keeps both tables with no catalog-row conflict.

The catalog row-merge still runs so rename-over-drop and dual-rename policy can build a canonical master root. Those row conflicts are discarded instead of recorded. Competing view/trigger SQL is recorded as a schema conflict. Leftover collisions the policy does not name (cherry-pick of a rename onto a reused table number) become schema conflicts too, so the pick is still refused.

## Tests

Fail-before / pass-after (Dolt oracle, in-transaction):

| | Unfixed | After |
|---|---|---|
| `merge_view_conflict_in_session` | `(sqlite_master)` present | `0\|1` — no catalog-row conflict, real conflict remains |
| `merge_view_both_add_different_not_master` | same phantom | same |

- Dual-rename still keeps both tables, 0 conflicts
- Identical view add still merges cleanly
- Nearby: merge oracle 85/85, schema-merge oracle 90/90, `doltlite_merge.sh` 113/113, `doltlite_merge_index_conflict.sh` 32/32

Co-Authored-By: Grok 4.6 <noreply@x.ai>