### PR TITLE
Resume interactive rebase after the database is reopened

### DIFF
--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -1240,6 +1240,8 @@ int doltliteSaveWorkingSetWithHash(sqlite3 *db, const ProllyHash *pWorkingCatHas
 int doltlitePersistWorkingSetWithHash(sqlite3 *db, const ProllyHash *pWorkingCatHash);
 void doltliteAdoptRollbackBaseline(sqlite3 *db, const ProllyHash *pCatalogHash);
 int doltliteLoadWorkingSet(sqlite3 *db, const char *zBranch);
+int doltliteBranchWorkingSetIsRebasing(sqlite3 *db, const char *zBranch,
+                                       int *pActive);
 int doltliteGetPersistedWorkingCatalogHash(sqlite3 *db, ProllyHash *pCatHash);
 int doltliteCheckoutBranchForRebase(sqlite3 *db, const char *zBranch);
 int doltliteCheckoutBranchForRebaseWithOldCatalog(

--- a/src/doltlite_rebase.c
+++ b/src/doltlite_rebase.c
@@ -1538,6 +1538,41 @@ fail:
   }
 }
 
+/* Reopen of $db lands on the default branch with a mirrored working set,
+** and $db/<orig> has no plan. Continue/abort must run on dolt_rebase_<orig>
+** so replay advances that tip instead of CAS-failing against feat. */
+static int rebaseAdoptPersistedRebase(sqlite3 *db){
+  const char *zCur;
+  const char *zOrig = 0;
+  char *zWorking = 0;
+  u8 isRebasing = 0;
+  int active = 0;
+  int rc;
+
+  zCur = doltliteGetSessionBranch(db);
+  doltliteGetSessionRebaseState(db, &isRebasing, 0, 0, &zOrig, 0);
+  if( isRebasing && zOrig && zOrig[0] ){
+    zWorking = rebaseBuildWorkingBranchName(zOrig);
+  }else if( zCur && zCur[0] ){
+    zWorking = rebaseBuildWorkingBranchName(zCur);
+    rc = doltliteBranchWorkingSetIsRebasing(db, zWorking, &active);
+    if( rc!=SQLITE_OK || !active ){
+      sqlite3_free(zWorking);
+      return rc;
+    }
+  }else{
+    return SQLITE_OK;
+  }
+  if( !zWorking ) return SQLITE_NOMEM;
+  if( !zCur || sqlite3_stricmp(zCur, zWorking)!=0 ){
+    rc = doltliteCheckoutBranchForRebase(db, zWorking);
+  }else{
+    rc = SQLITE_OK;
+  }
+  sqlite3_free(zWorking);
+  return rc;
+}
+
 static void doltliteRebaseInteractiveAbort(
   sqlite3_context *context,
   sqlite3 *db
@@ -1551,6 +1586,11 @@ static void doltliteRebaseInteractiveAbort(
   char *zWorking = 0;
   int rc;
 
+  rc = rebaseAdoptPersistedRebase(db);
+  if( rc!=SQLITE_OK ){
+    sqlite3_result_error_code(context, rc);
+    return;
+  }
   doltliteGetSessionRebaseState(db, &isRebasing, 0, 0,
                                 &zOrigBranchConst, &zReturnBranchConst);
   if( !isRebasing || !zOrigBranchConst || !zReturnBranchConst ){
@@ -1657,6 +1697,11 @@ static void doltliteRebaseInteractiveContinue(
   memset(&expectedOrigHead, 0, sizeof(expectedOrigHead));
   memset(&preRebaseCat, 0, sizeof(preRebaseCat));
 
+  rc = rebaseAdoptPersistedRebase(db);
+  if( rc!=SQLITE_OK ){
+    sqlite3_result_error_code(context, rc);
+    return;
+  }
   doltliteGetSessionRebaseState(db, &isRebasing, &preRebaseCat, &expectedOrigHead,
                                 &zOrigBranchConst, &zReturnBranchConst);
   if( !isRebasing || !zOrigBranchConst || !zReturnBranchConst ){

--- a/src/prolly_btree_state.c
+++ b/src/prolly_btree_state.c
@@ -1054,6 +1054,25 @@ int doltliteGetPersistedWorkingCatalogHash(sqlite3 *db, ProllyHash *pCatHash){
   return btreeReadWorkingCatalog(cs, zBranch, pCatHash, 0);
 }
 
+int doltliteBranchWorkingSetIsRebasing(
+  sqlite3 *db,
+  const char *zBranch,
+  int *pActive
+){
+  ChunkStore *cs = doltliteGetChunkStore(db);
+  u8 isRebasing = 0;
+  int rc;
+
+  if( pActive ) *pActive = 0;
+  if( !cs || !zBranch || !zBranch[0] ) return SQLITE_OK;
+  rc = btreeLoadWorkingSetBlob(cs, zBranch, 0, 0, 0, 0, 0, 0,
+                               &isRebasing, 0, 0, 0, 0, 0);
+  if( rc==SQLITE_NOTFOUND ) return SQLITE_OK;
+  if( rc!=SQLITE_OK ) return rc;
+  if( pActive ) *pActive = isRebasing!=0;
+  return SQLITE_OK;
+}
+
 int doltliteLoadWorkingSet(sqlite3 *db, const char *zBranch){
   ChunkStore *cs = doltliteGetChunkStore(db);
   Btree *pBtree;

--- a/test/doltlite_rebase.sh
+++ b/test/doltlite_rebase.sh
@@ -47,8 +47,8 @@ SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'm');
 SELECT dolt_checkout('feat');
 SQL
 
-# The plan lives in the session that started the interactive rebase, so the
-# edit and --continue must run together (as a user does interactively).
+# Invalid-plan --continue must leave the rebase in progress so the plan
+# can be edited and retried. Start, edit, and continue run in one session.
 run_test_match "invalid_plan_continue_errors" \
   "SELECT dolt_rebase('-i', 'main');
    UPDATE dolt_rebase SET action = 'oops' WHERE commit_message = 'f1';
@@ -249,6 +249,59 @@ feat
 1,2,3
 0" \
   "$DB5_SHORT/dolt_rebase_feat"
+
+# Reopen of the default DB used to see the mirrored plan then CAS-fail
+# (issue 1961). Reopen of the original branch had no plan at all.
+DB5_DEFAULT=/tmp/test_rebase_default_continue_$$.db
+seed_rebase_name_repo "$DB5_DEFAULT" "feat"
+run_test_match "rebase_default_reopen_starts" \
+  "SELECT dolt_rebase('-i','main');" \
+  "interactive rebase started" \
+  "$DB5_DEFAULT/feat"
+run_test "rebase_default_reopen_continues" \
+  "SELECT dolt_rebase('--continue');
+   SELECT active_branch();
+   SELECT group_concat(id, ',') FROM t;
+   SELECT count(*) FROM dolt_branches WHERE name='dolt_rebase_feat';" \
+  "Successfully rebased and updated refs/heads/feat
+feat
+1,2,3
+0" \
+  "$DB5_DEFAULT"
+
+DB5_ORIG=/tmp/test_rebase_orig_continue_$$.db
+seed_rebase_name_repo "$DB5_ORIG" "feat"
+run_test_match "rebase_orig_reopen_starts" \
+  "SELECT dolt_rebase('-i','main');" \
+  "interactive rebase started" \
+  "$DB5_ORIG/feat"
+run_test "rebase_orig_reopen_continues" \
+  "SELECT dolt_rebase('--continue');
+   SELECT active_branch();
+   SELECT group_concat(id, ',') FROM t;
+   SELECT count(*) FROM dolt_branches WHERE name='dolt_rebase_feat';" \
+  "Successfully rebased and updated refs/heads/feat
+feat
+1,2,3
+0" \
+  "$DB5_ORIG/feat"
+
+DB5_DEFAULT_ABORT=/tmp/test_rebase_default_abort_$$.db
+seed_rebase_name_repo "$DB5_DEFAULT_ABORT" "feat"
+run_test_match "rebase_default_reopen_starts_for_abort" \
+  "SELECT dolt_rebase('-i','main');" \
+  "interactive rebase started" \
+  "$DB5_DEFAULT_ABORT/feat"
+run_test "rebase_default_reopen_aborts" \
+  "SELECT dolt_rebase('--abort');
+   SELECT active_branch();
+   SELECT group_concat(id, ',') FROM t;
+   SELECT count(*) FROM dolt_branches WHERE name='dolt_rebase_feat';" \
+  "Interactive rebase aborted
+feat
+1,2
+0" \
+  "$DB5_DEFAULT_ABORT"
 
 DB6=/tmp/test_rebase_name_abort_$$.db
 seed_rebase_name_repo "$DB6" "$BRANCH63"


### PR DESCRIPTION
## Summary

Interactive rebase already persists the plan on `dolt_rebase_<orig>` and mirrors that working set onto the return branch. `--continue` / `--abort` still ran on whatever branch the new connection opened.

Reopening `$db` landed on `main` with the mirrored plan, then replay advanced `main` and CAS-failed against `feat` (`rebase aborted due to changes in branch feat`). That is #1961. Reopening `$db/feat` had no rebase session state, so continue said `no rebase in progress`.

Before continue or abort, check out the persisted working branch when the connection is not already on it. The default-DB path uses the mirrored `isRebasing` flag; the original-branch path peeks `dolt_rebase_<current>` and adopts it if that working set is still rebasing.

## Tests

Fail-before / pass-after (native, same SQL as #1961):

| | Unfixed | After |
|---|---|---|
| reopen `$db` then `--continue` | `rebase aborted due to changes in branch feat` | `Successfully rebased`, back on `feat`, rows `1,2,3` |
| reopen `$db/feat` then `--continue` | `no rebase in progress` | same success |
| reopen `$db` then `--abort` | `no rebase in progress` | aborted, back on `feat`, rows `1,2` |

Nearby: `doltlite_rebase.sh` 36/36, rebase oracle 52/52.

Closes #1961

Co-Authored-By: Grok 4.6 <noreply@x.ai>