### PR TITLE
Find rows whose primary key covers every column when checking constraints

### DIFF
--- a/src/doltlite_merge_constraints.c
+++ b/src/doltlite_merge_constraints.c
@@ -322,11 +322,22 @@ int recordPrefixEquals(
   return 1;
 }
 
+/* Find the row whose primary key matches pPkRec.
+**
+** The stored value carries the key columns for an ordinary table, but when
+** the primary key covers every column there is nothing left to store and
+** the value record is empty -- the row lives entirely in the sort key.
+** Matching on the value alone therefore never finds those rows, and every
+** caller reads that as "no such row" and skips the check it was about to
+** make. Fall back to the record the sort key decodes to, and hand that back
+** as the row so the caller has the columns it came for. */
 int fetchRowByPkRecord(
   ChunkStore *cs,
   ProllyCache *pCache,
   const ProllyHash *pRoot,
   u8 flags,
+  sqlite3 *db,
+  const char *zTable,
   const u8 *pPkRec, int nPkRec,
   int nPkField,
   u8 **ppKey, int *pnKey,
@@ -349,10 +360,44 @@ int fetchRowByPkRecord(
     const u8 *pVal = 0;
     int nVal = 0;
     prollyCursorValue(&cur, &pVal, &nVal);
-    if( pVal && recordPrefixEquals(pVal, nVal, pPkRec, nPkRec, nPkField) ){
+    if( pVal && nVal>0
+     && recordPrefixEquals(pVal, nVal, pPkRec, nPkRec, nPkField) ){
       rc = copyCursorRow(&cur, ppKey, pnKey, ppVal, pnVal);
       prollyCursorClose(&cur);
       return rc;
+    }
+    if( (!pVal || nVal==0) && db && zTable ){
+      const u8 *pKey = 0;
+      int nKey = 0;
+      u8 *pKeyRec = 0;
+      int nKeyRec = 0;
+      prollyCursorKey(&cur, &pKey, &nKey);
+      rc = doltliteRecordFromClusteredKey(db, zTable, pKey, nKey,
+                                          &pKeyRec, &nKeyRec);
+      if( rc!=SQLITE_OK ){
+        prollyCursorClose(&cur);
+        return rc;
+      }
+      if( pKeyRec
+       && recordPrefixEquals(pKeyRec, nKeyRec, pPkRec, nPkRec, nPkField) ){
+        u8 *pKeyCopy = 0;
+        if( nKey>0 ){
+          pKeyCopy = sqlite3_malloc(nKey);
+          if( !pKeyCopy ){
+            sqlite3_free(pKeyRec);
+            prollyCursorClose(&cur);
+            return SQLITE_NOMEM;
+          }
+          memcpy(pKeyCopy, pKey, nKey);
+        }
+        *ppKey = pKeyCopy;
+        *pnKey = nKey;
+        *ppVal = pKeyRec;
+        *pnVal = nKeyRec;
+        prollyCursorClose(&cur);
+        return SQLITE_OK;
+      }
+      sqlite3_free(pKeyRec);
     }
     rc = prollyCursorNext(&cur);
     if( rc!=SQLITE_OK ){
@@ -510,7 +555,8 @@ int fetchRowByPkFromTable(
   if( rc != SQLITE_OK ) return rc;
   if( flags & PROLLY_NODE_INTKEY ) return SQLITE_NOTFOUND;
 
-  return fetchRowByPkRecord(cs, pCache, &root, flags, pPkRec, nPkRec, nPkField,
+  return fetchRowByPkRecord(cs, pCache, &root, flags, db, zTable,
+                            pPkRec, nPkRec, nPkField,
                             ppKey, pnKey, ppVal, pnVal);
 }
 

--- a/src/doltlite_merge_constraints_int.h
+++ b/src/doltlite_merge_constraints_int.h
@@ -57,6 +57,7 @@ int recordPrefixEquals(
 );
 int fetchRowByPkRecord(
   ChunkStore *cs, ProllyCache *pCache, const ProllyHash *pRoot, u8 flags,
+  sqlite3 *db, const char *zTable,
   const u8 *pPkRec, int nPkRec, int nPkField,
   u8 **ppKey, int *pnKey, u8 **ppVal, int *pnVal
 );

--- a/test/doltlite_merge.sh
+++ b/test/doltlite_merge.sh
@@ -460,7 +460,7 @@ else
   ERRORS="$ERRORS\nFAIL: clean_merge_in_txn_rollback_refused\n  expected the post-merge ROLLBACK to find no open transaction"
 fi
 
-DB25=/tmp/test_merge25_$$.db; rm -f "$DB25" "$DB26" "$DB27" "$DB28" "$DB29" "$DB30" "$DB31" "$DB32"
+DB25=/tmp/test_merge25_$$.db; rm -f "$DB25" "$DB26" "$DB27" "$DB28" "$DB29" "$DB30" "$DB31" "$DB32" "$DB33" "$DB34" "$DB35" "$DB36"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'a');
 SELECT dolt_commit('-A','-m','base');
 SELECT dolt_checkout('-b','feat'); INSERT INTO t VALUES(2,'b'); SELECT dolt_commit('-A','-m','feat');
@@ -548,6 +548,51 @@ echo "INSERT INTO t VALUES(2,1,'y'); SELECT dolt_commit('-A','-m','feat row');" 
 echo "INSERT INTO t VALUES(3,1,'z'); SELECT dolt_commit('-A','-m','main row');" | $DOLTLITE "$DB32" > /dev/null 2>&1
 run_test_match "pk_same_desc_merges" "SELECT dolt_merge('feature');" "^[0-9a-f]{40}$" "$DB32"
 run_test "pk_same_desc_integrity" "PRAGMA integrity_check;" "ok" "$DB32"
+# When the primary key covers every column the value record is empty and the
+# row lives in the sort key, so a lookup that matched on the value alone
+# found nothing and every constraint detector skipped the row: violating
+# merges committed clean. Dolt records these and refuses the merge.
+DB33=/tmp/test_merge33_$$.db; rm -f "$DB33"
+echo "CREATE TABLE parent(id INTEGER PRIMARY KEY); CREATE TABLE child(pid INT REFERENCES parent(id), tag TEXT, PRIMARY KEY(pid,tag)); INSERT INTO parent VALUES(1); SELECT dolt_commit('-A','-m','base');" | $DOLTLITE "$DB33" > /dev/null 2>&1
+echo "SELECT dolt_branch('feature');" | $DOLTLITE "$DB33" > /dev/null 2>&1
+echo "INSERT INTO child VALUES(1,'t1'); SELECT dolt_commit('-A','-m','child row');" | $DOLTLITE "$DB33/feature" > /dev/null 2>&1
+echo "DELETE FROM parent WHERE id=1; SELECT dolt_commit('-A','-m','drop parent');" | $DOLTLITE "$DB33" > /dev/null 2>&1
+run_test_match "pk_only_fk_violation_detected" "SELECT dolt_merge('feature');" "constraint violations" "$DB33"
+TX33=$(echo "BEGIN;
+SELECT dolt_merge('feature');
+SELECT 'CV|' || (SELECT count(*) FROM dolt_constraint_violations);
+ROLLBACK;" | $DOLTLITE "$DB33" 2>&1 | grep '^CV|')
+if [ "$TX33" = "CV|1" ]; then
+  PASS=$((PASS+1))
+else
+  FAIL=$((FAIL+1))
+  ERRORS="$ERRORS\nFAIL: pk_only_fk_violation_recorded\n  expected: CV|1\n  got:      $TX33"
+fi
+
+DB34=/tmp/test_merge34_$$.db; rm -f "$DB34"
+echo "CREATE TABLE t(a INT, b INT, PRIMARY KEY(a,b), UNIQUE(b)); INSERT INTO t VALUES(1,1); SELECT dolt_commit('-A','-m','base');" | $DOLTLITE "$DB34" > /dev/null 2>&1
+echo "SELECT dolt_branch('feature');" | $DOLTLITE "$DB34" > /dev/null 2>&1
+echo "INSERT INTO t VALUES(2,5); SELECT dolt_commit('-A','-m','feat dup');" | $DOLTLITE "$DB34/feature" > /dev/null 2>&1
+echo "INSERT INTO t VALUES(3,5); SELECT dolt_commit('-A','-m','main dup');" | $DOLTLITE "$DB34" > /dev/null 2>&1
+run_test_match "pk_only_unique_violation_detected" "SELECT dolt_merge('feature');" "constraint violations" "$DB34"
+
+# A table with a non-key column still stores its value record, so the
+# ordinary path must keep working.
+DB35=/tmp/test_merge35_$$.db; rm -f "$DB35"
+echo "CREATE TABLE parent(id INTEGER PRIMARY KEY); CREATE TABLE child(pid INT REFERENCES parent(id), tag TEXT, note TEXT, PRIMARY KEY(pid,tag)); INSERT INTO parent VALUES(1); SELECT dolt_commit('-A','-m','base');" | $DOLTLITE "$DB35" > /dev/null 2>&1
+echo "SELECT dolt_branch('feature');" | $DOLTLITE "$DB35" > /dev/null 2>&1
+echo "INSERT INTO child VALUES(1,'t1','n'); SELECT dolt_commit('-A','-m','child row');" | $DOLTLITE "$DB35/feature" > /dev/null 2>&1
+echo "DELETE FROM parent WHERE id=1; SELECT dolt_commit('-A','-m','drop parent');" | $DOLTLITE "$DB35" > /dev/null 2>&1
+run_test_match "valued_row_fk_violation_detected" "SELECT dolt_merge('feature');" "constraint violations" "$DB35"
+
+# And a clean merge on a PK-only table must stay clean.
+DB36=/tmp/test_merge36_$$.db; rm -f "$DB36"
+echo "CREATE TABLE parent(id INTEGER PRIMARY KEY); CREATE TABLE child(pid INT REFERENCES parent(id), tag TEXT, PRIMARY KEY(pid,tag)); INSERT INTO parent VALUES(1),(2); SELECT dolt_commit('-A','-m','base');" | $DOLTLITE "$DB36" > /dev/null 2>&1
+echo "SELECT dolt_branch('feature');" | $DOLTLITE "$DB36" > /dev/null 2>&1
+echo "INSERT INTO child VALUES(1,'t1'); SELECT dolt_commit('-A','-m','child one');" | $DOLTLITE "$DB36/feature" > /dev/null 2>&1
+echo "INSERT INTO child VALUES(2,'t2'); SELECT dolt_commit('-A','-m','child two');" | $DOLTLITE "$DB36" > /dev/null 2>&1
+run_test_match "pk_only_clean_merge_hash" "SELECT dolt_merge('feature');" "^[0-9a-f]{40}$" "$DB36"
+run_test "pk_only_clean_merge_rows" "SELECT count(*) FROM child;" "2" "$DB36"
 
 rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8" "$DB8B" "$DB9" "$DB10" "$DB11" "$DB11D" "$DB11E" "$DB11F" "$DB12" "$DB13" "$DB14" "$DB15" "$DB16" "$DB17" "$DB18" "$DB19" "$DB20" "$DB20B" "$DB21" "$DB22" "$DB23" "$DB24" "$DB25"
 dltest_finish


### PR DESCRIPTION
## Problem

All five constraint detectors (foreign key, unique, check, not null, strict) look a row up by its primary key through one shared helper, and that helper matched the key against the row's stored **value** record.

A table whose primary key covers every column has nothing left to store: its value record is empty and the row lives entirely in the sort key. The lookup therefore matched nothing, every detector read that as "no such row" and skipped the check, and merges committed violations with nothing recorded at all:

```sql
CREATE TABLE parent(id INTEGER PRIMARY KEY);
CREATE TABLE child(pid INT REFERENCES parent(id), tag TEXT, PRIMARY KEY(pid,tag));
-- branch inserts child(1,'t1'); main deletes parent 1; merge
-- doltlite: merge succeeds, dolt_constraint_violations empty,
--           PRAGMA foreign_key_check shows the orphan
-- Dolt 2.2.2: records the FK violation and rolls the merge back
```

Same for a unique duplicate on a PK-only table. Found by the Aug 12 review.

## Fix

The lookup falls back to the record the sort key decodes to, and returns that as the row so callers read the columns they came for. The table name and connection needed for the key definition were already parameters of the wrapper every detector calls.

## Testing

Six cases in `doltlite_merge.sh`:

- `pk_only_fk_violation_detected` / `pk_only_fk_violation_recorded` — the FK orphan is now caught and one violation is recorded.
- `pk_only_unique_violation_detected` — the duplicate unique value is caught.
- `valued_row_fk_violation_detected` — control: a table that keeps a value record still works.
- `pk_only_clean_merge_hash` / `pk_only_clean_merge_rows` — control: a clean merge on a PK-only table stays clean.

The three detections fail on master; both controls pass on either side. Oracled against Dolt 2.2.2, which reports the same FK violation and the same rollback. Full battery 103/103; amalgamation compiles clean.

Third of three fixes from the merge-correctness cluster, after #2186 (primary key signature) and alongside the add-column default fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)