### PR TITLE
Allow indexed tables to survive dual rename merges

### DIFF
--- a/src/doltlite_merge.c
+++ b/src/doltlite_merge.c
@@ -182,6 +182,35 @@ static int mergeSchemaEntriesSame(
   return !pA->zSql || strcmp(pA->zSql, pB->zSql)==0;
 }
 
+static int mergeIndexColListSame(const char *zA, const char *zB){
+  if( !zA || !zB ) return zA==zB;
+  while( *zA && *zB ){
+    while( *zA=='"' || *zA=='\'' || *zA=='`' || *zA=='[' || *zA==']'
+        || *zA==' ' || *zA=='\t' ){
+      zA++;
+    }
+    while( *zB=='"' || *zB=='\'' || *zB=='`' || *zB=='[' || *zB==']'
+        || *zB==' ' || *zB=='\t' ){
+      zB++;
+    }
+    if( sqlite3UpperToLower[(u8)*zA]!=sqlite3UpperToLower[(u8)*zB] ){
+      return 0;
+    }
+    if( *zA==0 ) return 1;
+    zA++;
+    zB++;
+  }
+  while( *zA=='"' || *zA=='\'' || *zA=='`' || *zA=='[' || *zA==']'
+      || *zA==' ' || *zA=='\t' ){
+    zA++;
+  }
+  while( *zB=='"' || *zB=='\'' || *zB=='`' || *zB=='[' || *zB==']'
+      || *zB==' ' || *zB=='\t' ){
+    zB++;
+  }
+  return *zA==0 && *zB==0;
+}
+
 static int mergeIndexFollowsDualRename(
   SchemaEntry *aAnc, int nAnc,
   SchemaEntry *aOurs, int nOurs,
@@ -208,20 +237,23 @@ static int mergeIndexFollowsDualRename(
   pAncTable = findSchemaEntry(aAnc, nAnc, pAnc->zTblName);
   pOursTable = findSchemaEntry(aOurs, nOurs, pOurs->zTblName);
   pTheirsTable = findSchemaEntry(aTheirs, nTheirs, pTheirs->zTblName);
-  zAncBody = pAnc->zSql ? strchr(pAnc->zSql, '(') : 0;
-  zOursBody = pOurs->zSql ? strchr(pOurs->zSql, '(') : 0;
-  zTheirsBody = pTheirs->zSql ? strchr(pTheirs->zSql, '(') : 0;
-  return pAncTable && pAncTable->zType
-      && strcmp(pAncTable->zType, "table")==0
-      && pOursTable && pOursTable->zType
-      && strcmp(pOursTable->zType, "table")==0
-      && pTheirsTable && pTheirsTable->zType
-      && strcmp(pTheirsTable->zType, "table")==0
-      && zAncBody && zOursBody && zTheirsBody
-      && strcmp(zAncBody, zOursBody)==0
-      && strcmp(zAncBody, zTheirsBody)==0
-      && !findSchemaEntry(aAnc, nAnc, pOurs->zTblName)
-      && !findSchemaEntry(aAnc, nAnc, pTheirs->zTblName);
+  zAncBody = pAnc->zSql ? strrchr(pAnc->zSql, '(') : 0;
+  zOursBody = pOurs->zSql ? strrchr(pOurs->zSql, '(') : 0;
+  zTheirsBody = pTheirs->zSql ? strrchr(pTheirs->zSql, '(') : 0;
+  if( !pAncTable || !pAncTable->zType || strcmp(pAncTable->zType, "table")!=0
+   || !pOursTable || !pOursTable->zType || strcmp(pOursTable->zType, "table")!=0
+   || !pTheirsTable || !pTheirsTable->zType
+   || strcmp(pTheirsTable->zType, "table")!=0
+   || findSchemaEntry(aAnc, nAnc, pOurs->zTblName)
+   || findSchemaEntry(aAnc, nAnc, pTheirs->zTblName) ){
+    return 0;
+  }
+  if( zAncBody && zOursBody && zTheirsBody
+   && mergeIndexColListSame(zAncBody, zOursBody)
+   && mergeIndexColListSame(zAncBody, zTheirsBody) ){
+    return 1;
+  }
+  return zAncBody==0 && zOursBody==0 && zTheirsBody==0;
 }
 
 static int preDetectIndexSchemaConflicts(

--- a/src/doltlite_merge.c
+++ b/src/doltlite_merge.c
@@ -182,6 +182,48 @@ static int mergeSchemaEntriesSame(
   return !pA->zSql || strcmp(pA->zSql, pB->zSql)==0;
 }
 
+static int mergeIndexFollowsDualRename(
+  SchemaEntry *aAnc, int nAnc,
+  SchemaEntry *aOurs, int nOurs,
+  SchemaEntry *aTheirs, int nTheirs,
+  const SchemaEntry *pAnc,
+  const SchemaEntry *pOurs,
+  const SchemaEntry *pTheirs
+){
+  const char *zAncBody;
+  const char *zOursBody;
+  const char *zTheirsBody;
+  SchemaEntry *pAncTable;
+  SchemaEntry *pOursTable;
+  SchemaEntry *pTheirsTable;
+  if( !pAnc || !pOurs || !pTheirs || !pAnc->zTblName
+   || !pOurs->zTblName || !pTheirs->zTblName ){
+    return 0;
+  }
+  if( sqlite3_stricmp(pAnc->zTblName, pOurs->zTblName)==0
+   || sqlite3_stricmp(pAnc->zTblName, pTheirs->zTblName)==0
+   || sqlite3_stricmp(pOurs->zTblName, pTheirs->zTblName)==0 ){
+    return 0;
+  }
+  pAncTable = findSchemaEntry(aAnc, nAnc, pAnc->zTblName);
+  pOursTable = findSchemaEntry(aOurs, nOurs, pOurs->zTblName);
+  pTheirsTable = findSchemaEntry(aTheirs, nTheirs, pTheirs->zTblName);
+  zAncBody = pAnc->zSql ? strchr(pAnc->zSql, '(') : 0;
+  zOursBody = pOurs->zSql ? strchr(pOurs->zSql, '(') : 0;
+  zTheirsBody = pTheirs->zSql ? strchr(pTheirs->zSql, '(') : 0;
+  return pAncTable && pAncTable->zType
+      && strcmp(pAncTable->zType, "table")==0
+      && pOursTable && pOursTable->zType
+      && strcmp(pOursTable->zType, "table")==0
+      && pTheirsTable && pTheirsTable->zType
+      && strcmp(pTheirsTable->zType, "table")==0
+      && zAncBody && zOursBody && zTheirsBody
+      && strcmp(zAncBody, zOursBody)==0
+      && strcmp(zAncBody, zTheirsBody)==0
+      && !findSchemaEntry(aAnc, nAnc, pOurs->zTblName)
+      && !findSchemaEntry(aAnc, nAnc, pTheirs->zTblName);
+}
+
 static int preDetectIndexSchemaConflicts(
   SchemaEntry *aAnc, int nAnc,
   SchemaEntry *aOurs, int nOurs,
@@ -225,6 +267,11 @@ static int preDetectIndexSchemaConflicts(
       pTheirs = findSchemaEntry(aTheirs, nTheirs, a[i].zName);
       oursChanged = !mergeSchemaEntriesSame(pAnc, pOurs);
       theirsChanged = !mergeSchemaEntriesSame(pAnc, pTheirs);
+      if( mergeIndexFollowsDualRename(
+            aAnc, nAnc, aOurs, nOurs, aTheirs, nTheirs,
+            pAnc, pOurs, pTheirs) ){
+        continue;
+      }
       if( pAnc && pAnc->zTblName && !pOurs
        && pTheirs && pTheirs->zTblName
        && sqlite3_stricmp(pAnc->zTblName, pTheirs->zTblName)!=0 ){

--- a/src/doltlite_merge.c
+++ b/src/doltlite_merge.c
@@ -211,7 +211,7 @@ static int mergeIndexColListSame(const char *zA, const char *zB){
   return *zA==0 && *zB==0;
 }
 
-static int mergeIndexFollowsDualRename(
+int mergeIndexFollowsDualRename(
   SchemaEntry *aAnc, int nAnc,
   SchemaEntry *aOurs, int nOurs,
   SchemaEntry *aTheirs, int nTheirs,

--- a/src/doltlite_merge_int.h
+++ b/src/doltlite_merge_int.h
@@ -178,6 +178,15 @@ int hasAnySchemaConflict(
   int nConflictTables
 );
 
+int mergeIndexFollowsDualRename(
+  SchemaEntry *aAnc, int nAnc,
+  SchemaEntry *aOurs, int nOurs,
+  SchemaEntry *aTheirs, int nTheirs,
+  const SchemaEntry *pAnc,
+  const SchemaEntry *pOurs,
+  const SchemaEntry *pTheirs
+);
+
 int replayDropsDisjointSchemaObject(
   SchemaEntry *aAncSchema, int nAncSchema,
   SchemaEntry *aTheirsSchema, int nTheirsSchema

--- a/src/doltlite_merge_pass2.c
+++ b/src/doltlite_merge_pass2.c
@@ -34,6 +34,10 @@ int mergeCatalogPass2(
           aTheirsSchema, nTheirsSchema, aTheirs[i].iTable);
       if( pTheirSe && pTheirSe->zName && pTheirSe->zType
        && strcmp(pTheirSe->zType, "index")==0 ){
+        SchemaEntry *pAncSe = findSchemaEntry(
+            aAncSchema, nAncSchema, pTheirSe->zName);
+        SchemaEntry *pOurSe = findSchemaEntry(
+            aOursSchema, nOursSchema, pTheirSe->zName);
         struct TableEntry *pTheirTable = doltliteFindTableByName(
             aTheirs, nTheirs, pTheirSe->zTblName);
         if( hasSchemaConflictObject(aConflictTables, nConflictTables,
@@ -46,6 +50,11 @@ int mergeCatalogPass2(
          || !doltliteFindTableByName(aMerged, *pnMerged,
                                      pTheirSe->zTblName)
          ){
+          continue;
+        }
+        if( mergeIndexFollowsDualRename(
+              aAncSchema, nAncSchema, aOursSchema, nOursSchema,
+              aTheirsSchema, nTheirsSchema, pAncSe, pOurSe, pTheirSe) ){
           continue;
         }
         oursEntry = findCatalogEntryBySchemaObject(

--- a/test/doltlite_merge_index_conflict.sh
+++ b/test/doltlite_merge_index_conflict.sh
@@ -478,6 +478,31 @@ out=$("$DOLTLITE" "$DB" \
           (SELECT coalesce(sum(num_conflicts),0) FROM dolt_conflicts);" 2>/dev/null)
 check "rename_vs_rename_keeps_both_tables" "ours_t,theirs_t|1|1|0" "$out"
 
+DB="$TMPROOT/indexed_rename_vs_rename.db"; rm -rf "$DB"
+"$DOLTLITE" "$DB" <<'EOF' >/dev/null 2>&1
+CREATE TABLE a(id INTEGER PRIMARY KEY, payload TEXT);
+CREATE TABLE b(id INTEGER PRIMARY KEY, payload TEXT);
+CREATE INDEX i1 ON a(payload);
+CREATE INDEX i2 ON b(payload);
+INSERT INTO a VALUES(1,'a');
+INSERT INTO b VALUES(2,'b');
+SELECT dolt_commit('-Am','init');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+ALTER TABLE a RENAME TO theirs_a;
+SELECT dolt_commit('-Am','theirs rename');
+SELECT dolt_checkout('main');
+ALTER TABLE a RENAME TO ours_a;
+SELECT dolt_commit('-Am','ours rename');
+EOF
+out=$("$DOLTLITE" "$DB" "SELECT length(dolt_merge('feat'));" 2>/dev/null)
+check "indexed_rename_vs_rename_merge_clean" "40" "$out"
+out=$("$DOLTLITE" "$DB" \
+  "SELECT (SELECT group_concat(name,',') FROM (SELECT name FROM sqlite_master WHERE type='table' AND name IN ('ours_a','theirs_a') ORDER BY name)) || '|' ||
+          (SELECT group_concat(name || ':' || tbl_name,',') FROM (SELECT name,tbl_name FROM sqlite_master WHERE type='index' AND name IN ('i1','i2') ORDER BY name)) || '|' ||
+          (SELECT * FROM pragma_integrity_check LIMIT 1);" 2>/dev/null)
+check "indexed_rename_vs_rename_keeps_catalog_valid" "ours_a,theirs_a|i1:ours_a,i2:b|ok" "$out"
+
 echo
 echo "doltlite_merge_index_conflict: $pass passed, $fail failed"
 if [ "$fail" -gt 0 ]; then

--- a/test/doltlite_merge_index_conflict.sh
+++ b/test/doltlite_merge_index_conflict.sh
@@ -495,7 +495,7 @@ SELECT dolt_checkout('main');
 ALTER TABLE a RENAME TO ours_a;
 SELECT dolt_commit('-Am','ours rename');
 EOF
-out=$("$DOLTLITE" "$DB" "SELECT length(dolt_merge('feat'));" 2>/dev/null)
+out=$("$DOLTLITE" "$DB" "SELECT coalesce(length(dolt_merge('feat')), 'null');")
 check "indexed_rename_vs_rename_merge_clean" "40" "$out"
 out=$("$DOLTLITE" "$DB" \
   "SELECT (SELECT group_concat(name,',') FROM (SELECT name FROM sqlite_master WHERE type='table' AND name IN ('ours_a','theirs_a') ORDER BY name)) || '|' ||


### PR DESCRIPTION
## Summary

- recognize indexes whose only schema change is following divergent table renames
- keep both renamed tables without reporting a false schema conflict
- add the indexed dual-rename fixture from Ito review on #2187

Ito's RENAME-1 and RENAME-2 reports were duplicates of this valid defect. CATALOG-2 is not included: its asserted post-autocommit/reopen conflict state contradicts DoltLite's conflict non-persistence contract, and the operation already rolls back safely without exposing a raw sqlite_master conflict.

## Validation

- fail-before: indexed fixture rolled back and retained only ours_a
- pass-after: doltlite_merge_index_conflict.sh — 34/34
- doltlite_index_row_delta.sh — 31/31
- vc_oracle_merge_test.sh — 85/85
- make lint
- full native suite: all runnable suites passed; parity and regression-C were not runnable because this local build omitted sqlite3 and libdoltlite.a

Co-Authored-By: Codex <noreply@openai.com>