### PR TITLE
Restore blob-key cursors through the pending mutmap

### DIFF
--- a/src/prolly_btree_mutation.c
+++ b/src/prolly_btree_mutation.c
@@ -707,9 +707,25 @@ int restoreCursorPosition(BtCursor *pCur, int *pDifferentRow){
       pCur->pMutMap = (ProllyMutMap*)pTE->pPending;
     }
     if( pCur->pKey && pCur->nKey>0 ){
-      rc = prollyCursorSeekBlob(&pCur->pCur,
-                                 (const u8*)pCur->pKey, (int)pCur->nKey,
-                                 &res);
+      int landedMut = 0;
+      if( pCur->pMutMap && !prollyMutMapIsEmpty(pCur->pMutMap) ){
+        ProllyMutMapEntry *pEntry = 0;
+        rc = prollyMutMapFindRc(pCur->pMutMap,
+                                (const u8*)pCur->pKey, (int)pCur->nKey,
+                                0, &pEntry);
+        if( rc==SQLITE_OK && pEntry && pEntry->op==PROLLY_EDIT_INSERT ){
+          setCursorToMutMapEntryPhys(
+              pCur, (int)(pEntry - pCur->pMutMap->aEntries));
+          pCur->deferredTreeSeek = 1;
+          res = 0;
+          landedMut = 1;
+        }
+      }
+      if( rc==SQLITE_OK && !landedMut ){
+        rc = prollyCursorSeekBlob(&pCur->pCur,
+                                   (const u8*)pCur->pKey, (int)pCur->nKey,
+                                   &res);
+      }
     } else {
       pCur->eState = CURSOR_INVALID;
       if( pDifferentRow ) *pDifferentRow = 1;

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -11425,6 +11425,89 @@ static void run_storage_format_v12(void){
   removeDbFiles(dbpath);
 }
 
+static int collect_stepped_text(sqlite3_stmt *stmt, char *zOut, int nOut){
+  int n = 0;
+  int rc;
+  zOut[0] = 0;
+  while( (rc = sqlite3_step(stmt))==SQLITE_ROW ){
+    const unsigned char *z = sqlite3_column_text(stmt, 0);
+    int need = (int)strlen(zOut) + (n ? 1 : 0) + (z ? (int)strlen((const char*)z) : 4) + 1;
+    if( need>nOut ) return SQLITE_TOOBIG;
+    if( n ) strcat(zOut, ",");
+    strcat(zOut, z ? (const char*)z : "NULL");
+    n++;
+  }
+  return rc;
+}
+
+static void run_blob_restore_mutmap_keeps_scan(void){
+  sqlite3 *db = 0;
+  sqlite3_stmt *scan = 0;
+  sqlite3_stmt *ins = 0;
+  char dbpath[256];
+  char seen[128];
+  int rc;
+
+  printf("=== Blob Restore MutMap Keeps Scan Test ===\n\n");
+  make_dbpath(dbpath, sizeof(dbpath), "test_blob_restore_mutmap_keeps_scan");
+  removeDbFiles(dbpath);
+
+  check("open_db_for_blob_restore", open_db(dbpath, &db)==SQLITE_OK);
+  check("setup_wr_table_for_blob_restore", execSql(db,
+    "CREATE TABLE t(a TEXT PRIMARY KEY, b INT) WITHOUT ROWID;")==SQLITE_OK);
+  check("begin_wr_blob_restore_txn", execSql(db, "BEGIN;")==SQLITE_OK);
+  check("insert_pending_wr_rows",
+        execSql(db, "INSERT INTO t VALUES('a',1),('b',2),('c',3);")==SQLITE_OK);
+
+  rc = sqlite3_prepare_v2(db, "SELECT a FROM t ORDER BY a;", -1, &scan, 0);
+  check("prepare_wr_scan", rc==SQLITE_OK);
+  rc = sqlite3_prepare_v2(db, "INSERT INTO t VALUES('az',11);", -1, &ins, 0);
+  check("prepare_wr_insert", rc==SQLITE_OK);
+  if( scan && ins ){
+    rc = sqlite3_step(scan);
+    check("wr_scan_first", rc==SQLITE_ROW && stmt_column_text_equals(scan, 0, "a"));
+    check("wr_insert_mid_scan", sqlite3_step(ins)==SQLITE_DONE);
+    rc = collect_stepped_text(scan, seen, (int)sizeof(seen));
+    check("wr_scan_rest_done", rc==SQLITE_DONE);
+    check("wr_scan_sees_remaining", strcmp(seen, "az,b,c")==0);
+  }
+  sqlite3_finalize(scan);
+  sqlite3_finalize(ins);
+  scan = 0;
+  ins = 0;
+  check("wr_final_rows",
+        strcmp(queryScalarText(db,
+          "SELECT group_concat(a, ',') FROM (SELECT a FROM t ORDER BY a)"),
+          "a,az,b,c")==0);
+  check("commit_wr_blob_restore", execSql(db, "COMMIT;")==SQLITE_OK);
+
+  check("setup_index_for_blob_restore", execSql(db,
+    "CREATE TABLE w(id INTEGER PRIMARY KEY, v TEXT UNIQUE);"
+    "CREATE INDEX wv ON w(v);")==SQLITE_OK);
+  check("begin_idx_blob_restore_txn", execSql(db, "BEGIN;")==SQLITE_OK);
+  check("insert_pending_idx_rows",
+        execSql(db, "INSERT INTO w VALUES(1,'a'),(2,'c');")==SQLITE_OK);
+  rc = sqlite3_prepare_v2(db,
+    "SELECT v FROM w INDEXED BY wv WHERE v>='a';", -1, &scan, 0);
+  check("prepare_idx_scan", rc==SQLITE_OK);
+  rc = sqlite3_prepare_v2(db, "INSERT INTO w VALUES(3,'b');", -1, &ins, 0);
+  check("prepare_idx_insert", rc==SQLITE_OK);
+  if( scan && ins ){
+    rc = sqlite3_step(scan);
+    check("idx_scan_first", rc==SQLITE_ROW && stmt_column_text_equals(scan, 0, "a"));
+    check("idx_insert_mid_scan", sqlite3_step(ins)==SQLITE_DONE);
+    rc = collect_stepped_text(scan, seen, (int)sizeof(seen));
+    check("idx_scan_rest_done", rc==SQLITE_DONE);
+    check("idx_scan_sees_remaining", strcmp(seen, "b,c")==0);
+  }
+  sqlite3_finalize(scan);
+  sqlite3_finalize(ins);
+  check("commit_idx_blob_restore", execSql(db, "COMMIT;")==SQLITE_OK);
+
+  sqlite3_close(db);
+  removeDbFiles(dbpath);
+}
+
 static const RegressionCase aCases[] = {
   { "refs_vtab_snapshot_stability", "Refs Vtab Snapshot Stability Test", run_refs_vtab_snapshot_stability },
   { "storage_format_v12", "Storage Format Version 12 Test", run_storage_format_v12 },
@@ -11603,7 +11686,8 @@ static const RegressionCase aCases[] = {
   { "incrblob_chunked_and_multihandle", "Incrblob Chunked Record And Multi-Handle Test", run_incrblob_chunked_and_multihandle },
   { "rowid_named_pk_keeps_rowid_table", "Rowid-Named PK Keeps Rowid Table Test", run_rowid_named_pk_keeps_rowid_table },
   { "diff_side_schema_custom_function", "Diff Side Schema Custom Function Test", run_diff_side_schema_custom_function },
-  { "rollback_persist_failure_ends_txn", "Rollback Persist Failure Ends Write Txn Test", run_rollback_persist_failure_ends_txn }
+  { "rollback_persist_failure_ends_txn", "Rollback Persist Failure Ends Write Txn Test", run_rollback_persist_failure_ends_txn },
+  { "blob_restore_mutmap_keeps_scan", "Blob Restore MutMap Keeps Scan Test", run_blob_restore_mutmap_keeps_scan }
 };
 
 static int run_case_by_name(const char *zName){

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -3518,7 +3518,6 @@ fts4content fts4content-7.2.3 class=intentional issue=1852  # canonical adoption
 # assignment diverges in these assertions.
 fts4growth fts4growth-1.6 class=intentional
 fts4growth fts4growth-5.4 class=intentional
-fts4growth fts4growth-5.5 class=intentional
 fts4growth fts4growth-6.3 class=intentional
 fts4growth fts4growth-6.5 class=intentional
 

--- a/test/known_testfixture_exception_ratchet.txt
+++ b/test/known_testfixture_exception_ratchet.txt
@@ -6,8 +6,8 @@
 # Counts are per gate -- one divergent assertion, or one expected crash.
 # Lowering a number is the point. Raising one is a deliberate act that belongs
 # in a PR description.
-gates 4847
-intentional 3548
+gates 4846
+intentional 3547
 unsupported 1223
 harness 11
 engine-gap 65


### PR DESCRIPTION
## Summary

`restoreCursorPosition` reseated WITHOUT ROWID / index cursors with a tree-only `prollyCursorSeekBlob`. A second statement that writes the same table parks sibling scans at `REQUIRESEEK`; if the current row exists only in the mutmap, the tree miss ends the scan.

Integer PK restore already goes through mutmap-aware `TableMoveto`. Blob-key restore now does the same exact-INSERT probe and lands with `setCursorToMutMapEntryPhys` + deferred tree seek.

## Test plan

- `blob_restore_mutmap_keeps_scan` fail-before / pass-after:
  - uncommitted WITHOUT ROWID scan + mid-scan insert
  - uncommitted `INDEXED BY` scan + mid-scan insert
- Related existing cases still pass: `table_moveto_mutmap_exact_keeps_iteration_aligned`, `index_moveto_mutmap_exact_keeps_iteration_aligned`, `table_moveto_mutmap_delete_preserves_neighbors`, `doltlite_unique_index_delete.sh`