### PR TITLE
Preserve explicit NULLs during schema merge normalization

### DIFF
--- a/src/doltlite_merge.c
+++ b/src/doltlite_merge.c
@@ -6,9 +6,9 @@
 
 /* Rewrite every record in theirs' table root from theirs' column order into
 ** the merged column order (ours' columns, then theirs' added columns), using
-** the ancestor to retain renamed-column identity. A missing field is emitted as
-** NULL; trailing NULLs are dropped so an unchanged row re-encodes identically
-** to the ancestor's. This lets the positional cell-level three-way merge run
+** the ancestor to retain renamed-column identity. Missing fields use their
+** declared defaults where needed, while encoded NULLs remain NULL. This lets
+** the positional cell-level three-way merge run
 ** across a dual ADD COLUMN divergence: without it, theirs' added-column value
 ** would be read at the wrong ordinal. Records are content-addressed and rebuilt
 ** through the canonical doltliteBuildRecord, so the tree stays deterministic. */

--- a/src/doltlite_merge_schema.c
+++ b/src/doltlite_merge_schema.c
@@ -1151,6 +1151,7 @@ int normalizeTheirsToMergedLayout(
       m->eType = SQLITE_NULL;
       if( st==0 ){
         m->eType = SQLITE_NULL;
+        if( rowOnlyTheirs && tgt+1>nEmit ) nEmit = tgt+1;
       }else if( dlSerialIsInt(st) ){
         m->eType = SQLITE_INTEGER;
         if( st==8 ) m->i = 0;

--- a/test/doltlite_merge.sh
+++ b/test/doltlite_merge.sh
@@ -602,10 +602,10 @@ run_test "pk_only_clean_merge_rows" "SELECT count(*) FROM child;" "2" "$DB36"
 DB37=/tmp/test_merge37_$$.db; rm -f "$DB37"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'base'); SELECT dolt_commit('-A','-m','base');" | $DOLTLITE "$DB37" > /dev/null 2>&1
 echo "SELECT dolt_branch('feature');" | $DOLTLITE "$DB37" > /dev/null 2>&1
-echo "ALTER TABLE t ADD COLUMN m INT DEFAULT 5; INSERT INTO t VALUES(2,'from-feat',7); SELECT dolt_commit('-A','-m','feat col');" | $DOLTLITE "$DB37/feature" > /dev/null 2>&1
+echo "ALTER TABLE t ADD COLUMN m INT DEFAULT 5; INSERT INTO t VALUES(2,'from-feat',7); INSERT INTO t(id,v,m) VALUES(3,'null-feat',NULL); SELECT dolt_commit('-A','-m','feat col');" | $DOLTLITE "$DB37/feature" > /dev/null 2>&1
 echo "ALTER TABLE t ADD COLUMN n INT DEFAULT 9; SELECT dolt_commit('-A','-m','main col');" | $DOLTLITE "$DB37" > /dev/null 2>&1
 run_test_match "dual_add_column_merge_hash" "SELECT dolt_merge('feature');" "^[0-9a-f]{40}$" "$DB37"
-run_test "dual_add_column_defaults" "SELECT group_concat(id || ':' || n || ':' || m, ',') FROM (SELECT id,n,m FROM t ORDER BY id);" "1:9:5,2:9:7" "$DB37"
+run_test "dual_add_column_defaults" "SELECT group_concat(id || ':' || quote(n) || ':' || quote(m), ',') FROM (SELECT id,n,m FROM t ORDER BY id);" "1:9:5,2:9:7,3:9:NULL" "$DB37"
 
 # Text defaults take the same path, and a NOT NULL default must not turn
 # into a constraint violation invented by the rewrite.


### PR DESCRIPTION
## Summary

Addresses Ito's valid RECORD-2 finding on merged PR #2190.

During a dual `ADD COLUMN` merge, an incoming-only row with an explicitly stored trailing `NULL` was normalized into the merged column order. The normalizer decoded the NULL over the declared default, but then trimmed it from the rewritten record. On read, the now-absent field materialized its default again, silently changing NULL to that default.

The rewrite now keeps an encoded NULL within the record width when it was physically present on an incoming-only row. Genuinely absent fields still receive their declared defaults.

Ito's FAILURE-1 report was also investigated. Its supposedly malformed suffix, `BROKEN`, is valid SQLite syntax for a column named `BROKEN` with no declared type. Stock SQLite accepts the exact `CREATE TABLE` and reports `integrity_check = ok`, so this PR deliberately does not reject it.

## Tests

- fail-before / pass-after dual-ADD regression: incoming explicit NULL remains NULL while absent fields retain defaults
- native merge suite: 134/134
- Dolt merge oracle: 85/85
- `make lint`: all guards and 14/14 self-tests green

Follow-up to #2190.

Co-Authored-By: OpenAI Codex <noreply@openai.com>
