### PR TITLE
Check for unresolved conflicts before ending the caller's transaction

### DIFF
--- a/src/doltlite_commit_cmd.c
+++ b/src/doltlite_commit_cmd.c
@@ -730,6 +730,23 @@ static void doltliteCommitFunc(
     return;
   }
 
+  if( doltliteSessionHasSchemaConflicts(db) ){
+    sqlite3_result_error(context,
+      "cannot commit: unresolved schema conflicts. Abort the merge, align "
+      "the schemas on one side, then rerun the merge.", -1);
+    return;
+  }
+
+  {
+    ProllyHash cfHash;
+    doltliteGetSessionConflictsCatalog(db, &cfHash);
+    if( !prollyHashIsEmpty(&cfHash) ){
+      sqlite3_result_error(context,
+        "cannot commit: unresolved merge conflicts. Use dolt_conflicts_resolve() first.", -1);
+      return;
+    }
+  }
+
   if( !sealTopLevel
    && (!db->autoCommit
        || sqlite3_txn_state(db, "main")!=SQLITE_TXN_NONE
@@ -765,23 +782,6 @@ static void doltliteCommitFunc(
   }else if( addModifiedOnly ){
     rc = doltliteCommitStageModifiedOnly(db, context);
     if( rc!=SQLITE_OK ) return;
-  }
-
-  if( doltliteSessionHasSchemaConflicts(db) ){
-    sqlite3_result_error(context,
-      "cannot commit: unresolved schema conflicts. Abort the merge, align "
-      "the schemas on one side, then rerun the merge.", -1);
-    return;
-  }
-
-  {
-    ProllyHash cfHash;
-    doltliteGetSessionConflictsCatalog(db, &cfHash);
-    if( !prollyHashIsEmpty(&cfHash) ){
-      sqlite3_result_error(context,
-        "cannot commit: unresolved merge conflicts. Use dolt_conflicts_resolve() first.", -1);
-      return;
-    }
   }
 
   /* Final merge commits refresh derived sqlite_stat rows. */

--- a/test/doltlite_conflicts.sh
+++ b/test/doltlite_conflicts.sh
@@ -171,5 +171,65 @@ run_test_match "theirs_delete_trigger_skipped" \
   "BEGIN; SELECT dolt_merge('feature'); DROP TRIGGER IF EXISTS audit_delete; CREATE TRIGGER audit_delete BEFORE DELETE ON t BEGIN INSERT INTO trig_log VALUES('fired'); END; SELECT dolt_conflicts_resolve('--theirs','t'); SELECT 'TDT|' || count(*) FROM trig_log; ROLLBACK;" \
   "^TDT\\|0$" "$DB9"
 
-rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8" "$DB9"
+
+# A commit refused for unresolved conflicts must leave the transaction the
+# caller opened intact. Committing the transaction first and only then
+# checking left the session in autocommit with live merge state, so the next
+# resolve wrote the still-conflicted working set to disk -- the one thing a
+# conflicted merge must never do -- and reported success without applying.
+DB10=/tmp/test_conf10_$$.db; rm -f "$DB10"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+CREATE TABLE u(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'base'); INSERT INTO u VALUES(1,'base');
+SELECT dolt_commit('-Am','base');
+SELECT dolt_branch('br');" | $DOLTLITE "$DB10" > /dev/null 2>&1
+echo "UPDATE t SET v='theirs'; UPDATE u SET v='theirs'; SELECT dolt_commit('-Am','br');" | $DOLTLITE "$DB10/br" > /dev/null 2>&1
+echo "UPDATE t SET v='ours'; UPDATE u SET v='ours'; SELECT dolt_commit('-Am','ours');" | $DOLTLITE "$DB10" > /dev/null 2>&1
+
+echo "BEGIN;
+SELECT dolt_merge('br');
+SELECT dolt_conflicts_resolve('--theirs','t');
+SELECT dolt_commit('-A','-m','partial');
+SELECT dolt_conflicts_resolve('--ours','u');" | $DOLTLITE "$DB10" > /dev/null 2>&1
+run_test "refused_commit_leaves_nothing_merging" \
+  "SELECT count(*) FROM dolt_merge_status WHERE is_merging=1;" "0" "$DB10"
+run_test "refused_commit_leaves_no_conflicts" \
+  "SELECT count(*) FROM dolt_conflicts_u;" "0" "$DB10"
+run_test "refused_commit_keeps_our_rows" \
+  "SELECT v FROM t;" "ours" "$DB10"
+
+# The same refusal with nothing resolved first must also leave clean state,
+# and the surfaces that read merge state must stay readable.
+DB11=/tmp/test_conf11_$$.db; rm -f "$DB11"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'base');
+SELECT dolt_commit('-Am','base'); SELECT dolt_branch('br');" | $DOLTLITE "$DB11" > /dev/null 2>&1
+echo "UPDATE t SET v='theirs'; SELECT dolt_commit('-Am','br');" | $DOLTLITE "$DB11/br" > /dev/null 2>&1
+echo "UPDATE t SET v='ours'; SELECT dolt_commit('-Am','ours');" | $DOLTLITE "$DB11" > /dev/null 2>&1
+echo "BEGIN;
+SELECT dolt_merge('br');
+SELECT dolt_commit('-A','-m','nope');" | $DOLTLITE "$DB11" > /dev/null 2>&1
+run_test "refused_commit_no_prior_resolve_clean" \
+  "SELECT count(*) FROM dolt_merge_status WHERE is_merging=1;" "0" "$DB11"
+run_test "refused_commit_conflicts_readable" \
+  "SELECT count(*) FROM dolt_conflicts_t;" "0" "$DB11"
+
+# Resolving everything inside the transaction still commits the merge.
+DB12=/tmp/test_conf12_$$.db; rm -f "$DB12"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+CREATE TABLE u(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'base'); INSERT INTO u VALUES(1,'base');
+SELECT dolt_commit('-Am','base'); SELECT dolt_branch('br');" | $DOLTLITE "$DB12" > /dev/null 2>&1
+echo "UPDATE t SET v='theirs'; UPDATE u SET v='theirs'; SELECT dolt_commit('-Am','br');" | $DOLTLITE "$DB12/br" > /dev/null 2>&1
+echo "UPDATE t SET v='ours'; UPDATE u SET v='ours'; SELECT dolt_commit('-Am','ours');" | $DOLTLITE "$DB12" > /dev/null 2>&1
+echo "BEGIN;
+SELECT dolt_merge('br');
+SELECT dolt_conflicts_resolve('--theirs','t');
+SELECT dolt_conflicts_resolve('--ours','u');
+SELECT dolt_commit('-A','-m','resolved');" | $DOLTLITE "$DB12" > /dev/null 2>&1
+run_test "resolve_both_then_commit_lands" \
+  "SELECT (SELECT v FROM t) || '/' || (SELECT v FROM u);" "theirs/ours" "$DB12"
+run_test "resolve_both_then_commit_not_merging" \
+  "SELECT count(*) FROM dolt_merge_status WHERE is_merging=1;" "0" "$DB12"
+
+rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8" "$DB9" "$DB10" "$DB11" "$DB12"
 dltest_finish


### PR DESCRIPTION
## Problem

`dolt_commit` commits the caller's explicit transaction and *then* checks whether the merge still has unresolved conflicts — even though the comment on that commit says transactions "stay rollbackable until argument validation and basic commit guards have succeeded".

So a refused commit has already ended the transaction. The session lands in autocommit with its merge state still live, and the next `dolt_conflicts_resolve` runs as its own transaction — writing the still-conflicted working set to disk, which is exactly what `prolly_btree_txn.c` documents must never happen, and reporting success without applying anything:

```sql
BEGIN;
SELECT dolt_merge('br');                      -- two tables conflict
SELECT dolt_conflicts_resolve('--theirs','t');
SELECT dolt_commit('-A','-m','partial');      -- refused: u still conflicted
SELECT dolt_conflicts_resolve('--ours','u');  -- returns 0, applies nothing
-- fresh session: is_merging=1, dolt_conflicts_u still has a row,
--                and t holds 'theirs' though nothing was committed
```

A variant with no prior resolve strands merge state whose conflicts chunk was rolled back, so `dolt_merge_status` and the conflict tables error until `dolt_merge('--abort')`. Found by the Aug 12 review.

## Fix

The schema-conflict and unresolved-conflict gates move above that commit, so a refusal leaves the caller's transaction intact.

Measured directly with `sqlite3_get_autocommit`: after the refusal the transaction stays open (was ended), the follow-up resolve now applies (`u` conflicts 1 → 0), and a fresh session sees nothing stranded (`is_merging` 1 → 0, conflicts 1 → 0). Resolving everything inside the transaction still commits the merge, with the chosen values landing.

## Testing

Seven cases in `doltlite_conflicts.sh` covering the refusal with and without a prior resolve, that nothing merging or conflicted survives the session, that our rows are untouched, and the happy path. Three fail on master, one of them by overwriting the row.

Conflicts oracle suite 9/9, full battery 103/103, amalgamation and lint clean.

First of three fixes from the resolution/rendering cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)