### PR TITLE
Clear only the tables a scoped verify re-checks

### DIFF
--- a/src/doltlite_constraint_violations.c
+++ b/src/doltlite_constraint_violations.c
@@ -636,6 +636,50 @@ int doltliteAppendConstraintViolation(
   return rc;
 }
 
+/* Drop the recorded violations for the named tables, leaving every other
+** table's untouched. Verifying one table must not retract findings about
+** the others: the commit gate reads this catalog, so clearing it wholesale
+** turns a scoped re-check into permission to commit violating rows. */
+int doltliteClearConstraintViolationsForTables(
+  sqlite3 *db,
+  const char *const *azTables,
+  int nNames
+){
+  ChunkStore *cs = doltliteGetChunkStore(db);
+  ConstraintViolationTable *aTables = 0;
+  int nTables = 0;
+  int nKept = 0;
+  int i, j;
+  int rc;
+
+  if( !cs || nNames<=0 ) return SQLITE_OK;
+  rc = loadAllViolations(db, cs, &aTables, &nTables);
+  if( rc!=SQLITE_OK ) return rc;
+
+  for(i=0; i<nTables; i++){
+    int drop = 0;
+    for(j=0; j<nNames; j++){
+      if( aTables[i].zName && azTables[j]
+       && sqlite3_stricmp(aTables[i].zName, azTables[j])==0 ){
+        drop = 1;
+        break;
+      }
+    }
+    if( drop ){
+      /* Free this entry's contents only: the array itself is one block
+      ** that freeViolationTables releases once, at the end. */
+      freeViolationTable(&aTables[i]);
+      memset(&aTables[i], 0, sizeof(aTables[i]));
+    }else{
+      if( nKept!=i ) aTables[nKept] = aTables[i];
+      nKept++;
+    }
+  }
+  rc = storeUpdatedViolations(db, cs, aTables, nKept);
+  freeViolationTables(aTables, nKept);
+  return rc;
+}
+
 int doltliteClearAllConstraintViolations(sqlite3 *db){
   static const ProllyHash emptyHash = {{0}};
   int rc = doltliteSetSessionConstraintViolationsCatalog(db, &emptyHash);

--- a/src/doltlite_constraint_violations.h
+++ b/src/doltlite_constraint_violations.h
@@ -26,6 +26,10 @@ struct ConstraintViolationTable {
   ConstraintViolationRow *aRows;
 };
 
+int doltliteClearConstraintViolationsForTables(
+  sqlite3 *db, const char *const *azTables, int nNames
+);
+
 int doltliteAppendConstraintViolation(
   sqlite3 *db,
   const char *zTable,

--- a/src/doltlite_verify_constraints.c
+++ b/src/doltlite_verify_constraints.c
@@ -224,7 +224,15 @@ static void doltVerifyConstraintsFunc(
     hasSavedCv = 1;
   }
 
-  rc = doltliteClearAllConstraintViolations(db);
+  /* Only the tables about to be re-checked lose their recorded findings.
+  ** A scoped verify says nothing about the tables it does not scan, and the
+  ** commit gate reads this catalog. */
+  if( nArgTables>0 ){
+    rc = doltliteClearConstraintViolationsForTables(
+        db, (const char *const *)azArgTables, nArgTables);
+  }else{
+    rc = doltliteClearAllConstraintViolations(db);
+  }
   if( rc!=SQLITE_OK ){
     sqlite3_result_error_code(context, rc);
     goto cleanup;

--- a/test/vc_oracle_verify_constraints_test.sh
+++ b/test/vc_oracle_verify_constraints_test.sh
@@ -135,6 +135,32 @@ echo "--- FK: named table with no violations ---"
 run_oracle "fk_named_other" "$FK_SETUP" "'otherTable'" \
   "$FOLLOW_AGG_COUNT" 1
 
+
+# A merge records violations up front. Verifying an unrelated table must not
+# retract them: the commit gate reads that record, so clearing it wholesale
+# turns a scoped re-check into permission to commit violating rows.
+MERGE_CV_SETUP="
+CREATE TABLE parent(pk INTEGER PRIMARY KEY);
+CREATE TABLE child(pk INTEGER PRIMARY KEY, pid INT REFERENCES parent(pk));
+CREATE TABLE otherTable(pk INTEGER PRIMARY KEY);
+INSERT INTO parent VALUES (1);
+INSERT INTO otherTable VALUES (1);
+SELECT dolt_commit('-Am', 'init');
+SELECT dolt_branch('br');
+SELECT dolt_checkout('br');
+INSERT INTO child VALUES (1,1);
+SELECT dolt_commit('-Am', 'child row');
+SELECT dolt_checkout('main');
+DELETE FROM parent WHERE pk=1;
+SELECT dolt_commit('-Am', 'drop parent');
+BEGIN;
+SELECT dolt_merge('br');
+"
+
+echo "--- FK: merge-recorded violation survives a scoped verify ---"
+run_oracle "fk_merge_cv_survives_named_other" "$MERGE_CV_SETUP" "'otherTable'" \
+  "$FOLLOW_AGG_COUNT" 1
+
 echo "--- FK: default clean after force-commit ---"
 run_oracle "fk_default_clean_after_commit" \
 "$FK_SETUP


### PR DESCRIPTION
## Problem

`dolt_verify_constraints` calls `doltliteClearAllConstraintViolations` before scanning, regardless of which tables it was asked about. Verifying one table therefore retracts every other table's recorded violations — and the commit gate reads that record:

```sql
BEGIN;
SELECT dolt_merge('br');                     -- records an FK violation on child
SELECT count(*) FROM dolt_constraint_violations;   -- 1
SELECT dolt_verify_constraints('other');     -- unrelated table
SELECT count(*) FROM dolt_constraint_violations;   -- 0  (violation retracted)
SELECT dolt_commit('-A','-m','sneak');       -- succeeds, no --force needed
```

Dolt 2.2.2 keeps the other table's violation across the same call (measured: 1 before, 1 after). Found by the Aug 12 review.

## Fix

A scoped clear that drops only the named tables' entries. The unnamed and `--all` forms still clear everything, and verifying a table that does have violations still re-scans and re-records them (returns 1, count stays 1).

## Testing

New oracle case `fk_merge_cv_survives_named_other`: a merge records a violation, then an unrelated table is verified, then the aggregate is compared against Dolt. It fails on master (the violation disappears) and passes here; suite 14/14.

Full battery 103/103; amalgamation and lint clean.

Second of three fixes from the resolution/rendering cluster, after #2195.

🤖 Generated with [Claude Code](https://claude.com/claude-code)