### PR TITLE
Account for generated columns when mapping columns to record fields

### DIFF
--- a/src/doltlite_record.c
+++ b/src/doltlite_record.c
@@ -255,11 +255,22 @@ int doltliteGetColumnNames(sqlite3 *db, const char *zTable, DoltliteColInfo *ci)
   int nPkCols = 0;
   int iCandidateAlias = -1;
   int *aPk = 0;
+  int *aRecPos = 0;
+  int *aStoredPk = 0;
+  int *aStoredDecl = 0;
+  int nStored = 0;
+  int nRecPos = 0;
   int i, iNonPk;
 
   memset(ci, 0, sizeof(*ci));
   ci->iPkCol = -1;
-  zSql = sqlite3_mprintf("PRAGMA main.table_info(\"%w\")", zTable);
+  /* table_xinfo also lists generated columns. They matter even though the
+  ** vtabs do not expose them: a STORED one occupies a field in every stored
+  ** record, so the columns after it sit one slot further along than their
+  ** declared position suggests, and reading by declared position returns a
+  ** neighbour's value. A VIRTUAL one is never stored and occupies nothing.
+  ** hidden: 0 ordinary, 2 virtual generated, 3 stored generated. */
+  zSql = sqlite3_mprintf("PRAGMA main.table_xinfo(\"%w\")", zTable);
   if( !zSql ) return SQLITE_NOMEM;
 
   rc = sqlite3_prepare_v2(db, zSql, -1, &pStmt, 0);
@@ -281,7 +292,14 @@ int doltliteGetColumnNames(sqlite3 *db, const char *zTable, DoltliteColInfo *ci)
 
   if( nCol>0 ){
     aPk = sqlite3_malloc(nCol * (int)sizeof(int));
-    if( !aPk ){
+    aRecPos = sqlite3_malloc(nCol * (int)sizeof(int));
+    aStoredPk = sqlite3_malloc(nCol * (int)sizeof(int));
+    aStoredDecl = sqlite3_malloc(nCol * (int)sizeof(int));
+    if( !aPk || !aRecPos || !aStoredPk || !aStoredDecl ){
+      sqlite3_free(aPk);
+      sqlite3_free(aRecPos);
+      sqlite3_free(aStoredPk);
+      sqlite3_free(aStoredDecl);
       doltliteFreeColInfo(ci);
       sqlite3_finalize(pStmt);
       return SQLITE_NOMEM;
@@ -292,6 +310,20 @@ int doltliteGetColumnNames(sqlite3 *db, const char *zTable, DoltliteColInfo *ci)
     const char *zName = (const char*)sqlite3_column_text(pStmt, 1);
     int pk = sqlite3_column_int(pStmt, 5);
     const char *zType = (const char*)sqlite3_column_text(pStmt, 2);
+    int hidden = sqlite3_column_int(pStmt, 6);
+
+    if( hidden==2 ){
+      /* Virtual: computed on read, absent from the record entirely. */
+      continue;
+    }
+    if( hidden==3 ){
+      /* Stored: holds a field every later column sits behind. */
+      aStoredPk[nStored] = pk;
+      aStoredDecl[nStored] = -1;
+      nStored++;
+      nRecPos++;
+      continue;
+    }
 
     if( pk>0 ) nPkCols++;
     if( pk==1 && zType && sqlite3_stricmp(zType,"INTEGER")==0 ){
@@ -299,9 +331,16 @@ int doltliteGetColumnNames(sqlite3 *db, const char *zTable, DoltliteColInfo *ci)
     }
 
     aPk[ci->nCol] = pk;
+    aRecPos[ci->nCol] = nRecPos++;
+    aStoredPk[nStored] = pk;
+    aStoredDecl[nStored] = ci->nCol;
+    nStored++;
     ci->azName[ci->nCol] = sqlite3_mprintf("%s", zName ? zName : "");
     if( !ci->azName[ci->nCol] ){
       sqlite3_free(aPk);
+      sqlite3_free(aRecPos);
+      sqlite3_free(aStoredPk);
+      sqlite3_free(aStoredDecl);
       doltliteFreeColInfo(ci);
       sqlite3_finalize(pStmt);
       return SQLITE_NOMEM;
@@ -310,6 +349,9 @@ int doltliteGetColumnNames(sqlite3 *db, const char *zTable, DoltliteColInfo *ci)
   }
   if( rc!=SQLITE_DONE ){
     sqlite3_free(aPk);
+    sqlite3_free(aRecPos);
+    sqlite3_free(aStoredPk);
+    sqlite3_free(aStoredDecl);
     doltliteFreeColInfo(ci);
     sqlite3_finalize(pStmt);
     return rc;
@@ -357,19 +399,32 @@ int doltliteGetColumnNames(sqlite3 *db, const char *zTable, DoltliteColInfo *ci)
       return SQLITE_NOMEM;
     }
     if( ci->iPkCol>=0 || nPkCols==0 ){
-      for(i=0; i<ci->nCol; i++) ci->aColToRec[i] = i;
+      /* Declared order, but over record slots: a stored generated column
+      ** consumes one without being declared. */
+      for(i=0; i<ci->nCol; i++) ci->aColToRec[i] = aRecPos[i];
     }else{
+      /* Clustered layout: key columns in key order, then every other
+      ** stored column in declared order -- generated ones included, which
+      ** is why the walk is over stored columns rather than declared ones. */
+      int iSlot;
       for(i=0; i<ci->nCol; i++){
         if( aPk[i]>0 ) ci->aColToRec[i] = aPk[i] - 1;
       }
       iNonPk = nPkCols;
-      for(i=0; i<ci->nCol; i++){
-        if( aPk[i]==0 ) ci->aColToRec[i] = iNonPk++;
+      for(iSlot=0; iSlot<nStored; iSlot++){
+        if( aStoredPk[iSlot]>0 ) continue;
+        if( aStoredDecl[iSlot]>=0 ){
+          ci->aColToRec[aStoredDecl[iSlot]] = iNonPk;
+        }
+        iNonPk++;
       }
     }
   }
 
   sqlite3_free(aPk);
+  sqlite3_free(aRecPos);
+  sqlite3_free(aStoredPk);
+  sqlite3_free(aStoredDecl);
   sqlite3_finalize(pStmt);
   return SQLITE_OK;
 }

--- a/test/doltlite_diff_table.sh
+++ b/test/doltlite_diff_table.sh
@@ -316,4 +316,57 @@ run_test "ancestry_gate_reachable_commit" \
 
 rm -f "$DBG"
 
+
+# A STORED generated column holds a field in every record but is absent from
+# the declared column list, so every column after it sat one slot further
+# along than its declared position: reading by that position returned the
+# generated column's value instead. VIRTUAL ones are computed on read and
+# occupy nothing, so they must not shift anything.
+DBG1=/tmp/test_dt_gencol_$$.db; rm -f "$DBG1"
+echo "CREATE TABLE g(a INTEGER PRIMARY KEY, b TEXT, gs TEXT GENERATED ALWAYS AS (b||'S') STORED, gv TEXT AS (b||'V') VIRTUAL, c TEXT);
+INSERT INTO g(a,b,c) VALUES(1,'x','c1');
+SELECT dolt_commit('-Am','base');
+UPDATE g SET c='c2';
+SELECT dolt_commit('-am','upd');" | $DOLTLITE "$DBG1" > /dev/null 2>&1
+
+run_test "gencol_diff_sides" \
+  "SELECT to_c || '/' || from_c FROM dolt_diff_g WHERE diff_type='modified';" \
+  "c2/c1" "$DBG1"
+run_test "gencol_live_matches_diff" "SELECT c FROM g;" "c2" "$DBG1"
+run_test "gencol_history" \
+  "SELECT group_concat(c,',') FROM (SELECT c FROM dolt_history_g ORDER BY commit_date);" \
+  "c2,c1" "$DBG1"
+run_test "gencol_at" "SELECT c FROM dolt_at_g WHERE commit_ref='HEAD~1';" "c1" "$DBG1"
+
+# The clustered layout puts key columns first and the rest in declared
+# order, generated ones included, so it needs the same accounting.
+DBG2=/tmp/test_dt_gencol_wr_$$.db; rm -f "$DBG2"
+echo "CREATE TABLE w(k TEXT, b TEXT, gs TEXT GENERATED ALWAYS AS (b||'S') STORED, c TEXT, PRIMARY KEY(k)) WITHOUT ROWID;
+INSERT INTO w(k,b,c) VALUES('k1','x','c1');
+SELECT dolt_commit('-Am','base');
+UPDATE w SET c='c2';
+SELECT dolt_commit('-am','upd');" | $DOLTLITE "$DBG2" > /dev/null 2>&1
+
+run_test "gencol_clustered_diff_sides" \
+  "SELECT to_c || '/' || from_c FROM dolt_diff_w WHERE diff_type='modified';" \
+  "c2/c1" "$DBG2"
+run_test "gencol_clustered_history" \
+  "SELECT group_concat(c,',') FROM (SELECT c FROM dolt_history_w ORDER BY commit_date);" \
+  "c2,c1" "$DBG2"
+
+# A key column that is not the first declared column, with a generated
+# column between it and the rest.
+DBG3=/tmp/test_dt_gencol_nlpk_$$.db; rm -f "$DBG3"
+echo "CREATE TABLE z(a TEXT, k TEXT PRIMARY KEY, gs TEXT GENERATED ALWAYS AS (a||'S') STORED, c TEXT) WITHOUT ROWID;
+INSERT INTO z(a,k,c) VALUES('av','k1','c1');
+SELECT dolt_commit('-Am','base');
+UPDATE z SET c='c2';
+SELECT dolt_commit('-am','upd');" | $DOLTLITE "$DBG3" > /dev/null 2>&1
+
+run_test "gencol_nonleading_pk_diff" \
+  "SELECT to_a || '/' || to_c FROM dolt_diff_z WHERE diff_type='modified';" \
+  "av/c2" "$DBG3"
+
+rm -f "$DBG1" "$DBG2" "$DBG3"
+
 dltest_finish


### PR DESCRIPTION
## Problem

The column-to-record-field map is built from `PRAGMA table_info`, which omits generated columns. A **STORED** generated column still occupies a field in every stored record, so every declared column after it sits one slot further along than its position implies — and reading by that position returns the generated column's value:

```sql
CREATE TABLE g(a INTEGER PRIMARY KEY, b TEXT,
               gs TEXT GENERATED ALWAYS AS (b||'S') STORED,
               gv TEXT AS (b||'V') VIRTUAL,
               c TEXT);
INSERT INTO g(a,b,c) VALUES(1,'x','c1');   -- commit
UPDATE g SET c='c2';                        -- commit

SELECT c FROM g;                        -- c2      (correct)
SELECT to_c, from_c FROM dolt_diff_g;   -- xS, xS  (the generated value)
```

The row's only change was `c`, so the diff renders it identically on both sides: the real change is invisible *and* the value shown is wrong. Same on `dolt_history_<t>`, `dolt_at_<t>` and `dolt_workspace_<t>`. Dolt 2.2.2 renders `c2, c1`. Found by the Aug 12 review.

## Fix

The map is built from `table_xinfo`, which lists generated columns, and walks record slots instead of declared positions: a stored generated column consumes a slot without being declared, a virtual one is computed on read and consumes nothing.

The clustered (WITHOUT ROWID) layout needed the same accounting separately — it orders key columns first and then every *other stored* column, generated ones included — which is what a first pass over declared columns alone missed.

## Testing

Seven cases in `doltlite_diff_table.sh` across three shapes: rowid table with both a STORED and a VIRTUAL generated column, clustered table, and a clustered table whose key is not the first declared column. They cover `dolt_diff`, `dolt_history` and `dolt_at`.

Six fail on master. The seventh reads the table directly and passes either way — that contrast (live read right, historical read wrong) is what made the mismatch worth pinning. Verified against Dolt 2.2.2 for the rowid shape.

Full battery 103/103; amalgamation and lint clean.

Last of three fixes from the resolution/rendering cluster, after #2195 and #2196.

🤖 Generated with [Claude Code](https://claude.com/claude-code)