### PR TITLE
Pin that a clone refuses when a sweep lands in its ref-install window

### DIFF
--- a/src/doltlite_remote.c
+++ b/src/doltlite_remote.c
@@ -1343,6 +1343,10 @@ int doltliteClone(ChunkStore *pLocal, DoltliteRemote *pRemote){
 
     if( rc==SQLITE_OK ) rc = pLocalDst->xCommit(pLocalDst);
     pLocalDst->xClose(pLocalDst);
+    /* The synced chunks are rooted by nothing until the refs blob below
+    ** lands. A sweep in that window is refused because the store still holds
+    ** the pre-sweep file identity -- the hook lets a test drive one. */
+    if( rc==SQLITE_OK ) doltliteTestRunBeforeRefInstallHook();
     sqlite3_free(aRoots);
     aRoots = 0;
 

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -2165,6 +2165,74 @@ static void run_fetch_ref_install_survives_window_gc(void){
   removeDbFiles(localPath);
 }
 
+/* Clone has the same window as fetch: it commits the synced chunks, and
+** until the refs blob lands nothing roots them. A gc on the database being
+** cloned into collects the lot, and installing branch refs over that leaves
+** them naming absent chunks. */
+static void run_clone_ref_install_survives_window_gc(void){
+  sqlite3 *remoteDb = 0;
+  sqlite3 *cloneDb = 0;
+  sqlite3 *afterDb = 0;
+  char remotePath[256];
+  char clonePath[256];
+  char sql[512];
+  int rc;
+
+  printf("=== Clone Ref Install Survives Window GC Test ===\n\n");
+  make_dbpath(remotePath, sizeof(remotePath), "test_clone_window_gc_remote");
+  make_dbpath(clonePath, sizeof(clonePath), "test_clone_window_gc_clone");
+  removeDbFiles(remotePath);
+  removeDbFiles(clonePath);
+
+  check("clone_window_open_remote", open_db(remotePath, &remoteDb)==SQLITE_OK);
+  check("clone_window_seed_remote", execSql(remoteDb,
+    "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
+    "INSERT INTO t VALUES(1,'base');"
+    "SELECT dolt_commit('-A','-m','base');"
+    "INSERT INTO t VALUES(2,'more');"
+    "SELECT dolt_commit('-A','-m','more');")==SQLITE_OK);
+
+  check("clone_window_open_target", open_db(clonePath, &cloneDb)==SQLITE_OK);
+
+  gGcWindowPath = clonePath;
+  doltliteTestSetBeforeRefInstallHook(gcInFetchWindow, 0);
+  snprintf(sql, sizeof(sql), "SELECT dolt_clone('file://%s')", remotePath);
+  rc = execSqlSilent(cloneDb, sql);
+  if( gGcWindowCollected ){
+    check("clone_window_reports_failure", rc!=SQLITE_OK);
+  }else{
+    printf("  SKIP: clone_window_reports_failure (in-window gc unavailable)\n");
+  }
+  doltliteTestSetBeforeRefInstallHook(0, 0);
+  gGcWindowPath = 0;
+  check("clone_window_close_target_clean", sqlite3_close(cloneDb)==SQLITE_OK);
+  cloneDb = 0;
+  check("clone_window_close_remote_clean", sqlite3_close(remoteDb)==SQLITE_OK);
+  remoteDb = 0;
+
+  /* The refused clone must leave a database that still works: the function
+  ** registration chain aborts on its first failing member, so a branch ref
+  ** naming absent chunks takes every later function down with it. */
+  check("clone_window_reopen", open_db(clonePath, &afterDb)==SQLITE_OK);
+  check("clone_window_hashof_fn_alive",
+        execSqlSilent(afterDb, "SELECT dolt_hashof('HEAD')")==SQLITE_OK);
+  check("clone_window_gc_still_works",
+        execSqlSilent(afterDb, "SELECT dolt_gc()")==SQLITE_OK);
+
+  /* And it must heal on retry, re-syncing whatever the gc took. */
+  snprintf(sql, sizeof(sql), "SELECT dolt_clone('file://%s')", remotePath);
+  check("clone_window_retry_succeeds",
+        execSqlSilent(afterDb, sql)==SQLITE_OK);
+  check("clone_window_retry_rows",
+        strcmp(queryScalarText(afterDb, "SELECT count(*) FROM t"), "2")==0);
+  check("clone_window_retry_graph_complete",
+        execSqlSilent(afterDb, "SELECT dolt_gc()")==SQLITE_OK);
+
+  sqlite3_close(afterDb);
+  removeDbFiles(remotePath);
+  removeDbFiles(clonePath);
+}
+
 static void run_fetch_preserves_concurrent_local_refs(void){
   sqlite3 *remoteDb = 0;
   sqlite3 *localDb1 = 0;
@@ -11536,6 +11604,7 @@ static const RegressionCase aCases[] = {
   { "refs_commit_conflicting_peer_ref_fails", "Refs Commit Conflicting Peer Ref Fails Test", run_refs_commit_conflicting_peer_ref_fails },
   { "remote_refs_corruption", "Remote Refs Corruption Test", run_remote_refs_corruption },
   { "fetch_ref_install_survives_window_gc", "Fetch Ref Install Survives Window GC Test", run_fetch_ref_install_survives_window_gc },
+  { "clone_ref_install_survives_window_gc", "Clone Ref Install Survives Window GC Test", run_clone_ref_install_survives_window_gc },
   { "fetch_preserves_concurrent_local_refs", "Fetch Preserves Concurrent Local Refs Test", run_fetch_preserves_concurrent_local_refs },
   { "chunk_walk_corruption", "Chunk Walk Corruption Test", run_chunk_walk_corruption },
   { "catalog_deserialize_corruption", "Catalog Deserialize Corruption Test", run_catalog_deserialize_corruption },

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -2219,13 +2219,19 @@ static void run_clone_ref_install_survives_window_gc(void){
   check("clone_window_gc_still_works",
         execSqlSilent(afterDb, "SELECT dolt_gc()")==SQLITE_OK);
 
-  /* And it must heal on retry, re-syncing whatever the gc took. */
-  snprintf(sql, sizeof(sql), "SELECT dolt_clone('file://%s')", remotePath);
-  check("clone_window_retry_succeeds",
-        execSqlSilent(afterDb, sql)==SQLITE_OK);
-  check("clone_window_retry_rows",
+  /* And it must heal on retry, re-syncing whatever the gc took. Where the gc
+  ** could not run there was nothing to refuse, so the first clone landed and
+  ** a second one has nowhere to go -- the rows are already the proof. */
+  if( gGcWindowCollected ){
+    snprintf(sql, sizeof(sql), "SELECT dolt_clone('file://%s')", remotePath);
+    check("clone_window_retry_succeeds",
+          execSqlSilent(afterDb, sql)==SQLITE_OK);
+  }else{
+    printf("  SKIP: clone_window_retry_succeeds (in-window gc unavailable)\n");
+  }
+  check("clone_window_rows",
         strcmp(queryScalarText(afterDb, "SELECT count(*) FROM t"), "2")==0);
-  check("clone_window_retry_graph_complete",
+  check("clone_window_graph_complete",
         execSqlSilent(afterDb, "SELECT dolt_gc()")==SQLITE_OK);
 
   sqlite3_close(afterDb);


### PR DESCRIPTION
Test-only guard from investigating #2175. **No behavior change** — the one source edit fires an existing test hook.

## What this pins

Clone commits its synced chunks and only then installs the refs blob. Nothing roots those chunks in between, so a `dolt_gc()` (or the compaction a WAL checkpoint runs) on the database being cloned into can collect the whole cloned history in that window. Installing branch refs over that would leave them naming absent chunks — the permanent wedge #2177 fixed on the fetch side.

**Clone does not have that bug.** I instrumented master with only the hook call and drove both collectors through the window:

| collector in the window | clone rc | after reopen |
|---|---|---|
| `dolt_gc()` | 8 (`SQLITE_READONLY`) | `dolt_gc` OK, `dolt_branches` OK, retry clones clean |
| `PRAGMA wal_checkpoint` | 8 (`SQLITE_READONLY`) | same |

The reason is the mirror image of the fetch bug: `installFetchedRefs` takes the lock and force-refreshes, which *adopts* the post-sweep file and then installs over collected chunks. Clone never refreshes, so it still holds the pre-sweep file identity, the replacement is detected, and the write is refused.

That is the right outcome reached incidentally — nothing in the clone path is checking. So it is worth a test that says so, and that will speak up if the sweep ever stops replacing the file.

## Contents

- `doltliteTestRunBeforeRefInstallHook()` now fires in the clone path, as it already does in the fetch path. This is what lets a test put a sweep in the window at all; it compiles to nothing without a hook installed.
- `clone_ref_install_survives_window_gc`, 12 cases: the clone refuses, the database it refused into still answers `dolt_hashof` and `dolt_gc`, and a retry clones the rows and leaves a graph `dolt_gc` walks clean. It reuses the fetch test's sweep hook, including its skip for platforms that cannot rewrite a file another handle holds open.

## On #2175

I wrote the real fix too — hold the lock across validate + install + commit, mirroring the fetch path. It works, but it *introduces* the refresh that makes the fetch path dangerous and then needs new validation to undo it: a lot of delicate motion in the clone teardown path to convert one safe refusal into a differently-spelled one. I left it out and recommended closing #2175, with the evidence above in a comment there. This test is the part worth keeping either way.

Amalgamation and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)