### PR TITLE
Read the integer key only from a node that has one

### DIFF
--- a/src/doltlite_vtab_util.h
+++ b/src/doltlite_vtab_util.h
@@ -67,7 +67,10 @@ static SQLITE_INLINE int doltliteVtabCommonCaptureRowSide(
   const u8 *pVal; int nVal;
   sqlite3_free(c->pVal);
   c->pVal = 0; c->nVal = 0;
-  c->intKey = prollyCursorIntKey(&c->tblCur);
+  /* A blobkey node holds no integer key, and the column renderer ignores this
+  ** field without rootIntKey. History spanning a key-shape change visits both
+  ** shapes, so the read has to follow the node rather than the table. */
+  c->intKey = c->rootIntKey ? prollyCursorIntKey(&c->tblCur) : 0;
   prollyCursorValue(&c->tblCur, &pVal, &nVal);
   if( pVal && nVal>0 ){
     c->pVal = sqlite3_malloc(nVal);


### PR DESCRIPTION
Closes #2200.

## Problem

`doltliteVtabCommonCaptureRowSide` read the integer key from every captured row, whatever the node held:

```c
c->intKey = prollyCursorIntKey(&c->tblCur);
```

That is fine for a rowid table, but `dolt_history` and `dolt_at` walk *every commit* a table appears in. A table that was `WITHOUT ROWID` in an older commit and a rowid table later hands a blobkey node to the integer-key accessor, which takes the first eight bytes of the sort key as a signed integer:

```sql
CREATE TABLE s(a TEXT PRIMARY KEY, b TEXT) WITHOUT ROWID;
INSERT INTO s VALUES('x','one');
SELECT dolt_commit('-Am','v1');
SELECT * FROM dolt_history_s;
```

```
Assertion failed: ((pNode->flags & PROLLY_NODE_INTKEY)!=0),
function prollyNodeIntKey, file prolly_node.c, line 196.
```

## Fix

The read follows the node instead of the table. The surrounding code already decides per commit whether the node is integer-keyed (`rootIntKey`, set from the visited commit's flags in both `doltlite_history.c` and `doltlite_at.c`, before any capture), and `doltliteResultSideCol` ignores `intKey` without that flag — so the value was never used. It was read anyway, and an assert-enabled build died on it.

## Scope — read this before reviewing as a bug fix

**No release-build behavior changes.** Those eight bytes went nowhere: every consumer already gated on `rootIntKey`. What this fixes is a type-incorrect read and 16 assertions that abort a `--with-debug` build.

Verified by reverting this one line in the same worktree:

| suite | before | after |
|---|---|---|
| `doltlite_history.sh` | 48/51 | 51/51 |
| `doltlite_at.sh` | 48/52 | 52/52 |
| `doltlite_dolt_table_pushdown.sh` | 40/49 | 49/49 |

That is the whole `WITHOUT ROWID` cluster from the assert-build sweep (#2204). The battery under an assert build goes 95/103 → 98/103; the five that remain are the other three assert clusters (#2201, #2202, #2203) and two rig artifacts in my build dir (`./sqlite3` absent, `libdoltlite.a` not built).

Amalgamation and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)