### PR TITLE
Let a memory store satisfy the graph-lock assertion

### DIFF
--- a/src/chunk_store.h
+++ b/src/chunk_store.h
@@ -212,6 +212,14 @@ int chunkStoreClose(ChunkStore *cs);
 int chunkStoreLockAndRefresh(ChunkStore *cs);
 int chunkStoreLockAndRefreshChanged(ChunkStore *cs, int *pChanged);
 void chunkStoreUnlock(ChunkStore *cs);
+
+/* A memory store has no file to lock and no peer to race, so the lock calls
+** are no-ops there and leave lockDepth at zero. */
+#define PROLLY_ASSERT_STORE_GRAPH_LOCKED(cs) do{ \
+  assert( (cs)!=0 ); \
+  assert( (cs)->isMemory \
+       || ((cs)->pGraphLockFile!=0 && (cs)->lockDepth>0) ); \
+}while(0)
 int chunkStoreHasExternalChanges(ChunkStore *cs, int *pChanged);
 
 int chunkStoreReadBranchWorkingCatalog(ChunkStore *cs, const char *zBranch,

--- a/src/doltlite_core.c
+++ b/src/doltlite_core.c
@@ -737,7 +737,7 @@ int doltliteCompareAndAdvanceBranch(
     doltliteTxnStateClear(&saved);
     return rc;
   }
-  assert( cs->lockDepth>0 );
+  PROLLY_ASSERT_STORE_GRAPH_LOCKED(cs);
 
   /* Persist the tip under the confirm lock without SwitchCatalog: any SQL that
   ** cycles the graph lock between confirm and commit can let a peer land and
@@ -761,7 +761,7 @@ int doltliteCompareAndAdvanceBranch(
       ** Surface BUSY so the caller retries on a fresh view. */
     }
   }
-  assert( cs->lockDepth>0 );
+  PROLLY_ASSERT_STORE_GRAPH_LOCKED(cs);
   chunkStoreUnlock(cs);
 
   if( rc==SQLITE_OK ){

--- a/src/prolly_btree_int.h
+++ b/src/prolly_btree_int.h
@@ -116,8 +116,7 @@ u32 prollyBtreeGetU32LE(const u8 *p);
 
 #define PROLLY_ASSERT_GRAPH_LOCKED(pBt) do{ \
   assert( (pBt)!=0 ); \
-  assert( (pBt)->store.isMemory \
-       || ((pBt)->store.pGraphLockFile!=0 && (pBt)->store.lockDepth>0) ); \
+  PROLLY_ASSERT_STORE_GRAPH_LOCKED(&(pBt)->store); \
 }while(0)
 
 #define PROLLY_ASSERT_CURSOR_OWNED(pCur) do{ \


### PR DESCRIPTION
Closes #2201.

## Problem

```
doltlite ":memory:" "CREATE TABLE t(a INTEGER PRIMARY KEY); INSERT INTO t VALUES(1); SELECT dolt_commit('-Am','x');"
```

```
Assertion failed: (cs->lockDepth>0),
function doltliteCompareAndAdvanceBranch, file doltlite_core.c, line 740.
```

`chunkStoreLockAndRefreshChanged` returns immediately for a memory store — `if( cs->isMemory ) return SQLITE_OK;` — because there is no file to lock and no peer to race. `lockDepth` therefore stays zero, and the two assertions in `doltliteCompareAndAdvanceBranch` read it directly.

**The advance itself was right.** This is the assertion being wrong, not the code: on a memory store there is nothing to serialise against, which is exactly why the lock is a no-op.

## Fix

`PROLLY_ASSERT_GRAPH_LOCKED` has always exempted memory stores:

```c
assert( (pBt)->store.isMemory
     || ((pBt)->store.pGraphLockFile!=0 && (pBt)->store.lockDepth>0) );
```

It just could not be used at these two sites, since it takes a `Btree` and they hold a `ChunkStore`. Its condition moves to `PROLLY_ASSERT_STORE_GRAPH_LOCKED` in `chunk_store.h`, next to the lock API it describes, and the btree macro defers to it. The contract is now stated once rather than re-derived by hand — which is how two raw `lockDepth` asserts drifted from it in the first place.

## Scope

No release-build behavior changes; assertions only.

`doltlite_memory_db.sh` 6/8 → 8/8 (`memory_supports_dolt_commit`, `memory_supports_dolt_checkout_isolates_branches`), confirmed by reverting. Under an assert build the battery goes 98/103 → 99/103; the remaining four are #2202, #2203 and two rig artifacts in my build dir (`./sqlite3` absent, `libdoltlite.a` not built).

Second of the four assert clusters from #2204, after #2207.

Amalgamation and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)