### PR TITLE
Become a write transaction before mirroring the savepoint stack

### DIFF
--- a/src/prolly_btree_txn.c
+++ b/src/prolly_btree_txn.c
@@ -779,21 +779,32 @@ int prollyBtreeBeginTrans(Btree *p, int wrFlag, int *pSchemaVersion){
       }
     }
 
-    if( p->db ){
-      while( p->nSavepoint < p->db->nSavepoint ){
-        int rc2 = pushSavepoint(p, 0);
-        if( rc2!=SQLITE_OK ){
-          while( p->nSavepoint > nSavepointStart ){
-            p->nSavepoint--;
-            freeSavepointTables(&p->aSavepointTables[p->nSavepoint]);
+    /* The transaction becomes a write here rather than after the savepoint
+    ** mirror below: pushSavepoint snapshots per-table state on behalf of a
+    ** write and says so with an assertion, and this is the caller that
+    ** establishes the very state it asserts on. A failed push still has to
+    ** leave nothing behind, so it puts both fields back. */
+    {
+      u8 inTransBefore = p->inTrans;
+      u8 inTransactionBefore = p->inTransaction;
+      p->inTrans = TRANS_WRITE;
+      p->inTransaction = TRANS_WRITE;
+      if( p->db ){
+        while( p->nSavepoint < p->db->nSavepoint ){
+          int rc2 = pushSavepoint(p, 0);
+          if( rc2!=SQLITE_OK ){
+            while( p->nSavepoint > nSavepointStart ){
+              p->nSavepoint--;
+              freeSavepointTables(&p->aSavepointTables[p->nSavepoint]);
+            }
+            p->inTrans = inTransBefore;
+            p->inTransaction = inTransactionBefore;
+            chunkStoreUnlock(&pBt->store);
+            return rc2;
           }
-          chunkStoreUnlock(&pBt->store);
-          return rc2;
         }
       }
     }
-    p->inTrans = TRANS_WRITE;
-    p->inTransaction = TRANS_WRITE;
     PROLLY_ASSERT_GRAPH_LOCKED(pBt);
   } else {
     if( p->inTrans==TRANS_NONE ){


### PR DESCRIPTION
Closes #2202.

## Problem

```sql
CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
BEGIN;
SAVEPOINT sp1;
WITH RECURSIVE gen(x) AS (VALUES(1) UNION ALL SELECT x+1 FROM gen WHERE x<66000)
  INSERT INTO t SELECT x, printf('row-%d',x) FROM gen;
ROLLBACK TO sp1;
COMMIT;
```

```
Assertion failed: ((pBtree)!=0 && (pBtree)->inTrans==TRANS_WRITE),
function pushSavepoint, file prolly_btree_txn.c, line 616.
```

`-O2` inlines the frames away, so I captured the caller with a temporary `execinfo` hook:

```
DIAG pushSavepoint inTrans=0 bStatement=0
0  pushSavepoint + 76
1  prollyBtreeBeginTrans + 752
2  sqlite3VdbeExec + 24540
```

`prollyBtreeBeginTrans` mirrors SQLite's savepoint stack onto the btree when a write starts with a `SAVEPOINT` already open — and sets `inTrans = TRANS_WRITE` two lines *below* that loop. So the one caller that establishes the state `pushSavepoint` asserts on cannot satisfy it. The row count only matters because crossing the spill threshold begins a write of its own; the same assert fires for a small statement in the other three cases the issue lists (a failing `dolt_*` call inside a savepoint).

## Fix

The state moves before the mirror instead of after it. By that point the graph lock is held, the branch-deletion refusal has passed, and the working state is loaded — the transaction is a write in every respect but the field. A failed push restores both fields, since the existing error path has to leave nothing behind.

I chose this over relaxing the assertion. `pushSavepoint` has six callers and the invariant is real for the other five; weakening it for all of them, or threading a "still beginning" flag through every site, both cost more than moving two assignments.

## Scope

No release-build behavior changes beyond the ordering of two field assignments and their restoration on an error path that previously could not reach them.

`doltlite_savepoint.sh` 123/128 → 128/128, confirmed by reverting. Under an assert build the battery is 99/103 here — the remainder are #2201 (in flight as #2208), #2203, and two rig artifacts in my build dir.

Third of the four assert clusters from #2204, after #2207 and #2208.

Amalgamation and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)