### PR TITLE
Slice oversized VFS reads, and stop asserting a page bound on a record

### DIFF
--- a/src/chunk_index.c
+++ b/src/chunk_index.c
@@ -202,7 +202,7 @@ int csReadIndex(ChunkStore *cs){
     return SQLITE_NOMEM;
   }
 
-  rc = sqlite3OsRead(cs->file.pFile, aBuf, cs->index.nIndexSize, cs->index.iIndexOffset);
+  rc = csReadSliced(cs, aBuf, (i64)cs->index.nIndexSize, cs->index.iIndexOffset);
   if( rc != SQLITE_OK ){
     sqlite3_free(aBuf);
     sqlite3_free(cs->index.aIndex);

--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -4,6 +4,23 @@
 
 #include "chunk_store_int.h"
 #include "../ext/blake3/blake3.h"
+
+/* Stock bounds a single VFS read at 128KiB -- os_unix asserts it, and the
+** write side masks the length outright -- so whole-buffer reads slice the way
+** the commit and WAL-replay writers already do. */
+#define CS_IO_SLICE 65536
+int csReadSliced(ChunkStore *cs, void *pBuf, i64 nByte, i64 iOff){
+  u8 *p = (u8*)pBuf;
+  while( nByte > 0 ){
+    int n = nByte > CS_IO_SLICE ? CS_IO_SLICE : (int)nByte;
+    int rc = sqlite3OsRead(cs->file.pFile, p, n, iOff);
+    if( rc != SQLITE_OK ) return rc;
+    p += n;
+    iOff += n;
+    nByte -= n;
+  }
+  return SQLITE_OK;
+}
 #ifdef SQLITE_CRASH_TEST
 #endif
 
@@ -822,7 +839,7 @@ int chunkStoreGet(
       pBuf = (u8 *)sqlite3_malloc(sz + 4);
       if( pBuf == 0 ) return SQLITE_NOMEM;
 
-      rc = sqlite3OsRead(cs->file.pFile, pBuf, sz + 4, fileOff);
+      rc = csReadSliced(cs, pBuf, (i64)sz + 4, fileOff);
       if( rc != SQLITE_OK ){
         sqlite3_free(pBuf);
         return rc;
@@ -916,7 +933,7 @@ int chunkStoreGetSparse(
     nPhys = e->size - (int)zeroTail;
     pBuf = (u8*)sqlite3_malloc(nPhys + 4);
     if( !pBuf ) return SQLITE_NOMEM;
-    rc = sqlite3OsRead(cs->file.pFile, pBuf, nPhys + 4, e->offset);
+    rc = csReadSliced(cs, pBuf, (i64)nPhys + 4, e->offset);
     if( rc!=SQLITE_OK ){
       sqlite3_free(pBuf);
       return rc;

--- a/src/chunk_store.h
+++ b/src/chunk_store.h
@@ -209,6 +209,8 @@ int chunkStoreOpen(ChunkStore *cs, sqlite3_vfs *pVfs,
 
 int chunkStoreClose(ChunkStore *cs);
 
+int csReadSliced(ChunkStore *cs, void *pBuf, i64 nByte, i64 iOff);
+
 int chunkStoreLockAndRefresh(ChunkStore *cs);
 int chunkStoreLockAndRefreshChanged(ChunkStore *cs, int *pChanged);
 void chunkStoreUnlock(ChunkStore *cs);

--- a/src/vdbe.c
+++ b/src/vdbe.c
@@ -3141,7 +3141,12 @@ op_column_restart:
         goto op_column_corrupt;
       }
       assert( pC->szRow<=pC->payloadSize );
+#ifndef DOLTLITE_PROLLY
       assert( pC->szRow<=65536 );  /* Maximum page size is 64KiB */
+#else
+      /* No pages here: a prolly record is handed over whole, so the bound
+      ** above -- which is the maximum page size -- does not describe it. */
+#endif
     }
     pC->cacheStatus = p->cacheCtr;
     if( (aOffset[0] = pC->aRow[0])<0x80 ){


### PR DESCRIPTION
Closes #2203.

Two bounds, and they turned out to be different kinds of problem.

## 1. `seekAndRead` — doltlite's own convention, not applied

```sql
-- session 1
CREATE TABLE t(id INTEGER PRIMARY KEY, data BLOB);
INSERT INTO t VALUES(1, randomblob(1048576));
SELECT dolt_commit('-A','-m','1MB');
-- session 2 (reopen)
SELECT length(data) FROM t WHERE id=1;
```

```
Assertion failed: (cnt==(cnt&0x1ffff)), function seekAndRead, file os_unix.c, line 3470.
```

I expected this to be a genuine conflict between stock's page-oriented VFS and doltlite's whole-chunk reads. It is not. **Everywhere else doltlite moves bulk bytes it already slices at 65536:**

- `chunk_store_commit.c:419` — `int toWrite = remaining > 65536 ? 65536 : (int)remaining;`
- `chunk_wal.c:326` — WAL replay, same shape

And there is a good reason the writers do it. The write side does not merely assert the bound:

```c
/* os_unix.c seekAndWriteFd */
assert( nBuf==(nBuf&0x1ffff) );
nBuf &= 0x1ffff;          /* <-- silently truncates in a release build */
```

Two whole-chunk reads never got the same treatment, and were relying on the release build to issue a 1MB `pread` unchecked. They now go through one `csReadSliced` helper.

**Precaution, not a demonstrated fix:** the chunk-index read (`chunk_index.c:205`) reads `nIndexSize` in one call and the same argument covers it, so it uses the helper too — but I could not build a database large enough to cross the bound there (a 7.9MB store with 200k rows keeps that read just under 128KiB), so I am not claiming it as a reproduced bug.

## 2. The VDBE row bound — the assertion is what is wrong

```c
assert( pC->szRow<=65536 );  /* Maximum page size is 64KiB */
```

The comment states the rationale, and it does not hold here: doltlite has no pages, and `sqlite3BtreePayloadFetchWithSize` (already inside the `DOLTLITE_PROLLY` branch two lines above) hands over the whole record, so `szRow == payloadSize`. A 100KB row exceeds a limit derived from a page format it does not use. The assertion now applies to the paged build only.

## Testing

`doltlite_unicode_blob.sh` 41/46 → 46/46 (`1mb_blob_size`, `1mb_blob_on_branch`, `1mb_blob_after_merge`, `blob_count_after_merge` on the read bound; `100kb_length` on the row bound). Battery under an assert build 99/103 — the remainder are #2201/#2202 (in flight as #2208/#2209) and two rig artifacts in my build dir.

Release-build behavior: reads are now issued in 64KiB slices rather than one call. Short reads behave the same, since callers already treat `SQLITE_IOERR_SHORT_READ` as fatal and discard the buffer.

Last of the four assert clusters from #2204. With this, #2200–#2203 all have fixes, and an assert-enabled battery bucket becomes possible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)