### PR TITLE
Keep one-item oversized prolly leaves open for append

### DIFF
--- a/src/prolly_mutate.c
+++ b/src/prolly_mutate.c
@@ -303,12 +303,14 @@ streaming_cleanup:
 }
 
 /* Boundary predicate shared with the chunker (prolly_chunker.c addToLevel): an
-** entry of thisSize bytes whose key is pKey closes a chunk when the running
-** byte count reaches PROLLY_CHUNK_MAX, or PROLLY_CHUNK_MIN and the Weibull
-** roll fires. Seeded with the node level so leaves and internal nodes match
-** the shapes the chunker produces. */
-static int chunkBoundary(int nBytes, int thisSize,
+** entry of thisSize bytes whose key is pKey closes a chunk when more than one
+** item is present and the running byte count reaches PROLLY_CHUNK_MAX, or
+** PROLLY_CHUNK_MIN and the Weibull roll fires. A single entry cannot be split.
+** Seeded with the node level so leaves and internal nodes match the shapes the
+** chunker produces. */
+static int chunkBoundary(int nItems, int nBytes, int thisSize,
                          const u8 *pKey, int nKey, u8 level){
+  if( nItems<=1 ) return 0;
   if( nBytes >= PROLLY_CHUNK_MAX ) return 1;
   if( nBytes >= PROLLY_CHUNK_MIN ){
     u32 h = prollyXXH32(pKey, nKey, (u32)level);
@@ -345,13 +347,13 @@ static void nodeAppendState(const ProllyNode *pNode,
     int nLastKey, nLastVal;
     prollyNodeKey(pNode, (int)pNode->nItems - 1, &pLastKey, &nLastKey);
     prollyNodeValue(pNode, (int)pNode->nItems - 1, &pLastVal, &nLastVal);
-    *pEndsAtBoundary = chunkBoundary(nBytes,
+    *pEndsAtBoundary = chunkBoundary((int)pNode->nItems, nBytes,
         PROLLY_NODE_ENTRY_BYTES(pNode->level, nLastKey, nLastVal),
         pLastKey, nLastKey, pNode->level);
   }
 
-  *pWouldSplit = chunkBoundary(nBytes + thisSize, thisSize,
-                               pKey, nKey, pNode->level);
+  *pWouldSplit = chunkBoundary((int)pNode->nItems + 1, nBytes + thisSize,
+                               thisSize, pKey, nKey, pNode->level);
 }
 
 static int appendWouldSplitNode(const ProllyNode *pNode,
@@ -359,7 +361,8 @@ static int appendWouldSplitNode(const ProllyNode *pNode,
                                 int nVal){
   int thisSize = PROLLY_NODE_ENTRY_BYTES(pNode->level, nKey, nVal);
   int nBytes = nodeTotalBytes(pNode) + thisSize;
-  return chunkBoundary(nBytes, thisSize, pKey, nKey, pNode->level);
+  return chunkBoundary((int)pNode->nItems + 1, nBytes, thisSize,
+                       pKey, nKey, pNode->level);
 }
 
 static int nodeEndsAtChunkBoundary(const ProllyNode *pNode){
@@ -371,7 +374,7 @@ static int nodeEndsAtChunkBoundary(const ProllyNode *pNode){
   nBytes = nodeTotalBytes(pNode);
   prollyNodeKey(pNode, (int)pNode->nItems - 1, &pKey, &nKey);
   prollyNodeValue(pNode, (int)pNode->nItems - 1, &pVal, &nVal);
-  return chunkBoundary(nBytes,
+  return chunkBoundary((int)pNode->nItems, nBytes,
                        PROLLY_NODE_ENTRY_BYTES(pNode->level, nKey, nVal),
                        pKey, nKey, pNode->level);
 }
@@ -393,7 +396,8 @@ static int nodeHasSameChunkShape(const ProllyNode *pNode,
     (void)pVal;
     thisSize = PROLLY_NODE_ENTRY_BYTES(pNode->level, nKey, nVal);
     nBytes += thisSize;
-    isBoundary = chunkBoundary(nBytes, thisSize, pKey, nKey, pNode->level);
+    isBoundary = chunkBoundary(i + 1, nBytes, thisSize, pKey, nKey,
+                               pNode->level);
 
     if( i<(int)pNode->nItems - 1 && isBoundary ){
       return 0;

--- a/test/chunker_boundary_golden.sh
+++ b/test/chunker_boundary_golden.sh
@@ -68,6 +68,73 @@ db_hash2=$(echo "$out2" | sed -n '3p' | tr -d '\r')
 check "hashof_table_repeatable" "$table_hash" "$table_hash2"
 check "hashof_db_repeatable" "$db_hash" "$db_hash2"
 
+HASHDIR=$(mktemp -d)
+trap 'rm -rf "$DB" "$DB2" "$HASHDIR"' EXIT
+
+hashof_table() {
+  local db="$1" sql="$2"
+  rm -f "$db"
+  "$DOLTLITE" "$db" "$sql" | tail -n 1 | tr -d '\r'
+}
+
+echo "--- oversized singleton leaf vs one-shot chunk ---"
+small_two=$(hashof_table "$HASHDIR/small_two.db" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES(1, 1);
+SELECT dolt_commit('-Am','a');
+INSERT INTO t VALUES(2, 2);
+SELECT dolt_commit('-Am','b');
+SELECT dolt_hashof_table('t');
+")
+small_one=$(hashof_table "$HASHDIR/small_one.db" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES(1, 1), (2, 2);
+SELECT dolt_commit('-Am','both');
+SELECT dolt_hashof_table('t');
+")
+check "small_int_two_commit_vs_one" "$small_one" "$small_two"
+
+z8_two=$(hashof_table "$HASHDIR/z8_two.db" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v BLOB);
+INSERT INTO t VALUES(1, zeroblob(8192));
+SELECT dolt_commit('-Am','fat');
+INSERT INTO t VALUES(2, x'78');
+SELECT dolt_commit('-Am','small');
+SELECT dolt_hashof_table('t');
+")
+z8_one=$(hashof_table "$HASHDIR/z8_one.db" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v BLOB);
+INSERT INTO t VALUES(1, zeroblob(8192)), (2, x'78');
+SELECT dolt_commit('-Am','both');
+SELECT dolt_hashof_table('t');
+")
+z8_flush=$(hashof_table "$HASHDIR/z8_flush.db" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v BLOB);
+INSERT INTO t VALUES(1, zeroblob(8192));
+SELECT count(*) FROM t;
+INSERT INTO t VALUES(2, x'78');
+SELECT dolt_commit('-Am','both');
+SELECT dolt_hashof_table('t');
+")
+check "zeroblob_8192_two_commit_vs_one" "$z8_one" "$z8_two"
+check "zeroblob_8192_count_flush_vs_one" "$z8_one" "$z8_flush"
+
+z16_two=$(hashof_table "$HASHDIR/z16_two.db" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v BLOB);
+INSERT INTO t VALUES(1, zeroblob(16384));
+SELECT dolt_commit('-Am','fat');
+INSERT INTO t VALUES(2, x'78');
+SELECT dolt_commit('-Am','small');
+SELECT dolt_hashof_table('t');
+")
+z16_one=$(hashof_table "$HASHDIR/z16_one.db" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v BLOB);
+INSERT INTO t VALUES(1, zeroblob(16384)), (2, x'78');
+SELECT dolt_commit('-Am','both');
+SELECT dolt_hashof_table('t');
+")
+check "zeroblob_16384_two_commit_vs_one" "$z16_one" "$z16_two"
+
 echo
 if [ "$fail" -eq 0 ]; then
   echo "Results: $pass passed, 0 failed"

--- a/test/history_independence_test.sh
+++ b/test/history_independence_test.sh
@@ -3686,6 +3686,94 @@ CREATE INDEX idx_t_v ON t(v);
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'final');
 "
+
+echo "--- oversized singleton leaf append ---"
+
+assert_table_hash_pair() {
+  local name="$1"
+  local sql_a="$2"
+  local sql_b="$3"
+  local db_a="$TMPROOT/${name}_a.db"
+  local db_b="$TMPROOT/${name}_b.db"
+  run_setup "$db_a" "${name}_a" "$sql_a"
+  run_setup "$db_b" "${name}_b" "$sql_b"
+  local ha hb
+  ha=$(table_hash "$db_a" "${name}_a_th")
+  hb=$(table_hash "$db_b" "${name}_b_th")
+  assert_equal "$name" "$ha" "$hb"
+}
+
+assert_table_hash_pair \
+  "small_int_two_commit_vs_one" \
+  "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES(1, 1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'a');
+INSERT INTO t VALUES(2, 2);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'b');
+" \
+  "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES(1, 1), (2, 2);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'both');
+"
+
+assert_table_hash_pair \
+  "zeroblob_8192_two_commit_vs_one" \
+  "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v BLOB);
+INSERT INTO t VALUES(1, zeroblob(8192));
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'fat');
+INSERT INTO t VALUES(2, x'78');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'small');
+" \
+  "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v BLOB);
+INSERT INTO t VALUES(1, zeroblob(8192)), (2, x'78');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'both');
+"
+
+assert_table_hash_pair \
+  "zeroblob_8192_count_flush_vs_one" \
+  "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v BLOB);
+INSERT INTO t VALUES(1, zeroblob(8192));
+SELECT count(*) FROM t;
+INSERT INTO t VALUES(2, x'78');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'both');
+" \
+  "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v BLOB);
+INSERT INTO t VALUES(1, zeroblob(8192)), (2, x'78');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'both');
+"
+
+assert_table_hash_pair \
+  "zeroblob_16384_two_commit_vs_one" \
+  "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v BLOB);
+INSERT INTO t VALUES(1, zeroblob(16384));
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'fat');
+INSERT INTO t VALUES(2, x'78');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'small');
+" \
+  "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v BLOB);
+INSERT INTO t VALUES(1, zeroblob(16384)), (2, x'78');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'both');
+"
+
 echo "======================================="
 echo "Results: $PASS passed, $FAIL failed"
 echo "======================================="

--- a/test/vc_oracle_hashof_test.sh
+++ b/test/vc_oracle_hashof_test.sh
@@ -244,6 +244,65 @@ same "net_vs_delete_reinsert" "$H_NET" "$H_DR"
 
 echo ""
 
+echo "--- 3b. Oversized singleton leaf vs one-shot insert ---"
+
+SMALL_TWO="
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'a');
+INSERT INTO t VALUES (2, 2);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'b');
+"
+
+SMALL_ONE="
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 1), (2, 2);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'both');
+"
+
+H_SMALL_TWO=$(run_hash "small_two" "$SMALL_TWO" "SELECT dolt_hashof_table('t');")
+H_SMALL_ONE=$(run_hash "small_one" "$SMALL_ONE" "SELECT dolt_hashof_table('t');")
+same "small_int_two_commit_vs_one" "$H_SMALL_ONE" "$H_SMALL_TWO"
+
+FAT_TWO="
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t
+WITH RECURSIVE s(n, x) AS (
+  SELECT 1, 'x'
+  UNION ALL
+  SELECT n+1, x||x FROM s WHERE n<14
+)
+SELECT 1, x FROM s WHERE n=14;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'fat');
+INSERT INTO t VALUES (2, 'y');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'small');
+"
+
+FAT_ONE="
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t
+WITH RECURSIVE s(n, x) AS (
+  SELECT 1, 'x'
+  UNION ALL
+  SELECT n+1, x||x FROM s WHERE n<14
+)
+SELECT 1, x FROM s WHERE n=14;
+INSERT INTO t VALUES (2, 'y');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'both');
+"
+
+H_FAT_TWO=$(run_hash "fat_two" "$FAT_TWO" "SELECT dolt_hashof_table('t');")
+H_FAT_ONE=$(run_hash "fat_one" "$FAT_ONE" "SELECT dolt_hashof_table('t');")
+same "fat_text_8192_two_commit_vs_one" "$H_FAT_ONE" "$H_FAT_TWO"
+
+echo ""
+
 echo "--- 4. Cross-branch state invariance ---"
 
 BRANCH_CONVERGE="


### PR DESCRIPTION
## Summary

`chunkBoundary` in the no-rechunk mutator treated a 1-item leaf as a closed chunk as soon as its bytes hit `PROLLY_CHUNK_MIN` (Weibull) or `PROLLY_CHUNK_MAX`. The chunker does not: `addToLevel` requires `nItems>1` before flushing, because a single entry cannot be split.

After a committed fat row — or a `COUNT(*)` that flushes the mutmap — `tryAppendSingleNoSplit` therefore opened a sibling leaf for the next insert. A one-shot insert of the same two rows stayed in one leaf. Same final table, different `dolt_hashof_table`.

The predicate now takes `nItems` and returns 0 for a singleton, matching the chunker.

## Test plan

Fail-before / pass-after (small INT control already matched):

- two-commit vs one-commit `zeroblob(8192)` table hash
- `COUNT(*)` flush after the fat insert vs one-commit
- two-commit vs one-commit `zeroblob(16384)` (`PROLLY_CHUNK_MAX` path)
- `printf` 8192 TEXT (same mismatch, same fix)
- Dolt oracle: 8192-byte TEXT two-commit vs one-commit

`chunker_boundary_golden.sh`, `history_independence_test.sh`, `vc_oracle_hashof_test.sh`, `prolly_chunker_boundary_test`.