### PR TITLE
Probe batch replacements before validation

### DIFF
--- a/.github/workflows/nightly-performance.yml
+++ b/.github/workflows/nightly-performance.yml
@@ -118,6 +118,8 @@ jobs:
       env:
         BENCH_RUNS: ${{ github.event.inputs.runs || '55' }}
         BENCH_AC_WRITE_RUNS: ${{ github.event.inputs.runs || '55' }}
+        BENCH_MAX_MULTIPLIER: 2.3
+        BENCH_AVG_MAX_MULTIPLIER: 1.9
         BENCH_AC_WRITE_MAX_MULTIPLIER: 6
       run: |
         results="$RUNNER_TEMP/nightly-results"

--- a/src/prolly_mutate.c
+++ b/src/prolly_mutate.c
@@ -1125,6 +1125,45 @@ static int mutmapHasOnlyInserts(ProllyMutMap *pMap){
   return 1;
 }
 
+static int batchReplacementProbe(ProllyMutator *pMut){
+  ProllyCursor cur;
+  int nEdits = prollyMutMapCount(pMut->pEdits);
+  int nProbe = nEdits < 16 ? nEdits : 16;
+  int i;
+  int rc = SQLITE_OK;
+
+  prollyCursorInit(&cur, pMut->pStore, pMut->pCache, &pMut->oldRoot,
+                   pMut->flags);
+  for(i=0; i<nProbe; i++){
+    ProllyMutMapEntry *pEdit;
+    int idx = (int)(((i64)i * nEdits) / nProbe);
+    int res = 0;
+    rc = prollyMutMapEntryAt(pMut->pEdits, idx, &pEdit);
+    if( rc!=SQLITE_OK ) break;
+    if( pMut->flags & PROLLY_NODE_INTKEY ){
+      rc = prollyCursorSeekInt(&cur, prollyMutMapEntryIntKey(pEdit), &res);
+    }else{
+      rc = prollyCursorSeekBlob(&cur, pEdit->pKey, pEdit->nKey, &res);
+    }
+    if( rc!=SQLITE_OK || res!=0 || !prollyCursorIsValid(&cur) ){
+      if( rc==SQLITE_OK ) rc = SQLITE_NOTFOUND;
+      break;
+    }
+    {
+      const u8 *pOldVal;
+      int nOldVal;
+      prollyCursorValue(&cur, &pOldVal, &nOldVal);
+      (void)pOldVal;
+      if( pEdit->nZeroTail || pEdit->nVal!=nOldVal ){
+        rc = SQLITE_NOTFOUND;
+        break;
+      }
+    }
+  }
+  prollyCursorClose(&cur);
+  return rc;
+}
+
 static int tryReplaceBatchLeafDirect(
   ProllyMutator *pMut,
   const ProllyNode *pLeaf,
@@ -1453,6 +1492,9 @@ static int tryReplaceBatchNoRechunk(ProllyMutator *pMut){
   if( prollyHashIsEmpty(&pMut->oldRoot) ) return SQLITE_NOTFOUND;
   if( prollyMutMapCount(pMut->pEdits)<=1 ) return SQLITE_NOTFOUND;
   if( !mutmapHasOnlyInserts(pMut->pEdits) ) return SQLITE_NOTFOUND;
+
+  rc = batchReplacementProbe(pMut);
+  if( rc!=SQLITE_OK ) return rc;
 
   pRootEntry = pMut->pCache ? prollyCacheGet(pMut->pCache, &pMut->oldRoot) : 0;
   if( pRootEntry ){

--- a/test/nightly_performance_report.py
+++ b/test/nightly_performance_report.py
@@ -245,11 +245,11 @@ def escape_markdown(value):
 
 
 def individual_limit(result):
-    return 6.0 if result.section == "ac_writes" else 2.4
+    return 6.0 if result.section == "ac_writes" else 2.3
 
 
 def average_limit(section):
-    return 5.0 if section == "ac_writes" else 1.95
+    return 5.0 if section == "ac_writes" else 1.9
 
 
 def section_results(suites, section):
@@ -454,7 +454,7 @@ def render_report(suites, commit, run_url, generated_at, runner):
     lines.extend(render_sql_summary(sysbench_suites))
     lines.extend(
         [
-            "The absolute ceiling is 2.4× per ordinary workload and 1.95× "
+            "The absolute ceiling is 2.3× per ordinary workload and 1.9× "
             "for a section average. Durable autocommit writes use 6.0× "
             "and 5.0× ceilings respectively.",
             "",

--- a/test/nightly_performance_report_test.py
+++ b/test/nightly_performance_report_test.py
@@ -81,8 +81,10 @@ class NightlyPerformanceReportTest(unittest.TestCase):
         autocommit = nightly_report.Result(
             "ac_writes", "insert_ac", 100, 600
         )
-        self.assertEqual(nightly_report.individual_limit(ordinary), 2.4)
+        self.assertEqual(nightly_report.individual_limit(ordinary), 2.3)
         self.assertEqual(nightly_report.individual_limit(autocommit), 6.0)
+        self.assertEqual(nightly_report.average_limit("mem_reads"), 1.9)
+        self.assertEqual(nightly_report.average_limit("ac_writes"), 5.0)
 
         repository = pathlib.Path(__file__).parent.parent
         for script in (
@@ -104,6 +106,8 @@ class NightlyPerformanceReportTest(unittest.TestCase):
             repository / ".github" / "workflows" /
             "nightly-performance.yml"
         ).read_text(encoding="utf-8")
+        self.assertIn("BENCH_MAX_MULTIPLIER: 2.3", workflow)
+        self.assertIn("BENCH_AVG_MAX_MULTIPLIER: 1.9", workflow)
         self.assertIn("BENCH_AC_WRITE_MAX_MULTIPLIER: 6", workflow)
 
     def test_generates_complete_pass_report(self):


### PR DESCRIPTION
## Summary

- add a bounded eligibility probe before the no-rechunk batch-replacement tree walk
- bypass that walk when sampled edits target missing keys or change encoded value sizes
- preserve the existing fast path and its full validation for eligible replacement batches
- fix the composite-PK write regression reported in #2213
- tighten well-sampled nightly ordinary gates from 2.4×/1.95× to 2.3×/1.9× while leaving PR and autocommit gates unchanged

## Performance

100K-row, in-memory workloads; medians from alternating runs against the current master build:

| Workload | master | this PR | change |
|---|---:|---:|---:|
| compositepk `oltp_write_only` | 44.9 ms | 35.7 ms | -20.5% |
| compositepk `oltp_update_index` | 80.0 ms | 74.2 ms | -7.3% |
| compositepk `oltp_update_non_index` | 52.0 ms | 50.0 ms | -3.7% |
| compositepk `oltp_delete_insert` | 62.0 ms | 58.7 ms | -5.4% |
| compositepk `types_delete_insert` | 33.0 ms | 32.4 ms | -1.8% |
| compositepk `oltp_read_write` | 104.0 ms | 97.2 ms | -6.6% |
| integer-PK `oltp_update_non_index` | 34.5 ms | 33.9 ms | -1.7% |

The reported workload regressed when the no-rechunk path was extended to blob-key trees. Mixed replacement/insert batches paid for a full validation walk, failed eligibility, and then paid for the normal streaming merge. The bounded probe rejects these batches early without specializing for a particular workload or key shape.

## Validation

- `make lint`
- `doltlite_regression_test_c all` (310,598 passed)
- `python3 -m unittest test/nightly_performance_report_test.py`
- stock `DOLTLITE_PROLLY=0` build
- alternating before/after benchmarks above

Fixes #2213

Co-Authored-By: OpenAI Codex <noreply@openai.com>
