### PR TITLE
Keep scans alive when COUNT flushes the pending mutmap

### DIFF
--- a/src/prolly_btree_cursor_count.c
+++ b/src/prolly_btree_cursor_count.c
@@ -305,8 +305,18 @@ static int flushPendingForCount(BtCursor *pCur){
     if( !prollyMutMapIsEmpty(pMap) ){
       ProllyMutMap *pFlushMap = pMap;
       int captured = 0;
-      int rc = saveAllCursors(pCur->pBtree, pCur->pBt, pCur->pgnoRoot, pCur);
-      if( rc!=SQLITE_OK ) return rc;
+      int rc = SQLITE_OK;
+      BtCursor *p;
+      for(p=pCur->pBt->pCursor; p; p=p->pNext){
+        if( p->pBtree==pCur->pBtree
+         && p!=pCur
+         && p->pgnoRoot==pCur->pgnoRoot
+         && (p->curFlags & BTCF_WriteFlag)==0
+         && (p->eState==CURSOR_VALID || p->eState==CURSOR_SKIPNEXT) ){
+          rc = saveCursorPosition(p);
+          if( rc!=SQLITE_OK ) return rc;
+        }
+      }
       rc = snapshotPendingForFlush(pCur->pBtree, pCur->pgnoRoot,
                                        (ProllyMutMap**)&pTE->pPending,
                                        &pFlushMap, &captured);

--- a/src/prolly_btree_cursor_count.c
+++ b/src/prolly_btree_cursor_count.c
@@ -305,19 +305,19 @@ static int flushPendingForCount(BtCursor *pCur){
     if( !prollyMutMapIsEmpty(pMap) ){
       ProllyMutMap *pFlushMap = pMap;
       int captured = 0;
-      int rc = snapshotPendingForFlush(pCur->pBtree, pCur->pgnoRoot,
+      int rc = saveAllCursors(pCur->pBtree, pCur->pBt, pCur->pgnoRoot, pCur);
+      if( rc!=SQLITE_OK ) return rc;
+      rc = snapshotPendingForFlush(pCur->pBtree, pCur->pgnoRoot,
                                        (ProllyMutMap**)&pTE->pPending,
                                        &pFlushMap, &captured);
       if( rc!=SQLITE_OK ) return rc;
-      if( captured ){
-        refreshCursorMutMapAliases(pCur->pBtree, pCur->pBt, pCur->pgnoRoot,
-                                   (ProllyMutMap*)pTE->pPending);
-      }
       rc = applyMutMapToTableRoot(pCur->pBt, pTE, pFlushMap);
       if( rc!=SQLITE_OK ) return rc;
       if( pTE->pPending==pMap ){
         prollyMutMapClear(pMap);
       }
+      refreshCursorMutMapAliases(pCur->pBtree, pCur->pBt, pCur->pgnoRoot,
+                                 (ProllyMutMap*)pTE->pPending);
     }
   }
   flushIfNeeded(pCur);

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -11664,6 +11664,57 @@ static void run_intpk_scan_delete_keeps_scan(void){
   removeDbFiles(dbpath);
 }
 
+static void run_count_flush_keeps_scan(void){
+  sqlite3 *db = 0;
+  sqlite3_stmt *scan = 0;
+  char dbpath[256];
+  char seen[128];
+  int rc;
+
+  printf("=== Count Flush Keeps Scan Test ===\n\n");
+  make_dbpath(dbpath, sizeof(dbpath), "test_count_flush_keeps_scan");
+  removeDbFiles(dbpath);
+
+  check("open_db_for_count_flush", open_db(dbpath, &db)==SQLITE_OK);
+  check("setup_wr_for_count_flush", execSql(db,
+    "CREATE TABLE t(a TEXT PRIMARY KEY, b INT) WITHOUT ROWID;")==SQLITE_OK);
+  check("begin_wr_count_flush", execSql(db, "BEGIN;")==SQLITE_OK);
+  check("insert_wr_pending_for_count_flush",
+        execSql(db, "INSERT INTO t VALUES('a',1),('b',2),('c',3);")==SQLITE_OK);
+  rc = sqlite3_prepare_v2(db,
+    "SELECT a || '|' || (SELECT count(*) FROM t) FROM t ORDER BY a;",
+    -1, &scan, 0);
+  check("prepare_wr_count_flush_scan", rc==SQLITE_OK);
+  if( scan ){
+    rc = collect_stepped_text(scan, seen, (int)sizeof(seen));
+    check("wr_count_flush_scan_done", rc==SQLITE_DONE);
+    check("wr_count_flush_sees_all", strcmp(seen, "a|3,b|3,c|3")==0);
+  }
+  sqlite3_finalize(scan);
+  scan = 0;
+  check("rollback_wr_count_flush", execSql(db, "ROLLBACK;")==SQLITE_OK);
+
+  check("setup_intpk_for_count_flush", execSql(db,
+    "CREATE TABLE u(id INTEGER PRIMARY KEY, v TEXT);")==SQLITE_OK);
+  check("begin_intpk_count_flush", execSql(db, "BEGIN;")==SQLITE_OK);
+  check("insert_intpk_pending_for_count_flush",
+        execSql(db, "INSERT INTO u VALUES(1,'a'),(2,'b'),(3,'c');")==SQLITE_OK);
+  rc = sqlite3_prepare_v2(db,
+    "SELECT v || '|' || (SELECT count(*) FROM u) FROM u ORDER BY id;",
+    -1, &scan, 0);
+  check("prepare_intpk_count_flush_scan", rc==SQLITE_OK);
+  if( scan ){
+    rc = collect_stepped_text(scan, seen, (int)sizeof(seen));
+    check("intpk_count_flush_scan_done", rc==SQLITE_DONE);
+    check("intpk_count_flush_sees_all", strcmp(seen, "a|3,b|3,c|3")==0);
+  }
+  sqlite3_finalize(scan);
+  check("rollback_intpk_count_flush", execSql(db, "ROLLBACK;")==SQLITE_OK);
+
+  sqlite3_close(db);
+  removeDbFiles(dbpath);
+}
+
 static const RegressionCase aCases[] = {
   { "refs_vtab_snapshot_stability", "Refs Vtab Snapshot Stability Test", run_refs_vtab_snapshot_stability },
   { "storage_format_v12", "Storage Format Version 12 Test", run_storage_format_v12 },
@@ -11845,7 +11896,8 @@ static const RegressionCase aCases[] = {
   { "diff_side_schema_custom_function", "Diff Side Schema Custom Function Test", run_diff_side_schema_custom_function },
   { "rollback_persist_failure_ends_txn", "Rollback Persist Failure Ends Write Txn Test", run_rollback_persist_failure_ends_txn },
   { "blob_restore_mutmap_keeps_scan", "Blob Restore MutMap Keeps Scan Test", run_blob_restore_mutmap_keeps_scan },
-  { "intpk_scan_delete_keeps_scan", "INT PK Scan Delete Keeps Scan Test", run_intpk_scan_delete_keeps_scan }
+  { "intpk_scan_delete_keeps_scan", "INT PK Scan Delete Keeps Scan Test", run_intpk_scan_delete_keeps_scan },
+  { "count_flush_keeps_scan", "Count Flush Keeps Scan Test", run_count_flush_keeps_scan }
 };
 
 static int run_case_by_name(const char *zName){


### PR DESCRIPTION
## Summary

`flushPendingForCount` drained the pending mutmap so `COUNT(*)` could walk the tree, but it did not park sibling cursors the way the write path does. An outer scan sitting on a mutmap-only row then stepped with a cleared map and stopped after the first row.

SQLite:

```
a|3
b|3
c|3
```

DoltLite before: `a|3` only (WITHOUT ROWID and uncommitted INT PK). Committed tables and index scans that do not share the flushed root were already fine.

Count now calls `saveAllCursors` before apply/clear, then `refreshCursorMutMapAliases` so restore seeks the flushed tree.

## Test plan

Fail-before / pass-after (`count_flush_keeps_scan`):

- uncommitted WITHOUT ROWID + correlated `COUNT(*)`
- uncommitted INTEGER PRIMARY KEY + correlated `COUNT(*)`
- related: `blob_restore_mutmap_keeps_scan`
- full `doltlite_regression_test_c all`