### PR TITLE
Hold a transaction across constraint-violation detection

### DIFF
--- a/src/doltlite_merge_cmd.c
+++ b/src/doltlite_merge_cmd.c
@@ -266,9 +266,20 @@ static int mergeRefDetectConstraintViolations(
   int nFk = 0, nUnique = 0, nCheck = 0, nNotNull = 0, nStrict = 0;
   int vrc;
   int erc;
+  int bOwnTxn = 0;
 
   *pnViolations = 0;
   *pzErr = 0;
+  /* Each detector scans the merged tables with one statement and records what
+  ** it finds with another. In autocommit that inner write commits when it
+  ** halts, which ends the transaction the open scan is reading through -- the
+  ** next cursor it opens then has none, and an assert-enabled build dies on
+  ** it. Hold a transaction across the pass so the writes stay inside it. */
+  if( db->autoCommit ){
+    vrc = sqlite3_exec(db, "BEGIN", 0, 0, 0);
+    if( vrc!=SQLITE_OK ) return vrc;
+    bOwnTxn = 1;
+  }
   vrc = doltliteConstraintViolationBatchBegin(db);
   if( vrc==SQLITE_OK ){
     vrc = doltliteDetectMergeFkViolations(db, pAncCat, pzErr, &nFk, 0, 0);
@@ -289,6 +300,12 @@ static int mergeRefDetectConstraintViolations(
   }
   erc = doltliteConstraintViolationBatchEnd(db, vrc==SQLITE_OK);
   if( vrc==SQLITE_OK ) vrc = erc;
+  if( bOwnTxn ){
+    /* Commit what the pass recorded, as the individual writes used to do on
+    ** their own. The caller decides what a non-empty violation set means. */
+    erc = sqlite3_exec(db, vrc==SQLITE_OK ? "COMMIT" : "ROLLBACK", 0, 0, 0);
+    if( vrc==SQLITE_OK ) vrc = erc;
+  }
   if( vrc==SQLITE_OK ){
     *pnViolations = nFk + nUnique + nCheck + nNotNull + nStrict;
   }

--- a/test/doltlite_gc_session_state.sh
+++ b/test/doltlite_gc_session_state.sh
@@ -79,12 +79,23 @@ INSERT INTO c VALUES(20, 1);
 SELECT dolt_commit('-A','-m','feat insert');
 SELECT dolt_checkout('main');
 PRAGMA foreign_keys=1;
-SELECT dolt_merge('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
+SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+# The merge detects foreign-key violations, which it reports by scanning the
+# merged tables and recording what it finds. Assert the message rather than
+# discarding it: an assert-enabled build used to die inside that scan, and
+# matching only [0-9]+ on the counts below passed either way.
+CV_MERGE_OUT=$(dltest_run_sql "PRAGMA foreign_keys=1; SELECT dolt_merge('feat');" "$DB")
+case "$CV_MERGE_OUT" in
+  *"constraint violations"*) dltest_pass ;;
+  *) dltest_fail "cv_merge_reports_violations" \
+       "  expected: a constraint-violation error\n  got:      $CV_MERGE_OUT" ;;
+esac
 
 echo "SELECT dolt_gc();" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-run_test_match "cv_table_p" "SELECT count(*) FROM p;" "[0-9]+" "$DB"
-run_test_match "cv_table_c" "SELECT count(*) FROM c;" "[0-9]+" "$DB"
+run_test "cv_table_p" "SELECT count(*) FROM p;" "0" "$DB"
+run_test "cv_table_c" "SELECT count(*) FROM c;" "1" "$DB"
 
 db_rm "$DB"
 


### PR DESCRIPTION
Closes #2198.

## Problem

A merge that produces foreign-key violations kills an assert-enabled build:

```sql
CREATE TABLE p(id INTEGER PRIMARY KEY);
CREATE TABLE c(id INTEGER PRIMARY KEY, pid INTEGER, FOREIGN KEY(pid) REFERENCES p(id));
-- main deletes the parent, feat adds a child referencing it
PRAGMA foreign_keys=1;
SELECT dolt_merge('feat');
```

```
Assertion failed: (p->inTrans>=TRANS_READ), function prollyBtreeCursor, file prolly_btree.c, line 1441.
```

## Mechanism

Not a missing read transaction, which is what the issue and I both assumed. A backtrace at the point the transaction ends (`-O2` inlines the frames, so via a temporary `execinfo` hook):

```
prollyBtreeCommitPhaseTwo
vdbeCommit
sqlite3VdbeHalt
sqlite3VdbeExec
sqlite3_step
detectFkViolationsForSpec + 2216     <-- the inner write
doltliteDetectMergeFkViolations
mergeRefDetectConstraintViolations
```

Each detector **scans** the merged tables with one statement and **records** what it finds with another, stepped inside the scan loop. In autocommit that inner write halts and commits, ending the transaction the open scan is reading through; the next cursor the scan opens has none behind it, and the assert fires. It is a modify-while-iterating bug, not a missing-transaction one.

That is also why my first attempt (documented on the issue) failed: I wrapped the pass in a *read* transaction, but a read transaction does not stop an inner write from committing. Only an open transaction does — `sqlite3VdbeHalt` commits when `db->autoCommit` is set.

## Fix

The pass takes a transaction when the connection is in autocommit and commits it at the end, exactly where the individual writes used to commit. Inside a caller's explicit transaction nothing changes, because there is already one open.

## Behavior is unchanged

Both transaction modes match master exactly:

| | autocommit | inside `BEGIN` |
|---|---|---|
| master | refuses, rolls back — `c=1, cv=0` | lands, violation left to resolve — `c=2, cv=1` |
| this PR | refuses, rolls back — `c=1, cv=0` | lands, violation left to resolve — `c=2, cv=1` |

## Testing

`doltlite_gc_session_state.sh` already ran this exact merge as setup for its `cv_table_p`/`cv_table_c` cases — piped to `/dev/null`, then asserting the counts matched `[0-9]+`. That passed whether the merge worked or the process died mid-scan, so those cases never covered what they claimed. #2198 called this out; it is fixed here.

The case now asserts the merge reports violations, and the counts are concrete. Reverting the fix, it fails with the assertion text as its `got`:

```
FAIL: cv_merge_reports_violations
  expected: a constraint-violation error
  got:      Assertion failed: (p->inTrans>=TRANS_READ), function prollyBtreeCursor
```

Assert-build results: battery **103/103**, `vc_oracle_merge_test` 85/85, `vc_oracle_verify_constraints_test` 14/14, `vc_oracle_rebase_test` 52/52. Amalgamation and lint clean.

This is the fifth and last of the assert-only defects from #2204.

🤖 Generated with [Claude Code](https://claude.com/claude-code)