### PR TITLE
Keep the default dolt_docs AGENT synthetic

### DIFF
--- a/src/build.c
+++ b/src/build.c
@@ -424,6 +424,19 @@ Table *sqlite3LocateTable(
   }
 
   p = sqlite3FindTable(db, zName, zDbase);
+#if defined(DOLTLITE_PROLLY) && !defined(SQLITE_OMIT_VIRTUALTABLE)
+  if( p!=0
+   && p->pSchema==db->aDb[0].pSchema
+   && sqlite3StrICmp(zName, "dolt_docs")==0
+   && (pParse->prepFlags & SQLITE_PREPARE_NO_VTAB)==0
+   && db->init.busy==0 ){
+    Module *pMod = (Module*)sqlite3HashFind(&db->aModule, zName);
+    if( pMod && sqlite3VtabEponymousTableInit(pParse, pMod) ){
+      testcase( pMod->pEpoTab==0 );
+      return pMod->pEpoTab;
+    }
+  }
+#endif
   if( p==0 ){
 #ifndef SQLITE_OMIT_VIRTUALTABLE
     /* If zName is the not the name of a table in the schema created using
@@ -3810,6 +3823,13 @@ void sqlite3DropTable(Parse *pParse, SrcList *pName, int isView, int noErr){
     }
     goto exit_drop_table;
   }
+#ifdef DOLTLITE_PROLLY
+  if( IsVirtual(pTab) && sqlite3StrICmp(pTab->zName, "dolt_docs")==0 ){
+    Table *pBacking = sqlite3FindTable(db, pName->a[0].zName,
+                                       pName->a[0].u4.zDatabase);
+    if( pBacking && !IsVirtual(pBacking) ) pTab = pBacking;
+  }
+#endif
   iDb = sqlite3SchemaToIndex(db, pTab->pSchema);
   assert( iDb>=0 && iDb<db->nDb );
 

--- a/src/doltlite_docs.c
+++ b/src/doltlite_docs.c
@@ -5,13 +5,6 @@
 #include "doltlite_internal.h"
 #include <string.h>
 
-/* Eponymous stand-in for dolt_docs while no real table exists. Reads are
-** always empty; the first write statement materializes a real dolt_docs
-** table in main, which then shadows this module in name resolution
-** (sqlite3LocateTable only reaches eponymous modules when sqlite3FindTable
-** misses), so status/diff/merge/branching treat docs as an ordinary
-** versioned table exactly like Dolt's user-space system tables. */
-
 typedef struct DocsVtab DocsVtab;
 struct DocsVtab {
   sqlite3_vtab base;
@@ -21,11 +14,15 @@ struct DocsVtab {
 typedef struct DocsCursor DocsCursor;
 struct DocsCursor {
   sqlite3_vtab_cursor base;
-  int iRow;
+  sqlite3_stmt *pStmt;
+  int eof;
+  int synthetic;
+  int foundAgent;
 };
 
 static const char *zDocsVtabSchema =
-  "CREATE TABLE x(doc_name TEXT, doc_text TEXT)";
+  "CREATE TABLE x(doc_name TEXT NOT NULL PRIMARY KEY, "
+  "doc_text TEXT NOT NULL) WITHOUT ROWID";
 
 static const char *zDocsCreate =
   "CREATE TABLE main.dolt_docs("
@@ -33,9 +30,6 @@ static const char *zDocsCreate =
 
 static const char *zDocsAgentName = "AGENT.md";
 
-/* Default AGENT.md, seeded when the backing table materializes and served
-** by the module before that. DoltLite's counterpart to Dolt's embedded
-** doc/AGENT.md, rewritten for this engine's SQL surface. */
 static const char *zDocsAgentDefault =
   "# AGENT.md - DoltLite Database Operations Guide\n"
   "\n"
@@ -132,29 +126,83 @@ static int docsOpen(sqlite3_vtab *pVtab, sqlite3_vtab_cursor **ppCursor){
   return doltliteVtabOpenCursor(ppCursor, sizeof(DocsCursor));
 }
 
+static int docsSetErrMsg(DocsVtab *p, int rc){
+  sqlite3_free(p->base.zErrMsg);
+  p->base.zErrMsg = sqlite3_mprintf("%s", sqlite3_errmsg(p->db));
+  return rc;
+}
+
+static int docsAdvance(DocsCursor *c){
+  DocsVtab *p = (DocsVtab*)c->base.pVtab;
+  int rc;
+  if( !c->pStmt ){
+    c->eof = 1;
+    return SQLITE_OK;
+  }
+  rc = sqlite3_step(c->pStmt);
+  if( rc==SQLITE_ROW ){
+    const unsigned char *zName = sqlite3_column_text(c->pStmt, 0);
+    if( zName && strcmp((const char*)zName, zDocsAgentName)==0 ){
+      c->foundAgent = 1;
+    }
+    return SQLITE_OK;
+  }
+  rc = sqlite3_finalize(c->pStmt);
+  c->pStmt = 0;
+  if( rc!=SQLITE_OK ) return docsSetErrMsg(p, rc);
+  if( !c->foundAgent ){
+    c->synthetic = 1;
+  }else{
+    c->eof = 1;
+  }
+  return SQLITE_OK;
+}
+
 static int docsFilter(sqlite3_vtab_cursor *pCursor,
     int idxNum, const char *idxStr, int argc, sqlite3_value **argv){
+  DocsCursor *c = (DocsCursor*)pCursor;
+  DocsVtab *p = (DocsVtab*)pCursor->pVtab;
+  int rc;
   (void)idxNum; (void)idxStr; (void)argc; (void)argv;
-  ((DocsCursor*)pCursor)->iRow = 0;
-  return SQLITE_OK;
+  sqlite3_finalize(c->pStmt);
+  c->pStmt = 0;
+  c->eof = 0;
+  c->synthetic = 0;
+  c->foundAgent = 0;
+  if( !sqlite3FindTable(p->db, "dolt_docs", "main") ){
+    c->synthetic = 1;
+    return SQLITE_OK;
+  }
+  rc = sqlite3_prepare_v3(p->db,
+      "SELECT doc_name, doc_text FROM main.dolt_docs", -1,
+      SQLITE_PREPARE_NO_VTAB, &c->pStmt, 0);
+  if( rc!=SQLITE_OK ) return docsSetErrMsg(p, rc);
+  return docsAdvance(c);
 }
 
 static int docsNext(sqlite3_vtab_cursor *pCursor){
-  ((DocsCursor*)pCursor)->iRow++;
-  return SQLITE_OK;
+  DocsCursor *c = (DocsCursor*)pCursor;
+  if( c->synthetic ){
+    c->synthetic = 0;
+    c->eof = 1;
+    return SQLITE_OK;
+  }
+  return docsAdvance(c);
 }
 
 static int docsEof(sqlite3_vtab_cursor *pCursor){
-  return ((DocsCursor*)pCursor)->iRow >= 1;
+  return ((DocsCursor*)pCursor)->eof;
 }
 
 static int docsColumn(sqlite3_vtab_cursor *pCursor,
     sqlite3_context *ctx, int iCol){
-  (void)pCursor;
-  if( iCol==0 ){
+  DocsCursor *c = (DocsCursor*)pCursor;
+  if( c->synthetic && iCol==0 ){
     sqlite3_result_text(ctx, zDocsAgentName, -1, SQLITE_STATIC);
-  }else{
+  }else if( c->synthetic ){
     sqlite3_result_text(ctx, zDocsAgentDefault, -1, SQLITE_STATIC);
+  }else{
+    sqlite3_result_value(ctx, sqlite3_column_value(c->pStmt, iCol));
   }
   return SQLITE_OK;
 }
@@ -165,19 +213,23 @@ static int docsRowid(sqlite3_vtab_cursor *pCursor, sqlite3_int64 *pRowid){
   return SQLITE_OK;
 }
 
-static int docsSetErrMsg(DocsVtab *p, int rc){
-  sqlite3_free(p->base.zErrMsg);
-  p->base.zErrMsg = sqlite3_mprintf("%s", sqlite3_errmsg(p->db));
-  return rc;
+static int docsClose(sqlite3_vtab_cursor *pCursor){
+  DocsCursor *c = (DocsCursor*)pCursor;
+  sqlite3_finalize(c->pStmt);
+  sqlite3_free(c);
+  return SQLITE_OK;
 }
 
 static int docsExecBound(DocsVtab *p, const char *zSql,
-                         sqlite3_value *pArg1, sqlite3_value *pArg2){
+                         sqlite3_value *pArg1, sqlite3_value *pArg2,
+                         sqlite3_value *pArg3){
   sqlite3_stmt *pStmt = 0;
-  int rc = sqlite3_prepare_v2(p->db, zSql, -1, &pStmt, 0);
+  int rc = sqlite3_prepare_v3(p->db, zSql, -1,
+                              SQLITE_PREPARE_NO_VTAB, &pStmt, 0);
   if( rc!=SQLITE_OK ) return docsSetErrMsg(p, rc);
   if( pArg1 ) sqlite3_bind_value(pStmt, 1, pArg1);
   if( pArg2 ) sqlite3_bind_value(pStmt, 2, pArg2);
+  if( pArg3 ) sqlite3_bind_value(pStmt, 3, pArg3);
   sqlite3_step(pStmt);
   rc = sqlite3_finalize(pStmt);
   if( rc!=SQLITE_OK ) return docsSetErrMsg(p, rc);
@@ -187,7 +239,6 @@ static int docsExecBound(DocsVtab *p, const char *zSql,
 static int docsMaterialize(DocsVtab *p){
   int rc;
   char *zErr = 0;
-  sqlite3_stmt *pStmt = 0;
   if( sqlite3FindTable(p->db, "dolt_docs", "main") ) return SQLITE_OK;
   rc = sqlite3_exec(p->db, zDocsCreate, 0, 0, &zErr);
   if( rc!=SQLITE_OK ){
@@ -196,14 +247,6 @@ static int docsMaterialize(DocsVtab *p){
     sqlite3_free(zErr);
     return rc;
   }
-  rc = sqlite3_prepare_v2(p->db,
-      "INSERT INTO main.dolt_docs(doc_name, doc_text) VALUES('AGENT.md', ?1)",
-      -1, &pStmt, 0);
-  if( rc!=SQLITE_OK ) return docsSetErrMsg(p, rc);
-  sqlite3_bind_text(pStmt, 1, zDocsAgentDefault, -1, SQLITE_STATIC);
-  sqlite3_step(pStmt);
-  rc = sqlite3_finalize(pStmt);
-  if( rc!=SQLITE_OK ) return docsSetErrMsg(p, rc);
   return SQLITE_OK;
 }
 
@@ -211,27 +254,55 @@ static int docsBegin(sqlite3_vtab *pBase){
   return docsMaterialize((DocsVtab*)pBase);
 }
 
-/* True when the stored AGENT.md row still carries the text this statement's
-** materialization seeded, so an INSERT of AGENT.md should behave as if the
-** row did not exist yet — matching Dolt, where the default row is synthetic
-** and never blocks an insert. */
-static int docsAgentSeedUntouched(DocsVtab *p){
-  sqlite3_stmt *pStmt = 0;
-  int hit = 0;
-  int rc = sqlite3_prepare_v2(p->db,
-      "SELECT 1 FROM main.dolt_docs WHERE doc_name='AGENT.md' AND doc_text=?1",
-      -1, &pStmt, 0);
-  if( rc!=SQLITE_OK ) return 0;
-  sqlite3_bind_text(pStmt, 1, zDocsAgentDefault, -1, SQLITE_STATIC);
-  hit = sqlite3_step(pStmt)==SQLITE_ROW;
-  sqlite3_finalize(pStmt);
-  return hit;
+static int docsIsAgent(sqlite3_value *pValue){
+  const unsigned char *z;
+  if( sqlite3_value_type(pValue)!=SQLITE_TEXT ) return 0;
+  z = sqlite3_value_text(pValue);
+  return z && strcmp((const char*)z, zDocsAgentName)==0;
+}
+
+static const char *docsInsertSql(sqlite3 *db){
+  switch( sqlite3_vtab_on_conflict(db) ){
+    case SQLITE_REPLACE:
+      return "INSERT OR REPLACE INTO main.dolt_docs(doc_name, doc_text) "
+             "VALUES(?1, ?2)";
+    case SQLITE_IGNORE:
+      return "INSERT OR IGNORE INTO main.dolt_docs(doc_name, doc_text) "
+             "VALUES(?1, ?2)";
+    case SQLITE_FAIL:
+      return "INSERT OR FAIL INTO main.dolt_docs(doc_name, doc_text) "
+             "VALUES(?1, ?2)";
+    case SQLITE_ROLLBACK:
+      return "INSERT OR ROLLBACK INTO main.dolt_docs(doc_name, doc_text) "
+             "VALUES(?1, ?2)";
+    default:
+      return "INSERT INTO main.dolt_docs(doc_name, doc_text) VALUES(?1, ?2)";
+  }
+}
+
+static const char *docsUpdateSql(sqlite3 *db){
+  switch( sqlite3_vtab_on_conflict(db) ){
+    case SQLITE_REPLACE:
+      return "UPDATE OR REPLACE main.dolt_docs SET doc_name=?1, doc_text=?2 "
+             "WHERE doc_name=?3";
+    case SQLITE_IGNORE:
+      return "UPDATE OR IGNORE main.dolt_docs SET doc_name=?1, doc_text=?2 "
+             "WHERE doc_name=?3";
+    case SQLITE_FAIL:
+      return "UPDATE OR FAIL main.dolt_docs SET doc_name=?1, doc_text=?2 "
+             "WHERE doc_name=?3";
+    case SQLITE_ROLLBACK:
+      return "UPDATE OR ROLLBACK main.dolt_docs SET doc_name=?1, doc_text=?2 "
+             "WHERE doc_name=?3";
+    default:
+      return "UPDATE main.dolt_docs SET doc_name=?1, doc_text=?2 "
+             "WHERE doc_name=?3";
+  }
 }
 
 static int docsUpdate(sqlite3_vtab *pBase, int argc, sqlite3_value **argv,
                       sqlite3_int64 *pRowid){
   DocsVtab *p = (DocsVtab*)pBase;
-  const char *zSql;
   int rc;
 
   rc = docsMaterialize(p);
@@ -239,34 +310,28 @@ static int docsUpdate(sqlite3_vtab *pBase, int argc, sqlite3_value **argv,
 
   if( argc==1 ){
     return docsExecBound(p,
-        "DELETE FROM main.dolt_docs WHERE doc_name='AGENT.md'", 0, 0);
+        "DELETE FROM main.dolt_docs WHERE doc_name=?1", argv[0], 0, 0);
   }
   if( sqlite3_value_type(argv[0])!=SQLITE_NULL ){
+    if( docsIsAgent(argv[0]) ){
+      sqlite3_stmt *pStmt = 0;
+      int exists;
+      rc = sqlite3_prepare_v3(p->db,
+          "SELECT 1 FROM main.dolt_docs WHERE doc_name='AGENT.md'", -1,
+          SQLITE_PREPARE_NO_VTAB, &pStmt, 0);
+      if( rc!=SQLITE_OK ) return docsSetErrMsg(p, rc);
+      exists = sqlite3_step(pStmt)==SQLITE_ROW;
+      rc = sqlite3_finalize(pStmt);
+      if( rc!=SQLITE_OK ) return docsSetErrMsg(p, rc);
+      if( !exists ){
+        return docsExecBound(p, docsInsertSql(p->db), argv[2], argv[3], 0);
+      }
+    }
     return docsExecBound(p,
-        "UPDATE main.dolt_docs SET doc_name=?1, doc_text=?2 "
-        "WHERE doc_name='AGENT.md'", argv[2], argv[3]);
+        docsUpdateSql(p->db), argv[2], argv[3], argv[0]);
   }
 
-  switch( sqlite3_vtab_on_conflict(p->db) ){
-    case SQLITE_REPLACE:
-      zSql = "INSERT OR REPLACE INTO main.dolt_docs(doc_name, doc_text) "
-             "VALUES(?1, ?2)";
-      break;
-    case SQLITE_IGNORE:
-      zSql = "INSERT OR IGNORE INTO main.dolt_docs(doc_name, doc_text) "
-             "VALUES(?1, ?2)";
-      break;
-    default:
-      zSql = "INSERT INTO main.dolt_docs(doc_name, doc_text) VALUES(?1, ?2)";
-      break;
-  }
-  if( sqlite3_value_type(argv[2])==SQLITE_TEXT
-   && strcmp((const char*)sqlite3_value_text(argv[2]), zDocsAgentName)==0
-   && docsAgentSeedUntouched(p) ){
-    zSql = "INSERT OR REPLACE INTO main.dolt_docs(doc_name, doc_text) "
-           "VALUES(?1, ?2)";
-  }
-  rc = docsExecBound(p, zSql, argv[2], argv[3]);
+  rc = docsExecBound(p, docsInsertSql(p->db), argv[2], argv[3], 0);
   if( rc!=SQLITE_OK ) return rc;
   if( pRowid ) *pRowid = sqlite3_last_insert_rowid(p->db);
   return SQLITE_OK;
@@ -274,7 +339,7 @@ static int docsUpdate(sqlite3_vtab *pBase, int argc, sqlite3_value **argv,
 
 static sqlite3_module doltliteDocsModule = {
   0, 0, docsConnect, docsBestIndex, doltliteVtabDisconnect, 0,
-  docsOpen, doltliteVtabClose, docsFilter, docsNext, docsEof,
+  docsOpen, docsClose, docsFilter, docsNext, docsEof,
   docsColumn, docsRowid,
   docsUpdate, docsBegin, 0, 0, 0, 0, 0, 0, 0, 0, 0
 };

--- a/test/doltlite_docs.sh
+++ b/test/doltlite_docs.sh
@@ -18,11 +18,16 @@ run_test "fresh_not_in_sqlite_master" \
   "SELECT count(*) FROM sqlite_master WHERE name='dolt_docs';" \
   "0" "$DB"
 
-run_test "insert_materializes_and_seeds_agent" \
+run_test "insert_materializes_without_storing_agent" \
   "INSERT INTO dolt_docs VALUES('README.md','# hello');
    SELECT doc_name FROM dolt_docs ORDER BY doc_name;" \
   "AGENT.md
 README.md" "$DB"
+
+run_test "default_agent_not_in_working_diff" \
+  "SELECT rows_added, old_row_count, new_row_count
+     FROM dolt_diff_stat('HEAD','WORKING','dolt_docs');" \
+  "1|0|1" "$DB"
 
 run_test "status_new_table" \
   "SELECT table_name, staged, status FROM dolt_status;" \
@@ -128,17 +133,17 @@ run_test "conflict_inspect_and_resolve" \
    INSERT INTO dolt_docs VALUES('README.md','base');
    SELECT dolt_commit('-A','-m','base') IS NOT NULL;
    SELECT dolt_branch('b2') IS NOT NULL;
-   UPDATE dolt_docs SET doc_text='main edit';
+   UPDATE dolt_docs SET doc_text='main edit' WHERE doc_name='README.md';
    SELECT dolt_commit('-A','-m','m') IS NOT NULL;
    SELECT dolt_checkout('b2') IS NOT NULL;
-   UPDATE dolt_docs SET doc_text='b2 edit';
+   UPDATE dolt_docs SET doc_text='b2 edit' WHERE doc_name='README.md';
    SELECT dolt_commit('-A','-m','b') IS NOT NULL;
    SELECT dolt_checkout('main') IS NOT NULL;
    BEGIN;
    SELECT dolt_merge('b2') IS NOT NULL;
    SELECT base_doc_text, our_doc_text, their_doc_text FROM dolt_conflicts_dolt_docs;
    SELECT dolt_conflicts_resolve('--ours','dolt_docs') IS NOT NULL;
-   SELECT doc_text FROM dolt_docs;
+   SELECT doc_text FROM dolt_docs WHERE doc_name='README.md';
    COMMIT;" \
   "1
 1
@@ -177,16 +182,16 @@ rm -f "$DB"
 DB=/tmp/test_docs7_$$.db
 rm -f "$DB"
 
-run_test "agent_delete_sticks" \
+run_test "agent_delete_resynthesizes_default" \
   "DELETE FROM dolt_docs WHERE doc_name='AGENT.md';
-   SELECT count(*) FROM dolt_docs;" \
-  "0" "$DB"
+   SELECT count(*), length(doc_text) > 500 FROM dolt_docs;" \
+  "1|1" "$DB"
 
 rm -f "$DB"
 DB=/tmp/test_docs8_$$.db
 rm -f "$DB"
 
-run_test "agent_default_committable" \
+run_test "agent_default_visible_after_commit" \
   "INSERT INTO dolt_docs VALUES('README.md','hi');
    SELECT dolt_commit('-A','-m','docs') IS NOT NULL;
    SELECT count(*) FROM dolt_docs WHERE doc_name='AGENT.md';" \

--- a/test/vc_oracle_docs_test.sh
+++ b/test/vc_oracle_docs_test.sh
@@ -11,14 +11,13 @@ pass=0; fail=0
 FAILED_NAMES=""
 source "$(dirname "$0")/lib/vc_oracle_common.sh"
 
-# Both engines serve a default AGENT.md row on a fresh repo, but the text
-# differs (Dolt embeds its own guide, doltlite ships one for this engine)
-# and Dolt's row is synthetic while doltlite stores it on materialization.
-# Content comparisons filter AGENT.md; the agent scenarios below compare it
-# by name/count, or by full row after the test overwrote the text.
+# Both engines serve a synthetic default AGENT.md row, but the text differs.
+# Content comparisons filter it; agent scenarios compare it by name/count,
+# or by full row after the test overwrote the text.
 normalize_docs() { tr -d '\r"' | grep '^D|' | grep -v '^D|AGENT\.md|' | sort; }
 normalize_status() { tr -d '\r"' | grep '^S|' | sort; }
 normalize_agent() { tr -d '\r"' | grep '^A|' | sort; }
+normalize_diff_stat() { tr -d '\r"' | grep '^V|' | sort; }
 
 DOCS_QUERY_DL="SELECT 'D|' || doc_name || '|' || doc_text FROM dolt_docs;"
 DOCS_QUERY_DT="SELECT concat('D|', doc_name, '|', doc_text) FROM dolt_docs;"
@@ -28,6 +27,8 @@ AGENT_QUERY_DL="SELECT 'A|' || doc_name || '|' || doc_text FROM dolt_docs WHERE 
 AGENT_QUERY_DT="SELECT concat('A|', doc_name, '|', doc_text) FROM dolt_docs WHERE doc_name = 'AGENT.md';"
 AGENT_COUNT_DL="SELECT 'A|' || count(*) FROM dolt_docs WHERE doc_name = 'AGENT.md';"
 AGENT_COUNT_DT="SELECT concat('A|', count(*)) FROM dolt_docs WHERE doc_name = 'AGENT.md';"
+DIFF_STAT_DL="SELECT 'V|' || rows_added || '|' || rows_deleted || '|' || rows_modified || '|' || old_row_count || '|' || new_row_count FROM dolt_diff_stat('HEAD', 'WORKING', 'dolt_docs');"
+DIFF_STAT_DT="SELECT concat('V|', rows_added, '|', rows_deleted, '|', rows_modified, '|', old_row_count, '|', new_row_count) FROM dolt_diff_stat('HEAD', 'WORKING', 'dolt_docs');"
 
 oracle() {
   local kind="$1" name="$2" setup="$3" allow_empty="${4:-}"
@@ -39,6 +40,8 @@ oracle() {
     dl_query="$AGENT_QUERY_DL"; dt_query="$AGENT_QUERY_DT"; norm=normalize_agent
   elif [ "$kind" = "agent_count" ]; then
     dl_query="$AGENT_COUNT_DL"; dt_query="$AGENT_COUNT_DT"; norm=normalize_agent
+  elif [ "$kind" = "diff_stat" ]; then
+    dl_query="$DIFF_STAT_DL"; dt_query="$DIFF_STAT_DT"; norm=normalize_diff_stat
   else
     dl_query="$STATUS_QUERY_DL"; dt_query="$STATUS_QUERY_DT"; norm=normalize_status
   fi
@@ -73,6 +76,7 @@ oracle_docs() { oracle docs "$@"; }
 oracle_status() { oracle status "$@"; }
 oracle_agent() { oracle agent "$@"; }
 oracle_agent_count() { oracle agent_count "$@"; }
+oracle_diff_stat() { oracle diff_stat "$@"; }
 
 oracle_error() {
   local name="$1" setup="$2"
@@ -284,6 +288,10 @@ oracle_agent_count "agent_survives_other_writes" "
 INSERT INTO dolt_docs VALUES ('README.md', 'hi');
 "
 
+oracle_diff_stat "default_agent_is_not_versioned" "
+INSERT INTO dolt_docs VALUES ('README.md', 'hi');
+"
+
 oracle_agent "agent_replace_overrides_default" "
 REPLACE INTO dolt_docs VALUES ('AGENT.md', 'custom agent doc');
 "
@@ -294,6 +302,11 @@ UPDATE dolt_docs SET doc_text = 'edited agent doc' WHERE doc_name = 'AGENT.md';
 
 oracle_agent "agent_insert_as_first_write" "
 INSERT INTO dolt_docs VALUES ('AGENT.md', 'inserted agent doc');
+"
+
+oracle_agent_count "agent_delete_resynthesizes_default" "
+REPLACE INTO dolt_docs VALUES ('AGENT.md', 'custom agent doc');
+DELETE FROM dolt_docs WHERE doc_name = 'AGENT.md';
 "
 
 oracle_agent "agent_override_commits" "


### PR DESCRIPTION
## Summary

- keep the default AGENT.md visible through dolt_docs without storing it in the backing table
- route normal dolt_docs SQL through the overlay after lazy materialization while preserving raw backing-table access for version-control storage
- restore the default after deleting an explicit AGENT.md override, matching Dolt
- add native and Dolt oracle coverage for the reported README materialization sequence

## Validation

- make lint
- test/doltlite_docs.sh: 27 passed
- test/vc_oracle_docs_test.sh: 47 passed against Dolt
- attachmalloc: 4,916 passed, 3 existing known divergences, no new failures
- DoltLite CLI, library, amalgamation/testfixture, and stock DOLTLITE_PROLLY=0 builds

The new oracle fails on the old implementation because DoltLite reports two added rows after inserting README.md while Dolt reports one. It passes with this change because the default AGENT.md is no longer versioned.

Follow-up to #2169.

Co-Authored-By: OpenAI Codex <noreply@openai.com>