### PR TITLE
Let a step's timeout outlive its job's cap

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -102,7 +102,12 @@ jobs:
   build-and-test:
     name: ${{ matrix.platform }}
     runs-on: ${{ matrix.runs-on }}
-    timeout-minutes: 20
+    # Several steps here budget 20 minutes, which a 20-minute job cap made
+    # unreachable: the job died first with "The operation was canceled" rather
+    # than the step failing on its own budget and naming itself. Observed runs
+    # are 3-5m on macos, 6-7m on windows and 6-15m on ubuntu, so 30 keeps a
+    # real ceiling while letting a stuck step report which one it was.
+    timeout-minutes: 30
     env:
       CFLAGS: -O2 -g -Werror
       DOLTLITE_AMALG_HTTP_PROBE: ${{ github.workspace }}/build/amalgamation_http_probe${{ matrix.exe }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -182,7 +182,13 @@ jobs:
   oracle-tests:
     name: oracle-tests-${{ matrix.bucket }}
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    # The sql bucket budgets 10 minutes for the oracle suites and 25 for the
+    # differential sweep. A 20-minute job cap made both of those fiction: the
+    # cap always bit first, so a sweep slowed by runner load was killed at 20
+    # with "The operation was canceled" instead of failing on its own budget
+    # with a message naming the step. The other buckets ask for 18 and finish
+    # in about 4, so they keep a tight cap.
+    timeout-minutes: ${{ matrix.bucket == 'sql' && 40 || 25 }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
CI timing cleanup from flakes seen over the past day. No product code.

## The defect

Two jobs budget individual steps at or above their own job cap, which makes those step budgets fiction — the job cap always bites first. The symptom is a step slowed by runner load getting killed with a bare

```
##[error]The operation was canceled.
```

instead of failing on its own budget with a message naming the step. I audited every workflow for `step timeout-minutes >= job timeout-minutes`; these were the only two, and both are now clear.

## `test.yml` → `oracle-tests`

Cap was 20 for all five buckets. The **sql** bucket's steps ask for 10 (oracle suites) + 25 (differential sweep) = 35.

The sweep is 10,000 seeds of generated SQL compared against stock SQLite, spawning two engines and a generator per seed. Its own comment says so:

> The budget is deliberately more than double that: the sweep spawns two engines and a generator per seed, so it slows down with runner load rather than with anything about the change under test.

That is exactly the case the 25-minute budget exists to absorb, and the 20-minute cap prevented it from ever being used. It killed #2221, whose own oracle step had finished in **82 seconds** — the sweep was simply slow that hour. A green run of the same workflow an hour earlier finished the whole job in 8m47s.

Now per bucket: **40** for sql (35 of step budget plus setup), **25** for the rest, which ask for 18 and finish in about 4.

## `build-test.yml` → `build-and-test`

Cap 20, with four steps budgeted at 20 (`Doltlite feature tests`, `Windows Doltlite feature tests`, `Windows scale and feature tests`, `Windows HTTP remotesrv tests`). Measured across recent runs:

| platform | observed |
|---|---|
| macos | 3–5m |
| windows | 6–7m |
| ubuntu | 6–15m |

Raised to **30** — still a real ceiling (2x the worst observed) and low enough to catch a genuine hang, but a stuck step can now hit its own budget and name itself.

## Scope

I deliberately did not touch the step budgets themselves. Lowering them would make timeouts fire sooner but risks false reds on slow runners — ubuntu already reaches 15 minutes on a bad day. Raising the caps fixes the diagnosability problem without adding that risk.

The other recent timing flake, the scaling ratio gates, was handled separately in #2218 and is not duplicated here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)