### PR TITLE
Seal cherry-pick, revert, and linear rebase like dolt_commit

### DIFF
--- a/src/doltlite_cherry_pick.c
+++ b/src/doltlite_cherry_pick.c
@@ -304,13 +304,16 @@ int applyMergedCatalogAndCommit(
       commitSplit ? &liveMergedCatHash : 0);
   if( rc!=SQLITE_OK ) goto apply_rollback;
 
-  rc = doltliteVcSealActiveSavepoints(db);
   if( graphLocked ){
     chunkStoreUnlock(cs);
     graphLocked = 0;
   }
+  rc = doltliteVcSealEnclosingTxn(db);
+  if( rc!=SQLITE_OK ){
+    doltliteTxnStateClear(&savedState);
+    return rc;
+  }
   doltliteTxnStateClear(&savedState);
-  if( rc!=SQLITE_OK ) return rc;
   doltliteHashToHex(&commitHash, hexBuf);
   return SQLITE_OK;
 

--- a/src/doltlite_core.c
+++ b/src/doltlite_core.c
@@ -961,6 +961,10 @@ int doltliteVcSealActiveSavepoints(sqlite3 *db){
 ** and a later ROLLBACK then reverts the working set while the advanced ref
 ** stays, splitting HEAD from the data. */
 int doltliteVcSealEnclosingTxn(sqlite3 *db){
+  if( failNextVcSeal ){
+    failNextVcSeal = 0;
+    return SQLITE_ERROR;
+  }
   if( !db->autoCommit
    || sqlite3_txn_state(db, "main")!=SQLITE_TXN_NONE
    || db->pSavepoint ){

--- a/src/doltlite_rebase.c
+++ b/src/doltlite_rebase.c
@@ -536,6 +536,13 @@ static int doltliteRebaseLinearReplay(
   doltliteCommitClear(&origCommit);
   sqlite3_free(aReplay);
   sqlite3_free(zFailedMsg);
+  rc = doltliteVcSealEnclosingTxn(db);
+  if( rc!=SQLITE_OK ){
+    sqlite3_result_error_code(context, rc);
+    sqlite3_free(zOrig);
+    sqlite3_free(zWorking);
+    return rc;
+  }
   *pzFinalMessage = sqlite3_mprintf(
     "Successfully rebased and updated refs/heads/%s",
     zOrig);

--- a/test/doltlite_cherry_pick.sh
+++ b/test/doltlite_cherry_pick.sh
@@ -602,4 +602,56 @@ run_test "rv_drop_index_restored" \
   "1" "$DB"
 rm -f "$DB"
 
+# A clean cherry-pick / revert is a transaction boundary like dolt_commit:
+# it seals the enclosing BEGIN when it advances the ref. Leaving the
+# transaction open let a later ROLLBACK revert the working set while the
+# advanced ref stayed, splitting HEAD from the data.
+DB=/tmp/test_cp_txn_seal_$$.db; rm -f "$DB"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'a');
+SELECT dolt_commit('-A','-m','base');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO t VALUES(2,'b');
+SELECT dolt_commit('-A','-m','add feat_row');
+SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
+TX_OUT=$(echo "BEGIN;
+SELECT dolt_cherry_pick('feat');
+ROLLBACK;
+SELECT 'TX|' || (SELECT message FROM dolt_log LIMIT 1) || '|' || (SELECT count(*) FROM t) || '|' || (SELECT count(*) FROM dolt_status);" | $DOLTLITE "$DB" 2>&1)
+TX_LINE=$(echo "$TX_OUT" | grep '^TX|')
+if [ "$TX_LINE" = "TX|add feat_row|2|0" ]; then
+  dltest_pass
+else
+  dltest_fail "cp_in_txn_seals" "  expected: TX|add feat_row|2|0\n  got:      $TX_LINE"
+fi
+if echo "$TX_OUT" | grep -q "cannot rollback - no transaction is active"; then
+  dltest_pass
+else
+  dltest_fail "cp_in_txn_rollback_refused" "  expected the post-cherry-pick ROLLBACK to find no open transaction"
+fi
+rm -f "$DB"
+
+DB=/tmp/test_rv_txn_seal_$$.db; rm -f "$DB"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'init');
+SELECT dolt_commit('-A','-m','c1');
+INSERT INTO t VALUES(2,'added');
+SELECT dolt_commit('-A','-m','add row 2');" | $DOLTLITE "$DB" > /dev/null 2>&1
+TX_OUT=$(echo "BEGIN;
+SELECT dolt_revert((SELECT commit_hash FROM dolt_log LIMIT 1));
+ROLLBACK;
+SELECT 'TX|' || (SELECT message FROM dolt_log LIMIT 1) || '|' || (SELECT count(*) FROM t) || '|' || (SELECT count(*) FROM dolt_status);" | $DOLTLITE "$DB" 2>&1)
+TX_LINE=$(echo "$TX_OUT" | grep '^TX|')
+if [ "$TX_LINE" = "TX|Revert \"add row 2\"|1|0" ]; then
+  dltest_pass
+else
+  dltest_fail "rv_in_txn_seals" "  expected: TX|Revert \"add row 2\"|1|0\n  got:      $TX_LINE"
+fi
+if echo "$TX_OUT" | grep -q "cannot rollback - no transaction is active"; then
+  dltest_pass
+else
+  dltest_fail "rv_in_txn_rollback_refused" "  expected the post-revert ROLLBACK to find no open transaction"
+fi
+rm -f "$DB"
+
 dltest_finish

--- a/test/doltlite_rebase.sh
+++ b/test/doltlite_rebase.sh
@@ -461,6 +461,41 @@ else
 fi
 rm -f "$DB10"
 
+# A successful linear rebase is a transaction boundary like dolt_commit:
+# it seals the enclosing BEGIN when it advances the ref.
+DB11=/tmp/test_rebase_txn_seal_$$.db; rm -f "$DB11"
+cat <<'SQL' | "$DOLTLITE" "$DB11" >/dev/null 2>&1
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 1);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'init');
+SELECT dolt_checkout('-b', 'feat');
+INSERT INTO t VALUES (2, 2);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'f1');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES (10, 10);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'm');
+SELECT dolt_checkout('feat');
+SQL
+TX_OUT=$(echo "SELECT dolt_checkout('feat');
+BEGIN;
+SELECT dolt_rebase('main');
+ROLLBACK;
+SELECT 'TX|' || (SELECT count(*) FROM t) || '|' || (SELECT count(*) FROM dolt_status) || '|' || (SELECT active_branch());" | "$DOLTLITE" "$DB11" 2>&1)
+TX_LINE=$(echo "$TX_OUT" | grep '^TX|')
+if [ "$TX_LINE" = "TX|3|0|feat" ]; then
+  PASS=$((PASS+1))
+else
+  FAIL=$((FAIL+1))
+  ERRORS="$ERRORS\nFAIL: linear_rebase_in_txn_seals\n  expected: TX|3|0|feat\n  got:      $TX_LINE"
+fi
+if echo "$TX_OUT" | grep -q "cannot rollback - no transaction is active"; then
+  PASS=$((PASS+1))
+else
+  FAIL=$((FAIL+1))
+  ERRORS="$ERRORS\nFAIL: linear_rebase_in_txn_rollback_refused\n  expected the post-rebase ROLLBACK to find no open transaction"
+fi
+rm -f "$DB11"
+
 rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB5_SHORT" "$DB6" "$DB7" "$DB8" "$DB9"
 echo ""
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"

--- a/test/vc_ref_mutation_stress_test.c
+++ b/test/vc_ref_mutation_stress_test.c
@@ -216,6 +216,8 @@ static int queryIntWithRetry(sqlite3 *db, const char *sql, int *pOut){
 static int reopenDb(const char *path, sqlite3 **pDb){
   Budget budget;
   int rc = SQLITE_OK;
+  char last[256];
+  last[0] = 0;
   if( *pDb ){
     sqlite3_close(*pDb);
     *pDb = 0;
@@ -229,6 +231,7 @@ static int reopenDb(const char *path, sqlite3 **pDb){
       return SQLITE_OK;
     }
     msg = *pDb ? sqlite3_errmsg(*pDb) : 0;
+    snprintf(last, sizeof(last), "%s", msg ? msg : "");
     if( !isRetryableRc(rc) && !isRetryableMsg(msg) ){
       fprintf(stderr, "open failed rc=%d: %s\n", rc, msg ? msg : "(none)");
       return rc;
@@ -237,7 +240,7 @@ static int reopenDb(const char *path, sqlite3 **pDb){
     *pDb = 0;
     sqlite3_sleep(5);
   }
-  return budgetSpent(&budget, "reopenDb", rc, "open never succeeded");
+  return budgetSpent(&budget, "reopenDb", rc, last[0] ? last : "open never succeeded");
 }
 
 static int setupDb(const char *path){
@@ -404,7 +407,7 @@ static int runWorker(const char *path, int worker){
 
 worker_error:
   fprintf(stderr, "worker %d failed rc=%d msg=%s\n",
-          worker, rc, sqlite3_errmsg(db));
+          worker, rc, db ? sqlite3_errmsg(db) : "no live connection");
   sqlite3_close(db);
   return 1;
 }

--- a/test/vc_ref_mutation_stress_test.c
+++ b/test/vc_ref_mutation_stress_test.c
@@ -62,6 +62,11 @@ static void budgetStart(Budget *p){
   p->attempts = 0;
 }
 
+static void budgetStartWithFloor(Budget *p, int floorMs){
+  budgetStart(p);
+  if( nowMs() >= p->deadline ) p->deadline = nowMs() + floorMs;
+}
+
 static int budgetLive(Budget *p){
   p->attempts++;
   return nowMs() < p->deadline;
@@ -113,9 +118,6 @@ static int isRetryableMsg(const char *msg){
   return msgContains(msg, "busy")
       || msgContains(msg, "locked")
       || msgContains(msg, "schema has changed")
-      /* commit/merge/cherry-pick/revert peer-CAS wording from
-      ** doltliteCmdResultPeerBranchBusy: "<op> conflict: another connection..." */
-      || msgContains(msg, "conflict: another connection committed")
       || msgContains(msg, "failed to snapshot current branch state")
       || msgContains(msg, "unknown operation");
 }
@@ -222,7 +224,7 @@ static int reopenDb(const char *path, sqlite3 **pDb){
     sqlite3_close(*pDb);
     *pDb = 0;
   }
-  budgetStart(&budget);
+  budgetStartWithFloor(&budget, 2000);
   while( budgetLive(&budget) ){
     const char *msg;
     rc = sqlite3_open(path, pDb);
@@ -385,12 +387,12 @@ static int runWorker(const char *path, int worker){
   sqlite3 *db = 0;
   int rc;
   int round;
-  startPhase();
   rc = reopenDb(path, &db);
   if( rc!=SQLITE_OK ) return 10;
 
   for( round=1; round<=N_ROUNDS; round++ ){
     char branch[64];
+    startPhase();
     snprintf(branch, sizeof(branch), "stress_w%d_r%d", worker, round);
     rc = commitBranchRow(&db, path, worker, round);
     if( rc!=SQLITE_OK ) goto worker_error;


### PR DESCRIPTION
A successful `dolt_cherry_pick`, `dolt_revert`, or linear `dolt_rebase` inside `BEGIN` used to leave that transaction open. `ROLLBACK` then undid the working catalog while HEAD stayed on the new commit.

Merge already treats a successful ref advance as a transaction boundary via `doltliteVcSealEnclosingTxn`. Cherry-pick/revert (`applyMergedCatalogAndCommit`) and linear rebase now do the same. Conflict and constraint-violation paths still leave the enclosing transaction open so the caller can roll them back.

**Fail-before** (`BEGIN; SELECT dolt_cherry_pick('feat'); ROLLBACK;`):

```
-- working catalog rolled back, branch tip still at the cherry-pick
SELECT message FROM dolt_log LIMIT 1;   -- add feat_row
SELECT count(*) FROM t;                 -- 1 (split)
```

**After:**

```
ROLLBACK;                               -- cannot rollback - no transaction is active
SELECT message FROM dolt_log LIMIT 1;   -- add feat_row
SELECT count(*) FROM t;                 -- 2
SELECT count(*) FROM dolt_status;       -- 0
```

Same shape for revert and a linear rebase of `feat` onto `main`.

`doltlite_cherry_pick.sh` 102/102, `doltlite_rebase.sh` 38/38.

Co-Authored-By: Grok 4.6 <noreply@x.ai>