### PR TITLE
Rebuild ours-only indexes after merge

### DIFF
--- a/src/doltlite_merge_pass1.c
+++ b/src/doltlite_merge_pass1.c
@@ -371,6 +371,19 @@ static int mergePass1OursAdded(
     rc = mergePass1NoteSchemaConflict(c, zSchemaConflictTable, zSchemaMergeName);
     if( rc!=SQLITE_OK ) return rc;
   }
+  if( !theirsEntry && !zName && zSchemaMergeName && zSchemaMergeName[0]
+   && zSchemaConflictTable && zSchemaConflictTable[0] ){
+    struct TableEntry *pAncTable = doltliteFindTableByName(
+        c->aAnc, c->nAnc, zSchemaConflictTable);
+    struct TableEntry *pTheirTable = doltliteFindTableByName(
+        c->aTheirs, c->nTheirs, zSchemaConflictTable);
+    if( pTheirTable && (!pAncTable
+     || prollyHashCompare(&pTheirTable->root, &pAncTable->root)!=0) ){
+      rc = mergeAppendReindexName(
+          c->pazReindex, c->pnReindex, zSchemaMergeName);
+      if( rc!=SQLITE_OK ) return rc;
+    }
+  }
   c->aMerged[(*c->pnMerged)++] = c->aOurs[iOurs];
   return SQLITE_OK;
 }

--- a/test/doltlite_index_row_delta.sh
+++ b/test/doltlite_index_row_delta.sh
@@ -145,6 +145,30 @@ else
 fi
 rm -f "$DB"
 
+DB=/tmp/test_idx_delta_ours_index_$$.db
+rm -f "$DB"
+cat <<'EOF' | $DOLTLITE "$DB" > /dev/null 2>&1
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+SELECT dolt_commit('-Am','init');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO t VALUES(1,'Alpha'),(2,'Beta');
+SELECT dolt_commit('-Am','feat rows');
+SELECT dolt_checkout('main');
+CREATE INDEX tv ON t(v);
+CREATE INDEX tlower ON t(lower(v));
+SELECT dolt_commit('-Am','main indexes');
+SELECT dolt_merge('feat');
+EOF
+
+run_test "ours_index_merge_column_rows" \
+  "SELECT group_concat(id, ',') FROM (SELECT id FROM t INDEXED BY tv WHERE v>='' ORDER BY id);" \
+  "1,2" "$DB"
+run_test "ours_index_merge_expression_rows" \
+  "SELECT group_concat(id, ',') FROM (SELECT id FROM t INDEXED BY tlower WHERE lower(v)>='' ORDER BY id);" \
+  "1,2" "$DB"
+run_test_lastline "ours_index_merge_integrity" "PRAGMA integrity_check;" "ok" "$DB"
+rm -f "$DB"
+
 # Partial unique indexes only constrain rows that match WHERE. Both
 # branches inserting v=-1 must merge cleanly; v=9 on both is a real
 # unique violation.


### PR DESCRIPTION
## Summary

- rebuild an index added on ours when theirs changed the owning table rows
- keep rename and schema-conflict cases out of the rebuild path
- cover ordinary and expression indexes plus integrity checking

## Testing

- `DOLTLITE=build/doltlite bash test/doltlite_index_row_delta.sh` (34 passed)
- `DOLTLITE=build/doltlite bash test/doltlite_merge.sh` (134 passed)
- `bash test/doltlite_merge_index_conflict.sh build/doltlite` (34 passed)
- `bash test/vc_oracle_merge_test.sh build/doltlite dolt` (85 passed)
- `make -C build lint`
- `bash test/run_doltlite_tests.sh` (101/103 suites; `doltlite_parity.sh` lacks the local stock `build/sqlite3`, and `doltlite_regression_test_c.sh` has unrelated missing test-hook symbols in the local artifacts)

Co-Authored-By: Codex <noreply@openai.com>