### PR TITLE
Refuse to persist a conflicted working set from ref updates

### DIFF
--- a/src/doltlite_branch.c
+++ b/src/doltlite_branch.c
@@ -51,6 +51,12 @@ static void branchNamedResultError(
   const char *zNotFound,
   const char *zExists
 ){
+  sqlite3 *db = sqlite3_context_db_handle(ctx);
+  if( rc==SQLITE_CONSTRAINT && doltliteSessionHasUnresolvedConflicts(db) ){
+    branchError(ctx, bHadSavepoint,
+      "cannot update refs: unresolved merge conflicts");
+    return;
+  }
   branchSealSavepointsOnError(ctx, bHadSavepoint);
   doltliteRefResultError(ctx, rc, zNotFound, zExists);
 }
@@ -246,9 +252,14 @@ static void doltBranchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv)
       m.isDelete = 1;
       rc = doltliteMutateRefs(db, mutateBranchRef, &m);
       if( rc==SQLITE_CONSTRAINT ){
-        branchError(ctx, hadSavepoint,
-          "cannot delete the default branch; "
-          "call dolt_default_branch(<other>) first");
+        if( doltliteSessionHasUnresolvedConflicts(db) ){
+          branchError(ctx, hadSavepoint,
+            "cannot update refs: unresolved merge conflicts");
+        }else{
+          branchError(ctx, hadSavepoint,
+            "cannot delete the default branch; "
+            "call dolt_default_branch(<other>) first");
+        }
         return;
       }
       if( rc!=SQLITE_OK ){

--- a/src/doltlite_core.c
+++ b/src/doltlite_core.c
@@ -1,6 +1,7 @@
 #ifdef DOLTLITE_PROLLY
 
 #include "sqliteInt.h"
+#include "prolly_btree_int.h"
 #include "prolly_hash.h"
 #include "prolly_hashset.h"
 #include "chunk_store.h"
@@ -382,8 +383,11 @@ int doltliteMutateRefsExpected(
 ){
   ChunkStore *cs = doltliteGetChunkStore(db);
   ChunkStoreRefsSnapshot snapshot;
+  const BranchRef *aBr = 0;
   int haveSnapshot = 0;
   int i;
+  int nBr = 0;
+  int iBr;
   int rc;
 
   memset(&snapshot, 0, sizeof(snapshot));
@@ -425,6 +429,25 @@ int doltliteMutateRefsExpected(
   }
 
   if( rc==SQLITE_OK ) rc = xMutate(db, cs, pArg);
+  /* PersistWorkingSet and commit phase one refuse a conflicted working set.
+  ** Walk the refs about to land, not the session hash, so abort helpers
+  ** that rewrite a clean working set can still finish. */
+  if( rc==SQLITE_OK ){
+    refsTableGetBranches(&cs->refs, &nBr, &aBr);
+    for(iBr=0; rc==SQLITE_OK && iBr<nBr; iBr++){
+      ProllyHash conflicts;
+      int loadRc;
+      if( !aBr[iBr].zName ) continue;
+      loadRc = btreeLoadWorkingSetBlob(cs, aBr[iBr].zName, 0, 0, 0, 0, 0,
+                                       &conflicts, 0, 0, 0, 0, 0, 0);
+      if( loadRc==SQLITE_NOTFOUND ) continue;
+      if( loadRc!=SQLITE_OK ){
+        rc = loadRc;
+      }else if( !prollyHashIsEmpty(&conflicts) ){
+        rc = SQLITE_CONSTRAINT;
+      }
+    }
+  }
   if( rc==SQLITE_OK ){
     rc = chunkStoreSerializeRefs(cs);
     if( rc==SQLITE_OK ) rc = chunkStoreCommit(cs);

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -1226,6 +1226,7 @@ int doltliteSetSessionRebaseState(sqlite3 *db, u8 isRebasing,
                                   const char *zReturnBranch);
 int doltliteClearSessionRebaseState(sqlite3 *db);
 void doltliteGetSessionConflictsCatalog(sqlite3 *db, ProllyHash *pHash);
+int doltliteSessionHasUnresolvedConflicts(sqlite3 *db);
 int doltliteSetSessionConflictsCatalog(sqlite3 *db, const ProllyHash *pHash);
 void doltliteGetSessionConstraintViolationsCatalog(sqlite3 *db, ProllyHash *pHash);
 int doltliteSetSessionConstraintViolationsCatalog(sqlite3 *db, const ProllyHash *pHash);

--- a/src/doltlite_tag.c
+++ b/src/doltlite_tag.c
@@ -69,6 +69,11 @@ static void doltTagFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
     m.zName = zName;
     m.isDelete = 1;
     rc = doltliteMutateRefs(db, mutateTagRef, &m);
+    if( rc==SQLITE_CONSTRAINT && doltliteSessionHasUnresolvedConflicts(db) ){
+      doltliteVcResultError(ctx, db,
+        "cannot update refs: unresolved merge conflicts");
+      return;
+    }
     if( rc!=SQLITE_OK ){
       tagSealSavepointError(ctx);
       doltliteRefResultError(ctx, rc, "tag not found", 0);
@@ -156,6 +161,11 @@ static void doltTagFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   rc = doltliteMutateRefs(db, mutateTagRef, &m);
   sqlite3_free(zParsedTagger);
   sqlite3_free(zParsedEmail);
+  if( rc==SQLITE_CONSTRAINT && doltliteSessionHasUnresolvedConflicts(db) ){
+    doltliteVcResultError(ctx, db,
+      "cannot update refs: unresolved merge conflicts");
+    return;
+  }
   if( rc!=SQLITE_OK ){
     tagSealSavepointError(ctx);
     doltliteRefResultError(ctx, rc, "tag not found", "tag already exists");

--- a/src/prolly_btree_state.c
+++ b/src/prolly_btree_state.c
@@ -830,6 +830,13 @@ int doltliteClearSessionRebaseState(sqlite3 *db){
   return doltliteSetSessionRebaseState(db, 0, 0, 0, 0, 0);
 }
 
+int doltliteSessionHasUnresolvedConflicts(sqlite3 *db){
+  Btree *p;
+  if( !db || db->nDb<=0 || !db->aDb[0].pBt ) return 0;
+  p = db->aDb[0].pBt;
+  return !prollyHashIsEmpty(&p->vc.conflictsCatalogHash);
+}
+
 void doltliteGetSessionConflictsCatalog(sqlite3 *db, ProllyHash *pHash){
   u8 isMerging = 0;
   if( pHash ) memset(pHash, 0, sizeof(*pHash));

--- a/test/doltlite_conflicts.sh
+++ b/test/doltlite_conflicts.sh
@@ -231,5 +231,36 @@ run_test "resolve_both_then_commit_lands" \
 run_test "resolve_both_then_commit_not_merging" \
   "SELECT count(*) FROM dolt_merge_status WHERE is_merging=1;" "0" "$DB12"
 
-rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8" "$DB9" "$DB10" "$DB11" "$DB12"
+# dolt_branch/dolt_tag serialize the whole refs blob. A conflicted merge
+# in BEGIN saves the unfinished working set in memory; those commands
+# must not commit it.
+DB13=/tmp/test_conf13_$$.db; rm -f "$DB13"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'base');
+SELECT dolt_commit('-Am','base'); SELECT dolt_branch('br');" | $DOLTLITE "$DB13" > /dev/null 2>&1
+echo "UPDATE t SET v='theirs'; SELECT dolt_commit('-Am','br');" | $DOLTLITE "$DB13/br" > /dev/null 2>&1
+echo "UPDATE t SET v='ours'; SELECT dolt_commit('-Am','ours');" | $DOLTLITE "$DB13" > /dev/null 2>&1
+run_test_match "branch_during_conflicts_refused" \
+  "BEGIN; SELECT dolt_merge('br'); SELECT dolt_branch('backup');" \
+  "unresolved merge conflicts" "$DB13"
+run_test "branch_during_conflicts_no_backup" \
+  "SELECT count(*) FROM dolt_branches WHERE name='backup';" "0" "$DB13"
+run_test "branch_during_conflicts_not_persisted" \
+  "SELECT count(*) FROM dolt_merge_status WHERE is_merging=1;" "0" "$DB13"
+run_test "branch_during_conflicts_no_conflicts" \
+  "SELECT count(*) FROM dolt_conflicts;" "0" "$DB13"
+
+DB14=/tmp/test_conf14_$$.db; rm -f "$DB14"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'base');
+SELECT dolt_commit('-Am','base'); SELECT dolt_branch('br');" | $DOLTLITE "$DB14" > /dev/null 2>&1
+echo "UPDATE t SET v='theirs'; SELECT dolt_commit('-Am','br');" | $DOLTLITE "$DB14/br" > /dev/null 2>&1
+echo "UPDATE t SET v='ours'; SELECT dolt_commit('-Am','ours');" | $DOLTLITE "$DB14" > /dev/null 2>&1
+run_test_match "tag_during_conflicts_refused" \
+  "BEGIN; SELECT dolt_merge('br'); SELECT dolt_tag('v1');" \
+  "unresolved merge conflicts" "$DB14"
+run_test "tag_during_conflicts_no_tag" \
+  "SELECT count(*) FROM dolt_tags WHERE tag_name='v1';" "0" "$DB14"
+run_test "tag_during_conflicts_not_persisted" \
+  "SELECT count(*) FROM dolt_merge_status WHERE is_merging=1;" "0" "$DB14"
+
+rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8" "$DB9" "$DB10" "$DB11" "$DB12" "$DB13" "$DB14"
 dltest_finish


### PR DESCRIPTION
A conflicted merge inside `BEGIN` saves the unfinished working set in memory. `dolt_branch` / `dolt_tag` then serialized the whole refs blob and committed it, so the unfinished merge survived reopen. That breaks the rule that conflicts are never persisted.

`PersistWorkingSet` and commit phase one already refuse a non-empty conflicts catalog. `doltliteMutateRefsExpected` now walks the working sets about to land and returns `SQLITE_CONSTRAINT` if any still names one. Abort helpers that rewrite a clean working set can still finish.

**Fail-before:**

```sql
BEGIN;
SELECT dolt_merge('br');          -- conflicts
SELECT dolt_branch('backup');     -- succeeded, wrote them
ROLLBACK;
-- reopen: backup exists and/or merge state is inherited
```

**After:** `dolt_branch` / `dolt_tag` error with `cannot update refs: unresolved merge conflicts`. Reopen has no backup/tag, no merge, no conflicts.

`doltlite_conflicts.sh` 54/54, `doltlite_branch.sh` 66/66, `doltlite_merge.sh` 134/134, `doltlite_cherry_pick.sh` 98/98, `doltlite_rebase.sh` 36/36.

Co-Authored-By: Grok 4.6 <noreply@x.ai>