### PR TITLE
Do not infer revert from a commit message prefix

### DIFF
--- a/src/doltlite_cherry_pick.c
+++ b/src/doltlite_cherry_pick.c
@@ -103,6 +103,7 @@ int applyMergedCatalogAndCommit(
   const ProllyHash *ourHead,
   const ProllyHash *pCommitOurCatHash,
   const char *zMessage,
+  int bPreferOurMaster,
   int *pnConflicts,
   int *pnViolations,
   char *hexBuf
@@ -116,7 +117,6 @@ int applyMergedCatalogAndCommit(
   ProllyHash commitHash;
   char *zMergeErr = 0;
   int graphLocked = 0;
-  int bPreferOurMaster;
   const char *zOpLabel;
   const char *zBranch;
   int rc;
@@ -127,7 +127,6 @@ int applyMergedCatalogAndCommit(
   cs = doltliteGetChunkStore(db);
   memset(&savedState, 0, sizeof(savedState));
   if( hexBuf ) hexBuf[0] = '\0';
-  bPreferOurMaster = (sqlite3_strnicmp(zMessage, "Revert", 6)==0);
   zOpLabel = bPreferOurMaster ? "Revert" : "Cherry-pick";
   zBranch = doltliteGetSessionBranch(db);
 
@@ -415,7 +414,7 @@ static void doltliteCherryPickFunc(
 
     rc = applyMergedCatalogAndCommit(db, context,
         &parentCommit.catalogHash, &ourCommit.catalogHash,
-        &pickCommit.catalogHash, &ourHead, 0, zMsg, &nConflicts, 0,
+        &pickCommit.catalogHash, &ourHead, 0, zMsg, 0, &nConflicts, 0,
         hexBuf);
   }
 

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -1094,6 +1094,7 @@ int applyMergedCatalogAndCommit(
   const ProllyHash *ourHead,
   const ProllyHash *pCommitOurCatHash,
   const char *zMessage,
+  int bPreferOurMaster,
   int *pnConflicts,
   int *pnViolations,
   char *hexBuf

--- a/src/doltlite_rebase.c
+++ b/src/doltlite_rebase.c
@@ -488,7 +488,7 @@ static int doltliteRebaseLinearReplay(
         &replayCommit.catalogHash,
         &curHead, 0,
         replayCommit.zMessage ? replayCommit.zMessage : "",
-        &nConflicts, &nViolations, hexBuf);
+        0, &nConflicts, &nViolations, hexBuf);
 
     doltliteCommitClear(&replayCommit);
     doltliteCommitClear(&parentCommit);

--- a/src/doltlite_revert.c
+++ b/src/doltlite_revert.c
@@ -219,7 +219,7 @@ static void doltliteRevertFunc(
 
     rc = applyMergedCatalogAndCommit(db, context,
         &revertCommit.catalogHash, &liveOurCatalog,
-        &parentCommit.catalogHash, &ourHead, pCommitOurs, msg,
+        &parentCommit.catalogHash, &ourHead, pCommitOurs, msg, 1,
         &nConflicts, 0, hexBuf);
   }
 

--- a/test/doltlite_cherry_pick.sh
+++ b/test/doltlite_cherry_pick.sh
@@ -562,4 +562,44 @@ run_test "rv_violation_state" \
 
 rm -f "$DB"
 
+# Cherry-pick / rebase must not treat a commit message starting with
+# "Revert" as dolt_revert. That skipped index patches and left a DROP INDEX
+# unapplied. Real dolt_revert still prefers ours and restores the index.
+DB=/tmp/test_cp_revert_msg_$$.db; rm -f "$DB"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+CREATE INDEX t_v ON t(v);
+INSERT INTO t VALUES(1,'a');
+SELECT dolt_commit('-A','-m','base');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+DROP INDEX t_v;
+SELECT dolt_commit('-A','-m','Revert leftover');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES(2,'b');
+SELECT dolt_commit('-A','-m','main row');" | $DOLTLITE "$DB" > /dev/null 2>&1
+run_test_match "cp_revert_msg_hash" \
+  "SELECT dolt_cherry_pick('feat');" \
+  "^[0-9a-f]{40}$" "$DB"
+run_test "cp_revert_msg_drops_index" \
+  "SELECT count(*) FROM sqlite_master WHERE type='index' AND name='t_v';" \
+  "0" "$DB"
+run_test "cp_revert_msg_keeps_rows" \
+  "SELECT count(*) FROM t;" "2" "$DB"
+rm -f "$DB"
+
+DB=/tmp/test_rv_drop_index_$$.db; rm -f "$DB"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+CREATE INDEX t_v ON t(v);
+INSERT INTO t VALUES(1,'a');
+SELECT dolt_commit('-A','-m','base');
+DROP INDEX t_v;
+SELECT dolt_commit('-A','-m','drop idx');" | $DOLTLITE "$DB" > /dev/null 2>&1
+run_test_match "rv_drop_index_hash" \
+  "SELECT dolt_revert('HEAD');" \
+  "^[0-9a-f]{40}$" "$DB"
+run_test "rv_drop_index_restored" \
+  "SELECT count(*) FROM sqlite_master WHERE type='index' AND name='t_v';" \
+  "1" "$DB"
+rm -f "$DB"
+
 dltest_finish

--- a/test/doltlite_rebase.sh
+++ b/test/doltlite_rebase.sh
@@ -426,6 +426,41 @@ run_test "continue_in_savepoint_no_orphans" \
 feat adds child" \
   "$DB9"
 
+# Linear rebase used the replayed commit message to decide revert vs
+# cherry-pick. A DROP INDEX titled "Revert leftover" skipped index patches
+# and left the index in place.
+DB10=/tmp/test_rebase_revert_msg_$$.db; rm -f "$DB10"
+cat <<'SQL' | "$DOLTLITE" "$DB10" >/dev/null 2>&1
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+CREATE INDEX t_v ON t(v);
+INSERT INTO t VALUES(1,'a');
+SELECT dolt_commit('-A','-m','base');
+SELECT dolt_checkout('-b','feat');
+DROP INDEX t_v;
+SELECT dolt_commit('-A','-m','Revert leftover');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES(2,'b');
+SELECT dolt_commit('-A','-m','main row');
+SELECT dolt_checkout('feat');
+SQL
+TX_OUT=$(echo "SELECT dolt_checkout('feat');
+SELECT dolt_rebase('main');
+SELECT 'TX|' || (SELECT count(*) FROM sqlite_master WHERE type='index' AND name='t_v') || '|' || (SELECT count(*) FROM t);" | "$DOLTLITE" "$DB10" 2>&1)
+if echo "$TX_OUT" | grep -q "Successfully rebased"; then
+  PASS=$((PASS+1))
+else
+  FAIL=$((FAIL+1))
+  ERRORS="$ERRORS\nFAIL: linear_rebase_revert_msg_ok\n  expected Successfully rebased\n  got: $TX_OUT"
+fi
+TX_LINE=$(echo "$TX_OUT" | grep '^TX|')
+if [ "$TX_LINE" = "TX|0|2" ]; then
+  PASS=$((PASS+1))
+else
+  FAIL=$((FAIL+1))
+  ERRORS="$ERRORS\nFAIL: linear_rebase_revert_msg_result\n  expected: TX|0|2\n  got:      $TX_LINE"
+fi
+rm -f "$DB10"
+
 rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB5_SHORT" "$DB6" "$DB7" "$DB8" "$DB9"
 echo ""
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"


### PR DESCRIPTION
`applyMergedCatalogAndCommit` treated any message starting with `Revert` as `dolt_revert`. Linear rebase (and cherry-pick of such a commit) then set `bPreferOurMaster`, skipped index patches, and left a `DROP INDEX` unapplied.

Pass an explicit flag instead: `dolt_revert` sets it, cherry-pick and rebase do not. Interactive rebase already merged with prefer-ours off.

**Fail-before:** cherry-pick or rebase a `DROP INDEX` committed as `Revert leftover` — the index is still there.

**After:** the index is gone. A real `dolt_revert` of a drop still restores it.

`doltlite_cherry_pick.sh` 103/103, `doltlite_rebase.sh` 38/38, `doltlite_rebase_schema.sh` 23/23.

Co-Authored-By: Grok 4.6 <noreply@x.ai>