### PR TITLE
Fail closed on constraint detector errors

### DIFF
--- a/src/doltlite_core.c
+++ b/src/doltlite_core.c
@@ -842,7 +842,10 @@ int doltliteDetectConstraintViolationsFiltered(
   }else if( rc==SQLITE_DONE ){
     rc = SQLITE_OK;
   }
-  sqlite3_finalize(pStmt);
+  {
+    int finalizeRc = sqlite3_finalize(pStmt);
+    if( rc==SQLITE_OK ) rc = finalizeRc;
+  }
   if( rc!=SQLITE_OK ) return rc;
   if( !needsDetection ){
     if( pnViolations ) *pnViolations = 0;

--- a/src/doltlite_merge_constraints.c
+++ b/src/doltlite_merge_constraints.c
@@ -176,11 +176,25 @@ void freeMergePkInfo(MergePkInfo *pPk){
   memset(pPk, 0, sizeof(*pPk));
 }
 
+int finishConstraintStmt(sqlite3_stmt *pStmt, int rc){
+  int finalizeRc = sqlite3_finalize(pStmt);
+  return rc==SQLITE_OK ? finalizeRc : rc;
+}
+
+void setConstraintError(sqlite3 *db, char **pzErrMsg, int rc){
+  if( rc!=SQLITE_OK && pzErrMsg && !*pzErrMsg ){
+    const char *zErr = (sqlite3_errcode(db) & 0xff)==rc
+        ? sqlite3_errmsg(db) : sqlite3_errstr(rc);
+    *pzErrMsg = sqlite3_mprintf("%s", zErr);
+  }
+}
+
 int loadMergePkInfo(sqlite3 *db, const char *zTable, MergePkInfo *pPk){
   sqlite3_stmt *pStmt = 0;
   sqlite3_str *pCols = 0;
   char *zQuery = 0;
   int rc;
+  int stepRc;
   int nPk = 0;
   char **azPk = 0;
   int i;
@@ -192,28 +206,29 @@ int loadMergePkInfo(sqlite3 *db, const char *zTable, MergePkInfo *pPk){
   sqlite3_free(zQuery);
   if( rc!=SQLITE_OK ) return rc;
 
-  while( sqlite3_step(pStmt)==SQLITE_ROW ){
+  while( (stepRc = sqlite3_step(pStmt))==SQLITE_ROW ){
     int pk = sqlite3_column_int(pStmt, 5);
     if( pk>nPk ) nPk = pk;
   }
+  if( stepRc!=SQLITE_DONE ){
+    return finishConstraintStmt(pStmt, stepRc);
+  }
   rc = sqlite3_reset(pStmt);
   if( rc!=SQLITE_OK ){
-    sqlite3_finalize(pStmt);
-    return rc;
+    return finishConstraintStmt(pStmt, rc);
   }
   if( nPk<=0 ){
-    sqlite3_finalize(pStmt);
-    return SQLITE_NOTFOUND;
+    rc = finishConstraintStmt(pStmt, SQLITE_OK);
+    return rc==SQLITE_OK ? SQLITE_NOTFOUND : rc;
   }
 
   azPk = sqlite3_malloc64((sqlite3_int64)nPk * sizeof(char*));
   if( !azPk ){
-    sqlite3_finalize(pStmt);
-    return SQLITE_NOMEM;
+    return finishConstraintStmt(pStmt, SQLITE_NOMEM);
   }
   memset(azPk, 0, (size_t)nPk * sizeof(char*));
 
-  while( sqlite3_step(pStmt)==SQLITE_ROW ){
+  while( (stepRc = sqlite3_step(pStmt))==SQLITE_ROW ){
     const char *zCol = (const char*)sqlite3_column_text(pStmt, 1);
     int pk = sqlite3_column_int(pStmt, 5);
     if( pk<=0 || pk>nPk ) continue;
@@ -223,8 +238,9 @@ int loadMergePkInfo(sqlite3 *db, const char *zTable, MergePkInfo *pPk){
       break;
     }
   }
-  sqlite3_finalize(pStmt);
-  if( rc!=SQLITE_DONE && rc!=SQLITE_OK ){
+  if( rc==SQLITE_OK && stepRc!=SQLITE_DONE ) rc = stepRc;
+  rc = finishConstraintStmt(pStmt, rc);
+  if( rc!=SQLITE_OK ){
     doltliteFreeStringArray(azPk, nPk);
     return rc;
   }
@@ -483,16 +499,28 @@ int isRowPreExisting(
   return memcmp(pMergedVal, pAncVal, nMergedVal)==0 ? 1 : 0;
 }
 
-int tableHasRowid(sqlite3 *db, const char *zTable){
+int tableHasRowid(sqlite3 *db, const char *zTable, int *pHasRowid){
   sqlite3_stmt *pStmt = 0;
   char *zQuery;
   int rc;
-  zQuery = sqlite3_mprintf("SELECT rowid FROM main.\"%w\" LIMIT 0", zTable);
-  if( !zQuery ) return 1;
+  int stepRc;
+
+  *pHasRowid = 0;
+  zQuery = sqlite3_mprintf(
+      "SELECT wr FROM pragma_table_list WHERE schema='main' AND name=%Q",
+      zTable);
+  if( !zQuery ) return SQLITE_NOMEM;
   rc = sqlite3_prepare_v2(db, zQuery, -1, &pStmt, 0);
   sqlite3_free(zQuery);
-  if( pStmt ) sqlite3_finalize(pStmt);
-  return rc == SQLITE_OK ? 1 : 0;
+  if( rc!=SQLITE_OK ) return rc;
+  stepRc = sqlite3_step(pStmt);
+  if( stepRc==SQLITE_ROW ){
+    *pHasRowid = !sqlite3_column_int(pStmt, 0);
+    rc = SQLITE_OK;
+  }else{
+    rc = stepRc==SQLITE_DONE ? SQLITE_NOTFOUND : stepRc;
+  }
+  return finishConstraintStmt(pStmt, rc);
 }
 
 int fetchOrphanRow(

--- a/src/doltlite_merge_constraints_check.c
+++ b/src/doltlite_merge_constraints_check.c
@@ -2,6 +2,10 @@
 
 #include "doltlite_merge_constraints_int.h"
 
+static int checkIsIdent(char c){
+  return sqlite3Isalnum(c) || c=='_';
+}
+
 static int nextCheckClause(
   const char *zSql, int *pOffset, char **pzExpr, char **pzName
 ){
@@ -15,7 +19,8 @@ static int nextCheckClause(
   *pzName = 0;
 
   while( *p ){
-    if( (p[0]=='C' || p[0]=='c')
+    if( (p==zSql || !checkIsIdent(p[-1]))
+     && (p[0]=='C' || p[0]=='c')
      && sqlite3_strnicmp(p, "CONSTRAINT", 10)==0
      && (p[10]==' ' || p[10]=='\t' || p[10]=='\n') ){
       int i = 0;
@@ -27,7 +32,8 @@ static int nextCheckClause(
       lastConstraintName[i] = 0;
       continue;
     }
-    if( (p[0]=='C' || p[0]=='c')
+    if( (p==zSql || !checkIsIdent(p[-1]))
+     && (p[0]=='C' || p[0]=='c')
      && sqlite3_strnicmp(p, "CHECK", 5)==0
      && (p[5]==' ' || p[5]=='\t' || p[5]=='(' || p[5]=='\n') ){
       p += 5;
@@ -57,15 +63,20 @@ static int nextCheckClause(
         else if( c==')' ) depth--;
         if( depth>0 ) p++;
       }
-      if( depth!=0 ) return -1;
+      if( depth!=0 ) return -SQLITE_CORRUPT;
       pEnd = p;
       p++;
       *pzExpr = sqlite3_malloc((int)(pEnd - pExprStart) + 1);
-      if( !*pzExpr ) return -1;
+      if( !*pzExpr ) return -SQLITE_NOMEM;
       memcpy(*pzExpr, pExprStart, (size_t)(pEnd - pExprStart));
       (*pzExpr)[pEnd - pExprStart] = 0;
       if( lastConstraintName[0] ){
         *pzName = sqlite3_mprintf("%s", lastConstraintName);
+        if( !*pzName ){
+          sqlite3_free(*pzExpr);
+          *pzExpr = 0;
+          return -SQLITE_NOMEM;
+        }
       }
       *pOffset = (int)(p - zSql);
       return 1;
@@ -153,7 +164,12 @@ int doltliteDetectMergeCheckViolations(
       continue;
     }
     memset(&pkInfo, 0, sizeof(pkInfo));
-    hasRowid = tableHasRowid(db, zTable);
+    rc = tableHasRowid(db, zTable, &hasRowid);
+    if( rc!=SQLITE_OK ){
+      sqlite3_free(zTable);
+      sqlite3_free(zSql);
+      break;
+    }
     if( !hasRowid ){
       rc = loadMergePkInfo(db, zTable, &pkInfo);
       if( rc != SQLITE_OK ){
@@ -169,11 +185,12 @@ int doltliteDetectMergeCheckViolations(
       int clauseRc = nextCheckClause(zSql, &offset, &zExpr, &zCkName);
       char *zQuery;
       sqlite3_stmt *pQ = 0;
-      int prepareRc;
+      int queryStepRc;
 
       if( clauseRc <= 0 ){
         sqlite3_free(zExpr);
         sqlite3_free(zCkName);
+        if( clauseRc<0 ) rc = -clauseRc;
         break;
       }
 
@@ -192,15 +209,16 @@ int doltliteDetectMergeCheckViolations(
         rc = SQLITE_NOMEM;
         break;
       }
-      prepareRc = sqlite3_prepare_v2(db, zQuery, -1, &pQ, 0);
+      rc = sqlite3_prepare_v2(db, zQuery, -1, &pQ, 0);
       sqlite3_free(zQuery);
-      if( prepareRc != SQLITE_OK ){
+      if( rc != SQLITE_OK ){
+        setConstraintError(db, pzErrMsg, rc);
         sqlite3_free(zExpr);
         sqlite3_free(zCkName);
-        continue;
+        break;
       }
 
-      while( sqlite3_step(pQ) == SQLITE_ROW ){
+      while( (queryStepRc = sqlite3_step(pQ)) == SQLITE_ROW ){
         u8 *pKey = 0; int nKey = 0;
         u8 *pVal = 0; int nVal = 0;
         char *zInfo;
@@ -245,6 +263,12 @@ int doltliteDetectMergeCheckViolations(
         zInfo = sqlite3_mprintf(
             "{\"Name\": \"%w\", \"Expression\": \"%w\"}",
             zCkName ? zCkName : "", zExpr);
+        if( !zInfo ){
+          sqlite3_free(pKey);
+          sqlite3_free(pVal);
+          rc = SQLITE_NOMEM;
+          break;
+        }
         appendRc = doltliteAppendConstraintViolation(
             db, zTable, DOLTLITE_CV_CHECK_CONSTRAINT,
             intKey, pKey, nKey, pVal, nVal, zInfo);
@@ -254,7 +278,10 @@ int doltliteDetectMergeCheckViolations(
         if( appendRc != SQLITE_OK ){ rc = appendRc; break; }
         if( pnFound ) (*pnFound)++;
       }
-      sqlite3_finalize(pQ);
+      if( rc==SQLITE_OK && queryStepRc!=SQLITE_DONE ) rc = queryStepRc;
+      setConstraintError(db, pzErrMsg, rc);
+      rc = finishConstraintStmt(pQ, rc);
+      setConstraintError(db, pzErrMsg, rc);
       sqlite3_free(zExpr);
       sqlite3_free(zCkName);
       if( rc != SQLITE_OK ) break;
@@ -268,9 +295,10 @@ int doltliteDetectMergeCheckViolations(
   if( rc == SQLITE_OK && stepRc != SQLITE_DONE && stepRc != SQLITE_ROW ){
     rc = stepRc;
   }
-  sqlite3_finalize(pTbls);
+  rc = finishConstraintStmt(pTbls, rc);
   doltliteFreeCatalog(aAnc, nAnc);
   doltliteFreeCatalog(aCur, nCur);
+  setConstraintError(db, pzErrMsg, rc);
   return rc;
 }
 

--- a/src/doltlite_merge_constraints_fk.c
+++ b/src/doltlite_merge_constraints_fk.c
@@ -17,6 +17,13 @@ static int backfillParentPk(sqlite3 *db, const char *zParent,
     for(i=0; i<nCol; i++){
       if( !azTo[i] && i < parentPk.nPk ){
         azTo[i] = sqlite3_mprintf("%s", parentPk.azPk[i]);
+        if( !azTo[i] ){
+          rc = SQLITE_NOMEM;
+          break;
+        }
+      }else if( !azTo[i] ){
+        rc = SQLITE_CORRUPT;
+        break;
       }
     }
   }
@@ -157,7 +164,8 @@ static int fkParentExistsInCatalog(
 static char *buildFkViolationInfo(
   sqlite3 *db,
   const char *zChildTable,
-  int fkid
+  int fkid,
+  int *pRc
 ){
   sqlite3_stmt *pStmt = 0;
   sqlite3_str *pJson;
@@ -172,7 +180,9 @@ static char *buildFkViolationInfo(
   char *zResult;
   int rc;
   int nMatches = 0;
-  int fatal = 0;
+  int stepRc = SQLITE_DONE;
+
+  *pRc = SQLITE_OK;
 
   pJson = sqlite3_str_new(0);
   pCols = sqlite3_str_new(0);
@@ -180,14 +190,14 @@ static char *buildFkViolationInfo(
 
   zQuery = sqlite3_mprintf("PRAGMA main.foreign_key_list(%Q)", zChildTable);
   if( !zQuery ){
-    fatal = 1;
+    *pRc = SQLITE_NOMEM;
   }else{
     rc = sqlite3_prepare_v2(db, zQuery, -1, &pStmt, 0);
     sqlite3_free(zQuery);
     if( rc != SQLITE_OK ){
-      fatal = 1;
+      *pRc = rc;
     }else{
-      while( sqlite3_step(pStmt) == SQLITE_ROW ){
+      while( (stepRc = sqlite3_step(pStmt)) == SQLITE_ROW ){
         int id = sqlite3_column_int(pStmt, 0);
         const char *zParent, *zFrom, *zTo, *zOnUp, *zOnDel;
         if( id != fkid ) continue;
@@ -206,17 +216,23 @@ static char *buildFkViolationInfo(
           if( zParent ) zParentBuf = sqlite3_mprintf("%s", zParent);
           zOnUpBuf  = sqlite3_mprintf("%s", zOnUp  ? zOnUp  : "NO ACTION");
           zOnDelBuf = sqlite3_mprintf("%s", zOnDel ? zOnDel : "NO ACTION");
+          if( (zParent && !zParentBuf) || !zOnUpBuf || !zOnDelBuf ){
+            *pRc = SQLITE_NOMEM;
+            break;
+          }
         }
         nMatches++;
       }
+      if( *pRc==SQLITE_OK && stepRc!=SQLITE_DONE ) *pRc = stepRc;
     }
   }
-  sqlite3_finalize(pStmt);
+  *pRc = finishConstraintStmt(pStmt, *pRc);
 
   zColsBuf    = sqlite3_str_finish(pCols);
   zRefColsBuf = sqlite3_str_finish(pRefCols);
 
-  if( fatal ){
+  if( *pRc!=SQLITE_OK || !zColsBuf || !zRefColsBuf ){
+    if( *pRc==SQLITE_OK ) *pRc = SQLITE_NOMEM;
     sqlite3_free(sqlite3_str_finish(pJson));
     sqlite3_free(zColsBuf);
     sqlite3_free(zRefColsBuf);
@@ -237,6 +253,7 @@ static char *buildFkViolationInfo(
       zOnUpBuf ? zOnUpBuf : "NO ACTION",
       zOnDelBuf ? zOnDelBuf : "NO ACTION");
   zResult = sqlite3_str_finish(pJson);
+  if( !zResult ) *pRc = SQLITE_NOMEM;
   sqlite3_free(zColsBuf);
   sqlite3_free(zRefColsBuf);
   sqlite3_free(zParentBuf);
@@ -264,6 +281,7 @@ static int detectFkViolationsForSpec(
   sqlite3_stmt *pStmt = 0;
   int nKeyCol;
   int rc;
+  int stepRc;
 
   pSql = sqlite3_str_new(0);
   sqlite3_str_appendf(pSql, "SELECT %s", hasRowid ? "rowid" : pChildPk->zPkCols);
@@ -290,7 +308,7 @@ static int detectFkViolationsForSpec(
   if( rc!=SQLITE_OK ) return rc;
   nKeyCol = hasRowid ? 1 : pChildPk->nPk;
 
-  while( sqlite3_step(pStmt)==SQLITE_ROW ){
+  while( (stepRc = sqlite3_step(pStmt))==SQLITE_ROW ){
     u8 *pKey = 0; int nKey = 0;
     u8 *pVal = 0; int nVal = 0;
     u8 *pChildFkRec = 0; int nChildFkRec = 0;
@@ -359,7 +377,12 @@ static int detectFkViolationsForSpec(
       }
     }
 
-    zInfo = buildFkViolationInfo(db, zChildTable, fkid);
+    zInfo = buildFkViolationInfo(db, zChildTable, fkid, &rc);
+    if( rc!=SQLITE_OK ){
+      sqlite3_free(pKey);
+      sqlite3_free(pVal);
+      break;
+    }
     appendRc = doltliteAppendConstraintViolation(
         db, zChildTable, DOLTLITE_CV_FOREIGN_KEY,
         intKey, pKey, nKey, pVal, nVal, zInfo);
@@ -373,8 +396,8 @@ static int detectFkViolationsForSpec(
     if( pnFound ) (*pnFound)++;
   }
 
-  if( rc==SQLITE_DONE ) rc = SQLITE_OK;
-  sqlite3_finalize(pStmt);
+  if( rc==SQLITE_OK && stepRc!=SQLITE_DONE ) rc = stepRc;
+  rc = finishConstraintStmt(pStmt, rc);
   return rc;
 }
 
@@ -394,8 +417,6 @@ int doltliteDetectMergeFkViolations(
   int rc;
   int nFound = 0;
   int stepRc;
-
-  (void)pzErrMsg;
 
   if( pnFound ) *pnFound = 0;
 
@@ -427,6 +448,7 @@ int doltliteDetectMergeFkViolations(
     int nCol = 0;
     int nAlloc = 0;
     int childChanged;
+    int fkStepRc;
 
     if( !zTableRaw ) continue;
     zTable = sqlite3_mprintf("%s", zTableRaw);
@@ -437,7 +459,11 @@ int doltliteDetectMergeFkViolations(
     }
     childChanged = catalogTableChanged(aAnc, nAnc, aCur, nCur, zTable);
     memset(&childPk, 0, sizeof(childPk));
-    hasRowid = tableHasRowid(db, zTable);
+    rc = tableHasRowid(db, zTable, &hasRowid);
+    if( rc!=SQLITE_OK ){
+      sqlite3_free(zTable);
+      break;
+    }
     if( !hasRowid ){
       rc = loadMergePkInfo(db, zTable, &childPk);
       if( rc != SQLITE_OK ){
@@ -461,7 +487,7 @@ int doltliteDetectMergeFkViolations(
       break;
     }
 
-    while( sqlite3_step(pFk) == SQLITE_ROW ){
+    while( (fkStepRc = sqlite3_step(pFk)) == SQLITE_ROW ){
       int id = sqlite3_column_int(pFk, 0);
       const char *zParentRaw = (const char*)sqlite3_column_text(pFk, 2);
       const char *zFromRaw = (const char*)sqlite3_column_text(pFk, 3);
@@ -518,9 +544,7 @@ int doltliteDetectMergeFkViolations(
       nCol++;
     }
 
-    if( rc==SQLITE_ROW || rc==SQLITE_DONE ){
-      rc = SQLITE_OK;
-    }
+    if( rc==SQLITE_OK && fkStepRc!=SQLITE_DONE ) rc = fkStepRc;
     if( rc==SQLITE_OK && curId>=0 ){
       int parentChanged = catalogTableChanged(aAnc, nAnc, aCur, nCur, zParent);
       if( childChanged || parentChanged ){
@@ -538,7 +562,7 @@ int doltliteDetectMergeFkViolations(
     doltliteFreeStringArray(azFrom, nCol);
     doltliteFreeStringArray(azTo, nCol);
     sqlite3_free(zParent);
-    sqlite3_finalize(pFk);
+    rc = finishConstraintStmt(pFk, rc);
     freeMergePkInfo(&childPk);
     sqlite3_free(zTable);
     if( rc != SQLITE_OK ) break;
@@ -547,10 +571,11 @@ int doltliteDetectMergeFkViolations(
   if( rc == SQLITE_OK && stepRc != SQLITE_DONE && stepRc != SQLITE_ROW ){
     rc = stepRc;
   }
-  sqlite3_finalize(pTbls);
+  rc = finishConstraintStmt(pTbls, rc);
   doltliteFreeCatalog(aAnc, nAnc);
   doltliteFreeCatalog(aCur, nCur);
   if( pnFound ) *pnFound = nFound;
+  setConstraintError(db, pzErrMsg, rc);
   return rc;
 }
 

--- a/src/doltlite_merge_constraints_int.h
+++ b/src/doltlite_merge_constraints_int.h
@@ -23,6 +23,8 @@ struct MergePkInfo {
 
 void freeMergePkInfo(MergePkInfo *pPk);
 int loadMergePkInfo(sqlite3 *db, const char *zTable, MergePkInfo *pPk);
+int finishConstraintStmt(sqlite3_stmt *pStmt, int rc);
+void setConstraintError(sqlite3 *db, char **pzErrMsg, int rc);
 
 int copyCursorRow(
   ProllyCursor *pCur,
@@ -73,7 +75,7 @@ int isRowPreExisting(
   const u8 *pMergedVal, int nMergedVal,
   const u8 *pAncVal, int nAncVal
 );
-int tableHasRowid(sqlite3 *db, const char *zTable);
+int tableHasRowid(sqlite3 *db, const char *zTable, int *pHasRowid);
 int fetchOrphanRow(
   sqlite3 *db, const char *zTable, i64 rowid,
   u8 **ppKey, int *pnKey, u8 **ppVal, int *pnVal

--- a/src/doltlite_merge_constraints_notnull.c
+++ b/src/doltlite_merge_constraints_notnull.c
@@ -33,6 +33,7 @@ static int loadNotNullColumns(
   int n = 0;
   int nAlloc = 0;
   int rc;
+  int stepRc;
 
   *pazCols = 0;
   *pnCols = 0;
@@ -43,7 +44,7 @@ static int loadNotNullColumns(
   sqlite3_free(zSql);
   if( rc!=SQLITE_OK ) return rc;
 
-  while( sqlite3_step(pQ)==SQLITE_ROW ){
+  while( (stepRc = sqlite3_step(pQ))==SQLITE_ROW ){
     const char *zName = (const char*)sqlite3_column_text(pQ, 0);
     if( !zName ) continue;
     if( n==nAlloc ){
@@ -57,7 +58,8 @@ static int loadNotNullColumns(
     if( !az[n] ){ rc = SQLITE_NOMEM; break; }
     n++;
   }
-  sqlite3_finalize(pQ);
+  if( rc==SQLITE_OK && stepRc!=SQLITE_DONE ) rc = stepRc;
+  rc = finishConstraintStmt(pQ, rc);
   if( rc!=SQLITE_OK ){
     freeNames(az, n);
     return rc;
@@ -83,7 +85,6 @@ int doltliteDetectMergeNotNullViolations(
   int rc;
   int stepRc;
 
-  (void)pzErrMsg;
   if( pnFound ) *pnFound = 0;
 
   rc = loadAncestorAndCurrentCatalogs(db, pAncCatHash, &aAnc, &nAnc,
@@ -112,6 +113,7 @@ int doltliteDetectMergeNotNullViolations(
     char *zQuery = 0;
     sqlite3_stmt *pQ = 0;
     int i;
+    int queryStepRc;
 
     if( !zTableRaw ) continue;
     zTable = sqlite3_mprintf("%s", zTableRaw);
@@ -133,7 +135,12 @@ int doltliteDetectMergeNotNullViolations(
     }
 
     memset(&pkInfo, 0, sizeof(pkInfo));
-    hasRowid = tableHasRowid(db, zTable);
+    rc = tableHasRowid(db, zTable, &hasRowid);
+    if( rc!=SQLITE_OK ){
+      freeNames(azCols, nCols);
+      sqlite3_free(zTable);
+      break;
+    }
     if( !hasRowid ){
       rc = loadMergePkInfo(db, zTable, &pkInfo);
       if( rc!=SQLITE_OK ){
@@ -167,15 +174,13 @@ int doltliteDetectMergeNotNullViolations(
     rc = sqlite3_prepare_v2(db, zQuery, -1, &pQ, 0);
     sqlite3_free(zQuery);
     if( rc!=SQLITE_OK ){
-      /* A table the merge left unreadable is the other detectors' business. */
       freeNames(azCols, nCols);
       freeMergePkInfo(&pkInfo);
       sqlite3_free(zTable);
-      rc = SQLITE_OK;
-      continue;
+      break;
     }
 
-    while( sqlite3_step(pQ)==SQLITE_ROW ){
+    while( (queryStepRc = sqlite3_step(pQ))==SQLITE_ROW ){
       u8 *pKey = 0; int nKey = 0;
       u8 *pVal = 0; int nVal = 0;
       i64 intKey = 0;
@@ -246,7 +251,8 @@ int doltliteDetectMergeNotNullViolations(
       if( appendRc!=SQLITE_OK ){ rc = appendRc; break; }
       if( pnFound ) (*pnFound)++;
     }
-    sqlite3_finalize(pQ);
+    if( rc==SQLITE_OK && queryStepRc!=SQLITE_DONE ) rc = queryStepRc;
+    rc = finishConstraintStmt(pQ, rc);
     freeNames(azCols, nCols);
     freeMergePkInfo(&pkInfo);
     sqlite3_free(zTable);
@@ -255,9 +261,10 @@ int doltliteDetectMergeNotNullViolations(
   if( rc==SQLITE_OK && stepRc!=SQLITE_DONE && stepRc!=SQLITE_ROW ){
     rc = stepRc;
   }
-  sqlite3_finalize(pTbls);
+  rc = finishConstraintStmt(pTbls, rc);
   doltliteFreeCatalog(aAnc, nAnc);
   doltliteFreeCatalog(aCur, nCur);
+  setConstraintError(db, pzErrMsg, rc);
   return rc;
 }
 

--- a/src/doltlite_merge_constraints_strict.c
+++ b/src/doltlite_merge_constraints_strict.c
@@ -34,23 +34,28 @@ static const char *strictAllowedTypeof(const char *zDecl){
   return 0;
 }
 
-/* True when zTable is declared STRICT. */
-static int tableIsStrict(sqlite3 *db, const char *zTable){
+static int tableIsStrict(sqlite3 *db, const char *zTable, int *pStrict){
   sqlite3_stmt *pQ = 0;
   char *zSql;
-  int strict = 0;
+  int rc;
+  int stepRc;
 
+  *pStrict = 0;
   zSql = sqlite3_mprintf(
       "SELECT strict FROM pragma_table_list WHERE schema='main' AND name=%Q",
       zTable);
-  if( !zSql ) return 0;
-  if( sqlite3_prepare_v2(db, zSql, -1, &pQ, 0)==SQLITE_OK
-   && sqlite3_step(pQ)==SQLITE_ROW ){
-    strict = sqlite3_column_int(pQ, 0);
-  }
+  if( !zSql ) return SQLITE_NOMEM;
+  rc = sqlite3_prepare_v2(db, zSql, -1, &pQ, 0);
   sqlite3_free(zSql);
-  sqlite3_finalize(pQ);
-  return strict;
+  if( rc!=SQLITE_OK ) return rc;
+  stepRc = sqlite3_step(pQ);
+  if( stepRc==SQLITE_ROW ){
+    *pStrict = sqlite3_column_int(pQ, 0);
+    rc = SQLITE_OK;
+  }else{
+    rc = stepRc==SQLITE_DONE ? SQLITE_NOTFOUND : stepRc;
+  }
+  return finishConstraintStmt(pQ, rc);
 }
 
 /* The typed columns of a STRICT table with the storage class each admits. */
@@ -68,6 +73,7 @@ static int loadStrictColumns(
   int n = 0;
   int nAlloc = 0;
   int rc;
+  int stepRc;
 
   *pazCols = 0;
   *pazAllowed = 0;
@@ -79,7 +85,7 @@ static int loadStrictColumns(
   sqlite3_free(zSql);
   if( rc!=SQLITE_OK ) return rc;
 
-  while( sqlite3_step(pQ)==SQLITE_ROW ){
+  while( (stepRc = sqlite3_step(pQ))==SQLITE_ROW ){
     const char *zName = (const char*)sqlite3_column_text(pQ, 0);
     const char *zType = (const char*)sqlite3_column_text(pQ, 1);
     const char *zAllowed;
@@ -106,7 +112,8 @@ static int loadStrictColumns(
     }
     n++;
   }
-  sqlite3_finalize(pQ);
+  if( rc==SQLITE_OK && stepRc!=SQLITE_DONE ) rc = stepRc;
+  rc = finishConstraintStmt(pQ, rc);
   if( rc!=SQLITE_OK ){
     strictFreeNames(azCols, n);
     strictFreeNames(azAllowed, n);
@@ -134,7 +141,6 @@ int doltliteDetectMergeStrictViolations(
   int rc;
   int stepRc;
 
-  (void)pzErrMsg;
   if( pnFound ) *pnFound = 0;
 
   rc = loadAncestorAndCurrentCatalogs(db, pAncCatHash, &aAnc, &nAnc,
@@ -164,13 +170,23 @@ int doltliteDetectMergeStrictViolations(
     char *zQuery = 0;
     sqlite3_stmt *pQ = 0;
     int i;
+    int isStrict;
+    int queryStepRc;
 
     if( !zTableRaw ) continue;
     zTable = sqlite3_mprintf("%s", zTableRaw);
     if( !zTable ){ rc = SQLITE_NOMEM; break; }
     if( !cvTableAllowed(zTable, azTables, nTables)
-     || !catalogTableChanged(aAnc, nAnc, aCur, nCur, zTable)
-     || !tableIsStrict(db, zTable) ){
+     || !catalogTableChanged(aAnc, nAnc, aCur, nCur, zTable) ){
+      sqlite3_free(zTable);
+      continue;
+    }
+    rc = tableIsStrict(db, zTable, &isStrict);
+    if( rc!=SQLITE_OK ){
+      sqlite3_free(zTable);
+      break;
+    }
+    if( !isStrict ){
       sqlite3_free(zTable);
       continue;
     }
@@ -186,7 +202,13 @@ int doltliteDetectMergeStrictViolations(
     }
 
     memset(&pkInfo, 0, sizeof(pkInfo));
-    hasRowid = tableHasRowid(db, zTable);
+    rc = tableHasRowid(db, zTable, &hasRowid);
+    if( rc!=SQLITE_OK ){
+      strictFreeNames(azCols, nCols);
+      strictFreeNames(azAllowed, nCols);
+      sqlite3_free(zTable);
+      break;
+    }
     if( !hasRowid ){
       rc = loadMergePkInfo(db, zTable, &pkInfo);
       if( rc!=SQLITE_OK ){
@@ -224,16 +246,14 @@ int doltliteDetectMergeStrictViolations(
     rc = sqlite3_prepare_v2(db, zQuery, -1, &pQ, 0);
     sqlite3_free(zQuery);
     if( rc!=SQLITE_OK ){
-      /* A table the merge left unreadable is the other detectors' business. */
       strictFreeNames(azCols, nCols);
       strictFreeNames(azAllowed, nCols);
       freeMergePkInfo(&pkInfo);
       sqlite3_free(zTable);
-      rc = SQLITE_OK;
-      continue;
+      break;
     }
 
-    while( sqlite3_step(pQ)==SQLITE_ROW ){
+    while( (queryStepRc = sqlite3_step(pQ))==SQLITE_ROW ){
       u8 *pKey = 0; int nKey = 0;
       u8 *pVal = 0; int nVal = 0;
       i64 intKey = 0;
@@ -305,7 +325,8 @@ int doltliteDetectMergeStrictViolations(
       if( pnFound ) (*pnFound)++;
     }
 
-    sqlite3_finalize(pQ);
+    if( rc==SQLITE_OK && queryStepRc!=SQLITE_DONE ) rc = queryStepRc;
+    rc = finishConstraintStmt(pQ, rc);
     strictFreeNames(azCols, nCols);
     strictFreeNames(azAllowed, nCols);
     freeMergePkInfo(&pkInfo);
@@ -315,9 +336,10 @@ int doltliteDetectMergeStrictViolations(
   if( rc==SQLITE_OK && stepRc!=SQLITE_DONE && stepRc!=SQLITE_ROW ){
     rc = stepRc;
   }
-  sqlite3_finalize(pTbls);
+  rc = finishConstraintStmt(pTbls, rc);
   doltliteFreeCatalog(aAnc, nAnc);
   doltliteFreeCatalog(aCur, nCur);
+  setConstraintError(db, pzErrMsg, rc);
   return rc;
 }
 

--- a/src/doltlite_merge_constraints_unique.c
+++ b/src/doltlite_merge_constraints_unique.c
@@ -90,13 +90,18 @@ static int uniqueIsIdent(char c){
 }
 
 /* Trailing WHERE of a CREATE INDEX statement, or NULL. */
-static char *uniqueIndexWhereFromSql(const char *zSql){
+static char *uniqueIndexWhereFromSql(const char *zSql, int *pRc){
   const char *p = zSql;
   int depth = 0;
   int seenOn = 0;
   int quote = 0;
+  char *zWhere;
 
-  if( !zSql ) return 0;
+  *pRc = SQLITE_OK;
+  if( !zSql ){
+    *pRc = SQLITE_CORRUPT;
+    return 0;
+  }
   while( *p ){
     if( quote ){
       if( *p==quote ){
@@ -125,30 +130,43 @@ static char *uniqueIndexWhereFromSql(const char *zSql){
      && sqlite3_strnicmp(p, "WHERE", 5)==0 && !uniqueIsIdent(p[5]) ){
       p += 5;
       while( *p==' ' || *p=='\t' || *p=='\n' || *p=='\r' ) p++;
-      if( !*p ) return 0;
-      return sqlite3_mprintf("%s", p);
+      if( !*p ){
+        *pRc = SQLITE_CORRUPT;
+        return 0;
+      }
+      zWhere = sqlite3_mprintf("%s", p);
+      if( !zWhere ) *pRc = SQLITE_NOMEM;
+      return zWhere;
     }
     p++;
   }
+  *pRc = SQLITE_CORRUPT;
   return 0;
 }
 
-static char *uniqueIndexWhereSql(sqlite3 *db, Index *pIdx){
+static int uniqueIndexWhereSql(sqlite3 *db, Index *pIdx, char **pzWhere){
   sqlite3_stmt *pStmt = 0;
-  char *zWhere = 0;
   int rc;
+  int stepRc;
 
-  if( !pIdx || !pIdx->pPartIdxWhere || !pIdx->zName ) return 0;
+  *pzWhere = 0;
+  if( !pIdx || !pIdx->pPartIdxWhere ) return SQLITE_OK;
+  if( !pIdx->zName ) return SQLITE_CORRUPT;
   rc = sqlite3_prepare_v2(db,
       "SELECT sql FROM main.sqlite_master WHERE type='index' AND name=?1",
       -1, &pStmt, 0);
-  if( rc!=SQLITE_OK ) return 0;
-  sqlite3_bind_text(pStmt, 1, pIdx->zName, -1, SQLITE_STATIC);
-  if( sqlite3_step(pStmt)==SQLITE_ROW ){
-    zWhere = uniqueIndexWhereFromSql((const char*)sqlite3_column_text(pStmt, 0));
+  if( rc!=SQLITE_OK ) return rc;
+  rc = sqlite3_bind_text(pStmt, 1, pIdx->zName, -1, SQLITE_STATIC);
+  if( rc==SQLITE_OK ){
+    stepRc = sqlite3_step(pStmt);
+    if( stepRc==SQLITE_ROW ){
+      *pzWhere = uniqueIndexWhereFromSql(
+          (const char*)sqlite3_column_text(pStmt, 0), &rc);
+    }else{
+      rc = stepRc==SQLITE_DONE ? SQLITE_CORRUPT : stepRc;
+    }
   }
-  sqlite3_finalize(pStmt);
-  return zWhere;
+  return finishConstraintStmt(pStmt, rc);
 }
 
 static int uniqueValueFromRecord(
@@ -162,19 +180,25 @@ static int uniquePartialMatchesRecord(
   Index *pIdx,
   const char *zWhere,
   const u8 *pRec, int nRec,
-  const DoltliteColInfo *pCols
+  const DoltliteColInfo *pCols,
+  int *pMatch
 ){
   Table *pTab;
   sqlite3_str *pSql;
   char *zSql;
   sqlite3_stmt *pStmt = 0;
   DoltliteRecordInfo info;
-  int i, rc, match = 0;
+  int i, rc;
 
-  if( !zWhere || !zWhere[0] ) return 1;
-  if( !pIdx || !pIdx->pTable || !pRec || nRec<=0 ) return 0;
+  *pMatch = 0;
+  if( !zWhere || !zWhere[0] ){
+    *pMatch = 1;
+    return SQLITE_OK;
+  }
+  if( !pIdx || !pIdx->pTable || !pRec || nRec<=0 ) return SQLITE_CORRUPT;
   pTab = pIdx->pTable;
-  doltliteParseRecord(pRec, nRec, &info);
+  rc = doltliteParseRecordStrict(pRec, nRec, &info);
+  if( rc!=SQLITE_OK ) return rc;
   pSql = sqlite3_str_new(0);
   sqlite3_str_appendall(pSql, "SELECT 1 FROM (SELECT ");
   for(i=0; i<pTab->nCol; i++){
@@ -183,10 +207,10 @@ static int uniquePartialMatchesRecord(
   }
   sqlite3_str_appendf(pSql, ") WHERE (%s)", zWhere);
   zSql = sqlite3_str_finish(pSql);
-  if( !zSql ) return 0;
+  if( !zSql ) return SQLITE_NOMEM;
   rc = sqlite3_prepare_v2(db, zSql, -1, &pStmt, 0);
   sqlite3_free(zSql);
-  if( rc!=SQLITE_OK ) return 0;
+  if( rc!=SQLITE_OK ) return rc;
   for(i=0; i<pTab->nCol && rc==SQLITE_OK; i++){
     int iField = (pCols && i<pCols->nCol) ? pCols->aColToRec[i] : i;
     DoltliteSerialValue v;
@@ -208,10 +232,16 @@ static int uniquePartialMatchesRecord(
       rc = sqlite3_bind_blob(pStmt, i+1, v.p, v.n, SQLITE_TRANSIENT);
     }
   }
-  if( rc==SQLITE_OK ) rc = sqlite3_step(pStmt);
-  match = (rc==SQLITE_ROW);
-  sqlite3_finalize(pStmt);
-  return match;
+  if( rc==SQLITE_OK ){
+    rc = sqlite3_step(pStmt);
+    if( rc==SQLITE_ROW ){
+      *pMatch = 1;
+      rc = SQLITE_OK;
+    }else if( rc==SQLITE_DONE ){
+      rc = SQLITE_OK;
+    }
+  }
+  return finishConstraintStmt(pStmt, rc);
 }
 
 static KeyInfo *uniqueIndexKeyInfo(sqlite3 *db, Index *pIdx, int *pRc){
@@ -416,7 +446,9 @@ static int detectUniqueViolationsForIndex(
   pKeyInfo = uniqueIndexKeyInfo(db, pIdx, &rc);
   if( !pKeyInfo ) goto unique_done;
   {
-    char *zWhere = uniqueIndexWhereSql(db, pIdx);
+    char *zWhere = 0;
+    rc = uniqueIndexWhereSql(db, pIdx, &zWhere);
+    if( rc!=SQLITE_OK ) goto unique_done;
     if( zWhere ){
       zQuery = sqlite3_mprintf(
           "SELECT rowid, %s FROM main.\"%w\" NOT INDEXED WHERE (%s)",
@@ -512,7 +544,7 @@ static int detectUniqueViolationsForIndex(
   }
 
 unique_done:
-  sqlite3_finalize(pScan);
+  rc = finishConstraintStmt(pScan, rc);
   sqlite3_free(zQuery);
   uniqueIndexEntriesFree(db, aEntry, nEntry);
   sqlite3KeyInfoUnref(pKeyInfo);
@@ -551,7 +583,8 @@ static int detectUniqueViolationsForIndexWithoutRowid(
   pKeyInfo = uniqueIndexKeyInfo(db, pIdx, &rc);
   if( !pKeyInfo ) goto without_rowid_done;
   if( prollyHashIsEmpty(&pCurrent->root) ) goto without_rowid_done;
-  zPartWhere = uniqueIndexWhereSql(db, pIdx);
+  rc = uniqueIndexWhereSql(db, pIdx, &zPartWhere);
+  if( rc!=SQLITE_OK ) goto without_rowid_done;
 
   prollyCursorInit(
       &cursor, cs, pCache, &pCurrent->root, pCurrent->flags);
@@ -568,6 +601,7 @@ static int detectUniqueViolationsForIndexWithoutRowid(
     DoltliteRecordInfo info;
     UniqueIndexEntry entry;
     int hasNull = 0;
+    int partialMatch = 1;
 
     memset(&entry, 0, sizeof(entry));
     prollyCursorKey(&cursor, &pKey, &nKey);
@@ -581,9 +615,11 @@ static int detectUniqueViolationsForIndexWithoutRowid(
       pRecord = pOwnedRecord;
     }
     rc = doltliteParseRecordStrict(pRecord, nRecord, &info);
-    if( rc==SQLITE_OK && zPartWhere
-     && !uniquePartialMatchesRecord(db, pIdx, zPartWhere,
-                                    pRecord, nRecord, &cols) ){
+    if( rc==SQLITE_OK && zPartWhere ){
+      rc = uniquePartialMatchesRecord(db, pIdx, zPartWhere,
+                                      pRecord, nRecord, &cols, &partialMatch);
+    }
+    if( rc==SQLITE_OK && !partialMatch ){
       sqlite3_free(pOwnedRecord);
       rc = prollyCursorNext(&cursor);
       continue;
@@ -704,7 +740,6 @@ int doltliteDetectMergeUniqueViolations(
   int nCur = 0;
   int rc;
 
-  (void)pzErrMsg;
   if( pnFound ) *pnFound = 0;
 
   rc = loadAncestorAndCurrentCatalogs(db, pAncCatHash, &aAnc, &nAnc,
@@ -728,6 +763,7 @@ int doltliteDetectMergeUniqueViolations(
     char *zIdxQ;
     int hasRowid = 1;
     MergePkInfo pkInfo;
+    int indexStepRc;
 
     if( !zTableRaw ) continue;
     zTable = sqlite3_mprintf("%s", zTableRaw);
@@ -741,7 +777,11 @@ int doltliteDetectMergeUniqueViolations(
       continue;
     }
     memset(&pkInfo, 0, sizeof(pkInfo));
-    hasRowid = tableHasRowid(db, zTable);
+    rc = tableHasRowid(db, zTable, &hasRowid);
+    if( rc!=SQLITE_OK ){
+      sqlite3_free(zTable);
+      break;
+    }
     if( !hasRowid ){
       rc = loadMergePkInfo(db, zTable, &pkInfo);
       if( rc != SQLITE_OK ){
@@ -751,7 +791,12 @@ int doltliteDetectMergeUniqueViolations(
     }
 
     zIdxQ = sqlite3_mprintf("PRAGMA main.index_list(%Q)", zTable);
-    if( !zIdxQ ){ sqlite3_free(zTable); rc = SQLITE_NOMEM; break; }
+    if( !zIdxQ ){
+      freeMergePkInfo(&pkInfo);
+      sqlite3_free(zTable);
+      rc = SQLITE_NOMEM;
+      break;
+    }
     rc = sqlite3_prepare_v2(db, zIdxQ, -1, &pIdxList, 0);
     sqlite3_free(zIdxQ);
     if( rc != SQLITE_OK ){
@@ -760,7 +805,7 @@ int doltliteDetectMergeUniqueViolations(
       break;
     }
 
-    while( sqlite3_step(pIdxList) == SQLITE_ROW ){
+    while( (indexStepRc = sqlite3_step(pIdxList)) == SQLITE_ROW ){
       int unique = sqlite3_column_int(pIdxList, 2);
       const char *zIdxRaw;
       const char *zOrigin;
@@ -779,7 +824,10 @@ int doltliteDetectMergeUniqueViolations(
       if( zOrigin && strcmp(zOrigin, "pk")==0 ) continue;
 
       zIdx = sqlite3_mprintf("%s", zIdxRaw);
-      if( !zIdx ) break;
+      if( !zIdx ){
+        rc = SQLITE_NOMEM;
+        break;
+      }
       pIdx = sqlite3FindIndex(db, zIdx, "main");
       if( !pIdx ){
         sqlite3_free(zIdx);
@@ -800,6 +848,7 @@ int doltliteDetectMergeUniqueViolations(
         }
       }
       zColList = sqlite3_str_finish(pColList);
+      if( !zColList ) rc = SQLITE_NOMEM;
       if( supported && zColList && *zColList ){
         if( hasRowid ){
           rc = detectUniqueViolationsForIndex(
@@ -815,15 +864,17 @@ int doltliteDetectMergeUniqueViolations(
       if( rc != SQLITE_OK ) break;
     }
 
-    sqlite3_finalize(pIdxList);
+    if( rc==SQLITE_OK && indexStepRc!=SQLITE_DONE ) rc = indexStepRc;
+    rc = finishConstraintStmt(pIdxList, rc);
     freeMergePkInfo(&pkInfo);
     sqlite3_free(zTable);
     if( rc != SQLITE_OK ) break;
   }
   if( rc == SQLITE_DONE ) rc = SQLITE_OK;
-  sqlite3_finalize(pTbls);
+  rc = finishConstraintStmt(pTbls, rc);
   doltliteFreeCatalog(aAnc, nAnc);
   doltliteFreeCatalog(aCur, nCur);
+  setConstraintError(db, pzErrMsg, rc);
   return rc;
 }
 

--- a/test/doltlite_merge.sh
+++ b/test/doltlite_merge.sh
@@ -628,5 +628,13 @@ echo "ALTER TABLE t ADD COLUMN n INT; SELECT dolt_commit('-A','-m','main col');"
 run_test_match "dual_add_no_default_merge_hash" "SELECT dolt_merge('feature');" "^[0-9a-f]{40}$" "$DB39"
 run_test "dual_add_no_default_nulls" "SELECT group_concat(id || ':' || coalesce(n,'-') || ':' || coalesce(m,'-'), ',') FROM (SELECT id,n,m FROM t ORDER BY id);" "1:-:-,2:-:7" "$DB39"
 
-rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8" "$DB8B" "$DB9" "$DB10" "$DB11" "$DB11D" "$DB11E" "$DB11F" "$DB12" "$DB13" "$DB14" "$DB15" "$DB16" "$DB17" "$DB18" "$DB19" "$DB20" "$DB20B" "$DB21" "$DB22" "$DB23" "$DB24" "$DB25"
+DB40=/tmp/test_merge40_$$.db; rm -f "$DB40"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); SELECT dolt_commit('-A','-m','base'); SELECT dolt_branch('feature');" | $DOLTLITE "$DB40" > /dev/null 2>&1
+echo "INSERT INTO t VALUES(1,'not-json'); SELECT dolt_commit('-A','-m','invalid json');" | $DOLTLITE "$DB40/feature" > /dev/null 2>&1
+echo "CREATE TABLE t2(id INTEGER PRIMARY KEY, v TEXT CHECK(json_extract(v,'$.ok'))); DROP TABLE t; ALTER TABLE t2 RENAME TO t; SELECT dolt_commit('-A','-m','add json check');" | $DOLTLITE "$DB40" > /dev/null 2>&1
+run_test_match "constraint_detector_sql_error_merge_errors" "SELECT dolt_merge('feature');" "malformed JSON" "$DB40"
+run_test "constraint_detector_sql_error_restores_rows" "SELECT count(*) FROM t;" "0" "$DB40"
+run_test "constraint_detector_sql_error_preserves_head" "SELECT message FROM dolt_log LIMIT 1;" "add json check" "$DB40"
+
+rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8" "$DB8B" "$DB9" "$DB10" "$DB11" "$DB11D" "$DB11E" "$DB11F" "$DB12" "$DB13" "$DB14" "$DB15" "$DB16" "$DB17" "$DB18" "$DB19" "$DB20" "$DB20B" "$DB21" "$DB22" "$DB23" "$DB24" "$DB25" "$DB40"
 dltest_finish


### PR DESCRIPTION
## Summary

- propagate prepare, terminal step, and finalize errors from CHECK, NOT NULL, STRICT, foreign-key, and unique constraint detectors
- make shared rowid, primary-key metadata, and partial-index predicate helpers return evaluation failures instead of treating them as absent metadata or non-matches
- roll back merges when a CHECK expression cannot be evaluated and preserve the underlying SQLite error
- add a regression proving malformed JSON in a merged CHECK row does not advance HEAD or retain the incoming row

## Validation

- `make -j4 doltlite`
- `make lint`
- `DOLTLITE=build/doltlite bash test/doltlite_merge.sh` (137/137)
- `DOLTLITE=build/doltlite bash test/doltlite_schema_merge.sh` (111/111)
- `bash test/vc_oracle_constraint_violations_test.sh build/doltlite dolt` (11/11)
- `bash test/run_doltlite_tests.sh` (101/103 suites; the two existing local artifact failures are `doltlite_parity.sh` because `./sqlite3` is unavailable and `doltlite_regression_test_c.sh` because the local test archive lacks current test-hook symbols)

Co-Authored-By: Codex <noreply@openai.com>