### PR TITLE
Refuse same-table dirty revert when only indexes changed

### DIFF
--- a/src/doltlite_cherry_pick.c
+++ b/src/doltlite_cherry_pick.c
@@ -319,7 +319,13 @@ apply_rollback:
     chunkStoreUnlock(cs);
   }
   {
-    return doltliteRestoreTxnStateOnFailure(db, &savedState, rc);
+    ProllyHash restoredCat = savedState.sessionCatalogHash;
+    int restoreRc = doltliteRestoreTxnStateOnFailure(db, &savedState, rc);
+    if( restoreRc==rc && !prollyHashIsEmpty(&restoredCat) ){
+      int persistRc = doltlitePersistWorkingSetWithHash(db, &restoredCat);
+      if( persistRc!=SQLITE_OK && persistRc!=SQLITE_NOMEM ) restoreRc = persistRc;
+    }
+    return restoreRc;
   }
 }
 

--- a/src/doltlite_core.c
+++ b/src/doltlite_core.c
@@ -136,9 +136,6 @@ int doltliteRestoreTxnState(sqlite3 *db, DoltliteTxnState *p){
     rc = doltliteSetSessionConstraintViolationsCatalog(
         db, &p->sessionConstraintViolationsCatalog);
   }
-  if( rc==SQLITE_OK ){
-    rc = doltlitePersistWorkingSetWithHash(db, &p->sessionCatalogHash);
-  }
   return rc;
 }
 

--- a/src/doltlite_core.c
+++ b/src/doltlite_core.c
@@ -136,6 +136,9 @@ int doltliteRestoreTxnState(sqlite3 *db, DoltliteTxnState *p){
     rc = doltliteSetSessionConstraintViolationsCatalog(
         db, &p->sessionConstraintViolationsCatalog);
   }
+  if( rc==SQLITE_OK ){
+    rc = doltlitePersistWorkingSetWithHash(db, &p->sessionCatalogHash);
+  }
   return rc;
 }
 

--- a/src/doltlite_revert.c
+++ b/src/doltlite_revert.c
@@ -28,6 +28,23 @@ static int doltliteTableEntryDiffers(
   return 0;
 }
 
+static int revertTouchesTable(
+  struct TableEntry *aCommit, int nCommit,
+  struct TableEntry *aParent, int nParent,
+  SchemaEntry *aCommitSchema, int nCommitSchema,
+  SchemaEntry *aParentSchema, int nParentSchema,
+  const char *zName
+){
+  struct TableEntry *pInCommit;
+  struct TableEntry *pInParent;
+  if( !zName ) return 0;
+  pInCommit = doltliteFindTableByName(aCommit, nCommit, zName);
+  pInParent = doltliteFindTableByName(aParent, nParent, zName);
+  if( doltliteTableEntryDiffers(pInCommit, pInParent) ) return 1;
+  return doltliteIndexSchemaRowsDifferForTable(
+      aCommitSchema, nCommitSchema, aParentSchema, nParentSchema, zName);
+}
+
 static int doltliteRevertCheckDirty(
   sqlite3 *db,
   const ProllyHash *pCommitCat,
@@ -39,8 +56,10 @@ static int doltliteRevertCheckDirty(
   u8 *wBuf = 0; int nWBuf = 0;
   struct TableEntry *aCommit = 0, *aParent = 0;
   struct TableEntry *aWorking = 0, *aCompare = 0;
+  SchemaEntry *aCommitSchema = 0, *aParentSchema = 0;
   int nCommit = 0, nParent = 0;
   int nWorking = 0, nCompare = 0;
+  int nCommitSchema = 0, nParentSchema = 0;
   int i, rc;
 
   *pConflict = 0;
@@ -75,27 +94,33 @@ static int doltliteRevertCheckDirty(
     rc = doltliteLoadCatalog(db, &headCatHash, &aCompare, &nCompare, 0);
     if( rc!=SQLITE_OK ) goto done;
   }
+  rc = loadSchemaFromCatalog(db, cs, doltliteGetCache(db), pCommitCat,
+                             &aCommitSchema, &nCommitSchema);
+  if( rc!=SQLITE_OK ) goto done;
+  rc = loadSchemaFromCatalog(db, cs, doltliteGetCache(db), pParentCat,
+                             &aParentSchema, &nParentSchema);
+  if( rc!=SQLITE_OK ) goto done;
 
   for(i=0; i<nWorking; i++){
     struct TableEntry *pCmp;
-    struct TableEntry *pInCommit;
-    struct TableEntry *pInParent;
+    if( !aWorking[i].zName ) continue;
     pCmp = doltliteFindTableByName(aCompare, nCompare, aWorking[i].zName);
     if( !doltliteTableEntryDiffers(pCmp, &aWorking[i]) ) continue;
-    pInCommit = doltliteFindTableByName(aCommit, nCommit, aWorking[i].zName);
-    pInParent = doltliteFindTableByName(aParent, nParent, aWorking[i].zName);
-    if( doltliteTableEntryDiffers(pInCommit, pInParent) ){
+    if( revertTouchesTable(aCommit, nCommit, aParent, nParent,
+                           aCommitSchema, nCommitSchema,
+                           aParentSchema, nParentSchema,
+                           aWorking[i].zName) ){
       *pConflict = 1;
       goto done;
     }
   }
   for(i=0; i<nCompare; i++){
-    struct TableEntry *pInCommit;
-    struct TableEntry *pInParent;
+    if( !aCompare[i].zName ) continue;
     if( doltliteFindTableByName(aWorking, nWorking, aCompare[i].zName) ) continue;
-    pInCommit = doltliteFindTableByName(aCommit, nCommit, aCompare[i].zName);
-    pInParent = doltliteFindTableByName(aParent, nParent, aCompare[i].zName);
-    if( doltliteTableEntryDiffers(pInCommit, pInParent) ){
+    if( revertTouchesTable(aCommit, nCommit, aParent, nParent,
+                           aCommitSchema, nCommitSchema,
+                           aParentSchema, nParentSchema,
+                           aCompare[i].zName) ){
       *pConflict = 1;
       goto done;
     }
@@ -106,6 +131,8 @@ done:
   doltliteFreeCatalog(aParent, nParent);
   doltliteFreeCatalog(aWorking, nWorking);
   doltliteFreeCatalog(aCompare, nCompare);
+  freeSchemaEntries(aCommitSchema, nCommitSchema);
+  freeSchemaEntries(aParentSchema, nParentSchema);
   return rc;
 }
 

--- a/test/doltlite_revert_dirty.sh
+++ b/test/doltlite_revert_dirty.sh
@@ -55,6 +55,70 @@ run_test "rv_dirty_same_row_kept" \
 db_rm "$DB"
 
 
+# Index-only revert of table t plus a dirty row on t: Dolt refuses. The
+# table-entry overlap check misses this because DROP INDEX is a separate
+# catalog object, so the split revert used to write the restored index
+# into the working set, fail the commit-side merge, restore only in
+# memory, and reopen with the index back.
+DB=/tmp/test_rv_dirty_same_index_$$.db; db_rm "$DB"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'one');
+CREATE INDEX t_v ON t(v);
+SELECT dolt_commit('-A','-m','base with index');
+DROP INDEX t_v;
+SELECT dolt_commit('-A','-m','drop index');
+INSERT INTO t VALUES(99,'unrelated dirty');" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+run_test_match "rv_dirty_same_index_refuses" \
+  "SELECT dolt_revert('HEAD');" \
+  "Your local changes would be overwritten by revert" "$DB"
+run_test "rv_dirty_same_index_no_new_commit" \
+  "SELECT count(*) FROM dolt_log WHERE message LIKE 'Revert%';" \
+  "0" "$DB"
+run_test "rv_dirty_same_index_row_kept" \
+  "SELECT v FROM t WHERE id=99;" "unrelated dirty" "$DB"
+run_test "rv_dirty_same_index_still_absent" \
+  "SELECT count(*) FROM sqlite_master WHERE type='index' AND name='t_v';" \
+  "0" "$DB"
+run_test "rv_dirty_same_index_reopen_absent" \
+  "SELECT count(*) FROM sqlite_master WHERE type='index' AND name='t_v';" \
+  "0" "$DB"
+run_test "rv_dirty_same_index_reopen_row" \
+  "SELECT v FROM t WHERE id=99;" "unrelated dirty" "$DB"
+run_test "rv_dirty_same_index_reopen_no_revert" \
+  "SELECT count(*) FROM dolt_log WHERE message LIKE 'Revert%';" \
+  "0" "$DB"
+
+db_rm "$DB"
+
+
+DB=/tmp/test_rv_dirty_unrelated_index_$$.db; db_rm "$DB"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'one');
+CREATE INDEX t_v ON t(v);
+SELECT dolt_commit('-A','-m','base with index');
+DROP INDEX t_v;
+SELECT dolt_commit('-A','-m','drop index');
+CREATE TABLE meta(id INTEGER PRIMARY KEY, note TEXT);
+INSERT INTO meta VALUES(1,'side');" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+run_test_match "rv_dirty_unrelated_index_hash" \
+  "SELECT dolt_revert('HEAD');" \
+  "^[0-9a-f]{40}$" "$DB"
+run_test "rv_dirty_unrelated_index_restored" \
+  "SELECT count(*) FROM sqlite_master WHERE type='index' AND name='t_v';" \
+  "1" "$DB"
+run_test "rv_dirty_unrelated_index_meta_kept" \
+  "SELECT note FROM meta WHERE id=1;" "side" "$DB"
+run_test "rv_dirty_unrelated_index_reopen_index" \
+  "SELECT count(*) FROM sqlite_master WHERE type='index' AND name='t_v';" \
+  "1" "$DB"
+run_test "rv_dirty_unrelated_index_reopen_meta" \
+  "SELECT note FROM meta WHERE id=1;" "side" "$DB"
+
+db_rm "$DB"
+
+
 DB=/tmp/test_rv_staged_unrelated_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, x TEXT);
 CREATE TABLE meta(id INTEGER PRIMARY KEY, note TEXT);


### PR DESCRIPTION
## Why

Ito found this on #2230; it is pre-existing and not caused by that PR. Dolt refuses the same script.

```sql
CREATE TABLE t(...);
CREATE INDEX t_v ON t(v);
-- commit, DROP INDEX, commit
INSERT INTO t VALUES(99,'unrelated dirty');
SELECT dolt_revert('HEAD');
```

Dolt: `Your local changes would be overwritten by revert.`

DoltLite used to enter the split revert path because `DROP INDEX` is a separate catalog object, so the table-entry overlap check did not see a revert of `t`. That path wrote the restored index into the working set, then failed the commit-side merge (`nReindexC > 0`) and restored only in memory. Reopen reloaded the half-applied catalog: index count went from 0 to 1 while the session still looked rolled back.

## Fix

- Overlap gate: a dirty table also conflicts with a revert that changes that table's indexes (`doltliteIndexSchemaRowsDifferForTable`), matching Dolt.
- `doltliteRestoreTxnState` now persists the restored working set, so a failed apply cannot survive reopen.
- Unrelated dirty work (another table) plus an index revert still succeeds and keeps the side table, as before.

## Tests

`test/doltlite_revert_dirty.sh`: same-table dirty + drop-index revert is refused and stays refused after reopen; other-table dirty + drop-index revert still applies and keeps `meta`.

Also ran: cherry-pick 98, merge 137, conflicts 47, savepoint 128, branch 66, merge_status 31, rebase 36.