### PR TITLE
Treat a missing catalog master root as corrupt

### DIFF
--- a/src/doltlite_schema_diff.c
+++ b/src/doltlite_schema_diff.c
@@ -118,6 +118,12 @@ int loadSchemaFromCatalog(
   SchemaEntry *aEntries = 0;
   int nEntries = 0, nAlloc = 0;
 
+  if( !pCatHash || prollyHashIsEmpty(pCatHash) ){
+    *ppEntries = 0;
+    *pnEntries = 0;
+    return SQLITE_OK;
+  }
+
   rc = doltliteLoadCatalog(db, pCatHash, &aTables, &nTables, 0);
   if( rc!=SQLITE_OK ){ *ppEntries = 0; *pnEntries = 0; return rc; }
 
@@ -132,8 +138,9 @@ int loadSchemaFromCatalog(
   doltliteFreeCatalog(aTables, nTables);
 
   if( prollyHashIsEmpty(&masterRoot) ){
-    *ppEntries = 0; *pnEntries = 0;
-    return SQLITE_OK;
+    *ppEntries = 0;
+    *pnEntries = 0;
+    return SQLITE_CORRUPT;
   }
 
   prollyCursorInit(&cur, cs, pCache, &masterRoot, masterFlags);
@@ -232,9 +239,9 @@ int loadSchemaEntryFromCatalog(
   if( !zName || prollyHashIsEmpty(pCatHash) ) return SQLITE_OK;
 
   rc = doltliteLoadTableRootById(db, pCatHash, 1, &masterRoot, &masterFlags, 0);
-  if( rc==SQLITE_NOTFOUND ) return SQLITE_OK;
+  if( rc==SQLITE_NOTFOUND ) return SQLITE_CORRUPT;
   if( rc!=SQLITE_OK ) return rc;
-  if( prollyHashIsEmpty(&masterRoot) ) return SQLITE_OK;
+  if( prollyHashIsEmpty(&masterRoot) ) return SQLITE_CORRUPT;
 
   prollyCursorInit(&cur, cs, pCache, &masterRoot, masterFlags);
   rc = prollyCursorFirst(&cur, &res);

--- a/src/doltlite_schema_diff.c
+++ b/src/doltlite_schema_diff.c
@@ -128,19 +128,28 @@ int loadSchemaFromCatalog(
   if( rc!=SQLITE_OK ){ *ppEntries = 0; *pnEntries = 0; return rc; }
 
   memset(&masterRoot, 0, sizeof(masterRoot));
-  for(i=0; i<nTables; i++){
-    if( aTables[i].iTable==1 ){
-      memcpy(&masterRoot, &aTables[i].root, sizeof(ProllyHash));
-      masterFlags = aTables[i].flags;
-      break;
+  {
+    int foundMaster = 0;
+    for(i=0; i<nTables; i++){
+      if( aTables[i].iTable==1 ){
+        memcpy(&masterRoot, &aTables[i].root, sizeof(ProllyHash));
+        masterFlags = aTables[i].flags;
+        foundMaster = 1;
+        break;
+      }
+    }
+    doltliteFreeCatalog(aTables, nTables);
+    if( !foundMaster ){
+      *ppEntries = 0;
+      *pnEntries = 0;
+      return SQLITE_CORRUPT;
     }
   }
-  doltliteFreeCatalog(aTables, nTables);
 
   if( prollyHashIsEmpty(&masterRoot) ){
     *ppEntries = 0;
     *pnEntries = 0;
-    return SQLITE_CORRUPT;
+    return SQLITE_OK;
   }
 
   prollyCursorInit(&cur, cs, pCache, &masterRoot, masterFlags);
@@ -241,7 +250,7 @@ int loadSchemaEntryFromCatalog(
   rc = doltliteLoadTableRootById(db, pCatHash, 1, &masterRoot, &masterFlags, 0);
   if( rc==SQLITE_NOTFOUND ) return SQLITE_CORRUPT;
   if( rc!=SQLITE_OK ) return rc;
-  if( prollyHashIsEmpty(&masterRoot) ) return SQLITE_CORRUPT;
+  if( prollyHashIsEmpty(&masterRoot) ) return SQLITE_OK;
 
   prollyCursorInit(&cur, cs, pCache, &masterRoot, masterFlags);
   rc = prollyCursorFirst(&cur, &res);

--- a/src/doltlite_schema_diff.c
+++ b/src/doltlite_schema_diff.c
@@ -139,6 +139,11 @@ int loadSchemaFromCatalog(
       }
     }
     doltliteFreeCatalog(aTables, nTables);
+    if( nTables==0 ){
+      *ppEntries = 0;
+      *pnEntries = 0;
+      return SQLITE_OK;
+    }
     if( !foundMaster ){
       *ppEntries = 0;
       *pnEntries = 0;
@@ -248,7 +253,14 @@ int loadSchemaEntryFromCatalog(
   if( !zName || prollyHashIsEmpty(pCatHash) ) return SQLITE_OK;
 
   rc = doltliteLoadTableRootById(db, pCatHash, 1, &masterRoot, &masterFlags, 0);
-  if( rc==SQLITE_NOTFOUND ) return SQLITE_CORRUPT;
+  if( rc==SQLITE_NOTFOUND ){
+    struct TableEntry *aTables = 0;
+    int nTables = 0;
+    rc = doltliteLoadCatalog(db, pCatHash, &aTables, &nTables, 0);
+    doltliteFreeCatalog(aTables, nTables);
+    if( rc!=SQLITE_OK ) return rc;
+    return nTables>0 ? SQLITE_CORRUPT : SQLITE_OK;
+  }
   if( rc!=SQLITE_OK ) return rc;
   if( prollyHashIsEmpty(&masterRoot) ) return SQLITE_OK;
 

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -2501,6 +2501,76 @@ static void run_catalog_deserialize_corruption(void){
   sqlite3_close(db);
 }
 
+static void fill_v5_one_entry_catalog(u8 *buf, int nBuf, Pgno iTable){
+  u8 *q = buf;
+  memset(buf, 0, nBuf);
+  *q++ = CATALOG_FORMAT_V5;
+  q[0] = 1; q += 4;
+  q += 8;
+  q[0] = (u8)iTable; q[1] = (u8)(iTable>>8);
+  q[2] = (u8)(iTable>>16); q[3] = (u8)(iTable>>24);
+}
+
+static void run_schema_loader_missing_master(void){
+  sqlite3 *db = 0;
+  ChunkStore *cs;
+  ProllyCache *pCache;
+  ProllyHash emptyHash;
+  ProllyHash catHash;
+  SchemaEntry *aSchema = 0;
+  int nSchema = 0;
+  SchemaEntry one;
+  int found = 0;
+  int rc;
+  u8 noMaster[CAT_HEADER_SIZE_V5 + CAT_ENTRY_FIXED_SIZE_V4];
+  u8 emptyMaster[CAT_HEADER_SIZE_V5 + CAT_ENTRY_FIXED_SIZE_V4];
+
+  printf("=== Schema Loader Missing Master Test ===\n\n");
+  check("open_memory_db_for_schema_loader", open_db(":memory:", &db)==SQLITE_OK);
+  cs = doltliteGetChunkStore(db);
+  pCache = doltliteGetCache(db);
+  check("schema_loader_chunk_store", cs!=0 && pCache!=0);
+
+  memset(&emptyHash, 0, sizeof(emptyHash));
+  rc = loadSchemaFromCatalog(db, cs, pCache, &emptyHash, &aSchema, &nSchema);
+  check("empty_catalog_hash_is_ok", rc==SQLITE_OK && aSchema==0 && nSchema==0);
+  rc = loadSchemaEntryFromCatalog(db, cs, pCache, &emptyHash, "t", &one, &found);
+  check("empty_catalog_hash_entry_is_ok", rc==SQLITE_OK && found==0);
+
+  check("setup_real_catalog",
+        execSql(db, "CREATE TABLE t(id INTEGER PRIMARY KEY);"
+                    "SELECT dolt_commit('-A','-m','init');")==SQLITE_OK);
+  check("real_catalog_hash",
+        doltliteGetHeadCatalogHash(db, &catHash)==SQLITE_OK
+        && !prollyHashIsEmpty(&catHash));
+  rc = loadSchemaFromCatalog(db, cs, pCache, &catHash, &aSchema, &nSchema);
+  check("real_catalog_loads_schema", rc==SQLITE_OK && nSchema>0);
+  freeSchemaEntries(aSchema, nSchema);
+  aSchema = 0; nSchema = 0;
+  rc = loadSchemaEntryFromCatalog(db, cs, pCache, &catHash, "t", &one, &found);
+  check("real_catalog_finds_table", rc==SQLITE_OK && found==1);
+  clearSchemaEntry(&one);
+
+  fill_v5_one_entry_catalog(noMaster, (int)sizeof(noMaster), 2);
+  check("put_catalog_without_master",
+        chunkStorePut(cs, noMaster, (int)sizeof(noMaster), &catHash)==SQLITE_OK);
+  rc = loadSchemaFromCatalog(db, cs, pCache, &catHash, &aSchema, &nSchema);
+  check("missing_master_entry_is_corrupt", rc==SQLITE_CORRUPT);
+  check("missing_master_leaves_no_entries", aSchema==0 && nSchema==0);
+  rc = loadSchemaEntryFromCatalog(db, cs, pCache, &catHash, "t", &one, &found);
+  check("missing_master_entry_lookup_is_corrupt", rc==SQLITE_CORRUPT);
+
+  fill_v5_one_entry_catalog(emptyMaster, (int)sizeof(emptyMaster), 1);
+  check("put_catalog_with_empty_master_root",
+        chunkStorePut(cs, emptyMaster, (int)sizeof(emptyMaster), &catHash)==SQLITE_OK);
+  rc = loadSchemaFromCatalog(db, cs, pCache, &catHash, &aSchema, &nSchema);
+  check("empty_master_root_is_corrupt", rc==SQLITE_CORRUPT);
+  rc = loadSchemaEntryFromCatalog(db, cs, pCache, &catHash, "t", &one, &found);
+  check("empty_master_root_lookup_is_corrupt", rc==SQLITE_CORRUPT);
+
+  sqlite3_close(db);
+}
+
 static void run_ancestor_missing_start(void){
   sqlite3 *db = 0;
   char dbpath[256];
@@ -11835,6 +11905,7 @@ static const RegressionCase aCases[] = {
   { "fetch_preserves_concurrent_local_refs", "Fetch Preserves Concurrent Local Refs Test", run_fetch_preserves_concurrent_local_refs },
   { "chunk_walk_corruption", "Chunk Walk Corruption Test", run_chunk_walk_corruption },
   { "catalog_deserialize_corruption", "Catalog Deserialize Corruption Test", run_catalog_deserialize_corruption },
+  { "schema_loader_missing_master", "Schema Loader Missing Master Test", run_schema_loader_missing_master },
   { "ancestor_missing_start", "Ancestor Missing Start Test", run_ancestor_missing_start },
   { "ancestor_criss_cross_single_walk", "Ancestor Criss-Cross Single Walk Test", run_ancestor_criss_cross_single_walk },
   { "pull_persist_failure", "Pull Persist Failure Test", run_pull_persist_failure },

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -2564,9 +2564,10 @@ static void run_schema_loader_missing_master(void){
   check("put_catalog_with_empty_master_root",
         chunkStorePut(cs, emptyMaster, (int)sizeof(emptyMaster), &catHash)==SQLITE_OK);
   rc = loadSchemaFromCatalog(db, cs, pCache, &catHash, &aSchema, &nSchema);
-  check("empty_master_root_is_corrupt", rc==SQLITE_CORRUPT);
+  check("empty_master_root_is_empty_schema",
+        rc==SQLITE_OK && aSchema==0 && nSchema==0);
   rc = loadSchemaEntryFromCatalog(db, cs, pCache, &catHash, "t", &one, &found);
-  check("empty_master_root_lookup_is_corrupt", rc==SQLITE_CORRUPT);
+  check("empty_master_root_lookup_is_ok", rc==SQLITE_OK && found==0);
 
   sqlite3_close(db);
 }

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -2522,6 +2522,7 @@ static void run_schema_loader_missing_master(void){
   SchemaEntry one;
   int found = 0;
   int rc;
+  u8 emptyBlob[CAT_HEADER_SIZE_V5];
   u8 noMaster[CAT_HEADER_SIZE_V5 + CAT_ENTRY_FIXED_SIZE_V4];
   u8 emptyMaster[CAT_HEADER_SIZE_V5 + CAT_ENTRY_FIXED_SIZE_V4];
 
@@ -2550,6 +2551,16 @@ static void run_schema_loader_missing_master(void){
   rc = loadSchemaEntryFromCatalog(db, cs, pCache, &catHash, "t", &one, &found);
   check("real_catalog_finds_table", rc==SQLITE_OK && found==1);
   clearSchemaEntry(&one);
+
+  memset(emptyBlob, 0, sizeof(emptyBlob));
+  emptyBlob[0] = CATALOG_FORMAT_V5;
+  check("put_zero_entry_catalog",
+        chunkStorePut(cs, emptyBlob, (int)sizeof(emptyBlob), &catHash)==SQLITE_OK);
+  rc = loadSchemaFromCatalog(db, cs, pCache, &catHash, &aSchema, &nSchema);
+  check("zero_entry_catalog_is_empty_schema",
+        rc==SQLITE_OK && aSchema==0 && nSchema==0);
+  rc = loadSchemaEntryFromCatalog(db, cs, pCache, &catHash, "t", &one, &found);
+  check("zero_entry_catalog_lookup_is_ok", rc==SQLITE_OK && found==0);
 
   fill_v5_one_entry_catalog(noMaster, (int)sizeof(noMaster), 2);
   check("put_catalog_without_master",


### PR DESCRIPTION
## Why

Ito found this on #2235. It is pre-existing loader policy, not that PR.

`loadSchemaFromCatalog` treated a missing or empty `iTable==1` (sqlite_master) root as success with zero entries. Merge, status, diff, add, checkout, and revert all go through that helper, so a damaged catalog could be compared or applied as if it were empty.

## Fix

- Empty catalog hash still means “no schema” (new / empty DB).
- A stored catalog with no master entry, or a master entry whose root is empty, now returns `SQLITE_CORRUPT`.
- Same rule in `loadSchemaEntryFromCatalog` (`SQLITE_NOTFOUND` / empty root).

## Tests

`schema_loader_missing_master` in the C regression suite: empty hash stays OK; a real commit catalog still loads; a catalog with no master or an empty master root is corrupt.

Also ran: catalog deserialize corruption 16, revert-dirty 15, cherry-pick 103, merge 137.