### PR TITLE
Keep findings for tables a scoped verify never scans

### DIFF
--- a/src/doltlite_verify_constraints.c
+++ b/src/doltlite_verify_constraints.c
@@ -254,22 +254,6 @@ static void doltVerifyConstraintsFunc(
     azArgTables[nArgTables++] = zArg;
   }
 
-  /* Only the tables about to be re-checked lose their recorded findings.
-  ** A scoped verify says nothing about the tables it does not scan, and the
-  ** commit gate reads this catalog. */
-  if( !bOutputOnly ){
-    if( nArgTables>0 ){
-      rc = doltliteClearConstraintViolationsForTables(
-          db, (const char *const *)azArgTables, nArgTables);
-    }else{
-      rc = doltliteClearAllConstraintViolations(db);
-    }
-    if( rc!=SQLITE_OK ){
-      sqlite3_result_error_code(context, rc);
-      goto cleanup;
-    }
-  }
-
   doltliteGetSessionHead(db, &headHash);
   if( !prollyHashIsEmpty(&headHash) ){
     rc = doltliteLoadCommit(db, &headHash, &headCommit);
@@ -343,6 +327,25 @@ static void doltVerifyConstraintsFunc(
     nScan = nChanged;
   }
 
+  /* Only the tables about to be re-checked lose their recorded findings, so
+  ** the clear has to wait until the scan set is known. A default verify scans
+  ** just the tables that differ from HEAD; clearing the whole catalog would
+  ** drop findings for tables it never looks at, and the commit gate reads this
+  ** catalog. An empty scan set here means --all with no named tables, which
+  ** does re-check everything. */
+  if( !bOutputOnly ){
+    if( nScan>0 ){
+      rc = doltliteClearConstraintViolationsForTables(
+          db, (const char *const *)azScan, nScan);
+    }else{
+      rc = doltliteClearAllConstraintViolations(db);
+    }
+    if( rc!=SQLITE_OK ){
+      sqlite3_result_error_code(context, rc);
+      goto cleanup;
+    }
+  }
+
   rc = doltliteDetectConstraintViolationsFiltered(
       db, pDetectAnc, azScan, nScan, !bOutputOnly, &nViolations);
   if( rc!=SQLITE_OK ){
@@ -351,7 +354,11 @@ static void doltVerifyConstraintsFunc(
   }
 
 detection_done:
-  if( bOutputOnly && nViolations==0 ){
+  /* The result reports the catalog, not just this scan. A scoped verify that
+  ** looked at nothing violating still answers 1 while another table's finding
+  ** is recorded, because that finding is what the commit gate will refuse on.
+  ** Dolt answers the same way. */
+  if( nViolations==0 ){
     int found = 0;
     rc = hasRecordedViolations(db, azArgTables, nArgTables, &found);
     if( rc!=SQLITE_OK ){

--- a/test/vc_oracle_verify_constraints_test.sh
+++ b/test/vc_oracle_verify_constraints_test.sh
@@ -253,6 +253,44 @@ DELETE FROM t WHERE pk=2;
 "$FOLLOW_AGG
 $FOLLOW_T_ROWS" 0
 
+# A default verify scans only the tables that differ from HEAD. It must not
+# clear findings for a table it never scans -- the commit gate reads this
+# catalog, so dropping them lets a commit through over a live violation.
+UNSCANNED_SETUP="
+CREATE TABLE parent(pk INTEGER PRIMARY KEY, v INT UNIQUE);
+CREATE TABLE users(pk INTEGER PRIMARY KEY, v INT REFERENCES parent(v));
+CREATE TABLE orders(pk INTEGER PRIMARY KEY, note TEXT);
+INSERT INTO parent VALUES (1,10);
+SELECT dolt_commit('-Am', 'init');
+PRAGMA foreign_keys=OFF;
+INSERT INTO users VALUES (1,98);
+PRAGMA foreign_keys=ON;
+SELECT dolt_commit('-Am', 'commit the violating row into HEAD');
+SELECT dolt_verify_constraints('--all');
+INSERT INTO orders VALUES (1,'unrelated');
+"
+
+echo "--- default verify keeps findings for tables it does not scan ---"
+run_oracle "default_keeps_unscanned_findings" "$UNSCANNED_SETUP" "" \
+  "$FOLLOW_AGG
+$FOLLOW_AGG_COUNT" 0
+
+echo "--- default verify on a clean working set keeps recorded findings ---"
+run_oracle "default_clean_worktree_keeps_findings" \
+"CREATE TABLE parent(pk INTEGER PRIMARY KEY, v INT UNIQUE);
+CREATE TABLE users(pk INTEGER PRIMARY KEY, v INT REFERENCES parent(v));
+INSERT INTO parent VALUES (1,10);
+SELECT dolt_commit('-Am', 'init');
+PRAGMA foreign_keys=OFF;
+INSERT INTO users VALUES (1,98);
+PRAGMA foreign_keys=ON;
+SELECT dolt_commit('-Am', 'commit the violating row into HEAD');
+SELECT dolt_verify_constraints('--all');
+" \
+  "" \
+  "$FOLLOW_AGG
+$FOLLOW_AGG_COUNT" 0
+
 echo "--- clean database ---"
 run_oracle "clean_no_violations" \
 "


### PR DESCRIPTION
Found while investigating an itoqa finding reported on #2227. It is not related to that PR — it is a pre-existing bug on `master`, so it gets its own PR.

## The bug

A default `dolt_verify_constraints()` scans only the tables that differ from HEAD, but it cleared the **whole** catalog first. Any table holding a recorded violation that isn't currently dirty lost its finding and was never re-scanned to put it back.

The comment sitting directly above that code already claimed the correct behavior:

> `/* Only the tables about to be re-checked lose their recorded findings.`
> `** A scoped verify says nothing about the tables it does not scan, and the`
> `** commit gate reads this catalog. */`

…and then the `else` branch cleared everything.

## Why it matters

That last clause is the problem — **the commit gate reads this catalog**, so the violation stops blocking:

```
--all verify records            catalog=users:1    (live FK violation, committed in HEAD)
touch an UNRELATED table (orders)
dolt_verify_constraints()    -> rc=0               "no violations"
catalog after                -> empty              finding wiped
violating row                   still present      orphan_users_rows=1
dolt_commit                  -> SUCCEEDS           gate bypassed
```

On `master` that commit lands (`commit=870f1ece…`). With this fix it is refused:

```
cannot commit: unresolved entries in dolt_constraint_violations.
```

It also reproduces with **no working-set changes at all** — the default verify then scans nothing and empties the catalog outright.

## The fix

Two halves of the same hole.

**The clear** now waits until the scan set is resolved and clears exactly that set — which is what the comment already promised. An empty scan set still means `--all` with no named tables, which genuinely does re-check everything. A default verify with nothing to scan now clears nothing.

**The result value** had the same hole: it reported only what *this scan* found, so a verify that skipped the violating table answered `0` while the catalog — and therefore the commit gate — still held a violation. It now reports the catalog. That is what `--output-only` already did, and it is what Dolt answers.

## Provenance

Pre-existing, not from this week's merges. `87cc3afdd8` (Jul 23) introduced the feature with the clear-all; `f6344482cf` (Aug 12) scoped the *named-table* case and added the comment but left the default path; `e7c0e64c18` (#2231) moved code around it without touching this.

## Verification

Two new oracle cases, both **fail on the unfixed engine and pass with the fix**:

| engine | `vc_oracle_verify_constraints` |
|---|---|
| unfixed | **15 passed, 2 failed** |
| fixed | **17 passed, 0 failed** |

They match real Dolt 2.2.2 on both the catalog contents and the return value — the return-value half was found *because* Dolt disagreed with my first fix.

Everything else green locally:

- `vc_oracle_verify_constraints` 17/17, `vc_oracle_constraint_violations` 11/11, `vc_oracle_constraints_triggers_replay` 17/17 — all against real Dolt
- `run_doltlite_tests.sh` — 103/103 suites, 158/158 guards
- `run_c_tests.sh` — 29/29

🤖 Generated with [Claude Code](https://claude.com/claude-code)