### PR TITLE
Validate the clone graph before installing refs

### DIFF
--- a/src/doltlite_remote.c
+++ b/src/doltlite_remote.c
@@ -1308,6 +1308,7 @@ int doltliteClone(ChunkStore *pLocal, DoltliteRemote *pRemote){
   ProllyHash oldCommittedRefsHash;
   SavedRefsState savedRefs;
   int refsDetached = 0;
+  int locked = 0;
   u8 oldRefsStale;
   int rc;
 
@@ -1326,12 +1327,7 @@ int doltliteClone(ChunkStore *pLocal, DoltliteRemote *pRemote){
     return rc;
   }
 
-  if( nRoots == 0 ){
-
-    sqlite3_free(aRoots);
-
-  }else{
-
+  if( nRoots>0 ){
     pLocalDst = doltliteLocalAsRemote(pLocal);
     if( !pLocalDst ){
       sqlite3_free(aRoots);
@@ -1347,14 +1343,32 @@ int doltliteClone(ChunkStore *pLocal, DoltliteRemote *pRemote){
     ** lands. A sweep in that window is refused because the store still holds
     ** the pre-sweep file identity -- the hook lets a test drive one. */
     if( rc==SQLITE_OK ) doltliteTestRunBeforeRefInstallHook();
-    sqlite3_free(aRoots);
-    aRoots = 0;
-
     if( rc!=SQLITE_OK ){
+      sqlite3_free(aRoots);
       sqlite3_free(refsData);
       return rc;
     }
   }
+
+  /* Same window as fetch: nothing roots the synced chunks until this refs
+  ** blob lands. Hold the store lock across validate + install + commit
+  ** (chunkStoreCommit is reentrant at lockDepth>0). Re-walk every collected
+  ** root under the lock gc itself must hold, and fail SQLITE_BUSY_SNAPSHOT
+  ** so a retry re-syncs what went missing. Installing branch refs over a
+  ** collected graph wedges later connections: the dolt_* registration
+  ** chain aborts on the first missing member. */
+  rc = chunkStoreLockAndRefresh(pLocal);
+  if( rc==SQLITE_OK ){
+    locked = 1;
+    rc = chunkStoreForceRefresh(pLocal);
+  }
+  if( rc==SQLITE_OK && nRoots>0 ){
+    rc = remoteValidateGraph(pLocal, aRoots, nRoots);
+    if( rc==SQLITE_NOTFOUND || rc==SQLITE_CORRUPT ) rc = SQLITE_BUSY_SNAPSHOT;
+  }
+  sqlite3_free(aRoots);
+  aRoots = 0;
+  if( rc!=SQLITE_OK ) goto clone_restore_refs;
 
   if( refsData && nRefsData > 0 ){
     csDetachSavedRefsState(pLocal, &savedRefs);
@@ -1393,10 +1407,12 @@ int doltliteClone(ChunkStore *pLocal, DoltliteRemote *pRemote){
   }
 
   if( refsDetached ) csFreeSavedRefsState(&savedRefs);
+  if( locked ) chunkStoreUnlock(pLocal);
   return rc;
 
 clone_restore_refs:
   sqlite3_free(refsData);
+  sqlite3_free(aRoots);
   if( refsDetached ){
     csFreeRefsState(pLocal);
     csRestoreSavedRefsState(pLocal, &savedRefs);
@@ -1406,6 +1422,7 @@ clone_restore_refs:
   memcpy(&pLocal->refs.committedRefsHash, &oldCommittedRefsHash,
          sizeof(ProllyHash));
   pLocal->bRefsStale = oldRefsStale;
+  if( locked ) chunkStoreUnlock(pLocal);
   return rc;
 }
 

--- a/src/doltlite_remote_sql.c
+++ b/src/doltlite_remote_sql.c
@@ -742,7 +742,11 @@ static void doltCloneFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   rc = doltliteClone(cs, pRemote);
   if( rc!=SQLITE_OK ){
     const char *zMsg = remoteSqlRemoteMsg(pRemote, rc);
-    char *zOwned = zMsg ? sqlite3_mprintf("%s", zMsg) : 0;
+    char *zOwned;
+    if( !zMsg && rc==SQLITE_BUSY_SNAPSHOT ){
+      zMsg = "clone failed (graph changed during install; retry)";
+    }
+    zOwned = zMsg ? sqlite3_mprintf("%s", zMsg) : 0;
     pRemote->xClose(pRemote);
     remoteSqlRestoreAndReport(ctx, db, cs, &savedState, rc,
                               zOwned ? zOwned : "clone failed");

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -2200,8 +2200,11 @@ static void run_clone_ref_install_survives_window_gc(void){
   rc = execSqlSilent(cloneDb, sql);
   if( gGcWindowCollected ){
     check("clone_window_reports_failure", rc!=SQLITE_OK);
+    check("clone_window_busy_snapshot",
+          sqlite3_extended_errcode(cloneDb)==SQLITE_BUSY_SNAPSHOT);
   }else{
     printf("  SKIP: clone_window_reports_failure (in-window gc unavailable)\n");
+    printf("  SKIP: clone_window_busy_snapshot (in-window gc unavailable)\n");
   }
   doltliteTestSetBeforeRefInstallHook(0, 0);
   gGcWindowPath = 0;


### PR DESCRIPTION
## Why

Clone committed synced chunks, then installed the remote refs blob in a second unlocked commit. Nothing rooted those chunks in between. A peer `dolt_gc` or WAL-checkpoint compaction can collect them; installing branch refs over that leaves dangling tips.

Later connections abort the `dolt_*` registration chain on the first missing graph member (`dolt_hashof`, remotes, CV functions disappear). This is [#2175](https://github.com/dolthub/doltlite/issues/2175). Fetch already closed the same window.

## Fix

After the chunk commit (and the existing pre-install test hook):

- Lock and refresh the store
- Walk every collected branch/tag commit root with `remoteValidateGraph`
- Map `SQLITE_NOTFOUND` / `SQLITE_CORRUPT` to `SQLITE_BUSY_SNAPSHOT` so a retry re-syncs
- Install refs, clear working-set hashes, commit (reentrant at `lockDepth>0`)
- Unlock on the success path and every `clone_restore_refs` exit

`dolt_clone` reports `clone failed (graph changed during install; retry)` for that snapshot error.

## Tests

`clone_ref_install_survives_window_gc`: when in-window GC actually collects, clone now fails `SQLITE_BUSY_SNAPSHOT`; reopen still has `dolt_hashof` / `dolt_gc`; retry heals.

Also ran: `fetch_ref_install_survives_window_gc`, `fetch_preserves_concurrent_local_refs`, `clone_persist_failure`, `clone_error_code_test`, `remote_test.sh` (110/110).