### PR TITLE
Keep a failed rebase restore across ROLLBACK

### DIFF
--- a/src/doltlite_rebase.c
+++ b/src/doltlite_rebase.c
@@ -563,7 +563,7 @@ rollback:
   }
   doltliteCommitClear(&origCommit);
   if( rebaseRestoreBranchState(db, zOrig)==SQLITE_OK ){
-    if( workingCreated && db->autoCommit && !prollyHashIsEmpty(&origCat) ){
+    if( workingCreated && !prollyHashIsEmpty(&origCat) ){
       doltliteAdoptRollbackBaseline(db, &origCat);
     }
   }
@@ -816,6 +816,20 @@ static int rebaseRestoreBranchState(sqlite3 *db, const char *zBranch){
   }
   doltliteCommitClear(&headCommit);
   return rc;
+}
+
+/* SwitchCatalog updates the live catalog but not the txn rollback snapshot.
+** A later ROLLBACK of an enclosing BEGIN would otherwise undo the restore
+** and leave the original branch showing the working-branch (upstream)
+** catalog. Pin the committed baseline to HEAD's catalog so ROLLBACK keeps
+** the restored state. */
+static void rebaseAdoptRestoredCatalog(sqlite3 *db){
+  ProllyHash cat;
+  memset(&cat, 0, sizeof(cat));
+  if( doltliteGetHeadCatalogHash(db, &cat)==SQLITE_OK
+   && !prollyHashIsEmpty(&cat) ){
+    doltliteAdoptRollbackBaseline(db, &cat);
+  }
 }
 
 static int rebaseWritePlanRows(
@@ -1369,6 +1383,7 @@ static int rebaseAbortConflictedContinue(
   if( zOrigBranch && zOrigBranch[0] ){
     rc2 = rebaseRestoreBranchState(db, zOrigBranch);
     rebaseKeepFirstError(&rc, rc2);
+    if( rc2==SQLITE_OK ) rebaseAdoptRestoredCatalog(db);
     rc2 = doltliteClearSessionRebaseState(db);
     rebaseKeepFirstError(&rc, rc2);
   }

--- a/test/doltlite_rebase.sh
+++ b/test/doltlite_rebase.sh
@@ -496,6 +496,94 @@ else
 fi
 rm -f "$DB11"
 
+# A failed linear rebase restores feat, but AdoptRollbackBaseline used to
+# run only in autocommit. ROLLBACK of the enclosing BEGIN then reinstalled
+# the working-branch (upstream) catalog on feat.
+DB12=/tmp/test_rebase_fail_txn_$$.db; rm -f "$DB12"
+cat <<'SQL' | "$DOLTLITE" "$DB12" >/dev/null 2>&1
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES(1, 1);
+SELECT dolt_commit('-Am','init');
+SELECT dolt_checkout('-b','feat');
+UPDATE t SET v=2 WHERE id=1;
+SELECT dolt_commit('-am','feat changes');
+SELECT dolt_checkout('main');
+UPDATE t SET v=3 WHERE id=1;
+SELECT dolt_commit('-am','main changes');
+SELECT dolt_checkout('feat');
+SQL
+TX_OUT=$(echo "SELECT dolt_checkout('feat');
+BEGIN;
+SELECT dolt_rebase('main');
+SELECT 'AFTER_FAIL|' || (SELECT active_branch()) || '|' || (SELECT v FROM t WHERE id=1);
+ROLLBACK;
+SELECT 'AFTER_RB|' || (SELECT active_branch()) || '|' || (SELECT v FROM t WHERE id=1) || '|' || (SELECT count(*) FROM dolt_status);" | "$DOLTLITE" "$DB12" 2>&1)
+if echo "$TX_OUT" | grep -q 'conflict rebasing'; then
+  PASS=$((PASS+1))
+else
+  FAIL=$((FAIL+1))
+  ERRORS="$ERRORS\nFAIL: linear_rebase_conflict_in_txn\n  expected conflict rebasing\n  got: $TX_OUT"
+fi
+AFTER_FAIL=$(echo "$TX_OUT" | grep '^AFTER_FAIL|')
+AFTER_RB=$(echo "$TX_OUT" | grep '^AFTER_RB|')
+if [ "$AFTER_FAIL" = "AFTER_FAIL|feat|2" ]; then
+  PASS=$((PASS+1))
+else
+  FAIL=$((FAIL+1))
+  ERRORS="$ERRORS\nFAIL: linear_rebase_conflict_in_txn_restores\n  expected: AFTER_FAIL|feat|2\n  got:      $AFTER_FAIL"
+fi
+if [ "$AFTER_RB" = "AFTER_RB|feat|2|0" ]; then
+  PASS=$((PASS+1))
+else
+  FAIL=$((FAIL+1))
+  ERRORS="$ERRORS\nFAIL: linear_rebase_conflict_in_txn_rollback\n  expected: AFTER_RB|feat|2|0\n  got:      $AFTER_RB"
+fi
+rm -f "$DB12"
+
+# Same split after a conflicted interactive --continue aborts the rebase.
+DB13=/tmp/test_rebase_iconflict_txn_$$.db; rm -f "$DB13"
+cat <<'SQL' | "$DOLTLITE" "$DB13" >/dev/null 2>&1
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES(1, 1);
+SELECT dolt_commit('-Am','init');
+SELECT dolt_checkout('-b','feat');
+UPDATE t SET v=2 WHERE id=1;
+SELECT dolt_commit('-am','feat changes');
+SELECT dolt_checkout('main');
+UPDATE t SET v=3 WHERE id=1;
+SELECT dolt_commit('-am','main changes');
+SELECT dolt_checkout('feat');
+SQL
+TX_OUT=$(echo "SELECT dolt_checkout('feat');
+BEGIN;
+SELECT dolt_rebase('-i','main');
+UPDATE dolt_rebase SET action='pick';
+SELECT dolt_rebase('--continue');
+SELECT 'AFTER_CONT|' || (SELECT active_branch()) || '|' || (SELECT v FROM t WHERE id=1);
+ROLLBACK;
+SELECT 'AFTER_RB|' || (SELECT active_branch()) || '|' || (SELECT v FROM t WHERE id=1) || '|' || (SELECT count(*) FROM dolt_status);" | "$DOLTLITE" "$DB13" 2>&1)
+if echo "$TX_OUT" | grep -q 'data conflicts from rebase'; then
+  PASS=$((PASS+1))
+else
+  FAIL=$((FAIL+1))
+  ERRORS="$ERRORS\nFAIL: interactive_rebase_conflict_in_txn\n  expected data conflicts from rebase\n  got: $TX_OUT"
+fi
+AFTER_CONT=$(echo "$TX_OUT" | grep '^AFTER_CONT|')
+AFTER_RB=$(echo "$TX_OUT" | grep '^AFTER_RB|')
+if [ "$AFTER_CONT" = "AFTER_CONT|feat|2" ]; then
+  PASS=$((PASS+1))
+else
+  FAIL=$((FAIL+1))
+  ERRORS="$ERRORS\nFAIL: interactive_rebase_conflict_in_txn_restores\n  expected: AFTER_CONT|feat|2\n  got:      $AFTER_CONT"
+fi
+if [ "$AFTER_RB" = "AFTER_RB|feat|2|0" ]; then
+  PASS=$((PASS+1))
+else
+  FAIL=$((FAIL+1))
+  ERRORS="$ERRORS\nFAIL: interactive_rebase_conflict_in_txn_rollback\n  expected: AFTER_RB|feat|2|0\n  got:      $AFTER_RB"
+fi
+rm -f "$DB13"
+
 rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB5_SHORT" "$DB6" "$DB7" "$DB8" "$DB9"
 echo ""
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"


### PR DESCRIPTION
## Why

Ito found this on #2226. It is pre-existing, not that PR.

A conflicted linear rebase restores feat, then pinned that catalog as the txn rollback baseline **only in autocommit**. Inside `BEGIN` the restore was just another uncommitted `SwitchCatalog`. `ROLLBACK` reinstalled the working-branch (upstream) catalog:

```
BEGIN;
SELECT dolt_rebase('main');   -- conflict, "branch restored to pre-rebase state"
-- still feat, v=2
ROLLBACK;
-- still feat, but v=3 (main) and dirty
```

Same split after a conflicted interactive `--continue` abort. Dolt keeps feat’s pre-rebase data after that abort.

## Fix

- Linear abort: call `doltliteAdoptRollbackBaseline` after restore even when `!autoCommit`.
- Interactive conflict abort: adopt HEAD’s catalog after `rebaseRestoreBranchState`.

`SwitchCatalog` still updates only the live catalog; this makes the committed rollback snapshot match the restored branch so `ROLLBACK` cannot undo the abort.

## Tests

`doltlite_rebase.sh`:

- `linear_rebase_conflict_in_txn_rollback` — after `BEGIN` / failed rebase / `ROLLBACK`, feat still has feat’s row and a clean status
- `interactive_rebase_conflict_in_txn_rollback` — same after conflicted `--continue`

Full rebase suite: 46/46.