### PR TITLE
Reject invalid remote build settings

### DIFF
--- a/doltlite.mk
+++ b/doltlite.mk
@@ -74,6 +74,9 @@ PROLLY_OBJS = \
 DOLTLITE_PROLLY ?= 1
 DOLTLITE_VEC1 ?= 1
 DOLTLITE_ENABLE_REMOTES ?= 1
+ifneq ($(filter 0 1,$(DOLTLITE_ENABLE_REMOTES)),$(DOLTLITE_ENABLE_REMOTES))
+  $(error DOLTLITE_ENABLE_REMOTES must be 0 or 1)
+endif
 DOLTLITE_VERSION ?= $(shell cat $(TOP)/.dolt_release_version 2>/dev/null || git describe --tags --always 2>/dev/null || echo "dev")
 ifeq ($(DOLTLITE_ENABLE_REMOTES),1)
   DOLTLITE_REMOTE_OBJS = $(DOLTLITE_AUTH_OBJS) doltlite_remote.o \

--- a/test/amalgamation_http_remote_test.sh
+++ b/test/amalgamation_http_remote_test.sh
@@ -27,6 +27,16 @@ cleanup() {
 }
 trap cleanup EXIT
 
+if make -n DOLTLITE_ENABLE_REMOTES=2 doltlite >"$tmp/invalid-option.log" 2>&1; then
+  echo "FAIL: invalid DOLTLITE_ENABLE_REMOTES value accepted"
+  exit 1
+fi
+if ! grep -Fq "DOLTLITE_ENABLE_REMOTES must be 0 or 1" "$tmp/invalid-option.log"; then
+  echo "FAIL: invalid DOLTLITE_ENABLE_REMOTES value did not produce a clear error"
+  cat "$tmp/invalid-option.log"
+  exit 1
+fi
+
 if grep -Eq 'Begin file doltlite_remotesrv\.c|doltliteServe' ./sqlite3.c; then
   echo "FAIL: remote server implementation present in amalgamation"
   exit 1


### PR DESCRIPTION
## Summary

- require `DOLTLITE_ENABLE_REMOTES` to be exactly `0` or `1`
- reject unsupported values during Makefile parsing instead of failing later with missing linker symbols
- cover the invalid-value diagnostic in the amalgamation remote test

## Validation

- `make -C build lint`
- `bash test/amalgamation_http_remote_test.sh build`
- `make -C build -n DOLTLITE_ENABLE_REMOTES=0 doltlite`
- `make -C build -n DOLTLITE_ENABLE_REMOTES=1 doltlite`
- invalid-value diagnostic check for `DOLTLITE_ENABLE_REMOTES=2`

Co-Authored-By: Codex <noreply@openai.com>