### PR TITLE
Keep unistd out of Windows amalgamations

### DIFF
--- a/src/chunk_store_commit.c
+++ b/src/chunk_store_commit.c
@@ -5,7 +5,13 @@
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
+#ifdef SQLITE_TEST
+#ifdef _WIN32
+#include <process.h>
+#else
 #include <unistd.h>
+#endif
+#endif
 
 /* Chunk-store commit/rollback path. */
 

--- a/test/amalgamation_windows_source_test.sh
+++ b/test/amalgamation_windows_source_test.sh
@@ -54,4 +54,10 @@ if [ "$seh_defs" -ne 2 ]; then
   exit 1
 fi
 
+chunk_commit_section="$(sed -n '/Begin file chunk_store_commit\.c/,/End of chunk_store_commit\.c/p' "$amalgamation")"
+if ! grep -Fq 'include <process.h>' <<<"$chunk_commit_section"; then
+  echo "FAIL: chunk_store_commit.c lacks the Windows _exit declaration in $amalgamation"
+  exit 1
+fi
+
 echo "Windows amalgamation source invariants: PASS"


### PR DESCRIPTION
## Summary
- use `<process.h>` for the test-only `_exit()` declaration on Windows
- retain `<unistd.h>` for the same crash-test path on POSIX
- pin the Windows declaration in the amalgamation source test

## Validation
- `bash test/amalgamation_windows_source_test.sh build/sqlite3.c`
- clean crash-test compilation reaches link without an implicit `_exit` declaration (local final link is blocked by unavailable Tcl symbols)

Co-Authored-By: Codex <noreply@openai.com>
