### PR TITLE
Validate remote build settings exactly

### DIFF
--- a/doltlite.mk
+++ b/doltlite.mk
@@ -74,16 +74,17 @@ PROLLY_OBJS = \
 DOLTLITE_PROLLY ?= 1
 DOLTLITE_VEC1 ?= 1
 DOLTLITE_ENABLE_REMOTES ?= 1
-ifneq ($(filter 0 1,$(DOLTLITE_ENABLE_REMOTES)),$(DOLTLITE_ENABLE_REMOTES))
-  $(error DOLTLITE_ENABLE_REMOTES must be 0 or 1)
-endif
 DOLTLITE_VERSION ?= $(shell cat $(TOP)/.dolt_release_version 2>/dev/null || git describe --tags --always 2>/dev/null || echo "dev")
 ifeq ($(DOLTLITE_ENABLE_REMOTES),1)
   DOLTLITE_REMOTE_OBJS = $(DOLTLITE_AUTH_OBJS) doltlite_remote.o \
                          doltlite_remote_sql.o doltlite_http_remote.o \
                          doltlite_remotesrv.o
 else
-  DOLTLITE_REMOTE_OBJS = doltlite_remote_sql.o
+  ifeq ($(DOLTLITE_ENABLE_REMOTES),0)
+    DOLTLITE_REMOTE_OBJS = doltlite_remote_sql.o
+  else
+    $(error DOLTLITE_ENABLE_REMOTES must be 0 or 1)
+  endif
 endif
 LIBOBJS0 := $(filter-out vec1.o,$(LIBOBJS0))
 ifeq ($(DOLTLITE_PROLLY),1)

--- a/test/amalgamation_http_remote_test.sh
+++ b/test/amalgamation_http_remote_test.sh
@@ -27,15 +27,17 @@ cleanup() {
 }
 trap cleanup EXIT
 
-if make -n DOLTLITE_ENABLE_REMOTES=2 doltlite >"$tmp/invalid-option.log" 2>&1; then
-  echo "FAIL: invalid DOLTLITE_ENABLE_REMOTES value accepted"
-  exit 1
-fi
-if ! grep -Fq "DOLTLITE_ENABLE_REMOTES must be 0 or 1" "$tmp/invalid-option.log"; then
-  echo "FAIL: invalid DOLTLITE_ENABLE_REMOTES value did not produce a clear error"
-  cat "$tmp/invalid-option.log"
-  exit 1
-fi
+for invalid_setting in 2 "" "1 0"; do
+  if make -n "DOLTLITE_ENABLE_REMOTES=$invalid_setting" doltlite >"$tmp/invalid-option.log" 2>&1; then
+    echo "FAIL: invalid DOLTLITE_ENABLE_REMOTES value accepted: '$invalid_setting'"
+    exit 1
+  fi
+  if ! grep -Fq "DOLTLITE_ENABLE_REMOTES must be 0 or 1" "$tmp/invalid-option.log"; then
+    echo "FAIL: invalid DOLTLITE_ENABLE_REMOTES value did not produce a clear error: '$invalid_setting'"
+    cat "$tmp/invalid-option.log"
+    exit 1
+  fi
+done
 
 if grep -Eq 'Begin file doltlite_remotesrv\.c|doltliteServe' ./sqlite3.c; then
   echo "FAIL: remote server implementation present in amalgamation"


### PR DESCRIPTION
## Summary

- accept only exact `0` and `1` values for `DOLTLITE_ENABLE_REMOTES`
- reject empty and multiword assignments during Makefile parsing
- extend the remote build-option regression coverage

## Validation

- valid dry runs with `DOLTLITE_ENABLE_REMOTES=0` and `=1`
- invalid dry runs with `=2`, an empty assignment, and `='1 0'`
- `bash test/amalgamation_http_remote_test.sh build`
- `make -C build lint`

Co-Authored-By: Codex <noreply@openai.com>