### PR TITLE
Make the Windows release CLI self-contained

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -171,6 +171,12 @@ jobs:
         {
           make -j$(nproc) DOLTLITE_PROLLY_CHECK=1 \
             doltlite.exe doltlite-remotesrv.exe doltlite-lib
+          rm -f doltlite.exe
+          make -j$(nproc) DOLTLITE_PROLLY_CHECK=1 \
+            'T.link=$(T.cc.sqlite) -static' doltlite.exe
+          if objdump -p doltlite.exe | grep -Eq 'DLL Name: (libwinpthread-1\.dll|zlib1\.dll)'; then
+            exit 1
+          fi
           make DOLTLITE_PROLLY=1 DOLTLITE_PROLLY_CHECK=1 sqlite3.c sqlite3.h
           cc $CFLAGS -I. -I../src \
             -o doltlite_regression_test_c \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -215,7 +215,16 @@ jobs:
       run: |
         mkdir -p build && cd build
         ../configure
-        make -j$(nproc) doltlite.exe doltlite-lib
+        make -j$(nproc) 'T.link=$(T.cc.sqlite) -static' doltlite.exe
+        make -j$(nproc) doltlite-lib
+
+    - name: Verify Windows CLI runtime dependencies
+      if: runner.os == 'Windows'
+      shell: msys2 {0}
+      run: |
+        if objdump -p build/doltlite.exe | grep -Eq 'DLL Name: (libwinpthread-1\.dll|zlib1\.dll)'; then
+          exit 1
+        fi
 
     - name: Package CLI tools (Unix)
       if: runner.os != 'Windows'


### PR DESCRIPTION
## Summary
- statically link the Windows release CLI runtime dependencies
- reject release and checked builds that still import the unshipped pthread or zlib DLLs
- keep the Windows shared and static library builds unchanged

## Validation
- `git diff --check`
- fail-before: v0.11.48 `doltlite.exe` imports `libwinpthread-1.dll` and `zlib1.dll`, but its zip contains only the executable
- `checked-windows` builds and inspects the fixed executable

Co-Authored-By: Codex <noreply@openai.com>
