### PR TITLE
Add a markdown-aware CI gate

### DIFF
--- a/.github/workflows/nightly-performance.yml
+++ b/.github/workflows/nightly-performance.yml
@@ -407,7 +407,6 @@ jobs:
             steps.report.outputs.valid == '1' }}
       env:
         GH_TOKEN: ${{ github.token }}
-        PERFORMANCE_REPORT_REVIEWER: ${{ vars.PERFORMANCE_REPORT_REVIEWER }}
       run: |
         python3 tool/publish-performance-report.py \
           --report "${{ steps.report.outputs.report }}" \
@@ -415,8 +414,7 @@ jobs:
           --run-id "$GITHUB_RUN_ID" \
           --run-attempt "$GITHUB_RUN_ATTEMPT" \
           --run-url "${{ steps.report.outputs.run_url }}" \
-          --generated-date "${{ steps.report.outputs.generated_date }}" \
-          --reviewer "$PERFORMANCE_REPORT_REVIEWER"
+          --generated-date "${{ steps.report.outputs.generated_date }}"
 
     - name: Fail when a ceiling regressed
       if: ${{ always() && steps.report.outputs.failed == '1' }}

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -2,8 +2,6 @@ name: CI
 
 on:
   pull_request:
-    paths-ignore:
-      - '**/*.md'
   workflow_dispatch:
 
 permissions:
@@ -12,31 +10,91 @@ permissions:
   pull-requests: write
 
 jobs:
+  classify:
+    name: Classify changes
+    runs-on: ubuntu-latest
+    outputs:
+      docs_only: ${{ steps.files.outputs.docs_only }}
+    steps:
+      - id: files
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pull = context.payload.pull_request;
+            if (!pull) {
+              core.setOutput('docs_only', 'false');
+              return;
+            }
+            const files = await github.paginate(
+              github.rest.pulls.listFiles,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pull.number,
+                per_page: 100,
+              }
+            );
+            core.setOutput(
+              'docs_only',
+              String(files.length > 0 && files.every(file => file.filename.endsWith('.md')))
+            );
+
   build:
     name: Build all binaries
+    needs: classify
+    if: needs.classify.outputs.docs_only != 'true'
     uses: ./.github/workflows/ci-build.yml
 
-  build-test:
+  build_test:
     name: Build-Test
-    needs: build
+    needs: [classify, build]
+    if: needs.classify.outputs.docs_only != 'true'
     uses: ./.github/workflows/build-test.yml
 
-  test-suite:
+  test_suite:
     name: Test Suite
-    needs: build
+    needs: [classify, build]
+    if: needs.classify.outputs.docs_only != 'true'
     uses: ./.github/workflows/test.yml
 
   sanitizers:
     name: Sanitizers
-    needs: build
+    needs: [classify, build]
+    if: needs.classify.outputs.docs_only != 'true'
     uses: ./.github/workflows/sanitizers.yml
 
   smoke:
     name: Smoke
-    needs: build
+    needs: [classify, build]
+    if: needs.classify.outputs.docs_only != 'true'
     uses: ./.github/workflows/smoke.yml
 
   benchmark:
     name: Benchmark
-    needs: build
+    needs: [classify, build]
+    if: needs.classify.outputs.docs_only != 'true'
     uses: ./.github/workflows/benchmark.yml
+
+  gate:
+    name: CI Gate
+    needs: [classify, build, build_test, test_suite, sanitizers, smoke, benchmark]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - env:
+          DOCS_ONLY: ${{ needs.classify.outputs.docs_only }}
+          CLASSIFY: ${{ needs.classify.result }}
+          BUILD: ${{ needs.build.result }}
+          BUILD_TEST: ${{ needs.build_test.result }}
+          TEST_SUITE: ${{ needs.test_suite.result }}
+          SANITIZERS: ${{ needs.sanitizers.result }}
+          SMOKE: ${{ needs.smoke.result }}
+          BENCHMARK: ${{ needs.benchmark.result }}
+        run: |
+          test "$CLASSIFY" = success
+          if [ "$DOCS_ONLY" = true ]; then
+            exit 0
+          fi
+          for result in "$BUILD" "$BUILD_TEST" "$TEST_SUITE" "$SANITIZERS" "$SMOKE" "$BENCHMARK"; do
+            test "$result" = success
+          done

--- a/tool/publish-performance-report.py
+++ b/tool/publish-performance-report.py
@@ -246,25 +246,6 @@ def publish_report(args):
             f"warning: unable to add label {LABEL}",
             file=sys.stderr,
         )
-    if args.reviewer:
-        review = command(
-            [
-                "gh",
-                "pr",
-                "edit",
-                url,
-                "--repo",
-                args.repository,
-                "--add-reviewer",
-                args.reviewer,
-            ],
-            check=False,
-        )
-        if review.returncode:
-            print(
-                f"warning: unable to request review from {args.reviewer}",
-                file=sys.stderr,
-            )
 
 
 def parse_args(argv):
@@ -275,7 +256,6 @@ def parse_args(argv):
     parser.add_argument("--run-attempt", default="1")
     parser.add_argument("--run-url", required=True)
     parser.add_argument("--generated-date", required=True)
-    parser.add_argument("--reviewer", default="")
     return parser.parse_args(argv)
 
 


### PR DESCRIPTION
## Summary
- classify all-Markdown pull requests before starting CI
- report one stable `CI Gate` that requires the full matrix for code or mixed changes
- stop requesting a human reviewer for generated performance reports

## Validation
- `python3 test/publish_performance_report_test.py`
- `git diff --check`
- full PR CI will validate the non-Markdown path and aggregate gate

After merge, the `master-ci` ruleset will be changed from the individual dynamic checks to `CI Gate`, then #2247 will be retriggered to validate the Markdown-only path.

Co-Authored-By: Codex <noreply@openai.com>
