### PR TITLE
Accept all WAL checkpoint modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -750,8 +750,8 @@ For a DoltLite-format main database, the compatibility contract is:
   are available only on DoltLite-format databases.
 - No SQLite rollback-journal, WAL, or shared-memory sidecar is created.
   `PRAGMA journal_mode` reports `wal` as a compatibility value and ignores
-  requests to change it. A passive WAL checkpoint is a no-op; other checkpoint
-  modes are rejected.
+  requests to change it. All `PRAGMA wal_checkpoint` modes bridge to DoltLite
+  garbage collection and report zero WAL frames.
 - `PRAGMA auto_vacuum` reports `0`; attempts to enable it and
   `PRAGMA incremental_vacuum` are no-ops. `VACUUM` runs DoltLite garbage
   collection instead of rebuilding SQLite pages.

--- a/src/vdbe.c
+++ b/src/vdbe.c
@@ -8508,21 +8508,6 @@ case OP_Checkpoint: {
        || pOp->p2==SQLITE_CHECKPOINT_TRUNCATE
        || pOp->p2==SQLITE_CHECKPOINT_NOOP
   );
-#ifdef DOLTLITE_PROLLY
-  if( pOp->p2!=SQLITE_CHECKPOINT_PASSIVE ){
-    int iDb;
-    for(iDb=0; iDb<db->nDb; iDb++){
-      if( (pOp->p1==iDb || pOp->p1==SQLITE_MAX_DB)
-       && sqlite3BtreeIsDoltliteFormat(db->aDb[iDb].pBt) ){
-        rc = SQLITE_ERROR;
-        sqlite3VdbeError(p,
-          "wal_checkpoint mode is not configurable on doltlite-format "
-          "databases; use the default (PASSIVE) form");
-        goto abort_due_to_error;
-      }
-    }
-  }
-#endif
   rc = sqlite3Checkpoint(db, pOp->p1, pOp->p2, &aRes[1], &aRes[2]);
   if( rc ){
     if( rc!=SQLITE_BUSY ) goto abort_due_to_error;

--- a/test/doltlite_pragma_wal_checkpoint.sh
+++ b/test/doltlite_pragma_wal_checkpoint.sh
@@ -4,16 +4,6 @@ DOLTLITE="${1:-./doltlite}"
 SQLITE3=$(command -v sqlite3 2>/dev/null || echo /usr/bin/sqlite3)
 PASS=0; FAIL=0; ERRORS=""
 
-run_test_match() {
-  local n="$1" got="$2" pat="$3"
-  if echo "$got" | grep -qE "$pat"; then
-    PASS=$((PASS+1))
-  else
-    FAIL=$((FAIL+1))
-    ERRORS="$ERRORS\nFAIL: $n\n  pattern: $pat\n  got:     $got"
-  fi
-}
-
 run_test_eq() {
   local n="$1" got="$2" want="$3"
   if [ "$got" = "$want" ]; then
@@ -39,9 +29,8 @@ run_test_eq "wc_dl_passive_explicit" \
   "$($DOLTLITE "$DB" "PRAGMA wal_checkpoint(PASSIVE);" 2>&1)" "0|0|0"
 
 for mode in FULL RESTART TRUNCATE; do
-  out=$($DOLTLITE "$DB" "PRAGMA wal_checkpoint($mode);" 2>&1)
-  run_test_match "wc_dl_${mode}_rejected" "$out" \
-    "wal_checkpoint mode is not configurable on doltlite-format"
+  run_test_eq "wc_dl_${mode}_accepted" \
+    "$($DOLTLITE "$DB" "PRAGMA wal_checkpoint($mode);" 2>&1)" "0|0|0"
 done
 
 db_rm "$DB"
@@ -62,7 +51,7 @@ DELETE FROM big WHERE a%2=0;" > /dev/null 2>&1
 done
 
 main_before=$(wc -c < "$MAIN"); aux_before=$(wc -c < "$AUX")
-$DOLTLITE "$MAIN" "ATTACH '$AUX' AS aux; PRAGMA aux.wal_checkpoint;" > /dev/null 2>&1
+$DOLTLITE "$MAIN" "ATTACH '$AUX' AS aux; PRAGMA aux.wal_checkpoint(RESTART);" > /dev/null 2>&1
 main_after=$(wc -c < "$MAIN"); aux_after=$(wc -c < "$AUX")
 
 run_test_eq "wc_aux_leaves_main_untouched" "$main_after" "$main_before"
@@ -84,7 +73,7 @@ WITH RECURSIVE c(i) AS (SELECT 1 UNION ALL SELECT i+1 FROM c WHERE i<4000)
   INSERT INTO big SELECT i, 'padding-data-'||i FROM c;
 DELETE FROM big WHERE a%2=0;" > /dev/null 2>&1
 before=$(wc -c < "$DB")
-$DOLTLITE "$DB" "PRAGMA main.wal_checkpoint;" > /dev/null 2>&1
+$DOLTLITE "$DB" "PRAGMA main.wal_checkpoint(TRUNCATE);" > /dev/null 2>&1
 after=$(wc -c < "$DB")
 if [ "$after" -lt "$before" ]; then
   PASS=$((PASS+1))

--- a/test/doltlite_recover_jrnlwal_2.test
+++ b/test/doltlite_recover_jrnlwal_2.test
@@ -21,13 +21,13 @@ do_test doltlite_recover_jrnlwal_2-1.5 {
 } {0 0 0}
 do_catchsql_test doltlite_recover_jrnlwal_2-1.6 {
   PRAGMA wal_checkpoint=full
-} {1 {wal_checkpoint mode is not configurable on doltlite-format databases; use the default (PASSIVE) form}}
+} {0 {0 0 0}}
 do_catchsql_test doltlite_recover_jrnlwal_2-1.7 {
   PRAGMA wal_checkpoint=restart
-} {1 {wal_checkpoint mode is not configurable on doltlite-format databases; use the default (PASSIVE) form}}
+} {0 {0 0 0}}
 do_catchsql_test doltlite_recover_jrnlwal_2-1.8 {
   PRAGMA wal_checkpoint=truncate
-} {1 {wal_checkpoint mode is not configurable on doltlite-format databases; use the default (PASSIVE) form}}
+} {0 {0 0 0}}
 do_test doltlite_recover_jrnlwal_2-1.9 {
   execsql {PRAGMA wal_checkpoint=typo}
 } {0 0 0}

--- a/test/doltlite_recover_jrnlwal_3.test
+++ b/test/doltlite_recover_jrnlwal_3.test
@@ -64,7 +64,7 @@ do_execsql_test doltlite_recover_jrnlwal_3-1.19 {
 } {-1}
 do_catchsql_test doltlite_recover_jrnlwal_3-1.20 {
   PRAGMA wal_checkpoint(TRUNCATE);
-} {1 {wal_checkpoint mode is not configurable on doltlite-format databases; use the default (PASSIVE) form}}
+} {0 {0 0 0}}
 
 do_test doltlite_recover_jrnlwal_3-2.1 {
   execsql {

--- a/test/doltlite_recover_jrnlwal_4.test
+++ b/test/doltlite_recover_jrnlwal_4.test
@@ -2,8 +2,6 @@ set testdir [file dirname $argv0]
 source $testdir/tester.tcl
 
 
-set CKPT_ERR {wal_checkpoint mode is not configurable on doltlite-format databases; use the default (PASSIVE) form}
-
 do_execsql_test doltlite_recover_jrnlwal_4-1.1 {
   PRAGMA journal_mode;
   PRAGMA main.journal_mode;
@@ -151,7 +149,7 @@ do_execsql_test doltlite_recover_jrnlwal_4-5.2 {
 foreach {n ckmode} {3 noop 4 full 5 truncate} {
   do_test doltlite_recover_jrnlwal_4-5.$n {
     catchsql "PRAGMA wal_checkpoint = $ckmode"
-  } [list 1 $CKPT_ERR]
+  } [list 0 {0 0 0}]
 }
 do_test doltlite_recover_jrnlwal_4-5.6 {
   sqlite3_wal_checkpoint_v2 db noop

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -1692,7 +1692,6 @@ walrestart walrestart-1.0 class=unsupported issue=1836  # wal_checkpoint frame c
 walrestart walrestart-1.1 class=unsupported issue=1836  # wal_checkpoint frame counters zero (no-op checkpoint)
 walrestart walrestart-1.2 class=unsupported issue=1836  # wal_checkpoint frame counters zero (no-op checkpoint)
 walrestart walrestart-1.4 class=unsupported issue=1836  # wal_checkpoint frame counters zero (no-op checkpoint)
-walseh1 walseh1-6-seh.1 class=unsupported issue=1836  # wal_checkpoint mode explicitly rejected under fault injection
 walsetlk_recover walsetlk_recover-1.2 class=unsupported issue=1836  # WAL recovery blocking lock not raised; snapshot read proceeds
 walsetlk_recover walsetlk_recover-1.3 class=unsupported issue=1836  # WAL recovery blocking lock not raised; no wait
 walsetlk_recover walsetlk_recover-1.5.2 class=unsupported issue=1836  # no WAL lock wait, so xSleep is not called
@@ -1713,14 +1712,14 @@ backup4 backup4-2.4 class=unsupported issue=1839  # chunk-store file sizes; in-m
 backup4 backup4-3.2 class=unsupported issue=1839  # chunk-store file sizes; in-memory doltlite backup rejected
 backup4 backup4-3.3 class=unsupported issue=1839  # chunk-store file sizes; in-memory doltlite backup rejected
 backup4 backup4-3.4 class=unsupported issue=1839  # chunk-store file sizes; in-memory doltlite backup rejected
-busy2 busy2-2.1.2 class=intentional issue=1846  # wal_checkpoint counters zero; checkpoint mode rejected
-busy2 busy2-2.1.3 class=intentional issue=1846  # wal_checkpoint counters zero; checkpoint mode rejected
-busy2 busy2-2.1.4 class=intentional issue=1846  # wal_checkpoint counters zero; checkpoint mode rejected
-busy2 busy2-2.1.5 class=intentional issue=1846  # wal_checkpoint counters zero; checkpoint mode rejected
-busy2 busy2-2.2.2 class=intentional issue=1846  # wal_checkpoint counters zero; checkpoint mode rejected
-busy2 busy2-2.2.3 class=intentional issue=1846  # wal_checkpoint counters zero; checkpoint mode rejected
-busy2 busy2-2.2.4 class=intentional issue=1846  # wal_checkpoint counters zero; checkpoint mode rejected
-busy2 busy2-2.2.5 class=intentional issue=1846  # wal_checkpoint counters zero; checkpoint mode rejected
+busy2 busy2-2.1.2 class=intentional issue=1846  # wal_checkpoint counters zero; no external WAL frames
+busy2 busy2-2.1.3 class=intentional issue=1846  # wal_checkpoint counters zero; no external WAL frames
+busy2 busy2-2.1.4 class=intentional issue=1846  # wal_checkpoint counters zero; no external WAL frames
+busy2 busy2-2.1.5 class=intentional issue=1846  # wal_checkpoint counters zero; no external WAL frames
+busy2 busy2-2.2.2 class=intentional issue=1846  # wal_checkpoint counters zero; no external WAL frames
+busy2 busy2-2.2.3 class=intentional issue=1846  # wal_checkpoint counters zero; no external WAL frames
+busy2 busy2-2.2.4 class=intentional issue=1846  # wal_checkpoint counters zero; no external WAL frames
+busy2 busy2-2.2.5 class=intentional issue=1846  # wal_checkpoint counters zero; no external WAL frames
 busy2 busy2-3.1.2 class=intentional  # snapshot read instead of SQLITE_BUSY; busy handler correctly never invoked
 busy2 busy2-3.1.3 class=intentional  # snapshot read instead of SQLITE_BUSY; busy handler correctly never invoked
 busy2 busy2-3.2.2 class=intentional  # snapshot read instead of SQLITE_BUSY; busy handler correctly never invoked
@@ -2162,16 +2161,15 @@ wal7 wal7-1.2 class=unsupported issue=1836  # -wal sidecar absent
 wal7 wal7-2.0 class=unsupported issue=1836  # -wal sidecar absent
 wal7 wal7-3.0 class=unsupported issue=1836  # -wal sidecar absent
 wal7 wal7-4.0 class=unsupported issue=1836  # -wal sidecar absent
-walckptnoop walckptnoop-1.1 class=unsupported issue=1836  # wal_checkpoint counters zero; checkpoint mode rejected
-walckptnoop walckptnoop-1.2 class=unsupported issue=1836  # wal_checkpoint counters zero; checkpoint mode rejected
-walckptnoop walckptnoop-1.3 class=unsupported issue=1836  # wal_checkpoint counters zero; checkpoint mode rejected
-walckptnoop walckptnoop-1.4 class=unsupported issue=1836  # wal_checkpoint counters zero; checkpoint mode rejected
-walckptnoop walckptnoop-1.5 class=unsupported issue=1836  # wal_checkpoint counters zero; checkpoint mode rejected
-walckptnoop walckptnoop-1.6 class=unsupported issue=1836  # wal_checkpoint counters zero; checkpoint mode rejected
-walckptnoop walckptnoop-1.7 class=unsupported issue=1836  # wal_checkpoint counters zero; checkpoint mode rejected
-walckptnoop walckptnoop-1.8 class=unsupported issue=1836  # wal_checkpoint counters zero; checkpoint mode rejected
-walckptnoop walckptnoop-1.9 class=unsupported issue=1836  # wal_checkpoint counters zero; checkpoint mode rejected
-walckptnoop walckptnoop-1.10 class=unsupported issue=1836  # wal_checkpoint counters zero; checkpoint mode rejected
+walckptnoop walckptnoop-1.1 class=unsupported issue=1836  # wal_checkpoint counters zero; no external WAL frames
+walckptnoop walckptnoop-1.2 class=unsupported issue=1836  # wal_checkpoint counters zero; no external WAL frames
+walckptnoop walckptnoop-1.3 class=unsupported issue=1836  # wal_checkpoint counters zero; no external WAL frames
+walckptnoop walckptnoop-1.4 class=unsupported issue=1836  # wal_checkpoint counters zero; no external WAL frames
+walckptnoop walckptnoop-1.5 class=unsupported issue=1836  # wal_checkpoint counters zero; no external WAL frames
+walckptnoop walckptnoop-1.7 class=unsupported issue=1836  # wal_checkpoint counters zero; no external WAL frames
+walckptnoop walckptnoop-1.8 class=unsupported issue=1836  # wal_checkpoint counters zero; no external WAL frames
+walckptnoop walckptnoop-1.9 class=unsupported issue=1836  # wal_checkpoint counters zero; no external WAL frames
+walckptnoop walckptnoop-1.10 class=unsupported issue=1836  # wal_checkpoint counters zero; no external WAL frames
 walhook walhook-1.1 class=unsupported issue=1836  # wal hook never fires (no WAL frames); got []
 walhook walhook-1.2 class=unsupported issue=1836  # wal hook never fires (no WAL frames); got []
 walhook walhook-1.3 class=unsupported issue=1836  # wal-hook page counts; file sizes differ
@@ -2569,11 +2567,9 @@ wal5 wal5-pragma-3.2.2 class=unsupported issue=1836  # WAL checkpoint/frame coun
 wal5 wal5-pragma-3.2.3 class=unsupported issue=1836  # WAL checkpoint/frame counters zero; sidecar absent
 wal5 wal5-pragma-3.2.4 class=unsupported issue=1836  # WAL checkpoint/frame counters zero; sidecar absent
 wal5 wal5-pragma-4.1.1 class=unsupported issue=1836  # WAL checkpoint/frame counters zero; sidecar absent
-wal5 wal5-pragma-4.1.2 class=unsupported issue=1836  # WAL checkpoint/frame counters zero; sidecar absent
 wal5 wal5-pragma-4.1.3 class=unsupported issue=1836  # WAL checkpoint/frame counters zero; sidecar absent
 wal5 wal5-pragma-4.1.5 class=unsupported issue=1836  # WAL checkpoint/frame counters zero; sidecar absent
 wal5 wal5-pragma-4.2.1 class=unsupported issue=1836  # WAL checkpoint/frame counters zero; sidecar absent
-wal5 wal5-pragma-4.2.2 class=unsupported issue=1836  # WAL checkpoint/frame counters zero; sidecar absent
 wal5 wal5-pragma-4.2.3 class=unsupported issue=1836  # WAL checkpoint/frame counters zero; sidecar absent
 wal5 wal5-pragma-4.2.5 class=unsupported issue=1836  # WAL checkpoint/frame counters zero; sidecar absent
 wal5 wal5-pragma-5.1.1 class=unsupported issue=1836  # WAL checkpoint/frame counters zero; sidecar absent
@@ -2583,7 +2579,6 @@ wal5 wal5-pragma-5.1.6 class=unsupported issue=1836  # WAL checkpoint/frame coun
 wal5 wal5-pragma-5.1.8 class=unsupported issue=1836  # WAL checkpoint/frame counters zero; sidecar absent
 wal5 wal5-pragma-5.1.9 class=unsupported issue=1836  # WAL checkpoint/frame counters zero; sidecar absent
 wal5 wal5-pragma-5.1.10 class=unsupported issue=1836  # WAL checkpoint/frame counters zero; sidecar absent
-wal5 wal5-pragma-5.1.11 class=unsupported issue=1836  # WAL checkpoint/frame counters zero; sidecar absent
 wal5 wal5-pragma-5.1.12 class=unsupported issue=1836  # WAL checkpoint/frame counters zero; sidecar absent
 wal5 wal5-pragma-5.1.14 class=unsupported issue=1836  # WAL checkpoint/frame counters zero; sidecar absent
 wal5 wal5-pragma-5.1.15 class=unsupported issue=1836  # WAL checkpoint/frame counters zero; sidecar absent
@@ -2591,7 +2586,6 @@ wal5 wal5-pragma-5.1.16 class=unsupported issue=1836  # WAL checkpoint/frame cou
 wal5 wal5-pragma-5.1.17 class=unsupported issue=1836  # WAL checkpoint/frame counters zero; sidecar absent
 wal5 wal5-pragma-5.1.18 class=unsupported issue=1836  # WAL checkpoint/frame counters zero; sidecar absent
 wal5 wal5-pragma-5.1.19 class=unsupported issue=1836  # WAL checkpoint/frame counters zero; sidecar absent
-wal5 wal5-pragma-5.1.20 class=unsupported issue=1836  # WAL checkpoint/frame counters zero; sidecar absent
 wal5 wal5-pragma-5.1.21 class=unsupported issue=1836  # WAL checkpoint/frame counters zero; sidecar absent
 wal5 wal5-pragma-5.2.1 class=unsupported issue=1836  # WAL checkpoint/frame counters zero; sidecar absent
 wal5 wal5-pragma-5.2.3 class=unsupported issue=1836  # WAL checkpoint/frame counters zero; sidecar absent
@@ -2600,7 +2594,6 @@ wal5 wal5-pragma-5.2.6 class=unsupported issue=1836  # WAL checkpoint/frame coun
 wal5 wal5-pragma-5.2.8 class=unsupported issue=1836  # WAL checkpoint/frame counters zero; sidecar absent
 wal5 wal5-pragma-5.2.9 class=unsupported issue=1836  # WAL checkpoint/frame counters zero; sidecar absent
 wal5 wal5-pragma-5.2.10 class=unsupported issue=1836  # WAL checkpoint/frame counters zero; sidecar absent
-wal5 wal5-pragma-5.2.11 class=unsupported issue=1836  # WAL checkpoint/frame counters zero; sidecar absent
 wal5 wal5-pragma-5.2.12 class=unsupported issue=1836  # WAL checkpoint/frame counters zero; sidecar absent
 wal5 wal5-pragma-5.2.14 class=unsupported issue=1836  # WAL checkpoint/frame counters zero; sidecar absent
 wal5 wal5-pragma-5.2.15 class=unsupported issue=1836  # WAL checkpoint/frame counters zero; sidecar absent
@@ -2608,7 +2601,6 @@ wal5 wal5-pragma-5.2.16 class=unsupported issue=1836  # WAL checkpoint/frame cou
 wal5 wal5-pragma-5.2.17 class=unsupported issue=1836  # WAL checkpoint/frame counters zero; sidecar absent
 wal5 wal5-pragma-5.2.18 class=unsupported issue=1836  # WAL checkpoint/frame counters zero; sidecar absent
 wal5 wal5-pragma-5.2.19 class=unsupported issue=1836  # WAL checkpoint/frame counters zero; sidecar absent
-wal5 wal5-pragma-5.2.20 class=unsupported issue=1836  # WAL checkpoint/frame counters zero; sidecar absent
 wal5 wal5-pragma-5.2.21 class=unsupported issue=1836  # WAL checkpoint/frame counters zero; sidecar absent
 wal5 wal5-capi-1.1.1 class=unsupported issue=1836  # WAL checkpoint/frame counters zero; sidecar absent
 wal5 wal5-capi-1.1.3 class=unsupported issue=1836  # WAL checkpoint/frame counters zero; sidecar absent
@@ -2732,14 +2724,14 @@ wal5 wal5-capi-5.2.17 class=unsupported issue=1836  # WAL checkpoint/frame count
 wal5 wal5-capi-5.2.18 class=unsupported issue=1836  # WAL checkpoint/frame counters zero; sidecar absent
 wal5 wal5-capi-5.2.19 class=unsupported issue=1836  # WAL checkpoint/frame counters zero; sidecar absent
 wal5 wal5-capi-5.2.21 class=unsupported issue=1836  # WAL checkpoint/frame counters zero; sidecar absent
-wal5 wal5-capi-2.4.4.1.3 class=unsupported issue=1836  # non-PASSIVE checkpoint mode rejected; busy handler not fired by opportunistic compaction
-wal5 wal5-capi-2.4.4.2.3 class=unsupported issue=1836  # non-PASSIVE checkpoint mode rejected; busy handler not fired by opportunistic compaction
-wal5 wal5-capi-2.4.8.1.3 class=unsupported issue=1836  # non-PASSIVE checkpoint mode rejected; busy handler not fired by opportunistic compaction
-wal5 wal5-capi-2.4.8.2.3 class=unsupported issue=1836  # non-PASSIVE checkpoint mode rejected; busy handler not fired by opportunistic compaction
-wal5 wal5-capi-2.4.11.1.2 class=unsupported issue=1836  # non-PASSIVE checkpoint mode rejected; busy handler not fired by opportunistic compaction
-wal5 wal5-capi-2.4.11.2.2 class=unsupported issue=1836  # non-PASSIVE checkpoint mode rejected; busy handler not fired by opportunistic compaction
-wal5 wal5-capi-2.4.12.1.3 class=unsupported issue=1836  # non-PASSIVE checkpoint mode rejected; busy handler not fired by opportunistic compaction
-wal5 wal5-capi-2.4.12.2.3 class=unsupported issue=1836  # non-PASSIVE checkpoint mode rejected; busy handler not fired by opportunistic compaction
+wal5 wal5-capi-2.4.4.1.3 class=unsupported issue=1836  # busy handler not fired by opportunistic compaction
+wal5 wal5-capi-2.4.4.2.3 class=unsupported issue=1836  # busy handler not fired by opportunistic compaction
+wal5 wal5-capi-2.4.8.1.3 class=unsupported issue=1836  # busy handler not fired by opportunistic compaction
+wal5 wal5-capi-2.4.8.2.3 class=unsupported issue=1836  # busy handler not fired by opportunistic compaction
+wal5 wal5-capi-2.4.11.1.2 class=unsupported issue=1836  # busy handler not fired by opportunistic compaction
+wal5 wal5-capi-2.4.11.2.2 class=unsupported issue=1836  # busy handler not fired by opportunistic compaction
+wal5 wal5-capi-2.4.12.1.3 class=unsupported issue=1836  # busy handler not fired by opportunistic compaction
+wal5 wal5-capi-2.4.12.2.3 class=unsupported issue=1836  # busy handler not fired by opportunistic compaction
 pagerfault3 pagerfault3-pre1 class=intentional issue=1846  # synthetic chunk-format page_count
 pagerfault3 pagerfault3-pre2 class=intentional issue=1846  # synthetic chunk-format page_count
 
@@ -2814,47 +2806,31 @@ e_walckpt e_walckpt-2.2.2.b class=unsupported issue=1836
 e_walckpt e_walckpt-2.3.1 class=unsupported issue=1836
 e_walckpt e_walckpt-2.3.2.1 class=unsupported issue=1836
 e_walckpt e_walckpt-2.3.2.2 class=unsupported issue=1836
+e_walckpt e_walckpt-2.3.2.3 class=unsupported issue=1836
 e_walckpt e_walckpt-2.full.1.14 class=unsupported issue=1836
 e_walckpt e_walckpt-2.full.1.16 class=unsupported issue=1836
-e_walckpt e_walckpt-2.full.1.3 class=unsupported issue=1836
 e_walckpt e_walckpt-2.full.1.9 class=unsupported issue=1836
-e_walckpt e_walckpt-2.full.2.10.1 class=unsupported issue=1836
-e_walckpt e_walckpt-2.full.2.11 class=unsupported issue=1836
-e_walckpt e_walckpt-2.full.2.3 class=unsupported issue=1836
 e_walckpt e_walckpt-2.full.2.7 class=unsupported issue=1836
 e_walckpt e_walckpt-2.full.2.9 class=unsupported issue=1836
-e_walckpt e_walckpt-2.full.3.10.1 class=unsupported issue=1836
-e_walckpt e_walckpt-2.full.3.11 class=unsupported issue=1836
-e_walckpt e_walckpt-2.full.3.3 class=unsupported issue=1836
 e_walckpt e_walckpt-2.full.3.7 class=unsupported issue=1836
 e_walckpt e_walckpt-2.full.3.9 class=unsupported issue=1836
 e_walckpt e_walckpt-2.passive.1.4 class=unsupported issue=1836
 e_walckpt e_walckpt-2.passive.1.7 class=unsupported issue=1836
 e_walckpt e_walckpt-2.restart.1.14 class=unsupported issue=1836
 e_walckpt e_walckpt-2.restart.1.16 class=unsupported issue=1836
-e_walckpt e_walckpt-2.restart.1.3 class=unsupported issue=1836
 e_walckpt e_walckpt-2.restart.1.9 class=unsupported issue=1836
-e_walckpt e_walckpt-2.restart.2.10.1 class=unsupported issue=1836
-e_walckpt e_walckpt-2.restart.2.11 class=unsupported issue=1836
-e_walckpt e_walckpt-2.restart.2.3 class=unsupported issue=1836
 e_walckpt e_walckpt-2.restart.2.7 class=unsupported issue=1836
 e_walckpt e_walckpt-2.restart.2.9 class=unsupported issue=1836
-e_walckpt e_walckpt-2.restart.3.10.1 class=unsupported issue=1836
-e_walckpt e_walckpt-2.restart.3.3 class=unsupported issue=1836
+e_walckpt e_walckpt-2.restart.3.11 class=unsupported issue=1836
 e_walckpt e_walckpt-2.restart.3.7 class=unsupported issue=1836
 e_walckpt e_walckpt-2.restart.3.9 class=unsupported issue=1836
 e_walckpt e_walckpt-2.truncate.1.14 class=unsupported issue=1836
 e_walckpt e_walckpt-2.truncate.1.16 class=unsupported issue=1836
-e_walckpt e_walckpt-2.truncate.1.3 class=unsupported issue=1836
 e_walckpt e_walckpt-2.truncate.1.9 class=unsupported issue=1836
-e_walckpt e_walckpt-2.truncate.2.10.1 class=unsupported issue=1836
-e_walckpt e_walckpt-2.truncate.2.11 class=unsupported issue=1836
-e_walckpt e_walckpt-2.truncate.2.3 class=unsupported issue=1836
 e_walckpt e_walckpt-2.truncate.2.7 class=unsupported issue=1836
 e_walckpt e_walckpt-2.truncate.2.9 class=unsupported issue=1836
-e_walckpt e_walckpt-2.truncate.3.10.1 class=unsupported issue=1836
+e_walckpt e_walckpt-2.truncate.3.11 class=unsupported issue=1836
 e_walckpt e_walckpt-2.truncate.3.12 class=unsupported issue=1836
-e_walckpt e_walckpt-2.truncate.3.3 class=unsupported issue=1836
 e_walckpt e_walckpt-2.truncate.3.7 class=unsupported issue=1836
 e_walckpt e_walckpt-2.truncate.3.9 class=unsupported issue=1836
 e_walckpt e_walckpt-3.3.1 class=unsupported issue=1836

--- a/test/known_testfixture_exception_ratchet.txt
+++ b/test/known_testfixture_exception_ratchet.txt
@@ -6,8 +6,8 @@
 # Counts are per gate -- one divergent assertion, or one expected crash.
 # Lowering a number is the point. Raising one is a deliberate act that belongs
 # in a PR description.
-gates 4851
+gates 4827
 intentional 3552
-unsupported 1223
+unsupported 1199
 harness 11
 engine-gap 65

--- a/test/sqlite_compatibility_contract.tsv
+++ b/test/sqlite_compatibility_contract.tsv
@@ -3,7 +3,7 @@ api.public_surface	compatible	test/install_layout_test.sh#static link via <doltl
 storage.format_routing	adapted	test/doltlite_open_sqlite_file.sh#R1_select_star_count,test/doltlite_open_sqlite_file.sh#VC_UNAVAILABLE	DoltLite-format databases use the prolly engine while stock SQLite files route to the original B-tree without Dolt version control
 storage.sqlite_sidecars	adapted	test/sqlite_compatibility_contract_test.sh#sidecars_absent	DoltLite-format databases do not create SQLite rollback-journal WAL or shared-memory sidecars
 pragma.journal_mode	adapted	test/doltlite_pragma_journal_mode.sh#jm_dl_set_${mode}_noop	journal_mode reports wal and ignores mode changes on DoltLite-format databases
-pragma.wal_checkpoint	adapted	test/doltlite_pragma_wal_checkpoint.sh#wc_dl_default,test/doltlite_pragma_wal_checkpoint.sh#wc_dl_${mode}_rejected	passive WAL checkpoint is a no-op and other modes are rejected on DoltLite-format databases
+pragma.wal_checkpoint	adapted	test/doltlite_pragma_wal_checkpoint.sh#wc_dl_default,test/doltlite_pragma_wal_checkpoint.sh#wc_dl_${mode}_accepted	all WAL checkpoint modes run DoltLite garbage collection and report zero WAL frames
 pragma.auto_vacuum	adapted	test/doltlite_pragma_auto_vacuum.sh#av_dl_set_full_noop,test/doltlite_pragma_auto_vacuum.sh#av_dl_incr_noop	auto_vacuum reports zero and attempts to enable it or run incremental_vacuum are no-ops
 pragma.vacuum	adapted	test/doltlite_vacuum.sh#vacuum_and_dolt_gc_leave_same_state	VACUUM runs DoltLite garbage collection instead of rebuilding SQLite pages
 pragma.encoding	adapted	test/doltlite_pragma_encoding.sh#encoding_after_ignored_still_utf8	DoltLite-format databases remain UTF-8 when UTF-16 encoding is requested


### PR DESCRIPTION
## Summary
- accept `PRAGMA wal_checkpoint(FULL|RESTART|TRUNCATE)` on DoltLite-format databases
- route every mode through the existing GC-backed checkpoint implementation and report zero external WAL frames
- verify `RESTART` and `TRUNCATE` compact only the named attached store
- remove 27 inherited divergences that now pass, record three newly reachable no-sidecar differences, and lower the exception inventory by a net 24 gates
- update the SQLite compatibility contract and README; storage format version 12 is unchanged

## Behavior
DoltLite has no SQLite `-wal` or `-shm` sidecars, so FULL, RESTART, and TRUNCATE cannot preserve their page-WAL distinctions. They now share the existing PASSIVE adaptation: run chunk-store garbage collection and return `0|0|0` because there are no external WAL frames.

## Validation
- fail-before: updated focused test reports 5 failures against the old binary
- `make doltlite testfixture`
- `bash test/doltlite_pragma_wal_checkpoint.sh build/doltlite` — 10 passed
- `bash test/sqlite_compatibility_contract_test.sh build/doltlite` — 5 passed
- focused inherited suites: `e_walckpt walckptnoop nockpt walrestart walseh1 busy2 wal5` — 422 passing, 419 known architectural divergences, no unexpected results
- `make lint`
- `git diff --check`

Related to #1836 and #1846.

Co-Authored-By: Codex <noreply@openai.com>