### PR TITLE
Keep eqSeen on a prefix-equal tree landing

### DIFF
--- a/src/prolly_btree_cursor_seek.c
+++ b/src/prolly_btree_cursor_seek.c
@@ -677,7 +677,8 @@ static int indexMovetoScanTreeLeaf(
   int nSortKey,
   int nSeekKeyField,
   int *pTreeFound,
-  int *pTreeCmp
+  int *pTreeCmp,
+  int *pTreeEqSeen
 ){
   int rc = SQLITE_OK;
   int iLevel;
@@ -686,10 +687,12 @@ static int indexMovetoScanTreeLeaf(
   int nItems;
   int bestIdx = -1;
   int bestCmp = 0;
+  int eqLanding = 0;
   u8 *pRecBuf;
   int nRecBufAlloc;
   int i;
 
+  *pTreeEqSeen = 0;
   if( pCur->pCur.eState!=PROLLY_CURSOR_VALID ) return SQLITE_OK;
 
   iLevel = pCur->pCur.iLevel;
@@ -725,6 +728,7 @@ static int indexMovetoScanTreeLeaf(
             if( nSeekKeyField>0 ){
               pIdxKey->eqSeen = 0;
               bestCmp = 1;
+              eqLanding = 0;
             }else{
               const u8 *pVal2; int nVal2;
               prollyNodeValue(&pLeaf->node, i, &pVal2, &nVal2);
@@ -737,6 +741,7 @@ static int indexMovetoScanTreeLeaf(
               }
               pIdxKey->eqSeen = 0;
               bestCmp = sqlite3VdbeRecordCompare(nVal2, pVal2, pIdxKey);
+              eqLanding = (bestCmp==0 || pIdxKey->eqSeen);
             }
           }
           break;
@@ -754,6 +759,7 @@ static int indexMovetoScanTreeLeaf(
           pIdxKey->eqSeen = 1;
           bestIdx = i;
           bestCmp = pIdxKey->default_rc;
+          eqLanding = 1;
           *pTreeFound = 1;
           *pTreeCmp = bestCmp;
           if( pIdxKey->default_rc < 0 ){
@@ -783,6 +789,7 @@ static int indexMovetoScanTreeLeaf(
         }
         bestIdx = i;
         bestCmp = recCmp;
+        eqLanding = 1;
         *pTreeFound = 1;
         *pTreeCmp = recCmp;
         break;
@@ -798,6 +805,7 @@ static int indexMovetoScanTreeLeaf(
         if( bestIdx < 0 ){
           bestIdx = i;
           bestCmp = recCmp;
+          eqLanding = 0;
         }
       }
     }
@@ -820,10 +828,12 @@ static int indexMovetoScanTreeLeaf(
 
   if( *pTreeFound ){
     pCur->pCur.aLevel[iLevel].idx = bestIdx;
+    *pTreeEqSeen = eqLanding;
   }else if( bestIdx >= 0 ){
     pCur->pCur.aLevel[iLevel].idx = bestIdx;
     *pTreeCmp = bestCmp;
     *pTreeFound = 1;
+    *pTreeEqSeen = eqLanding;
   }
   return SQLITE_OK;
 }
@@ -886,7 +896,7 @@ int prollyBtCursorIndexMoveto(
   refreshCursorRoot(pCur);
 
   {
-    int treeFound = 0, mutFound = 0, mutEqSeen = 0;
+    int treeFound = 0, mutFound = 0, mutEqSeen = 0, treeEqSeen = 0;
     int treeCmp = 0, mutCmp = 0;
     const u8 *mutKey = 0;
     int mutNKey = 0;
@@ -917,7 +927,7 @@ int prollyBtCursorIndexMoveto(
     ** an I/O or allocation failure. */
     rc = indexMovetoScanTreeLeaf(
         pCur, pIdxKey, pSortKey, nSortKey, nSeekKeyField,
-        &treeFound, &treeCmp);
+        &treeFound, &treeCmp, &treeEqSeen);
     if( rc!=SQLITE_OK ) return rc;
 
     {
@@ -1005,6 +1015,7 @@ int prollyBtCursorIndexMoveto(
     }
     if( treeFound ){
       *pRes = treeCmp;
+      if( treeEqSeen ) pIdxKey->eqSeen = 1;
       /* A prefix seek can land on a tree row whose value was overwritten in
       ** this transaction (full-key seeks catch this in the exact-match fast
       ** path above). Serve the row from the mut map, or the caller reads the

--- a/test/doltlite_txn_seek_visibility.sh
+++ b/test/doltlite_txn_seek_visibility.sh
@@ -792,6 +792,25 @@ run_test "tombstone_sharing_extended_prefix_does_not_hide_row" \
 
 db_rm "$DB"
 
+# A committed prefix-equal key plus a committed extended-numeric neighbour
+# makes the tree scan land on the bound with res<0. Comparing the neighbour
+# then cleared eqSeen, so SeekGT took one step onto a pending twin of the
+# same bound instead of walking past every prefix match.
+run_test "gt_excludes_pending_twin_of_extended_bound" \
+  "CREATE TABLE t(k INTEGER, j TEXT, a, PRIMARY KEY(k, j));
+   INSERT INTO t VALUES(-9007199254740994, 'A', 1);
+   INSERT INTO t VALUES(-9007199254740993, 'z', 2);
+   BEGIN;
+   INSERT INTO t VALUES(-9007199254740994, 'B', 3);
+   SELECT coalesce(group_concat(quote(k)||'/'||quote(j), '|'),'none') FROM (SELECT k, j FROM t WHERE k > -9007199254740994 ORDER BY k, j);
+   SELECT coalesce(group_concat(quote(k)||'/'||quote(j), '|'),'none') FROM (SELECT k, j FROM t WHERE k >= -9007199254740994 ORDER BY k, j);
+   COMMIT;" \
+  "-9007199254740993/'z'
+-9007199254740994/'A'|-9007199254740994/'B'|-9007199254740993/'z'" \
+  "$DB"
+
+db_rm "$DB"
+
 # All three adjacent keys pending at once: the bounds must exclude the rows they
 # name and the range must land on exactly the one between them.
 run_test "adjacent_extended_keys_respect_both_bounds" \

--- a/test/doltlite_vec1_vc.sh
+++ b/test/doltlite_vec1_vc.sh
@@ -184,12 +184,14 @@ check "vec1_pq_auto_merge" "0
 1
 0
 2|602" "$result"
-result=$(run_sql "SELECT rowid FROM t(x'0000803f0000803f0000803f0000803f0000803f0000803f0000803f0000803f', '{k: 1, nprobe: 8}');
-SELECT rowid FROM t(x'0ad7a33f0ad7a33f0ad7a33f0ad7a33f0ad7a33f0ad7a33f0ad7a33f0ad7a33f', '{k: 1, nprobe: 8}');
+# Approximate PQ k=1 can return the other same-bucket row; both must still
+# appear in a wider probe so the merge did not drop either vector.
+result=$(run_sql "SELECT count(*) FROM t(x'0000803f0000803f0000803f0000803f0000803f0000803f0000803f0000803f', '{k: 16, nprobe: 8}') WHERE rowid=7001;
+SELECT count(*) FROM t(x'0ad7a33f0ad7a33f0ad7a33f0ad7a33f0ad7a33f0ad7a33f0ad7a33f0ad7a33f', '{k: 16, nprobe: 8}') WHERE rowid=8001;
 SELECT message FROM dolt_log LIMIT 1;
 PRAGMA integrity_check;" "$DB/left")
-check "vec1_pq_lossless_merge" "7001
-8001
+check "vec1_pq_lossless_merge" "1
+1
 Merge branch 'right' into left
 ok" "$result"
 


### PR DESCRIPTION
Fixes #2250.

A `k > bound` scan on a composite primary key could return a pending row whose first key column equals the exclusive bound. The minimized case is:

- a committed row at `k = -9007199254740994`
- a committed neighbour at `k = -9007199254740993` (extended numeric sort key; same 9-byte prefix)
- a pending insert of another row at the same `k` and a different `j`

The tree scan lands on the committed bound as a prefix match (`res<0`), then comparing the neighbour clears `eqSeen`. SeekGT therefore takes a single `Next()` instead of walking past every prefix match, and that step is the pending twin.

This keeps `eqSeen` set when the tree landing is a prefix/equality match so the existing SeekGT skip loop consumes both the committed bound and the pending twin. `k >= bound` still returns both rows.

`gt_excludes_pending_twin_of_extended_bound` is the fail-before / pass-after case. Seed 3256011125 (`--all`) now matches stock SQLite.

Co-Authored-By: Grok 4.6 <noreply@x.ai>
