### PR TITLE
Reject backups redirected by schema reattachment

### DIFF
--- a/src/pager_shim.c
+++ b/src/pager_shim.c
@@ -939,7 +939,9 @@ struct DoltliteBackup {
   Btree *pSrcBt;
   char *zDestDb;
   char *zSrcFile;
+  char *zDestFile;
   sqlite3_vfs *pSrcVfs;
+  sqlite3_vfs *pDestVfs;
   int done;
   int rc;
 };
@@ -1095,6 +1097,7 @@ static sqlite3_backup *backupInitLocked(sqlite3 *pDest, const char *zDestDb,
   p->pDestDb = pDest;
   p->pSrcBt = pSrc->aDb[iSrc].pBt;
   p->pSrcVfs = chunkFileGetVfs(&srcCs->file);
+  p->pDestVfs = chunkFileGetVfs(&destCs->file);
   p->zDestDb = sqlite3_mprintf("%s", zDestDb);
   if( !p->zDestDb ){
     sqlite3_free(p);
@@ -1106,6 +1109,14 @@ static sqlite3_backup *backupInitLocked(sqlite3 *pDest, const char *zDestDb,
   p->zSrcFile = 0;
   if( chunkStoreDupFilenameDoubleNul(chunkFileGetFilename(&srcCs->file),
                                      &p->zSrcFile)!=SQLITE_OK ){
+    sqlite3_free(p->zDestDb);
+    sqlite3_free(p);
+    sqlite3Error(pDest, SQLITE_NOMEM);
+    return 0;
+  }
+  if( chunkStoreDupFilenameDoubleNul(chunkFileGetFilename(&destCs->file),
+                                     &p->zDestFile)!=SQLITE_OK ){
+    sqlite3_free(p->zSrcFile);
     sqlite3_free(p->zDestDb);
     sqlite3_free(p);
     sqlite3Error(pDest, SQLITE_NOMEM);
@@ -1171,6 +1182,24 @@ int sqlite3_backup_step(sqlite3_backup *pBackup, int nPage){
                         "destination database is not backed by a file");
     rc = SQLITE_ERROR;
     goto backup_step_done;
+  }
+  {
+    int sameRc = SQLITE_OK;
+    int same = doltliteBackupSameFile(p->pDestVfs, p->zDestFile,
+                                      chunkFileGetVfs(&destCs->file),
+                                      chunkFileGetFilename(&destCs->file),
+                                      &sameRc);
+    if( sameRc!=SQLITE_OK ){
+      rc = sameRc==SQLITE_IOERR_NOMEM ? SQLITE_NOMEM : sameRc;
+      sqlite3Error(p->pDestDb, rc);
+      goto backup_step_done;
+    }
+    if( !same ){
+      sqlite3ErrorWithMsg(p->pDestDb, SQLITE_ERROR,
+                          "unknown database %s", p->zDestDb);
+      rc = SQLITE_ERROR;
+      goto backup_step_done;
+    }
   }
   if( sqlite3BtreeTxnState(pDestBt)!=SQLITE_TXN_NONE ){
     sqlite3ErrorWithMsg(p->pDestDb, SQLITE_ERROR,
@@ -1336,6 +1365,7 @@ int sqlite3_backup_finish(sqlite3_backup *pBackup){
   sqlite3Error(p->pDestDb, rc);
   sqlite3_mutex_leave(p->pDestDb->mutex);
   sqlite3_free(p->zSrcFile);
+  sqlite3_free(p->zDestFile);
   sqlite3_free(p->zDestDb);
   sqlite3_free(p);
   return rc;

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -405,6 +405,7 @@ static void run_backup_safety(void){
   char zDestHost[512];
   char zSrcAux[512];
   char zDestAux[512];
+  char zDestOther[512];
   char *sql = 0;
   sqlite3_int64 nSmall;
   sqlite3_int64 nDest;
@@ -418,6 +419,7 @@ static void run_backup_safety(void){
   make_dbpath(zDestHost, sizeof(zDestHost), "backup_safety_dest_host");
   make_dbpath(zSrcAux, sizeof(zSrcAux), "backup_safety_src_aux");
   make_dbpath(zDestAux, sizeof(zDestAux), "backup_safety_dest_aux");
+  make_dbpath(zDestOther, sizeof(zDestOther), "backup_safety_dest_other");
   removeDbFiles(zBig);
   removeDbFiles(zSmall);
   removeDbFiles(zDest);
@@ -426,6 +428,7 @@ static void run_backup_safety(void){
   removeDbFiles(zDestHost);
   removeDbFiles(zSrcAux);
   removeDbFiles(zDestAux);
+  removeDbFiles(zDestOther);
 
   check("backup_safety_open_big", open_db(zBig, &srcBig)==SQLITE_OK);
   check("backup_safety_open_dest", open_db(zDest, &dest)==SQLITE_OK);
@@ -509,12 +512,27 @@ static void run_backup_safety(void){
     if( pBackup ){
       check("backup_safety_attached_dest_detach",
             execSqlSilent(destAttached, "DETACH aux")==SQLITE_OK);
-      check("backup_safety_attached_missing_dest",
+      sql = sqlite3_mprintf(
+          "ATTACH %Q AS aux;"
+          "CREATE TABLE aux.other(v TEXT);"
+          "INSERT INTO aux.other VALUES('other');",
+          zDestOther);
+      check("backup_safety_attach_replacement_alloc", sql!=0);
+      check("backup_safety_attach_replacement",
+            sql && execSql(destAttached, sql)==SQLITE_OK);
+      sqlite3_free(sql);
+      sql = 0;
+      check("backup_safety_attached_replaced_dest",
             sqlite3_backup_step(pBackup, 1)==SQLITE_ERROR);
-      check("backup_safety_attached_missing_dest_message",
+      check("backup_safety_attached_replaced_dest_message",
             strstr(sqlite3_errmsg(destAttached), "unknown database aux")!=0);
-      check("backup_safety_attached_missing_dest_finish",
+      check("backup_safety_attached_replaced_dest_finish",
             sqlite3_backup_finish(pBackup)==SQLITE_ERROR);
+      check("backup_safety_replacement_unchanged",
+            strcmp(queryScalarText(destAttached,
+              "SELECT v FROM aux.other"), "other")==0);
+      check("backup_safety_detach_replacement",
+            execSql(destAttached, "DETACH aux")==SQLITE_OK);
     }
 
     sql = sqlite3_mprintf("ATTACH %Q AS aux", zDestAux);
@@ -523,6 +541,9 @@ static void run_backup_safety(void){
           sql && execSql(destAttached, sql)==SQLITE_OK);
     sqlite3_free(sql);
     sql = 0;
+    check("backup_safety_original_unchanged",
+          strcmp(queryScalarText(destAttached,
+            "SELECT v FROM aux.old"), "old")==0);
 
     pBackup = sqlite3_backup_init(destAttached, "aux", srcAttached, "aux");
     check("backup_safety_attached_init", pBackup!=0);
@@ -569,6 +590,7 @@ backup_safety_done:
   removeDbFiles(zDestHost);
   removeDbFiles(zSrcAux);
   removeDbFiles(zDestAux);
+  removeDbFiles(zDestOther);
 }
 
 static void run_integer_pk_autocommit_append_correctness(void){


### PR DESCRIPTION
## Summary

- pin the destination VFS and canonical file identity when a DoltLite backup handle is initialized
- reject a later same-name attachment that resolves to a different file before opening, copying, or replacing destination data
- preserve both the originally selected database and the newly attached database on rejection
- add a native regression for DETACH followed by ATTACH of a different file under the same schema name

This follows up on Ito QA feedback on #2255. It does not change storage format version 12.

## Validation

- ./doltlite_regression_test_c backup_safety — 45 passed
- focused testfixture suites backup5, doltlite_recover_backup_fault, and doltlite_recover_rawformat_2 — 97 passed, 0 divergences
- make lint
- git diff --check

Co-Authored-By: OpenAI Codex <noreply@openai.com>