### PR TITLE
Overlay rebase metadata onto a dirty return branch

### DIFF
--- a/src/chunk_store.h
+++ b/src/chunk_store.h
@@ -105,6 +105,12 @@
 #define WS_CONFLICTS_OFF    (WS_MERGE_COMMIT_OFF + PROLLY_HASH_SIZE)
 #define WS_TOTAL_SIZE_V2    (WS_CONFLICTS_OFF + PROLLY_HASH_SIZE)
 #define WS_REBASING_OFF     WS_TOTAL_SIZE_V2
+/* Bit 0: rebase in progress. Bit 1: return-branch blob is a metadata
+** overlay that must not replace a dirty catalog. Whole-blob mirror is
+** bit 0 alone. Stay inside the v5 size: GC classifies working sets by
+** exact length. */
+#define WS_REBASE_FLAG_ACTIVE      0x01
+#define WS_REBASE_FLAG_META_MIRROR 0x02
 #define WS_PRE_REBASE_CAT_OFF (WS_REBASING_OFF + 1)
 #define WS_REBASE_ONTO_OFF  (WS_PRE_REBASE_CAT_OFF + PROLLY_HASH_SIZE)
 #define WS_REBASE_BRANCH_OFF (WS_REBASE_ONTO_OFF + PROLLY_HASH_SIZE)

--- a/src/doltlite_checkout.c
+++ b/src/doltlite_checkout.c
@@ -263,7 +263,8 @@ static void checkoutSaveSession(sqlite3 *db, CheckoutMutationCtx *p){
   doltliteGetSessionMergeState(db, &p->savedIsMerging,
                                &p->savedMergeCommit,
                                &p->savedConflictsCatalog);
-  doltliteGetSessionRebaseState(db, &p->savedIsRebasing,
+  p->savedIsRebasing = doltliteGetSessionRebaseFlags(db);
+  doltliteGetSessionRebaseState(db, 0,
                                 &p->savedPreRebaseCat,
                                 &p->savedRebaseOnto,
                                 &p->zSavedRebaseOrigBranch,

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -1220,12 +1220,15 @@ void doltliteGetSessionRebaseState(sqlite3 *db, u8 *pIsRebasing,
                                    ProllyHash *pRebaseOnto,
                                    const char **pzOrigBranch,
                                    const char **pzReturnBranch);
+u8 doltliteGetSessionRebaseFlags(sqlite3 *db);
 int doltliteSetSessionRebaseState(sqlite3 *db, u8 isRebasing,
                                   const ProllyHash *pPreRebaseCat,
                                   const ProllyHash *pRebaseOnto,
                                   const char *zOrigBranch,
                                   const char *zReturnBranch);
 int doltliteClearSessionRebaseState(sqlite3 *db);
+int doltliteBranchWorkingSetRebaseFlags(sqlite3 *db, const char *zBranch, u8 *pFlags);
+int doltliteClearBranchRebaseMetadata(sqlite3 *db, const char *zBranch);
 void doltliteGetSessionConflictsCatalog(sqlite3 *db, ProllyHash *pHash);
 int doltliteSessionHasUnresolvedConflicts(sqlite3 *db);
 int doltliteSetSessionConflictsCatalog(sqlite3 *db, const ProllyHash *pHash);

--- a/src/doltlite_rebase.c
+++ b/src/doltlite_rebase.c
@@ -92,9 +92,16 @@ static int rebaseRestoreReturnBranchWorkingState(
   ChunkStore *cs = doltliteGetChunkStore(db);
   DoltliteCommit c;
   ProllyHash headHash;
+  u8 flags = 0;
   int rc;
 
   if( !cs || !zBranch || !zBranch[0] ) return SQLITE_OK;
+  rc = doltliteBranchWorkingSetRebaseFlags(db, zBranch, &flags);
+  if( rc!=SQLITE_OK ) return rc;
+  if( flags & WS_REBASE_FLAG_META_MIRROR ){
+    return doltliteClearBranchRebaseMetadata(db, zBranch);
+  }
+  if( (flags & WS_REBASE_FLAG_ACTIVE)==0 ) return SQLITE_OK;
   rc = chunkStoreFindBranch(cs, zBranch, &headHash);
   if( rc!=SQLITE_OK ) return rc;
   memset(&c, 0, sizeof(c));
@@ -106,11 +113,11 @@ static int rebaseRestoreReturnBranchWorkingState(
   return rc;
 }
 /* True if zBranch holds working-set changes its head commit does not. An
-** interactive rebase mirrors its working set onto the return branch so a
-** reopen can resume, and clears that branch at the end -- both of which
-** destroy uncommitted work, so a dirty branch must not be adopted as the
-** mirror target. Rebase already refuses to start with a dirty current branch;
-** the return branch is a different one and has no such guarantee. */
+** interactive rebase mirrors onto the return branch so a reopen can resume.
+** A dirty return branch keeps its catalog and only receives rebase metadata;
+** a clean one gets the whole working-set blob. Restore undoes the same
+** choice. Rebase already refuses to start with a dirty current branch; the
+** return branch is a different one and has no such guarantee. */
 static int rebaseBranchHasUncommittedWork(
   sqlite3 *db,
   const char *zBranch,
@@ -894,7 +901,9 @@ static int rebaseRestoreInProgress(
   do {
     rc = rebaseWritePlanRows(db, aPlan, nPlan);
     if( rc==SQLITE_OK ){
-      rc = doltliteSetSessionRebaseState(db, 1, pPreRebaseCat, pExpectedOrigHead,
+      u8 flags = (u8)(WS_REBASE_FLAG_ACTIVE |
+        (doltliteGetSessionRebaseFlags(db) & WS_REBASE_FLAG_META_MIRROR));
+      rc = doltliteSetSessionRebaseState(db, flags, pPreRebaseCat, pExpectedOrigHead,
                                          zOrigBranch, zReturnBranch);
     }
     if( rc==SQLITE_OK ) rc = doltlitePersistWorkingSet(db);
@@ -1417,6 +1426,7 @@ static void doltliteRebaseInteractiveStart(
   int rc;
   int dirty = 0;
   u8 curIsRebasing = 0;
+  u8 rebaseFlags = WS_REBASE_FLAG_ACTIVE;
   int bWorkingBranchCreated = 0;
   const char *zFailMsg = 0;
 
@@ -1510,11 +1520,7 @@ static void doltliteRebaseInteractiveStart(
     int dirty = 0;
     rc = rebaseBranchHasUncommittedWork(db, zReturnBranch, &dirty);
     if( rc!=SQLITE_OK ) goto fail;
-    if( dirty ){
-      /* Empty disables both the mirror and the end-of-rebase clear. The rebase
-      ** still runs; only resuming it after a reopen is given up. */
-      zReturnBranch[0] = 0;
-    }
+    if( dirty ) rebaseFlags = (u8)(WS_REBASE_FLAG_ACTIVE | WS_REBASE_FLAG_META_MIRROR);
   }
   if( strlen(zReturnBranch)>=WS_REBASE_BRANCH_LEN ){
     sqlite3_free(zOrig);
@@ -1553,7 +1559,7 @@ static void doltliteRebaseInteractiveStart(
     goto fail;
   }
 
-  rc = doltliteSetSessionRebaseState(db, 1, &preRebaseCat, &headHash,
+  rc = doltliteSetSessionRebaseState(db, rebaseFlags, &preRebaseCat, &headHash,
                                      zOrig, zReturnBranch);
   if( rc==SQLITE_OK ) rc = doltlitePersistWorkingSet(db);
   if( rc!=SQLITE_OK ) goto fail;

--- a/src/doltlite_rebase.c
+++ b/src/doltlite_rebase.c
@@ -1223,11 +1223,36 @@ static int rebaseReadActiveRetry(
   return rc;
 }
 
+/* Put cleared claim ownership back so a later abort/continue can retry.
+** The rollback persist must not share the claim-commit fault point. */
+static int rebaseUnclaimActiveEnd(
+  sqlite3 *db,
+  u8 flags,
+  const ProllyHash *pPreRebaseCat,
+  const ProllyHash *pRebaseOnto,
+  const char *zOrigBranch,
+  const char *zReturnBranch
+){
+  ChunkStore *cs = doltliteGetChunkStore(db);
+  int rc;
+
+  if( !cs ) return SQLITE_ERROR;
+  rc = doltliteSetSessionRebaseState(db, flags, pPreRebaseCat, pRebaseOnto,
+                                     zOrigBranch, zReturnBranch);
+  if( rc!=SQLITE_OK ) return rc;
+  rc = doltliteSaveWorkingSet(db);
+  if( rc!=SQLITE_OK ) return rc;
+  rc = chunkStoreSerializeRefs(cs);
+  if( rc!=SQLITE_OK ) return rc;
+  return chunkStoreCommit(cs);
+}
+
 /* Claim exclusive ownership of ending the active rebase.
 **
 ** Returns SQLITE_DONE if durable isRebasing is already clear (peer won).
 ** Returns SQLITE_OK after this connection clears isRebasing. Storage failures
-** return an error without reporting "no rebase in progress".
+** after mutation restore ownership so a retry can still abort or continue,
+** and return an error without reporting "no rebase in progress".
 ** Callers must copy branch names out of session state before claiming. */
 static int rebaseClaimActiveEnd(
   sqlite3 *db,
@@ -1236,11 +1261,19 @@ static int rebaseClaimActiveEnd(
   ChunkStore *cs = doltliteGetChunkStore(db);
   const char *zBranch;
   const char *zReturnBranchConst = 0;
+  const char *zOrigBranchConst = 0;
   char *zReturnBranch = 0;
+  char *zSavedOrig = 0;
+  ProllyHash savedPre;
+  ProllyHash savedOnto;
   u8 isRebasing = 0;
+  u8 savedFlags = 0;
   int rc;
   int locked = 0;
+  int mutated = 0;
 
+  memset(&savedPre, 0, sizeof(savedPre));
+  memset(&savedOnto, 0, sizeof(savedOnto));
   if( !cs || !db || !zWorkingBranch || !zWorkingBranch[0] ){
     return SQLITE_ERROR;
   }
@@ -1256,23 +1289,26 @@ static int rebaseClaimActiveEnd(
   ** working branch is canonical for terminal-operation ownership. */
   rc = doltliteLoadWorkingSet(db, zWorkingBranch);
   if( rc!=SQLITE_OK ) goto claim_done;
-  doltliteGetSessionRebaseState(db, &isRebasing, 0, 0,
-                                0, &zReturnBranchConst);
+  savedFlags = doltliteGetSessionRebaseFlags(db);
+  doltliteGetSessionRebaseState(db, &isRebasing, &savedPre, &savedOnto,
+                                &zOrigBranchConst, &zReturnBranchConst);
   if( !isRebasing ){
     rc = SQLITE_DONE;
     goto claim_done;
   }
-  zReturnBranch = sqlite3_mprintf("%s", zReturnBranchConst);
-  if( !zReturnBranch ){
+  zReturnBranch = sqlite3_mprintf("%s", zReturnBranchConst ? zReturnBranchConst : "");
+  zSavedOrig = sqlite3_mprintf("%s", zOrigBranchConst ? zOrigBranchConst : "");
+  if( !zReturnBranch || !zSavedOrig ){
     rc = SQLITE_NOMEM;
     goto claim_done;
   }
 
   rc = doltliteClearSessionRebaseState(db);
   if( rc!=SQLITE_OK ) goto claim_done;
+  mutated = 1;
   rc = doltliteSaveWorkingSet(db);
   if( rc!=SQLITE_OK ) goto claim_done;
-  if( zReturnBranch && zReturnBranch[0]
+  if( zReturnBranch[0]
    && sqlite3_stricmp(zBranch, zReturnBranch)!=0 ){
     rc = rebaseRestoreReturnBranchWorkingState(db, zReturnBranch);
     if( rc!=SQLITE_OK ) goto claim_done;
@@ -1282,12 +1318,17 @@ static int rebaseClaimActiveEnd(
     if( rc!=SQLITE_OK ) goto claim_done;
   }
   rc = chunkStoreSerializeRefs(cs);
-  if( rc!=SQLITE_OK ) goto claim_done;
-  rc = chunkStoreCommit(cs);
+  if( rc==SQLITE_OK && sqlite3FaultSim(961) ) rc = SQLITE_IOERR;
+  if( rc==SQLITE_OK ) rc = chunkStoreCommit(cs);
 
 claim_done:
+  if( mutated && rc!=SQLITE_OK ){
+    (void)rebaseUnclaimActiveEnd(db, savedFlags, &savedPre, &savedOnto,
+                                 zSavedOrig, zReturnBranch);
+  }
   if( locked ) chunkStoreUnlock(cs);
   sqlite3_free(zReturnBranch);
+  sqlite3_free(zSavedOrig);
   return rc;
 }
 

--- a/src/prolly_btree_int.h
+++ b/src/prolly_btree_int.h
@@ -732,6 +732,10 @@ int btreeStoreWorkingSetBlob(ChunkStore*, const char*, const ProllyHash*,
                              const ProllyHash*, const ProllyHash*, u8,
                              const ProllyHash*, const ProllyHash*, const char*,
                              const char*, const ProllyHash*);
+int btreePutRebaseMetadataOnBranch(ChunkStore*, const char*, u8,
+                                   const ProllyHash*, const ProllyHash*,
+                                   const char*, const char*);
+int btreeClearRebaseMetadataOnBranch(ChunkStore*, const char*);
 int btreeReadWorkingCatalog(ChunkStore*, const char*, ProllyHash*, ProllyHash*);
 int btreeWriteWorkingState(ChunkStore*, const char*, const ProllyHash*,
                            const ProllyHash*);

--- a/src/prolly_btree_state.c
+++ b/src/prolly_btree_state.c
@@ -293,6 +293,66 @@ int btreeStoreWorkingSetBlob(
   return rc;
 }
 
+int btreePutRebaseMetadataOnBranch(
+  ChunkStore *cs,
+  const char *zBranch,
+  u8 rebaseFlags,
+  const ProllyHash *pPreRebaseCat,
+  const ProllyHash *pRebaseOnto,
+  const char *zOrig,
+  const char *zReturn
+){
+  ProllyHash cat, commit, staged, mergeC, conflicts, cvs;
+  char *zIgnoreOrig = 0;
+  char *zIgnoreReturn = 0;
+  u8 merging = 0;
+  u8 oldFlags = 0;
+  int rc;
+
+  if( !cs || !zBranch || !zBranch[0] ) return SQLITE_OK;
+  rc = btreeLoadWorkingSetBlob(cs, zBranch, &cat, &commit, &staged, &merging,
+                               &mergeC, &conflicts, &oldFlags, 0, 0,
+                               &zIgnoreOrig, &zIgnoreReturn, &cvs);
+  sqlite3_free(zIgnoreOrig);
+  sqlite3_free(zIgnoreReturn);
+  if( rc==SQLITE_NOTFOUND ){
+    rc = btreeLoadBranchHeadCatalog(cs, zBranch, &cat, &commit);
+    if( rc!=SQLITE_OK ) return rc;
+    memset(&staged, 0, sizeof(staged));
+    memset(&mergeC, 0, sizeof(mergeC));
+    memset(&conflicts, 0, sizeof(conflicts));
+    memset(&cvs, 0, sizeof(cvs));
+    merging = 0;
+  }else if( rc!=SQLITE_OK ){
+    return rc;
+  }
+  return btreeStoreWorkingSetBlob(cs, zBranch, &cat, &commit, &staged, merging,
+                                  &mergeC, &conflicts, rebaseFlags,
+                                  pPreRebaseCat, pRebaseOnto, zOrig, zReturn,
+                                  &cvs);
+}
+
+int btreeClearRebaseMetadataOnBranch(ChunkStore *cs, const char *zBranch){
+  ProllyHash cat, commit, staged, mergeC, conflicts, cvs;
+  char *zIgnoreOrig = 0;
+  char *zIgnoreReturn = 0;
+  u8 merging = 0;
+  u8 oldFlags = 0;
+  int rc;
+
+  if( !cs || !zBranch || !zBranch[0] ) return SQLITE_OK;
+  rc = btreeLoadWorkingSetBlob(cs, zBranch, &cat, &commit, &staged, &merging,
+                               &mergeC, &conflicts, &oldFlags, 0, 0,
+                               &zIgnoreOrig, &zIgnoreReturn, &cvs);
+  sqlite3_free(zIgnoreOrig);
+  sqlite3_free(zIgnoreReturn);
+  if( rc==SQLITE_NOTFOUND ) return SQLITE_OK;
+  if( rc!=SQLITE_OK ) return rc;
+  if( (oldFlags & WS_REBASE_FLAG_META_MIRROR)==0 ) return SQLITE_OK;
+  return btreeStoreWorkingSetBlob(cs, zBranch, &cat, &commit, &staged, merging,
+                                  &mergeC, &conflicts, 0, 0, 0, 0, 0, &cvs);
+}
+
 int btreeReadWorkingCatalog(
   ChunkStore *cs,
   const char *zBranch,
@@ -768,7 +828,8 @@ void doltliteGetSessionRebaseState(sqlite3 *db, u8 *pIsRebasing,
                                     const char **pzReturnBranch){
   if( db && db->nDb>0 && db->aDb[0].pBt ){
     Btree *p = db->aDb[0].pBt;
-    if( pIsRebasing ) *pIsRebasing = p->isRebasing;
+    /* Callers treat this as a boolean; META_MIRROR is persist-mode only. */
+    if( pIsRebasing ) *pIsRebasing = p->isRebasing & WS_REBASE_FLAG_ACTIVE;
     if( pPreRebaseCat ) memcpy(pPreRebaseCat, &p->preRebaseWorkingCat, sizeof(ProllyHash));
     if( pRebaseOnto ) memcpy(pRebaseOnto, &p->rebaseOntoCommit, sizeof(ProllyHash));
     if( pzOrigBranch ) *pzOrigBranch = p->zRebaseOrigBranch;
@@ -780,6 +841,11 @@ void doltliteGetSessionRebaseState(sqlite3 *db, u8 *pIsRebasing,
     if( pzOrigBranch ) *pzOrigBranch = 0;
     if( pzReturnBranch ) *pzReturnBranch = 0;
   }
+}
+
+u8 doltliteGetSessionRebaseFlags(sqlite3 *db){
+  if( db && db->nDb>0 && db->aDb[0].pBt ) return db->aDb[0].pBt->isRebasing;
+  return 0;
 }
 
 int doltliteSetSessionRebaseState(sqlite3 *db, u8 isRebasing,
@@ -828,6 +894,31 @@ int doltliteSetSessionRebaseState(sqlite3 *db, u8 isRebasing,
 
 int doltliteClearSessionRebaseState(sqlite3 *db){
   return doltliteSetSessionRebaseState(db, 0, 0, 0, 0, 0);
+}
+
+int doltliteBranchWorkingSetRebaseFlags(
+  sqlite3 *db,
+  const char *zBranch,
+  u8 *pFlags
+){
+  ChunkStore *cs = doltliteGetChunkStore(db);
+  int rc;
+
+  if( pFlags ) *pFlags = 0;
+  if( !cs || !zBranch || !zBranch[0] ) return SQLITE_OK;
+  rc = btreeLoadWorkingSetBlob(cs, zBranch, 0, 0, 0, 0, 0, 0,
+                               pFlags, 0, 0, 0, 0, 0);
+  if( rc==SQLITE_NOTFOUND ){
+    if( pFlags ) *pFlags = 0;
+    return SQLITE_OK;
+  }
+  return rc;
+}
+
+int doltliteClearBranchRebaseMetadata(sqlite3 *db, const char *zBranch){
+  ChunkStore *cs = doltliteGetChunkStore(db);
+  if( !cs ) return SQLITE_ERROR;
+  return btreeClearRebaseMetadataOnBranch(cs, zBranch);
 }
 
 int doltliteSessionHasUnresolvedConflicts(sqlite3 *db){
@@ -1008,13 +1099,22 @@ int doltliteSaveWorkingSetWithHash(sqlite3 *db, const ProllyHash *pWorkingCatHas
                                 &pBtree->vc.constraintViolationsHash);
   if( rc!=SQLITE_OK ) return rc;
 
-  if( pBtree->isRebasing
+  if( (pBtree->isRebasing & WS_REBASE_FLAG_ACTIVE)
    && pBtree->zRebaseReturnBranch
    && pBtree->zRebaseReturnBranch[0]
    && sqlite3_stricmp(zBranch, pBtree->zRebaseReturnBranch)!=0 ){
-    rc = chunkStoreGetBranchWorkingSet(cs, zBranch, &wsHash);
-    if( rc!=SQLITE_OK ) return rc;
-    rc = chunkStoreSetBranchWorkingSet(cs, pBtree->zRebaseReturnBranch, &wsHash);
+    if( pBtree->isRebasing & WS_REBASE_FLAG_META_MIRROR ){
+      rc = btreePutRebaseMetadataOnBranch(
+          cs, pBtree->zRebaseReturnBranch,
+          (u8)(WS_REBASE_FLAG_ACTIVE | WS_REBASE_FLAG_META_MIRROR),
+          &pBtree->preRebaseWorkingCat, &pBtree->rebaseOntoCommit,
+          pBtree->zRebaseOrigBranch, pBtree->zRebaseReturnBranch);
+    }else{
+      rc = chunkStoreGetBranchWorkingSet(cs, zBranch, &wsHash);
+      if( rc!=SQLITE_OK ) return rc;
+      rc = chunkStoreSetBranchWorkingSet(cs, pBtree->zRebaseReturnBranch,
+                                         &wsHash);
+    }
     if( rc!=SQLITE_OK ) return rc;
   }
 

--- a/test/doltlite_rebase.sh
+++ b/test/doltlite_rebase.sh
@@ -162,6 +162,42 @@ run_test_match "noninteractive_rebase_keeps_other_branch_uncommitted_work" \
   "^1$" \
   "$DB3"
 
+# Reopen used to lose the rebase when main was dirty: no mirror meant
+# --abort said "no rebase in progress" and dolt_rebase_feat was left behind.
+seed_dirty_main "$DB3"
+run_test_match "interactive_rebase_dirty_main_starts" \
+  "SELECT dolt_checkout('feat');
+   SELECT dolt_rebase('-i','main');" \
+  "interactive rebase started" \
+  "$DB3"
+run_test "interactive_rebase_abort_after_reopen_dirty_main" \
+  "SELECT dolt_rebase('--abort');
+   SELECT dolt_checkout('main');
+   SELECT count(*) FROM t WHERE v='row99';
+   SELECT count(*) FROM dolt_branches WHERE name='dolt_rebase_feat';" \
+  "Interactive rebase aborted
+0
+1
+0" \
+  "$DB3"
+
+seed_dirty_main "$DB3"
+run_test_match "interactive_rebase_dirty_main_starts_for_continue" \
+  "SELECT dolt_checkout('feat');
+   SELECT dolt_rebase('-i','main');" \
+  "interactive rebase started" \
+  "$DB3"
+run_test "interactive_rebase_continue_after_reopen_dirty_main" \
+  "SELECT dolt_rebase('--continue');
+   SELECT dolt_checkout('main');
+   SELECT count(*) FROM t WHERE v='row99';
+   SELECT count(*) FROM dolt_branches WHERE name='dolt_rebase_feat';" \
+  "Successfully rebased and updated refs/heads/feat
+0
+1
+0" \
+  "$DB3"
+
 # An unrecognised plan verb used to report a bare "rebase failed", which reads
 # as though the rebase had been rolled back. It is not: the plan and working
 # branch are deliberately kept so the action can be corrected and --continue

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -8395,6 +8395,119 @@ static void run_rebase_abort_after_reopen_restores_durable_state(void){
   removeDbFiles(dbpath);
 }
 
+static int setup_dirty_default_rebase(sqlite3 *db){
+  return execSql(db,
+    "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
+    "INSERT INTO t VALUES(1,'one');"
+    "SELECT dolt_add('-A'); SELECT dolt_commit('-m','init');"
+    "SELECT dolt_checkout('-b','feat');"
+    "INSERT INTO t VALUES(10,'f1');"
+    "SELECT dolt_add('-A'); SELECT dolt_commit('-m','f1');"
+    "SELECT dolt_checkout('main');"
+    "INSERT INTO t VALUES(2,'m1');"
+    "SELECT dolt_add('-A'); SELECT dolt_commit('-m','m1');"
+    "INSERT INTO t VALUES(99,'row99');"
+    "SELECT dolt_checkout('feat');");
+}
+
+static void run_rebase_abort_after_reopen_dirty_default(void){
+  sqlite3 *db = 0;
+  char dbpath[256];
+  u8 isRebasing = 0;
+  const char *zOrigBranch = 0;
+
+  printf("=== Rebase Abort After Reopen Dirty Default Test ===\n\n");
+  make_dbpath(dbpath, sizeof(dbpath), "test_rebase_abort_after_reopen_dirty_default");
+  removeDbFiles(dbpath);
+
+  check("open_db_for_rebase_abort_after_reopen_dirty",
+        open_db(dbpath, &db)==SQLITE_OK);
+  check("setup_repo_for_rebase_abort_after_reopen_dirty",
+        setup_dirty_default_rebase(db)==SQLITE_OK);
+  check("start_interactive_rebase_dirty_default",
+        strstr(queryScalarText(db, "SELECT dolt_rebase('-i', 'main')"),
+               "interactive rebase started on branch dolt_rebase_feat")!=0);
+
+  sqlite3_close(db);
+  db = 0;
+
+  check("reopen_db_for_rebase_abort_dirty_default", open_db(dbpath, &db)==SQLITE_OK);
+  check("rebase_abort_dirty_reopen_lands_on_main",
+        strcmp(queryScalarText(db, "SELECT active_branch()"), "main")==0);
+  check("rebase_abort_dirty_reopen_keeps_uncommitted_row",
+        strcmp(queryScalarText(db, "SELECT count(*) FROM t WHERE v='row99'"), "1")==0);
+  check("rebase_abort_dirty_reopen_plan_stays_off_return",
+        strcmp(queryScalarText(db,
+          "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='dolt_rebase'"),
+          "0")==0);
+  doltliteGetSessionRebaseState(db, &isRebasing, 0, 0, &zOrigBranch, 0);
+  check("rebase_abort_dirty_reopen_flag", isRebasing==1);
+  check("rebase_abort_dirty_reopen_orig_branch",
+        zOrigBranch && strcmp(zOrigBranch, "feat")==0);
+  check("rebase_abort_after_reopen_dirty_returns_success",
+        strcmp(queryScalarText(db, "SELECT dolt_rebase('--abort')"),
+               "Interactive rebase aborted")==0);
+  check("rebase_abort_after_reopen_dirty_restores_branch",
+        strcmp(queryScalarText(db, "SELECT active_branch()"), "feat")==0);
+  check("rebase_abort_after_reopen_dirty_checkout_main",
+        strcmp(queryScalarText(db, "SELECT dolt_checkout('main')"), "0")==0);
+  check("rebase_abort_after_reopen_dirty_row_survives",
+        strcmp(queryScalarText(db, "SELECT count(*) FROM t WHERE v='row99'"), "1")==0);
+  check("rebase_abort_after_reopen_dirty_drops_temp_branch",
+        strcmp(queryScalarText(db,
+          "SELECT count(*) FROM dolt_branches WHERE name='dolt_rebase_feat'"), "0")==0);
+  doltliteGetSessionRebaseState(db, &isRebasing, 0, 0, 0, 0);
+  check("rebase_abort_after_reopen_dirty_clears_flag", isRebasing==0);
+
+  sqlite3_close(db);
+  removeDbFiles(dbpath);
+}
+
+static void run_rebase_continue_after_reopen_dirty_default(void){
+  sqlite3 *db = 0;
+  char dbpath[256];
+  u8 isRebasing = 0;
+
+  printf("=== Rebase Continue After Reopen Dirty Default Test ===\n\n");
+  make_dbpath(dbpath, sizeof(dbpath),
+              "test_rebase_continue_after_reopen_dirty_default");
+  removeDbFiles(dbpath);
+
+  check("open_db_for_rebase_continue_after_reopen_dirty",
+        open_db(dbpath, &db)==SQLITE_OK);
+  check("setup_repo_for_rebase_continue_after_reopen_dirty",
+        setup_dirty_default_rebase(db)==SQLITE_OK);
+  check("start_interactive_rebase_dirty_default_for_continue",
+        strstr(queryScalarText(db, "SELECT dolt_rebase('-i', 'main')"),
+               "interactive rebase started on branch dolt_rebase_feat")!=0);
+
+  sqlite3_close(db);
+  db = 0;
+
+  check("reopen_db_for_rebase_continue_dirty_default", open_db(dbpath, &db)==SQLITE_OK);
+  check("rebase_continue_dirty_reopen_lands_on_main",
+        strcmp(queryScalarText(db, "SELECT active_branch()"), "main")==0);
+  check("rebase_continue_dirty_reopen_keeps_uncommitted_row",
+        strcmp(queryScalarText(db, "SELECT count(*) FROM t WHERE v='row99'"), "1")==0);
+  doltliteGetSessionRebaseState(db, &isRebasing, 0, 0, 0, 0);
+  check("rebase_continue_dirty_reopen_flag", isRebasing==1);
+  check("rebase_continue_after_reopen_dirty_succeeds",
+        strcmp(queryScalarText(db, "SELECT dolt_rebase('--continue')"),
+               "Successfully rebased and updated refs/heads/feat")==0);
+  check("rebase_continue_after_reopen_dirty_checkout_main",
+        strcmp(queryScalarText(db, "SELECT dolt_checkout('main')"), "0")==0);
+  check("rebase_continue_after_reopen_dirty_row_survives",
+        strcmp(queryScalarText(db, "SELECT count(*) FROM t WHERE v='row99'"), "1")==0);
+  check("rebase_continue_after_reopen_dirty_drops_temp_branch",
+        strcmp(queryScalarText(db,
+          "SELECT count(*) FROM dolt_branches WHERE name='dolt_rebase_feat'"), "0")==0);
+  doltliteGetSessionRebaseState(db, &isRebasing, 0, 0, 0, 0);
+  check("rebase_continue_after_reopen_dirty_clears_flag", isRebasing==0);
+
+  sqlite3_close(db);
+  removeDbFiles(dbpath);
+}
+
 static void run_rebase_main_table_schema_guard(void){
   sqlite3 *db = 0;
   char dbpath[256];
@@ -12657,6 +12770,8 @@ static const RegressionCase aCases[] = {
   { "merge_abort_after_reopen_restores_durable_state", "Merge Abort After Reopen Restores Durable State Test", run_merge_abort_after_reopen_restores_durable_state },
   { "rebase_continue_without_active_preserves_durable_state", "Rebase Continue Without Active Preserves Durable State Test", run_rebase_continue_without_active_preserves_durable_state },
   { "rebase_abort_after_reopen_restores_durable_state", "Rebase Abort After Reopen Restores Durable State Test", run_rebase_abort_after_reopen_restores_durable_state },
+  { "rebase_abort_after_reopen_dirty_default", "Rebase Abort After Reopen Dirty Default Test", run_rebase_abort_after_reopen_dirty_default },
+  { "rebase_continue_after_reopen_dirty_default", "Rebase Continue After Reopen Dirty Default Test", run_rebase_continue_after_reopen_dirty_default },
   { "rebase_plan_read_error_is_not_partial", "Rebase Plan Read Error Is Not Partial Test", run_rebase_plan_read_error_is_not_partial },
   { "rebase_upstream_history_failure_is_atomic", "Rebase Upstream History Failure Is Atomic Test", run_rebase_upstream_history_failure_is_atomic },
   { "rebase_start_failure_cleans_working_branch", "Rebase Start Failure Cleans Working Branch Test", run_rebase_start_failure_cleans_working_branch },

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -8508,6 +8508,75 @@ static void run_rebase_continue_after_reopen_dirty_default(void){
   removeDbFiles(dbpath);
 }
 
+static void run_rebase_abort_retry_after_claim_commit_error(void){
+  sqlite3 *db = 0;
+  char dbpath[256];
+  const char *res;
+  u8 isRebasing = 0;
+
+  printf("=== Rebase Abort Retry After Claim Commit Error Test ===\n\n");
+  make_dbpath(dbpath, sizeof(dbpath),
+              "test_rebase_abort_retry_after_claim_commit_error");
+  removeDbFiles(dbpath);
+
+  check("open_db_for_rebase_abort_retry_after_claim_error",
+        open_db(dbpath, &db)==SQLITE_OK);
+  check("setup_repo_for_rebase_abort_retry_after_claim_error",
+        setup_dirty_default_rebase(db)==SQLITE_OK);
+  check("start_interactive_rebase_for_claim_commit_error",
+        strstr(queryScalarText(db, "SELECT dolt_rebase('-i', 'main')"),
+               "interactive rebase started on branch dolt_rebase_feat")!=0);
+
+  sqlite3_close(db);
+  db = 0;
+  check("reopen_db_before_claim_commit_error", open_db(dbpath, &db)==SQLITE_OK);
+
+  gRegressionFaultCode = 961;
+  gRegressionFaultHits = 0;
+  sqlite3_test_control(SQLITE_TESTCTRL_FAULT_INSTALL, regressionFaultCallback);
+  res = queryScalarText(db, "SELECT dolt_rebase('--abort')");
+  sqlite3_test_control(SQLITE_TESTCTRL_FAULT_INSTALL, 0);
+  gRegressionFaultCode = 0;
+
+  check("rebase_abort_claim_commit_error_was_injected", gRegressionFaultHits==1);
+  check("rebase_abort_claim_commit_error_is_recovery_failure",
+        strstr(res, "ERROR: rebase recovery failed")!=0);
+  check("rebase_abort_claim_commit_error_does_not_report_success",
+        strstr(res, "Interactive rebase aborted")==0);
+
+  sqlite3_close(db);
+  db = 0;
+  check("reopen_db_after_claim_commit_error", open_db(dbpath, &db)==SQLITE_OK);
+  check("rebase_abort_retry_after_claim_error_lands_on_main",
+        strcmp(queryScalarText(db, "SELECT active_branch()"), "main")==0);
+  check("rebase_abort_retry_after_claim_error_keeps_uncommitted_row",
+        strcmp(queryScalarText(db, "SELECT count(*) FROM t WHERE v='row99'"),
+               "1")==0);
+  check("rebase_abort_retry_after_claim_error_keeps_temp_branch",
+        strcmp(queryScalarText(db,
+          "SELECT count(*) FROM dolt_branches WHERE name='dolt_rebase_feat'"),
+          "1")==0);
+  doltliteGetSessionRebaseState(db, &isRebasing, 0, 0, 0, 0);
+  check("rebase_abort_retry_after_claim_error_keeps_flag", isRebasing==1);
+  check("rebase_abort_retry_after_claim_error_succeeds",
+        strcmp(queryScalarText(db, "SELECT dolt_rebase('--abort')"),
+               "Interactive rebase aborted")==0);
+  check("rebase_abort_retry_after_claim_error_checkout_main",
+        strcmp(queryScalarText(db, "SELECT dolt_checkout('main')"), "0")==0);
+  check("rebase_abort_retry_after_claim_error_row_survives",
+        strcmp(queryScalarText(db, "SELECT count(*) FROM t WHERE v='row99'"),
+               "1")==0);
+  check("rebase_abort_retry_after_claim_error_drops_temp_branch",
+        strcmp(queryScalarText(db,
+          "SELECT count(*) FROM dolt_branches WHERE name='dolt_rebase_feat'"),
+          "0")==0);
+  doltliteGetSessionRebaseState(db, &isRebasing, 0, 0, 0, 0);
+  check("rebase_abort_retry_after_claim_error_clears_flag", isRebasing==0);
+
+  sqlite3_close(db);
+  removeDbFiles(dbpath);
+}
+
 static void run_rebase_main_table_schema_guard(void){
   sqlite3 *db = 0;
   char dbpath[256];
@@ -12772,6 +12841,7 @@ static const RegressionCase aCases[] = {
   { "rebase_abort_after_reopen_restores_durable_state", "Rebase Abort After Reopen Restores Durable State Test", run_rebase_abort_after_reopen_restores_durable_state },
   { "rebase_abort_after_reopen_dirty_default", "Rebase Abort After Reopen Dirty Default Test", run_rebase_abort_after_reopen_dirty_default },
   { "rebase_continue_after_reopen_dirty_default", "Rebase Continue After Reopen Dirty Default Test", run_rebase_continue_after_reopen_dirty_default },
+  { "rebase_abort_retry_after_claim_commit_error", "Rebase Abort Retry After Claim Commit Error Test", run_rebase_abort_retry_after_claim_commit_error },
   { "rebase_plan_read_error_is_not_partial", "Rebase Plan Read Error Is Not Partial Test", run_rebase_plan_read_error_is_not_partial },
   { "rebase_upstream_history_failure_is_atomic", "Rebase Upstream History Failure Is Atomic Test", run_rebase_upstream_history_failure_is_atomic },
   { "rebase_start_failure_cleans_working_branch", "Rebase Start Failure Cleans Working Branch Test", run_rebase_start_failure_cleans_working_branch },


### PR DESCRIPTION
Fixes #1964.

#1958 stopped an interactive rebase from destroying uncommitted work on the branch a reopen lands on by refusing to adopt that branch as the whole-blob mirror. The rebase then lived only on `dolt_rebase_<orig>`. Closing and reopening the database landed on the dirty default branch with no rebase metadata, so `--abort` reported "no rebase in progress" and the temporary branch was left behind.

A working-set V6 byte was tried and backed out: it fixed this case, but growing the blob made the GC walk stop classifying working sets (exact-size check, including `setup_repo_for_integrity_walk`).

This keeps the v5 blob size. Bit 1 of the existing rebasing byte is a sticky metadata-overlay flag:

- clean return branch: whole-blob mirror, as before. `dolt_rebase` stays visible after reopen (`rebase_invalid_plan_persists_plan_table`, `rebase_abort_after_reopen_plan_before_abort`).
- dirty return branch: overlay rebase fields only; the dirty catalog is left alone.
- restore undoes the same choice. A second restore after the overlay bit is cleared is a no-op, so it cannot clean-from-HEAD and wipe the uncommitted row.
- `GetSessionRebaseState` still reports the in-progress bit as `1`, so existing `isRebasing==1` checks stay valid.

`--abort` and `--continue` after reopen now recover, remove `dolt_rebase_<branch>`, and keep the uncommitted row.

Co-Authored-By: Grok 4.6 <noreply@x.ai>