### PR TITLE
Read every merge side at merged column positions

### DIFF
--- a/src/doltlite_merge_int.h
+++ b/src/doltlite_merge_int.h
@@ -229,7 +229,7 @@ void mergeColDefaultsFree(MergeColDefaults *p);
 int mergeColDefaultsLoad(const char *zSql, const char *zTable,
                          MergeColDefaults *pOut);
 
-int normalizeTheirsToMergedLayout(
+int normalizeSideToMergedLayout(
   sqlite3 *db,
   const char *zTable,
   const ProllyHash *pOursRoot,

--- a/src/doltlite_merge_pass1.c
+++ b/src/doltlite_merge_pass1.c
@@ -578,6 +578,55 @@ static int mergePass1CheckPrimaryKeysMatch(
   return SQLITE_ERROR;
 }
 
+/* Exactly one side changed the table's columns, so the merged layout is that
+** side's. The other side and the ancestor still hold records in the old
+** layout, and the row merge addresses every side by merged column position,
+** so both are re-laid out first: otherwise a column the merged layout no
+** longer has shifts every later value one slot left, and an ancestor read at
+** the wrong positions reports cells as changed that neither side touched. */
+static int mergePass1RelayoutOneSidedSchema(
+  MergePass1Ctx *c,
+  const char *zName,
+  int bMergedIsOurs,
+  struct TableEntry *pOurs,
+  struct TableEntry *pAnc,
+  struct TableEntry *pTheirs,
+  ProllyHash *pOtherOut,
+  ProllyHash *pAncOut,
+  int *pbRelaid
+){
+  SchemaEntry *ourSE = findSchemaEntry(c->aOursSchema, c->nOursSchema, zName);
+  SchemaEntry *theirSE = findSchemaEntry(c->aTheirsSchema, c->nTheirsSchema, zName);
+  SchemaEntry *ancSE = findSchemaEntry(c->aAncSchema, c->nAncSchema, zName);
+  const char *zMergedSql;
+  const char *zOtherSql;
+  const ProllyHash *pMergedRoot;
+  const ProllyHash *pOtherRoot;
+  int rc;
+
+  *pbRelaid = 0;
+  if( !ancSE || !ancSE->zSql || !ourSE || !ourSE->zSql
+   || !theirSE || !theirSE->zSql ){
+    return SQLITE_OK;
+  }
+
+  zMergedSql = bMergedIsOurs ? ourSE->zSql : theirSE->zSql;
+  zOtherSql = bMergedIsOurs ? theirSE->zSql : ourSE->zSql;
+  pMergedRoot = bMergedIsOurs ? &pOurs->root : &pTheirs->root;
+  pOtherRoot = bMergedIsOurs ? &pTheirs->root : &pOurs->root;
+
+  rc = normalizeSideToMergedLayout(c->db, zName, pMergedRoot, pOtherRoot,
+                                   pOurs->flags, ancSE->zSql,
+                                   zMergedSql, zOtherSql, pOtherOut);
+  if( rc!=SQLITE_OK ) return rc;
+  rc = normalizeSideToMergedLayout(c->db, zName, pMergedRoot, &pAnc->root,
+                                   pOurs->flags, ancSE->zSql,
+                                   zMergedSql, ancSE->zSql, pAncOut);
+  if( rc!=SQLITE_OK ) return rc;
+  *pbRelaid = 1;
+  return SQLITE_OK;
+}
+
 /* Both sides still have the object. */
 static int mergePass1BothSides(
   MergePass1Ctx *c,
@@ -603,6 +652,12 @@ static int mergePass1BothSides(
   int bDualAddColMerge = 0;
   int bSchemaConflict = 0;
   ProllyHash theirsNormRoot;
+  ProllyHash otherNormRoot;
+  ProllyHash ancNormRoot;
+  struct TableEntry oursAdj;
+  struct TableEntry ancAdj;
+  struct TableEntry *pMergeOurs = &c->aOurs[iOurs];
+  struct TableEntry *pMergeAnc = ancEntry;
   const ProllyHash *pMergeTheirsRoot = &theirsEntry->root;
   int rc = SQLITE_OK;
 
@@ -664,13 +719,23 @@ static int mergePass1BothSides(
       SchemaEntry *ancSE = findSchemaEntry(c->aAncSchema, c->nAncSchema, zName);
       if( ancSE && ancSE->zSql && ourSE && ourSE->zSql
        && theirSE && theirSE->zSql ){
-        rc = normalizeTheirsToMergedLayout(c->db, zName,
+        rc = normalizeSideToMergedLayout(c->db, zName,
                                            &c->aOurs[iOurs].root,
                                            &theirsEntry->root,
                                            c->aOurs[iOurs].flags, ancSE->zSql,
                                            ourSE->zSql, theirSE->zSql,
                                            &theirsNormRoot);
         if( rc!=SQLITE_OK ) return rc;
+        rc = normalizeSideToMergedLayout(c->db, zName,
+                                           &c->aOurs[iOurs].root,
+                                           &ancEntry->root,
+                                           c->aOurs[iOurs].flags, ancSE->zSql,
+                                           ourSE->zSql, ancSE->zSql,
+                                           &ancNormRoot);
+        if( rc!=SQLITE_OK ) return rc;
+        ancAdj = *ancEntry;
+        memcpy(&ancAdj.root, &ancNormRoot, sizeof(ProllyHash));
+        pMergeAnc = &ancAdj;
         pMergeTheirsRoot = &theirsNormRoot;
         bDualAddColMerge = 1;
         skipRowMerge = 0;
@@ -699,9 +764,30 @@ static int mergePass1BothSides(
 
   if( skipRowMerge ) return SQLITE_OK;
 
+  if( zName && oursChanged && theirsChanged
+   && ourSchemaChanged!=theirSchemaChanged ){
+    int bRelaid = 0;
+    rc = mergePass1RelayoutOneSidedSchema(
+        c, zName, ourSchemaChanged, &c->aOurs[iOurs], ancEntry, theirsEntry,
+        &otherNormRoot, &ancNormRoot, &bRelaid);
+    if( rc!=SQLITE_OK ) return rc;
+    if( bRelaid ){
+      ancAdj = *ancEntry;
+      memcpy(&ancAdj.root, &ancNormRoot, sizeof(ProllyHash));
+      pMergeAnc = &ancAdj;
+      if( ourSchemaChanged ){
+        pMergeTheirsRoot = &otherNormRoot;
+      }else{
+        oursAdj = c->aOurs[iOurs];
+        memcpy(&oursAdj.root, &otherNormRoot, sizeof(ProllyHash));
+        pMergeOurs = &oursAdj;
+      }
+    }
+  }
+
   if( bDualAddColMerge || (oursChanged && theirsChanged) ){
     return mergePass1MergeTableData(
-        c, zName, zLogicalName, &c->aOurs[iOurs], ancEntry,
+        c, zName, zLogicalName, pMergeOurs, pMergeAnc,
         pMergeTheirsRoot, ourSchemaChanged, theirSchemaChanged,
         schemaChoice, theirsEntry);
   }

--- a/src/doltlite_merge_schema.c
+++ b/src/doltlite_merge_schema.c
@@ -996,7 +996,11 @@ done:
 }
 
 
-int normalizeTheirsToMergedLayout(
+/* Rewrite the tree at pTheirsRoot, whose records follow zTheirsSql, into the
+** merged layout described by zOursSql. pOursRoot is the other side of the
+** merge, read only to tell rows that side also holds from rows this one
+** introduces. Either side of a merge can be the one converted. */
+int normalizeSideToMergedLayout(
   sqlite3 *db,
   const char *zTable,
   const ProllyHash *pOursRoot,
@@ -1013,6 +1017,7 @@ int normalizeTheirsToMergedLayout(
   int nAnc = 0, nOurs = 0, nTheirs = 0;
   int *aMap = 0;
   int nMerged;
+  int nDropped = 0;
   ProllyMutMap mm;
   int mmInit = 0;
   ProllyCursor cur;
@@ -1045,6 +1050,7 @@ int normalizeTheirsToMergedLayout(
   for(j=0; j<nTheirs; j++){
     int found = parsedColumnIndexByName(
         aOurs, nOurs, aTheirs[j].zName);
+    int bInAnc = 0;
     if( found<0 ){
       int ai = parsedColumnIndexByName(
           aAnc, nAnc, aTheirs[j].zName);
@@ -1055,6 +1061,7 @@ int normalizeTheirsToMergedLayout(
         ai = j;
       }
       if( ai>=0 ){
+        bInAnc = 1;
         found = parsedColumnIndexByName(
             aOurs, nOurs, aAnc[ai].zName);
         if( found<0 && ai<nOurs
@@ -1065,9 +1072,33 @@ int normalizeTheirsToMergedLayout(
         }
       }
     }
-    aMap[j] = (found>=0) ? found : nMerged++;
+    if( found>=0 ){
+      aMap[j] = found;
+    }else if( bInAnc ){
+      /* The ancestor had this column and the merged layout does not, so the
+      ** merged side dropped it. Appending it as a new column instead would
+      ** resurrect dropped data as a trailing field the schema cannot name. */
+      aMap[j] = -1;
+      nDropped++;
+    }else{
+      aMap[j] = nMerged++;
+    }
   }
   if( nMerged > DOLTLITE_MAX_RECORD_FIELDS ){ rc = SQLITE_ERROR; goto done; }
+
+  /* Records already sit at their merged positions, so the existing tree is
+  ** the answer. Trailing columns the merged layout adds read as absent from a
+  ** short record, which is what a rewrite would store anyway. */
+  if( nDropped==0 ){
+    int bSamePositions = 1;
+    for(j=0; j<nTheirs; j++){
+      if( aMap[j]!=j ){ bSamePositions = 0; break; }
+    }
+    if( bSamePositions ){
+      memcpy(pOutRoot, pTheirsRoot, sizeof(*pOutRoot));
+      goto done;
+    }
+  }
 
   /* Slots this side does not supply take the declared default of whichever
   ** schema owns them: ours for the columns we keep, theirs for the ones
@@ -1146,7 +1177,9 @@ int normalizeTheirsToMergedLayout(
       int tgt = aMap[j];
       int st = info.aType[j];
       const u8 *body = pVal + info.aOffset[j];
-      DoltliteSerialValue *m = &aMem[tgt];
+      DoltliteSerialValue *m;
+      if( tgt<0 ) continue;
+      m = &aMem[tgt];
       memset(m, 0, sizeof(*m));
       m->eType = SQLITE_NULL;
       if( st==0 ){

--- a/test/doltlite_schema_merge.sh
+++ b/test/doltlite_schema_merge.sh
@@ -729,4 +729,133 @@ run_test "schema_tokenizer_comment" \
   "2" "$DB"
 rm -f "$DB"
 
+# Only one side changes the columns, so the other side and the ancestor still
+# store the dropped column. Every value right of it must not shift left, and a
+# cell neither side touched must not read as a conflict. Values verified
+# against Dolt 2.2.2.
+DB=/tmp/test_drop_col_merge_$$.db; rm -f "$DB"
+cat <<'EOF' | $DOLTLITE "$DB" > /dev/null 2>&1
+CREATE TABLE t(k INTEGER PRIMARY KEY, a TEXT, b TEXT, c TEXT);
+INSERT INTO t VALUES(1,'a1','b1','c1'),(2,'a2','b2','c2');
+SELECT dolt_commit('-A','-m','base');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+INSERT INTO t VALUES(3,'a3','b3','c3');
+SELECT dolt_commit('-A','-m','insert on feat');
+SELECT dolt_checkout('main');
+ALTER TABLE t DROP COLUMN b;
+SELECT dolt_commit('-A','-m','drop b on main');
+EOF
+run_test_match "drop_col_merge_hash" "SELECT dolt_merge('feat');" \
+  "^[0-9a-f]{40}$" "$DB"
+run_test "drop_col_merge_incoming_row" "SELECT a||'|'||c FROM t WHERE k=3;" \
+  "a3|c3" "$DB"
+run_test "drop_col_merge_existing_row" "SELECT a||'|'||c FROM t WHERE k=1;" \
+  "a1|c1" "$DB"
+run_test "drop_col_merge_cols" \
+  "SELECT count(*) FROM pragma_table_info('t') WHERE name='b';" "0" "$DB"
+run_test "drop_col_merge_integrity" "PRAGMA integrity_check;" "ok" "$DB"
+rm -f "$DB"
+
+# The mirror direction: the side that dropped the column is the one merged in,
+# so it is our own rows that have to move into the merged layout.
+DB=/tmp/test_drop_col_merge_rev_$$.db; rm -f "$DB"
+cat <<'EOF' | $DOLTLITE "$DB" > /dev/null 2>&1
+CREATE TABLE t(k INTEGER PRIMARY KEY, a TEXT, b TEXT, c TEXT);
+INSERT INTO t VALUES(1,'a1','b1','c1'),(2,'a2','b2','c2');
+SELECT dolt_commit('-A','-m','base');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+ALTER TABLE t DROP COLUMN b;
+SELECT dolt_commit('-A','-m','drop b on feat');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES(3,'a3','b3','c3');
+SELECT dolt_commit('-A','-m','insert on main');
+EOF
+run_test_match "drop_col_merge_rev_hash" "SELECT dolt_merge('feat');" \
+  "^[0-9a-f]{40}$" "$DB"
+run_test "drop_col_merge_rev_our_row" "SELECT a||'|'||c FROM t WHERE k=3;" \
+  "a3|c3" "$DB"
+run_test "drop_col_merge_rev_cols" \
+  "SELECT count(*) FROM pragma_table_info('t') WHERE name='b';" "0" "$DB"
+run_test "drop_col_merge_rev_integrity" "PRAGMA integrity_check;" "ok" "$DB"
+rm -f "$DB"
+
+# A row both sides hold, changed only by them: the ancestor has to be read at
+# merged positions or the untouched cell looks like a competing edit.
+DB=/tmp/test_drop_col_merge_mod_$$.db; rm -f "$DB"
+cat <<'EOF' | $DOLTLITE "$DB" > /dev/null 2>&1
+CREATE TABLE t(k INTEGER PRIMARY KEY, a TEXT, b TEXT, c TEXT);
+INSERT INTO t VALUES(1,'a1','b1','c1'),(2,'a2','b2','c2');
+SELECT dolt_commit('-A','-m','base');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+UPDATE t SET c='c2new' WHERE k=2;
+SELECT dolt_commit('-A','-m','modify shared row');
+SELECT dolt_checkout('main');
+ALTER TABLE t DROP COLUMN b;
+SELECT dolt_commit('-A','-m','drop b on main');
+EOF
+run_test_match "drop_col_merge_mod_hash" "SELECT dolt_merge('feat');" \
+  "^[0-9a-f]{40}$" "$DB"
+run_test "drop_col_merge_mod_row" "SELECT a||'|'||c FROM t WHERE k=2;" \
+  "a2|c2new" "$DB"
+run_test "drop_col_merge_mod_untouched" "SELECT a||'|'||c FROM t WHERE k=1;" \
+  "a1|c1" "$DB"
+run_test "drop_col_merge_mod_conflicts" \
+  "SELECT count(*) FROM dolt_conflicts;" "0" "$DB"
+rm -f "$DB"
+
+# Both sides change columns and one of them drops: the ancestor no longer
+# lines up with either side, so it too is read at merged positions.
+DB=/tmp/test_drop_col_merge_dual_$$.db; rm -f "$DB"
+cat <<'EOF' | $DOLTLITE "$DB" > /dev/null 2>&1
+CREATE TABLE t(k INTEGER PRIMARY KEY, a TEXT, b TEXT, c TEXT);
+INSERT INTO t VALUES(1,'a1','b1','c1'),(2,'a2','b2','c2');
+SELECT dolt_commit('-A','-m','base');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+ALTER TABLE t ADD COLUMN d TEXT;
+UPDATE t SET c='c2new' WHERE k=2;
+SELECT dolt_commit('-A','-m','add d and modify on feat');
+SELECT dolt_checkout('main');
+ALTER TABLE t DROP COLUMN b;
+SELECT dolt_commit('-A','-m','drop b on main');
+EOF
+run_test_match "drop_col_merge_dual_hash" "SELECT dolt_merge('feat');" \
+  "^[0-9a-f]{40}$" "$DB"
+run_test "drop_col_merge_dual_modified" "SELECT a||'|'||c FROM t WHERE k=2;" \
+  "a2|c2new" "$DB"
+run_test "drop_col_merge_dual_untouched" "SELECT a||'|'||c FROM t WHERE k=1;" \
+  "a1|c1" "$DB"
+run_test "drop_col_merge_dual_added_col" \
+  "SELECT count(*) FROM t WHERE d IS NOT NULL;" "0" "$DB"
+run_test "drop_col_merge_dual_conflicts" \
+  "SELECT count(*) FROM dolt_conflicts;" "0" "$DB"
+rm -f "$DB"
+
+# Dropping the trailing column leaves the incoming value with nowhere to go,
+# the one shape where no surviving column later claims its slot.
+DB=/tmp/test_drop_last_col_merge_$$.db; rm -f "$DB"
+cat <<'EOF' | $DOLTLITE "$DB" > /dev/null 2>&1
+CREATE TABLE t(k INTEGER PRIMARY KEY, a TEXT, b TEXT, c TEXT);
+INSERT INTO t VALUES(1,'a1','b1','c1');
+SELECT dolt_commit('-A','-m','base');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+INSERT INTO t VALUES(2,'a2','b2','c2');
+SELECT dolt_commit('-A','-m','insert on feat');
+SELECT dolt_checkout('main');
+ALTER TABLE t DROP COLUMN c;
+SELECT dolt_commit('-A','-m','drop trailing column');
+EOF
+run_test_match "drop_last_col_merge_hash" "SELECT dolt_merge('feat');" \
+  "^[0-9a-f]{40}$" "$DB"
+run_test "drop_last_col_merge_incoming_row" "SELECT a||'|'||b FROM t WHERE k=2;" \
+  "a2|b2" "$DB"
+run_test "drop_last_col_merge_cols" \
+  "SELECT count(*) FROM pragma_table_info('t') WHERE name='c';" "0" "$DB"
+run_test "drop_last_col_merge_integrity" "PRAGMA integrity_check;" "ok" "$DB"
+rm -f "$DB"
+
 dltest_finish


### PR DESCRIPTION
A merge where one side drops a column and the other only writes rows silently corrupts data. Only the both-sides-changed-schema path ever moved a side into the merged layout, so the side that kept the old layout is read at the merged column positions and every value right of the dropped column shifts one slot left.

On `t(k,a,b,c)` where main drops `b` and a branch inserts `(2,'a2','b2','c2')`:

```
merged row 2 -> a='a2'  c='b2'      the value 'c2' is gone
```

The merge returns a commit hash, records no conflict, and prints no warning. Dolt 2.2.2 returns `c2`. It happens in both merge directions — when the dropping side is the one merged in, it is our own rows that are read at the wrong positions.

The ancestor is misread the same way. For a row both sides hold, comparing against an ancestor laid out differently reports a cell as changed on both sides, so a merge Dolt completes cleanly stops with a conflict:

```
main drops b, branch does UPDATE t SET c='c2new' WHERE k=2
doltlite: cannot merge: conflicts detected      dolt: merge successful, c='c2new'
```

## What changed

The side whose schema was not adopted, and the ancestor, are re-laid into the merged layout before rows are merged — in both directions, and in the dual-schema-change path that previously moved only theirs.

The layout mapping could not express a drop at all: a source column missing from the merged layout was appended as a new column, which would restore dropped data as a trailing field no column names. It is discarded when the ancestor had it, since only a drop accounts for a column that the ancestor has and the merged layout does not. A side already sitting at its merged positions is returned untouched, so add-column merges do no extra work and keep their current behaviour.

## Testing

`test/doltlite_schema_merge.sh` gains cases for both directions, the shared-row edit that used to conflict, the dual-schema-change variant, and a trailing-column drop. Expected values were taken from Dolt 2.2.2.

- Fail-before/pass-after: 7 of the new assertions fail on master (`126 passed, 7 failed`), all pass with the fix (`133 passed, 0 failed`).
- Full shell battery: **104/104 suites**, including the C regression suite at 310853/310853 assertions.
- Suite passes identically under an ASAN+UBSAN build.
- Differential sweep vs stock SQLite 3.54.0, all feature groups: 150/150 seeds.
- `vc_oracle_merge_test` and `vc_oracle_schema_merge_test` have pre-existing failures; counts are byte-identical before and after this change.

The trailing-column case earns its own test because it is the only shape that reaches the discard path — for a middle column, a surviving column later claims the same slot and overwrites it. Reaching that path unguarded is a stack-buffer underflow (`aMem[-1]`), which UBSAN and ASAN both report; the bounds guard is covered by that test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)