### PR TITLE
Stop counting the extended-numeric neighbor in BETWEEN

### DIFF
--- a/src/prolly_btree_cursor_count.c
+++ b/src/prolly_btree_cursor_count.c
@@ -208,6 +208,25 @@ static int blobPrefixSuccessor(const u8 *pKey, int nKey, u8 **ppOut, int *pnOut)
   return SQLITE_OK;
 }
 
+/* Exclusive end after a complete first-field encoding. A 9-byte exact
+** numeric is a byte prefix of the 18-byte neighbor that shares its IEEE
+** base; a raw prefix successor sits above that neighbor and would count
+** it as still inside the range. Extra composite columns start with a
+** field tag below 0x80, so appending the continuation marker keeps them
+** inside and leaves the neighbor out. */
+static int blobFieldSuccessor(const u8 *pKey, int nKey, u8 **ppOut, int *pnOut){
+  if( nKey==9 && pKey[0]==SORTKEY_NUM ){
+    u8 *pOut = sqlite3_malloc(10);
+    if( !pOut ) return SQLITE_NOMEM;
+    memcpy(pOut, pKey, 9);
+    pOut[9] = 0x80;
+    *ppOut = pOut;
+    *pnOut = 10;
+    return SQLITE_OK;
+  }
+  return blobPrefixSuccessor(pKey, nKey, ppOut, pnOut);
+}
+
 static int countBlobKeysBefore(
   Btree *pBtree,
   const ProllyHash *pRoot,
@@ -272,7 +291,7 @@ static int countTreeBlobPrefixRange(
   rc = sortKeyFromUnpackedForCount(
       pCur, pUpper, &pUpperKey, &nUpperAlloc, &nUpperKey);
   if( rc!=SQLITE_OK ) goto done;
-  rc = blobPrefixSuccessor(pUpperKey, nUpperKey, &pUpperNext, &nUpperNext);
+  rc = blobFieldSuccessor(pUpperKey, nUpperKey, &pUpperNext, &nUpperNext);
   if( rc!=SQLITE_OK ) goto done;
 
   rc = countBlobKeysBefore(pCur->pBtree, &pTE->root, pTE->flags,

--- a/test/doltlite_count_numeric_range.sh
+++ b/test/doltlite_count_numeric_range.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+
+source "$(dirname "$0")/lib/doltlite_test_common.sh"
+
+db_rm() {
+  rm -rf "$1" "${1}-wal"
+}
+
+echo "=== Count index range: extended-numeric BETWEEN ==="
+echo ""
+
+# COUNT(*) WHERE k BETWEEN lo AND hi uses OP_CountIndexRange. The upper
+# exclusive bound used to be a raw byte successor of the encoded sort
+# key. An integer beyond ±2^53 is 18 bytes whose first 9 are the IEEE
+# neighbor, so that successor sat above the neighbor and counted it.
+#
+#   lo  = -9007199254740995
+#   eq  = -9007199254740994   (9-byte exact)
+#   ext = -9007199254740993   (18-byte, same 9-byte prefix as eq)
+
+DB=/tmp/test_count_numeric_range_$$.db
+db_rm "$DB"
+
+run_test "numeric_pk_between_lo_eq" \
+  "CREATE TABLE t(k NUMERIC PRIMARY KEY);
+   INSERT INTO t VALUES(-9007199254740995);
+   INSERT INTO t VALUES(-9007199254740994);
+   INSERT INTO t VALUES(-9007199254740993);
+   SELECT count(*) FROM t WHERE k BETWEEN -9007199254740995 AND -9007199254740994;" \
+  "2" \
+  "$DB"
+
+db_rm "$DB"
+run_test "numeric_pk_between_eq_eq" \
+  "CREATE TABLE t(k NUMERIC PRIMARY KEY);
+   INSERT INTO t VALUES(-9007199254740995);
+   INSERT INTO t VALUES(-9007199254740994);
+   INSERT INTO t VALUES(-9007199254740993);
+   SELECT count(*) FROM t WHERE k BETWEEN -9007199254740994 AND -9007199254740994;" \
+  "1" \
+  "$DB"
+
+db_rm "$DB"
+run_test "numeric_pk_between_matches_scan" \
+  "CREATE TABLE t(k NUMERIC PRIMARY KEY);
+   INSERT INTO t VALUES(-9007199254740995);
+   INSERT INTO t VALUES(-9007199254740994);
+   INSERT INTO t VALUES(-9007199254740993);
+   SELECT count(*) FROM t WHERE k BETWEEN -9007199254740994 AND -9007199254740994;
+   SELECT count(*) FROM (SELECT k FROM t WHERE k BETWEEN -9007199254740994 AND -9007199254740994);" \
+  "1
+1" \
+  "$DB"
+
+db_rm "$DB"
+run_test "without_rowid_between_eq_eq" \
+  "CREATE TABLE t(k INTEGER PRIMARY KEY) WITHOUT ROWID;
+   INSERT INTO t VALUES(-9007199254740995);
+   INSERT INTO t VALUES(-9007199254740994);
+   INSERT INTO t VALUES(-9007199254740993);
+   SELECT count(*) FROM t WHERE k BETWEEN -9007199254740994 AND -9007199254740994;" \
+  "1" \
+  "$DB"
+
+db_rm "$DB"
+run_test "secondary_index_between_eq_eq" \
+  "CREATE TABLE t(id INTEGER PRIMARY KEY, k INTEGER NOT NULL);
+   CREATE INDEX t_k ON t(k);
+   INSERT INTO t VALUES(1,-9007199254740995);
+   INSERT INTO t VALUES(2,-9007199254740994);
+   INSERT INTO t VALUES(3,-9007199254740993);
+   SELECT count(*) FROM t WHERE k BETWEEN -9007199254740994 AND -9007199254740994;" \
+  "1" \
+  "$DB"
+
+db_rm "$DB"
+run_test "composite_pk_between_keeps_twins" \
+  "CREATE TABLE t(k INTEGER, j TEXT, PRIMARY KEY(k, j));
+   INSERT INTO t VALUES(-9007199254740994, 'A');
+   INSERT INTO t VALUES(-9007199254740994, 'B');
+   INSERT INTO t VALUES(-9007199254740993, 'z');
+   SELECT count(*) FROM t WHERE k BETWEEN -9007199254740994 AND -9007199254740994;" \
+  "2" \
+  "$DB"
+
+db_rm "$DB"
+run_test "positive_numeric_pk_between_eq_eq" \
+  "CREATE TABLE t(k NUMERIC PRIMARY KEY);
+   INSERT INTO t VALUES(9007199254740993);
+   INSERT INTO t VALUES(9007199254740994);
+   INSERT INTO t VALUES(9007199254740995);
+   SELECT count(*) FROM t WHERE k BETWEEN 9007199254740994 AND 9007199254740994;" \
+  "1" \
+  "$DB"
+
+dltest_finish

--- a/test/lib/doltlite_suite_manifest.sh
+++ b/test/lib/doltlite_suite_manifest.sh
@@ -103,6 +103,7 @@ doltlite_gc_scale.sh
 doltlite_index_prefix.sh
 doltlite_txn_seek_visibility.sh
 doltlite_txn_seek_prefix_contract.sh
+doltlite_count_numeric_range.sh
 doltlite_row_count_estimate.sh
 doltlite_regression_test_c.sh
 review_regression_test.sh


### PR DESCRIPTION
`SELECT count(*) FROM t WHERE k BETWEEN lo AND hi` on a single-column ASC numeric PK or index uses `OP_CountIndexRange`. The exclusive upper bound was a raw byte successor of the encoded sort key.

Integers outside ±2^53 are stored as 18-byte keys whose first 9 bytes are the IEEE neighbor. The successor of that 9-byte encoding sits *above* the 18-byte neighbor, so the neighbor was counted as still inside the range. A scan of the same predicate did not.

```sql
CREATE TABLE t(k NUMERIC PRIMARY KEY);
INSERT INTO t VALUES(-9007199254740995);
INSERT INTO t VALUES(-9007199254740994);
INSERT INTO t VALUES(-9007199254740993);
SELECT count(*) FROM t WHERE k BETWEEN -9007199254740994 AND -9007199254740994;
-- was 2; stock SQLite and SELECT k both return 1
```

The exclusive end after a complete 9-byte exact numeric is now the `0x80` continuation marker. Extra composite columns start with a field tag below `0x80`, so twins of the bound stay inside the range.

`numeric_pk_between_eq_eq` is the fail-before / pass-after case.

Co-Authored-By: Grok 4.6 <noreply@x.ai>