### PR TITLE
Keep a column deletion when a rename adopts the other schema

### DIFF
--- a/src/doltlite_core.c
+++ b/src/doltlite_core.c
@@ -492,6 +492,10 @@ void freeSchemaMergeActions(SchemaMergeAction *a, int n){
       sqlite3_free(a[i].azAddColumns[j]);
     }
     sqlite3_free(a[i].azAddColumns);
+    for(j=0; j<a[i].nDropColumns; j++){
+      sqlite3_free(a[i].azDropColumns[j]);
+    }
+    sqlite3_free(a[i].azDropColumns);
     sqlite3_free(a[i].zTableName);
   }
   sqlite3_free(a);

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -1308,6 +1308,8 @@ struct SchemaMergeAction {
   char *zTableName;
   char **azAddColumns;
   int nAddColumns;
+  char **azDropColumns;
+  int nDropColumns;
 };
 
 void freeSchemaMergeActions(SchemaMergeAction *a, int n);

--- a/src/doltlite_merge.c
+++ b/src/doltlite_merge.c
@@ -369,12 +369,14 @@ static int preDetectIndexSchemaConflicts(
   return SQLITE_OK;
 }
 
-int recordSchemaAddColumns(
+int recordSchemaColumnChanges(
   SchemaMergeAction **ppSchemaActions,
   int *pnSchemaActions,
   const char *zName,
   char **azAddCols,
-  int nAddCols
+  int nAddCols,
+  char **azDropCols,
+  int nDropCols
 ){
   SchemaMergeAction *aNew;
   aNew = sqlite3_realloc(*ppSchemaActions,
@@ -385,8 +387,21 @@ int recordSchemaAddColumns(
   if( !aNew[*pnSchemaActions].zTableName ) return SQLITE_NOMEM;
   aNew[*pnSchemaActions].azAddColumns = azAddCols;
   aNew[*pnSchemaActions].nAddColumns = nAddCols;
+  aNew[*pnSchemaActions].azDropColumns = azDropCols;
+  aNew[*pnSchemaActions].nDropColumns = nDropCols;
   (*pnSchemaActions)++;
   return SQLITE_OK;
+}
+
+int recordSchemaAddColumns(
+  SchemaMergeAction **ppSchemaActions,
+  int *pnSchemaActions,
+  const char *zName,
+  char **azAddCols,
+  int nAddCols
+){
+  return recordSchemaColumnChanges(ppSchemaActions, pnSchemaActions, zName,
+                                   azAddCols, nAddCols, 0, 0);
 }
 
 int schemaEntryChangedByName(
@@ -1026,6 +1041,8 @@ int tryResolveSchemaDivergence(
   SchemaEntry *theirSchEntry;
   char **azAddCols = 0;
   int nAddCols = 0;
+  char **azDropCols = 0;
+  int nDropCols = 0;
   int schemaChoice = SCHEMA_MERGE_DEFAULT;
   int resolvedDivergence = 0;
   char *zSchemaErr = 0;
@@ -1048,7 +1065,7 @@ int tryResolveSchemaDivergence(
    && theirSchEntry && theirSchEntry->zSql ){
     rc = trySchemaColumnMerge(
       ancSchEntry->zSql, ourSchEntry->zSql, theirSchEntry->zSql,
-      &azAddCols, &nAddCols, &schemaChoice,
+      &azAddCols, &nAddCols, &azDropCols, &nDropCols, &schemaChoice,
       &resolvedDivergence, &zSchemaErr);
   }else{
     rc = SQLITE_ERROR;
@@ -1073,23 +1090,29 @@ int tryResolveSchemaDivergence(
     }
     sqlite3_free(zSchemaErr);
     freeAddedColumns(azAddCols, nAddCols);
+    freeAddedColumns(azDropCols, nDropCols);
     return SQLITE_ERROR;
   }
   sqlite3_free(zSchemaErr);
 
   if( schemaChoice!=SCHEMA_MERGE_DEFAULT ){
     if( ppSchemaActions && pnSchemaActions ){
-      rc = recordSchemaAddColumns(ppSchemaActions, pnSchemaActions, zName,
-                                  azAddCols, nAddCols);
+      rc = recordSchemaColumnChanges(ppSchemaActions, pnSchemaActions, zName,
+                                     azAddCols, nAddCols,
+                                     azDropCols, nDropCols);
       if( rc!=SQLITE_OK ){
         freeAddedColumns(azAddCols, nAddCols);
+        freeAddedColumns(azDropCols, nDropCols);
         return rc;
       }
       azAddCols = 0;
       nAddCols = 0;
+      azDropCols = 0;
+      nDropCols = 0;
     }
     *pSchemaChoice = schemaChoice;
     freeAddedColumns(azAddCols, nAddCols);
+    freeAddedColumns(azDropCols, nDropCols);
     return SQLITE_OK;
   }
 

--- a/src/doltlite_merge_cmd.c
+++ b/src/doltlite_merge_cmd.c
@@ -115,6 +115,15 @@ static int doltliteApplyMergeSchemaActions(
       sqlite3_free(zAlter);
       if( rc!=SQLITE_OK ) break;
     }
+    /* Deletions the side whose schema was not adopted had already made. */
+    for(sj=0; rc==SQLITE_OK && sj<aSchemaActions[si].nDropColumns; sj++){
+      char *zAlter = sqlite3_mprintf("ALTER TABLE \"%w\" DROP COLUMN \"%w\"",
+                                      aSchemaActions[si].zTableName,
+                                      aSchemaActions[si].azDropColumns[sj]);
+      if( !zAlter ) return SQLITE_NOMEM;
+      rc = sqlite3_exec(db, zAlter, 0, 0, 0);
+      sqlite3_free(zAlter);
+    }
   }
 
   /* Row data (theirs' adds, edits to shared columns, deletes, and added-column

--- a/src/doltlite_merge_int.h
+++ b/src/doltlite_merge_int.h
@@ -121,6 +121,7 @@ int trySchemaColumnMerge(
   const char *zOursSql,
   const char *zTheirsSql,
   char ***ppAddCols, int *pnAddCols,
+  char ***ppDropCols, int *pnDropCols,
   int *pSchemaChoice,
   int *pResolvedDivergence,
   char **pzErrDetail
@@ -145,6 +146,16 @@ int appendSchemaConflict(
   const char *zTable,
   const char *zObject,
   int *pAddedTable
+);
+
+int recordSchemaColumnChanges(
+  SchemaMergeAction **ppSchemaActions,
+  int *pnSchemaActions,
+  const char *zName,
+  char **azAddCols,
+  int nAddCols,
+  char **azDropCols,
+  int nDropCols
 );
 
 int recordSchemaAddColumns(

--- a/src/doltlite_merge_pass1.c
+++ b/src/doltlite_merge_pass1.c
@@ -578,12 +578,46 @@ static int mergePass1CheckPrimaryKeysMatch(
   return SQLITE_ERROR;
 }
 
-/* Exactly one side changed the table's columns, so the merged layout is that
-** side's. The other side and the ancestor still hold records in the old
-** layout, and the row merge addresses every side by merged column position,
-** so both are re-laid out first: otherwise a column the merged layout no
-** longer has shifts every later value one slot left, and an ancestor read at
-** the wrong positions reports cells as changed that neither side touched. */
+/* The row merge addresses every side by merged column position, so a side
+** still holding the old layout has to be re-laid out first: otherwise a
+** column the merged layout no longer has shifts every later value one slot
+** left, and an ancestor read at the wrong positions reports cells as changed
+** that neither side touched. zOtherSql is the layout of the side that did not
+** supply the merged one, which is not always what the schema arrays hold —
+** adopting theirs overwrites our entry's SQL. */
+static int mergePass1RelayoutToMergedSchema(
+  MergePass1Ctx *c,
+  const char *zName,
+  const char *zAncSql,
+  const char *zMergedSql,
+  const char *zOtherSql,
+  u8 flags,
+  const ProllyHash *pMergedRoot,
+  const ProllyHash *pOtherRoot,
+  const ProllyHash *pAncRoot,
+  ProllyHash *pOtherOut,
+  ProllyHash *pAncOut,
+  int *pbRelaid
+){
+  int rc;
+
+  *pbRelaid = 0;
+  if( !zAncSql || !zMergedSql || !zOtherSql ) return SQLITE_OK;
+
+  rc = normalizeSideToMergedLayout(c->db, zName, pMergedRoot, pOtherRoot,
+                                   flags, zAncSql,
+                                   zMergedSql, zOtherSql, pOtherOut);
+  if( rc!=SQLITE_OK ) return rc;
+  rc = normalizeSideToMergedLayout(c->db, zName, pMergedRoot, pAncRoot,
+                                   flags, zAncSql,
+                                   zMergedSql, zAncSql, pAncOut);
+  if( rc!=SQLITE_OK ) return rc;
+  *pbRelaid = 1;
+  return SQLITE_OK;
+}
+
+/* Exactly one side changed the table's columns, so the merged layout is
+** that side's and the other side plus the ancestor have to move onto it. */
 static int mergePass1RelayoutOneSidedSchema(
   MergePass1Ctx *c,
   const char *zName,
@@ -598,33 +632,17 @@ static int mergePass1RelayoutOneSidedSchema(
   SchemaEntry *ourSE = findSchemaEntry(c->aOursSchema, c->nOursSchema, zName);
   SchemaEntry *theirSE = findSchemaEntry(c->aTheirsSchema, c->nTheirsSchema, zName);
   SchemaEntry *ancSE = findSchemaEntry(c->aAncSchema, c->nAncSchema, zName);
-  const char *zMergedSql;
-  const char *zOtherSql;
-  const ProllyHash *pMergedRoot;
-  const ProllyHash *pOtherRoot;
-  int rc;
 
   *pbRelaid = 0;
-  if( !ancSE || !ancSE->zSql || !ourSE || !ourSE->zSql
-   || !theirSE || !theirSE->zSql ){
-    return SQLITE_OK;
-  }
+  if( !ancSE || !ourSE || !theirSE ) return SQLITE_OK;
 
-  zMergedSql = bMergedIsOurs ? ourSE->zSql : theirSE->zSql;
-  zOtherSql = bMergedIsOurs ? theirSE->zSql : ourSE->zSql;
-  pMergedRoot = bMergedIsOurs ? &pOurs->root : &pTheirs->root;
-  pOtherRoot = bMergedIsOurs ? &pTheirs->root : &pOurs->root;
-
-  rc = normalizeSideToMergedLayout(c->db, zName, pMergedRoot, pOtherRoot,
-                                   pOurs->flags, ancSE->zSql,
-                                   zMergedSql, zOtherSql, pOtherOut);
-  if( rc!=SQLITE_OK ) return rc;
-  rc = normalizeSideToMergedLayout(c->db, zName, pMergedRoot, &pAnc->root,
-                                   pOurs->flags, ancSE->zSql,
-                                   zMergedSql, ancSE->zSql, pAncOut);
-  if( rc!=SQLITE_OK ) return rc;
-  *pbRelaid = 1;
-  return SQLITE_OK;
+  return mergePass1RelayoutToMergedSchema(c, zName, ancSE->zSql,
+      bMergedIsOurs ? ourSE->zSql : theirSE->zSql,
+      bMergedIsOurs ? theirSE->zSql : ourSE->zSql,
+      pOurs->flags,
+      bMergedIsOurs ? &pOurs->root : &pTheirs->root,
+      bMergedIsOurs ? &pTheirs->root : &pOurs->root,
+      &pAnc->root, pOtherOut, pAncOut, pbRelaid);
 }
 
 /* Both sides still have the object. */
@@ -654,6 +672,7 @@ static int mergePass1BothSides(
   ProllyHash theirsNormRoot;
   ProllyHash otherNormRoot;
   ProllyHash ancNormRoot;
+  char *zOursPrevSql = 0;
   struct TableEntry oursAdj;
   struct TableEntry ancAdj;
   struct TableEntry *pMergeOurs = &c->aOurs[iOurs];
@@ -709,7 +728,9 @@ static int mergePass1BothSides(
         sqlite3_free(zSql);
         return pOurSe ? SQLITE_NOMEM : SQLITE_CORRUPT;
       }
-      sqlite3_free(pOurSe->zSql);
+      /* Our rows still follow the layout being replaced here; keep it so the
+      ** relayout below can move them onto the adopted one. */
+      zOursPrevSql = pOurSe->zSql;
       pOurSe->zSql = zSql;
     }
     if( !bSchemaConflict && skipRowMerge && zName ){
@@ -762,7 +783,38 @@ static int mergePass1BothSides(
     skipRowMerge = 1;
   }
 
-  if( skipRowMerge ) return SQLITE_OK;
+  if( skipRowMerge ){
+    sqlite3_free(zOursPrevSql);
+    return SQLITE_OK;
+  }
+
+  /* Their schema was adopted whole for a rename, so the merged layout is
+  ** theirs and our rows are the ones left behind. */
+  if( zName && zOursPrevSql && oursChanged && theirsChanged ){
+    SchemaEntry *ancSE = findSchemaEntry(c->aAncSchema, c->nAncSchema, zName);
+    SchemaEntry *mergedSE = findSchemaEntry(c->aOursSchema, c->nOursSchema, zName);
+    int bRelaid = 0;
+    if( ancSE && mergedSE ){
+      rc = mergePass1RelayoutToMergedSchema(c, zName, ancSE->zSql,
+          mergedSE->zSql, zOursPrevSql, c->aOurs[iOurs].flags,
+          &theirsEntry->root, &c->aOurs[iOurs].root, &ancEntry->root,
+          &otherNormRoot, &ancNormRoot, &bRelaid);
+      if( rc!=SQLITE_OK ){
+        sqlite3_free(zOursPrevSql);
+        return rc;
+      }
+    }
+    if( bRelaid ){
+      ancAdj = *ancEntry;
+      memcpy(&ancAdj.root, &ancNormRoot, sizeof(ProllyHash));
+      pMergeAnc = &ancAdj;
+      oursAdj = c->aOurs[iOurs];
+      memcpy(&oursAdj.root, &otherNormRoot, sizeof(ProllyHash));
+      pMergeOurs = &oursAdj;
+    }
+  }
+  sqlite3_free(zOursPrevSql);
+  zOursPrevSql = 0;
 
   if( zName && oursChanged && theirsChanged
    && ourSchemaChanged!=theirSchemaChanged ){

--- a/src/doltlite_merge_pass1.c
+++ b/src/doltlite_merge_pass1.c
@@ -789,8 +789,10 @@ static int mergePass1BothSides(
   }
 
   /* Their schema was adopted whole for a rename, so the merged layout is
-  ** theirs and our rows are the ones left behind. */
-  if( zName && zOursPrevSql && oursChanged && theirsChanged ){
+  ** theirs and our rows are the ones left behind. A rename rewrites no rows,
+  ** so their root can be unchanged while the layout still moved: the move has
+  ** to be judged on the schema, never on whether either side wrote rows. */
+  if( zName && zOursPrevSql ){
     SchemaEntry *ancSE = findSchemaEntry(c->aAncSchema, c->nAncSchema, zName);
     SchemaEntry *mergedSE = findSchemaEntry(c->aOursSchema, c->nOursSchema, zName);
     int bRelaid = 0;
@@ -844,13 +846,13 @@ static int mergePass1BothSides(
         schemaChoice, theirsEntry);
   }
   if( theirsChanged ){
-    struct TableEntry merged = c->aOurs[iOurs];
+    struct TableEntry merged = *pMergeOurs;
     memcpy(&merged.root, &theirsEntry->root, sizeof(ProllyHash));
     memcpy(&merged.schemaHash, &theirsEntry->schemaHash, sizeof(ProllyHash));
     merged.flags = theirsEntry->flags;
     c->aMerged[(*c->pnMerged)++] = merged;
   }else{
-    c->aMerged[(*c->pnMerged)++] = c->aOurs[iOurs];
+    c->aMerged[(*c->pnMerged)++] = *pMergeOurs;
   }
   return SQLITE_OK;
 }

--- a/src/doltlite_merge_schema.c
+++ b/src/doltlite_merge_schema.c
@@ -640,6 +640,7 @@ int trySchemaColumnMerge(
   const char *zOursSql,
   const char *zTheirsSql,
   char ***ppAddCols, int *pnAddCols,
+  char ***ppDropCols, int *pnDropCols,
   int *pSchemaChoice,
   int *pResolvedDivergence,
   char **pzErrDetail
@@ -649,10 +650,14 @@ int trySchemaColumnMerge(
   int rc;
   char **azAdd = 0;
   int nAdd = 0, nAddAlloc = 0;
+  char **azDrop = 0;
+  int nDrop = 0, nDropAlloc = 0;
   int i;
 
   *ppAddCols = 0;
   *pnAddCols = 0;
+  if( ppDropCols ) *ppDropCols = 0;
+  if( pnDropCols ) *pnDropCols = 0;
   *pSchemaChoice = SCHEMA_MERGE_DEFAULT;
   *pResolvedDivergence = 0;
 
@@ -837,14 +842,48 @@ int trySchemaColumnMerge(
   }
 
 schema_merge_done:
+  /* Adopting one side's schema whole would also reinstate the columns the
+  ** other side deleted, so carry those deletions across. A column the other
+  ** side renamed is absent under its old name too, and its replacement sits
+  ** at the same position, which is what tells the two apart. */
+  if( *pSchemaChoice!=SCHEMA_MERGE_DEFAULT && ppDropCols && pnDropCols ){
+    ParsedColumn *aSel = *pSchemaChoice==SCHEMA_MERGE_OURS ? aOurs : aTheirs;
+    ParsedColumn *aOth = *pSchemaChoice==SCHEMA_MERGE_OURS ? aTheirs : aOurs;
+    int nSel = *pSchemaChoice==SCHEMA_MERGE_OURS ? nOurs : nTheirs;
+    int nOth = *pSchemaChoice==SCHEMA_MERGE_OURS ? nTheirs : nOurs;
+    for(i=0; i<nAnc; i++){
+      if( !findColumn(aSel, nSel, aAnc[i].zName) ) continue;
+      if( findColumn(aOth, nOth, aAnc[i].zName) ) continue;
+      if( i<nOth
+       && !findColumn(aAnc, nAnc, aOth[i].zName)
+       && parsedColumnDefinitionsMatch(&aOth[i], &aAnc[i]) ){
+        continue;
+      }
+      rc = DOLTLITE_GROW_ARRAY(&azDrop, &nDropAlloc, nDrop+1, 4);
+      if( rc!=SQLITE_OK ) goto schema_merge_cleanup;
+      azDrop[nDrop] = sqlite3_mprintf("%s", aAnc[i].zName);
+      if( !azDrop[nDrop] ){
+        rc = SQLITE_NOMEM;
+        goto schema_merge_cleanup;
+      }
+      nDrop++;
+    }
+  }
   *ppAddCols = azAdd;
   *pnAddCols = nAdd;
   azAdd = 0; nAdd = 0;
+  if( ppDropCols && pnDropCols ){
+    *ppDropCols = azDrop;
+    *pnDropCols = nDrop;
+    azDrop = 0; nDrop = 0;
+  }
 
 schema_merge_cleanup:
   freeColumns(aAnc, nAnc);
   freeColumns(aOurs, nOurs);
   freeColumns(aTheirs, nTheirs);
+  { int j; for(j=0;j<nDrop;j++) sqlite3_free(azDrop[j]); }
+  sqlite3_free(azDrop);
   if( rc!=SQLITE_OK ){
     { int j; for(j=0;j<nAdd;j++) sqlite3_free(azAdd[j]); }
     sqlite3_free(azAdd);
@@ -867,7 +906,7 @@ int doltliteTableSchemaConflictDetail(
   *pzDetail = 0;
   if( !zAncestorSql || !zOurSql || !zTheirSql ) return SQLITE_OK;
   rc = trySchemaColumnMerge(zAncestorSql, zOurSql, zTheirSql,
-                            &azAdd, &nAdd, &schemaChoice,
+                            &azAdd, &nAdd, 0, 0, &schemaChoice,
                             &resolvedDivergence, pzDetail);
   for(i=0; i<nAdd; i++) sqlite3_free(azAdd[i]);
   sqlite3_free(azAdd);

--- a/test/doltlite_schema_merge.sh
+++ b/test/doltlite_schema_merge.sh
@@ -914,6 +914,35 @@ run_test "drop_vs_rename_edit_conflicts" \
   "SELECT count(*) FROM dolt_conflicts;" "0" "$DB"
 rm -f "$DB"
 
+# A rename rewrites no rows, so their root can be identical while the layout
+# has still moved. Nothing about whether a side wrote rows may decide whether
+# our rows are moved onto the adopted layout.
+DB=/tmp/test_drop_vs_rename_norows_$$.db; rm -f "$DB"
+cat <<'EOF' | $DOLTLITE "$DB" > /dev/null 2>&1
+CREATE TABLE t(k INTEGER PRIMARY KEY, a TEXT, b TEXT, c TEXT, d INT);
+INSERT INTO t VALUES(1,'a1','b1','c1',505);
+SELECT dolt_commit('-A','-m','base');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+ALTER TABLE t RENAME COLUMN c TO renamed_c;
+SELECT dolt_commit('-A','-m','rename only, no rows written');
+SELECT dolt_checkout('main');
+ALTER TABLE t DROP COLUMN b;
+SELECT dolt_commit('-A','-m','drop b on main');
+EOF
+run_test_match "drop_vs_rename_norows_hash" "SELECT dolt_merge('feat');" \
+  "^[0-9a-f]{40}$" "$DB"
+run_test "drop_vs_rename_norows_cols" \
+  "SELECT group_concat(name) FROM pragma_table_info('t');" \
+  "k,a,renamed_c,d" "$DB"
+run_test "drop_vs_rename_norows_row" \
+  "SELECT a||'|'||renamed_c||'|'||d FROM t WHERE k=1;" "a1|c1|505" "$DB"
+run_test "drop_vs_rename_norows_types" \
+  "SELECT typeof(renamed_c)||'|'||typeof(d) FROM t WHERE k=1;" \
+  "text|integer" "$DB"
+run_test "drop_vs_rename_norows_integrity" "PRAGMA integrity_check;" "ok" "$DB"
+rm -f "$DB"
+
 # A rename with no deletion opposite it must still keep every column.
 DB=/tmp/test_rename_no_drop_$$.db; rm -f "$DB"
 cat <<'EOF' | $DOLTLITE "$DB" > /dev/null 2>&1

--- a/test/doltlite_schema_merge.sh
+++ b/test/doltlite_schema_merge.sh
@@ -858,4 +858,85 @@ run_test "drop_last_col_merge_cols" \
 run_test "drop_last_col_merge_integrity" "PRAGMA integrity_check;" "ok" "$DB"
 rm -f "$DB"
 
+# A rename makes the merge adopt the other side's schema whole, which would
+# also bring back the column this side deleted and read our rows at the
+# adopted positions. Values verified against Dolt 2.2.2.
+DB=/tmp/test_drop_vs_rename_$$.db; rm -f "$DB"
+cat <<'EOF' | $DOLTLITE "$DB" > /dev/null 2>&1
+CREATE TABLE t(k INTEGER PRIMARY KEY, a TEXT, b TEXT, c TEXT, d INT);
+INSERT INTO t VALUES(1,'a1','b1','c1',101);
+SELECT dolt_commit('-A','-m','base');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+ALTER TABLE t RENAME COLUMN c TO renamed_c;
+INSERT INTO t VALUES(2,'a2','b2','c2',202);
+SELECT dolt_commit('-A','-m','rename c on feat');
+SELECT dolt_checkout('main');
+ALTER TABLE t DROP COLUMN b;
+SELECT dolt_commit('-A','-m','drop b on main');
+EOF
+run_test_match "drop_vs_rename_hash" "SELECT dolt_merge('feat');" \
+  "^[0-9a-f]{40}$" "$DB"
+run_test "drop_vs_rename_cols" \
+  "SELECT group_concat(name) FROM pragma_table_info('t');" \
+  "k,a,renamed_c,d" "$DB"
+run_test "drop_vs_rename_base_row" \
+  "SELECT a||'|'||renamed_c||'|'||d FROM t WHERE k=1;" "a1|c1|101" "$DB"
+run_test "drop_vs_rename_incoming_row" \
+  "SELECT a||'|'||renamed_c||'|'||d FROM t WHERE k=2;" "a2|c2|202" "$DB"
+run_test "drop_vs_rename_conflicts" "SELECT count(*) FROM dolt_conflicts;" \
+  "0" "$DB"
+run_test "drop_vs_rename_integrity" "PRAGMA integrity_check;" "ok" "$DB"
+rm -f "$DB"
+
+# The same pairing where their side also edits a row both sides hold.
+DB=/tmp/test_drop_vs_rename_edit_$$.db; rm -f "$DB"
+cat <<'EOF' | $DOLTLITE "$DB" > /dev/null 2>&1
+CREATE TABLE t(k INTEGER PRIMARY KEY, a TEXT, b TEXT, c TEXT, d INT);
+INSERT INTO t VALUES(1,'a1','b1','c1',101),(2,'a2','b2','c2',202);
+SELECT dolt_commit('-A','-m','base');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+ALTER TABLE t RENAME COLUMN c TO renamed_c;
+UPDATE t SET d=999 WHERE k=2;
+SELECT dolt_commit('-A','-m','rename and edit on feat');
+SELECT dolt_checkout('main');
+ALTER TABLE t DROP COLUMN b;
+SELECT dolt_commit('-A','-m','drop b on main');
+EOF
+run_test_match "drop_vs_rename_edit_hash" "SELECT dolt_merge('feat');" \
+  "^[0-9a-f]{40}$" "$DB"
+run_test "drop_vs_rename_edit_row" \
+  "SELECT a||'|'||renamed_c||'|'||d FROM t WHERE k=2;" "a2|c2|999" "$DB"
+run_test "drop_vs_rename_edit_untouched" \
+  "SELECT a||'|'||renamed_c||'|'||d FROM t WHERE k=1;" "a1|c1|101" "$DB"
+run_test "drop_vs_rename_edit_conflicts" \
+  "SELECT count(*) FROM dolt_conflicts;" "0" "$DB"
+rm -f "$DB"
+
+# A rename with no deletion opposite it must still keep every column.
+DB=/tmp/test_rename_no_drop_$$.db; rm -f "$DB"
+cat <<'EOF' | $DOLTLITE "$DB" > /dev/null 2>&1
+CREATE TABLE t(k INTEGER PRIMARY KEY, a TEXT, b TEXT, c TEXT, d INT);
+INSERT INTO t VALUES(1,'a1','b1','c1',101);
+SELECT dolt_commit('-A','-m','base');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+ALTER TABLE t RENAME COLUMN c TO renamed_c;
+INSERT INTO t VALUES(2,'a2','b2','c2',202);
+SELECT dolt_commit('-A','-m','rename c on feat');
+SELECT dolt_checkout('main');
+UPDATE t SET a='a1x' WHERE k=1;
+SELECT dolt_commit('-A','-m','edit on main');
+EOF
+run_test_match "rename_no_drop_hash" "SELECT dolt_merge('feat');" \
+  "^[0-9a-f]{40}$" "$DB"
+run_test "rename_no_drop_cols" \
+  "SELECT group_concat(name) FROM pragma_table_info('t');" \
+  "k,a,b,renamed_c,d" "$DB"
+run_test "rename_no_drop_rows" \
+  "SELECT group_concat(k||':'||a||':'||renamed_c) FROM t;" \
+  "1:a1x:c1,2:a2:c2" "$DB"
+rm -f "$DB"
+
 dltest_finish


### PR DESCRIPTION
Fixes #2268, found by ito QA on #2265 and confirmed there to be pre-existing.

Merging a branch that renamed a column into a branch that deleted a *different* column brought the deleted column back and put values under the wrong names:

```sql
-- base: t(k, a, b, c, d), row (1,'a1','b1','c1',101)
-- feat: ALTER TABLE t RENAME COLUMN c TO renamed_c; INSERT (2,'a2','b2','c2',202)
-- main: ALTER TABLE t DROP COLUMN b
SELECT dolt_merge('feat');
```

| | columns | row 1 |
|---|---|---|
| before | `k, a, b, renamed_c, d` | `a1`, `renamed_c=101`, `d=NULL` |
| after / Dolt 2.2.2 | `k, a, renamed_c, d` | `a1`, `renamed_c=c1`, `d=101` |

The merge returned a commit hash and reported no conflict, and `PRAGMA integrity_check` was red afterwards. A variant where their side also edits a row both sides hold stopped with a conflict Dolt does not raise.

## Cause

A rename is indistinguishable from a drop plus an add by comparing catalogs, so when `trySchemaColumnMerge` recognizes one it selects that side's schema wholesale. Two things were then lost:

- **The other side's deletions.** Only the columns that side *added* were replayed onto the adopted schema (`ALTER TABLE ... ADD COLUMN`); columns it had deleted came back.
- **The other side's row layout.** Adopting their schema makes the merged layout theirs, but our records still followed ours, and the row merge addresses every side by merged column position. That is what shifted values under the wrong names and dropped the last one, and what made an untouched cell read as edited on both sides.

## Change

Deletions are now carried across as drop actions, applied alongside the added columns once the merged catalog is live, and our rows are re-laid onto the adopted layout before the row merge. A column the other side renamed is absent under its old name too; its replacement sitting at the same ancestor position is what separates a rename from a deletion.

## Not fixed here

This does not give a column an identity that survives a rename, which is what would settle the question outright rather than inferring it. That is the same gap behind the table-level confusion in #2016 and #1999.

The mirror pairing — *ours* renames, *theirs* deletes — still stops with a schema conflict where Dolt merges cleanly, because the rename search only scans their columns. That is pre-existing, unchanged by this PR, and fails safe rather than corrupting; I've noted it on #2268.

## Testing

`test/doltlite_schema_merge.sh` gains the reported case, the edit variant that used to conflict, and a rename with no deletion opposite it as a guard that unrelated columns are still kept. Expected values taken from Dolt 2.2.2.

- Fail-before/pass-after: 6 of the new assertions fail on master (`140 passed, 6 failed`), all pass with the fix (`146 passed, 0 failed`). One of the six is `integrity_check`.
- Full shell battery: **104/104 suites**, including the C regression suite.
- Same suite clean under an ASAN+UBSAN build, no sanitizer reports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)