### PR TITLE
Keep a loadable rebase mirror when upstream is not the default

### DIFF
--- a/src/doltlite_rebase.c
+++ b/src/doltlite_rebase.c
@@ -114,10 +114,12 @@ static int rebaseRestoreReturnBranchWorkingState(
 }
 /* True if zBranch holds working-set changes its head commit does not. An
 ** interactive rebase mirrors onto the return branch so a reopen can resume.
-** A dirty return branch keeps its catalog and only receives rebase metadata;
-** a clean one gets the whole working-set blob. Restore undoes the same
-** choice. Rebase already refuses to start with a dirty current branch; the
-** return branch is a different one and has no such guarantee. */
+** The whole-blob mirror is only loadable when workingCommit equals that
+** branch's HEAD, so a dirty return branch -- or one whose HEAD is not the
+** rebase upstream -- keeps its catalog and only receives rebase metadata.
+** Restore undoes the same choice. Rebase already refuses to start with a
+** dirty current branch; the return branch is a different one and has no
+** such guarantee. */
 static int rebaseBranchHasUncommittedWork(
   sqlite3 *db,
   const char *zBranch,
@@ -1559,9 +1561,16 @@ static void doltliteRebaseInteractiveStart(
 
   {
     int dirty = 0;
+    ProllyHash returnHead;
     rc = rebaseBranchHasUncommittedWork(db, zReturnBranch, &dirty);
     if( rc!=SQLITE_OK ) goto fail;
-    if( dirty ) rebaseFlags = (u8)(WS_REBASE_FLAG_ACTIVE | WS_REBASE_FLAG_META_MIRROR);
+    memset(&returnHead, 0, sizeof(returnHead));
+    rc = chunkStoreFindBranch(cs, zReturnBranch, &returnHead);
+    if( rc==SQLITE_NOTFOUND ) rc = SQLITE_OK;
+    if( rc!=SQLITE_OK ) goto fail;
+    if( dirty || prollyHashCompare(&returnHead, &upstreamHash)!=0 ){
+      rebaseFlags = (u8)(WS_REBASE_FLAG_ACTIVE | WS_REBASE_FLAG_META_MIRROR);
+    }
   }
   if( strlen(zReturnBranch)>=WS_REBASE_BRANCH_LEN ){
     sqlite3_free(zOrig);

--- a/src/prolly_btree_state.c
+++ b/src/prolly_btree_state.c
@@ -1103,7 +1103,18 @@ int doltliteSaveWorkingSetWithHash(sqlite3 *db, const ProllyHash *pWorkingCatHas
    && pBtree->zRebaseReturnBranch
    && pBtree->zRebaseReturnBranch[0]
    && sqlite3_stricmp(zBranch, pBtree->zRebaseReturnBranch)!=0 ){
-    if( pBtree->isRebasing & WS_REBASE_FLAG_META_MIRROR ){
+    int metaMirror = (pBtree->isRebasing & WS_REBASE_FLAG_META_MIRROR)!=0;
+    if( !metaMirror ){
+      ProllyHash returnHead;
+      memset(&returnHead, 0, sizeof(returnHead));
+      if( chunkStoreFindBranch(cs, pBtree->zRebaseReturnBranch, &returnHead)
+            ==SQLITE_OK
+       && prollyHashCompare(&pBtree->headCommit, &returnHead)!=0 ){
+        metaMirror = 1;
+      }
+    }
+    if( metaMirror ){
+      pBtree->isRebasing = (u8)(pBtree->isRebasing | WS_REBASE_FLAG_META_MIRROR);
       rc = btreePutRebaseMetadataOnBranch(
           cs, pBtree->zRebaseReturnBranch,
           (u8)(WS_REBASE_FLAG_ACTIVE | WS_REBASE_FLAG_META_MIRROR),

--- a/test/doltlite_rebase.sh
+++ b/test/doltlite_rebase.sh
@@ -198,6 +198,67 @@ run_test "interactive_rebase_continue_after_reopen_dirty_main" \
 0" \
   "$DB3"
 
+# Rebase onto a non-default upstream used to stamp that tip as the default
+# branch's workingCommit. Open of $DB then discarded the mirror, so continue
+# and abort reported no rebase in progress and left dolt_rebase_<orig> behind.
+seed_onto_other() {
+  rm -f "$1"
+  cat <<'SQL' | "$DOLTLITE" "$1" >/dev/null 2>&1
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'base');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','init');
+SELECT dolt_checkout('-b','other');
+INSERT INTO t VALUES(2,'other');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','other');
+SELECT dolt_checkout('main');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO t VALUES(3,'feat');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','feat');
+SQL
+}
+
+DB_OTHER_CONT=/tmp/test_rebase_other_continue_$$.db
+seed_onto_other "$DB_OTHER_CONT"
+run_test_match "interactive_rebase_onto_other_starts" \
+  "SELECT dolt_rebase('-i','other');" \
+  "interactive rebase started" \
+  "$DB_OTHER_CONT/feat"
+run_test "interactive_rebase_continue_after_reopen_onto_other" \
+  "SELECT dolt_rebase('--continue');
+   SELECT active_branch();
+   SELECT group_concat(v, ',') FROM t;
+   SELECT count(*) FROM dolt_branches WHERE name='dolt_rebase_feat';
+   SELECT dolt_checkout('main');
+   SELECT group_concat(v, ',') FROM t;" \
+  "Successfully rebased and updated refs/heads/feat
+feat
+base,other,feat
+0
+0
+base" \
+  "$DB_OTHER_CONT"
+
+DB_OTHER_ABORT=/tmp/test_rebase_other_abort_$$.db
+seed_onto_other "$DB_OTHER_ABORT"
+run_test_match "interactive_rebase_onto_other_starts_for_abort" \
+  "SELECT dolt_rebase('-i','other');" \
+  "interactive rebase started" \
+  "$DB_OTHER_ABORT/feat"
+run_test "interactive_rebase_abort_after_reopen_onto_other" \
+  "SELECT dolt_rebase('--abort');
+   SELECT active_branch();
+   SELECT group_concat(v, ',') FROM t;
+   SELECT count(*) FROM dolt_branches WHERE name='dolt_rebase_feat';
+   SELECT dolt_checkout('main');
+   SELECT group_concat(v, ',') FROM t;" \
+  "Interactive rebase aborted
+feat
+base,feat
+0
+0
+base" \
+  "$DB_OTHER_ABORT"
+
 # An unrecognised plan verb used to report a bare "rebase failed", which reads
 # as though the rebase had been rolled back. It is not: the plan and working
 # branch are deliberately kept so the action can be corrected and --continue

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -8508,6 +8508,133 @@ static void run_rebase_continue_after_reopen_dirty_default(void){
   removeDbFiles(dbpath);
 }
 
+static int setup_onto_other_rebase(sqlite3 *db){
+  return execSql(db,
+    "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
+    "INSERT INTO t VALUES(1,'base');"
+    "SELECT dolt_add('-A'); SELECT dolt_commit('-m','init');"
+    "SELECT dolt_checkout('-b','other');"
+    "INSERT INTO t VALUES(2,'other');"
+    "SELECT dolt_add('-A'); SELECT dolt_commit('-m','other');"
+    "SELECT dolt_checkout('main');"
+    "SELECT dolt_checkout('-b','feat');"
+    "INSERT INTO t VALUES(3,'feat');"
+    "SELECT dolt_add('-A'); SELECT dolt_commit('-m','feat');");
+}
+
+static void run_rebase_abort_after_reopen_onto_other(void){
+  sqlite3 *db = 0;
+  char dbpath[256];
+  u8 isRebasing = 0;
+  const char *zOrigBranch = 0;
+
+  printf("=== Rebase Abort After Reopen Onto Other Test ===\n\n");
+  make_dbpath(dbpath, sizeof(dbpath), "test_rebase_abort_after_reopen_onto_other");
+  removeDbFiles(dbpath);
+
+  check("open_db_for_rebase_abort_after_reopen_onto_other",
+        open_db(dbpath, &db)==SQLITE_OK);
+  check("setup_repo_for_rebase_abort_after_reopen_onto_other",
+        setup_onto_other_rebase(db)==SQLITE_OK);
+  check("start_interactive_rebase_onto_other",
+        strstr(queryScalarText(db, "SELECT dolt_rebase('-i', 'other')"),
+               "interactive rebase started on branch dolt_rebase_feat")!=0);
+
+  sqlite3_close(db);
+  db = 0;
+
+  check("reopen_db_for_rebase_abort_onto_other", open_db(dbpath, &db)==SQLITE_OK);
+  check("rebase_abort_onto_other_reopen_lands_on_main",
+        strcmp(queryScalarText(db, "SELECT active_branch()"), "main")==0);
+  check("rebase_abort_onto_other_reopen_keeps_main_rows",
+        strcmp(queryScalarText(db, "SELECT group_concat(v, ',') FROM t"),
+               "base")==0);
+  check("rebase_abort_onto_other_reopen_plan_stays_off_return",
+        strcmp(queryScalarText(db,
+          "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='dolt_rebase'"),
+          "0")==0);
+  doltliteGetSessionRebaseState(db, &isRebasing, 0, 0, &zOrigBranch, 0);
+  check("rebase_abort_onto_other_reopen_flag", isRebasing==1);
+  check("rebase_abort_onto_other_reopen_orig_branch",
+        zOrigBranch && strcmp(zOrigBranch, "feat")==0);
+  check("rebase_abort_after_reopen_onto_other_returns_success",
+        strcmp(queryScalarText(db, "SELECT dolt_rebase('--abort')"),
+               "Interactive rebase aborted")==0);
+  check("rebase_abort_after_reopen_onto_other_restores_branch",
+        strcmp(queryScalarText(db, "SELECT active_branch()"), "feat")==0);
+  check("rebase_abort_after_reopen_onto_other_feat_rows",
+        strcmp(queryScalarText(db, "SELECT group_concat(v, ',') FROM t"),
+               "base,feat")==0);
+  check("rebase_abort_after_reopen_onto_other_checkout_main",
+        strcmp(queryScalarText(db, "SELECT dolt_checkout('main')"), "0")==0);
+  check("rebase_abort_after_reopen_onto_other_main_rows",
+        strcmp(queryScalarText(db, "SELECT group_concat(v, ',') FROM t"),
+               "base")==0);
+  check("rebase_abort_after_reopen_onto_other_drops_temp_branch",
+        strcmp(queryScalarText(db,
+          "SELECT count(*) FROM dolt_branches WHERE name='dolt_rebase_feat'"), "0")==0);
+  doltliteGetSessionRebaseState(db, &isRebasing, 0, 0, 0, 0);
+  check("rebase_abort_after_reopen_onto_other_clears_flag", isRebasing==0);
+
+  sqlite3_close(db);
+  removeDbFiles(dbpath);
+}
+
+static void run_rebase_continue_after_reopen_onto_other(void){
+  sqlite3 *db = 0;
+  char dbpath[256];
+  u8 isRebasing = 0;
+  const char *zOrigBranch = 0;
+
+  printf("=== Rebase Continue After Reopen Onto Other Test ===\n\n");
+  make_dbpath(dbpath, sizeof(dbpath),
+              "test_rebase_continue_after_reopen_onto_other");
+  removeDbFiles(dbpath);
+
+  check("open_db_for_rebase_continue_after_reopen_onto_other",
+        open_db(dbpath, &db)==SQLITE_OK);
+  check("setup_repo_for_rebase_continue_after_reopen_onto_other",
+        setup_onto_other_rebase(db)==SQLITE_OK);
+  check("start_interactive_rebase_onto_other_for_continue",
+        strstr(queryScalarText(db, "SELECT dolt_rebase('-i', 'other')"),
+               "interactive rebase started on branch dolt_rebase_feat")!=0);
+
+  sqlite3_close(db);
+  db = 0;
+
+  check("reopen_db_for_rebase_continue_onto_other", open_db(dbpath, &db)==SQLITE_OK);
+  check("rebase_continue_onto_other_reopen_lands_on_main",
+        strcmp(queryScalarText(db, "SELECT active_branch()"), "main")==0);
+  check("rebase_continue_onto_other_reopen_keeps_main_rows",
+        strcmp(queryScalarText(db, "SELECT group_concat(v, ',') FROM t"),
+               "base")==0);
+  doltliteGetSessionRebaseState(db, &isRebasing, 0, 0, &zOrigBranch, 0);
+  check("rebase_continue_onto_other_reopen_flag", isRebasing==1);
+  check("rebase_continue_onto_other_reopen_orig_branch",
+        zOrigBranch && strcmp(zOrigBranch, "feat")==0);
+  check("rebase_continue_after_reopen_onto_other_succeeds",
+        strcmp(queryScalarText(db, "SELECT dolt_rebase('--continue')"),
+               "Successfully rebased and updated refs/heads/feat")==0);
+  check("rebase_continue_after_reopen_onto_other_branch",
+        strcmp(queryScalarText(db, "SELECT active_branch()"), "feat")==0);
+  check("rebase_continue_after_reopen_onto_other_feat_rows",
+        strcmp(queryScalarText(db, "SELECT group_concat(v, ',') FROM t"),
+               "base,other,feat")==0);
+  check("rebase_continue_after_reopen_onto_other_checkout_main",
+        strcmp(queryScalarText(db, "SELECT dolt_checkout('main')"), "0")==0);
+  check("rebase_continue_after_reopen_onto_other_main_rows",
+        strcmp(queryScalarText(db, "SELECT group_concat(v, ',') FROM t"),
+               "base")==0);
+  check("rebase_continue_after_reopen_onto_other_drops_temp_branch",
+        strcmp(queryScalarText(db,
+          "SELECT count(*) FROM dolt_branches WHERE name='dolt_rebase_feat'"), "0")==0);
+  doltliteGetSessionRebaseState(db, &isRebasing, 0, 0, 0, 0);
+  check("rebase_continue_after_reopen_onto_other_clears_flag", isRebasing==0);
+
+  sqlite3_close(db);
+  removeDbFiles(dbpath);
+}
+
 static void run_rebase_abort_retry_after_claim_commit_error(void){
   sqlite3 *db = 0;
   char dbpath[256];
@@ -12841,6 +12968,8 @@ static const RegressionCase aCases[] = {
   { "rebase_abort_after_reopen_restores_durable_state", "Rebase Abort After Reopen Restores Durable State Test", run_rebase_abort_after_reopen_restores_durable_state },
   { "rebase_abort_after_reopen_dirty_default", "Rebase Abort After Reopen Dirty Default Test", run_rebase_abort_after_reopen_dirty_default },
   { "rebase_continue_after_reopen_dirty_default", "Rebase Continue After Reopen Dirty Default Test", run_rebase_continue_after_reopen_dirty_default },
+  { "rebase_abort_after_reopen_onto_other", "Rebase Abort After Reopen Onto Other Test", run_rebase_abort_after_reopen_onto_other },
+  { "rebase_continue_after_reopen_onto_other", "Rebase Continue After Reopen Onto Other Test", run_rebase_continue_after_reopen_onto_other },
   { "rebase_abort_retry_after_claim_commit_error", "Rebase Abort Retry After Claim Commit Error Test", run_rebase_abort_retry_after_claim_commit_error },
   { "rebase_plan_read_error_is_not_partial", "Rebase Plan Read Error Is Not Partial Test", run_rebase_plan_read_error_is_not_partial },
   { "rebase_upstream_history_failure_is_atomic", "Rebase Upstream History Failure Is Atomic Test", run_rebase_upstream_history_failure_is_atomic },


### PR DESCRIPTION
Interactive rebase always mirrors onto the default branch so a later open of `$DB` can `--continue` / `--abort`. The whole-blob copy used for a clean default stamps the **upstream tip** as that branch's `workingCommit`. On open, `btreeLoadBranchState` throws the blob away unless `workingCommit` equals that branch's HEAD.

That only holds when you rebase *onto* the default. Rebase `feat` onto `other`, close, reopen `$DB`:

```sql
SELECT dolt_rebase('--continue');
-- no rebase in progress
SELECT count(*) FROM dolt_branches WHERE name='dolt_rebase_feat';  -- 1
```

`$DB/feat` and `$DB/dolt_rebase_feat` still resume. `$DB` does not.

The whole-blob mirror is only loadable when `workingCommit` equals the return-branch HEAD, so a dirty return branch — or one whose HEAD is not the rebase upstream — now keeps its catalog and only receives rebase metadata. Restore undoes the same choice. Persist also takes the metadata path if the live working commit would not match the return-branch HEAD.

Reopen of `$DB` after `feat` onto `other` now continues and aborts, keeps main's rows, and deletes `dolt_rebase_feat`. Onto-default whole-blob behavior is unchanged.

Co-Authored-By: Grok 4.6 <noreply@x.ai>