### PR TITLE
Do not remirror a dirty default after rebase continue CAS fail

### DIFF
--- a/src/doltlite_rebase.c
+++ b/src/doltlite_rebase.c
@@ -903,8 +903,11 @@ static int rebaseRestoreInProgress(
   do {
     rc = rebaseWritePlanRows(db, aPlan, nPlan);
     if( rc==SQLITE_OK ){
-      u8 flags = (u8)(WS_REBASE_FLAG_ACTIVE |
-        (doltliteGetSessionRebaseFlags(db) & WS_REBASE_FLAG_META_MIRROR));
+      /* Claim already cleared session flags. Persist remirrors the working
+      ** catalog onto the return branch unless META_MIRROR is set, which
+      ** would replace uncommitted work on a dirty default. Restore is not
+      ** a finish, so overlay metadata only. */
+      u8 flags = (u8)(WS_REBASE_FLAG_ACTIVE | WS_REBASE_FLAG_META_MIRROR);
       rc = doltliteSetSessionRebaseState(db, flags, pPreRebaseCat, pExpectedOrigHead,
                                          zOrigBranch, zReturnBranch);
     }

--- a/test/doltlite_rebase.sh
+++ b/test/doltlite_rebase.sh
@@ -198,6 +198,63 @@ run_test "interactive_rebase_continue_after_reopen_dirty_main" \
 0" \
   "$DB3"
 
+# --continue claims first, which drops META_MIRROR. If the source tip moved,
+# restore used to persist a whole-blob remirror onto the dirty default.
+# Replay of a pick now moves the working HEAD and persist overlays, but an
+# all-drop plan never moves HEAD and still remirrored without this restore.
+seed_dirty_main "$DB3"
+run_test_match "interactive_rebase_dirty_main_starts_for_cas_drop" \
+  "SELECT dolt_checkout('feat');
+   SELECT dolt_rebase('-i','main');
+   UPDATE dolt_rebase SET action='drop';" \
+  "interactive rebase started" \
+  "$DB3"
+"$DOLTLITE" "$DB3/feat" >/dev/null 2>&1 <<'SQL'
+INSERT INTO t VALUES(123,'peer');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','move feat');
+SQL
+run_test "interactive_rebase_continue_cas_keeps_dirty_main" \
+  "SELECT dolt_rebase('--continue');
+   SELECT dolt_checkout('main');
+   SELECT count(*) FROM t WHERE v='row99';
+   SELECT count(*) FROM dolt_branches WHERE name='dolt_rebase_feat';" \
+  "Error near line 1: rebase aborted due to changes in branch feat
+0
+1
+1" \
+  "$DB3"
+run_test "interactive_rebase_abort_after_cas_keeps_dirty_main" \
+  "SELECT dolt_rebase('--abort');
+   SELECT dolt_checkout('main');
+   SELECT count(*) FROM t WHERE v='row99';
+   SELECT count(*) FROM dolt_branches WHERE name='dolt_rebase_feat';" \
+  "Interactive rebase aborted
+0
+1
+0" \
+  "$DB3"
+
+seed_dirty_main "$DB3"
+run_test_match "interactive_rebase_dirty_main_starts_for_cas_pick" \
+  "SELECT dolt_checkout('feat');
+   SELECT dolt_rebase('-i','main');" \
+  "interactive rebase started" \
+  "$DB3"
+"$DOLTLITE" "$DB3/feat" >/dev/null 2>&1 <<'SQL'
+INSERT INTO t VALUES(124,'peer2');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','move feat again');
+SQL
+run_test "interactive_rebase_continue_cas_pick_keeps_dirty_main" \
+  "SELECT dolt_rebase('--continue');
+   SELECT dolt_checkout('main');
+   SELECT count(*) FROM t WHERE v='row99';
+   SELECT count(*) FROM dolt_branches WHERE name='dolt_rebase_feat';" \
+  "Error near line 1: rebase aborted due to changes in branch feat
+0
+1
+1" \
+  "$DB3"
+
 # Rebase onto a non-default upstream used to stamp that tip as the default
 # branch's workingCommit. Open of $DB then discarded the mirror, so continue
 # and abort reported no rebase in progress and left dolt_rebase_<orig> behind.

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -8508,6 +8508,76 @@ static void run_rebase_continue_after_reopen_dirty_default(void){
   removeDbFiles(dbpath);
 }
 
+static void run_rebase_continue_cas_keeps_dirty_default(void){
+  sqlite3 *db1 = 0;
+  sqlite3 *db2 = 0;
+  sqlite3 *db3 = 0;
+  char dbpath[256];
+  const char *res;
+  u8 isRebasing = 0;
+
+  printf("=== Rebase Continue CAS Keeps Dirty Default Test ===\n\n");
+  make_dbpath(dbpath, sizeof(dbpath),
+              "test_rebase_continue_cas_keeps_dirty_default");
+  removeDbFiles(dbpath);
+
+  check("open_db1_for_rebase_continue_cas_dirty",
+        open_db(dbpath, &db1)==SQLITE_OK);
+  check("setup_repo_for_rebase_continue_cas_dirty",
+        setup_dirty_default_rebase(db1)==SQLITE_OK);
+  check("start_rebase_for_continue_cas_dirty",
+        strstr(queryScalarText(db1, "SELECT dolt_rebase('-i', 'main')"),
+               "interactive rebase started on branch dolt_rebase_feat")!=0);
+  check("drop_plan_for_continue_cas_dirty",
+        execSql(db1, "UPDATE dolt_rebase SET action='drop';")==SQLITE_OK);
+
+  check("open_db2_for_rebase_continue_cas_dirty",
+        open_db(dbpath, &db2)==SQLITE_OK);
+  check("checkout_feat_for_continue_cas_dirty",
+        strcmp(queryScalarText(db2, "SELECT dolt_checkout('feat')"), "0")==0);
+  check("peer_commit_for_continue_cas_dirty", execSql(db2,
+    "INSERT INTO t VALUES(123,'peer');"
+    "SELECT dolt_commit('-A','-m','move feat');")==SQLITE_OK);
+
+  res = queryScalarText(db1, "SELECT dolt_rebase('--continue')");
+  check("continue_cas_dirty_names_source_branch",
+        strstr(res, "changes in branch feat")!=0);
+  check("continue_cas_dirty_checkout_main",
+        strcmp(queryScalarText(db1, "SELECT dolt_checkout('main')"), "0")==0);
+  check("continue_cas_dirty_row_survives_same_session",
+        strcmp(queryScalarText(db1, "SELECT count(*) FROM t WHERE v='row99'"),
+               "1")==0);
+
+  sqlite3_close(db2);
+  sqlite3_close(db1);
+
+  check("reopen_after_continue_cas_dirty", open_db(dbpath, &db3)==SQLITE_OK);
+  check("continue_cas_dirty_row_survives_reopen",
+        strcmp(queryScalarText(db3, "SELECT count(*) FROM t WHERE v='row99'"),
+               "1")==0);
+  check("continue_cas_dirty_keeps_temp_branch",
+        strcmp(queryScalarText(db3,
+          "SELECT count(*) FROM dolt_branches WHERE name='dolt_rebase_feat'"),
+          "1")==0);
+  doltliteGetSessionRebaseState(db3, &isRebasing, 0, 0, 0, 0);
+  check("continue_cas_dirty_keeps_flag", isRebasing==1);
+  check("continue_cas_dirty_abort_after",
+        strcmp(queryScalarText(db3, "SELECT dolt_rebase('--abort')"),
+               "Interactive rebase aborted")==0);
+  check("continue_cas_dirty_abort_checkout_main",
+        strcmp(queryScalarText(db3, "SELECT dolt_checkout('main')"), "0")==0);
+  check("continue_cas_dirty_row_survives_abort",
+        strcmp(queryScalarText(db3, "SELECT count(*) FROM t WHERE v='row99'"),
+               "1")==0);
+  check("continue_cas_dirty_drops_temp_branch",
+        strcmp(queryScalarText(db3,
+          "SELECT count(*) FROM dolt_branches WHERE name='dolt_rebase_feat'"),
+          "0")==0);
+
+  sqlite3_close(db3);
+  removeDbFiles(dbpath);
+}
+
 static int setup_onto_other_rebase(sqlite3 *db){
   return execSql(db,
     "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
@@ -12968,6 +13038,7 @@ static const RegressionCase aCases[] = {
   { "rebase_abort_after_reopen_restores_durable_state", "Rebase Abort After Reopen Restores Durable State Test", run_rebase_abort_after_reopen_restores_durable_state },
   { "rebase_abort_after_reopen_dirty_default", "Rebase Abort After Reopen Dirty Default Test", run_rebase_abort_after_reopen_dirty_default },
   { "rebase_continue_after_reopen_dirty_default", "Rebase Continue After Reopen Dirty Default Test", run_rebase_continue_after_reopen_dirty_default },
+  { "rebase_continue_cas_keeps_dirty_default", "Rebase Continue CAS Keeps Dirty Default Test", run_rebase_continue_cas_keeps_dirty_default },
   { "rebase_abort_after_reopen_onto_other", "Rebase Abort After Reopen Onto Other Test", run_rebase_abort_after_reopen_onto_other },
   { "rebase_continue_after_reopen_onto_other", "Rebase Continue After Reopen Onto Other Test", run_rebase_continue_after_reopen_onto_other },
   { "rebase_abort_retry_after_claim_commit_error", "Rebase Abort Retry After Claim Commit Error Test", run_rebase_abort_retry_after_claim_commit_error },


### PR DESCRIPTION
`--continue` claims the rebase first (`doltliteClearSessionRebaseState`), which drops `META_MIRROR` from the session. On a source-tip CAS reject it then restored `ACTIVE` only and persisted. Persist remirrors the working catalog onto the return branch whenever `META_MIRROR` is unset and the working HEAD still matches that branch's HEAD.

That wipes uncommitted work on a dirty default. A pick now moves the working HEAD, so persist's HEAD-mismatch overlay hides the hole. An all-drop plan never moves HEAD:

```sql
-- main has uncommitted row99; rebase feat onto main
SELECT dolt_checkout('feat');
SELECT dolt_rebase('-i','main');
UPDATE dolt_rebase SET action='drop';

-- other connection: commit on feat
SELECT dolt_rebase('--continue');
-- rebase aborted due to changes in branch feat

SELECT dolt_checkout('main');
SELECT count(*) FROM t WHERE v='row99';  -- was 0; now 1
```

Restore-in-progress always overlays metadata. It is not a finish, so it must not remirror. `--abort` after the CAS reject still works and still keeps the dirty row.

Co-Authored-By: Grok 4.6 <noreply@x.ai>