### PR TITLE
Refuse to republish a store this connection may not write

### DIFF
--- a/src/doltlite_gc.c
+++ b/src/doltlite_gc.c
@@ -980,6 +980,18 @@ static int gcRun(
     *pzPhase = "failed to acquire lock for gc";
     return rc;
   }
+  /* The sweep republishes the store by renaming a rebuilt file over this path.
+  ** A connection that may not write must not do that, and neither may one
+  ** whose file was replaced underneath it: the path now names a database this
+  ** handle never opened, and the rename would destroy it. Checked after the
+  ** refresh, which is what detects the replacement. */
+  if( cs->readOnly || cs->movedReadOnly ){
+    chunkStoreUnlock(cs);
+    *pzPhase = cs->readOnly
+             ? "attempt to write a readonly database"
+             : "cannot rewrite a database file that was replaced";
+    return SQLITE_READONLY;
+  }
   if( bForceRefresh ){
     rc = chunkStoreForceRefresh(cs);
     if( rc!=SQLITE_OK ){

--- a/src/pager_shim.c
+++ b/src/pager_shim.c
@@ -373,8 +373,11 @@ static int shimPagerCheckpoint(Pager *p, sqlite3 *db, int eMode,
     rc = doltliteGcCompactStore(db, pCs);
     /* Compacting here is opportunistic -- stock does not compact on checkpoint
     ** at all, and answers a checkpoint on a database it may not write with
-    ** success. A store this connection may not rewrite just stays uncompacted. */
-    if( rc==SQLITE_READONLY ) rc = SQLITE_OK;
+    ** success, so a read-only store just stays uncompacted. A store whose file
+    ** was replaced is not that: stock has no such state to be consistent with,
+    ** and the caller is checkpointing a path that no longer holds the database
+    ** it opened, which it can only learn if we say so. */
+    if( rc==SQLITE_READONLY && !pCs->movedReadOnly ) rc = SQLITE_OK;
   }
   if( pCs ) pCs->checkpointActive = 0;
   if( rc!=SQLITE_OK ) return rc;

--- a/src/pager_shim.c
+++ b/src/pager_shim.c
@@ -371,6 +371,10 @@ static int shimPagerCheckpoint(Pager *p, sqlite3 *db, int eMode,
 #endif
   if( rc==SQLITE_OK && db && pCs ){
     rc = doltliteGcCompactStore(db, pCs);
+    /* Compacting here is opportunistic -- stock does not compact on checkpoint
+    ** at all, and answers a checkpoint on a database it may not write with
+    ** success. A store this connection may not rewrite just stays uncompacted. */
+    if( rc==SQLITE_READONLY ) rc = SQLITE_OK;
   }
   if( pCs ) pCs->checkpointActive = 0;
   if( rc!=SQLITE_OK ) return rc;
@@ -1258,6 +1262,16 @@ int sqlite3_backup_step(sqlite3_backup *pBackup, int nPage){
     goto backup_step_done;
   }
   destLocked = 1;
+
+  /* The refresh above is what learns the destination file was replaced. The
+  ** path now names a database this handle never opened, and finishing would
+  ** rename our copy over it. */
+  if( destCs->movedReadOnly ){
+    rc = SQLITE_READONLY;
+    p->rc = rc;
+    sqlite3Error(p->pDestDb, rc);
+    goto backup_step_done;
+  }
 
   if( destCs->isMemory ){
     openFlags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE

--- a/test/doltlite_readonly_file_replacement.sh
+++ b/test/doltlite_readonly_file_replacement.sh
@@ -68,4 +68,30 @@ SELECT dolt_commit('-A','-m','victim');" | $DOLTLITE "$ROOT/victim.db" > /dev/nu
   rm -f "$DB"
 done
 
+# Surviving is not enough: the caller is working on a path that no longer
+# holds the database it opened, and only the refusal tells it so. A merely
+# read-only store stays silent instead, because stock answers that with
+# success and compacting on checkpoint is opportunistic either way.
+DB="$ROOT/live.db"
+seed_db "$DB"
+rm -f "$ROOT/victim.db"
+echo "CREATE TABLE victim(x TEXT);
+INSERT INTO victim VALUES('untouched');
+SELECT dolt_commit('-A','-m','victim');" | $DOLTLITE "$ROOT/victim.db" > /dev/null 2>&1
+out=$(printf 'SELECT count(*) FROM t;\n.shell mv %s %s\nPRAGMA wal_checkpoint;\n' \
+        "$ROOT/victim.db" "$DB" | $DOLTLITE "$DB" 2>&1 | tail -1)
+case "$out" in
+  *readonly*) dltest_pass "replaced_checkpoint_reports" ;;
+  *) dltest_fail "replaced_checkpoint_reports" \
+       "  expected a readonly refusal\n  got:      $out" ;;
+esac
+rm -f "$DB"
+
+DB="$ROOT/ro2.db"
+seed_db "$DB"
+chmod 0444 "$DB"
+run_test_match "readonly_checkpoint_stays_quiet" "PRAGMA wal_checkpoint;" \
+  "^[0-9]+\|" "file:$DB?mode=ro"
+chmod u+w "$DB"; rm -f "$DB"
+
 dltest_finish

--- a/test/doltlite_readonly_file_replacement.sh
+++ b/test/doltlite_readonly_file_replacement.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+# GC republishes the store by renaming a rebuilt file over the database path,
+# and VACUUM and a WAL checkpoint both reach it. Neither may run for a
+# connection that may not write, nor for one whose file was replaced
+# underneath it -- that path now names a database this handle never opened,
+# and the rename would destroy it.
+DOLTLITE="${1:-${DOLTLITE:-./doltlite}}"
+. "$(dirname "$0")/lib/doltlite_test_common.sh"
+
+if [ "$(uname -s)" != "Darwin" ] && [ "$(uname -s)" != "Linux" ]; then
+  echo "SKIP: file-replacement test is unix-only"
+  exit 0
+fi
+
+echo "=== Doltlite read-only and replaced-file rejection ==="
+echo ""
+
+ROOT=$(mktemp -d /tmp/dl_ro_repl_XXXXXX)
+trap 'chmod -R u+w "$ROOT" 2>/dev/null; rm -rf "$ROOT"' EXIT
+
+seed_db() {
+  rm -f "$1"
+  echo "CREATE TABLE t(a INTEGER PRIMARY KEY, b TEXT);
+INSERT INTO t VALUES(1,'kept');
+SELECT dolt_commit('-A','-m','seed');" | $DOLTLITE "$1" > /dev/null 2>&1
+}
+
+# --- A read-only connection must not rewrite the file --------------------
+for op in "VACUUM;" "PRAGMA wal_checkpoint;" "SELECT dolt_gc();"; do
+  DB="$ROOT/ro.db"
+  seed_db "$DB"
+  ln "$DB" "$ROOT/link.db"
+  chmod 0444 "$DB"
+  before=$(stat -f "%z-%Lp-%i-%l" "$DB" 2>/dev/null || stat -c "%s-%a-%i-%h" "$DB")
+  $DOLTLITE "file:$DB?mode=ro" "$op" > /dev/null 2>&1
+  after=$(stat -f "%z-%Lp-%i-%l" "$DB" 2>/dev/null || stat -c "%s-%a-%i-%h" "$DB")
+  label=$(echo "$op" | tr -cd '[:alnum:]_')
+  if [ "$before" = "$after" ]; then
+    dltest_pass "readonly_untouched_$label"
+  else
+    dltest_fail "readonly_untouched_$label" \
+      "  file changed: $before -> $after (size-mode-inode-links)"
+  fi
+  chmod u+w "$DB"; rm -f "$DB" "$ROOT/link.db"
+done
+
+# Reads keep working on such a connection.
+DB="$ROOT/ro.db"
+seed_db "$DB"
+chmod 0444 "$DB"
+run_test "readonly_still_reads" "SELECT b FROM t WHERE a=1;" "kept" "file:$DB?mode=ro"
+chmod u+w "$DB"; rm -f "$DB"
+
+# --- A replaced file must not be overwritten -----------------------------
+# The session reads once so the store has the file open, the path is then
+# replaced by an unrelated database, and the operation must leave it alone.
+for op in "VACUUM;" "PRAGMA wal_checkpoint;" "SELECT dolt_gc();"; do
+  DB="$ROOT/live.db"
+  seed_db "$DB"
+  rm -f "$ROOT/victim.db"
+  echo "CREATE TABLE victim(x TEXT);
+INSERT INTO victim VALUES('untouched');
+SELECT dolt_commit('-A','-m','victim');" | $DOLTLITE "$ROOT/victim.db" > /dev/null 2>&1
+  printf 'SELECT count(*) FROM t;\n.shell mv %s %s\n%s\n' \
+    "$ROOT/victim.db" "$DB" "$op" | $DOLTLITE "$DB" > /dev/null 2>&1
+  label=$(echo "$op" | tr -cd '[:alnum:]_')
+  run_test "replaced_survives_$label" "SELECT x FROM victim;" "untouched" "$DB"
+  rm -f "$DB"
+done
+
+dltest_finish

--- a/test/lib/doltlite_suite_manifest.sh
+++ b/test/lib/doltlite_suite_manifest.sh
@@ -80,6 +80,7 @@ doltlite_arm_correctness.sh
 doltlite_open_sqlite_file.sh
 doltlite_open_nofollow.sh
 doltlite_readonly_directory.sh
+doltlite_readonly_file_replacement.sh
 doltlite_open_missing_path.sh
 doltlite_comparison.sh
 doltlite_pragma_auto_vacuum.sh


### PR DESCRIPTION
Found in the deep review. Garbage collection finishes by renaming a rebuilt file over the database path, and `VACUUM`, `PRAGMA wal_checkpoint` and `dolt_gc` all reach that code. Nothing checked whether writing was permitted, or whether the file still belonged to this handle.

## A read-only connection rewrote the database

```
$ ln r.db link.db && chmod 0444 r.db
$ doltlite "file:r.db?mode=ro" "INSERT INTO t VALUES(2,'y');"
Error: attempt to write a readonly database          correctly refused

$ doltlite "file:r.db?mode=ro" "VACUUM;"             silently succeeded
before  size=3633  mode=0444  inode=741850319  links=2
after   size=1212  mode=0644  inode=741850359  links=1
```

The file shrank, its permissions were reset, it became a different inode, and the second name for it stopped sharing the data. `PRAGMA wal_checkpoint` and `SELECT dolt_gc()` did the same. Stock SQLite refuses `VACUUM` here and leaves the file alone.

That means a "safe" read-only connection — a reporting replica, an audit sidecar — was not read-only, and an unprivileged-by-intent process could strip the mode bits off a deliberately protected database.

## A replaced file was overwritten with stale content

If the path is replaced under an open handle, that path now names a database this connection never opened. Renaming our rebuilt copy over it destroys it:

```
session: SELECT count(*) FROM t;          -- store has the file open
         (path.db is replaced by an unrelated database)
         VACUUM;                          -- silently succeeded
$ doltlite path.db "SELECT x FROM victim;"
Error: no such table: victim              the other database is gone
```

`VACUUM`, `wal_checkpoint` and `sqlite3_backup_step` all destroyed it. `dolt_gc` already refused, because it forces a refresh whose own guard catches this.

## Change

Both conditions are refused once the lock is held — the point at which a replacement has been detected. Backup gains the same check for its destination; it already refused a read-only one.

A checkpoint still answers success: compacting there is opportunistic, stock does not compact on checkpoint at all, and stock likewise answers `PRAGMA wal_checkpoint` on a database it cannot write with success rather than an error. Such a store simply stays uncompacted. `VACUUM` and `dolt_gc` report the refusal, matching stock's behaviour for a `VACUUM` it cannot write.

Reads on both kinds of connection are unaffected, and a normal writable connection still collects and vacuums as before.

## Testing

New suite `test/doltlite_readonly_file_replacement.sh`, registered in the manifest, covering all three operations against both conditions plus a read that must still work.

- Fail-before/pass-after: 5 of the 7 assertions fail on master, all pass with the fix. The two that already pass are the read, and `dolt_gc` on a replaced file.
- Backup was verified with a C harness against both a pre-fix and post-fix library: pre-fix `backup_step` returned `SQLITE_DONE` and the unrelated database was gone; post-fix it returns `SQLITE_READONLY` and that database survives.
- Stock parity re-checked directly: stock errors on `VACUUM` and succeeds on `wal_checkpoint` for a read-only database, which is what this now does.
- Full battery **106/106 suites**. New suite and the GC suite are also clean under an ASAN+UBSAN build with no sanitizer reports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)