### PR TITLE
Do not treat a conflicted cherry-pick as a merge

### DIFF
--- a/src/doltlite_checkout.c
+++ b/src/doltlite_checkout.c
@@ -1183,6 +1183,11 @@ void doltCheckoutFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
       doltliteVcResultError(ctx, db, "unresolved merge conflicts \xe2\x80\x94 commit or abort first");
       return;
     }
+    if( doltliteSessionHasUnresolvedConflicts(db) ){
+      doltliteVcResultError(ctx, db,
+        "unresolved conflicts \xe2\x80\x94 resolve them or roll back first");
+      return;
+    }
   }
 
   if( strcmp(zBranch, "-b")==0 ){

--- a/src/doltlite_cmd.c
+++ b/src/doltlite_cmd.c
@@ -74,6 +74,13 @@ void doltliteCmdResultPeerBranchBusy(sqlite3_context *ctx, const char *zOp){
   }
 }
 
+static int markPendingReplayIfNotMerging(sqlite3 *db){
+  u8 isMerging = 0;
+  doltliteGetSessionMergeState(db, &isMerging, 0, 0);
+  if( isMerging ) return SQLITE_OK;
+  return doltliteSetSessionPendingReplayCommit(db, 1);
+}
+
 int doltliteReportConflicts(
   sqlite3 *db,
   sqlite3_context *ctx,
@@ -85,6 +92,8 @@ int doltliteReportConflicts(
   rc = doltliteRegisterConflictTables(db);
   if( rc!=SQLITE_OK ) return rc;
   rc = doltlitePersistOrSaveWorkingSet(db);
+  if( rc!=SQLITE_OK ) return rc;
+  rc = markPendingReplayIfNotMerging(db);
   if( rc!=SQLITE_OK ) return rc;
   sqlite3_snprintf(sizeof(msg), msg,
     "%s has %d conflict(s). Resolve and then commit with dolt_commit.",
@@ -101,6 +110,8 @@ int doltliteReportConstraintViolations(
   char msg[256];
   int rc;
   rc = doltlitePersistOrSaveWorkingSet(db);
+  if( rc!=SQLITE_OK ) return rc;
+  rc = markPendingReplayIfNotMerging(db);
   if( rc!=SQLITE_OK ) return rc;
   sqlite3_snprintf(sizeof(msg), msg,
     "%s resulted in constraint violations. Resolve the rows in "
@@ -121,6 +132,8 @@ int doltliteReportConflictsAndConstraintViolations(
   rc = doltliteRegisterConflictTables(db);
   if( rc!=SQLITE_OK ) return rc;
   rc = doltlitePersistOrSaveWorkingSet(db);
+  if( rc!=SQLITE_OK ) return rc;
+  rc = markPendingReplayIfNotMerging(db);
   if( rc!=SQLITE_OK ) return rc;
   sqlite3_snprintf(sizeof(msg), msg,
     "%s has %d conflict(s) and constraint violations. Resolve "

--- a/src/doltlite_commit_cmd.c
+++ b/src/doltlite_commit_cmd.c
@@ -834,7 +834,7 @@ static void doltliteCommitFunc(
   {
     u8 isMerging = 0;
     doltliteGetSessionMergeState(db, &isMerging, 0, 0);
-    if( !isMerging && !amend ){
+    if( !isMerging && !amend && !doltliteSessionHasPendingReplayCommit(db) ){
       ProllyHash headCatHash;
       rc = doltliteGetHeadCatalogHash(db, &headCatHash);
       if( rc==SQLITE_OK && !prollyHashIsEmpty(&headCatHash)
@@ -903,6 +903,7 @@ static void doltliteCommitFunc(
     return;
   }
   doltliteTxnStateClear(&mutationState);
+  (void)doltliteSetSessionPendingReplayCommit(db, 0);
 
   doltliteHashToHex(&commitHash, hexBuf);
 

--- a/src/doltlite_conflicts.c
+++ b/src/doltlite_conflicts.c
@@ -395,9 +395,6 @@ static int storeConflictBytes(
     rc = chunkStorePut(cs, pData, nData, &newHash);
     if( rc!=SQLITE_OK ) return rc;
     rc = doltliteSetSessionConflictsCatalog(db, &newHash);
-    if( rc==SQLITE_OK ){
-      rc = doltliteSetSessionMergeConflicts(db, &newHash);
-    }
   }
   if( rc!=SQLITE_OK ) return rc;
   mode = doltliteVcTxnMode(db);

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -1210,6 +1210,8 @@ int doltliteSetSessionMergeState(sqlite3 *db, u8 isMerging,
                                  const ProllyHash *pMergeCommit,
                                  const ProllyHash *pConflictsCatalog);
 int doltliteClearSessionMergeState(sqlite3 *db);
+int doltliteSetSessionPendingReplayCommit(sqlite3 *db, u8 pending);
+int doltliteSessionHasPendingReplayCommit(sqlite3 *db);
 int doltliteSetSessionMergeSourceSpec(sqlite3 *db, const char *zSpec,
                                       const ProllyHash *pMergeCommit);
 const char *doltliteGetSessionMergeSourceSpec(sqlite3 *db,

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -1210,7 +1210,6 @@ int doltliteSetSessionMergeState(sqlite3 *db, u8 isMerging,
                                  const ProllyHash *pMergeCommit,
                                  const ProllyHash *pConflictsCatalog);
 int doltliteClearSessionMergeState(sqlite3 *db);
-int doltliteSetSessionMergeConflicts(sqlite3 *db, const ProllyHash *pConflicts);
 int doltliteSetSessionMergeSourceSpec(sqlite3 *db, const char *zSpec,
                                       const ProllyHash *pMergeCommit);
 const char *doltliteGetSessionMergeSourceSpec(sqlite3 *db,

--- a/src/doltlite_merge.c
+++ b/src/doltlite_merge.c
@@ -1201,9 +1201,7 @@ static int recordMergeConflicts(
       aConflictTables, nConflictTables,
       &conflictsHash);
   if( rc!=SQLITE_OK ) return rc;
-  rc = doltliteSetSessionConflictsCatalog(db, &conflictsHash);
-  if( rc!=SQLITE_OK ) return rc;
-  return doltliteSetSessionMergeConflicts(db, &conflictsHash);
+  return doltliteSetSessionConflictsCatalog(db, &conflictsHash);
 }
 
 int doltliteMergeCatalogs(

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -791,6 +791,7 @@ int sqlite3BtreeOpen(
     p->headCommit = state.headCommit;
     p->vc.stagedCatalog = state.stagedCatalog;
     p->vc.isMerging = state.isMerging;
+    p->vc.pendingReplayCommit = 0;
     p->vc.mergeCommitHash = state.mergeCommit;
     p->vc.conflictsCatalogHash = state.conflictsCatalog;
     p->isRebasing = state.isRebasing;

--- a/src/prolly_btree_int.h
+++ b/src/prolly_btree_int.h
@@ -284,6 +284,7 @@ struct BtCursorOps {
 typedef struct DoltVcState {
   ProllyHash stagedCatalog;
   u8 isMerging;
+  u8 pendingReplayCommit;
   ProllyHash mergeCommitHash;
   ProllyHash conflictsCatalogHash;
   ProllyHash constraintViolationsHash;

--- a/src/prolly_btree_state.c
+++ b/src/prolly_btree_state.c
@@ -781,16 +781,6 @@ int doltliteClearSessionMergeState(sqlite3 *db){
   return doltliteSetSessionMergeState(db, 0, 0, 0);
 }
 
-/* Record a new conflicts catalog without disturbing the source commit already
-** on the session. Reaching for doltliteSetSessionMergeState with a null
-** pMergeCommit zeroes it, which drops the second parent commit owes the merged
-** branch and blanks dolt_merge_status.source. */
-int doltliteSetSessionMergeConflicts(sqlite3 *db, const ProllyHash *pConflicts){
-  ProllyHash mergeCommit;
-  doltliteGetSessionMergeState(db, 0, &mergeCommit, 0);
-  return doltliteSetSessionMergeState(db, 1, &mergeCommit, pConflicts);
-}
-
 int doltliteSetSessionMergeSourceSpec(sqlite3 *db, const char *zSpec,
                                       const ProllyHash *pMergeCommit){
   Btree *p;

--- a/src/prolly_btree_state.c
+++ b/src/prolly_btree_state.c
@@ -935,9 +935,8 @@ void doltliteGetSessionConflictsCatalog(sqlite3 *db, ProllyHash *pHash){
   {
     Btree *p = db->aDb[0].pBt;
     if( !db->autoCommit || sqlite3_txn_state(db, "main")!=SQLITE_TXN_NONE || db->pSavepoint ){
-      if( p->vc.isMerging ){
-        memcpy(pHash, &p->vc.conflictsCatalogHash, sizeof(*pHash));
-      }
+      /* Cherry-pick and revert record conflicts without isMerging. */
+      memcpy(pHash, &p->vc.conflictsCatalogHash, sizeof(*pHash));
       return;
     }
   }

--- a/src/prolly_btree_state.c
+++ b/src/prolly_btree_state.c
@@ -479,6 +479,7 @@ int btreeReloadBranchWorkingStateInto(
 
   p->vc.stagedCatalog = state.stagedCatalog;
   p->vc.isMerging = state.isMerging;
+  p->vc.pendingReplayCommit = 0;
   p->vc.mergeCommitHash = state.mergeCommit;
   p->vc.conflictsCatalogHash = state.conflictsCatalog;
   p->isRebasing = state.isRebasing;
@@ -779,6 +780,21 @@ int doltliteSetSessionMergeState(sqlite3 *db, u8 isMerging,
 
 int doltliteClearSessionMergeState(sqlite3 *db){
   return doltliteSetSessionMergeState(db, 0, 0, 0);
+}
+
+int doltliteSetSessionPendingReplayCommit(sqlite3 *db, u8 pending){
+  if( db && db->nDb>0 && db->aDb[0].pBt ){
+    Btree *p = db->aDb[0].pBt;
+    int rc = sessionStateSyncSavepoints(p);
+    if( rc!=SQLITE_OK ) return rc;
+    p->vc.pendingReplayCommit = pending ? 1 : 0;
+  }
+  return SQLITE_OK;
+}
+
+int doltliteSessionHasPendingReplayCommit(sqlite3 *db){
+  if( !db || db->nDb<=0 || !db->aDb[0].pBt ) return 0;
+  return db->aDb[0].pBt->vc.pendingReplayCommit!=0;
 }
 
 int doltliteSetSessionMergeSourceSpec(sqlite3 *db, const char *zSpec,
@@ -1217,6 +1233,7 @@ int doltliteLoadWorkingSet(sqlite3 *db, const char *zBranch){
   if( rc == SQLITE_NOTFOUND ){
     memset(&pBtree->vc.stagedCatalog, 0, sizeof(ProllyHash));
     pBtree->vc.isMerging = 0;
+    pBtree->vc.pendingReplayCommit = 0;
     memset(&pBtree->vc.mergeCommitHash, 0, sizeof(ProllyHash));
     memset(&pBtree->vc.conflictsCatalogHash, 0, sizeof(ProllyHash));
     pBtree->isRebasing = 0;
@@ -1230,6 +1247,7 @@ int doltliteLoadWorkingSet(sqlite3 *db, const char *zBranch){
     return SQLITE_OK;
   }
   if( rc==SQLITE_OK ){
+    pBtree->vc.pendingReplayCommit = 0;
     sqlite3_free(pBtree->zRebaseOrigBranch);
     pBtree->zRebaseOrigBranch = zNewRebaseOrigBranch;
     sqlite3_free(pBtree->zRebaseReturnBranch);

--- a/test/doltlite_cherry_pick.sh
+++ b/test/doltlite_cherry_pick.sh
@@ -602,6 +602,56 @@ run_test "rv_drop_index_restored" \
   "1" "$DB"
 rm -f "$DB"
 
+# A conflicted cherry-pick is not a merge: is_merging stays 0,
+# dolt_merge('--abort') has nothing to abort, and checkout refuses
+# because conflicts cannot be persisted (not because a merge is open).
+DB=/tmp/test_cp_conflict_not_merge_$$.db; rm -f "$DB"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'a');
+SELECT dolt_commit('-A','-m','init');
+SELECT dolt_checkout('-b','feat');
+UPDATE t SET v='F';
+SELECT dolt_commit('-A','-m','f');
+SELECT dolt_checkout('main');
+UPDATE t SET v='M';
+SELECT dolt_commit('-A','-m','m');
+SELECT dolt_branch('other');" | $DOLTLITE "$DB" > /dev/null 2>&1
+run_test "cp_conflict_not_a_merge" \
+  "BEGIN;
+   SELECT dolt_cherry_pick('feat');
+   SELECT is_merging FROM dolt_merge_status;
+   SELECT count(*) FROM dolt_conflicts;
+   SELECT dolt_checkout('other');
+   SELECT dolt_merge('--abort');" \
+  "Error near line 2: Cherry-pick has 1 conflict(s). Resolve and then commit with dolt_commit.
+0
+1
+Error near line 5: unresolved conflicts — resolve them or roll back first
+Error near line 6: no merge in progress" \
+  "$DB"
+rm -f "$DB"
+
+DB=/tmp/test_rv_conflict_not_merge_$$.db; rm -f "$DB"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'a');
+SELECT dolt_commit('-A','-m','init');
+UPDATE t SET v='b';
+SELECT dolt_commit('-A','-m','b');
+UPDATE t SET v='c';
+SELECT dolt_commit('-A','-m','c');" | $DOLTLITE "$DB" > /dev/null 2>&1
+run_test "rv_conflict_not_a_merge" \
+  "BEGIN;
+   SELECT dolt_revert('HEAD~1');
+   SELECT is_merging FROM dolt_merge_status;
+   SELECT count(*) FROM dolt_conflicts;
+   SELECT dolt_merge('--abort');" \
+  "Error near line 2: Revert has 1 conflict(s). Resolve and then commit with dolt_commit.
+0
+1
+Error near line 5: no merge in progress" \
+  "$DB"
+rm -f "$DB"
+
 # A clean cherry-pick / revert is a transaction boundary like dolt_commit:
 # it seals the enclosing BEGIN when it advances the ref. Leaving the
 # transaction open let a later ROLLBACK revert the working set while the

--- a/test/doltlite_cherry_pick.sh
+++ b/test/doltlite_cherry_pick.sh
@@ -631,6 +631,36 @@ Error near line 6: no merge in progress" \
   "$DB"
 rm -f "$DB"
 
+# --ours can leave the working tree identical to HEAD. The concluding
+# commit must still be created as a single-parent commit, not refused
+# as empty and not recorded as a merge.
+DB=/tmp/test_cp_conflict_ours_commit_$$.db; rm -f "$DB"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'a');
+SELECT dolt_commit('-A','-m','init');
+SELECT dolt_checkout('-b','feat');
+UPDATE t SET v='F';
+SELECT dolt_commit('-A','-m','f');
+SELECT dolt_checkout('main');
+UPDATE t SET v='M';
+SELECT dolt_commit('-A','-m','m');" | $DOLTLITE "$DB" > /dev/null 2>&1
+run_test "cp_conflict_ours_commits_single_parent" \
+  "BEGIN;
+   SELECT dolt_cherry_pick('feat');
+   SELECT dolt_conflicts_resolve('--ours', 't');
+   SELECT length(dolt_commit('-A','-m','picked'))>=40;
+   SELECT count(*) FROM dolt_commit_ancestors WHERE commit_hash = dolt_hashof('HEAD');
+   SELECT is_merging FROM dolt_merge_status;
+   SELECT message FROM dolt_log LIMIT 1;" \
+  "Error near line 2: Cherry-pick has 1 conflict(s). Resolve and then commit with dolt_commit.
+0
+1
+1
+0
+picked" \
+  "$DB"
+rm -f "$DB"
+
 DB=/tmp/test_rv_conflict_not_merge_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'a');

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -4530,6 +4530,97 @@ static void run_cherry_pick_stale_conflict_clears_session(void){
   removeDbFiles(dbpath);
 }
 
+static void run_cherry_pick_conflict_is_not_a_merge(void){
+  sqlite3 *db = 0;
+  char dbpath[256];
+  const char *res;
+  u8 isMerging = 0;
+
+  printf("=== Cherry-pick Conflict Is Not A Merge Test ===\n\n");
+  make_dbpath(dbpath, sizeof(dbpath),
+              "test_cherry_pick_conflict_is_not_a_merge");
+  removeDbFiles(dbpath);
+
+  check("open_db_for_cherry_pick_conflict_not_merge",
+        open_db(dbpath, &db)==SQLITE_OK);
+  check("setup_repo_for_cherry_pick_conflict_not_merge", execSql(db,
+    "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
+    "INSERT INTO t VALUES(1,'a');"
+    "SELECT dolt_commit('-A','-m','init');"
+    "SELECT dolt_checkout('-b','feat');"
+    "UPDATE t SET v='F';"
+    "SELECT dolt_commit('-A','-m','f');"
+    "SELECT dolt_checkout('main');"
+    "UPDATE t SET v='M';"
+    "SELECT dolt_commit('-A','-m','m');"
+    "SELECT dolt_branch('other');")==SQLITE_OK);
+
+  check("begin_for_cherry_pick_conflict_not_merge",
+        execSql(db, "BEGIN;")==SQLITE_OK);
+  res = queryScalarText(db, "SELECT dolt_cherry_pick('feat')");
+  check("cherry_pick_conflict_reports_conflicts",
+        strstr(res, "conflict")!=0);
+  doltliteGetSessionMergeState(db, &isMerging, 0, 0);
+  check("cherry_pick_conflict_is_not_merging", isMerging==0);
+  check("cherry_pick_conflict_rows_are_visible",
+        strcmp(queryScalarText(db, "SELECT count(*) FROM dolt_conflicts"),
+               "1")==0);
+  res = queryScalarText(db, "SELECT dolt_checkout('other')");
+  check("cherry_pick_conflict_blocks_checkout",
+        strstr(res, "unresolved conflicts")!=0);
+  check("cherry_pick_conflict_checkout_is_not_a_merge",
+        strstr(res, "unresolved merge conflicts")==0);
+  res = queryScalarText(db, "SELECT dolt_merge('--abort')");
+  check("cherry_pick_conflict_has_no_merge_to_abort",
+        strstr(res, "no merge in progress")!=0);
+  check("rollback_cherry_pick_conflict_not_merge",
+        execSql(db, "ROLLBACK;")==SQLITE_OK);
+
+  sqlite3_close(db);
+  removeDbFiles(dbpath);
+}
+
+static void run_revert_conflict_is_not_a_merge(void){
+  sqlite3 *db = 0;
+  char dbpath[256];
+  const char *res;
+  u8 isMerging = 0;
+
+  printf("=== Revert Conflict Is Not A Merge Test ===\n\n");
+  make_dbpath(dbpath, sizeof(dbpath), "test_revert_conflict_is_not_a_merge");
+  removeDbFiles(dbpath);
+
+  check("open_db_for_revert_conflict_not_merge",
+        open_db(dbpath, &db)==SQLITE_OK);
+  check("setup_repo_for_revert_conflict_not_merge", execSql(db,
+    "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
+    "INSERT INTO t VALUES(1,'a');"
+    "SELECT dolt_commit('-A','-m','init');"
+    "UPDATE t SET v='b';"
+    "SELECT dolt_commit('-A','-m','b');"
+    "UPDATE t SET v='c';"
+    "SELECT dolt_commit('-A','-m','c');")==SQLITE_OK);
+
+  check("begin_for_revert_conflict_not_merge",
+        execSql(db, "BEGIN;")==SQLITE_OK);
+  res = queryScalarText(db, "SELECT dolt_revert('HEAD~1')");
+  check("revert_conflict_reports_conflicts",
+        strstr(res, "conflict")!=0);
+  doltliteGetSessionMergeState(db, &isMerging, 0, 0);
+  check("revert_conflict_is_not_merging", isMerging==0);
+  check("revert_conflict_rows_are_visible",
+        strcmp(queryScalarText(db, "SELECT count(*) FROM dolt_conflicts"),
+               "1")==0);
+  res = queryScalarText(db, "SELECT dolt_merge('--abort')");
+  check("revert_conflict_has_no_merge_to_abort",
+        strstr(res, "no merge in progress")!=0);
+  check("rollback_revert_conflict_not_merge",
+        execSql(db, "ROLLBACK;")==SQLITE_OK);
+
+  sqlite3_close(db);
+  removeDbFiles(dbpath);
+}
+
 static void run_cherry_pick_seal_fail_keeps_advanced_tip(void){
   sqlite3 *db = 0;
   ChunkStore *cs;
@@ -12955,6 +13046,8 @@ static const RegressionCase aCases[] = {
   { "failed_merge_reopen_preserves_working_set_state", "Failed Merge Reopen Preserves Working Set State Test", run_failed_merge_reopen_clears_ephemeral_conflict_state },
   { "cherry_pick_stale_branch", "Cherry-pick Stale Branch Test", run_cherry_pick_stale_branch },
   { "cherry_pick_stale_conflict_clears_session", "Cherry-pick Stale Conflict Clears Session Test", run_cherry_pick_stale_conflict_clears_session },
+  { "cherry_pick_conflict_is_not_a_merge", "Cherry-pick Conflict Is Not A Merge Test", run_cherry_pick_conflict_is_not_a_merge },
+  { "revert_conflict_is_not_a_merge", "Revert Conflict Is Not A Merge Test", run_revert_conflict_is_not_a_merge },
   { "cherry_pick_seal_fail_keeps_advanced_tip", "Cherry-pick Seal Failure Keeps Advanced Tip Test", run_cherry_pick_seal_fail_keeps_advanced_tip },
   { "failed_cherry_pick_reopen_preserves_conflict_state", "Failed Cherry-pick Reopen Preserves Conflict State Test", run_failed_cherry_pick_reopen_preserves_conflict_state },
   { "branches_metadata_corruption", "Branches Metadata Corruption Test", run_branches_metadata_corruption },

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -4580,6 +4580,56 @@ static void run_cherry_pick_conflict_is_not_a_merge(void){
   removeDbFiles(dbpath);
 }
 
+static void run_cherry_pick_conflict_ours_commits_single_parent(void){
+  sqlite3 *db = 0;
+  char dbpath[256];
+  const char *res;
+  u8 isMerging = 0;
+
+  printf("=== Cherry-pick Conflict Ours Commits Single Parent Test ===\n\n");
+  make_dbpath(dbpath, sizeof(dbpath),
+              "test_cherry_pick_conflict_ours_commits_single_parent");
+  removeDbFiles(dbpath);
+
+  check("open_db_for_cherry_pick_ours_commit",
+        open_db(dbpath, &db)==SQLITE_OK);
+  check("setup_repo_for_cherry_pick_ours_commit", execSql(db,
+    "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
+    "INSERT INTO t VALUES(1,'a');"
+    "SELECT dolt_commit('-A','-m','init');"
+    "SELECT dolt_checkout('-b','feat');"
+    "UPDATE t SET v='F';"
+    "SELECT dolt_commit('-A','-m','f');"
+    "SELECT dolt_checkout('main');"
+    "UPDATE t SET v='M';"
+    "SELECT dolt_commit('-A','-m','m');")==SQLITE_OK);
+
+  check("begin_for_cherry_pick_ours_commit",
+        execSql(db, "BEGIN;")==SQLITE_OK);
+  res = queryScalarText(db, "SELECT dolt_cherry_pick('feat')");
+  check("cherry_pick_ours_commit_reports_conflicts",
+        strstr(res, "conflict")!=0);
+  check("cherry_pick_ours_commit_resolve",
+        execSql(db, "SELECT dolt_conflicts_resolve('--ours', 't');")==SQLITE_OK);
+  res = queryScalarText(db, "SELECT dolt_commit('-A','-m','picked')");
+  check("cherry_pick_ours_commit_creates_commit",
+        strstr(res, "ERROR:")==0 && strlen(res)>=40);
+  doltliteGetSessionMergeState(db, &isMerging, 0, 0);
+  check("cherry_pick_ours_commit_is_not_merging", isMerging==0);
+  check("cherry_pick_ours_commit_single_parent",
+        strcmp(queryScalarText(db,
+          "SELECT count(*) FROM dolt_commit_ancestors "
+          "WHERE commit_hash = dolt_hashof('HEAD')"), "1")==0);
+  check("cherry_pick_ours_commit_message",
+        strcmp(queryScalarText(db,
+          "SELECT message FROM dolt_log LIMIT 1"), "picked")==0);
+  check("cherry_pick_ours_commit_keeps_ours",
+        strcmp(queryScalarText(db, "SELECT v FROM t WHERE id=1"), "M")==0);
+
+  sqlite3_close(db);
+  removeDbFiles(dbpath);
+}
+
 static void run_revert_conflict_is_not_a_merge(void){
   sqlite3 *db = 0;
   char dbpath[256];
@@ -13047,6 +13097,7 @@ static const RegressionCase aCases[] = {
   { "cherry_pick_stale_branch", "Cherry-pick Stale Branch Test", run_cherry_pick_stale_branch },
   { "cherry_pick_stale_conflict_clears_session", "Cherry-pick Stale Conflict Clears Session Test", run_cherry_pick_stale_conflict_clears_session },
   { "cherry_pick_conflict_is_not_a_merge", "Cherry-pick Conflict Is Not A Merge Test", run_cherry_pick_conflict_is_not_a_merge },
+  { "cherry_pick_conflict_ours_commits_single_parent", "Cherry-pick Conflict Ours Commits Single Parent Test", run_cherry_pick_conflict_ours_commits_single_parent },
   { "revert_conflict_is_not_a_merge", "Revert Conflict Is Not A Merge Test", run_revert_conflict_is_not_a_merge },
   { "cherry_pick_seal_fail_keeps_advanced_tip", "Cherry-pick Seal Failure Keeps Advanced Tip Test", run_cherry_pick_seal_fail_keeps_advanced_tip },
   { "failed_cherry_pick_reopen_preserves_conflict_state", "Failed Cherry-pick Reopen Preserves Conflict State Test", run_failed_cherry_pick_reopen_preserves_conflict_state },


### PR DESCRIPTION
A cherry-pick or revert that hits a cell conflict reused catalog merge, which forced `isMerging=1` so `dolt_conflicts` would show rows. That made a pick look like a real merge:

```sql
BEGIN;
SELECT dolt_cherry_pick('feat');          -- cell conflict
SELECT is_merging FROM dolt_merge_status; -- was 1
SELECT dolt_checkout('other');            -- unresolved merge conflicts
SELECT dolt_merge('--abort');             -- wiped the pick
```

`dolt_commit` already treats cherry-pick as a single-parent commit (empty merge source). Only the merge flag was wrong.

Conflicts are now recorded without setting `isMerging`. In-transaction `dolt_conflicts` reads the conflicts catalog even when that flag is clear. A real `dolt_merge` still sets `isMerging` itself. Checkout still refuses unresolved cherry-pick conflicts because DoltLite never persists a conflicted working set; the error is no longer a merge abort.

After this change: `is_merging=0`, `dolt_conflicts` still has the row, `dolt_merge('--abort')` reports no merge in progress, and checkout says to resolve or roll back.

Co-Authored-By: Grok 4.6 <noreply@x.ai>