### PR TITLE
Validate sealed WAL root manifests

### DIFF
--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -223,6 +223,54 @@ int csManifestHashStateOffsetless(const u8 *aBuf){
   return csManifestHashStateImpl(aBuf, 0, 0);
 }
 
+int csValidateWalRootManifest(
+  const ChunkStore *cs,
+  const u8 *aBuf,
+  i64 iRootOffset
+){
+  u32 nChunks = CS_READ_U32(aBuf + CS_MANIFEST_CHUNK_COUNT_OFF);
+  u32 nIndexSize = CS_READ_U32(aBuf + CS_MANIFEST_INDEX_SIZE_OFF);
+  i64 iIndexOffset = CS_READ_I64(aBuf + CS_MANIFEST_INDEX_OFFSET_OFF);
+  i64 iWalOffset = CS_READ_I64(aBuf + CS_MANIFEST_WAL_OFFSET_OFF);
+  i64 durableTo = CS_READ_I64(aBuf + CS_MANIFEST_DURABLE_TO_OFF);
+  i64 batchStart = CS_READ_I64(aBuf + CS_MANIFEST_BATCH_START_OFF);
+  i64 rootEnd;
+  i64 nextOff = CS_READ_I64(aBuf + CS_MANIFEST_NEXT_OFF_OFF);
+
+  if( CS_READ_U32(aBuf + CS_MANIFEST_MAGIC_OFF)!=CHUNK_STORE_MAGIC
+   || CS_READ_U32(aBuf + CS_MANIFEST_VERSION_OFF)!=CHUNK_STORE_VERSION
+   || nChunks>(u32)INT_MAX || nIndexSize>(u32)INT_MAX
+   || nIndexSize%CHUNK_INDEX_ENTRY_SIZE!=0
+   || nIndexSize/CHUNK_INDEX_ENTRY_SIZE>nChunks
+   || iIndexOffset<0 || iWalOffset<CHUNK_MANIFEST_SIZE
+   || (nIndexSize>0 && iIndexOffset<CHUNK_MANIFEST_SIZE) ){
+    return SQLITE_CORRUPT;
+  }
+  if( iIndexOffset>0
+   && (iWalOffset<iIndexOffset
+       || iWalOffset-iIndexOffset<(i64)nIndexSize) ){
+    return SQLITE_CORRUPT;
+  }
+  if( cs
+   && (iWalOffset!=cs->wal.iWalOffset
+       || iIndexOffset!=cs->index.iIndexOffset
+       || (i64)nIndexSize!=cs->index.nIndexSize) ){
+    return SQLITE_CORRUPT;
+  }
+  if( iRootOffset<iWalOffset
+   || iRootOffset>LARGEST_INT64-(1+CHUNK_MANIFEST_SIZE) ){
+    return SQLITE_CORRUPT;
+  }
+  rootEnd = iRootOffset + 1 + CHUNK_MANIFEST_SIZE;
+  /* Both gaps are sector-alignment padding; writers cap sectors at 64KiB. */
+  if( durableTo<iWalOffset || durableTo>batchStart
+   || batchStart>iRootOffset || batchStart-durableTo>=65536
+   || nextOff<rootEnd || nextOff-rootEnd>=65536 ){
+    return SQLITE_CORRUPT;
+  }
+  return SQLITE_OK;
+}
+
 static int csReadManifest(ChunkStore *cs){
   u8 aBuf[CHUNK_MANIFEST_SIZE];
   u32 magic, version;
@@ -303,6 +351,10 @@ static int csScanForCommittedRoot(ChunkStore *cs, int *pEverCommitted,
         if( rc != SQLITE_OK ) return rc;
         state = csManifestHashState(m, q + i);
         if( state==CS_MANIFEST_HASH_OK ){
+          if( csValidateWalRootManifest(0, m, q+i)!=SQLITE_OK ){
+            *pEverCommitted = 1;
+            return SQLITE_OK;
+          }
           if( CS_READ_I64(m + CS_MANIFEST_DURABLE_TO_OFF) > CHUNK_MANIFEST_SIZE ){
             *pEverCommitted = 1;
             return SQLITE_OK;

--- a/src/chunk_store_int.h
+++ b/src/chunk_store_int.h
@@ -41,6 +41,8 @@ int csSyncFile(ChunkStore *cs);
 void csFillChunkHdr(u8 *p, const ProllyHash *pHash, u32 size);
 void csSerializeManifest(const ChunkStore *cs, u8 *aBuf);
 int csManifestHashStateOffsetless(const u8 *aBuf);
+int csValidateWalRootManifest(const ChunkStore *cs, const u8 *aBuf,
+                              i64 iRootOffset);
 int csReadDiskRefsHash(ChunkStore *cs, ProllyHash *pOut);
 
 #endif /* CHUNK_STORE_INT_H */

--- a/src/chunk_store_refs_api.c
+++ b/src/chunk_store_refs_api.c
@@ -79,6 +79,8 @@ int csDiskStateMatchesMemory(ChunkStore *cs){
   }
   return aRoot[0]==CS_WAL_TAG_ROOT
       && hashState==CS_MANIFEST_HASH_OK
+      && csValidateWalRootManifest(
+           cs, aRoot+1, contentEnd-(i64)sizeof(aRoot))==SQLITE_OK
       && memcmp(aRoot + 1 + CS_MANIFEST_REFS_HASH_OFF,
                 cs->refs.refsHash.data, PROLLY_HASH_SIZE)==0;
 }
@@ -92,6 +94,7 @@ int csDiskStateMatchesMemory(ChunkStore *cs){
 int csReadDiskRefsHash(ChunkStore *cs, ProllyHash *pOut){
   i64 physSize = 0;
   u8 aRoot[1 + CHUNK_MANIFEST_SIZE];
+  int hashState;
 
   memset(pOut, 0, sizeof(*pOut));
   if( cs->file.pFile==0 ) return 0;
@@ -108,6 +111,15 @@ int csReadDiskRefsHash(ChunkStore *cs, ProllyHash *pOut){
   ** write) is not a published state; report "cannot prove" and let the
   ** caller fall back to its in-memory comparison. */
   if( aRoot[0]!=CS_WAL_TAG_ROOT ) return 0;
+  hashState = csManifestHashState(aRoot+1, physSize-(i64)sizeof(aRoot));
+  if( hashState==CS_MANIFEST_HASH_BAD ){
+    hashState = csManifestHashStateOffsetless(aRoot+1);
+  }
+  if( hashState!=CS_MANIFEST_HASH_OK
+   || csValidateWalRootManifest(
+        cs, aRoot+1, physSize-(i64)sizeof(aRoot))!=SQLITE_OK ){
+    return 0;
+  }
   memcpy(pOut->data, aRoot + 1 + CS_MANIFEST_REFS_HASH_OFF, PROLLY_HASH_SIZE);
   return 1;
 }

--- a/src/chunk_wal.c
+++ b/src/chunk_wal.c
@@ -194,7 +194,9 @@ static int csWalResolveDamage(
                            cs->wal.iWalOffset + cand + 1);
         if( rc != SQLITE_OK ) return rc;
         state = csManifestHashState(m, cs->wal.iWalOffset + cand);
-        if( state==CS_MANIFEST_HASH_OK ){
+        if( state==CS_MANIFEST_HASH_OK
+         && csValidateWalRootManifest(
+              cs, m, cs->wal.iWalOffset+cand)==SQLITE_OK ){
           i64 durableTo = CS_READ_I64(m + CS_MANIFEST_DURABLE_TO_OFF);
           i64 batchStart = CS_READ_I64(m + CS_MANIFEST_BATCH_START_OFF);
           if( durableTo > damageAbs ){
@@ -400,6 +402,16 @@ int csReplayWal(ChunkStore *cs){
         if( damageAction==CS_DAMAGE_RESUME ){ pos = resumePos; continue; }
         sawMidStream = (damageAction==CS_DAMAGE_MIDSTREAM);
         break;
+      }
+      if( hashState==CS_MANIFEST_HASH_OK
+       && csValidateWalRootManifest(
+            cs, m, cs->wal.iWalOffset+recPos)!=SQLITE_OK ){
+        sqlite3_log(SQLITE_CORRUPT,
+          "doltlite: invalid sealed WAL root manifest at offset %lld",
+          (long long)(cs->wal.iWalOffset + recPos));
+        cs->corruptMidStream = 1;
+        rc = SQLITE_CORRUPT;
+        goto replay_error;
       }
 
       cs->index.nChunks = (int)CS_READ_U32(m + CS_MANIFEST_CHUNK_COUNT_OFF);

--- a/test/corruption_test.c
+++ b/test/corruption_test.c
@@ -177,6 +177,45 @@ static off_t last_wal_chunk_body_offset(const char *path){
   return last;
 }
 
+static off_t last_sealed_wal_root_offset(const char *path){
+  long long walOffset = read_i64_le_at(path, CS_MANIFEST_WAL_OFFSET_OFF);
+  off_t sz = file_size(path);
+  unsigned char *data;
+  off_t pos;
+  off_t last = -1;
+  if( walOffset < MANIFEST_SIZE || sz <= (off_t)walOffset ) return -1;
+  data = sqlite3_malloc64((sqlite3_uint64)sz);
+  if( data==0 ) return -1;
+  if( read_bytes(path, 0, data, (size_t)sz)!=0 ){
+    sqlite3_free(data);
+    return -1;
+  }
+  for(pos=(off_t)walOffset; pos+1+MANIFEST_SIZE<=sz; pos++){
+    if( data[pos]==CS_WAL_TAG_ROOT
+     && CS_READ_U32(data+pos+1+CS_MANIFEST_MAGIC_OFF)==CHUNK_STORE_MAGIC
+     && csManifestHashState(data+pos+1, (i64)pos)==CS_MANIFEST_HASH_OK ){
+      last = pos;
+    }
+  }
+  sqlite3_free(data);
+  return last;
+}
+
+static int rewrite_sealed_root_field(
+  const char *path,
+  off_t rootOff,
+  int fieldOff,
+  const unsigned char *value,
+  size_t len
+){
+  unsigned char manifest[CHUNK_MANIFEST_SIZE];
+  if( fieldOff<0 || len>(size_t)(CHUNK_MANIFEST_SIZE-fieldOff) ) return -1;
+  if( read_bytes(path, rootOff+1, manifest, sizeof(manifest))!=0 ) return -1;
+  memcpy(manifest+fieldOff, value, len);
+  csManifestSeal(manifest, (i64)rootOff);
+  return corrupt_bytes(path, rootOff+1, manifest, sizeof(manifest));
+}
+
 static void removeDb(const char *path){
   char wal[512];
   remove(path);
@@ -1227,6 +1266,88 @@ static void test_index_end_overflow_bounds_wal_offset(void){
   removeDb(dbpath);
 }
 
+static void test_sealed_wal_root_manifest_validation(void){
+  const char *base = "/tmp/test_corr_wal_root_manifest_base.db";
+  const char *dbpath = "/tmp/test_corr_wal_root_manifest.db";
+  sqlite3 *db = 0;
+  off_t rootOff;
+  long long walOffset;
+  long long rootEnd;
+  unsigned char value[8];
+  int i;
+  struct RootMutation {
+    const char *name;
+    int fieldOff;
+    int nValue;
+    long long value;
+  } mutations[] = {
+    { "version", CS_MANIFEST_VERSION_OFF, 4, CHUNK_STORE_VERSION+1 },
+    { "chunk_count", CS_MANIFEST_CHUNK_COUNT_OFF, 4, 0x80000000LL },
+    { "index_offset", CS_MANIFEST_INDEX_OFFSET_OFF, 8, -1 },
+    { "index_size", CS_MANIFEST_INDEX_SIZE_OFF, 4, 1 },
+    { "wal_offset", CS_MANIFEST_WAL_OFFSET_OFF, 8, 0 },
+    { "durable_before_wal", CS_MANIFEST_DURABLE_TO_OFF, 8, 0 },
+    { "durable_after_batch", CS_MANIFEST_DURABLE_TO_OFF, 8, 0 },
+    { "batch_before_durable", CS_MANIFEST_BATCH_START_OFF, 8, 0 },
+    { "batch_after_root", CS_MANIFEST_BATCH_START_OFF, 8, 0 },
+    { "batch_gap", CS_MANIFEST_DURABLE_TO_OFF, 8, 0 },
+    { "next_before_root_end", CS_MANIFEST_NEXT_OFF_OFF, 8, 0 },
+    { "next_gap", CS_MANIFEST_NEXT_OFF_OFF, 8, 0 },
+  };
+
+  printf("--- Test 30: Sealed WAL root manifest fields are validated ---\n");
+
+  removeDb(base);
+  check("root_manifest_open", sqlite3_open(base, &db)==SQLITE_OK);
+  if( db ){
+    check("root_manifest_schema",
+      execSql(db, "CREATE TABLE t1(id INTEGER PRIMARY KEY, val)")==SQLITE_OK);
+    check("root_manifest_large_row",
+      execSql(db, "INSERT INTO t1 VALUES(1, randomblob(70000))")==SQLITE_OK);
+    sqlite3_close(db);
+  }
+  rootOff = last_sealed_wal_root_offset(base);
+  walOffset = read_i64_le_at(base, CS_MANIFEST_WAL_OFFSET_OFF);
+  rootEnd = (long long)rootOff + 1 + MANIFEST_SIZE;
+  check("root_manifest_find_root", rootOff>walOffset+65536);
+
+  mutations[4].value = walOffset + 1;
+  mutations[5].value = walOffset - 1;
+  mutations[6].value = (long long)rootOff + 1;
+  mutations[7].value = (long long)rootOff - 1;
+  mutations[8].value = (long long)rootOff + 1;
+  mutations[9].value = (long long)rootOff - 65536;
+  mutations[10].value = rootEnd - 1;
+  mutations[11].value = rootEnd + 65536;
+
+  for(i=0; i<(int)(sizeof(mutations)/sizeof(mutations[0])); i++){
+    ChunkStore cs;
+    int rc;
+    off_t before;
+    char name[128];
+    check("root_manifest_copy", copy_file(base, dbpath)==0);
+    if( mutations[i].nValue==4 ){
+      CS_WRITE_U32(value, (u32)mutations[i].value);
+    }else{
+      CS_WRITE_I64(value, mutations[i].value);
+    }
+    snprintf(name, sizeof(name), "root_manifest_rewrite_%s", mutations[i].name);
+    check(name, rewrite_sealed_root_field(dbpath, rootOff,
+          mutations[i].fieldOff, value, (size_t)mutations[i].nValue)==0);
+    before = file_size(dbpath);
+    rc = chunkStoreOpen(&cs, sqlite3_vfs_find(0), dbpath,
+        SQLITE_OPEN_READWRITE | SQLITE_OPEN_MAIN_DB);
+    snprintf(name, sizeof(name), "root_manifest_reject_%s", mutations[i].name);
+    check(name, rc==SQLITE_CORRUPT);
+    if( rc==SQLITE_OK ) chunkStoreClose(&cs);
+    snprintf(name, sizeof(name), "root_manifest_unchanged_%s", mutations[i].name);
+    check(name, file_size(dbpath)==before);
+  }
+
+  removeDb(base);
+  removeDb(dbpath);
+}
+
 int main(void){
   printf("=== DoltLite Corruption Detection Tests ===\n\n");
 
@@ -1258,6 +1379,7 @@ int main(void){
   test_unsealed_header_still_opens();
   test_unsealed_header_bounds_checks_wal_offset();
   test_index_end_overflow_bounds_wal_offset();
+  test_sealed_wal_root_manifest_validation();
 
   printf("\n=== Results: %d passed, %d failed out of %d tests ===\n",
     nPass, nFail, nPass+nFail);


### PR DESCRIPTION
## Summary

- reject sealed WAL roots whose version, counts, index metadata, or commit positioning cannot have been emitted by the writer
- validate roots before replay mutates chunk counts, refs, or the logical append offset
- require the same validation in damage classification, crashed-creation recovery, and tail-root fast paths
- preserve version 12 compatibility without a storage-format change

## Validation

- fail-before: all 12 crafted, correctly resealed manifest mutations were accepted on `master`
- corruption suite: 178 passed
- crash recovery: 123 passed
- version 12 storage-format contract: 23 passed
- concurrency and GC spot checks: 130 passed
- `make lint`
- `git diff --check`

Co-Authored-By: OpenAI Codex <noreply@openai.com>