### PR TITLE
Seal the enclosing transaction when a branch switch runs inside one

### DIFF
--- a/src/doltlite_core.c
+++ b/src/doltlite_core.c
@@ -993,7 +993,13 @@ int doltliteVcSealBranchStyleTxn(sqlite3 *db){
   int rc;
   if( db->autoCommit ) return SQLITE_OK;
   if( db->pSavepoint ){
-    return doltliteVcSealActiveSavepoints(db);
+    rc = doltliteVcSealActiveSavepoints(db);
+    if( rc!=SQLITE_OK ) return rc;
+    /* Releasing the savepoints leaves any enclosing BEGIN open, and a later
+    ** ROLLBACK would then revert the working set to the branch we left while
+    ** the ref already names the one we switched to. Seal that too. A top-level
+    ** SAVEPOINT was the transaction, so releasing it ended everything. */
+    if( db->autoCommit ) return SQLITE_OK;
   }
   rc = sqlite3_exec(db, "COMMIT", 0, 0, 0);
   if( rc!=SQLITE_OK ) return rc;

--- a/test/doltlite_savepoint.sh
+++ b/test/doltlite_savepoint.sh
@@ -697,6 +697,61 @@ run_test_match "branch_name_after_rollback" \
   "SELECT name FROM dolt_branches ORDER BY name;" \
   "main" "$DB9"
 
+# A branch switch seals the transaction it runs in. Releasing the savepoints
+# is not enough on its own: an enclosing BEGIN left open means a later
+# ROLLBACK reverts the working set to the branch we left while the ref already
+# names the one we switched to, and that mismatch is what gets persisted. The
+# plain-BEGIN and bare-SAVEPOINT shapes above never had the open BEGIN, so the
+# combination is the case that needs pinning.
+DBSP1=/tmp/test_sp_begin_checkout_$$.db; rm -f "$DBSP1"
+echo "CREATE TABLE t(a INTEGER PRIMARY KEY, b INT);
+INSERT INTO t VALUES(1,10),(2,20);
+SELECT dolt_commit('-A','-m','init');
+SELECT dolt_branch('side');
+INSERT INTO t VALUES(4,40);
+SELECT dolt_commit('-A','-m','main row 4');
+SELECT dolt_checkout('side');
+INSERT INTO t VALUES(9,90);
+SELECT dolt_commit('-A','-m','side row 9');
+SELECT dolt_checkout('main');" | $DOLTLITE "$DBSP1" > /dev/null 2>&1
+echo "BEGIN;
+SAVEPOINT s;
+INSERT INTO t VALUES(7,70);
+SELECT dolt_checkout('side');
+ROLLBACK;" | $DOLTLITE "$DBSP1" > /dev/null 2>&1
+
+run_test "begin_savepoint_checkout_keeps_target_rows" \
+  "SELECT group_concat(a) FROM t;" "1,2,9" "$DBSP1/side"
+run_test "begin_savepoint_checkout_target_clean" \
+  "SELECT count(*) FROM dolt_status;" "0" "$DBSP1/side"
+run_test "begin_savepoint_checkout_source_intact" \
+  "SELECT group_concat(a) FROM t WHERE a IN (1,2,4);" "1,2,4" "$DBSP1"
+
+# The same seal carries the interactive rebase claim and plan, which are
+# written before the switch and are lost with the transaction if it stays open.
+DBSP2=/tmp/test_sp_begin_rebase_$$.db; rm -f "$DBSP2"
+echo "CREATE TABLE t(a INTEGER PRIMARY KEY, b INT);
+INSERT INTO t VALUES(1,10);
+SELECT dolt_commit('-A','-m','init');
+SELECT dolt_branch('side');
+SELECT dolt_checkout('side');
+INSERT INTO t VALUES(9,90);
+SELECT dolt_commit('-A','-m','side');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES(4,40);
+SELECT dolt_commit('-A','-m','main');" | $DOLTLITE "$DBSP2" > /dev/null 2>&1
+echo "BEGIN;
+SAVEPOINT s;
+SELECT dolt_rebase('-i','main');
+ROLLBACK;" | $DOLTLITE "$DBSP2/side" > /dev/null 2>&1
+
+run_test_match "begin_savepoint_rebase_plan_survives" \
+  "SELECT count(*) FROM dolt_rebase;" "^[1-9][0-9]*$" "$DBSP2/dolt_rebase_side"
+run_test_match "begin_savepoint_rebase_continues" \
+  "SELECT dolt_rebase('--continue');" "Successfully rebased" "$DBSP2/side"
+
+rm -f "$DBSP1" "$DBSP2"
+
 rm -f "$DB1" "$DB2" "$DB3" "$DB4" "$DB4b" "$DB5" "$DB6" "$DB6b" "$DB7" "$DB8" "$DB9" \
   "$DB6g1" "$DB6g2" "$DB6g3" "$DB6g4" "$DB6g5" "$DB6g6" "$DB6g7" "$DB6g8" "$DB6g9" "$DB6g10" \
   "$DB6g1u" "$DB6g1v" "$DB6g1w" "$DB7d" "$DB7e" "$DB7f"


### PR DESCRIPTION
Found in the deep review. `dolt_checkout` run inside `BEGIN` + `SAVEPOINT` destroyed the target branch's working set.

```sql
-- main = {1,2,4}, side = {1,2,9}, both committed
BEGIN;
SAVEPOINT s;
INSERT INTO t VALUES(7,70);
SELECT dolt_checkout('side');
ROLLBACK;
```

| | side after |
|---|---|
| before | `1,2,4` — its own row 9 gone, main's row 4 in its place, status dirty |
| after / Dolt 2.2.2 | `1,2,9` clean |

The wrong rows then commit into `side`'s own history, so this is silent cross-branch data loss. `SAVEPOINT` inside a transaction is what SQLAlchemy, Django and Rails emit for a nested transaction, so it is the common shape rather than an exotic one.

## Cause

A branch switch seals the transaction it runs in — the same boundary `dolt_commit` draws — precisely so a later `ROLLBACK` cannot revert the working set out from under a ref that has already advanced. `doltliteVcSealBranchStyleTxn` did that correctly for a plain `BEGIN` (`COMMIT` then `BEGIN`), but when a savepoint was open it released the savepoints and returned. The enclosing `BEGIN` stayed open, so the `ROLLBACK` restored the branch we left while the ref named the branch we switched to, and that pairing was persisted as the target's working set.

`src/doltlite_rebase.c:1903` already worked around this locally, and its comment names the bug outright: *"Releasing savepoints alone leaves that BEGIN open."* This fixes it in the helper, for every caller.

## Change

Release the savepoints, then seal the transaction they were nested in. A top-level `SAVEPOINT` was itself the transaction, so releasing it has already ended everything and there is nothing further to seal — that case returns early.

The helper is shared by checkout, `dolt_branch`, rebase and pull, so all of them are covered. Interactive rebase was losing its claim and plan the same way, leaving a stray `dolt_rebase_*` branch whose rebase could not be continued; that is fixed by the same change.

## Not changed

Uncommitted work in the sealed transaction is committed to the source branch's working set rather than discarded — `main` keeps row 7 above. That is inherent to sealing, is identical across all three transaction shapes including the two that were already correct, and predates this PR. Dolt rolls that row back instead. Worth a decision on its own, but it is a design-level divergence rather than part of this defect, so it is untouched here.

## Testing

`test/doltlite_savepoint.sh` already covered `BEGIN; …; ROLLBACK` and a bare `SAVEPOINT`, but never the combination, which is why this slipped through. It gains that shape for both the branch switch and the interactive rebase.

- Fail-before/pass-after: 4 new assertions fail on master (`129 passed, 4 failed`), all pass with the fix (`133 passed, 0 failed`).
- Verified against Dolt 2.2.2: the target branch keeps `1,2,9` and is clean.
- Plain `BEGIN` and bare top-level `SAVEPOINT` re-checked and unchanged.
- Full battery **106/106 suites**; savepoint suite also clean under an ASAN+UBSAN build with no sanitizer reports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)