### PR TITLE
Let SELECT FROM dolt_ignore work on a fresh database

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,22 +116,25 @@ conformance bugs. When comparing against Dolt, only **row-level semantics** must
 match; do not file conformance issues over the vtable/function shape or column
 naming.
 
-`dolt_docs` is a hybrid: an eponymous writable vtab answers reads while no
-backing table exists (always-empty scans, so `SELECT` never errors on a fresh
-repo), and the first write statement materializes a real
+`dolt_ignore`, `dolt_docs`, and `dolt_tests` are lazy user-space system
+tables: an eponymous writable vtab answers reads while no backing table
+exists (`SELECT` never errors on a fresh repo), and the first write
+statement materializes the real table, which then shadows the module.
+That is Dolt's lazy-creation UX without the open-time auto-materialization
+that sank the original `dolt_ignore` attempt (`fcb7720e00`). `dolt_ignore`
+materializes
+`dolt_ignore(pattern TEXT NOT NULL, ignored TINYINT NOT NULL, PRIMARY KEY(pattern))`.
+`dolt_docs` materializes
 `dolt_docs(doc_name TEXT NOT NULL, doc_text TEXT NOT NULL, PRIMARY KEY(doc_name))`
-table that shadows the module from then on — Dolt's lazy-creation UX without
-the open-time auto-materialization that sank the original `dolt_ignore`
-attempt (`fcb7720e00`). A default `AGENT.md` row (DoltLite's own operations
-guide, not Dolt's embedded text) is served by the module pre-materialization
-and seeded as a stored row when the table materializes. Deliberate
-divergences from Dolt: the table shows in `.tables`/`.schema` once it exists
-(same accepted divergence as `dolt_ignore`); the default `AGENT.md` text
-differs (the docs oracle compares it by name/count, or by full row after a
-test overwrites it); and because the row is stored rather than synthesized,
-deleting `AGENT.md` sticks (Dolt resurrects it on the next read) and it
-appears in row-level diffs. A `build.c` shape guard beside `dolt_ignore`'s
-keeps hand-issued `CREATE TABLE dolt_docs` on the exact schema the module
+and serves a default `AGENT.md` row (DoltLite's own operations guide, not
+Dolt's embedded text) from the module before materialization; that row is
+seeded as a stored row when the table materializes. Deliberate divergences
+from Dolt: the table shows in `.tables`/`.schema` once it exists; the
+default `AGENT.md` text differs (the docs oracle compares it by name/count,
+or by full row after a test overwrites it); and because the row is stored
+rather than synthesized, deleting `AGENT.md` sticks (Dolt resurrects it on
+the next read) and it appears in row-level diffs. `build.c` shape guards
+keep hand-issued `CREATE TABLE` statements on the exact schema each module
 creates.
 
 `dolt_tests` uses the same lazy user-space system-table pattern: empty reads

--- a/README.md
+++ b/README.md
@@ -259,16 +259,13 @@ SELECT dolt_commit('-m', 'accept higher-confidence edits');
 #### Ignoring Tables (`dolt_ignore`)
 
 Patterns skipped by `dolt_add` and hidden from `dolt_status` (tables stay in
-the working set). Create once per repo, then insert patterns (`*`/`%` =
-any; `?` = one char). Most-specific match wins; equal-specificity conflicts
-error.
+the working set). `SELECT` works before any pattern exists; the first write
+creates the backing table, which then commits, diffs, branches and merges
+like any other table. Patterns use `*`/`%` = any and `?` = one char.
+Most-specific match wins; equal-specificity conflicts error.
 
 ```sql
-CREATE TABLE dolt_ignore(
-  pattern TEXT NOT NULL,
-  ignored TINYINT NOT NULL,
-  PRIMARY KEY(pattern)
-);
+SELECT * FROM dolt_ignore;                       -- empty on a fresh repo
 INSERT INTO dolt_ignore VALUES ('tmp_*', 1);
 INSERT INTO dolt_ignore VALUES ('tmp_keep', 0);  -- un-ignore
 ```

--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -25,6 +25,7 @@ extern int doltliteConstraintViolationsRegister(sqlite3 *db);
 extern int doltliteVerifyConstraintsRegister(sqlite3 *db);
 extern int doltliteDocsRegister(sqlite3 *db);
 extern int doltliteTestsRegister(sqlite3 *db);
+extern int doltliteIgnoreRegister(sqlite3 *db);
 
 int doltliteRegister(sqlite3 *db){
   int rc;
@@ -59,6 +60,7 @@ int doltliteRegister(sqlite3 *db){
   if( (rc = doltliteVerifyConstraintsRegister(db))!=SQLITE_OK ) return rc;
   if( (rc = doltliteDocsRegister(db))!=SQLITE_OK ) return rc;
   if( (rc = doltliteTestsRegister(db))!=SQLITE_OK ) return rc;
+  if( (rc = doltliteIgnoreRegister(db))!=SQLITE_OK ) return rc;
   return doltliteMaybeSeedRepo(db);
 }
 

--- a/src/doltlite_ignore.c
+++ b/src/doltlite_ignore.c
@@ -2,6 +2,7 @@
 #ifdef DOLTLITE_PROLLY
 
 #include "sqliteInt.h"
+#include "doltlite_internal.h"
 #include "doltlite_ignore.h"
 #include <string.h>
 
@@ -199,6 +200,191 @@ int doltliteCheckIgnore(
   sqlite3_free(zBestPat);
   sqlite3_free(zTiePat);
   return SQLITE_OK;
+}
+
+typedef struct IgnoreVtab IgnoreVtab;
+struct IgnoreVtab {
+  sqlite3_vtab base;
+  sqlite3 *db;
+};
+
+typedef struct IgnoreCursor IgnoreCursor;
+struct IgnoreCursor {
+  sqlite3_vtab_cursor base;
+};
+
+static const char *zIgnoreVtabSchema =
+  "CREATE TABLE x(pattern TEXT NOT NULL PRIMARY KEY, "
+  "ignored TINYINT NOT NULL) WITHOUT ROWID";
+
+static const char *zIgnoreCreate =
+  "CREATE TABLE main.dolt_ignore("
+  "pattern TEXT NOT NULL, ignored TINYINT NOT NULL, PRIMARY KEY(pattern))";
+
+static int ignoreSetErr(IgnoreVtab *p, int rc){
+  sqlite3_free(p->base.zErrMsg);
+  p->base.zErrMsg = sqlite3_mprintf("%s", sqlite3_errmsg(p->db));
+  return rc;
+}
+
+static int ignoreConnect(sqlite3 *db, void *pAux, int argc,
+    const char *const*argv, sqlite3_vtab **ppVtab, char **pzErr){
+  IgnoreVtab *pVtab;
+  int rc;
+  (void)pAux; (void)argc; (void)argv; (void)pzErr;
+  rc = doltliteVtabConnectSimple(db, zIgnoreVtabSchema,
+      sizeof(*pVtab), ppVtab);
+  if( rc!=SQLITE_OK ) return rc;
+  pVtab = (IgnoreVtab*)*ppVtab;
+  pVtab->db = db;
+  return SQLITE_OK;
+}
+
+static int ignoreBestIndex(sqlite3_vtab *pVtab, sqlite3_index_info *pInfo){
+  (void)pVtab;
+  pInfo->estimatedCost = 10.0;
+  pInfo->estimatedRows = 0;
+  return SQLITE_OK;
+}
+
+static int ignoreOpen(sqlite3_vtab *pVtab, sqlite3_vtab_cursor **ppCursor){
+  (void)pVtab;
+  return doltliteVtabOpenCursor(ppCursor, sizeof(IgnoreCursor));
+}
+
+static int ignoreFilter(sqlite3_vtab_cursor *pCursor,
+    int idxNum, const char *idxStr, int argc, sqlite3_value **argv){
+  (void)pCursor; (void)idxNum; (void)idxStr; (void)argc; (void)argv;
+  return SQLITE_OK;
+}
+
+static int ignoreNext(sqlite3_vtab_cursor *pCursor){
+  (void)pCursor;
+  return SQLITE_OK;
+}
+
+static int ignoreEof(sqlite3_vtab_cursor *pCursor){
+  (void)pCursor;
+  return 1;
+}
+
+static int ignoreColumn(sqlite3_vtab_cursor *pCursor,
+    sqlite3_context *ctx, int iCol){
+  (void)pCursor; (void)ctx; (void)iCol;
+  return SQLITE_OK;
+}
+
+static int ignoreRowid(sqlite3_vtab_cursor *pCursor, sqlite3_int64 *pRowid){
+  (void)pCursor;
+  *pRowid = 0;
+  return SQLITE_OK;
+}
+
+static int ignoreMaterialize(IgnoreVtab *p){
+  char *zErr = 0;
+  int rc;
+  if( sqlite3FindTable(p->db, "dolt_ignore", "main") ) return SQLITE_OK;
+  rc = sqlite3_exec(p->db, zIgnoreCreate, 0, 0, &zErr);
+  if( rc!=SQLITE_OK ){
+    sqlite3_free(p->base.zErrMsg);
+    p->base.zErrMsg = sqlite3_mprintf("%s",
+        zErr ? zErr : sqlite3_errstr(rc));
+    sqlite3_free(zErr);
+  }
+  return rc;
+}
+
+static int ignoreBegin(sqlite3_vtab *pBase){
+  return ignoreMaterialize((IgnoreVtab*)pBase);
+}
+
+static int ignoreExecBound(IgnoreVtab *p, const char *zSql,
+                           sqlite3_value *pArg1, sqlite3_value *pArg2,
+                           sqlite3_value *pArg3){
+  sqlite3_stmt *pStmt = 0;
+  int rc = sqlite3_prepare_v3(p->db, zSql, -1,
+                              SQLITE_PREPARE_NO_VTAB, &pStmt, 0);
+  if( rc!=SQLITE_OK ) return ignoreSetErr(p, rc);
+  if( pArg1 ) sqlite3_bind_value(pStmt, 1, pArg1);
+  if( pArg2 ) sqlite3_bind_value(pStmt, 2, pArg2);
+  if( pArg3 ) sqlite3_bind_value(pStmt, 3, pArg3);
+  sqlite3_step(pStmt);
+  rc = sqlite3_finalize(pStmt);
+  if( rc!=SQLITE_OK ) return ignoreSetErr(p, rc);
+  return SQLITE_OK;
+}
+
+static const char *ignoreInsertSql(sqlite3 *db){
+  switch( sqlite3_vtab_on_conflict(db) ){
+    case SQLITE_REPLACE:
+      return "INSERT OR REPLACE INTO main.dolt_ignore(pattern, ignored) "
+             "VALUES(?1, ?2)";
+    case SQLITE_IGNORE:
+      return "INSERT OR IGNORE INTO main.dolt_ignore(pattern, ignored) "
+             "VALUES(?1, ?2)";
+    case SQLITE_FAIL:
+      return "INSERT OR FAIL INTO main.dolt_ignore(pattern, ignored) "
+             "VALUES(?1, ?2)";
+    case SQLITE_ROLLBACK:
+      return "INSERT OR ROLLBACK INTO main.dolt_ignore(pattern, ignored) "
+             "VALUES(?1, ?2)";
+    default:
+      return "INSERT INTO main.dolt_ignore(pattern, ignored) VALUES(?1, ?2)";
+  }
+}
+
+static const char *ignoreUpdateSql(sqlite3 *db){
+  switch( sqlite3_vtab_on_conflict(db) ){
+    case SQLITE_REPLACE:
+      return "UPDATE OR REPLACE main.dolt_ignore SET pattern=?1, ignored=?2 "
+             "WHERE pattern=?3";
+    case SQLITE_IGNORE:
+      return "UPDATE OR IGNORE main.dolt_ignore SET pattern=?1, ignored=?2 "
+             "WHERE pattern=?3";
+    case SQLITE_FAIL:
+      return "UPDATE OR FAIL main.dolt_ignore SET pattern=?1, ignored=?2 "
+             "WHERE pattern=?3";
+    case SQLITE_ROLLBACK:
+      return "UPDATE OR ROLLBACK main.dolt_ignore SET pattern=?1, ignored=?2 "
+             "WHERE pattern=?3";
+    default:
+      return "UPDATE main.dolt_ignore SET pattern=?1, ignored=?2 "
+             "WHERE pattern=?3";
+  }
+}
+
+static int ignoreUpdate(sqlite3_vtab *pBase, int argc, sqlite3_value **argv,
+                        sqlite3_int64 *pRowid){
+  IgnoreVtab *p = (IgnoreVtab*)pBase;
+  int rc;
+
+  rc = ignoreMaterialize(p);
+  if( rc!=SQLITE_OK ) return rc;
+
+  if( argc==1 ){
+    return ignoreExecBound(p,
+        "DELETE FROM main.dolt_ignore WHERE pattern=?1", argv[0], 0, 0);
+  }
+  if( sqlite3_value_type(argv[0])!=SQLITE_NULL ){
+    return ignoreExecBound(p,
+        ignoreUpdateSql(p->db), argv[2], argv[3], argv[0]);
+  }
+
+  rc = ignoreExecBound(p, ignoreInsertSql(p->db), argv[2], argv[3], 0);
+  if( rc!=SQLITE_OK ) return rc;
+  if( pRowid ) *pRowid = sqlite3_last_insert_rowid(p->db);
+  return SQLITE_OK;
+}
+
+static sqlite3_module doltliteIgnoreModule = {
+  0, 0, ignoreConnect, ignoreBestIndex, doltliteVtabDisconnect, 0,
+  ignoreOpen, doltliteVtabClose, ignoreFilter, ignoreNext, ignoreEof,
+  ignoreColumn, ignoreRowid,
+  ignoreUpdate, ignoreBegin, 0, 0, 0, 0, 0, 0, 0, 0, 0
+};
+
+int doltliteIgnoreRegister(sqlite3 *db){
+  return sqlite3_create_module(db, "dolt_ignore", &doltliteIgnoreModule, 0);
 }
 
 #endif

--- a/src/doltlite_ignore.h
+++ b/src/doltlite_ignore.h
@@ -6,5 +6,6 @@ typedef struct sqlite3 sqlite3;
 
 int doltliteCheckIgnore(sqlite3 *db, const char *zTable,
                         int *pIgnored, char **pzErr);
+int doltliteIgnoreRegister(sqlite3 *db);
 
 #endif

--- a/test/doltlite_ignore.sh
+++ b/test/doltlite_ignore.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+. "$(dirname "$0")/lib/doltlite_test_common.sh"
+
+echo "=== Doltlite dolt_ignore Tests ==="
+
+DB=/tmp/test_ignore_$$.db
+rm -f "$DB"
+
+run_test "fresh_select_empty" \
+  "SELECT count(*) FROM dolt_ignore;" \
+  "0" "$DB"
+
+run_test "fresh_not_materialized" \
+  "SELECT count(*) FROM sqlite_master WHERE name='dolt_ignore';
+   SELECT count(*) FROM dolt_status;" \
+  "0
+0" "$DB"
+
+run_test "fresh_schema" \
+  "SELECT name, type, \"notnull\", pk FROM pragma_table_info('dolt_ignore');" \
+  "pattern|TEXT|1|1
+ignored|TINYINT|1|0" "$DB"
+
+run_test "insert_materializes" \
+  "INSERT INTO dolt_ignore VALUES('tmp_*', 1);
+   SELECT * FROM dolt_ignore;" \
+  "tmp_*|1" "$DB"
+
+run_test "status_new_table" \
+  "SELECT table_name, staged, status FROM dolt_status;" \
+  "dolt_ignore|0|new table" "$DB"
+
+run_test "visible_in_sqlite_master" \
+  "SELECT count(*) FROM sqlite_master WHERE name='dolt_ignore' AND type='table';" \
+  "1" "$DB"
+
+run_test_match "dup_pk_rejected" \
+  "INSERT INTO dolt_ignore VALUES('tmp_*', 0);" \
+  "UNIQUE constraint failed: dolt_ignore.pattern" "$DB"
+
+run_test_match "null_pattern_rejected" \
+  "INSERT INTO dolt_ignore VALUES(NULL, 1);" \
+  "NOT NULL constraint failed: dolt_ignore.pattern" "$DB"
+
+run_test "insert_or_ignore_dup" \
+  "INSERT OR IGNORE INTO dolt_ignore VALUES('tmp_*', 0);
+   SELECT ignored FROM dolt_ignore WHERE pattern='tmp_*';" \
+  "1" "$DB"
+
+run_test "update_replace_delete" \
+  "INSERT INTO dolt_ignore VALUES('keep_me', 0);
+   UPDATE dolt_ignore SET ignored=1 WHERE pattern='keep_me';
+   REPLACE INTO dolt_ignore VALUES('tmp_*', 0);
+   DELETE FROM dolt_ignore WHERE pattern='keep_me';
+   SELECT * FROM dolt_ignore;" \
+  "tmp_*|0" "$DB"
+
+run_test "add_respects_ignore" \
+  "UPDATE dolt_ignore SET ignored=1 WHERE pattern='tmp_*';
+   CREATE TABLE tmp_secret(id INTEGER PRIMARY KEY);
+   CREATE TABLE keep(id INTEGER PRIMARY KEY);
+   INSERT INTO keep VALUES(1);
+   SELECT dolt_add('-A');
+   SELECT table_name, staged, status FROM dolt_status ORDER BY table_name;" \
+  "0
+dolt_ignore|1|new table
+keep|1|new table" "$DB"
+
+run_test "commit_ignore" \
+  "SELECT dolt_commit('-m','ignore tmp') IS NOT NULL;
+   SELECT count(*) FROM dolt_status;" \
+  "1
+0" "$DB"
+
+run_test "drop_falls_back_to_module" \
+  "DROP TABLE dolt_ignore;
+   SELECT count(*) FROM dolt_ignore;
+   SELECT count(*) FROM sqlite_master WHERE name='dolt_ignore';" \
+  "0
+0" "$DB"
+
+dltest_finish

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -1541,12 +1541,13 @@ attach2 attach2-4.12 class=intentional issue=1846  # PRAGMA lock_status: doltlit
 # paths, shifting OOM fault indices (same #1859 brittleness as backup_malloc).
 # vec1's built-in registration adds ~25 allocations at connection open,
 # shifting every entry by +25. The dolt_tests and dolt_test_run module
-# registrations add four more.
-attachmalloc attachmalloc-1.transient.500 class=unsupported issue=1839  # OOM fault-point shift (parent probe)
-attachmalloc attachmalloc-1.transient.925 @no-coverage class=unsupported issue=1839  # OOM fault-point shift (ATTACH seed)
-attachmalloc attachmalloc-1.transient.1419 @no-coverage class=unsupported issue=1839  # OOM fault-point shift (ATTACH seed)
-attachmalloc attachmalloc-1.transient.933 @coverage class=unsupported issue=1839  # OOM fault-point shift (ATTACH seed)
-attachmalloc attachmalloc-1.transient.1435 @coverage class=unsupported issue=1839  # OOM fault-point shift (ATTACH seed)
+# registrations add four more. The dolt_ignore module registration adds
+# two more.
+attachmalloc attachmalloc-1.transient.502 class=unsupported issue=1839  # OOM fault-point shift (parent probe)
+attachmalloc attachmalloc-1.transient.927 @no-coverage class=unsupported issue=1839  # OOM fault-point shift (ATTACH seed)
+attachmalloc attachmalloc-1.transient.1421 @no-coverage class=unsupported issue=1839  # OOM fault-point shift (ATTACH seed)
+attachmalloc attachmalloc-1.transient.935 @coverage class=unsupported issue=1839  # OOM fault-point shift (ATTACH seed)
+attachmalloc attachmalloc-1.transient.1437 @coverage class=unsupported issue=1839  # OOM fault-point shift (ATTACH seed)
 
 # temptable2 section 8 — page_count is a chunk-store metric, not SQLite
 # pages; backup_init needs the page-image backup API, unsupported on prolly.

--- a/test/lib/doltlite_suite_manifest.sh
+++ b/test/lib/doltlite_suite_manifest.sh
@@ -12,6 +12,7 @@ doltlite_staging.sh
 doltlite_workspace.sh
 doltlite_docs.sh
 doltlite_tests.sh
+doltlite_ignore.sh
 doltlite_diff.sh
 doltlite_reset.sh
 doltlite_branch.sh
@@ -144,6 +145,7 @@ doltlite_staging.sh
 doltlite_workspace.sh
 doltlite_docs.sh
 doltlite_tests.sh
+doltlite_ignore.sh
 doltlite_branch.sh
 doltlite_open_branch.sh
 doltlite_tag.sh

--- a/test/vc_oracle_ignore_test.sh
+++ b/test/vc_oracle_ignore_test.sh
@@ -13,18 +13,13 @@ source "$(dirname "$0")/lib/vc_oracle_common.sh"
 
 normalize() { tr -d '\r' | grep -v '^S|dolt_ignore|' | sort; }
 
-DL_IGNORE_PREFIX="CREATE TABLE IF NOT EXISTS dolt_ignore(pattern TEXT NOT NULL, ignored TINYINT NOT NULL, PRIMARY KEY(pattern));"
-
 oracle() {
   local name="$1" setup="$2" allow_empty="${3:-}"
   local dir="$TMPROOT/$name"
   mkdir -p "$dir/dl" "$dir/dt"
 
-  local dl_setup="$DL_IGNORE_PREFIX
-$setup"
-
   local dl_out
-  dl_out=$(printf "%s\n.headers off\n.mode list\n.separator '\t'\nSELECT 'S|' || table_name || '|' || staged || '|' || status FROM dolt_status;\n" "$dl_setup" \
+  dl_out=$(printf "%s\n.headers off\n.mode list\n.separator '\t'\nSELECT 'S|' || table_name || '|' || staged || '|' || status FROM dolt_status;\n" "$setup" \
            | "$DOLTLITE" "$dir/dl/db" 2>"$dir/dl.err" \
            | grep '^S|' \
            | normalize)
@@ -70,11 +65,8 @@ oracle_error() {
   local dir="$TMPROOT/${name}_err"
   mkdir -p "$dir/dl" "$dir/dt"
 
-  local dl_setup="$DL_IGNORE_PREFIX
-$setup"
-
   local dl_rc
-  vc_oracle_run_doltlite_script "$dir/dl/db" "$dir/dl.out" "$dir/dl.err" "$dl_setup"
+  vc_oracle_run_doltlite_script "$dir/dl/db" "$dir/dl.out" "$dir/dl.err" "$setup"
   dl_rc=$?
 
   local dolt_setup
@@ -403,7 +395,6 @@ doltlite_runtime_reject() {
 }
 
 doltlite_runtime_expect "temp_shadow_ignored_main_wins" "
-CREATE TABLE dolt_ignore(pattern TEXT NOT NULL, ignored TINYINT NOT NULL, PRIMARY KEY(pattern));
 INSERT INTO dolt_ignore VALUES ('tmp_*', 1);
 CREATE TEMP TABLE dolt_ignore(pattern TEXT NOT NULL, ignored TINYINT NOT NULL, PRIMARY KEY(pattern));
 INSERT INTO temp.dolt_ignore VALUES ('tmp_*', 0);


### PR DESCRIPTION
Dolt answers `SELECT * FROM dolt_ignore` on a brand-new repo (zero rows). DoltLite raised `no such table` until the user issued `CREATE TABLE`.

```sql
SELECT count(*) FROM dolt_ignore;   -- was error; now 0
INSERT INTO dolt_ignore VALUES ('tmp_*', 1);
SELECT * FROM dolt_ignore;          -- tmp_*|1
```

`dolt_ignore` now uses the same lazy eponymous vtab as `dolt_docs` and `dolt_tests`: empty reads before a backing table exists, first write materializes

`dolt_ignore(pattern TEXT NOT NULL, ignored TINYINT NOT NULL, PRIMARY KEY(pattern))`.

That is Dolt's lazy-creation UX without the open-time auto-materialization that previously went wrong. `dolt_add` still treats a missing table as no rules, and still honors patterns after the first insert. Hand-issued `CREATE TABLE` still has to match the shape guard.

Co-Authored-By: Grok 4.6 <noreply@x.ai>