### PR TITLE
Rebuild a merged index, or refuse the merge

### DIFF
--- a/src/doltlite_merge.c
+++ b/src/doltlite_merge.c
@@ -1323,9 +1323,19 @@ int doltliteMergeCatalogs(
   if( rc!=SQLITE_OK ) goto merge_cleanup;
 
   if( rc==SQLITE_OK && nConflictTables>0 && pazRebuildVtabs ){
+    char *zRefuse = 0;
     rc = mergeFilterDerivedShadowConflicts(db,
         aConflictTables, &nConflictTables, &totalConflicts,
-        pazRebuildVtabs, pnRebuildVtabs);
+        pazRebuildVtabs, pnRebuildVtabs, &zRefuse);
+    if( rc==SQLITE_OK && zRefuse ){
+      if( pzErrMsg ){
+        sqlite3_free(*pzErrMsg);
+        *pzErrMsg = zRefuse;
+      }else{
+        sqlite3_free(zRefuse);
+      }
+      rc = SQLITE_ERROR;
+    }
   }
   if( rc!=SQLITE_OK ) goto merge_cleanup;
 

--- a/src/doltlite_merge_cmd.c
+++ b/src/doltlite_merge_cmd.c
@@ -219,11 +219,24 @@ static int mergeRefInstallMergedCatalog(
   ** filter proved otherwise conflict-free. */
   if( *pnRebuildVtabs>0 && nMergeConflicts==0 ){
     int ri;
+    /* The owners live in the just-switched catalog, which sqlite3FindTable
+    ** cannot see until the schema is reloaded. */
+    (void)sqlite3_exec(db, "SELECT 1 FROM sqlite_master LIMIT 1", 0, 0, 0);
     for(ri=0; ri<*pnRebuildVtabs && rc==SQLITE_OK; ri++){
-      char *zSql = sqlite3_mprintf(
-          "INSERT INTO \"%w\"(cmd, arg) VALUES('rebuild',"
-          " (SELECT val FROM \"%w_model\" WHERE id=1))",
-          (*pazRebuildVtabs)[ri], (*pazRebuildVtabs)[ri]);
+      const char *zOwner = (*pazRebuildVtabs)[ri];
+      Table *pTab = sqlite3FindTable(db, zOwner, "main");
+      char *zSql;
+      /* Each module spells its rebuild differently: vec1 takes the stored
+      ** model as an argument, fts names itself in its own hidden column. */
+      if( pTab && IsVirtual(pTab) && pTab->u.vtab.nArg>0
+       && sqlite3_stricmp(pTab->u.vtab.azArg[0], "vec1")!=0 ){
+        zSql = sqlite3_mprintf(
+            "INSERT INTO \"%w\"(\"%w\") VALUES('rebuild')", zOwner, zOwner);
+      }else{
+        zSql = sqlite3_mprintf(
+            "INSERT INTO \"%w\"(cmd, arg) VALUES('rebuild',"
+            " (SELECT val FROM \"%w_model\" WHERE id=1))", zOwner, zOwner);
+      }
       if( !zSql ){
         rc = SQLITE_NOMEM;
         break;

--- a/src/doltlite_merge_int.h
+++ b/src/doltlite_merge_int.h
@@ -270,7 +270,8 @@ int tryResolveSchemaDivergence(
 int mergeAppendReindexName(char ***paz, int *pn, const char *zName);
 int mergeFilterDerivedShadowConflicts(sqlite3 *db,
     MergeConflictTable *aConflictTables, int *pnConflictTables,
-    int *pTotalConflicts, char ***pazRebuild, int *pnRebuild);
+    int *pTotalConflicts, char ***pazRebuild, int *pnRebuild,
+    char **pzRefuse);
 
 int mergeCatalogPass1(
   sqlite3 *db,

--- a/src/doltlite_merge_pass2.c
+++ b/src/doltlite_merge_pass2.c
@@ -222,19 +222,56 @@ int mergeCatalogPass2(
   return SQLITE_OK;
 }
 
-/* If zTable is a derived shadow (%_idx, %_meta, %_model, %_config) of a
-** vec1 virtual table whose %_base still holds raw vectors, return the
-** malloc'd owner name; else NULL. Uncompressed builds store bucket
-** numbers in %_base instead of vectors, so auto-resolving their index
-** conflicts would silently lose the discarded side's vectors — those
-** stay loud. %_base itself is authoritative and is never derived. */
-static char *mergeVec1DerivedShadowOwner(sqlite3 *db, const char *zTable){
-  static const char *azSuffix[] = { "_idx", "_meta", "_model", "_config" };
+/* Is this fts table contentless? Such a table has no authoritative copy of
+** the indexed text -- the index IS the data -- so nothing can regenerate a
+** discarded side, and fts5 refuses 'rebuild' on one outright. */
+static int mergeFtsIsContentless(Table *pTab){
+  int i;
+  for(i=3; i<pTab->u.vtab.nArg; i++){
+    const char *z = pTab->u.vtab.azArg[i];
+    const char *zEq;
+    if( !z ) continue;
+    while( *z==' ' ) z++;
+    if( sqlite3_strnicmp(z, "content", 7)!=0 ) continue;
+    zEq = &z[7];
+    while( *zEq==' ' ) zEq++;
+    if( *zEq!='=' ) continue;
+    zEq++;
+    while( *zEq==' ' ) zEq++;
+    /* content='' names no table; content='x' names an authoritative one. */
+    if( (zEq[0]=='\'' && zEq[1]=='\'') || (zEq[0]=='"' && zEq[1]=='"')
+     || zEq[0]==0 ){
+      return 1;
+    }
+    return 0;
+  }
+  return 0;
+}
+
+/* Classify zTable as a derived shadow of a virtual table: a shadow holding
+** state that is regenerated from data living elsewhere. Returns the malloc'd
+** owner name and sets *pbRebuildable to whether that regeneration is actually
+** possible. A shadow that is itself authoritative (%_content, %_base) is not
+** derived and is never reported here -- a conflict there is a conflict in the
+** data, which stays loud. */
+static char *mergeDerivedShadowOwner(
+  sqlite3 *db,
+  const char *zTable,
+  int *pbRebuildable
+){
+  static const char *azSuffix[] = {
+    /* vec1 */   "_idx", "_meta", "_model", "_config",
+    /* fts5 */   "_data", "_docsize",
+    /* fts3/4 */ "_segments", "_segdir", "_stat",
+    /* rtree */  "_node", "_parent", "_rowid"
+  };
   unsigned int i;
   size_t nTable = strlen(zTable);
 
+  *pbRebuildable = 0;
   for(i=0; i<sizeof(azSuffix)/sizeof(azSuffix[0]); i++){
     size_t nSfx = strlen(azSuffix[i]);
+    const char *zModule;
     char *zOwner;
     Table *pTab;
     if( nTable<=nSfx || strcmp(&zTable[nTable-nSfx], azSuffix[i])!=0 ){
@@ -243,15 +280,45 @@ static char *mergeVec1DerivedShadowOwner(sqlite3 *db, const char *zTable){
     zOwner = sqlite3_mprintf("%.*s", (int)(nTable-nSfx), zTable);
     if( !zOwner ) return 0;
     pTab = sqlite3FindTable(db, zOwner, "main");
-    if( pTab && IsVirtual(pTab)
-     && pTab->u.vtab.nArg>0
-     && sqlite3_stricmp(pTab->u.vtab.azArg[0], "vec1")==0
-     && sqlite3IsShadowTableOf(db, pTab, zTable) ){
+    if( !pTab || !IsVirtual(pTab) || pTab->u.vtab.nArg<=0
+     || !sqlite3IsShadowTableOf(db, pTab, zTable) ){
+      sqlite3_free(zOwner);
+      return 0;
+    }
+    zModule = pTab->u.vtab.azArg[0];
+
+    if( sqlite3_stricmp(zModule, "fts5")==0
+     || sqlite3_stricmp(zModule, "fts4")==0
+     || sqlite3_stricmp(zModule, "fts3")==0 ){
+      /* The merged content is authoritative, so a rebuild regenerates the
+      ** index over both sides' rows. Contentless has no such content. */
+      *pbRebuildable = !mergeFtsIsContentless(pTab);
+      return zOwner;
+    }
+    if( sqlite3_stricmp(zModule, "rtree")==0
+     || sqlite3_stricmp(zModule, "rtree_i32")==0 ){
+      /* An r-tree keeps its coordinates in %_node and offers no rebuild, so
+      ** a conflicting node is a conflict in the data itself. */
+      *pbRebuildable = 0;
+      return zOwner;
+    }
+    if( sqlite3_stricmp(zModule, "vec1")!=0 ){
+      sqlite3_free(zOwner);
+      return 0;
+    }
+    {
       /* Eligible only when %_base still holds raw vectors AND the stored
       ** model the rebuild depends on is present: vec1 treats a NULL
       ** rebuild argument as "keep the current model" and proceeds on
       ** cached state, so a missing model row would let the merge commit
       ** a stale index instead of failing. */
+      /* Eligible only when %_base still holds raw vectors AND the stored
+      ** model the rebuild depends on is present: vec1 treats a NULL
+      ** rebuild argument as "keep the current model" and proceeds on
+      ** cached state, so a missing model row would let the merge commit
+      ** a stale index instead of failing. Uncompressed builds store bucket
+      ** numbers in %_base instead of vectors, so auto-resolving their index
+      ** conflicts would silently lose the discarded side's vectors. */
       char *zQry = sqlite3_mprintf(
           "SELECT (SELECT count(*) FROM \"%w_base\""
           "         WHERE typeof(vector)!='blob')=0"
@@ -266,10 +333,15 @@ static char *mergeVec1DerivedShadowOwner(sqlite3 *db, const char *zTable){
       }
       sqlite3_finalize(pStmt);
       sqlite3_free(zQry);
-      if( bEligible ) return zOwner;
+      if( bEligible ){
+        *pbRebuildable = 1;
+        return zOwner;
+      }
+      /* An ineligible vec1 shadow keeps its conflicts resolvable, which is
+      ** this module's existing contract; it is not reported as derived. */
+      sqlite3_free(zOwner);
+      return 0;
     }
-    sqlite3_free(zOwner);
-    return 0;
   }
   return 0;
 }
@@ -287,7 +359,8 @@ int mergeFilterDerivedShadowConflicts(
   int *pnConflictTables,
   int *pTotalConflicts,
   char ***pazRebuild,
-  int *pnRebuild
+  int *pnRebuild,
+  char **pzRefuse
 ){
   int i, j, rc = SQLITE_OK;
   char **azOwner = 0;
@@ -297,10 +370,25 @@ int mergeFilterDerivedShadowConflicts(
   memset(azOwner, 0, (*pnConflictTables)*sizeof(char*));
 
   for(i=0; i<*pnConflictTables; i++){
+    int bRebuildable = 0;
     if( aConflictTables[i].nSchemaObjects>0
      || aConflictTables[i].nConflicts<=0
-     || (azOwner[i] = mergeVec1DerivedShadowOwner(
-            db, aConflictTables[i].zName))==0 ){
+     || (azOwner[i] = mergeDerivedShadowOwner(
+            db, aConflictTables[i].zName, &bRebuildable))==0 ){
+      doltliteFreeNameList(azOwner, *pnConflictTables);
+      return SQLITE_OK;
+    }
+    if( !bRebuildable ){
+      /* Neither resolution can be right: the discarded side's rows are gone
+      ** from an index nothing can regenerate, and committing either one puts
+      ** an index that disagrees with its own table into history. Refuse. */
+      if( pzRefuse && *pzRefuse==0 ){
+        *pzRefuse = sqlite3_mprintf(
+            "cannot merge: '%s' indexes data that cannot be rebuilt from the "
+            "merged rows, and both sides changed it. Merge on one branch, or "
+            "drop and recreate '%s' after merging",
+            azOwner[i], azOwner[i]);
+      }
       doltliteFreeNameList(azOwner, *pnConflictTables);
       return SQLITE_OK;
     }

--- a/test/doltlite_vtab_vc_matrix.sh
+++ b/test/doltlite_vtab_vc_matrix.sh
@@ -267,7 +267,13 @@ run_sql "SELECT dolt_checkout('-b','side'); $MUTATE SELECT dolt_commit('-am','si
 SELECT dolt_checkout('main'); SELECT dolt_merge('side');" "$DB" > /dev/null
 verify "merge_ff_vtab_content" "$DB" "$MUT_STATE"
 
-scenario "conflicted merge: resolve then rebuild the index"
+# Both sides writing an fts5 table collide in its segment shadows, and
+# neither side of that collision is the answer: taking one loses the other's
+# rows from the index while the content table keeps them. Since the merged
+# content is authoritative, the merge regenerates the index from it rather
+# than offering a resolution that cannot be right. (Before, this stopped
+# with conflicts whose only two resolutions both committed a broken index.)
+scenario "colliding vtab writes: the merge rebuilds the index itself"
 newdb
 run_sql "$FIXTURE SELECT dolt_commit('-Am','base');" "$DB" > /dev/null
 run_sql "SELECT dolt_checkout('-b','side');
@@ -278,21 +284,17 @@ INSERT INTO f5(rowid, body) VALUES(20,'delta main');
 SELECT dolt_commit('-am','main doc');" "$DB" > /dev/null
 result=$(run_sql "BEGIN;
 SELECT dolt_merge('side');
-SELECT 'TX|' || (SELECT count(*)>0 FROM dolt_conflicts) || '|' || (SELECT count(*) FROM sqlite_master WHERE name='f5');
+SELECT 'TX|' || (SELECT count(*) FROM dolt_conflicts) || '|' || (SELECT count(*) FROM sqlite_master WHERE name='f5');
 ROLLBACK;" "$DB" | grep '^TX|')
-check "merge_conflict_pending_state" "TX|1|1" "$result"
-# The documented recovery: take one side's shadows wholesale, then rebuild
-# the index from its content table so the segments match the row set.
-result=$(run_sql "BEGIN;
-SELECT dolt_merge('side');
-SELECT dolt_conflicts_resolve('--theirs', (SELECT \"table\" FROM dolt_conflicts LIMIT 1));
-SELECT CASE WHEN (SELECT count(*) FROM dolt_conflicts)>0
-  THEN dolt_conflicts_resolve('--theirs', (SELECT \"table\" FROM dolt_conflicts LIMIT 1)) END;
-SELECT CASE WHEN (SELECT count(*) FROM dolt_conflicts)>0
-  THEN dolt_conflicts_resolve('--theirs', (SELECT \"table\" FROM dolt_conflicts LIMIT 1)) END;
-INSERT INTO f5(f5) VALUES('rebuild');
-SELECT length(dolt_commit('-Am','resolved + rebuilt'))=40;" "$DB" | tail -1)
-check "merge_conflict_resolve_rebuild_commit" "1" "$result"
+check "merge_colliding_vtab_no_conflicts" "TX|0|1" "$result"
+check "merge_colliding_vtab_keeps_both_rows" "5" \
+  "$(run_sql "SELECT count(*) FROM f5_content;" "$DB")"
+# Each side's row has to be reachable through the index, not merely present
+# in the content table -- that is exactly what the discarded side lost.
+check "merge_colliding_vtab_finds_ours" "20" \
+  "$(run_sql "SELECT group_concat(rowid) FROM f5 WHERE f5 MATCH 'main';" "$DB")"
+check "merge_colliding_vtab_finds_theirs" "10" \
+  "$(run_sql "SELECT group_concat(rowid) FROM f5 WHERE f5 MATCH 'side';" "$DB")"
 result=$(run_sql "INSERT INTO f5(f5) VALUES('integrity-check'); SELECT 'ok'; PRAGMA integrity_check;" "$DB")
 check "merge_conflict_rebuilt_index_valid" "ok
 ok" "$result"
@@ -384,6 +386,82 @@ ok
 ok" "$result"
 run_sql "SELECT dolt_branch('old','HEAD~3');" "$DB" > /dev/null
 verify "gc_history_reachable" "$DB/old" "$BASE_STATE"
+
+# Concurrent writes on two branches always collide in a vtab's derived
+# shadows: the structures they keep are rewritten wholesale by every write.
+# Neither side of such a collision is a correct answer, so a merge either
+# regenerates the index from data that survived the merge, or refuses.
+DBM=/tmp/test_vtab_merge_shadow_$$.db; rm -f "$DBM"
+run_sql "CREATE VIRTUAL TABLE ft USING fts5(body);
+INSERT INTO ft(rowid,body) VALUES(1,'alpha common'),(2,'beta common');
+SELECT dolt_commit('-A','-m','init');
+SELECT dolt_branch('b1');
+SELECT dolt_branch('b2');" "$DBM" > /dev/null
+run_sql "INSERT INTO ft(rowid,body) VALUES(101,'zebra one');
+SELECT dolt_commit('-A','-m','b1');" "$DBM/b1" > /dev/null
+run_sql "INSERT INTO ft(rowid,body) VALUES(201,'banana two');
+SELECT dolt_commit('-A','-m','b2');" "$DBM/b2" > /dev/null
+run_sql "SELECT dolt_merge('b1');" "$DBM" > /dev/null
+result=$(run_sql "SELECT dolt_merge('b2');" "$DBM")
+case "$result" in
+  [0-9a-f]*) PASS=$((PASS+1));;
+  *) note_fail "fts5_merge_rebuilds" "merge did not succeed: $result";;
+esac
+check "fts5_merge_finds_ours" "101" \
+  "$(run_sql "SELECT group_concat(rowid) FROM ft WHERE ft MATCH 'zebra';" "$DBM")"
+check "fts5_merge_finds_theirs" "201" \
+  "$(run_sql "SELECT group_concat(rowid) FROM ft WHERE ft MATCH 'banana';" "$DBM")"
+check "fts5_merge_content_complete" "4" \
+  "$(run_sql "SELECT count(*) FROM ft_content;" "$DBM")"
+check "fts5_merge_integrity" "" \
+  "$(run_sql "INSERT INTO ft(ft) VALUES('integrity-check');" "$DBM")"
+rm -f "$DBM"
+
+# Contentless fts5 keeps no copy of the indexed text, so the discarded side
+# is unrecoverable and fts5 refuses 'rebuild' outright.
+DBC=/tmp/test_vtab_merge_contentless_$$.db; rm -f "$DBC"
+run_sql "CREATE VIRTUAL TABLE ftc USING fts5(body, content='');
+INSERT INTO ftc(rowid,body) VALUES(1,'seed');
+SELECT dolt_commit('-A','-m','init');
+SELECT dolt_branch('b1');
+SELECT dolt_branch('b2');" "$DBC" > /dev/null
+run_sql "INSERT INTO ftc(rowid,body) VALUES(101,'apple pie');
+SELECT dolt_commit('-A','-m','b1');" "$DBC/b1" > /dev/null
+run_sql "INSERT INTO ftc(rowid,body) VALUES(201,'banana split');
+SELECT dolt_commit('-A','-m','b2');" "$DBC/b2" > /dev/null
+run_sql "SELECT dolt_merge('b1');" "$DBC" > /dev/null
+result=$(run_sql "SELECT dolt_merge('b2');" "$DBC")
+case "$result" in
+  *"cannot be rebuilt"*) PASS=$((PASS+1));;
+  *) note_fail "contentless_fts5_merge_refused" "expected a refusal, got: $result";;
+esac
+rm -f "$DBC"
+
+# An r-tree stores its coordinates in the node blobs themselves and offers
+# no rebuild, so a colliding node cannot be regenerated from anything.
+DBR=/tmp/test_vtab_merge_rtree_$$.db; rm -f "$DBR"
+run_sql "CREATE VIRTUAL TABLE rt2 USING rtree(id,x0,x1,y0,y1);
+WITH RECURSIVE c(i) AS (SELECT 1 UNION ALL SELECT i+1 FROM c WHERE i<300)
+  INSERT INTO rt2 SELECT i, i%50, i%50+1, i/50, i/50+1 FROM c;
+SELECT dolt_commit('-A','-m','init');
+SELECT dolt_branch('b1');
+SELECT dolt_branch('b2');" "$DBR" > /dev/null
+run_sql "INSERT INTO rt2 VALUES(1001,10.0,10.1,1.0,1.1);
+SELECT dolt_commit('-A','-m','b1');" "$DBR/b1" > /dev/null
+run_sql "INSERT INTO rt2 VALUES(2001,10.2,10.3,1.2,1.3);
+SELECT dolt_commit('-A','-m','b2');" "$DBR/b2" > /dev/null
+run_sql "SELECT dolt_merge('b1');" "$DBR" > /dev/null
+result=$(run_sql "SELECT dolt_merge('b2');" "$DBR")
+case "$result" in
+  *"cannot be rebuilt"*) PASS=$((PASS+1));;
+  *) note_fail "rtree_merge_refused" "expected a refusal, got: $result";;
+esac
+check "rtree_refusal_leaves_tree_intact" "ok" \
+  "$(run_sql "SELECT rtreecheck('rt2');" "$DBR")"
+# A refusal must not cost the merge that had already landed cleanly.
+check "rtree_refusal_keeps_first_merge" "1001" \
+  "$(run_sql "SELECT group_concat(id) FROM rt2 WHERE id>1000;" "$DBR")"
+rm -f "$DBR"
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"


### PR DESCRIPTION
The last of the five findings from the deep review. Merging an FTS or R-Tree table committed a corrupt index.

```sql
-- ft holds rows 1,2; b1 adds 'zebra one'; b2 adds 'banana two'
SELECT dolt_merge('b1');
SELECT dolt_merge('b2');   -- conflict in ft_data; resolve either way and commit
```

| | before | after / expected |
|---|---|---|
| `MATCH 'zebra'` | 101 | 101 |
| `MATCH 'banana'` | **nothing** | 201 |
| `ft_content` | holds all 4 rows | holds all 4 rows |
| fts5 `integrity-check` | **database disk image is malformed** | ok |
| `dolt_commit` | **accepted** | — |

The collision is unavoidable in practice: the structures these modules keep are rewritten by every write, so any two branches that both write the table conflict there. Neither `--ours` nor `--theirs` is ever correct, because taking one side drops the other's rows from the index while the content table still lists them — and the result committed.

## Change

Per Tim's decree — *if you can't merge, you gotta refuse.*

**Where the merged rows are authoritative, the index is not information: regenerate it.** fts3, fts4 and fts5 with content now absorb the shadow collision and rebuild from the merged content, which is exactly what vec1 already did for its own shadows. The generalized classifier lives where vec1's did, and the rebuild statement is now chosen per module (`INSERT INTO t(t) VALUES('rebuild')` for fts, vec1 keeps its model-argument form).

**Where nothing can regenerate it, refuse.** A contentless fts5 table keeps no copy of the indexed text and fts5 refuses `rebuild` on one outright; an r-tree stores coordinates in the node blobs and has no rebuild at all. For those, a colliding shadow is a conflict in the data itself, so the merge now stops with a message naming the table rather than offering two wrong answers.

## Unchanged on purpose

- **Ineligible vec1 shadows keep their conflicts resolvable.** My first cut swept them into the refusal and broke five existing assertions that pin that contract; the classifier now reports them exactly as before.
- **Merges that collide in no shadow, and one-sided merges, are untouched** — the filter only runs when there are conflicts. A one-sided r-tree merge and a disjoint fts merge were both re-checked.
- A conflict in `%_content` itself is a genuine data conflict and stays loud. Resolving one still leaves the index needing a manual rebuild; wiring the rebuild into conflict resolution is separate work.

## Testing

`test/doltlite_vtab_vc_matrix.sh` — the existing intent-level oracle for this class — gains the colliding-write case for fts5, and the refusal cases for contentless fts5 and r-tree, including that a refusal leaves the tree intact and does not cost an earlier clean merge.

One existing scenario changed meaning: it asserted that a colliding fts5 merge leaves conflicts pending and documented resolving them by hand. That expectation is what this PR deliberately removes, so it now asserts the merge yields no conflicts, and its end-state checks are kept and extended to require each side's row to be reachable *through the index* rather than merely present in the content table.

- Fail-before/pass-after: 7 assertions fail on master (`41 passed, 7 failed`), all pass with the fix (`48 passed, 0 failed`).
- vec1 suite 27/27, unchanged.
- Full battery **106/106 suites**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)