### PR TITLE
Keep private credentials out of remote trust stores

### DIFF
--- a/README.md
+++ b/README.md
@@ -677,9 +677,18 @@ in `build/`):
 
 Each `.db` is at `http://host:8080/filename.db` (or the HTTPS URL). Clients use
 the system trust store (`DOLTLITE_CA_FILE` for a private CA); credentials live
-in `~/.doltlite/creds` (`SELECT dolt_creds_new();`). Default HTTP timeout is
-30s (`DOLTLITE_HTTP_TIMEOUT_MS`). Embeddable as `doltliteServeAsync` in
-`doltlite_remotesrv.h`. Transfers are content-addressed.
+in `~/.doltlite/creds` (`SELECT dolt_creds_new();`). Authorize one without
+copying its private seed by exporting its public JWK directly into the server's
+key directory:
+
+```sql
+SELECT dolt_creds('export', '<credential-id>', '/path/to/authorized-keys');
+```
+
+With no directory argument, `dolt_creds('export', '<credential-id>')` returns
+the public JWK. The server rejects private credential files in `--auth-keys`.
+Default HTTP timeout is 30s (`DOLTLITE_HTTP_TIMEOUT_MS`). Embeddable as
+`doltliteServeAsync` in `doltlite_remotesrv.h`. Transfers are content-addressed.
 
 #### Version String
 

--- a/src/doltlite_creds.c
+++ b/src/doltlite_creds.c
@@ -973,6 +973,49 @@ done:
   return rc;
 }
 
+static int credsFileContainsPrivateJwk(const char *dir, const char *name) {
+  char *path = NULL;
+  FILE *f = NULL;
+  char *json = NULL;
+  size_t pathLen;
+  long sz;
+  int found = 0;
+#ifdef _WIN32
+  DWORD attrs;
+#else
+  struct stat st;
+#endif
+
+  pathLen = strlen(dir) + strlen(name) + 2;
+  path = (char *)sqlite3_malloc(pathLen);
+  if (!path) return 0;
+  snprintf(path, pathLen, "%s/%s", dir, name);
+#ifdef _WIN32
+  attrs = GetFileAttributesA(path);
+  if (attrs == INVALID_FILE_ATTRIBUTES ||
+      (attrs & FILE_ATTRIBUTE_DIRECTORY) != 0) goto done;
+#else
+  if (stat(path, &st) != 0 || !S_ISREG(st.st_mode)) goto done;
+#endif
+  f = fopen(path, "rb");
+  if (!f) goto done;
+  if (fseek(f, 0, SEEK_END) != 0) goto done;
+  sz = ftell(f);
+  if (sz < 0 || sz > 1 << 20) goto done;
+  if (fseek(f, 0, SEEK_SET) != 0) goto done;
+  json = (char *)sqlite3_malloc((size_t)sz + 1);
+  if (!json) goto done;
+  if (fread(json, 1, (size_t)sz, f) != (size_t)sz) goto done;
+  json[sz] = '\0';
+  found = credsJsonObjectValue(json, "d") != NULL;
+
+done:
+  if (f) fclose(f);
+  sqlite3_free(json);
+  sqlite3_free(path);
+  return found;
+}
+
 int doltliteCredsValidateAuthDir(const char *dir) {
   DirIter it;
   const char *name;
@@ -983,7 +1026,13 @@ int doltliteCredsValidateAuthDir(const char *dir) {
     size_t n = strlen(name);
     char *kid;
     unsigned char pub[DOLTLITE_PUBKEY_LEN];
-    if (!(n > 4 && strcmp(name + n - 4, ".jwk") == 0)) continue;
+    if (!(n > 4 && strcmp(name + n - 4, ".jwk") == 0)) {
+      if (credsFileContainsPrivateJwk(dir, name)) {
+        rc = 1;
+        break;
+      }
+      continue;
+    }
     kid = (char *)sqlite3_malloc(n - 4 + 1);
     if (!kid) {
       rc = 1;

--- a/src/doltlite_creds.c
+++ b/src/doltlite_creds.c
@@ -335,6 +335,21 @@ char *doltliteCredsToJwk(const DoltliteCreds *c) {
   return json;
 }
 
+char *doltliteCredsToPublicJwk(const DoltliteCreds *c) {
+  char *x = doltliteBase64UrlEncode(c->pub, DOLTLITE_PUBKEY_LEN);
+  char *json = NULL;
+  if (x) {
+    size_t n = strlen(x) + 48;
+    json = (char *)sqlite3_malloc(n);
+    if (json) {
+      snprintf(json, n,
+               "{\"kty\":\"OKP\",\"crv\":\"Ed25519\",\"x\":\"%s\"}", x);
+    }
+  }
+  sqlite3_free(x);
+  return json;
+}
+
 static const char *jsonSkipWs(const char *p){
   while( p && (*p==' ' || *p=='\t' || *p=='\r' || *p=='\n') ) p++;
   return p;
@@ -601,7 +616,8 @@ static char *credsFilePath(const char *dir, const char *kid) {
   return path;
 }
 
-int doltliteCredsSave(const DoltliteCreds *c, const char *dir) {
+static int credsSaveJwk(const DoltliteCreds *c, const char *dir,
+                        int publicOnly) {
   char *owned = NULL;
   char *kid = NULL;
   char *path = NULL;
@@ -619,13 +635,22 @@ int doltliteCredsSave(const DoltliteCreds *c, const char *dir) {
   if (!kid) goto done;
   path = credsFilePath(dir, kid);
   if (!path) goto done;
-  json = doltliteCredsToJwk(c);
+  json = publicOnly ? doltliteCredsToPublicJwk(c) : doltliteCredsToJwk(c);
   if (!json) goto done;
 
   {
     size_t len = strlen(json);
 #ifdef _WIN32
-    FILE *f = fopen(path, "wb");
+    FILE *existing = NULL;
+    FILE *f;
+    if (publicOnly) {
+      existing = fopen(path, "rb");
+      if (existing) {
+        fclose(existing);
+        goto done;
+      }
+    }
+    f = fopen(path, "wb");
     if (!f) goto done;
     if (fwrite(json, 1, len, f) != len) {
       fclose(f);
@@ -634,7 +659,8 @@ int doltliteCredsSave(const DoltliteCreds *c, const char *dir) {
     if (fclose(f) != 0) goto done;
 #else
     size_t off = 0;
-    int fd = open(path, O_WRONLY | O_CREAT | O_TRUNC, 0600);
+    int flags = O_WRONLY | O_CREAT | (publicOnly ? O_EXCL : O_TRUNC);
+    int fd = open(path, flags, 0600);
     if (fd < 0) goto done;
     (void)fchmod(fd, 0600);
     while (off < len) {
@@ -657,6 +683,14 @@ done:
   sqlite3_free(kid);
   sqlite3_free(owned);
   return rc;
+}
+
+int doltliteCredsSave(const DoltliteCreds *c, const char *dir) {
+  return credsSaveJwk(c, dir, 0);
+}
+
+int doltliteCredsSavePublic(const DoltliteCreds *c, const char *dir) {
+  return credsSaveJwk(c, dir, 1);
 }
 
 int doltliteCredsLoad(const char *dir, const char *kid, DoltliteCreds **out) {
@@ -882,8 +916,12 @@ int doltliteCredsLoadPubKey(const char *dir, const char *kid,
   char *path = NULL;
   FILE *f = NULL;
   char *json = NULL;
+  char *kty = NULL;
+  char *crv = NULL;
   char *xstr = NULL;
+  char *derivedKid = NULL;
   unsigned char *raw = NULL;
+  unsigned char kidRaw[DOLTLITE_KID_RAW_LEN];
   size_t rawlen = 0;
   long sz;
   int rc = 1;
@@ -907,10 +945,18 @@ int doltliteCredsLoadPubKey(const char *dir, const char *kid,
   if (fread(json, 1, (size_t)sz, f) != (size_t)sz) goto done;
   json[sz] = '\0';
 
+  if (credsJsonObjectValue(json, "d")) goto done;
+  kty = jsonFindString(json, "kty");
+  crv = jsonFindString(json, "crv");
+  if (!kty || strcmp(kty, "OKP") != 0) goto done;
+  if (!crv || strcmp(crv, "Ed25519") != 0) goto done;
   xstr = jsonFindString(json, "x");
   if (!xstr) goto done;
   if (doltliteBase64UrlDecode(xstr, &raw, &rawlen)) goto done;
   if (rawlen != DOLTLITE_PUBKEY_LEN) goto done;
+  doltliteSha512_224(raw, rawlen, kidRaw);
+  derivedKid = doltliteBase32Encode(kidRaw, sizeof(kidRaw));
+  if (!derivedKid || strcmp(derivedKid, kid) != 0) goto done;
   memcpy(pub, raw, DOLTLITE_PUBKEY_LEN);
   rc = 0;
 
@@ -919,8 +965,40 @@ done:
   sqlite3_free(json);
   sqlite3_free(path);
   sqlite3_free(owned);
+  sqlite3_free(kty);
+  sqlite3_free(crv);
   sqlite3_free(xstr);
+  sqlite3_free(derivedKid);
   sqlite3_free(raw);
+  return rc;
+}
+
+int doltliteCredsValidateAuthDir(const char *dir) {
+  DirIter it;
+  const char *name;
+  int rc = 0;
+
+  if (!dir || dirOpen(&it, dir)) return 1;
+  while ((name = dirNext(&it)) != NULL) {
+    size_t n = strlen(name);
+    char *kid;
+    unsigned char pub[DOLTLITE_PUBKEY_LEN];
+    if (!(n > 4 && strcmp(name + n - 4, ".jwk") == 0)) continue;
+    kid = (char *)sqlite3_malloc(n - 4 + 1);
+    if (!kid) {
+      rc = 1;
+      break;
+    }
+    memcpy(kid, name, n - 4);
+    kid[n - 4] = '\0';
+    if (!credsKidValid(kid) || doltliteCredsLoadPubKey(dir, kid, pub) != 0) {
+      rc = 1;
+      sqlite3_free(kid);
+      break;
+    }
+    sqlite3_free(kid);
+  }
+  dirClose(&it);
   return rc;
 }
 

--- a/src/doltlite_creds.h
+++ b/src/doltlite_creds.h
@@ -50,10 +50,12 @@ int doltliteCredsBearerTokenAt(const DoltliteCreds *cred, const char *audience,
                                long iat, char **jwtOut);
 
 char *doltliteCredsToJwk(const DoltliteCreds *cred);
+char *doltliteCredsToPublicJwk(const DoltliteCreds *cred);
 int doltliteCredsFromJwk(const char *json, DoltliteCreds **out);
 
 char *doltliteCredsDir(void);
 int doltliteCredsSave(const DoltliteCreds *cred, const char *dir);
+int doltliteCredsSavePublic(const DoltliteCreds *cred, const char *dir);
 int doltliteCredsLoad(const char *dir, const char *kid, DoltliteCreds **out);
 int doltliteCredsLoadDefault(const char *dir, DoltliteCreds **out);
 
@@ -64,6 +66,7 @@ int doltliteCredsRemove(const char *dir, const char *kid);
 
 int doltliteCredsLoadPubKey(const char *dir, const char *kid,
                             unsigned char pub[DOLTLITE_PUBKEY_LEN]);
+int doltliteCredsValidateAuthDir(const char *dir);
 
 int doltliteCredsVerifyBearer(const char *authValue, const char *expectedAudience,
                               const char *authKeysDir, long now, char **kidOut);

--- a/src/doltlite_remote_sql.c
+++ b/src/doltlite_remote_sql.c
@@ -1027,9 +1027,48 @@ static void doltCredsFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
         sqlite3_result_int(ctx, 0);
       }
     }
+  }else if( strcmp(action, "export")==0 ){
+    const char *kid;
+    DoltliteCreds *cred = 0;
+    if( argc<2 || argc>3 || !sqlite3_value_text(argv[1]) ||
+        (argc==3 && !sqlite3_value_text(argv[2])) ){
+      doltliteVcResultError(ctx, db,
+          "usage: dolt_creds('export', <kid> [, <authorized-keys-dir>])");
+      return;
+    }
+    kid = (const char*)sqlite3_value_text(argv[1]);
+    if( doltliteCredsLoad(0, kid, &cred)!=0 ){
+      doltliteVcResultError(ctx, db, "no such credential");
+      return;
+    }
+    if( argc==2 ){
+      char *json = doltliteCredsToPublicJwk(cred);
+      if( json ){
+        sqlite3_result_text(ctx, json, -1, SQLITE_TRANSIENT);
+        sqlite3_free(json);
+      }else{
+        doltliteVcResultError(ctx, db, "out of memory");
+      }
+    }else{
+      const char *dir = (const char*)sqlite3_value_text(argv[2]);
+      if( doltliteCredsSavePublic(cred, dir)!=0 ){
+        doltliteVcResultError(ctx, db, "failed to export public credential");
+      }else{
+        char *msg = sqlite3_mprintf(
+            "Exported public credential %s to %s", kid, dir);
+        if( msg ){
+          sqlite3_result_text(ctx, msg, -1, SQLITE_TRANSIENT);
+          sqlite3_free(msg);
+        }else{
+          doltliteVcResultError(ctx, db, "out of memory");
+        }
+      }
+    }
+    doltliteCredsFree(cred);
   }else{
     doltliteVcResultError(ctx, db,
-        "usage: dolt_creds(['list'] | 'rm', <kid>); use SELECT dolt_creds_new() to create");
+        "usage: dolt_creds(['list'] | 'rm', <kid> | 'export', <kid> "
+        "[, <authorized-keys-dir>]); use SELECT dolt_creds_new() to create");
   }
 }
 #endif /* DOLTLITE_HAVE_AUTH */

--- a/src/doltlite_remotesrv.c
+++ b/src/doltlite_remotesrv.c
@@ -1395,6 +1395,10 @@ static int serverInit(DoltliteServer *pSrv, const DoltliteServeOpts *o){
       serverCleanup(pSrv);
       return SQLITE_ERROR;
     }
+    if( doltliteCredsValidateAuthDir(o->authKeysDir)!=0 ){
+      serverCleanup(pSrv);
+      return SQLITE_ERROR;
+    }
     pSrv->authKeysDir = dupStr(o->authKeysDir);
     if( !pSrv->authKeysDir ){ serverCleanup(pSrv); return SQLITE_NOMEM; }
   }

--- a/src/remotesrv_main.c
+++ b/src/remotesrv_main.c
@@ -8,6 +8,7 @@
 #else
 #include <unistd.h>
 #endif
+#include "doltlite_creds.h"
 #include "doltlite_remotesrv.h"
 #include "doltlite_parse.h"
 
@@ -24,7 +25,8 @@ static void usage(const char *prog){
     "  --cert FILE     PEM certificate chain (enables TLS; requires --key)\n"
     "  --key FILE      PEM private key (requires --cert)\n"
     "  --auth-keys DIR Require a bearer credential; authorized public keys are\n"
-    "                  <kid>.jwk files in DIR. Omitted, requests are\n"
+    "                  <kid>.jwk files from dolt_creds('export', ...).\n"
+    "                  Omitted, requests are\n"
     "                  unauthenticated and may read and push.\n"
     "  --audience AUD  Expected JWT audience (required with --auth-keys)\n"
     "  --timeout-ms MS Connection I/O timeout (default: 30000)\n"
@@ -101,6 +103,12 @@ int main(int argc, char **argv){
   }
   if( o.authKeysDir && (!o.audience || !o.audience[0]) ){
     fprintf(stderr, "Error: --audience is required with --auth-keys\n");
+    return 1;
+  }
+  if( o.authKeysDir && doltliteCredsValidateAuthDir(o.authKeysDir)!=0 ){
+    fprintf(stderr,
+      "Error: --auth-keys must contain only public JWK files created by "
+      "dolt_creds('export', ...)\n");
     return 1;
   }
   signal(SIGINT, onSignal);

--- a/test/creds_path_test.sh
+++ b/test/creds_path_test.sh
@@ -5,7 +5,7 @@ set -o pipefail
 DOLTLITE="${1:-./doltlite}"
 TMP=$(mktemp -d)
 trap 'rm -rf "$TMP"' EXIT
-mkdir -p "$TMP/creds"
+mkdir -p "$TMP/creds" "$TMP/authkeys"
 pass=0
 fail=0
 
@@ -27,6 +27,15 @@ reject_remove() {
     "SELECT dolt_creds('rm','$kid');" >/dev/null 2>&1
 }
 
+has_no_private_key() {
+  ! grep -q '"d"' "$1"
+}
+
+reject_export_to_private() {
+  ! DOLTLITE_CREDS_DIR="$TMP/creds" "$DOLTLITE" :memory: \
+    "SELECT dolt_creds('export','$kid','$TMP/creds');" >/dev/null 2>&1
+}
+
 echo "=== doltlite credential path tests ==="
 printf '{}' > "$TMP/victim.jwk"
 check "parent traversal removal rejected" reject_remove "../victim"
@@ -42,6 +51,24 @@ kid=$(printf '%s\n' "$created" | sed -n \
   's/^Created credential \([0-9a-v][0-9a-v]*\)$/\1/p' | head -1)
 check "canonical credential created" test "${#kid}" -eq 45
 check "canonical credential stored" test -f "$TMP/creds/$kid.jwk"
+public=$(DOLTLITE_CREDS_DIR="$TMP/creds" "$DOLTLITE" :memory: \
+  "SELECT dolt_creds('export','$kid');" 2>/dev/null)
+check "public export contains public key" grep -q '"x"' <<<"$public"
+if [[ "$public" != *'"d"'* ]]; then
+  check "public export omits private seed" true
+else
+  check "public export omits private seed" false
+fi
+check "public credential exports to authorization directory" env \
+  DOLTLITE_CREDS_DIR="$TMP/creds" "$DOLTLITE" :memory: \
+  "SELECT dolt_creds('export','$kid','$TMP/authkeys');"
+check "authorization file created" test -f "$TMP/authkeys/$kid.jwk"
+check "authorization file omits private seed" has_no_private_key \
+  "$TMP/authkeys/$kid.jwk"
+check "public export cannot overwrite private credential" \
+  reject_export_to_private
+check "private credential survives refused export" grep -q '"d"' \
+  "$TMP/creds/$kid.jwk"
 check "canonical credential removal succeeds" env \
   DOLTLITE_CREDS_DIR="$TMP/creds" "$DOLTLITE" :memory: \
   "SELECT dolt_creds('rm','$kid');"

--- a/test/creds_verify_kat.c
+++ b/test/creds_verify_kat.c
@@ -93,11 +93,13 @@ int main(int argc, char **argv) {
   const char *authDir = argc > 1 ? argv[1] : ".";
   const char *emptyDir = argc > 2 ? argv[2] : ".";
   const char *outsideDir = argc > 3 ? argv[3] : ".";
+  const char *mismatchDir = argc > 4 ? argv[4] : ".";
   unsigned char seed[32];
   DoltliteCreds *c = NULL;
   char *jwt = NULL, *kid = NULL, *kidOut = NULL;
   char *bearer = NULL, *tampered = NULL;
   char *invalidExp = NULL, *overflowExp = NULL;
+  unsigned char pub[DOLTLITE_PUBKEY_LEN];
   int i;
 
   for (i = 0; i < 32; i++) seed[i] = (unsigned char)i;
@@ -107,10 +109,12 @@ int main(int argc, char **argv) {
   }
   kid = doltliteCredsKid(c);
 
-  if (doltliteCredsSave(c, authDir) != 0) {
+  if (doltliteCredsSavePublic(c, authDir) != 0) {
     printf("  FAIL  save authorized key\n");
     return 1;
   }
+  check("public authorization directory accepted",
+        doltliteCredsValidateAuthDir(authDir) == 0);
 
   if (doltliteCredsBearerTokenAt(c, AUD, IAT, &jwt) != 0 || !jwt) {
     printf("  FAIL  build bearer token\n");
@@ -186,11 +190,39 @@ int main(int argc, char **argv) {
         doltliteCredsVerifyBearer(tampered, AUD, authDir, MID, NULL) != 0);
 
   {
+    char *otherKid = (char *)malloc(strlen(kid) + 1);
+    char *from;
+    char *to;
+    size_t pathLen = strlen(mismatchDir) + strlen(kid) + 7;
+    strcpy(otherKid, kid);
+    otherKid[0] = otherKid[0] == '0' ? '1' : '0';
+    from = (char *)malloc(pathLen);
+    to = (char *)malloc(pathLen);
+    snprintf(from, pathLen, "%s/%s.jwk", mismatchDir, kid);
+    snprintf(to, pathLen, "%s/%s.jwk", mismatchDir, otherKid);
+    check("save public key for filename mismatch test",
+          doltliteCredsSavePublic(c, mismatchDir) == 0);
+    check("rename public key to a different canonical id",
+          rename(from, to) == 0);
+    check("public key filename must match its derived id",
+          doltliteCredsLoadPubKey(mismatchDir, otherKid, pub) != 0);
+    check("mismatched key id invalidates authorization directory",
+          doltliteCredsValidateAuthDir(mismatchDir) != 0);
+    free(otherKid);
+    free(from);
+    free(to);
+  }
+
+  {
     char *traversalKid;
     char *traversalJwt;
     size_t n = strlen(kid) + strlen("../outside/") + 1;
     check("save key outside authorized directory",
           doltliteCredsSave(c, outsideDir) == 0);
+    check("private credential rejected as an authorization key",
+          doltliteCredsLoadPubKey(outsideDir, kid, pub) != 0);
+    check("private credential invalidates authorization directory",
+          doltliteCredsValidateAuthDir(outsideDir) != 0);
     traversalKid = (char *)malloc(n);
     snprintf(traversalKid, n, "../outside/%s", kid);
     traversalJwt = tokenForKid(c, traversalKid, "1700000030");

--- a/test/creds_verify_kat.c
+++ b/test/creds_verify_kat.c
@@ -94,6 +94,7 @@ int main(int argc, char **argv) {
   const char *emptyDir = argc > 2 ? argv[2] : ".";
   const char *outsideDir = argc > 3 ? argv[3] : ".";
   const char *mismatchDir = argc > 4 ? argv[4] : ".";
+  const char *disguisedDir = argc > 5 ? argv[5] : ".";
   unsigned char seed[32];
   DoltliteCreds *c = NULL;
   char *jwt = NULL, *kid = NULL, *kidOut = NULL;
@@ -115,6 +116,19 @@ int main(int argc, char **argv) {
   }
   check("public authorization directory accepted",
         doltliteCredsValidateAuthDir(authDir) == 0);
+  {
+    char *notePath = (char *)malloc(strlen(authDir) + 10);
+    FILE *note;
+    sprintf(notePath, "%s/note.txt", authDir);
+    note = fopen(notePath, "wb");
+    if (note) {
+      fputs("operator note\n", note);
+      fclose(note);
+    }
+    check("unrelated authorization-directory file accepted",
+          doltliteCredsValidateAuthDir(authDir) == 0);
+    free(notePath);
+  }
 
   if (doltliteCredsBearerTokenAt(c, AUD, IAT, &jwt) != 0 || !jwt) {
     printf("  FAIL  build bearer token\n");
@@ -231,6 +245,24 @@ int main(int argc, char **argv) {
               doltliteCredsVerifyBearer(traversalJwt, AUD, authDir, MID, NULL) != 0);
     free(traversalKid);
     free(traversalJwt);
+  }
+
+  {
+    char *from;
+    char *to;
+    size_t pathLen = strlen(disguisedDir) + strlen(kid) + 7;
+    from = (char *)malloc(pathLen);
+    to = (char *)malloc(strlen(disguisedDir) + 14);
+    snprintf(from, pathLen, "%s/%s.jwk", disguisedDir, kid);
+    sprintf(to, "%s/private.json", disguisedDir);
+    check("save private credential for disguised-file test",
+          doltliteCredsSave(c, disguisedDir) == 0);
+    check("rename private credential outside JWK convention",
+          rename(from, to) == 0);
+    check("disguised private credential invalidates authorization directory",
+          doltliteCredsValidateAuthDir(disguisedDir) != 0);
+    free(from);
+    free(to);
   }
 
   sqlite3_free(jwt);

--- a/test/creds_verify_test.sh
+++ b/test/creds_verify_test.sh
@@ -10,7 +10,7 @@ TMP=$(mktemp -d)
 trap 'rm -rf "$TMP"' EXIT
 
 BIN="${DOLTLITE_CREDS_VERIFY_BIN:-$TMP/creds_verify_kat}"
-mkdir -p "$TMP/authkeys" "$TMP/empty" "$TMP/outside"
+mkdir -p "$TMP/authkeys" "$TMP/empty" "$TMP/outside" "$TMP/mismatch"
 
 echo "=== doltlite credential-verify KAT ==="
 if [ -z "${DOLTLITE_CREDS_VERIFY_BIN:-}" ]; then
@@ -39,4 +39,4 @@ if [ ! -x "$BIN" ]; then
   exit 1
 fi
 
-"$BIN" "$TMP/authkeys" "$TMP/empty" "$TMP/outside"
+"$BIN" "$TMP/authkeys" "$TMP/empty" "$TMP/outside" "$TMP/mismatch"

--- a/test/creds_verify_test.sh
+++ b/test/creds_verify_test.sh
@@ -10,7 +10,8 @@ TMP=$(mktemp -d)
 trap 'rm -rf "$TMP"' EXIT
 
 BIN="${DOLTLITE_CREDS_VERIFY_BIN:-$TMP/creds_verify_kat}"
-mkdir -p "$TMP/authkeys" "$TMP/empty" "$TMP/outside" "$TMP/mismatch"
+mkdir -p "$TMP/authkeys" "$TMP/empty" "$TMP/outside" "$TMP/mismatch" \
+  "$TMP/disguised"
 
 echo "=== doltlite credential-verify KAT ==="
 if [ -z "${DOLTLITE_CREDS_VERIFY_BIN:-}" ]; then
@@ -39,4 +40,5 @@ if [ ! -x "$BIN" ]; then
   exit 1
 fi
 
-"$BIN" "$TMP/authkeys" "$TMP/empty" "$TMP/outside" "$TMP/mismatch"
+"$BIN" "$TMP/authkeys" "$TMP/empty" "$TMP/outside" "$TMP/mismatch" \
+  "$TMP/disguised"

--- a/test/doltlite_creds_kat.c
+++ b/test/doltlite_creds_kat.c
@@ -192,6 +192,14 @@ int main(int argc, char **argv) {
   }
 
   {
+    char *json = doltliteCredsToPublicJwk(c);
+    check_str("public JWK omits private seed", json,
+              "{\"kty\":\"OKP\",\"crv\":\"Ed25519\","
+              "\"x\":\"A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg=\"}");
+    sqlite3_free(json);
+  }
+
+  {
     char *jwt = NULL;
     check_bool("null audience rejected at mint",
                doltliteCredsBearerTokenAt(c, NULL, 1700000000L, &jwt) != 0);

--- a/test/remote_https_auth_test.sh
+++ b/test/remote_https_auth_test.sh
@@ -7,7 +7,13 @@ HERE=$(cd "$(dirname "$0")/.." && pwd)
 CC="${CC:-cc}"
 TMP=$(mktemp -d)
 SRV_PID=""
+PRIVATE_PID=""
 cleanup() {
+  if [ -n "$PRIVATE_PID" ]; then
+    kill "$PRIVATE_PID" 2>/dev/null || true
+    wait "$PRIVATE_PID" 2>/dev/null || true
+    PRIVATE_PID=""
+  fi
   if [ -n "$SRV_PID" ]; then
     kill "$SRV_PID" 2>/dev/null || true
     wait "$SRV_PID" 2>/dev/null || true
@@ -44,9 +50,30 @@ openssl req -x509 -newkey rsa:2048 -nodes -days 1 \
 openssl req -x509 -newkey rsa:2048 -nodes -days 1 \
   -keyout /dev/null -out "$TMP/other_ca.pem" -subj "/CN=other" >/dev/null 2>&1
 
-mkdir -p "$TMP/cc" "$TMP/cc_unauth" "$TMP/empty" "$TMP/authkeys" "$TMP/srv" "$TMP/srv2"
+mkdir -p "$TMP/cc" "$TMP/cc_unauth" "$TMP/empty" "$TMP/authkeys" \
+  "$TMP/private_authkeys" "$TMP/srv" "$TMP/srv2"
 DOLTLITE_CREDS_DIR="$TMP/cc" "$DOLTLITE" "$TMP/throwaway.db" "SELECT dolt_creds_new();" >/dev/null 2>&1
-cp "$TMP"/cc/*.jwk "$TMP/authkeys/" 2>/dev/null || { echo "FAIL: no credential generated"; exit 1; }
+private_jwk=$(find "$TMP/cc" -maxdepth 1 -name '*.jwk' -print | head -1)
+[ -n "$private_jwk" ] || { echo "FAIL: no credential generated"; exit 1; }
+kid=$(basename "$private_jwk" .jwk)
+cp "$private_jwk" "$TMP/private_authkeys/"
+"$REMOTESRV" --cert "$TMP/cert.pem" --key "$TMP/key.pem" \
+  --auth-keys "$TMP/private_authkeys" --audience localhost \
+  -p 0 --bind 127.0.0.1 "$TMP/srv" >"$TMP/private.log" 2>&1 &
+PRIVATE_PID=$!
+sleep 0.5
+if kill -0 "$PRIVATE_PID" 2>/dev/null; then
+  kill "$PRIVATE_PID" 2>/dev/null || true
+  wait "$PRIVATE_PID" 2>/dev/null || true
+  echo "FAIL: server accepted a private credential in --auth-keys"
+  exit 1
+fi
+wait "$PRIVATE_PID" 2>/dev/null || true
+PRIVATE_PID=""
+DOLTLITE_CREDS_DIR="$TMP/cc" "$DOLTLITE" :memory: \
+  "SELECT dolt_creds('export','$kid','$TMP/authkeys');" >/dev/null 2>&1 || {
+  echo "FAIL: public credential export failed"; exit 1;
+}
 DOLTLITE_CREDS_DIR="$TMP/cc_unauth" "$DOLTLITE" "$TMP/throwaway2.db" "SELECT dolt_creds_new();" >/dev/null 2>&1
 
 "$REMOTESRV" --cert "$TMP/cert.pem" --key "$TMP/key.pem" \

--- a/test/remotesrv_bind_warning_test.sh
+++ b/test/remotesrv_bind_warning_test.sh
@@ -41,9 +41,12 @@ if command -v openssl >/dev/null 2>&1 \
 fi
 
 HAVE_KEYS=0
-DOLTLITE_CREDS_DIR="$TMP/cc" "$DOLTLITE" "$TMP/throwaway.db" \
-  "SELECT dolt_creds_new();" >/dev/null 2>&1
-if cp "$TMP"/cc/*.jwk "$TMP/keys/" 2>/dev/null; then
+created=$(DOLTLITE_CREDS_DIR="$TMP/cc" "$DOLTLITE" "$TMP/throwaway.db" \
+  "SELECT dolt_creds_new();" 2>/dev/null)
+kid=$(printf '%s\n' "$created" | sed -n \
+  's/^Created credential \([0-9a-v][0-9a-v]*\)$/\1/p' | head -1)
+if [ -n "$kid" ] && DOLTLITE_CREDS_DIR="$TMP/cc" "$DOLTLITE" :memory: \
+  "SELECT dolt_creds('export','$kid','$TMP/keys');" >/dev/null 2>&1; then
   HAVE_KEYS=1
 fi
 


### PR DESCRIPTION
## Summary

- add `dolt_creds('export', kid)` for public-only JWK output and an optional authorization-directory destination
- reject private, malformed, wrong-curve, and key-ID-mismatched JWKs at remote-server startup and token verification
- make public exports create-only so they cannot overwrite a private signing credential
- migrate HTTPS authentication tests and documentation to the public-key workflow

Existing `--auth-keys` directories populated by copying private credential files must be rebuilt with `dolt_creds('export', kid, directory)`. No storage-format change.

## Validation

- fail-before: public export was unsupported and the server accepted copied private credentials
- credential KAT: 36 passed
- credential verifier KAT: 26 passed
- credential SQL/path suite: 16 passed
- authenticated HTTPS suite: 15 passed
- server bind/warning suite: 15 passed
- amalgamation remote and remotes-disabled stripping test
- `make lint`
- `git diff --check`

Fixes #1977.

Co-Authored-By: OpenAI Codex <noreply@openai.com>