### PR TITLE
Let a merge keep a deleted view or trigger deleted

### DIFF
--- a/src/doltlite_merge.c
+++ b/src/doltlite_merge.c
@@ -1337,8 +1337,41 @@ int doltliteMergeCatalogs(
   }
   if( rc!=SQLITE_OK ) goto merge_cleanup;
 
-  rc = serializeMergedCatalog(db, ours, aMerged, nMerged, iNextMerged,
-                              aTheirsSchema, nTheirsSchema, pMergedHash);
+  /* Their schema supplies anything the merged rows do not carry, and an
+  ** object we deleted is exactly that, so the fallback would reinstate it --
+  ** and a reinstated trigger fires on the next write. Drop the ones we
+  ** deleted while their side left them alone. Tables and indexes are already
+  ** excluded by the serializer, and a deletion racing a change on their side
+  ** keeps today's behaviour rather than growing a new conflict here. */
+  {
+    SchemaEntry *aFallback = aTheirsSchema;
+    int nFallback = nTheirsSchema;
+    SchemaEntry *aKept = 0;
+    int k;
+    if( nTheirsSchema>0 ){
+      aKept = sqlite3_malloc(nTheirsSchema*(int)sizeof(SchemaEntry));
+      if( !aKept ){ rc = SQLITE_NOMEM; goto merge_cleanup; }
+      nFallback = 0;
+      for(k=0; k<nTheirsSchema; k++){
+        SchemaEntry *pT = &aTheirsSchema[k];
+        SchemaEntry *pAnc;
+        if( pT->zType && pT->zName
+         && strcmp(pT->zType, "table")!=0 && strcmp(pT->zType, "index")!=0
+         && findSchemaEntry(aOursSchema, nOursSchema, pT->zName)==0
+         && (pAnc = findSchemaEntry(aAncSchema, nAncSchema, pT->zName))!=0
+         && pAnc->zType && strcmp(pAnc->zType, pT->zType)==0
+         && (pAnc->zSql==0)==(pT->zSql==0)
+         && (pAnc->zSql==0 || strcmp(pAnc->zSql, pT->zSql)==0) ){
+          continue;
+        }
+        aKept[nFallback++] = *pT;
+      }
+      aFallback = aKept;
+    }
+    rc = serializeMergedCatalog(db, ours, aMerged, nMerged, iNextMerged,
+                                aFallback, nFallback, pMergedHash);
+    sqlite3_free(aKept);
+  }
 
   if( totalConflicts>0 && nConflictTables>0 && rc==SQLITE_OK ){
     rc = recordMergeConflicts(db, aConflictTables, nConflictTables);

--- a/test/doltlite_schema_merge.sh
+++ b/test/doltlite_schema_merge.sh
@@ -968,4 +968,58 @@ run_test "rename_no_drop_rows" \
   "1:a1x:c1,2:a2:c2" "$DB"
 rm -f "$DB"
 
+# Their schema supplies whatever the merged rows do not carry, and an object
+# this side deleted is exactly that -- so it came back, and a resurrected
+# trigger fires on the next write. Verified against Dolt 2.2.2, which keeps
+# the deletion.
+DB=/tmp/test_merge_dropped_objects_$$.db; rm -f "$DB"
+cat <<'EOF' | $DOLTLITE "$DB" > /dev/null 2>&1
+CREATE TABLE t(a INTEGER PRIMARY KEY, b TEXT);
+CREATE VIEW v AS SELECT a,b FROM t;
+CREATE TRIGGER tg AFTER INSERT ON t BEGIN UPDATE t SET b='TRIG'; END;
+INSERT INTO t VALUES(1,'x');
+SELECT dolt_commit('-A','-m','base');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+INSERT INTO t VALUES(2,'y');
+SELECT dolt_commit('-A','-m','insert on feat');
+SELECT dolt_checkout('main');
+DROP VIEW v;
+DROP TRIGGER tg;
+SELECT dolt_commit('-A','-m','drop view and trigger');
+EOF
+run_test_match "merge_keeps_drop_hash" "SELECT dolt_merge('feat');" \
+  "^[0-9a-f]{40}$" "$DB"
+run_test "merge_keeps_view_dropped" \
+  "SELECT count(*) FROM sqlite_master WHERE name='v';" "0" "$DB"
+run_test "merge_keeps_trigger_dropped" \
+  "SELECT count(*) FROM sqlite_master WHERE name='tg';" "0" "$DB"
+# A trigger that came back would rewrite this row on the way in.
+run_test "merge_dropped_trigger_stays_silent" \
+  "INSERT INTO t VALUES(3,'kept'); SELECT b FROM t WHERE a=3;" "kept" "$DB"
+rm -f "$DB"
+
+# Nothing was deleted, so both objects have to survive the same merge.
+DB=/tmp/test_merge_keeps_objects_$$.db; rm -f "$DB"
+cat <<'EOF' | $DOLTLITE "$DB" > /dev/null 2>&1
+CREATE TABLE t(a INTEGER PRIMARY KEY, b TEXT);
+CREATE VIEW v AS SELECT a,b FROM t;
+CREATE TRIGGER tg AFTER INSERT ON t BEGIN UPDATE t SET b='TRIG'; END;
+INSERT INTO t VALUES(1,'x');
+SELECT dolt_commit('-A','-m','base');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+INSERT INTO t VALUES(2,'y');
+SELECT dolt_commit('-A','-m','insert on feat');
+SELECT dolt_checkout('main');
+UPDATE t SET b='z' WHERE a=1;
+SELECT dolt_commit('-A','-m','edit on main');
+EOF
+run_test_match "merge_undeleted_objects_hash" "SELECT dolt_merge('feat');" \
+  "^[0-9a-f]{40}$" "$DB"
+run_test "merge_keeps_undeleted_objects" \
+  "SELECT group_concat(type||':'||name) FROM sqlite_master
+   WHERE name IN ('v','tg') ORDER BY name;" "view:v,trigger:tg" "$DB"
+rm -f "$DB"
+
 dltest_finish


### PR DESCRIPTION
The remaining finding from the deep review. A merge reinstated views and triggers that had been dropped, and a reinstated trigger then rewrote data.

```sql
-- base has view v and trigger tg
-- main: DROP VIEW v; DROP TRIGGER tg;   commit
-- feat: INSERT INTO t VALUES(2,'y');    commit
SELECT dolt_merge('feat');
```

| | before | after / Dolt 2.2.2 |
|---|---|---|
| objects after merge | `view:v, trigger:tg` — both back | none |
| next `INSERT INTO t VALUES(3,'kept')` | row reads **`TRIG`** | reads `kept` |

The merge reported success, so the schema deletions were silently undone and the resurrected trigger then modified every row it fired on.

## Cause

The merged catalog is serialized with their schema as the fallback for anything the merged rows do not carry — and an object this side deleted is precisely something the merged rows do not carry, so the fallback pass added it back. Tables and indexes were already excluded there, which is why only views and triggers regressed.

## Change

Before serializing, drop from that fallback the objects we deleted while their side left them alone — the case where the deletion is unambiguous. Everything else is untouched:

- **A deletion racing a change on their side keeps today's behaviour.** That is a delete-versus-modify conflict and deserves a considered answer rather than one smuggled into this fix.
- **The mirror — their side deleting — already worked**, verified on master, and is unchanged.
- Objects nobody deleted still survive the same merge.

## Testing

`test/doltlite_schema_merge.sh` gains the reported case, an assertion that a resurrected trigger would be caught by the value it writes rather than only by the schema, and a guard that an undeleted view and trigger still survive.

- Fail-before/pass-after: 3 assertions fail on master (`154 passed, 3 failed`), all pass with the fix (`157 passed, 0 failed`).
- Expected values taken from Dolt 2.2.2, which keeps the deletion in this direction and in the mirror.
- Full battery **106/106 suites**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)