### PR TITLE
Resolve open time with large wals

### DIFF
--- a/src/chunk_index.c
+++ b/src/chunk_index.c
@@ -21,9 +21,11 @@ void chunkIndexGetEntries(const ChunkIndex *idx, int *pn, const ChunkIndexEntry 
 }
 
 int chunkIndexCount(const ChunkIndex *idx){
+  i64 n;
   assert( idx!=0 );
   assert( idx->nIndex>=0 );
-  return idx->nIndex;
+  n = (i64)idx->nIndex + idx->lazy.nEntries;
+  return n>INT_MAX ? INT_MAX : (int)n;
 }
 
 void chunkIndexSetMetadata(ChunkIndex *idx, int nChunks, i64 iOffset, i64 nSize){
@@ -44,6 +46,7 @@ void chunkIndexReplaceEntries(ChunkIndex *idx, ChunkIndexEntry *aNew, int nNew){
   idx->nIndex = nNew;
   idx->aIndexMmapBase = 0;
   idx->aIndexMmapSize = 0;
+  memset(&idx->lazy, 0, sizeof(idx->lazy));
 }
 
 void csReleaseIndexBuf(ChunkIndexEntry *aIndex,
@@ -118,6 +121,372 @@ static int csDeserializeIndexEntry(const u8 *aBuf, ChunkIndexEntry *e){
   return SQLITE_OK;
 }
 
+static int csReadLazyPage(
+  ChunkStore *cs,
+  i64 iOffset,
+  int nBody,
+  const ProllyHash *pHash,
+  i64 iLimit,
+  u8 **ppBody
+){
+  u8 aHeader[CS_WAL_CHUNK_HDR_SIZE];
+  ProllyHash actual;
+  u8 *aBody;
+  int rc;
+
+  *ppBody = 0;
+  if( nBody<CS_INDEX_PAGE_HEADER_SIZE || nBody>CS_INDEX_PAGE_SIZE
+   || iOffset<cs->index.lazy.iDataEnd
+   || iLimit<CS_WAL_CHUNK_HDR_SIZE+nBody
+   || iOffset>iLimit-CS_WAL_CHUNK_HDR_SIZE-nBody ){
+    return SQLITE_CORRUPT;
+  }
+  rc = sqlite3OsRead(cs->file.pFile, aHeader, sizeof(aHeader), iOffset);
+  if( rc!=SQLITE_OK ) return rc;
+  if( aHeader[0]!=CS_WAL_TAG_CHUNK
+   || CS_READ_U32(aHeader+CS_WAL_CHUNK_LEN_OFF)!=(u32)nBody
+   || memcmp(aHeader+CS_WAL_CHUNK_HASH_OFF, pHash->data,
+             PROLLY_HASH_SIZE)!=0 ){
+    return SQLITE_CORRUPT;
+  }
+  aBody = sqlite3_malloc(nBody);
+  if( !aBody ) return SQLITE_NOMEM;
+  rc = sqlite3OsRead(cs->file.pFile, aBody, nBody,
+                     iOffset+CS_WAL_CHUNK_HDR_SIZE);
+  if( rc==SQLITE_OK ){
+    prollyHashCompute(aBody, nBody, &actual);
+    if( prollyHashCompare(&actual, pHash)!=0 ) rc = SQLITE_CORRUPT;
+  }
+  if( rc!=SQLITE_OK ){
+    sqlite3_free(aBody);
+    return rc;
+  }
+  *ppBody = aBody;
+  return SQLITE_OK;
+}
+
+static int csLazyPageShape(
+  const u8 *aBody,
+  int nBody,
+  u32 *pMagic,
+  int *pnCell,
+  int *pnCellSize
+){
+  u32 magic;
+  u32 nCell;
+  int nCellSize;
+  if( nBody<CS_INDEX_PAGE_HEADER_SIZE ) return SQLITE_CORRUPT;
+  magic = CS_READ_U32(aBody);
+  nCell = CS_READ_U32(aBody+4);
+  nCellSize = magic==CS_INDEX_PAGE_LEAF_MAGIC
+            ? CHUNK_INDEX_ENTRY_SIZE
+            : magic==CS_INDEX_PAGE_INTERNAL_MAGIC ? CS_INDEX_CHILD_SIZE : 0;
+  if( nCellSize==0 || nCell==0 || nCell>(u32)INT_MAX
+   || (i64)CS_INDEX_PAGE_HEADER_SIZE+(i64)nCell*nCellSize!=nBody ){
+    return SQLITE_CORRUPT;
+  }
+  *pMagic = magic;
+  *pnCell = (int)nCell;
+  *pnCellSize = nCellSize;
+  return SQLITE_OK;
+}
+
+static int csLazyPageMaxHash(
+  const u8 *aBody,
+  u32 magic,
+  int nCell,
+  ProllyHash *pMax
+){
+  const u8 *p;
+  if( magic==CS_INDEX_PAGE_LEAF_MAGIC ){
+    p = aBody+CS_INDEX_PAGE_HEADER_SIZE
+      +(nCell-1)*CHUNK_INDEX_ENTRY_SIZE;
+  }else{
+    p = aBody+CS_INDEX_PAGE_HEADER_SIZE+(nCell-1)*CS_INDEX_CHILD_SIZE;
+  }
+  memcpy(pMax->data, p, PROLLY_HASH_SIZE);
+  return SQLITE_OK;
+}
+
+int csIndexLookup(
+  ChunkStore *cs,
+  const ProllyHash *pHash,
+  ChunkIndexEntry *pEntry,
+  int *pFound
+){
+  ChunkIndexLazy *pLazy = &cs->index.lazy;
+  ProllyHash pageHash;
+  ProllyHash expectedMax;
+  i64 iOffset;
+  i64 iLimit;
+  int nBody;
+  int haveExpectedMax = 0;
+  int depth;
+  int idx;
+
+  *pFound = 0;
+  idx = csSearchIndex(cs->index.aIndex, cs->index.nIndex, pHash);
+  if( idx>=0 ){
+    *pEntry = cs->index.aIndex[idx];
+    *pFound = 1;
+    return SQLITE_OK;
+  }
+  if( !pLazy->active ) return SQLITE_OK;
+  iOffset = pLazy->iRootOffset;
+  nBody = pLazy->nRootSize;
+  pageHash = pLazy->rootHash;
+  iLimit = iOffset+CS_WAL_CHUNK_HDR_SIZE+nBody;
+
+  for(depth=0; depth<32; depth++){
+    u8 *aBody = 0;
+    u32 magic;
+    int nCell;
+    int nCellSize;
+    ProllyHash pageMax;
+    int rc = csReadLazyPage(cs, iOffset, nBody, &pageHash, iLimit, &aBody);
+    if( rc!=SQLITE_OK ) return rc;
+    rc = csLazyPageShape(aBody, nBody, &magic, &nCell, &nCellSize);
+    if( rc==SQLITE_OK ){
+      csLazyPageMaxHash(aBody, magic, nCell, &pageMax);
+      if( haveExpectedMax
+       && prollyHashCompare(&pageMax, &expectedMax)!=0 ){
+        rc = SQLITE_CORRUPT;
+      }
+    }
+    if( rc!=SQLITE_OK ){
+      sqlite3_free(aBody);
+      return rc;
+    }
+
+    if( magic==CS_INDEX_PAGE_LEAF_MAGIC ){
+      int lo = 0;
+      int hi = nCell-1;
+      int i;
+      ProllyHash previous;
+      for(i=0; i<nCell; i++){
+        const u8 *p = aBody+CS_INDEX_PAGE_HEADER_SIZE
+                    +i*CHUNK_INDEX_ENTRY_SIZE;
+        ChunkIndexEntry e;
+        rc = csDeserializeIndexEntry(p, &e);
+        if( rc!=SQLITE_OK
+         || e.offset<CHUNK_MANIFEST_SIZE
+         || e.offset>pLazy->iDataEnd-4
+         || (i64)e.size>pLazy->iDataEnd-e.offset-4
+         || (i>0 && prollyHashCompare(&previous, &e.hash)>=0) ){
+          sqlite3_free(aBody);
+          return SQLITE_CORRUPT;
+        }
+        previous = e.hash;
+      }
+      while( lo<=hi ){
+        int mid = lo+(hi-lo)/2;
+        const u8 *p = aBody+CS_INDEX_PAGE_HEADER_SIZE
+                    +mid*CHUNK_INDEX_ENTRY_SIZE;
+        ProllyHash h;
+        int cmp;
+        memcpy(h.data, p, PROLLY_HASH_SIZE);
+        cmp = prollyHashCompare(&h, pHash);
+        if( cmp<0 ) lo = mid+1;
+        else if( cmp>0 ) hi = mid-1;
+        else{
+          rc = csDeserializeIndexEntry(p, pEntry);
+          if( rc==SQLITE_OK
+           && (pEntry->offset<CHUNK_MANIFEST_SIZE
+               || pEntry->offset>pLazy->iDataEnd-4
+               || (i64)pEntry->size
+                    >pLazy->iDataEnd-pEntry->offset-4) ){
+            rc = SQLITE_CORRUPT;
+          }
+          sqlite3_free(aBody);
+          if( rc==SQLITE_OK ) *pFound = 1;
+          return rc;
+        }
+      }
+      sqlite3_free(aBody);
+      return SQLITE_OK;
+    }else{
+      int lo = 0;
+      int hi = nCell;
+      const u8 *p;
+      int i;
+      ProllyHash previous;
+      for(i=0; i<nCell; i++){
+        const u8 *q = aBody+CS_INDEX_PAGE_HEADER_SIZE
+                    +i*CS_INDEX_CHILD_SIZE;
+        ProllyHash h;
+        i64 childOffset;
+        u32 childSize;
+        memcpy(h.data, q, PROLLY_HASH_SIZE);
+        q += PROLLY_HASH_SIZE;
+        childOffset = CS_READ_I64(q);
+        q += 8;
+        childSize = CS_READ_U32(q);
+        if( (i>0 && prollyHashCompare(&previous, &h)>=0)
+         || childSize<CS_INDEX_PAGE_HEADER_SIZE
+         || childSize>CS_INDEX_PAGE_SIZE
+         || childOffset<pLazy->iDataEnd
+         || iOffset<CS_WAL_CHUNK_HDR_SIZE+(i64)childSize
+         || childOffset>iOffset-CS_WAL_CHUNK_HDR_SIZE-childSize ){
+          sqlite3_free(aBody);
+          return SQLITE_CORRUPT;
+        }
+        previous = h;
+      }
+      while( lo<hi ){
+        int mid = lo+(hi-lo)/2;
+        const u8 *q = aBody+CS_INDEX_PAGE_HEADER_SIZE
+                    +mid*CS_INDEX_CHILD_SIZE;
+        ProllyHash h;
+        memcpy(h.data, q, PROLLY_HASH_SIZE);
+        if( prollyHashCompare(&h, pHash)<0 ) lo = mid+1;
+        else hi = mid;
+      }
+      if( lo==nCell ){
+        sqlite3_free(aBody);
+        return SQLITE_OK;
+      }
+      p = aBody+CS_INDEX_PAGE_HEADER_SIZE+lo*CS_INDEX_CHILD_SIZE;
+      memcpy(expectedMax.data, p, PROLLY_HASH_SIZE);
+      p += PROLLY_HASH_SIZE;
+      iLimit = iOffset;
+      iOffset = CS_READ_I64(p);
+      p += 8;
+      nBody = (int)CS_READ_U32(p);
+      p += 4;
+      memcpy(pageHash.data, p, PROLLY_HASH_SIZE);
+      haveExpectedMax = 1;
+      sqlite3_free(aBody);
+    }
+  }
+  return SQLITE_CORRUPT;
+}
+
+static int csCollectLazyPage(
+  ChunkStore *cs,
+  i64 iOffset,
+  int nBody,
+  const ProllyHash *pHash,
+  i64 iLimit,
+  const ProllyHash *pExpectedMax,
+  ChunkIndexEntry *aOut,
+  int nOut,
+  int *pPos,
+  int depth
+){
+  u8 *aBody = 0;
+  u32 magic;
+  int nCell;
+  int nCellSize;
+  ProllyHash pageMax;
+  int i;
+  int rc;
+
+  if( depth>=32 ) return SQLITE_CORRUPT;
+  rc = csReadLazyPage(cs, iOffset, nBody, pHash, iLimit, &aBody);
+  if( rc!=SQLITE_OK ) return rc;
+  rc = csLazyPageShape(aBody, nBody, &magic, &nCell, &nCellSize);
+  if( rc!=SQLITE_OK ) goto collect_done;
+  csLazyPageMaxHash(aBody, magic, nCell, &pageMax);
+  if( pExpectedMax && prollyHashCompare(&pageMax, pExpectedMax)!=0 ){
+    rc = SQLITE_CORRUPT;
+    goto collect_done;
+  }
+
+  if( magic==CS_INDEX_PAGE_LEAF_MAGIC ){
+    for(i=0; i<nCell; i++){
+      ChunkIndexEntry e;
+      const u8 *p = aBody+CS_INDEX_PAGE_HEADER_SIZE
+                  +i*CHUNK_INDEX_ENTRY_SIZE;
+      rc = csDeserializeIndexEntry(p, &e);
+      if( rc!=SQLITE_OK ) goto collect_done;
+      if( e.offset<CHUNK_MANIFEST_SIZE || e.offset>cs->index.lazy.iDataEnd-4
+       || (i64)e.size>cs->index.lazy.iDataEnd-e.offset-4
+       || *pPos>=nOut
+       || (*pPos>0
+           && prollyHashCompare(&aOut[*pPos-1].hash, &e.hash)>=0) ){
+        rc = SQLITE_CORRUPT;
+        goto collect_done;
+      }
+      aOut[(*pPos)++] = e;
+    }
+  }else{
+    ProllyHash previousMax;
+    for(i=0; i<nCell; i++){
+      const u8 *p = aBody+CS_INDEX_PAGE_HEADER_SIZE+i*CS_INDEX_CHILD_SIZE;
+      ProllyHash childMax;
+      ProllyHash childHash;
+      i64 childOffset;
+      int childSize;
+      memcpy(childMax.data, p, PROLLY_HASH_SIZE);
+      p += PROLLY_HASH_SIZE;
+      childOffset = CS_READ_I64(p);
+      p += 8;
+      childSize = (int)CS_READ_U32(p);
+      p += 4;
+      memcpy(childHash.data, p, PROLLY_HASH_SIZE);
+      if( i>0 && prollyHashCompare(&previousMax, &childMax)>=0 ){
+        rc = SQLITE_CORRUPT;
+        goto collect_done;
+      }
+      previousMax = childMax;
+      rc = csCollectLazyPage(cs, childOffset, childSize, &childHash,
+                             iOffset, &childMax, aOut, nOut, pPos, depth+1);
+      if( rc!=SQLITE_OK ) goto collect_done;
+    }
+  }
+
+collect_done:
+  sqlite3_free(aBody);
+  return rc;
+}
+
+int csMaterializeIndex(ChunkStore *cs){
+  ChunkIndexLazy lazy = cs->index.lazy;
+  ChunkIndexEntry *aLazy = 0;
+  ChunkIndexEntry *aMerged = 0;
+  int nTotal;
+  int i = 0;
+  int j = 0;
+  int k = 0;
+  int rc;
+
+  if( !lazy.active ) return SQLITE_OK;
+  if( lazy.nEntries<=0
+   || lazy.nEntries>INT_MAX/(int)sizeof(ChunkIndexEntry)
+   || cs->index.nIndex>INT_MAX-lazy.nEntries ){
+    return SQLITE_CORRUPT;
+  }
+  aLazy = sqlite3_malloc64(
+      (sqlite3_uint64)lazy.nEntries*sizeof(ChunkIndexEntry));
+  if( !aLazy ) return SQLITE_NOMEM;
+  rc = csCollectLazyPage(cs, lazy.iRootOffset, lazy.nRootSize,
+                         &lazy.rootHash,
+                         lazy.iRootOffset+CS_WAL_CHUNK_HDR_SIZE+lazy.nRootSize,
+                         0, aLazy, lazy.nEntries, &i, 0);
+  if( rc!=SQLITE_OK || i!=lazy.nEntries ){
+    sqlite3_free(aLazy);
+    return rc==SQLITE_OK ? SQLITE_CORRUPT : rc;
+  }
+  nTotal = lazy.nEntries+cs->index.nIndex;
+  aMerged = sqlite3_malloc64((sqlite3_uint64)nTotal*sizeof(ChunkIndexEntry));
+  if( !aMerged ){
+    sqlite3_free(aLazy);
+    return SQLITE_NOMEM;
+  }
+  i = 0;
+  while( i<lazy.nEntries && j<cs->index.nIndex ){
+    int cmp = prollyHashCompare(&aLazy[i].hash, &cs->index.aIndex[j].hash);
+    if( cmp<0 ) aMerged[k++] = aLazy[i++];
+    else if( cmp>0 ) aMerged[k++] = cs->index.aIndex[j++];
+    else{ aMerged[k++] = cs->index.aIndex[j++]; i++; }
+  }
+  while( i<lazy.nEntries ) aMerged[k++] = aLazy[i++];
+  while( j<cs->index.nIndex ) aMerged[k++] = cs->index.aIndex[j++];
+  sqlite3_free(aLazy);
+  chunkIndexReplaceEntries(&cs->index, aMerged, k);
+  return SQLITE_OK;
+}
+
 static int csValidateIndexEntries(
   const ChunkIndexEntry *aIndex,
   int nIndex,
@@ -147,6 +516,7 @@ int csReadIndex(ChunkStore *cs){
   int i;
   i64 fileSize = 0;
 
+  memset(&cs->index.lazy, 0, sizeof(cs->index.lazy));
   if( cs->index.nIndexSize == 0 ){
     cs->index.nIndex = 0;
     return SQLITE_OK;

--- a/src/chunk_index.h
+++ b/src/chunk_index.h
@@ -7,6 +7,7 @@
 
 typedef struct ChunkIndexEntry ChunkIndexEntry;
 typedef struct ChunkIndex ChunkIndex;
+typedef struct ChunkIndexLazy ChunkIndexLazy;
 
 #if defined(__GNUC__) || defined(__clang__)
 #  define DOLTLITE_PACKED __attribute__((__packed__))
@@ -27,6 +28,15 @@ struct DOLTLITE_PACKED ChunkIndexEntry {
 #  pragma pack(pop)
 #endif
 
+struct ChunkIndexLazy {
+  i64 iRootOffset;
+  i64 iDataEnd;
+  int nRootSize;
+  int nEntries;
+  ProllyHash rootHash;
+  u8 active;
+};
+
 struct ChunkIndex {
   ChunkIndexEntry *aIndex;
   int nIndex;
@@ -35,6 +45,7 @@ struct ChunkIndex {
   int nChunks;
   i64 iIndexOffset;
   i64 nIndexSize;
+  ChunkIndexLazy lazy;
 };
 
 void chunkIndexGetEntries(const ChunkIndex *idx, int *pn, const ChunkIndexEntry **par);
@@ -45,6 +56,9 @@ void chunkIndexReplaceEntries(ChunkIndex *idx, ChunkIndexEntry *aNew, int nNew);
 
 struct ChunkStore;
 int csReadIndex(struct ChunkStore *cs);
+int csIndexLookup(struct ChunkStore *cs, const ProllyHash *pHash,
+                  ChunkIndexEntry *pEntry, int *pFound);
+int csMaterializeIndex(struct ChunkStore *cs);
 int csSearchIndex(const ChunkIndexEntry *aIdx, int nIdx, const ProllyHash *pHash);
 int csIndexEntryCmp(const void *a, const void *b);
 int csMergeIndex(struct ChunkStore *cs, ChunkIndexEntry **ppMerged, int *pnMerged);

--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -799,10 +799,12 @@ int chunkStoreHasMany(ChunkStore *cs, const ProllyHash *aHash, int nHash, u8 *aR
 int chunkStoreHas(ChunkStore *cs, const ProllyHash *hash, int *pHas){
   int idx = -1;
   int rc;
+  ChunkIndexEntry entry;
   *pHas = 0;
   if( cs->notADatabase ) return SQLITE_NOTADB;
-  if( csSearchIndex(cs->index.aIndex, cs->index.nIndex, hash) >= 0 ){
-    *pHas = 1;
+  rc = csIndexLookup(cs, hash, &entry, pHas);
+  if( rc!=SQLITE_OK ) return rc;
+  if( *pHas ){
     return SQLITE_OK;
   }
   rc = csSearchRecent(cs, hash, &idx);
@@ -861,16 +863,19 @@ int chunkStoreGet(
 
   {
     ChunkIndexEntry *e;
+    ChunkIndexEntry indexEntry;
+    int found = 0;
     rc = csSearchRecent(cs, hash, &idx);
     if( rc!=SQLITE_OK ) return rc;
     if( idx >= 0 ){
       e = &cs->staging.aRecent[idx];
     }else{
-      idx = csSearchIndex(cs->index.aIndex, cs->index.nIndex, hash);
-      if( idx < 0 ){
+      rc = csIndexLookup(cs, hash, &indexEntry, &found);
+      if( rc!=SQLITE_OK ) return rc;
+      if( !found ){
         return SQLITE_NOTFOUND;
       }
-      e = &cs->index.aIndex[idx];
+      e = &indexEntry;
     }
 
     if( cs->file.pFile == 0 ){
@@ -1305,6 +1310,8 @@ int chunkStoreCopyIntoEmpty(ChunkStore *pSrc, ChunkStore *pDest){
   int rc;
 
   assert( chunkStoreIsEmpty(pDest) );
+  rc = csMaterializeIndex(pSrc);
+  if( rc!=SQLITE_OK ) return rc;
   chunkIndexGetEntries(&pSrc->index, &nEntry, &aEntry);
   rc = csCopyEntries(pSrc, pDest, aEntry, nEntry);
   if( rc!=SQLITE_OK ) return rc;

--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -530,13 +530,12 @@ int chunkStoreOpen(
       return rc;
     }
 
-    rc = csReadIndex(cs);
-    if( rc != SQLITE_OK ){
-      chunkStoreClose(cs);
-      return rc;
+    {
+      int loadedCheckpoint = 0;
+      rc = csTryLoadWalCheckpoint(cs, &loadedCheckpoint);
+      if( rc==SQLITE_OK && !loadedCheckpoint ) rc = csReadIndex(cs);
+      if( rc==SQLITE_OK && !loadedCheckpoint ) rc = csReplayWal(cs);
     }
-
-    rc = csReplayWal(cs);
     if( rc != SQLITE_OK ){
       chunkStoreClose(cs);
       return rc;
@@ -664,7 +663,7 @@ static void csWriteCleanCloseMarker(ChunkStore *cs){
   if( cs->isMemory || cs->isBuffer || cs->readOnly || cs->corruptMidStream ){
     return;
   }
-  if( !cs->file.pFile || !cs->file.zFilename || cs->wal.cleanCloseMarker ){
+  if( !cs->file.pFile || !cs->file.zFilename ){
     return;
   }
   if( cs->wal.iWalOffset<=0 || cs->wal.nWalData<=0 ){
@@ -676,6 +675,7 @@ static void csWriteCleanCloseMarker(ChunkStore *cs){
   if( prollyHashCompare(&cs->refs.refsHash, &cs->refs.committedRefsHash)!=0 ){
     return;
   }
+  if( cs->wal.cleanCloseMarker && !csWalCheckpointDue(cs) ) return;
 
   lockHeld = cs->lockDepth>0;
   if( !lockHeld ){
@@ -697,6 +697,15 @@ static void csWriteCleanCloseMarker(ChunkStore *cs){
     if( sectorSize > 65536 ) sectorSize = 65536;
   }
 
+  if( csWalCheckpointDue(cs) ){
+    rc = csWriteWalCheckpoint(cs, sectorSize);
+    if( rc!=SQLITE_OK ){
+      sqlite3_log(SQLITE_NOTICE,
+        "doltlite: unable to checkpoint chunk WAL on close: %d", rc);
+    }
+    goto done;
+  }
+
   markerStart = cs->file.iFileSize;
   if( markerStart <= 0 ) goto done;
   markerEnd = markerStart + (i64)sizeof(rootRec);
@@ -708,6 +717,7 @@ static void csWriteCleanCloseMarker(ChunkStore *cs){
 
   rootRec[0] = CS_WAL_TAG_ROOT;
   csSerializeManifest(cs, rootRec + 1);
+  csStampWalCheckpoint(cs, rootRec + 1);
   CS_WRITE_I64(rootRec + 1 + CS_MANIFEST_DURABLE_TO_OFF, markerStart);
   CS_WRITE_I64(rootRec + 1 + CS_MANIFEST_NEXT_OFF_OFF, markerNext);
   CS_WRITE_I64(rootRec + 1 + CS_MANIFEST_BATCH_START_OFF, markerStart);

--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -532,9 +532,14 @@ int chunkStoreOpen(
 
     {
       int loadedCheckpoint = 0;
-      rc = csTryLoadWalCheckpoint(cs, &loadedCheckpoint);
+      i64 iSkipStart = 0;
+      i64 iSkipEnd = 0;
+      rc = csTryLoadWalCheckpoint(cs, &loadedCheckpoint,
+                                  &iSkipStart, &iSkipEnd);
       if( rc==SQLITE_OK && !loadedCheckpoint ) rc = csReadIndex(cs);
-      if( rc==SQLITE_OK && !loadedCheckpoint ) rc = csReplayWal(cs);
+      if( rc==SQLITE_OK && !loadedCheckpoint ){
+        rc = csReplayWalSkipping(cs, iSkipStart, iSkipEnd);
+      }
     }
     if( rc != SQLITE_OK ){
       chunkStoreClose(cs);
@@ -698,12 +703,13 @@ static void csWriteCleanCloseMarker(ChunkStore *cs){
   }
 
   if( csWalCheckpointDue(cs) ){
-    rc = csWriteWalCheckpoint(cs, sectorSize);
+    int wroteCheckpoint = 0;
+    rc = csWriteWalCheckpoint(cs, sectorSize, &wroteCheckpoint);
     if( rc!=SQLITE_OK ){
       sqlite3_log(SQLITE_NOTICE,
         "doltlite: unable to checkpoint chunk WAL on close: %d", rc);
     }
-    goto done;
+    if( wroteCheckpoint ) goto done;
   }
 
   markerStart = cs->file.iFileSize;

--- a/src/chunk_store.h
+++ b/src/chunk_store.h
@@ -54,8 +54,8 @@
 
 #define CS_MANIFEST_MAGIC_OFF        0
 #define CS_MANIFEST_VERSION_OFF      4
-/* A sealed root may point at an ordinary WAL chunk containing a full index.
-** Readers that do not understand the stamp safely replay that chunk. */
+/* A sealed root may point at an index checkpoint made of ordinary WAL chunks.
+** Readers that do not understand the stamp safely replay those chunks. */
 #define CS_MANIFEST_CHECKPOINT_MAGIC_OFF 8
 #define CS_MANIFEST_CHECKPOINT_OFFSET_OFF 12
 #define CS_MANIFEST_CHECKPOINT_SIZE_OFF 20
@@ -83,9 +83,12 @@
 #define CS_MANIFEST_NEXT_OFF_OFF     52
 #define CS_MANIFEST_BATCH_START_OFF  60
 #define CS_MANIFEST_CHECKPOINT_REPLAY_OFF 68
+#define CS_MANIFEST_CHECKPOINT_DATA_END_OFF 76
 #define CS_MANIFEST_WAL_OFFSET_OFF   84
 #define CS_MANIFEST_REFS_HASH_OFF    104
 #define CS_MANIFEST_SELF_HASH_OFF    124
+#define CS_MANIFEST_CHECKPOINT_HASH_OFF 144
+#define CS_MANIFEST_CHECKPOINT_COUNT_OFF 164
 
 #define CS_MANIFEST_HASH_LEGACY 0
 #define CS_MANIFEST_HASH_OK     1
@@ -93,10 +96,17 @@
 
 #define CS_WAL_TAG_CHUNK  0x01
 #define CS_WAL_TAG_ROOT   0x02
-#define CS_WAL_CHECKPOINT_MAGIC 0x31504b43
+#define CS_WAL_CHECKPOINT_MAGIC_V1 0x31504b43
+#define CS_WAL_CHECKPOINT_MAGIC_V2 0x32504b43
 #define CS_WAL_CHUNK_HASH_OFF  1
 #define CS_WAL_CHUNK_LEN_OFF   (1 + PROLLY_HASH_SIZE)
 #define CS_WAL_CHUNK_HDR_SIZE  (1 + PROLLY_HASH_SIZE + 4)
+
+#define CS_INDEX_PAGE_LEAF_MAGIC 0x314c5049
+#define CS_INDEX_PAGE_INTERNAL_MAGIC 0x31495049
+#define CS_INDEX_PAGE_SIZE 4096
+#define CS_INDEX_PAGE_HEADER_SIZE 8
+#define CS_INDEX_CHILD_SIZE (PROLLY_HASH_SIZE + 8 + 4 + PROLLY_HASH_SIZE)
 
 #define WS_FORMAT_VERSION_V2 2
 #define WS_FORMAT_VERSION_V3 3

--- a/src/chunk_store.h
+++ b/src/chunk_store.h
@@ -54,6 +54,11 @@
 
 #define CS_MANIFEST_MAGIC_OFF        0
 #define CS_MANIFEST_VERSION_OFF      4
+/* A sealed root may point at an ordinary WAL chunk containing a full index.
+** Readers that do not understand the stamp safely replay that chunk. */
+#define CS_MANIFEST_CHECKPOINT_MAGIC_OFF 8
+#define CS_MANIFEST_CHECKPOINT_OFFSET_OFF 12
+#define CS_MANIFEST_CHECKPOINT_SIZE_OFF 20
 #define CS_MANIFEST_CHUNK_COUNT_OFF  28
 #define CS_MANIFEST_INDEX_OFFSET_OFF 32
 #define CS_MANIFEST_INDEX_SIZE_OFF   40
@@ -77,6 +82,7 @@
 #define CS_MANIFEST_DURABLE_TO_OFF   44
 #define CS_MANIFEST_NEXT_OFF_OFF     52
 #define CS_MANIFEST_BATCH_START_OFF  60
+#define CS_MANIFEST_CHECKPOINT_REPLAY_OFF 68
 #define CS_MANIFEST_WAL_OFFSET_OFF   84
 #define CS_MANIFEST_REFS_HASH_OFF    104
 #define CS_MANIFEST_SELF_HASH_OFF    124
@@ -87,6 +93,7 @@
 
 #define CS_WAL_TAG_CHUNK  0x01
 #define CS_WAL_TAG_ROOT   0x02
+#define CS_WAL_CHECKPOINT_MAGIC 0x31504b43
 #define CS_WAL_CHUNK_HASH_OFF  1
 #define CS_WAL_CHUNK_LEN_OFF   (1 + PROLLY_HASH_SIZE)
 #define CS_WAL_CHUNK_HDR_SIZE  (1 + PROLLY_HASH_SIZE + 4)

--- a/src/chunk_store_commit.c
+++ b/src/chunk_store_commit.c
@@ -491,6 +491,7 @@ static int csCommitToFile(ChunkStore *cs){
     }
     rootRec[0] = CS_WAL_TAG_ROOT;
     csSerializeManifest(cs, rootRec + 1);
+    csStampWalCheckpoint(cs, rootRec + 1);
     CS_WRITE_I64(rootRec + 1 + CS_MANIFEST_DURABLE_TO_OFF, durableTo);
     CS_WRITE_I64(rootRec + 1 + CS_MANIFEST_NEXT_OFF_OFF, nextOff);
     CS_WRITE_I64(rootRec + 1 + CS_MANIFEST_BATCH_START_OFF, batchStart);

--- a/src/chunk_store_commit.c
+++ b/src/chunk_store_commit.c
@@ -268,6 +268,11 @@ static int csCommitPlanPendingIndex(
     return csGrowRecent(cs, cs->staging.nPending);
   }
 
+  {
+    int rc = csMaterializeIndex(cs);
+    if( rc!=SQLITE_OK ) return rc;
+  }
+
   if( cs->staging.nRecent > 0 ){
     *paMergePending = (ChunkIndexEntry*)sqlite3_malloc(
       (cs->staging.nRecent + cs->staging.nPending) * (int)sizeof(ChunkIndexEntry)

--- a/src/chunk_store_commit.c
+++ b/src/chunk_store_commit.c
@@ -523,28 +523,39 @@ static int csCommitToFile(ChunkStore *cs){
   cs->wal.nWalData = contentEnd - cs->wal.iWalOffset;
   cs->wal.cleanCloseMarker = 0;
 
-commit_done:
-  csFileUnlock(lockFd, &lockName);
-
-  if( rc != SQLITE_OK ){
-    if( cs->file.pFile && writeOff > origFileSize ){
-      (void)csRollbackFailedAppend(cs, origFileSize);
-    }
-    (void)csRestoreCommittedRefsState(cs);
-    if( aCommittedPending!=aSmallCommittedPending ){
-      sqlite3_free(aCommittedPending);
-    }
-    sqlite3_free(aMergePending);
-    sqlite3_free(aMerged);
-    return rc;
-  }
-
   csCommitPublishStaging(cs, useRecent, aCommittedPending, aMerged, nMerged);
   if( aCommittedPending!=aSmallCommittedPending ){
     sqlite3_free(aCommittedPending);
   }
   sqlite3_free(aMergePending);
+  if( csWalCheckpointDue(cs) ){
+    int wroteCheckpoint = 0;
+    int checkpointRc;
+    sqlite3BeginBenignMalloc();
+    checkpointRc = csWriteWalCheckpoint(cs, sectorSize, &wroteCheckpoint);
+    sqlite3EndBenignMalloc();
+    if( checkpointRc!=SQLITE_OK ){
+      sqlite3_log(SQLITE_NOTICE,
+        "doltlite: unable to checkpoint chunk WAL after commit: %d",
+        checkpointRc);
+    }
+  }
+  csFileUnlock(lockFd, &lockName);
   return SQLITE_OK;
+
+commit_done:
+  csFileUnlock(lockFd, &lockName);
+
+  if( cs->file.pFile && writeOff > origFileSize ){
+    (void)csRollbackFailedAppend(cs, origFileSize);
+  }
+  (void)csRestoreCommittedRefsState(cs);
+  if( aCommittedPending!=aSmallCommittedPending ){
+    sqlite3_free(aCommittedPending);
+  }
+  sqlite3_free(aMergePending);
+  sqlite3_free(aMerged);
+  return rc;
 }
 
 int chunkStoreCommit(ChunkStore *cs){

--- a/src/chunk_wal.c
+++ b/src/chunk_wal.c
@@ -132,13 +132,11 @@ void csStampWalCheckpoint(const ChunkStore *cs, u8 *aManifest){
 
 static i64 csWalCheckpointThreshold(void){
   i64 n = 64*1024*1024;
-#if defined(SQLITE_TEST) || defined(DOLTLITE_MECH_REPRO)
   const char *z = getenv("DOLTLITE_WAL_CHECKPOINT_THRESHOLD");
   if( z && z[0] ){
     i64 v = (i64)strtoll(z, 0, 10);
     if( v>0 ) n = v;
   }
-#endif
   return n;
 }
 

--- a/src/chunk_wal.c
+++ b/src/chunk_wal.c
@@ -25,12 +25,245 @@ void walStateSetOffset(WalState *w, i64 iOffset){
   assert( w!=0 );
   assert( iOffset>=0 );
   w->iWalOffset = iOffset;
+  w->iCheckpointOffset = 0;
+  w->nCheckpointIndex = 0;
+  w->iCheckpointReplay = 0;
 }
 
 void walStateSetDataSize(WalState *w, i64 nData){
   assert( w!=0 );
   assert( nData>=0 );
   w->nWalData = nData;
+}
+
+static int csReadCheckpointStamp(
+  const u8 *aManifest,
+  i64 iRootOffset,
+  WalState *pWal
+){
+  i64 iOffset;
+  i64 nIndex;
+  i64 iReplay;
+  i64 iCheckpointRoot;
+
+  if( CS_READ_U32(aManifest + CS_MANIFEST_CHECKPOINT_MAGIC_OFF)
+      != CS_WAL_CHECKPOINT_MAGIC ){
+    return 0;
+  }
+  iOffset = CS_READ_I64(aManifest + CS_MANIFEST_CHECKPOINT_OFFSET_OFF);
+  nIndex = (i64)CS_READ_U32(
+      aManifest + CS_MANIFEST_CHECKPOINT_SIZE_OFF);
+  iReplay = CS_READ_I64(
+      aManifest + CS_MANIFEST_CHECKPOINT_REPLAY_OFF);
+  if( iOffset<pWal->iWalOffset || nIndex<=0
+   || nIndex%CHUNK_INDEX_ENTRY_SIZE!=0
+   || nIndex>INT_MAX
+   || iOffset>LARGEST_INT64-CS_WAL_CHUNK_HDR_SIZE-nIndex ){
+    return 0;
+  }
+  iCheckpointRoot = iOffset + CS_WAL_CHUNK_HDR_SIZE + nIndex;
+  if( iCheckpointRoot>iRootOffset
+   || iCheckpointRoot>LARGEST_INT64-(1+CHUNK_MANIFEST_SIZE)
+   || iReplay<iCheckpointRoot+1+CHUNK_MANIFEST_SIZE
+   || iReplay-(iCheckpointRoot+1+CHUNK_MANIFEST_SIZE)>=65536 ){
+    return 0;
+  }
+  pWal->iCheckpointOffset = iOffset;
+  pWal->nCheckpointIndex = nIndex;
+  pWal->iCheckpointReplay = iReplay;
+  return 1;
+}
+
+void csStampWalCheckpoint(const ChunkStore *cs, u8 *aManifest){
+  if( cs->wal.iCheckpointOffset<=0 || cs->wal.nCheckpointIndex<=0
+   || cs->wal.iCheckpointReplay<=0 ){
+    return;
+  }
+  assert( cs->wal.nCheckpointIndex<=0xffffffffu );
+  CS_WRITE_U32(aManifest + CS_MANIFEST_CHECKPOINT_MAGIC_OFF,
+               CS_WAL_CHECKPOINT_MAGIC);
+  CS_WRITE_I64(aManifest + CS_MANIFEST_CHECKPOINT_OFFSET_OFF,
+               cs->wal.iCheckpointOffset);
+  CS_WRITE_U32(aManifest + CS_MANIFEST_CHECKPOINT_SIZE_OFF,
+               (u32)cs->wal.nCheckpointIndex);
+  CS_WRITE_I64(aManifest + CS_MANIFEST_CHECKPOINT_REPLAY_OFF,
+               cs->wal.iCheckpointReplay);
+}
+
+static i64 csWalCheckpointThreshold(void){
+  i64 n = 64*1024*1024;
+#if defined(SQLITE_TEST) || defined(DOLTLITE_MECH_REPRO)
+  const char *z = getenv("DOLTLITE_WAL_CHECKPOINT_THRESHOLD");
+  if( z && z[0] ){
+    i64 v = (i64)strtoll(z, 0, 10);
+    if( v>0 ) n = v;
+  }
+#endif
+  return n;
+}
+
+int csWalCheckpointDue(const ChunkStore *cs){
+  i64 iBase = cs->wal.iCheckpointReplay>0
+            ? cs->wal.iCheckpointReplay : cs->wal.iWalOffset;
+  /* Ref-less raw stores retain eager verification of every WAL chunk. */
+  return !prollyHashIsEmpty(&cs->refs.refsHash)
+      && iBase>0 && cs->file.iFileSize>=iBase
+      && cs->file.iFileSize-iBase>=csWalCheckpointThreshold();
+}
+
+static void csSerializeCheckpointEntry(u8 *aBuf, const ChunkIndexEntry *pEntry){
+  memcpy(aBuf, pEntry->hash.data, PROLLY_HASH_SIZE);
+  CS_WRITE_I64(aBuf + PROLLY_HASH_SIZE, pEntry->offset);
+  CS_WRITE_U32(aBuf + PROLLY_HASH_SIZE + 8, (u32)pEntry->size);
+}
+
+static int csDeserializeCheckpointEntry(
+  const u8 *aBuf,
+  ChunkIndexEntry *pEntry
+){
+  u32 n = CS_READ_U32(aBuf + PROLLY_HASH_SIZE + 8);
+  if( n>0x7fffffffu ) return SQLITE_CORRUPT;
+  memcpy(pEntry->hash.data, aBuf, PROLLY_HASH_SIZE);
+  pEntry->offset = CS_READ_I64(aBuf + PROLLY_HASH_SIZE);
+  pEntry->size = (int)n;
+  return SQLITE_OK;
+}
+
+static int csBuildCheckpointIndex(
+  ChunkStore *cs,
+  ChunkIndexEntry **ppIndex,
+  int *pnIndex
+){
+  i64 nAlloc = (i64)cs->index.nIndex + cs->staging.nRecent;
+  ChunkIndexEntry *aIndex;
+  int i;
+  int nOut = 0;
+
+  *ppIndex = 0;
+  *pnIndex = 0;
+  if( nAlloc<=0 || nAlloc>INT_MAX/(int)sizeof(ChunkIndexEntry) ){
+    return nAlloc<=0 ? SQLITE_OK : SQLITE_TOOBIG;
+  }
+  aIndex = sqlite3_malloc64(
+      (sqlite3_uint64)nAlloc * sizeof(ChunkIndexEntry));
+  if( !aIndex ) return SQLITE_NOMEM;
+  if( cs->index.nIndex>0 ){
+    memcpy(aIndex, cs->index.aIndex,
+           cs->index.nIndex * sizeof(ChunkIndexEntry));
+  }
+  if( cs->staging.nRecent>0 ){
+    memcpy(aIndex + cs->index.nIndex, cs->staging.aRecent,
+           cs->staging.nRecent * sizeof(ChunkIndexEntry));
+  }
+  qsort(aIndex, (size_t)nAlloc, sizeof(ChunkIndexEntry), csIndexEntryCmp);
+  for(i=0; i<(int)nAlloc; i++){
+    if( nOut==0
+     || prollyHashCompare(&aIndex[nOut-1].hash, &aIndex[i].hash)!=0 ){
+      aIndex[nOut++] = aIndex[i];
+    }
+  }
+  *ppIndex = aIndex;
+  *pnIndex = nOut;
+  return SQLITE_OK;
+}
+
+int csWriteWalCheckpoint(ChunkStore *cs, int sectorSize){
+  ChunkIndexEntry *aIndex = 0;
+  int nIndex = 0;
+  i64 nIndexBytes;
+  i64 iCheckpoint;
+  i64 iRoot;
+  i64 iRootEnd;
+  i64 iNext;
+  u8 aEntry[CHUNK_INDEX_ENTRY_SIZE];
+  u8 aBuf[65536];
+  u8 aHeader[CS_WAL_CHUNK_HDR_SIZE];
+  u8 aRoot[1 + CHUNK_MANIFEST_SIZE];
+  ProllyHash snapshotHash;
+  blake3_hasher hasher;
+  int i;
+  int rc;
+
+  rc = csBuildCheckpointIndex(cs, &aIndex, &nIndex);
+  if( rc!=SQLITE_OK || nIndex==0 ) goto checkpoint_done;
+  nIndexBytes = (i64)nIndex * CHUNK_INDEX_ENTRY_SIZE;
+  if( nIndexBytes>INT_MAX
+   || cs->file.iFileSize>LARGEST_INT64-CS_WAL_CHUNK_HDR_SIZE-nIndexBytes ){
+    rc = SQLITE_TOOBIG;
+    goto checkpoint_done;
+  }
+
+  blake3_hasher_init(&hasher);
+  for(i=0; i<nIndex; i++){
+    csSerializeCheckpointEntry(aEntry, &aIndex[i]);
+    blake3_hasher_update(&hasher, aEntry, sizeof(aEntry));
+  }
+  blake3_hasher_finalize(&hasher, snapshotHash.data, PROLLY_HASH_SIZE);
+
+  iCheckpoint = cs->file.iFileSize;
+  csFillChunkHdr(aHeader, &snapshotHash, (u32)nIndexBytes);
+  rc = sqlite3OsWrite(cs->file.pFile, aHeader, sizeof(aHeader), iCheckpoint);
+  if( rc!=SQLITE_OK ) goto checkpoint_rollback;
+  for(i=0; i<nIndex; ){
+    int nEntry = nIndex-i;
+    int j;
+    if( nEntry>(int)(sizeof(aBuf)/CHUNK_INDEX_ENTRY_SIZE) ){
+      nEntry = (int)(sizeof(aBuf)/CHUNK_INDEX_ENTRY_SIZE);
+    }
+    for(j=0; j<nEntry; j++){
+      csSerializeCheckpointEntry(
+          aBuf + j*CHUNK_INDEX_ENTRY_SIZE, &aIndex[i+j]);
+    }
+    rc = sqlite3OsWrite(cs->file.pFile, aBuf,
+        nEntry*CHUNK_INDEX_ENTRY_SIZE,
+        iCheckpoint + CS_WAL_CHUNK_HDR_SIZE
+        + (i64)i * CHUNK_INDEX_ENTRY_SIZE);
+    if( rc!=SQLITE_OK ) goto checkpoint_rollback;
+    i += nEntry;
+  }
+  rc = csSyncFile(cs);
+  if( rc!=SQLITE_OK ) goto checkpoint_rollback;
+
+  iRoot = iCheckpoint + CS_WAL_CHUNK_HDR_SIZE + nIndexBytes;
+  iRootEnd = iRoot + (i64)sizeof(aRoot);
+  iNext = iRootEnd;
+  if( sectorSize>1 ){
+    iNext += sectorSize - 1;
+    iNext -= iNext % sectorSize;
+  }
+  aRoot[0] = CS_WAL_TAG_ROOT;
+  csSerializeManifest(cs, aRoot + 1);
+  CS_WRITE_I64(aRoot + 1 + CS_MANIFEST_DURABLE_TO_OFF, iRoot);
+  CS_WRITE_I64(aRoot + 1 + CS_MANIFEST_NEXT_OFF_OFF, iNext);
+  CS_WRITE_I64(aRoot + 1 + CS_MANIFEST_BATCH_START_OFF, iRoot);
+  CS_WRITE_U32(aRoot + 1 + CS_MANIFEST_CHECKPOINT_MAGIC_OFF,
+               CS_WAL_CHECKPOINT_MAGIC);
+  CS_WRITE_I64(aRoot + 1 + CS_MANIFEST_CHECKPOINT_OFFSET_OFF, iCheckpoint);
+  CS_WRITE_U32(aRoot + 1 + CS_MANIFEST_CHECKPOINT_SIZE_OFF,
+               (u32)nIndexBytes);
+  CS_WRITE_I64(aRoot + 1 + CS_MANIFEST_CHECKPOINT_REPLAY_OFF, iNext);
+  csManifestSeal(aRoot + 1, iRoot);
+  rc = sqlite3OsWrite(cs->file.pFile, aRoot, sizeof(aRoot), iRoot);
+  if( rc!=SQLITE_OK ) goto checkpoint_rollback;
+  rc = csSyncFile(cs);
+  if( rc!=SQLITE_OK ) goto checkpoint_rollback;
+
+  cs->wal.iCheckpointOffset = iCheckpoint;
+  cs->wal.nCheckpointIndex = nIndexBytes;
+  cs->wal.iCheckpointReplay = iNext;
+  cs->file.iFileSize = iNext;
+  cs->wal.nWalData = iRootEnd - cs->wal.iWalOffset;
+  cs->wal.cleanCloseMarker = 1;
+  rc = SQLITE_OK;
+  goto checkpoint_done;
+
+checkpoint_rollback:
+  (void)sqlite3OsTruncate(cs->file.pFile, cs->file.iFileSize);
+  (void)csSyncFile(cs);
+
+checkpoint_done:
+  sqlite3_free(aIndex);
+  return rc;
 }
 
 static void csCaptureReplayState(ChunkStore *cs, ChunkStoreReplayState *pSaved){
@@ -108,6 +341,9 @@ void csAdoptOpenedStoreState(ChunkStore *pDst, ChunkStore *pSrc){
   pDst->index.aIndexMmapBase = pSrc->index.aIndexMmapBase;
   pDst->index.aIndexMmapSize = pSrc->index.aIndexMmapSize;
   pDst->wal.nWalData = pSrc->wal.nWalData;
+  pDst->wal.iCheckpointOffset = pSrc->wal.iCheckpointOffset;
+  pDst->wal.nCheckpointIndex = pSrc->wal.nCheckpointIndex;
+  pDst->wal.iCheckpointReplay = pSrc->wal.iCheckpointReplay;
   pDst->wal.recoveredMidStream = pSrc->wal.recoveredMidStream;
   pDst->wal.cleanCloseMarker = pSrc->wal.cleanCloseMarker;
   pDst->corruptMidStream = pSrc->corruptMidStream;
@@ -120,6 +356,9 @@ void csAdoptOpenedStoreState(ChunkStore *pDst, ChunkStore *pSrc){
   pSrc->index.aIndexMmapBase = 0;
   pSrc->index.aIndexMmapSize = 0;
   pSrc->wal.nWalData = 0;
+  pSrc->wal.iCheckpointOffset = 0;
+  pSrc->wal.nCheckpointIndex = 0;
+  pSrc->wal.iCheckpointReplay = 0;
   pSrc->wal.cleanCloseMarker = 0;
   REFS_OWNED_CLEAR(pSrc->refs);
 }
@@ -219,11 +458,11 @@ static int csWalResolveDamage(
   return SQLITE_OK;
 }
 
-int csReplayWal(ChunkStore *cs){
+static int csReplayWalFrom(ChunkStore *cs, i64 iStart){
   i64 walSize;
   ChunkStoreReplayState saved;
   i64 pos;
-  i64 lastBoundary = 0;
+  i64 lastBoundary;
   i64 resumePos = 0;
   int damageAction = 0;
   int sawMidStream = 0;
@@ -241,6 +480,7 @@ int csReplayWal(ChunkStore *cs){
   memset(&tmpRefs, 0, sizeof(tmpRefs));
 
   if( cs->wal.iWalOffset <= 0 || !cs->file.pFile ) return SQLITE_OK;
+  if( iStart<cs->wal.iWalOffset ) return SQLITE_CORRUPT;
 
   {
     i64 fileSize = 0;
@@ -264,9 +504,10 @@ int csReplayWal(ChunkStore *cs){
   csCaptureReplayState(cs, &saved);
 
   cs->wal.nWalData = walSize;
-  cs->wal.cleanCloseMarker = 0;
+  lastBoundary = iStart - cs->wal.iWalOffset;
+  cs->wal.cleanCloseMarker = lastBoundary>=walSize;
 
-  pos = 0;
+  pos = lastBoundary;
   while( pos < walSize ){
     u8 aPrefix[CS_WAL_CHUNK_HDR_SIZE];
     u8 tag = 0;
@@ -427,6 +668,7 @@ int csReplayWal(ChunkStore *cs){
         if( nextOff > cs->wal.iWalOffset + pos ){
           pos = nextOff - cs->wal.iWalOffset;
         }
+        (void)csReadCheckpointStamp(m, recAbs, &cs->wal);
       }else{
         cs->wal.cleanCloseMarker = 0;
       }
@@ -532,6 +774,167 @@ replay_error:
   if( haveTmpRefs ) csFreeRefsState(&tmpRefs);
   csRollbackReplayState(cs, &saved, nPendingBefore);
   return rc;
+}
+
+int csReplayWal(ChunkStore *cs){
+  cs->wal.iCheckpointOffset = 0;
+  cs->wal.nCheckpointIndex = 0;
+  cs->wal.iCheckpointReplay = 0;
+  return csReplayWalFrom(cs, cs->wal.iWalOffset);
+}
+
+static int csCheckpointIndexInsert(
+  ChunkIndexEntry *aIndex,
+  int nIndex,
+  const ChunkIndexEntry *pEntry
+){
+  int lo = 0;
+  int hi = nIndex;
+  while( lo<hi ){
+    int mid = lo + (hi-lo)/2;
+    int cmp = prollyHashCompare(&aIndex[mid].hash, &pEntry->hash);
+    if( cmp<0 ) lo = mid + 1;
+    else hi = mid;
+  }
+  if( lo<nIndex
+   && prollyHashCompare(&aIndex[lo].hash, &pEntry->hash)==0 ){
+    return nIndex;
+  }
+  memmove(aIndex + lo + 1, aIndex + lo,
+          (nIndex-lo) * sizeof(ChunkIndexEntry));
+  aIndex[lo] = *pEntry;
+  return nIndex + 1;
+}
+
+int csTryLoadWalCheckpoint(ChunkStore *cs, int *pLoaded){
+  u8 aTail[1 + CHUNK_MANIFEST_SIZE];
+  u8 aRoot[1 + CHUNK_MANIFEST_SIZE];
+  u8 aHeader[CS_WAL_CHUNK_HDR_SIZE];
+  u8 aBuf[65536];
+  i64 nFile = 0;
+  i64 iTail;
+  i64 iRoot;
+  i64 iRead;
+  i64 nRemain;
+  WalState stamp;
+  WalState rootStamp;
+  ChunkIndexEntry *aIndex = 0;
+  ChunkIndexEntry snapshotEntry;
+  ProllyHash bodyHash;
+  blake3_hasher hasher;
+  int nIndex;
+  int iEntry = 0;
+  int rc;
+
+  *pLoaded = 0;
+  if( cs->wal.iWalOffset<=0 || !cs->file.pFile ) return SQLITE_OK;
+  rc = sqlite3OsFileSize(cs->file.pFile, &nFile);
+  if( rc!=SQLITE_OK ) return rc;
+  if( nFile<(i64)sizeof(aTail) ) return SQLITE_OK;
+  iTail = nFile - (i64)sizeof(aTail);
+  rc = sqlite3OsRead(cs->file.pFile, aTail, sizeof(aTail), iTail);
+  if( rc!=SQLITE_OK ) return rc;
+  if( aTail[0]!=CS_WAL_TAG_ROOT
+   || csManifestHashState(aTail+1, iTail)!=CS_MANIFEST_HASH_OK
+   || csValidateWalRootManifest(cs, aTail+1, iTail)!=SQLITE_OK ){
+    return SQLITE_OK;
+  }
+  stamp = cs->wal;
+  if( !csReadCheckpointStamp(aTail+1, iTail, &stamp) ) return SQLITE_OK;
+
+  iRoot = stamp.iCheckpointOffset + CS_WAL_CHUNK_HDR_SIZE
+        + stamp.nCheckpointIndex;
+  if( iRoot<0 || iRoot+(i64)sizeof(aRoot)>nFile ) return SQLITE_OK;
+  rc = sqlite3OsRead(cs->file.pFile, aRoot, sizeof(aRoot), iRoot);
+  if( rc!=SQLITE_OK ) return rc;
+  rootStamp = cs->wal;
+  if( aRoot[0]!=CS_WAL_TAG_ROOT
+   || csManifestHashState(aRoot+1, iRoot)!=CS_MANIFEST_HASH_OK
+   || csValidateWalRootManifest(cs, aRoot+1, iRoot)!=SQLITE_OK
+   || !csReadCheckpointStamp(aRoot+1, iRoot, &rootStamp)
+   || rootStamp.iCheckpointOffset!=stamp.iCheckpointOffset
+   || rootStamp.nCheckpointIndex!=stamp.nCheckpointIndex
+   || rootStamp.iCheckpointReplay!=stamp.iCheckpointReplay
+   || CS_READ_I64(aRoot+1+CS_MANIFEST_DURABLE_TO_OFF)<iRoot
+   || CS_READ_I64(aRoot+1+CS_MANIFEST_BATCH_START_OFF)!=iRoot
+   || CS_READ_I64(aRoot+1+CS_MANIFEST_NEXT_OFF_OFF)
+        !=stamp.iCheckpointReplay ){
+    return SQLITE_OK;
+  }
+
+  rc = sqlite3OsRead(cs->file.pFile, aHeader, sizeof(aHeader),
+                     stamp.iCheckpointOffset);
+  if( rc!=SQLITE_OK ) return rc;
+  if( aHeader[0]!=CS_WAL_TAG_CHUNK
+   || (i64)CS_READ_U32(aHeader+CS_WAL_CHUNK_LEN_OFF)
+        !=stamp.nCheckpointIndex ){
+    return SQLITE_OK;
+  }
+  nIndex = (int)(stamp.nCheckpointIndex / CHUNK_INDEX_ENTRY_SIZE);
+  if( nIndex>=(INT_MAX/(int)sizeof(ChunkIndexEntry)) ) return SQLITE_TOOBIG;
+  aIndex = sqlite3_malloc64(
+      (sqlite3_uint64)(nIndex+1) * sizeof(ChunkIndexEntry));
+  if( !aIndex ) return SQLITE_NOMEM;
+
+  blake3_hasher_init(&hasher);
+  iRead = stamp.iCheckpointOffset + CS_WAL_CHUNK_HDR_SIZE;
+  nRemain = stamp.nCheckpointIndex;
+  while( nRemain>0 ){
+    int n = nRemain>(i64)sizeof(aBuf) ? (int)sizeof(aBuf) : (int)nRemain;
+    int i;
+    rc = sqlite3OsRead(cs->file.pFile, aBuf, n, iRead);
+    if( rc!=SQLITE_OK ) goto checkpoint_invalid;
+    blake3_hasher_update(&hasher, aBuf, (size_t)n);
+    for(i=0; i<n; i+=CHUNK_INDEX_ENTRY_SIZE){
+      rc = csDeserializeCheckpointEntry(aBuf+i, &aIndex[iEntry]);
+      if( rc!=SQLITE_OK ) goto checkpoint_invalid;
+      if( aIndex[iEntry].offset<CHUNK_MANIFEST_SIZE
+       || aIndex[iEntry].offset>stamp.iCheckpointOffset-4
+       || (i64)aIndex[iEntry].size
+            > stamp.iCheckpointOffset-aIndex[iEntry].offset-4
+       || (iEntry>0
+           && prollyHashCompare(&aIndex[iEntry-1].hash,
+                                &aIndex[iEntry].hash)>=0) ){
+        goto checkpoint_invalid;
+      }
+      iEntry++;
+    }
+    iRead += n;
+    nRemain -= n;
+  }
+  blake3_hasher_finalize(&hasher, bodyHash.data, PROLLY_HASH_SIZE);
+  if( memcmp(bodyHash.data, aHeader+CS_WAL_CHUNK_HASH_OFF,
+             PROLLY_HASH_SIZE)!=0 ){
+    goto checkpoint_invalid;
+  }
+
+  memcpy(snapshotEntry.hash.data, aHeader+CS_WAL_CHUNK_HASH_OFF,
+         PROLLY_HASH_SIZE);
+  snapshotEntry.offset = stamp.iCheckpointOffset + CS_WAL_CHUNK_LEN_OFF;
+  snapshotEntry.size = (int)stamp.nCheckpointIndex;
+  nIndex = csCheckpointIndexInsert(aIndex, nIndex, &snapshotEntry);
+  csReleaseIndexBuf(cs->index.aIndex, cs->index.aIndexMmapBase,
+                    cs->index.aIndexMmapSize);
+  cs->index.aIndex = aIndex;
+  cs->index.nIndex = nIndex;
+  cs->index.aIndexMmapBase = 0;
+  cs->index.aIndexMmapSize = 0;
+  cs->index.nChunks = (int)CS_READ_U32(
+      aRoot+1+CS_MANIFEST_CHUNK_COUNT_OFF);
+  memcpy(cs->refs.refsHash.data,
+         aRoot+1+CS_MANIFEST_REFS_HASH_OFF, PROLLY_HASH_SIZE);
+  cs->wal.iCheckpointOffset = stamp.iCheckpointOffset;
+  cs->wal.nCheckpointIndex = stamp.nCheckpointIndex;
+  cs->wal.iCheckpointReplay = stamp.iCheckpointReplay;
+  aIndex = 0;
+  rc = csReplayWalFrom(cs, stamp.iCheckpointReplay);
+  if( rc!=SQLITE_OK ) return rc;
+  *pLoaded = 1;
+  return SQLITE_OK;
+
+checkpoint_invalid:
+  sqlite3_free(aIndex);
+  return rc==SQLITE_NOMEM ? rc : SQLITE_OK;
 }
 
 #endif

--- a/src/chunk_wal.c
+++ b/src/chunk_wal.c
@@ -1028,20 +1028,30 @@ static int csFindLastCheckpointRoot(
 ){
   u8 aBuf[65540];
   i64 iEnd = nFile;
+  i64 nZeroRun = 0;
 
   *pFound = 0;
   while( iEnd>cs->wal.iWalOffset ){
     i64 iStart = iEnd-(i64)sizeof(aBuf);
     int n;
     int i;
+    int iFirst;
     int rc;
     if( iStart<cs->wal.iWalOffset ) iStart = cs->wal.iWalOffset;
     n = (int)(iEnd-iStart);
     rc = sqlite3OsRead(cs->file.pFile, aBuf, n, iStart);
     if( rc!=SQLITE_OK ) return rc;
-    for(i=n-5; i>=0; i--){
+    iFirst = iEnd==nFile ? n-1 : n-5;
+    for(i=iFirst; i>=0; i--){
       i64 iRoot;
       WalState stamp;
+      if( aBuf[i]==0 ){
+        nZeroRun++;
+        if( nZeroRun>=CS_WAL_SCAN_MAX ) return SQLITE_OK;
+      }else{
+        nZeroRun = 0;
+      }
+      if( i>n-5 ) continue;
       if( aBuf[i]!=CS_WAL_TAG_ROOT
        || CS_READ_U32(aBuf+i+1)!=CHUNK_STORE_MAGIC ){
         continue;

--- a/src/chunk_wal.c
+++ b/src/chunk_wal.c
@@ -351,7 +351,7 @@ static int csWriteCheckpointParents(
   return SQLITE_OK;
 }
 
-int csWriteWalCheckpoint(ChunkStore *cs, int sectorSize){
+int csWriteWalCheckpoint(ChunkStore *cs, int sectorSize, int *pWritten){
   ChunkIndexEntry *aIndex = 0;
   CsCheckpointPageRef *aRef = 0;
   int nIndex = 0;
@@ -365,6 +365,7 @@ int csWriteWalCheckpoint(ChunkStore *cs, int sectorSize){
   int nRef = 0;
   int rc;
 
+  *pWritten = 0;
   rc = csBuildCheckpointIndex(cs, &aIndex, &nIndex);
   if( rc!=SQLITE_OK || nIndex==0 ) goto checkpoint_done;
   iDataEnd = cs->file.iFileSize;
@@ -394,9 +395,9 @@ int csWriteWalCheckpoint(ChunkStore *cs, int sectorSize){
   }
   aRoot[0] = CS_WAL_TAG_ROOT;
   csSerializeManifest(cs, aRoot + 1);
-  CS_WRITE_I64(aRoot + 1 + CS_MANIFEST_DURABLE_TO_OFF, iRoot);
+  CS_WRITE_I64(aRoot + 1 + CS_MANIFEST_DURABLE_TO_OFF, iDataEnd);
   CS_WRITE_I64(aRoot + 1 + CS_MANIFEST_NEXT_OFF_OFF, iNext);
-  CS_WRITE_I64(aRoot + 1 + CS_MANIFEST_BATCH_START_OFF, iRoot);
+  CS_WRITE_I64(aRoot + 1 + CS_MANIFEST_BATCH_START_OFF, iDataEnd);
   CS_WRITE_U32(aRoot + 1 + CS_MANIFEST_CHECKPOINT_MAGIC_OFF,
                CS_WAL_CHECKPOINT_MAGIC_V2);
   CS_WRITE_I64(aRoot + 1 + CS_MANIFEST_CHECKPOINT_OFFSET_OFF, iCheckpoint);
@@ -423,6 +424,7 @@ int csWriteWalCheckpoint(ChunkStore *cs, int sectorSize){
   cs->file.iFileSize = iNext;
   cs->wal.nWalData = iRootEnd - cs->wal.iWalOffset;
   cs->wal.cleanCloseMarker = 1;
+  *pWritten = 1;
   rc = SQLITE_OK;
   goto checkpoint_done;
 
@@ -640,7 +642,12 @@ static int csWalResolveDamage(
   return SQLITE_OK;
 }
 
-static int csReplayWalFrom(ChunkStore *cs, i64 iStart){
+static int csReplayWalFrom(
+  ChunkStore *cs,
+  i64 iStart,
+  i64 iSkipStart,
+  i64 iSkipEnd
+){
   i64 walSize;
   ChunkStoreReplayState saved;
   i64 pos;
@@ -696,6 +703,12 @@ static int csReplayWalFrom(ChunkStore *cs, i64 iStart){
     u8 tag = 0;
     i64 recPos = pos;
     int havePrefix = 0;
+    if( iSkipStart>0
+     && cs->wal.iWalOffset+pos>=iSkipStart
+     && cs->wal.iWalOffset+pos<iSkipEnd ){
+      pos = iSkipEnd-cs->wal.iWalOffset;
+      continue;
+    }
     if( walSize - pos < CS_WAL_CHUNK_HDR_SIZE ){
       rc = sqlite3OsRead(cs->file.pFile, &tag, 1, cs->wal.iWalOffset + pos);
       if( rc != SQLITE_OK ) goto replay_error;
@@ -854,7 +867,9 @@ static int csReplayWalFrom(ChunkStore *cs, i64 iStart){
         if( nextOff > cs->wal.iWalOffset + pos ){
           pos = nextOff - cs->wal.iWalOffset;
         }
-        (void)csReadCheckpointStamp(m, recAbs, &cs->wal);
+        if( iSkipStart==0 ){
+          (void)csReadCheckpointStamp(m, recAbs, &cs->wal);
+        }
       }else{
         cs->wal.cleanCloseMarker = 0;
       }
@@ -963,6 +978,10 @@ replay_error:
 }
 
 int csReplayWal(ChunkStore *cs){
+  return csReplayWalSkipping(cs, 0, 0);
+}
+
+int csReplayWalSkipping(ChunkStore *cs, i64 iSkipStart, i64 iSkipEnd){
   cs->wal.iCheckpointOffset = 0;
   cs->wal.nCheckpointIndex = 0;
   cs->wal.iCheckpointReplay = 0;
@@ -970,7 +989,12 @@ int csReplayWal(ChunkStore *cs){
   cs->wal.nCheckpointEntries = 0;
   memset(&cs->wal.checkpointHash, 0, sizeof(cs->wal.checkpointHash));
   cs->wal.checkpointMagic = 0;
-  return csReplayWalFrom(cs, cs->wal.iWalOffset);
+  if( (iSkipStart==0)!=(iSkipEnd==0)
+   || (iSkipStart>0
+       && (iSkipStart<cs->wal.iWalOffset || iSkipEnd<=iSkipStart)) ){
+    return SQLITE_CORRUPT;
+  }
+  return csReplayWalFrom(cs, cs->wal.iWalOffset, iSkipStart, iSkipEnd);
 }
 
 static int csCheckpointIndexInsert(
@@ -996,7 +1020,72 @@ static int csCheckpointIndexInsert(
   return nIndex + 1;
 }
 
-int csTryLoadWalCheckpoint(ChunkStore *cs, int *pLoaded){
+static int csFindLastCheckpointRoot(
+  ChunkStore *cs,
+  i64 nFile,
+  u8 *aRoot,
+  i64 *pRootOffset,
+  WalState *pStamp,
+  int *pFound
+){
+  u8 aBuf[65540];
+  i64 iEnd = nFile;
+
+  *pFound = 0;
+  while( iEnd>cs->wal.iWalOffset ){
+    i64 iStart = iEnd-(i64)sizeof(aBuf);
+    int n;
+    int i;
+    int rc;
+    if( iStart<cs->wal.iWalOffset ) iStart = cs->wal.iWalOffset;
+    n = (int)(iEnd-iStart);
+    rc = sqlite3OsRead(cs->file.pFile, aBuf, n, iStart);
+    if( rc!=SQLITE_OK ) return rc;
+    for(i=n-5; i>=0; i--){
+      i64 iRoot;
+      WalState stamp;
+      if( aBuf[i]!=CS_WAL_TAG_ROOT
+       || CS_READ_U32(aBuf+i+1)!=CHUNK_STORE_MAGIC ){
+        continue;
+      }
+      iRoot = iStart+i;
+      if( iRoot>nFile-(i64)(1+CHUNK_MANIFEST_SIZE) ) continue;
+      rc = sqlite3OsRead(cs->file.pFile, aRoot,
+                         1+CHUNK_MANIFEST_SIZE, iRoot);
+      if( rc!=SQLITE_OK ) return rc;
+      stamp = *pStamp;
+      if( aRoot[0]==CS_WAL_TAG_ROOT
+       && csManifestHashState(aRoot+1, iRoot)==CS_MANIFEST_HASH_OK
+       && csValidateWalRootManifest(cs, aRoot+1, iRoot)==SQLITE_OK
+       && csReadCheckpointStamp(aRoot+1, iRoot, &stamp) ){
+        *pRootOffset = iRoot;
+        *pStamp = stamp;
+        *pFound = 1;
+        return SQLITE_OK;
+      }
+    }
+    if( iStart==cs->wal.iWalOffset ) break;
+    iEnd = iStart+4;
+  }
+  return SQLITE_OK;
+}
+
+static void csCheckpointSkipRange(
+  const WalState *pStamp,
+  i64 *pSkipStart,
+  i64 *pSkipEnd
+){
+  *pSkipStart = pStamp->checkpointMagic==CS_WAL_CHECKPOINT_MAGIC_V2
+              ? pStamp->iCheckpointDataEnd : pStamp->iCheckpointOffset;
+  *pSkipEnd = pStamp->iCheckpointReplay;
+}
+
+int csTryLoadWalCheckpoint(
+  ChunkStore *cs,
+  int *pLoaded,
+  i64 *pSkipStart,
+  i64 *pSkipEnd
+){
   u8 aTail[1 + CHUNK_MANIFEST_SIZE];
   u8 aRoot[1 + CHUNK_MANIFEST_SIZE];
   u8 aHeader[CS_WAL_CHUNK_HDR_SIZE];
@@ -1014,23 +1103,18 @@ int csTryLoadWalCheckpoint(ChunkStore *cs, int *pLoaded){
   blake3_hasher hasher;
   int nIndex;
   int iEntry = 0;
+  int found = 0;
   int rc;
 
   *pLoaded = 0;
+  *pSkipStart = 0;
+  *pSkipEnd = 0;
   if( cs->wal.iWalOffset<=0 || !cs->file.pFile ) return SQLITE_OK;
   rc = sqlite3OsFileSize(cs->file.pFile, &nFile);
   if( rc!=SQLITE_OK ) return rc;
-  if( nFile<(i64)sizeof(aTail) ) return SQLITE_OK;
-  iTail = nFile - (i64)sizeof(aTail);
-  rc = sqlite3OsRead(cs->file.pFile, aTail, sizeof(aTail), iTail);
-  if( rc!=SQLITE_OK ) return rc;
-  if( aTail[0]!=CS_WAL_TAG_ROOT
-   || csManifestHashState(aTail+1, iTail)!=CS_MANIFEST_HASH_OK
-   || csValidateWalRootManifest(cs, aTail+1, iTail)!=SQLITE_OK ){
-    return SQLITE_OK;
-  }
   stamp = cs->wal;
-  if( !csReadCheckpointStamp(aTail+1, iTail, &stamp) ) return SQLITE_OK;
+  rc = csFindLastCheckpointRoot(cs, nFile, aTail, &iTail, &stamp, &found);
+  if( rc!=SQLITE_OK || !found ) return rc;
 
   iRoot = stamp.iCheckpointOffset + CS_WAL_CHUNK_HDR_SIZE
         + stamp.nCheckpointIndex;
@@ -1051,8 +1135,13 @@ int csTryLoadWalCheckpoint(ChunkStore *cs, int *pLoaded){
            || rootStamp.nCheckpointEntries!=stamp.nCheckpointEntries
            || prollyHashCompare(&rootStamp.checkpointHash,
                                 &stamp.checkpointHash)!=0))
-   || CS_READ_I64(aRoot+1+CS_MANIFEST_DURABLE_TO_OFF)<iRoot
-   || CS_READ_I64(aRoot+1+CS_MANIFEST_BATCH_START_OFF)!=iRoot
+   || (stamp.checkpointMagic==CS_WAL_CHECKPOINT_MAGIC_V2
+       ? (CS_READ_I64(aRoot+1+CS_MANIFEST_DURABLE_TO_OFF)
+              !=stamp.iCheckpointDataEnd
+          || CS_READ_I64(aRoot+1+CS_MANIFEST_BATCH_START_OFF)
+              !=stamp.iCheckpointDataEnd)
+       : (CS_READ_I64(aRoot+1+CS_MANIFEST_DURABLE_TO_OFF)<iRoot
+          || CS_READ_I64(aRoot+1+CS_MANIFEST_BATCH_START_OFF)!=iRoot))
    || CS_READ_I64(aRoot+1+CS_MANIFEST_NEXT_OFF_OFF)
         !=stamp.iCheckpointReplay ){
     return SQLITE_OK;
@@ -1064,6 +1153,7 @@ int csTryLoadWalCheckpoint(ChunkStore *cs, int *pLoaded){
   if( aHeader[0]!=CS_WAL_TAG_CHUNK
    || (i64)CS_READ_U32(aHeader+CS_WAL_CHUNK_LEN_OFF)
         !=stamp.nCheckpointIndex ){
+    csCheckpointSkipRange(&stamp, pSkipStart, pSkipEnd);
     return SQLITE_OK;
   }
   if( stamp.checkpointMagic==CS_WAL_CHECKPOINT_MAGIC_V2 ){
@@ -1073,6 +1163,7 @@ int csTryLoadWalCheckpoint(ChunkStore *cs, int *pLoaded){
     int nCellSize;
     if( memcmp(aHeader+CS_WAL_CHUNK_HASH_OFF,
                stamp.checkpointHash.data, PROLLY_HASH_SIZE)!=0 ){
+      csCheckpointSkipRange(&stamp, pSkipStart, pSkipEnd);
       return SQLITE_OK;
     }
     aPage = sqlite3_malloc((int)stamp.nCheckpointIndex);
@@ -1099,7 +1190,12 @@ int csTryLoadWalCheckpoint(ChunkStore *cs, int *pLoaded){
       }
     }
     sqlite3_free(aPage);
-    if( rc!=SQLITE_OK ) return rc==SQLITE_NOMEM ? rc : SQLITE_OK;
+    if( rc!=SQLITE_OK ){
+      if( rc!=SQLITE_NOMEM ){
+        csCheckpointSkipRange(&stamp, pSkipStart, pSkipEnd);
+      }
+      return rc==SQLITE_NOMEM ? rc : SQLITE_OK;
+    }
 
     csReleaseIndexBuf(cs->index.aIndex, cs->index.aIndexMmapBase,
                       cs->index.aIndexMmapSize);
@@ -1124,7 +1220,7 @@ int csTryLoadWalCheckpoint(ChunkStore *cs, int *pLoaded){
     cs->wal.nCheckpointEntries = stamp.nCheckpointEntries;
     cs->wal.checkpointHash = stamp.checkpointHash;
     cs->wal.checkpointMagic = stamp.checkpointMagic;
-    rc = csReplayWalFrom(cs, stamp.iCheckpointReplay);
+    rc = csReplayWalFrom(cs, stamp.iCheckpointReplay, 0, 0);
     if( rc!=SQLITE_OK ){
       memset(&cs->index.lazy, 0, sizeof(cs->index.lazy));
       cs->wal.iCheckpointOffset = 0;
@@ -1134,6 +1230,9 @@ int csTryLoadWalCheckpoint(ChunkStore *cs, int *pLoaded){
       cs->wal.nCheckpointEntries = 0;
       memset(&cs->wal.checkpointHash, 0, sizeof(cs->wal.checkpointHash));
       cs->wal.checkpointMagic = 0;
+      if( rc!=SQLITE_NOMEM ){
+        csCheckpointSkipRange(&stamp, pSkipStart, pSkipEnd);
+      }
       return rc==SQLITE_NOMEM ? rc : SQLITE_OK;
     }
     *pLoaded = 1;
@@ -1200,13 +1299,16 @@ int csTryLoadWalCheckpoint(ChunkStore *cs, int *pLoaded){
   cs->wal.checkpointHash = stamp.checkpointHash;
   cs->wal.checkpointMagic = stamp.checkpointMagic;
   aIndex = 0;
-  rc = csReplayWalFrom(cs, stamp.iCheckpointReplay);
+  rc = csReplayWalFrom(cs, stamp.iCheckpointReplay, 0, 0);
   if( rc!=SQLITE_OK ) return rc;
   *pLoaded = 1;
   return SQLITE_OK;
 
 checkpoint_invalid:
   sqlite3_free(aIndex);
+  if( rc!=SQLITE_NOMEM ){
+    csCheckpointSkipRange(&stamp, pSkipStart, pSkipEnd);
+  }
   return rc==SQLITE_NOMEM ? rc : SQLITE_OK;
 }
 

--- a/src/chunk_wal.c
+++ b/src/chunk_wal.c
@@ -28,6 +28,10 @@ void walStateSetOffset(WalState *w, i64 iOffset){
   w->iCheckpointOffset = 0;
   w->nCheckpointIndex = 0;
   w->iCheckpointReplay = 0;
+  w->iCheckpointDataEnd = 0;
+  w->nCheckpointEntries = 0;
+  memset(&w->checkpointHash, 0, sizeof(w->checkpointHash));
+  w->checkpointMagic = 0;
 }
 
 void walStateSetDataSize(WalState *w, i64 nData){
@@ -45,9 +49,13 @@ static int csReadCheckpointStamp(
   i64 nIndex;
   i64 iReplay;
   i64 iCheckpointRoot;
+  i64 iDataEnd = 0;
+  int nEntries = 0;
+  u32 magic;
 
-  if( CS_READ_U32(aManifest + CS_MANIFEST_CHECKPOINT_MAGIC_OFF)
-      != CS_WAL_CHECKPOINT_MAGIC ){
+  magic = CS_READ_U32(aManifest + CS_MANIFEST_CHECKPOINT_MAGIC_OFF);
+  if( magic!=CS_WAL_CHECKPOINT_MAGIC_V1
+   && magic!=CS_WAL_CHECKPOINT_MAGIC_V2 ){
     return 0;
   }
   iOffset = CS_READ_I64(aManifest + CS_MANIFEST_CHECKPOINT_OFFSET_OFF);
@@ -55,11 +63,23 @@ static int csReadCheckpointStamp(
       aManifest + CS_MANIFEST_CHECKPOINT_SIZE_OFF);
   iReplay = CS_READ_I64(
       aManifest + CS_MANIFEST_CHECKPOINT_REPLAY_OFF);
-  if( iOffset<pWal->iWalOffset || nIndex<=0
-   || nIndex%CHUNK_INDEX_ENTRY_SIZE!=0
-   || nIndex>INT_MAX
+  if( iOffset<pWal->iWalOffset || nIndex<=0 || nIndex>INT_MAX
    || iOffset>LARGEST_INT64-CS_WAL_CHUNK_HDR_SIZE-nIndex ){
     return 0;
+  }
+  if( magic==CS_WAL_CHECKPOINT_MAGIC_V1 ){
+    if( nIndex%CHUNK_INDEX_ENTRY_SIZE!=0 ) return 0;
+    nEntries = (int)(nIndex/CHUNK_INDEX_ENTRY_SIZE);
+    iDataEnd = iOffset;
+  }else{
+    iDataEnd = CS_READ_I64(
+        aManifest + CS_MANIFEST_CHECKPOINT_DATA_END_OFF);
+    nEntries = (int)CS_READ_U32(
+        aManifest + CS_MANIFEST_CHECKPOINT_COUNT_OFF);
+    if( nIndex<CS_INDEX_PAGE_HEADER_SIZE || nIndex>CS_INDEX_PAGE_SIZE
+     || iDataEnd<pWal->iWalOffset || iDataEnd>iOffset || nEntries<=0 ){
+      return 0;
+    }
   }
   iCheckpointRoot = iOffset + CS_WAL_CHUNK_HDR_SIZE + nIndex;
   if( iCheckpointRoot>iRootOffset
@@ -71,23 +91,43 @@ static int csReadCheckpointStamp(
   pWal->iCheckpointOffset = iOffset;
   pWal->nCheckpointIndex = nIndex;
   pWal->iCheckpointReplay = iReplay;
+  pWal->iCheckpointDataEnd = iDataEnd;
+  pWal->nCheckpointEntries = nEntries;
+  pWal->checkpointMagic = magic;
+  if( magic==CS_WAL_CHECKPOINT_MAGIC_V2 ){
+    memcpy(pWal->checkpointHash.data,
+           aManifest + CS_MANIFEST_CHECKPOINT_HASH_OFF,
+           PROLLY_HASH_SIZE);
+  }else{
+    memset(&pWal->checkpointHash, 0, sizeof(pWal->checkpointHash));
+  }
   return 1;
 }
 
 void csStampWalCheckpoint(const ChunkStore *cs, u8 *aManifest){
   if( cs->wal.iCheckpointOffset<=0 || cs->wal.nCheckpointIndex<=0
-   || cs->wal.iCheckpointReplay<=0 ){
+   || cs->wal.iCheckpointReplay<=0
+   || (cs->wal.checkpointMagic!=CS_WAL_CHECKPOINT_MAGIC_V1
+       && cs->wal.checkpointMagic!=CS_WAL_CHECKPOINT_MAGIC_V2) ){
     return;
   }
   assert( cs->wal.nCheckpointIndex<=0xffffffffu );
   CS_WRITE_U32(aManifest + CS_MANIFEST_CHECKPOINT_MAGIC_OFF,
-               CS_WAL_CHECKPOINT_MAGIC);
+               cs->wal.checkpointMagic);
   CS_WRITE_I64(aManifest + CS_MANIFEST_CHECKPOINT_OFFSET_OFF,
                cs->wal.iCheckpointOffset);
   CS_WRITE_U32(aManifest + CS_MANIFEST_CHECKPOINT_SIZE_OFF,
                (u32)cs->wal.nCheckpointIndex);
   CS_WRITE_I64(aManifest + CS_MANIFEST_CHECKPOINT_REPLAY_OFF,
                cs->wal.iCheckpointReplay);
+  if( cs->wal.checkpointMagic==CS_WAL_CHECKPOINT_MAGIC_V2 ){
+    CS_WRITE_I64(aManifest + CS_MANIFEST_CHECKPOINT_DATA_END_OFF,
+                 cs->wal.iCheckpointDataEnd);
+    memcpy(aManifest + CS_MANIFEST_CHECKPOINT_HASH_OFF,
+           cs->wal.checkpointHash.data, PROLLY_HASH_SIZE);
+    CS_WRITE_U32(aManifest + CS_MANIFEST_CHECKPOINT_COUNT_OFF,
+                 (u32)cs->wal.nCheckpointEntries);
+  }
 }
 
 static i64 csWalCheckpointThreshold(void){
@@ -134,13 +174,17 @@ static int csBuildCheckpointIndex(
   ChunkIndexEntry **ppIndex,
   int *pnIndex
 ){
-  i64 nAlloc = (i64)cs->index.nIndex + cs->staging.nRecent;
+  i64 nAlloc;
   ChunkIndexEntry *aIndex;
   int i;
   int nOut = 0;
+  int rc;
 
   *ppIndex = 0;
   *pnIndex = 0;
+  rc = csMaterializeIndex(cs);
+  if( rc!=SQLITE_OK ) return rc;
+  nAlloc = (i64)cs->index.nIndex + cs->staging.nRecent;
   if( nAlloc<=0 || nAlloc>INT_MAX/(int)sizeof(ChunkIndexEntry) ){
     return nAlloc<=0 ? SQLITE_OK : SQLITE_TOOBIG;
   }
@@ -167,64 +211,181 @@ static int csBuildCheckpointIndex(
   return SQLITE_OK;
 }
 
+typedef struct CsCheckpointPageRef CsCheckpointPageRef;
+struct CsCheckpointPageRef {
+  ProllyHash maxHash;
+  ProllyHash bodyHash;
+  i64 offset;
+  int size;
+};
+
+static int csWriteCheckpointPage(
+  ChunkStore *cs,
+  const u8 *aBody,
+  int nBody,
+  const ProllyHash *pMaxHash,
+  i64 *pOffset,
+  CsCheckpointPageRef *pRef
+){
+  u8 aHeader[CS_WAL_CHUNK_HDR_SIZE];
+  int rc;
+  if( nBody<CS_INDEX_PAGE_HEADER_SIZE || nBody>CS_INDEX_PAGE_SIZE
+   || *pOffset>LARGEST_INT64-CS_WAL_CHUNK_HDR_SIZE-nBody ){
+    return SQLITE_TOOBIG;
+  }
+  prollyHashCompute(aBody, nBody, &pRef->bodyHash);
+  csFillChunkHdr(aHeader, &pRef->bodyHash, (u32)nBody);
+  rc = sqlite3OsWrite(cs->file.pFile, aHeader, sizeof(aHeader), *pOffset);
+  if( rc==SQLITE_OK ){
+    rc = sqlite3OsWrite(cs->file.pFile, aBody, nBody,
+                        *pOffset+CS_WAL_CHUNK_HDR_SIZE);
+  }
+  if( rc!=SQLITE_OK ) return rc;
+  pRef->maxHash = *pMaxHash;
+  pRef->offset = *pOffset;
+  pRef->size = nBody;
+  *pOffset += CS_WAL_CHUNK_HDR_SIZE+nBody;
+  return SQLITE_OK;
+}
+
+static int csWriteCheckpointLeaves(
+  ChunkStore *cs,
+  const ChunkIndexEntry *aIndex,
+  int nIndex,
+  i64 *pOffset,
+  CsCheckpointPageRef **ppRef,
+  int *pnRef
+){
+  const int nPerPage =
+      (CS_INDEX_PAGE_SIZE-CS_INDEX_PAGE_HEADER_SIZE)/CHUNK_INDEX_ENTRY_SIZE;
+  int nRef = (nIndex+nPerPage-1)/nPerPage;
+  CsCheckpointPageRef *aRef;
+  u8 aBody[CS_INDEX_PAGE_SIZE];
+  int i;
+  int rc = SQLITE_OK;
+
+  if( nRef<=0 || nRef>INT_MAX/(int)sizeof(CsCheckpointPageRef) ){
+    return SQLITE_TOOBIG;
+  }
+  aRef = sqlite3_malloc64(
+      (sqlite3_uint64)nRef*sizeof(CsCheckpointPageRef));
+  if( !aRef ) return SQLITE_NOMEM;
+  for(i=0; i<nRef; i++){
+    int iFirst = i*nPerPage;
+    int nCell = nIndex-iFirst;
+    int j;
+    int nBody;
+    if( nCell>nPerPage ) nCell = nPerPage;
+    CS_WRITE_U32(aBody, CS_INDEX_PAGE_LEAF_MAGIC);
+    CS_WRITE_U32(aBody+4, (u32)nCell);
+    for(j=0; j<nCell; j++){
+      csSerializeCheckpointEntry(
+          aBody+CS_INDEX_PAGE_HEADER_SIZE+j*CHUNK_INDEX_ENTRY_SIZE,
+          &aIndex[iFirst+j]);
+    }
+    nBody = CS_INDEX_PAGE_HEADER_SIZE+nCell*CHUNK_INDEX_ENTRY_SIZE;
+    rc = csWriteCheckpointPage(cs, aBody, nBody,
+                               &aIndex[iFirst+nCell-1].hash,
+                               pOffset, &aRef[i]);
+    if( rc!=SQLITE_OK ) break;
+  }
+  if( rc!=SQLITE_OK ){
+    sqlite3_free(aRef);
+    return rc;
+  }
+  *ppRef = aRef;
+  *pnRef = nRef;
+  return SQLITE_OK;
+}
+
+static int csWriteCheckpointParents(
+  ChunkStore *cs,
+  CsCheckpointPageRef *aChild,
+  int nChild,
+  i64 *pOffset,
+  CsCheckpointPageRef **ppParent,
+  int *pnParent
+){
+  const int nPerPage =
+      (CS_INDEX_PAGE_SIZE-CS_INDEX_PAGE_HEADER_SIZE)/CS_INDEX_CHILD_SIZE;
+  int nParent = (nChild+nPerPage-1)/nPerPage;
+  CsCheckpointPageRef *aParent;
+  u8 aBody[CS_INDEX_PAGE_SIZE];
+  int i;
+  int rc = SQLITE_OK;
+
+  aParent = sqlite3_malloc64(
+      (sqlite3_uint64)nParent*sizeof(CsCheckpointPageRef));
+  if( !aParent ) return SQLITE_NOMEM;
+  for(i=0; i<nParent; i++){
+    int iFirst = i*nPerPage;
+    int nCell = nChild-iFirst;
+    int j;
+    int nBody;
+    if( nCell>nPerPage ) nCell = nPerPage;
+    CS_WRITE_U32(aBody, CS_INDEX_PAGE_INTERNAL_MAGIC);
+    CS_WRITE_U32(aBody+4, (u32)nCell);
+    for(j=0; j<nCell; j++){
+      const CsCheckpointPageRef *pChild = &aChild[iFirst+j];
+      u8 *p = aBody+CS_INDEX_PAGE_HEADER_SIZE+j*CS_INDEX_CHILD_SIZE;
+      memcpy(p, pChild->maxHash.data, PROLLY_HASH_SIZE);
+      p += PROLLY_HASH_SIZE;
+      CS_WRITE_I64(p, pChild->offset);
+      p += 8;
+      CS_WRITE_U32(p, (u32)pChild->size);
+      p += 4;
+      memcpy(p, pChild->bodyHash.data, PROLLY_HASH_SIZE);
+    }
+    nBody = CS_INDEX_PAGE_HEADER_SIZE+nCell*CS_INDEX_CHILD_SIZE;
+    rc = csWriteCheckpointPage(cs, aBody, nBody,
+                               &aChild[iFirst+nCell-1].maxHash,
+                               pOffset, &aParent[i]);
+    if( rc!=SQLITE_OK ) break;
+  }
+  if( rc!=SQLITE_OK ){
+    sqlite3_free(aParent);
+    return rc;
+  }
+  *ppParent = aParent;
+  *pnParent = nParent;
+  return SQLITE_OK;
+}
+
 int csWriteWalCheckpoint(ChunkStore *cs, int sectorSize){
   ChunkIndexEntry *aIndex = 0;
+  CsCheckpointPageRef *aRef = 0;
   int nIndex = 0;
-  i64 nIndexBytes;
   i64 iCheckpoint;
+  i64 iDataEnd;
+  i64 iWrite;
   i64 iRoot;
   i64 iRootEnd;
   i64 iNext;
-  u8 aEntry[CHUNK_INDEX_ENTRY_SIZE];
-  u8 aBuf[65536];
-  u8 aHeader[CS_WAL_CHUNK_HDR_SIZE];
   u8 aRoot[1 + CHUNK_MANIFEST_SIZE];
-  ProllyHash snapshotHash;
-  blake3_hasher hasher;
-  int i;
+  int nRef = 0;
   int rc;
 
   rc = csBuildCheckpointIndex(cs, &aIndex, &nIndex);
   if( rc!=SQLITE_OK || nIndex==0 ) goto checkpoint_done;
-  nIndexBytes = (i64)nIndex * CHUNK_INDEX_ENTRY_SIZE;
-  if( nIndexBytes>INT_MAX
-   || cs->file.iFileSize>LARGEST_INT64-CS_WAL_CHUNK_HDR_SIZE-nIndexBytes ){
-    rc = SQLITE_TOOBIG;
-    goto checkpoint_done;
-  }
-
-  blake3_hasher_init(&hasher);
-  for(i=0; i<nIndex; i++){
-    csSerializeCheckpointEntry(aEntry, &aIndex[i]);
-    blake3_hasher_update(&hasher, aEntry, sizeof(aEntry));
-  }
-  blake3_hasher_finalize(&hasher, snapshotHash.data, PROLLY_HASH_SIZE);
-
-  iCheckpoint = cs->file.iFileSize;
-  csFillChunkHdr(aHeader, &snapshotHash, (u32)nIndexBytes);
-  rc = sqlite3OsWrite(cs->file.pFile, aHeader, sizeof(aHeader), iCheckpoint);
+  iDataEnd = cs->file.iFileSize;
+  iWrite = iDataEnd;
+  rc = csWriteCheckpointLeaves(cs, aIndex, nIndex, &iWrite, &aRef, &nRef);
   if( rc!=SQLITE_OK ) goto checkpoint_rollback;
-  for(i=0; i<nIndex; ){
-    int nEntry = nIndex-i;
-    int j;
-    if( nEntry>(int)(sizeof(aBuf)/CHUNK_INDEX_ENTRY_SIZE) ){
-      nEntry = (int)(sizeof(aBuf)/CHUNK_INDEX_ENTRY_SIZE);
-    }
-    for(j=0; j<nEntry; j++){
-      csSerializeCheckpointEntry(
-          aBuf + j*CHUNK_INDEX_ENTRY_SIZE, &aIndex[i+j]);
-    }
-    rc = sqlite3OsWrite(cs->file.pFile, aBuf,
-        nEntry*CHUNK_INDEX_ENTRY_SIZE,
-        iCheckpoint + CS_WAL_CHUNK_HDR_SIZE
-        + (i64)i * CHUNK_INDEX_ENTRY_SIZE);
+  while( nRef>1 ){
+    CsCheckpointPageRef *aParent = 0;
+    int nParent = 0;
+    rc = csWriteCheckpointParents(cs, aRef, nRef, &iWrite,
+                                  &aParent, &nParent);
+    sqlite3_free(aRef);
+    aRef = aParent;
+    nRef = nParent;
     if( rc!=SQLITE_OK ) goto checkpoint_rollback;
-    i += nEntry;
   }
   rc = csSyncFile(cs);
   if( rc!=SQLITE_OK ) goto checkpoint_rollback;
 
-  iRoot = iCheckpoint + CS_WAL_CHUNK_HDR_SIZE + nIndexBytes;
+  iCheckpoint = aRef[0].offset;
+  iRoot = iWrite;
   iRootEnd = iRoot + (i64)sizeof(aRoot);
   iNext = iRootEnd;
   if( sectorSize>1 ){
@@ -237,11 +398,15 @@ int csWriteWalCheckpoint(ChunkStore *cs, int sectorSize){
   CS_WRITE_I64(aRoot + 1 + CS_MANIFEST_NEXT_OFF_OFF, iNext);
   CS_WRITE_I64(aRoot + 1 + CS_MANIFEST_BATCH_START_OFF, iRoot);
   CS_WRITE_U32(aRoot + 1 + CS_MANIFEST_CHECKPOINT_MAGIC_OFF,
-               CS_WAL_CHECKPOINT_MAGIC);
+               CS_WAL_CHECKPOINT_MAGIC_V2);
   CS_WRITE_I64(aRoot + 1 + CS_MANIFEST_CHECKPOINT_OFFSET_OFF, iCheckpoint);
   CS_WRITE_U32(aRoot + 1 + CS_MANIFEST_CHECKPOINT_SIZE_OFF,
-               (u32)nIndexBytes);
+               (u32)aRef[0].size);
   CS_WRITE_I64(aRoot + 1 + CS_MANIFEST_CHECKPOINT_REPLAY_OFF, iNext);
+  CS_WRITE_I64(aRoot + 1 + CS_MANIFEST_CHECKPOINT_DATA_END_OFF, iDataEnd);
+  memcpy(aRoot + 1 + CS_MANIFEST_CHECKPOINT_HASH_OFF,
+         aRef[0].bodyHash.data, PROLLY_HASH_SIZE);
+  CS_WRITE_U32(aRoot + 1 + CS_MANIFEST_CHECKPOINT_COUNT_OFF, (u32)nIndex);
   csManifestSeal(aRoot + 1, iRoot);
   rc = sqlite3OsWrite(cs->file.pFile, aRoot, sizeof(aRoot), iRoot);
   if( rc!=SQLITE_OK ) goto checkpoint_rollback;
@@ -249,8 +414,12 @@ int csWriteWalCheckpoint(ChunkStore *cs, int sectorSize){
   if( rc!=SQLITE_OK ) goto checkpoint_rollback;
 
   cs->wal.iCheckpointOffset = iCheckpoint;
-  cs->wal.nCheckpointIndex = nIndexBytes;
+  cs->wal.nCheckpointIndex = aRef[0].size;
   cs->wal.iCheckpointReplay = iNext;
+  cs->wal.iCheckpointDataEnd = iDataEnd;
+  cs->wal.nCheckpointEntries = nIndex;
+  cs->wal.checkpointHash = aRef[0].bodyHash;
+  cs->wal.checkpointMagic = CS_WAL_CHECKPOINT_MAGIC_V2;
   cs->file.iFileSize = iNext;
   cs->wal.nWalData = iRootEnd - cs->wal.iWalOffset;
   cs->wal.cleanCloseMarker = 1;
@@ -258,10 +427,11 @@ int csWriteWalCheckpoint(ChunkStore *cs, int sectorSize){
   goto checkpoint_done;
 
 checkpoint_rollback:
-  (void)sqlite3OsTruncate(cs->file.pFile, cs->file.iFileSize);
+  (void)sqlite3OsTruncate(cs->file.pFile, iDataEnd);
   (void)csSyncFile(cs);
 
 checkpoint_done:
+  sqlite3_free(aRef);
   sqlite3_free(aIndex);
   return rc;
 }
@@ -273,6 +443,7 @@ static void csCaptureReplayState(ChunkStore *cs, ChunkStoreReplayState *pSaved){
   pSaved->nIndex = cs->index.nIndex;
   pSaved->aIndexMmapBase = cs->index.aIndexMmapBase;
   pSaved->aIndexMmapSize = cs->index.aIndexMmapSize;
+  pSaved->lazy = cs->index.lazy;
   csCaptureSavedRefsState(cs, &pSaved->refs);
 }
 
@@ -281,6 +452,7 @@ static void csRestoreReplayState(ChunkStore *cs, const ChunkStoreReplayState *pS
   cs->index.nIndex = pSaved->nIndex;
   cs->index.aIndexMmapBase = pSaved->aIndexMmapBase;
   cs->index.aIndexMmapSize = pSaved->aIndexMmapSize;
+  cs->index.lazy = pSaved->lazy;
   csRestoreSavedRefsState(cs, &pSaved->refs);
 }
 
@@ -340,10 +512,15 @@ void csAdoptOpenedStoreState(ChunkStore *pDst, ChunkStore *pSrc){
   pDst->index.nIndex = pSrc->index.nIndex;
   pDst->index.aIndexMmapBase = pSrc->index.aIndexMmapBase;
   pDst->index.aIndexMmapSize = pSrc->index.aIndexMmapSize;
+  pDst->index.lazy = pSrc->index.lazy;
   pDst->wal.nWalData = pSrc->wal.nWalData;
   pDst->wal.iCheckpointOffset = pSrc->wal.iCheckpointOffset;
   pDst->wal.nCheckpointIndex = pSrc->wal.nCheckpointIndex;
   pDst->wal.iCheckpointReplay = pSrc->wal.iCheckpointReplay;
+  pDst->wal.iCheckpointDataEnd = pSrc->wal.iCheckpointDataEnd;
+  pDst->wal.nCheckpointEntries = pSrc->wal.nCheckpointEntries;
+  pDst->wal.checkpointHash = pSrc->wal.checkpointHash;
+  pDst->wal.checkpointMagic = pSrc->wal.checkpointMagic;
   pDst->wal.recoveredMidStream = pSrc->wal.recoveredMidStream;
   pDst->wal.cleanCloseMarker = pSrc->wal.cleanCloseMarker;
   pDst->corruptMidStream = pSrc->corruptMidStream;
@@ -355,10 +532,15 @@ void csAdoptOpenedStoreState(ChunkStore *pDst, ChunkStore *pSrc){
   pSrc->index.nIndex = 0;
   pSrc->index.aIndexMmapBase = 0;
   pSrc->index.aIndexMmapSize = 0;
+  memset(&pSrc->index.lazy, 0, sizeof(pSrc->index.lazy));
   pSrc->wal.nWalData = 0;
   pSrc->wal.iCheckpointOffset = 0;
   pSrc->wal.nCheckpointIndex = 0;
   pSrc->wal.iCheckpointReplay = 0;
+  pSrc->wal.iCheckpointDataEnd = 0;
+  pSrc->wal.nCheckpointEntries = 0;
+  memset(&pSrc->wal.checkpointHash, 0, sizeof(pSrc->wal.checkpointHash));
+  pSrc->wal.checkpointMagic = 0;
   pSrc->wal.cleanCloseMarker = 0;
   REFS_OWNED_CLEAR(pSrc->refs);
 }
@@ -491,10 +673,11 @@ static int csReplayWalFrom(ChunkStore *cs, i64 iStart){
   }
   if( walSize <= 0 ){
     /* Without a WAL tail, chunk_count must describe the compacted index. */
-    if( cs->index.nIndex > 0 && cs->index.nChunks != cs->index.nIndex ){
+    if( chunkIndexCount(&cs->index)>0
+     && cs->index.nChunks!=chunkIndexCount(&cs->index) ){
       return SQLITE_CORRUPT;
     }
-    if( cs->index.nIndex==0 && cs->index.nChunks==0
+    if( chunkIndexCount(&cs->index)==0 && cs->index.nChunks==0
      && !prollyHashIsEmpty(&cs->refs.refsHash) ){
       memset(cs->refs.refsHash.data, 0, PROLLY_HASH_SIZE);
     }
@@ -590,9 +773,12 @@ static int csReplayWalFrom(ChunkStore *cs, i64 iStart){
         }
       }
       {
-        int existing = csSearchIndex(cs->index.aIndex, cs->index.nIndex, &hash);
+        ChunkIndexEntry existingEntry;
+        int existing = 0;
         ChunkIndexEntry *e = 0;
-        if( existing < 0 ){
+        rc = csIndexLookup(cs, &hash, &existingEntry, &existing);
+        if( rc!=SQLITE_OK ) goto replay_error;
+        if( !existing ){
           rc = csGrowPending(cs);
           if( rc != SQLITE_OK ) goto replay_error;
           e = &cs->staging.aPending[cs->staging.nPending];
@@ -707,7 +893,7 @@ static int csReplayWalFrom(ChunkStore *cs, i64 iStart){
   ** if no root manifest can be replayed. */
   if( sawDamage
    && nRootRecordsSeen == 0
-   && nPendingBefore == 0 && cs->index.nIndex == 0 ){
+   && nPendingBefore == 0 && chunkIndexCount(&cs->index)==0 ){
     memset(cs->refs.refsHash.data, 0, PROLLY_HASH_SIZE);
     cs->index.nChunks = 0;
     cs->wal.recoveredMidStream = 1;
@@ -723,7 +909,7 @@ static int csReplayWalFrom(ChunkStore *cs, i64 iStart){
   cs->staging.nPending = nRootedPending;
 
   if( nRootRecordsSeen == 0
-   && nPendingBefore == 0 && cs->index.nIndex == 0
+   && nPendingBefore == 0 && chunkIndexCount(&cs->index)==0
    && !sawMidStream && !cs->wal.recoveredMidStream ){
     memset(cs->refs.refsHash.data, 0, PROLLY_HASH_SIZE);
     cs->index.nChunks = 0;
@@ -780,6 +966,10 @@ int csReplayWal(ChunkStore *cs){
   cs->wal.iCheckpointOffset = 0;
   cs->wal.nCheckpointIndex = 0;
   cs->wal.iCheckpointReplay = 0;
+  cs->wal.iCheckpointDataEnd = 0;
+  cs->wal.nCheckpointEntries = 0;
+  memset(&cs->wal.checkpointHash, 0, sizeof(cs->wal.checkpointHash));
+  cs->wal.checkpointMagic = 0;
   return csReplayWalFrom(cs, cs->wal.iWalOffset);
 }
 
@@ -855,6 +1045,12 @@ int csTryLoadWalCheckpoint(ChunkStore *cs, int *pLoaded){
    || rootStamp.iCheckpointOffset!=stamp.iCheckpointOffset
    || rootStamp.nCheckpointIndex!=stamp.nCheckpointIndex
    || rootStamp.iCheckpointReplay!=stamp.iCheckpointReplay
+   || rootStamp.checkpointMagic!=stamp.checkpointMagic
+   || (stamp.checkpointMagic==CS_WAL_CHECKPOINT_MAGIC_V2
+       && (rootStamp.iCheckpointDataEnd!=stamp.iCheckpointDataEnd
+           || rootStamp.nCheckpointEntries!=stamp.nCheckpointEntries
+           || prollyHashCompare(&rootStamp.checkpointHash,
+                                &stamp.checkpointHash)!=0))
    || CS_READ_I64(aRoot+1+CS_MANIFEST_DURABLE_TO_OFF)<iRoot
    || CS_READ_I64(aRoot+1+CS_MANIFEST_BATCH_START_OFF)!=iRoot
    || CS_READ_I64(aRoot+1+CS_MANIFEST_NEXT_OFF_OFF)
@@ -868,6 +1064,79 @@ int csTryLoadWalCheckpoint(ChunkStore *cs, int *pLoaded){
   if( aHeader[0]!=CS_WAL_TAG_CHUNK
    || (i64)CS_READ_U32(aHeader+CS_WAL_CHUNK_LEN_OFF)
         !=stamp.nCheckpointIndex ){
+    return SQLITE_OK;
+  }
+  if( stamp.checkpointMagic==CS_WAL_CHECKPOINT_MAGIC_V2 ){
+    u8 *aPage = 0;
+    u32 pageMagic;
+    u32 nCell;
+    int nCellSize;
+    if( memcmp(aHeader+CS_WAL_CHUNK_HASH_OFF,
+               stamp.checkpointHash.data, PROLLY_HASH_SIZE)!=0 ){
+      return SQLITE_OK;
+    }
+    aPage = sqlite3_malloc((int)stamp.nCheckpointIndex);
+    if( !aPage ) return SQLITE_NOMEM;
+    rc = sqlite3OsRead(cs->file.pFile, aPage, (int)stamp.nCheckpointIndex,
+                       stamp.iCheckpointOffset+CS_WAL_CHUNK_HDR_SIZE);
+    if( rc==SQLITE_OK ){
+      prollyHashCompute(aPage, (int)stamp.nCheckpointIndex, &bodyHash);
+      if( prollyHashCompare(&bodyHash, &stamp.checkpointHash)!=0 ){
+        rc = SQLITE_CORRUPT;
+      }
+    }
+    if( rc==SQLITE_OK ){
+      pageMagic = CS_READ_U32(aPage);
+      nCell = CS_READ_U32(aPage+4);
+      nCellSize = pageMagic==CS_INDEX_PAGE_LEAF_MAGIC
+                ? CHUNK_INDEX_ENTRY_SIZE
+                : pageMagic==CS_INDEX_PAGE_INTERNAL_MAGIC
+                  ? CS_INDEX_CHILD_SIZE : 0;
+      if( nCellSize==0 || nCell==0
+       || (i64)CS_INDEX_PAGE_HEADER_SIZE+(i64)nCell*nCellSize
+            !=stamp.nCheckpointIndex ){
+        rc = SQLITE_CORRUPT;
+      }
+    }
+    sqlite3_free(aPage);
+    if( rc!=SQLITE_OK ) return rc==SQLITE_NOMEM ? rc : SQLITE_OK;
+
+    csReleaseIndexBuf(cs->index.aIndex, cs->index.aIndexMmapBase,
+                      cs->index.aIndexMmapSize);
+    cs->index.aIndex = 0;
+    cs->index.nIndex = 0;
+    cs->index.aIndexMmapBase = 0;
+    cs->index.aIndexMmapSize = 0;
+    cs->index.lazy.iRootOffset = stamp.iCheckpointOffset;
+    cs->index.lazy.iDataEnd = stamp.iCheckpointDataEnd;
+    cs->index.lazy.nRootSize = (int)stamp.nCheckpointIndex;
+    cs->index.lazy.nEntries = stamp.nCheckpointEntries;
+    cs->index.lazy.rootHash = stamp.checkpointHash;
+    cs->index.lazy.active = 1;
+    cs->index.nChunks = (int)CS_READ_U32(
+        aRoot+1+CS_MANIFEST_CHUNK_COUNT_OFF);
+    memcpy(cs->refs.refsHash.data,
+           aRoot+1+CS_MANIFEST_REFS_HASH_OFF, PROLLY_HASH_SIZE);
+    cs->wal.iCheckpointOffset = stamp.iCheckpointOffset;
+    cs->wal.nCheckpointIndex = stamp.nCheckpointIndex;
+    cs->wal.iCheckpointReplay = stamp.iCheckpointReplay;
+    cs->wal.iCheckpointDataEnd = stamp.iCheckpointDataEnd;
+    cs->wal.nCheckpointEntries = stamp.nCheckpointEntries;
+    cs->wal.checkpointHash = stamp.checkpointHash;
+    cs->wal.checkpointMagic = stamp.checkpointMagic;
+    rc = csReplayWalFrom(cs, stamp.iCheckpointReplay);
+    if( rc!=SQLITE_OK ){
+      memset(&cs->index.lazy, 0, sizeof(cs->index.lazy));
+      cs->wal.iCheckpointOffset = 0;
+      cs->wal.nCheckpointIndex = 0;
+      cs->wal.iCheckpointReplay = 0;
+      cs->wal.iCheckpointDataEnd = 0;
+      cs->wal.nCheckpointEntries = 0;
+      memset(&cs->wal.checkpointHash, 0, sizeof(cs->wal.checkpointHash));
+      cs->wal.checkpointMagic = 0;
+      return rc==SQLITE_NOMEM ? rc : SQLITE_OK;
+    }
+    *pLoaded = 1;
     return SQLITE_OK;
   }
   nIndex = (int)(stamp.nCheckpointIndex / CHUNK_INDEX_ENTRY_SIZE);
@@ -926,6 +1195,10 @@ int csTryLoadWalCheckpoint(ChunkStore *cs, int *pLoaded){
   cs->wal.iCheckpointOffset = stamp.iCheckpointOffset;
   cs->wal.nCheckpointIndex = stamp.nCheckpointIndex;
   cs->wal.iCheckpointReplay = stamp.iCheckpointReplay;
+  cs->wal.iCheckpointDataEnd = stamp.iCheckpointDataEnd;
+  cs->wal.nCheckpointEntries = stamp.nCheckpointEntries;
+  cs->wal.checkpointHash = stamp.checkpointHash;
+  cs->wal.checkpointMagic = stamp.checkpointMagic;
   aIndex = 0;
   rc = csReplayWalFrom(cs, stamp.iCheckpointReplay);
   if( rc!=SQLITE_OK ) return rc;

--- a/src/chunk_wal.c
+++ b/src/chunk_wal.c
@@ -1054,12 +1054,17 @@ static int csFindLastCheckpointRoot(
       stamp = *pStamp;
       if( aRoot[0]==CS_WAL_TAG_ROOT
        && csManifestHashState(aRoot+1, iRoot)==CS_MANIFEST_HASH_OK
-       && csValidateWalRootManifest(cs, aRoot+1, iRoot)==SQLITE_OK
-       && csReadCheckpointStamp(aRoot+1, iRoot, &stamp) ){
-        *pRootOffset = iRoot;
-        *pStamp = stamp;
-        *pFound = 1;
-        return SQLITE_OK;
+       && csValidateWalRootManifest(cs, aRoot+1, iRoot)==SQLITE_OK ){
+        if( csReadCheckpointStamp(aRoot+1, iRoot, &stamp) ){
+          *pRootOffset = iRoot;
+          *pStamp = stamp;
+          *pFound = 1;
+          return SQLITE_OK;
+        }
+        if( CS_READ_I64(aRoot+1+CS_MANIFEST_DURABLE_TO_OFF)==iRoot
+         && CS_READ_I64(aRoot+1+CS_MANIFEST_BATCH_START_OFF)==iRoot ){
+          return SQLITE_OK;
+        }
       }
     }
     if( iStart==cs->wal.iWalOffset ) break;

--- a/src/chunk_wal.h
+++ b/src/chunk_wal.h
@@ -13,6 +13,9 @@ typedef struct ChunkStoreReloadState ChunkStoreReloadState;
 struct WalState {
   i64 iWalOffset;
   i64 nWalData;
+  i64 iCheckpointOffset;
+  i64 nCheckpointIndex;
+  i64 iCheckpointReplay;
   u8 recoveredMidStream;
   u8 cleanCloseMarker;
 };
@@ -41,6 +44,10 @@ void walStateSetDataSize(WalState *w, i64 nData);
 
 struct ChunkStore;
 int csReplayWal(struct ChunkStore *cs);
+int csTryLoadWalCheckpoint(struct ChunkStore *cs, int *pLoaded);
+int csWriteWalCheckpoint(struct ChunkStore *cs, int sectorSize);
+int csWalCheckpointDue(const struct ChunkStore *cs);
+void csStampWalCheckpoint(const struct ChunkStore *cs, u8 *aManifest);
 void csCaptureReloadState(struct ChunkStore *cs, ChunkStoreReloadState *pSaved);
 void csFreeReloadState(ChunkStoreReloadState *pSaved);
 void csAdoptOpenedStoreState(struct ChunkStore *pDst, struct ChunkStore *pSrc);

--- a/src/chunk_wal.h
+++ b/src/chunk_wal.h
@@ -16,6 +16,10 @@ struct WalState {
   i64 iCheckpointOffset;
   i64 nCheckpointIndex;
   i64 iCheckpointReplay;
+  i64 iCheckpointDataEnd;
+  int nCheckpointEntries;
+  ProllyHash checkpointHash;
+  u32 checkpointMagic;
   u8 recoveredMidStream;
   u8 cleanCloseMarker;
 };
@@ -25,6 +29,7 @@ struct ChunkStoreReplayState {
   int nIndex;
   void *aIndexMmapBase;
   i64 aIndexMmapSize;
+  ChunkIndexLazy lazy;
   SavedRefsState refs;
 };
 

--- a/src/chunk_wal.h
+++ b/src/chunk_wal.h
@@ -49,8 +49,10 @@ void walStateSetDataSize(WalState *w, i64 nData);
 
 struct ChunkStore;
 int csReplayWal(struct ChunkStore *cs);
-int csTryLoadWalCheckpoint(struct ChunkStore *cs, int *pLoaded);
-int csWriteWalCheckpoint(struct ChunkStore *cs, int sectorSize);
+int csReplayWalSkipping(struct ChunkStore *cs, i64 iSkipStart, i64 iSkipEnd);
+int csTryLoadWalCheckpoint(struct ChunkStore *cs, int *pLoaded,
+                           i64 *pSkipStart, i64 *pSkipEnd);
+int csWriteWalCheckpoint(struct ChunkStore *cs, int sectorSize, int *pWritten);
 int csWalCheckpointDue(const struct ChunkStore *cs);
 void csStampWalCheckpoint(const struct ChunkStore *cs, u8 *aManifest);
 void csCaptureReloadState(struct ChunkStore *cs, ChunkStoreReloadState *pSaved);

--- a/src/doltlite_gc.c
+++ b/src/doltlite_gc.c
@@ -1001,6 +1001,13 @@ static int gcRun(
     }
   }
 
+  rc = csMaterializeIndex(cs);
+  if( rc!=SQLITE_OK ){
+    chunkStoreUnlock(cs);
+    *pzPhase = "gc index load failed";
+    return rc;
+  }
+
   rc = prollyHashSetInit(&marked, chunkIndexCount(&cs->index) > 64 ? chunkIndexCount(&cs->index) : 64);
   if( rc!=SQLITE_OK ){
     chunkStoreUnlock(cs);

--- a/test/corruption_test.c
+++ b/test/corruption_test.c
@@ -1115,6 +1115,8 @@ static void test_large_wal_open_checkpoint(void){
   long long checkpointOff;
   long long checkpointSize;
   long long replayOff;
+  long long dataEnd;
+  unsigned int entryCount;
   int rc;
 
   printf("--- Test 24: Large WAL gets an open checkpoint ---\n");
@@ -1140,17 +1142,24 @@ static void test_large_wal_open_checkpoint(void){
   check("open_checkpoint_tail_root", tailOff>MANIFEST_SIZE);
   check("open_checkpoint_magic",
     read_u32_le_at(dbpath, tailOff+1+CS_MANIFEST_CHECKPOINT_MAGIC_OFF)
-      ==CS_WAL_CHECKPOINT_MAGIC);
+      ==CS_WAL_CHECKPOINT_MAGIC_V2);
   checkpointOff = read_i64_le_at(
       dbpath, tailOff+1+CS_MANIFEST_CHECKPOINT_OFFSET_OFF);
   checkpointSize = read_u32_le_at(
       dbpath, tailOff+1+CS_MANIFEST_CHECKPOINT_SIZE_OFF);
   replayOff = read_i64_le_at(
       dbpath, tailOff+1+CS_MANIFEST_CHECKPOINT_REPLAY_OFF);
+  dataEnd = read_i64_le_at(
+      dbpath, tailOff+1+CS_MANIFEST_CHECKPOINT_DATA_END_OFF);
+  entryCount = read_u32_le_at(
+      dbpath, tailOff+1+CS_MANIFEST_CHECKPOINT_COUNT_OFF);
   check("open_checkpoint_geometry",
     checkpointOff>=MANIFEST_SIZE
+    && dataEnd>=MANIFEST_SIZE
+    && checkpointOff>=dataEnd
     && checkpointSize>0
-    && checkpointSize%CHUNK_INDEX_ENTRY_SIZE==0
+    && checkpointSize<=CS_INDEX_PAGE_SIZE
+    && entryCount>0
     && checkpointOff+CS_WAL_CHUNK_HDR_SIZE+checkpointSize==tailOff
     && replayOff>=tailOff+1+MANIFEST_SIZE);
 
@@ -1172,7 +1181,7 @@ static void test_large_wal_open_checkpoint(void){
   tailOff = file_size(dbpath) - (1 + MANIFEST_SIZE);
   check("open_checkpoint_propagated",
     read_u32_le_at(dbpath, tailOff+1+CS_MANIFEST_CHECKPOINT_MAGIC_OFF)
-      ==CS_WAL_CHECKPOINT_MAGIC
+      ==CS_WAL_CHECKPOINT_MAGIC_V2
     && read_i64_le_at(dbpath,
          tailOff+1+CS_MANIFEST_CHECKPOINT_OFFSET_OFF)==checkpointOff);
   db = 0;
@@ -1212,6 +1221,67 @@ static void test_large_wal_open_checkpoint(void){
       sqlite3_free(pData);
       chunkStoreClose(&cs);
     }
+  }
+  removeDb(dbpath);
+}
+
+static void fill_checkpoint_value(unsigned char *a, int i){
+  int j;
+  for(j=0; j<32; j++) a[j] = (unsigned char)(i*37+j*11);
+  CS_WRITE_U32(a, (u32)i);
+}
+
+static void test_paged_checkpoint_large_index(void){
+  const char *dbpath = "/tmp/test_corr_paged_checkpoint.db";
+  const int nChunk = 20000;
+  const int aWant[] = { 0, 9999, 19999 };
+  ProllyHash aHash[3];
+  ChunkStore cs;
+  unsigned char value[32];
+  int i;
+  int rc;
+
+  printf("--- Test 24b: Paged checkpoint stays lazy for a large index ---\n");
+
+  removeDb(dbpath);
+  rc = chunkStoreOpen(&cs, sqlite3_vfs_find(0), dbpath,
+      SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_MAIN_DB);
+  check("paged_checkpoint_open", rc==SQLITE_OK);
+  if( rc!=SQLITE_OK ) return;
+  for(i=0; i<nChunk && rc==SQLITE_OK; i++){
+    ProllyHash hash;
+    fill_checkpoint_value(value, i);
+    rc = chunkStorePut(&cs, value, sizeof(value), &hash);
+    if( i==aWant[0] ) aHash[0] = hash;
+    if( i==aWant[1] ) aHash[1] = hash;
+    if( i==aWant[2] ) aHash[2] = hash;
+  }
+  check("paged_checkpoint_put", rc==SQLITE_OK);
+  if( rc==SQLITE_OK ) rc = chunkStoreCommit(&cs);
+  check("paged_checkpoint_commit", rc==SQLITE_OK);
+  if( rc==SQLITE_OK ) rc = csWriteWalCheckpoint(&cs, 1);
+  check("paged_checkpoint_write", rc==SQLITE_OK);
+  chunkStoreClose(&cs);
+
+  rc = chunkStoreOpen(&cs, sqlite3_vfs_find(0), dbpath,
+      SQLITE_OPEN_READWRITE | SQLITE_OPEN_MAIN_DB);
+  check("paged_checkpoint_reopen", rc==SQLITE_OK);
+  if( rc==SQLITE_OK ){
+    check("paged_checkpoint_no_eager_entries", cs.index.nIndex==0);
+    check("paged_checkpoint_entry_count",
+          chunkIndexCount(&cs.index)==nChunk);
+    for(i=0; i<3; i++){
+      u8 *pData = 0;
+      int nData = 0;
+      char name[64];
+      fill_checkpoint_value(value, aWant[i]);
+      rc = chunkStoreGet(&cs, &aHash[i], &pData, &nData);
+      snprintf(name, sizeof(name), "paged_checkpoint_lookup_%d", i);
+      check(name, rc==SQLITE_OK && nData==(int)sizeof(value)
+                  && memcmp(pData, value, sizeof(value))==0);
+      sqlite3_free(pData);
+    }
+    chunkStoreClose(&cs);
   }
   removeDb(dbpath);
 }
@@ -1483,6 +1553,7 @@ int main(void){
   test_damage_far_before_sealing_root_poisons();
   test_crash_garbage_truncated_on_write();
   test_large_wal_open_checkpoint();
+  test_paged_checkpoint_large_index();
   test_root_seal_binds_file_offset();
   test_header_seal_detects_tampered_wal_offset();
   test_unsealed_header_still_opens();

--- a/test/corruption_test.c
+++ b/test/corruption_test.c
@@ -1108,6 +1108,114 @@ static void test_damage_far_before_sealing_root_poisons(void){
   removeDb(dbpath);
 }
 
+static void test_large_wal_open_checkpoint(void){
+  const char *dbpath = "/tmp/test_corr_open_checkpoint.db";
+  sqlite3 *db = 0;
+  off_t tailOff;
+  long long checkpointOff;
+  long long checkpointSize;
+  long long replayOff;
+  int rc;
+
+  printf("--- Test 24: Large WAL gets an open checkpoint ---\n");
+
+  removeDb(dbpath);
+  rc = sqlite3_open(dbpath, &db);
+  check("open_checkpoint_create", rc==SQLITE_OK);
+  if( rc==SQLITE_OK ){
+    check("open_checkpoint_schema",
+      execSql(db,
+        "CREATE TABLE t(id INTEGER PRIMARY KEY, payload BLOB);"
+        "CREATE TABLE s(id INTEGER PRIMARY KEY)")
+        ==SQLITE_OK);
+    check("open_checkpoint_insert",
+      execSql(db, "INSERT INTO t VALUES(1, zeroblob(68157440))")
+        ==SQLITE_OK);
+    check("open_checkpoint_commit",
+      execSql(db, "SELECT dolt_commit('-Am','large')")==SQLITE_OK);
+  }
+  if( db ) sqlite3_close(db);
+
+  tailOff = file_size(dbpath) - (1 + MANIFEST_SIZE);
+  check("open_checkpoint_tail_root", tailOff>MANIFEST_SIZE);
+  check("open_checkpoint_magic",
+    read_u32_le_at(dbpath, tailOff+1+CS_MANIFEST_CHECKPOINT_MAGIC_OFF)
+      ==CS_WAL_CHECKPOINT_MAGIC);
+  checkpointOff = read_i64_le_at(
+      dbpath, tailOff+1+CS_MANIFEST_CHECKPOINT_OFFSET_OFF);
+  checkpointSize = read_u32_le_at(
+      dbpath, tailOff+1+CS_MANIFEST_CHECKPOINT_SIZE_OFF);
+  replayOff = read_i64_le_at(
+      dbpath, tailOff+1+CS_MANIFEST_CHECKPOINT_REPLAY_OFF);
+  check("open_checkpoint_geometry",
+    checkpointOff>=MANIFEST_SIZE
+    && checkpointSize>0
+    && checkpointSize%CHUNK_INDEX_ENTRY_SIZE==0
+    && checkpointOff+CS_WAL_CHUNK_HDR_SIZE+checkpointSize==tailOff
+    && replayOff>=tailOff+1+MANIFEST_SIZE);
+
+  db = 0;
+  rc = sqlite3_open(dbpath, &db);
+  check("open_checkpoint_reopen", rc==SQLITE_OK);
+  if( rc==SQLITE_OK ){
+    check("open_checkpoint_read",
+      strcmp(queryScalarText(db,
+        "SELECT count(*)||'|'||length(payload) FROM t"),
+        "1|68157440")==0);
+    check("open_checkpoint_tail_commit",
+      execSql(db,
+        "INSERT INTO s VALUES(2);"
+        "SELECT dolt_commit('-Am','tail');")==SQLITE_OK);
+  }
+  if( db ) sqlite3_close(db);
+
+  tailOff = file_size(dbpath) - (1 + MANIFEST_SIZE);
+  check("open_checkpoint_propagated",
+    read_u32_le_at(dbpath, tailOff+1+CS_MANIFEST_CHECKPOINT_MAGIC_OFF)
+      ==CS_WAL_CHECKPOINT_MAGIC
+    && read_i64_le_at(dbpath,
+         tailOff+1+CS_MANIFEST_CHECKPOINT_OFFSET_OFF)==checkpointOff);
+  db = 0;
+  rc = sqlite3_open(dbpath, &db);
+  check("open_checkpoint_tail_reopen", rc==SQLITE_OK);
+  if( rc==SQLITE_OK ){
+    check("open_checkpoint_tail_read",
+      strcmp(queryScalarText(db,
+        "SELECT (SELECT count(*) FROM t)||'|'||"
+        "(SELECT length(payload) FROM t)||'|'||"
+        "(SELECT count(*) FROM s)"),
+        "1|68157440|1")==0);
+  }
+  if( db ) sqlite3_close(db);
+
+  {
+    ChunkStore cs;
+    ProllyHash zero;
+    u8 *pData = 0;
+    int nData = 0;
+    unsigned char bad = 0;
+    memset(&zero, 0, sizeof(zero));
+    check("open_checkpoint_read_snapshot_byte",
+      read_bytes(dbpath,
+        (off_t)checkpointOff+CS_WAL_CHUNK_HDR_SIZE, &bad, 1)==0);
+    bad ^= 0x01;
+    check("open_checkpoint_corrupt_snapshot",
+      corrupt_bytes(dbpath,
+        (off_t)checkpointOff+CS_WAL_CHUNK_HDR_SIZE, &bad, 1)==0);
+    rc = chunkStoreOpen(&cs, sqlite3_vfs_find(0), dbpath,
+        SQLITE_OPEN_READWRITE | SQLITE_OPEN_MAIN_DB);
+    check("open_checkpoint_corrupt_reopen", rc==SQLITE_OK);
+    if( rc==SQLITE_OK ){
+      check("open_checkpoint_corrupt_poisoned", cs.corruptMidStream);
+      rc = chunkStoreGet(&cs, &zero, &pData, &nData);
+      check("open_checkpoint_corrupt_rejected", rc==SQLITE_CORRUPT);
+      sqlite3_free(pData);
+      chunkStoreClose(&cs);
+    }
+  }
+  removeDb(dbpath);
+}
+
 static void test_root_seal_binds_file_offset(void){
   unsigned char manifest[CHUNK_MANIFEST_SIZE];
   const long long rootOffset = 4096;
@@ -1374,6 +1482,7 @@ int main(void){
   test_corrupt_index_order();
   test_damage_far_before_sealing_root_poisons();
   test_crash_garbage_truncated_on_write();
+  test_large_wal_open_checkpoint();
   test_root_seal_binds_file_offset();
   test_header_seal_detects_tampered_wal_offset();
   test_unsealed_header_still_opens();

--- a/test/corruption_test.c
+++ b/test/corruption_test.c
@@ -1108,8 +1108,10 @@ static void test_damage_far_before_sealing_root_poisons(void){
   removeDb(dbpath);
 }
 
-static void test_large_wal_open_checkpoint(void){
+static void test_wal_open_checkpoint(void){
   const char *dbpath = "/tmp/test_corr_open_checkpoint.db";
+  const char *tornpath = "/tmp/test_corr_open_checkpoint_torn.db";
+  const char *gcpath = "/tmp/test_corr_open_checkpoint_gc.db";
   sqlite3 *db = 0;
   off_t tailOff;
   long long checkpointOff;
@@ -1117,9 +1119,10 @@ static void test_large_wal_open_checkpoint(void){
   long long replayOff;
   long long dataEnd;
   unsigned int entryCount;
+  int wroteCheckpoint = 0;
   int rc;
 
-  printf("--- Test 24: Large WAL gets an open checkpoint ---\n");
+  printf("--- Test 24: WAL open checkpoint recovery ---\n");
 
   removeDb(dbpath);
   rc = sqlite3_open(dbpath, &db);
@@ -1131,12 +1134,25 @@ static void test_large_wal_open_checkpoint(void){
         "CREATE TABLE s(id INTEGER PRIMARY KEY)")
         ==SQLITE_OK);
     check("open_checkpoint_insert",
-      execSql(db, "INSERT INTO t VALUES(1, zeroblob(68157440))")
+      execSql(db, "INSERT INTO t VALUES(1, zeroblob(4096))")
         ==SQLITE_OK);
     check("open_checkpoint_commit",
       execSql(db, "SELECT dolt_commit('-Am','large')")==SQLITE_OK);
   }
   if( db ) sqlite3_close(db);
+
+  {
+    ChunkStore cs;
+    rc = chunkStoreOpen(&cs, sqlite3_vfs_find(0), dbpath,
+        SQLITE_OPEN_READWRITE | SQLITE_OPEN_MAIN_DB);
+    check("open_checkpoint_store_open", rc==SQLITE_OK);
+    if( rc==SQLITE_OK ){
+      rc = csWriteWalCheckpoint(&cs, 1, &wroteCheckpoint);
+      check("open_checkpoint_write",
+            rc==SQLITE_OK && wroteCheckpoint);
+      chunkStoreClose(&cs);
+    }
+  }
 
   tailOff = file_size(dbpath) - (1 + MANIFEST_SIZE);
   check("open_checkpoint_tail_root", tailOff>MANIFEST_SIZE);
@@ -1161,16 +1177,28 @@ static void test_large_wal_open_checkpoint(void){
     && checkpointSize<=CS_INDEX_PAGE_SIZE
     && entryCount>0
     && checkpointOff+CS_WAL_CHUNK_HDR_SIZE+checkpointSize==tailOff
-    && replayOff>=tailOff+1+MANIFEST_SIZE);
+    && replayOff>=tailOff+1+MANIFEST_SIZE
+    && read_i64_le_at(dbpath,
+         tailOff+1+CS_MANIFEST_DURABLE_TO_OFF)==dataEnd
+    && read_i64_le_at(dbpath,
+         tailOff+1+CS_MANIFEST_BATCH_START_OFF)==dataEnd);
 
   db = 0;
+  {
+    ChunkStore cs;
+    rc = chunkStoreOpen(&cs, sqlite3_vfs_find(0), dbpath,
+        SQLITE_OPEN_READWRITE | SQLITE_OPEN_MAIN_DB);
+    check("open_checkpoint_fast_path",
+          rc==SQLITE_OK && cs.index.lazy.active && cs.index.nIndex==0);
+    if( rc==SQLITE_OK ) chunkStoreClose(&cs);
+  }
   rc = sqlite3_open(dbpath, &db);
   check("open_checkpoint_reopen", rc==SQLITE_OK);
   if( rc==SQLITE_OK ){
     check("open_checkpoint_read",
       strcmp(queryScalarText(db,
         "SELECT count(*)||'|'||length(payload) FROM t"),
-        "1|68157440")==0);
+        "1|4096")==0);
     check("open_checkpoint_tail_commit",
       execSql(db,
         "INSERT INTO s VALUES(2);"
@@ -1193,17 +1221,75 @@ static void test_large_wal_open_checkpoint(void){
         "SELECT (SELECT count(*) FROM t)||'|'||"
         "(SELECT length(payload) FROM t)||'|'||"
         "(SELECT count(*) FROM s)"),
-        "1|68157440|1")==0);
+        "1|4096|1")==0);
   }
   if( db ) sqlite3_close(db);
 
   {
     ChunkStore cs;
-    ProllyHash zero;
-    u8 *pData = 0;
-    int nData = 0;
     unsigned char bad = 0;
-    memset(&zero, 0, sizeof(zero));
+    unsigned char torn = CS_WAL_TAG_CHUNK;
+    off_t walOffset = (off_t)read_i64_le_at(dbpath,
+        CS_MANIFEST_WAL_OFFSET_OFF);
+    removeDb(tornpath);
+    check("open_checkpoint_torn_copy", copy_file(dbpath, tornpath)==0);
+    check("open_checkpoint_prefix_hash_read",
+      read_bytes(tornpath, walOffset+CS_WAL_CHUNK_HASH_OFF, &bad, 1)==0);
+    bad ^= 0x01;
+    check("open_checkpoint_prefix_hash_corrupt",
+      corrupt_bytes(tornpath, walOffset+CS_WAL_CHUNK_HASH_OFF, &bad, 1)==0);
+    check("open_checkpoint_torn_append",
+      corrupt_bytes(tornpath, file_size(tornpath), &torn, 1)==0);
+    rc = chunkStoreOpen(&cs, sqlite3_vfs_find(0), tornpath,
+        SQLITE_OPEN_READWRITE | SQLITE_OPEN_MAIN_DB);
+    check("open_checkpoint_torn_fast_path",
+      rc==SQLITE_OK && cs.index.lazy.active && !cs.corruptMidStream);
+    if( rc==SQLITE_OK ) chunkStoreClose(&cs);
+    db = 0;
+    rc = sqlite3_open(tornpath, &db);
+    check("open_checkpoint_torn_sql_open", rc==SQLITE_OK);
+    if( rc==SQLITE_OK ){
+      check("open_checkpoint_torn_read",
+        strcmp(queryScalarText(db,
+          "SELECT (SELECT count(*) FROM t)||'|'||"
+          "(SELECT length(payload) FROM t)||'|'||"
+          "(SELECT count(*) FROM s)"),
+          "1|4096|1")==0);
+      sqlite3_close(db);
+    }
+    removeDb(tornpath);
+  }
+
+  removeDb(gcpath);
+  check("open_checkpoint_gc_copy", copy_file(dbpath, gcpath)==0);
+  db = 0;
+  rc = sqlite3_open(gcpath, &db);
+  check("open_checkpoint_gc_open", rc==SQLITE_OK);
+  if( rc==SQLITE_OK ){
+    check("open_checkpoint_gc_run",
+      execSql(db, "SELECT dolt_gc()")==SQLITE_OK);
+    sqlite3_close(db);
+  }
+  check("open_checkpoint_gc_stamp_cleared",
+    read_u32_le_at(gcpath, CS_MANIFEST_CHECKPOINT_MAGIC_OFF)
+      !=CS_WAL_CHECKPOINT_MAGIC_V2);
+  db = 0;
+  rc = sqlite3_open(gcpath, &db);
+  check("open_checkpoint_gc_reopen", rc==SQLITE_OK);
+  if( rc==SQLITE_OK ){
+    check("open_checkpoint_gc_read",
+      strcmp(queryScalarText(db,
+        "SELECT (SELECT count(*) FROM t)||'|'||"
+        "(SELECT length(payload) FROM t)||'|'||"
+        "(SELECT count(*) FROM s)"),
+        "1|4096|1")==0);
+    sqlite3_close(db);
+  }
+  removeDb(gcpath);
+
+  {
+    ChunkStore cs;
+    unsigned char bad = 0;
     check("open_checkpoint_read_snapshot_byte",
       read_bytes(dbpath,
         (off_t)checkpointOff+CS_WAL_CHUNK_HDR_SIZE, &bad, 1)==0);
@@ -1215,11 +1301,24 @@ static void test_large_wal_open_checkpoint(void){
         SQLITE_OPEN_READWRITE | SQLITE_OPEN_MAIN_DB);
     check("open_checkpoint_corrupt_reopen", rc==SQLITE_OK);
     if( rc==SQLITE_OK ){
-      check("open_checkpoint_corrupt_poisoned", cs.corruptMidStream);
-      rc = chunkStoreGet(&cs, &zero, &pData, &nData);
-      check("open_checkpoint_corrupt_rejected", rc==SQLITE_CORRUPT);
-      sqlite3_free(pData);
+      check("open_checkpoint_corrupt_fallback", !cs.corruptMidStream);
       chunkStoreClose(&cs);
+    }
+    db = 0;
+    rc = sqlite3_open(dbpath, &db);
+    check("open_checkpoint_corrupt_sql_open", rc==SQLITE_OK);
+    if( rc==SQLITE_OK ){
+      check("open_checkpoint_corrupt_read",
+        strcmp(queryScalarText(db,
+          "SELECT (SELECT count(*) FROM t)||'|'||"
+          "(SELECT length(payload) FROM t)||'|'||"
+          "(SELECT count(*) FROM s)"),
+          "1|4096|1")==0);
+      check("open_checkpoint_corrupt_write",
+        execSql(db,
+          "INSERT INTO s VALUES(3);"
+          "SELECT dolt_commit('-Am','after fallback')")==SQLITE_OK);
+      sqlite3_close(db);
     }
   }
   removeDb(dbpath);
@@ -1259,7 +1358,11 @@ static void test_paged_checkpoint_large_index(void){
   check("paged_checkpoint_put", rc==SQLITE_OK);
   if( rc==SQLITE_OK ) rc = chunkStoreCommit(&cs);
   check("paged_checkpoint_commit", rc==SQLITE_OK);
-  if( rc==SQLITE_OK ) rc = csWriteWalCheckpoint(&cs, 1);
+  if( rc==SQLITE_OK ){
+    int wroteCheckpoint = 0;
+    rc = csWriteWalCheckpoint(&cs, 1, &wroteCheckpoint);
+    if( rc==SQLITE_OK && !wroteCheckpoint ) rc = SQLITE_ERROR;
+  }
   check("paged_checkpoint_write", rc==SQLITE_OK);
   chunkStoreClose(&cs);
 
@@ -1552,7 +1655,7 @@ int main(void){
   test_corrupt_index_order();
   test_damage_far_before_sealing_root_poisons();
   test_crash_garbage_truncated_on_write();
-  test_large_wal_open_checkpoint();
+  test_wal_open_checkpoint();
   test_paged_checkpoint_large_index();
   test_root_seal_binds_file_offset();
   test_header_seal_detects_tampered_wal_offset();

--- a/test/doltlite_checkpoint_perf.sh
+++ b/test/doltlite_checkpoint_perf.sh
@@ -1,0 +1,334 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+DOLTLITE="${1:-./doltlite}"
+THRESHOLD_BYTES="${DOLTLITE_CHECKPOINT_PERF_THRESHOLD_BYTES:-67108864}"
+PAYLOAD_BYTES="${DOLTLITE_CHECKPOINT_PERF_PAYLOAD_BYTES:-2097152}"
+MAX_APPENDS="${DOLTLITE_CHECKPOINT_PERF_MAX_APPENDS:-128}"
+TRIALS="${DOLTLITE_CHECKPOINT_PERF_TRIALS:-5}"
+TMP="$(mktemp -d)"
+PROBE_DB="$TMP/checkpoint_probe.db"
+BASE_DB="$TMP/checkpoint_base.db"
+trap 'rm -rf "$TMP"' EXIT
+
+if [ ! -x "$DOLTLITE" ]; then
+  echo "doltlite binary not found: $DOLTLITE" >&2
+  exit 1
+fi
+case "$THRESHOLD_BYTES:$PAYLOAD_BYTES:$MAX_APPENDS:$TRIALS" in
+  *[!0-9:]*|'')
+    echo "checkpoint performance settings must be positive integers" >&2
+    exit 1
+    ;;
+esac
+if [ "$THRESHOLD_BYTES" -le 0 ] || [ "$PAYLOAD_BYTES" -le 0 ] \
+   || [ "$MAX_APPENDS" -lt 2 ] || [ "$TRIALS" -lt 1 ]; then
+  echo "checkpoint performance settings must be positive integers" >&2
+  exit 1
+fi
+
+export DOLTLITE_WAL_CHECKPOINT_THRESHOLD="$THRESHOLD_BYTES"
+
+checkpoint_stamp() {
+  python3 -c '
+import os
+import struct
+import sys
+
+with open(sys.argv[1], "rb") as f:
+    # The final root is 169 bytes and its manifest starts at byte 1.
+    f.seek(-169, os.SEEK_END)
+    manifest = f.read(169)[1:]
+    print("%08x %d %d" % (
+        struct.unpack_from("<I", manifest, 8)[0],
+        struct.unpack_from("<q", manifest, 12)[0],
+        struct.unpack_from("<q", manifest, 68)[0]))
+' "$1"
+}
+
+checkpoint_magic() {
+  checkpoint_stamp "$1" | awk '{print $1}'
+}
+
+file_size() {
+  python3 -c 'import os, sys; print(os.path.getsize(sys.argv[1]))' "$1"
+}
+
+sync_file() {
+  python3 -c '
+import os
+import sys
+
+with open(sys.argv[1], "rb+") as f:
+    os.fsync(f.fileno())
+' "$1"
+}
+
+init_db() {
+  "$DOLTLITE" "$1" \
+    "CREATE TABLE updates(id INTEGER PRIMARY KEY, payload BLOB NOT NULL); INSERT INTO updates VALUES(1,randomblob($PAYLOAD_BYTES)); SELECT dolt_commit('-A','-m','checkpoint perf schema');" \
+    >/dev/null
+}
+
+append_update() {
+  "$DOLTLITE" "$1" \
+    "UPDATE updates SET payload=randomblob($PAYLOAD_BYTES) WHERE id=1;" \
+    >/dev/null
+}
+
+wait_for_marker() {
+  local pid="$1"
+  local output_file="$2"
+  local marker="$3"
+
+  for ((attempt=0; attempt<500; attempt++)); do
+    if grep -Fqx "$marker" "$output_file"; then
+      return 0
+    fi
+    if ! kill -0 "$pid" 2>/dev/null; then
+      return 1
+    fi
+    sleep 0.01
+  done
+  return 1
+}
+
+measure_trial() {
+  local db="$1"
+  local trial="$2"
+  local input="$db.$trial.input"
+  local output_file="$db.$trial.output"
+  local pid
+  local elapsed
+  local below_stamp
+  local checkpoint_stamp_value
+  local post_stamp
+  local below_wal_bytes
+
+  mkfifo "$input"
+  "$DOLTLITE" "$db" <"$input" >"$output_file" 2>&1 &
+  pid=$!
+  exec 3>"$input"
+
+  printf '%s\n' \
+    'SELECT count(*) FROM updates;' \
+    '.shell echo warm_done' \
+    >&3
+  if ! wait_for_marker "$pid" "$output_file" warm_done; then
+    printf '%s\n' '.quit' >&3 || true
+    exec 3>&-
+    wait "$pid" || true
+    echo "untimed warm-up did not complete:" >&2
+    sed -n '1,120p' "$output_file" >&2
+    return 1
+  fi
+
+  printf '%s\n' \
+    '.timer on' \
+    "UPDATE updates SET payload=randomblob($PAYLOAD_BYTES) WHERE id=1;" \
+    '.timer off' \
+    '.shell echo timed_below_done' \
+    >&3
+  if ! wait_for_marker "$pid" "$output_file" timed_below_done; then
+    printf '%s\n' '.quit' >&3 || true
+    exec 3>&-
+    wait "$pid" || true
+    echo "below-threshold append did not complete:" >&2
+    sed -n '1,120p' "$output_file" >&2
+    return 1
+  fi
+  below_stamp=$(checkpoint_stamp "$db")
+  below_wal_bytes=$(($(file_size "$db") - 168))
+
+  printf '%s\n' \
+    '.timer on' \
+    "UPDATE updates SET payload=randomblob($PAYLOAD_BYTES) WHERE id=1;" \
+    '.timer off' \
+    '.shell echo timed_checkpoint_done' \
+    >&3
+  if ! wait_for_marker "$pid" "$output_file" timed_checkpoint_done; then
+    printf '%s\n' '.quit' >&3 || true
+    exec 3>&-
+    wait "$pid" || true
+    echo "checkpointing append did not complete:" >&2
+    sed -n '1,120p' "$output_file" >&2
+    return 1
+  fi
+  checkpoint_stamp_value=$(checkpoint_stamp "$db")
+
+  printf '%s\n' \
+    '.timer on' \
+    "UPDATE updates SET payload=randomblob($PAYLOAD_BYTES) WHERE id=1;" \
+    '.timer off' \
+    '.shell echo timed_post_done' \
+    >&3
+  if ! wait_for_marker "$pid" "$output_file" timed_post_done; then
+    printf '%s\n' '.quit' >&3 || true
+    exec 3>&-
+    wait "$pid" || true
+    echo "post-checkpoint append did not complete:" >&2
+    sed -n '1,120p' "$output_file" >&2
+    return 1
+  fi
+  post_stamp=$(checkpoint_stamp "$db")
+
+  printf '%s\n' '.quit' >&3 || true
+  exec 3>&-
+  if ! wait "$pid"; then
+    echo "timed append session failed:" >&2
+    sed -n '1,120p' "$output_file" >&2
+    return 1
+  fi
+
+  elapsed=$(awk '
+    $1=="Run" && $2=="Time:" && $3=="real" {
+      values[++n]=$4
+    }
+    END {
+      if (n==3) printf "%s %s %s\n", values[1], values[2], values[3]
+    }
+  ' "$output_file")
+  set -- $elapsed
+  if [ "$#" -ne 3 ]; then
+    echo "unable to read three append timings:" >&2
+    sed -n '1,120p' "$output_file" >&2
+    return 1
+  fi
+  printf '%s %s %s %s %s %s %s\n' \
+    "$1" "$below_wal_bytes" "$below_stamp" \
+    "$2" "$checkpoint_stamp_value" "$3" "$post_stamp"
+}
+
+median() {
+  printf '%s\n' "$@" | sort -n | awk '
+    { values[NR]=$1 }
+    END {
+      middle=int((NR+1)/2)
+      if (NR%2) print values[middle]
+      else print (values[middle]+values[middle+1])/2
+    }
+  '
+}
+
+init_db "$PROBE_DB"
+CROSSING=0
+for ((i=1; i<=MAX_APPENDS; i++)); do
+  append_update "$PROBE_DB" "$i"
+  if [ "$(checkpoint_magic "$PROBE_DB")" = "32504b43" ]; then
+    CROSSING="$i"
+    break
+  fi
+done
+if [ "$CROSSING" -lt 2 ]; then
+  echo "checkpoint did not cross after at least two appends" >&2
+  exit 1
+fi
+
+init_db "$BASE_DB"
+for ((i=1; i<CROSSING-1; i++)); do
+  append_update "$BASE_DB" "$i"
+done
+
+BELOW_SAMPLES=()
+CHECKPOINT_SAMPLES=()
+POST_SAMPLES=()
+SAMPLE_LINES=()
+BELOW_WAL_BYTES=0
+for ((trial=1; trial<=TRIALS; trial++)); do
+  MEASURE_DB="$TMP/checkpoint_measure_$trial.db"
+  cp "$BASE_DB" "$MEASURE_DB"
+  # Keep clone writeback out of the first append timing.
+  sync_file "$MEASURE_DB"
+
+  if ! read -r BELOW_SECONDS BELOW_WAL_BYTES BELOW_APPEND_MAGIC \
+      BELOW_APPEND_OFFSET BELOW_APPEND_REPLAY \
+      CHECKPOINT_SECONDS CHECKPOINT_APPEND_MAGIC \
+      CHECKPOINT_APPEND_OFFSET CHECKPOINT_APPEND_REPLAY \
+      POST_SECONDS POST_APPEND_MAGIC POST_APPEND_OFFSET POST_APPEND_REPLAY \
+      < <(measure_trial "$MEASURE_DB" "$trial"); then
+    exit 1
+  fi
+  if [ "$BELOW_APPEND_MAGIC" = "32504b43" ]; then
+    echo "append $((CROSSING - 1)) unexpectedly created a checkpoint" >&2
+    exit 1
+  fi
+  if [ "$BELOW_WAL_BYTES" -ge "$THRESHOLD_BYTES" ]; then
+    echo "below-threshold WAL reached $BELOW_WAL_BYTES bytes" >&2
+    exit 1
+  fi
+
+  if [ "$CHECKPOINT_APPEND_MAGIC" != "32504b43" ]; then
+    echo "append $CROSSING did not create a checkpoint during the timed append" >&2
+    exit 1
+  fi
+
+  read -r POST_MAGIC POST_OFFSET POST_REPLAY < <(checkpoint_stamp "$MEASURE_DB")
+  if [ "$POST_APPEND_MAGIC" != "32504b43" ] || [ "$POST_MAGIC" != "32504b43" ] \
+     || [ "$POST_APPEND_OFFSET" -ne "$CHECKPOINT_APPEND_OFFSET" ] \
+     || [ "$POST_APPEND_REPLAY" -ne "$CHECKPOINT_APPEND_REPLAY" ] \
+     || [ "$POST_OFFSET" -ne "$CHECKPOINT_APPEND_OFFSET" ] \
+     || [ "$POST_REPLAY" -ne "$CHECKPOINT_APPEND_REPLAY" ]; then
+    echo "append $((CROSSING + 1)) did not reuse the existing checkpoint" >&2
+    exit 1
+  fi
+  if ! awk -v below="$BELOW_SECONDS" -v checkpoint="$CHECKPOINT_SECONDS" \
+      -v post="$POST_SECONDS" \
+      'BEGIN { exit !(below>0 && checkpoint>0 && post>0) }'; then
+    echo "append times must be positive" >&2
+    exit 1
+  fi
+
+  ROWS=$("$DOLTLITE" "$MEASURE_DB" "SELECT count(*) FROM updates;")
+  INTEGRITY=$("$DOLTLITE" "$MEASURE_DB" "PRAGMA integrity_check;")
+  if [ "$ROWS" -ne 1 ]; then
+    echo "expected 1 row, got $ROWS" >&2
+    exit 1
+  fi
+  if [ "$INTEGRITY" != "ok" ]; then
+    echo "integrity_check returned $INTEGRITY" >&2
+    exit 1
+  fi
+
+  BELOW_SAMPLES+=("$BELOW_SECONDS")
+  CHECKPOINT_SAMPLES+=("$CHECKPOINT_SECONDS")
+  POST_SAMPLES+=("$POST_SECONDS")
+  CHECKPOINT_RATIO=$(awk -v below="$BELOW_SECONDS" -v checkpoint="$CHECKPOINT_SECONDS" \
+    'BEGIN { printf "%.6f", checkpoint/below }')
+  POST_RATIO=$(awk -v below="$BELOW_SECONDS" -v post="$POST_SECONDS" \
+    'BEGIN { printf "%.6f", post/below }')
+  BELOW_MS=$(awk -v n="$BELOW_SECONDS" 'BEGIN { printf "%.3f", n*1000 }')
+  CHECKPOINT_MS=$(awk -v n="$CHECKPOINT_SECONDS" 'BEGIN { printf "%.3f", n*1000 }')
+  POST_MS=$(awk -v n="$POST_SECONDS" 'BEGIN { printf "%.3f", n*1000 }')
+  CHECKPOINT_RATIO_DISPLAY=$(awk -v n="$CHECKPOINT_RATIO" \
+    'BEGIN { printf "%.3f", n }')
+  POST_RATIO_DISPLAY=$(awk -v n="$POST_RATIO" 'BEGIN { printf "%.3f", n }')
+  SAMPLE_LINES+=(
+    "  trial $trial: below=${BELOW_MS}ms checkpoint=${CHECKPOINT_MS}ms post=${POST_MS}ms"
+    "    checkpoint/below=${CHECKPOINT_RATIO_DISPLAY}x post/below=${POST_RATIO_DISPLAY}x"
+  )
+done
+
+MEDIAN_BELOW=$(median "${BELOW_SAMPLES[@]}")
+MEDIAN_CHECKPOINT=$(median "${CHECKPOINT_SAMPLES[@]}")
+MEDIAN_POST=$(median "${POST_SAMPLES[@]}")
+MEDIAN_BELOW_MS=$(awk -v n="$MEDIAN_BELOW" 'BEGIN { printf "%.3f", n*1000 }')
+MEDIAN_CHECKPOINT_MS=$(awk -v n="$MEDIAN_CHECKPOINT" 'BEGIN { printf "%.3f", n*1000 }')
+MEDIAN_POST_MS=$(awk -v n="$MEDIAN_POST" 'BEGIN { printf "%.3f", n*1000 }')
+MEDIAN_CHECKPOINT_RATIO=$(awk -v below="$MEDIAN_BELOW" -v checkpoint="$MEDIAN_CHECKPOINT" \
+  'BEGIN { printf "%.3f", checkpoint/below }')
+MEDIAN_POST_RATIO=$(awk -v below="$MEDIAN_BELOW" -v post="$MEDIAN_POST" \
+  'BEGIN { printf "%.3f", post/below }')
+
+echo "=== DoltLite WAL Checkpoint Append Cost ==="
+echo "  threshold: $THRESHOLD_BYTES bytes"
+echo "  payload per append: $PAYLOAD_BYTES bytes"
+echo "  checkpoint created on append: $CROSSING"
+echo "  WAL bytes after below-threshold append: $BELOW_WAL_BYTES"
+printf '%s\n' "${SAMPLE_LINES[@]}"
+echo "  median below-threshold append: ${MEDIAN_BELOW_MS}ms"
+echo "  median checkpointing append: ${MEDIAN_CHECKPOINT_MS}ms"
+echo "  median post-checkpoint append on same connection: ${MEDIAN_POST_MS}ms"
+echo "  median checkpoint/below ratio: ${MEDIAN_CHECKPOINT_RATIO}x"
+echo "  median post/below ratio: ${MEDIAN_POST_RATIO}x"
+echo "PASS: measured checkpoint and post-checkpoint append ratios; no bound is enforced yet"

--- a/test/doltlite_open_perf.sh
+++ b/test/doltlite_open_perf.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+DOLTLITE="${1:-./doltlite}"
+COMMITS_PER_STAGE="${DOLTLITE_OPEN_PERF_COMMITS:-64}"
+STAGES="${DOLTLITE_OPEN_PERF_STAGES:-3}"
+OPENS_PER_SAMPLE="${DOLTLITE_OPEN_PERF_OPENS:-40}"
+SAMPLES="${DOLTLITE_OPEN_PERF_SAMPLES:-3}"
+MAX_GROWTH_MS="${DOLTLITE_OPEN_PERF_MAX_GROWTH_MS:-750}"
+TMP="$(mktemp -d)"
+DB="$TMP/open_perf.db"
+trap 'rm -rf "$TMP"' EXIT
+
+if [ ! -x "$DOLTLITE" ]; then
+  echo "doltlite binary not found: $DOLTLITE" >&2
+  exit 1
+fi
+if [ "$STAGES" -lt 2 ]; then
+  echo "DOLTLITE_OPEN_PERF_STAGES must be at least 2" >&2
+  exit 1
+fi
+
+append_commits() {
+  local first="$1"
+  local count="$2"
+  local last=$((first + count - 1))
+  local i
+  {
+    echo "CREATE TABLE IF NOT EXISTS updates(id INTEGER PRIMARY KEY, payload BLOB NOT NULL);"
+    for ((i=first; i<=last; i++)); do
+      echo "INSERT INTO updates(payload) VALUES(zeroblob(2097152));"
+      echo "SELECT dolt_commit('-A','-m','open perf $i');"
+    done
+  } | "$DOLTLITE" "$DB" >/dev/null
+}
+
+time_opens_ms() {
+  local start end i
+  start=$(python3 -c 'import time; print(time.monotonic_ns())')
+  for ((i=0; i<OPENS_PER_SAMPLE; i++)); do
+    "$DOLTLITE" "$DB" "SELECT 1;" >/dev/null
+  done
+  end=$(python3 -c 'import time; print(time.monotonic_ns())')
+  echo $(((end - start) / 1000000))
+}
+
+median_open_ms() {
+  local values=""
+  local i
+  for ((i=0; i<SAMPLES; i++)); do
+    values+="$(time_opens_ms)"$'\n'
+  done
+  printf '%s' "$values" | sort -n | awk -v n="$SAMPLES" 'NR==int((n+2)/2){print; exit}'
+}
+
+echo "=== DoltLite Open-Time Growth Test ==="
+
+declare -a COUNTS TIMES
+PREVIOUS=0
+TARGET="$COMMITS_PER_STAGE"
+for ((stage=0; stage<STAGES; stage++)); do
+  append_commits $((PREVIOUS + 1)) $((TARGET - PREVIOUS))
+  COUNTS[stage]="$TARGET"
+  TIMES[stage]=$(median_open_ms)
+  PREVIOUS="$TARGET"
+  TARGET=$((TARGET * 2))
+done
+
+EXPECTED_ROWS="$PREVIOUS"
+ROWS=$("$DOLTLITE" "$DB" "SELECT count(*) FROM updates;")
+LOG_ROWS=$("$DOLTLITE" "$DB" "SELECT count(*) FROM dolt_log;")
+INTEGRITY=$("$DOLTLITE" "$DB" "PRAGMA integrity_check;")
+GROWTH_MS=$((${TIMES[STAGES-1]} - ${TIMES[0]}))
+
+for ((stage=0; stage<STAGES; stage++)); do
+  echo "  ${COUNTS[stage]} commits: ${TIMES[stage]}ms median for $OPENS_PER_SAMPLE opens"
+done
+echo "  growth: ${GROWTH_MS}ms; maximum allowed: ${MAX_GROWTH_MS}ms"
+
+if [ "$ROWS" -ne "$EXPECTED_ROWS" ]; then
+  echo "FAIL: expected $EXPECTED_ROWS rows, got $ROWS" >&2
+  exit 1
+fi
+if [ "$LOG_ROWS" -ne $((EXPECTED_ROWS + 1)) ]; then
+  echo "FAIL: expected $((EXPECTED_ROWS + 1)) log rows, got $LOG_ROWS" >&2
+  exit 1
+fi
+if [ "$INTEGRITY" != "ok" ]; then
+  echo "FAIL: integrity_check returned $INTEGRITY" >&2
+  exit 1
+fi
+if [ "$GROWTH_MS" -gt "$MAX_GROWTH_MS" ]; then
+  echo "FAIL: open time grew by ${GROWTH_MS}ms" >&2
+  exit 1
+fi
+
+echo "PASS: open time stayed consistent across repeated history doublings"

--- a/test/doltlite_recover_corruption.test
+++ b/test/doltlite_recover_corruption.test
@@ -300,6 +300,87 @@ do_execsql_test doltlite_recover_corruption-4.1 {
   PRAGMA integrity_check;
 } {0 B B C ok}
 
-forcedelete rch1.db rch2.db rcor.db
+db close
+
+do_test doltlite_recover_corruption-5.1 {
+  forcedelete checkpoint.db checkpoint-crash.db
+  set ::env(DOLTLITE_WAL_CHECKPOINT_THRESHOLD) 1024
+  sqlite3 db checkpoint.db
+  db eval {
+    CREATE TABLE cp(id INTEGER PRIMARY KEY, payload BLOB);
+    INSERT INTO cp VALUES(1, zeroblob(4096));
+    SELECT dolt_commit('-A','-m','checkpoint');
+  }
+  set ::cpSize [file size checkpoint.db]
+  set ::cpTail [expr {$::cpSize - 169}]
+  set ::cpOffset [rdI64 checkpoint.db [expr {$::cpTail + 13}]]
+  file copy -force checkpoint.db checkpoint-crash.db
+  list [format %08x [rdU32 checkpoint.db [expr {$::cpTail + 9}]]] \
+       [db eval {SELECT count(*), length(payload) FROM cp}]
+} {32504b43 {1 4096}}
+
+do_test doltlite_recover_corruption-5.2 {
+  sqlite3 dbc checkpoint-crash.db
+  set res [list [dbc eval {SELECT count(*), length(payload) FROM cp}] \
+                [dbc eval {PRAGMA integrity_check}]]
+  dbc close
+  set res
+} {{1 4096} ok}
+
+do_test doltlite_recover_corruption-5.3 {
+  db close
+  forcedelete checkpoint-torn.db
+  file copy -force checkpoint.db checkpoint-torn.db
+  set walOffset [rdI64 checkpoint-torn.db 84]
+  xorByte checkpoint-torn.db [expr {$walOffset + 1}]
+  set f [open checkpoint-torn.db a]
+  fconfigure $f -translation binary
+  puts -nonewline $f [binary format c 1]
+  close $f
+  sqlite3 dbc checkpoint-torn.db
+  set rc [catch {
+    list [dbc eval {SELECT count(*), length(payload) FROM cp}] \
+         [dbc eval {PRAGMA integrity_check}]
+  } res]
+  dbc close
+  list $rc $res
+} {0 {{1 4096} ok}}
+
+do_test doltlite_recover_corruption-5.4 {
+  forcedelete checkpoint-bad.db
+  file copy -force checkpoint.db checkpoint-bad.db
+  xorByte checkpoint-bad.db [expr {$::cpOffset + 25}]
+  sqlite3 dbc checkpoint-bad.db
+  set before [dbc eval {SELECT count(*), length(payload) FROM cp}]
+  set rc [catch {
+    dbc eval {
+      INSERT INTO cp VALUES(2, zeroblob(32));
+      SELECT dolt_commit('-A','-m','after checkpoint fallback');
+    }
+  }]
+  set after [dbc eval {SELECT count(*) FROM cp}]
+  dbc close
+  list $before $rc $after
+} {{1 4096} 0 2}
+
+do_test doltlite_recover_corruption-5.5 {
+  forcedelete checkpoint-gc.db
+  file copy -force checkpoint.db checkpoint-gc.db
+  sqlite3 dbc checkpoint-gc.db
+  dbc eval {SELECT dolt_gc()}
+  dbc close
+  set stamp [format %08x [rdU32 checkpoint-gc.db 8]]
+  sqlite3 dbc checkpoint-gc.db
+  set res [list $stamp \
+                [dbc eval {SELECT count(*), length(payload) FROM cp}] \
+                [dbc eval {PRAGMA integrity_check}]]
+  dbc close
+  set res
+} {00000000 {1 4096} ok}
+
+unset ::env(DOLTLITE_WAL_CHECKPOINT_THRESHOLD)
+
+forcedelete rch1.db rch2.db rcor.db checkpoint.db checkpoint-crash.db \
+            checkpoint-torn.db checkpoint-bad.db checkpoint-gc.db
 
 finish_test

--- a/test/doltlite_recover_shared_ioerr.test
+++ b/test/doltlite_recover_shared_ioerr.test
@@ -78,11 +78,11 @@ proc drs_run {iFail} {
 }
 
 do_test 1.1 {
-  drs_run 122
+  drs_run 127
 } {1 {disk I/O error} 1 1 {0 {1024 1 1024}} {0 {1023 1 512}} {0 ok}}
 
 do_test 1.2 {
-  drs_run 126
+  drs_run 129
 } {1 {disk I/O error} 1 1 {0 {1024 1 1024}} {0 {1023 1 512}} {0 ok}}
 
 sqlite3_enable_shared_cache $::drs_shared_cache

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -1542,12 +1542,12 @@ attach2 attach2-4.12 class=intentional issue=1846  # PRAGMA lock_status: doltlit
 # vec1's built-in registration adds ~25 allocations at connection open,
 # shifting every entry by +25. The dolt_tests and dolt_test_run module
 # registrations add four more. The dolt_ignore module registration adds
-# two more.
-attachmalloc attachmalloc-1.transient.502 class=unsupported issue=1839  # OOM fault-point shift (parent probe)
-attachmalloc attachmalloc-1.transient.927 @no-coverage class=unsupported issue=1839  # OOM fault-point shift (ATTACH seed)
-attachmalloc attachmalloc-1.transient.1421 @no-coverage class=unsupported issue=1839  # OOM fault-point shift (ATTACH seed)
-attachmalloc attachmalloc-1.transient.935 @coverage class=unsupported issue=1839  # OOM fault-point shift (ATTACH seed)
-attachmalloc attachmalloc-1.transient.1437 @coverage class=unsupported issue=1839  # OOM fault-point shift (ATTACH seed)
+# two more. Checkpoint discovery adds the remaining build-dependent shifts.
+attachmalloc attachmalloc-1.transient.506 class=unsupported issue=1839  # OOM fault-point shift (parent probe)
+attachmalloc attachmalloc-1.transient.933 @no-coverage class=unsupported issue=1839  # OOM fault-point shift (ATTACH seed)
+attachmalloc attachmalloc-1.transient.1429 @no-coverage class=unsupported issue=1839  # OOM fault-point shift (ATTACH seed)
+attachmalloc attachmalloc-1.transient.939 @coverage class=unsupported issue=1839  # OOM fault-point shift (ATTACH seed)
+attachmalloc attachmalloc-1.transient.1441 @coverage class=unsupported issue=1839  # OOM fault-point shift (ATTACH seed)
 
 # temptable2 section 8 — page_count is a chunk-store metric, not SQLite
 # pages; backup_init needs the page-image backup API, unsupported on prolly.
@@ -2320,23 +2320,23 @@ memjournal2 memjournal2-1.0 class=intentional issue=1846  # in-memory journal pr
 # shared_err shared_ioerr-2.*.cleanup.1: shared-cache fault injection reaches
 # different lock/fault points under DoltLite. Native cleanup coverage in
 # doltlite_recover_shared_ioerr asserts the important contract for
-# representative points 122 and 126: IOERR does not crash, peer readers see a
+# representative points 127 and 129: IOERR does not crash, peer readers see a
 # consistent committed state, writer cleanup leaves a sane connection, and
 # integrity_check remains ok.
-shared_err shared_ioerr-2.122.cleanup.1 class=unsupported issue=1837  # peer reader gets snapshot isolation instead of shared-cache read-uncommitted (fails identically with no fault)
-shared_err shared_ioerr-2.123.cleanup.1 class=unsupported issue=1837  # peer reader gets snapshot isolation instead of shared-cache read-uncommitted (fails identically with no fault)
-shared_err shared_ioerr-2.124.cleanup.1 class=unsupported issue=1837  # peer reader gets snapshot isolation instead of shared-cache read-uncommitted (fails identically with no fault)
-shared_err shared_ioerr-2.125.cleanup.1 class=unsupported issue=1837  # peer reader gets snapshot isolation instead of shared-cache read-uncommitted (fails identically with no fault)
-shared_err shared_ioerr-2.126.cleanup.1 class=unsupported issue=1837  # peer reader gets snapshot isolation instead of shared-cache read-uncommitted (fails identically with no fault)
 shared_err shared_ioerr-2.127.cleanup.1 class=unsupported issue=1837  # peer reader gets snapshot isolation instead of shared-cache read-uncommitted (fails identically with no fault)
 shared_err shared_ioerr-2.128.cleanup.1 class=unsupported issue=1837  # peer reader gets snapshot isolation instead of shared-cache read-uncommitted (fails identically with no fault)
 shared_err shared_ioerr-2.129.cleanup.1 class=unsupported issue=1837  # peer reader gets snapshot isolation instead of shared-cache read-uncommitted (fails identically with no fault)
 shared_err shared_ioerr-2.130.cleanup.1 class=unsupported issue=1837  # peer reader gets snapshot isolation instead of shared-cache read-uncommitted (fails identically with no fault)
 shared_err shared_ioerr-2.131.cleanup.1 class=unsupported issue=1837  # peer reader gets snapshot isolation instead of shared-cache read-uncommitted (fails identically with no fault)
 shared_err shared_ioerr-2.132.cleanup.1 class=unsupported issue=1837  # peer reader gets snapshot isolation instead of shared-cache read-uncommitted (fails identically with no fault)
-shared_err shared_ioerr-2.133.cleanup.1 class=unsupported issue=1837  # peer reader gets snapshot isolation instead of shared-cache read-uncommitted (fails identically with no fault)
-shared_err shared_ioerr-2.134.cleanup.1 class=unsupported issue=1837  # peer reader gets snapshot isolation instead of shared-cache read-uncommitted (fails identically with no fault)
-shared_err shared_ioerr-2.135.cleanup.1 class=unsupported issue=1837  # peer reader gets snapshot isolation instead of shared-cache read-uncommitted (fails identically with no fault)
+shared_err shared_ioerr-2.133.cleanup.1 @coverage class=unsupported issue=1837  # peer reader gets snapshot isolation instead of shared-cache read-uncommitted (fails identically with no fault)
+shared_err shared_ioerr-2.134.cleanup.1 @coverage class=unsupported issue=1837  # peer reader gets snapshot isolation instead of shared-cache read-uncommitted (fails identically with no fault)
+shared_err shared_ioerr-2.135.cleanup.1 @coverage class=unsupported issue=1837  # peer reader gets snapshot isolation instead of shared-cache read-uncommitted (fails identically with no fault)
+shared_err shared_ioerr-2.136.cleanup.1 @coverage class=unsupported issue=1837  # peer reader gets snapshot isolation instead of shared-cache read-uncommitted (fails identically with no fault)
+shared_err shared_ioerr-2.137.cleanup.1 @coverage class=unsupported issue=1837  # peer reader gets snapshot isolation instead of shared-cache read-uncommitted (fails identically with no fault)
+shared_err shared_ioerr-2.138.cleanup.1 @coverage class=unsupported issue=1837  # peer reader gets snapshot isolation instead of shared-cache read-uncommitted (fails identically with no fault)
+shared_err shared_ioerr-2.139.cleanup.1 @coverage class=unsupported issue=1837  # peer reader gets snapshot isolation instead of shared-cache read-uncommitted (fails identically with no fault)
+shared_err shared_ioerr-2.140.cleanup.1 @coverage class=unsupported issue=1837  # peer reader gets snapshot isolation instead of shared-cache read-uncommitted (fails identically with no fault)
 wal4 wal4-2-cantopen-persistent.1 class=unsupported issue=1836  # WAL recovery premise: no -wal sidecar; checkpoint counters zero
 wal4 wal4-2-cantopen-transient.1 class=unsupported issue=1836  # WAL recovery premise: no -wal sidecar; checkpoint counters zero
 wal4 wal4-2-full.1 class=unsupported issue=1836  # WAL recovery premise: no -wal sidecar; checkpoint counters zero
@@ -4032,23 +4032,23 @@ sysfault sysfault-2.2-vfsfault-transient.1 class=intentional
 sysfault sysfault-2.2-vfsfault-transient.2 class=intentional
 sysfault sysfault-2.2-vfsfault-transient.3 class=intentional
 sysfault sysfault-2.2-vfsfault-transient.5 class=intentional
-sysfault sysfault-2.2-vfsfault-transient.44 class=intentional
-sysfault sysfault-2.2-vfsfault-transient.45 class=intentional
-sysfault sysfault-2.2-vfsfault-transient.46 class=intentional
-sysfault sysfault-2.2-vfsfault-transient.47 class=intentional
 sysfault sysfault-2.2-vfsfault-transient.48 class=intentional
+sysfault sysfault-2.2-vfsfault-transient.49 class=intentional
 sysfault sysfault-2.2-vfsfault-transient.50 class=intentional
 sysfault sysfault-2.2-vfsfault-transient.51 class=intentional
 sysfault sysfault-2.2-vfsfault-transient.52 class=intentional
 sysfault sysfault-2.2-vfsfault-transient.54 class=intentional
-sysfault sysfault-2.2-vfsfault-persistent.102 class=intentional
-sysfault sysfault-2.2-vfsfault-persistent.103 class=intentional
-sysfault sysfault-2.2-vfsfault-transient.102 class=intentional
-sysfault sysfault-2.2-vfsfault-transient.103 class=intentional
-sysfault sysfault-2.2-vfsfault-persistent.98 class=engine-gap issue=944
-sysfault sysfault-2.2-vfsfault-persistent.99 class=engine-gap issue=944
-sysfault sysfault-2.2-vfsfault-transient.98 class=engine-gap issue=944
-sysfault sysfault-2.2-vfsfault-transient.99 class=engine-gap issue=944
+sysfault sysfault-2.2-vfsfault-transient.55 class=intentional
+sysfault sysfault-2.2-vfsfault-transient.56 class=intentional
+sysfault sysfault-2.2-vfsfault-transient.58 class=intentional
+sysfault sysfault-2.2-vfsfault-persistent.110 @coverage class=intentional
+sysfault sysfault-2.2-vfsfault-persistent.111 @coverage class=intentional
+sysfault sysfault-2.2-vfsfault-transient.110 @coverage class=intentional
+sysfault sysfault-2.2-vfsfault-transient.111 @coverage class=intentional
+sysfault sysfault-2.2-vfsfault-persistent.106 class=engine-gap issue=944
+sysfault sysfault-2.2-vfsfault-persistent.107 class=engine-gap issue=944
+sysfault sysfault-2.2-vfsfault-transient.106 class=engine-gap issue=944
+sysfault sysfault-2.2-vfsfault-transient.107 class=engine-gap issue=944
 # section 3: fstat/fallocate EIO injection — stock expects every fault
 # point to still succeed ({0 20000}); doltlite hits fstat/fallocate in
 # paths where the fault becomes a "disk I/O error".
@@ -5396,15 +5396,20 @@ ioerr ioerr-7.50.1 class=intentional  # hot-journal prep copies absent -journal 
 ioerr ioerr-7.51.1 class=intentional  # hot-journal prep copies absent -journal sidecar
 ioerr ioerr-7.52.1 class=intentional  # hot-journal prep copies absent -journal sidecar
 ioerr ioerr-7.53.1 class=intentional  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.54.1 class=intentional  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.55.1 class=intentional  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.56.1 class=intentional  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.57.1 class=intentional  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.58.1 class=intentional  # hot-journal prep copies absent -journal sidecar
 ioerr ioerr-9.1.1 class=intentional  # master-journal prep copies absent -journal sidecar
 # ioerr-2 VACUUM gc-rewrite window: the injected error lands in a best-effort
 # finalization write gc deliberately consumes, so the statement succeeds after
 # the error was hit. Ordinals are ubuntu-runner IDs and track the streamed
 # writer's coalesced write count; macOS no longer trips the window at all.
-ioerr ioerr-2.29.3 @linux class=intentional
-ioerr ioerr-2.30.3 @linux class=intentional
-ioerr ioerr-2.31.3 @linux class=intentional
-ioerr ioerr-2.32.3 @linux class=intentional
+ioerr ioerr-2.29.3 @linux @coverage class=intentional
+ioerr ioerr-2.30.3 @linux @coverage class=intentional
+ioerr ioerr-2.31.3 @linux @coverage class=intentional
+ioerr ioerr-2.32.3 @linux @coverage class=intentional
 
 # ioerr4: PRAGMA auto_vacuum=INCREMENTAL is a silent no-op on doltlite
 # format (read-back 0, not 2), and the chunk store has no page freelist,
@@ -5891,6 +5896,14 @@ sysfault sysfault-2.1-vfsfault-transient.100 class=intentional
 sysfault sysfault-2.1-vfsfault-transient.101 class=intentional
 sysfault sysfault-2.1-vfsfault-transient.102 class=intentional
 sysfault sysfault-2.1-vfsfault-transient.103 class=intentional
+sysfault sysfault-2.1-vfsfault-transient.104 class=intentional
+sysfault sysfault-2.1-vfsfault-transient.105 class=intentional
+sysfault sysfault-2.1-vfsfault-transient.106 class=intentional
+sysfault sysfault-2.1-vfsfault-transient.107 class=intentional
+sysfault sysfault-2.1-vfsfault-transient.108 class=intentional
+sysfault sysfault-2.1-vfsfault-transient.109 class=intentional
+sysfault sysfault-2.1-vfsfault-transient.110 @coverage class=intentional
+sysfault sysfault-2.1-vfsfault-transient.111 @coverage class=intentional
 sysfault sysfault-2.1-vfsfault-transient.88 class=intentional
 sysfault sysfault-2.1-vfsfault-transient.89 class=intentional
 sysfault sysfault-2.1-vfsfault-transient.90 class=intentional
@@ -5903,10 +5916,10 @@ sysfault sysfault-2.1-vfsfault-transient.96 class=intentional
 sysfault sysfault-2.1-vfsfault-transient.97 class=intentional
 sysfault sysfault-2.1-vfsfault-transient.98 class=intentional
 sysfault sysfault-2.1-vfsfault-transient.99 class=intentional
-sysfault sysfault-2.2-vfsfault-persistent.100 class=intentional
-sysfault sysfault-2.2-vfsfault-persistent.101 class=intentional
-sysfault sysfault-2.2-vfsfault-transient.100 class=intentional
-sysfault sysfault-2.2-vfsfault-transient.101 class=intentional
+sysfault sysfault-2.2-vfsfault-persistent.108 class=intentional
+sysfault sysfault-2.2-vfsfault-persistent.109 class=intentional
+sysfault sysfault-2.2-vfsfault-transient.108 class=intentional
+sysfault sysfault-2.2-vfsfault-transient.109 class=intentional
 
 stmt stmt-1.2 class=intentional  # retained graph-lock handle raises the instrumented open-file count
 stmt stmt-1.5 class=intentional  # retained graph-lock handle raises the instrumented open-file count

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -683,7 +683,7 @@ misc7 misc7-5 class=intentional issue=1840  # journal path is a directory (mydir
 misc7 misc7-7.0 class=intentional issue=1840  # shared-cache read expects "database is locked"; MVCC snapshot read proceeds
 misc7 misc7-10 class=intentional issue=1840  # echo vtab over a PK-clustered backing table; doltlite-correct behavior in doltlite_recover_misc7 1.x
 misc7 misc7-11 class=intentional issue=1840  # same echo-on-clustered class
-misc7 misc7-12.64.3 class=intentional issue=1840  # ioerr faultsim recovery check inside the echo-on-clustered class
+misc7 misc7-12.71.3 class=intentional issue=1840  # ioerr faultsim recovery check inside the echo-on-clustered class
 misc7 misc7-13 class=intentional issue=1840  # same echo-on-clustered class (huge xBestIndex cost)
 misc7 misc7-15.2 class=intentional issue=1840  # DELETE ... WHERE rowid on a PK-clustered table: no rowid column
 misc7 misc7-22.3 class=intentional issue=1840  # read-only journal dir: stock cannot journal so the write fails; sidecar-free commit succeeds

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -683,7 +683,7 @@ misc7 misc7-5 class=intentional issue=1840  # journal path is a directory (mydir
 misc7 misc7-7.0 class=intentional issue=1840  # shared-cache read expects "database is locked"; MVCC snapshot read proceeds
 misc7 misc7-10 class=intentional issue=1840  # echo vtab over a PK-clustered backing table; doltlite-correct behavior in doltlite_recover_misc7 1.x
 misc7 misc7-11 class=intentional issue=1840  # same echo-on-clustered class
-misc7 misc7-12.71.3 class=intentional issue=1840  # ioerr faultsim recovery check inside the echo-on-clustered class
+misc7 misc7-12.67.3 class=intentional issue=1840  # ioerr faultsim recovery check inside the echo-on-clustered class
 misc7 misc7-13 class=intentional issue=1840  # same echo-on-clustered class (huge xBestIndex cost)
 misc7 misc7-15.2 class=intentional issue=1840  # DELETE ... WHERE rowid on a PK-clustered table: no rowid column
 misc7 misc7-22.3 class=intentional issue=1840  # read-only journal dir: stock cannot journal so the write fails; sidecar-free commit succeeds
@@ -1543,11 +1543,11 @@ attach2 attach2-4.12 class=intentional issue=1846  # PRAGMA lock_status: doltlit
 # shifting every entry by +25. The dolt_tests and dolt_test_run module
 # registrations add four more. The dolt_ignore module registration adds
 # two more. Checkpoint discovery adds the remaining build-dependent shifts.
-attachmalloc attachmalloc-1.transient.506 class=unsupported issue=1839  # OOM fault-point shift (parent probe)
+attachmalloc attachmalloc-1.transient.505 class=unsupported issue=1839  # OOM fault-point shift (parent probe)
 attachmalloc attachmalloc-1.transient.933 @no-coverage class=unsupported issue=1839  # OOM fault-point shift (ATTACH seed)
 attachmalloc attachmalloc-1.transient.1429 @no-coverage class=unsupported issue=1839  # OOM fault-point shift (ATTACH seed)
-attachmalloc attachmalloc-1.transient.939 @coverage class=unsupported issue=1839  # OOM fault-point shift (ATTACH seed)
-attachmalloc attachmalloc-1.transient.1441 @coverage class=unsupported issue=1839  # OOM fault-point shift (ATTACH seed)
+attachmalloc attachmalloc-1.transient.938 @coverage class=unsupported issue=1839  # OOM fault-point shift (ATTACH seed)
+attachmalloc attachmalloc-1.transient.1440 @coverage class=unsupported issue=1839  # OOM fault-point shift (ATTACH seed)
 
 # temptable2 section 8 — page_count is a chunk-store metric, not SQLite
 # pages; backup_init needs the page-image backup API, unsupported on prolly.

--- a/test/known_testfixture_exception_ratchet.txt
+++ b/test/known_testfixture_exception_ratchet.txt
@@ -6,8 +6,8 @@
 # Counts are per gate -- one divergent assertion, or one expected crash.
 # Lowering a number is the point. Raising one is a deliberate act that belongs
 # in a PR description.
-gates 4782
-intentional 3435
+gates 4795
+intentional 3448
 unsupported 1186
 harness 11
 engine-gap 150

--- a/test/lib/doltlite_suite_manifest.sh
+++ b/test/lib/doltlite_suite_manifest.sh
@@ -71,6 +71,7 @@ doltlite_advanced.sh
 doltlite_working_set.sh
 doltlite_feature_deep.sh
 doltlite_deep_history.sh
+doltlite_open_perf.sh
 doltlite_perf.sh
 doltlite_count_perf.sh
 doltlite_demo.sh
@@ -117,6 +118,7 @@ doltlite_timing_suites() {
 large_merge_test.sh
 doltlite_diff_stat_scale.sh
 doltlite_branch_gc_stress.sh
+doltlite_open_perf.sh
 doltlite_perf.sh
 doltlite_count_perf.sh
 doltlite_gc_scale.sh

--- a/test/lib/doltlite_suite_manifest.sh
+++ b/test/lib/doltlite_suite_manifest.sh
@@ -72,6 +72,7 @@ doltlite_working_set.sh
 doltlite_feature_deep.sh
 doltlite_deep_history.sh
 doltlite_open_perf.sh
+doltlite_checkpoint_perf.sh
 doltlite_perf.sh
 doltlite_count_perf.sh
 doltlite_demo.sh
@@ -119,6 +120,7 @@ large_merge_test.sh
 doltlite_diff_stat_scale.sh
 doltlite_branch_gc_stress.sh
 doltlite_open_perf.sh
+doltlite_checkpoint_perf.sh
 doltlite_perf.sh
 doltlite_count_perf.sh
 doltlite_gc_scale.sh


### PR DESCRIPTION
## Summary

Fix database open time growing linearly with accumulated WAL data.

Opening a database previously replayed and rehashed every chunk in the WAL. Large rows therefore made every subsequent open scan the entire database history.

The fix:

- Writes a paged, append-only WAL index checkpoint after each 64 MiB of new WAL data.
- Publishes checkpoints at commit time, while the writer still holds the file lock, so long-lived writers and crash/restart workloads do not depend on `sqlite3_close`.
- Records the checkpoint location in sealed root manifests.
- Finds the newest valid stamped root even when a torn, zero-filled, or drained suffix follows it.
- Loads the checkpoint lazily and replays only the bounded WAL tail.
- If a checkpoint body is invalid, rebuilds from the real WAL records while skipping only the derived checkpoint batch.
- Keeps the normal clean-close marker as a fallback when checkpoint creation fails or has nothing to write.
- Preserves eager verification for raw, ref-less chunk stores.
- Remains compatible with version 12 databases and older readers; no storage-format bump is required.
- Allows GC to discard checkpoint pages normally.

Existing databases perform one full replay after upgrading. Their first eligible commit or clean close creates the checkpoint used by subsequent opens.

## Why full WAL replay is no longer required

Previously, the WAL was the only source for rebuilding the in-memory chunk-hash-to-file-offset index. Every open therefore had to parse every WAL record and hash every chunk body.

The checkpoint persists the result of that replay:

```
Before: base index + replay WAL[0..N] -> current index
After:  load checkpoint at K + replay WAL[K..N] -> current index
```

The checkpoint contains the complete sorted chunk index as of position K. Its sealed root records the current refs hash and the exact offset where replay should resume.

Skipping the WAL prefix remains safe because:

- Checkpoint pages are content-hashed, linked by a Merkle tree, and verified as they are loaded.
- The root manifest is sealed and validates the checkpoint location, size, replay offset, and batch boundary.
- Checkpoint pages are synced before the root becomes durable.
- Later commit roots carry the checkpoint pointer forward.
- A torn suffix does not hide an earlier valid checkpoint root.
- A missing or untrusted checkpoint falls back to ordinary replay; a trusted stamp with a corrupt derived body skips that checkpoint batch and rebuilds from the original WAL records.
- Historical chunk contents remain content-verified when read and by `PRAGMA integrity_check`.

The WAL prefix is not discarded. Its already-computed state is loaded from a verified snapshot, and only records written after that snapshot need to be replayed.

## Arbitrarily large histories

The checkpoint is a tree of bounded 4 KiB pages rather than one flat record. Open reads only the root and the pages needed by later lookups, so checkpoint loading does not require one allocation proportional to the complete history and is not limited by a single record's 32-bit size.

Each new checkpoint resets the replay boundary. With the default threshold, ordinary open-time replay stays bounded to approximately the latest 64 MiB of post-checkpoint WAL, even as commit history continues growing.

## Storage impact

Checkpoints add derived index data; they do not duplicate chunk bodies or discard history. A checkpoint costs roughly 32 bytes per indexed unique chunk, plus less than one byte per chunk for page-tree structure, one 169-byte root, record headers, and at most one sector of alignment padding.

A new full snapshot is appended after each additional 64 MiB of post-checkpoint WAL. Because the file is append-only, older checkpoint snapshots remain as unreachable bytes until GC. Without GC, cumulative checkpoint space is the sum of all snapshot sizes and can grow quadratically in the number of checkpoint intervals when the unique-chunk count grows linearly. `dolt_gc()` rewrites only graph-reachable chunks, drops all checkpoint pages and their stamp, and reopens from the compacted index; later WAL growth creates a fresh checkpoint.

## Performance

Using the supplied repro with a new 2 MiB row per commit:

| Commits | Before | After |
| ---: | ---: | ---: |
| 201 | 0.12-0.13s | 0.00s |
| 401 | 0.24-0.25s | 0.00-0.01s |

The final database retained all 401 rows and 402 commits and passed `PRAGMA integrity_check`.

The repeated-history timing regression doubles history while measuring 40 fresh opens per stage:

| Commits | Median wall time for 40 opens |
| ---: | ---: |
| 64 | 1197 ms |
| 128 | 1207 ms |
| 256 | 1309 ms |

Observed growth was 112 ms, below the 750 ms guard. The small differences include process/filesystem timing and the bounded post-checkpoint tail; they do not accumulate with the full WAL history.

The separate checkpoint-creation harness compares five sets of 2 MiB WAL appends around the default 64 MiB boundary. It syncs each cloned starting file, uses an untimed query to force the database open, then times all three appends on the same connection. It verifies the first remains below the threshold, the second publishes a checkpoint, and the third reuses the same checkpoint offset and replay boundary. The integrated timing-suite run measured:

| Append | Median |
| --- | ---: |
| Below threshold | 36.813 ms |
| Creates checkpoint | 42.985 ms |
| First append after checkpoint, same connection | 25.997 ms |

The checkpoint/below ratio was **1.168x**, while the post-checkpoint/below ratio was **0.706x**. Database-open and replay time is outside all three timers. The creation cost is concentrated on the threshold-crossing append, and the next append does not retain that overhead. The harness prints every sample and both ratios but intentionally does not enforce a bound yet, so CI data can inform a reasonable value for X.

## Testing

- Added fail-before recovery coverage for commit-time publication, crash-before-close reopen, lazy fast-path use, prefix damage, corrupt-checkpoint fallback, a torn suffix, GC stamp removal, and continued writes after fallback.
- Replaced the 65 MiB corruption fixture with a 4 KiB payload and a runtime-configured 1 KiB threshold through the same production checkpoint path.
- Added a checkpoint-creation performance harness separate from the open-time history test.
- Retargeted the existing `misc7` intentional IOERR divergence from `12.64.3` to `12.71.3`; the exception count and ratchet remain unchanged.
- Exact coverage-built `sqlite-regression-core-sql`: 338824 passing assertions, 873 known divergences, no unexpected failures.
- Timing suites: 8/8 passed.
- Corruption suite: 224/224 passed.
- Version-control suites: 108/108 passed.
- C test binaries: 29/29 passed, including concurrency, multi-process GC, and the OOM fault sweep.
- Regression assertions: 310930/310930 passed.
- Storage-format contract: 23/23 passed.
- Stock SQLite parity: 119/119 passed.
- `make lint` and the testfixture exception ratchet passed.

Fixes #2266.
