### PR TITLE
Recognize a column rename on our own side of a merge

### DIFF
--- a/src/doltlite_merge_pass1.c
+++ b/src/doltlite_merge_pass1.c
@@ -818,6 +818,28 @@ static int mergePass1BothSides(
   sqlite3_free(zOursPrevSql);
   zOursPrevSql = 0;
 
+  /* The mirror: our schema was kept for a rename on our side, so theirs is
+  ** the layout left behind. Judged on the schema for the same reason. */
+  if( zName && !bSchemaConflict && schemaChoice==SCHEMA_MERGE_OURS ){
+    SchemaEntry *ancSE = findSchemaEntry(c->aAncSchema, c->nAncSchema, zName);
+    SchemaEntry *ourSE = findSchemaEntry(c->aOursSchema, c->nOursSchema, zName);
+    SchemaEntry *theirSE = findSchemaEntry(c->aTheirsSchema, c->nTheirsSchema, zName);
+    int bRelaid = 0;
+    if( ancSE && ourSE && theirSE ){
+      rc = mergePass1RelayoutToMergedSchema(c, zName, ancSE->zSql,
+          ourSE->zSql, theirSE->zSql, c->aOurs[iOurs].flags,
+          &c->aOurs[iOurs].root, &theirsEntry->root, &ancEntry->root,
+          &otherNormRoot, &ancNormRoot, &bRelaid);
+      if( rc!=SQLITE_OK ) return rc;
+    }
+    if( bRelaid ){
+      ancAdj = *ancEntry;
+      memcpy(&ancAdj.root, &ancNormRoot, sizeof(ProllyHash));
+      pMergeAnc = &ancAdj;
+      pMergeTheirsRoot = &otherNormRoot;
+    }
+  }
+
   if( zName && oursChanged && theirsChanged
    && ourSchemaChanged!=theirSchemaChanged ){
     int bRelaid = 0;

--- a/src/doltlite_merge_schema.c
+++ b/src/doltlite_merge_schema.c
@@ -795,6 +795,36 @@ int trySchemaColumnMerge(
     }
   }
 
+  /* The scan above only recognizes a rename on their side, so one on ours
+  ** went unseen and the merge fell through to incompatible. A column of ours
+  ** that the ancestor never had, sitting where a vanished ancestor column
+  ** used to sit and carrying its definition, is that rename. */
+  if( *pSchemaChoice==SCHEMA_MERGE_DEFAULT ){
+    for(i=0; i<nOurs; i++){
+      ParsedColumn *theirAncestor;
+      if( findColumn(aAnc, nAnc, aOurs[i].zName)
+       || findColumn(aTheirs, nTheirs, aOurs[i].zName)
+       || i>=nAnc
+       || sqlite3_stricmp(aOurs[i].zName, aAnc[i].zName)==0
+       || findColumn(aOurs, nOurs, aAnc[i].zName)
+       || !parsedColumnDefinitionsMatch(&aOurs[i], &aAnc[i]) ){
+        continue;
+      }
+      theirAncestor = findColumn(aTheirs, nTheirs, aAnc[i].zName);
+      if( theirAncestor && strcmp(theirAncestor->zDef, aAnc[i].zDef)==0 ){
+        *pSchemaChoice = SCHEMA_MERGE_OURS;
+      }else{
+        if( pzErrDetail ){
+          *pzErrDetail = sqlite3_mprintf(
+            "column '%s' renamed on one branch and modified on another",
+            aAnc[i].zName);
+        }
+        rc = SQLITE_ERROR;
+        goto schema_merge_cleanup;
+      }
+    }
+  }
+
   for(i=0; i<nOurs; i++){
     ParsedColumn *ancCol = findColumn(aAnc, nAnc, aOurs[i].zName);
     if( ancCol ){

--- a/test/doltlite_schema_merge.sh
+++ b/test/doltlite_schema_merge.sh
@@ -834,6 +834,37 @@ run_test "drop_col_merge_dual_conflicts" \
   "SELECT count(*) FROM dolt_conflicts;" "0" "$DB"
 rm -f "$DB"
 
+# The same pairing with the sides swapped. Only a rename on their side was
+# recognized, so ours went unseen and the merge stopped as incompatible.
+# Values verified against Dolt 2.2.2, which merges this cleanly.
+DB=/tmp/test_rename_ours_drop_theirs_$$.db; rm -f "$DB"
+cat <<'EOF' | $DOLTLITE "$DB" > /dev/null 2>&1
+CREATE TABLE t(k INTEGER PRIMARY KEY, a TEXT, b TEXT, c TEXT, d INT);
+INSERT INTO t VALUES(1,'a1','b1','c1',101),(2,'a2','b2','c2',202);
+SELECT dolt_commit('-A','-m','base');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+ALTER TABLE t DROP COLUMN b;
+INSERT INTO t(k,a,c,d) VALUES(3,'a3','c3',303);
+SELECT dolt_commit('-A','-m','drop b and insert on feat');
+SELECT dolt_checkout('main');
+ALTER TABLE t RENAME COLUMN c TO renamed_c;
+SELECT dolt_commit('-A','-m','rename c on main');
+EOF
+run_test_match "rename_ours_drop_theirs_hash" "SELECT dolt_merge('feat');" \
+  "^[0-9a-f]{40}$" "$DB"
+run_test "rename_ours_drop_theirs_cols" \
+  "SELECT group_concat(name) FROM pragma_table_info('t');" \
+  "k,a,renamed_c,d" "$DB"
+run_test "rename_ours_drop_theirs_base_row" \
+  "SELECT a||'|'||renamed_c||'|'||d FROM t WHERE k=1;" "a1|c1|101" "$DB"
+run_test "rename_ours_drop_theirs_incoming_row" \
+  "SELECT a||'|'||renamed_c||'|'||d FROM t WHERE k=3;" "a3|c3|303" "$DB"
+run_test "rename_ours_drop_theirs_conflicts" \
+  "SELECT count(*) FROM dolt_conflicts;" "0" "$DB"
+run_test "rename_ours_drop_theirs_integrity" "PRAGMA integrity_check;" "ok" "$DB"
+rm -f "$DB"
+
 # Dropping the trailing column leaves the incoming value with nowhere to go,
 # the one shape where no surviving column later claims its slot.
 DB=/tmp/test_drop_last_col_merge_$$.db; rm -f "$DB"


### PR DESCRIPTION
Closes #2268. The first half — their side renaming — was fixed in #2269; this is the mirror, which that PR deliberately left open.

Renaming a column on one branch while another branch deletes a *different* one could not be merged in this direction at all:

```sql
-- base: t(k, a, b, c, d)
-- feat: ALTER TABLE t DROP COLUMN b; INSERT INTO t(k,a,c,d) VALUES(3,'a3','c3',303)
-- main: ALTER TABLE t RENAME COLUMN c TO renamed_c
SELECT dolt_merge('feat');
```

| | before | after / Dolt 2.2.2 |
|---|---|---|
| result | `cannot merge: conflicts detected` — `incompatible schema changes for table 't'` | merge succeeds |
| columns | — | `k, a, renamed_c, d` |
| rows | — | `a1\|c1\|101`, `a2\|c2\|202`, `a3\|c3\|303` |

There was no resolution available: `dolt_schema_conflicts` reported the three schemas and nothing could reconcile them, so the branch pair was simply unmergeable this way round while merging the other way worked.

## Cause

The scan that recognizes a rename walked only *their* columns, looking for one the ancestor never had. A rename on our side produces exactly that shape on our own list, which nothing looked at, so the merge fell through to incompatible.

## Change

Recognize it symmetrically: a column of ours that the ancestor never had, sitting where a vanished ancestor column used to sit and carrying its definition, is that rename. Our schema is then the merged one, so their rows and the ancestor are the layouts left behind and are moved onto it — mirroring what the other direction already does.

Their deletion still carries across unchanged, because the deletions are collected from whichever side did not supply the merged schema, which #2269 already made symmetric.

The rename-versus-modify case keeps its existing error on this side too, matching the treatment of the same clash on theirs.

## Testing

`test/doltlite_schema_merge.sh` gains the reported pairing with the sides swapped, asserting the merged columns, both a pre-existing and an incoming row by name, zero conflicts, and `integrity_check`.

- Fail-before/pass-after: the new assertions fail on master, all 163 pass with the fix.
- Swept all 12 drop×rename column-position pairs in this direction: correct columns, every surviving value still under its own name, clean integrity.
- The direction fixed in #2269 re-checked and unchanged.
- Full battery **106/106 suites**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)