### PR TITLE
Bound and retry apt calls in CI

### DIFF
--- a/.github/scripts/install-apt-deps.sh
+++ b/.github/scripts/install-apt-deps.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 for path in /etc/apt/sources.list.d/*.list /etc/apt/sources.list.d/*.sources; do
   [ -e "$path" ] || continue
   if grep -qiE 'packages[.]microsoft[.]com|azure-cli' "$path"; then
@@ -8,14 +10,5 @@ for path in /etc/apt/sources.list.d/*.list /etc/apt/sources.list.d/*.sources; do
   fi
 done
 
-for attempt in 1 2 3; do
-  if sudo apt-get update; then
-    break
-  fi
-  if [ "$attempt" -eq 3 ]; then
-    exit 1
-  fi
-  sleep $((attempt * 5))
-done
-
-sudo apt-get install -y "$@"
+bash "$script_dir/retry-apt-get.sh" update
+bash "$script_dir/retry-apt-get.sh" install -y "$@"

--- a/.github/scripts/retry-apt-get-test.sh
+++ b/.github/scripts/retry-apt-get-test.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+runner="$script_dir/retry-apt-get.sh"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+mkdir "$tmp/bin"
+has_timeout=1
+if ! command -v timeout >/dev/null 2>&1; then
+  has_timeout=0
+  cat >"$tmp/bin/timeout" <<'EOF'
+#!/usr/bin/env bash
+while [[ "$1" == --* ]]; do
+  shift
+done
+shift
+exec "$@"
+EOF
+fi
+
+cat >"$tmp/bin/sudo" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$@" >>"$APT_FAKE_SUDO_ARGS"
+exec "$@"
+EOF
+
+cat >"$tmp/bin/apt-get" <<'EOF'
+#!/usr/bin/env bash
+count=0
+if [ -f "$APT_FAKE_COUNT" ]; then
+  count="$(cat "$APT_FAKE_COUNT")"
+fi
+count=$((count + 1))
+printf '%s\n' "$count" >"$APT_FAKE_COUNT"
+printf '%s\n' "$@" >>"$APT_FAKE_ARGS"
+case "$APT_FAKE_MODE" in
+  fail-once) [ "$count" -ge 2 ] || exit 42 ;;
+  fail) exit 42 ;;
+  hang) sleep 30 ;;
+esac
+EOF
+
+chmod +x "$tmp/bin/"*
+
+run_fake() (
+  export PATH="$tmp/bin:$PATH"
+  export APT_FAKE_COUNT="$tmp/count"
+  export APT_FAKE_ARGS="$tmp/args"
+  export APT_FAKE_SUDO_ARGS="$tmp/sudo-args"
+  export APT_FAKE_MODE="$1"
+  export APT_RETRY_DELAY_SECONDS=0
+  unset APT_RETRY_ATTEMPTS APT_RETRY_TIMEOUT_SECONDS
+  if [ "$#" -ge 3 ]; then
+    export APT_RETRY_ATTEMPTS="$2"
+    export APT_RETRY_TIMEOUT_SECONDS="$3"
+  fi
+  bash "$runner" update
+)
+
+run_fake fail-once
+[ "$(cat "$tmp/count")" = 2 ]
+grep -Fxq 'Acquire::Retries=2' "$tmp/args"
+grep -Fxq 'DPkg::Lock::Timeout=30' "$tmp/args"
+grep -Fxq -- '--signal=TERM' "$tmp/sudo-args"
+grep -Fxq -- '--kill-after=10s' "$tmp/sudo-args"
+grep -Fxq '300s' "$tmp/sudo-args"
+
+rm "$tmp/count" "$tmp/args"
+set +e
+run_fake fail
+rc=$?
+set -e
+[ "$rc" = 42 ]
+[ "$(cat "$tmp/count")" = 2 ]
+
+if [ "$has_timeout" = 1 ]; then
+  rm "$tmp/count" "$tmp/args"
+  set +e
+  run_fake hang 1 1
+  rc=$?
+  set -e
+  [ "$rc" = 124 ]
+  [ "$(cat "$tmp/count")" = 1 ]
+fi
+
+echo "retry-apt-get tests passed"

--- a/.github/scripts/retry-apt-get.sh
+++ b/.github/scripts/retry-apt-get.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+attempts="${APT_RETRY_ATTEMPTS:-2}"
+timeout_seconds="${APT_RETRY_TIMEOUT_SECONDS:-300}"
+delay_seconds="${APT_RETRY_DELAY_SECONDS:-5}"
+
+if ! [[ "$attempts" =~ ^[0-9]+$ ]] || [ "$attempts" -lt 1 ] \
+    || ! [[ "$timeout_seconds" =~ ^[0-9]+$ ]] || [ "$timeout_seconds" -lt 1 ] \
+    || ! [[ "$delay_seconds" =~ ^[0-9]+$ ]]; then
+  echo "invalid apt retry configuration" >&2
+  exit 2
+fi
+
+rc=1
+for ((attempt = 1; attempt <= attempts; attempt++)); do
+  echo "apt-get attempt $attempt/$attempts: $*"
+  sudo timeout --signal=TERM --kill-after=10s "${timeout_seconds}s" \
+    apt-get \
+      -o Acquire::Retries=2 \
+      -o Acquire::http::Timeout=20 \
+      -o Acquire::https::Timeout=20 \
+      -o DPkg::Lock::Timeout=30 \
+      "$@"
+  rc=$?
+  if [ "$rc" -eq 0 ]; then
+    exit 0
+  fi
+  if [ "$attempt" -lt "$attempts" ]; then
+    wait_seconds=$((attempt * delay_seconds))
+    echo "apt-get exited with $rc; retrying in ${wait_seconds}s" >&2
+    sleep "$wait_seconds"
+  fi
+done
+
+echo "apt-get failed after $attempts attempts (exit $rc)" >&2
+exit "$rc"

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -89,7 +89,7 @@ jobs:
         set -e
         if [ "$rc" -ne 0 ]; then
           echo "::error::assert-enabled regression suite failed (exit $rc)"
-          sudo apt-get install -y -qq gdb >/dev/null 2>&1 || true
+          bash .github/scripts/retry-apt-get.sh install -y -qq gdb >/dev/null 2>&1 || true
           core=$(ls -1 core.* 2>/dev/null | head -1)
           if [ -n "$core" ] && command -v gdb >/dev/null 2>&1; then
             gdb -batch -ex 'bt full' build-assert/doltlite_regression_test_c "$core" 2>&1 | head -120

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -24,6 +24,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    - name: Test bounded apt retries
+      if: matrix.platform == 'ubuntu'
+      run: bash .github/scripts/retry-apt-get-test.sh
+
     - name: Install Linux build dependencies
       if: matrix.platform == 'ubuntu'
       run: |


### PR DESCRIPTION
## Summary

- route CI dependency installs and the best-effort gdb install through one bounded apt-get runner
- retry transient failures twice with APT network and lock timeouts
- cap each attempt at 300 seconds, with forced termination after a 10-second grace period
- add an Ubuntu self-test for production defaults, retry success, exhaustion, option forwarding, and hung-command termination

The 300-second bound is more than twice the observed 143-second healthy update while a continuously stuck apt-get command now releases its runner in roughly ten minutes instead of consuming the full job timeout.

## Validation

- retry helper self-test
- bash syntax checks
- parsed all workflow YAML
- orphaned-suite lint
- git diff --check

Co-Authored-By: OpenAI Codex <noreply@openai.com>