### PR TITLE
Serialize from the catalog this connection is on

### DIFF
--- a/src/doltlite_checkout.c
+++ b/src/doltlite_checkout.c
@@ -363,6 +363,10 @@ static int checkoutMutateRefs(sqlite3 *db, ChunkStore *cs, void *pArg){
   if( !bSavepoint || p->bPersistUnderSavepoint ){
     rc = doltlitePersistWorkingSetWithHash(db, &p->targetCatHash);
     if( rc!=SQLITE_OK ) return rc;
+    /* The target branch is durable now, so it is what a rollback returns to.
+    ** Keeping the branch we left as the baseline reinstates its catalog --
+    ** its tables, under this branch. */
+    doltliteAdoptRollbackBaseline(db, &p->targetCatHash);
   }
 
   if( p->haveOldState && !p->savedWasDetached ){

--- a/src/prolly_btree_catalog.c
+++ b/src/prolly_btree_catalog.c
@@ -1685,7 +1685,17 @@ static int serializeCatalogPatchRoots(Btree *pBtree, u8 **ppOut, int *pnOut){
     if( iTable!=1 || pBtree->bMasterRootChangedTxn ){
       memcpy(q, pTE->root.data, PROLLY_HASH_SIZE);
     }
-    q += PROLLY_HASH_SIZE + PROLLY_HASH_SIZE;
+    q += PROLLY_HASH_SIZE;
+    /* Only roots are patched, so every object the baseline names is published
+    ** as it stands there. Matching entry counts and table numbers do not make
+    ** it this catalog -- a connection that switched branches has a baseline
+    ** describing the branch it left -- and its schema hash is what tells the
+    ** two apart. */
+    if( iTable!=1 && memcmp(q, pTE->schemaHash.data, PROLLY_HASH_SIZE)!=0 ){
+      sqlite3_free(buf);
+      return SQLITE_NOTFOUND;
+    }
+    q += PROLLY_HASH_SIZE;
     nPatched++;
 
     if( iFormat!=CATALOG_FORMAT_V3 ){

--- a/test/doltlite_failed_merge_working_set.sh
+++ b/test/doltlite_failed_merge_working_set.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+
+set -u
+
+DOLTLITE="${1:-./doltlite}"
+TMPROOT=$(mktemp -d)
+trap "rm -rf $TMPROOT" EXIT
+pass=0
+fail=0
+FAILED_NAMES=""
+
+check() {
+  local name="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    pass=$((pass+1))
+  else
+    fail=$((fail+1))
+    FAILED_NAMES="$FAILED_NAMES $name"
+    echo "  FAIL: $name"
+    echo "    expected: $expected"
+    echo "    actual:   $actual"
+  fi
+}
+
+objs() {
+  "$DOLTLITE" "$1" \
+    "SELECT coalesce(group_concat(type || ':' || name), '<none>') FROM sqlite_master;"
+}
+
+# A merge whose source branch was visited earlier in the same session used to
+# publish that branch's catalog as our working set: the branch we left won the
+# working tree, dolt_status reported it as the user's own edits, and the next
+# commit wrote it into history.
+DB="$TMPROOT/failed_merge.db"
+"$DOLTLITE" "$DB" <<'EOF' >/dev/null 2>&1
+CREATE TABLE t(k INTEGER PRIMARY KEY, a TEXT);
+INSERT INTO t VALUES(1,'a1');
+SELECT dolt_add('-A'), dolt_commit('-m','init');
+SELECT dolt_branch('side');
+ALTER TABLE t RENAME TO t2;
+SELECT dolt_add('-A'), dolt_commit('-m','ours rename');
+SELECT dolt_checkout('side');
+CREATE TRIGGER tg AFTER INSERT ON t BEGIN UPDATE t SET a='TG' WHERE k=new.k; END;
+SELECT dolt_add('-A'), dolt_commit('-m','theirs trigger');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('side');
+EOF
+
+check "failed_merge_keeps_our_schema" "table:t2" "$(objs "$DB")"
+check "failed_merge_keeps_our_rows" "1|a1" \
+  "$("$DOLTLITE" "$DB" "SELECT k || '|' || a FROM t2 ORDER BY k;")"
+check "failed_merge_leaves_no_edits" "" \
+  "$("$DOLTLITE" "$DB" "SELECT group_concat(table_name || '/' || status) FROM dolt_status;")"
+check "failed_merge_keeps_our_head" "ours rename" \
+  "$("$DOLTLITE" "$DB" "SELECT message FROM dolt_log LIMIT 1;")"
+check "failed_merge_side_untouched" "table:t,trigger:tg" "$(objs "$DB/side")"
+
+# The same staleness reached any write commit after a same-session checkout:
+# the catalog the connection left behind was the one serialized from.
+DB="$TMPROOT/checkout_then_write.db"
+"$DOLTLITE" "$DB" <<'EOF' >/dev/null 2>&1
+CREATE TABLE t(k INTEGER PRIMARY KEY, a TEXT);
+INSERT INTO t VALUES(1,'a1');
+SELECT dolt_add('-A'), dolt_commit('-m','init');
+SELECT dolt_branch('side');
+SELECT dolt_checkout('side');
+CREATE TABLE only_on_side(x INTEGER PRIMARY KEY);
+SELECT dolt_add('-A'), dolt_commit('-m','side table');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES(2,'a2');
+EOF
+
+check "write_after_checkout_keeps_our_schema" "table:t" "$(objs "$DB")"
+check "write_after_checkout_keeps_rows" "1|a1
+2|a2" "$("$DOLTLITE" "$DB" "SELECT k || '|' || a FROM t ORDER BY k;")"
+
+# Rolling back after a same-session checkout must restore the branch we are on,
+# not the catalog of the branch we visited.
+DB="$TMPROOT/rollback_after_checkout.db"
+"$DOLTLITE" "$DB" <<'EOF' >/dev/null 2>&1
+CREATE TABLE t(k INTEGER PRIMARY KEY, a TEXT);
+INSERT INTO t VALUES(1,'a1');
+SELECT dolt_add('-A'), dolt_commit('-m','init');
+SELECT dolt_branch('side');
+SELECT dolt_checkout('side');
+CREATE TABLE only_on_side(x INTEGER PRIMARY KEY);
+SELECT dolt_add('-A'), dolt_commit('-m','side table');
+SELECT dolt_checkout('main');
+BEGIN;
+INSERT INTO t VALUES(3,'a3');
+ROLLBACK;
+EOF
+
+check "rollback_after_checkout_keeps_our_schema" "table:t" "$(objs "$DB")"
+check "rollback_after_checkout_discards_row" "1|a1" \
+  "$("$DOLTLITE" "$DB" "SELECT k || '|' || a FROM t ORDER BY k;")"
+
+echo
+echo "=== Results: $pass passed, $fail failed ==="
+if [ "$fail" -ne 0 ]; then
+  echo "failed:$FAILED_NAMES"
+  exit 1
+fi

--- a/test/lib/doltlite_suite_manifest.sh
+++ b/test/lib/doltlite_suite_manifest.sh
@@ -23,6 +23,7 @@ doltlite_merge.sh
 doltlite_merge_status.sh
 doltlite_merge_index_conflict.sh
 doltlite_merge_nocase_reindex.sh
+doltlite_failed_merge_working_set.sh
 doltlite_index_row_delta.sh
 doltlite_index_vc_matrix.sh
 doltlite_vtab_vc_matrix.sh


### PR DESCRIPTION
A connection keeps the last catalog it committed as the baseline it serializes from and rolls back to, and `dolt_checkout` did not move it. The branch we left then won in two ways.

**The working set of the branch we left gets published as ours.** `serializeCatalogPatchRoots` patches roots into the baseline's bytes instead of building them, so every object the baseline names is published as it stands there. Matching entry counts and table numbers were the only guards, and two branches routinely agree on both. A merge whose source branch had been visited earlier in the same session therefore published *that* branch's tables as our working set:

```sql
CREATE TABLE t(k INTEGER PRIMARY KEY, a TEXT);
INSERT INTO t VALUES(1,'a1');
SELECT dolt_add('-A'), dolt_commit('-m','init');
SELECT dolt_branch('side');
ALTER TABLE t RENAME TO t2;
SELECT dolt_add('-A'), dolt_commit('-m','ours rename');
SELECT dolt_checkout('side');
CREATE TRIGGER tg AFTER INSERT ON t BEGIN UPDATE t SET a='TG' WHERE k=new.k; END;
SELECT dolt_add('-A'), dolt_commit('-m','theirs trigger');
SELECT dolt_checkout('main');
SELECT dolt_merge('side');       -- fails
```

Before: the merge fails, and main's working set becomes `table:t, trigger:tg` while HEAD still says `t2`. `dolt_status` presents it as the user's own edits (`t2 -> t/renamed`, `dolt_schemas/new table`), so a routine `dolt_add('-A'); dolt_commit()` writes the reverted rename into history. Only `dolt_reset('--hard')` recovers. After: the working set stays `table:t2` and status is clean.

Fix: compare each entry's schema hash against the live catalog as the patch walk goes. Only roots are patched, so a baseline that disagrees on any object's schema is not this catalog, and it has to be serialized in full.

**A rollback reinstates the other branch's tables.** `restoreFromCommitted` restores the same baseline, so `checkout side` (which creates a table) then `checkout main` then `BEGIN; INSERT; ROLLBACK` left `only_on_side` sitting on main. Fix: adopt the target catalog as the baseline once the checkout has persisted it, the way `doltlite_cherry_pick.c` and `doltlite_rebase.c` already adopt theirs.

The merge in the repro still fails — that is a separate bug in how a merged catalog adopts an index over a dropped column, and it gets its own PR.

## Testing

`test/doltlite_failed_merge_working_set.sh` (new, registered in the manifest) covers both manifestations plus a plain write after a checkout. 4 of its 9 assertions fail on master, all 9 pass here.

- 108/108 shell suites (`test/run_doltlite_tests.sh`)
- 310,930/310,930 C regression tests with `DOLTLITE_PROLLY_CHECK=1`
- 100/100 `vc_oracle_*` suites against the Dolt 2.2.2 oracle
- testfixture `alter*`/`schema*`/`savepoint*`/`trigger1`/`view`/`tableapi`: 1472 passing, no new failures (`savepoint4-2.8.1.2` fails identically on master — the known layout-sensitive case)
- `make lint` clean; amalgamation (`make testfixture`) compiles

Found during a full deep review; first cut moved the baseline inside `doltliteSwitchCatalog` itself, which broke a vec1 rebuild-after-conflict case by moving the rollback target mid-merge — hence the narrower split between the fast-path guard and the checkout adoption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)