### PR TITLE
Match ignore wildcards by UTF-8 character

### DIFF
--- a/src/doltlite_ignore.c
+++ b/src/doltlite_ignore.c
@@ -13,6 +13,12 @@ struct IgnoreMatch {
   u8 removed;
 };
 
+static const char *ignoreUtf8Next(const char *z){
+  z++;
+  while( ((unsigned char)*z & 0xc0)==0x80 ) z++;
+  return z;
+}
+
 static int ignorePatternMatchMode(
   const char *zPat,
   const char *zStr,
@@ -30,13 +36,13 @@ static int ignorePatternMatchMode(
       zPat++;
     }else if( c=='?' && (!patternMode || (*zStr!='*' && *zStr!='%')) ){
       zPat++;
-      zStr++;
+      zStr = ignoreUtf8Next(zStr);
     }else if( c==(unsigned char)*zStr ){
       zPat++;
       zStr++;
     }else if( pStar ){
       zPat = pStar + 1;
-      sStar++;
+      sStar = ignoreUtf8Next(sStar);
       zStr = sStar;
     }else{
       return 0;

--- a/test/doltlite_ignore.sh
+++ b/test/doltlite_ignore.sh
@@ -91,6 +91,19 @@ run_test "patterns_are_case_sensitive" \
 dolt_ignore|1|new table
 tmp_a|1|new table" "$DB2"
 
+DB4=/tmp/test_ignore_utf8_$$.db
+rm -f "$DB4"
+
+run_test "question_mark_matches_utf8_character" \
+  "INSERT INTO dolt_ignore VALUES('tmp_?', 1);
+   CREATE TABLE \"tmp_é\"(id INTEGER PRIMARY KEY);
+   CREATE TABLE tmp_xy(id INTEGER PRIMARY KEY);
+   SELECT dolt_add('-A');
+   SELECT table_name, staged, status FROM dolt_status ORDER BY table_name;" \
+  "0
+dolt_ignore|1|new table
+tmp_xy|1|new table" "$DB4"
+
 DB3=/tmp/test_ignore_specificity_$$.db
 rm -f "$DB3"
 
@@ -100,6 +113,6 @@ run_test_match "incomparable_patterns_conflict" \
    SELECT dolt_add('-A');" \
   "matches conflicting patterns" "$DB3"
 
-rm -f "$DB" "$DB2" "$DB3"
+rm -f "$DB" "$DB2" "$DB3" "$DB4"
 
 dltest_finish

--- a/test/vc_oracle_ignore_test.sh
+++ b/test/vc_oracle_ignore_test.sh
@@ -146,6 +146,12 @@ CREATE TABLE ea(x INT PRIMARY KEY);
 CREATE TABLE eabc(x INT PRIMARY KEY);
 "
 
+oracle "question_mark_utf8" "
+INSERT INTO dolt_ignore VALUES ('tmp_?', 1);
+CREATE TABLE \"tmp_é\"(x INT PRIMARY KEY);
+CREATE TABLE tmp_xy(x INT PRIMARY KEY);
+"
+
 oracle "case_sensitive" "
 INSERT INTO dolt_ignore VALUES ('TMP_*', 1);
 CREATE TABLE tmp_a(x INT PRIMARY KEY);


### PR DESCRIPTION
## Summary

- make `?` in `dolt_ignore` patterns consume one UTF-8 character instead of one byte
- keep wildcard backtracking on UTF-8 character boundaries
- add native and Dolt-oracle coverage for non-ASCII table names

## Testing

- `make -j4 doltlite`
- `make -j4 doltlite-lib`
- `make lint`
- `DOLTLITE=build/doltlite bash test/doltlite_ignore.sh` (16 passed)
- `bash test/vc_oracle_ignore_test.sh build/doltlite dolt` (46 passed)

Co-Authored-By: OpenAI Codex <noreply@openai.com>
