### PR TITLE
Report empty table diffs as schema-only

### DIFF
--- a/src/doltlite_diff.c
+++ b/src/doltlite_diff.c
@@ -4,6 +4,7 @@
 #include "sqliteInt.h"
 #include "prolly_hash.h"
 #include "prolly_diff.h"
+#include "prolly_cursor.h"
 #include "prolly_cache.h"
 #include "chunk_store.h"
 #include "doltlite_commit.h"
@@ -248,6 +249,19 @@ static int loadIndexSchemaRows(
                                ppRows, pnRows);
 }
 
+static int diffRootHasRows(sqlite3 *db, const ProllyHash *pRoot, u8 *pHasRows){
+  ChunkStore *cs = doltliteGetChunkStore(db);
+  ProllyCache *pCache = doltliteGetCache(db);
+  u64 n = 0;
+  int rc;
+  *pHasRows = 0;
+  if( !cs || !pCache ) return SQLITE_ERROR;
+  if( prollyHashIsEmpty(pRoot) ) return SQLITE_OK;
+  rc = prollySubtreeCount(cs, pCache, pRoot, &n);
+  if( rc==SQLITE_OK ) *pHasRows = n>0;
+  return rc;
+}
+
 static int diffFilteredTableRoots(
   DoltliteDiffCursor *pCur,
   sqlite3 *db,
@@ -288,7 +302,12 @@ static int diffFilteredTableRoots(
   if( !childFound && !parentFound ) return SQLITE_OK;
 
   if( !childFound || !parentFound ){
-    return batchAppend(pCur, zHex, pCur->zFilterTable, pCommit, 1, 1);
+    u8 dataChange;
+    rc = diffRootHasRows(db, childFound ? &childRoot : &parentRoot,
+                         &dataChange);
+    if( rc!=SQLITE_OK ) return rc;
+    return batchAppend(pCur, zHex, pCur->zFilterTable, pCommit,
+                       dataChange, 1);
   }
   {
     u8 dataChange = prollyHashCompare(&childRoot, &parentRoot)!=0;
@@ -327,6 +346,7 @@ static int diffCatalogPairOne(
   struct TableEntry *p;
   u8 dataChange;
   u8 schemaChange;
+  int rc;
 
   if( !pCur->zFilterTable ) return SQLITE_OK;
 
@@ -337,7 +357,6 @@ static int diffCatalogPairOne(
     struct TableEntry *pOldMaster;
     int hasDiff;
     int oldHas;
-    int rc;
 
     memset(&emptyRoot, 0, sizeof(emptyRoot));
     pNewMaster = doltliteFindTableByNumber(aChild, nChild, 1);
@@ -362,7 +381,8 @@ static int diffCatalogPairOne(
   if( !e && !p ) return SQLITE_OK;
 
   if( !p || !e ){
-    dataChange = 1;
+    rc = diffRootHasRows(db, e ? &e->root : &p->root, &dataChange);
+    if( rc!=SQLITE_OK ) return rc;
     schemaChange = 1;
   }else{
     dataChange   = (prollyHashCompare(&e->root, &p->root) != 0) ? 1 : 0;
@@ -432,7 +452,8 @@ static int diffCatalogPair(
     }
     p = diffNameIndexFind(&parentIdx, e->zName);
     if( !p ){
-      dataChange = 1;
+      rc = diffRootHasRows(db, &e->root, &dataChange);
+      if( rc!=SQLITE_OK ) goto diff_done;
       schemaChange = 1;
     }else{
       dataChange   = (prollyHashCompare(&e->root, &p->root) != 0) ? 1 : 0;
@@ -449,9 +470,12 @@ static int diffCatalogPair(
   }
   for(i=0; i<nParent; i++){
     struct TableEntry *p = &aParent[i];
+    u8 dataChange;
     if( !p->zName ) continue;
     if( diffNameIndexFind(&childIdx, p->zName) ) continue;
-    rc = batchAppend(pCur, zHex, p->zName, pCommit, 1, 1);
+    rc = diffRootHasRows(db, &p->root, &dataChange);
+    if( rc!=SQLITE_OK ) goto diff_done;
+    rc = batchAppend(pCur, zHex, p->zName, pCommit, dataChange, 1);
     if( rc!=SQLITE_OK ) goto diff_done;
   }
 diff_done:

--- a/test/doltlite_diff.sh
+++ b/test/doltlite_diff.sh
@@ -244,6 +244,27 @@ run_test "diff_stat_real_pos_neg_zero_no_diff" \
   "SELECT rows_modified FROM dolt_diff_stat('HEAD~1', 'HEAD', 'r');" \
   "0" "$DB17"
 
-rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8" "$DB9" "$DB10" "$DB11" "$DB12" "$DB13" "$DB14" "$DB15" "$DB16" "$DB17"
+DB18=/tmp/test_diff18_$$.db; rm -f "$DB18"
+echo "CREATE TABLE baseline(id INTEGER PRIMARY KEY);
+SELECT dolt_commit('-A','-m','baseline');
+CREATE TABLE empty_t(id INTEGER PRIMARY KEY);
+SELECT dolt_commit('-A','-m','create_empty');
+DROP TABLE empty_t;
+SELECT dolt_commit('-A','-m','drop_empty');" | $DOLTLITE "$DB18" > /dev/null 2>&1
+
+run_test "diff_empty_table_history" \
+  "SELECT group_concat(message || '|' || data_change || '|' || schema_change, ',') FROM (SELECT message, data_change, schema_change FROM dolt_diff WHERE table_name || '' = 'empty_t' ORDER BY message);" \
+  "create_empty|0|1,drop_empty|0|1" "$DB18"
+
+run_test "diff_empty_table_history_filtered" \
+  "SELECT group_concat(message || '|' || data_change || '|' || schema_change, ',') FROM (SELECT message, data_change, schema_change FROM dolt_diff WHERE table_name = 'empty_t' ORDER BY message);" \
+  "create_empty|0|1,drop_empty|0|1" "$DB18"
+
+echo "CREATE TABLE empty_working(id INTEGER PRIMARY KEY);" | $DOLTLITE "$DB18" > /dev/null 2>&1
+run_test "diff_empty_table_working" \
+  "SELECT data_change || '|' || schema_change FROM dolt_diff WHERE commit_hash='WORKING' AND table_name='empty_working';" \
+  "0|1" "$DB18"
+
+rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8" "$DB9" "$DB10" "$DB11" "$DB12" "$DB13" "$DB14" "$DB15" "$DB16" "$DB17" "$DB18"
 
 dltest_finish

--- a/test/vc_oracle_diff_test.sh
+++ b/test/vc_oracle_diff_test.sh
@@ -989,6 +989,18 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'ix_only');
 "
 
+oracle_summary "summary_empty_table_create_drop" "
+CREATE TABLE baseline(id INTEGER PRIMARY KEY);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'baseline');
+CREATE TABLE empty_t(id INTEGER PRIMARY KEY);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'create_empty');
+DROP TABLE empty_t;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'drop_empty');
+"
+
 oracle_summary_filter_name "summary_filter_index_only_commit" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
 INSERT INTO t VALUES (1, 10);


### PR DESCRIPTION
## Summary

- derive `dolt_diff.data_change` from the added or dropped table row count
- apply the same semantics to history, filtered, staged, and working diff paths
- add native create/drop/working regressions and a Dolt oracle comparison

## Testing

- `make -j4 doltlite doltlite-lib`
- `make lint`
- `DOLTLITE=build/doltlite bash test/doltlite_diff.sh` (45 passed)
- `bash test/vc_oracle_diff_test.sh build/doltlite dolt` (68 passed)
- `bash test/run_doltlite_tests.sh build/doltlite` (107 DoltLite suites passed; parity wrapper lacked `build/sqlite3`)
- `bash test/doltlite_parity.sh build/doltlite` (119 passed against the repo-root stock SQLite binary)

Co-Authored-By: OpenAI Codex <noreply@openai.com>