### PR TITLE
Drop a merged expression index along with the column it covers

### DIFF
--- a/src/doltlite_merge_schema.c
+++ b/src/doltlite_merge_schema.c
@@ -1313,28 +1313,42 @@ done:
   return rc;
 }
 
-/* The identifier a plain index column-list item names, with quoting, sort
-** order and collation stripped. */
-static char *mergeIndexItemColumn(const char *z, int n){
-  int i = 0;
-  int j;
-  char *zOut;
-  while( i<n && (sqlite3Isspace(z[i]) || z[i]=='"' || z[i]=='`' || z[i]=='[') ){
-    i++;
+/* Skip a quoted span starting at z. q is the opening quote; ']' closes '['. */
+static const char *mergeIndexSkipQuoted(const char *z, char q){
+  char qEnd = (q=='[') ? ']' : q;
+  z++;
+  while( *z && *z!=qEnd ){
+    if( q=='\'' && *z=='\'' && z[1]=='\'' ){ z += 2; continue; }
+    z++;
   }
-  j = i;
-  while( j<n && (sqlite3Isalnum(z[j]) || z[j]=='_' || z[j]=='$') ) j++;
-  if( j==i ) return 0;
-  zOut = sqlite3_malloc(j-i+1);
+  return *z ? z+1 : z;
+}
+
+static int mergeIndexIsSortKeyword(const char *z, int n){
+  static const char *const azKw[] = {
+    "ASC", "COLLATE", "DESC", "FIRST", "LAST", "NULLS"
+  };
+  int i;
+  for(i=0; i<(int)(sizeof(azKw)/sizeof(azKw[0])); i++){
+    if( sqlite3_strnicmp(z, azKw[i], n)==0 && azKw[i][n]==0 ) return 1;
+  }
+  return 0;
+}
+
+static char *mergeIndexDupIdent(const char *z, int n){
+  char *zOut;
+  if( n<=0 ) return 0;
+  zOut = sqlite3_malloc(n+1);
   if( !zOut ) return 0;
-  memcpy(zOut, z+i, j-i);
-  zOut[j-i] = 0;
+  memcpy(zOut, z, n);
+  zOut[n] = 0;
   return zOut;
 }
 
-/* Walk the column list of a CREATE INDEX, calling xEach for each column it
-** names. An expression index has a nested paren and no plain column list to
-** read, so it reports nothing rather than guessing. */
+/* Walk identifiers in a CREATE INDEX column list, including those nested
+** inside expression indexes such as abs(length(b)). Function names (an
+** ident followed by '(') and ASC/DESC/COLLATE tokens are skipped so a
+** dropped column named abs is not required to kill every abs() index. */
 static int mergeIndexEachColumn(
   const char *zIndexSql,
   int (*xEach)(void*, const char*),
@@ -1342,28 +1356,61 @@ static int mergeIndexEachColumn(
 ){
   const char *zOpen = zIndexSql ? strchr(zIndexSql, '(') : 0;
   const char *zEnd;
-  const char *zItem;
   const char *z;
+  int depth;
   int rc = SQLITE_OK;
 
   if( !zOpen ) return SQLITE_OK;
+  depth = 1;
   zEnd = zOpen + 1;
-  while( *zEnd && *zEnd!=')' ){
-    if( *zEnd=='(' ) return SQLITE_OK;
-    zEnd++;
+  while( *zEnd && depth>0 ){
+    if( *zEnd=='\'' || *zEnd=='"' || *zEnd=='`' || *zEnd=='[' ){
+      zEnd = mergeIndexSkipQuoted(zEnd, *zEnd);
+      continue;
+    }
+    if( *zEnd=='(' ) depth++;
+    else if( *zEnd==')' ) depth--;
+    if( depth>0 ) zEnd++;
   }
-  if( *zEnd!=')' ) return SQLITE_OK;
+  if( depth!=0 ) return SQLITE_OK;
 
-  zItem = zOpen + 1;
-  for(z=zItem; z<=zEnd && rc==SQLITE_OK; z++){
-    if( z==zEnd || *z==',' ){
-      char *zCol = mergeIndexItemColumn(zItem, (int)(z-zItem));
+  z = zOpen + 1;
+  while( z<zEnd && rc==SQLITE_OK ){
+    const char *zIdent;
+    int nIdent;
+    char *zCol;
+    const char *zLook;
+
+    if( *z=='\'' || *z=='"' || *z=='`' || *z=='[' ){
+      char q = *z;
+      char qEnd = (q=='[') ? ']' : q;
+      zIdent = z + 1;
+      z = mergeIndexSkipQuoted(z, q);
+      nIdent = (int)((z>zIdent+1 && z[-1]==qEnd) ? (z-zIdent-1) : 0);
+      zCol = mergeIndexDupIdent(zIdent, nIdent);
+      if( !zCol && nIdent>0 ) return SQLITE_NOMEM;
       if( zCol ){
         rc = xEach(pCtx, zCol);
         sqlite3_free(zCol);
       }
-      zItem = z + 1;
+      continue;
     }
+    if( !(sqlite3Isalnum(*z) || *z=='_' || *z=='$') ){
+      z++;
+      continue;
+    }
+    zIdent = z;
+    z++;
+    while( z<zEnd && (sqlite3Isalnum(*z) || *z=='_' || *z=='$') ) z++;
+    nIdent = (int)(z-zIdent);
+    zLook = z;
+    while( zLook<zEnd && sqlite3Isspace(*zLook) ) zLook++;
+    if( zLook<zEnd && *zLook=='(' ) continue;
+    if( mergeIndexIsSortKeyword(zIdent, nIdent) ) continue;
+    zCol = mergeIndexDupIdent(zIdent, nIdent);
+    if( !zCol ) return SQLITE_NOMEM;
+    rc = xEach(pCtx, zCol);
+    sqlite3_free(zCol);
   }
   return rc;
 }

--- a/test/doltlite_schema_merge.sh
+++ b/test/doltlite_schema_merge.sh
@@ -1112,6 +1112,61 @@ run_test "merge_composite_index_over_dropped_column_objects" \
   "table:t" "$DB"
 rm -f "$DB"
 
+# Expression indexes name columns inside function calls (nested parens), not
+# as a plain list. Dropping that column used to leave the index in the catalog
+# and fail the merge with "database disk image is malformed".
+for dir in ours theirs; do
+  DB=/tmp/test_merge_idx_dropcol_expr_${dir}_$$.db; rm -f "$DB"
+  if [ "$dir" = ours ]; then
+    OURS="ALTER TABLE t DROP COLUMN b;"; THEIRS="CREATE INDEX ix ON t(abs(length(b)));"
+  else
+    OURS="CREATE INDEX ix ON t(abs(length(b)));"; THEIRS="ALTER TABLE t DROP COLUMN b;"
+  fi
+  cat <<EOF | $DOLTLITE "$DB" > /dev/null 2>&1
+CREATE TABLE t(k INTEGER PRIMARY KEY, a TEXT, b TEXT);
+INSERT INTO t VALUES(1,'a1','b1'),(2,'a2','b2');
+SELECT dolt_commit('-A','-m','base');
+SELECT dolt_branch('feat');
+$OURS
+SELECT dolt_commit('-A','-m','main side');
+SELECT dolt_checkout('feat');
+$THEIRS
+SELECT dolt_commit('-A','-m','feat side');
+SELECT dolt_checkout('main');
+EOF
+  run_test_match "merge_expr_index_over_dropped_column_${dir}_hash" \
+    "SELECT dolt_merge('feat');" "^[0-9a-f]{40}$" "$DB"
+  run_test "merge_expr_index_over_dropped_column_${dir}_objects" \
+    "SELECT group_concat(type||':'||name) FROM sqlite_master ORDER BY name;" \
+    "table:t" "$DB"
+  run_test "merge_expr_index_over_dropped_column_${dir}_rows" \
+    "SELECT group_concat(k||':'||a) FROM t ORDER BY k;" "1:a1,2:a2" "$DB"
+  run_test "merge_expr_index_over_dropped_column_${dir}_integrity" \
+    "PRAGMA integrity_check;" "ok" "$DB"
+  rm -f "$DB"
+done
+
+# An expression index over a surviving column is not dropped just because a
+# different column disappeared, including when the expression calls abs().
+DB=/tmp/test_merge_idx_expr_survives_$$.db; rm -f "$DB"
+cat <<'EOF' | $DOLTLITE "$DB" > /dev/null 2>&1
+CREATE TABLE t(k INTEGER PRIMARY KEY, a TEXT, b TEXT);
+INSERT INTO t VALUES(1,'a1','b1');
+SELECT dolt_commit('-A','-m','base');
+SELECT dolt_branch('feat');
+CREATE INDEX ix ON t(abs(length(a)));
+SELECT dolt_commit('-A','-m','index on a');
+SELECT dolt_checkout('feat');
+ALTER TABLE t DROP COLUMN b;
+SELECT dolt_commit('-A','-m','drop b');
+SELECT dolt_checkout('main');
+EOF
+run_test_match "merge_expr_index_surviving_column_hash" \
+  "SELECT dolt_merge('feat');" "^[0-9a-f]{40}$" "$DB"
+run_test "merge_expr_index_surviving_column_kept" \
+  "SELECT group_concat(name) FROM sqlite_master WHERE type='index';" "ix" "$DB"
+rm -f "$DB"
+
 # An index whose columns all survive must be adopted exactly as before: both
 # branches indexing different surviving columns keeps both indexes, and an
 # index over a column their side added comes across with it.


### PR DESCRIPTION
Follow-up to #2289. Ito found that `CREATE INDEX ix ON t(abs(length(b)))` on one side and `DROP COLUMN b` on the other still fails the merge with `database disk image is malformed`. `integrity_check` is `ok`; the user cannot finish.

#2289's walker treated a nested `(` as "not a column list" and reported no columns, so the index was adopted over a missing column. That was deliberate for not guessing, but it left the same brick wall as a plain `INDEX (b)`.

This walks identifiers inside the column-list parens (matching nested depth, skipping quotes). An ident followed by `(` is a function name and is skipped, so `abs(length(a))` is not dropped when some other column disappears. The existing rename guard still applies if a referenced column was renamed rather than dropped.

Does not overlap #2294 (`trySchemaColumnMerge` drop collection) or #2290 (dual-rename replay in that same function). This only changes `mergeIndexEachColumn` at the bottom of `doltlite_merge_schema.c`.

## Testing

- Both directions of drop-vs-`abs(length(b))`: merge succeeds, index gone, rows kept, `integrity_check` ok
- Expression index on a surviving column while another column is dropped: index kept
- `test/doltlite_schema_merge.sh`: 187/187 (was 177 on #2289; +10 here)

Found by [Ito on #2289](https://github.com/dolthub/doltlite/pull/2289#issuecomment-5349102503).