### PR TITLE
Preserve comment markers in quoted schema identifiers

### DIFF
--- a/src/doltlite_hashof.c
+++ b/src/doltlite_hashof.c
@@ -179,6 +179,8 @@ char *doltliteCanonicalizeSchemaSql(const char *zSql, const char *zName){
   const char *z = zSql;
   int inSingle = 0;
   int inDouble = 0;
+  int inBacktick = 0;
+  int inBracket = 0;
   int pendingSpace = 0;
   int rc;
 
@@ -222,7 +224,31 @@ char *doltliteCanonicalizeSchemaSql(const char *zSql, const char *zName){
     }
     if( inDouble ){
       sqlite3_str_appendchar(pStr, 1, (char)c);
-      if( c=='"' ) inDouble = 0;
+      if( c=='"' ){
+        if( z[1]=='"' ){
+          sqlite3_str_appendchar(pStr, 1, '"');
+          z++;
+        }else{
+          inDouble = 0;
+        }
+      }
+      continue;
+    }
+    if( inBacktick ){
+      sqlite3_str_appendchar(pStr, 1, (char)c);
+      if( c=='`' ){
+        if( z[1]=='`' ){
+          sqlite3_str_appendchar(pStr, 1, '`');
+          z++;
+        }else{
+          inBacktick = 0;
+        }
+      }
+      continue;
+    }
+    if( inBracket ){
+      sqlite3_str_appendchar(pStr, 1, (char)c);
+      if( c==']' ) inBracket = 0;
       continue;
     }
     if( c=='\'' ){
@@ -241,6 +267,24 @@ char *doltliteCanonicalizeSchemaSql(const char *zSql, const char *zName){
       pendingSpace = 0;
       inDouble = 1;
       sqlite3_str_appendchar(pStr, 1, '"');
+      continue;
+    }
+    if( c=='`' ){
+      if( pendingSpace && sqlite3_str_length(pStr)>0 ){
+        sqlite3_str_appendchar(pStr, 1, ' ');
+      }
+      pendingSpace = 0;
+      inBacktick = 1;
+      sqlite3_str_appendchar(pStr, 1, '`');
+      continue;
+    }
+    if( c=='[' ){
+      if( pendingSpace && sqlite3_str_length(pStr)>0 ){
+        sqlite3_str_appendchar(pStr, 1, ' ');
+      }
+      pendingSpace = 0;
+      inBracket = 1;
+      sqlite3_str_appendchar(pStr, 1, '[');
       continue;
     }
     if( isspace(c) ){

--- a/test/doltlite_stable_catalog_numbers.sh
+++ b/test/doltlite_stable_catalog_numbers.sh
@@ -82,6 +82,45 @@ EOF
 REOPEN_SQL=$("$DOLTLITE" "$TMPROOT/sql" "SELECT sql FROM sqlite_master WHERE name='t'" 2>/dev/null)
 check "sql_stable_across_reopen" "$(printf '%s\n' "$INSESSION_SQL" | grep CREATE)" "$REOPEN_SQL"
 
+echo "--- comment markers inside quoted identifiers remain schema text ---"
+
+QUOTED=$("$DOLTLITE" "$TMPROOT/quoted" 2>/dev/null <<'EOF'
+CREATE TABLE q(
+  `back--tick` TEXT,
+  [bracket/*name] INTEGER,
+  "double""--quote" TEXT
+);
+CREATE INDEX `index--name` ON q(`back--tick`);
+CREATE VIEW `view--name` AS
+ SELECT `back--tick`, [bracket/*name] FROM q;
+CREATE TRIGGER `trigger--name` AFTER INSERT ON q BEGIN
+  UPDATE q SET `back--tick`=NEW.`back--tick`
+   WHERE [bracket/*name]=NEW.[bracket/*name];
+END;
+INSERT INTO q VALUES('value',1,'quoted');
+SELECT 'C:'||(dolt_commit('-A','-m','quoted') IS NOT NULL);
+SELECT 'Q:'||count(*) FROM pragma_table_xinfo('q')
+ WHERE name IN ('back--tick','bracket/*name','double"--quote');
+SELECT 'O:'||count(*) FROM sqlite_master
+ WHERE name IN ('index--name','view--name','trigger--name');
+SELECT 'V:'||count(*) FROM `view--name` WHERE `back--tick`='value';
+SELECT 'K:'||integrity_check FROM pragma_integrity_check;
+EOF
+)
+check "quoted_comment_markers_in_session" "C:1 Q:3 O:3 V:1 K:ok" \
+  "$(printf '%s\n' "$QUOTED" | tr '\n' ' ' | sed 's/ $//')"
+QUOTED_REOPEN=$("$DOLTLITE" "$TMPROOT/quoted" 2>/dev/null <<'EOF'
+SELECT 'Q:'||count(*) FROM pragma_table_xinfo('q')
+ WHERE name IN ('back--tick','bracket/*name','double"--quote');
+SELECT 'O:'||count(*) FROM sqlite_master
+ WHERE name IN ('index--name','view--name','trigger--name');
+SELECT 'V:'||count(*) FROM `view--name` WHERE `back--tick`='value';
+SELECT 'K:'||integrity_check FROM pragma_integrity_check;
+EOF
+)
+check "quoted_comment_markers_after_reopen" "Q:3 O:3 V:1 K:ok" \
+  "$(printf '%s\n' "$QUOTED_REOPEN" | tr '\n' ' ' | sed 's/ $//')"
+
 echo "--- rolled-back DDL leaves view and cleanliness intact ---"
 
 RB=$("$DOLTLITE" "$DB" 2>/dev/null <<EOF


### PR DESCRIPTION
## Summary

- recognize backtick- and bracket-quoted identifiers while canonicalizing schema SQL
- preserve doubled delimiters inside quoted identifiers
- keep comment stripping restricted to unquoted schema text
- cover tables, indexes, views, and triggers across commit and reopen

## Testing

- fail-before: `bash test/doltlite_stable_catalog_numbers.sh /tmp/doltlite-review.2eVmS6/build/doltlite` (12 passed, 2 failed)
- pass-after: `bash test/doltlite_stable_catalog_numbers.sh build/doltlite` (14 passed)
- `make lint`
- `bash test/run_doltlite_tests.sh build/doltlite` (107 DoltLite suites passed; parity wrapper lacked `build/sqlite3`)
- `bash test/doltlite_parity.sh build/doltlite` (119 passed against the repo-root stock SQLite binary)
- C regressions in the full shell battery: 310,930 passed

Co-Authored-By: OpenAI Codex <noreply@openai.com>