### PR TITLE
Keep collation names and quoted index columns out of drop-index

### DIFF
--- a/src/doltlite_merge_schema.c
+++ b/src/doltlite_merge_schema.c
@@ -1315,15 +1315,30 @@ done:
   return rc;
 }
 
-/* Skip a quoted span starting at z. q is the opening quote; ']' closes '['. */
+/* Skip a quoted span starting at z. q is the opening quote; ']' closes '['.
+** Doubled quotes inside ', ", or ` are the escaped quote, not the closer. */
 static const char *mergeIndexSkipQuoted(const char *z, char q){
   char qEnd = (q=='[') ? ']' : q;
   z++;
-  while( *z && *z!=qEnd ){
-    if( q=='\'' && *z=='\'' && z[1]=='\'' ){ z += 2; continue; }
+  while( *z ){
+    if( q!='[' && *z==q && z[1]==q ){ z += 2; continue; }
+    if( *z==qEnd ) return z+1;
     z++;
   }
-  return *z ? z+1 : z;
+  return z;
+}
+
+static const char *mergeIndexSkipName(const char *z, const char *zEnd){
+  while( z<zEnd && sqlite3Isspace(*z) ) z++;
+  if( z>=zEnd ) return z;
+  if( *z=='\'' || *z=='"' || *z=='`' || *z=='[' ){
+    return mergeIndexSkipQuoted(z, *z);
+  }
+  if( sqlite3Isalnum(*z) || *z=='_' || *z=='$' ){
+    z++;
+    while( z<zEnd && (sqlite3Isalnum(*z) || *z=='_' || *z=='$') ) z++;
+  }
+  return z;
 }
 
 static int mergeIndexIsSortKeyword(const char *z, int n){
@@ -1348,9 +1363,11 @@ static char *mergeIndexDupIdent(const char *z, int n){
 }
 
 /* Walk identifiers in a CREATE INDEX column list, including those nested
-** inside expression indexes such as abs(length(b)). Function names (an
-** ident followed by '(') and ASC/DESC/COLLATE tokens are skipped so a
-** dropped column named abs is not required to kill every abs() index. */
+** inside expression indexes such as abs(length(b)), and in a trailing WHERE
+** predicate. Function names (an ident followed by '(') and ASC/DESC/COLLATE
+** tokens are skipped so a dropped column named abs is not required to kill
+** every abs() index. The ident after COLLATE is the collation, not a column.
+** Single-quoted spans are string literals, not identifiers. */
 static int mergeIndexEachColumn(
   const char *zIndexSql,
   int (*xEach)(void*, const char*),
@@ -1377,24 +1394,25 @@ static int mergeIndexEachColumn(
   if( depth!=0 ) return SQLITE_OK;
 
   z = zOpen + 1;
+  zEnd = zIndexSql + strlen(zIndexSql);
   while( z<zEnd && rc==SQLITE_OK ){
     const char *zIdent;
     int nIdent;
     char *zCol;
     const char *zLook;
 
-    if( *z=='\'' || *z=='"' || *z=='`' || *z=='[' ){
-      char q = *z;
-      char qEnd = (q=='[') ? ']' : q;
-      zIdent = z + 1;
-      z = mergeIndexSkipQuoted(z, q);
-      nIdent = (int)((z>zIdent+1 && z[-1]==qEnd) ? (z-zIdent-1) : 0);
-      zCol = mergeIndexDupIdent(zIdent, nIdent);
-      if( !zCol && nIdent>0 ) return SQLITE_NOMEM;
-      if( zCol ){
-        rc = xEach(pCtx, zCol);
-        sqlite3_free(zCol);
-      }
+    if( *z=='\'' ){
+      z = mergeIndexSkipQuoted(z, '\'');
+      continue;
+    }
+    if( *z=='"' || *z=='`' || *z=='[' ){
+      zIdent = z;
+      z = mergeIndexSkipQuoted(z, *z);
+      zCol = mergeIndexDupIdent(zIdent, (int)(z-zIdent));
+      if( !zCol ) return SQLITE_NOMEM;
+      sqlite3Dequote(zCol);
+      if( zCol[0] ) rc = xEach(pCtx, zCol);
+      sqlite3_free(zCol);
       continue;
     }
     if( !(sqlite3Isalnum(*z) || *z=='_' || *z=='$') ){
@@ -1408,7 +1426,12 @@ static int mergeIndexEachColumn(
     zLook = z;
     while( zLook<zEnd && sqlite3Isspace(*zLook) ) zLook++;
     if( zLook<zEnd && *zLook=='(' ) continue;
-    if( mergeIndexIsSortKeyword(zIdent, nIdent) ) continue;
+    if( mergeIndexIsSortKeyword(zIdent, nIdent) ){
+      if( nIdent==7 && sqlite3_strnicmp(zIdent, "COLLATE", 7)==0 ){
+        z = mergeIndexSkipName(z, zEnd);
+      }
+      continue;
+    }
     zCol = mergeIndexDupIdent(zIdent, nIdent);
     if( !zCol ) return SQLITE_NOMEM;
     rc = xEach(pCtx, zCol);

--- a/src/doltlite_merge_schema.c
+++ b/src/doltlite_merge_schema.c
@@ -1315,8 +1315,6 @@ done:
   return rc;
 }
 
-/* Skip a quoted span starting at z. q is the opening quote; ']' closes '['.
-** Doubled quotes inside ', ", or ` are the escaped quote, not the closer. */
 static const char *mergeIndexSkipQuoted(const char *z, char q){
   char qEnd = (q=='[') ? ']' : q;
   z++;
@@ -1331,9 +1329,7 @@ static const char *mergeIndexSkipQuoted(const char *z, char q){
 static const char *mergeIndexSkipName(const char *z, const char *zEnd){
   while( z<zEnd && sqlite3Isspace(*z) ) z++;
   if( z>=zEnd ) return z;
-  if( *z=='\'' || *z=='"' || *z=='`' || *z=='[' ){
-    return mergeIndexSkipQuoted(z, *z);
-  }
+  if( *z=='\'' || *z=='"' || *z=='`' || *z=='[' ) return mergeIndexSkipQuoted(z, *z);
   if( sqlite3Isalnum(*z) || *z=='_' || *z=='$' ){
     z++;
     while( z<zEnd && (sqlite3Isalnum(*z) || *z=='_' || *z=='$') ) z++;
@@ -1353,31 +1349,22 @@ static int mergeIndexIsSortKeyword(const char *z, int n){
 }
 
 static char *mergeIndexDupIdent(const char *z, int n){
-  char *zOut;
-  if( n<=0 ) return 0;
-  zOut = sqlite3_malloc(n+1);
-  if( !zOut ) return 0;
-  memcpy(zOut, z, n);
-  zOut[n] = 0;
+  char *zOut = n>0 ? sqlite3_malloc(n+1) : 0;
+  if( zOut ){ memcpy(zOut, z, n); zOut[n] = 0; }
   return zOut;
 }
 
-/* Walk identifiers in a CREATE INDEX column list, including those nested
-** inside expression indexes such as abs(length(b)), and in a trailing WHERE
-** predicate. Function names (an ident followed by '(') and ASC/DESC/COLLATE
-** tokens are skipped so a dropped column named abs is not required to kill
-** every abs() index. The ident after COLLATE is the collation, not a column.
-** Single-quoted spans are string literals, not identifiers. */
+/* Walk CREATE INDEX column-list and WHERE identifiers. Skip function names,
+** sort keywords, the ident after COLLATE, and single-quoted literals. */
 static int mergeIndexEachColumn(
   const char *zIndexSql,
   int (*xEach)(void*, const char*),
   void *pCtx
 ){
   const char *zOpen = zIndexSql ? strchr(zIndexSql, '(') : 0;
-  const char *zEnd;
-  const char *z;
-  int depth;
-  int rc = SQLITE_OK;
+  const char *zEnd, *z, *zIdent, *zLook;
+  char *zCol;
+  int depth, nIdent, rc = SQLITE_OK;
 
   if( !zOpen ) return SQLITE_OK;
   depth = 1;
@@ -1396,15 +1383,7 @@ static int mergeIndexEachColumn(
   z = zOpen + 1;
   zEnd = zIndexSql + strlen(zIndexSql);
   while( z<zEnd && rc==SQLITE_OK ){
-    const char *zIdent;
-    int nIdent;
-    char *zCol;
-    const char *zLook;
-
-    if( *z=='\'' ){
-      z = mergeIndexSkipQuoted(z, '\'');
-      continue;
-    }
+    if( *z=='\'' ){ z = mergeIndexSkipQuoted(z, '\''); continue; }
     if( *z=='"' || *z=='`' || *z=='[' ){
       zIdent = z;
       z = mergeIndexSkipQuoted(z, *z);
@@ -1415,12 +1394,8 @@ static int mergeIndexEachColumn(
       sqlite3_free(zCol);
       continue;
     }
-    if( !(sqlite3Isalnum(*z) || *z=='_' || *z=='$') ){
-      z++;
-      continue;
-    }
-    zIdent = z;
-    z++;
+    if( !(sqlite3Isalnum(*z) || *z=='_' || *z=='$') ){ z++; continue; }
+    zIdent = z++;
     while( z<zEnd && (sqlite3Isalnum(*z) || *z=='_' || *z=='$') ) z++;
     nIdent = (int)(z-zIdent);
     zLook = z;

--- a/test/doltlite_schema_merge.sh
+++ b/test/doltlite_schema_merge.sh
@@ -1167,6 +1167,140 @@ run_test "merge_expr_index_surviving_column_kept" \
   "SELECT group_concat(name) FROM sqlite_master WHERE type='index';" "ix" "$DB"
 rm -f "$DB"
 
+# COLLATE names the collation, not a column. A dropped column whose name
+# happens to be nocase must not take an index on (a COLLATE nocase) with it.
+DB=/tmp/test_merge_idx_collate_survives_$$.db; rm -f "$DB"
+cat <<'EOF' | $DOLTLITE "$DB" > /dev/null 2>&1
+CREATE TABLE t(k INTEGER PRIMARY KEY, a TEXT, nocase TEXT, b TEXT);
+INSERT INTO t VALUES(1,'a1','n1','b1');
+SELECT dolt_commit('-A','-m','base');
+SELECT dolt_branch('feat');
+CREATE INDEX ix ON t(a COLLATE nocase);
+SELECT dolt_commit('-A','-m','index on a');
+SELECT dolt_checkout('feat');
+ALTER TABLE t DROP COLUMN nocase;
+SELECT dolt_commit('-A','-m','drop nocase');
+SELECT dolt_checkout('main');
+EOF
+run_test_match "merge_collate_index_survives_dropped_collation_name_hash" \
+  "SELECT dolt_merge('feat');" "^[0-9a-f]{40}$" "$DB"
+run_test "merge_collate_index_survives_dropped_collation_name_kept" \
+  "SELECT group_concat(name) FROM sqlite_master WHERE type='index';" "ix" "$DB"
+run_test "merge_collate_index_survives_dropped_collation_name_integrity" \
+  "PRAGMA integrity_check;" "ok" "$DB"
+rm -f "$DB"
+
+# An index over a quoted identifier with an embedded quote still tracks the
+# real column. Dropping "odd""name" has to drop the index; dropping some other
+# column must not.
+for dir in ours theirs; do
+  DB=/tmp/test_merge_idx_dropcol_quoted_${dir}_$$.db; rm -f "$DB"
+  if [ "$dir" = ours ]; then
+    OURS='ALTER TABLE t DROP COLUMN "odd""name";'
+    THEIRS='CREATE INDEX ix ON t("odd""name");'
+  else
+    OURS='CREATE INDEX ix ON t("odd""name");'
+    THEIRS='ALTER TABLE t DROP COLUMN "odd""name";'
+  fi
+  cat <<EOF | $DOLTLITE "$DB" > /dev/null 2>&1
+CREATE TABLE t(k INTEGER PRIMARY KEY, "odd""name" TEXT, b TEXT);
+INSERT INTO t VALUES(1,'o1','b1'),(2,'o2','b2');
+SELECT dolt_commit('-A','-m','base');
+SELECT dolt_branch('feat');
+$OURS
+SELECT dolt_commit('-A','-m','main side');
+SELECT dolt_checkout('feat');
+$THEIRS
+SELECT dolt_commit('-A','-m','feat side');
+SELECT dolt_checkout('main');
+EOF
+  run_test_match "merge_quoted_index_over_dropped_column_${dir}_hash" \
+    "SELECT dolt_merge('feat');" "^[0-9a-f]{40}$" "$DB"
+  run_test "merge_quoted_index_over_dropped_column_${dir}_objects" \
+    "SELECT group_concat(type||':'||name) FROM sqlite_master ORDER BY name;" \
+    "table:t" "$DB"
+  run_test "merge_quoted_index_over_dropped_column_${dir}_rows" \
+    "SELECT group_concat(k||':'||b) FROM t ORDER BY k;" "1:b1,2:b2" "$DB"
+  run_test "merge_quoted_index_over_dropped_column_${dir}_integrity" \
+    "PRAGMA integrity_check;" "ok" "$DB"
+  rm -f "$DB"
+done
+
+DB=/tmp/test_merge_idx_quoted_survives_$$.db; rm -f "$DB"
+cat <<'EOF' | $DOLTLITE "$DB" > /dev/null 2>&1
+CREATE TABLE t(k INTEGER PRIMARY KEY, "odd""name" TEXT, b TEXT);
+INSERT INTO t VALUES(1,'o1','b1');
+SELECT dolt_commit('-A','-m','base');
+SELECT dolt_branch('feat');
+CREATE INDEX ix ON t("odd""name");
+SELECT dolt_commit('-A','-m','index on quoted');
+SELECT dolt_checkout('feat');
+ALTER TABLE t DROP COLUMN b;
+SELECT dolt_commit('-A','-m','drop b');
+SELECT dolt_checkout('main');
+EOF
+run_test_match "merge_quoted_index_surviving_column_hash" \
+  "SELECT dolt_merge('feat');" "^[0-9a-f]{40}$" "$DB"
+run_test "merge_quoted_index_surviving_column_kept" \
+  "SELECT group_concat(name) FROM sqlite_master WHERE type='index';" "ix" "$DB"
+rm -f "$DB"
+
+# A partial index's WHERE clause names columns too. Dropping one of those
+# used to leave the index in the catalog and fail the merge as malformed.
+for dir in ours theirs; do
+  DB=/tmp/test_merge_idx_dropcol_where_${dir}_$$.db; rm -f "$DB"
+  if [ "$dir" = ours ]; then
+    OURS="ALTER TABLE t DROP COLUMN b;"
+    THEIRS="CREATE INDEX ix ON t(a) WHERE b = 'keep';"
+  else
+    OURS="CREATE INDEX ix ON t(a) WHERE b = 'keep';"
+    THEIRS="ALTER TABLE t DROP COLUMN b;"
+  fi
+  cat <<EOF | $DOLTLITE "$DB" > /dev/null 2>&1
+CREATE TABLE t(k INTEGER PRIMARY KEY, a TEXT, b TEXT);
+INSERT INTO t VALUES(1,'a1','keep'),(2,'a2','drop');
+SELECT dolt_commit('-A','-m','base');
+SELECT dolt_branch('feat');
+$OURS
+SELECT dolt_commit('-A','-m','main side');
+SELECT dolt_checkout('feat');
+$THEIRS
+SELECT dolt_commit('-A','-m','feat side');
+SELECT dolt_checkout('main');
+EOF
+  run_test_match "merge_partial_index_over_dropped_column_${dir}_hash" \
+    "SELECT dolt_merge('feat');" "^[0-9a-f]{40}$" "$DB"
+  run_test "merge_partial_index_over_dropped_column_${dir}_objects" \
+    "SELECT group_concat(type||':'||name) FROM sqlite_master ORDER BY name;" \
+    "table:t" "$DB"
+  run_test "merge_partial_index_over_dropped_column_${dir}_rows" \
+    "SELECT group_concat(k||':'||a) FROM t ORDER BY k;" "1:a1,2:a2" "$DB"
+  run_test "merge_partial_index_over_dropped_column_${dir}_integrity" \
+    "PRAGMA integrity_check;" "ok" "$DB"
+  rm -f "$DB"
+done
+
+# The WHERE literal is not a column. Dropping some other column keeps a
+# partial index whose predicate only names surviving columns.
+DB=/tmp/test_merge_idx_where_survives_$$.db; rm -f "$DB"
+cat <<'EOF' | $DOLTLITE "$DB" > /dev/null 2>&1
+CREATE TABLE t(k INTEGER PRIMARY KEY, a TEXT, b TEXT);
+INSERT INTO t VALUES(1,'keep','b1');
+SELECT dolt_commit('-A','-m','base');
+SELECT dolt_branch('feat');
+CREATE INDEX ix ON t(a) WHERE a = 'keep';
+SELECT dolt_commit('-A','-m','partial on a');
+SELECT dolt_checkout('feat');
+ALTER TABLE t DROP COLUMN b;
+SELECT dolt_commit('-A','-m','drop b');
+SELECT dolt_checkout('main');
+EOF
+run_test_match "merge_partial_index_surviving_predicate_hash" \
+  "SELECT dolt_merge('feat');" "^[0-9a-f]{40}$" "$DB"
+run_test "merge_partial_index_surviving_predicate_kept" \
+  "SELECT group_concat(name) FROM sqlite_master WHERE type='index';" "ix" "$DB"
+rm -f "$DB"
+
 # An index whose columns all survive must be adopted exactly as before: both
 # branches indexing different surviving columns keeps both indexes, and an
 # index over a column their side added comes across with it.


### PR DESCRIPTION
Follow-up to #2295. [Ito on that PR](https://github.com/dolthub/doltlite/pull/2295#issuecomment-5349695648) found three remaining holes in `mergeIndexEachColumn`:

1. **COLLATE name treated as a column.** The walker skipped the `COLLATE` keyword but still fed the following ident to the gone-column check. `CREATE INDEX ix ON t(a COLLATE nocase)` disappeared when a column actually named `nocase` was dropped. Consume the collation name (quoted or not) and ignore it.
2. **Escaped quotes in identifiers.** `mergeIndexSkipQuoted` stopped at the first matching quote. The doubled-quote check never ran because that quote already ended the loop, so `"odd""name"` split into `odd` / `name` and an index on that column survived `DROP COLUMN`. Consume `''` / `""` / `` `` `` as escaped quotes, and `sqlite3Dequote` the token so it matches `parseColumns`.
3. **Partial-index `WHERE`.** The walk stopped at the column-list `)`, so `CREATE INDEX ix ON t(a) WHERE b = 'keep'` was kept after `b` was dropped and the merge failed `database disk image is malformed`. Continue through the rest of the statement. Single-quoted spans are string literals, not columns, so `'keep'` does not kill an index when some other column named `keep` disappears.

The `abs(length(b))` drop from #2295 is unchanged.

## Testing

- Index on `(a COLLATE nocase)` kept when a column named `nocase` is dropped
- Both directions of drop-vs-index on `"odd""name"`: merge succeeds, index gone, rows kept, `integrity_check` ok
- Index on `"odd""name"` kept when a different column is dropped
- Both directions of drop-vs-partial `INDEX (a) WHERE b = 'keep'`: merge succeeds, index gone
- Partial index whose predicate only names surviving columns is kept
- `test/doltlite_schema_merge.sh`: 219/219 (was 187 on #2295)