### PR TITLE
Reject PRAGMAs in dolt_test_run

### DIFF
--- a/src/doltlite_tests.c
+++ b/src/doltlite_tests.c
@@ -575,6 +575,7 @@ struct TestAuth {
   sqlite3_xauth xAuth;
   void *pAuthArg;
   int hasCommand;
+  int hasPragma;
 };
 
 static int testAuthorizer(void *pArg, int action, const char *z1,
@@ -587,6 +588,10 @@ static int testAuthorizer(void *pArg, int action, const char *z1,
     if( pFunc && (pFunc->funcFlags & SQLITE_FUNC_DIRECT)!=0 ){
       p->hasCommand = 1;
     }
+  }
+  if( rc==SQLITE_OK && action==SQLITE_PRAGMA ){
+    p->hasPragma = 1;
+    rc = SQLITE_DENY;
   }
   return rc;
 }
@@ -603,11 +608,17 @@ static int testPrepare(sqlite3 *db, const char *zQuery,
   auth.xAuth = db->xAuth;
   auth.pAuthArg = db->pAuthArg;
   auth.hasCommand = 0;
+  auth.hasPragma = 0;
   db->xAuth = testAuthorizer;
   db->pAuthArg = &auth;
   rc = sqlite3_prepare_v2(db, zQuery, -1, &pStmt, &zTail);
   db->xAuth = auth.xAuth;
   db->pAuthArg = auth.pAuthArg;
+  if( auth.hasPragma ){
+    sqlite3_finalize(pStmt);
+    *pzMessage = sqlite3_mprintf("Cannot execute PRAGMA queries");
+    return SQLITE_OK;
+  }
   if( rc!=SQLITE_OK ){
     *pzMessage = testPrepareError(db);
     return SQLITE_OK;
@@ -622,7 +633,19 @@ static int testPrepare(sqlite3 *db, const char *zQuery,
     return SQLITE_OK;
   }
   while( zTail && zTail[0] ){
+    auth.hasCommand = 0;
+    auth.hasPragma = 0;
+    db->xAuth = testAuthorizer;
+    db->pAuthArg = &auth;
     rc = sqlite3_prepare_v2(db, zTail, -1, &pExtra, &zNext);
+    db->xAuth = auth.xAuth;
+    db->pAuthArg = auth.pAuthArg;
+    if( auth.hasPragma ){
+      sqlite3_finalize(pExtra);
+      sqlite3_finalize(pStmt);
+      *pzMessage = sqlite3_mprintf("Cannot execute PRAGMA queries");
+      return SQLITE_OK;
+    }
     if( rc!=SQLITE_OK ){
       sqlite3_finalize(pStmt);
       *pzMessage = sqlite3_mprintf("Can only run exactly one query");

--- a/test/doltlite_tests.sh
+++ b/test/doltlite_tests.sh
@@ -123,20 +123,31 @@ run_test "runner_validation_results" \
      ('multi_stmt','validation','SELECT 1; SELECT 2','expected_rows','==','1'),
      ('write_stmt','validation','CREATE TABLE nope(x INT)','expected_rows','==','1'),
      ('command_stmt','validation','SELECT dolt_branch(''side_effect'')','expected_rows','==','1'),
+     ('pragma_read','validation','PRAGMA table_info(fixture)','expected_rows','>=','1'),
+     ('pragma_tail','validation','SELECT 1; PRAGMA query_only=ON','expected_rows','==','1'),
+     ('pragma_write','validation','PRAGMA query_only=ON','expected_rows','==','0'),
      ('recursive','validation','SELECT * FROM dolt_test_run()','expected_rows','==','1'),
      ('zero_rows','validation','SELECT i FROM fixture WHERE 0','expected_single_value','==','1'),
      ('many_cols','validation','SELECT i,s FROM fixture LIMIT 1','expected_single_value','==','1'),
      ('many_rows','validation','SELECT i FROM fixture','expected_single_value','==','1');
    SELECT test_name, status, message FROM dolt_test_run('validation');
-   SELECT count(*) FROM dolt_branches WHERE name='side_effect';" \
+   SELECT count(*) FROM dolt_branches WHERE name='side_effect';
+   PRAGMA query_only;
+   CREATE TABLE pragma_guard(id INT);
+   SELECT count(*) FROM sqlite_master WHERE name='pragma_guard';" \
   "command_stmt|FAIL|Cannot execute write queries
 many_cols|FAIL|expected_single_value expects exactly one cell. Received multiple columns
 many_rows|FAIL|expected_single_value expects exactly one cell. Received multiple rows
 multi_stmt|FAIL|Can only run exactly one query
+pragma_read|FAIL|Cannot execute PRAGMA queries
+pragma_tail|FAIL|Cannot execute PRAGMA queries
+pragma_write|FAIL|Cannot execute PRAGMA queries
 recursive|FAIL|Cannot call dolt_test_run in dolt_tests
 write_stmt|FAIL|Cannot execute write queries
 zero_rows|FAIL|expected_single_value expects exactly one cell. Received 0 rows
-0" "$DB"
+0
+0
+1" "$DB"
 
 run_test "runner_query_error" \
   "INSERT INTO dolt_tests VALUES


### PR DESCRIPTION
## Summary

- reject every PRAGMA statement in `dolt_test_run()` through SQLite’s authorizer
- deny PRAGMAs during preparation because some mutate connection state before stepping
- cover read-only, mutating, and trailing PRAGMAs while proving the caller remains writable

## Testing

- fail-before: `DOLTLITE=./doltlite bash test/doltlite_tests.sh` (28 passed, 1 failed; `query_only` leaked and blocked the guard write)
- pass-after: `DOLTLITE=build/doltlite bash test/doltlite_tests.sh` (29 passed)
- `make lint`
- `bash test/run_doltlite_tests.sh build/doltlite` (107 DoltLite suites passed; 310,930 C assertions passed; parity wrapper lacked `build/sqlite3`)
- `bash test/doltlite_parity.sh build/doltlite` (119 passed against the repo-root stock SQLite binary)

Co-Authored-By: OpenAI Codex <noreply@openai.com>