### PR TITLE
Resolve dolt_reset table paths case-insensitively

### DIFF
--- a/src/doltlite_reset.c
+++ b/src/doltlite_reset.c
@@ -19,7 +19,7 @@
 #include <time.h>
 
 static int resetPathMatchesName(const struct TableEntry *pEntry, const char *zName){
-  return pEntry->zName && strcmp(pEntry->zName, zName)==0;
+  return pEntry->zName && sqlite3_stricmp(pEntry->zName, zName)==0;
 }
 
 static int resetFindTableIndex(struct TableEntry *aTables, int nTables,
@@ -105,9 +105,11 @@ static int resetStageNamedPaths(
   }
 
   for(p=0; p<nPaths; p++){
-    const char *zTable = azPaths[p];
-    int iH = resetFindTableIndex(aHead, nHead, zTable);
-    int iS = resetFindTableIndex(aStaged, nStaged, zTable);
+    const char *zPath = azPaths[p];
+    int iH = resetFindTableIndex(aHead, nHead, zPath);
+    int iS = resetFindTableIndex(aStaged, nStaged, zPath);
+    const char *zHeadTable = iH>=0 ? aHead[iH].zName : 0;
+    const char *zStagedTable = iS>=0 ? aStaged[iS].zName : 0;
     char *zDup;
     if( iH<0 && iS<0 ){
       rc = SQLITE_NOTFOUND;
@@ -125,8 +127,8 @@ static int resetStageNamedPaths(
       if( rc!=SQLITE_OK ) goto done;
       if( pMate ) continue;
       addRemoveIndexEntriesOfTable(aStaged, &nStaged,
-                                   aStagedSchema, nStagedSchema, zTable);
-      iS = resetFindTableIndex(aStaged, nStaged, zTable);
+                                   aStagedSchema, nStagedSchema, zStagedTable);
+      iS = resetFindTableIndex(aStaged, nStaged, zStagedTable);
       sqlite3_free(aStaged[iS].zName);
       if( iS+1<nStaged ){
         memmove(&aStaged[iS], &aStaged[iS+1],
@@ -174,7 +176,7 @@ static int resetStageNamedPaths(
       }
       aStaged = aNew;
       addRemoveIndexEntriesOfTable(aStaged, &nStaged,
-                                   aStagedSchema, nStagedSchema, zTable);
+                                   aStagedSchema, nStagedSchema, zHeadTable);
       zDup = aHead[iH].zName ? sqlite3_mprintf("%s", aHead[iH].zName) : 0;
       if( aHead[iH].zName && !zDup ){
         rc = SQLITE_NOMEM;
@@ -187,14 +189,19 @@ static int resetStageNamedPaths(
       rc = addAppendIndexEntriesOfTable(0, &aStaged, &nStaged,
                                         aHead, nHead,
                                         aHeadSchema, nHeadSchema,
-                                        zTable);
+                                        zHeadTable);
       if( rc!=SQLITE_OK ) goto done;
     }else{
       /* Take HEAD's content under the STAGED entry's number so the entry
       ** keeps pairing with the staged catalog's schema row. The table's
       ** index set resets with it: replace whatever index entries staging
       ** carried for this table with HEAD's. */
-      Pgno iKeep = aStaged[iS].iTable;
+      Pgno iKeep;
+      addRemoveIndexEntriesOfTable(aStaged, &nStaged,
+                                   aStagedSchema, nStagedSchema,
+                                   zStagedTable);
+      iS = resetFindTableIndex(aStaged, nStaged, zStagedTable);
+      iKeep = aStaged[iS].iTable;
       zDup = aHead[iH].zName ? sqlite3_mprintf("%s", aHead[iH].zName) : 0;
       if( aHead[iH].zName && !zDup ){
         rc = SQLITE_NOMEM;
@@ -204,12 +211,10 @@ static int resetStageNamedPaths(
       aStaged[iS] = aHead[iH];
       aStaged[iS].zName = zDup;
       aStaged[iS].iTable = iKeep;
-      addRemoveIndexEntriesOfTable(aStaged, &nStaged,
-                                   aStagedSchema, nStagedSchema, zTable);
       rc = addAppendIndexEntriesOfTable(0, &aStaged, &nStaged,
                                         aHead, nHead,
                                         aHeadSchema, nHeadSchema,
-                                        zTable);
+                                        zHeadTable);
       if( rc!=SQLITE_OK ) goto done;
     }
   }

--- a/test/doltlite_reset.sh
+++ b/test/doltlite_reset.sh
@@ -106,6 +106,18 @@ run_test "multipath_reset_all_missing_unstages_all" \
   "SELECT count(*) FROM dolt_status WHERE staged=1;" \
   "0" "$DB3C"
 
+DB3D=/tmp/test_reset3d_$$.db; rm -f "$DB3D"
+echo "CREATE TABLE Camel(id INTEGER PRIMARY KEY, v INT); CREATE INDEX Camel_v ON Camel(v); INSERT INTO Camel VALUES(1,10); SELECT dolt_commit('-Am','base'); UPDATE Camel SET v=20; SELECT dolt_add('Camel'); SELECT dolt_reset('cAmEl');" | $DOLTLITE "$DB3D" > /dev/null 2>&1
+run_test "path_reset_is_case_insensitive" \
+  "SELECT staged, status FROM dolt_status WHERE table_name='Camel';" \
+  "0|modified" "$DB3D"
+run_test "case_insensitive_reset_keeps_working_change" \
+  "SELECT v FROM Camel WHERE id=1;" \
+  "20" "$DB3D"
+run_test_match "case_insensitive_reset_clears_staged_indexes" \
+  "SELECT dolt_commit('-m','unexpected');" \
+  "nothing to commit" "$DB3D"
+
 DB4=/tmp/test_reset4_$$.db; rm -f "$DB4"
 echo "CREATE TABLE t(x); INSERT INTO t VALUES(1); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB4" > /dev/null 2>&1
 echo "INSERT INTO t VALUES(2);" | $DOLTLITE "$DB4" > /dev/null 2>&1

--- a/test/vc_oracle_reset_test.sh
+++ b/test/vc_oracle_reset_test.sh
@@ -446,6 +446,26 @@ SELECT concat('Q|vals|', group_concat(s ORDER BY id SEPARATOR '|')) FROM a;"
 
 echo "--- table-name positional unstage ---"
 
+CASE_RESET_SEED="
+CREATE TABLE Camel(id INTEGER PRIMARY KEY, v INT);
+CREATE INDEX Camel_v ON Camel(v);
+INSERT INTO Camel VALUES (1, 10);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'base');
+UPDATE Camel SET v=20;
+SELECT dolt_add('Camel');
+SELECT dolt_reset('cAmEl');
+"
+
+oracle "reset_path_is_case_insensitive" "
+$CASE_RESET_SEED
+"
+
+oracle_error "reset_case_insensitive_clears_staged_indexes" "
+$CASE_RESET_SEED
+SELECT dolt_commit('-m', 'nothing is staged');
+"
+
 oracle "reset_specific_table_unstages_only_that" "
 CREATE TABLE a(id INTEGER PRIMARY KEY, v INT);
 CREATE TABLE b(id INTEGER PRIMARY KEY, v INT);


### PR DESCRIPTION
## Summary

- resolve named `dolt_reset` table paths with SQLite-compatible case-insensitive matching
- use catalog-canonical table names when resetting associated index entries
- add native and Dolt-oracle coverage for mixed-case reset paths

## Testing

- Dolt 2.2.2 comparison: `CALL DOLT_RESET('cAmEl')` unstages `Camel` and preserves its working change
- fail-before: `DOLTLITE=build/doltlite bash test/doltlite_reset.sh` (57 passed, 2 failed; table remained staged and an unexpected commit succeeded)
- pass-after: `DOLTLITE=build/doltlite bash test/doltlite_reset.sh` (59 passed)
- `bash test/vc_oracle_reset_test.sh build/doltlite dolt` (56 passed)
- `make lint`
- `bash test/run_doltlite_tests.sh build/doltlite` (107 DoltLite suites passed; 310,930 C assertions passed; parity wrapper lacked `build/sqlite3`)
- `bash test/doltlite_parity.sh build/doltlite` (119 passed against the repo-root stock SQLite binary)

Co-Authored-By: OpenAI Codex <noreply@openai.com>