### PR TITLE
Centralize Dolt command option parsing

### DIFF
--- a/src/doltlite_add.c
+++ b/src/doltlite_add.c
@@ -657,7 +657,7 @@ int doltliteStageNamedTables(
     const char *zTable = (const char*)sqlite3_value_text(argv[i]);
     Pgno iTable = 0;
     int j;
-    if( !zTable || zTable[0]=='-' || strcmp(zTable, ".")==0 ) continue;
+    if( !zTable || strcmp(zTable, ".")==0 ) continue;
 
     {
       int ignored = 0;
@@ -977,8 +977,12 @@ static void doltliteAddFunc(
   int sealTopLevel = doltliteSavepointIsTopLevelTxn(db);
   int rc;
   int i;
+  int endOptions = 0;
+  int nTables = 0;
   int stageAll = 0;
+  int parsed = 0;
   int opRc = SQLITE_OK;
+  sqlite3_value **aTables = 0;
 
   if( doltliteCmdRejectDetached(context) ) return;
   if( !cs ){
@@ -989,21 +993,36 @@ static void doltliteAddFunc(
     sqlite3_result_error(context, "dolt_add requires table name or '-A'", -1);
     goto add_cleanup;
   }
+  aTables = sqlite3_malloc(argc * (int)sizeof(*aTables));
+  if( !aTables ){
+    sqlite3_result_error_nomem(context);
+    goto add_cleanup;
+  }
 
   for(i=0; i<argc; i++){
     const char *arg = (const char*)sqlite3_value_text(argv[i]);
     if( !arg ) continue;
-    if( strcmp(arg, "-A")==0
-     || strcmp(arg, "--all")==0
-     || strcmp(arg, ".")==0 ){
+    if( !endOptions && strcmp(arg, "--")==0 ){
+      endOptions = 1;
+    }else if( (!endOptions && (strcmp(arg, "-A")==0
+                            || strcmp(arg, "--all")==0))
+           || strcmp(arg, ".")==0 ){
       stageAll = 1;
-    }else if( arg[0]=='-' ){
+    }else if( !endOptions && arg[0]=='-' ){
       doltliteCmdResultUnknownOption(context, arg);
       goto add_cleanup;
+    }else{
+      aTables[nTables++] = argv[i];
     }
   }
+  if( !stageAll && nTables==0 ){
+    sqlite3_result_error(context, "dolt_add requires table name or '-A'", -1);
+    goto add_cleanup;
+  }
 
-  opRc = doltliteStageArgsAndPersist(db, context, cs, argc, argv, stageAll);
+  parsed = 1;
+  opRc = doltliteStageArgsAndPersist(
+      db, context, cs, nTables, aTables, stageAll);
   if( opRc!=SQLITE_OK ) goto add_cleanup;
 
   sqlite3_result_int(context, 0);
@@ -1011,8 +1030,9 @@ static void doltliteAddFunc(
 add_cleanup:
   if( sealTopLevel ){
     rc = doltliteVcSealTopLevelSavepointTxn(db);
-    if( rc==SQLITE_OK && opRc==SQLITE_OK ){
-      rc = doltliteStageArgsAndPersist(db, context, cs, argc, argv, stageAll);
+    if( rc==SQLITE_OK && parsed && opRc==SQLITE_OK ){
+      rc = doltliteStageArgsAndPersist(
+          db, context, cs, nTables, aTables, stageAll);
       if( rc!=SQLITE_OK ){
         opRc = rc;
       }
@@ -1025,6 +1045,7 @@ add_cleanup:
   }else if( opRc!=SQLITE_OK ){
     sqlite3_result_error_code(context, opRc);
   }
+  sqlite3_free(aTables);
 }
 
 

--- a/src/doltlite_add.c
+++ b/src/doltlite_add.c
@@ -975,14 +975,18 @@ static void doltliteAddFunc(
   sqlite3 *db = sqlite3_context_db_handle(context);
   ChunkStore *cs = doltliteGetChunkStore(db);
   int sealTopLevel = doltliteSavepointIsTopLevelTxn(db);
+  int stageAll = 0;
+  DoltliteCmdArgs args;
+  DoltliteCmdOption aOption[] = {
+    { "all", 'A', DOLTLITE_CMD_OPTION_FLAG, &stageAll, 0 }
+  };
   int rc;
   int i;
-  int endOptions = 0;
   int nTables = 0;
-  int stageAll = 0;
   int parsed = 0;
   int opRc = SQLITE_OK;
-  sqlite3_value **aTables = 0;
+
+  memset(&args, 0, sizeof(args));
 
   if( doltliteCmdRejectDetached(context) ) return;
   if( !cs ){
@@ -993,26 +997,15 @@ static void doltliteAddFunc(
     sqlite3_result_error(context, "dolt_add requires table name or '-A'", -1);
     goto add_cleanup;
   }
-  aTables = sqlite3_malloc(argc * (int)sizeof(*aTables));
-  if( !aTables ){
-    sqlite3_result_error_nomem(context);
-    goto add_cleanup;
-  }
-
-  for(i=0; i<argc; i++){
-    const char *arg = (const char*)sqlite3_value_text(argv[i]);
-    if( !arg ) continue;
-    if( !endOptions && strcmp(arg, "--")==0 ){
-      endOptions = 1;
-    }else if( (!endOptions && (strcmp(arg, "-A")==0
-                            || strcmp(arg, "--all")==0))
-           || strcmp(arg, ".")==0 ){
+  rc = doltliteCmdParseArgs(context, argc, argv, aOption, ArraySize(aOption),
+                            0, &args);
+  if( rc!=SQLITE_OK ) goto add_cleanup;
+  for(i=0; i<args.nPositional; i++){
+    if( strcmp(args.azPositional[i], ".")==0 ){
       stageAll = 1;
-    }else if( !endOptions && arg[0]=='-' ){
-      doltliteCmdResultUnknownOption(context, arg);
-      goto add_cleanup;
     }else{
-      aTables[nTables++] = argv[i];
+      args.apPositional[nTables] = args.apPositional[i];
+      args.azPositional[nTables++] = args.azPositional[i];
     }
   }
   if( !stageAll && nTables==0 ){
@@ -1022,7 +1015,7 @@ static void doltliteAddFunc(
 
   parsed = 1;
   opRc = doltliteStageArgsAndPersist(
-      db, context, cs, nTables, aTables, stageAll);
+      db, context, cs, nTables, args.apPositional, stageAll);
   if( opRc!=SQLITE_OK ) goto add_cleanup;
 
   sqlite3_result_int(context, 0);
@@ -1032,7 +1025,7 @@ add_cleanup:
     rc = doltliteVcSealTopLevelSavepointTxn(db);
     if( rc==SQLITE_OK && parsed && opRc==SQLITE_OK ){
       rc = doltliteStageArgsAndPersist(
-          db, context, cs, nTables, aTables, stageAll);
+          db, context, cs, nTables, args.apPositional, stageAll);
       if( rc!=SQLITE_OK ){
         opRc = rc;
       }
@@ -1045,7 +1038,7 @@ add_cleanup:
   }else if( opRc!=SQLITE_OK ){
     sqlite3_result_error_code(context, opRc);
   }
-  sqlite3_free(aTables);
+  doltliteCmdArgsClear(&args);
 }
 
 

--- a/src/doltlite_branch.c
+++ b/src/doltlite_branch.c
@@ -157,64 +157,24 @@ static int mutateBranchMove(sqlite3 *db, ChunkStore *cs, void *pArg){
   return rc;
 }
 
-static void doltBranchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
+enum DoltliteBranchMode {
+  MODE_CREATE, MODE_DELETE, MODE_COPY, MODE_MOVE
+};
+
+static void doltBranchParsedFunc(
+  sqlite3_context *ctx,
+  enum DoltliteBranchMode mode,
+  int force,
+  int nPositional,
+  const char **aPositional
+){
   sqlite3 *db = sqlite3_context_db_handle(ctx);
   ChunkStore *cs = doltliteGetChunkStore(db);
-  enum { MODE_CREATE, MODE_DELETE, MODE_COPY, MODE_MOVE } mode = MODE_CREATE;
-  int force = 0;
-  const char *aPositional[3] = {0, 0, 0};
-  int nPositional = 0;
   int hadExplicitTxn = !db->autoCommit;
   int hadSavepoint = db->pSavepoint!=0;
-  int i, rc;
+  int rc;
 
-  if( doltliteCmdRejectDetached(ctx) ) return;
   if( !cs ){ branchError(ctx, hadSavepoint, doltliteVcUnavailableMessage(db)); return; }
-  if( argc<1 ){ branchError(ctx, hadSavepoint, "dolt_branch requires arguments"); return; }
-
-  for(i=0; i<argc; i++){
-    const char *arg = (const char*)sqlite3_value_text(argv[i]);
-    if( !arg ) continue;
-    if( strcmp(arg, "-d")==0 || strcmp(arg, "--delete")==0 ){
-      if( mode!=MODE_CREATE ){
-        branchError(ctx, hadSavepoint, "conflicting flags"); return;
-      }
-      mode = MODE_DELETE;
-    }else if( strcmp(arg, "-D")==0 ){
-
-      if( mode!=MODE_CREATE ){
-        branchError(ctx, hadSavepoint, "conflicting flags"); return;
-      }
-      mode = MODE_DELETE;
-      force = 1;
-    }else if( strcmp(arg, "-c")==0 || strcmp(arg, "--copy")==0 ){
-      if( mode!=MODE_CREATE ){
-        branchError(ctx, hadSavepoint, "conflicting flags"); return;
-      }
-      mode = MODE_COPY;
-    }else if( strcmp(arg, "-m")==0 || strcmp(arg, "--move")==0 ){
-      if( mode!=MODE_CREATE ){
-        branchError(ctx, hadSavepoint, "conflicting flags"); return;
-      }
-      mode = MODE_MOVE;
-    }else if( strcmp(arg, "-f")==0 || strcmp(arg, "--force")==0 ){
-      force = 1;
-    }else if( arg[0]=='-' ){
-      char *zErr = sqlite3_mprintf("unknown option `%s`", arg);
-      if( zErr ){
-        branchError(ctx, hadSavepoint, zErr);
-        sqlite3_free(zErr);
-      }else{
-        sqlite3_result_error_nomem(ctx);
-      }
-      return;
-    }else{
-      if( nPositional >= 3 ){
-        branchError(ctx, hadSavepoint, "too many arguments"); return;
-      }
-      aPositional[nPositional++] = arg;
-    }
-  }
 
   switch( mode ){
     case MODE_DELETE: {
@@ -418,6 +378,51 @@ static void doltBranchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv)
     }
   }
   sqlite3_result_int(ctx, 0);
+}
+
+static void doltBranchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
+  sqlite3 *db = sqlite3_context_db_handle(ctx);
+  DoltliteCmdArgs args;
+  enum DoltliteBranchMode mode = MODE_CREATE;
+  int isDelete = 0, isForceDelete = 0, isCopy = 0, isMove = 0, force = 0;
+  int hadSavepoint = db->pSavepoint!=0;
+  DoltliteCmdOption aOption[] = {
+    { "delete", 'd', DOLTLITE_CMD_OPTION_FLAG, &isDelete, 0 },
+    { 0, 'D', DOLTLITE_CMD_OPTION_FLAG, &isForceDelete, 0 },
+    { "copy", 'c', DOLTLITE_CMD_OPTION_FLAG, &isCopy, 0 },
+    { "move", 'm', DOLTLITE_CMD_OPTION_FLAG, &isMove, 0 },
+    { "force", 'f', DOLTLITE_CMD_OPTION_FLAG, &force, 0 }
+  };
+  int rc;
+
+  if( doltliteCmdRejectDetached(ctx) ) return;
+  if( argc<1 ){
+    branchError(ctx, hadSavepoint, "dolt_branch requires arguments");
+    return;
+  }
+  rc = doltliteCmdParseArgs(ctx, argc, argv, aOption, ArraySize(aOption),
+                            0, &args);
+  if( rc!=SQLITE_OK ){
+    (void)doltliteVcSealSavepointError(db);
+    return;
+  }
+  if( isDelete + isForceDelete + isCopy + isMove > 1 ){
+    doltliteCmdArgsClear(&args);
+    branchError(ctx, hadSavepoint, "conflicting flags");
+    return;
+  }
+  if( isDelete || isForceDelete ) mode = MODE_DELETE;
+  else if( isCopy ) mode = MODE_COPY;
+  else if( isMove ) mode = MODE_MOVE;
+  if( isForceDelete ) force = 1;
+  if( args.nPositional>3 ){
+    doltliteCmdArgsClear(&args);
+    branchError(ctx, hadSavepoint, "too many arguments");
+    return;
+  }
+  doltBranchParsedFunc(ctx, mode, force, args.nPositional,
+                       args.azPositional);
+  doltliteCmdArgsClear(&args);
 }
 
 

--- a/src/doltlite_checkout.c
+++ b/src/doltlite_checkout.c
@@ -1136,7 +1136,12 @@ static int doltliteCheckoutTables(
   return rc;
 }
 
-void doltCheckoutFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
+static void doltCheckoutParsedFunc(
+  sqlite3_context *ctx,
+  int argc,
+  sqlite3_value **argv,
+  int parseOptions
+){
   sqlite3 *db = sqlite3_context_db_handle(ctx);
   ChunkStore *cs = doltliteGetChunkStore(db);
   CheckoutMutationCtx m;
@@ -1157,7 +1162,7 @@ void doltCheckoutFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
 
   if( doltliteIsDetached(db) ){
     ProllyHash probe;
-    if( strcmp(zBranch, "-b")==0 ){
+    if( parseOptions && strcmp(zBranch, "-b")==0 ){
       doltliteVcResultError(ctx, db,
           "unable to create new branch in a read-only database");
       return;
@@ -1194,7 +1199,7 @@ void doltCheckoutFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
     }
   }
 
-  if( strcmp(zBranch, "-b")==0 ){
+  if( parseOptions && strcmp(zBranch, "-b")==0 ){
     if( argc<2 ){ doltliteVcResultError(ctx, db, "branch name required after -b"); return; }
     if( argc>3 ){ doltliteVcResultError(ctx, db, "too many arguments"); return; }
     zBranch = (const char*)sqlite3_value_text(argv[1]);
@@ -1390,6 +1395,35 @@ checkout_done:
     }
   }
   sqlite3_result_int(ctx, 0);
+}
+
+void doltCheckoutFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
+  sqlite3_value **aArgs;
+  int endOptions = 0;
+  int parseOptions = 1;
+  int nArgs = 0;
+  int i;
+
+  if( argc==0 ){
+    doltCheckoutParsedFunc(ctx, argc, argv, parseOptions);
+    return;
+  }
+  aArgs = sqlite3_malloc(argc * (int)sizeof(*aArgs));
+  if( !aArgs ){
+    sqlite3_result_error_nomem(ctx);
+    return;
+  }
+  for(i=0; i<argc; i++){
+    const char *zArg = (const char*)sqlite3_value_text(argv[i]);
+    if( !endOptions && zArg && strcmp(zArg, "--")==0 ){
+      endOptions = 1;
+      if( nArgs==0 ) parseOptions = 0;
+      continue;
+    }
+    aArgs[nArgs++] = argv[i];
+  }
+  doltCheckoutParsedFunc(ctx, nArgs, aArgs, parseOptions);
+  sqlite3_free(aArgs);
 }
 
 #endif

--- a/src/doltlite_checkout.c
+++ b/src/doltlite_checkout.c
@@ -1140,7 +1140,7 @@ static void doltCheckoutParsedFunc(
   sqlite3_context *ctx,
   int argc,
   sqlite3_value **argv,
-  int parseOptions
+  int createBranch
 ){
   sqlite3 *db = sqlite3_context_db_handle(ctx);
   ChunkStore *cs = doltliteGetChunkStore(db);
@@ -1162,7 +1162,7 @@ static void doltCheckoutParsedFunc(
 
   if( doltliteIsDetached(db) ){
     ProllyHash probe;
-    if( parseOptions && strcmp(zBranch, "-b")==0 ){
+    if( createBranch ){
       doltliteVcResultError(ctx, db,
           "unable to create new branch in a read-only database");
       return;
@@ -1199,18 +1199,18 @@ static void doltCheckoutParsedFunc(
     }
   }
 
-  if( parseOptions && strcmp(zBranch, "-b")==0 ){
-    if( argc<2 ){ doltliteVcResultError(ctx, db, "branch name required after -b"); return; }
-    if( argc>3 ){ doltliteVcResultError(ctx, db, "too many arguments"); return; }
-    zBranch = (const char*)sqlite3_value_text(argv[1]);
+  if( createBranch ){
+    if( argc<1 ){ doltliteVcResultError(ctx, db, "branch name required after -b"); return; }
+    if( argc>2 ){ doltliteVcResultError(ctx, db, "too many arguments"); return; }
+    zBranch = (const char*)sqlite3_value_text(argv[0]);
     if( branchNameEmpty(zBranch) ){ doltliteVcResultError(ctx, db, "branch name required after -b"); return; }
     if( !doltliteUserRefNameIsValid(zBranch) ){
       doltliteVcResultError(ctx, db, "invalid branch name");
       return;
     }
 
-    if( argc>=3 ){
-      const char *zStart = (const char*)sqlite3_value_text(argv[2]);
+    if( argc>=2 ){
+      const char *zStart = (const char*)sqlite3_value_text(argv[1]);
       if( !zStart ){
         doltliteVcResultError(ctx, db, "start point not found");
         return;
@@ -1398,32 +1398,26 @@ checkout_done:
 }
 
 void doltCheckoutFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
-  sqlite3_value **aArgs;
-  int endOptions = 0;
-  int parseOptions = 1;
-  int nArgs = 0;
-  int i;
+  DoltliteCmdArgs args;
+  int createBranch = 0;
+  DoltliteCmdOption aOption[] = {
+    { 0, 'b', DOLTLITE_CMD_OPTION_FLAG, &createBranch, 0 }
+  };
+  int rc;
 
   if( argc==0 ){
-    doltCheckoutParsedFunc(ctx, argc, argv, parseOptions);
+    doltCheckoutParsedFunc(ctx, argc, argv, createBranch);
     return;
   }
-  aArgs = sqlite3_malloc(argc * (int)sizeof(*aArgs));
-  if( !aArgs ){
-    sqlite3_result_error_nomem(ctx);
+  rc = doltliteCmdParseArgs(ctx, argc, argv, aOption, ArraySize(aOption),
+                            0, &args);
+  if( rc!=SQLITE_OK ){
+    (void)doltliteVcSealSavepointError(sqlite3_context_db_handle(ctx));
     return;
   }
-  for(i=0; i<argc; i++){
-    const char *zArg = (const char*)sqlite3_value_text(argv[i]);
-    if( !endOptions && zArg && strcmp(zArg, "--")==0 ){
-      endOptions = 1;
-      if( nArgs==0 ) parseOptions = 0;
-      continue;
-    }
-    aArgs[nArgs++] = argv[i];
-  }
-  doltCheckoutParsedFunc(ctx, nArgs, aArgs, parseOptions);
-  sqlite3_free(aArgs);
+  doltCheckoutParsedFunc(ctx, args.nPositional, args.apPositional,
+                         createBranch);
+  doltliteCmdArgsClear(&args);
 }
 
 #endif

--- a/src/doltlite_cmd.c
+++ b/src/doltlite_cmd.c
@@ -7,11 +7,154 @@
 
 #include <string.h>
 
-/*
-** Shared scaffolding for dolt_* SQL command functions: argv option errors,
-** peer-branch BUSY messages, and the three-way VC txn outcome switch for
-** merge conflicts / constraint violations.
-*/
+static DoltliteCmdOption *cmdFindLongOption(
+  DoltliteCmdOption *aOption,
+  int nOption,
+  const char *zName
+){
+  int i;
+  for(i=0; i<nOption; i++){
+    if( aOption[i].zLong && strcmp(aOption[i].zLong, zName)==0 ){
+      return &aOption[i];
+    }
+  }
+  return 0;
+}
+
+static DoltliteCmdOption *cmdFindShortOption(
+  DoltliteCmdOption *aOption,
+  int nOption,
+  char name
+){
+  int i;
+  for(i=0; i<nOption; i++){
+    if( aOption[i].shortName==name ) return &aOption[i];
+  }
+  return 0;
+}
+
+static int cmdSetOption(
+  sqlite3_context *ctx,
+  DoltliteCmdOption *pOption,
+  const char *zOpt,
+  const char *zAttached,
+  int argc,
+  sqlite3_value **argv,
+  int *pI
+){
+  const char *zValue;
+  if( pOption->eType==DOLTLITE_CMD_OPTION_FLAG ){
+    if( pOption->pSeen ) *pOption->pSeen = 1;
+    return SQLITE_OK;
+  }
+  if( zAttached && zAttached[0] ){
+    zValue = zAttached;
+  }else if( *pI+1<argc ){
+    zValue = (const char*)sqlite3_value_text(argv[++*pI]);
+  }else{
+    doltliteCmdResultMissingOptionValue(ctx, zOpt);
+    return SQLITE_ERROR;
+  }
+  if( !zValue ){
+    doltliteCmdResultMissingOptionValue(ctx, zOpt);
+    return SQLITE_ERROR;
+  }
+  if( pOption->pSeen ) *pOption->pSeen = 1;
+  if( pOption->pzValue ) *pOption->pzValue = zValue;
+  return SQLITE_OK;
+}
+
+void doltliteCmdArgsClear(DoltliteCmdArgs *pArgs){
+  if( !pArgs ) return;
+  sqlite3_free(pArgs->apPositional);
+  sqlite3_free((void*)pArgs->azPositional);
+  memset(pArgs, 0, sizeof(*pArgs));
+}
+
+int doltliteCmdParseArgs(
+  sqlite3_context *ctx,
+  int argc,
+  sqlite3_value **argv,
+  DoltliteCmdOption *aOption,
+  int nOption,
+  int flags,
+  DoltliteCmdArgs *pArgs
+){
+  int endOptions = 0;
+  int i;
+  memset(pArgs, 0, sizeof(*pArgs));
+  for(i=0; i<nOption; i++){
+    if( aOption[i].pSeen ) *aOption[i].pSeen = 0;
+    if( aOption[i].pzValue ) *aOption[i].pzValue = 0;
+  }
+  if( argc>0 ){
+    pArgs->apPositional = sqlite3_malloc64((sqlite3_uint64)argc * sizeof(*argv));
+    pArgs->azPositional = sqlite3_malloc64(
+        (sqlite3_uint64)argc * sizeof(*pArgs->azPositional));
+    if( !pArgs->apPositional || !pArgs->azPositional ){
+      doltliteCmdArgsClear(pArgs);
+      sqlite3_result_error_nomem(ctx);
+      return SQLITE_NOMEM;
+    }
+  }
+  for(i=0; i<argc; i++){
+    const char *zArg = (const char*)sqlite3_value_text(argv[i]);
+    DoltliteCmdOption *pOption = 0;
+    int rc;
+    if( !zArg ) continue;
+    if( !endOptions && strcmp(zArg, "--")==0 ){
+      endOptions = 1;
+      continue;
+    }
+    if( !endOptions && zArg[0]=='-' && zArg[1]=='-' && zArg[2] ){
+      pOption = cmdFindLongOption(aOption, nOption, zArg+2);
+      if( !pOption ){
+        doltliteCmdResultUnknownOption(ctx, zArg);
+        doltliteCmdArgsClear(pArgs);
+        return SQLITE_ERROR;
+      }
+      rc = cmdSetOption(ctx, pOption, pOption->zLong, 0, argc, argv, &i);
+      if( rc!=SQLITE_OK ){
+        doltliteCmdArgsClear(pArgs);
+        return rc;
+      }
+      continue;
+    }
+    if( !endOptions && zArg[0]=='-' && zArg[1] && zArg[1]!='-' ){
+      int j;
+      int nShort = (flags & DOLTLITE_CMD_PARSE_SHORT_GROUPS)
+                 ? sqlite3Strlen30(zArg)-1 : 1;
+      if( !(flags & DOLTLITE_CMD_PARSE_SHORT_GROUPS) && zArg[2] ){
+        doltliteCmdResultUnknownOption(ctx, zArg);
+        doltliteCmdArgsClear(pArgs);
+        return SQLITE_ERROR;
+      }
+      for(j=1; j<=nShort; j++){
+        char zOpt[2] = { zArg[j], 0 };
+        pOption = cmdFindShortOption(aOption, nOption, zArg[j]);
+        if( !pOption ){
+          char zUnknown[3] = { '-', zArg[j], 0 };
+          doltliteCmdResultUnknownOption(ctx, zUnknown);
+          doltliteCmdArgsClear(pArgs);
+          return SQLITE_ERROR;
+        }
+        rc = cmdSetOption(ctx, pOption,
+            pOption->zLong ? pOption->zLong : zOpt,
+            pOption->eType==DOLTLITE_CMD_OPTION_VALUE ? zArg+j+1 : 0,
+            argc, argv, &i);
+        if( rc!=SQLITE_OK ){
+          doltliteCmdArgsClear(pArgs);
+          return rc;
+        }
+        if( pOption->eType==DOLTLITE_CMD_OPTION_VALUE ) break;
+      }
+      continue;
+    }
+    pArgs->apPositional[pArgs->nPositional] = argv[i];
+    pArgs->azPositional[pArgs->nPositional++] = zArg;
+  }
+  return SQLITE_OK;
+}
 
 int doltliteCmdRejectDetached(sqlite3_context *ctx){
   sqlite3 *db = sqlite3_context_db_handle(ctx);
@@ -43,22 +186,6 @@ void doltliteCmdResultMissingOptionValue(
   }else{
     sqlite3_result_error_nomem(ctx);
   }
-}
-
-const char *doltliteCmdTakeValueArg(
-  sqlite3_context *ctx,
-  int argc,
-  sqlite3_value **argv,
-  int *pI,
-  const char *zOptName
-){
-  int i = *pI;
-  if( i+1>=argc ){
-    doltliteCmdResultMissingOptionValue(ctx, zOptName);
-    return 0;
-  }
-  *pI = i+1;
-  return (const char*)sqlite3_value_text(argv[i+1]);
 }
 
 void doltliteCmdResultPeerBranchBusy(sqlite3_context *ctx, const char *zOp){

--- a/src/doltlite_commit_cmd.c
+++ b/src/doltlite_commit_cmd.c
@@ -80,79 +80,37 @@ static int doltliteCommitParseOptions(
   sqlite3_value **argv,
   DoltliteCommitOptions *opts
 ){
-  int i;
+  DoltliteCmdArgs args;
+  DoltliteCmdOption aOption[] = {
+    { 0, 'A', DOLTLITE_CMD_OPTION_FLAG, &opts->addAll, 0 },
+    { "all", 'a', DOLTLITE_CMD_OPTION_FLAG, &opts->addModifiedOnly, 0 },
+    { "force", 'f', DOLTLITE_CMD_OPTION_FLAG, &opts->force, 0 },
+    { "message", 'm', DOLTLITE_CMD_OPTION_VALUE, 0, &opts->zMessage },
+    { "author", 0, DOLTLITE_CMD_OPTION_VALUE, 0, &opts->zAuthor },
+    { "date", 0, DOLTLITE_CMD_OPTION_VALUE, 0, &opts->zDate },
+    { "amend", 0, DOLTLITE_CMD_OPTION_FLAG, &opts->amend, 0 },
+    { "allow-empty", 0, DOLTLITE_CMD_OPTION_FLAG, &opts->allowEmpty, 0 },
+    { "skip-empty", 0, DOLTLITE_CMD_OPTION_FLAG, &opts->skipEmpty, 0 }
+  };
+  int rc;
   memset(opts, 0, sizeof(*opts));
-  for(i=0; i<argc; i++){
-    const char *arg = (const char*)sqlite3_value_text(argv[i]);
-    if( !arg ) continue;
-    if( arg[0]=='-' && arg[1]!='-' && arg[1]!=0 && arg[2]!=0 ){
-      int j;
-      for(j=1; arg[j]; j++){
-        if( arg[j]=='A' ){
-          opts->addAll = 1;
-        }else if( arg[j]=='a' ){
-          opts->addModifiedOnly = 1;
-        }else if( arg[j]=='f' ){
-          opts->force = 1;
-        }else if( arg[j]=='m' ){
-          if( arg[j+1]!=0 ){
-            opts->zMessage = &arg[j+1];
-          }else if( i+1<argc ){
-            opts->zMessage = (const char*)sqlite3_value_text(argv[++i]);
-          }else{
-            doltliteCmdResultMissingOptionValue(context, "message");
-            return SQLITE_ERROR;
-          }
-          break;
-        }else{
-          char opt[3] = { '-', (char)arg[j], 0 };
-          doltliteCmdResultUnknownOption(context, opt);
-          return SQLITE_ERROR;
-        }
-      }
-    }else if( strcmp(arg, "-m")==0 ){
-      opts->zMessage = doltliteCmdTakeValueArg(
-          context, argc, argv, &i, "message");
-      if( !opts->zMessage ) return SQLITE_ERROR;
-    }else if( strcmp(arg, "--message")==0 ){
-      opts->zMessage = doltliteCmdTakeValueArg(
-          context, argc, argv, &i, "message");
-      if( !opts->zMessage ) return SQLITE_ERROR;
-    }else if( strcmp(arg, "--author")==0 ){
-      opts->zAuthor = doltliteCmdTakeValueArg(
-          context, argc, argv, &i, "author");
-      if( !opts->zAuthor ) return SQLITE_ERROR;
-    }else if( strcmp(arg, "--date")==0 ){
-      opts->zDate = doltliteCmdTakeValueArg(
-          context, argc, argv, &i, "date");
-      if( !opts->zDate ) return SQLITE_ERROR;
-    }else if( strcmp(arg, "--amend")==0 ){
-      opts->amend = 1;
-    }else if( strcmp(arg, "--allow-empty")==0 ){
-      opts->allowEmpty = 1;
-    }else if( strcmp(arg, "--skip-empty")==0 ){
-      opts->skipEmpty = 1;
-    }else if( strcmp(arg, "-f")==0 || strcmp(arg, "--force")==0 ){
-      opts->force = 1;
-    }else if( strcmp(arg, "-A")==0 ){
-      opts->addAll = 1;
-    }else if( strcmp(arg, "-a")==0 || strcmp(arg, "--all")==0 ){
-      opts->addModifiedOnly = 1;
-    }else if( arg[0]=='-' ){
-      doltliteCmdResultUnknownOption(context, arg);
-      return SQLITE_ERROR;
+  rc = doltliteCmdParseArgs(context, argc, argv, aOption, ArraySize(aOption),
+                            DOLTLITE_CMD_PARSE_SHORT_GROUPS, &args);
+  if( rc!=SQLITE_OK ) return rc;
+  if( args.nPositional>0 ){
+    const char *arg = args.azPositional[0];
+    char *zErr = sqlite3_mprintf(
+        "commit does not take positional arguments, but found 1: %s", arg);
+    if( zErr ){
+      sqlite3_result_error(context, zErr, -1);
+      sqlite3_free(zErr);
     }else{
-      char *zErr = sqlite3_mprintf(
-          "commit does not take positional arguments, but found 1: %s", arg);
-      if( zErr ){
-        sqlite3_result_error(context, zErr, -1);
-        sqlite3_free(zErr);
-      }else{
-        sqlite3_result_error_nomem(context);
-      }
-      return SQLITE_ERROR;
+      sqlite3_result_error_nomem(context);
     }
+    doltliteCmdArgsClear(&args);
+    return SQLITE_ERROR;
   }
+  doltliteCmdArgsClear(&args);
   return SQLITE_OK;
 }
 

--- a/src/doltlite_conflicts.c
+++ b/src/doltlite_conflicts.c
@@ -1384,21 +1384,18 @@ static void conflictsResolveFinishNoConflictTable(
   sqlite3_result_error(ctx, "table not found", -1);
 }
 
-static void conflictsResolveFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
+static void conflictsResolveParsedFunc(
+  sqlite3_context *ctx,
+  int useOurs,
+  const char *zTable
+){
   sqlite3 *db = sqlite3_context_db_handle(ctx);
   ChunkStore *cs = doltliteGetChunkStore(db);
-  const char *zMode, *zTable;
   ConflictTableInfo table;
   int found = 0;
   int j, rc;
 
-  if( doltliteCmdRejectDetached(ctx) ) return;
   if(!cs){ sqlite3_result_error(ctx,"no database",-1); return; }
-  if(argc!=2){ sqlite3_result_error(ctx,"usage: dolt_conflicts_resolve('--ours'|'--theirs','table')",-1); return; }
-
-  zMode = (const char*)sqlite3_value_text(argv[0]);
-  zTable = (const char*)sqlite3_value_text(argv[1]);
-  if(!zMode||!zTable){ sqlite3_result_error(ctx,"invalid args",-1); return; }
 
   rc = loadConflictTable(db, cs, zTable, &table, &found);
   if( rc!=SQLITE_OK ){
@@ -1416,7 +1413,7 @@ static void conflictsResolveFunc(sqlite3_context *ctx, int argc, sqlite3_value *
   freeConflictTable(&table);
   found = 0;
 
-  if( strcmp(zMode,"--ours")==0 ){
+  if( useOurs ){
     rc = removeConflictTableFromCatalog(db, cs, zTable, &found);
     if( rc!=SQLITE_OK ){
       sqlite3_result_error_code(ctx, rc);
@@ -1428,7 +1425,7 @@ static void conflictsResolveFunc(sqlite3_context *ctx, int argc, sqlite3_value *
       conflictsResolveFinishNoConflictTable(ctx, db, zTable);
     }
 
-  }else if( strcmp(zMode,"--theirs")==0 ){
+  }else{
     rc = loadConflictTable(db, cs, zTable, &table, &found);
     if( rc!=SQLITE_OK ){
       sqlite3_result_error_code(ctx, rc);
@@ -1458,9 +1455,30 @@ static void conflictsResolveFunc(sqlite3_context *ctx, int argc, sqlite3_value *
       conflictsResolveFinishNoConflictTable(ctx, db, zTable);
     }
 
-  }else{
-    sqlite3_result_error(ctx, "use --ours or --theirs", -1);
   }
+}
+
+static void conflictsResolveFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
+  DoltliteCmdArgs args;
+  int useOurs = 0, useTheirs = 0;
+  DoltliteCmdOption aOption[] = {
+    { "ours", 0, DOLTLITE_CMD_OPTION_FLAG, &useOurs, 0 },
+    { "theirs", 0, DOLTLITE_CMD_OPTION_FLAG, &useTheirs, 0 }
+  };
+  int rc;
+
+  if( doltliteCmdRejectDetached(ctx) ) return;
+  rc = doltliteCmdParseArgs(ctx, argc, argv, aOption, ArraySize(aOption),
+                            0, &args);
+  if( rc!=SQLITE_OK ) return;
+  if( useOurs + useTheirs!=1 || args.nPositional!=1 ){
+    doltliteCmdArgsClear(&args);
+    sqlite3_result_error(ctx,
+      "usage: dolt_conflicts_resolve('--ours'|'--theirs','table')", -1);
+    return;
+  }
+  conflictsResolveParsedFunc(ctx, useOurs, args.azPositional[0]);
+  doltliteCmdArgsClear(&args);
 }
 
 int doltliteConflictsRegister(sqlite3 *db){

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -899,15 +899,37 @@ int doltliteCompareAndAdvanceBranch(
   const ProllyHash *pWorkingCatHash
 );
 int doltlitePersistOrSaveWorkingSet(sqlite3 *db);
+#define DOLTLITE_CMD_OPTION_FLAG 0
+#define DOLTLITE_CMD_OPTION_VALUE 1
+#define DOLTLITE_CMD_PARSE_SHORT_GROUPS 0x01
+
+typedef struct DoltliteCmdOption DoltliteCmdOption;
+struct DoltliteCmdOption {
+  const char *zLong;
+  char shortName;
+  u8 eType;
+  int *pSeen;
+  const char **pzValue;
+};
+
+typedef struct DoltliteCmdArgs DoltliteCmdArgs;
+struct DoltliteCmdArgs {
+  sqlite3_value **apPositional;
+  const char **azPositional;
+  int nPositional;
+};
+
 /* Shared dolt_* command scaffolding (doltlite_cmd.c). */
+int doltliteCmdParseArgs(
+  sqlite3_context *ctx, int argc, sqlite3_value **argv,
+  DoltliteCmdOption *aOption, int nOption, int flags,
+  DoltliteCmdArgs *pArgs
+);
+void doltliteCmdArgsClear(DoltliteCmdArgs *pArgs);
 int doltliteCmdRejectDetached(sqlite3_context *ctx);
 void doltliteCmdResultUnknownOption(sqlite3_context *ctx, const char *zOpt);
 void doltliteCmdResultMissingOptionValue(
   sqlite3_context *ctx, const char *zOptName
-);
-const char *doltliteCmdTakeValueArg(
-  sqlite3_context *ctx, int argc, sqlite3_value **argv, int *pI,
-  const char *zOptName
 );
 void doltliteCmdResultPeerBranchBusy(sqlite3_context *ctx, const char *zOp);
 int doltliteCmdFinishWithConflicts(

--- a/src/doltlite_merge_cmd.c
+++ b/src/doltlite_merge_cmd.c
@@ -682,10 +682,16 @@ static void doltliteMergeFunc(
   sqlite3 *db = sqlite3_context_db_handle(context);
   const char *zBranch = 0;
   const char *zMessage = 0;
+  DoltliteCmdArgs args;
   int isAbort = 0;
   int noFastForward = 0;
+  DoltliteCmdOption aOption[] = {
+    { "abort", 0, DOLTLITE_CMD_OPTION_FLAG, &isAbort, 0 },
+    { "no-ff", 0, DOLTLITE_CMD_OPTION_FLAG, &noFastForward, 0 },
+    { "message", 'm', DOLTLITE_CMD_OPTION_VALUE, 0, &zMessage }
+  };
   u8 isMerging = 0;
-  int rc, i;
+  int rc;
 
   if( doltliteCmdRejectDetached(context) ) return;
   if( !doltliteGetChunkStore(db) ){
@@ -697,48 +703,42 @@ static void doltliteMergeFunc(
     return;
   }
 
-  for(i=0; i<argc; i++){
-    const char *arg = (const char*)sqlite3_value_text(argv[i]);
-    if( !arg ) continue;
-    if( strcmp(arg, "--abort")==0 ){
-      isAbort = 1;
-    }else if( strcmp(arg, "--no-ff")==0 ){
-      noFastForward = 1;
-    }else if( strcmp(arg, "-m")==0 || strcmp(arg, "--message")==0 ){
-      zMessage = doltliteCmdTakeValueArg(context, argc, argv, &i, "message");
-      if( !zMessage ) return;
-    }else if( arg[0]=='-' ){
-      doltliteCmdResultUnknownOption(context, arg);
-      return;
-    }else if( !zBranch ){
-      zBranch = arg;
-    }else{
-      sqlite3_result_error(context, "too many positional arguments to dolt_merge", -1);
-      return;
-    }
+  rc = doltliteCmdParseArgs(context, argc, argv, aOption, ArraySize(aOption),
+                            0, &args);
+  if( rc!=SQLITE_OK ) return;
+  if( args.nPositional>1 ){
+    doltliteCmdArgsClear(&args);
+    sqlite3_result_error(context, "too many positional arguments to dolt_merge", -1);
+    return;
   }
+  if( args.nPositional==1 ) zBranch = args.azPositional[0];
 
   if( isAbort ){
     if( zBranch || zMessage || noFastForward ){
       sqlite3_result_error(context,
         "--abort does not take other arguments", -1);
+      doltliteCmdArgsClear(&args);
       return;
     }
     doltliteGetSessionMergeState(db, &isMerging, 0, 0);
     if( !isMerging ){
       sqlite3_result_error(context, "no merge in progress", -1);
+      doltliteCmdArgsClear(&args);
       return;
     }
     rc = mergeAbortInPlace(db);
     if( rc!=SQLITE_OK ){
       sqlite3_result_error_code(context, rc);
+      doltliteCmdArgsClear(&args);
       return;
     }
     sqlite3_result_int(context, 0);
+    doltliteCmdArgsClear(&args);
     return;
   }
 
   (void)doltliteMergeRef(db, context, zBranch, zMessage, noFastForward);
+  doltliteCmdArgsClear(&args);
 }
 
 

--- a/src/doltlite_rebase.c
+++ b/src/doltlite_rebase.c
@@ -2090,9 +2090,19 @@ static void doltliteRebaseFunc(
 ){
   sqlite3 *db = sqlite3_context_db_handle(context);
   ChunkStore *cs = doltliteGetChunkStore(db);
-  const char *zArg0;
+  DoltliteCmdArgs args;
+  const char *zArg0 = 0;
+  int isAbort = 0, isContinue = 0, isInteractive = 0;
+  DoltliteCmdOption aOption[] = {
+    { "abort", 0, DOLTLITE_CMD_OPTION_FLAG, &isAbort, 0 },
+    { "continue", 0, DOLTLITE_CMD_OPTION_FLAG, &isContinue, 0 },
+    { "interactive", 'i', DOLTLITE_CMD_OPTION_FLAG, &isInteractive, 0 }
+  };
   int sealTopLevel = db->pSavepoint!=0 && db->nSavepoint==0;
   int keepTopLevelSavepoint = 0;
+  int rc;
+
+  memset(&args, 0, sizeof(args));
 
   if( doltliteCmdRejectDetached(context) ) return;
   if( !cs ){ sqlite3_result_error(context, "no database", -1); goto rebase_cleanup; }
@@ -2101,49 +2111,56 @@ static void doltliteRebaseFunc(
     goto rebase_cleanup;
   }
 
-  zArg0 = (const char*)sqlite3_value_text(argv[0]);
-  if( !zArg0 ){
-    sqlite3_result_error(context, "upstream ref required", -1);
+  rc = doltliteCmdParseArgs(context, argc, argv, aOption, ArraySize(aOption),
+                            0, &args);
+  if( rc!=SQLITE_OK ) goto rebase_cleanup;
+  if( isAbort + isContinue + isInteractive > 1 ){
+    sqlite3_result_error(context, "conflicting flags", -1);
     goto rebase_cleanup;
   }
+  if( args.nPositional>0 ) zArg0 = args.azPositional[0];
 
-  if( strcmp(zArg0, "--abort")==0 ){
+  if( isAbort ){
+    if( args.nPositional!=0 ){
+      sqlite3_result_error(context, "--abort does not take other arguments", -1);
+      goto rebase_cleanup;
+    }
     doltliteRebaseInteractiveAbort(context, db);
     goto rebase_cleanup;
   }
-  if( strcmp(zArg0, "--continue")==0 ){
+  if( isContinue ){
+    if( args.nPositional!=0 ){
+      sqlite3_result_error(context, "--continue does not take other arguments", -1);
+      goto rebase_cleanup;
+    }
     keepTopLevelSavepoint = 1;
     doltliteRebaseInteractiveContinue(context, db);
     goto rebase_cleanup;
   }
-  if( strcmp(zArg0, "-i")==0 || strcmp(zArg0, "--interactive")==0 ){
+  if( isInteractive ){
     const char *zUpstream;
     keepTopLevelSavepoint = 1;
-    if( argc<2 ){
+    if( args.nPositional<1 ){
       sqlite3_result_error(context,
         "interactive rebase requires upstream branch: "
         "dolt_rebase('-i', 'upstream')", -1);
       goto rebase_cleanup;
     }
-    if( argc!=2 ){
+    if( args.nPositional!=1 ){
       sqlite3_result_error(context,
         "interactive rebase takes exactly one upstream branch", -1);
       goto rebase_cleanup;
     }
-    zUpstream = (const char*)sqlite3_value_text(argv[1]);
-    if( !zUpstream ){
-      sqlite3_result_error(context, "upstream ref required", -1);
-      goto rebase_cleanup;
-    }
+    zUpstream = args.azPositional[0];
     doltliteRebaseInteractiveStart(context, db, zUpstream);
     goto rebase_cleanup;
   }
 
-  if( zArg0[0]=='-' ){
-    doltliteCmdResultUnknownOption(context, zArg0);
+  if( !zArg0 ){
+    sqlite3_result_error(context, "upstream ref required", -1);
     goto rebase_cleanup;
   }
-  if( argc!=1 ){
+  if( args.nPositional!=1 ){
     sqlite3_result_error(context,
       "too many positional arguments to dolt_rebase", -1);
     goto rebase_cleanup;
@@ -2158,6 +2175,7 @@ static void doltliteRebaseFunc(
   }
 
 rebase_cleanup:
+  doltliteCmdArgsClear(&args);
   if( sealTopLevel && !keepTopLevelSavepoint ){
     (void)doltliteVcSealTopLevelSavepointTxn(db);
   }

--- a/src/doltlite_remote_sql.c
+++ b/src/doltlite_remote_sql.c
@@ -238,43 +238,19 @@ static void doltRemoteFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv)
   sqlite3_result_int(ctx, 0);
 }
 
-static void doltPushFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
+static void doltPushParsedFunc(
+  sqlite3_context *ctx,
+  const char *zRemoteName,
+  const char *zBranch,
+  int bForce
+){
   sqlite3 *db = sqlite3_context_db_handle(ctx);
   ChunkStore *cs = doltliteGetChunkStore(db);
   DoltliteRemote *pRemote = 0;
   const char *zUrl = 0;
-  const char *zRemoteName;
-  const char *zBranch;
-  int bForce = 0;
   int rc;
 
   if( !cs ){ doltliteVcResultError(ctx, db, "no database"); return; }
-  if( argc<2 ){
-    doltliteVcResultError(ctx, db, "usage: dolt_push(remote, branch [, '--force'])");
-    return;
-  }
-
-  zRemoteName = (const char*)sqlite3_value_text(argv[0]);
-  zBranch = (const char*)sqlite3_value_text(argv[1]);
-  if( !zRemoteName || !zBranch ){
-    doltliteVcResultError(ctx, db, "remote and branch required");
-    return;
-  }
-
-  if( argc>=3 ){
-    const char *zOpt = (const char*)sqlite3_value_text(argv[2]);
-    if( argc>3 ){
-      doltliteVcResultError(ctx, db, "too many arguments");
-      return;
-    }
-    if( zOpt && strcmp(zOpt, "--force")==0 ){
-      bForce = 1;
-    }else{
-      (void)doltliteVcSealSavepointError(db);
-      doltliteCmdResultUnknownOption(ctx, zOpt);
-      return;
-    }
-  }
 
   rc = remoteSqlOpenNamedRemote(cs, zRemoteName, &zUrl, &pRemote);
   if( remoteSqlReportOpenError(ctx, db, rc, 0) ) return;
@@ -295,6 +271,40 @@ static void doltPushFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   }
   pRemote->xClose(pRemote);
   sqlite3_result_int(ctx, 0);
+}
+
+static void doltPushFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
+  sqlite3 *db = sqlite3_context_db_handle(ctx);
+  DoltliteCmdArgs args;
+  int bForce = 0;
+  DoltliteCmdOption aOption[] = {
+    { "force", 0, DOLTLITE_CMD_OPTION_FLAG, &bForce, 0 }
+  };
+  int rc;
+
+  if( argc<2 ){
+    doltliteVcResultError(ctx, db,
+        "usage: dolt_push(remote, branch [, '--force'])");
+    return;
+  }
+  rc = doltliteCmdParseArgs(ctx, argc, argv, aOption, ArraySize(aOption),
+                            0, &args);
+  if( rc!=SQLITE_OK ){
+    (void)doltliteVcSealSavepointError(db);
+    return;
+  }
+  if( args.nPositional<2 ){
+    doltliteCmdArgsClear(&args);
+    doltliteVcResultError(ctx, db, "remote and branch required");
+    return;
+  }
+  if( args.nPositional>2 ){
+    doltliteCmdArgsClear(&args);
+    doltliteVcResultError(ctx, db, "too many arguments");
+    return;
+  }
+  doltPushParsedFunc(ctx, args.azPositional[0], args.azPositional[1], bForce);
+  doltliteCmdArgsClear(&args);
 }
 
 static int parseRemoteBranchNames(

--- a/src/doltlite_reset.c
+++ b/src/doltlite_reset.c
@@ -458,6 +458,7 @@ static void doltliteResetFunc(
   int nPaths = 0;
   int rc;
   int i;
+  int endOptions = 0;
   int graphLocked = 0;
   u8 isMerging = 0;
   int bSucceeded = 0;
@@ -480,9 +481,13 @@ static void doltliteResetFunc(
   for(i=0; i<argc; i++){
     const char *arg = (const char*)sqlite3_value_text(argv[i]);
     if( !arg ) continue;
-    if( strcmp(arg, "--hard")==0 ){ isHard = 1; }
-    else if( strcmp(arg, "--soft")==0 ){ isSoft = 1; }
-    else if( arg[0]=='-' ){
+    if( !endOptions && strcmp(arg, "--")==0 ){
+      endOptions = 1;
+      continue;
+    }
+    if( !endOptions && strcmp(arg, "--hard")==0 ){ isHard = 1; }
+    else if( !endOptions && strcmp(arg, "--soft")==0 ){ isSoft = 1; }
+    else if( !endOptions && arg[0]=='-' ){
       doltliteCmdResultUnknownOption(context, arg);
       sqlite3_free(azPaths);
       azPaths = 0;

--- a/src/doltlite_reset.c
+++ b/src/doltlite_reset.c
@@ -453,15 +453,21 @@ static void doltliteResetFunc(
   int havePreResetHead = 0;
   int isHard = 0;
   int isSoft = 0;
+  DoltliteCmdArgs args;
+  DoltliteCmdOption aOption[] = {
+    { "hard", 0, DOLTLITE_CMD_OPTION_FLAG, &isHard, 0 },
+    { "soft", 0, DOLTLITE_CMD_OPTION_FLAG, &isSoft, 0 }
+  };
   const char *zRef = 0;
   const char **azPaths = 0;
   int nPaths = 0;
   int rc;
   int i;
-  int endOptions = 0;
   int graphLocked = 0;
   u8 isMerging = 0;
   int bSucceeded = 0;
+
+  memset(&args, 0, sizeof(args));
 
   assert( context!=0 );
   assert( argc>=0 );
@@ -476,24 +482,15 @@ static void doltliteResetFunc(
     havePreResetHead = 1;
   }
 
-  azPaths = (const char**)sqlite3_malloc(sizeof(char*) * (argc>0?argc:1));
+  rc = doltliteCmdParseArgs(context, argc, argv, aOption, ArraySize(aOption),
+                            0, &args);
+  if( rc!=SQLITE_OK ) goto reset_cleanup;
+  azPaths = (const char**)sqlite3_malloc(
+      sizeof(char*) * (args.nPositional>0 ? args.nPositional : 1));
   if( !azPaths ){ sqlite3_result_error_nomem(context); goto reset_cleanup; }
-  for(i=0; i<argc; i++){
-    const char *arg = (const char*)sqlite3_value_text(argv[i]);
-    if( !arg ) continue;
-    if( !endOptions && strcmp(arg, "--")==0 ){
-      endOptions = 1;
-      continue;
-    }
-    if( !endOptions && strcmp(arg, "--hard")==0 ){ isHard = 1; }
-    else if( !endOptions && strcmp(arg, "--soft")==0 ){ isSoft = 1; }
-    else if( !endOptions && arg[0]=='-' ){
-      doltliteCmdResultUnknownOption(context, arg);
-      sqlite3_free(azPaths);
-      azPaths = 0;
-      goto reset_cleanup;
-    }
-    else if( !zRef ){
+  for(i=0; i<args.nPositional; i++){
+    const char *arg = args.azPositional[i];
+    if( !zRef ){
 
       if( isHard || isSoft ){
         zRef = arg;
@@ -702,6 +699,7 @@ static void doltliteResetFunc(
   bSucceeded = 1;
 reset_cleanup:
   sqlite3_free(azPaths);
+  doltliteCmdArgsClear(&args);
   if( graphLocked ){
     chunkStoreUnlock(cs);
   }

--- a/src/doltlite_tag.c
+++ b/src/doltlite_tag.c
@@ -35,38 +35,34 @@ static int mutateTagRef(sqlite3 *db, ChunkStore *cs, void *pArg){
                               p->timestamp, p->zMessage);
 }
 
-static void doltTagFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
+static void doltTagParsedFunc(
+  sqlite3_context *ctx,
+  int isDelete,
+  int nPositional,
+  const char **azPositional,
+  const char *zMessage,
+  const char *zAuthor
+){
   sqlite3 *db = sqlite3_context_db_handle(ctx);
   ChunkStore *cs = doltliteGetChunkStore(db);
   TagMutationCtx m;
-  const char *arg0;
-  const char *zMessage = 0;
-  const char *zAuthor = 0;
-  const char *zCommitRef = 0;
+  const char *arg0 = nPositional>0 ? azPositional[0] : 0;
+  const char *zCommitRef = nPositional>1 ? azPositional[1] : 0;
   char *zParsedTagger = 0;
   char *zParsedEmail = 0;
-  int rc, i;
+  int rc;
 
-  if( doltliteCmdRejectDetached(ctx) ) return;
   if( !cs ){ doltliteVcResultError(ctx, db, "no database"); return; }
-  if( argc<1 ){ doltliteVcResultError(ctx, db, "tag name required"); return; }
+  if( nPositional<1 ){ doltliteVcResultError(ctx, db, "tag name required"); return; }
 
   memset(&m, 0, sizeof(m));
 
-  arg0 = (const char*)sqlite3_value_text(argv[0]);
-  if( !arg0 ){ doltliteVcResultError(ctx, db, "tag name required"); return; }
-
-
-  if( strcmp(arg0, "-d")==0 || strcmp(arg0, "--delete")==0 ){
-    const char *zName;
-    if( argc<2 ){ doltliteVcResultError(ctx, db, "tag name required for delete"); return; }
-    if( argc!=2 ){
+  if( isDelete ){
+    if( nPositional!=1 ){
       doltliteVcResultError(ctx, db, "too many positional arguments to dolt_tag");
       return;
     }
-    zName = (const char*)sqlite3_value_text(argv[1]);
-    if( !zName ){ doltliteVcResultError(ctx, db, "tag name required"); return; }
-    m.zName = zName;
+    m.zName = arg0;
     m.isDelete = 1;
     rc = doltliteMutateRefs(db, mutateTagRef, &m);
     if( rc==SQLITE_CONSTRAINT && doltliteSessionHasUnresolvedConflicts(db) ){
@@ -94,25 +90,9 @@ static void doltTagFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   }
 
 
-  for(i=1; i<argc; i++){
-    const char *arg = (const char*)sqlite3_value_text(argv[i]);
-    if( !arg ) continue;
-    if( strcmp(arg, "-m")==0 || strcmp(arg, "--message")==0 ){
-      zMessage = doltliteCmdTakeValueArg(ctx, argc, argv, &i, "message");
-      if( !zMessage ){ tagSealSavepointError(ctx); return; }
-    }else if( strcmp(arg, "--author")==0 ){
-      zAuthor = doltliteCmdTakeValueArg(ctx, argc, argv, &i, "author");
-      if( !zAuthor ){ tagSealSavepointError(ctx); return; }
-    }else if( arg[0]=='-' ){
-      tagSealSavepointError(ctx);
-      doltliteCmdResultUnknownOption(ctx, arg);
-      return;
-    }else if( !zCommitRef ){
-      zCommitRef = arg;
-    }else{
-      doltliteVcResultError(ctx, db, "too many positional arguments to dolt_tag");
-      return;
-    }
+  if( nPositional>2 ){
+    doltliteVcResultError(ctx, db, "too many positional arguments to dolt_tag");
+    return;
   }
 
   if( zCommitRef ){
@@ -177,6 +157,41 @@ static void doltTagFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
     return;
   }
   sqlite3_result_int(ctx, 0);
+}
+
+static void doltTagFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
+  DoltliteCmdArgs args;
+  int isDelete = 0;
+  const char *zMessage = 0;
+  const char *zAuthor = 0;
+  DoltliteCmdOption aOption[] = {
+    { "delete", 'd', DOLTLITE_CMD_OPTION_FLAG, &isDelete, 0 },
+    { "message", 'm', DOLTLITE_CMD_OPTION_VALUE, 0, &zMessage },
+    { "author", 0, DOLTLITE_CMD_OPTION_VALUE, 0, &zAuthor }
+  };
+  int rc;
+
+  if( doltliteCmdRejectDetached(ctx) ) return;
+  if( argc<1 ){
+    doltliteVcResultError(ctx, sqlite3_context_db_handle(ctx),
+                          "tag name required");
+    return;
+  }
+  rc = doltliteCmdParseArgs(ctx, argc, argv, aOption, ArraySize(aOption),
+                            0, &args);
+  if( rc!=SQLITE_OK ){
+    tagSealSavepointError(ctx);
+    return;
+  }
+  if( isDelete && (zMessage || zAuthor) ){
+    doltliteCmdArgsClear(&args);
+    doltliteVcResultError(ctx, sqlite3_context_db_handle(ctx),
+                          "too many positional arguments to dolt_tag");
+    return;
+  }
+  doltTagParsedFunc(ctx, isDelete, args.nPositional, args.azPositional,
+                    zMessage, zAuthor);
+  doltliteCmdArgsClear(&args);
 }
 
 typedef struct TagVtab TagVtab;

--- a/src/doltlite_verify_constraints.c
+++ b/src/doltlite_verify_constraints.c
@@ -185,6 +185,7 @@ static void doltVerifyConstraintsFunc(
   const char **azScan = 0;
   int nScan = 0;
   int i;
+  int endOptions = 0;
   int rc;
   int nViolations = 0;
   ProllyHash headCat;
@@ -206,15 +207,20 @@ static void doltVerifyConstraintsFunc(
       sqlite3_result_error(context, "invalid empty argument", -1);
       goto cleanup;
     }
-    if( strcmp(zArg, "--all")==0 || strcmp(zArg, "-a")==0 ){
+    if( !endOptions && strcmp(zArg, "--")==0 ){
+      endOptions = 1;
+      continue;
+    }
+    if( !endOptions
+     && (strcmp(zArg, "--all")==0 || strcmp(zArg, "-a")==0) ){
       bAll = 1;
       continue;
     }
-    if( strcmp(zArg, "--output-only")==0 ){
+    if( !endOptions && strcmp(zArg, "--output-only")==0 ){
       bOutputOnly = 1;
       continue;
     }
-    if( zArg[0]=='-' ){
+    if( !endOptions && zArg[0]=='-' ){
       char *zErr = sqlite3_mprintf(
           "unknown flag '%s' (supported: --all, --output-only)", zArg);
       if( zErr ){

--- a/src/doltlite_verify_constraints.c
+++ b/src/doltlite_verify_constraints.c
@@ -177,6 +177,11 @@ static void doltVerifyConstraintsFunc(
   sqlite3 *db = sqlite3_context_db_handle(context);
   int bAll = 0;
   int bOutputOnly = 0;
+  DoltliteCmdArgs args;
+  DoltliteCmdOption aOption[] = {
+    { "all", 'a', DOLTLITE_CMD_OPTION_FLAG, &bAll, 0 },
+    { "output-only", 0, DOLTLITE_CMD_OPTION_FLAG, &bOutputOnly, 0 }
+  };
   const char **azArgTables = 0;
   int nArgTables = 0;
   int nArgAlloc = 0;
@@ -185,7 +190,6 @@ static void doltVerifyConstraintsFunc(
   const char **azScan = 0;
   int nScan = 0;
   int i;
-  int endOptions = 0;
   int rc;
   int nViolations = 0;
   ProllyHash headCat;
@@ -198,39 +202,22 @@ static void doltVerifyConstraintsFunc(
   memset(&emptyCat, 0, sizeof(emptyCat));
   memset(&headCommit, 0, sizeof(headCommit));
   memset(&headHash, 0, sizeof(headHash));
+  memset(&args, 0, sizeof(args));
 
   if( doltliteCmdRejectDetached(context) ) return;
   for(i=0; i<argc; i++){
     const char *zArg = (const char*)sqlite3_value_text(argv[i]);
-    int exists;
     if( !zArg || !zArg[0] ){
       sqlite3_result_error(context, "invalid empty argument", -1);
       goto cleanup;
     }
-    if( !endOptions && strcmp(zArg, "--")==0 ){
-      endOptions = 1;
-      continue;
-    }
-    if( !endOptions
-     && (strcmp(zArg, "--all")==0 || strcmp(zArg, "-a")==0) ){
-      bAll = 1;
-      continue;
-    }
-    if( !endOptions && strcmp(zArg, "--output-only")==0 ){
-      bOutputOnly = 1;
-      continue;
-    }
-    if( !endOptions && zArg[0]=='-' ){
-      char *zErr = sqlite3_mprintf(
-          "unknown flag '%s' (supported: --all, --output-only)", zArg);
-      if( zErr ){
-        sqlite3_result_error(context, zErr, -1);
-        sqlite3_free(zErr);
-      }else{
-        sqlite3_result_error_nomem(context);
-      }
-      goto cleanup;
-    }
+  }
+  rc = doltliteCmdParseArgs(context, argc, argv, aOption, ArraySize(aOption),
+                            0, &args);
+  if( rc!=SQLITE_OK ) goto cleanup;
+  for(i=0; i<args.nPositional; i++){
+    const char *zArg = args.azPositional[i];
+    int exists;
     exists = tableExists(db, zArg);
     if( exists<0 ){
       sqlite3_result_error_nomem(context);
@@ -387,6 +374,7 @@ detection_done:
 cleanup:
   freeStringList(azChanged, nChanged);
   sqlite3_free((void*)azArgTables);
+  doltliteCmdArgsClear(&args);
 }
 
 int doltliteVerifyConstraintsRegister(sqlite3 *db){

--- a/test/vc_oracle_add_test.sh
+++ b/test/vc_oracle_add_test.sh
@@ -664,6 +664,14 @@ INSERT INTO beta VALUES (1, 10);
 SELECT dolt_add('alpha');
 "
 
+oracle "add_end_options_dash_table" "
+CREATE TABLE \`-A\`(id INT PRIMARY KEY);
+CREATE TABLE other(id INT PRIMARY KEY);
+INSERT INTO \`-A\` VALUES (1);
+INSERT INTO other VALUES (2);
+SELECT dolt_add('--', '-A');
+"
+
 echo ""
 echo "=== Results: $pass passed, $fail failed ==="
 if [ $fail -gt 0 ]; then

--- a/test/vc_oracle_branch_test.sh
+++ b/test/vc_oracle_branch_test.sh
@@ -182,6 +182,11 @@ $SEED
 SELECT dolt_branch('feature');
 "
 
+oracle "create_after_end_options" "
+$SEED
+SELECT dolt_branch('--', 'feature');
+"
+
 oracle "create_at_start_point" "
 $SEED
 INSERT INTO t VALUES (2, 20);

--- a/test/vc_oracle_checkout_test.sh
+++ b/test/vc_oracle_checkout_test.sh
@@ -1219,6 +1219,21 @@ UPDATE u SET v = 99;
 SELECT dolt_checkout('HEAD', 't');
 "
 
+oracle "checkout_end_options_dash_table" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+CREATE TABLE \`-b\`(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 10);
+INSERT INTO \`-b\` VALUES (1, 10);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'base');
+UPDATE t SET v = 99;
+UPDATE \`-b\` SET v = 99;
+SELECT dolt_checkout('--', '-b');
+UPDATE \`-b\` SET v = 88;
+SELECT dolt_checkout('HEAD', '--', '-b');
+UPDATE t SET v = (SELECT v FROM \`-b\` WHERE id = 1) WHERE id = 1;
+"
+
 echo ""
 echo "=== Results: $pass passed, $fail failed ==="
 if [ $fail -gt 0 ]; then

--- a/test/vc_oracle_merge_test.sh
+++ b/test/vc_oracle_merge_test.sh
@@ -233,6 +233,16 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feature');
 "
 
+oracle "fast_forward_after_end_options" "
+$SEED
+SELECT dolt_checkout('feature');
+INSERT INTO t VALUES (2, 20);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feat1');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('--', 'feature');
+"
+
 echo "--- three-way no conflict ---"
 
 oracle "three_way_independent_inserts" "

--- a/test/vc_oracle_reset_test.sh
+++ b/test/vc_oracle_reset_test.sh
@@ -987,6 +987,16 @@ SELECT dolt_reset('t');
 SELECT dolt_commit('-m', 'nothing is staged');
 "
 
+oracle "reset_end_options_dash_table" "
+CREATE TABLE \`--hard\`(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO \`--hard\` VALUES (1, 10);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'base');
+UPDATE \`--hard\` SET v = 20;
+SELECT dolt_add('--', '--hard');
+SELECT dolt_reset('--', '--hard');
+"
+
 echo ""
 echo "=== Results: $pass passed, $fail failed ==="
 if [ $fail -gt 0 ]; then

--- a/test/vc_oracle_tags_test.sh
+++ b/test/vc_oracle_tags_test.sh
@@ -135,6 +135,14 @@ SELECT dolt_commit('-m', 'first');
 SELECT dolt_tag('v1.0');
 "
 
+oracle "tag_after_end_options" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES (1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'first');
+SELECT dolt_tag('--', 'v1.0');
+"
+
 oracle "tag_head_with_message" "
 CREATE TABLE t(id INTEGER PRIMARY KEY);
 INSERT INTO t VALUES (1);

--- a/test/vc_oracle_verify_constraints_test.sh
+++ b/test/vc_oracle_verify_constraints_test.sh
@@ -310,6 +310,22 @@ SELECT dolt_commit('-Am', 'clean');
 "'--all'" \
 "$FOLLOW_AGG_COUNT" 1
 
+run_oracle "end_options_dash_table" \
+"
+CREATE TABLE parent(pk INTEGER PRIMARY KEY);
+CREATE TABLE bad(pk INTEGER PRIMARY KEY, parent_pk INT REFERENCES parent(pk));
+CREATE TABLE \`--all\`(pk INTEGER PRIMARY KEY, v INT);
+INSERT INTO parent VALUES (1);
+INSERT INTO \`--all\` VALUES (1, 10);
+SELECT dolt_commit('-Am', 'base');
+PRAGMA foreign_keys=OFF;
+INSERT INTO bad VALUES (1, 99);
+PRAGMA foreign_keys=ON;
+UPDATE \`--all\` SET v = 20 WHERE pk = 1;
+" \
+"'--', '--all'" \
+"$FOLLOW_AGG_COUNT" 0
+
 echo ""
 echo "Results: $pass passed, $fail failed"
 if [ "$fail" -ne 0 ]; then


### PR DESCRIPTION
## Summary

- add a shared declarative argument parser for DoltLite SQL commands, covering long and short flags, value options, compact commit flags, positional arguments, and the `--` separator
- migrate `dolt_add`, `dolt_reset`, `dolt_checkout`, `dolt_commit`, `dolt_merge`, `dolt_branch`, `dolt_tag`, `dolt_rebase`, `dolt_push`, `dolt_conflicts_resolve`, and `dolt_verify_constraints` to the common parser
- preserve command-specific transaction and savepoint error behavior around parsing failures
- keep option-name collisions such as `-A`, `--hard`, `-b`, and `--all` usable as table names after the separator
- add Dolt oracle coverage for separator handling in add, reset, checkout, verify-constraints, branch, tag, and merge

## Testing

- fail-before: the pre-refactor engine rejects the added separator cases in add, reset, checkout, verify-constraints, branch, tag, and merge
- Dolt oracles: add 43/43, commit 44/44, reset 57/57, branch 46/46, tags 20/20, checkout 69/69, merge 86/86, verify-constraints 18/18
- focused native suites: commit 65/65, reset 59/59, branch 66/66, tag 22/22, merge 137/137, rebase 59/59, conflict rows 29/29
- `bash test/remote_test.sh build/doltlite` (110/110)
- `bash test/run_doltlite_tests.sh build/doltlite` (107 DoltLite suites and 310,930 C assertions passed; the aggregate wrapper initially could not locate its stock SQLite binary)
- `bash test/doltlite_parity.sh build/doltlite` (119/119)
- `make -C build lint`

Co-Authored-By: OpenAI Codex <noreply@openai.com>
