### PR TITLE
Schema merge correctness: match Dolt or refuse

### DIFF
--- a/src/doltlite_merge.c
+++ b/src/doltlite_merge.c
@@ -1286,6 +1286,12 @@ int doltliteMergeCatalogs(
   iNextMerged = iNextOurs > iNextTheirs ? iNextOurs : iNextTheirs;
   bDisjointSchemaChanges = catalogHasDisjointSchemaChanges(db, ancestor, ours, theirs);
 
+  rc = mergePreDetectDualIndexOverlap(
+      aAncSchema, nAncSchema, aOursSchema, nOursSchema,
+      aTheirsSchema, nTheirsSchema,
+      &aConflictTables, &nConflictTables, &totalConflicts);
+  if( rc!=SQLITE_OK ) goto merge_cleanup;
+
   rc = preDetectIndexSchemaConflicts(
       aAncSchema, nAncSchema, aOursSchema, nOursSchema,
       aTheirsSchema, nTheirsSchema,

--- a/src/doltlite_merge_int.h
+++ b/src/doltlite_merge_int.h
@@ -192,6 +192,13 @@ int hasAnySchemaConflict(
   int nConflictTables
 );
 
+int mergeIndexColumnRenamedAway(
+  const char *zIndexSql,
+  const char *zAncTableSql,
+  const char *zSideTableSql,
+  char **pzColumn
+);
+
 int mergeIndexColumnGoneFrom(
   const char *zIndexSql,
   const char *zAncTableSql,

--- a/src/doltlite_merge_int.h
+++ b/src/doltlite_merge_int.h
@@ -192,6 +192,17 @@ int hasAnySchemaConflict(
   int nConflictTables
 );
 
+int mergeIndexColumnsOverlap(const char *zSqlA, const char *zSqlB);
+
+int mergePreDetectDualIndexOverlap(
+  SchemaEntry *aAnc, int nAnc,
+  SchemaEntry *aOurs, int nOurs,
+  SchemaEntry *aTheirs, int nTheirs,
+  MergeConflictTable **ppConflictTables,
+  int *pnConflictTables,
+  int *pTotalConflicts
+);
+
 int mergeIndexColumnRenamedAway(
   const char *zIndexSql,
   const char *zAncTableSql,

--- a/src/doltlite_merge_pass1.c
+++ b/src/doltlite_merge_pass1.c
@@ -1056,6 +1056,54 @@ static int mergePass1CollectDualRename(
   return SQLITE_OK;
 }
 
+/* An index one side added over a column the other side renamed. Nothing here
+** retargets the index to the new name, and a merged catalog naming a column
+** its table does not have cannot be loaded at all -- the merge used to report
+** the database as corrupt. Refuse it instead, the way a primary-key change is
+** refused, and say why.
+**
+** This is a deliberate divergence from Dolt, which merges these and keeps the
+** index on the renamed column. */
+static int mergePass1CheckIndexOverRenamedColumn(MergePass1Ctx *c){
+  int side, i;
+
+  for(side=0; side<2; side++){
+    SchemaEntry *aNew = side ? c->aTheirsSchema : c->aOursSchema;
+    int nNew = side ? c->nTheirsSchema : c->nOursSchema;
+    SchemaEntry *aOther = side ? c->aOursSchema : c->aTheirsSchema;
+    int nOther = side ? c->nOursSchema : c->nTheirsSchema;
+
+    for(i=0; i<nNew; i++){
+      SchemaEntry *pAncTbl;
+      SchemaEntry *pOtherTbl;
+      char *zCol = 0;
+      if( !aNew[i].zType || strcmp(aNew[i].zType, "index")!=0 ) continue;
+      if( !aNew[i].zName || !aNew[i].zSql || !aNew[i].zTblName ) continue;
+      if( findSchemaEntry(c->aAncSchema, c->nAncSchema, aNew[i].zName) ){
+        continue;
+      }
+      if( findSchemaEntry(aOther, nOther, aNew[i].zName) ) continue;
+      pAncTbl = findSchemaEntry(c->aAncSchema, c->nAncSchema, aNew[i].zTblName);
+      pOtherTbl = findSchemaEntry(aOther, nOther, aNew[i].zTblName);
+      if( !pAncTbl || !pOtherTbl ) continue;
+      if( !mergeIndexColumnRenamedAway(aNew[i].zSql, pAncTbl->zSql,
+                                       pOtherTbl->zSql, &zCol) ){
+        continue;
+      }
+      if( c->pzErrMsg ){
+        sqlite3_free(*c->pzErrMsg);
+        *c->pzErrMsg = sqlite3_mprintf(
+            "cannot merge: index '%s' covers column '%s' of table '%s', which "
+            "the other branch renamed; drop or recreate the index, then merge",
+            aNew[i].zName, zCol, aNew[i].zTblName);
+      }
+      sqlite3_free(zCol);
+      return SQLITE_ERROR;
+    }
+  }
+  return SQLITE_OK;
+}
+
 static void mergePass1FreeRowPolicy(MergeRowPolicy *pPolicy){
   sqlite3_free((void*)pPolicy->azRenameOverDrop);
   sqlite3_free((void*)pPolicy->azDualRename);
@@ -1305,6 +1353,12 @@ int mergeCatalogPass1(
   c.bDisjointSchemaChanges = bDisjointSchemaChanges;
   c.bPreferOurMaster = bPreferOurMaster;
   c.pazReindex = pazReindex; c.pnReindex = pnReindex;
+
+  rc = mergePass1CheckIndexOverRenamedColumn(&c);
+  if( rc!=SQLITE_OK ){
+    mergePass1Free(&c);
+    return rc;
+  }
 
   for(i=0; i<nOurs; i++){
     if( aOurs[i].iTable==1 ){

--- a/src/doltlite_merge_pass2.c
+++ b/src/doltlite_merge_pass2.c
@@ -188,6 +188,84 @@ static int mergeIndexColumnScan(
 ** column still exists under the new name, but nothing here retargets the index
 ** to it, and a merged catalog naming a column the table does not have cannot be
 ** loaded -- so the merge has to refuse instead of producing one. */
+typedef struct MergeIndexNameList MergeIndexNameList;
+struct MergeIndexNameList { char **az; int n; };
+
+static int mergeIndexCollectName(void *pCtx, const char *zCol){
+  MergeIndexNameList *p = (MergeIndexNameList*)pCtx;
+  char **azNew = sqlite3_realloc(p->az, (p->n+1)*(int)sizeof(char*));
+  if( !azNew ) return SQLITE_NOMEM;
+  p->az = azNew;
+  p->az[p->n] = sqlite3_mprintf("%s", zCol);
+  if( !p->az[p->n] ) return SQLITE_NOMEM;
+  p->n++;
+  return SQLITE_OK;
+}
+
+static void mergeIndexNameListFree(MergeIndexNameList *p){
+  int i;
+  for(i=0; i<p->n; i++) sqlite3_free(p->az[i]);
+  sqlite3_free(p->az);
+}
+
+/* Two index definitions that name a column in common. */
+int mergeIndexColumnsOverlap(const char *zSqlA, const char *zSqlB){
+  MergeIndexNameList a;
+  MergeIndexNameList b;
+  int i, j, bOverlap = 0;
+
+  if( !zSqlA || !zSqlB ) return 0;
+  memset(&a, 0, sizeof(a));
+  memset(&b, 0, sizeof(b));
+  if( mergeIndexEachColumn(zSqlA, mergeIndexCollectName, &a)==SQLITE_OK
+   && mergeIndexEachColumn(zSqlB, mergeIndexCollectName, &b)==SQLITE_OK ){
+    for(i=0; i<a.n && !bOverlap; i++){
+      for(j=0; j<b.n && !bOverlap; j++){
+        if( sqlite3_stricmp(a.az[i], b.az[j])==0 ) bOverlap = 1;
+      }
+    }
+  }
+  mergeIndexNameListFree(&a);
+  mergeIndexNameListFree(&b);
+  return bOverlap;
+}
+
+/* Each side added its own index, under its own name, over a column they share.
+** That is a disagreement about how the column is indexed rather than two
+** independent additions -- keeping both would also impose one side's
+** uniqueness on the other -- and Dolt reports it as a conflict. */
+int mergePreDetectDualIndexOverlap(
+  SchemaEntry *aAnc, int nAnc,
+  SchemaEntry *aOurs, int nOurs,
+  SchemaEntry *aTheirs, int nTheirs,
+  MergeConflictTable **ppConflictTables,
+  int *pnConflictTables,
+  int *pTotalConflicts
+){
+  int i, j, rc;
+
+  for(i=0; i<nOurs; i++){
+    if( !aOurs[i].zType || strcmp(aOurs[i].zType, "index")!=0 ) continue;
+    if( !aOurs[i].zName || !aOurs[i].zSql || !aOurs[i].zTblName ) continue;
+    if( findSchemaEntry(aAnc, nAnc, aOurs[i].zName) ) continue;
+    for(j=0; j<nTheirs; j++){
+      int added = 0;
+      if( !aTheirs[j].zType || strcmp(aTheirs[j].zType, "index")!=0 ) continue;
+      if( !aTheirs[j].zName || !aTheirs[j].zSql || !aTheirs[j].zTblName ) continue;
+      if( findSchemaEntry(aAnc, nAnc, aTheirs[j].zName) ) continue;
+      if( sqlite3_stricmp(aOurs[i].zName, aTheirs[j].zName)==0 ) continue;
+      if( sqlite3_stricmp(aOurs[i].zTblName, aTheirs[j].zTblName)!=0 ) continue;
+      if( !mergeIndexColumnsOverlap(aOurs[i].zSql, aTheirs[j].zSql) ) continue;
+      rc = appendSchemaConflict(ppConflictTables, pnConflictTables,
+                                aOurs[i].zTblName, aOurs[i].zName, &added);
+      if( rc!=SQLITE_OK ) return rc;
+      if( pTotalConflicts ) *pTotalConflicts += added;
+      break;
+    }
+  }
+  return SQLITE_OK;
+}
+
 int mergeIndexColumnRenamedAway(
   const char *zIndexSql,
   const char *zAncTableSql,

--- a/src/doltlite_merge_pass2.c
+++ b/src/doltlite_merge_pass2.c
@@ -133,6 +133,71 @@ static int mergeIndexColSurvives(void *pCtx, const char *zCol){
   return p->zMissing ? SQLITE_OK : SQLITE_NOMEM;
 }
 
+static int mergeIndexColRenamed(void *pCtx, const char *zCol){
+  MergeIndexColCtx *p = (MergeIndexColCtx*)pCtx;
+  int iAnc;
+  if( p->zMissing ) return SQLITE_OK;
+  if( parsedColumnIndexByName(p->aSide, p->nSide, zCol)>=0 ) return SQLITE_OK;
+  iAnc = parsedColumnIndexByName(p->aAnc, p->nAnc, zCol);
+  if( iAnc<0 ) return SQLITE_OK;
+  if( iAnc<p->nSide
+   && parsedColumnIndexByName(p->aAnc, p->nAnc, p->aSide[iAnc].zName)<0
+   && parsedColumnDefinitionsMatch(&p->aSide[iAnc], &p->aAnc[iAnc]) ){
+    p->zMissing = sqlite3_mprintf("%s", zCol);
+    return p->zMissing ? SQLITE_OK : SQLITE_NOMEM;
+  }
+  return SQLITE_OK;
+}
+
+/* Shared body: walk the index's columns with xEach and report the first one it
+** flagged. */
+static int mergeIndexColumnScan(
+  const char *zIndexSql,
+  const char *zAncTableSql,
+  const char *zSideTableSql,
+  int (*xEach)(void*, const char*),
+  char **pzColumn
+){
+  MergeIndexColCtx ctx;
+  int rc;
+
+  if( pzColumn ) *pzColumn = 0;
+  if( !zIndexSql || !zAncTableSql || !zSideTableSql ) return 0;
+  memset(&ctx, 0, sizeof(ctx));
+  if( parseColumns(zAncTableSql, &ctx.aAnc, &ctx.nAnc)!=SQLITE_OK ) return 0;
+  if( parseColumns(zSideTableSql, &ctx.aSide, &ctx.nSide)!=SQLITE_OK ){
+    freeColumns(ctx.aAnc, ctx.nAnc);
+    return 0;
+  }
+  rc = mergeIndexEachColumn(zIndexSql, xEach, &ctx);
+  freeColumns(ctx.aAnc, ctx.nAnc);
+  freeColumns(ctx.aSide, ctx.nSide);
+  if( rc!=SQLITE_OK || !ctx.zMissing ){
+    sqlite3_free(ctx.zMissing);
+    return 0;
+  }
+  if( pzColumn ){
+    *pzColumn = ctx.zMissing;
+  }else{
+    sqlite3_free(ctx.zMissing);
+  }
+  return 1;
+}
+
+/* The index names a column this side renamed rather than dropped. The indexed
+** column still exists under the new name, but nothing here retargets the index
+** to it, and a merged catalog naming a column the table does not have cannot be
+** loaded -- so the merge has to refuse instead of producing one. */
+int mergeIndexColumnRenamedAway(
+  const char *zIndexSql,
+  const char *zAncTableSql,
+  const char *zSideTableSql,
+  char **pzColumn
+){
+  return mergeIndexColumnScan(zIndexSql, zAncTableSql, zSideTableSql,
+                              mergeIndexColRenamed, pzColumn);
+}
+
 int mergeIndexColumnGoneFrom(
   const char *zIndexSql,
   const char *zAncTableSql,

--- a/test/doltlite_schema_merge.sh
+++ b/test/doltlite_schema_merge.sh
@@ -1482,4 +1482,88 @@ run_test "merge_dual_rename_quoted_values" \
 run_test "merge_dual_rename_quoted_integrity" "PRAGMA integrity_check;" "ok" "$DB"
 rm -f "$DB"
 
+# An index one side adds over a column the other side renames. The indexed
+# column still exists under the new name, but nothing retargets the index to
+# it, and a merged catalog naming a column its table does not have cannot be
+# loaded -- the merge used to report the database as corrupt. Refuse it with a
+# message naming the index and column instead, leaving the branch untouched.
+#
+# Dolt merges these and keeps the index on the renamed column, so this is a
+# deliberate divergence, asserted as such in vc_oracle_schema_merge_test.sh.
+# Retargeting the index would close it (issue #2302).
+for dir in ours theirs; do
+  DB=/tmp/test_merge_ix_over_rename_${dir}_$$.db; rm -f "$DB"
+  if [ "$dir" = ours ]; then
+    MAIN="CREATE INDEX ix ON t(b);"; FEAT="ALTER TABLE t RENAME COLUMN b TO b2;"
+    WANTCOLS="k,a,b"
+  else
+    MAIN="ALTER TABLE t RENAME COLUMN b TO b2;"; FEAT="CREATE INDEX ix ON t(b);"
+    WANTCOLS="k,a,b2"
+  fi
+  cat <<EOF | $DOLTLITE "$DB" > /dev/null 2>&1
+CREATE TABLE t(k INTEGER PRIMARY KEY, a TEXT, b TEXT);
+INSERT INTO t VALUES(1,'a1','b1'),(2,'a2','b2');
+SELECT dolt_commit('-A','-m','base');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+$FEAT
+SELECT dolt_commit('-A','-m','feat side');
+SELECT dolt_checkout('main');
+$MAIN
+SELECT dolt_commit('-A','-m','main side');
+EOF
+  run_test_match "merge_index_over_renamed_column_${dir}_refused" \
+    "SELECT dolt_merge('feat');" \
+    "cannot merge: index 'ix' covers column 'b' of table 't'" "$DB"
+  run_test "merge_index_over_renamed_column_${dir}_schema_intact" \
+    "SELECT group_concat(name) FROM pragma_table_info('t');" "$WANTCOLS" "$DB"
+  run_test "merge_index_over_renamed_column_${dir}_rows_intact" \
+    "SELECT count(*) FROM t;" "2" "$DB"
+  run_test "merge_index_over_renamed_column_${dir}_integrity" \
+    "PRAGMA integrity_check;" "ok" "$DB"
+  run_test "merge_index_over_renamed_column_${dir}_clean_status" \
+    "SELECT count(*) FROM dolt_status;" "0" "$DB"
+  rm -f "$DB"
+done
+
+# A unique index gets the same refusal: dropping it silently would drop the
+# constraint with it.
+DB=/tmp/test_merge_ux_over_rename_$$.db; rm -f "$DB"
+cat <<'EOF' | $DOLTLITE "$DB" > /dev/null 2>&1
+CREATE TABLE t(k INTEGER PRIMARY KEY, a TEXT, b TEXT);
+INSERT INTO t VALUES(1,'a1','b1');
+SELECT dolt_commit('-A','-m','base');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+ALTER TABLE t RENAME COLUMN b TO b2;
+SELECT dolt_commit('-A','-m','feat renames');
+SELECT dolt_checkout('main');
+CREATE UNIQUE INDEX ux ON t(b);
+SELECT dolt_commit('-A','-m','main indexes');
+EOF
+run_test_match "merge_unique_index_over_renamed_column_refused" \
+  "SELECT dolt_merge('feat');" "cannot merge: index 'ux' covers column 'b'" "$DB"
+rm -f "$DB"
+
+# An index over a column nobody renamed still merges, and so does an index over
+# a column the other side dropped -- that one drops with the column (#2289).
+DB=/tmp/test_merge_ix_unaffected_$$.db; rm -f "$DB"
+cat <<'EOF' | $DOLTLITE "$DB" > /dev/null 2>&1
+CREATE TABLE t(k INTEGER PRIMARY KEY, a TEXT, b TEXT);
+INSERT INTO t VALUES(1,'a1','b1');
+SELECT dolt_commit('-A','-m','base');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+ALTER TABLE t RENAME COLUMN b TO b2;
+SELECT dolt_commit('-A','-m','feat renames b');
+SELECT dolt_checkout('main');
+CREATE INDEX ix ON t(a);
+SELECT dolt_commit('-A','-m','main indexes a');
+EOF
+run_test_match "merge_index_over_other_column_still_merges" \
+  "SELECT dolt_merge('feat');" "^[0-9a-f]{40}$" "$DB"
+run_test "merge_index_over_other_column_result" \
+  "SELECT group_concat(name) FROM pragma_table_info('t');" "k,a,b2" "$DB"
+rm -f "$DB"
+
 dltest_finish

--- a/test/oracle-buckets/merge-replay-schema.txt
+++ b/test/oracle-buckets/merge-replay-schema.txt
@@ -3,6 +3,7 @@ vc_oracle_conflicts_table_test.sh
 vc_oracle_conflicts_test.sh
 vc_oracle_constraint_violations_test.sh
 vc_oracle_constraints_triggers_replay_test.sh
+vc_oracle_correct_schema_merge_matrix_test.sh
 vc_oracle_cross_op_conflict_cv_test.sh
 vc_oracle_fk_merge_test.sh
 vc_oracle_merge_base_test.sh

--- a/test/vc_oracle_correct_schema_merge_matrix_test.sh
+++ b/test/vc_oracle_correct_schema_merge_matrix_test.sh
@@ -1,0 +1,238 @@
+#!/bin/bash
+
+# Every ours x theirs schema-change pair, merged in DoltLite and in Dolt, with
+# the merged schema, the merged index set and the merged table data compared
+# column by column.
+#
+# The contract this enforces: either we produce exactly what Dolt produces, or
+# we refuse the merge. Merging to a different answer than Dolt is a failure,
+# and so is merging where Dolt refuses. A refusal where Dolt merges is a
+# divergence, allowed only while it is listed in KNOWN_DIVERGENCES below with
+# the reason and the issue that would close it -- an unlisted one fails, and so
+# does a listed one that starts passing, so the list cannot rot.
+
+set -u
+
+DOLTLITE="${1:-./doltlite}"
+DOLT="${2:-dolt}"
+TMPROOT=$(mktemp -d)
+trap "rm -rf $TMPROOT" EXIT
+pass=0; fail=0; gaps=0; FAILED_NAMES=""; GAP_NAMES=""
+
+# Pairs we refuse while Dolt merges. Safe: refusing loses no data and the user
+# can still get there by hand. Each needs the reason and the issue that closes
+# it. A pair that starts merging fails here, so the list cannot rot.
+REFUSE_WHERE_DOLT_MERGES="
+idx_b:ren_b:index over a renamed column is not retargeted (#2302)
+ren_b:idx_b:index over a renamed column is not retargeted (#2302)
+uniq_b:ren_b:unique index over a renamed column is not retargeted (#2302)
+ren_b:uniq_b:unique index over a renamed column is not retargeted (#2302)
+idx_b:ren_b_view:index over a renamed column is not retargeted (#2302)
+ren_b_view:idx_b:index over a renamed column is not retargeted (#2302)
+uniq_b:ren_b_view:index over a renamed column is not retargeted (#2302)
+ren_b_view:uniq_b:index over a renamed column is not retargeted (#2302)
+idx_a:ren_a:index over a renamed column is not retargeted (#2302)
+ren_a:idx_a:index over a renamed column is not retargeted (#2302)
+ren_b_view:ren_a:dual rename with a dependent view naming the renamed column (#2301)
+"
+
+# Pairs we MERGE while Dolt refuses. Not safe: we resolve on the user's behalf
+# a disagreement Dolt hands back to them, so our answer is one Dolt would never
+# produce. Every entry here is a bug to fix by refusing, not a difference to
+# keep, and the suite prints them as gaps rather than passes.
+MERGE_WHERE_DOLT_REFUSES="
+drop_b:rows:a row edit of a column the other branch dropped (#2306)
+rows:drop_b:a row edit of a column the other branch dropped (#2306)
+drop_b:ren_b_view:a column dropped on one branch and renamed on the other, with a dependent view present (#2307)
+ren_b_view:drop_b:a column dropped on one branch and renamed on the other, with a dependent view present (#2307)
+"
+
+pass_name() { pass=$((pass+1)); echo "  PASS: $1"; }
+fail_name() {
+  fail=$((fail+1)); FAILED_NAMES="$FAILED_NAMES $1"
+  echo "  FAIL: $1"
+}
+
+dl_op() {
+  case "$1" in
+    ren_a)      echo "ALTER TABLE t RENAME COLUMN a TO a2;";;
+    ren_b)      echo "ALTER TABLE t RENAME COLUMN b TO b2;";;
+    drop_a)     echo "ALTER TABLE t DROP COLUMN a;";;
+    drop_b)     echo "ALTER TABLE t DROP COLUMN b;";;
+    add_d)      echo "ALTER TABLE t ADD COLUMN d VARCHAR(9);";;
+    idx_b)      echo "CREATE INDEX ix ON t(b);";;
+    uniq_b)     echo "CREATE UNIQUE INDEX uq ON t(b);";;
+    idx_a)      echo "CREATE INDEX ia ON t(a);";;
+    rows)       echo "UPDATE t SET b='edit' WHERE k=1;";;
+    ins)        echo "INSERT INTO t VALUES(9,'a9','b9',99);";;
+    ren_b_view) echo "ALTER TABLE t RENAME COLUMN b TO b2;";;
+  esac
+}
+dt_op() { dl_op "$1"; }
+
+# A view on b exists from the start only for the shapes that need it, so the
+# rename cases that carry a dependent are distinguishable from the bare ones.
+needs_view() { [ "$1" = ren_b_view ] || [ "$2" = ren_b_view ]; }
+
+OPS="ren_a ren_b drop_a drop_b add_d idx_b uniq_b idx_a rows ins ren_b_view"
+
+dl_state() {
+  local db="$1" tbl cols c out idx
+  tbl=$("$DOLTLITE" "$db" \
+    "SELECT name FROM sqlite_master WHERE type='table' AND name IN ('t','t2') LIMIT 1;" 2>/dev/null)
+  [ -z "$tbl" ] && { echo "MISSING TABLE"; return; }
+  cols=$("$DOLTLITE" "$db" \
+    "SELECT group_concat(name) FROM pragma_table_info('$tbl');" 2>/dev/null)
+  echo "cols=$cols"
+  idx=$("$DOLTLITE" "$db" "SELECT group_concat(x, ' ') FROM (
+      SELECT m.name || '(' || (SELECT group_concat(ii.name)
+        FROM pragma_index_info(m.name) ii) || ')' AS x
+      FROM sqlite_master m WHERE m.type='index' AND m.sql IS NOT NULL
+      ORDER BY m.name);" 2>/dev/null)
+  echo "idx=$idx"
+  for c in $(echo "$cols" | tr ',' ' '); do
+    out=$("$DOLTLITE" "$db" \
+      "SELECT group_concat(v, '|') FROM (SELECT coalesce(CAST(\"$c\" AS TEXT),'~') AS v
+        FROM \"$tbl\" ORDER BY k);" 2>/dev/null)
+    echo "data.$c=$out"
+  done
+}
+
+dt_state() {
+  local repo="$1" tbl cols c out idx
+  tbl=$(cd "$repo" && "$DOLT" sql -r csv -q "SELECT table_name FROM information_schema.tables
+      WHERE table_schema=database() AND table_name IN ('t','t2') LIMIT 1;" 2>/dev/null | tail -n +2 | tr -d '"')
+  [ -z "$tbl" ] && { echo "MISSING TABLE"; return; }
+  cols=$(cd "$repo" && "$DOLT" sql -r csv -q "SELECT group_concat(column_name ORDER BY ordinal_position)
+      FROM information_schema.columns WHERE table_name='$tbl';" 2>/dev/null | tail -n +2 | tr -d '"')
+  echo "cols=$cols"
+  idx=$(cd "$repo" && "$DOLT" sql -r csv -q "SELECT group_concat(x SEPARATOR ' ') FROM (
+      SELECT concat(index_name,'(',group_concat(column_name ORDER BY seq_in_index),')') AS x
+      FROM information_schema.statistics WHERE table_name='$tbl' AND index_name<>'PRIMARY'
+      GROUP BY index_name ORDER BY index_name) q;" 2>/dev/null | tail -n +2 | tr -d '"')
+  echo "idx=$idx"
+  for c in $(echo "$cols" | tr ',' ' '); do
+    out=$(cd "$repo" && "$DOLT" sql -r csv -q "SELECT group_concat(v SEPARATOR '|') FROM
+      (SELECT coalesce(CAST(\`$c\` AS CHAR),'~') AS v FROM \`$tbl\` ORDER BY k) q;" \
+      2>/dev/null | tail -n +2 | tr -d '"')
+    echo "data.$c=$out"
+  done
+}
+
+run_case() {
+  local o="$1" t="$2" name="${1}__${2}"
+  local db="$TMPROOT/$name.db" repo="$TMPROOT/repo_$name"
+  local view="" dl_out dt_out dl_ok dt_ok dl_st dt_st reason dt_cf
+
+  rm -f "$db" "$db-lock"; rm -rf "$repo"; mkdir -p "$repo"
+  (cd "$repo" && "$DOLT" init --name oracle --email o@t >/dev/null 2>&1)
+  if needs_view "$o" "$t"; then view="CREATE VIEW v AS SELECT b FROM t;"; fi
+
+  "$DOLTLITE" "$db" >/dev/null 2>&1 <<EOF
+CREATE TABLE t(k INT PRIMARY KEY, a VARCHAR(9), b VARCHAR(9), n INT);
+INSERT INTO t VALUES(1,'a1','b1',11),(2,'a2','b2',22);
+$view
+SELECT dolt_add('-A'), dolt_commit('-m','base');
+SELECT dolt_branch('feat');
+$(dl_op "$o")
+SELECT dolt_add('-A'), dolt_commit('-m','ours');
+SELECT dolt_checkout('feat');
+$(dl_op "$t")
+SELECT dolt_add('-A'), dolt_commit('-m','theirs');
+SELECT dolt_checkout('main');
+EOF
+  (cd "$repo" && "$DOLT" sql >/dev/null 2>&1 <<EOF
+CREATE TABLE t(k INT PRIMARY KEY, a VARCHAR(9), b VARCHAR(9), n INT);
+INSERT INTO t VALUES(1,'a1','b1',11),(2,'a2','b2',22);
+$view
+CALL dolt_add('-A'); CALL dolt_commit('-m','base');
+CALL dolt_branch('feat');
+$(dt_op "$o")
+CALL dolt_add('-A'); CALL dolt_commit('-m','ours');
+CALL dolt_checkout('feat');
+$(dt_op "$t")
+CALL dolt_add('-A'); CALL dolt_commit('-m','theirs');
+EOF
+  )
+
+  # Setup has to have produced the table on both sides, or the case says
+  # nothing about merging.
+  if ! "$DOLTLITE" "$db" "SELECT 1 FROM sqlite_master WHERE name IN ('t','t2') LIMIT 1;" \
+        >/dev/null 2>&1; then
+    fail_name "$name (doltlite setup failed)"; return
+  fi
+
+  dl_out=$("$DOLTLITE" "$db" "SELECT coalesce(dolt_merge('feat'),'NULL');" 2>&1)
+  # dolt_merge's own result table has a column called "conflicts", so the
+  # outcome has to be read from that column's value, never from the text.
+  dt_out=$(cd "$repo" && "$DOLT" sql -r csv -q "CALL dolt_merge('feat');" 2>&1)
+  dl_ok=1; dt_ok=1
+  case "$dl_out" in *rror*|*onflict*|*NULL*) dl_ok=0;; esac
+  if printf '%s\n' "$dt_out" | grep -qiE '^error|error:'; then
+    dt_ok=0
+  else
+    dt_cf=$(printf '%s\n' "$dt_out" | tail -n +2 | head -1 | cut -d, -f3 | tr -d '" ')
+    [ "${dt_cf:-0}" != 0 ] && dt_ok=0
+  fi
+
+  if [ "$dl_ok" = 1 ] && [ "$dt_ok" = 0 ]; then
+    reason=$(printf '%s\n' "$MERGE_WHERE_DOLT_REFUSES" | grep "^$o:$t:" | cut -d: -f3-)
+    if [ -n "$reason" ]; then
+      gaps=$((gaps+1)); GAP_NAMES="$GAP_NAMES $name"
+      echo "  GAP:  $name -- we merge where Dolt refuses: $reason"
+    else
+      fail_name "$name (we merged; Dolt refused)"
+      echo "    dolt: $(echo "$dt_out" | head -2 | tr '\n' ' ')"
+    fi
+    return
+  fi
+  if [ "$dl_ok" = 0 ] && [ "$dt_ok" = 0 ]; then pass_name "$name (both refuse)"; return; fi
+
+  reason=$(printf '%s\n' "$REFUSE_WHERE_DOLT_MERGES" | grep "^$o:$t:" | cut -d: -f3-)
+  if [ "$dl_ok" = 0 ] && [ "$dt_ok" = 1 ]; then
+    if [ -n "$reason" ]; then
+      pass_name "$name (refuses by design: $reason)"
+    else
+      fail_name "$name (we refused; Dolt merged)"
+      echo "    doltlite: $(echo "$dl_out" | head -1 | cut -c1-100)"
+    fi
+    return
+  fi
+  if [ -n "$reason" ]; then
+    fail_name "$name (listed as refusing by design but now merges -- delete the entry)"
+    return
+  fi
+  if printf '%s\n' "$MERGE_WHERE_DOLT_REFUSES" | grep -q "^$o:$t:"; then
+    fail_name "$name (listed as a gap but Dolt merges it too -- delete the entry)"
+    return
+  fi
+
+  dl_st=$(dl_state "$db"); dt_st=$(dt_state "$repo")
+  if [ "$dl_st" = "$dt_st" ]; then
+    pass_name "$name"
+  else
+    fail_name "$name (merged, but not what Dolt produced)"
+    diff <(printf '%s\n' "$dl_st") <(printf '%s\n' "$dt_st") \
+      | sed 's/^/      /' | head -12
+  fi
+}
+
+echo "=== Correct schema merge matrix (DoltLite vs Dolt) ==="
+for o in $OPS; do
+  for t in $OPS; do
+    [ "$o" = "$t" ] && continue
+    run_case "$o" "$t"
+  done
+done
+
+echo ""
+echo "======================================="
+echo "Results: $pass passed, $fail failed, $gaps known gaps"
+if [ "$gaps" -ne 0 ]; then
+  echo "gaps (we merge where Dolt refuses -- fix by refusing):$GAP_NAMES"
+fi
+echo "======================================="
+if [ "$fail" -ne 0 ]; then
+  echo "failed:$FAILED_NAMES"
+  exit 1
+fi

--- a/test/vc_oracle_schema_merge_test.sh
+++ b/test/vc_oracle_schema_merge_test.sh
@@ -103,6 +103,21 @@ expect_merge_outcome() {
 expect_merge_ok() { expect_merge_outcome "$1" "$2" ok; }
 expect_merge_conflict() { expect_merge_outcome "$1" "$2" conflict; }
 
+# A merge DoltLite deliberately refuses while Dolt completes it. Asserting both
+# sides pins the difference instead of leaving it to be rediscovered, and turns
+# a future fix into a visible failure here rather than a silent change.
+expect_merge_divergence() {
+  local name="$1" db="$2" dl_want="$3" dt_want="$4" dl_got dt_got
+  dl_got=$(run_merge_outcome doltlite "$db" "$name")
+  dt_got=$(run_merge_outcome dolt "$db" "$name")
+  if [ "$dl_got" = "$dl_want" ] && [ "$dt_got" = "$dt_want" ]; then
+    pass_name "$name"
+  else
+    fail_name "$name"
+    echo "    expected doltlite=$dl_want dolt=$dt_want; got doltlite=$dl_got dolt=$dt_got"
+  fi
+}
+
 run_dual_command_outcome() {
   local name="$1" db="$2" dl_sql="$3" dt_sql="$4" want="$5"
   local repo dl_rc dt_rc dl_got=ok dt_got=ok
@@ -1222,6 +1237,38 @@ expect_dual_value "generated_vs_plain_ours_generated_value" "$DB" \
   "1:10,2:14,3:22" \
   "SELECT group_concat(id || ':' || x, ',') FROM (SELECT id,x FROM t ORDER BY id);" \
   "SELECT GROUP_CONCAT(CONCAT(id, ':', x) ORDER BY id SEPARATOR ',') FROM t;"
+
+echo ""
+echo "--- Index over a renamed column (deliberate divergence) ---"
+
+# One branch indexes a column the other renames. Nothing retargets the index to
+# the new name, and a merged catalog naming a column its table does not have
+# cannot be loaded, so DoltLite refuses the merge and says which index and
+# column are in the way. Dolt merges these and keeps the index on the renamed
+# column; closing that gap needs the index to follow the rename, tracked in
+# issue #2302. Until then the refusal is the behavior worth pinning: it used to
+# report the database as corrupt instead.
+for dir in ours theirs; do
+  DB="$TMPROOT/ixren_$dir.db"; rm -f "$DB"
+  if [ "$dir" = ours ]; then
+    MAIN="CREATE INDEX ix ON t(b);"; FEAT="ALTER TABLE t RENAME COLUMN b TO b2;"
+  else
+    MAIN="ALTER TABLE t RENAME COLUMN b TO b2;"; FEAT="CREATE INDEX ix ON t(b);"
+  fi
+  cat <<SQL | dl_setup "$DB" "ixren_$dir"
+CREATE TABLE t(id INTEGER PRIMARY KEY, a VARCHAR(9), b VARCHAR(9));
+INSERT INTO t VALUES(1,'a1','b1');
+SELECT dolt_commit('-Am','ancestor');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+$FEAT
+SELECT dolt_commit('-Am','feat_side');
+SELECT dolt_checkout('main');
+$MAIN
+SELECT dolt_commit('-Am','main_side');
+SQL
+  expect_merge_divergence "index_over_renamed_column_$dir" "$DB" conflict ok
+done
 
 echo ""
 echo "--- Column renames on both sides ---"


### PR DESCRIPTION
Two commits: a refusal that replaces a corruption report, and the matrix that makes the whole contract checkable.

**The contract:** for any pair of schema changes, either we produce exactly what Dolt produces, or we refuse. Merging to a different answer than Dolt — or merging where Dolt refuses — is a bug.

## 1. Refuse a merge whose index covers a renamed column

One branch indexes a column the other renames. Nothing retargets the index, so the merged catalog names a column its table does not have, and such a catalog cannot be loaded:

Before: `database disk image is malformed`, on every retry, both directions, for a database that is fine.
After: `cannot merge: index 'ix' covers column 'b' of table 't', which the other branch renamed; drop or recreate the index, then merge`

The check runs before any merged catalog is assembled, so both directions answer the same way and the branch is left untouched — schema, rows, clean `dolt_status`.

## 2. `vc_oracle_correct_schema_merge_matrix_test.sh`

Every ours × theirs pair merges in both engines, and the results are compared **column by column**: the merged column list in order, the merged index set with each index's columns, and the table data for every surviving column. Each pair lands in one of four buckets:

| | meaning |
|---|---|
| both merged and matched | pass |
| both refused | pass |
| we refused, Dolt merged | divergence — safe, must be listed with reason + issue |
| we merged, Dolt refused | **gap** — unsafe, reported as a gap, each names an issue |

Both lists fail if an entry starts behaving differently, so a fix turns into a failure here telling you to delete the line. Neither list can rot.

Current state: **106 passed, 0 failed, 4 known gaps.**

## 3. One gap fixed by this PR

Each side adding its own index over a column they share is a disagreement about that column, not two independent additions — and keeping both silently imposes one side's uniqueness on the other. It now conflicts, matching Dolt. Two indexes with the *same* name were already caught; the cross-name case (`ix` on ours vs `uq` on theirs, both over `b`) was not.

## Remaining gaps, both listed in the suite

- **#2306** — a row edit of a column the other branch dropped. Needs per-column row comparison to tell it from an edit elsewhere in the row, which is why it is not in this PR.
- **#2307** — a column dropped on one branch and renamed on the other, *only when a dependent view exists*. Without the view it already refuses; the view sends it down a different arm.

Eleven refusal-divergences are recorded, all the index-over-renamed-column class (#2302) plus one dual rename with a dependent view (#2301).

## Testing

- new matrix suite: 106 pass / 0 fail / 4 gaps; registered in the `merge-replay-schema` oracle bucket (`check_oracle_buckets.sh` OK)
- `doltlite_schema_merge.sh` 243/243 (3 assertions fail on master), `vc_oracle_schema_merge_test.sh` 105/105
- 108/108 shell suites · 310,930/310,930 C regression tests with `DOLTLITE_PROLLY_CHECK=1`
- `make lint` clean — the new detector lives in `merge_pass2.c` beside the index helpers, keeping `doltlite_merge.c` under the 1500-line cap
- amalgamation compiles; zero compiler warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)