### PR TITLE
Ratchet schema-merge gaps that close by refusing

### DIFF
--- a/test/vc_oracle_correct_schema_merge_matrix_test.sh
+++ b/test/vc_oracle_correct_schema_merge_matrix_test.sh
@@ -222,10 +222,14 @@ EOF
   fi
 
   dl_out=$("$DOLTLITE" "$db" "SELECT coalesce(dolt_merge('feat'),'NULL');" 2>&1)
+  dl_rc=$?
   # dolt_merge's own result table has a column called "conflicts", so the
   # outcome has to be read from that column's value, never from the text.
   dt_out=$(cd "$repo" && "$DOLT" sql -r csv -q "CALL dolt_merge('feat');" 2>&1)
+  dt_rc=$?
   dl_ok=1; dt_ok=1; dl_corrupt=0
+  [ "$dl_rc" -ne 0 ] && dl_ok=0
+  [ "$dt_rc" -ne 0 ] && dt_ok=0
   case "$dl_out" in *rror*|*onflict*|*NULL*) dl_ok=0;; esac
   case "$dl_out" in *"disk image is malformed"*) dl_corrupt=1;; esac
   if printf '%s\n' "$dt_out" | grep -qiE '^error|error:'; then
@@ -262,7 +266,14 @@ EOF
     fi
     return
   fi
-  if [ "$dl_ok" = 0 ] && [ "$dt_ok" = 0 ]; then pass_name "$name (both refuse)"; return; fi
+  if [ "$dl_ok" = 0 ] && [ "$dt_ok" = 0 ]; then
+    if printf '%s\n' "$MERGE_WHERE_DOLT_REFUSES" | grep -q "^$o:$t:"; then
+      fail_name "$name (listed as a gap but we no longer merge -- delete the entry)"
+      return
+    fi
+    pass_name "$name (both refuse)"
+    return
+  fi
 
   reason=$(printf '%s\n' "$REFUSE_WHERE_DOLT_MERGES" | grep "^$o:$t:" | cut -d: -f3-)
   if [ "$dl_ok" = 0 ] && [ "$dt_ok" = 1 ]; then


### PR DESCRIPTION
Follow-up to #2312. Test-only. Two holes in the schema-merge matrix harness that let a listed exception rot, or let a failed merge command enter the success path.

## Stale gap when both refuse

#2312 ratchets every other class: a listed pair that stops matching its class fails until the list is updated. `MERGE_WHERE_DOLT_REFUSES` returned `PASS: both refuse` before that check, so if we start refusing a listed gap it stays on the list forever.

A listed pair that now both refuse fails with `listed as a gap but we no longer merge -- delete the entry`.

## Nonzero merge exit treated as success

`dolt_merge` / `CALL dolt_merge` stdout was classified with `dl_ok`/`dt_ok` defaulting to 1. `$?` was ignored, so a crash or an unrecognized diagnostic could walk into schema comparison as a successful merge. Capture the exit status and force the matching ok flag off when it is nonzero. Existing stdout parsing still applies.

## Testing

- `vc_oracle_correct_schema_merge_matrix_test.sh`: 167 passed, 0 failed, 6 gaps, 3 corrupting (same standing as master; ratchet did not fire on current lists)

No `src/` changes.

Co-Authored-By: Grok <noreply@x.ai>