### PR TITLE
Match Dolt author parsing for commit and tag

### DIFF
--- a/src/doltlite_cmd.c
+++ b/src/doltlite_cmd.c
@@ -188,6 +188,60 @@ void doltliteCmdResultMissingOptionValue(
   }
 }
 
+int doltliteCmdParseAuthor(
+  sqlite3_context *ctx,
+  const char *zAuthor,
+  char **pzName,
+  char **pzEmail
+){
+  const char *z = zAuthor;
+  if( pzName ) *pzName = 0;
+  if( pzEmail ) *pzEmail = 0;
+  if( !z || !z[0] ){
+    sqlite3_result_error(ctx, "Option 'author' requires a value", -1);
+    return SQLITE_ERROR;
+  }
+  while( 1 ){
+    const char *zEnd = strchr(z, ')');
+    const char *zSep = 0;
+    const char *p;
+    char *zName;
+    char *zEmail;
+    int nEmail;
+    int i;
+    int j;
+    if( !zEnd ) zEnd = z + strlen(z);
+    for(p=z+1; p+2<zEnd; p++){
+      if( p[0]==' ' && p[1]=='<' ) zSep = p;
+    }
+    if( zSep ){
+      if( !pzName || !pzEmail ) return SQLITE_OK;
+      zName = sqlite3_mprintf("%.*s", (int)(zSep-z), z);
+      nEmail = (int)(zEnd-zSep-2);
+      zEmail = sqlite3_malloc64((sqlite3_uint64)nEmail+1);
+      if( !zName || !zEmail ){
+        sqlite3_free(zName);
+        sqlite3_free(zEmail);
+        sqlite3_result_error_nomem(ctx);
+        return SQLITE_NOMEM;
+      }
+      for(i=0, j=0; i<nEmail; i++){
+        if( zSep[i+2]!='>' ) zEmail[j++] = zSep[i+2];
+      }
+      zEmail[j] = 0;
+      *pzName = zName;
+      *pzEmail = zEmail;
+      return SQLITE_OK;
+    }
+    if( !zEnd[0] ) break;
+    z = zEnd + 1;
+  }
+  sqlite3_result_error(ctx,
+    "Author not formatted correctly. Use 'Name <author@example.com>' format",
+    -1);
+  return SQLITE_ERROR;
+}
+
 void doltliteCmdResultPeerBranchBusy(sqlite3_context *ctx, const char *zOp){
   char *zErr = sqlite3_mprintf(
     "%s conflict: another connection committed to this branch. "

--- a/src/doltlite_commit_cmd.c
+++ b/src/doltlite_commit_cmd.c
@@ -114,6 +114,23 @@ static int doltliteCommitParseOptions(
   return SQLITE_OK;
 }
 
+static int doltliteCommitValidateAuthor(
+  sqlite3_context *context,
+  const char *zAuthor
+){
+  char *zName = 0;
+  char *zEmail = 0;
+  int rc = doltliteCmdParseAuthor(context, zAuthor, &zName, &zEmail);
+  if( rc==SQLITE_OK && zEmail[0]==0 ){
+    sqlite3_result_error(context,
+      "Aborting commit due to empty author email. Is your config set?", -1);
+    rc = SQLITE_ERROR;
+  }
+  sqlite3_free(zName);
+  sqlite3_free(zEmail);
+  return rc;
+}
+
 /* Rebuild the staged catalog for `dolt_commit -a`, overlaying working-tree
 ** changes for tables that already exist in HEAD onto the staged catalog, and
 ** publish it as the session's staged catalog. On failure the context error is
@@ -568,17 +585,9 @@ static int doltliteCommitCreateObject(
   }
 
   if( zAuthor ){
-    const char *lt = strchr(zAuthor, '<');
-    const char *gt = lt ? strchr(lt, '>') : 0;
-    if( lt && gt ){
-      int nameLen = (int)(lt - zAuthor);
-      while( nameLen>0 && zAuthor[nameLen-1]==' ' ) nameLen--;
-      zParsedName = sqlite3_mprintf("%.*s", nameLen, zAuthor);
-      zParsedEmail = sqlite3_mprintf("%.*s", (int)(gt-lt-1), lt+1);
-    }else{
-      zParsedName = sqlite3_mprintf("%s", zAuthor);
-      zParsedEmail = sqlite3_mprintf("");
-    }
+    rc = doltliteCmdParseAuthor(context, zAuthor,
+                                &zParsedName, &zParsedEmail);
+    if( rc!=SQLITE_OK ) return rc;
   }
 
   {
@@ -643,6 +652,10 @@ static void doltliteCommitFunc(
   }
 
   if( doltliteCommitParseOptions(context, argc, argv, &opts)!=SQLITE_OK ){
+    return;
+  }
+  if( opts.zAuthor
+   && doltliteCommitValidateAuthor(context, opts.zAuthor)!=SQLITE_OK ){
     return;
   }
   zMessage = opts.zMessage;

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -931,6 +931,10 @@ void doltliteCmdResultUnknownOption(sqlite3_context *ctx, const char *zOpt);
 void doltliteCmdResultMissingOptionValue(
   sqlite3_context *ctx, const char *zOptName
 );
+int doltliteCmdParseAuthor(
+  sqlite3_context *ctx, const char *zAuthor,
+  char **pzName, char **pzEmail
+);
 void doltliteCmdResultPeerBranchBusy(sqlite3_context *ctx, const char *zOp);
 int doltliteCmdFinishWithConflicts(
   sqlite3 *db, sqlite3_context *ctx, DoltliteTxnState *pSaved,

--- a/src/doltlite_tag.c
+++ b/src/doltlite_tag.c
@@ -110,22 +110,10 @@ static void doltTagParsedFunc(
   }
 
   if( zAuthor ){
-    const char *lt = strchr(zAuthor, '<');
-    const char *gt = lt ? strchr(lt, '>') : 0;
-    if( lt && gt ){
-      int nameLen = (int)(lt - zAuthor);
-      while( nameLen>0 && zAuthor[nameLen-1]==' ' ) nameLen--;
-      zParsedTagger = sqlite3_mprintf("%.*s", nameLen, zAuthor);
-      zParsedEmail  = sqlite3_mprintf("%.*s", (int)(gt-lt-1), lt+1);
-    }else{
-      zParsedTagger = sqlite3_mprintf("%s", zAuthor);
-      zParsedEmail  = sqlite3_mprintf("");
-    }
-    if( !zParsedTagger || !zParsedEmail ){
-      sqlite3_free(zParsedTagger);
-      sqlite3_free(zParsedEmail);
+    rc = doltliteCmdParseAuthor(ctx, zAuthor,
+                                &zParsedTagger, &zParsedEmail);
+    if( rc!=SQLITE_OK ){
       tagSealSavepointError(ctx);
-      sqlite3_result_error_nomem(ctx);
       return;
     }
     m.zTagger = zParsedTagger;

--- a/test/doltlite_commit.sh
+++ b/test/doltlite_commit.sh
@@ -436,7 +436,47 @@ PRAGMA integrity_check;"   "0
 aux|kv
 ok" "$DB14"
 
-rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8" "$DB9" "$DB10" "$DB11" "$DB12" "$DB13" "$DB14"
+DB15=/tmp/test_dolt_author_$$.db; rm -f "$DB15"
+
+run_test_match "author_validation_setup"   "CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES(1);
+SELECT dolt_commit('-Am','base');
+INSERT INTO t VALUES(2);
+SELECT dolt_commit('-Am','bad','--author','not-an-author');" \
+  "Author not formatted correctly" "$DB15"
+
+run_test "malformed_author_does_not_commit" \
+  "SELECT count(*) FROM dolt_log WHERE message='bad';" "0" "$DB15"
+
+run_test_match "empty_author_rejected" \
+  "SELECT dolt_commit('-m','bad','--author','');" \
+  "Option 'author' requires a value" "$DB15"
+
+run_test_match "empty_author_email_rejected" \
+  "SELECT dolt_commit('-Am','empty email','--author','Edge Case <>');" \
+  "Aborting commit due to empty author email" "$DB15"
+
+run_test "empty_author_email_does_not_commit" \
+  "SELECT count(*) FROM dolt_log WHERE message='empty email';" "0" "$DB15"
+
+run_test_match "author_without_closing_bracket" \
+  "SELECT dolt_commit('-Am','missing close','--author','John Doe <john@example.com');" \
+  "^[0-9a-f]{40}$" "$DB15"
+
+run_test "author_without_closing_bracket_fields" \
+  "SELECT committer || '|' || email FROM dolt_log WHERE message='missing close';" \
+  "John Doe|john@example.com" "$DB15"
+
+run_test_match "author_removes_closing_brackets" \
+  "INSERT INTO t VALUES(3);
+SELECT dolt_commit('-Am','brackets','--author','Angle <a>b>');" \
+  "^[0-9a-f]{40}$" "$DB15"
+
+run_test "author_removes_closing_brackets_fields" \
+  "SELECT committer || '|' || email FROM dolt_log WHERE message='brackets';" \
+  "Angle|ab" "$DB15"
+
+rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8" "$DB9" "$DB10" "$DB11" "$DB12" "$DB13" "$DB14" "$DB15"
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"

--- a/test/doltlite_tag.sh
+++ b/test/doltlite_tag.sh
@@ -61,5 +61,26 @@ run_test "tag_persists" "SELECT tag_name FROM dolt_tags ORDER BY tag_name;" "par
 parenttilde
 v1.0" "$DB"
 
-rm -f "$DB" "$DB2"
+DB3=/tmp/test_tag_author_$$.db; rm -f "$DB3"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES(1);
+SELECT dolt_commit('-Am','base');" | $DOLTLITE "$DB3" > /dev/null 2>&1
+
+run_test_match "tag_malformed_author" \
+  "SELECT dolt_tag('bad','--author','not-an-author');" \
+  "Author not formatted correctly" "$DB3"
+run_test "tag_malformed_author_not_created" \
+  "SELECT count(*) FROM dolt_tags WHERE tag_name='bad';" "0" "$DB3"
+run_test "tag_author_without_closing_bracket" \
+  "SELECT dolt_tag('missing-close','--author','Tag Name <tag@example.com');
+SELECT tagger || '|' || email FROM dolt_tags WHERE tag_name='missing-close';" \
+  "0
+Tag Name|tag@example.com" "$DB3"
+run_test "tag_author_resumes_after_parenthesis" \
+  "SELECT dolt_tag('after-paren','--author','ignored)Real Name <real@example.com>');
+SELECT tagger || '|' || email FROM dolt_tags WHERE tag_name='after-paren';" \
+  "0
+Real Name|real@example.com" "$DB3"
+
+rm -f "$DB" "$DB2" "$DB3"
 dltest_finish

--- a/test/vc_oracle_commit_test.sh
+++ b/test/vc_oracle_commit_test.sh
@@ -264,6 +264,27 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'first', '--author', 'Bob Bare-Name <bob@example.com>');
 "
 
+oracle "commit_author_missing_closing_bracket" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 10);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'first', '--author', 'Alice Author <alice@example.com');
+"
+
+oracle_error "commit_malformed_author" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 10);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'first', '--author', 'not-an-author');
+"
+
+oracle_error "commit_empty_author_email" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 10);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'first', '--author', 'Alice Author <>');
+"
+
 echo "--- --amend ---"
 
 oracle "commit_amend_message_only" "

--- a/test/vc_oracle_tags_test.sh
+++ b/test/vc_oracle_tags_test.sh
@@ -159,6 +159,22 @@ SELECT dolt_commit('-m', 'first');
 SELECT dolt_tag('v1.0', '-m', 'fix: x<y & z>w, ok?');
 "
 
+oracle "tag_author_missing_closing_bracket" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES (1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'first');
+SELECT dolt_tag('v1.0', '--author', 'Alice Author <alice@example.com');
+"
+
+oracle_error "tag_malformed_author" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES (1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'first');
+SELECT dolt_tag('v1.0', '--author', 'not-an-author');
+"
+
 echo "--- multiple tags ---"
 
 oracle "two_tags_on_same_commit" "


### PR DESCRIPTION
Summary:
- add one shared Dolt-compatible parser for command author values
- reject malformed and empty authors in dolt_commit and dolt_tag
- preserve Dolt accepted forms, including a missing closing bracket and its bracket-stripping behavior
- validate commit authors before clean-working-tree checks, matching Dolt error ordering

Testing:
- fail-before on untouched master: native commit 6 failures, native tag 4 failures, commit oracle 2 failures, tag oracle 1 failure
- bash test/doltlite_commit.sh build/doltlite (72 passed)
- DOLTLITE=build/doltlite bash test/doltlite_tag.sh (26 passed)
- bash test/vc_oracle_commit_test.sh build/doltlite dolt (46 passed)
- bash test/vc_oracle_tags_test.sh build/doltlite dolt (22 passed)
- make lint
- C regression corpus (310,928 passed)
- clean stock-SQLite parity (119 passed)
- full native runner: 108 substantive suites passed; its two local artifact failures were rerun successfully after rebuilding the missing stock SQLite and stale C binary

Co-Authored-By: OpenAI Codex <noreply@openai.com>