### PR TITLE
Split ASan oracle sanitizers so the VC glob stays under 25m

### DIFF
--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -13,6 +13,7 @@ jobs:
       matrix:
         suite:
           - oracles
+          - oracles-merge
           - native
           - c-regression
 
@@ -24,7 +25,7 @@ jobs:
         bash .github/scripts/install-apt-deps.sh tcl-dev build-essential zlib1g-dev
 
     - name: Install Dolt
-      if: matrix.suite == 'oracles'
+      if: matrix.suite == 'oracles' || matrix.suite == 'oracles-merge'
       run: bash .github/scripts/install-dolt-oracle.sh
 
     - name: Download ASan/UBSan build
@@ -46,9 +47,10 @@ jobs:
         echo "LSAN_OPTIONS=suppressions=$GITHUB_WORKSPACE/.github/lsan.supp:print_suppressions=0" >> $GITHUB_ENV
         echo "UBSAN_OPTIONS=abort_on_error=1:halt_on_error=1:print_stacktrace=1" >> $GITHUB_ENV
 
-    # Keep this in lockstep with the normal oracle-tests job. Globbing the
-    # suites makes every new oracle sanitizer-covered automatically instead
-    # of relying on a hand-maintained subset that can silently drift.
+    # SQL oracles plus the non-merge VC glob. Merge/schema VC oracles run on
+    # oracles-merge (the same bucket as oracle-tests) so the 25-minute VC step
+    # stays under budget. New vc_oracle_* files still land here until they are
+    # added to merge-replay-schema.txt.
     - name: SQL oracle tests (vs stock SQLite and Dolt)
       if: matrix.suite == 'oracles'
       run: |
@@ -66,10 +68,26 @@ jobs:
       if: matrix.suite == 'oracles'
       run: |
         cd build
+        bucket="../test/oracle-buckets/merge-replay-schema.txt"
         for f in ../test/vc_oracle_*_test.sh; do
-          echo "--- $(basename "$f") ---"
+          base=$(basename "$f")
+          if grep -Fxq "$base" "$bucket"; then
+            continue
+          fi
+          echo "--- $base ---"
           bash "$f" ./doltlite dolt || exit 1
         done
+      timeout-minutes: 25
+
+    - name: Merge/schema version control oracle tests (vs Dolt)
+      if: matrix.suite == 'oracles-merge'
+      run: |
+        cd build
+        while IFS= read -r oracle; do
+          [ -z "$oracle" ] && continue
+          echo "--- $oracle ---"
+          bash "../test/$oracle" ./doltlite dolt || exit 1
+        done < "../test/oracle-buckets/merge-replay-schema.txt"
       timeout-minutes: 25
 
     - name: Correctness regression tests


### PR DESCRIPTION
The 25-minute cap on \`Sanitizers / asan-ubsan-oracles\` is the **VC oracle step**, not the job (job is 45m). That step serially globs all 65 \`vc_oracle_*_test.sh\` files under ASan/UBSan. Recent whole-job times are 12–14 minutes typically and 19–28 minutes on the heavy end; #2315 just timed that step out.

Bumping 25 → 40 only moves the cliff. Every new \`vc_oracle_*\` file is supposed to join the glob automatically.

## Change

Add an \`oracles-merge\` matrix shard next to \`oracles\` / \`native\` / \`c-regression\`:

- **oracles** — SQL oracles + every \`vc_oracle_*\` **except** \`test/oracle-buckets/merge-replay-schema.txt\`
- **oracles-merge** — that bucket (schema-merge matrix, conflicts, rebase, …), the same list the coverage \`oracle-tests-merge-replay-schema\` job already runs

Same ASan artifact. Dolt is installed on both shards. Each VC step stays at 25 minutes. CI Gate still keys off the whole Sanitizers workflow.

No \`src/\` changes.

Co-Authored-By: Grok <noreply@x.ai>