### PR TITLE
Validate and normalize remote names

### DIFF
--- a/src/doltlite_remote_sql.c
+++ b/src/doltlite_remote_sql.c
@@ -21,6 +21,28 @@ struct RemoteMutationCtx {
   int isDelete;
 };
 
+static const char *remoteSqlNormalizeName(
+  sqlite3_context *ctx,
+  const char *zName,
+  char **pzOwned
+){
+  const char *zInput = zName;
+  const char *zEnd;
+  *pzOwned = 0;
+  while( sqlite3Isspace(*zName) ) zName++;
+  zEnd = zName + strlen(zName);
+  while( zEnd>zName && sqlite3Isspace(zEnd[-1]) ) zEnd--;
+  if( zName==zInput && zEnd[0]==0 ) return zName;
+  *pzOwned = sqlite3_mprintf("%.*s", (int)(zEnd-zName), zName);
+  if( !*pzOwned ) sqlite3_result_error_nomem(ctx);
+  return *pzOwned;
+}
+
+static int remoteSqlNameIsValid(const char *zName){
+  return strpbrk(zName,
+    " \t\n\r./\\!@#$%^&*(){}[],.<>'\"?=+|")==0;
+}
+
 static int mutateRemoteRef(sqlite3 *db, ChunkStore *cs, void *pArg){
   RemoteMutationCtx *p = (RemoteMutationCtx*)pArg;
   (void)db;
@@ -189,6 +211,8 @@ static void doltRemoteFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv)
 
   if( strcmp(zAction, "add")==0 ){
     const char *zUrl;
+    const char *zNormalizedName;
+    char *zOwnedName;
     if( argc<3 ){
       doltliteVcResultError(ctx, db, "url required for add");
       return;
@@ -202,9 +226,17 @@ static void doltRemoteFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv)
       doltliteVcResultError(ctx, db, "url required for add");
       return;
     }
-    m.zName = zName;
+    zNormalizedName = remoteSqlNormalizeName(ctx, zName, &zOwnedName);
+    if( !zNormalizedName ) return;
+    if( !remoteSqlNameIsValid(zNormalizedName) ){
+      sqlite3_free(zOwnedName);
+      doltliteVcResultError(ctx, db, "remote name invalid");
+      return;
+    }
+    m.zName = zNormalizedName;
     m.zUrl = zUrl;
     rc = doltliteMutateRefs(db, mutateRemoteRef, &m);
+    sqlite3_free(zOwnedName);
     if( rc!=SQLITE_OK ){
       (void)doltliteVcSealSavepointError(db);
       remoteSqlResultError(ctx, rc,
@@ -212,13 +244,18 @@ static void doltRemoteFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv)
       return;
     }
   }else if( strcmp(zAction, "remove")==0 ){
+    const char *zNormalizedName;
+    char *zOwnedName;
     if( argc>2 ){
       doltliteVcResultError(ctx, db, "too many arguments");
       return;
     }
-    m.zName = zName;
+    zNormalizedName = remoteSqlNormalizeName(ctx, zName, &zOwnedName);
+    if( !zNormalizedName ) return;
+    m.zName = zNormalizedName;
     m.isDelete = 1;
     rc = doltliteMutateRefs(db, mutateRemoteRef, &m);
+    sqlite3_free(zOwnedName);
     if( rc!=SQLITE_OK ){
       (void)doltliteVcSealSavepointError(db);
       remoteSqlResultError(ctx, rc,

--- a/test/remote_test.sh
+++ b/test/remote_test.sh
@@ -67,6 +67,22 @@ check_match "remote add extra arg errors" "too many arguments|invalid argument|E
 result=$("$DB" "$TMPDIR/src.db" "SELECT count(*) FROM dolt_remotes;")
 check "remote add extra arg preserves remotes" "1" "$result"
 
+result=$("$DB" "$TMPDIR/src.db" "SELECT dolt_remote('add','bad/name','$R/bad.db');" 2>&1)
+check_match "remote add rejects invalid name" "remote name invalid" "$result"
+
+result=$("$DB" "$TMPDIR/src.db" "SELECT count(*) FROM dolt_remotes WHERE name='bad/name';")
+check "invalid remote not stored" "0" "$result"
+
+result=$("$DB" "$TMPDIR/src.db" "SELECT dolt_remote('add','  spaced  ','$R/spaced.db');")
+check "remote add trims name" "0" "$result"
+
+result=$("$DB" "$TMPDIR/src.db" "SELECT name FROM dolt_remotes WHERE name='spaced';")
+check "trimmed remote stored canonically" "spaced" "$result"
+
+"$DB" "$TMPDIR/src.db" "SELECT dolt_remote('remove','  spaced  ');" > /dev/null
+result=$("$DB" "$TMPDIR/src.db" "SELECT count(*) FROM dolt_remotes;")
+check "remote remove trims name" "1" "$result"
+
 result=$("$DB" "$TMPDIR/src.db" "SELECT dolt_remote('remove','origin','extra');" 2>&1)
 check_match "remote remove extra arg errors" "too many arguments|invalid argument|ERROR" "$result"
 

--- a/test/vc_oracle_remotes_test.sh
+++ b/test/vc_oracle_remotes_test.sh
@@ -668,6 +668,14 @@ oracle "add_remote_with_non_standard_name" "
 SELECT dolt_remote('add', 'backup-1', 'file:///tmp/oracle_backup');
 "
 
+oracle "add_remote_trims_name" "
+SELECT dolt_remote('add', '  backup  ', 'file:///tmp/oracle_backup');
+"
+
+oracle "add_remote_with_allowed_punctuation" "
+SELECT dolt_remote('add', 'backup:local~1', 'file:///tmp/oracle_backup');
+"
+
 echo "--- remove ---"
 
 oracle "remove_only_remote" "
@@ -692,6 +700,14 @@ echo "--- error paths ---"
 oracle_error "add_duplicate_remote" "
 SELECT dolt_remote('add', 'origin', 'file:///tmp/oracle_origin');
 SELECT dolt_remote('add', 'origin', 'file:///tmp/oracle_other');
+"
+
+oracle_error "add_remote_with_slash" "
+SELECT dolt_remote('add', 'bad/name', 'file:///tmp/oracle_bad');
+"
+
+oracle_error "add_remote_with_internal_space" "
+SELECT dolt_remote('add', 'bad name', 'file:///tmp/oracle_bad');
 "
 
 oracle_error "remove_nonexistent_remote" "


### PR DESCRIPTION
Summary:
- trim remote names for add and remove, matching Dolt
- reject Dolt-invalid remote delimiters before refs are mutated
- preserve accepted punctuation instead of applying broader branch-name rules

Testing:
- fail-before: native remote suite failed 5 assertions and the Dolt oracle failed 3 cases
- bash test/remote_test.sh build/doltlite (115 passed)
- bash test/vc_oracle_remotes_test.sh build/doltlite dolt (39 passed)
- make lint
- full native runner: 109 substantive suites passed and 310,930 C assertions passed
- bash test/doltlite_parity.sh build/doltlite (119 passed)

Co-Authored-By: OpenAI Codex <noreply@openai.com>