### PR TITLE
Match verify-constraints table name casing

### DIFF
--- a/src/doltlite_verify_constraints.c
+++ b/src/doltlite_verify_constraints.c
@@ -28,7 +28,8 @@ static int tableExists(sqlite3 *db, const char *zName){
   int rc;
 
   zSql = sqlite3_mprintf(
-      "SELECT 1 FROM main.sqlite_master WHERE type='table' AND name=%Q",
+      "SELECT 1 FROM main.sqlite_master "
+      "WHERE type='table' AND name=%Q COLLATE NOCASE",
       zName);
   if( !zSql ) return -1;
   rc = sqlite3_prepare_v2(db, zSql, -1, &pStmt, 0);

--- a/test/vc_oracle_verify_constraints_test.sh
+++ b/test/vc_oracle_verify_constraints_test.sh
@@ -135,6 +135,17 @@ echo "--- FK: named table with no violations ---"
 run_oracle "fk_named_other" "$FK_SETUP" "'otherTable'" \
   "$FOLLOW_AGG_COUNT" 1
 
+echo "--- FK: named table lookup is case insensitive ---"
+run_oracle "fk_named_table_case_insensitive" \
+"CREATE TABLE parent(pk INTEGER PRIMARY KEY);
+CREATE TABLE \`MiXeD\`(pk INTEGER PRIMARY KEY, parent_pk INT REFERENCES parent(pk));
+PRAGMA foreign_keys=OFF;
+INSERT INTO \`MiXeD\` VALUES (1,99);
+PRAGMA foreign_keys=ON;
+" \
+"'mixed'" \
+"$FOLLOW_AGG" 0
+
 
 # A merge records violations up front. Verifying an unrelated table must not
 # retract them: the commit gate reads that record, so clearing it wholesale


### PR DESCRIPTION
Summary:
- resolve named tables case-insensitively in dolt_verify_constraints, matching SQLite and Dolt identifier semantics
- preserve the canonical table name in recorded constraint-violation output
- add a Dolt oracle regression using a lowercase argument for a mixed-case table

Testing:
- fail-before: oracle case failed with table not found: mixed while Dolt returned the MiXeD violation
- bash test/vc_oracle_verify_constraints_test.sh build/doltlite dolt (19 passed)
- bash test/vc_oracle_constraint_violations_test.sh build/doltlite dolt (11 passed)
- make lint
- full native runner: 109 substantive suites and 310,930 C assertions passed; aggregate wrapper only missed its repo-root sqlite3 path
- bash test/doltlite_parity.sh build/doltlite (119 passed)

Co-Authored-By: OpenAI Codex <noreply@openai.com>