### PR TITLE
Refuse two merges whose answer Dolt hands back to the user

### DIFF
--- a/doltlite.mk
+++ b/doltlite.mk
@@ -58,7 +58,7 @@ PROLLY_OBJS = \
               prolly_btree.o prolly_btree_catalog.o prolly_btree_cursor.o prolly_btree_cursor_seek.o prolly_btree_cursor_payload.o prolly_btree_cursor_count.o prolly_btree_mutation.o \
               prolly_btree_orig.o prolly_btree_state.o prolly_btree_txn.o pager_shim.o sortkey.o \
               doltlite.o doltlite_core.o doltlite_cmd.o doltlite_add.o doltlite_commit_cmd.o doltlite_reset.o doltlite_merge_cmd.o doltlite_cherry_pick.o doltlite_revert.o doltlite_rebase.o doltlite_config.o doltlite_commit.o doltlite_ref.o doltlite_log.o doltlite_commit_ancestors.o doltlite_status.o doltlite_merge_status.o \
-              doltlite_diff.o doltlite_diff_table.o doltlite_workspace.o doltlite_branch.o doltlite_branches.o doltlite_checkout.o doltlite_tag.o doltlite_ancestor.o doltlite_merge.o doltlite_merge_pass1.o doltlite_merge_pass2.o doltlite_merge_rows.o doltlite_merge_schema.o doltlite_conflicts.o \
+              doltlite_diff.o doltlite_diff_table.o doltlite_workspace.o doltlite_branch.o doltlite_branches.o doltlite_checkout.o doltlite_tag.o doltlite_ancestor.o doltlite_merge.o doltlite_merge_pass1.o doltlite_merge_pass2.o doltlite_merge_predetect.o doltlite_merge_rows.o doltlite_merge_schema.o doltlite_conflicts.o \
               doltlite_gc.o doltlite_chunk_walk.o doltlite_history.o doltlite_at.o doltlite_blame.o doltlite_schema_diff.o doltlite_patch.o doltlite_schemas.o doltlite_diff_stat.o doltlite_record.o \
               doltlite_ignore.o doltlite_docs.o doltlite_tests.o doltlite_hashof.o \
               doltlite_constraint_violations.o doltlite_verify_constraints.o \

--- a/main.mk
+++ b/main.mk
@@ -1625,6 +1625,8 @@ doltlite_merge_pass1.o:	$(TOP)/src/doltlite_merge_pass1.c $(TOP)/src/doltlite_me
 
 doltlite_merge_pass2.o:	$(TOP)/src/doltlite_merge_pass2.c $(TOP)/src/doltlite_merge_int.h $(DEPS_OBJ_COMMON)
 	$(T.cc.sqlite) -c $(TOP)/src/doltlite_merge_pass2.c
+doltlite_merge_predetect.o:	$(TOP)/src/doltlite_merge_predetect.c $(TOP)/src/doltlite_merge_int.h $(DEPS_OBJ_COMMON)
+	$(T.cc.sqlite) -c $(TOP)/src/doltlite_merge_predetect.c
 
 doltlite_merge_rows.o:	$(TOP)/src/doltlite_merge_rows.c $(TOP)/src/doltlite_merge_int.h $(DEPS_OBJ_COMMON)
 	$(T.cc.sqlite) -c $(TOP)/src/doltlite_merge_rows.c

--- a/src/doltlite_cherry_pick.c
+++ b/src/doltlite_cherry_pick.c
@@ -148,7 +148,8 @@ int applyMergedCatalogAndCommit(
     int nReindex = 0;
     rc = doltliteMergeCatalogs(db, ancCatHash, ourCatHash, theirCatHash,
                                 &mergedCatHash, pnConflicts, &zMergeErr, 0, 0,
-                                bPreferOurMaster, &azReindex, &nReindex, 0, 0);
+                                bPreferOurMaster, 0,
+                                &azReindex, &nReindex, 0, 0);
     if( rc!=SQLITE_OK ){
       sqlite3_free(zMergeErr);
       doltliteTxnStateClear(&savedState);
@@ -285,7 +286,7 @@ int applyMergedCatalogAndCommit(
     char *zCErr = 0;
     rc = doltliteMergeCatalogs(db, ourCatHash, &liveMergedCatHash,
                                pCommitOurCatHash, &commitCatHash,
-                               &nCommitConflicts, &zCErr, 0, 0, 0,
+                               &nCommitConflicts, &zCErr, 0, 0, 0, 0,
                                &azReindexC, &nReindexC, 0, 0);
     sqlite3_free(zCErr);
     doltliteFreeNameList(azReindexC, nReindexC);

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -1350,6 +1350,7 @@ int doltliteMergeCatalogs(sqlite3 *db,
     int *pnConflicts, char **pzErrMsg,
     SchemaMergeAction **ppActions, int *pnActions,
     int bPreferOurMaster,
+    int bBranchMerge,
     char ***pazReindex, int *pnReindex,
     char ***pazRebuildVtabs, int *pnRebuildVtabs);
 void doltliteFreeNameList(char **az, int n);

--- a/src/doltlite_merge.c
+++ b/src/doltlite_merge.c
@@ -1258,6 +1258,7 @@ int doltliteMergeCatalogs(
   SchemaMergeAction **ppActions,
   int *pnActions,
   int bPreferOurMaster,
+  int bBranchMerge,
   char ***pazReindex,
   int *pnReindex,
   char ***pazRebuildVtabs,
@@ -1325,6 +1326,7 @@ int doltliteMergeCatalogs(
                           ppActions, pnActions,
                           bDisjointSchemaChanges,
                           bPreferOurMaster,
+                          bBranchMerge,
                           pazReindex, pnReindex);
   if( rc!=SQLITE_OK ){
     int k;

--- a/src/doltlite_merge_cmd.c
+++ b/src/doltlite_merge_cmd.c
@@ -537,7 +537,7 @@ int doltliteMergeRef(
 
   rc = doltliteMergeCatalogs(db, &ancCatHash, &ourCatHash, &theirCatHash,
                               &mergedCatHash, &nMergeConflicts, &zOwnedErr,
-                              &aSchemaActions, &nSchemaActions, 0,
+                              &aSchemaActions, &nSchemaActions, 0, 1,
                               &azReindex, &nReindex,
                               &azRebuildVtabs, &nRebuildVtabs);
   if( rc!=SQLITE_OK ){

--- a/src/doltlite_merge_int.h
+++ b/src/doltlite_merge_int.h
@@ -54,6 +54,55 @@ struct SchemaRootpageRemap {
 
 /* ── rows (doltlite_merge_rows.c) ─────────────────────────────────────── */
 
+/* Shared with the pre-detection module, which reads the same pass-1 state. */
+typedef struct IndexMergePatch IndexMergePatch;
+struct IndexMergePatch {
+  Pgno iTable;
+  ProllyHash mergedRoot;
+};
+
+/* Shared state for pass-1 catalog merge. Keeps the long parameter list off
+** the leaf helpers and makes the patch list a single ownership root. */
+typedef struct MergePass1Ctx MergePass1Ctx;
+struct MergePass1Ctx {
+  sqlite3 *db;
+  struct TableEntry *aAnc; int nAnc;
+  struct TableEntry *aOurs; int nOurs;
+  struct TableEntry *aTheirs; int nTheirs;
+  SchemaEntry *aAncSchema; int nAncSchema;
+  SchemaEntry *aOursSchema; int nOursSchema;
+  SchemaEntry *aTheirsSchema; int nTheirsSchema;
+  struct TableEntry *aMerged; int *pnMerged;
+  MergeConflictTable **ppConflictTables; int *pnConflictTables;
+  int *pTotalConflicts;
+  char **pzErrMsg;
+  const ProllyHash *pCatAnc;
+  const ProllyHash *pCatOurs;
+  const ProllyHash *pCatTheirs;
+  SchemaMergeAction **ppSchemaActions; int *pnSchemaActions;
+  int bDisjointSchemaChanges;
+  int bPreferOurMaster;
+  char ***pazReindex; int *pnReindex;
+  IndexMergePatch *aPatches;
+  int nPatches;
+  int nPatchesAlloc;
+};
+
+int mergePass1CheckIndexOverRenamedColumn(MergePass1Ctx *c);
+int mergePass1CheckTriggerOverRenamedTable(MergePass1Ctx *c);
+int mergePass1CheckRowEditOfDroppedColumn(MergePass1Ctx *c);
+int mergePass1CheckDuplicateIndexColumns(MergePass1Ctx *c);
+
+int mergeRowEditsColumn(
+  sqlite3 *db,
+  const ProllyHash *pAncRoot,
+  const ProllyHash *pOtherRoot,
+  u8 ancFlags,
+  u8 otherFlags,
+  int iField,
+  int *pbEdited
+);
+
 int canFastMerge(
   sqlite3 *db,
   const char *zName,

--- a/src/doltlite_merge_int.h
+++ b/src/doltlite_merge_int.h
@@ -82,6 +82,10 @@ struct MergePass1Ctx {
   SchemaMergeAction **ppSchemaActions; int *pnSchemaActions;
   int bDisjointSchemaChanges;
   int bPreferOurMaster;
+  /* A merge of two branches, as opposed to a replay of one commit onto
+  ** another (revert, cherry-pick, rebase). Refusals that encode Dolt's
+  ** judgement about a merge only apply to the former. */
+  int bBranchMerge;
   char ***pazReindex; int *pnReindex;
   IndexMergePatch *aPatches;
   int nPatches;
@@ -368,6 +372,7 @@ int mergeCatalogPass1(
   SchemaMergeAction **ppSchemaActions, int *pnSchemaActions,
   int bDisjointSchemaChanges,
   int bPreferOurMaster,
+  int bBranchMerge,
   char ***pazReindex, int *pnReindex
 );
 

--- a/src/doltlite_merge_pass1.c
+++ b/src/doltlite_merge_pass1.c
@@ -18,39 +18,6 @@ int mergeAppendReindexName(char ***paz, int *pn, const char *zName){
   return SQLITE_OK;
 }
 
-typedef struct IndexMergePatch IndexMergePatch;
-struct IndexMergePatch {
-  Pgno iTable;
-  ProllyHash mergedRoot;
-};
-
-/* Shared state for pass-1 catalog merge. Keeps the long parameter list off
-** the leaf helpers and makes the patch list a single ownership root. */
-typedef struct MergePass1Ctx MergePass1Ctx;
-struct MergePass1Ctx {
-  sqlite3 *db;
-  struct TableEntry *aAnc; int nAnc;
-  struct TableEntry *aOurs; int nOurs;
-  struct TableEntry *aTheirs; int nTheirs;
-  SchemaEntry *aAncSchema; int nAncSchema;
-  SchemaEntry *aOursSchema; int nOursSchema;
-  SchemaEntry *aTheirsSchema; int nTheirsSchema;
-  struct TableEntry *aMerged; int *pnMerged;
-  MergeConflictTable **ppConflictTables; int *pnConflictTables;
-  int *pTotalConflicts;
-  char **pzErrMsg;
-  const ProllyHash *pCatAnc;
-  const ProllyHash *pCatOurs;
-  const ProllyHash *pCatTheirs;
-  SchemaMergeAction **ppSchemaActions; int *pnSchemaActions;
-  int bDisjointSchemaChanges;
-  int bPreferOurMaster;
-  char ***pazReindex; int *pnReindex;
-  IndexMergePatch *aPatches;
-  int nPatches;
-  int nPatchesAlloc;
-};
-
 static void mergePass1Free(MergePass1Ctx *c){
   sqlite3_free(c->aPatches);
   c->aPatches = 0;
@@ -1056,141 +1023,6 @@ static int mergePass1CollectDualRename(
   return SQLITE_OK;
 }
 
-/* A trigger whose table the other side renamed or dropped. A trigger has to
-** resolve when the schema loads -- unlike a view, which is only text until it
-** is used -- so a merged catalog holding a trigger on a table that is no
-** longer there cannot be loaded, and the merge reported the database as
-** malformed.
-**
-** Dolt merges a rename and keeps the trigger pointing at the old name, which
-** is a dangling trigger its own information_schema cannot read. That is not a
-** result this engine can represent, so refuse and say why. A drop of the
-** table is the same hole: refuse as dropped, not as renamed. */
-static int mergePass1CheckTriggerOverRenamedTable(MergePass1Ctx *c){
-  int side, i, j;
-
-  for(side=0; side<2; side++){
-    SchemaEntry *aTrig = side ? c->aTheirsSchema : c->aOursSchema;
-    int nTrig = side ? c->nTheirsSchema : c->nOursSchema;
-    SchemaEntry *aOther = side ? c->aOursSchema : c->aTheirsSchema;
-    int nOther = side ? c->nOursSchema : c->nTheirsSchema;
-
-    for(i=0; i<nTrig; i++){
-      const char *zTable = aTrig[i].zTblName;
-      int bRenamed = 0;
-      if( !aTrig[i].zType || strcmp(aTrig[i].zType, "trigger")!=0 ) continue;
-      if( !aTrig[i].zName || !zTable ) continue;
-      /* A trigger the ancestor already had went through the rename with the
-      ** table on the renaming side, so the merge has a correct copy to keep.
-      ** Only one added beside the rename has nowhere to land. */
-      if( findSchemaEntry(c->aAncSchema, c->nAncSchema, aTrig[i].zName) ){
-        continue;
-      }
-      if( !findSchemaEntry(c->aAncSchema, c->nAncSchema, zTable) ) continue;
-      if( findSchemaEntry(aOther, nOther, zTable) ) continue;
-      /* Gone from the other side under its ancestor name. A table of theirs the
-      ** ancestor never had, whose columns are the ancestor table's columns, is
-      ** that table under a new name. Dropping it and creating something
-      ** unrelated looks the same from the names alone, so the columns decide
-      ** whether this is a rename or a drop. */
-      {
-        SchemaEntry *pAncTbl = findSchemaEntry(c->aAncSchema, c->nAncSchema,
-                                               zTable);
-        ParsedColumn *aAncCols = 0;
-        int nAncCols = 0;
-        if( !pAncTbl || !pAncTbl->zSql ) continue;
-        if( parseColumns(pAncTbl->zSql, &aAncCols, &nAncCols)!=SQLITE_OK ){
-          continue;
-        }
-        for(j=0; j<nOther && !bRenamed; j++){
-          ParsedColumn *aCand = 0;
-          int nCand = 0, m, same;
-          if( !aOther[j].zType || strcmp(aOther[j].zType, "table")!=0 ) continue;
-          if( !aOther[j].zName || !aOther[j].zSql ) continue;
-          if( findSchemaEntry(c->aAncSchema, c->nAncSchema, aOther[j].zName) ){
-            continue;
-          }
-          if( parseColumns(aOther[j].zSql, &aCand, &nCand)!=SQLITE_OK ) continue;
-          same = nCand==nAncCols;
-          for(m=0; m<nCand && same; m++){
-            if( sqlite3_stricmp(aCand[m].zName, aAncCols[m].zName)!=0
-             || !parsedColumnDefinitionsMatch(&aCand[m], &aAncCols[m]) ){
-              same = 0;
-            }
-          }
-          freeColumns(aCand, nCand);
-          if( same ) bRenamed = 1;
-        }
-        freeColumns(aAncCols, nAncCols);
-      }
-      if( c->pzErrMsg ){
-        sqlite3_free(*c->pzErrMsg);
-        if( bRenamed ){
-          *c->pzErrMsg = sqlite3_mprintf(
-              "cannot merge: trigger '%s' runs on table '%s', which the other "
-              "branch renamed; drop or recreate the trigger, then merge",
-              aTrig[i].zName, zTable);
-        }else{
-          *c->pzErrMsg = sqlite3_mprintf(
-              "cannot merge: trigger '%s' runs on table '%s', which the other "
-              "branch dropped; drop or recreate the trigger, then merge",
-              aTrig[i].zName, zTable);
-        }
-      }
-      return SQLITE_ERROR;
-    }
-  }
-  return SQLITE_OK;
-}
-
-/* An index one side added over a column the other side renamed. Nothing here
-** retargets the index to the new name, and a merged catalog naming a column
-** its table does not have cannot be loaded at all -- the merge used to report
-** the database as corrupt. Refuse it instead, the way a primary-key change is
-** refused, and say why.
-**
-** This is a deliberate divergence from Dolt, which merges these and keeps the
-** index on the renamed column. */
-static int mergePass1CheckIndexOverRenamedColumn(MergePass1Ctx *c){
-  int side, i;
-
-  for(side=0; side<2; side++){
-    SchemaEntry *aNew = side ? c->aTheirsSchema : c->aOursSchema;
-    int nNew = side ? c->nTheirsSchema : c->nOursSchema;
-    SchemaEntry *aOther = side ? c->aOursSchema : c->aTheirsSchema;
-    int nOther = side ? c->nOursSchema : c->nTheirsSchema;
-
-    for(i=0; i<nNew; i++){
-      SchemaEntry *pAncTbl;
-      SchemaEntry *pOtherTbl;
-      char *zCol = 0;
-      if( !aNew[i].zType || strcmp(aNew[i].zType, "index")!=0 ) continue;
-      if( !aNew[i].zName || !aNew[i].zSql || !aNew[i].zTblName ) continue;
-      if( findSchemaEntry(c->aAncSchema, c->nAncSchema, aNew[i].zName) ){
-        continue;
-      }
-      if( findSchemaEntry(aOther, nOther, aNew[i].zName) ) continue;
-      pAncTbl = findSchemaEntry(c->aAncSchema, c->nAncSchema, aNew[i].zTblName);
-      pOtherTbl = findSchemaEntry(aOther, nOther, aNew[i].zTblName);
-      if( !pAncTbl || !pOtherTbl ) continue;
-      if( !mergeIndexColumnRenamedAway(aNew[i].zSql, pAncTbl->zSql,
-                                       pOtherTbl->zSql, &zCol) ){
-        continue;
-      }
-      if( c->pzErrMsg ){
-        sqlite3_free(*c->pzErrMsg);
-        *c->pzErrMsg = sqlite3_mprintf(
-            "cannot merge: index '%s' covers column '%s' of table '%s', which "
-            "the other branch renamed; drop or recreate the index, then merge",
-            aNew[i].zName, zCol, aNew[i].zTblName);
-      }
-      sqlite3_free(zCol);
-      return SQLITE_ERROR;
-    }
-  }
-  return SQLITE_OK;
-}
-
 static void mergePass1FreeRowPolicy(MergeRowPolicy *pPolicy){
   sqlite3_free((void*)pPolicy->azRenameOverDrop);
   sqlite3_free((void*)pPolicy->azDualRename);
@@ -1443,6 +1275,8 @@ int mergeCatalogPass1(
 
   rc = mergePass1CheckIndexOverRenamedColumn(&c);
   if( rc==SQLITE_OK ) rc = mergePass1CheckTriggerOverRenamedTable(&c);
+  if( rc==SQLITE_OK ) rc = mergePass1CheckRowEditOfDroppedColumn(&c);
+  if( rc==SQLITE_OK ) rc = mergePass1CheckDuplicateIndexColumns(&c);
   if( rc!=SQLITE_OK ){
     mergePass1Free(&c);
     return rc;

--- a/src/doltlite_merge_pass1.c
+++ b/src/doltlite_merge_pass1.c
@@ -1248,6 +1248,7 @@ int mergeCatalogPass1(
   SchemaMergeAction **ppSchemaActions, int *pnSchemaActions,
   int bDisjointSchemaChanges,
   int bPreferOurMaster,
+  int bBranchMerge,
   char ***pazReindex, int *pnReindex
 ){
   MergePass1Ctx c;
@@ -1271,6 +1272,7 @@ int mergeCatalogPass1(
   c.ppSchemaActions = ppSchemaActions; c.pnSchemaActions = pnSchemaActions;
   c.bDisjointSchemaChanges = bDisjointSchemaChanges;
   c.bPreferOurMaster = bPreferOurMaster;
+  c.bBranchMerge = bBranchMerge;
   c.pazReindex = pazReindex; c.pnReindex = pnReindex;
 
   rc = mergePass1CheckIndexOverRenamedColumn(&c);

--- a/src/doltlite_merge_predetect.c
+++ b/src/doltlite_merge_predetect.c
@@ -1,0 +1,354 @@
+#ifdef DOLTLITE_PROLLY
+
+#include "doltlite_merge_int.h"
+
+/* Merge pre-detection: refusals decided by reading the three schemas, before
+** pass 1 walks a single entry. A merge whose correct answer this engine cannot
+** represent has to be refused here, while the branches are still intact. */
+
+/* The index's key columns, but only for the plain case: a parenthesised list of
+** bare column names with nothing after it. An expression index, a partial
+** index's WHERE clause, an explicit collation or a sort order all make two
+** indexes over the same column different things, and this reports those as not
+** plain rather than trying to compare them. Returns 0 unless every element is a
+** bare name. */
+static int mergeIndexPlainKey(const char *zSql, char ***pazCol, int *pnCol){
+  const char *zOpen, *zClose, *z;
+  char **az = 0;
+  int n = 0, i;
+
+  *pazCol = 0;
+  *pnCol = 0;
+  if( !zSql ) return 0;
+  zOpen = strchr(zSql, '(');
+  if( !zOpen ) return 0;
+  for(zClose=zOpen+1; *zClose && *zClose!=')'; zClose++){
+    /* A nested paren is a function call or a parenthesised expression. */
+    if( *zClose=='(' ) return 0;
+  }
+  if( *zClose!=')' ) return 0;
+  for(z=zClose+1; *z; z++){
+    if( !sqlite3Isspace(*z) && *z!=';' ) return 0;
+  }
+  z = zOpen + 1;
+  while( z<zClose ){
+    const char *zTok;
+    int nTok;
+    while( z<zClose && (sqlite3Isspace(*z) || *z==',') ) z++;
+    if( z>=zClose ) break;
+    zTok = z;
+    while( z<zClose && *z!=',' ) z++;
+    nTok = (int)(z-zTok);
+    while( nTok>0 && sqlite3Isspace(zTok[nTok-1]) ) nTok--;
+    if( nTok<=0 ) goto plain_key_fail;
+    for(i=0; i<nTok; i++){
+      /* Anything but one bare name -- ASC, COLLATE, a quoted form -- is not a
+      ** comparison this can make safely. */
+      if( !(sqlite3Isalnum(zTok[i]) || zTok[i]=='_' || zTok[i]=='$') ){
+        goto plain_key_fail;
+      }
+    }
+    {
+      char **azNew = sqlite3_realloc(az, (n+1)*(int)sizeof(char*));
+      if( !azNew ) goto plain_key_fail;
+      az = azNew;
+      az[n] = sqlite3_mprintf("%.*s", nTok, zTok);
+      if( !az[n] ) goto plain_key_fail;
+      n++;
+    }
+  }
+  if( n==0 ) goto plain_key_fail;
+  *pazCol = az;
+  *pnCol = n;
+  return 1;
+
+plain_key_fail:
+  for(i=0; i<n; i++) sqlite3_free(az[i]);
+  sqlite3_free(az);
+  return 0;
+}
+
+/* Two indexes whose key is the same bare columns in the same order. */
+static int mergeIndexSameKey(const char *zSqlA, const char *zSqlB){
+  char **azA = 0, **azB = 0;
+  int nA = 0, nB = 0, i, same = 0;
+
+  if( mergeIndexPlainKey(zSqlA, &azA, &nA)
+   && mergeIndexPlainKey(zSqlB, &azB, &nB)
+   && nA==nB ){
+    same = 1;
+    for(i=0; i<nA && same; i++){
+      if( sqlite3_stricmp(azA[i], azB[i])!=0 ) same = 0;
+    }
+  }
+  for(i=0; i<nA; i++) sqlite3_free(azA[i]);
+  for(i=0; i<nB; i++) sqlite3_free(azB[i]);
+  sqlite3_free(azA);
+  sqlite3_free(azB);
+  return same;
+}
+
+/* One side added an index covering the same columns as an index that already
+** existed. Dolt refuses to merge that -- "multiple indexes covering the same
+** column set cannot be merged" -- because it cannot tell which of the two the
+** merged table should keep, and keeping both would impose one side's
+** uniqueness on the other. Only a merge that also has to reconcile the other
+** branch's work reaches this; an addition on its own is the user's business. */
+int mergePass1CheckDuplicateIndexColumns(MergePass1Ctx *c){
+  int side, i, j;
+
+  for(side=0; side<2; side++){
+    SchemaEntry *aNew = side ? c->aTheirsSchema : c->aOursSchema;
+    int nNew = side ? c->nTheirsSchema : c->nOursSchema;
+
+    for(i=0; i<nNew; i++){
+      if( !aNew[i].zType || strcmp(aNew[i].zType, "index")!=0 ) continue;
+      if( !aNew[i].zName || !aNew[i].zSql || !aNew[i].zTblName ) continue;
+      if( findSchemaEntry(c->aAncSchema, c->nAncSchema, aNew[i].zName) ){
+        continue;
+      }
+      for(j=0; j<c->nAncSchema; j++){
+        SchemaEntry *pOld = &c->aAncSchema[j];
+        if( !pOld->zType || strcmp(pOld->zType, "index")!=0 ) continue;
+        if( !pOld->zName || !pOld->zSql || !pOld->zTblName ) continue;
+        if( sqlite3_stricmp(pOld->zTblName, aNew[i].zTblName)!=0 ) continue;
+        if( !mergeIndexSameKey(aNew[i].zSql, pOld->zSql) ) continue;
+        if( c->pzErrMsg ){
+          sqlite3_free(*c->pzErrMsg);
+          *c->pzErrMsg = sqlite3_mprintf(
+              "cannot merge: indexes '%s' and '%s' cover the same columns of "
+              "table '%s'; drop one of them, then merge",
+              aNew[i].zName, pOld->zName, aNew[i].zTblName);
+        }
+        return SQLITE_ERROR;
+      }
+    }
+  }
+  return SQLITE_OK;
+}
+
+/* One side dropped a column while the other edited that same column's value in
+** a row they both already had. The edit has nowhere to go in the merged table,
+** and discarding it decides for the user which branch's intent wins. Dolt
+** reports it as a conflict; refuse rather than resolve it here. Rows the other
+** side added or removed are not affected, and neither is an edit to any other
+** column. */
+int mergePass1CheckRowEditOfDroppedColumn(MergePass1Ctx *c){
+  int side, i, j;
+
+  for(side=0; side<2; side++){
+    SchemaEntry *aDrop = side ? c->aTheirsSchema : c->aOursSchema;
+    int nDrop = side ? c->nTheirsSchema : c->nOursSchema;
+    SchemaEntry *aEdit = side ? c->aOursSchema : c->aTheirsSchema;
+    int nEdit = side ? c->nOursSchema : c->nTheirsSchema;
+    struct TableEntry *aEditCat = side ? c->aOurs : c->aTheirs;
+    int nEditCat = side ? c->nOurs : c->nTheirs;
+
+    for(i=0; i<c->nAncSchema; i++){
+      const char *zTable = c->aAncSchema[i].zName;
+      SchemaEntry *pDropSe;
+      SchemaEntry *pEditSe;
+      struct TableEntry *pAncCat;
+      struct TableEntry *pEditCatEnt;
+      ParsedColumn *aAncCols = 0;
+      ParsedColumn *aDropCols = 0;
+      int nAncCols = 0, nDropCols = 0;
+
+      if( !zTable || !c->aAncSchema[i].zType ) continue;
+      if( strcmp(c->aAncSchema[i].zType, "table")!=0 ) continue;
+      pDropSe = findSchemaEntry(aDrop, nDrop, zTable);
+      pEditSe = findSchemaEntry(aEdit, nEdit, zTable);
+      if( !pDropSe || !pEditSe || !pDropSe->zSql || !pEditSe->zSql ) continue;
+      /* The editing side must have left the columns alone, or this is a schema
+      ** disagreement the schema merge already judges. */
+      if( strcmp(pEditSe->zSql, c->aAncSchema[i].zSql)!=0 ) continue;
+      if( strcmp(pDropSe->zSql, c->aAncSchema[i].zSql)==0 ) continue;
+      pAncCat = doltliteFindTableByName(c->aAnc, c->nAnc, zTable);
+      pEditCatEnt = doltliteFindTableByName(aEditCat, nEditCat, zTable);
+      if( !pAncCat || !pEditCatEnt ) continue;
+      if( prollyHashCompare(&pAncCat->root, &pEditCatEnt->root)==0 ) continue;
+      if( parseColumns(c->aAncSchema[i].zSql, &aAncCols, &nAncCols)!=SQLITE_OK ){
+        continue;
+      }
+      if( parseColumns(pDropSe->zSql, &aDropCols, &nDropCols)!=SQLITE_OK ){
+        freeColumns(aAncCols, nAncCols);
+        continue;
+      }
+      for(j=0; j<nAncCols; j++){
+        int bEdited = 0;
+        int rc;
+        if( parsedColumnIndexByName(aDropCols, nDropCols,
+                                    aAncCols[j].zName)>=0 ){
+          continue;
+        }
+        /* Renamed rather than dropped keeps its own behaviour. */
+        if( j<nDropCols
+         && parsedColumnIndexByName(aAncCols, nAncCols,
+                                    aDropCols[j].zName)<0 ){
+          continue;
+        }
+        rc = mergeRowEditsColumn(c->db, &pAncCat->root, &pEditCatEnt->root,
+                                 pAncCat->flags, pEditCatEnt->flags,
+                                 j, &bEdited);
+        if( rc!=SQLITE_OK ){
+          freeColumns(aAncCols, nAncCols);
+          freeColumns(aDropCols, nDropCols);
+          return rc;
+        }
+        if( bEdited ){
+          if( c->pzErrMsg ){
+            sqlite3_free(*c->pzErrMsg);
+            *c->pzErrMsg = sqlite3_mprintf(
+                "cannot merge: column '%s' of table '%s' was dropped on one "
+                "branch and its value changed on the other; drop the column "
+                "on both branches, or revert the change, then merge",
+                aAncCols[j].zName, zTable);
+          }
+          freeColumns(aAncCols, nAncCols);
+          freeColumns(aDropCols, nDropCols);
+          return SQLITE_ERROR;
+        }
+      }
+      freeColumns(aAncCols, nAncCols);
+      freeColumns(aDropCols, nDropCols);
+    }
+  }
+  return SQLITE_OK;
+}
+
+/* A trigger whose table the other side renamed or dropped. A trigger has to
+** resolve when the schema loads -- unlike a view, which is only text until it
+** is used -- so a merged catalog holding a trigger on a table that is no
+** longer there cannot be loaded, and the merge reported the database as
+** malformed.
+**
+** Dolt merges a rename and keeps the trigger pointing at the old name, which
+** is a dangling trigger its own information_schema cannot read. That is not a
+** result this engine can represent, so refuse and say why. A drop of the
+** table is the same hole: refuse as dropped, not as renamed. */
+int mergePass1CheckTriggerOverRenamedTable(MergePass1Ctx *c){
+  int side, i, j;
+
+  for(side=0; side<2; side++){
+    SchemaEntry *aTrig = side ? c->aTheirsSchema : c->aOursSchema;
+    int nTrig = side ? c->nTheirsSchema : c->nOursSchema;
+    SchemaEntry *aOther = side ? c->aOursSchema : c->aTheirsSchema;
+    int nOther = side ? c->nOursSchema : c->nTheirsSchema;
+
+    for(i=0; i<nTrig; i++){
+      const char *zTable = aTrig[i].zTblName;
+      int bRenamed = 0;
+      if( !aTrig[i].zType || strcmp(aTrig[i].zType, "trigger")!=0 ) continue;
+      if( !aTrig[i].zName || !zTable ) continue;
+      /* A trigger the ancestor already had went through the rename with the
+      ** table on the renaming side, so the merge has a correct copy to keep.
+      ** Only one added beside the rename has nowhere to land. */
+      if( findSchemaEntry(c->aAncSchema, c->nAncSchema, aTrig[i].zName) ){
+        continue;
+      }
+      if( !findSchemaEntry(c->aAncSchema, c->nAncSchema, zTable) ) continue;
+      if( findSchemaEntry(aOther, nOther, zTable) ) continue;
+      /* Gone from the other side under its ancestor name. A table of theirs the
+      ** ancestor never had, whose columns are the ancestor table's columns, is
+      ** that table under a new name. Dropping it and creating something
+      ** unrelated looks the same from the names alone, so the columns decide
+      ** whether this is a rename or a drop. */
+      {
+        SchemaEntry *pAncTbl = findSchemaEntry(c->aAncSchema, c->nAncSchema,
+                                               zTable);
+        ParsedColumn *aAncCols = 0;
+        int nAncCols = 0;
+        if( !pAncTbl || !pAncTbl->zSql ) continue;
+        if( parseColumns(pAncTbl->zSql, &aAncCols, &nAncCols)!=SQLITE_OK ){
+          continue;
+        }
+        for(j=0; j<nOther && !bRenamed; j++){
+          ParsedColumn *aCand = 0;
+          int nCand = 0, m, same;
+          if( !aOther[j].zType || strcmp(aOther[j].zType, "table")!=0 ) continue;
+          if( !aOther[j].zName || !aOther[j].zSql ) continue;
+          if( findSchemaEntry(c->aAncSchema, c->nAncSchema, aOther[j].zName) ){
+            continue;
+          }
+          if( parseColumns(aOther[j].zSql, &aCand, &nCand)!=SQLITE_OK ) continue;
+          same = nCand==nAncCols;
+          for(m=0; m<nCand && same; m++){
+            if( sqlite3_stricmp(aCand[m].zName, aAncCols[m].zName)!=0
+             || !parsedColumnDefinitionsMatch(&aCand[m], &aAncCols[m]) ){
+              same = 0;
+            }
+          }
+          freeColumns(aCand, nCand);
+          if( same ) bRenamed = 1;
+        }
+        freeColumns(aAncCols, nAncCols);
+      }
+      if( c->pzErrMsg ){
+        sqlite3_free(*c->pzErrMsg);
+        if( bRenamed ){
+          *c->pzErrMsg = sqlite3_mprintf(
+              "cannot merge: trigger '%s' runs on table '%s', which the other "
+              "branch renamed; drop or recreate the trigger, then merge",
+              aTrig[i].zName, zTable);
+        }else{
+          *c->pzErrMsg = sqlite3_mprintf(
+              "cannot merge: trigger '%s' runs on table '%s', which the other "
+              "branch dropped; drop or recreate the trigger, then merge",
+              aTrig[i].zName, zTable);
+        }
+      }
+      return SQLITE_ERROR;
+    }
+  }
+  return SQLITE_OK;
+}
+
+/* An index one side added over a column the other side renamed. Nothing here
+** retargets the index to the new name, and a merged catalog naming a column
+** its table does not have cannot be loaded at all -- the merge used to report
+** the database as corrupt. Refuse it instead, the way a primary-key change is
+** refused, and say why.
+**
+** This is a deliberate divergence from Dolt, which merges these and keeps the
+** index on the renamed column. */
+int mergePass1CheckIndexOverRenamedColumn(MergePass1Ctx *c){
+  int side, i;
+
+  for(side=0; side<2; side++){
+    SchemaEntry *aNew = side ? c->aTheirsSchema : c->aOursSchema;
+    int nNew = side ? c->nTheirsSchema : c->nOursSchema;
+    SchemaEntry *aOther = side ? c->aOursSchema : c->aTheirsSchema;
+    int nOther = side ? c->nOursSchema : c->nTheirsSchema;
+
+    for(i=0; i<nNew; i++){
+      SchemaEntry *pAncTbl;
+      SchemaEntry *pOtherTbl;
+      char *zCol = 0;
+      if( !aNew[i].zType || strcmp(aNew[i].zType, "index")!=0 ) continue;
+      if( !aNew[i].zName || !aNew[i].zSql || !aNew[i].zTblName ) continue;
+      if( findSchemaEntry(c->aAncSchema, c->nAncSchema, aNew[i].zName) ){
+        continue;
+      }
+      if( findSchemaEntry(aOther, nOther, aNew[i].zName) ) continue;
+      pAncTbl = findSchemaEntry(c->aAncSchema, c->nAncSchema, aNew[i].zTblName);
+      pOtherTbl = findSchemaEntry(aOther, nOther, aNew[i].zTblName);
+      if( !pAncTbl || !pOtherTbl ) continue;
+      if( !mergeIndexColumnRenamedAway(aNew[i].zSql, pAncTbl->zSql,
+                                       pOtherTbl->zSql, &zCol) ){
+        continue;
+      }
+      if( c->pzErrMsg ){
+        sqlite3_free(*c->pzErrMsg);
+        *c->pzErrMsg = sqlite3_mprintf(
+            "cannot merge: index '%s' covers column '%s' of table '%s', which "
+            "the other branch renamed; drop or recreate the index, then merge",
+            aNew[i].zName, zCol, aNew[i].zTblName);
+      }
+      sqlite3_free(zCol);
+      return SQLITE_ERROR;
+    }
+  }
+  return SQLITE_OK;
+}
+
+#endif /* DOLTLITE_PROLLY */

--- a/src/doltlite_merge_predetect.c
+++ b/src/doltlite_merge_predetect.c
@@ -97,6 +97,12 @@ static int mergeIndexSameKey(const char *zSqlA, const char *zSqlB){
 int mergePass1CheckDuplicateIndexColumns(MergePass1Ctx *c){
   int side, i, j;
 
+  /* A merge only. Reverting, cherry-picking or rebasing a commit has one
+  ** intended result, and the branch it replays onto asked for it, so there is
+  ** no disagreement here to hand back. Refusing would also reject restoring a
+  ** state the branch held before. */
+  if( !c->bBranchMerge ) return SQLITE_OK;
+
   for(side=0; side<2; side++){
     SchemaEntry *aNew = side ? c->aTheirsSchema : c->aOursSchema;
     int nNew = side ? c->nTheirsSchema : c->nOursSchema;
@@ -142,6 +148,12 @@ int mergePass1CheckDuplicateIndexColumns(MergePass1Ctx *c){
 ** column. */
 int mergePass1CheckRowEditOfDroppedColumn(MergePass1Ctx *c){
   int side, i, j;
+
+  /* A merge only. Reverting, cherry-picking or rebasing a commit has one
+  ** intended result, and the branch it replays onto asked for it, so there is
+  ** no disagreement here to hand back. Refusing would also reject restoring a
+  ** state the branch held before. */
+  if( !c->bBranchMerge ) return SQLITE_OK;
 
   for(side=0; side<2; side++){
     SchemaEntry *aDrop = side ? c->aTheirsSchema : c->aOursSchema;

--- a/src/doltlite_merge_predetect.c
+++ b/src/doltlite_merge_predetect.c
@@ -100,6 +100,8 @@ int mergePass1CheckDuplicateIndexColumns(MergePass1Ctx *c){
   for(side=0; side<2; side++){
     SchemaEntry *aNew = side ? c->aTheirsSchema : c->aOursSchema;
     int nNew = side ? c->nTheirsSchema : c->nOursSchema;
+    SchemaEntry *aOther = side ? c->aOursSchema : c->aTheirsSchema;
+    int nOther = side ? c->nOursSchema : c->nTheirsSchema;
 
     for(i=0; i<nNew; i++){
       if( !aNew[i].zType || strcmp(aNew[i].zType, "index")!=0 ) continue;
@@ -112,6 +114,11 @@ int mergePass1CheckDuplicateIndexColumns(MergePass1Ctx *c){
         if( !pOld->zType || strcmp(pOld->zType, "index")!=0 ) continue;
         if( !pOld->zName || !pOld->zSql || !pOld->zTblName ) continue;
         if( sqlite3_stricmp(pOld->zTblName, aNew[i].zTblName)!=0 ) continue;
+        /* Only a merge that keeps both of them duplicates anything. A side that
+        ** dropped the older index replaced it rather than doubling it, and the
+        ** drop carries into the merge, so there is nothing to refuse. */
+        if( !findSchemaEntry(aNew, nNew, pOld->zName) ) continue;
+        if( !findSchemaEntry(aOther, nOther, pOld->zName) ) continue;
         if( !mergeIndexSameKey(aNew[i].zSql, pOld->zSql) ) continue;
         if( c->pzErrMsg ){
           sqlite3_free(*c->pzErrMsg);

--- a/src/doltlite_merge_rows.c
+++ b/src/doltlite_merge_rows.c
@@ -1152,6 +1152,62 @@ static int rowMergeCallback(void *pCtx, const ThreeWayChange *pChange){
   return rc;
 }
 
+/* Did the other side change this column's value in a row that already existed?
+** Dropping a column and editing that same column's value on another branch is
+** a cell-level modify-versus-delete, which Dolt reports as a conflict. Rows
+** the other side added or removed do not count, and neither does an edit to
+** any other column, so the comparison has to be per row and per field. */
+int mergeRowEditsColumn(
+  sqlite3 *db,
+  const ProllyHash *pAncRoot,
+  const ProllyHash *pOtherRoot,
+  u8 ancFlags,
+  u8 otherFlags,
+  int iField,
+  int *pbEdited
+){
+  ChunkStore *cs = doltliteGetChunkStore(db);
+  ProllyCache *pCache = doltliteGetCache(db);
+  ProllyDiffIter iter;
+  ProllyDiffChange *pChange = 0;
+  int rc;
+
+  *pbEdited = 0;
+  if( !cs || !pCache || iField<0 ) return SQLITE_OK;
+  if( prollyHashIsEmpty(pAncRoot) || prollyHashIsEmpty(pOtherRoot) ){
+    return SQLITE_OK;
+  }
+  memset(&iter, 0, sizeof(iter));
+  rc = prollyDiffIterOpen(&iter, cs, pCache, pAncRoot, pOtherRoot,
+                          ancFlags, otherFlags);
+  if( rc!=SQLITE_OK ) return rc;
+
+  while( (rc = prollyDiffIterStep(&iter, &pChange))==SQLITE_ROW ){
+    RecField *aOld = 0;
+    RecField *aNew = 0;
+    int nOld = 0, nNew = 0;
+    if( pChange->type!=PROLLY_DIFF_MODIFY ) continue;
+    if( !pChange->pOldVal || !pChange->pNewVal ) continue;
+    if( parseRecordFields(pChange->pOldVal, pChange->nOldVal, &aOld, &nOld)<0 ){
+      continue;
+    }
+    if( parseRecordFields(pChange->pNewVal, pChange->nNewVal, &aNew, &nNew)<0 ){
+      sqlite3_free(aOld);
+      continue;
+    }
+    if( iField<nOld && iField<nNew
+     && fieldEquals(pChange->pOldVal, &aOld[iField],
+                    pChange->pNewVal, &aNew[iField])!=0 ){
+      *pbEdited = 1;
+    }
+    sqlite3_free(aOld);
+    sqlite3_free(aNew);
+    if( *pbEdited ) break;
+  }
+  prollyDiffIterClose(&iter);
+  return rc==SQLITE_ROW || rc==SQLITE_DONE ? SQLITE_OK : rc;
+}
+
 int canFastMerge(
   sqlite3 *db,
   const char *zName,

--- a/src/doltlite_rebase.c
+++ b/src/doltlite_rebase.c
@@ -997,7 +997,7 @@ static int rebaseApplyPlanRowCatalog(
     int nReindex = 0;
     rc = doltliteMergeCatalogs(db, &parentC.catalogHash, pCurCat,
                                &replayC.catalogHash, pMergedCat,
-                               &nConflicts, 0, 0, 0, 0,
+                               &nConflicts, 0, 0, 0, 0, 0,
                                &azReindex, &nReindex, 0, 0);
     if( rc==SQLITE_OK && nConflicts==0 ){
       rc = doltliteSwitchCatalog(db, pMergedCat);

--- a/test/doltlite_schema_merge.sh
+++ b/test/doltlite_schema_merge.sh
@@ -1836,6 +1836,26 @@ run_test_match "merge_duplicate_index_columns_refused" "SELECT dolt_merge('feat'
   "indexes 'ia' and 'ix0' cover the same columns of table 't'" "$DB"
 rm -f "$DB"
 
+# The duplicate-index and dropped-column refusals are Dolt's judgement about a
+# merge of two branches. A revert replays one commit onto the branch that asked
+# for it, with one intended result, so they must not fire there -- and must not
+# reject restoring a state the branch held before.
+DB=/tmp/test_revert_restores_dup_index_$$.db; rm -f "$DB"
+cat <<'EOF' | $DOLTLITE "$DB" > /dev/null 2>&1
+CREATE TABLE t(k INTEGER PRIMARY KEY, c TEXT);
+CREATE INDEX iA ON t(c);
+CREATE INDEX iB ON t(c);
+INSERT INTO t VALUES(1,'x');
+SELECT dolt_commit('-Am','base holds two indexes over c');
+DROP INDEX iA;
+SELECT dolt_commit('-Am','drop iA');
+EOF
+run_test_match "revert_restoring_same_key_index_hash" "SELECT dolt_revert('HEAD');" \
+  "^[0-9a-f]{40}$" "$DB"
+run_test "revert_restoring_same_key_index_objects" \
+  "SELECT group_concat(name) FROM sqlite_master WHERE type='index';" "iA,iB" "$DB"
+rm -f "$DB"
+
 # Replacing an index rather than doubling it: the same side drops the older
 # index and adds one over the same column, so the merge keeps a single index and
 # has nothing to refuse. Dolt merges this and keeps the new index.

--- a/test/doltlite_schema_merge.sh
+++ b/test/doltlite_schema_merge.sh
@@ -1762,5 +1762,100 @@ run_test_match "merge_trigger_over_dropped_table_no_replacement_refused" \
 run_test "merge_trigger_over_dropped_table_no_replacement_integrity" \
   "PRAGMA integrity_check;" "ok" "$DB"
 rm -f "$DB"
+# One side drops a column while the other edits that same column's value in a
+# row they both already had. The edit cannot land in the merged table, and
+# discarding it silently decides which branch's intent wins, so refuse -- which
+# is what Dolt does. The rule is per row and per column: an edit to another
+# column, an inserted row carrying a value, and a deleted row all still merge.
+for dir in ours theirs; do
+  DB=/tmp/test_merge_drop_vs_edit_${dir}_$$.db; rm -f "$DB"
+  if [ "$dir" = ours ]; then
+    MAIN="ALTER TABLE t DROP COLUMN b;"; FEAT="UPDATE t SET b='edit' WHERE k=1;"
+  else
+    MAIN="UPDATE t SET b='edit' WHERE k=1;"; FEAT="ALTER TABLE t DROP COLUMN b;"
+  fi
+  cat <<EOF | $DOLTLITE "$DB" > /dev/null 2>&1
+CREATE TABLE t(k INTEGER PRIMARY KEY, a TEXT, b TEXT, n INTEGER);
+INSERT INTO t VALUES(1,'a1','b1',11),(2,'a2','b2',22);
+SELECT dolt_commit('-A','-m','base');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+$FEAT
+SELECT dolt_commit('-Am','feat side');
+SELECT dolt_checkout('main');
+$MAIN
+SELECT dolt_commit('-Am','main side');
+EOF
+  run_test_match "merge_drop_vs_edit_of_that_column_${dir}_refused" \
+    "SELECT dolt_merge('feat');" \
+    "column 'b' of table 't' was dropped on one branch and its value changed" "$DB"
+  run_test "merge_drop_vs_edit_of_that_column_${dir}_integrity" \
+    "PRAGMA integrity_check;" "ok" "$DB"
+  rm -f "$DB"
+done
+
+# Everything the rule must leave alone.
+for theirs in "UPDATE t SET n=99 WHERE k=1;" "UPDATE t SET a='edit' WHERE k=1;" \
+              "INSERT INTO t VALUES(9,'a9','b9',99);" "DELETE FROM t WHERE k=1;"; do
+  DB=/tmp/test_merge_drop_vs_other_$$.db; rm -f "$DB"
+  cat <<EOF | $DOLTLITE "$DB" > /dev/null 2>&1
+CREATE TABLE t(k INTEGER PRIMARY KEY, a TEXT, b TEXT, n INTEGER);
+INSERT INTO t VALUES(1,'a1','b1',11),(2,'a2','b2',22);
+SELECT dolt_commit('-A','-m','base');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+$theirs
+SELECT dolt_commit('-Am','feat side');
+SELECT dolt_checkout('main');
+ALTER TABLE t DROP COLUMN b;
+SELECT dolt_commit('-Am','main drops b');
+EOF
+  run_test_match "merge_drop_vs_unrelated_change_merges" "SELECT dolt_merge('feat');" \
+    "^[0-9a-f]{40}$" "$DB"
+  rm -f "$DB"
+done
+
+# An index added over the columns an existing index already covers. Dolt refuses
+# it -- "multiple indexes covering the same column set cannot be merged" -- and
+# keeping both would impose one side's uniqueness on the other, so refuse too.
+DB=/tmp/test_merge_dup_index_$$.db; rm -f "$DB"
+cat <<'EOF' | $DOLTLITE "$DB" > /dev/null 2>&1
+CREATE TABLE t(k INTEGER PRIMARY KEY, a TEXT, b TEXT, n INTEGER);
+CREATE INDEX ix0 ON t(a);
+INSERT INTO t VALUES(1,'a1','b1',11);
+SELECT dolt_commit('-A','-m','base');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+ALTER TABLE t DROP COLUMN b;
+SELECT dolt_commit('-Am','feat drops b');
+SELECT dolt_checkout('main');
+CREATE INDEX ia ON t(a);
+SELECT dolt_commit('-Am','main duplicates the index');
+EOF
+run_test_match "merge_duplicate_index_columns_refused" "SELECT dolt_merge('feat');" \
+  "indexes 'ia' and 'ix0' cover the same columns of table 't'" "$DB"
+rm -f "$DB"
+
+# An index over a column nothing else indexes is not affected.
+DB=/tmp/test_merge_new_index_ok_$$.db; rm -f "$DB"
+cat <<'EOF' | $DOLTLITE "$DB" > /dev/null 2>&1
+CREATE TABLE t(k INTEGER PRIMARY KEY, a TEXT, b TEXT, n INTEGER);
+CREATE INDEX ix0 ON t(a);
+INSERT INTO t VALUES(1,'a1','b1',11);
+SELECT dolt_commit('-A','-m','base');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+ALTER TABLE t DROP COLUMN b;
+SELECT dolt_commit('-Am','feat drops b');
+SELECT dolt_checkout('main');
+CREATE INDEX ic ON t(n);
+SELECT dolt_commit('-Am','main indexes n');
+EOF
+run_test_match "merge_new_index_other_column_merges" "SELECT dolt_merge('feat');" \
+  "^[0-9a-f]{40}$" "$DB"
+run_test "merge_new_index_other_column_keeps_both" \
+  "SELECT group_concat(name) FROM (SELECT name FROM sqlite_master WHERE type='index' ORDER BY name);" \
+  "ic,ix0" "$DB"
+rm -f "$DB"
 
 dltest_finish

--- a/test/doltlite_schema_merge.sh
+++ b/test/doltlite_schema_merge.sh
@@ -1836,6 +1836,30 @@ run_test_match "merge_duplicate_index_columns_refused" "SELECT dolt_merge('feat'
   "indexes 'ia' and 'ix0' cover the same columns of table 't'" "$DB"
 rm -f "$DB"
 
+# Replacing an index rather than doubling it: the same side drops the older
+# index and adds one over the same column, so the merge keeps a single index and
+# has nothing to refuse. Dolt merges this and keeps the new index.
+DB=/tmp/test_merge_replace_index_$$.db; rm -f "$DB"
+cat <<'EOF' | $DOLTLITE "$DB" > /dev/null 2>&1
+CREATE TABLE t(k INTEGER PRIMARY KEY, a TEXT, b TEXT);
+CREATE INDEX ix0 ON t(a);
+INSERT INTO t VALUES(1,'a1','b1');
+SELECT dolt_commit('-Am','base');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+DROP INDEX ix0;
+CREATE INDEX ix_new ON t(a);
+SELECT dolt_commit('-Am','feat replaces the index');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES(2,'a2','b2');
+SELECT dolt_commit('-Am','main adds a row');
+EOF
+run_test_match "merge_index_replaced_not_duplicated_hash" "SELECT dolt_merge('feat');" \
+  "^[0-9a-f]{40}$" "$DB"
+run_test "merge_index_replaced_not_duplicated_objects" \
+  "SELECT group_concat(name) FROM sqlite_master WHERE type='index';" "ix_new" "$DB"
+rm -f "$DB"
+
 # An index over a column nothing else indexes is not affected.
 DB=/tmp/test_merge_new_index_ok_$$.db; rm -f "$DB"
 cat <<'EOF' | $DOLTLITE "$DB" > /dev/null 2>&1

--- a/test/lint_layers.sh
+++ b/test/lint_layers.sh
@@ -104,6 +104,7 @@ for f in \
   "$SRCDIR"/doltlite_merge.c \
   "$SRCDIR"/doltlite_merge_pass1.c \
   "$SRCDIR"/doltlite_merge_pass2.c \
+  "$SRCDIR"/doltlite_merge_predetect.c \
   "$SRCDIR"/doltlite_merge_rows.c \
   "$SRCDIR"/doltlite_merge_schema.c
 do

--- a/test/vc_oracle_correct_schema_merge_matrix_test.sh
+++ b/test/vc_oracle_correct_schema_merge_matrix_test.sh
@@ -43,12 +43,6 @@ ren_tbl:trig:Dolt keeps a trigger on the old table name, which no loadable catal
 # produce. Every entry here is a bug to fix by refusing, not a difference to
 # keep, and the suite prints them as gaps rather than passes.
 MERGE_WHERE_DOLT_REFUSES="
-drop_b:rows:a row edit of a column the other branch dropped (#2306)
-rows:drop_b:a row edit of a column the other branch dropped (#2306)
-idx_a:drop_b_with_index:adding an index while they drop a column, table already indexed (#2311)
-drop_b_with_index:idx_a:adding an index while they drop a column, table already indexed (#2311)
-rows:drop_b_with_index:a row edit of a column the other branch dropped, table indexed (#2306)
-drop_b_with_index:rows:a row edit of a column the other branch dropped, table indexed (#2306)
 "
 
 # Pairs that still fail with "database disk image is malformed" -- a report of

--- a/test/vc_stateful_fuzzer.py
+++ b/test/vc_stateful_fuzzer.py
@@ -546,8 +546,15 @@ def merge_branch(doltlite, db_path, branches, model, rng):
         "merge_%s_into_%s" % (source, target),
         timeout=30,
         # An autocommit merge that conflicts is rolled back whole, so the model
-        # below still matches: the target keeps the state it had before.
-        allowed_errors=("cannot merge: conflicts detected",),
+        # below still matches: the target keeps the state it had before. The
+        # refusals below are the same outcome by a different route -- Dolt
+        # reports each of these shapes as a conflict and rolls the merge back,
+        # and so do we, rather than resolving them on the user's behalf.
+        allowed_errors=(
+            "cannot merge: conflicts detected",
+            "cover the same columns of table",
+            "was dropped on one branch and its value changed",
+        ),
     )
     sync_vc_result(doltlite, db_path, target, model)
 

--- a/tool/mksqlite3c.tcl
+++ b/tool/mksqlite3c.tcl
@@ -838,7 +838,7 @@ proc emit_doltlite_engine_block {} {
     doltlite_commit.c doltlite_ref.c doltlite_log.c
     doltlite_commit_ancestors.c doltlite_status.c doltlite_merge_status.c doltlite_diff.c doltlite_diff_table.c
     doltlite_workspace.c
-    doltlite_branch.c doltlite_branches.c doltlite_checkout.c doltlite_tag.c doltlite_ancestor.c doltlite_merge.c doltlite_merge_pass1.c doltlite_merge_pass2.c doltlite_merge_rows.c doltlite_merge_schema.c
+    doltlite_branch.c doltlite_branches.c doltlite_checkout.c doltlite_tag.c doltlite_ancestor.c doltlite_merge.c doltlite_merge_pass1.c doltlite_merge_pass2.c doltlite_merge_predetect.c doltlite_merge_rows.c doltlite_merge_schema.c
     doltlite_conflicts.c doltlite_gc.c doltlite_chunk_walk.c
     doltlite_history.c doltlite_at.c doltlite_blame.c doltlite_schema_diff.c doltlite_patch.c
     doltlite_schemas.c doltlite_diff_stat.c doltlite_record.c doltlite_ignore.c


### PR DESCRIPTION
Closes #2306. Closes #2311.

Two merges that DoltLite resolves today and Dolt refuses. Merging them decides on the user's behalf a disagreement Dolt gives back to them, so our answer is one Dolt would never produce. Both are shipped as refusals, which takes the schema merge matrix to **176 passed, 0 gaps, 0 differing, 0 corrupting** — every comparable ours×theirs pair now either reproduces Dolt or refuses.

Combined into one PR to spend a single CI run; they are adjacent refusals in the same module and share the matrix's gap list.

### Row edit of a dropped column (#2306)

One branch drops a column, the other changes that same column's value in a row they both already had. That is a cell-level modify-versus-delete: the edit has nowhere to land, and discarding it silently picks a winner.

The rule is per row and per column, so `mergeRowEditsColumn` walks the ancestor→other diff and compares only the dropped column's field on `MODIFY` rows. Verified against Dolt on all eight cases — an edit to a *different* column, an inserted row carrying a value, and a deleted row all still merge.

### Duplicate index columns (#2311)

One branch adds an index covering the columns an existing index already covers. Dolt refuses: *"multiple indexes covering the same column set cannot be merged"* — it cannot tell which the merged table should keep, and keeping both imposes one side's uniqueness on the other.

Comparison is on the index key alone, and only when both keys are a plain list of bare column names. An expression index, a partial index, a collation or a sort order make two indexes over the same column different things, and those are left to merge.

This part is deliberately narrow: comparing by *shared column name* instead — reusing the existing `mergeIndexColumnsOverlap` — refuses a merge that adds an index on `e` to a table that already has one on `abs(e)`, because that helper skips function names and scans past the closing paren. It is built for "does this index mention column X" (rename/drop detection, where over-inclusion is safe) and is wrong for this question. Caught by `doltlite_index_vc_matrix.sh`.

Being strict about "plain key" means a shape like `t(a ASC)` versus `t(a)` will still merge where Dolt refuses. That errs toward today's behaviour rather than toward a wrong refusal.

### Module split

The four pre-detection refusals move to `src/doltlite_merge_predetect.c`. They run before pass 1 walks a single entry, which is a different job from the walk, and pass 1 was at 1480 of its 1500-line cap with no room to grow. Their shared state moves to the internal header. `doltlite_merge_predetect.c` is added to the capped list in `lint_layers.sh` so the new module is held to the same limit.

### Testing

- `doltlite_schema_merge.sh` — 274 pass (11 new, covering both refusals and the merges they must not catch)
- `vc_oracle_correct_schema_merge_matrix_test.sh` — 176 passed, 0 failed, 0 gaps, 0 differing, 0 corrupting
- `run_doltlite_tests.sh` — 110/110 suites
- amalgamation regenerated and compiled clean (new file in the concatenation)
- `lint_layers.sh` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)