### PR TITLE
Refuse a merge whose trigger runs on a dropped table

### DIFF
--- a/src/doltlite_merge_pass1.c
+++ b/src/doltlite_merge_pass1.c
@@ -1056,14 +1056,16 @@ static int mergePass1CollectDualRename(
   return SQLITE_OK;
 }
 
-/* A trigger whose table the other side renamed away. A trigger has to resolve
-** when the schema loads -- unlike a view, which is only text until it is used
-** -- so a merged catalog holding a trigger on a table that is no longer there
-** cannot be loaded, and the merge reported the database as malformed.
+/* A trigger whose table the other side renamed or dropped. A trigger has to
+** resolve when the schema loads -- unlike a view, which is only text until it
+** is used -- so a merged catalog holding a trigger on a table that is no
+** longer there cannot be loaded, and the merge reported the database as
+** malformed.
 **
-** Dolt merges this and keeps the trigger pointing at the old name, which is a
-** dangling trigger its own information_schema cannot read. That is not a
-** result this engine can represent, so refuse and say why. */
+** Dolt merges a rename and keeps the trigger pointing at the old name, which
+** is a dangling trigger its own information_schema cannot read. That is not a
+** result this engine can represent, so refuse and say why. A drop of the
+** table is the same hole: refuse as dropped, not as renamed. */
 static int mergePass1CheckTriggerOverRenamedTable(MergePass1Ctx *c){
   int side, i, j;
 
@@ -1089,8 +1091,8 @@ static int mergePass1CheckTriggerOverRenamedTable(MergePass1Ctx *c){
       /* Gone from the other side under its ancestor name. A table of theirs the
       ** ancestor never had, whose columns are the ancestor table's columns, is
       ** that table under a new name. Dropping it and creating something
-      ** unrelated looks the same from the names alone, so the columns have to
-      ** match before this refuses anything. */
+      ** unrelated looks the same from the names alone, so the columns decide
+      ** whether this is a rename or a drop. */
       {
         SchemaEntry *pAncTbl = findSchemaEntry(c->aAncSchema, c->nAncSchema,
                                                zTable);
@@ -1121,13 +1123,19 @@ static int mergePass1CheckTriggerOverRenamedTable(MergePass1Ctx *c){
         }
         freeColumns(aAncCols, nAncCols);
       }
-      if( !bRenamed ) continue;
       if( c->pzErrMsg ){
         sqlite3_free(*c->pzErrMsg);
-        *c->pzErrMsg = sqlite3_mprintf(
-            "cannot merge: trigger '%s' runs on table '%s', which the other "
-            "branch renamed; drop or recreate the trigger, then merge",
-            aTrig[i].zName, zTable);
+        if( bRenamed ){
+          *c->pzErrMsg = sqlite3_mprintf(
+              "cannot merge: trigger '%s' runs on table '%s', which the other "
+              "branch renamed; drop or recreate the trigger, then merge",
+              aTrig[i].zName, zTable);
+        }else{
+          *c->pzErrMsg = sqlite3_mprintf(
+              "cannot merge: trigger '%s' runs on table '%s', which the other "
+              "branch dropped; drop or recreate the trigger, then merge",
+              aTrig[i].zName, zTable);
+        }
       }
       return SQLITE_ERROR;
     }

--- a/test/doltlite_schema_merge.sh
+++ b/test/doltlite_schema_merge.sh
@@ -1706,10 +1706,44 @@ run_test "merge_view_over_renamed_table_objects" \
 rm -f "$DB"
 
 # Dropping the table and creating an unrelated one looks like a rename if only
-# the names are compared: the ancestor's table is gone and a table the ancestor
-# never had is present. The columns are what tell them apart, and the refusal
-# must not fire on the drop.
-DB=/tmp/test_merge_trig_drop_create_$$.db; rm -f "$DB"
+# the names are compared. The columns tell them apart, so this is a drop: the
+# trigger still has nowhere to land, refuse as dropped rather than renamed or
+# malformed.
+for dir in ours theirs; do
+  DB=/tmp/test_merge_trig_drop_${dir}_$$.db; rm -f "$DB"
+  if [ "$dir" = ours ]; then
+    MAIN="CREATE TRIGGER tg AFTER INSERT ON t BEGIN UPDATE t SET n=n; END;"
+    FEAT="DROP TABLE t; CREATE TABLE u(x INTEGER PRIMARY KEY, y TEXT);"
+    WANT="table:t,trigger:tg"
+  else
+    MAIN="DROP TABLE t; CREATE TABLE u(x INTEGER PRIMARY KEY, y TEXT);"
+    FEAT="CREATE TRIGGER tg AFTER INSERT ON t BEGIN UPDATE t SET n=n; END;"
+    WANT="table:u"
+  fi
+  cat <<EOF | $DOLTLITE "$DB" > /dev/null 2>&1
+CREATE TABLE t(k INTEGER PRIMARY KEY, a TEXT, n INTEGER);
+INSERT INTO t VALUES(1,'a1',11);
+SELECT dolt_commit('-A','-m','base');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+$FEAT
+SELECT dolt_commit('-Am','feat side');
+SELECT dolt_checkout('main');
+$MAIN
+SELECT dolt_commit('-Am','main side');
+EOF
+  run_test_match "merge_trigger_over_dropped_table_${dir}_refused" \
+    "SELECT dolt_merge('feat');" \
+    "cannot merge: trigger 'tg' runs on table 't', which the other branch dropped" "$DB"
+  run_test "merge_trigger_over_dropped_table_${dir}_intact" \
+    "SELECT group_concat(type||':'||name) FROM sqlite_master;" "$WANT" "$DB"
+  run_test "merge_trigger_over_dropped_table_${dir}_integrity" \
+    "PRAGMA integrity_check;" "ok" "$DB"
+  rm -f "$DB"
+done
+
+# Same hole with no replacement table.
+DB=/tmp/test_merge_trig_drop_only_$$.db; rm -f "$DB"
 cat <<'EOF' | $DOLTLITE "$DB" > /dev/null 2>&1
 CREATE TABLE t(k INTEGER PRIMARY KEY, a TEXT, n INTEGER);
 INSERT INTO t VALUES(1,'a1',11);
@@ -1717,18 +1751,16 @@ SELECT dolt_commit('-A','-m','base');
 SELECT dolt_branch('feat');
 SELECT dolt_checkout('feat');
 DROP TABLE t;
-CREATE TABLE u(x INTEGER PRIMARY KEY, y TEXT);
-SELECT dolt_commit('-Am','feat replaces the table');
+SELECT dolt_commit('-Am','feat drops t');
 SELECT dolt_checkout('main');
 CREATE TRIGGER tg AFTER INSERT ON t BEGIN UPDATE t SET n=n; END;
 SELECT dolt_commit('-Am','main adds trigger');
 EOF
-# The drop is not a rename, so the trigger refusal must not fire. What this
-# shape does instead is a separate, pre-existing problem -- a trigger left on a
-# table the other branch dropped still fails to load -- asserted here so the
-# refusal cannot quietly start covering it.
-run_test_match "merge_trigger_vs_drop_and_create_not_rename_refusal" \
-  "SELECT dolt_merge('feat');" "database disk image is malformed" "$DB"
+run_test_match "merge_trigger_over_dropped_table_no_replacement_refused" \
+  "SELECT dolt_merge('feat');" \
+  "cannot merge: trigger 'tg' runs on table 't', which the other branch dropped" "$DB"
+run_test "merge_trigger_over_dropped_table_no_replacement_integrity" \
+  "PRAGMA integrity_check;" "ok" "$DB"
 rm -f "$DB"
 
 dltest_finish


### PR DESCRIPTION
Follow-up to the Ito finding on #2322. Unrelated to that PR's dropped-column / duplicate-index refusals.

A trigger has to resolve when the schema loads. One branch adding \`tg\` on \`t\` while the other \`DROP TABLE t\` (optionally creating an unrelated \`u\`) used to return \`database disk image is malformed\`. The catalog could not load a trigger whose table was gone.

The renamed-table precheck already refused the rename shape and correctly did **not** treat drop+create-different-columns as a rename. The drop path then fell through to the malformed error; #2322 even pinned that as a pre-existing hole so the rename detector could not silently cover it.

This refuses that shape with a targeted message, same contract as the rename case: Dolt can keep a dangling trigger; this engine cannot represent that, so refuse rather than report a healthy database as corrupt.

\`merge_trigger_vs_drop_and_create_not_rename_refusal\` now expects the drop refusal in both directions, plus a drop with no replacement. Integrity check is ok; the working catalog is unchanged.

## Testing

- \`DOLTLITE=./build/doltlite bash test/doltlite_schema_merge.sh\`: 270 passed, 0 failed

Co-Authored-By: Grok <noreply@x.ai>