### PR TITLE
Let the vc fuzzer accept merge refusals on pull

### DIFF
--- a/test/doltlite_schema_merge.sh
+++ b/test/doltlite_schema_merge.sh
@@ -1836,6 +1836,35 @@ run_test_match "merge_duplicate_index_columns_refused" "SELECT dolt_merge('feat'
   "indexes 'ia' and 'ix0' cover the same columns of table 't'" "$DB"
 rm -f "$DB"
 
+# Same refusal through dolt_pull: the branches diverged after a push, and pull's
+# merge half has to roll back rather than keep both indexes.
+DB=/tmp/test_pull_dup_index_$$.db
+REMOTE=/tmp/test_pull_dup_index_remote_$$.db
+rm -f "$DB" "$REMOTE"
+cat <<EOF | $DOLTLITE "$DB" > /dev/null 2>&1
+CREATE TABLE t(k INTEGER PRIMARY KEY, a TEXT, b TEXT, n INTEGER);
+CREATE INDEX ix0 ON t(a);
+INSERT INTO t VALUES(1,'a1','b1',11);
+SELECT dolt_commit('-A','-m','base');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+CREATE INDEX ia ON t(a);
+SELECT dolt_commit('-Am','feat duplicates the index');
+SELECT dolt_remote('add','origin','file://$REMOTE');
+SELECT dolt_push('origin','feat');
+SELECT dolt_reset('--hard','HEAD~1');
+ALTER TABLE t DROP COLUMN b;
+SELECT dolt_commit('-Am','feat drops b after reset');
+EOF
+run_test_match "pull_duplicate_index_columns_refused" \
+  "SELECT dolt_pull('origin','feat');" \
+  "indexes 'ia' and 'ix0' cover the same columns of table 't'" "$DB/feat"
+run_test "pull_duplicate_index_columns_integrity" \
+  "PRAGMA integrity_check;" "ok" "$DB/feat"
+run_test "pull_duplicate_index_columns_rolled_back" \
+  "SELECT group_concat(name) FROM sqlite_master WHERE type='index';" "ix0" "$DB/feat"
+rm -f "$DB" "$REMOTE"
+
 # The duplicate-index and dropped-column refusals are Dolt's judgement about a
 # merge of two branches. A revert replays one commit onto the branch that asked
 # for it, with one intended result, so they must not fire there -- and must not

--- a/test/vc_stateful_fuzzer.py
+++ b/test/vc_stateful_fuzzer.py
@@ -7,6 +7,12 @@ import sys
 import tempfile
 import time
 
+# Autocommit merge refusals roll the merge back whole, so the in-memory
+# model still matches. dolt_pull's merge half is the same outcome. Every
+# such message -- conflicts, duplicate-index, dropped-column-vs-edit,
+# trigger-over-renamed/dropped-table -- starts with this prefix.
+MERGE_ROLLED_BACK = ("cannot merge:",)
+
 
 def sql_quote(s):
     return "'" + s.replace("'", "''") + "'"
@@ -545,16 +551,7 @@ def merge_branch(doltlite, db_path, branches, model, rng):
         "SELECT dolt_merge(%s);" % sql_quote(source),
         "merge_%s_into_%s" % (source, target),
         timeout=30,
-        # An autocommit merge that conflicts is rolled back whole, so the model
-        # below still matches: the target keeps the state it had before. The
-        # refusals below are the same outcome by a different route -- Dolt
-        # reports each of these shapes as a conflict and rolls the merge back,
-        # and so do we, rather than resolving them on the user's behalf.
-        allowed_errors=(
-            "cannot merge: conflicts detected",
-            "cover the same columns of table",
-            "was dropped on one branch and its value changed",
-        ),
+        allowed_errors=MERGE_ROLLED_BACK,
     )
     sync_vc_result(doltlite, db_path, target, model)
 
@@ -756,7 +753,8 @@ def remote_operation(doltlite, db_path, branches, model, pushed, rng, step, op):
                 "conflict",
                 "diverged",
                 "non-fast-forward",
-            ),
+            )
+            + MERGE_ROLLED_BACK,
         )
         if op == "pull":
             sync_vc_result(doltlite, db_path, branch, model)
@@ -851,7 +849,10 @@ def main():
     op_counts = {}
     current_op = "setup"
 
-    print("stateful vc fuzzer: seed=%d seconds=%d db=%s" % (seed, seconds, db_path))
+    print(
+        "stateful vc fuzzer: seed=%d seconds=%d db=%s" % (seed, seconds, db_path),
+        flush=True,
+    )
     try:
         setup_repo(doltlite, db_path, remote_path)
         while time.time() < deadline:
@@ -944,7 +945,11 @@ def main():
 
             check_invariants(doltlite, db_path, branches, tags, model, rng)
             if step % 25 == 0:
-                print("  steps=%d branches=%d operations=%d" % (step, len(branches), len(op_counts)))
+                print(
+                    "  steps=%d branches=%d operations=%d"
+                    % (step, len(branches), len(op_counts)),
+                    flush=True,
+                )
 
         for b in list(branches):
             commit_branch(doltlite, db_path, b, model, step)
@@ -953,16 +958,19 @@ def main():
         assert_refs(doltlite, db_path, branches, tags)
         print(
             "OK: stateful vc fuzzer completed %d steps across %d branches; operations=%s"
-            % (step, len(branches), ",".join(sorted(op_counts)))
+            % (step, len(branches), ",".join(sorted(op_counts))),
+            flush=True,
         )
         return 0
     except Exception as e:
-        print(
-            "FAIL: stateful vc fuzzer seed=%d step=%d op=%s"
-            % (seed, step, current_op),
-            file=sys.stderr,
+        fail = "FAIL: stateful vc fuzzer seed=%d step=%d op=%s\n%s" % (
+            seed,
+            step,
+            current_op,
+            e,
         )
-        print(str(e), file=sys.stderr)
+        print(fail, flush=True)
+        print(fail, file=sys.stderr, flush=True)
         return 1
     finally:
         if os.environ.get("DOLTLITE_VC_STATEFUL_KEEP_DB") != "1":


### PR DESCRIPTION
## Summary

Nightly stress vc-fuzzer died at seed `1787292917` step 3219 on:

```
SELECT dolt_pull('origin','b177');
Error: cannot merge: indexes 'aux_idx_3052' and 'aux_idx_2082' cover the same columns of table 'aux_1955'; drop one of them, then merge
```

That is a correct engine refusal (same duplicate-index precheck as `dolt_merge`). `#2322` taught `merge_branch` to treat it as a rolled-back merge, but `dolt_pull`'s merge half still used only `conflict` / `diverged` / `non-fast-forward`. Any later `cannot merge:` refusal (dropped-column-vs-edit, trigger over a renamed or dropped table, …) would have failed the same way.

- Share a `cannot merge:` allowlist between `dolt_merge` and `dolt_pull` / `dolt_fetch`.
- Print `FAIL` to stdout (flushed) as well as stderr so redirected soak logs keep the error at the tail. Nightly issue bodies `tail -80` the log, and Python block-buffers stdout, so the previous FAIL-on-stderr landed at the *top* of `run.log`.
- Add a `dolt_pull` regression next to the existing duplicate-index merge test: diverged tracking, same refusal, working set rolled back.

Closes #2326

Co-Authored-By: Grok <noreply@x.ai>