### PR TITLE
Refuse a dual rename that would lose an index or trigger

### DIFF
--- a/src/doltlite_merge_int.h
+++ b/src/doltlite_merge_int.h
@@ -96,6 +96,7 @@ int mergePass1CheckIndexOverRenamedColumn(MergePass1Ctx *c);
 int mergePass1CheckTriggerOverRenamedTable(MergePass1Ctx *c);
 int mergePass1CheckRowEditOfDroppedColumn(MergePass1Ctx *c);
 int mergePass1CheckDuplicateIndexColumns(MergePass1Ctx *c);
+int mergePass1CheckDependentOverDualRename(MergePass1Ctx *c);
 
 int mergeRowEditsColumn(
   sqlite3 *db,

--- a/src/doltlite_merge_pass1.c
+++ b/src/doltlite_merge_pass1.c
@@ -1279,6 +1279,7 @@ int mergeCatalogPass1(
   if( rc==SQLITE_OK ) rc = mergePass1CheckTriggerOverRenamedTable(&c);
   if( rc==SQLITE_OK ) rc = mergePass1CheckRowEditOfDroppedColumn(&c);
   if( rc==SQLITE_OK ) rc = mergePass1CheckDuplicateIndexColumns(&c);
+  if( rc==SQLITE_OK ) rc = mergePass1CheckDependentOverDualRename(&c);
   if( rc!=SQLITE_OK ){
     mergePass1Free(&c);
     return rc;

--- a/src/doltlite_merge_predetect.c
+++ b/src/doltlite_merge_predetect.c
@@ -235,11 +235,12 @@ int mergePass1CheckRowEditOfDroppedColumn(MergePass1Ctx *c){
   return SQLITE_OK;
 }
 
-/* Does this object's definition name the given column? The scan is by bare
-** identifier, and for an index it starts at the column list so the index's own
-** name cannot match. It over-matches by design: an expression index over the
-** column, or a view naming it in any clause, breaks the same way a plain
-** reference does. */
+/* Does this object's definition name the given column? The scan is by
+** identifier, quoted or bare -- a definition SQLite wrote may quote the name,
+** and comparing only bare tokens let a quoted one through. For an index the
+** scan starts at the column list so the index's own name cannot match. It
+** over-matches by design: an expression index over the column, or a view
+** naming it in any clause, breaks the same way a plain reference does. */
 static int mergeSqlNamesColumn(const char *zSql, const char *zType,
                                const char *zColumn){
   const char *z;
@@ -255,22 +256,23 @@ static int mergeSqlNamesColumn(const char *zSql, const char *zType,
   }
   while( *z ){
     const char *zTok;
-    if( !(sqlite3Isalnum(*z) || *z=='_' || *z=='$') ){
-      if( *z=='\'' || *z=='"' || *z=='`' ){
-        char q = *z=='[' ? ']' : *z;
-        z++;
-        while( *z && *z!=q ) z++;
-        if( *z ) z++;
-        continue;
-      }
+    int nTok;
+    if( *z=='"' || *z=='`' || *z=='[' || *z=='\'' ){
+      char cEnd = *z=='[' ? ']' : *z;
+      z++;
+      zTok = z;
+      while( *z && *z!=cEnd ) z++;
+      nTok = (int)(z-zTok);
+      if( *z ) z++;
+    }else if( sqlite3Isalnum(*z) || *z=='_' || *z=='$' ){
+      zTok = z;
+      while( *z && (sqlite3Isalnum(*z) || *z=='_' || *z=='$') ) z++;
+      nTok = (int)(z-zTok);
+    }else{
       z++;
       continue;
     }
-    zTok = z;
-    while( *z && (sqlite3Isalnum(*z) || *z=='_' || *z=='$') ) z++;
-    if( (int)(z-zTok)==nCol && sqlite3_strnicmp(zTok, zColumn, nCol)==0 ){
-      return 1;
-    }
+    if( nTok==nCol && sqlite3_strnicmp(zTok, zColumn, nCol)==0 ) return 1;
   }
   return 0;
 }

--- a/src/doltlite_merge_predetect.c
+++ b/src/doltlite_merge_predetect.c
@@ -235,6 +235,196 @@ int mergePass1CheckRowEditOfDroppedColumn(MergePass1Ctx *c){
   return SQLITE_OK;
 }
 
+/* Does this object's definition name the given column? The scan is by bare
+** identifier, and for an index it starts at the column list so the index's own
+** name cannot match. It over-matches by design: an expression index over the
+** column, or a view naming it in any clause, breaks the same way a plain
+** reference does. */
+static int mergeSqlNamesColumn(const char *zSql, const char *zType,
+                               const char *zColumn){
+  const char *z;
+  int nCol;
+
+  if( !zSql || !zType || !zColumn || !zColumn[0] ) return 0;
+  nCol = (int)strlen(zColumn);
+  z = zSql;
+  if( strcmp(zType, "index")==0 ){
+    z = strchr(zSql, '(');
+    if( !z ) return 0;
+    z++;
+  }
+  while( *z ){
+    const char *zTok;
+    if( !(sqlite3Isalnum(*z) || *z=='_' || *z=='$') ){
+      if( *z=='\'' || *z=='"' || *z=='`' ){
+        char q = *z=='[' ? ']' : *z;
+        z++;
+        while( *z && *z!=q ) z++;
+        if( *z ) z++;
+        continue;
+      }
+      z++;
+      continue;
+    }
+    zTok = z;
+    while( *z && (sqlite3Isalnum(*z) || *z=='_' || *z=='$') ) z++;
+    if( (int)(z-zTok)==nCol && sqlite3_strnicmp(zTok, zColumn, nCol)==0 ){
+      return 1;
+    }
+  }
+  return 0;
+}
+
+/* The columns this side renamed away, relative to the ancestor: an ancestor
+** column at the same position, with a matching definition, under a new name
+** the side does not otherwise have. */
+static int mergeSideRenamedColumnTo(const char *zAncSql, const char *zSideSql,
+                                    const char *zColumn, char **pzNew){
+  ParsedColumn *aAnc = 0;
+  ParsedColumn *aSide = 0;
+  int nAnc = 0, nSide = 0, i, bRenamed = 0;
+
+  if( pzNew ) *pzNew = 0;
+  if( !zAncSql || !zSideSql ) return 0;
+  if( parseColumns(zAncSql, &aAnc, &nAnc)!=SQLITE_OK ) return 0;
+  if( parseColumns(zSideSql, &aSide, &nSide)!=SQLITE_OK ){
+    freeColumns(aAnc, nAnc);
+    return 0;
+  }
+  for(i=0; i<nAnc && i<nSide; i++){
+    if( sqlite3_stricmp(aAnc[i].zName, zColumn)!=0 ) continue;
+    if( sqlite3_stricmp(aSide[i].zName, aAnc[i].zName)==0 ) break;
+    if( parsedColumnIndexByName(aSide, nSide, aAnc[i].zName)>=0 ) break;
+    if( !parsedColumnDefinitionsMatch(&aSide[i], &aAnc[i]) ) break;
+    bRenamed = 1;
+    if( pzNew ) *pzNew = sqlite3_mprintf("%s", aSide[i].zName);
+    break;
+  }
+  freeColumns(aAnc, nAnc);
+  freeColumns(aSide, nSide);
+  return bRenamed;
+}
+
+static int mergeSideRenamedColumn(const char *zAncSql, const char *zSideSql,
+                                  const char *zColumn){
+  return mergeSideRenamedColumnTo(zAncSql, zSideSql, zColumn, 0);
+}
+
+/* Did this side rename any column of the table? */
+static int mergeSideRenamedAnyColumn(const char *zAncSql, const char *zSideSql){
+  ParsedColumn *aAnc = 0;
+  int nAnc = 0, i, bAny = 0;
+
+  if( parseColumns(zAncSql, &aAnc, &nAnc)!=SQLITE_OK ) return 0;
+  for(i=0; i<nAnc && !bAny; i++){
+    if( mergeSideRenamedColumn(zAncSql, zSideSql, aAnc[i].zName) ) bAny = 1;
+  }
+  freeColumns(aAnc, nAnc);
+  return bAny;
+}
+
+/* Both sides renamed a column of one table, and an index, view or trigger on it
+** names a column this side renamed. The merged catalog takes its table from one
+** side and this object from the other, so the object names a column the adopted
+** table does not have: the catalog cannot be loaded, and the rename that would
+** retarget the object only runs once it has. Dolt merges these and renames the
+** object with the table, so this is a refusal where Dolt succeeds -- but a
+** refusal the user can act on, rather than a database reported as malformed. */
+int mergePass1CheckDependentOverDualRename(MergePass1Ctx *c){
+  int side, i, j;
+
+  for(side=0; side<2; side++){
+    SchemaEntry *aDep = side ? c->aTheirsSchema : c->aOursSchema;
+    int nDep = side ? c->nTheirsSchema : c->nOursSchema;
+    SchemaEntry *aOther = side ? c->aOursSchema : c->aTheirsSchema;
+    int nOther = side ? c->nOursSchema : c->nTheirsSchema;
+
+    for(i=0; i<nDep; i++){
+      SchemaEntry *pDep = &aDep[i];
+      SchemaEntry *pAncTbl;
+      SchemaEntry *pDepTbl;
+      SchemaEntry *pOtherTbl;
+      ParsedColumn *aAncCols = 0;
+      int nAncCols = 0;
+
+      if( !pDep->zType || !pDep->zSql || !pDep->zTblName ) continue;
+      if( strcmp(pDep->zType, "table")==0 ) continue;
+      pAncTbl = findSchemaEntry(c->aAncSchema, c->nAncSchema, pDep->zTblName);
+      pDepTbl = findSchemaEntry(aDep, nDep, pDep->zTblName);
+      pOtherTbl = findSchemaEntry(aOther, nOther, pDep->zTblName);
+      if( !pAncTbl || !pDepTbl || !pOtherTbl ) continue;
+      if( !pAncTbl->zSql || !pDepTbl->zSql || !pOtherTbl->zSql ) continue;
+      /* Only a merge that has to reconcile a rename on each side lands here.
+      ** One side renaming alone already carries its objects across. */
+      if( !mergeSideRenamedAnyColumn(pAncTbl->zSql, pOtherTbl->zSql) ) continue;
+      if( !mergeSideRenamedAnyColumn(pAncTbl->zSql, pDepTbl->zSql) ) continue;
+      /* Whose table the merged catalog takes, decided by the same code that
+      ** will decide it for real. This object goes in beside that table, so it
+      ** only breaks the catalog when the two come from different sides. */
+      {
+        char **azAdd = 0, **azDrop = 0, **azRen = 0;
+        int nAdd = 0, nDrop = 0, nRen = 0, k;
+        int choice = SCHEMA_MERGE_DEFAULT, resolved = 0, bLoser;
+        char *zErr = 0;
+        const char *zOursTblSql = side ? pOtherTbl->zSql : pDepTbl->zSql;
+        const char *zTheirsTblSql = side ? pDepTbl->zSql : pOtherTbl->zSql;
+        if( trySchemaColumnMerge(pAncTbl->zSql, zOursTblSql, zTheirsTblSql,
+                                 &azAdd, &nAdd, &azDrop, &nDrop,
+                                 &azRen, &nRen, &choice, &resolved,
+                                 &zErr)!=SQLITE_OK ){
+          choice = SCHEMA_MERGE_DEFAULT;
+        }
+        for(k=0; k<nAdd; k++) sqlite3_free(azAdd[k]);
+        for(k=0; k<nDrop; k++) sqlite3_free(azDrop[k]);
+        for(k=0; k<nRen; k++) sqlite3_free(azRen[k]);
+        sqlite3_free(azAdd);
+        sqlite3_free(azDrop);
+        sqlite3_free(azRen);
+        sqlite3_free(zErr);
+        bLoser = side ? (choice==SCHEMA_MERGE_OURS)
+                      : (choice==SCHEMA_MERGE_THEIRS);
+        if( !bLoser ) continue;
+      }
+      if( parseColumns(pAncTbl->zSql, &aAncCols, &nAncCols)!=SQLITE_OK ){
+        continue;
+      }
+      for(j=0; j<nAncCols; j++){
+        const char *zCol = aAncCols[j].zName;
+        char *zNew = 0;
+        int bNames;
+        if( !mergeSideRenamedColumnTo(pAncTbl->zSql, pDepTbl->zSql, zCol,
+                                      &zNew) ){
+          sqlite3_free(zNew);
+          continue;
+        }
+        /* This side's own rename already rewrote the object, so it names the
+        ** column as this side left it, not as the ancestor had it. */
+        bNames = zNew && mergeSqlNamesColumn(pDep->zSql, pDep->zType, zNew);
+        sqlite3_free(zNew);
+        if( !bNames ) continue;
+        /* The other side renamed this one too: that disagreement is judged
+        ** elsewhere, and both sides' objects move together. */
+        if( mergeSideRenamedColumn(pAncTbl->zSql, pOtherTbl->zSql, zCol) ){
+          continue;
+        }
+        if( c->pzErrMsg ){
+          sqlite3_free(*c->pzErrMsg);
+          *c->pzErrMsg = sqlite3_mprintf(
+              "cannot merge: %s '%s' covers column '%s' of table '%s', which "
+              "one branch renamed while the other renamed another column of "
+              "the same table; rename on one branch only, or drop the %s, "
+              "then merge",
+              pDep->zType, pDep->zName, zCol, pDep->zTblName, pDep->zType);
+        }
+        freeColumns(aAncCols, nAncCols);
+        return SQLITE_ERROR;
+      }
+      freeColumns(aAncCols, nAncCols);
+    }
+  }
+  return SQLITE_OK;
+}
+
 /* A trigger whose table the other side renamed or dropped. A trigger has to
 ** resolve when the schema loads -- unlike a view, which is only text until it
 ** is used -- so a merged catalog holding a trigger on a table that is no

--- a/test/doltlite_schema_merge.sh
+++ b/test/doltlite_schema_merge.sh
@@ -1900,6 +1900,34 @@ EOF
   rm -f "$DB"
 done
 
+# The same shape with the column quoted in the index definition. A definition
+# SQLite wrote may quote the name, so a scan that compares only bare tokens let
+# this through and the merge failed as a SQL logic error instead of refusing.
+for q in dquote backtick bracket; do
+  DB=/tmp/test_merge_dual_rename_q_${q}_$$.db; rm -f "$DB"
+  case "$q" in
+    dquote)   DEP='CREATE INDEX ix0 ON t("a");';;
+    backtick) DEP='CREATE INDEX ix0 ON t(`a`);';;
+    bracket)  DEP='CREATE INDEX ix0 ON t([a]);';;
+  esac
+  cat <<EOF | $DOLTLITE "$DB" > /dev/null 2>&1
+CREATE TABLE t(k INTEGER PRIMARY KEY, a TEXT, b TEXT);
+$DEP
+INSERT INTO t VALUES(1,'a1','b1');
+SELECT dolt_commit('-Am','base');
+SELECT dolt_branch('feat');
+ALTER TABLE t RENAME COLUMN a TO a2;
+SELECT dolt_commit('-Am','ours renames the covered column');
+SELECT dolt_checkout('feat');
+ALTER TABLE t RENAME COLUMN b TO b2;
+SELECT dolt_commit('-Am','theirs renames another column');
+SELECT dolt_checkout('main');
+EOF
+  run_test_match "merge_dual_rename_over_quoted_${q}_refused" \
+    "SELECT dolt_merge('feat');" "index 'ix0' covers column 'a'" "$DB"
+  rm -f "$DB"
+done
+
 # The mirror merges: the object names the column the OTHER branch renamed, so it
 # arrives beside the table it belongs to and the rename retargets both.
 DB=/tmp/test_merge_dual_rename_other_side_$$.db; rm -f "$DB"

--- a/test/doltlite_schema_merge.sh
+++ b/test/doltlite_schema_merge.sh
@@ -1864,6 +1864,85 @@ run_test "pull_duplicate_index_columns_integrity" \
 run_test "pull_duplicate_index_columns_rolled_back" \
   "SELECT group_concat(name) FROM sqlite_master WHERE type='index';" "ix0" "$DB/feat"
 rm -f "$DB" "$REMOTE"
+# Each branch renames a different column of one table, and an index or trigger
+# on it names the column its own branch renamed. The merged catalog takes the
+# table from one branch and the object from the other, so the object names a
+# column the adopted table does not have: the catalog cannot be loaded, and the
+# rename that would retarget the object only runs once it has.
+#
+# DIVERGENCE FROM DOLT: Dolt merges all of these and renames the object along
+# with the table. We cannot represent that today (see the issue linked from the
+# commit), so refuse -- the user gets something to act on instead of a database
+# reported as malformed.
+for dep in idx trig; do
+  DB=/tmp/test_merge_dual_rename_${dep}_$$.db; rm -f "$DB"
+  if [ "$dep" = idx ]; then
+    DEP="CREATE INDEX ix0 ON t(a);"; WANT="index 'ix0' covers column 'a'"
+  else
+    DEP="CREATE TRIGGER tg AFTER INSERT ON t BEGIN UPDATE t SET a=a; END;"
+    WANT="trigger 'tg' covers column 'a'"
+  fi
+  cat <<EOF | $DOLTLITE "$DB" > /dev/null 2>&1
+CREATE TABLE t(k INTEGER PRIMARY KEY, a TEXT, b TEXT);
+$DEP
+INSERT INTO t VALUES(1,'a1','b1');
+SELECT dolt_commit('-Am','base');
+SELECT dolt_branch('feat');
+ALTER TABLE t RENAME COLUMN a TO a2;
+SELECT dolt_commit('-Am','ours renames the covered column');
+SELECT dolt_checkout('feat');
+ALTER TABLE t RENAME COLUMN b TO b2;
+SELECT dolt_commit('-Am','theirs renames another column');
+SELECT dolt_checkout('main');
+EOF
+  run_test_match "merge_dual_rename_over_${dep}_refused" "SELECT dolt_merge('feat');" \
+    "$WANT" "$DB"
+  rm -f "$DB"
+done
+
+# The mirror merges: the object names the column the OTHER branch renamed, so it
+# arrives beside the table it belongs to and the rename retargets both.
+DB=/tmp/test_merge_dual_rename_other_side_$$.db; rm -f "$DB"
+cat <<'EOF' | $DOLTLITE "$DB" > /dev/null 2>&1
+CREATE TABLE t(k INTEGER PRIMARY KEY, a TEXT, b TEXT);
+CREATE INDEX ix0 ON t(a);
+INSERT INTO t VALUES(1,'a1','b1');
+SELECT dolt_commit('-Am','base');
+SELECT dolt_branch('feat');
+ALTER TABLE t RENAME COLUMN b TO b2;
+SELECT dolt_commit('-Am','ours renames another column');
+SELECT dolt_checkout('feat');
+ALTER TABLE t RENAME COLUMN a TO a2;
+SELECT dolt_commit('-Am','theirs renames the covered column');
+SELECT dolt_checkout('main');
+EOF
+run_test_match "merge_dual_rename_over_index_other_side_hash" "SELECT dolt_merge('feat');" \
+  "^[0-9a-f]{40}$" "$DB"
+run_test "merge_dual_rename_over_index_other_side_cols" \
+  "SELECT group_concat(name) FROM pragma_table_info('t');" "k,a2,b2" "$DB"
+rm -f "$DB"
+
+# One branch renaming alone still carries its index across untouched.
+DB=/tmp/test_merge_single_rename_index_$$.db; rm -f "$DB"
+cat <<'EOF' | $DOLTLITE "$DB" > /dev/null 2>&1
+CREATE TABLE t(k INTEGER PRIMARY KEY, a TEXT, b TEXT);
+CREATE INDEX ix0 ON t(a);
+INSERT INTO t VALUES(1,'a1','b1');
+SELECT dolt_commit('-Am','base');
+SELECT dolt_branch('feat');
+ALTER TABLE t RENAME COLUMN a TO a2;
+SELECT dolt_commit('-Am','ours renames the covered column');
+SELECT dolt_checkout('feat');
+INSERT INTO t VALUES(2,'a2','b2');
+SELECT dolt_commit('-Am','theirs adds a row');
+SELECT dolt_checkout('main');
+EOF
+run_test_match "merge_single_rename_over_index_hash" "SELECT dolt_merge('feat');" \
+  "^[0-9a-f]{40}$" "$DB"
+run_test "merge_single_rename_over_index_idx" \
+  "SELECT sql FROM sqlite_master WHERE type='index';" \
+  "CREATE INDEX ix0 ON t(a2)" "$DB"
+rm -f "$DB"
 
 # The duplicate-index and dropped-column refusals are Dolt's judgement about a
 # merge of two branches. A revert replays one commit onto the branch that asked


### PR DESCRIPTION
Closes #2301. Parity gap tracked in #2331.

Each branch renames a different column of one table, and an index or trigger on it names the column its own branch renamed. That merge reported `database disk image is malformed` (or, for a trigger, `SQL logic error`). It now refuses with something the user can act on.

```
cannot merge: index 'ix0' covers column 'a' of table 't', which one branch
renamed while the other renamed another column of the same table; rename on
one branch only, or drop the index, then merge
```

### Why it happened

The merged catalog takes the table from whichever side `trySchemaColumnMerge` chooses, but a dependent object's schema row is chosen independently — `mergedSchemaChoice` takes whichever side *changed* it. When those are different sides the object names a column the adopted table does not have, so the catalog cannot load — and the `ALTER TABLE ... RENAME COLUMN` action that would retarget the object only runs *after* it loads:

```
adopted table:  CREATE TABLE t(k INTEGER PRIMARY KEY, a TEXT, b2 TEXT)
kept index row: CREATE INDEX ix0 ON t(a2)      <-- a2 is not in that table
=> malformed database schema (ix0) - no such column: a2
```

### The part worth reviewing

Whether the object and its table come from different sides is decided by **calling `trySchemaColumnMerge`** — the same function that makes the real decision — not by re-deriving it. My first two versions inferred it, and the second **over-refused two merges that are correct today**: the choice turns on which column *position* each side renamed, which is not something to guess at. Both of those shapes are now pinned as tests.

### DIVERGENCE FROM DOLT

Dolt merges all of these cleanly (`conflicts=0`, `k,a2,b2`, index retargeted). That is the result we should produce; #2331 has the diagnosis and the two approaches that do **not** work, so the next attempt does not repeat them. Until then a refusal beats reporting a sound database as corrupt.

### Not covered

The **view** form still reports `SQL logic error` — a view's `tbl_name` is the view itself, so nothing links it to the table. Unchanged from master, not a regression, documented in #2331. I left it rather than widen the check on guesswork, having already over-refused twice here.

### Testing

- `doltlite_schema_merge.sh` — 291 pass (6 new). The 2 refusal tests **fail on a pre-fix binary and pass with the fix**; the 3 control tests (mirror shape, single-sided rename) pass on both, which is what caught the over-refusal.
- `run_doltlite_tests.sh` — 110/110 suites
- `vc_oracle_correct_schema_merge_matrix_test.sh` — 176 passed, 0 gaps, 0 differing, 0 corrupting (unchanged)
- amalgamation regenerated and compiled clean; `lint_layers.sh` clean

Note the matrix does **not** cover this shape: its base fixture has no index, so `ren_a x ren_b` is only ever exercised on an unindexed table. #2331 records that gap — varying the base fixture is the highest-value extension to that suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)