### PR TITLE
Protect edited values from replayed column drops

### DIFF
--- a/src/doltlite_cherry_pick.c
+++ b/src/doltlite_cherry_pick.c
@@ -107,6 +107,7 @@ int applyMergedCatalogAndCommit(
   int bRejectUnchanged,
   int *pnConflicts,
   int *pnViolations,
+  char **pzApplyErr,
   char *hexBuf
 ){
   ChunkStore *cs;
@@ -125,6 +126,7 @@ int applyMergedCatalogAndCommit(
   assert( db!=0 && context!=0 );
   assert( ancCatHash!=0 && ourCatHash!=0 && theirCatHash!=0 );
   assert( ourHead!=0 && zMessage!=0 && pnConflicts!=0 );
+  if( pzApplyErr ) *pzApplyErr = 0;
   cs = doltliteGetChunkStore(db);
   memset(&savedState, 0, sizeof(savedState));
   if( hexBuf ) hexBuf[0] = '\0';
@@ -151,6 +153,10 @@ int applyMergedCatalogAndCommit(
                                 bPreferOurMaster, 0,
                                 &azReindex, &nReindex, 0, 0);
     if( rc!=SQLITE_OK ){
+      if( pzApplyErr && zMergeErr ){
+        *pzApplyErr = zMergeErr;
+        zMergeErr = 0;
+      }
       sqlite3_free(zMergeErr);
       doltliteTxnStateClear(&savedState);
       doltliteFreeNameList(azReindex, nReindex);
@@ -370,6 +376,7 @@ static void doltliteCherryPickFunc(
   int nConflicts = 0;
   int dirty = 0;
   int rc;
+  char *zApplyErr = 0;
   char hexBuf[PROLLY_HASH_SIZE*2+1];
 
   memset(&pickCommit, 0, sizeof(pickCommit));
@@ -449,7 +456,7 @@ static void doltliteCherryPickFunc(
     rc = applyMergedCatalogAndCommit(db, context,
         &parentCommit.catalogHash, &ourCommit.catalogHash,
         &pickCommit.catalogHash, &ourHead, 0, zMsg, 0, 0, &nConflicts, 0,
-        hexBuf);
+        &zApplyErr, hexBuf);
   }
 
   doltliteCommitClear(&pickCommit);
@@ -457,15 +464,22 @@ static void doltliteCherryPickFunc(
   doltliteCommitClear(&ourCommit);
 
   if( rc==SQLITE_BUSY ){
+    sqlite3_free(zApplyErr);
     doltliteCmdResultPeerBranchBusy(context, "cherry-pick");
     return;
   }
   if( rc!=SQLITE_OK ){
-    char *zMsg = sqlite3_mprintf("cherry-pick of %s failed", zRef);
-    sqlite3_result_error(context, zMsg ? zMsg : "cherry-pick failed", -1);
-    sqlite3_free(zMsg);
+    if( zApplyErr ){
+      sqlite3_result_error(context, zApplyErr, -1);
+    }else{
+      char *zMsg = sqlite3_mprintf("cherry-pick of %s failed", zRef);
+      sqlite3_result_error(context, zMsg ? zMsg : "cherry-pick failed", -1);
+      sqlite3_free(zMsg);
+    }
+    sqlite3_free(zApplyErr);
     return;
   }
+  sqlite3_free(zApplyErr);
 
   /* Conflict / CV finish helpers already set the context error (including the
   ** combined conflicts+CVs message). Do not overwrite it here. */

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -1123,6 +1123,7 @@ int applyMergedCatalogAndCommit(
   int bRejectUnchanged,
   int *pnConflicts,
   int *pnViolations,
+  char **pzApplyErr,
   char *hexBuf
 );
 

--- a/src/doltlite_merge_int.h
+++ b/src/doltlite_merge_int.h
@@ -104,6 +104,7 @@ int mergeRowEditsColumn(
   u8 ancFlags,
   u8 otherFlags,
   int iField,
+  int bNonNullOnly,
   int *pbEdited
 );
 

--- a/src/doltlite_merge_predetect.c
+++ b/src/doltlite_merge_predetect.c
@@ -149,12 +149,6 @@ int mergePass1CheckDuplicateIndexColumns(MergePass1Ctx *c){
 int mergePass1CheckRowEditOfDroppedColumn(MergePass1Ctx *c){
   int side, i, j;
 
-  /* A merge only. Reverting, cherry-picking or rebasing a commit has one
-  ** intended result, and the branch it replays onto asked for it, so there is
-  ** no disagreement here to hand back. Refusing would also reject restoring a
-  ** state the branch held before. */
-  if( !c->bBranchMerge ) return SQLITE_OK;
-
   for(side=0; side<2; side++){
     SchemaEntry *aDrop = side ? c->aTheirsSchema : c->aOursSchema;
     int nDrop = side ? c->nTheirsSchema : c->nOursSchema;
@@ -162,6 +156,10 @@ int mergePass1CheckRowEditOfDroppedColumn(MergePass1Ctx *c){
     int nEdit = side ? c->nOursSchema : c->nTheirsSchema;
     struct TableEntry *aEditCat = side ? c->aOurs : c->aTheirs;
     int nEditCat = side ? c->nOurs : c->nTheirs;
+
+    /* On replay, theirs is the patch being applied. Dolt protects non-NULL
+    ** live values; a NULL or a column already absent from ours can be dropped. */
+    if( !c->bBranchMerge && side==0 ) continue;
 
     for(i=0; i<c->nAncSchema; i++){
       const char *zTable = c->aAncSchema[i].zName;
@@ -208,7 +206,7 @@ int mergePass1CheckRowEditOfDroppedColumn(MergePass1Ctx *c){
         }
         rc = mergeRowEditsColumn(c->db, &pAncCat->root, &pEditCatEnt->root,
                                  pAncCat->flags, pEditCatEnt->flags,
-                                 j, &bEdited);
+                                 j, !c->bBranchMerge, &bEdited);
         if( rc!=SQLITE_OK ){
           freeColumns(aAncCols, nAncCols);
           freeColumns(aDropCols, nDropCols);
@@ -217,11 +215,18 @@ int mergePass1CheckRowEditOfDroppedColumn(MergePass1Ctx *c){
         if( bEdited ){
           if( c->pzErrMsg ){
             sqlite3_free(*c->pzErrMsg);
-            *c->pzErrMsg = sqlite3_mprintf(
-                "cannot merge: column '%s' of table '%s' was dropped on one "
-                "branch and its value changed on the other; drop the column "
-                "on both branches, or revert the change, then merge",
-                aAncCols[j].zName, zTable);
+            if( c->bBranchMerge ){
+              *c->pzErrMsg = sqlite3_mprintf(
+                  "cannot merge: column '%s' of table '%s' was dropped on one "
+                  "branch and its value changed on the other; drop the column "
+                  "on both branches, or revert the change, then merge",
+                  aAncCols[j].zName, zTable);
+            }else{
+              *c->pzErrMsg = sqlite3_mprintf(
+                  "cannot apply: column '%s' of table '%s' would be dropped, "
+                  "discarding a changed value",
+                  aAncCols[j].zName, zTable);
+            }
           }
           freeColumns(aAncCols, nAncCols);
           freeColumns(aDropCols, nDropCols);

--- a/src/doltlite_merge_rows.c
+++ b/src/doltlite_merge_rows.c
@@ -1164,6 +1164,7 @@ int mergeRowEditsColumn(
   u8 ancFlags,
   u8 otherFlags,
   int iField,
+  int bNonNullOnly,
   int *pbEdited
 ){
   ChunkStore *cs = doltliteGetChunkStore(db);
@@ -1185,6 +1186,7 @@ int mergeRowEditsColumn(
   while( (rc = prollyDiffIterStep(&iter, &pChange))==SQLITE_ROW ){
     RecField *aOld = 0;
     RecField *aNew = 0;
+    static const RecField kNullField = { 0, 0, 0 };
     int nOld = 0, nNew = 0;
     if( pChange->type!=PROLLY_DIFF_MODIFY ) continue;
     if( !pChange->pOldVal || !pChange->pNewVal ) continue;
@@ -1195,9 +1197,11 @@ int mergeRowEditsColumn(
       sqlite3_free(aOld);
       continue;
     }
-    if( iField<nOld && iField<nNew
-     && fieldEquals(pChange->pOldVal, &aOld[iField],
-                    pChange->pNewVal, &aNew[iField])!=0 ){
+    if( (!bNonNullOnly || (iField<nNew && aNew[iField].st!=0))
+     && fieldEquals(pChange->pOldVal,
+                    iField<nOld ? &aOld[iField] : (RecField*)&kNullField,
+                    pChange->pNewVal,
+                    iField<nNew ? &aNew[iField] : (RecField*)&kNullField)!=0 ){
       *pbEdited = 1;
     }
     sqlite3_free(aOld);

--- a/src/doltlite_rebase.c
+++ b/src/doltlite_rebase.c
@@ -341,6 +341,7 @@ static int doltliteRebaseLinearReplay(
   int i;
   int dirty = 0;
   char *zFailedMsg = 0;
+  char *zApplyErr = 0;
   int bConflict = 0;
   int bViolation = 0;
   assert( db!=0 && context!=0 && zUpstream!=0 && pzFinalMessage!=0 );
@@ -497,7 +498,7 @@ static int doltliteRebaseLinearReplay(
         &replayCommit.catalogHash,
         &curHead, 0,
         replayCommit.zMessage ? replayCommit.zMessage : "",
-        0, 0, &nConflicts, &nViolations, 0, hexBuf);
+        0, 0, &nConflicts, &nViolations, &zApplyErr, hexBuf);
 
     doltliteCommitClear(&replayCommit);
     doltliteCommitClear(&parentCommit);
@@ -545,6 +546,7 @@ static int doltliteRebaseLinearReplay(
   doltliteCommitClear(&origCommit);
   sqlite3_free(aReplay);
   sqlite3_free(zFailedMsg);
+  sqlite3_free(zApplyErr);
   rc = doltliteVcSealEnclosingTxn(db);
   if( rc!=SQLITE_OK ){
     sqlite3_result_error_code(context, rc);
@@ -580,7 +582,10 @@ rollback:
   sqlite3_free(aReplay);
   {
     char *zErr;
-    if( bConflict && zFailedMsg && zFailedMsg[0] ){
+    if( zApplyErr ){
+      zErr = zApplyErr;
+      zApplyErr = 0;
+    }else if( bConflict && zFailedMsg && zFailedMsg[0] ){
       zErr = sqlite3_mprintf(
           "conflict rebasing \"%s\"; rebase aborted, branch restored to pre-rebase state",
           zFailedMsg);
@@ -605,6 +610,7 @@ rollback:
     }
   }
   sqlite3_free(zFailedMsg);
+  sqlite3_free(zApplyErr);
   sqlite3_free(zOrig);
   sqlite3_free(zWorking);
   if( sealTopLevel ) (void)doltliteVcSealTopLevelSavepointTxn(db);

--- a/src/doltlite_rebase.c
+++ b/src/doltlite_rebase.c
@@ -497,7 +497,7 @@ static int doltliteRebaseLinearReplay(
         &replayCommit.catalogHash,
         &curHead, 0,
         replayCommit.zMessage ? replayCommit.zMessage : "",
-        0, 0, &nConflicts, &nViolations, hexBuf);
+        0, 0, &nConflicts, &nViolations, 0, hexBuf);
 
     doltliteCommitClear(&replayCommit);
     doltliteCommitClear(&parentCommit);

--- a/src/doltlite_revert.c
+++ b/src/doltlite_revert.c
@@ -149,6 +149,7 @@ static void doltliteRevertFunc(
   DoltliteCommit revertCommit, parentCommit, ourCommit;
   int nConflicts = 0;
   int rc;
+  char *zApplyErr = 0;
   char hexBuf[PROLLY_HASH_SIZE*2+1];
 
   memset(&revertCommit, 0, sizeof(revertCommit));
@@ -247,7 +248,7 @@ static void doltliteRevertFunc(
     rc = applyMergedCatalogAndCommit(db, context,
         &revertCommit.catalogHash, &liveOurCatalog,
         &parentCommit.catalogHash, &ourHead, pCommitOurs, msg, 1, 1,
-        &nConflicts, 0, hexBuf);
+        &nConflicts, 0, &zApplyErr, hexBuf);
   }
 
   doltliteCommitClear(&revertCommit);
@@ -255,19 +256,27 @@ static void doltliteRevertFunc(
   doltliteCommitClear(&ourCommit);
 
   if( rc==SQLITE_BUSY ){
+    sqlite3_free(zApplyErr);
     doltliteCmdResultPeerBranchBusy(context, "revert");
     return;
   }
   if( rc==SQLITE_DONE ){
+    sqlite3_free(zApplyErr);
     sqlite3_result_error(context, "nothing to commit", -1);
     return;
   }
   if( rc!=SQLITE_OK ){
-    char *zMsg = sqlite3_mprintf("revert of \"%s\" failed", zRef);
-    sqlite3_result_error(context, zMsg ? zMsg : "revert failed", -1);
-    sqlite3_free(zMsg);
+    if( zApplyErr ){
+      sqlite3_result_error(context, zApplyErr, -1);
+    }else{
+      char *zMsg = sqlite3_mprintf("revert of \"%s\" failed", zRef);
+      sqlite3_result_error(context, zMsg ? zMsg : "revert failed", -1);
+      sqlite3_free(zMsg);
+    }
+    sqlite3_free(zApplyErr);
     return;
   }
+  sqlite3_free(zApplyErr);
 
   /* Conflict / CV finish helpers already set the context error (including the
   ** combined conflicts+CVs message). Do not overwrite it here. */

--- a/test/doltlite_cherry_pick.sh
+++ b/test/doltlite_cherry_pick.sh
@@ -682,6 +682,97 @@ Error near line 5: no merge in progress" \
   "$DB"
 rm -f "$DB"
 
+DB=/tmp/test_rv_drop_edited_column_$$.db; rm -f "$DB"
+echo "CREATE TABLE t(k INTEGER PRIMARY KEY, a TEXT);
+INSERT INTO t VALUES(1,'a1'),(2,'a2');
+SELECT dolt_commit('-Am','base');
+ALTER TABLE t ADD COLUMN d TEXT;
+SELECT dolt_commit('-Am','add d');
+UPDATE t SET d='x' WHERE k=1;
+SELECT dolt_commit('-Am','set d');" | $DOLTLITE "$DB" > /dev/null 2>&1
+run_test_match "rv_drop_edited_column_refuses" \
+  "SELECT dolt_revert('HEAD~1');" \
+  "column 'd' of table 't' would be dropped, discarding a changed value" "$DB"
+run_test "rv_drop_edited_column_schema_kept" \
+  "SELECT count(*) FROM pragma_table_info('t') WHERE name='d';" "1" "$DB"
+run_test "rv_drop_edited_column_value_kept" \
+  "SELECT d FROM t WHERE k=1;" "x" "$DB"
+run_test "rv_drop_edited_column_no_commit" \
+  "SELECT message FROM dolt_log LIMIT 1;" "set d" "$DB"
+run_test "rv_drop_edited_column_integrity" "PRAGMA integrity_check;" "ok" "$DB"
+rm -f "$DB"
+
+DB=/tmp/test_cp_drop_edited_column_$$.db; rm -f "$DB"
+echo "CREATE TABLE t(k INTEGER PRIMARY KEY, a TEXT, d TEXT);
+INSERT INTO t VALUES(1,'a1',NULL),(2,'a2',NULL);
+SELECT dolt_commit('-Am','base');
+SELECT dolt_checkout('-b','dropper');
+ALTER TABLE t DROP COLUMN d;
+SELECT dolt_commit('-Am','drop d');
+SELECT dolt_checkout('main');
+UPDATE t SET d='x' WHERE k=1;
+SELECT dolt_commit('-Am','set d');" | $DOLTLITE "$DB" > /dev/null 2>&1
+run_test_match "cp_drop_edited_column_refuses" \
+  "SELECT dolt_cherry_pick('dropper');" \
+  "column 'd' of table 't' would be dropped, discarding a changed value" "$DB"
+run_test "cp_drop_edited_column_schema_kept" \
+  "SELECT count(*) FROM pragma_table_info('t') WHERE name='d';" "1" "$DB"
+run_test "cp_drop_edited_column_value_kept" \
+  "SELECT d FROM t WHERE k=1;" "x" "$DB"
+run_test "cp_drop_edited_column_no_commit" \
+  "SELECT message FROM dolt_log LIMIT 1;" "set d" "$DB"
+run_test "cp_drop_edited_column_integrity" "PRAGMA integrity_check;" "ok" "$DB"
+rm -f "$DB"
+
+DB=/tmp/test_rv_drop_unedited_column_$$.db; rm -f "$DB"
+echo "CREATE TABLE t(k INTEGER PRIMARY KEY, a TEXT);
+INSERT INTO t VALUES(1,'a1');
+SELECT dolt_commit('-Am','base');
+ALTER TABLE t ADD COLUMN d TEXT;
+SELECT dolt_commit('-Am','add d');
+UPDATE t SET a='a1x' WHERE k=1;
+SELECT dolt_commit('-Am','edit a');" | $DOLTLITE "$DB" > /dev/null 2>&1
+run_test_match "rv_drop_unedited_column_hash" \
+  "SELECT dolt_revert('HEAD~1');" \
+  "^[0-9a-f]{40}$" "$DB"
+run_test "rv_drop_unedited_column_result" \
+  "SELECT (SELECT count(*) FROM pragma_table_info('t') WHERE name='d') || '|' || a FROM t WHERE k=1;" \
+  "0|a1x" "$DB"
+rm -f "$DB"
+
+DB=/tmp/test_rv_drop_null_column_$$.db; rm -f "$DB"
+echo "CREATE TABLE t(k INTEGER PRIMARY KEY, a TEXT);
+INSERT INTO t VALUES(1,'a1');
+SELECT dolt_commit('-Am','base');
+ALTER TABLE t ADD COLUMN d TEXT DEFAULT 'z';
+SELECT dolt_commit('-Am','add d');
+UPDATE t SET d=NULL WHERE k=1;
+SELECT dolt_commit('-Am','clear d');" | $DOLTLITE "$DB" > /dev/null 2>&1
+run_test_match "rv_drop_null_column_hash" \
+  "SELECT dolt_revert('HEAD~1');" \
+  "^[0-9a-f]{40}$" "$DB"
+run_test "rv_drop_null_column_result" \
+  "SELECT (SELECT count(*) FROM pragma_table_info('t') WHERE name='d') || '|' || a FROM t WHERE k=1;" \
+  "0|a1" "$DB"
+rm -f "$DB"
+
+DB=/tmp/test_rv_edit_of_already_dropped_column_$$.db; rm -f "$DB"
+echo "CREATE TABLE t(k INTEGER PRIMARY KEY, a TEXT, d TEXT);
+INSERT INTO t VALUES(1,'a1','before');
+SELECT dolt_commit('-Am','base');
+UPDATE t SET d='after' WHERE k=1;
+SELECT dolt_commit('-Am','edit d');
+ALTER TABLE t DROP COLUMN d;
+SELECT dolt_commit('-Am','drop d');" | $DOLTLITE "$DB" > /dev/null 2>&1
+run_test_match "rv_edit_of_already_dropped_column_hash" \
+  "SELECT dolt_revert('HEAD~1');" \
+  "nothing to commit" "$DB"
+run_test "rv_edit_of_already_dropped_column_schema" \
+  "SELECT count(*) FROM pragma_table_info('t') WHERE name='d';" "0" "$DB"
+run_test "rv_edit_of_already_dropped_column_row" \
+  "SELECT k || '|' || a FROM t;" "1|a1" "$DB"
+rm -f "$DB"
+
 # A clean cherry-pick / revert is a transaction boundary like dolt_commit:
 # it seals the enclosing BEGIN when it advances the ref. Leaving the
 # transaction open let a later ROLLBACK revert the working set while the

--- a/test/doltlite_rebase_schema.sh
+++ b/test/doltlite_rebase_schema.sh
@@ -312,6 +312,39 @@ DELETE FROM gp WHERE id = 1;
 SELECT (SELECT count(*) FROM gp) || '|' || (SELECT count(*) FROM p) || '|' || (SELECT count(*) FROM c);
 " "1|0|0"
 
+DROP_RESTORE_SETUP="
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT, d TEXT);
+INSERT INTO t VALUES(1,'base','base-d');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_branch('feat');
+UPDATE t SET d='main-live';
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','set d main');
+SELECT dolt_checkout('feat');
+ALTER TABLE t DROP COLUMN d;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','drop d feature');
+ALTER TABLE t ADD COLUMN d TEXT;
+UPDATE t SET d='feature-live';
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','restore d feature');
+"
+
+run_db_match "rebase_schema_drop_changed_column_error" "
+$DROP_RESTORE_SETUP
+SELECT dolt_rebase('main');
+" "cannot apply: column 'd' of table 't' would be dropped, discarding a changed value"
+
+run_db_eq "rebase_schema_drop_changed_column_rollback" "
+$DROP_RESTORE_SETUP
+SELECT dolt_rebase('main');
+SELECT active_branch() || '|' || d || '|' ||
+  (SELECT count(*) FROM dolt_log WHERE message='restore d feature') || '|' ||
+  (SELECT count(*) FROM sqlite_master WHERE name='dolt_rebase')
+FROM t;
+" "feat|feature-live|1|0"
+
 echo ""
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"
 if [ $FAIL -gt 0 ]; then

--- a/test/doltlite_schema_merge.sh
+++ b/test/doltlite_schema_merge.sh
@@ -1794,6 +1794,28 @@ EOF
   rm -f "$DB"
 done
 
+DB=/tmp/test_merge_drop_vs_edit_added_column_$$.db; rm -f "$DB"
+cat <<'EOF' | $DOLTLITE "$DB" > /dev/null 2>&1
+CREATE TABLE t(k INTEGER PRIMARY KEY, a TEXT);
+INSERT INTO t VALUES(1,'a1');
+SELECT dolt_commit('-Am','base');
+ALTER TABLE t ADD COLUMN b TEXT;
+SELECT dolt_commit('-Am','add b');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+ALTER TABLE t DROP COLUMN b;
+SELECT dolt_commit('-Am','feat drops b');
+SELECT dolt_checkout('main');
+UPDATE t SET b='edit' WHERE k=1;
+SELECT dolt_commit('-Am','main edits b');
+EOF
+run_test_match "merge_drop_vs_edit_added_column_refused" \
+  "SELECT dolt_merge('feat');" \
+  "column 'b' of table 't' was dropped on one branch and its value changed" "$DB"
+run_test "merge_drop_vs_edit_added_column_kept" \
+  "SELECT b FROM t WHERE k=1;" "edit" "$DB"
+rm -f "$DB"
+
 # Everything the rule must leave alone.
 for theirs in "UPDATE t SET n=99 WHERE k=1;" "UPDATE t SET a='edit' WHERE k=1;" \
               "INSERT INTO t VALUES(9,'a9','b9',99);" "DELETE FROM t WHERE k=1;"; do

--- a/test/vc_oracle_revert_cherrypick_test.sh
+++ b/test/vc_oracle_revert_cherrypick_test.sh
@@ -613,6 +613,32 @@ SELECT dolt_revert('HEAD~1');
 " "SELECT (SELECT count(*) FROM dolt_conflicts) || '|' || (SELECT group_concat(id || ':' || v, ',') FROM (SELECT id, v FROM t ORDER BY id) AS ordered_rows)" \
 "SELECT CONCAT((SELECT COUNT(*) FROM dolt_conflicts), '|', (SELECT GROUP_CONCAT(CONCAT(id, ':', v) ORDER BY id SEPARATOR ',') FROM t))"
 
+oracle_error_poststate "revert_added_column_edit_rolls_back" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1, 'a');
+SELECT dolt_commit('-Am', 'base');
+ALTER TABLE t ADD COLUMN d TEXT;
+SELECT dolt_commit('-Am', 'add d');
+UPDATE t SET d = 'x' WHERE id = 1;
+SELECT dolt_commit('-Am', 'set d');
+SELECT dolt_revert('HEAD~1');
+" "SELECT 'Q|' || d || '|' || (SELECT message FROM dolt_log LIMIT 1) FROM t WHERE id = 1" \
+"SELECT CONCAT('Q|', d, '|', (SELECT message FROM dolt_log LIMIT 1)) FROM t WHERE id = 1"
+
+oracle_error_poststate "cherry_pick_drop_edited_column_rolls_back" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT, d TEXT);
+INSERT INTO t VALUES (1, 'a', NULL);
+SELECT dolt_commit('-Am', 'base');
+SELECT dolt_checkout('-b', 'dropper');
+ALTER TABLE t DROP COLUMN d;
+SELECT dolt_commit('-Am', 'drop d');
+SELECT dolt_checkout('main');
+UPDATE t SET d = 'x' WHERE id = 1;
+SELECT dolt_commit('-Am', 'set d');
+SELECT dolt_cherry_pick('dropper');
+" "SELECT 'Q|' || d || '|' || (SELECT message FROM dolt_log LIMIT 1) FROM t WHERE id = 1" \
+"SELECT CONCAT('Q|', d, '|', (SELECT message FROM dolt_log LIMIT 1)) FROM t WHERE id = 1"
+
 echo "--- error paths ---"
 
 oracle_error "cherry_pick_no_args" "


### PR DESCRIPTION
Fixes #2325.

Revert and cherry-pick now refuse a replayed column drop when it would discard a changed non-NULL value. The replay-specific role check leaves valid inverse replays and NULL-only drops alone, matching Dolt.

The row detector now treats omitted trailing record fields as NULL, covering values written to columns added after the rows were first encoded. Replay refusals also surface the specific destructive-column error instead of a generic command failure.

Tests cover the reported revert, the equivalent cherry-pick, safe replay controls, the omitted-field merge shape, rollback post-state against Dolt, and integrity/reopen behavior.

Validation:
- doltlite_cherry_pick.sh: 127 passed
- doltlite_schema_merge.sh: 290 passed
- vc_oracle_revert_cherrypick_test.sh: 60 passed
- doltlite_rebase.sh: 59 passed
- doltlite_revert_dirty.sh: 42 passed
- full DoltLite suite: 110/110 effective (109/110 harness run plus standalone stock-SQLite parity 119/119)
- C gates: 29/29
- make lint

Co-Authored-By: OpenAI Codex <noreply@openai.com>