### PR TITLE
Count BETWEEN on stock SQLite files through the orig adapter

### DIFF
--- a/src/btree_orig_api.c
+++ b/src/btree_orig_api.c
@@ -164,6 +164,15 @@ void origBtreeIncrblobCursor(void *pCur){
 int origBtreeCount(sqlite3 *db, void *pCur, i64 *pn){
   return orig_sqlite3BtreeCount(db, C(pCur), pn);
 }
+int origBtreeCountRange(
+  sqlite3 *db,
+  void *pCur,
+  i64 iLower,
+  i64 iUpper,
+  i64 *pn
+){
+  return orig_sqlite3BtreeCountRange(db, C(pCur), iLower, iUpper, pn);
+}
 int origBtreeCountIndexRange(
   sqlite3 *db,
   void *pCur,

--- a/src/btree_orig_api.h
+++ b/src/btree_orig_api.h
@@ -75,6 +75,8 @@ int origBtreePutData(void *pCur, u32 offset, u32 amt, void *pBuf);
 void origBtreeIncrblobCursor(void *pCur);
 #endif
 int origBtreeCount(sqlite3 *db, void *pCur, i64 *pnEntry);
+int origBtreeCountRange(sqlite3 *db, void *pCur, i64 iLower, i64 iUpper,
+                        i64 *pnEntry);
 int origBtreeCountIndexRange(sqlite3 *db, void *pCur, UnpackedRecord *pLower,
                              UnpackedRecord *pUpper, i64 *pnEntry);
 int origBtreeClosesWithCursor(void *p, void *pCur);

--- a/src/prolly_btree_orig.c
+++ b/src/prolly_btree_orig.c
@@ -273,26 +273,7 @@ int origCursorCountRangeVt(
   i64 iUpper,
   i64 *pnEntry
 ){
-  int rc;
-  int res = 0;
-  i64 n = 0;
-  (void)db;
-
-  *pnEntry = 0;
-  if( iLower>iUpper ) return SQLITE_OK;
-  rc = origBtreeTableMoveto(pCur->pOrigCursor, iLower, 0, &res);
-  if( rc!=SQLITE_OK ) return rc;
-  if( res!=0 && origBtreeEof(pCur->pOrigCursor) ){
-    return SQLITE_OK;
-  }
-  while( !origBtreeEof(pCur->pOrigCursor) ){
-    if( origBtreeIntegerKey(pCur->pOrigCursor)>iUpper ) break;
-    n++;
-    rc = origBtreeNext(pCur->pOrigCursor, 0);
-    if( rc!=SQLITE_OK ) return rc;
-  }
-  *pnEntry = n;
-  return SQLITE_OK;
+  return origBtreeCountRange(db, pCur->pOrigCursor, iLower, iUpper, pnEntry);
 }
 int origCursorCountIndexRangeVt(
   sqlite3 *db,

--- a/test/doltlite_attach_sqlite.sh
+++ b/test/doltlite_attach_sqlite.sh
@@ -155,7 +155,28 @@ PRAGMA side.integrity_check;" \
   "1
 ok" "$DLDB_IC"
 
-rm -f "$SQLDB1" "$SQLDB2" "$DLDB" "$SQLDB_W" "$SQLDB_IC" "$DLDB_IC"
+SQLDB_CR=/tmp/test_attach_countrange_$$.db
+$SQLITE3 "$SQLDB_CR" "CREATE TABLE t(id INTEGER PRIMARY KEY); INSERT INTO t VALUES(1),(2),(3),(5),(8),(10);"
+run_test "attach_count_between_last" \
+  "ATTACH DATABASE '$SQLDB_CR' AS s;
+SELECT count(*) FROM s.t WHERE id BETWEEN 8 AND 10;" \
+  "2" ":memory:"
+run_test "attach_count_between_gap" \
+  "ATTACH DATABASE '$SQLDB_CR' AS s;
+SELECT count(*) FROM s.t WHERE id BETWEEN 6 AND 7;" \
+  "0" ":memory:"
+
+DLDB_CR=/tmp/test_attach_dl_countrange_$$.db
+rm -f "$DLDB_CR"
+run_test "doltlite_main_attach_count_between_last" \
+  "CREATE TABLE m(x INTEGER); INSERT INTO m VALUES(1);
+SELECT dolt_commit('-Am','init') IS NOT NULL;
+ATTACH DATABASE '$SQLDB_CR' AS s;
+SELECT count(*) FROM s.t WHERE id BETWEEN 8 AND 10;" \
+  "1
+2" "$DLDB_CR"
+
+rm -f "$SQLDB1" "$SQLDB2" "$DLDB" "$SQLDB_W" "$SQLDB_IC" "$DLDB_IC" "$SQLDB_CR" "$DLDB_CR"
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed"

--- a/test/doltlite_open_sqlite_file.sh
+++ b/test/doltlite_open_sqlite_file.sh
@@ -106,6 +106,27 @@ want_eq "R12_blob_pk_reads_payload_columns" \
   "$(dl_last "SELECT group_concat(hex(k)||':'||label||':'||n, ',') FROM (SELECT * FROM blobs ORDER BY k);" "$DB")" \
   "01:one:1,0203:two-three:23"
 
+# COUNT(*) WHERE INTEGER PK BETWEEN uses OP_CountRange on the orig adapter.
+DB=$TMP/r14.db
+seed_stock "$DB" "CREATE TABLE t(id INTEGER PRIMARY KEY); INSERT INTO t VALUES(1),(2),(3),(5),(8),(10);"
+want_eq "R14_count_between_last_row" \
+  "$(dl_last "SELECT count(*) FROM t WHERE id BETWEEN 8 AND 10;" "$DB")" "2"
+want_eq "R14_count_between_gap" \
+  "$(dl_last "SELECT count(*) FROM t WHERE id BETWEEN 6 AND 7;" "$DB")" "0"
+want_eq "R14_count_between_all" \
+  "$(dl_last "SELECT count(*) FROM t WHERE id BETWEEN 1 AND 10;" "$DB")" "6"
+want_eq "R14_count_between_mid" \
+  "$(dl_last "SELECT count(*) FROM t WHERE id BETWEEN 4 AND 9;" "$DB")" "2"
+
+DB=$TMP/r14b.db
+seed_stock "$DB" "CREATE TABLE t(id INTEGER PRIMARY KEY); INSERT INTO t VALUES(5);"
+want_eq "R14b_count_between_one_hit" \
+  "$(dl_last "SELECT count(*) FROM t WHERE id BETWEEN 1 AND 10;" "$DB")" "1"
+want_eq "R14b_count_between_miss_high" \
+  "$(dl_last "SELECT count(*) FROM t WHERE id BETWEEN 6 AND 10;" "$DB")" "0"
+want_eq "R14b_count_between_miss_low" \
+  "$(dl_last "SELECT count(*) FROM t WHERE id BETWEEN 1 AND 4;" "$DB")" "0"
+
 for page_size in 1024 4096 8192 16384; do
   DB=$TMP/r13-$page_size.db
   seed_stock "$DB" "PRAGMA page_size=$page_size; CREATE TABLE t(id INTEGER PRIMARY KEY, b BLOB, s TEXT); WITH r(i) AS (VALUES(1),(2),(3)) INSERT INTO t SELECT i,CAST(char(64+i)||substr(hex(zeroblob(25000)),1,49999) AS BLOB),char(96+i)||substr(hex(zeroblob(25000)),1,49999) FROM r;"


### PR DESCRIPTION
## Summary

`COUNT(*) WHERE id BETWEEN lo AND hi` on a stock SQLite file (opened directly, or ATTACHed from a DoltLite main DB) went through a hand-rolled orig-adapter count-range. That loop did not skip keys below `lo` after `TableMoveto`, and it treated `SQLITE_DONE` from `Next` as a hard error.

Stock SQLite already implements this correctly as `sqlite3BtreeCountRange`. Forward that, same pattern as the overflow-offset fix.

## Repro (before)

```sql
-- stock sqlite3 file with INTEGER PRIMARY KEY rows 1,2,3,5,8,10
SELECT count(*) FROM t WHERE id BETWEEN 8 AND 10;
-- stock sqlite3: 2
-- doltlite: Error: no more rows available

SELECT count(*) FROM t WHERE id BETWEEN 6 AND 7;
-- stock sqlite3: 0
-- doltlite: 1
```

Native DoltLite-format tables were already correct. Only the orig adapter was wrong.

## Testing

- fail-before: `doltlite_open_sqlite_file.sh` 100/105 (the five new BETWEEN cases failed as above); `doltlite_attach_sqlite.sh` 13/16
- pass-after: 105/105 and 16/16
- native `doltlite_count_numeric_range.sh` still 7/7

Co-Authored-By: Grok <noreply@x.ai>