### PR TITLE
Oracle stock SQLite files against sqlite3, and lint the orig adapter

### DIFF
--- a/main.mk
+++ b/main.mk
@@ -308,6 +308,7 @@ lint:
 	@bash $(TOP)/test/lint_layers.sh $(TOP)/src
 	@bash $(TOP)/test/lint_no_raw_os_fileio.sh $(TOP)/src
 	@bash $(TOP)/test/lint_export_filters.sh $(TOP)/src
+	@bash $(TOP)/test/lint_orig_btree_adapter.sh $(TOP)/src
 	@bash $(TOP)/test/lint_layers_selftest.sh
 	@bash $(TOP)/test/check_testfixture_exception_inventory.sh
 	@bash $(TOP)/test/check_testfixture_exception_inventory_test.sh

--- a/src/btree_orig_api.c
+++ b/src/btree_orig_api.c
@@ -164,6 +164,15 @@ void origBtreeIncrblobCursor(void *pCur){
 int origBtreeCount(sqlite3 *db, void *pCur, i64 *pn){
   return orig_sqlite3BtreeCount(db, C(pCur), pn);
 }
+int origBtreeCountRange(
+  sqlite3 *db,
+  void *pCur,
+  i64 iLower,
+  i64 iUpper,
+  i64 *pn
+){
+  return orig_sqlite3BtreeCountRange(db, C(pCur), iLower, iUpper, pn);
+}
 int origBtreeCountIndexRange(
   sqlite3 *db,
   void *pCur,

--- a/src/btree_orig_api.h
+++ b/src/btree_orig_api.h
@@ -75,6 +75,8 @@ int origBtreePutData(void *pCur, u32 offset, u32 amt, void *pBuf);
 void origBtreeIncrblobCursor(void *pCur);
 #endif
 int origBtreeCount(sqlite3 *db, void *pCur, i64 *pnEntry);
+int origBtreeCountRange(sqlite3 *db, void *pCur, i64 iLower, i64 iUpper,
+                        i64 *pnEntry);
 int origBtreeCountIndexRange(sqlite3 *db, void *pCur, UnpackedRecord *pLower,
                              UnpackedRecord *pUpper, i64 *pnEntry);
 int origBtreeClosesWithCursor(void *p, void *pCur);

--- a/src/prolly_btree_orig.c
+++ b/src/prolly_btree_orig.c
@@ -273,26 +273,7 @@ int origCursorCountRangeVt(
   i64 iUpper,
   i64 *pnEntry
 ){
-  int rc;
-  int res = 0;
-  i64 n = 0;
-  (void)db;
-
-  *pnEntry = 0;
-  if( iLower>iUpper ) return SQLITE_OK;
-  rc = origBtreeTableMoveto(pCur->pOrigCursor, iLower, 0, &res);
-  if( rc!=SQLITE_OK ) return rc;
-  if( res!=0 && origBtreeEof(pCur->pOrigCursor) ){
-    return SQLITE_OK;
-  }
-  while( !origBtreeEof(pCur->pOrigCursor) ){
-    if( origBtreeIntegerKey(pCur->pOrigCursor)>iUpper ) break;
-    n++;
-    rc = origBtreeNext(pCur->pOrigCursor, 0);
-    if( rc!=SQLITE_OK ) return rc;
-  }
-  *pnEntry = n;
-  return SQLITE_OK;
+  return origBtreeCountRange(db, pCur->pOrigCursor, iLower, iUpper, pnEntry);
 }
 int origCursorCountIndexRangeVt(
   sqlite3 *db,

--- a/test/doltlite_sqlite_file_oracle.sh
+++ b/test/doltlite_sqlite_file_oracle.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+# Stock sqlite3 seeds the file; doltlite and sqlite3 must agree on the same SQL.
+
+DOLTLITE="${1:-./doltlite}"
+SQLITE3=$(command -v sqlite3 2>/dev/null || echo /usr/bin/sqlite3)
+TMP=$(mktemp -d)
+trap "rm -rf $TMP" EXIT
+PASS=0
+FAIL=0
+SKIP=0
+ERRORS=""
+
+want_eq() {
+  local name="$1" got="$2" want="$3"
+  got="${got//$'\r'/}"
+  want="${want//$'\r'/}"
+  if [ "$got" = "$want" ]; then
+    PASS=$((PASS+1))
+  else
+    FAIL=$((FAIL+1))
+    ERRORS="$ERRORS\n  FAIL: $name\n    want: $(printf %q "$want")\n    got:  $(printf %q "$got")"
+  fi
+}
+
+oracle() {
+  local name="$1" sql="$2" db="$3"
+  local s d
+  s=$(printf '%s\n' "$sql" | $SQLITE3 "$db" 2>&1)
+  d=$(printf '%s\n' "$sql" | $DOLTLITE "$db" 2>&1)
+  s="${s//$'\r'/}"
+  d="${d//$'\r'/}"
+  if [ "$s" = "$d" ]; then
+    PASS=$((PASS+1))
+  else
+    FAIL=$((FAIL+1))
+    ERRORS="$ERRORS\n  FAIL: $name\n    sqlite3:  $(printf %q "$s")\n    doltlite: $(printf %q "$d")"
+  fi
+}
+
+seed_stock() {
+  rm -f "$1" "$1-wal" "$1-shm" "$1-journal"
+  $SQLITE3 "$1" "$2" >/dev/null
+}
+
+echo "=== doltlite vs stock sqlite3 on a sqlite3-created file ==="
+
+if [ ! -x "$SQLITE3" ]; then
+  echo "SKIP: stock sqlite3 binary not found at $SQLITE3"
+  echo "Results: 0 passed, 0 failed, 1 skipped"
+  exit 0
+fi
+
+echo ""
+echo "--- INTEGER PK / page sizes ---"
+
+for page_size in 512 1024 4096 8192 16384 65536; do
+  DB=$TMP/intpk-$page_size.db
+  seed_stock "$DB" "PRAGMA page_size=$page_size; CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'a'),(2,'b'),(3,'c'),(5,'e'),(8,'h'),(10,'j');"
+  want_eq "O_intpk_${page_size}_engine_is_orig" \
+    "$(printf '%s\n' "SELECT doltlite_engine();" | $DOLTLITE "$DB" 2>&1 | tr -d '\r' | tail -1)" \
+    "orig"
+  oracle "O_intpk_${page_size}_page_size" "PRAGMA page_size;" "$DB"
+  oracle "O_intpk_${page_size}_count" "SELECT count(*) FROM t;" "$DB"
+  oracle "O_intpk_${page_size}_by_pk" "SELECT v FROM t WHERE id=8;" "$DB"
+  oracle "O_intpk_${page_size}_between_last" "SELECT count(*) FROM t WHERE id BETWEEN 8 AND 10;" "$DB"
+  oracle "O_intpk_${page_size}_between_gap" "SELECT count(*) FROM t WHERE id BETWEEN 6 AND 7;" "$DB"
+  oracle "O_intpk_${page_size}_between_all" "SELECT count(*) FROM t WHERE id BETWEEN 1 AND 10;" "$DB"
+done
+
+# Stable name the compatibility contract pins.
+oracle "O_intpk_between_last" "SELECT count(*) FROM t WHERE id BETWEEN 8 AND 10;" "$TMP/intpk-4096.db"
+
+echo ""
+echo "--- overflow DISTINCT ---"
+
+for page_size in 1024 4096 8192 16384; do
+  DB=$TMP/ov-$page_size.db
+  seed_stock "$DB" "PRAGMA page_size=$page_size; CREATE TABLE t(id INTEGER PRIMARY KEY, b BLOB, s TEXT); WITH r(i) AS (VALUES(1),(2),(3)) INSERT INTO t SELECT i, CAST(char(64+i)||substr(hex(zeroblob(25000)),1,49999) AS BLOB), char(96+i)||substr(hex(zeroblob(25000)),1,49999) FROM r;"
+  oracle "O_overflow_${page_size}_distinct" \
+    "SELECT (SELECT count(DISTINCT b) FROM t)||':'||(SELECT count(DISTINCT s) FROM t);" "$DB"
+  oracle "O_overflow_${page_size}_group" \
+    "SELECT (SELECT count(*) FROM (SELECT b FROM t GROUP BY b))||':'||(SELECT count(*) FROM (SELECT s FROM t GROUP BY s));" "$DB"
+done
+
+echo ""
+echo "--- WAL round-trip ---"
+
+DB=$TMP/wal.db
+seed_stock "$DB" "PRAGMA journal_mode=WAL; CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'a');"
+oracle "O_wal_mode" "PRAGMA journal_mode;" "$DB"
+oracle "O_wal_count_seed" "SELECT count(*) FROM t;" "$DB"
+printf '%s\n' "INSERT INTO t VALUES(2,'b');" | $DOLTLITE "$DB" >/dev/null
+want_eq "O_wal_sqlite3_sees_doltlite_insert" \
+  "$(printf '%s\n' "SELECT count(*)||group_concat(v,'') FROM (SELECT v FROM t ORDER BY id);" | $SQLITE3 "$DB" | tr -d '\r')" \
+  "2ab"
+printf '%s\n' "INSERT INTO t VALUES(3,'c');" | $SQLITE3 "$DB" >/dev/null
+want_eq "O_wal_doltlite_sees_sqlite3_insert" \
+  "$(printf '%s\n' "SELECT count(*)||group_concat(v,'') FROM (SELECT v FROM t ORDER BY id);" | $DOLTLITE "$DB" 2>&1 | tr -d '\r' | tail -1)" \
+  "3abc"
+
+echo ""
+echo "============================="
+echo "Results: $PASS passed, $FAIL failed, $SKIP skipped"
+echo "============================="
+if [ $FAIL -gt 0 ]; then echo -e "$ERRORS"; exit 1; fi

--- a/test/lib/doltlite_suite_manifest.sh
+++ b/test/lib/doltlite_suite_manifest.sh
@@ -82,6 +82,7 @@ doltlite_attach_sqlite.sh
 doltlite_dbpage.sh
 doltlite_arm_correctness.sh
 doltlite_open_sqlite_file.sh
+doltlite_sqlite_file_oracle.sh
 doltlite_open_nofollow.sh
 doltlite_readonly_directory.sh
 doltlite_readonly_file_replacement.sh
@@ -179,6 +180,7 @@ doltlite_storage_locking.sh
 chunk_physical_dups_test.sh
 chunker_boundary_golden.sh
 doltlite_open_sqlite_file.sh
+doltlite_sqlite_file_oracle.sh
 doltlite_open_missing_path.sh
 doltlite_comparison.sh
 doltlite_merge_ignore_corners.sh

--- a/test/lint_orig_btree_adapter.sh
+++ b/test/lint_orig_btree_adapter.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Orig-adapter cursor ops must forward to stock B-tree, not stub or reimplement.
+# Dummy Offset/CountRange returns were silent SQLite-file corruption.
+
+set -euo pipefail
+
+SRCDIR="${1:-src}"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/.." && pwd)"
+cd "$REPO"
+
+python3 - "$SRCDIR" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+src = Path(sys.argv[1])
+orig_c = (src / "prolly_btree_orig.c").read_text()
+btree_c = (src / "prolly_btree.c").read_text()
+api_c = (src / "btree_orig_api.c").read_text()
+
+allow = {
+    "origCursorRowCountEstVt": "unknown estimate is a valid stock answer",
+    "origCursorCursorHintFlagsVt": "SEEK_EQ not forwarded; slower, not wrong",
+    "origCursorCursorHasHintVt": "SEEK_EQ not forwarded; slower, not wrong",
+    "origCursorCursorIsValidVt": "debug-only",
+}
+
+m = re.search(
+    r"const struct BtCursorOps origCursorVtOps = \{([^}]+)\}",
+    btree_c,
+)
+if not m:
+    print("lint_orig_btree_adapter: origCursorVtOps not found", file=sys.stderr)
+    sys.exit(1)
+vtable = re.findall(r"\borigCursor\w+Vt\b", m.group(1))
+if not vtable:
+    print("lint_orig_btree_adapter: origCursorVtOps has no members", file=sys.stderr)
+    sys.exit(1)
+
+
+def func_body(text, name):
+    pat = re.compile(
+        r"(?:^|\n)(?:[\w\s\*]+?)" + re.escape(name) + r"\s*\((?:[^;]*?)\)\s*\{",
+        re.S,
+    )
+    match = pat.search(text)
+    if not match:
+        return None
+    start = match.end() - 1
+    depth = 0
+    for i, ch in enumerate(text[start:], start):
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return text[start : i + 1]
+    return None
+
+
+fails = []
+for name in vtable:
+    if name in allow:
+        continue
+    body = func_body(orig_c, name)
+    if body is None:
+        fails.append("%s: missing definition in prolly_btree_orig.c" % name)
+        continue
+    expected = "origBtree" + name[len("origCursor") : -2]
+    if expected not in body:
+        fails.append(
+            "%s: must call %s (do not stub or reimplement stock btree)"
+            % (name, expected)
+        )
+
+for name, _reason in allow.items():
+    if name in vtable and func_body(orig_c, name) is None:
+        fails.append("%s: allowlisted but missing from prolly_btree_orig.c" % name)
+
+if "origBtreeOffset" not in api_c or "orig_sqlite3BtreeOffset" not in api_c:
+    fails.append("origBtreeOffset must forward orig_sqlite3BtreeOffset")
+if "origBtreeCountRange" not in api_c or "orig_sqlite3BtreeCountRange" not in api_c:
+    fails.append("origBtreeCountRange must forward orig_sqlite3BtreeCountRange")
+
+if fails:
+    print("lint_orig_btree_adapter: %d violation(s)" % len(fails), file=sys.stderr)
+    for f in fails:
+        print("  %s" % f, file=sys.stderr)
+    sys.exit(1)
+print("lint_orig_btree_adapter: all checks passed")
+PY

--- a/test/sqlite_compatibility_contract.tsv
+++ b/test/sqlite_compatibility_contract.tsv
@@ -1,6 +1,6 @@
 id	status	evidence	contract
 api.public_surface	compatible	test/install_layout_test.sh#static link via <doltlite.h>,test/lint_export_filters.sh#map_pats	doltlite.h exposes the bundled SQLite declarations and libdoltlite exports sqlite3_* entry points
-storage.format_routing	adapted	test/doltlite_open_sqlite_file.sh#R1_select_star_count,test/doltlite_open_sqlite_file.sh#VC_UNAVAILABLE	DoltLite-format databases use the prolly engine while stock SQLite files route to the original B-tree without Dolt version control
+storage.format_routing	adapted	test/doltlite_open_sqlite_file.sh#R1_select_star_count,test/doltlite_open_sqlite_file.sh#VC_UNAVAILABLE,test/doltlite_sqlite_file_oracle.sh#O_intpk_between_last	DoltLite-format databases use the prolly engine while stock SQLite files route to the original B-tree without Dolt version control
 storage.sqlite_sidecars	adapted	test/sqlite_compatibility_contract_test.sh#sidecars_absent	DoltLite-format databases do not create SQLite rollback-journal WAL or shared-memory sidecars
 pragma.journal_mode	adapted	test/doltlite_pragma_journal_mode.sh#jm_dl_set_${mode}_noop	journal_mode reports wal and ignores mode changes on DoltLite-format databases
 pragma.wal_checkpoint	adapted	test/doltlite_pragma_wal_checkpoint.sh#wc_dl_default,test/doltlite_pragma_wal_checkpoint.sh#wc_dl_${mode}_accepted	all WAL checkpoint modes run DoltLite garbage collection and report zero WAL frames


### PR DESCRIPTION
## Summary

First slice of the DoltLite-opens-SQLite-files test plan.

Two real bugs in this adapter were dummy/reimplemented cursor ops (`Offset`, `CountRange`) that sqlite3's VDBE trusts. This PR:

1. **Lint** (`test/lint_orig_btree_adapter.sh`, wired into `make lint`): every `origCursorVtOps` method must call the matching `origBtree*` forward, except an explicit allowlist (row-count estimate, SEEK_EQ hints, debug). Also requires `origBtreeOffset` and `origBtreeCountRange` to call the prefixed stock functions. Fail-before on current master: CountRange reimplementation is rejected.
2. **Oracle** (`test/doltlite_sqlite_file_oracle.sh`): stock `sqlite3` creates the file; the same SQL must match on `sqlite3` and `doltlite`.
   - INTEGER PK across page sizes 512–65536
   - `COUNT(*) WHERE id BETWEEN` (last row, gap, full span)
   - overflow DISTINCT / GROUP BY (the 2329 query shape)
   - WAL: doltlite insert visible to sqlite3, and the reverse
3. Pin `storage.format_routing` at the BETWEEN case, not only `count(*)`.

## Overlap with #2335

The CountRange forward is the same engine change as #2335. This PR carries it so the oracle and lint can land on master without stacking. Land #2335 first and this rebases to tests+lint only; land this first and #2335 keeps its extra `open_sqlite_file` / ATTACH cases.

## Testing

- lint fail-before on origin/master orig adapter (CountRange)
- `lint_orig_btree_adapter.sh` pass on this branch
- `doltlite_sqlite_file_oracle.sh` 55/55
- `sqlite_compatibility_contract_test.sh` 5/5
- `lint_orphaned_suites.sh` OK

Co-Authored-By: Grok <noreply@x.ai>