### PR TITLE
Grow the stock-SQLite file oracle matrix

### DIFF
--- a/test/doltlite_sqlite_file_oracle.sh
+++ b/test/doltlite_sqlite_file_oracle.sh
@@ -42,6 +42,52 @@ seed_stock() {
   $SQLITE3 "$1" "$2" >/dev/null
 }
 
+copy_db() {
+  cp "$1" "$2"
+  [ -f "$1-wal" ] && cp "$1-wal" "$2-wal" || true
+  [ -f "$1-shm" ] && cp "$1-shm" "$2-shm" || true
+}
+
+# Mutating SQL: each engine gets its own copy of the sqlite3-seeded file.
+oracle_copy() {
+  local name="$1" sql="$2" src="$3"
+  local sdb="$TMP/ora-s.db" ddb="$TMP/ora-d.db"
+  local s d
+  rm -f "$sdb" "$sdb-wal" "$sdb-shm" "$ddb" "$ddb-wal" "$ddb-shm"
+  copy_db "$src" "$sdb"
+  copy_db "$src" "$ddb"
+  s=$(printf '%s\n' "$sql" | $SQLITE3 "$sdb" 2>&1)
+  d=$(printf '%s\n' "$sql" | $DOLTLITE "$ddb" 2>&1)
+  s="${s//$'\r'/}"
+  d="${d//$'\r'/}"
+  if [ "$s" = "$d" ]; then
+    PASS=$((PASS+1))
+  else
+    FAIL=$((FAIL+1))
+    ERRORS="$ERRORS\n  FAIL: $name\n    sqlite3:  $(printf %q "$s")\n    doltlite: $(printf %q "$d")"
+  fi
+}
+
+both_contain() {
+  local name="$1" sql="$2" db="$3" needle="$4"
+  local s d
+  s=$(printf '%s\n' "$sql" | $SQLITE3 "$db" 2>&1)
+  d=$(printf '%s\n' "$sql" | $DOLTLITE "$db" 2>&1)
+  s="${s//$'\r'/}"
+  d="${d//$'\r'/}"
+  if echo "$s" | grep -q -- "$needle" && echo "$d" | grep -q -- "$needle"; then
+    PASS=$((PASS+1))
+  else
+    FAIL=$((FAIL+1))
+    ERRORS="$ERRORS\n  FAIL: $name\n    needle: $needle\n    sqlite3:  $(printf %q "$s")\n    doltlite: $(printf %q "$d")"
+  fi
+}
+
+skip() {
+  SKIP=$((SKIP+1))
+  echo "  SKIP: $1 — $2"
+}
+
 echo "=== doltlite vs stock sqlite3 on a sqlite3-created file ==="
 
 if [ ! -x "$SQLITE3" ]; then
@@ -97,6 +143,102 @@ printf '%s\n' "INSERT INTO t VALUES(3,'c');" | $SQLITE3 "$DB" >/dev/null
 want_eq "O_wal_doltlite_sees_sqlite3_insert" \
   "$(printf '%s\n' "SELECT count(*)||group_concat(v,'') FROM (SELECT v FROM t ORDER BY id);" | $DOLTLITE "$DB" 2>&1 | tr -d '\r' | tail -1)" \
   "3abc"
+
+echo ""
+echo "--- encodings ---"
+
+for enc in UTF-8 UTF-16le UTF-16be; do
+  DB=$TMP/enc-$enc.db
+  seed_stock "$DB" "PRAGMA encoding='$enc'; CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1, char(233)),(2, 'ok'),(3, char(233)||'x');"
+  oracle "O_enc_${enc}_pragma" "PRAGMA encoding;" "$DB"
+  oracle "O_enc_${enc}_hex_len" "SELECT group_concat(id||':'||length(v)||':'||hex(v), ',') FROM (SELECT * FROM t ORDER BY id);" "$DB"
+  oracle "O_enc_${enc}_distinct" "SELECT count(DISTINCT v) FROM t;" "$DB"
+done
+
+echo ""
+echo "--- WITHOUT ROWID ---"
+
+DB=$TMP/wor.db
+seed_stock "$DB" "CREATE TABLE t(k TEXT PRIMARY KEY, n INTEGER) WITHOUT ROWID; INSERT INTO t VALUES('a',1),('b',2),('c',3); CREATE TABLE u(x INTEGER PRIMARY KEY, y TEXT) WITHOUT ROWID; INSERT INTO u VALUES(1,'one'),(2,'two'),(10,'ten');"
+oracle "O_wor_select" "SELECT group_concat(k||n, ',') FROM (SELECT * FROM t ORDER BY k);" "$DB"
+oracle "O_wor_int_between" "SELECT count(*) FROM u WHERE x BETWEEN 2 AND 10;" "$DB"
+oracle_copy "O_wor_update" "UPDATE t SET n=n+1 WHERE k='b'; SELECT group_concat(k||n, ',') FROM (SELECT * FROM t ORDER BY k);" "$DB"
+
+echo ""
+echo "--- STRICT / generated ---"
+
+DB=$TMP/strict.db
+seed_stock "$DB" "CREATE TABLE t(id INTEGER PRIMARY KEY, n INTEGER NOT NULL) STRICT; INSERT INTO t VALUES(1,10),(2,20);"
+oracle "O_strict_select" "SELECT group_concat(id||':'||n, ',') FROM (SELECT * FROM t ORDER BY id);" "$DB"
+both_contain "O_strict_reject_text" "INSERT INTO t VALUES(3,'x');" "$DB" "cannot store TEXT"
+
+DB=$TMP/gen.db
+seed_stock "$DB" "CREATE TABLE g(id INTEGER PRIMARY KEY, n INT, d INT GENERATED ALWAYS AS (n*2) STORED, v INT GENERATED ALWAYS AS (n+1) VIRTUAL); INSERT INTO g(id,n) VALUES(1,5),(2,7);"
+oracle "O_gen_select" "SELECT group_concat(id||':'||n||':'||d||':'||v, ',') FROM (SELECT * FROM g ORDER BY id);" "$DB"
+oracle_copy "O_gen_update" "UPDATE g SET n=n+1 WHERE id=1; SELECT n||':'||d||':'||v FROM g WHERE id=1;" "$DB"
+
+echo ""
+echo "--- FTS5 / rtree ---"
+
+if $SQLITE3 :memory: "CREATE VIRTUAL TABLE docs USING fts5(title, body);" >/dev/null 2>&1; then
+  DB=$TMP/fts.db
+  seed_stock "$DB" "CREATE VIRTUAL TABLE docs USING fts5(title, body); INSERT INTO docs VALUES('one','alpha beta'),('two','beta gamma');"
+  oracle "O_fts5_match" "SELECT group_concat(title) FROM (SELECT title FROM docs WHERE docs MATCH 'beta' ORDER BY title);" "$DB"
+else
+  skip "O_fts5_match" "stock sqlite3 has no FTS5"
+fi
+
+if $SQLITE3 :memory: "CREATE VIRTUAL TABLE r USING rtree(id, minX, maxX, minY, maxY);" >/dev/null 2>&1; then
+  DB=$TMP/rtree.db
+  seed_stock "$DB" "CREATE VIRTUAL TABLE r USING rtree(id, minX, maxX, minY, maxY); INSERT INTO r VALUES(1,0,1,0,1),(2,5,6,5,6);"
+  oracle "O_rtree_query" "SELECT group_concat(id) FROM (SELECT id FROM r WHERE minX>=0 AND maxX<=2 ORDER BY id);" "$DB"
+else
+  skip "O_rtree_query" "stock sqlite3 has no rtree"
+fi
+
+echo ""
+echo "--- ATTACH overflow copy into a doltlite dest ---"
+
+SRC=$TMP/ov-4096.db
+if [ ! -f "$SRC" ]; then
+  seed_stock "$SRC" "PRAGMA page_size=4096; CREATE TABLE t(id INTEGER PRIMARY KEY, b BLOB, s TEXT); WITH r(i) AS (VALUES(1),(2),(3)) INSERT INTO t SELECT i, CAST(char(64+i)||substr(hex(zeroblob(25000)),1,49999) AS BLOB), char(96+i)||substr(hex(zeroblob(25000)),1,49999) FROM r;"
+fi
+
+copy_overflow() {
+  local distinct_name="$1" except_name="$2" ddl="$3" insert="$4" except_sql="$5"
+  local dst="$TMP/copy-$distinct_name.db"
+  rm -f "$dst"
+  printf '%s\n' \
+    "ATTACH '$SRC' AS s;" \
+    "$ddl" \
+    "$insert" \
+    "SELECT dolt_commit('-A','-m','overflow copy');" \
+    | $DOLTLITE "$dst" >/dev/null 2>&1
+  want_eq "$distinct_name" \
+    "$(printf '%s\n' "SELECT count(DISTINCT b) FROM d;" | $DOLTLITE "$dst" 2>&1 | tr -d '\r' | tail -1)" \
+    "3"
+  want_eq "$except_name" \
+    "$(printf '%s\n' "ATTACH '$SRC' AS s; $except_sql" | $DOLTLITE "$dst" 2>&1 | tr -d '\r' | tail -1)" \
+    "0:0"
+}
+
+copy_overflow \
+  "O_attach_ov_textpk_distinct" "O_attach_ov_textpk_except" \
+  "CREATE TABLE d(g TEXT PRIMARY KEY, id INTEGER, b BLOB);" \
+  "INSERT INTO d SELECT 'g'||id, id, b FROM s.t;" \
+  "SELECT (SELECT count(*) FROM (SELECT id,b FROM d EXCEPT SELECT id,b FROM s.t))||':'||(SELECT count(*) FROM (SELECT id,b FROM s.t EXCEPT SELECT id,b FROM d));"
+
+copy_overflow \
+  "O_attach_ov_intpk_distinct" "O_attach_ov_intpk_except" \
+  "CREATE TABLE d(id INTEGER PRIMARY KEY, b BLOB);" \
+  "INSERT INTO d SELECT id, b FROM s.t;" \
+  "SELECT (SELECT count(*) FROM (SELECT id,b FROM d EXCEPT SELECT id,b FROM s.t))||':'||(SELECT count(*) FROM (SELECT id,b FROM s.t EXCEPT SELECT id,b FROM d));"
+
+copy_overflow \
+  "O_attach_ov_keyless_distinct" "O_attach_ov_keyless_except" \
+  "CREATE TABLE d(id INTEGER, b BLOB);" \
+  "INSERT INTO d SELECT id, b FROM s.t;" \
+  "SELECT (SELECT count(*) FROM (SELECT id,b FROM d EXCEPT SELECT id,b FROM s.t))||':'||(SELECT count(*) FROM (SELECT id,b FROM s.t EXCEPT SELECT id,b FROM d));"
 
 echo ""
 echo "============================="

--- a/test/sqlite_compatibility_contract.tsv
+++ b/test/sqlite_compatibility_contract.tsv
@@ -1,6 +1,6 @@
 id	status	evidence	contract
 api.public_surface	compatible	test/install_layout_test.sh#static link via <doltlite.h>,test/lint_export_filters.sh#map_pats	doltlite.h exposes the bundled SQLite declarations and libdoltlite exports sqlite3_* entry points
-storage.format_routing	adapted	test/doltlite_open_sqlite_file.sh#R1_select_star_count,test/doltlite_open_sqlite_file.sh#VC_UNAVAILABLE,test/doltlite_sqlite_file_oracle.sh#O_intpk_between_last	DoltLite-format databases use the prolly engine while stock SQLite files route to the original B-tree without Dolt version control
+storage.format_routing	adapted	test/doltlite_open_sqlite_file.sh#R1_select_star_count,test/doltlite_open_sqlite_file.sh#VC_UNAVAILABLE,test/doltlite_sqlite_file_oracle.sh#O_intpk_between_last,test/doltlite_sqlite_file_oracle.sh#O_attach_ov_textpk_except	DoltLite-format databases use the prolly engine while stock SQLite files route to the original B-tree without Dolt version control
 storage.sqlite_sidecars	adapted	test/sqlite_compatibility_contract_test.sh#sidecars_absent	DoltLite-format databases do not create SQLite rollback-journal WAL or shared-memory sidecars
 pragma.journal_mode	adapted	test/doltlite_pragma_journal_mode.sh#jm_dl_set_${mode}_noop	journal_mode reports wal and ignores mode changes on DoltLite-format databases
 pragma.wal_checkpoint	adapted	test/doltlite_pragma_wal_checkpoint.sh#wc_dl_default,test/doltlite_pragma_wal_checkpoint.sh#wc_dl_${mode}_accepted	all WAL checkpoint modes run DoltLite garbage collection and report zero WAL frames


### PR DESCRIPTION
## Summary

Second slice of the DoltLite-opens-SQLite-files test plan. Extends `test/doltlite_sqlite_file_oracle.sh` so stock `sqlite3` still seeds the file and doltlite must match:

- encodings UTF-8 / UTF-16le / UTF-16be (pragma, hex/length, DISTINCT)
- WITHOUT ROWID (select, INTEGER PK BETWEEN, update on a per-engine copy)
- STRICT (select + both engines reject TEXT into INTEGER)
- generated stored + virtual (select and update)
- FTS5 MATCH and rtree query (skipped only if stock sqlite3 lacks the module)
- ATTACH overflow copy into a DoltLite dest with text PK, INTEGER PK, and keyless tables: DISTINCT count and EXCEPT vs the attached source after commit (the 2327 corruption shape)

Mutating SQL uses a copied DB per engine so sqlite3 cannot run first on the same file.

Pins `storage.format_routing` at `O_attach_ov_textpk_except` as well as BETWEEN.

## Testing

`doltlite_sqlite_file_oracle.sh` 79/79 (was 55). `sqlite_compatibility_contract_test.sh` 5/5.

Co-Authored-By: Grok <noreply@x.ai>