### PR TITLE
Reject embedded NULs in command arguments

### DIFF
--- a/src/doltlite_cmd.c
+++ b/src/doltlite_cmd.c
@@ -33,6 +33,33 @@ static DoltliteCmdOption *cmdFindShortOption(
   return 0;
 }
 
+static int cmdValueText(
+  sqlite3_context *ctx,
+  sqlite3_value *pValue,
+  const char **pzValue
+){
+  const char *zValue;
+  int eType = sqlite3_value_type(pValue);
+  int nValue;
+  *pzValue = 0;
+  zValue = (const char*)sqlite3_value_text(pValue);
+  if( !zValue ){
+    if( eType!=SQLITE_NULL ){
+      sqlite3_result_error_nomem(ctx);
+      return SQLITE_NOMEM;
+    }
+    return SQLITE_OK;
+  }
+  nValue = sqlite3_value_bytes(pValue);
+  if( memchr(zValue, 0, (size_t)nValue) ){
+    sqlite3_result_error(ctx,
+        "command arguments may not contain NUL bytes", -1);
+    return SQLITE_ERROR;
+  }
+  *pzValue = zValue;
+  return SQLITE_OK;
+}
+
 static int cmdSetOption(
   sqlite3_context *ctx,
   DoltliteCmdOption *pOption,
@@ -43,6 +70,7 @@ static int cmdSetOption(
   int *pI
 ){
   const char *zValue;
+  int rc;
   if( pOption->eType==DOLTLITE_CMD_OPTION_FLAG ){
     if( pOption->pSeen ) *pOption->pSeen = 1;
     return SQLITE_OK;
@@ -50,7 +78,8 @@ static int cmdSetOption(
   if( zAttached && zAttached[0] ){
     zValue = zAttached;
   }else if( *pI+1<argc ){
-    zValue = (const char*)sqlite3_value_text(argv[++*pI]);
+    rc = cmdValueText(ctx, argv[++*pI], &zValue);
+    if( rc!=SQLITE_OK ) return rc;
   }else{
     doltliteCmdResultMissingOptionValue(ctx, zOpt);
     return SQLITE_ERROR;
@@ -98,9 +127,14 @@ int doltliteCmdParseArgs(
     }
   }
   for(i=0; i<argc; i++){
-    const char *zArg = (const char*)sqlite3_value_text(argv[i]);
+    const char *zArg;
     DoltliteCmdOption *pOption = 0;
     int rc;
+    rc = cmdValueText(ctx, argv[i], &zArg);
+    if( rc!=SQLITE_OK ){
+      doltliteCmdArgsClear(pArgs);
+      return rc;
+    }
     if( !zArg ) continue;
     if( !endOptions && strcmp(zArg, "--")==0 ){
       endOptions = 1;

--- a/test/doltlite_commit.sh
+++ b/test/doltlite_commit.sh
@@ -476,7 +476,46 @@ run_test "author_removes_closing_brackets_fields" \
   "SELECT committer || '|' || email FROM dolt_log WHERE message='brackets';" \
   "Angle|ab" "$DB15"
 
-rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8" "$DB9" "$DB10" "$DB11" "$DB12" "$DB13" "$DB14" "$DB15"
+DB16=/tmp/test_dolt_nul_args_$$.db; rm -f "$DB16"
+
+run_test_match "nul_argument_setup" \
+  "CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES(1);
+SELECT dolt_commit('-Am','base');
+INSERT INTO t VALUES(2);" \
+  "^[0-9a-f]{40}$" "$DB16"
+
+run_test_match "nul_positional_rejected" \
+  "SELECT dolt_branch('visible' || char(0) || 'hidden');" \
+  "command arguments may not contain NUL bytes" "$DB16"
+
+run_test "nul_positional_does_not_create_prefix_branch" \
+  "SELECT count(*) FROM dolt_branches WHERE name='visible';" \
+  "0" "$DB16"
+
+run_test_match "nul_table_argument_rejected" \
+  "SELECT dolt_add('t' || char(0) || 'hidden');" \
+  "command arguments may not contain NUL bytes" "$DB16"
+
+run_test "nul_table_argument_does_not_stage_prefix" \
+  "SELECT staged FROM dolt_status WHERE table_name='t';" \
+  "0" "$DB16"
+
+run_test_match "nul_detached_option_value_rejected" \
+  "SELECT dolt_commit('-A','-m','visible' || char(0) || 'hidden');" \
+  "command arguments may not contain NUL bytes" "$DB16"
+
+run_test_match "nul_attached_option_value_rejected" \
+  "SELECT dolt_commit('-A','-mvisible' || char(0) || 'hidden');" \
+  "command arguments may not contain NUL bytes" "$DB16"
+
+run_test "nul_option_values_do_not_commit_or_stage" \
+  "SELECT count(*) FROM dolt_log WHERE message='visible';
+SELECT staged FROM dolt_status WHERE table_name='t';" \
+  "0
+0" "$DB16"
+
+rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8" "$DB9" "$DB10" "$DB11" "$DB12" "$DB13" "$DB14" "$DB15" "$DB16"
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"


### PR DESCRIPTION
Dolt command functions now reject SQLite arguments containing embedded NUL bytes instead of silently treating the prefix as the complete branch, table, or option value. Validation lives in the shared command parser, so every migrated command receives the same behavior.

Regression coverage proves positional branch and table arguments, detached option values, and attached short-option values all fail without creating refs, staging tables, or creating commits. The new tests fail seven assertions on the unfixed engine and pass after the fix.

Validation:
- `doltlite_commit.sh`: 82 passed
- full DoltLite suite: 110 runnable suites passed; `doltlite_parity.sh` could not run because the separate `build/sqlite3` prerequisite was absent
- regression C suite within the full run: 310,930 passed
- `make lint`
- `git diff --check`

Co-Authored-By: OpenAI Codex <noreply@openai.com>