### PR TITLE
Compare views and triggers in the merge matrix

### DIFF
--- a/test/vc_oracle_correct_schema_merge_matrix_test.sh
+++ b/test/vc_oracle_correct_schema_merge_matrix_test.sh
@@ -164,7 +164,8 @@ dl_state() {
   dep=$("$DOLTLITE" "$db" "SELECT group_concat(x, ' ') FROM (
       SELECT type || ':' || name || '->' || coalesce(tbl_name,'') AS x
       FROM sqlite_master WHERE type IN ('view','trigger') ORDER BY x);" 2>&1)
-  case "$dep" in *rror*) dep=UNREADABLE;; esac
+  case "$(printf '%s' "$dep" | tr 'A-Z' 'a-z')" in
+    *error*|*"table not found"*|*malformed*) dep=UNREADABLE;; esac
   echo "dep=$dep"
   for c in $(echo "$cols" | tr ',' ' '); do
     out=$("$DOLTLITE" "$db" \
@@ -199,7 +200,10 @@ dt_state() {
       SELECT concat('view:', table_name, '->', table_name) AS x
         FROM information_schema.tables
         WHERE table_schema=database() AND table_type='VIEW') q;" 2>&1)
-  case "$dep" in *error*|*Error*) dep=UNREADABLE;;
+  # Matched case-insensitively: an engine is free to shout its errors, and a
+  # read that failed must never be scored as a catalog with nothing in it.
+  case "$(printf '%s' "$dep" | tr 'A-Z' 'a-z')" in
+    *error*|*"table not found"*|*malformed*) dep=UNREADABLE;;
     *) dep=$(printf '%s\n' "$dep" | tail -n +2 | tr -d '"');; esac
   echo "dep=$dep"
   for c in $(echo "$cols" | tr ',' ' '); do

--- a/test/vc_oracle_correct_schema_merge_matrix_test.sh
+++ b/test/vc_oracle_correct_schema_merge_matrix_test.sh
@@ -155,6 +155,17 @@ dl_state() {
       FROM sqlite_master m WHERE m.type='index' AND m.sql IS NOT NULL
       ORDER BY m.name);" 2>/dev/null)
   echo "idx=$idx"
+  # Views and triggers, by name and the table they run on. The definitions
+  # themselves are not comparable across engines -- a trigger body is written in
+  # each engine's own dialect -- but a dependent that the merge dropped, kept
+  # when it should have gone, or left pointing at another table shows up here.
+  # Without this a merge could match on columns, indexes and rows while its
+  # view or trigger was missing.
+  dep=$("$DOLTLITE" "$db" "SELECT group_concat(x, ' ') FROM (
+      SELECT type || ':' || name || '->' || coalesce(tbl_name,'') AS x
+      FROM sqlite_master WHERE type IN ('view','trigger') ORDER BY x);" 2>&1)
+  case "$dep" in *rror*) dep=UNREADABLE;; esac
+  echo "dep=$dep"
   for c in $(echo "$cols" | tr ',' ' '); do
     out=$("$DOLTLITE" "$db" \
       "SELECT group_concat(v, '|') FROM (SELECT coalesce(CAST(\"$c\" AS TEXT),'~') AS v
@@ -176,6 +187,21 @@ dt_state() {
       FROM information_schema.statistics WHERE table_name='$tbl' AND index_name<>'PRIMARY'
       GROUP BY index_name ORDER BY index_name) q;" 2>/dev/null | tail -n +2 | tr -d '"')
   echo "idx=$idx"
+  # Dolt cannot always read its own trigger catalog back: a trigger whose body
+  # names a renamed column makes information_schema.triggers fail outright
+  # ("table not found: new"). Swallowing that would report the trigger as
+  # absent and score a false divergence, so it is reported as unreadable and
+  # the case is not compared.
+  dep=$(cd "$repo" && "$DOLT" sql -r csv -q "SELECT group_concat(x ORDER BY x SEPARATOR ' ') FROM (
+      SELECT concat('trigger:', trigger_name, '->', event_object_table) AS x
+        FROM information_schema.triggers WHERE trigger_schema=database()
+      UNION ALL
+      SELECT concat('view:', table_name, '->', table_name) AS x
+        FROM information_schema.tables
+        WHERE table_schema=database() AND table_type='VIEW') q;" 2>&1)
+  case "$dep" in *error*|*Error*) dep=UNREADABLE;;
+    *) dep=$(printf '%s\n' "$dep" | tail -n +2 | tr -d '"');; esac
+  echo "dep=$dep"
   for c in $(echo "$cols" | tr ',' ' '); do
     out=$(cd "$repo" && "$DOLT" sql -r csv -q "SELECT group_concat(v SEPARATOR '|') FROM
       (SELECT coalesce(CAST(\`$c\` AS CHAR),'~') AS v FROM \`$tbl\` ORDER BY k) q;" \
@@ -327,6 +353,11 @@ EOF
   fi
 
   dl_st=$(dl_state "$db"); dt_st=$(dt_state "$repo")
+  if printf '%s%s' "$dl_st" "$dt_st" | grep -q 'dep=UNREADABLE'; then
+    skipped=$((skipped+1)); SKIP_NAMES="$SKIP_NAMES $name"
+    echo "  SKIP: $name -- an engine could not read its own dependent catalog back"
+    return
+  fi
   if [ "$dl_st" = "$dt_st" ]; then
     if printf '%s\n' "$MERGE_DIFFERS_TODAY" | grep -q "^$key:"; then
       fail_name "$name (listed as differing but now matches -- delete the entry)"


### PR DESCRIPTION
Fixes ito's finding on #2337.

The oracle compared the table, its columns, its index set and its row data — and **nothing about views or triggers**. A merge that dropped a dependent or left one pointing at the wrong table scored equal as long as the visible table data matched. That gap was in code I added: #2337 introduced `bview` and `btrig` base variants, so those cases were checking the table *around* the dependent rather than the dependent itself.

Now both state functions emit an inventory of dependents by type, name and target table. The definitions themselves are not comparable across engines — a trigger body is written in each engine's dialect — but a dependent that went missing or moved shows up.

### The part worth reading

My first cut reported **5 divergences**, and they were false. Dolt cannot always read its own trigger catalog back: after `ALTER TABLE t RENAME COLUMN a TO a2`, a trigger whose body names `NEW.a` makes `information_schema.triggers` fail outright with `table not found: new`. My query swallowed that with `2>/dev/null` and recorded "no dependents", so DoltLite keeping the trigger looked like a divergence.

Verified directly before believing it:

```
before rename: trigger:tg0->t
after rename:  error ... : table not found: new
```

So an unreadable catalog is now reported as unreadable and the case is **not compared**. The suite cannot compare what an engine will not tell it, and reading a query failure as an empty result is how an oracle manufactures findings.

Result: **261 passed, 0 failed, 0 gaps, 0 differing, 0 corrupting, 47 not comparable** — the 42 pre-existing skips plus these 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)