### PR TITLE
Reject failed overflow oracle copies

### DIFF
--- a/test/doltlite_sqlite_file_oracle.sh
+++ b/test/doltlite_sqlite_file_oracle.sh
@@ -207,13 +207,18 @@ fi
 copy_overflow() {
   local distinct_name="$1" except_name="$2" ddl="$3" insert="$4" except_sql="$5"
   local dst="$TMP/copy-$distinct_name.db"
+  local output
   rm -f "$dst"
-  printf '%s\n' \
-    "ATTACH '$SRC' AS s;" \
-    "$ddl" \
-    "$insert" \
-    "SELECT dolt_commit('-A','-m','overflow copy');" \
-    | $DOLTLITE "$dst" >/dev/null 2>&1
+  if ! output=$(printf '%s\n' \
+      "ATTACH '$SRC' AS s;" \
+      "$ddl" \
+      "$insert" \
+      "SELECT dolt_commit('-A','-m','overflow copy');" \
+      | "$DOLTLITE" "$dst" 2>&1); then
+    FAIL=$((FAIL+1))
+    ERRORS="$ERRORS\n  FAIL: ${distinct_name%_distinct}_copy\n    output: $(printf %q "$output")"
+    return
+  fi
   want_eq "$distinct_name" \
     "$(printf '%s\n' "SELECT count(DISTINCT b) FROM d;" | $DOLTLITE "$dst" 2>&1 | tr -d '\r' | tail -1)" \
     "3"

--- a/test/doltlite_sqlite_file_oracle_failure.sh
+++ b/test/doltlite_sqlite_file_oracle_failure.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+DOLTLITE="${1:-./doltlite}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TMP="$(mktemp -d)"
+WRAPPER="$TMP/doltlite-fail-overflow-copy"
+trap 'rm -rf "$TMP"' EXIT
+
+if ! command -v sqlite3 >/dev/null 2>&1; then
+  echo "SKIP: stock sqlite3 binary not found"
+  exit 0
+fi
+
+cat > "$WRAPPER" <<'EOF'
+#!/bin/bash
+sql=$(cat)
+if [[ "$sql" == *"SELECT dolt_commit('-A','-m','overflow copy');"* ]]; then
+  echo "injected overflow copy failure" >&2
+  exit 37
+fi
+printf '%s\n' "$sql" | "$REAL_DOLTLITE" "$@"
+EOF
+chmod +x "$WRAPPER"
+
+export REAL_DOLTLITE="$DOLTLITE"
+output=$(bash "$SCRIPT_DIR/doltlite_sqlite_file_oracle.sh" "$WRAPPER" 2>&1)
+status=$?
+FAIL=0
+
+if [ "$status" -eq 0 ]; then
+  echo "FAIL: oracle accepted failed overflow copies"
+  FAIL=$((FAIL+1))
+fi
+
+for shape in textpk intpk keyless; do
+  if ! grep -q "FAIL: O_attach_ov_${shape}_copy" <<<"$output"; then
+    echo "FAIL: missing ${shape} copy failure"
+    FAIL=$((FAIL+1))
+  fi
+  if grep -q "FAIL: O_attach_ov_${shape}_distinct\|FAIL: O_attach_ov_${shape}_except" <<<"$output"; then
+    echo "FAIL: ${shape} post-copy checks ran after the copy failed"
+    FAIL=$((FAIL+1))
+  fi
+done
+
+if [ "$FAIL" -ne 0 ]; then
+  echo "$output"
+  exit 1
+fi
+
+echo "PASS: failed overflow copies stop before post-copy assertions"

--- a/test/lib/doltlite_suite_manifest.sh
+++ b/test/lib/doltlite_suite_manifest.sh
@@ -83,6 +83,7 @@ doltlite_dbpage.sh
 doltlite_arm_correctness.sh
 doltlite_open_sqlite_file.sh
 doltlite_sqlite_file_oracle.sh
+doltlite_sqlite_file_oracle_failure.sh
 doltlite_open_nofollow.sh
 doltlite_readonly_directory.sh
 doltlite_readonly_file_replacement.sh
@@ -181,6 +182,7 @@ chunk_physical_dups_test.sh
 chunker_boundary_golden.sh
 doltlite_open_sqlite_file.sh
 doltlite_sqlite_file_oracle.sh
+doltlite_sqlite_file_oracle_failure.sh
 doltlite_open_missing_path.sh
 doltlite_comparison.sh
 doltlite_merge_ignore_corners.sh


### PR DESCRIPTION
Follow-up to #2338.

The stock-SQLite overflow-copy oracle now captures the DoltLite batch status and records one precise copy failure before returning. It no longer runs DISTINCT or bidirectional EXCEPT assertions when the setup or commit batch failed.

A new failure-path suite wraps DoltLite to reject every overflow-copy commit. Before this fix, it observes six misleading post-copy failures and no copy failure; after the fix, all three table shapes report the failed copy and skip their downstream durability assertions.

Validation:
- `doltlite_sqlite_file_oracle_failure.sh`: pass
- `doltlite_sqlite_file_oracle.sh`: 79 passed, 0 failed, 0 skipped
- `lint_orphaned_suites.sh`: pass
- `git diff --check`

Co-Authored-By: OpenAI Codex <noreply@openai.com>