### PR TITLE
Don't livelock TSan merge retries on a dirty working set

### DIFF
--- a/test/vc_ref_mutation_stress_test.c
+++ b/test/vc_ref_mutation_stress_test.c
@@ -195,12 +195,17 @@ static int queryIntWithRetry(sqlite3 *db, const char *sql, int *pOut){
   return rc;
 }
 
-/* Merge refuses a dirty working set. Retrying checkout/merge without reset
-** livelocks the TSan phase (thousands of attempts, full 120s) on that error. */
-static void discardWorking(sqlite3 *db){
+/* Merge refuses a dirty working set. A failed reset must surface so the
+** retry loop does not treat leftover dirt as a successful cleanup. */
+static int discardWorking(sqlite3 *db, char *out, int nOut){
   char *err = 0;
-  sqlite3_exec(db, "SELECT dolt_reset('--hard')", 0, 0, &err);
+  int rc = sqlite3_exec(db, "SELECT dolt_reset('--hard')", 0, 0, &err);
+  if( rc!=SQLITE_OK && out && nOut>0 ){
+    const char *msg = err ? err : sqlite3_errmsg(db);
+    snprintf(out, nOut, "%s", msg && msg[0] ? msg : "reset failed");
+  }
   sqlite3_free(err);
+  return rc;
 }
 
 /* Open racing the store lock is retryable; unretried it returned "not an error". */
@@ -321,20 +326,22 @@ static int mergeBranchToMain(sqlite3 **pDb, const char *path, int worker, int ro
                "SELECT count(*) FROM ref_rows WHERE id=%d", rowid);
       rc = queryIntWithRetry(db, sql, &count);
       if( rc==SQLITE_OK && count==1 ) return SQLITE_OK;
-      discardWorking(db);
-      snprintf(sql, sizeof(sql), "SELECT dolt_merge('%s')", branch);
-      rc = queryTextWithRetry(db, sql, out, sizeof(out));
-      if( rc==SQLITE_OK
-       && (strlen(out)==40 || msgContains(out, "Already up to date")) ){
-        /* Hash is not success unless the worker row is on main (CAS clobber). */
-        count = 0;
-        snprintf(sql, sizeof(sql),
-                 "SELECT count(*) FROM ref_rows WHERE id=%d", rowid);
-        rc = queryIntWithRetry(db, sql, &count);
-        if( rc==SQLITE_OK && count==1 ) return SQLITE_OK;
-      }
-      if( msgContains(out, "uncommitted changes") ){
-        discardWorking(db);
+      rc = discardWorking(db, out, sizeof(out));
+      if( rc==SQLITE_OK ){
+        snprintf(sql, sizeof(sql), "SELECT dolt_merge('%s')", branch);
+        rc = queryTextWithRetry(db, sql, out, sizeof(out));
+        if( rc==SQLITE_OK
+         && (strlen(out)==40 || msgContains(out, "Already up to date")) ){
+          /* Hash is not success unless the worker row is on main (CAS clobber). */
+          count = 0;
+          snprintf(sql, sizeof(sql),
+                   "SELECT count(*) FROM ref_rows WHERE id=%d", rowid);
+          rc = queryIntWithRetry(db, sql, &count);
+          if( rc==SQLITE_OK && count==1 ) return SQLITE_OK;
+        }
+        if( msgContains(out, "uncommitted changes") ){
+          discardWorking(db, out, sizeof(out));
+        }
       }
     }
     sqlite3_sleep(msgContains(out, "uncommitted changes") ? 25 : 5);

--- a/test/vc_ref_mutation_stress_test.c
+++ b/test/vc_ref_mutation_stress_test.c
@@ -195,6 +195,14 @@ static int queryIntWithRetry(sqlite3 *db, const char *sql, int *pOut){
   return rc;
 }
 
+/* Merge refuses a dirty working set. Retrying checkout/merge without reset
+** livelocks the TSan phase (thousands of attempts, full 120s) on that error. */
+static void discardWorking(sqlite3 *db){
+  char *err = 0;
+  sqlite3_exec(db, "SELECT dolt_reset('--hard')", 0, 0, &err);
+  sqlite3_free(err);
+}
+
 /* Open racing the store lock is retryable; unretried it returned "not an error". */
 static int reopenDb(const char *path, sqlite3 **pDb){
   Budget budget;
@@ -313,6 +321,7 @@ static int mergeBranchToMain(sqlite3 **pDb, const char *path, int worker, int ro
                "SELECT count(*) FROM ref_rows WHERE id=%d", rowid);
       rc = queryIntWithRetry(db, sql, &count);
       if( rc==SQLITE_OK && count==1 ) return SQLITE_OK;
+      discardWorking(db);
       snprintf(sql, sizeof(sql), "SELECT dolt_merge('%s')", branch);
       rc = queryTextWithRetry(db, sql, out, sizeof(out));
       if( rc==SQLITE_OK
@@ -324,8 +333,11 @@ static int mergeBranchToMain(sqlite3 **pDb, const char *path, int worker, int ro
         rc = queryIntWithRetry(db, sql, &count);
         if( rc==SQLITE_OK && count==1 ) return SQLITE_OK;
       }
+      if( msgContains(out, "uncommitted changes") ){
+        discardWorking(db);
+      }
     }
-    sqlite3_sleep(5);
+    sqlite3_sleep(msgContains(out, "uncommitted changes") ? 25 : 5);
     rc = reopenDb(path, pDb);
     if( rc!=SQLITE_OK ) return rc;
     db = *pDb;
@@ -513,6 +525,7 @@ static void runDefaultRenameStress(void){
     char value = 0;
     char sql[256];
     int rc;
+    startPhase();
     check("default_rename_signal_setter", pipeSend(toChild[1], '1')==0);
     check("default_rename_setter_completed",
           pipeReceive(fromChild[0], &value)==0 && value=='1');


### PR DESCRIPTION
## Problem

`Sanitizers / tsan` failed in `vc_ref_mutation_stress_test` with:

```
gave up on mergeBranchToMain after 1803 attempts in 120000ms; last rc=5 msg=BUSY
gave up on mergeBranchToMain after 1753 attempts in 120000ms; last rc=5 msg=uncommitted changes — commit or reset before merging
FAIL: worker_exited_cleanly
```

No TSan data-race report. The same binary's `vc_concurrency_test` passed, and Test Suite / vc-concurrency-stress (no TSan) passed. Passing TSan jobs on nearby PRs finish the whole job in ~2.5 minutes; this path burned the entire 120s phase without making progress.

`dolt_merge` refuses a dirty working set. The worker retried checkout + merge + reopen, but a persisted dirty working set survives reopen, so the loop livelocks. Peers then sit on `BUSY` until the phase budget expires.

This is the same family as the earlier TSan stress-test fix that stopped inner-retrying a peer CAS on the same handle: the retry has to change something the next attempt can observe.

## Change

In `mergeBranchToMain`:

- `SELECT dolt_reset('--hard')` after checkout to `main` and before merge (the documented recovery for that error).
- Reset again if merge still reports uncommitted changes, with a slightly longer backoff.

Also start a fresh phase budget per default-branch rename round, so one slow round cannot starve the remaining 49.

Test-only. Three local runs of `vc_ref_mutation_stress_test` at `DOLTLITE_STRESS_BUSY_MS=120000` plus `vc_concurrency_test` all passed.