### PR TITLE
Accept values attached to long options

### DIFF
--- a/src/doltlite_cmd.c
+++ b/src/doltlite_cmd.c
@@ -10,11 +10,15 @@
 static DoltliteCmdOption *cmdFindLongOption(
   DoltliteCmdOption *aOption,
   int nOption,
-  const char *zName
+  const char *zName,
+  int nName
 ){
   int i;
   for(i=0; i<nOption; i++){
-    if( aOption[i].zLong && strcmp(aOption[i].zLong, zName)==0 ){
+    if( aOption[i].zLong
+     && sqlite3Strlen30(aOption[i].zLong)==nName
+     && memcmp(aOption[i].zLong, zName, (size_t)nName)==0
+    ){
       return &aOption[i];
     }
   }
@@ -141,13 +145,17 @@ int doltliteCmdParseArgs(
       continue;
     }
     if( !endOptions && zArg[0]=='-' && zArg[1]=='-' && zArg[2] ){
-      pOption = cmdFindLongOption(aOption, nOption, zArg+2);
-      if( !pOption ){
+      const char *zName = zArg + 2;
+      const char *zEquals = strchr(zName, '=');
+      int nName = zEquals ? (int)(zEquals-zName) : sqlite3Strlen30(zName);
+      pOption = cmdFindLongOption(aOption, nOption, zName, nName);
+      if( !pOption || (zEquals && pOption->eType!=DOLTLITE_CMD_OPTION_VALUE) ){
         doltliteCmdResultUnknownOption(ctx, zArg);
         doltliteCmdArgsClear(pArgs);
         return SQLITE_ERROR;
       }
-      rc = cmdSetOption(ctx, pOption, pOption->zLong, 0, argc, argv, &i);
+      rc = cmdSetOption(ctx, pOption, pOption->zLong,
+                        zEquals ? zEquals+1 : 0, argc, argv, &i);
       if( rc!=SQLITE_OK ){
         doltliteCmdArgsClear(pArgs);
         return rc;

--- a/test/vc_oracle_commit_test.sh
+++ b/test/vc_oracle_commit_test.sh
@@ -195,6 +195,13 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('--message', 'first commit');
 "
 
+oracle "commit_long_message_equals" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 10);
+SELECT dolt_add('-A');
+SELECT dolt_commit('--message=first commit');
+"
+
 echo "--- combo / stage-all flags ---"
 
 oracle "commit_uppercase_A_new_table" "

--- a/test/vc_oracle_merge_test.sh
+++ b/test/vc_oracle_merge_test.sh
@@ -386,6 +386,19 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feature', '--message', 'release sync');
 "
 
+oracle "merge_with_message_long_equals" "
+$SEED
+INSERT INTO t VALUES (10, 100);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'main2');
+SELECT dolt_checkout('feature');
+INSERT INTO t VALUES (20, 200);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feat1');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feature', '--message=release sync');
+"
+
 echo "--- conflict (no merge commit) ---"
 
 oracle_no_merge_commit "modify_modify_conflict_blocks_merge" "


### PR DESCRIPTION
## Summary
- accept Dolt-style `--option=value` arguments in the shared command parser
- reject attached values for flag-only options
- add Dolt oracles for commit and merge long-option values

## Tests
- `bash test/vc_oracle_commit_test.sh build/doltlite dolt` (48 passed)
- `bash test/vc_oracle_merge_test.sh build/doltlite dolt` (87 passed)
- `bash test/doltlite_commit.sh build/doltlite` (82 passed)
- `bash test/run_doltlite_tests.sh build/doltlite` (111 runnable suites passed; `doltlite_parity.sh` prerequisite `./sqlite3` unavailable locally)
- `make -C build lint`

Co-Authored-By: OpenAI Codex <noreply@openai.com>