### PR TITLE
Compare the recovered trigger cases, and split the sanitizer VC oracles by bucket

### DIFF
--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -11,11 +11,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        suite:
-          - oracles
-          - oracles-merge
-          - native
-          - c-regression
+        include:
+          - suite: oracles
+          - suite: oracles-refs-workspace
+            bucket: refs-workspace
+          - suite: oracles-diff-history-data
+            bucket: diff-history-data
+          - suite: oracles-remotes-recovery
+            bucket: remotes-recovery
+          - suite: oracles-merge
+            bucket: merge-replay-schema
+          - suite: native
+          - suite: c-regression
 
     steps:
     - uses: actions/checkout@v4
@@ -25,7 +32,7 @@ jobs:
         bash .github/scripts/install-apt-deps.sh tcl-dev build-essential zlib1g-dev
 
     - name: Install Dolt
-      if: matrix.suite == 'oracles' || matrix.suite == 'oracles-merge'
+      if: startsWith(matrix.suite, 'oracles')
       run: bash .github/scripts/install-dolt-oracle.sh
 
     - name: Download ASan/UBSan build
@@ -47,10 +54,6 @@ jobs:
         echo "LSAN_OPTIONS=suppressions=$GITHUB_WORKSPACE/.github/lsan.supp:print_suppressions=0" >> $GITHUB_ENV
         echo "UBSAN_OPTIONS=abort_on_error=1:halt_on_error=1:print_stacktrace=1" >> $GITHUB_ENV
 
-    # SQL oracles plus the non-merge VC glob. Merge/schema VC oracles run on
-    # oracles-merge (the same bucket as oracle-tests) so the 25-minute VC step
-    # stays under budget. New vc_oracle_* files still land here until they are
-    # added to merge-replay-schema.txt.
     - name: SQL oracle tests (vs stock SQLite and Dolt)
       if: matrix.suite == 'oracles'
       run: |
@@ -64,30 +67,22 @@ jobs:
         done
       timeout-minutes: 15
 
-    - name: Version control oracle tests (vs Dolt)
-      if: matrix.suite == 'oracles'
-      run: |
-        cd build
-        bucket="../test/oracle-buckets/merge-replay-schema.txt"
-        for f in ../test/vc_oracle_*_test.sh; do
-          base=$(basename "$f")
-          if grep -Fxq "$base" "$bucket"; then
-            continue
-          fi
-          echo "--- $base ---"
-          bash "$f" ./doltlite dolt || exit 1
-        done
-      timeout-minutes: 25
+    # One job per bucket, matching oracle-tests. The manifest check is what
+    # makes that safe to rely on: it proves every vc_oracle_*_test.sh is in
+    # exactly one bucket, so nothing runs twice and nothing goes unrun.
+    - name: Check oracle bucket manifests
+      if: startsWith(matrix.suite, 'oracles')
+      run: bash test/check_oracle_buckets.sh
 
-    - name: Merge/schema version control oracle tests (vs Dolt)
-      if: matrix.suite == 'oracles-merge'
+    - name: Version control oracle tests (vs Dolt)
+      if: matrix.bucket
       run: |
         cd build
         while IFS= read -r oracle; do
           [ -z "$oracle" ] && continue
           echo "--- $oracle ---"
           bash "../test/$oracle" ./doltlite dolt || exit 1
-        done < "../test/oracle-buckets/merge-replay-schema.txt"
+        done < "../test/oracle-buckets/${{ matrix.bucket }}.txt"
       timeout-minutes: 25
 
     - name: Correctness regression tests

--- a/test/vc_oracle_correct_schema_merge_matrix_test.sh
+++ b/test/vc_oracle_correct_schema_merge_matrix_test.sh
@@ -160,23 +160,25 @@ dt_state() {
       FROM information_schema.statistics WHERE table_name='$tbl' AND index_name<>'PRIMARY'
       GROUP BY index_name ORDER BY index_name) q;" 2>/dev/null | tail -n +2 | tr -d '"')
   echo "idx=$idx"
-  # Dolt cannot always read its own trigger catalog back: a trigger whose body
-  # names a renamed column makes information_schema.triggers fail outright
-  # ("table not found: new"). Swallowing that would report the trigger as
-  # absent and score a false divergence, so it is reported as unreadable and
-  # the case is not compared.
-  dep=$(cd "$repo" && "$DOLT" sql -r csv -q "SELECT group_concat(x ORDER BY x SEPARATOR ' ') FROM (
-      SELECT concat('trigger:', trigger_name, '->', event_object_table) AS x
-        FROM information_schema.triggers WHERE trigger_schema=database()
-      UNION ALL
-      SELECT concat('view:', table_name, '->', table_name) AS x
-        FROM information_schema.tables
-        WHERE table_schema=database() AND table_type='VIEW') q;" 2>&1)
-  # Matched case-insensitively: an engine is free to shout its errors, and a
-  # read that failed must never be scored as a catalog with nothing in it.
-  case "$(printf '%s' "$dep" | tr 'A-Z' 'a-z')" in
+  # Triggers come from SHOW TRIGGERS, not information_schema.triggers: that
+  # view resolves the trigger body and fails outright once a rename has left it
+  # naming a column that is gone (dolthub/dolt#11587), which took five
+  # comparable cases out of the suite. SHOW TRIGGERS returns the stored
+  # definition without resolving it. The unreadable guard stays as a backstop.
+  dep_trg=$(cd "$repo" && "$DOLT" sql -r csv -q "SHOW TRIGGERS;" 2>&1)
+  case "$(printf '%s' "$dep_trg" | tr 'A-Z' 'a-z')" in
     *error*|*"table not found"*|*malformed*) dep=UNREADABLE;;
-    *) dep=$(printf '%s\n' "$dep" | tail -n +2 | tr -d '"');; esac
+    *)
+      dep_trg=$(printf '%s\n' "$dep_trg" | tail -n +2 \
+        | awk -F, 'NF>2 {gsub(/"/,"",$1); gsub(/"/,"",$3); print "trigger:" $1 "->" $3}')
+      dep_vw=$(cd "$repo" && "$DOLT" sql -r csv -q "SELECT table_name
+          FROM information_schema.tables
+          WHERE table_schema=database() AND table_type='VIEW';" 2>/dev/null \
+        | tail -n +2 | tr -d '"' | awk 'NF {print "view:" $1 "->" $1}')
+      dep=$(printf '%s\n%s\n' "$dep_trg" "$dep_vw" | grep -v '^$' | sort \
+        | tr '\n' ' ' | sed 's/ *$//')
+      ;;
+  esac
   echo "dep=$dep"
   for c in $(echo "$cols" | tr ',' ' '); do
     out=$(cd "$repo" && "$DOLT" sql -r csv -q "SELECT group_concat(v SEPARATOR '|') FROM


### PR DESCRIPTION
Follow-up to #2341, and a correction to its rationale.

#2341 read dependents from `information_schema.triggers`. That view **resolves** the trigger body, so once a rename has left the body naming a column that is gone it fails outright — taking five otherwise comparable cases out of the suite as "unreadable".

`SHOW TRIGGERS` returns the stored definition without resolving it, so those cases are compared for real again.

### Correcting the record

#2341 said Dolt "cannot always read its own trigger catalog back". That claimed more than was shown. The trigger is present throughout — both `dolt_schemas` and `SHOW TRIGGERS` return it with its body intact — and Dolt **does** carry triggers across a merge. Only that one `information_schema` view fails. Filed upstream as [dolthub/dolt#11587](https://github.com/dolthub/dolt/issues/11587) with the exact repro.

The unreadable guard from #2341 stays rather than being reverted: an engine that will not report its dependents must still never be scored as having none.

### Verification

The queue that opened this PR refused to do so unless the matrix came back `0 failed` **and** zero cases remained unreadable, so the five recovered cases are compared and passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Also: the sanitizer VC oracles run one job per bucket

`asan-ubsan-oracles` ran **46** version-control oracles in one step and **timed out at 25 minutes twice today** — runs [32520858328](https://github.com/dolthub/doltlite/actions/runs/32520858328) and [32527471972](https://github.com/dolthub/doltlite/actions/runs/32527471972).

It was not short of budget in the ordinary case. Measured across eleven recent runs the step takes **~8.5–9.5 minutes**; the two failures sat at exactly 25:00. In both, *every* suite inflated together — `feature_interaction` 202s→604s, `error_recovery` 59s→131s, `checkout` 16s→69s — so this is a uniformly ~3x slow runner, not one suite hanging. The job needed the runner to stay within **2.7x** of typical, and GitHub's runners vary by about 3x. It was going to keep flapping.

Splitting by the buckets `oracle-tests` already uses:

| job | suites | healthy | at 3x slow | vs 25m cap |
| --- | ---: | ---: | ---: | --- |
| **old** single glob | 46 | 9.4m | **28.2m** | exceeded |
| `oracles-remotes-recovery` | 7 | 5.0m | 15.0m | OK |
| `oracles-refs-workspace` | 24 | 2.8m | 8.3m | OK |
| `oracles-diff-history-data` | 15 | 1.6m | 4.9m | OK |
| `oracles-merge` | 19 | unchanged | | OK |

The buckets already isolate the hot spots: `remotes-recovery` is the smallest bucket by count but holds the two heaviest oracles, so it stays the long pole at a comfortable margin.

The glob and its skip list are **gone**. One bucket-driven step now serves every oracle job, which removes the failure mode where adding a bucket silently changes what the glob excludes. `check_oracle_buckets.sh` now runs in the sanitizer job too — the glob used to be the catch-all for an unbucketed suite, and the manifest check replaces it by failing loudly instead of letting a suite run nowhere under the sanitizers.

### Note on scope

An earlier revision of this PR split the *schema-merge matrix* into its own job. That was aimed at the wrong target — `merge-replay-schema` takes 4m07s against an 18-minute cap and was never at risk. That commit has been dropped from the branch and replaced with this one.
