### PR TITLE
Delete multiple branches and tags

### DIFF
--- a/src/doltlite_branch.c
+++ b/src/doltlite_branch.c
@@ -161,6 +161,46 @@ enum DoltliteBranchMode {
   MODE_CREATE, MODE_DELETE, MODE_COPY, MODE_MOVE
 };
 
+typedef struct BranchDeleteCtx BranchDeleteCtx;
+struct BranchDeleteCtx {
+  int nName;
+  const char **azName;
+  int force;
+  int notMerged;
+  int isDefault;
+};
+
+static int mutateBranchDelete(sqlite3 *db, ChunkStore *cs, void *pArg){
+  BranchDeleteCtx *p = (BranchDeleteCtx*)pArg;
+  ProllyHash currentHead;
+  const char *zDefault = chunkStoreGetDefaultBranch(cs);
+  int i;
+  int rc;
+
+  if( !p->force ) doltliteGetSessionHead(db, &currentHead);
+  for(i=0; i<p->nName; i++){
+    ProllyHash branchHead, ancestor;
+    if( zDefault && strcmp(p->azName[i], zDefault)==0 ){
+      p->isDefault = 1;
+      return SQLITE_CONSTRAINT;
+    }
+    rc = chunkStoreFindBranch(cs, p->azName[i], &branchHead);
+    if( rc!=SQLITE_OK ) return rc;
+    if( !p->force ){
+      rc = doltliteFindAncestor(db, &currentHead, &branchHead, &ancestor);
+      if( rc!=SQLITE_OK || prollyHashCompare(&ancestor, &branchHead)!=0 ){
+        p->notMerged = 1;
+        return rc==SQLITE_OK ? SQLITE_CONSTRAINT : rc;
+      }
+    }
+  }
+  for(i=0; i<p->nName; i++){
+    rc = chunkStoreDeleteBranch(cs, p->azName[i]);
+    if( rc!=SQLITE_OK ) return rc;
+  }
+  return SQLITE_OK;
+}
+
 static void doltBranchParsedFunc(
   sqlite3_context *ctx,
   enum DoltliteBranchMode mode,
@@ -178,48 +218,42 @@ static void doltBranchParsedFunc(
 
   switch( mode ){
     case MODE_DELETE: {
-      BranchMutationCtx m;
-      ProllyHash branchHead, currentHead, ancestor;
-      if( nPositional>1 ){
-        branchError(ctx, hadSavepoint, "too many arguments");
-        return;
-      }
+      BranchDeleteCtx m;
+      int i;
       if( nPositional<1 ){
         branchError(ctx, hadSavepoint, "branch name required"); return;
       }
-      if( branchNameEmpty(aPositional[0]) ){
-        branchError(ctx, hadSavepoint, "branch name required"); return;
-      }
-      if( strcmp(aPositional[0], doltliteGetSessionBranch(db))==0 ){
-        branchError(ctx, hadSavepoint, "cannot delete the current branch");
-        return;
-      }
-      if( !force ){
-        rc = chunkStoreFindBranch(cs, aPositional[0], &branchHead);
-        if( rc!=SQLITE_OK ){
-          branchNamedResultError(ctx, hadSavepoint, rc, "branch not found", 0);
-          return;
+      for(i=0; i<nPositional; i++){
+        if( branchNameEmpty(aPositional[i]) ){
+          branchError(ctx, hadSavepoint, "branch name required"); return;
         }
-        doltliteGetSessionHead(db, &currentHead);
-        rc = doltliteFindAncestor(db, &currentHead, &branchHead, &ancestor);
-        if( rc!=SQLITE_OK || prollyHashCompare(&ancestor, &branchHead)!=0 ){
-          branchError(ctx, hadSavepoint, "branch is not fully merged");
+        if( strcmp(aPositional[i], doltliteGetSessionBranch(db))==0 ){
+          branchError(ctx, hadSavepoint, "cannot delete the current branch");
           return;
         }
       }
       memset(&m, 0, sizeof(m));
-      m.zName = aPositional[0];
-      m.isDelete = 1;
-      rc = doltliteMutateRefs(db, mutateBranchRef, &m);
+      m.nName = nPositional;
+      m.azName = aPositional;
+      m.force = force;
+      rc = doltliteMutateRefs(db, mutateBranchDelete, &m);
       if( rc==SQLITE_CONSTRAINT ){
         if( doltliteSessionHasUnresolvedConflicts(db) ){
           branchError(ctx, hadSavepoint,
             "cannot update refs: unresolved merge conflicts");
-        }else{
+        }else if( m.isDefault ){
           branchError(ctx, hadSavepoint,
             "cannot delete the default branch; "
             "call dolt_default_branch(<other>) first");
+        }else if( m.notMerged ){
+          branchError(ctx, hadSavepoint, "branch is not fully merged");
+        }else{
+          branchErrorCode(ctx, hadSavepoint, rc);
         }
+        return;
+      }
+      if( m.notMerged ){
+        branchError(ctx, hadSavepoint, "branch is not fully merged");
         return;
       }
       if( rc!=SQLITE_OK ){
@@ -415,11 +449,6 @@ static void doltBranchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv)
   else if( isCopy ) mode = MODE_COPY;
   else if( isMove ) mode = MODE_MOVE;
   if( isForceDelete ) force = 1;
-  if( args.nPositional>3 ){
-    doltliteCmdArgsClear(&args);
-    branchError(ctx, hadSavepoint, "too many arguments");
-    return;
-  }
   doltBranchParsedFunc(ctx, mode, force, args.nPositional,
                        args.azPositional);
   doltliteCmdArgsClear(&args);

--- a/src/doltlite_tag.c
+++ b/src/doltlite_tag.c
@@ -13,7 +13,6 @@ typedef struct TagMutationCtx TagMutationCtx;
 struct TagMutationCtx {
   const char *zName;
   ProllyHash commitHash;
-  int isDelete;
   const char *zTagger;
   const char *zEmail;
   i64 timestamp;
@@ -28,11 +27,32 @@ static void tagSealSavepointError(sqlite3_context *ctx){
 static int mutateTagRef(sqlite3 *db, ChunkStore *cs, void *pArg){
   TagMutationCtx *p = (TagMutationCtx*)pArg;
   (void)db;
-  if( p->isDelete ) return chunkStoreDeleteTag(cs, p->zName);
   if( !doltliteUserRefNameIsValid(p->zName) ) return SQLITE_CONSTRAINT;
   return chunkStoreAddTagFull(cs, p->zName, &p->commitHash,
                               p->zTagger, p->zEmail,
                               p->timestamp, p->zMessage);
+}
+
+typedef struct TagDeleteCtx TagDeleteCtx;
+struct TagDeleteCtx {
+  int nName;
+  const char **azName;
+};
+
+static int mutateTagDelete(sqlite3 *db, ChunkStore *cs, void *pArg){
+  TagDeleteCtx *p = (TagDeleteCtx*)pArg;
+  int i;
+  int rc;
+  (void)db;
+  for(i=0; i<p->nName; i++){
+    rc = chunkStoreFindTag(cs, p->azName[i], 0);
+    if( rc!=SQLITE_OK ) return rc;
+  }
+  for(i=0; i<p->nName; i++){
+    rc = chunkStoreDeleteTag(cs, p->azName[i]);
+    if( rc!=SQLITE_OK ) return rc;
+  }
+  return SQLITE_OK;
 }
 
 static void doltTagParsedFunc(
@@ -58,13 +78,10 @@ static void doltTagParsedFunc(
   memset(&m, 0, sizeof(m));
 
   if( isDelete ){
-    if( nPositional!=1 ){
-      doltliteVcResultError(ctx, db, "too many positional arguments to dolt_tag");
-      return;
-    }
-    m.zName = arg0;
-    m.isDelete = 1;
-    rc = doltliteMutateRefs(db, mutateTagRef, &m);
+    TagDeleteCtx d;
+    d.nName = nPositional;
+    d.azName = azPositional;
+    rc = doltliteMutateRefs(db, mutateTagDelete, &d);
     if( rc==SQLITE_CONSTRAINT && doltliteSessionHasUnresolvedConflicts(db) ){
       doltliteVcResultError(ctx, db,
         "cannot update refs: unresolved merge conflicts");

--- a/test/doltlite_branch.sh
+++ b/test/doltlite_branch.sh
@@ -173,5 +173,16 @@ run_test "inactive_branch_staged_changes_are_dirty" "SELECT dirty FROM dolt_bran
 echo "SELECT dolt_checkout('feature'); SELECT dolt_commit('-m','feature change'); SELECT dolt_checkout('main');" | $DOLTLITE "$DB14" > /dev/null 2>&1
 run_test "inactive_branch_committed_changes_are_clean" "SELECT dirty FROM dolt_branches WHERE name='feature';" "0" "$DB14"
 
-rm -f "$DB" "$DB2" "$DB2B" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8" "$DB9" "$DB10" "$DB11" "$DB12" "$DB13" "$DB14"
+DB15=/tmp/test_branch15_$$.db; rm -f "$DB15"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY); INSERT INTO t VALUES(1); SELECT dolt_commit('-A','-m','init'); SELECT dolt_branch('one'); SELECT dolt_branch('two');" | $DOLTLITE "$DB15" > /dev/null 2>&1
+run_test "delete_multiple_branches" "SELECT dolt_branch('-d','one','two');" "0" "$DB15"
+run_test "delete_multiple_branches_removed" "SELECT count(*) FROM dolt_branches WHERE name IN ('one','two');" "0" "$DB15"
+echo "SELECT dolt_branch('one'); SELECT dolt_branch('two');" | $DOLTLITE "$DB15" > /dev/null 2>&1
+run_test_match "delete_multiple_missing_is_atomic" "SELECT dolt_branch('-d','one','missing','two');" "not found" "$DB15"
+run_test "delete_multiple_missing_keeps_branches" "SELECT count(*) FROM dolt_branches WHERE name IN ('one','two');" "2" "$DB15"
+echo "SELECT dolt_checkout('one'); INSERT INTO t VALUES(2); SELECT dolt_commit('-A','-m','one'); SELECT dolt_checkout('main');" | $DOLTLITE "$DB15" > /dev/null 2>&1
+run_test "force_delete_multiple_branches" "SELECT dolt_branch('-D','one','two');" "0" "$DB15"
+run_test "force_delete_multiple_branches_removed" "SELECT count(*) FROM dolt_branches WHERE name IN ('one','two');" "0" "$DB15"
+
+rm -f "$DB" "$DB2" "$DB2B" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8" "$DB9" "$DB10" "$DB11" "$DB12" "$DB13" "$DB14" "$DB15"
 dltest_finish

--- a/test/doltlite_tag.sh
+++ b/test/doltlite_tag.sh
@@ -49,10 +49,10 @@ run_test "delete_tag" "SELECT dolt_tag('-d','v0.9');" "0" "$DB"
 run_test "delete_and_recreate_same_name" "SELECT dolt_tag('-d','parenttilde'); SELECT dolt_tag('parenttilde');" "0
 0" "$DB"
 run_test "three_tags_left" "SELECT count(*) FROM dolt_tags;" "3" "$DB"
-run_test_match "delete_tag_extra_arg" \
+run_test_match "delete_multiple_tags_with_missing" \
   "SELECT dolt_tag('-d','v1.0','extra');" \
-  "too many positional arguments to dolt_tag" "$DB"
-run_test "delete_extra_arg_keeps_tag" \
+  "not found" "$DB"
+run_test "delete_multiple_tags_with_missing_keeps_tag" \
   "SELECT count(*) FROM dolt_tags WHERE tag_name='v1.0';" "1" "$DB"
 
 run_test_match "delete_missing" "SELECT dolt_tag('-d','nope');" "not found" "$DB"
@@ -82,5 +82,13 @@ SELECT tagger || '|' || email FROM dolt_tags WHERE tag_name='after-paren';" \
   "0
 Real Name|real@example.com" "$DB3"
 
-rm -f "$DB" "$DB2" "$DB3"
+DB4=/tmp/test_tag_batch_$$.db; rm -f "$DB4"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY); INSERT INTO t VALUES(1); SELECT dolt_commit('-A','-m','init'); SELECT dolt_tag('one'); SELECT dolt_tag('two');" | $DOLTLITE "$DB4" > /dev/null 2>&1
+run_test "delete_multiple_tags" "SELECT dolt_tag('-d','one','two');" "0" "$DB4"
+run_test "delete_multiple_tags_removed" "SELECT count(*) FROM dolt_tags;" "0" "$DB4"
+echo "SELECT dolt_tag('one'); SELECT dolt_tag('two');" | $DOLTLITE "$DB4" > /dev/null 2>&1
+run_test_match "delete_multiple_tags_missing_is_atomic" "SELECT dolt_tag('-d','one','missing','two');" "not found" "$DB4"
+run_test "delete_multiple_tags_missing_keeps_tags" "SELECT count(*) FROM dolt_tags;" "2" "$DB4"
+
+rm -f "$DB" "$DB2" "$DB3" "$DB4"
 dltest_finish

--- a/test/vc_oracle_branch_test.sh
+++ b/test/vc_oracle_branch_test.sh
@@ -234,6 +234,13 @@ SELECT dolt_branch('feature');
 SELECT dolt_branch('-d', 'feature');
 "
 
+oracle "delete_multiple" "
+$SEED
+SELECT dolt_branch('one');
+SELECT dolt_branch('two');
+SELECT dolt_branch('-d', 'one', 'two');
+"
+
 oracle "delete_force" "
 $SEED
 SELECT dolt_branch('feature');
@@ -260,6 +267,18 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'feat');
 SELECT dolt_checkout('main');
 SELECT dolt_branch('-D', 'feature');
+"
+
+oracle "delete_multiple_unmerged_force" "
+$SEED
+SELECT dolt_branch('one');
+SELECT dolt_branch('two');
+SELECT dolt_checkout('one');
+INSERT INTO t VALUES (2, 20);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'one');
+SELECT dolt_checkout('main');
+SELECT dolt_branch('-D', 'one', 'two');
 "
 
 echo "--- copy ---"
@@ -488,10 +507,10 @@ SELECT dolt_branch('src');
 SELECT dolt_branch('-m', 'src', 'dest', 'extra');
 "
 
-oracle_error "delete_extra_arg" "
+oracle_error "delete_multiple_with_missing" "
 $SEED
 SELECT dolt_branch('feature');
-SELECT dolt_branch('-d', 'feature', 'extra');
+SELECT dolt_branch('-d', 'feature', 'missing');
 "
 
 oracle_error "no_args" "

--- a/test/vc_oracle_tags_test.sh
+++ b/test/vc_oracle_tags_test.sh
@@ -258,6 +258,16 @@ SELECT dolt_tag('temp');
 SELECT dolt_tag('-d', 'temp');
 " "EXPECT_EMPTY"
 
+oracle "delete_multiple_tags" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES (1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'first');
+SELECT dolt_tag('one');
+SELECT dolt_tag('two');
+SELECT dolt_tag('-d', 'one', 'two');
+" "EXPECT_EMPTY"
+
 oracle "delete_one_keep_others" "
 CREATE TABLE t(id INTEGER PRIMARY KEY);
 INSERT INTO t VALUES (1);


### PR DESCRIPTION
## Summary
- accept multiple branch names for `dolt_branch(-d/-D, ...)`
- accept multiple tag names for `dolt_tag(-d, ...)`
- validate and delete each batch inside one locked refs mutation so failures roll back the entire list
- add Dolt oracles plus native success, force-delete, and atomic-failure coverage

## Tests
- `bash test/vc_oracle_branch_test.sh build/doltlite dolt` (48 passed)
- `bash test/vc_oracle_tags_test.sh build/doltlite dolt` (23 passed)
- `DOLTLITE=build/doltlite bash test/doltlite_branch.sh` (72 passed)
- `DOLTLITE=build/doltlite bash test/doltlite_tag.sh` (30 passed)
- `bash test/run_doltlite_tests.sh` (111 runnable suites passed; `doltlite_parity.sh` prerequisite `build/sqlite3` unavailable locally)
- `make -C build lint`

Co-Authored-By: OpenAI Codex <noreply@openai.com>