### PR TITLE
Store the default agent document

### DIFF
--- a/src/doltlite_docs.c
+++ b/src/doltlite_docs.c
@@ -17,7 +17,6 @@ struct DocsCursor {
   sqlite3_stmt *pStmt;
   int eof;
   int synthetic;
-  int foundAgent;
 };
 
 static const char *zDocsVtabSchema =
@@ -140,21 +139,11 @@ static int docsAdvance(DocsCursor *c){
     return SQLITE_OK;
   }
   rc = sqlite3_step(c->pStmt);
-  if( rc==SQLITE_ROW ){
-    const unsigned char *zName = sqlite3_column_text(c->pStmt, 0);
-    if( zName && strcmp((const char*)zName, zDocsAgentName)==0 ){
-      c->foundAgent = 1;
-    }
-    return SQLITE_OK;
-  }
+  if( rc==SQLITE_ROW ) return SQLITE_OK;
   rc = sqlite3_finalize(c->pStmt);
   c->pStmt = 0;
   if( rc!=SQLITE_OK ) return docsSetErrMsg(p, rc);
-  if( !c->foundAgent ){
-    c->synthetic = 1;
-  }else{
-    c->eof = 1;
-  }
+  c->eof = 1;
   return SQLITE_OK;
 }
 
@@ -168,7 +157,6 @@ static int docsFilter(sqlite3_vtab_cursor *pCursor,
   c->pStmt = 0;
   c->eof = 0;
   c->synthetic = 0;
-  c->foundAgent = 0;
   if( !sqlite3FindTable(p->db, "dolt_docs", "main") ){
     c->synthetic = 1;
     return SQLITE_OK;
@@ -236,6 +224,20 @@ static int docsExecBound(DocsVtab *p, const char *zSql,
   return SQLITE_OK;
 }
 
+static int docsSeedAgent(DocsVtab *p){
+  sqlite3_stmt *pStmt = 0;
+  int rc = sqlite3_prepare_v3(p->db,
+      "INSERT INTO main.dolt_docs(doc_name, doc_text) VALUES(?1, ?2)", -1,
+      SQLITE_PREPARE_NO_VTAB, &pStmt, 0);
+  if( rc!=SQLITE_OK ) return docsSetErrMsg(p, rc);
+  sqlite3_bind_text(pStmt, 1, zDocsAgentName, -1, SQLITE_STATIC);
+  sqlite3_bind_text(pStmt, 2, zDocsAgentDefault, -1, SQLITE_STATIC);
+  sqlite3_step(pStmt);
+  rc = sqlite3_finalize(pStmt);
+  if( rc!=SQLITE_OK ) return docsSetErrMsg(p, rc);
+  return SQLITE_OK;
+}
+
 static int docsMaterialize(DocsVtab *p){
   int rc;
   char *zErr = 0;
@@ -247,18 +249,11 @@ static int docsMaterialize(DocsVtab *p){
     sqlite3_free(zErr);
     return rc;
   }
-  return SQLITE_OK;
+  return docsSeedAgent(p);
 }
 
 static int docsBegin(sqlite3_vtab *pBase){
   return docsMaterialize((DocsVtab*)pBase);
-}
-
-static int docsIsAgent(sqlite3_value *pValue){
-  const unsigned char *z;
-  if( sqlite3_value_type(pValue)!=SQLITE_TEXT ) return 0;
-  z = sqlite3_value_text(pValue);
-  return z && strcmp((const char*)z, zDocsAgentName)==0;
 }
 
 static const char *docsInsertSql(sqlite3 *db){
@@ -313,20 +308,6 @@ static int docsUpdate(sqlite3_vtab *pBase, int argc, sqlite3_value **argv,
         "DELETE FROM main.dolt_docs WHERE doc_name=?1", argv[0], 0, 0);
   }
   if( sqlite3_value_type(argv[0])!=SQLITE_NULL ){
-    if( docsIsAgent(argv[0]) ){
-      sqlite3_stmt *pStmt = 0;
-      int exists;
-      rc = sqlite3_prepare_v3(p->db,
-          "SELECT 1 FROM main.dolt_docs WHERE doc_name='AGENT.md'", -1,
-          SQLITE_PREPARE_NO_VTAB, &pStmt, 0);
-      if( rc!=SQLITE_OK ) return docsSetErrMsg(p, rc);
-      exists = sqlite3_step(pStmt)==SQLITE_ROW;
-      rc = sqlite3_finalize(pStmt);
-      if( rc!=SQLITE_OK ) return docsSetErrMsg(p, rc);
-      if( !exists ){
-        return docsExecBound(p, docsInsertSql(p->db), argv[2], argv[3], 0);
-      }
-    }
     return docsExecBound(p,
         docsUpdateSql(p->db), argv[2], argv[3], argv[0]);
   }

--- a/test/doltlite_docs.sh
+++ b/test/doltlite_docs.sh
@@ -18,16 +18,16 @@ run_test "fresh_not_in_sqlite_master" \
   "SELECT count(*) FROM sqlite_master WHERE name='dolt_docs';" \
   "0" "$DB"
 
-run_test "insert_materializes_without_storing_agent" \
+run_test "insert_materializes_and_stores_agent" \
   "INSERT INTO dolt_docs VALUES('README.md','# hello');
    SELECT doc_name FROM dolt_docs ORDER BY doc_name;" \
   "AGENT.md
 README.md" "$DB"
 
-run_test "default_agent_not_in_working_diff" \
+run_test "default_agent_in_working_diff" \
   "SELECT rows_added, old_row_count, new_row_count
      FROM dolt_diff_stat('HEAD','WORKING','dolt_docs');" \
-  "1|0|1" "$DB"
+  "2|0|2" "$DB"
 
 run_test "status_new_table" \
   "SELECT table_name, staged, status FROM dolt_status;" \
@@ -160,8 +160,16 @@ rm -f "$DB"
 DB=/tmp/test_docs5_$$.db
 rm -f "$DB"
 
-run_test "agent_insert_over_seed_first_write" \
-  "INSERT INTO dolt_docs VALUES('AGENT.md','mine');
+run_test_match "agent_insert_over_seed_first_write_rejected" \
+  "INSERT INTO dolt_docs VALUES('AGENT.md','mine');" \
+  "UNIQUE constraint failed: dolt_docs.doc_name" "$DB"
+
+run_test "agent_default_survives_rejected_insert" \
+  "SELECT doc_name, length(doc_text) > 500 FROM dolt_docs;" \
+  "AGENT.md|1" "$DB"
+
+run_test "agent_replace_over_seed_first_write" \
+  "REPLACE INTO dolt_docs VALUES('AGENT.md','mine');
    SELECT doc_name, doc_text FROM dolt_docs;" \
   "AGENT.md|mine" "$DB"
 
@@ -182,10 +190,14 @@ rm -f "$DB"
 DB=/tmp/test_docs7_$$.db
 rm -f "$DB"
 
-run_test "agent_delete_resynthesizes_default" \
+run_test "agent_delete_sticks" \
   "DELETE FROM dolt_docs WHERE doc_name='AGENT.md';
-   SELECT count(*), length(doc_text) > 500 FROM dolt_docs;" \
-  "1|1" "$DB"
+   SELECT count(*) FROM dolt_docs;" \
+  "0" "$DB"
+
+run_test "agent_delete_sticks_after_reopen" \
+  "SELECT count(*) FROM dolt_docs;" \
+  "0" "$DB"
 
 rm -f "$DB"
 DB=/tmp/test_docs8_$$.db
@@ -196,6 +208,38 @@ run_test "agent_default_visible_after_commit" \
    SELECT dolt_commit('-A','-m','docs') IS NOT NULL;
    SELECT count(*) FROM dolt_docs WHERE doc_name='AGENT.md';" \
   "1
+1" "$DB"
+
+rm -f "$DB"
+
+DB=/tmp/test_docs9_$$.db
+rm -f "$DB"
+
+echo "INSERT INTO dolt_docs VALUES('README.md','hi'); SELECT dolt_commit('-A','-m','docs');" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+run_test "agent_delete_has_row_diff" \
+  "DELETE FROM dolt_docs WHERE doc_name='AGENT.md';
+   SELECT rows_deleted, old_row_count, new_row_count
+     FROM dolt_diff_stat('HEAD','WORKING','dolt_docs');" \
+  "1|2|1" "$DB"
+
+run_test "agent_reset_restores_stored_row" \
+  "SELECT dolt_reset('--hard');
+   SELECT count(*) FROM dolt_docs WHERE doc_name='AGENT.md';" \
+  "0
+1" "$DB"
+
+run_test "agent_committed_delete_sticks" \
+  "DELETE FROM dolt_docs WHERE doc_name='AGENT.md';
+   SELECT dolt_commit('-A','-m','delete agent') IS NOT NULL;
+   SELECT count(*) FROM dolt_docs WHERE doc_name='AGENT.md';" \
+  "1
+0" "$DB"
+
+run_test "agent_table_checkout_restores_historical_row" \
+  "SELECT dolt_checkout('HEAD~1','dolt_docs');
+   SELECT count(*) FROM dolt_docs WHERE doc_name='AGENT.md';" \
+  "0
 1" "$DB"
 
 rm -f "$DB"

--- a/test/vc_oracle_docs_test.sh
+++ b/test/vc_oracle_docs_test.sh
@@ -76,6 +76,56 @@ oracle_agent() { oracle agent "$@"; }
 oracle_agent_count() { oracle agent_count "$@"; }
 oracle_diff_stat() { oracle diff_stat "$@"; }
 
+oracle_divergence() {
+  local name="$1" setup="$2" dl_query="$3" dt_query="$4"
+  local dl_expected="$5" dt_expected="$6"
+  local dl_expect_error="$7" dt_expect_error="$8"
+  local dir="$TMPROOT/${name}_div"
+  local dl_rc dt_rc dl_out dt_out dl_rc_ok=0 dt_rc_ok=0
+  mkdir -p "$dir/dl" "$dir/dt"
+
+  printf "%s\n%s\n" "$setup" "$dl_query" \
+    | "$DOLTLITE" "$dir/dl/db" >"$dir/dl.raw" 2>"$dir/dl.err"
+  dl_rc=$?
+  dl_out=$(tr -d '\r"' < "$dir/dl.raw" | grep '^X|')
+
+  local dolt_setup
+  dolt_setup=$(vc_oracle_translate_for_dolt "$setup")
+  (
+    cd "$dir/dt" || exit 1
+    vc_oracle_init_repo
+    printf "%s\n%s\n" "$dolt_setup" "$dt_query" \
+      | "$DOLT" sql -c -r csv 2>"$dir/dt.err"
+  ) > "$dir/dt.raw"
+  dt_rc=$?
+  dt_out=$(tr -d '\r"' < "$dir/dt.raw" | grep '^X|')
+
+  if [ "$dl_expect_error" = "1" ]; then
+    vc_oracle_is_clean_error "$dl_rc" && dl_rc_ok=1
+  elif [ "$dl_rc" -eq 0 ]; then
+    dl_rc_ok=1
+  fi
+  if [ "$dt_expect_error" = "1" ]; then
+    vc_oracle_is_clean_error "$dt_rc" && dt_rc_ok=1
+  elif [ "$dt_rc" -eq 0 ]; then
+    dt_rc_ok=1
+  fi
+
+  if [ "$dl_rc_ok" -eq 1 ] && [ "$dt_rc_ok" -eq 1 ] \
+     && [ "$dl_out" = "$dl_expected" ] \
+     && [ "$dt_out" = "$dt_expected" ]; then
+    pass=$((pass+1))
+  else
+    fail=$((fail+1))
+    FAILED_NAMES="$FAILED_NAMES $name"
+    echo "  FAIL: $name"
+    echo "    doltlite rc/output: $dl_rc / $dl_out"
+    echo "    expected:           $dl_expect_error / $dl_expected"
+    echo "    dolt rc/output:     $dt_rc / $dt_out"
+    echo "    expected:           $dt_expect_error / $dt_expected"
+  fi
+}
+
 oracle_error() {
   local name="$1" setup="$2"
   local dir="$TMPROOT/${name}_err"
@@ -286,9 +336,12 @@ oracle_agent_count "agent_survives_other_writes" "
 INSERT INTO dolt_docs VALUES ('README.md', 'hi');
 "
 
-oracle_diff_stat "default_agent_is_not_versioned" "
+oracle_divergence "default_agent_is_versioned_in_doltlite" "
 INSERT INTO dolt_docs VALUES ('README.md', 'hi');
-"
+" \
+"SELECT 'X|' || rows_added || '|' || rows_deleted || '|' || rows_modified || '|' || old_row_count || '|' || new_row_count FROM dolt_diff_stat('HEAD', 'WORKING', 'dolt_docs');" \
+"SELECT concat('X|', rows_added, '|', rows_deleted, '|', rows_modified, '|', old_row_count, '|', new_row_count) FROM dolt_diff_stat('HEAD', 'WORKING', 'dolt_docs');" \
+"X|2|0|0|0|2" "X|1|0|0|0|1" 0 0
 
 oracle_agent "agent_replace_overrides_default" "
 REPLACE INTO dolt_docs VALUES ('AGENT.md', 'custom agent doc');
@@ -298,14 +351,20 @@ oracle_agent "agent_update_overrides_default" "
 UPDATE dolt_docs SET doc_text = 'edited agent doc' WHERE doc_name = 'AGENT.md';
 "
 
-oracle_agent "agent_insert_as_first_write" "
+oracle_divergence "agent_insert_obeys_stored_primary_key" "
 INSERT INTO dolt_docs VALUES ('AGENT.md', 'inserted agent doc');
-"
+" \
+"SELECT 'X|' || count(*) || '|' || coalesce(max(CASE WHEN doc_text='inserted agent doc' THEN 1 ELSE 0 END), 0) FROM dolt_docs WHERE doc_name='AGENT.md';" \
+"SELECT concat('X|', count(*), '|', coalesce(max(CASE WHEN doc_text='inserted agent doc' THEN 1 ELSE 0 END), 0)) FROM dolt_docs WHERE doc_name='AGENT.md';" \
+"X|1|0" "X|1|1" 1 0
 
-oracle_agent_count "agent_delete_resynthesizes_default" "
+oracle_divergence "agent_delete_sticks_in_doltlite" "
 REPLACE INTO dolt_docs VALUES ('AGENT.md', 'custom agent doc');
 DELETE FROM dolt_docs WHERE doc_name = 'AGENT.md';
-"
+" \
+"SELECT 'X|' || count(*) FROM dolt_docs WHERE doc_name='AGENT.md';" \
+"SELECT concat('X|', count(*)) FROM dolt_docs WHERE doc_name='AGENT.md';" \
+"X|0" "X|1" 0 0
 
 oracle_agent "agent_override_commits" "
 REPLACE INTO dolt_docs VALUES ('AGENT.md', 'committed agent doc');


### PR DESCRIPTION
## Summary
- seed the default `AGENT.md` as a stored row when `dolt_docs` materializes
- stop synthesizing the row once the backing table exists, so deletes stick and version-control operations see it
- pin the intentional Dolt divergences for versioned defaults, insert conflicts, and deletion

## Tests
- `DOLTLITE=build/doltlite bash test/doltlite_docs.sh` (34 passed)
- `bash test/vc_oracle_docs_test.sh build/doltlite dolt` (47 passed)
- `bash test/run_doltlite_tests.sh` (111 runnable suites and 310,930 regression assertions passed; `doltlite_parity.sh` prerequisite `build/sqlite3` unavailable locally)
- `make -C build lint`

Co-Authored-By: OpenAI Codex <noreply@openai.com>