### PR TITLE
Refuse a merge that adds the same column and drops another

### DIFF
--- a/src/doltlite_merge_schema.c
+++ b/src/doltlite_merge_schema.c
@@ -882,6 +882,36 @@ int trySchemaColumnMerge(
   }
 
 schema_merge_done:
+  /* Same-position replacement looks like a rename. If the surviving side
+  ** already has the new name, both branches added it independently. */
+  for(i=0; i<nAnc; i++){
+    ParsedColumn *pDropping;
+    ParsedColumn *pSurviving;
+    int nDropping, nSurviving;
+    int inOurs = findColumn(aOurs, nOurs, aAnc[i].zName)!=0;
+    int inTheirs = findColumn(aTheirs, nTheirs, aAnc[i].zName)!=0;
+    if( inOurs==inTheirs ) continue;
+    if( inOurs ){
+      pDropping = aTheirs; nDropping = nTheirs;
+      pSurviving = aOurs; nSurviving = nOurs;
+    }else{
+      pDropping = aOurs; nDropping = nOurs;
+      pSurviving = aTheirs; nSurviving = nTheirs;
+    }
+    if( i<nDropping
+     && !findColumn(aAnc, nAnc, pDropping[i].zName)
+     && parsedColumnDefinitionsMatch(&pDropping[i], &aAnc[i])
+     && findColumn(pSurviving, nSurviving, pDropping[i].zName) ){
+      if( pzErrDetail ){
+        *pzErrDetail = sqlite3_mprintf(
+          "column '%s' dropped on one branch while both branches add column '%s'",
+          aAnc[i].zName, pDropping[i].zName);
+      }
+      rc = SQLITE_ERROR;
+      goto schema_merge_cleanup;
+    }
+  }
+
   /* Carry the other side's deletions. A rename is absent under the
   ** old name too; same-position replacement distinguishes it. */
   if( ppDropCols && pnDropCols ){

--- a/test/doltlite_schema_merge.sh
+++ b/test/doltlite_schema_merge.sh
@@ -1949,4 +1949,72 @@ run_test "merge_new_index_other_column_keeps_both" \
   "ic,ix0" "$DB"
 rm -f "$DB"
 
+# Both add the same column and one side drops another: not a rename of the
+# dropped column onto the shared new name (that was SQL logic error).
+for dir in ours theirs; do
+  DB=/tmp/test_merge_both_add_and_drop_${dir}_$$.db; rm -f "$DB"
+  if [ "$dir" = ours ]; then
+    MAIN="ALTER TABLE t ADD COLUMN c1699 TEXT;"
+    FEAT="ALTER TABLE t DROP COLUMN c1899; ALTER TABLE t ADD COLUMN c1699 TEXT;"
+  else
+    MAIN="ALTER TABLE t DROP COLUMN c1899; ALTER TABLE t ADD COLUMN c1699 TEXT;"
+    FEAT="ALTER TABLE t ADD COLUMN c1699 TEXT;"
+  fi
+  cat <<EOF | $DOLTLITE "$DB" > /dev/null 2>&1
+CREATE TABLE t(id INTEGER PRIMARY KEY, payload TEXT, c1113 TEXT, c1899 TEXT);
+INSERT INTO t VALUES(1,'p','x','y');
+SELECT dolt_commit('-A','-m','base');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+$FEAT
+SELECT dolt_commit('-Am','feat side');
+SELECT dolt_checkout('main');
+$MAIN
+SELECT dolt_commit('-Am','main side');
+EOF
+  run_test_match "merge_both_add_same_col_and_drop_other_${dir}_refused" \
+    "SELECT dolt_merge('feat');" \
+    "cannot merge: conflicts detected" "$DB"
+  sc_both_add() { printf "BEGIN;\nSELECT dolt_merge('feat');\n%s\nROLLBACK;\n" "$1"; }
+  run_test_lastline "merge_both_add_same_col_and_drop_other_${dir}_description" \
+    "$(sc_both_add "SELECT description FROM dolt_schema_conflicts;")" \
+    "column 'c1899' dropped on one branch while both branches add column 'c1699'" "$DB"
+  run_test "merge_both_add_same_col_and_drop_other_${dir}_integrity" \
+    "PRAGMA integrity_check;" "ok" "$DB"
+  rm -f "$DB"
+done
+
+DB=/tmp/test_merge_both_add_same_col_no_drop_$$.db; rm -f "$DB"
+cat <<'EOF' | $DOLTLITE "$DB" > /dev/null 2>&1
+CREATE TABLE t(id INTEGER PRIMARY KEY, payload TEXT, c1113 TEXT, c1899 TEXT);
+INSERT INTO t VALUES(1,'p','x','y');
+SELECT dolt_commit('-A','-m','base');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+ALTER TABLE t ADD COLUMN c1699 TEXT;
+SELECT dolt_commit('-Am','feat adds');
+SELECT dolt_checkout('main');
+ALTER TABLE t ADD COLUMN c1699 TEXT;
+SELECT dolt_commit('-Am','main adds');
+EOF
+run_test_match "merge_both_add_same_col_no_drop_merges" \
+  "SELECT dolt_merge('feat');" "^[0-9a-f]{40}$" "$DB"
+rm -f "$DB"
+
+DB=/tmp/test_merge_one_side_drop_and_add_$$.db; rm -f "$DB"
+cat <<'EOF' | $DOLTLITE "$DB" > /dev/null 2>&1
+CREATE TABLE t(id INTEGER PRIMARY KEY, payload TEXT, c1113 TEXT, c1899 TEXT);
+INSERT INTO t VALUES(1,'p','x','y');
+SELECT dolt_commit('-A','-m','base');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+ALTER TABLE t DROP COLUMN c1899;
+ALTER TABLE t ADD COLUMN c1699 TEXT;
+SELECT dolt_commit('-Am','feat drop and add');
+SELECT dolt_checkout('main');
+EOF
+run_test_match "merge_one_side_drop_and_add_merges" \
+  "SELECT dolt_merge('feat');" "^[0-9a-f]{40}$" "$DB"
+rm -f "$DB"
+
 dltest_finish

--- a/test/vc_oracle_schema_merge_test.sh
+++ b/test/vc_oracle_schema_merge_test.sh
@@ -1484,6 +1484,22 @@ expect_merge_ok "pk_change_ours_only_theirs_untouched" "$DB"
 expect_dual_value "pk_change_ours_only_kept" "$DB" "7:70" \
   "SELECT pk || ':' || v FROM t;" "SELECT CONCAT(pk, ':', v) FROM t;"
 
+DB="$TMPROOT/both_add_and_drop.db"; rm -f "$DB"
+cat <<'SQL' | dl_setup "$DB" "both_add_and_drop"
+CREATE TABLE t(id INTEGER PRIMARY KEY, payload TEXT, c1113 TEXT, c1899 TEXT);
+INSERT INTO t VALUES(1,'p','x','y');
+SELECT dolt_commit('-Am','ancestor');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+ALTER TABLE t DROP COLUMN c1899;
+ALTER TABLE t ADD COLUMN c1699 TEXT;
+SELECT dolt_commit('-Am','feat_drop_and_add');
+SELECT dolt_checkout('main');
+ALTER TABLE t ADD COLUMN c1699 TEXT;
+SELECT dolt_commit('-Am','main_add');
+SQL
+expect_merge_conflict "both_add_same_column_and_drop_other" "$DB"
+
 echo ""
 echo "======================================="
 echo "Results: $pass passed, $fail failed"


### PR DESCRIPTION
Fixes https://github.com/dolthub/doltlite/issues/2349

## Problem

`dolt_merge` failed with a bare `SQL logic error` when both branches added the same column name and one branch also dropped a different ancestor column:

```sql
CREATE TABLE t(id INTEGER PRIMARY KEY, payload TEXT, c1113 TEXT, c1899 TEXT);
-- ours:  ALTER TABLE t ADD COLUMN c1699 TEXT;
-- theirs: ALTER TABLE t DROP COLUMN c1899; ALTER TABLE t ADD COLUMN c1699 TEXT;
SELECT dolt_merge('b');  -- SQL logic error
```

The drop+add sat in the same ordinal as the ancestor column, so schema merge treated it as a rename of `c1899` onto `c1699`. Applying that rename onto a schema that already had `c1699` is an illegal duplicate column.

Dolt raises a schema conflict and rolls the merge back. Doltlite should refuse too, with a message that names the table/columns — not `SQL logic error`.

Both-add with no drop, a one-sided drop+add, and a drop plus a *different* added name still merge.

## Change

Before classifying a same-position replacement as a rename, check whether the surviving side already has the new name. If it does, both branches added that column independently; record a schema conflict:

`column 'c1899' dropped on one branch while both branches add column 'c1699'`

Autocommit merge then reports `cannot merge: conflicts detected` (which the VC fuzzer already allows). Inside `BEGIN`/`COMMIT`, `dolt_schema_conflicts.description` carries that text.

## Tests

- `test/doltlite_schema_merge.sh`: both directions of the failing shape, plus both-add-no-drop and one-sided drop+add still merge.
- `test/vc_oracle_schema_merge_test.sh`: same shape conflicts on both doltlite and Dolt.

Local: schema merge suite 307/307; schema merge oracle 106/106 including the new case.