### PR TITLE
Reject incomplete revision ranges

### DIFF
--- a/src/doltlite_diff_table.c
+++ b/src/doltlite_diff_table.c
@@ -1073,6 +1073,11 @@ static int dtFilter(sqlite3_vtab_cursor *cur,
       pVtab->base.zErrMsg = sqlite3_mprintf(
           "dolt_diff_%s requires a '..' or '...' revision range",
           pVtab->zTableName);
+    }else if( rc==SQLITE_ERROR ){
+      sqlite3_free(pVtab->base.zErrMsg);
+      pVtab->base.zErrMsg = sqlite3_mprintf(
+          "dolt_diff_%s: invalid revision range '%s'",
+          pVtab->zTableName, zSpec ? zSpec : "");
     }
   }else if( (idxNum & DT_IDX_TO_COMMIT_EQ)!=0 && argc>=1 ){
     const char *zToCommit = (const char*)sqlite3_value_text(argv[0]);

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -52,10 +52,9 @@ static SQLITE_INLINE int doltliteSplitRevisionRange(
   if( strstr(zSep + nSep, "..") ) return SQLITE_ERROR;
 
   nLeft = (int)(zSep - zSpec);
-  *pzLeft = nLeft ? sqlite3_mprintf("%.*s", nLeft, zSpec)
-                  : sqlite3_mprintf("HEAD");
-  *pzRight = zSep[nSep] ? sqlite3_mprintf("%s", zSep + nSep)
-                        : sqlite3_mprintf("HEAD");
+  if( nLeft==0 || zSep[nSep]==0 ) return SQLITE_ERROR;
+  *pzLeft = sqlite3_mprintf("%.*s", nLeft, zSpec);
+  *pzRight = sqlite3_mprintf("%s", zSep + nSep);
   if( !*pzLeft || !*pzRight ){
     sqlite3_free(*pzLeft);
     sqlite3_free(*pzRight);

--- a/src/doltlite_patch.c
+++ b/src/doltlite_patch.c
@@ -1440,20 +1440,6 @@ static int patchFilter(sqlite3_vtab_cursor *pCursor, int idxNum,
     patchSetError(&pVtab->base,"dolt_patch: invalid arguments%s","");
     return SQLITE_ERROR;
   }
-  {
-    const char *zDots = strstr(zArg1,"...");
-    int nDots = 3;
-    if( !zDots ){
-      zDots = strstr(zArg1,"..");
-      nDots = 2;
-    }
-    if( zDots && (zDots==zArg1 || zDots[nDots]==0) ){
-      patchSetError(&pVtab->base,
-                    "dolt_patch: range endpoints must not be empty near '%s'",
-                    zArg1);
-      return SQLITE_ERROR;
-    }
-  }
   rc=doltliteSplitRevisionRange(zArg1,&zLeft,&zRight,&rangeType);
   if( rc==SQLITE_OK ){
     zFrom=zLeft; zTo=zRight; zFilter=zArg2;

--- a/src/doltlite_schema_diff.c
+++ b/src/doltlite_schema_diff.c
@@ -820,31 +820,15 @@ static int sdParseArgs(
   }
 
   if( zFromRef && !zToRef ){
-    const char *zDots = strstr(zFromRef, "..");
-    if( zDots ){
-      int nFrom = (int)(zDots - zFromRef);
-      int nTo = (int)strlen(zDots + 2);
-      char *zRangeFrom = 0;
-      char *zRangeTo = 0;
+    char *zRangeFrom = 0;
+    char *zRangeTo = 0;
+    int rangeType = DOLTLITE_RANGE_NONE;
+    int rc;
+
+    rc = doltliteSplitRevisionRange(zFromRef, &zRangeFrom, &zRangeTo,
+                                    &rangeType);
+    if( rc==SQLITE_OK && rangeType==DOLTLITE_RANGE_TWO_DOT ){
       ProllyHash probe;
-      int rc;
-
-      if( nFrom<=0 || nTo<=0 ){
-        sqlite3_free(pVtab->zErrMsg);
-        pVtab->zErrMsg = sqlite3_mprintf(
-          "Invalid argument to dolt_schema_diff: %s",
-          zFromRef
-        );
-        return SQLITE_ERROR;
-      }
-
-      zRangeFrom = sqlite3_mprintf("%.*s", nFrom, zFromRef);
-      zRangeTo = sqlite3_mprintf("%s", zDots + 2);
-      if( !zRangeFrom || !zRangeTo ){
-        sqlite3_free(zRangeFrom);
-        sqlite3_free(zRangeTo);
-        return SQLITE_NOMEM;
-      }
 
       rc = doltliteResolveCatalogHashForRef(db, zRangeFrom, &probe);
       if( rc==SQLITE_OK ){
@@ -868,9 +852,13 @@ static int sdParseArgs(
       zFromRef = zRangeFrom;
       zToRef = zRangeTo;
     }else{
+      sqlite3_free(zRangeFrom);
+      sqlite3_free(zRangeTo);
+      if( rc==SQLITE_NOMEM ) return rc;
       sqlite3_free(pVtab->zErrMsg);
       pVtab->zErrMsg = sqlite3_mprintf(
-        "Invalid argument to dolt_schema_diff: There are less than 2 arguments present, and the first does not contain '..'"
+        "Invalid argument to dolt_schema_diff: %s",
+        zFromRef
       );
       return SQLITE_ERROR;
     }

--- a/test/doltlite_diff_table_range.sh
+++ b/test/doltlite_diff_table_range.sh
@@ -33,8 +33,21 @@ run_test "two_dot_snapshot_diff" \
         FROM dolt_diff_t('main..feature') ORDER BY id);" \
   "1:removed,2:added" "$DB"
 
-run_test "two_dot_omitted_head" \
-  "SELECT count(*) FROM dolt_diff_t('..feature');" "2" "$DB"
+run_test_match "two_dot_missing_left_rejected" \
+  "SELECT count(*) FROM dolt_diff_t('..feature');" \
+  "invalid revision range" "$DB"
+
+run_test_match "two_dot_missing_right_rejected" \
+  "SELECT count(*) FROM dolt_diff_t('feature..');" \
+  "invalid revision range" "$DB"
+
+run_test_match "three_dot_missing_left_rejected" \
+  "SELECT count(*) FROM dolt_diff_t('...feature');" \
+  "invalid revision range" "$DB"
+
+run_test_match "three_dot_missing_right_rejected" \
+  "SELECT count(*) FROM dolt_diff_t('feature...');" \
+  "invalid revision range" "$DB"
 
 run_test "three_dot_feature" \
   "SELECT coalesce(from_id,to_id) || ':' || diff_type
@@ -63,6 +76,22 @@ run_test "log_three_dot" \
   "SELECT group_concat(message, ',') FROM
      (SELECT message FROM dolt_log('main...feature') ORDER BY message);" \
   "feature change,main change" "$DB"
+
+run_test_match "log_two_dot_missing_left_rejected" \
+  "SELECT count(*) FROM dolt_log('..feature');" \
+  "invalid dolt_log revision" "$DB"
+
+run_test_match "log_two_dot_missing_right_rejected" \
+  "SELECT count(*) FROM dolt_log('feature..');" \
+  "invalid dolt_log revision" "$DB"
+
+run_test_match "log_three_dot_missing_left_rejected" \
+  "SELECT count(*) FROM dolt_log('...feature');" \
+  "invalid dolt_log revision" "$DB"
+
+run_test_match "log_three_dot_missing_right_rejected" \
+  "SELECT count(*) FROM dolt_log('feature...');" \
+  "invalid dolt_log revision" "$DB"
 
 HDB=/tmp/test_dt_history_$$.db; rm -f "$HDB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);

--- a/test/doltlite_schema_diff.sh
+++ b/test/doltlite_schema_diff.sh
@@ -61,6 +61,12 @@ run_test_match "bad_to_ref_errors" \
 run_test_match "bad_single_arg_errors" \
   "SELECT count(*) FROM dolt_schema_diff('definitely_not_a_ref');" \
   "Error" "$DB"
+run_test_match "range_missing_left_errors" \
+  "SELECT count(*) FROM dolt_schema_diff('..HEAD');" \
+  "Invalid argument" "$DB"
+run_test_match "range_missing_right_errors" \
+  "SELECT count(*) FROM dolt_schema_diff('HEAD..');" \
+  "Invalid argument" "$DB"
 # Malformed range endpoint must name the unresolvable ref, matching the two-arg form.
 run_test_match "bad_range_from_names_endpoint" \
   "SELECT count(*) FROM dolt_schema_diff('does-not-exist..HEAD');" \

--- a/test/vc_oracle_diff_tvf_test.sh
+++ b/test/vc_oracle_diff_tvf_test.sh
@@ -50,6 +50,31 @@ oracle() {
   fi
 }
 
+oracle_error() {
+  local name="$1" setup="$2" query="$3"
+  local dir="$TMPROOT/${name}_err"
+  local dl_rc dt_rc dolt_setup dolt_query
+  mkdir -p "$dir/dl" "$dir/dt"
+
+  vc_oracle_run_doltlite_script "$dir/dl/db" "$dir/dl.out" \
+    "$dir/dl.err" "$(printf '%s\n%s\n' "$setup" "$query")"
+  dl_rc=$?
+
+  dolt_setup=$(echo "$setup" | translate_for_dolt)
+  dolt_query=$(echo "$query" | translate_for_dolt)
+  vc_oracle_run_dolt_script_for_error "$dir/dt" "$dir/dt.out" \
+    "$dir/dt.err" "$(printf '%s\n%s\n' "$dolt_setup" "$dolt_query")"
+  dt_rc=$?
+
+  if vc_oracle_is_clean_error "$dl_rc" && vc_oracle_is_clean_error "$dt_rc"; then
+    pass=$((pass+1))
+  else
+    fail=$((fail+1))
+    FAILED_NAMES="$FAILED_NAMES $name"
+    echo "  FAIL: $name (doltlite rc=$dl_rc, dolt rc=$dt_rc)"
+  fi
+}
+
 oracle_reopen() {
   local name="$1" setup="$2" query="$3"
   local dir="$TMPROOT/$name"
@@ -196,6 +221,30 @@ oracle "log_two_dot" "$SETUP_DIVERGENT" \
 
 oracle "log_three_dot" "$SETUP_DIVERGENT" \
   "SELECT CONCAT('R|', message) FROM dolt_log('main...feature');"
+
+oracle_error "diff_two_dot_missing_left" "$SETUP_DIVERGENT" \
+  "SELECT count(*) FROM dolt_diff_t('..feature');"
+
+oracle_error "diff_two_dot_missing_right" "$SETUP_DIVERGENT" \
+  "SELECT count(*) FROM dolt_diff_t('feature..');"
+
+oracle_error "diff_three_dot_missing_left" "$SETUP_DIVERGENT" \
+  "SELECT count(*) FROM dolt_diff_t('...feature');"
+
+oracle_error "diff_three_dot_missing_right" "$SETUP_DIVERGENT" \
+  "SELECT count(*) FROM dolt_diff_t('feature...');"
+
+oracle_error "log_two_dot_missing_left" "$SETUP_DIVERGENT" \
+  "SELECT count(*) FROM dolt_log('..feature');"
+
+oracle_error "log_two_dot_missing_right" "$SETUP_DIVERGENT" \
+  "SELECT count(*) FROM dolt_log('feature..');"
+
+oracle_error "log_three_dot_missing_left" "$SETUP_DIVERGENT" \
+  "SELECT count(*) FROM dolt_log('...feature');"
+
+oracle_error "log_three_dot_missing_right" "$SETUP_DIVERGENT" \
+  "SELECT count(*) FROM dolt_log('feature...');"
 
 echo "--- multi-column table ---"
 

--- a/test/vc_oracle_patch_test.sh
+++ b/test/vc_oracle_patch_test.sh
@@ -362,6 +362,8 @@ oracle_error bad_to_ref "$error_setup" "SELECT * FROM dolt_patch('HEAD','missing
 oracle_error missing_table "$error_setup" "SELECT * FROM dolt_patch('HEAD~1','HEAD','missing_table');"
 oracle_error empty_range_right "$error_setup" "SELECT * FROM dolt_patch('HEAD~1..');"
 oracle_error empty_range_left "$error_setup" "SELECT * FROM dolt_patch('..HEAD');"
+oracle_error empty_three_dot_range_right "$error_setup" "SELECT * FROM dolt_patch('HEAD~1...');"
+oracle_error empty_three_dot_range_left "$error_setup" "SELECT * FROM dolt_patch('...HEAD');"
 oracle_error four_arguments "$error_setup" \
   "SELECT * FROM dolt_patch('HEAD~1','HEAD','t','extra');"
 oracle_error null_arguments "$error_setup" \

--- a/test/vc_oracle_schema_diff_test.sh
+++ b/test/vc_oracle_schema_diff_test.sh
@@ -697,6 +697,12 @@ oracle_error "bad_to_ref" "$SEED" \
 oracle_error "bad_single_arg" "$SEED" \
   "SELECT * FROM dolt_schema_diff('nope');"
 
+oracle_error "range_missing_left" "$SEED" \
+  "SELECT * FROM dolt_schema_diff('..HEAD');"
+
+oracle_error "range_missing_right" "$SEED" \
+  "SELECT * FROM dolt_schema_diff('HEAD..');"
+
 echo ""
 echo "--- schema objects (pinned per-system shapes) ---"
 


### PR DESCRIPTION
## Summary
- reject empty `..` and `...` endpoints in the shared revision-range parser
- route schema-diff range syntax through the common parser and remove patch's duplicate guard
- return a useful table-diff error and add Dolt parity coverage across log, diff, patch, and schema diff

## Tests
- fail-before: 8 new log/diff endpoint cases failed against the old engine
- `DOLTLITE=build/doltlite bash test/doltlite_diff_table_range.sh` (22 passed)
- `DOLTLITE=build/doltlite bash test/doltlite_schema_diff.sh` (60 passed)
- `DOLTLITE=build/doltlite bash test/doltlite_log.sh` (7 passed)
- `bash test/vc_oracle_diff_tvf_test.sh build/doltlite dolt` (29 passed)
- `bash test/vc_oracle_patch_test.sh build/doltlite dolt` (85 passed)
- `bash test/vc_oracle_schema_diff_test.sh build/doltlite dolt` (67 passed)
- `bash test/run_doltlite_tests.sh` (111 runnable suites and 310,930 regression assertions passed; `doltlite_parity.sh` prerequisite `./sqlite3` unavailable locally)
- `make -C build lint`

Co-Authored-By: OpenAI Codex <noreply@openai.com>