### PR TITLE
Decide the both-add pair by drop count, not by position

### DIFF
--- a/src/doltlite_merge_schema.c
+++ b/src/doltlite_merge_schema.c
@@ -633,6 +633,41 @@ static int schemaConstraintModifyDeleteChoice(
   return rc;
 }
 
+/* True when zName sits on this side as a plain addition: absent from the
+** ancestor, and not standing in an ancestor column's slot with its type,
+** which is what a rename leaves behind. */
+static int columnPlainlyAdded(
+  ParsedColumn *aSide, int nSide,
+  ParsedColumn *aAnc, int nAnc,
+  const char *zName
+){
+  int i = parsedColumnIndexByName(aSide, nSide, zName);
+  if( i<0 || findColumn(aAnc, nAnc, zName) ) return 0;
+  if( i<nAnc
+   && !findColumn(aSide, nSide, aAnc[i].zName)
+   && parsedColumnDefinitionsMatch(&aSide[i], &aAnc[i]) ){
+    return 0;
+  }
+  return 1;
+}
+
+/* True when the ancestor column at iAnc left this side by being renamed
+** rather than dropped. The other side decides the ambiguous case: if the
+** replacement's name is a plain addition over there, both sides added it
+** and this side really did drop a column. */
+static int columnRenamedAt(
+  ParsedColumn *aSide, int nSide,
+  ParsedColumn *aAnc, int nAnc,
+  int iAnc,
+  ParsedColumn *aOther, int nOther
+){
+  if( iAnc>=nSide ) return 0;
+  if( findColumn(aAnc, nAnc, aSide[iAnc].zName) ) return 0;
+  if( !parsedColumnDefinitionsMatch(&aSide[iAnc], &aAnc[iAnc]) ) return 0;
+  if( columnPlainlyAdded(aOther, nOther, aAnc, nAnc, aSide[iAnc].zName) ) return 0;
+  return 1;
+}
+
 int trySchemaColumnMerge(
   const char *zAncSql,
   const char *zOursSql,
@@ -882,33 +917,42 @@ int trySchemaColumnMerge(
   }
 
 schema_merge_done:
-  /* Same-position replacement looks like a rename. If the surviving side
-  ** already has the new name, both branches added it independently. */
-  for(i=0; i<nAnc; i++){
-    ParsedColumn *pDropping;
-    ParsedColumn *pSurviving;
-    int nDropping, nSurviving;
-    int inOurs = findColumn(aOurs, nOurs, aAnc[i].zName)!=0;
-    int inTheirs = findColumn(aTheirs, nTheirs, aAnc[i].zName)!=0;
-    if( inOurs==inTheirs ) continue;
-    if( inOurs ){
-      pDropping = aTheirs; nDropping = nTheirs;
-      pSurviving = aOurs; nSurviving = nOurs;
-    }else{
-      pDropping = aOurs; nDropping = nOurs;
-      pSurviving = aTheirs; nSurviving = nTheirs;
-    }
-    if( i<nDropping
-     && !findColumn(aAnc, nAnc, pDropping[i].zName)
-     && parsedColumnDefinitionsMatch(&pDropping[i], &aAnc[i])
-     && findColumn(pSurviving, nSurviving, pDropping[i].zName) ){
-      if( pzErrDetail ){
-        *pzErrDetail = sqlite3_mprintf(
-          "column '%s' dropped on one branch while both branches add column '%s'",
-          aAnc[i].zName, pDropping[i].zName);
+  /* Both branches independently adding a column of the same name is only
+  ** mergeable when they dropped the same number of ancestor columns; Dolt
+  ** reports a schema conflict otherwise, whichever columns went and wherever
+  ** the added one sits. Renames must not be counted as drops, and a rename is
+  ** what a same-position replacement of matching type looks like -- so the
+  ** shared name has to turn up somewhere it cannot be a rename before this
+  ** reads the pair as two independent adds. */
+  {
+    int nDropOurs = 0, nDropTheirs = 0, iAsym = -1;
+    for(i=0; i<nAnc; i++){
+      int inOurs = findColumn(aOurs, nOurs, aAnc[i].zName)!=0;
+      int inTheirs = findColumn(aTheirs, nTheirs, aAnc[i].zName)!=0;
+      if( !inOurs && !columnRenamedAt(aOurs, nOurs, aAnc, nAnc, i, aTheirs, nTheirs) ){
+        nDropOurs++;
       }
-      rc = SQLITE_ERROR;
-      goto schema_merge_cleanup;
+      if( !inTheirs && !columnRenamedAt(aTheirs, nTheirs, aAnc, nAnc, i, aOurs, nOurs) ){
+        nDropTheirs++;
+      }
+      if( inOurs!=inTheirs && iAsym<0 ) iAsym = i;
+    }
+    if( nDropOurs!=nDropTheirs && iAsym>=0 ){
+      for(i=0; i<nOurs; i++){
+        if( findColumn(aAnc, nAnc, aOurs[i].zName) ) continue;
+        if( !findColumn(aTheirs, nTheirs, aOurs[i].zName) ) continue;
+        if( !columnPlainlyAdded(aOurs, nOurs, aAnc, nAnc, aOurs[i].zName)
+         && !columnPlainlyAdded(aTheirs, nTheirs, aAnc, nAnc, aOurs[i].zName) ){
+          continue;
+        }
+        if( pzErrDetail ){
+          *pzErrDetail = sqlite3_mprintf(
+            "column '%s' dropped on one branch while both branches add column '%s'",
+            aAnc[iAsym].zName, aOurs[i].zName);
+        }
+        rc = SQLITE_ERROR;
+        goto schema_merge_cleanup;
+      }
     }
   }
 

--- a/test/doltlite_schema_merge.sh
+++ b/test/doltlite_schema_merge.sh
@@ -2017,4 +2017,59 @@ run_test_match "merge_one_side_drop_and_add_merges" \
   "SELECT dolt_merge('feat');" "^[0-9a-f]{40}$" "$DB"
 rm -f "$DB"
 
+# Dolt decides this pair on how many columns each side dropped, not on which
+# ones or where the added column landed: same count merges, differing count is
+# a schema conflict. Each expectation below was read off Dolt 2.2.2.
+both_add_drop_case() {
+  DB=/tmp/test_merge_bothadd_$1_$$.db; rm -f "$DB"
+  cat <<EOF | $DOLTLITE "$DB" > /dev/null 2>&1
+CREATE TABLE t(id INTEGER PRIMARY KEY, payload TEXT, c1113 TEXT, c1899 TEXT, c2000 TEXT);
+INSERT INTO t VALUES(1,'p','x','y','z');
+SELECT dolt_commit('-A','-m','base');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+$3
+ALTER TABLE t ADD COLUMN c1699 TEXT;
+SELECT dolt_commit('-Am','feat side');
+SELECT dolt_checkout('main');
+$2
+ALTER TABLE t ADD COLUMN c1699 TEXT;
+SELECT dolt_commit('-Am','main side');
+EOF
+  if [ "$4" = refuse ]; then
+    run_test_match "merge_bothadd_$1_refused" "SELECT dolt_merge('feat');" \
+      "cannot merge: conflicts detected" "$DB"
+  else
+    run_test_match "merge_bothadd_$1_merges" "SELECT dolt_merge('feat');" \
+      "^[0-9a-f]{40}$" "$DB"
+  fi
+  run_test "merge_bothadd_$1_integrity" "PRAGMA integrity_check;" "ok" "$DB"
+  rm -f "$DB"
+}
+
+# Unequal drop counts: a conflict wherever the dropped column sat.
+both_add_drop_case "theirs_drops_middle" \
+  "" "ALTER TABLE t DROP COLUMN c1113;" refuse
+both_add_drop_case "ours_drops_middle" \
+  "ALTER TABLE t DROP COLUMN c1113;" "" refuse
+both_add_drop_case "ours_drops_last" \
+  "ALTER TABLE t DROP COLUMN c2000;" "" refuse
+both_add_drop_case "theirs_drops_two" \
+  "" "ALTER TABLE t DROP COLUMN c1113; ALTER TABLE t DROP COLUMN c1899;" refuse
+both_add_drop_case "one_versus_two_overlapping" \
+  "ALTER TABLE t DROP COLUMN c1113;" \
+  "ALTER TABLE t DROP COLUMN c1113; ALTER TABLE t DROP COLUMN c1899;" refuse
+both_add_drop_case "one_versus_two_disjoint" \
+  "ALTER TABLE t DROP COLUMN c1113;" \
+  "ALTER TABLE t DROP COLUMN c1899; ALTER TABLE t DROP COLUMN c2000;" refuse
+
+# Equal drop counts merge, even when the sides dropped different columns.
+both_add_drop_case "one_each_disjoint" \
+  "ALTER TABLE t DROP COLUMN c1899;" "ALTER TABLE t DROP COLUMN c1113;" merge
+both_add_drop_case "one_each_same_column" \
+  "ALTER TABLE t DROP COLUMN c1113;" "ALTER TABLE t DROP COLUMN c1113;" merge
+both_add_drop_case "two_each_overlapping" \
+  "ALTER TABLE t DROP COLUMN c1113; ALTER TABLE t DROP COLUMN c1899;" \
+  "ALTER TABLE t DROP COLUMN c2000; ALTER TABLE t DROP COLUMN c1113;" merge
+
 dltest_finish


### PR DESCRIPTION
Follow-up to #2350, which fixed the reported case but only when the dropped column was the **last** one.

#2350 pairs the added column against the ancestor slot the dropped column vacated, so a drop anywhere else slips past and the merge fails with `SQL logic error` again:

```sql
CREATE TABLE t(id INTEGER PRIMARY KEY, payload TEXT, c1113 TEXT, c1899 TEXT);
-- ours:   ADD c1699
-- theirs: DROP c1113  (a middle column, not the last)
--         ADD c1699
SELECT dolt_merge('b');   -->  SQL logic error   (before this change)
```

## What Dolt actually does

Read off Dolt 2.2.2 across fifteen shapes. It decides this pair on **how many** columns each side dropped — not which ones, and not where the added column landed:

| ours drops | theirs drops | Dolt |
| --- | --- | --- |
| ∅ | one | CONFLICT |
| one | ∅ | CONFLICT |
| one | two, overlapping | CONFLICT |
| one | two, disjoint | CONFLICT |
| one | one, disjoint | **MERGE** |
| one | one, same column | **MERGE** |
| two | two, overlapping | **MERGE** |
| ∅ | ∅ | **MERGE** |

Worth recording that two rules fit the first handful of shapes and then mispredicted, so neither is what this implements: *proper subset of dropped columns* (dies on one-vs-two disjoint, which conflicts) and *differing final column count* (dies on a one-sided drop that adds two columns, which conflicts at equal counts).

The precondition still matters: with the sides adding **different** names, a 0-vs-1 drop merges fine.

## Why counting alone is not enough

A rename leaves exactly what a drop plus an add leaves — the ancestor name gone, a new name in its slot with its type. That is precisely why #2350 paired by position, and my first attempt at counting over-refused and broke `merge_after_merged_rename_*`.

So a positional replacement still reads as a rename, and stops reading as one only when the same name appears on the other side somewhere it *cannot* be a rename. That is what makes the pair two independent adds rather than the same rename done twice.

## Verification

- `doltlite_schema_merge.sh`: **325 passed, 0 failed** (18 new tests)
- the same tests on master: **7 fail** — 3 are #2350's own, 4 are the shapes this fixes
- `vc_oracle_correct_schema_merge_matrix_test.sh` vs Dolt: **261 passed, 0 failed, 0 differing, 0 corrupting** — unchanged from baseline, so no new divergence
- all 15 oracled shapes match Dolt except the one filed as #2354
- `lint_layers.sh` passes; `doltlite_merge_schema.c` at 1399/1500 lines
- amalgamation regenerated and compiled — two new statics, no collisions

## Left open

#2354: equal drop counts where one side drops the **last** column still fails with `SQL logic error`, and Dolt merges it — so a refusal would be the wrong answer and it needs the merge itself to work. Reproduces on master and is untouched by both #2350 and this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)