### PR TITLE
Merge shared additions with disjoint last-column drops

### DIFF
--- a/src/doltlite_merge_schema.c
+++ b/src/doltlite_merge_schema.c
@@ -966,9 +966,7 @@ schema_merge_done:
     for(i=0; i<nAnc; i++){
       if( !findColumn(aSel, nSel, aAnc[i].zName) ) continue;
       if( findColumn(aOth, nOth, aAnc[i].zName) ) continue;
-      if( i<nOth
-       && !findColumn(aAnc, nAnc, aOth[i].zName)
-       && parsedColumnDefinitionsMatch(&aOth[i], &aAnc[i]) ){
+      if( columnRenamedAt(aOth, nOth, aAnc, nAnc, i, aSel, nSel) ){
         /* Renamed, not deleted. Carry the new name or it is lost. */
         if( ppRenameCols && pnRenameCols ){
           rc = DOLTLITE_GROW_ARRAY(&azRename, &nRenameAlloc, nRename+2, 4);

--- a/test/doltlite_schema_merge.sh
+++ b/test/doltlite_schema_merge.sh
@@ -2042,6 +2042,14 @@ EOF
   else
     run_test_match "merge_bothadd_$1_merges" "SELECT dolt_merge('feat');" \
       "^[0-9a-f]{40}$" "$DB"
+    if [ -n "${5:-}" ]; then
+      run_test "merge_bothadd_$1_schema" \
+        "SELECT group_concat(name, ',') FROM pragma_table_info('t');" \
+        "$5" "$DB"
+      run_test "merge_bothadd_$1_row" \
+        "SELECT id || ':' || payload || ':' || c1899 || ':' || COALESCE(c1699, 'NULL') FROM t;" \
+        "1:p:y:NULL" "$DB"
+    fi
   fi
   run_test "merge_bothadd_$1_integrity" "PRAGMA integrity_check;" "ok" "$DB"
   rm -f "$DB"
@@ -2066,6 +2074,12 @@ both_add_drop_case "one_versus_two_disjoint" \
 # Equal drop counts merge, even when the sides dropped different columns.
 both_add_drop_case "one_each_disjoint" \
   "ALTER TABLE t DROP COLUMN c1899;" "ALTER TABLE t DROP COLUMN c1113;" merge
+both_add_drop_case "one_each_disjoint_last_theirs" \
+  "ALTER TABLE t DROP COLUMN c1113;" "ALTER TABLE t DROP COLUMN c2000;" \
+  merge "id,payload,c1899,c1699"
+both_add_drop_case "one_each_disjoint_last_ours" \
+  "ALTER TABLE t DROP COLUMN c2000;" "ALTER TABLE t DROP COLUMN c1113;" \
+  merge "id,payload,c1899,c1699"
 both_add_drop_case "one_each_same_column" \
   "ALTER TABLE t DROP COLUMN c1113;" "ALTER TABLE t DROP COLUMN c1113;" merge
 both_add_drop_case "two_each_overlapping" \

--- a/test/vc_oracle_schema_merge_test.sh
+++ b/test/vc_oracle_schema_merge_test.sh
@@ -1500,6 +1500,31 @@ SELECT dolt_commit('-Am','main_add');
 SQL
 expect_merge_conflict "both_add_same_column_and_drop_other" "$DB"
 
+DB="$TMPROOT/both_add_and_disjoint_drop.db"; rm -f "$DB"
+cat <<'SQL' | dl_setup "$DB" "both_add_and_disjoint_drop"
+CREATE TABLE t(id INTEGER PRIMARY KEY, payload TEXT, c1113 TEXT, c1899 TEXT, c2000 TEXT);
+INSERT INTO t VALUES(1,'p','x','y','z');
+SELECT dolt_commit('-Am','ancestor');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+ALTER TABLE t DROP COLUMN c2000;
+ALTER TABLE t ADD COLUMN c1699 TEXT;
+SELECT dolt_commit('-Am','feat_drop_last_and_add');
+SELECT dolt_checkout('main');
+ALTER TABLE t DROP COLUMN c1113;
+ALTER TABLE t ADD COLUMN c1699 TEXT;
+SELECT dolt_commit('-Am','main_drop_middle_and_add');
+SQL
+expect_merge_ok "both_add_same_column_and_disjoint_drop" "$DB"
+expect_dual_value "both_add_same_column_and_disjoint_drop_schema" "$DB" \
+  "id,payload,c1899,c1699" \
+  "SELECT group_concat(name, ',') FROM pragma_table_info('t');" \
+  "SELECT GROUP_CONCAT(column_name ORDER BY ordinal_position SEPARATOR ',') FROM information_schema.columns WHERE table_schema=DATABASE() AND table_name='t';"
+expect_dual_value "both_add_same_column_and_disjoint_drop_row" "$DB" \
+  "1:p:y:NULL" \
+  "SELECT id || ':' || payload || ':' || c1899 || ':' || COALESCE(c1699, 'NULL') FROM t;" \
+  "SELECT CONCAT(id, ':', payload, ':', c1899, ':', COALESCE(c1699, 'NULL')) FROM t;"
+
 echo ""
 echo "======================================="
 echo "Results: $pass passed, $fail failed"


### PR DESCRIPTION
Fix the remaining equal-drop-count schema merge from #2354.

The final drop carrier still used the old positional rename heuristic, so a last-column drop followed by a shared addition became a bogus rename onto an existing column. Reuse the cross-branch classifier introduced by the previous fix so the operation is carried as a drop.

Tests cover both branch orientations, final schema and row values, integrity, and a Dolt oracle.

Validation:
- `make lint`
- `DOLTLITE=build/doltlite bash test/doltlite_schema_merge.sh` (333 passed)
- `bash test/vc_oracle_schema_merge_test.sh build/doltlite dolt` (109 passed)
- `bash test/run_doltlite_tests.sh build/doltlite` (111 applicable suites passed; parity rerun separately with clean stock SQLite)
- `test/doltlite_parity.sh` with clean `DOLTLITE_PROLLY=0` SQLite (119 passed)

Fixes #2354

Co-Authored-By: OpenAI Codex <noreply@openai.com>