### PR TITLE
Dependents follow their table through a merge

### DIFF
--- a/src/doltlite_merge.c
+++ b/src/doltlite_merge.c
@@ -890,14 +890,42 @@ static int rebuildDisjointSchemaRows(
     if( rc!=SQLITE_OK ) return rc;
   }
 
+  /* Every surviving index writes its row from the merge's own arrays. An
+  ** unchanged index used to ride on the serializer's live-schema top-up,
+  ** which resurrects this connection's pre-merge text; when the merge has
+  ** normalized a rename away, that text names a column the merged table
+  ** does not have. Survival is judged by name — a rootpage number can be
+  ** reused by a drop-and-recreate on the other side. */
   for(i=0; i<nOursSchema; i++){
     SchemaEntry *pSe = &aOursSchema[i];
-    if( !pSe->zName || !pSe->zType ) continue;
+    if( !pSe->zName || !pSe->zType || !pSe->zSql ) continue;
     if( strcmp(pSe->zType, "index")!=0 ) continue;
+    if( !pSe->zTblName
+     || !doltliteFindTableByName(aMerged, nMerged, pSe->zTblName) ){
+      continue;
+    }
+    if( findSchemaEntry(aAncSchema, nAncSchema, pSe->zName)
+     && !findSchemaEntry(aTheirsSchema, nTheirsSchema, pSe->zName) ){
+      /* Theirs dropped it. */
+      continue;
+    }
     if( !schemaEntryChangedByName(aAncSchema, nAncSchema,
                                   aOursSchema, nOursSchema,
                                   pSe->zName) ){
-      continue;
+      /* Unchanged here: theirs' loop below writes it if they changed it,
+      ** and a conflicted object keeps its pre-merge projection. */
+      if( hasSchemaConflictObject(aConflictTables, nConflictTables, pSe->zName)
+       || (pSe->zTblName
+           && hasSchemaConflictTable(aConflictTables, nConflictTables,
+                                     pSe->zTblName)) ){
+        continue;
+      }
+      if( findSchemaEntry(aTheirsSchema, nTheirsSchema, pSe->zName)
+       && schemaEntryChangedByName(aAncSchema, nAncSchema,
+                                   aTheirsSchema, nTheirsSchema,
+                                   pSe->zName) ){
+        continue;
+      }
     }
     rc = appendMergedSchemaCatalogRecord(db, &root, pMaster->flags, iNextRowid++,
                                          pSe, pSe->iRootpage);
@@ -1280,6 +1308,20 @@ int doltliteMergeCatalogs(
     rc = loadSchemaFromCatalog(db, cs, pCache, ancestor, &aAncSchema, &nAncSchema);
     if( rc==SQLITE_OK ) rc = loadSchemaFromCatalog(db, cs, pCache, ours, &aOursSchema, &nOursSchema);
     if( rc==SQLITE_OK ) rc = loadSchemaFromCatalog(db, cs, pCache, theirs, &aTheirsSchema, &nTheirsSchema);
+    if( rc!=SQLITE_OK ) goto merge_cleanup;
+  }
+
+  /* Column renames with dependents in play are lifted out of the merge
+  ** here and re-applied as post-load schema actions, so every later pass
+  ** sees a world where the rename never happened. Only a branch merge has
+  ** the action plumbing to re-apply them. */
+  if( ppActions && pnActions && bBranchMerge ){
+    rc = mergePreNormalizeRenamedDependents(aAnc, nAnc, aOurs, nOurs,
+                                            aTheirs, nTheirs,
+                                            aAncSchema, nAncSchema,
+                                            aOursSchema, nOursSchema,
+                                            aTheirsSchema, nTheirsSchema,
+                                            ppActions, pnActions);
     if( rc!=SQLITE_OK ) goto merge_cleanup;
   }
 

--- a/src/doltlite_merge_int.h
+++ b/src/doltlite_merge_int.h
@@ -89,6 +89,15 @@ int mergePass1CheckTriggerOverRenamedTable(MergePass1Ctx *c);
 int mergePass1CheckRowEditOfDroppedColumn(MergePass1Ctx *c);
 int mergePass1CheckDuplicateIndexColumns(MergePass1Ctx *c);
 int mergePass1CheckDependentOverDualRename(MergePass1Ctx *c);
+int mergePreNormalizeRenamedDependents(
+  struct TableEntry *aAnc, int nAnc,
+  struct TableEntry *aOurs, int nOurs,
+  struct TableEntry *aTheirs, int nTheirs,
+  SchemaEntry *aAncSchema, int nAncSchema,
+  SchemaEntry *aOursSchema, int nOursSchema,
+  SchemaEntry *aTheirsSchema, int nTheirsSchema,
+  SchemaMergeAction **ppActions, int *pnActions
+);
 
 int mergeRowEditsColumn(
   sqlite3 *db,

--- a/src/doltlite_merge_predetect.c
+++ b/src/doltlite_merge_predetect.c
@@ -741,7 +741,7 @@ int mergePreNormalizeRenamedDependents(
     int bPureO = 0, bPureT = 0;
     const char *zBase = 0;
     int bBaseOurs = 0, bBaseTheirs = 0;
-    int bAllCoherent, bBail;
+    int bBail;
 
     if( !pAncT->zType || strcmp(pAncT->zType, "table")!=0 ) continue;
     if( !pAncT->zName || !pAncT->zSql ) continue;
@@ -777,7 +777,6 @@ int mergePreNormalizeRenamedDependents(
       azCand[1] = pOurT->zSql;
       azCand[2] = pTheirT->zSql;
       zBase = 0;
-      bAllCoherent = 1;
       bBail = 0;
       for(c=0; c<3 && !bBail; c++){
         int bOk = 1;
@@ -821,7 +820,6 @@ int mergePreNormalizeRenamedDependents(
           pPick = pDepOurs ? pDepOurs : pDepTheirs;
           if( !mergeDependentCoherent(pPick, azCand[c], azUni, nUni) ){
             bOk = 0;
-            if( c==0 ) bAllCoherent = 0;
           }
         }
         if( bBail ) break;

--- a/src/doltlite_merge_predetect.c
+++ b/src/doltlite_merge_predetect.c
@@ -515,4 +515,477 @@ int mergePass1CheckIndexOverRenamedColumn(MergePass1Ctx *c){
   return SQLITE_OK;
 }
 
+/* ================= dependents follow their table =================
+**
+** A table's dependents (indexes, triggers, views) are adopted per name,
+** independently of the table, so a column rename on one side can pair an
+** adopted table with a dependent that names a column it does not have,
+** and the merged catalog cannot load. Dolt retargets the dependent.
+**
+** Rather than repairing the assembled catalog, subtract the rename from
+** the merge's view of the world: rewrite the three schema arrays so the
+** table and its dependents carry one baseline text on every side, equalize
+** the table entries' schema hashes so pass1 sees the schema as unchanged,
+** and queue the renames as post-load schema actions. ALTER TABLE RENAME
+** COLUMN then rewrites the table and every dependent through SQLite's own
+** machinery, and the post-action flush serializes the coherent result.
+*/
+
+/* Flat old,new rename pairs anc->side when the delta is pure renames:
+** same column count, every definition matches its position, and no name
+** moves to another position. Anything else (adds, drops, swaps, type
+** changes) is not normalizable here. */
+static int mergePureRenamePairs(
+  const char *zAncSql,
+  const char *zSideSql,
+  char ***pazPairs, int *pnPairs,
+  int *pbPure
+){
+  ParsedColumn *aAnc = 0, *aSide = 0;
+  int nAnc = 0, nSide = 0, i, rc = SQLITE_OK;
+  char **az = 0;
+  int n = 0;
+
+  *pazPairs = 0;
+  *pnPairs = 0;
+  *pbPure = 0;
+  if( parseColumns(zAncSql, &aAnc, &nAnc)!=SQLITE_OK ) return SQLITE_OK;
+  if( parseColumns(zSideSql, &aSide, &nSide)!=SQLITE_OK ){
+    freeColumns(aAnc, nAnc);
+    return SQLITE_OK;
+  }
+  if( nAnc!=nSide ) goto pure_done;
+  for(i=0; i<nAnc; i++){
+    if( !parsedColumnDefinitionsMatch(&aSide[i], &aAnc[i]) ) goto pure_done;
+    if( sqlite3_stricmp(aAnc[i].zName, aSide[i].zName)==0 ) continue;
+    if( parsedColumnIndexByName(aSide, nSide, aAnc[i].zName)>=0 ) goto pure_done;
+    if( parsedColumnIndexByName(aAnc, nAnc, aSide[i].zName)>=0 ) goto pure_done;
+    {
+      char **azNew = sqlite3_realloc(az, (n+2)*(int)sizeof(char*));
+      if( !azNew ){ rc = SQLITE_NOMEM; goto pure_done; }
+      az = azNew;
+      az[n] = sqlite3_mprintf("%s", aAnc[i].zName);
+      az[n+1] = sqlite3_mprintf("%s", aSide[i].zName);
+      if( !az[n] || !az[n+1] ){ n += 2; rc = SQLITE_NOMEM; goto pure_done; }
+      n += 2;
+    }
+  }
+  *pbPure = 1;
+  *pazPairs = az;
+  *pnPairs = n;
+  az = 0;
+  n = 0;
+pure_done:
+  freeAddedColumns(az, n);
+  freeColumns(aAnc, nAnc);
+  freeColumns(aSide, nSide);
+  return rc;
+}
+
+static const char *mergeRenameMapLookup(char **az, int n, const char *zOld){
+  int i;
+  for(i=0; i+1<n; i+=2){
+    if( sqlite3_stricmp(az[i], zOld)==0 ) return az[i+1];
+  }
+  return 0;
+}
+
+/* zSide is zAnc with side renames applied by SQLite's rewriter and nothing
+** else: identical byte-for-byte outside identifier tokens, and each
+** identifier either matches or maps old->new. */
+static int mergeTextsEqualModuloRenames(
+  const char *zAnc,
+  const char *zSide,
+  char **azPairs, int nPairs
+){
+  const char *a = zAnc;
+  const char *s = zSide;
+
+  if( !zAnc || !zSide ) return 0;
+  while( *a || *s ){
+    int aId = sqlite3Isalnum(*a) || *a=='_' || *a=='$' || *a=='"' || *a=='`' || *a=='[';
+    int sId = sqlite3Isalnum(*s) || *s=='_' || *s=='$' || *s=='"' || *s=='`' || *s=='[';
+    if( !aId || !sId ){
+      if( *a!=*s ) return 0;
+      if( *a==0 ) break;
+      a++;
+      s++;
+      continue;
+    }
+    {
+      const char *aTok, *sTok;
+      int nATok, nSTok;
+      if( *a=='"' || *a=='`' || *a=='[' ){
+        char cEnd = *a=='[' ? ']' : *a;
+        a++; aTok = a;
+        while( *a && *a!=cEnd ) a++;
+        nATok = (int)(a-aTok);
+        if( *a ) a++;
+      }else{
+        aTok = a;
+        while( sqlite3Isalnum(*a) || *a=='_' || *a=='$' ) a++;
+        nATok = (int)(a-aTok);
+      }
+      if( *s=='"' || *s=='`' || *s=='[' ){
+        char cEnd = *s=='[' ? ']' : *s;
+        s++; sTok = s;
+        while( *s && *s!=cEnd ) s++;
+        nSTok = (int)(s-sTok);
+        if( *s ) s++;
+      }else{
+        sTok = s;
+        while( sqlite3Isalnum(*s) || *s=='_' || *s=='$' ) s++;
+        nSTok = (int)(s-sTok);
+      }
+      if( nATok==nSTok && sqlite3_strnicmp(aTok, sTok, nATok)==0 ) continue;
+      {
+        int i;
+        for(i=0; i+1<nPairs; i+=2){
+          if( (int)strlen(azPairs[i])==nATok
+           && sqlite3_strnicmp(azPairs[i], aTok, nATok)==0
+           && (int)strlen(azPairs[i+1])==nSTok
+           && sqlite3_strnicmp(azPairs[i+1], sTok, nSTok)==0 ){
+            break;
+          }
+        }
+        if( i+1>=nPairs ) return 0;
+      }
+    }
+  }
+  return 1;
+}
+
+static int mergeTableTextHasColumn(const char *zTblSql, const char *zName){
+  ParsedColumn *aCols = 0;
+  int nCols = 0, bHas;
+  if( parseColumns(zTblSql, &aCols, &nCols)!=SQLITE_OK ) return 0;
+  bHas = parsedColumnIndexByName(aCols, nCols, zName)>=0;
+  freeColumns(aCols, nCols);
+  return bHas;
+}
+
+/* Loadable against zTblSql: every rename-universe name the dependent's text
+** mentions must be a column of that table text. Names outside the universe
+** cannot have moved, so they are not checked. */
+static int mergeDependentCoherent(
+  const SchemaEntry *pDep,
+  const char *zTblSql,
+  char **azUniverse, int nUniverse
+){
+  int i;
+  for(i=0; i<nUniverse; i++){
+    if( !mergeSqlNamesColumn(pDep->zSql, pDep->zType, azUniverse[i]) ) continue;
+    if( !mergeTableTextHasColumn(zTblSql, azUniverse[i]) ) return 0;
+  }
+  return 1;
+}
+
+static void mergeSetEntryText(SchemaEntry *pSe, const char *zSql){
+  char *z = sqlite3_mprintf("%s", zSql);
+  if( z ){
+    sqlite3_free(pSe->zSql);
+    pSe->zSql = z;
+  }
+}
+
+/* A dependent of zTbl surviving into the merge, or a view whose cross-side
+** texts are the mechanical shadow of these renames. Views carry their own
+** name in zTblName, so they qualify by shape rather than by parent. */
+static int mergeCollectDependent(
+  const char *zTbl,
+  SchemaEntry *pAnc, SchemaEntry *pOurs, SchemaEntry *pTheirs,
+  char **azRenO, int nRenO,
+  char **azRenT, int nRenT,
+  int *pbMechanical
+){
+  SchemaEntry *pAny = pOurs ? pOurs : (pTheirs ? pTheirs : pAnc);
+
+  *pbMechanical = 0;
+  if( !pAny || !pAny->zType || !pAny->zSql ) return 0;
+  if( strcmp(pAny->zType, "index")==0 || strcmp(pAny->zType, "trigger")==0 ){
+    if( !pAny->zTblName || sqlite3_stricmp(pAny->zTblName, zTbl)!=0 ) return 0;
+  }else if( strcmp(pAny->zType, "view")!=0 ){
+    return 0;
+  }
+  /* Dropped on a side: it does not survive, so it constrains nothing. */
+  if( pAnc && (!pOurs || !pTheirs) ) return 0;
+  if( pAnc ){
+    if( !pAnc->zSql || !pOurs->zSql || !pTheirs->zSql ) return 0;
+    if( !mergeTextsEqualModuloRenames(pAnc->zSql, pOurs->zSql, azRenO, nRenO) ){
+      return -1;
+    }
+    if( !mergeTextsEqualModuloRenames(pAnc->zSql, pTheirs->zSql, azRenT, nRenT) ){
+      return -1;
+    }
+    *pbMechanical = 1;
+  }
+  return 1;
+}
+
+int mergePreNormalizeRenamedDependents(
+  struct TableEntry *aAnc, int nAnc,
+  struct TableEntry *aOurs, int nOurs,
+  struct TableEntry *aTheirs, int nTheirs,
+  SchemaEntry *aAncSchema, int nAncSchema,
+  SchemaEntry *aOursSchema, int nOursSchema,
+  SchemaEntry *aTheirsSchema, int nTheirsSchema,
+  SchemaMergeAction **ppActions, int *pnActions
+){
+  int t, i, rc = SQLITE_OK;
+
+  for(t=0; t<nAncSchema; t++){
+    SchemaEntry *pAncT = &aAncSchema[t];
+    SchemaEntry *pOurT, *pTheirT;
+    char **azRenO = 0, **azRenT = 0, **azUni = 0;
+    int nRenO = 0, nRenT = 0, nUni = 0;
+    int bPureO = 0, bPureT = 0;
+    const char *zBase = 0;
+    int bBaseOurs = 0, bBaseTheirs = 0;
+    int bAllCoherent, bBail;
+
+    if( !pAncT->zType || strcmp(pAncT->zType, "table")!=0 ) continue;
+    if( !pAncT->zName || !pAncT->zSql ) continue;
+    pOurT = findSchemaEntry(aOursSchema, nOursSchema, pAncT->zName);
+    pTheirT = findSchemaEntry(aTheirsSchema, nTheirsSchema, pAncT->zName);
+    if( !pOurT || !pTheirT || !pOurT->zSql || !pTheirT->zSql ) continue;
+
+    rc = mergePureRenamePairs(pAncT->zSql, pOurT->zSql, &azRenO, &nRenO, &bPureO);
+    if( rc==SQLITE_OK ){
+      rc = mergePureRenamePairs(pAncT->zSql, pTheirT->zSql, &azRenT, &nRenT, &bPureT);
+    }
+    if( rc!=SQLITE_OK ) goto table_done;
+    if( !bPureO || !bPureT || (nRenO==0 && nRenT==0) ) goto table_done;
+    /* The same ancestor column renamed on both sides is a real conflict
+    ** (different names) or already coherent (same name); leave both. */
+    for(i=0; i+1<nRenO; i+=2){
+      if( mergeRenameMapLookup(azRenT, nRenT, azRenO[i]) ) goto table_done;
+    }
+
+    /* Old and new names of every rename: the only identifiers whose
+    ** presence can differ between the three table texts. */
+    azUni = sqlite3_malloc((nRenO+nRenT)*(int)sizeof(char*));
+    if( !azUni ){ rc = SQLITE_NOMEM; goto table_done; }
+    for(i=0; i<nRenO; i++) azUni[nUni++] = azRenO[i];
+    for(i=0; i<nRenT; i++) azUni[nUni++] = azRenT[i];
+
+    /* Baseline candidates, ancestor first: the text every surviving
+    ** dependent can load against. */
+    {
+      const char *azCand[3];
+      int c;
+      azCand[0] = pAncT->zSql;
+      azCand[1] = pOurT->zSql;
+      azCand[2] = pTheirT->zSql;
+      zBase = 0;
+      bAllCoherent = 1;
+      bBail = 0;
+      for(c=0; c<3 && !bBail; c++){
+        int bOk = 1;
+        for(i=0; i<nOursSchema+nTheirsSchema && bOk && !bBail; i++){
+          SchemaEntry *pSide = i<nOursSchema ? &aOursSchema[i]
+                                             : &aTheirsSchema[i-nOursSchema];
+          SchemaEntry *pDepAnc, *pDepOurs, *pDepTheirs, *pPick;
+          int bMech = 0, q;
+          if( !pSide->zName ) continue;
+          /* Each dependent once: ours' array wins when present on both. */
+          if( i>=nOursSchema
+           && findSchemaEntry(aOursSchema, nOursSchema, pSide->zName) ){
+            continue;
+          }
+          pDepAnc = findSchemaEntry(aAncSchema, nAncSchema, pSide->zName);
+          pDepOurs = findSchemaEntry(aOursSchema, nOursSchema, pSide->zName);
+          pDepTheirs = findSchemaEntry(aTheirsSchema, nTheirsSchema, pSide->zName);
+          if( pDepAnc==pAncT ) continue;
+          q = mergeCollectDependent(pAncT->zName, pDepAnc, pDepOurs, pDepTheirs,
+                                    azRenO, nRenO, azRenT, nRenT, &bMech);
+          if( q<0 ){
+            /* Materially edited beside a rename: only a problem if it
+            ** names a renamed column, then no baseline is safe. */
+            SchemaEntry *pDep = pDepOurs ? pDepOurs : pDepTheirs;
+            int u;
+            for(u=0; u<nUni; u++){
+              if( mergeSqlNamesColumn(pDep->zSql, pDep->zType, azUni[u]) ){
+                bBail = 1;
+                break;
+              }
+            }
+            continue;
+          }
+          if( q==0 ) continue;
+          if( bMech ){
+            /* Mechanical shadow: the version from the baseline's own side
+            ** is coherent with it by construction. */
+            continue;
+          }
+          /* New on one side: its only text must load against the baseline. */
+          pPick = pDepOurs ? pDepOurs : pDepTheirs;
+          if( !mergeDependentCoherent(pPick, azCand[c], azUni, nUni) ){
+            bOk = 0;
+            if( c==0 ) bAllCoherent = 0;
+          }
+        }
+        if( bBail ) break;
+        if( bOk && c==0 ){
+          /* Everything loads against the ancestor text; but is everything
+          ** also coherent with the text the merge would adopt today? Probe
+          ** the adopted side: with renames on it, an old-name dependent
+          ** cannot load, so normalization is still required. */
+          int bAdoptedIncoherent = 0;
+          const char *zAdopted = 0;
+          int oursChanged = strcmp(pAncT->zSql, pOurT->zSql)!=0;
+          int theirsChanged = strcmp(pAncT->zSql, pTheirT->zSql)!=0;
+          if( oursChanged && theirsChanged ){
+            char **azA=0, **azD=0, **azR=0;
+            int nA=0, nD=0, nR=0, choice=SCHEMA_MERGE_DEFAULT, res=0;
+            char *zErr = 0;
+            if( trySchemaColumnMerge(pAncT->zSql, pOurT->zSql, pTheirT->zSql,
+                                     &azA, &nA, &azD, &nD, &azR, &nR,
+                                     &choice, &res, &zErr)==SQLITE_OK ){
+              zAdopted = choice==SCHEMA_MERGE_THEIRS ? pTheirT->zSql
+                                                     : pOurT->zSql;
+            }
+            sqlite3_free(zErr);
+            freeAddedColumns(azA, nA);
+            freeAddedColumns(azD, nD);
+            freeAddedColumns(azR, nR);
+          }else{
+            zAdopted = oursChanged ? pOurT->zSql : pTheirT->zSql;
+          }
+          if( zAdopted ){
+            for(i=0; i<nOursSchema+nTheirsSchema && !bAdoptedIncoherent; i++){
+              SchemaEntry *pSide = i<nOursSchema ? &aOursSchema[i]
+                                                 : &aTheirsSchema[i-nOursSchema];
+              SchemaEntry *pDepAnc, *pDepOurs, *pDepTheirs, *pPick;
+              int bMech = 0, q;
+              if( !pSide->zName ) continue;
+              if( i>=nOursSchema
+               && findSchemaEntry(aOursSchema, nOursSchema, pSide->zName) ){
+                continue;
+              }
+              pDepAnc = findSchemaEntry(aAncSchema, nAncSchema, pSide->zName);
+              pDepOurs = findSchemaEntry(aOursSchema, nOursSchema, pSide->zName);
+              pDepTheirs = findSchemaEntry(aTheirsSchema, nTheirsSchema,
+                                           pSide->zName);
+              if( pDepAnc==pAncT ) continue;
+              q = mergeCollectDependent(pAncT->zName, pDepAnc, pDepOurs,
+                                        pDepTheirs, azRenO, nRenO,
+                                        azRenT, nRenT, &bMech);
+              if( q<=0 ) continue;
+              /* Today's adoption: the side that changed it, ours on ties. */
+              if( pDepAnc ){
+                int chO = pDepOurs && strcmp(pDepAnc->zSql, pDepOurs->zSql)!=0;
+                int chT = pDepTheirs && strcmp(pDepAnc->zSql, pDepTheirs->zSql)!=0;
+                pPick = chT && !chO ? pDepTheirs : pDepOurs;
+              }else{
+                pPick = pDepOurs ? pDepOurs : pDepTheirs;
+              }
+              if( pPick && !mergeDependentCoherent(pPick, zAdopted, azUni, nUni) ){
+                bAdoptedIncoherent = 1;
+              }
+            }
+          }
+          if( !bAdoptedIncoherent ){
+            /* Today's merge already loads; do not disturb it. */
+            goto table_done;
+          }
+        }
+        if( bOk ){
+          zBase = azCand[c];
+          bBaseOurs = (c==1);
+          bBaseTheirs = (c==2);
+          break;
+        }
+      }
+      if( bBail || !zBase ) goto table_done;
+    }
+
+    /* Queue the renames the baseline still needs before mutating any text
+    ** they are derived from. */
+    {
+      char **azQ = 0;
+      int nQ = 0, k;
+      char **azFromO = bBaseOurs ? 0 : azRenO;
+      int nFromO = bBaseOurs ? 0 : nRenO;
+      char **azFromT = bBaseTheirs ? 0 : azRenT;
+      int nFromT = bBaseTheirs ? 0 : nRenT;
+      azQ = sqlite3_malloc((nFromO+nFromT)*(int)sizeof(char*)+1);
+      if( !azQ ){ rc = SQLITE_NOMEM; goto table_done; }
+      for(k=0; k<nFromO; k++) azQ[nQ++] = sqlite3_mprintf("%s", azFromO[k]);
+      for(k=0; k<nFromT; k++) azQ[nQ++] = sqlite3_mprintf("%s", azFromT[k]);
+      for(k=0; k<nQ; k++){
+        if( !azQ[k] ){ freeAddedColumns(azQ, nQ); rc = SQLITE_NOMEM; goto table_done; }
+      }
+      if( nQ>0 ){
+        /* The action owns azQ from here. */
+        rc = recordSchemaColumnChanges(ppActions, pnActions, pAncT->zName,
+                                       0, 0, 0, 0, azQ, nQ);
+        if( rc!=SQLITE_OK ){ freeAddedColumns(azQ, nQ); goto table_done; }
+      }else{
+        sqlite3_free(azQ);
+      }
+    }
+
+    /* One baseline text on every side: the merge no longer sees a schema
+    ** change on this table or its shadowed dependents. zBase aliases one of
+    ** the entries about to be rewritten, so it needs its own copy first. */
+    {
+      char *zBaseOwned = sqlite3_mprintf("%s", zBase);
+      if( !zBaseOwned ){ rc = SQLITE_NOMEM; goto table_done; }
+      mergeSetEntryText(pAncT, zBaseOwned);
+      mergeSetEntryText(pOurT, zBaseOwned);
+      mergeSetEntryText(pTheirT, zBaseOwned);
+      sqlite3_free(zBaseOwned);
+    }
+    for(i=0; i<nOursSchema+nTheirsSchema; i++){
+      SchemaEntry *pSide = i<nOursSchema ? &aOursSchema[i]
+                                         : &aTheirsSchema[i-nOursSchema];
+      SchemaEntry *pDepAnc, *pDepOurs, *pDepTheirs, *pFrom;
+      char *zDepOwned;
+      int bMech = 0, q;
+      if( !pSide->zName ) continue;
+      if( i>=nOursSchema
+       && findSchemaEntry(aOursSchema, nOursSchema, pSide->zName) ){
+        continue;
+      }
+      pDepAnc = findSchemaEntry(aAncSchema, nAncSchema, pSide->zName);
+      pDepOurs = findSchemaEntry(aOursSchema, nOursSchema, pSide->zName);
+      pDepTheirs = findSchemaEntry(aTheirsSchema, nTheirsSchema, pSide->zName);
+      if( pDepAnc==pAncT ) continue;
+      q = mergeCollectDependent(pAncT->zName, pDepAnc, pDepOurs, pDepTheirs,
+                                azRenO, nRenO, azRenT, nRenT, &bMech);
+      if( q<=0 || !bMech ) continue;
+      pFrom = bBaseOurs ? pDepOurs : (bBaseTheirs ? pDepTheirs : pDepAnc);
+      if( !pFrom || !pFrom->zSql ) continue;
+      zDepOwned = sqlite3_mprintf("%s", pFrom->zSql);
+      if( !zDepOwned ){ rc = SQLITE_NOMEM; goto table_done; }
+      mergeSetEntryText(pDepAnc, zDepOwned);
+      mergeSetEntryText(pDepOurs, zDepOwned);
+      mergeSetEntryText(pDepTheirs, zDepOwned);
+      sqlite3_free(zDepOwned);
+    }
+    {
+      struct TableEntry *pEntAnc =
+          doltliteFindTableByName(aAnc, nAnc, pAncT->zName);
+      struct TableEntry *pEntOurs =
+          doltliteFindTableByName(aOurs, nOurs, pAncT->zName);
+      struct TableEntry *pEntTheirs =
+          doltliteFindTableByName(aTheirs, nTheirs, pAncT->zName);
+      struct TableEntry *pEntBase = bBaseOurs ? pEntOurs
+                                  : (bBaseTheirs ? pEntTheirs : pEntAnc);
+      if( pEntAnc && pEntOurs && pEntTheirs && pEntBase ){
+        pEntAnc->schemaHash = pEntBase->schemaHash;
+        pEntOurs->schemaHash = pEntBase->schemaHash;
+        pEntTheirs->schemaHash = pEntBase->schemaHash;
+      }
+    }
+
+table_done:
+    freeAddedColumns(azRenO, nRenO);
+    freeAddedColumns(azRenT, nRenT);
+    sqlite3_free(azUni);
+    if( rc!=SQLITE_OK ) return rc;
+  }
+  return SQLITE_OK;
+}
+
 #endif /* DOLTLITE_PROLLY */

--- a/test/doltlite_schema_merge.sh
+++ b/test/doltlite_schema_merge.sh
@@ -1430,15 +1430,14 @@ run_test "merge_dual_rename_quoted_values" \
 run_test "merge_dual_rename_quoted_integrity" "PRAGMA integrity_check;" "ok" "$DB"
 rm -f "$DB"
 
-# Index added over a column the other side renamed: refuse (Dolt retargets; we cannot).
+# Index added over a column the other side renamed: the dependent follows
+# its table, so the index is retargeted to the new name, as Dolt does.
 for dir in ours theirs; do
   DB=/tmp/test_merge_ix_over_rename_${dir}_$$.db; rm -f "$DB"
   if [ "$dir" = ours ]; then
     MAIN="CREATE INDEX ix ON t(b);"; FEAT="ALTER TABLE t RENAME COLUMN b TO b2;"
-    WANTCOLS="k,a,b"
   else
     MAIN="ALTER TABLE t RENAME COLUMN b TO b2;"; FEAT="CREATE INDEX ix ON t(b);"
-    WANTCOLS="k,a,b2"
   fi
   cat <<EOF | $DOLTLITE "$DB" > /dev/null 2>&1
 CREATE TABLE t(k INTEGER PRIMARY KEY, a TEXT, b TEXT);
@@ -1452,21 +1451,21 @@ SELECT dolt_checkout('main');
 $MAIN
 SELECT dolt_commit('-A','-m','main side');
 EOF
-  run_test_match "merge_index_over_renamed_column_${dir}_refused" \
-    "SELECT dolt_merge('feat');" \
-    "cannot merge: index 'ix' covers column 'b' of table 't'" "$DB"
-  run_test "merge_index_over_renamed_column_${dir}_schema_intact" \
-    "SELECT group_concat(name) FROM pragma_table_info('t');" "$WANTCOLS" "$DB"
-  run_test "merge_index_over_renamed_column_${dir}_rows_intact" \
-    "SELECT count(*) FROM t;" "2" "$DB"
+  run_test_match "merge_index_over_renamed_column_${dir}_merges" \
+    "SELECT dolt_merge('feat');" "^[0-9a-f]{40}$" "$DB"
+  run_test "merge_index_over_renamed_column_${dir}_retargeted" \
+    "SELECT sql FROM sqlite_master WHERE type='index';" \
+    "CREATE INDEX ix ON t(b2)" "$DB"
+  run_test "merge_index_over_renamed_column_${dir}_schema" \
+    "SELECT group_concat(name) FROM pragma_table_info('t');" "k,a,b2" "$DB"
+  run_test "merge_index_over_renamed_column_${dir}_lookup" \
+    "SELECT count(*) FROM t WHERE b2='b1';" "1" "$DB"
   run_test "merge_index_over_renamed_column_${dir}_integrity" \
     "PRAGMA integrity_check;" "ok" "$DB"
-  run_test "merge_index_over_renamed_column_${dir}_clean_status" \
-    "SELECT count(*) FROM dolt_status;" "0" "$DB"
   rm -f "$DB"
 done
 
-# Unique index: the same refusal; dropping it silently would drop the constraint.
+# Unique index: retargeted the same way, and the constraint still enforces.
 DB=/tmp/test_merge_ux_over_rename_$$.db; rm -f "$DB"
 cat <<'EOF' | $DOLTLITE "$DB" > /dev/null 2>&1
 CREATE TABLE t(k INTEGER PRIMARY KEY, a TEXT, b TEXT);
@@ -1480,8 +1479,13 @@ SELECT dolt_checkout('main');
 CREATE UNIQUE INDEX ux ON t(b);
 SELECT dolt_commit('-A','-m','main indexes');
 EOF
-run_test_match "merge_unique_index_over_renamed_column_refused" \
-  "SELECT dolt_merge('feat');" "cannot merge: index 'ux' covers column 'b'" "$DB"
+run_test_match "merge_unique_index_over_renamed_column_merges" \
+  "SELECT dolt_merge('feat');" "^[0-9a-f]{40}$" "$DB"
+run_test "merge_unique_index_over_renamed_column_retargeted" \
+  "SELECT sql FROM sqlite_master WHERE type='index';" \
+  "CREATE UNIQUE INDEX ux ON t(b2)" "$DB"
+run_test_match "merge_unique_index_over_renamed_column_enforces" \
+  "INSERT INTO t VALUES(2,'x','b1');" "UNIQUE constraint failed" "$DB"
 rm -f "$DB"
 
 # Index over an un-renamed column still merges; one over a dropped column drops with it.
@@ -1794,14 +1798,18 @@ run_test "pull_duplicate_index_columns_integrity" \
 run_test "pull_duplicate_index_columns_rolled_back" \
   "SELECT group_concat(name) FROM sqlite_master WHERE type='index';" "ix0" "$DB/feat"
 rm -f "$DB" "$REMOTE"
-# Dual rename + index/trigger naming one renamed column: refuse (Dolt retargets; we cannot).
+# Dual rename + index/trigger naming one renamed column: the dependent
+# follows its table through both renames, as Dolt does.
 for dep in idx trig; do
   DB=/tmp/test_merge_dual_rename_${dep}_$$.db; rm -f "$DB"
   if [ "$dep" = idx ]; then
-    DEP="CREATE INDEX ix0 ON t(a);"; WANT="index 'ix0' covers column 'a'"
+    DEP="CREATE INDEX ix0 ON t(a);"
+    WANTQ="SELECT sql FROM sqlite_master WHERE type='index';"
+    WANT="CREATE INDEX ix0 ON t(a2)"
   else
     DEP="CREATE TRIGGER tg AFTER INSERT ON t BEGIN UPDATE t SET a=a; END;"
-    WANT="trigger 'tg' covers column 'a'"
+    WANTQ="SELECT sql FROM sqlite_master WHERE type='trigger';"
+    WANT="CREATE TRIGGER tg AFTER INSERT ON t BEGIN UPDATE t SET a2=a2; END"
   fi
   cat <<EOF | $DOLTLITE "$DB" > /dev/null 2>&1
 CREATE TABLE t(k INTEGER PRIMARY KEY, a TEXT, b TEXT);
@@ -1816,12 +1824,17 @@ ALTER TABLE t RENAME COLUMN b TO b2;
 SELECT dolt_commit('-Am','theirs renames another column');
 SELECT dolt_checkout('main');
 EOF
-  run_test_match "merge_dual_rename_over_${dep}_refused" "SELECT dolt_merge('feat');" \
-    "$WANT" "$DB"
+  run_test_match "merge_dual_rename_over_${dep}_merges" "SELECT dolt_merge('feat');" \
+    "^[0-9a-f]{40}$" "$DB"
+  run_test "merge_dual_rename_over_${dep}_follows" "$WANTQ" "$WANT" "$DB"
+  run_test "merge_dual_rename_over_${dep}_cols" \
+    "SELECT group_concat(name) FROM pragma_table_info('t');" "k,a2,b2" "$DB"
+  run_test "merge_dual_rename_over_${dep}_integrity" \
+    "PRAGMA integrity_check;" "ok" "$DB"
   rm -f "$DB"
 done
 
-# Same refusal when SQLite quoted the indexed column.
+# The retarget still lands when SQLite quoted the indexed column.
 for q in dquote backtick bracket; do
   DB=/tmp/test_merge_dual_rename_q_${q}_$$.db; rm -f "$DB"
   case "$q" in
@@ -1842,8 +1855,13 @@ ALTER TABLE t RENAME COLUMN b TO b2;
 SELECT dolt_commit('-Am','theirs renames another column');
 SELECT dolt_checkout('main');
 EOF
-  run_test_match "merge_dual_rename_over_quoted_${q}_refused" \
-    "SELECT dolt_merge('feat');" "index 'ix0' covers column 'a'" "$DB"
+  run_test_match "merge_dual_rename_over_quoted_${q}_merges" \
+    "SELECT dolt_merge('feat');" "^[0-9a-f]{40}$" "$DB"
+  run_test_match "merge_dual_rename_over_quoted_${q}_retargeted" \
+    "SELECT sql FROM sqlite_master WHERE type='index';" \
+    "CREATE INDEX ix0 ON t\(.?a2.?\)" "$DB"
+  run_test "merge_dual_rename_over_quoted_${q}_lookup" \
+    "SELECT count(*) FROM t WHERE a2='a1';" "1" "$DB"
   rm -f "$DB"
 done
 
@@ -2071,5 +2089,77 @@ both_add_drop_case "one_each_same_column" \
 both_add_drop_case "two_each_overlapping" \
   "ALTER TABLE t DROP COLUMN c1113; ALTER TABLE t DROP COLUMN c1899;" \
   "ALTER TABLE t DROP COLUMN c2000; ALTER TABLE t DROP COLUMN c1113;" merge
+
+# A view over the renamed column follows its table through a dual rename.
+# The rename mechanically rewrote the view on its own branch; the merge
+# regenerates that rewrite instead of pairing it with the other side's table.
+DB=/tmp/test_merge_view_dual_rename_$$.db; rm -f "$DB"
+cat <<'EOF' | $DOLTLITE "$DB" > /dev/null 2>&1
+CREATE TABLE t(k INTEGER PRIMARY KEY, a TEXT, b TEXT);
+CREATE VIEW v0 AS SELECT a FROM t;
+INSERT INTO t VALUES(1,'a1','b1');
+SELECT dolt_commit('-Am','base');
+SELECT dolt_branch('feat');
+ALTER TABLE t RENAME COLUMN a TO a2;
+SELECT dolt_commit('-Am','ours renames the viewed column');
+SELECT dolt_checkout('feat');
+ALTER TABLE t RENAME COLUMN b TO b2;
+SELECT dolt_commit('-Am','theirs renames another column');
+SELECT dolt_checkout('main');
+EOF
+run_test_match "merge_view_over_dual_rename_merges" "SELECT dolt_merge('feat');" \
+  "^[0-9a-f]{40}$" "$DB"
+run_test "merge_view_over_dual_rename_follows" \
+  "SELECT sql FROM sqlite_master WHERE type='view';" \
+  "CREATE VIEW v0 AS SELECT a2 FROM t" "$DB"
+run_test "merge_view_over_dual_rename_readable" "SELECT * FROM v0;" "a1" "$DB"
+rm -f "$DB"
+
+# Rename plus an index on the new name, against a rename of another column:
+# the new index pins the merge baseline to its own side.
+DB=/tmp/test_merge_rename_newname_index_$$.db; rm -f "$DB"
+cat <<'EOF' | $DOLTLITE "$DB" > /dev/null 2>&1
+CREATE TABLE t(k INTEGER PRIMARY KEY, a TEXT, b TEXT);
+INSERT INTO t VALUES(1,'a1','b1');
+SELECT dolt_commit('-Am','base');
+SELECT dolt_branch('feat');
+ALTER TABLE t RENAME COLUMN a TO a2;
+CREATE INDEX ixn ON t(a2);
+SELECT dolt_commit('-Am','ours renames and indexes the new name');
+SELECT dolt_checkout('feat');
+ALTER TABLE t RENAME COLUMN b TO b2;
+SELECT dolt_commit('-Am','theirs renames another column');
+SELECT dolt_checkout('main');
+EOF
+run_test_match "merge_rename_newname_index_merges" "SELECT dolt_merge('feat');" \
+  "^[0-9a-f]{40}$" "$DB"
+run_test "merge_rename_newname_index_kept" \
+  "SELECT sql FROM sqlite_master WHERE type='index';" \
+  "CREATE INDEX ixn ON t(a2)" "$DB"
+run_test "merge_rename_newname_index_cols" \
+  "SELECT group_concat(name) FROM pragma_table_info('t');" "k,a2,b2" "$DB"
+rm -f "$DB"
+
+# The merged database must stay readable in a fresh connection, and the
+# retargeted index must serve lookups there.
+DB=/tmp/test_merge_retarget_reopen_$$.db; rm -f "$DB"
+cat <<'EOF' | $DOLTLITE "$DB" > /dev/null 2>&1
+CREATE TABLE t(k INTEGER PRIMARY KEY, a TEXT, b TEXT);
+CREATE INDEX ix0 ON t(a);
+INSERT INTO t VALUES(1,'a1','b1');
+SELECT dolt_commit('-Am','base');
+SELECT dolt_branch('feat');
+ALTER TABLE t RENAME COLUMN a TO a2;
+SELECT dolt_commit('-Am','ours renames');
+SELECT dolt_checkout('feat');
+ALTER TABLE t RENAME COLUMN b TO b2;
+SELECT dolt_commit('-Am','theirs renames');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feat');
+EOF
+run_test "merge_retarget_reopen_lookup" \
+  "SELECT k||'/'||a2 FROM t WHERE a2='a1';" "1/a1" "$DB"
+run_test "merge_retarget_reopen_integrity" "PRAGMA integrity_check;" "ok" "$DB"
+rm -f "$DB"
 
 dltest_finish

--- a/test/vc_oracle_correct_schema_merge_matrix_test.sh
+++ b/test/vc_oracle_correct_schema_merge_matrix_test.sh
@@ -13,27 +13,11 @@ trap "rm -rf $TMPROOT" EXIT
 pass=0; fail=0; gaps=0; corrupt=0; differs=0; skipped=0; FAILED_NAMES=""; GAP_NAMES=""; CORRUPT_NAMES=""; DIFFER_NAMES=""; SKIP_NAMES=""
 
 # Refuse while Dolt merges. A pair that starts merging fails here.
+# Dolt keeps a trigger on a renamed-away table name; no loadable SQLite
+# catalog can hold that, so the refusal stands as a documented divergence.
 REFUSE_WHERE_DOLT_MERGES="
-idx_b:ren_b:index over a renamed column is not retargeted (#2333)
-ren_b:idx_b:index over a renamed column is not retargeted (#2333)
-uniq_b:ren_b:unique index over a renamed column is not retargeted (#2333)
-ren_b:uniq_b:unique index over a renamed column is not retargeted (#2333)
-idx_b:ren_b_view:index over a renamed column is not retargeted (#2333)
-ren_b_view:idx_b:index over a renamed column is not retargeted (#2333)
-uniq_b:ren_b_view:index over a renamed column is not retargeted (#2333)
-ren_b_view:uniq_b:index over a renamed column is not retargeted (#2333)
-idx_a:ren_a:index over a renamed column is not retargeted (#2333)
-ren_a:idx_a:index over a renamed column is not retargeted (#2333)
-ren_b_view:ren_a:dual rename with a dependent view naming the renamed column (#2333)
 trig:ren_tbl:Dolt keeps a trigger on the old table name, which no loadable catalog can hold (#2333)
 ren_tbl:trig:Dolt keeps a trigger on the old table name, which no loadable catalog can hold (#2333)
-bidx:ren_a:ren_b:dual rename with a pre-existing index on the renamed column (#2333)
-bview:ren_a:ren_b:dual rename with a pre-existing view on the renamed column (#2333)
-bview:ren_a:idx_a:rename under a pre-existing view while the other side indexes it (#2333)
-bview:idx_a:ren_a:rename under a pre-existing view while the other side indexes it (#2333)
-btrig:ren_a:ren_b:dual rename with a pre-existing trigger on the renamed column (#2333)
-btrig:ren_a:idx_a:rename under a pre-existing trigger while the other side indexes it (#2333)
-btrig:idx_a:ren_a:rename under a pre-existing trigger while the other side indexes it (#2333)
 "
 
 # Merge while Dolt refuses: a bug to fix by refusing, printed as a gap.

--- a/test/vc_oracle_schema_merge_test.sh
+++ b/test/vc_oracle_schema_merge_test.sh
@@ -1231,9 +1231,8 @@ expect_dual_value "generated_vs_plain_ours_generated_value" "$DB" \
   "SELECT GROUP_CONCAT(CONCAT(id, ':', x) ORDER BY id SEPARATOR ',') FROM t;"
 
 echo ""
-echo "--- Index over a renamed column (deliberate divergence) ---"
+echo "--- Index over a renamed column (follows the table, as Dolt) ---"
 
-# Index on a renamed column: DoltLite refuses (used to report corrupt); Dolt keeps the index.
 for dir in ours theirs; do
   DB="$TMPROOT/ixren_$dir.db"; rm -f "$DB"
   if [ "$dir" = ours ]; then
@@ -1253,7 +1252,11 @@ SELECT dolt_checkout('main');
 $MAIN
 SELECT dolt_commit('-Am','main_side');
 SQL
-  expect_merge_divergence "index_over_renamed_column_$dir" "$DB" conflict ok
+  expect_merge_ok "index_over_renamed_column_$dir" "$DB"
+  expect_dual_value "index_over_renamed_column_${dir}_lookup" "$DB" \
+    "1:b1" \
+    "SELECT group_concat(id || ':' || b2, ',') FROM (SELECT id,b2 FROM t WHERE b2='b1' ORDER BY id);" \
+    "SELECT GROUP_CONCAT(CONCAT(id, ':', b2) ORDER BY id SEPARATOR ',') FROM t WHERE b2='b1';"
 done
 
 echo ""


### PR DESCRIPTION
Fixes the retarget class of #2333: six shapes that refused where Dolt merges, plus the view form that was never refused and failed as a bare `SQL logic error`.

## The approach: subtract the rename, re-apply it through DDL

A merge chose the table and its dependents **independently** — the table row from whichever side the schema merge picked, an index/trigger/view row from whichever side changed it. A rename on one side paired an adopted table with a dependent naming a column it doesn't have, and the catalog couldn't load (or, for lazy views, blew up later inside the post-load ALTER's rewrite pass — that's exactly where the unrefused view form's `SQL logic error` came from).

Instead of repairing the assembled catalog, a pre-pass1 normalization makes the rename invisible to the merge: the table and its rename-shadowed dependents get **one baseline text on every side**, the table entries' schema hashes are equalized so every arm sees the schema as unchanged, and the renames are queued as post-load actions. The merge then runs down the plain row-merge path — the most-tested code in the module — and `ALTER TABLE RENAME COLUMN` retargets the table and every dependent through SQLite's own rewriter before the final flush serializes the result.

The baseline is whichever of {ancestor, ours, theirs} every surviving dependent can load against. A dependent created *after* its own side's rename names new-style columns and pins the baseline to that side; the queued delta is baseline→final. Scope guards: pure column renames only (a side that also adds/drops keeps today's refusal), branch merges only (replays have no action plumbing), and a materially-edited dependent that names a renamed column bails to today's behavior.

## The two dead ends in #2333, explained

- *"Rewriting the dependent's zSql — rows are rebuilt from a separate path"*: `rebuildDisjointSchemaRows` only wrote rows for **changed** indexes; unchanged ones rode on the serializer's live-schema top-up, which resurrects this connection's **pre-merge** text. Every surviving index now writes its row from the merge's own arrays.
- The survival gate is **by name**, not rootpage: a drop-and-recreate on the other side reuses the number, and a rootpage gate resurrected the dropped index (a battery control caught it).

## What stays refused, and a correction to #2333

- trigger vs table-**rename**: Dolt keeps the trigger on the old table name — no loadable SQLite catalog holds that.
- trigger vs table-**drop**: #2333 claims Dolt drops the trigger with the table. Re-verified: Dolt keeps an **orphaned** trigger row in `dolt_schemas` (`SHOW TRIGGERS` errors on it) — the same unrepresentable class, so this refusal stands and the issue is corrected below.

## Verification (all on a fully rebuilt binary)

| check | result |
| --- | --- |
| `vc_oracle_correct_schema_merge_matrix_test.sh` vs Dolt | **266 passed, 0 failed, 0 gaps, 0 differing, 0 corrupting** — allowlist 20 → 2, the cleared pairs now compared at data level |
| `doltlite_schema_merge.sh` | 347 passed, 0 failed (refusal tests rewritten to Dolt-verified merge outcomes; new view/dual-rename/reopen coverage) |
| `vc_oracle_schema_merge_test.sh` vs Dolt | 108 passed (stale divergence expectation → parity) |
| `doltlite_index_vc_matrix.sh` | 49 passed |
| `run_doltlite_tests.sh` | **112 passed, 0 failed** |
| stateful vc fuzzer | seeds 1787347777 (4635 steps) and 424242 (4833 steps) clean |
| replays | revert of index-add and cherry-pick of index-drop verified by hand |
| amalgamation | regenerated + compiled, no static collisions; `lint_layers` passes |

Merged results were re-opened in fresh connections and served **indexed lookups** — the failure mode #2357 taught us `integrity_check` does not catch.

Note for the next change here: `doltlite_merge.c` is at exactly 1500 lines, the lint cap.

Closes the retarget scope of #2333.

🤖 Generated with [Claude Code](https://claude.com/claude-code)