### PR TITLE
Catch nightlies that vanish instead of failing

### DIFF
--- a/.github/workflows/nightly-fuzz.yml
+++ b/.github/workflows/nightly-fuzz.yml
@@ -303,3 +303,30 @@ jobs:
       run: |
         echo "::error::SQL differential sweep diverged from stock SQLite"
         exit 1
+
+  # A red or cancelled night must never be silent. Specific failures above
+  # cut their own issues; this catches the classes they cannot: a setup or
+  # build step failing before the reporter arms, or a job cancelled while
+  # the run survives. A whole-run cancellation kills this job too, which is
+  # what the weekly nightly-heartbeat exists to catch.
+  watchdog:
+    needs: [fuzz, differential]
+    if: failure() || cancelled()
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Describe the incident
+      run: |
+        {
+          echo "The scheduled nightly-fuzz run did not finish green and no step-level reporter covered it."
+          echo ""
+          echo "Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          echo ""
+          echo "If a more specific issue (fuzz crash, stress failure) was filed for this night, triage there; this entry exists so no red nightly is silent."
+        } > "$RUNNER_TEMP/watchdog-body.md"
+    - uses: ./.github/actions/report-failure-issue
+      with:
+        label: nightly-fuzz-watchdog
+        title: "Nightly fuzz run did not finish"
+        body-file: ${{ runner.temp }}/watchdog-body.md
+        token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nightly-heartbeat.yml
+++ b/.github/workflows/nightly-heartbeat.yml
@@ -1,0 +1,76 @@
+# The nightlies are silent when green and cut issues when they fail — but a
+# run that is cancelled whole, or never scheduled at all, produces nothing.
+# GitHub cancels every job in a cancelled run, per-run watchdogs included, so
+# absence cannot be detected from inside the run. This weekly job looks at
+# the record from outside: each of the last seven nights must show a
+# scheduled run that reached a conclusion (success, or failure — failures
+# report themselves) for every nightly workflow, and each workflow must
+# still be active (a repo without pushes for 60 days gets its schedules
+# disabled by GitHub). Silent when the record is complete.
+name: Nightly Heartbeat
+
+on:
+  schedule:
+    - cron: '30 7 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+  actions: read
+
+jobs:
+  heartbeat:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Audit the last seven nights
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        BODY="$RUNNER_TEMP/heartbeat-body.md"
+        : > "$BODY"
+        SINCE=$(date -u -d '8 days ago' +%Y-%m-%d)
+        for wf in nightly-fuzz nightly-stress nightly-scale nightly-performance; do
+          state=$(gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/${wf}.yml" --jq .state)
+          if [ "$state" != "active" ]; then
+            echo "- \`$wf\` is **$state** — its schedule is not running at all." >> "$BODY"
+            continue
+          fi
+          runs=$(gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/${wf}.yml/runs?event=schedule&created=>=${SINCE}&per_page=50" \
+                 --jq '[.workflow_runs[] | {day: (.run_started_at[0:10]), conclusion}]')
+          for i in 1 2 3 4 5 6 7; do
+            day=$(date -u -d "-$i days" +%Y-%m-%d)
+            day_concls=$(printf '%s' "$runs" | jq -r --arg d "$day" '[.[] | select(.day==$d) | .conclusion // "in_progress"] | join(",")')
+            if [ -z "$day_concls" ]; then
+              echo "- \`$wf\` has **no scheduled run** on $day." >> "$BODY"
+            elif ! printf '%s' "$day_concls" | grep -qE 'success|failure'; then
+              echo "- \`$wf\` on $day never reached a conclusion (got: $day_concls) — likely cancelled, and a cancelled run reports nothing." >> "$BODY"
+            fi
+          done
+        done
+        if [ -s "$BODY" ]; then
+          {
+            echo "The nightly record for the last seven nights has holes. A missing or"
+            echo "cancelled night reports nothing on its own — that is why this check exists."
+            echo ""
+            cat "$BODY"
+          } > "$RUNNER_TEMP/heartbeat-issue.md"
+          echo "gaps=1" >> "$GITHUB_OUTPUT"
+          echo "HEARTBEAT_GAPS=1" >> "$GITHUB_ENV"
+          cat "$RUNNER_TEMP/heartbeat-issue.md"
+        else
+          echo "All four nightlies ran to a conclusion every night. Silent."
+        fi
+
+    - name: Report the gaps
+      if: env.HEARTBEAT_GAPS == '1'
+      uses: ./.github/actions/report-failure-issue
+      with:
+        label: nightly-heartbeat
+        title: "Nightly runs are missing or cancelled"
+        body-file: ${{ runner.temp }}/heartbeat-issue.md
+        token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nightly-performance.yml
+++ b/.github/workflows/nightly-performance.yml
@@ -419,3 +419,30 @@ jobs:
     - name: Fail when a ceiling regressed
       if: ${{ always() && steps.report.outputs.failed == '1' }}
       run: exit 1
+
+  # A red or cancelled night must never be silent. Specific failures above
+  # cut their own issues; this catches the classes they cannot: a setup or
+  # build step failing before the reporter arms, or a job cancelled while
+  # the run survives. A whole-run cancellation kills this job too, which is
+  # what the weekly nightly-heartbeat exists to catch.
+  watchdog:
+    needs: [build, sysbench, version-control, report]
+    if: failure() || cancelled()
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Describe the incident
+      run: |
+        {
+          echo "The scheduled nightly-performance run did not finish green and no step-level reporter covered it."
+          echo ""
+          echo "Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          echo ""
+          echo "If a more specific issue (fuzz crash, stress failure) was filed for this night, triage there; this entry exists so no red nightly is silent."
+        } > "$RUNNER_TEMP/watchdog-body.md"
+    - uses: ./.github/actions/report-failure-issue
+      with:
+        label: nightly-performance-watchdog
+        title: "Nightly performance run did not finish"
+        body-file: ${{ runner.temp }}/watchdog-body.md
+        token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nightly-scale.yml
+++ b/.github/workflows/nightly-scale.yml
@@ -182,3 +182,30 @@ jobs:
       run: |
         echo "::error::nightly scale failure in large_scale_test full mode"
         exit 1
+
+  # A red or cancelled night must never be silent. Specific failures above
+  # cut their own issues; this catches the classes they cannot: a setup or
+  # build step failing before the reporter arms, or a job cancelled while
+  # the run survives. A whole-run cancellation kills this job too, which is
+  # what the weekly nightly-heartbeat exists to catch.
+  watchdog:
+    needs: [build, large-full]
+    if: failure() || cancelled()
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Describe the incident
+      run: |
+        {
+          echo "The scheduled nightly-scale run did not finish green and no step-level reporter covered it."
+          echo ""
+          echo "Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          echo ""
+          echo "If a more specific issue (fuzz crash, stress failure) was filed for this night, triage there; this entry exists so no red nightly is silent."
+        } > "$RUNNER_TEMP/watchdog-body.md"
+    - uses: ./.github/actions/report-failure-issue
+      with:
+        label: nightly-scale-watchdog
+        title: "Nightly scale run did not finish"
+        body-file: ${{ runner.temp }}/watchdog-body.md
+        token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nightly-stress.yml
+++ b/.github/workflows/nightly-stress.yml
@@ -377,3 +377,30 @@ jobs:
       run: |
         echo "::error::nightly stress failure in ${{ matrix.suite }}"
         exit 1
+
+  # A red or cancelled night must never be silent. Specific failures above
+  # cut their own issues; this catches the classes they cannot: a setup or
+  # build step failing before the reporter arms, or a job cancelled while
+  # the run survives. A whole-run cancellation kills this job too, which is
+  # what the weekly nightly-heartbeat exists to catch.
+  watchdog:
+    needs: [build, stress]
+    if: failure() || cancelled()
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Describe the incident
+      run: |
+        {
+          echo "The scheduled nightly-stress run did not finish green and no step-level reporter covered it."
+          echo ""
+          echo "Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          echo ""
+          echo "If a more specific issue (fuzz crash, stress failure) was filed for this night, triage there; this entry exists so no red nightly is silent."
+        } > "$RUNNER_TEMP/watchdog-body.md"
+    - uses: ./.github/actions/report-failure-issue
+      with:
+        label: nightly-stress-watchdog
+        title: "Nightly stress run did not finish"
+        body-file: ${{ runner.temp }}/watchdog-body.md
+        token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The nightlies are silent-when-green and cut issues on failure — which means a run that is **cancelled whole, or never scheduled**, is indistinguishable from a passing one. That's not hypothetical: on **August 19 both nightly-fuzz and nightly-scale were cancelled mid-run** and nothing reported it. Four of five fuzz targets didn't run that night.

Two layers, because they cover different failure planes:

## Per-run watchdog (in each of the four nightlies)

A final job with `if: failure() || cancelled()` that files into a per-workflow tracking issue via the shared `report-failure-issue` action. Catches what the step-level reporters can't: a setup/build step failing **before** the crash reporter arms, and job-level cancellation where the run survives.

Known limitation, stated rather than papered over: a **whole-run** cancellation kills the watchdog too — GitHub cancels every job in the run. On crash nights the watchdog adds one comment to its tracking issue alongside the crash issue; the action appends to one open issue per label, so this is a comment, not spam.

## Weekly heartbeat (`nightly-heartbeat.yml`, Mondays 07:30 UTC)

Audits the record **from outside the runs**, which is the only vantage point that can see absence:

- each of the last 7 nights must show a scheduled run reaching `success` or `failure` for each of the four nightlies (`failure` passes the audit — failures report themselves)
- each workflow must still be `active` — GitHub silently disables schedules on repos with no pushes for 60 days

Anything else — a missing night, a cancelled-only night, a disabled workflow — files into a `nightly-heartbeat` tracking issue. Silent when the record is complete.

## Verification

The audit logic was dry-run against the real run history: it flags exactly the August 19 cancellations (`nightly-fuzz` and `nightly-scale` both show `cancelled` that day) and passes the self-reported August 16 failure. All five workflow files parse; job graphs verified (`watchdog` needs every job in its workflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)