### PR TITLE
Keep dolt_log hash filters in current history

### DIFF
--- a/src/doltlite_log.c
+++ b/src/doltlite_log.c
@@ -152,6 +152,39 @@ static int logAddReachable(
   return rc;
 }
 
+static int logIsReachable(
+  sqlite3 *db,
+  const ProllyHash *pHead,
+  const ProllyHash *pTarget,
+  int *pReachable
+){
+  DoltliteCommitQueue queue;
+  int rc;
+
+  memset(&queue, 0, sizeof(queue));
+  *pReachable = 0;
+  rc = doltliteCommitQueueInit(&queue, pHead);
+  while( rc==SQLITE_OK ){
+    ProllyHash hash;
+    DoltliteCommit commit;
+    int hasHash = 0;
+    rc = doltliteCommitQueueNext(&queue, &hash, &hasHash);
+    if( rc!=SQLITE_OK || !hasHash ) break;
+    if( prollyHashCompare(&hash, pTarget)==0 ){
+      *pReachable = 1;
+      break;
+    }
+    memset(&commit, 0, sizeof(commit));
+    rc = doltliteLoadCommit(db, &hash, &commit);
+    if( rc==SQLITE_OK ){
+      rc = doltliteCommitQueueEnqueueParents(&queue, &commit);
+    }
+    doltliteCommitClear(&commit);
+  }
+  doltliteCommitQueueClear(&queue);
+  return rc;
+}
+
 static int doltliteLogNext(sqlite3_vtab_cursor *pCursor){
   DoltliteLogCursor *pCur = (DoltliteLogCursor*)pCursor;
   DoltliteLogVtab *pVtab = (DoltliteLogVtab*)pCursor->pVtab;
@@ -237,6 +270,12 @@ static int doltliteLogFilter(
   }
 
   if( useStart==1 ){
+    int reachable;
+    doltliteGetSessionHead(pVtab->db, &head);
+    if( prollyHashIsEmpty(&head) ) return SQLITE_OK;
+    rc = logIsReachable(pVtab->db, &head, &startHash, &reachable);
+    if( rc!=SQLITE_OK ) return rc;
+    if( !reachable ) return SQLITE_OK;
     head = startHash;
     pCur->singleCommit = 1;
   }else if( useStart==0 ){

--- a/test/doltlite_log.sh
+++ b/test/doltlite_log.sh
@@ -20,5 +20,12 @@ echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'ba
 run_test "tag_does_not_change_log_count_after_reopen" "SELECT count(*) FROM dolt_log;" "3" "$DB3"
 run_test "tag_does_not_change_log_top_message_after_reopen" "SELECT message FROM dolt_log LIMIT 1;" "c2" "$DB3"
 
-rm -f "$DB1" "$DB2" "$DB3"
+DB4=/tmp/test_log4_$$.db; rm -f "$DB4"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY); INSERT INTO t VALUES(1); SELECT dolt_commit('-Am','base'); SELECT dolt_checkout('-b','feat'); INSERT INTO t VALUES(2); SELECT dolt_commit('-Am','feat-only'); SELECT dolt_checkout('main');" | $DOLTLITE "$DB4" > /dev/null 2>&1
+run_test "hash_filter_excludes_unreachable_commit" "SELECT count(*) FROM dolt_log WHERE commit_hash=dolt_hashof('feat');" "0" "$DB4"
+run_test "hash_filter_matches_unpushed_predicate" "SELECT count(*) FROM dolt_log WHERE (commit_hash||'')=dolt_hashof('feat');" "0" "$DB4"
+run_test "hash_filter_includes_reachable_commit" "SELECT count(*) FROM dolt_log WHERE commit_hash=dolt_hashof('main');" "1" "$DB4"
+run_test "hash_filter_honors_explicit_revision" "SELECT count(*) FROM dolt_log('feat') WHERE commit_hash=dolt_hashof('feat');" "1" "$DB4"
+
+rm -f "$DB1" "$DB2" "$DB3" "$DB4"
 dltest_finish

--- a/test/vc_oracle_log_test.sh
+++ b/test/vc_oracle_log_test.sh
@@ -375,6 +375,32 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'feat1');
 "
 
+oracle_commit_relations "commit_hash_filter_stays_in_current_history" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES (1);
+SELECT 'C1|' || dolt_commit('-Am', 'base');
+SELECT dolt_checkout('-b', 'feat');
+INSERT INTO t VALUES (2);
+SELECT 'C2|' || dolt_commit('-Am', 'feat-only');
+SELECT dolt_checkout('main');
+SELECT 'L1|' || count(*) FROM dolt_log WHERE message='feat-only';
+SELECT 'L2|' || count(*) FROM dolt_log WHERE commit_hash=dolt_hashof('feat');
+SELECT 'L3|' || count(*) FROM dolt_log WHERE (commit_hash||'')=dolt_hashof('feat');
+SELECT 'L4|' || count(*) FROM dolt_log WHERE commit_hash=dolt_hashof('main');
+" "
+CREATE TABLE t(id int primary key);
+INSERT INTO t VALUES (1);
+CALL dolt_commit('-Am', 'base');
+CALL dolt_checkout('-b', 'feat');
+INSERT INTO t VALUES (2);
+CALL dolt_commit('-Am', 'feat-only');
+CALL dolt_checkout('main');
+SELECT concat('L1|', count(*)) FROM dolt_log WHERE message='feat-only';
+SELECT concat('L2|', count(*)) FROM dolt_log WHERE commit_hash=dolt_hashof('feat');
+SELECT concat('L3|', count(*)) FROM dolt_log WHERE concat(commit_hash,'')=dolt_hashof('feat');
+SELECT concat('L4|', count(*)) FROM dolt_log WHERE commit_hash=dolt_hashof('main');
+"
+
 oracle "log_on_branch_created_from_tag_ref" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
 INSERT INTO t VALUES (1, 10);


### PR DESCRIPTION
## Summary

- require exact `dolt_log.commit_hash` filters to be reachable from the selected session history
- preserve the one-row fast path for reachable commits and explicit revision scoping
- add native and Dolt-oracle coverage for sibling-branch, reachable, and unpushed predicates

## Validation

- `make -C build doltlite`
- `make lint`
- `DOLTLITE=build/doltlite bash test/doltlite_log.sh` (11 passed)
- `bash test/vc_oracle_log_test.sh build/doltlite dolt` (21 passed)
- `DOLTLITE="$(pwd)/build/doltlite" bash test/run_doltlite_tests.sh` (112 suites passed, 0 failed)

Co-Authored-By: OpenAI Codex <noreply@openai.com>