### PR TITLE
Keep AUTOINCREMENT sequences per schema

### DIFF
--- a/src/alter.c
+++ b/src/alter.c
@@ -248,12 +248,12 @@ void sqlite3AlterRenameTable(
         "UPDATE \"%w\".sqlite_sequence set name = %Q WHERE name = %Q",
         zDb, zName, pTab->zName);
 #if defined(DOLTLITE_PROLLY) && !defined(SQLITE_TEST)
-    {
+    if( iDb!=1 && db->aDb[iDb].pBt && !sqlite3BtreeUsesOrig(db->aDb[iDb].pBt) ){
       int regOld = ++pParse->nMem;
       int regNew = ++pParse->nMem;
       sqlite3VdbeLoadString(v, regOld, pTab->zName);
       sqlite3VdbeLoadString(v, regNew, zName);
-      sqlite3VdbeAddOp2(v, OP_DoltliteSeqRename, regOld, regNew);
+      sqlite3VdbeAddOp3(v, OP_DoltliteSeqRename, regOld, regNew, iDb);
     }
 #endif
   }

--- a/src/build.c
+++ b/src/build.c
@@ -3718,12 +3718,12 @@ void sqlite3CodeDropTable(Parse *pParse, Table *pTab, int iDb, int isView){
       pDb->zDbSName, pTab->zName
     );
 #if defined(DOLTLITE_PROLLY) && !defined(SQLITE_TEST)
-    {
+    if( iDb!=1 && pDb->pBt && !sqlite3BtreeUsesOrig(pDb->pBt) ){
       Vdbe *vSeq = sqlite3GetVdbe(pParse);
       if( vSeq ){
         int regName = ++pParse->nMem;
         sqlite3VdbeLoadString(vSeq, regName, pTab->zName);
-        sqlite3VdbeAddOp1(vSeq, OP_DoltliteSeqDrop, regName);
+        sqlite3VdbeAddOp3(vSeq, OP_DoltliteSeqDrop, regName, 0, iDb);
       }
     }
 #endif

--- a/src/insert.c
+++ b/src/insert.c
@@ -512,11 +512,12 @@ void sqlite3AutoincrementBegin(Parse *pParse){
     aOp[7].p1 = memId;
     aOp[10].p2 = memId;
 #if defined(DOLTLITE_PROLLY) && !defined(SQLITE_TEST)
-    /* Consult the shared per-database AUTOINCREMENT counter so branches
-    ** see each other's allocations even though sqlite_sequence is
-    ** branch-local. memId holds the max read from the local table; the
-    ** shared counter (keyed by table name in memId-1) wins if higher. */
-    sqlite3VdbeAddOp2(v, OP_DoltliteSeqMax, memId, memId-1);
+    /* Shared counter is per chunk-store (P3=iDb). TEMP and orig-format
+    ** schemas keep sqlite_sequence only — a name-only key would leak
+    ** allocations across schemas. */
+    if( p->iDb!=1 && pDb->pBt && !sqlite3BtreeUsesOrig(pDb->pBt) ){
+      sqlite3VdbeAddOp3(v, OP_DoltliteSeqMax, memId, memId-1, p->iDb);
+    }
 #endif
     if( pParse->nTab==0 ) pParse->nTab = 1;
   }
@@ -579,10 +580,9 @@ static SQLITE_NOINLINE void autoIncrementEnd(Parse *pParse){
     aOp[3].p3 = memId+1;
     aOp[3].p5 = OPFLAG_APPEND;
 #if defined(DOLTLITE_PROLLY) && !defined(SQLITE_TEST)
-    /* Mirror the new max into the shared per-database counter. Emitted
-    ** at the Le jump target so it runs on both the write path and the
-    ** no-change path — the bump is a max-merge and is safe either way. */
-    sqlite3VdbeAddOp2(v, OP_DoltliteSeqBump, memId, memId-1);
+    if( p->iDb!=1 && pDb->pBt && !sqlite3BtreeUsesOrig(pDb->pBt) ){
+      sqlite3VdbeAddOp3(v, OP_DoltliteSeqBump, memId, memId-1, p->iDb);
+    }
 #endif
     sqlite3ReleaseTempReg(pParse, iRec);
   }

--- a/src/vdbe.c
+++ b/src/vdbe.c
@@ -26,7 +26,11 @@ const void *sqlite3BtreePayloadFetchWithSize(BtCursor*, u32*, u32*);
 #endif
 #if defined(DOLTLITE_PROLLY) && !defined(SQLITE_TEST)
 #include "chunk_store.h"
-struct ChunkStore *doltliteGetChunkStore(sqlite3 *db);
+ChunkStore *doltliteBtreeChunkStore(Btree*);
+static ChunkStore *vdbeDoltliteSeqStore(sqlite3 *db, int iDb){
+  if( iDb<0 || iDb>=db->nDb || iDb==1 ) return 0;
+  return doltliteBtreeChunkStore(db->aDb[iDb].pBt);
+}
 #endif
 /*
 ** High-resolution hardware timer used for debugging and testing only.
@@ -3962,15 +3966,15 @@ case OP_CountRange: {    /* out2 */
 }
 
 #if defined(DOLTLITE_PROLLY) && !defined(SQLITE_TEST)
-/* Opcode: DoltliteSeqMax P1 P2 * * *
+/* Opcode: DoltliteSeqMax P1 P2 P3 * *
 ** Synopsis: r[P1]=max(r[P1], chunkStoreGetSequenceValue(r[P2]))
 **
-** Doltlite-only. Consult the per-database shared AUTOINCREMENT counter
-** for the table name in register P2 and raise the value in register P1
-** (the autoinc max-rowid register) to at least that value. This is how
-** branches see each other's allocations without sharing sqlite_sequence
-** itself — the counter lives in ChunkRefs.aSequences, not in any
-** branch's working set.
+** Doltlite-only. Consult the shared AUTOINCREMENT counter for the table
+** name in register P2 on the doltlite-format schema P3 and raise register
+** P1 to at least that value. TEMP (iDb==1) and orig-format schemas have
+** no shared counter: sqlite_sequence in that schema is enough. The
+** counter lives in ChunkRefs.aSequences so branches of the same file
+** see each other's allocations without sharing sqlite_sequence itself.
 */
 case OP_DoltliteSeqMax: {
   Mem *pCtr;
@@ -3981,7 +3985,7 @@ case OP_DoltliteSeqMax: {
   pCtr  = &aMem[pOp->p1];
   pName = &aMem[pOp->p2];
   if( (pName->flags & MEM_Str)==0 ) break;
-  pCs = doltliteGetChunkStore(db);
+  pCs = vdbeDoltliteSeqStore(db, pOp->p3);
   if( !pCs ) break;
   zName = (const char*)pName->z;
   if( !zName ) break;
@@ -3993,13 +3997,12 @@ case OP_DoltliteSeqMax: {
   break;
 }
 
-/* Opcode: DoltliteSeqBump P1 P2 * * *
+/* Opcode: DoltliteSeqBump P1 P2 P3 * *
 ** Synopsis: chunkStoreBumpSequence(r[P2], r[P1])
 **
-** Doltlite-only. Raise the per-database shared AUTOINCREMENT counter
-** for the table name in register P2 to at least r[P1]. Emitted at
-** autoIncrementEnd to mirror the local sqlite_sequence update into
-** the shared counter so other branches see the new max.
+** Doltlite-only. Raise the shared AUTOINCREMENT counter for the table
+** name in register P2 on schema P3 to at least r[P1]. Emitted at
+** autoIncrementEnd so other branches of that file see the new max.
 */
 case OP_DoltliteSeqBump: {
   Mem *pCtr;
@@ -4010,7 +4013,7 @@ case OP_DoltliteSeqBump: {
   pName = &aMem[pOp->p2];
   if( (pCtr->flags & MEM_Int)==0 ) break;
   if( (pName->flags & MEM_Str)==0 ) break;
-  pCs = doltliteGetChunkStore(db);
+  pCs = vdbeDoltliteSeqStore(db, pOp->p3);
   if( !pCs ) break;
   zName = (const char*)pName->z;
   if( !zName ) break;
@@ -4018,31 +4021,31 @@ case OP_DoltliteSeqBump: {
   break;
 }
 
-/* Opcode: DoltliteSeqDrop P1 * * * *
+/* Opcode: DoltliteSeqDrop P1 * P3 * *
 ** Synopsis: chunkStoreDropSequence(r[P1])
 **
 ** Doltlite-only. Remove the shared AUTOINCREMENT counter for the table
-** name in register P1. Emitted at DROP TABLE so a later CREATE+INSERT
-** of the same name starts fresh from 1, matching Dolt's behavior.
+** name in register P1 on schema P3. Emitted at DROP TABLE so a later
+** CREATE+INSERT of the same name on that schema starts from 1.
 */
 case OP_DoltliteSeqDrop: {
   Mem *pName;
   ChunkStore *pCs;
   pName = &aMem[pOp->p1];
   if( (pName->flags & MEM_Str)==0 ) break;
-  pCs = doltliteGetChunkStore(db);
+  pCs = vdbeDoltliteSeqStore(db, pOp->p3);
   if( !pCs ) break;
   if( !pName->z ) break;
   chunkStoreDropSequence(pCs, (const char*)pName->z);
   break;
 }
 
-/* Opcode: DoltliteSeqRename P1 P2 * * *
+/* Opcode: DoltliteSeqRename P1 P2 P3 * *
 ** Synopsis: chunkStoreRenameSequence(r[P1], r[P2])
 **
 ** Doltlite-only. Rename the shared AUTOINCREMENT counter from r[P1] to
-** r[P2]. Emitted at ALTER TABLE RENAME so inserts under the new name
-** continue from the existing max.
+** r[P2] on schema P3. Emitted at ALTER TABLE RENAME so inserts under
+** the new name continue from the existing max on that schema.
 */
 case OP_DoltliteSeqRename: {
   Mem *pOld;
@@ -4052,7 +4055,7 @@ case OP_DoltliteSeqRename: {
   pNew = &aMem[pOp->p2];
   if( (pOld->flags & MEM_Str)==0 ) break;
   if( (pNew->flags & MEM_Str)==0 ) break;
-  pCs = doltliteGetChunkStore(db);
+  pCs = vdbeDoltliteSeqStore(db, pOp->p3);
   if( !pCs ) break;
   if( !pOld->z || !pNew->z ) break;
   chunkStoreRenameSequence(pCs, (const char*)pOld->z, (const char*)pNew->z);

--- a/test/doltlite_autoinc_schema.sh
+++ b/test/doltlite_autoinc_schema.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+. "$(dirname "$0")/lib/doltlite_test_common.sh"
+
+echo "=== DoltLite AUTOINCREMENT is per schema, not per table name ==="
+echo ""
+
+DB=/tmp/test_doltlite_autoinc_schema_$$.db
+OTHER=/tmp/test_doltlite_autoinc_schema_other_$$.db
+rm -f "$DB" "$OTHER"
+trap 'rm -f "$DB" "$OTHER"' EXIT
+
+run_test "temp_same_name_starts_at_1" "
+CREATE TABLE t(id INTEGER PRIMARY KEY AUTOINCREMENT);
+INSERT INTO t DEFAULT VALUES;
+INSERT INTO t DEFAULT VALUES;
+CREATE TEMP TABLE t(id INTEGER PRIMARY KEY AUTOINCREMENT);
+INSERT INTO temp.t DEFAULT VALUES;
+SELECT group_concat(id) FROM main.t;
+SELECT id FROM temp.t;
+" "1,2
+1" "$DB"
+
+rm -f "$DB"
+run_test "rename_temp_does_not_steal_main" "
+CREATE TABLE t(id INTEGER PRIMARY KEY AUTOINCREMENT);
+INSERT INTO t DEFAULT VALUES;
+CREATE TEMP TABLE u(id INTEGER PRIMARY KEY AUTOINCREMENT);
+INSERT INTO temp.u DEFAULT VALUES;
+ALTER TABLE temp.u RENAME TO t;
+INSERT INTO temp.t DEFAULT VALUES;
+INSERT INTO main.t DEFAULT VALUES;
+SELECT group_concat(id) FROM main.t;
+SELECT group_concat(id) FROM temp.t;
+" "1,2
+1,2" "$DB"
+
+rm -f "$DB"
+run_test "drop_temp_does_not_reset_main" "
+CREATE TABLE t(id INTEGER PRIMARY KEY AUTOINCREMENT);
+INSERT INTO t DEFAULT VALUES;
+INSERT INTO t DEFAULT VALUES;
+CREATE TEMP TABLE t(id INTEGER PRIMARY KEY AUTOINCREMENT);
+INSERT INTO temp.t DEFAULT VALUES;
+DROP TABLE temp.t;
+INSERT INTO main.t DEFAULT VALUES;
+SELECT group_concat(id) FROM main.t;
+" "1,2,3" "$DB"
+
+rm -f "$DB"
+run_test "drop_recreate_main_starts_at_1" "
+CREATE TABLE t(id INTEGER PRIMARY KEY AUTOINCREMENT);
+INSERT INTO t DEFAULT VALUES;
+INSERT INTO t DEFAULT VALUES;
+DROP TABLE t;
+CREATE TABLE t(id INTEGER PRIMARY KEY AUTOINCREMENT);
+INSERT INTO t DEFAULT VALUES;
+SELECT id FROM t;
+" "1" "$DB"
+
+rm -f "$DB"
+run_test "rename_main_continues_sequence" "
+CREATE TABLE t(id INTEGER PRIMARY KEY AUTOINCREMENT);
+INSERT INTO t DEFAULT VALUES;
+ALTER TABLE t RENAME TO u;
+INSERT INTO u DEFAULT VALUES;
+SELECT group_concat(id) FROM u;
+" "1,2" "$DB"
+
+rm -f "$DB" "$OTHER"
+printf '%s\n' "CREATE TABLE t(id INTEGER PRIMARY KEY AUTOINCREMENT);" \
+  | "$DOLTLITE" "$OTHER" >/dev/null
+run_test "attached_same_name_starts_at_1" "
+CREATE TABLE t(id INTEGER PRIMARY KEY AUTOINCREMENT);
+INSERT INTO t DEFAULT VALUES;
+INSERT INTO t DEFAULT VALUES;
+ATTACH '$OTHER' AS o;
+INSERT INTO o.t DEFAULT VALUES;
+SELECT group_concat(id) FROM main.t;
+SELECT id FROM o.t;
+" "1,2
+1" "$DB"
+
+dltest_finish

--- a/test/lib/doltlite_suite_manifest.sh
+++ b/test/lib/doltlite_suite_manifest.sh
@@ -59,6 +59,7 @@ chunker_boundary_golden.sh
 doltlite_savepoint.sh
 doltlite_rollback_durability.sh
 doltlite_delete_or.sh
+doltlite_autoinc_schema.sh
 doltlite_nocase_index.sh
 doltlite_update_replace_trigger.sh
 doltlite_unique_index_delete.sh


### PR DESCRIPTION
## Problem

The shared AUTOINCREMENT counter lived in the main chunk-store and was keyed only by table name. TEMP tables and attached databases that reused a name stole ids from `main`.

```sql
CREATE TABLE t(id INTEGER PRIMARY KEY AUTOINCREMENT);
INSERT INTO t DEFAULT VALUES;
INSERT INTO t DEFAULT VALUES;
CREATE TEMP TABLE t(id INTEGER PRIMARY KEY AUTOINCREMENT);
INSERT INTO temp.t DEFAULT VALUES;
SELECT id FROM temp.t;   -- was 3, SQLite is 1
```

Renaming a TEMP table onto main's name also skipped main's next id. Attaching another DoltLite file with the same table name did the same.

## Change

`OP_DoltliteSeq*` now take the schema (`iDb`) as P3 and look up **that** schema's chunk store.

- TEMP (`iDb==1`) and orig-format schemas skip the shared counter and use only `sqlite_sequence`.
- Attached DoltLite files bump their own store, so branches of that file still share allocations.
- Main-file branch sharing is unchanged.

## Tests

`test/doltlite_autoinc_schema.sh`: TEMP same name, TEMP rename, DROP TEMP, attached same name, DROP/recreate main, RENAME main. Failed 3/4 on the unfixed engine; 6/6 after.

Local: suite 6/6; `doltlite_parity.sh` 119/119.

Co-Authored-By: Grok 4.6 <noreply@x.ai>