### PR TITLE
Preserve SQLite affinity in VC PK pushdown

### DIFF
--- a/src/doltlite_at.c
+++ b/src/doltlite_at.c
@@ -508,7 +508,7 @@ static int atFilter(sqlite3_vtab_cursor *cur,
   seekable = c->common.rootIntKey
           && (idxNum & AT_IDX_PK_ANY) != 0;
 
-  if( seekable && (idxNum & AT_IDX_PK_EQ) ){
+  if( seekable && (idxNum & AT_IDX_PK_EQ) && c->pkRange.hasPkLo ){
     rc = prollyCursorSeekInt(&c->common.tblCur, c->pkRange.pkLo, &res);
     if( rc!=SQLITE_OK ){
       prollyCursorClose(&c->common.tblCur);
@@ -575,7 +575,8 @@ static int atNext(sqlite3_vtab_cursor *cur){
     return SQLITE_OK;
   }
   /* EQ probe only positions intkey roots; mismatched shapes must keep stepping. */
-  if( (c->idxNum & AT_IDX_PK_EQ) && c->common.rootIntKey ){
+  if( (c->idxNum & AT_IDX_PK_EQ) && c->pkRange.hasPkLo
+   && c->common.rootIntKey ){
     prollyCursorClose(&c->common.tblCur);
     c->common.tblCurOpen = 0;
     c->common.hasRow = 0;

--- a/src/doltlite_blame.c
+++ b/src/doltlite_blame.c
@@ -251,7 +251,7 @@ static int blameCollectLiveRows(
   if( prollyHashIsEmpty(pRoot) ) return SQLITE_OK;
   prollyCursorInit(&cur, cs, pCache, pRoot, flags);
 
-  if( pushIntKey && (idxNum & BLAME_IDX_PK_EQ) ){
+  if( pushIntKey && (idxNum & BLAME_IDX_PK_EQ) && hasPkLo ){
     rc = prollyCursorSeekInt(&cur, pkLo, &res);
     if( rc!=SQLITE_OK ){ prollyCursorClose(&cur); return rc; }
     if( res!=0 || !prollyCursorIsValid(&cur) ){
@@ -277,7 +277,7 @@ static int blameCollectLiveRows(
     int nKey = 0, nVal = 0;
     BlameRow *r;
 
-    if( pushIntKey && (idxNum & BLAME_IDX_PK_EQ) ){
+    if( pushIntKey && (idxNum & BLAME_IDX_PK_EQ) && hasPkLo ){
       i64 k = prollyCursorIntKey(&cur);
       if( k != pkLo ) break;
     }else if( pushIntKey && hasPkHi ){

--- a/src/doltlite_history.c
+++ b/src/doltlite_history.c
@@ -125,7 +125,7 @@ static int htOpenTableAtCommit(HistCursor *c, sqlite3 *db,
   seekable = c->common.rootIntKey
           && (c->idxNum & HIST_IDX_PK_ANY) != 0;
 
-  if( seekable && (c->idxNum & HIST_IDX_PK_EQ) ){
+  if( seekable && (c->idxNum & HIST_IDX_PK_EQ) && c->pkRange.hasPkLo ){
     rc = prollyCursorSeekInt(&c->common.tblCur, c->pkRange.pkLo, &res);
     if( rc!=SQLITE_OK ){
       prollyCursorClose(&c->common.tblCur);
@@ -183,7 +183,8 @@ static int htAdvance(HistCursor *c, sqlite3 *db, const char *zTableName){
   int rc;
 
   if( c->common.tblCurOpen ){
-    if( (c->idxNum & HIST_IDX_PK_EQ) && c->common.rootIntKey ){
+    if( (c->idxNum & HIST_IDX_PK_EQ) && c->pkRange.hasPkLo
+     && c->common.rootIntKey ){
       prollyCursorClose(&c->common.tblCur);
       c->common.tblCurOpen = 0;
     }else{

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -383,6 +383,16 @@ static SQLITE_INLINE int doltliteBestIndexIntPkRange(
   return SQLITE_OK;
 }
 
+static SQLITE_INLINE int doltlitePkRangeIntArg(
+  sqlite3_value *pArg,
+  i64 *pValue
+){
+  if( sqlite3_value_type(pArg)==SQLITE_NULL ) return -1;
+  if( sqlite3_value_numeric_type(pArg)!=SQLITE_INTEGER ) return 0;
+  *pValue = sqlite3_value_int64(pArg);
+  return 1;
+}
+
 static SQLITE_INLINE void doltlitePkRangeFromArgs(
   int idxNum,
   int idxEq,
@@ -395,69 +405,80 @@ static SQLITE_INLINE void doltlitePkRangeFromArgs(
   DoltlitePkRange *pRange
 ){
   int iArg = 0;
+  int eArg;
+  i64 v;
   memset(pRange, 0, sizeof(*pRange));
 
-  /* NULL bound empties the scan. sqlite3_value_int64 would treat it as 0;
-  ** xBestIndex omits these, so nothing rechecks them. */
   if( idxNum & idxEq ){
     if( iArg < argc ){
-      if( sqlite3_value_type(argv[iArg])==SQLITE_NULL ){
+      eArg = doltlitePkRangeIntArg(argv[iArg++], &v);
+      if( eArg<0 ){
         pRange->isEmpty = 1;
         return;
       }
-      pRange->pkLo = sqlite3_value_int64(argv[iArg++]);
-      pRange->hasPkLo = 1;
+      if( eArg>0 ){
+        pRange->pkLo = v;
+        pRange->hasPkLo = 1;
+      }
     }
   }else{
     if( idxNum & idxGe ){
       if( iArg < argc ){
-        if( sqlite3_value_type(argv[iArg])==SQLITE_NULL ){
+        eArg = doltlitePkRangeIntArg(argv[iArg++], &v);
+        if( eArg<0 ){
           pRange->isEmpty = 1;
           return;
         }
-        pRange->pkLo = sqlite3_value_int64(argv[iArg++]);
-        pRange->hasPkLo = 1;
-        pRange->pkLoStrict = 0;
+        if( eArg>0 ){
+          pRange->pkLo = v;
+          pRange->hasPkLo = 1;
+          pRange->pkLoStrict = 0;
+        }
       }
     }
     if( idxNum & idxGt ){
       if( iArg < argc ){
-        i64 v2;
-        if( sqlite3_value_type(argv[iArg])==SQLITE_NULL ){
+        eArg = doltlitePkRangeIntArg(argv[iArg++], &v);
+        if( eArg<0 ){
           pRange->isEmpty = 1;
           return;
         }
-        v2 = sqlite3_value_int64(argv[iArg++]);
-        if( !pRange->hasPkLo || v2 >= pRange->pkLo ){
-          pRange->pkLo = v2;
-          pRange->hasPkLo = 1;
-          pRange->pkLoStrict = 1;
+        if( eArg>0 ){
+          if( !pRange->hasPkLo || v >= pRange->pkLo ){
+            pRange->pkLo = v;
+            pRange->hasPkLo = 1;
+            pRange->pkLoStrict = 1;
+          }
         }
       }
     }
     if( idxNum & idxLe ){
       if( iArg < argc ){
-        if( sqlite3_value_type(argv[iArg])==SQLITE_NULL ){
+        eArg = doltlitePkRangeIntArg(argv[iArg++], &v);
+        if( eArg<0 ){
           pRange->isEmpty = 1;
           return;
         }
-        pRange->pkHi = sqlite3_value_int64(argv[iArg++]);
-        pRange->hasPkHi = 1;
-        pRange->pkHiStrict = 0;
+        if( eArg>0 ){
+          pRange->pkHi = v;
+          pRange->hasPkHi = 1;
+          pRange->pkHiStrict = 0;
+        }
       }
     }
     if( idxNum & idxLt ){
       if( iArg < argc ){
-        i64 v2;
-        if( sqlite3_value_type(argv[iArg])==SQLITE_NULL ){
+        eArg = doltlitePkRangeIntArg(argv[iArg++], &v);
+        if( eArg<0 ){
           pRange->isEmpty = 1;
           return;
         }
-        v2 = sqlite3_value_int64(argv[iArg++]);
-        if( !pRange->hasPkHi || v2 <= pRange->pkHi ){
-          pRange->pkHi = v2;
-          pRange->hasPkHi = 1;
-          pRange->pkHiStrict = 1;
+        if( eArg>0 ){
+          if( !pRange->hasPkHi || v <= pRange->pkHi ){
+            pRange->pkHi = v;
+            pRange->hasPkHi = 1;
+            pRange->pkHiStrict = 1;
+          }
         }
       }
     }

--- a/test/doltlite_dolt_table_pushdown.sh
+++ b/test/doltlite_dolt_table_pushdown.sh
@@ -285,4 +285,46 @@ run_test "rowid_blame_renders_pk" \
 
 rm -f "$DB5"
 
+DB6=/tmp/test_pushdown_affinity_$$.db
+rm -f "$DB6"
+echo "CREATE TABLE t(pk INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(-5,'negative'),(0,'zero'),(5,'positive');
+SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB6" > /dev/null 2>&1
+
+run_test "history_text_range_matches_integer_affinity" \
+  "SELECT group_concat(pk, ',') FROM (SELECT pk FROM dolt_history_t WHERE pk<'abc' ORDER BY pk);" \
+  "-5,0,5" "$DB6"
+run_test "blame_text_range_matches_integer_affinity" \
+  "SELECT group_concat(pk, ',') FROM (SELECT pk FROM dolt_blame_t WHERE pk<'abc' ORDER BY pk);" \
+  "-5,0,5" "$DB6"
+run_test "at_text_range_matches_integer_affinity" \
+  "SELECT group_concat(pk, ',') FROM (SELECT pk FROM dolt_at_t WHERE commit_ref='HEAD' AND pk<'abc' ORDER BY pk);" \
+  "-5,0,5" "$DB6"
+run_test "history_real_range_preserves_fraction" \
+  "SELECT group_concat(pk, ',') FROM (SELECT pk FROM dolt_history_t WHERE pk<0.5 ORDER BY pk);" \
+  "-5,0" "$DB6"
+run_test "blame_real_range_preserves_fraction" \
+  "SELECT group_concat(pk, ',') FROM (SELECT pk FROM dolt_blame_t WHERE pk<0.5 ORDER BY pk);" \
+  "-5,0" "$DB6"
+run_test "at_blob_range_preserves_storage_class" \
+  "SELECT group_concat(pk, ',') FROM (SELECT pk FROM dolt_at_t WHERE commit_ref='HEAD' AND pk<x'00' ORDER BY pk);" \
+  "-5,0,5" "$DB6"
+run_test "history_mixed_range_ignores_only_unsafe_bound" \
+  "SELECT group_concat(pk, ',') FROM (SELECT pk FROM dolt_history_t WHERE pk>=0 AND pk<'abc' ORDER BY pk);" \
+  "0,5" "$DB6"
+run_test "history_numeric_text_range_still_matches" \
+  "SELECT group_concat(pk, ',') FROM (SELECT pk FROM dolt_history_t WHERE pk<'1' ORDER BY pk);" \
+  "-5,0" "$DB6"
+run_test "history_integral_real_equality_matches" \
+  "SELECT group_concat(pk, ',') FROM dolt_history_t WHERE pk=5.0;" \
+  "5" "$DB6"
+run_test "blame_integral_real_equality_matches" \
+  "SELECT group_concat(pk, ',') FROM dolt_blame_t WHERE pk=5.0;" \
+  "5" "$DB6"
+run_test "at_integral_real_equality_matches" \
+  "SELECT group_concat(pk, ',') FROM dolt_at_t WHERE commit_ref='HEAD' AND pk=5.0;" \
+  "5" "$DB6"
+
+rm -f "$DB6"
+
 dltest_finish

--- a/test/doltlite_history.sh
+++ b/test/doltlite_history.sh
@@ -359,7 +359,7 @@ run_test "keyshape_history_eq_filters" \
   "7|seven" "$DB"
 run_test "keyshape_history_upper_bound" \
   "SELECT count(*) FROM dolt_history_s WHERE a<'z';" \
-  "2" "$DB"
+  "5" "$DB"
 run_test "keyshape_history_values_render" \
   "SELECT a FROM dolt_history_s ORDER BY a;" \
   "1


### PR DESCRIPTION
## Summary

- seek integer primary-key ranges only when SQLite numeric affinity yields an exact integer
- fall back to SQLite constraint rechecks for REAL, nonnumeric TEXT, and BLOB bounds in `dolt_history_*`, `dolt_blame_*`, and `dolt_at_*`
- preserve valid mixed bounds and integral-REAL equality behavior
- add fail-before coverage for every affected virtual-table family and correct the schema-evolution expectation that the old seek had truncated

## Validation

- `make -B -C build doltlite`
- `make lint`
- `DOLTLITE="$(pwd)/build/doltlite" bash test/doltlite_dolt_table_pushdown.sh` (60 passed)
- `bash test/vc_oracle_history_test.sh build/doltlite dolt` (31 passed)
- `bash test/vc_oracle_at_test.sh build/doltlite dolt` (26 passed)
- `bash test/vc_oracle_blame_test.sh build/doltlite dolt` (25 passed)
- `DOLTLITE="$(pwd)/build/doltlite" bash test/run_doltlite_tests.sh` (113 suites passed, 0 failed; 310,930 C assertions passed)

Co-Authored-By: OpenAI Codex <noreply@openai.com>
