### PR TITLE
Respect SQL collations in VC equality pushdown

### DIFF
--- a/src/doltlite_commit_ancestors.c
+++ b/src/doltlite_commit_ancestors.c
@@ -276,7 +276,8 @@ static int caBestIndex(sqlite3_vtab *pVtab, sqlite3_index_info *pInfo){
   for(i=0; i<pInfo->nConstraint; i++){
     const struct sqlite3_index_constraint *pC = &pInfo->aConstraint[i];
     if( !pC->usable ) continue;
-    if( pC->iColumn==0 && pC->op==SQLITE_INDEX_CONSTRAINT_EQ ){
+    if( pC->iColumn==0 && pC->op==SQLITE_INDEX_CONSTRAINT_EQ
+     && doltliteVtabConstraintIsBinary(pInfo, i) ){
       iCommitEq = i;
       break;
     }
@@ -284,7 +285,7 @@ static int caBestIndex(sqlite3_vtab *pVtab, sqlite3_index_info *pInfo){
 
   if( iCommitEq>=0 ){
     pInfo->aConstraintUsage[iCommitEq].argvIndex = 1;
-    pInfo->aConstraintUsage[iCommitEq].omit = 1;
+    pInfo->aConstraintUsage[iCommitEq].omit = 0;
     pInfo->idxNum = CA_IDX_COMMIT_EQ;
     pInfo->estimatedCost = 10.0;
     pInfo->estimatedRows = 2;

--- a/src/doltlite_diff.c
+++ b/src/doltlite_diff.c
@@ -719,6 +719,7 @@ static int diffBestIndex(sqlite3_vtab *pVtab, sqlite3_index_info *pInfo){
   for(i=0; i<pInfo->nConstraint; i++){
     if( !pInfo->aConstraint[i].usable ) continue;
     if( pInfo->aConstraint[i].op!=SQLITE_INDEX_CONSTRAINT_EQ ) continue;
+    if( !doltliteVtabConstraintIsBinary(pInfo, i) ) continue;
     switch( pInfo->aConstraint[i].iColumn ){
       case DIFF_COL_TABLE_NAME:
         if( iTableName<0 ) iTableName = i;
@@ -731,12 +732,12 @@ static int diffBestIndex(sqlite3_vtab *pVtab, sqlite3_index_info *pInfo){
 
   if( iCommitHash>=0 ){
     pInfo->aConstraintUsage[iCommitHash].argvIndex = argvIdx++;
-    pInfo->aConstraintUsage[iCommitHash].omit = 1;
+    pInfo->aConstraintUsage[iCommitHash].omit = 0;
     idxNum |= DIFF_IDX_COMMIT_HASH;
   }
   if( iTableName>=0 ){
     pInfo->aConstraintUsage[iTableName].argvIndex = argvIdx++;
-    pInfo->aConstraintUsage[iTableName].omit = 1;
+    pInfo->aConstraintUsage[iTableName].omit = 0;
     idxNum |= DIFF_IDX_TABLE_NAME;
   }
 

--- a/src/doltlite_history.c
+++ b/src/doltlite_history.c
@@ -264,6 +264,7 @@ static int htBestIndex(sqlite3_vtab *v, sqlite3_index_info *p){
     if( !pC->usable ) continue;
     if( pC->iColumn==iCommitCol
      && pC->op==SQLITE_INDEX_CONSTRAINT_EQ
+     && doltliteVtabConstraintIsBinary(p, i)
      && !sqlite3DoltliteVtabConstraintIsCorrelated(p, i) ){
       iCommitEq = i;
     }else if( pC->iColumn==iStartRefCol
@@ -273,7 +274,7 @@ static int htBestIndex(sqlite3_vtab *v, sqlite3_index_info *p){
   }
   if( iCommitEq>=0 ){
     p->aConstraintUsage[iCommitEq].argvIndex = ++nArg;
-    p->aConstraintUsage[iCommitEq].omit = 1;
+    p->aConstraintUsage[iCommitEq].omit = 0;
     idxNum |= HIST_IDX_COMMIT_EQ;
     p->estimatedCost = (idxNum & HIST_IDX_PK_ANY) ? 10.0 : 50.0;
     p->estimatedRows = (idxNum & HIST_IDX_PK_ANY) ? 1 : 10;

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -242,6 +242,14 @@ static SQLITE_INLINE struct TableEntry *doltliteFindTableByName(
   return 0;
 }
 
+static SQLITE_INLINE int doltliteVtabConstraintIsBinary(
+  sqlite3_index_info *pInfo,
+  int iConstraint
+){
+  const char *zColl = sqlite3_vtab_collation(pInfo, iConstraint);
+  return zColl && sqlite3_stricmp(zColl, "BINARY")==0;
+}
+
 static SQLITE_INLINE int doltliteBestIndexRefs(
   sqlite3_index_info *pInfo,
   int iFromCol,
@@ -293,8 +301,9 @@ static SQLITE_INLINE int doltliteBestIndexEq(
     if( !pInfo->aConstraint[i].usable ) continue;
     if( pInfo->aConstraint[i].op!=SQLITE_INDEX_CONSTRAINT_EQ ) continue;
     if( pInfo->aConstraint[i].iColumn!=iColumn ) continue;
+    if( !doltliteVtabConstraintIsBinary(pInfo, i) ) continue;
     pInfo->aConstraintUsage[i].argvIndex = 1;
-    pInfo->aConstraintUsage[i].omit = 1;
+    pInfo->aConstraintUsage[i].omit = 0;
     pInfo->idxNum = 1;
     pInfo->estimatedCost = 1.0;
     pInfo->estimatedRows = 1;

--- a/src/doltlite_log.c
+++ b/src/doltlite_log.c
@@ -347,7 +347,8 @@ static int doltliteLogBestIndex(sqlite3_vtab *pVtab, sqlite3_index_info *pInfo){
     const struct sqlite3_index_constraint *pC = &pInfo->aConstraint[i];
     if( !pC->usable ) continue;
     if( pC->op != SQLITE_INDEX_CONSTRAINT_EQ ) continue;
-    if( pC->iColumn == 0 && iHashEq < 0 ){
+    if( pC->iColumn == 0 && iHashEq < 0
+     && doltliteVtabConstraintIsBinary(pInfo, i) ){
       iHashEq = i;
     }else if( pC->iColumn == 5 && iRevisionEq < 0 ){
       iRevisionEq = i;
@@ -362,7 +363,7 @@ static int doltliteLogBestIndex(sqlite3_vtab *pVtab, sqlite3_index_info *pInfo){
     pInfo->estimatedRows = 10;
   }else if( iHashEq >= 0 ){
     pInfo->aConstraintUsage[iHashEq].argvIndex = 1;
-    pInfo->aConstraintUsage[iHashEq].omit = 1;
+    pInfo->aConstraintUsage[iHashEq].omit = 0;
     idxNum |= LOG_IDX_HASH_EQ;
     pInfo->estimatedCost = 10.0;
     pInfo->estimatedRows = 1;

--- a/src/doltlite_patch.c
+++ b/src/doltlite_patch.c
@@ -1373,7 +1373,11 @@ static int patchBestIndex(sqlite3_vtab *pVtab, sqlite3_index_info *pInfo){
     if( !pInfo->aConstraint[i].usable
      || pInfo->aConstraint[i].op!=SQLITE_INDEX_CONSTRAINT_EQ ) continue;
     switch( pInfo->aConstraint[i].iColumn ){
-      case 4: iType=i; break;
+      case 4:
+        if( doltliteVtabConstraintIsBinary(pInfo, i) ){
+          iType=i;
+        }
+        break;
       case 6: iFrom=i; break;
       case 7: iTo=i; break;
       case 8: iTable=i; break;
@@ -1393,7 +1397,7 @@ static int patchBestIndex(sqlite3_vtab *pVtab, sqlite3_index_info *pInfo){
   }
   if( iType>=0 ){
     pInfo->aConstraintUsage[iType].argvIndex=iArg++;
-    pInfo->aConstraintUsage[iType].omit=1;
+    pInfo->aConstraintUsage[iType].omit=0;
   }
   pInfo->idxNum=(iFrom>=0?1:0)|(iTo>=0?2:0)|(iTable>=0?4:0)|(iType>=0?8:0);
   pInfo->estimatedCost=1000.0;

--- a/src/doltlite_schemas.c
+++ b/src/doltlite_schemas.c
@@ -65,6 +65,7 @@ static int schemasBestIndex(sqlite3_vtab *pVtab, sqlite3_index_info *pInfo){
     const struct sqlite3_index_constraint *pC = &pInfo->aConstraint[i];
     if( !pC->usable ) continue;
     if( pC->op!=SQLITE_INDEX_CONSTRAINT_EQ ) continue;
+    if( !doltliteVtabConstraintIsBinary(pInfo, i) ) continue;
     if( pC->iColumn==0 && iTypeEq<0 ){
       iTypeEq = i;
     }else if( pC->iColumn==1 && iNameEq<0 ){
@@ -74,12 +75,12 @@ static int schemasBestIndex(sqlite3_vtab *pVtab, sqlite3_index_info *pInfo){
 
   if( iTypeEq>=0 ){
     pInfo->aConstraintUsage[iTypeEq].argvIndex = argvIdx++;
-    pInfo->aConstraintUsage[iTypeEq].omit = 1;
+    pInfo->aConstraintUsage[iTypeEq].omit = 0;
     idxNum |= SCHEMAS_IDX_TYPE_EQ;
   }
   if( iNameEq>=0 ){
     pInfo->aConstraintUsage[iNameEq].argvIndex = argvIdx++;
-    pInfo->aConstraintUsage[iNameEq].omit = 1;
+    pInfo->aConstraintUsage[iNameEq].omit = 0;
     idxNum |= SCHEMAS_IDX_NAME_EQ;
   }
 

--- a/src/doltlite_status.c
+++ b/src/doltlite_status.c
@@ -1280,7 +1280,8 @@ static int statusBestIndex(sqlite3_vtab *pVtab, sqlite3_index_info *pInfo){
     if( pC->op!=SQLITE_INDEX_CONSTRAINT_EQ ) continue;
     if( pC->iColumn==1 ){
       iStagedEq = i;
-    }else if( pC->iColumn==0 ){
+    }else if( pC->iColumn==0
+           && doltliteVtabConstraintIsBinary(pInfo, i) ){
       iTableEq = i;
     }
   }
@@ -1292,7 +1293,7 @@ static int statusBestIndex(sqlite3_vtab *pVtab, sqlite3_index_info *pInfo){
   }
   if( iTableEq>=0 ){
     pInfo->aConstraintUsage[iTableEq].argvIndex = argvIdx++;
-    pInfo->aConstraintUsage[iTableEq].omit = 1;
+    pInfo->aConstraintUsage[iTableEq].omit = 0;
     idxNum |= STATUS_IDX_TABLE_EQ;
   }
 

--- a/test/doltlite_dolt_table_pushdown.sh
+++ b/test/doltlite_dolt_table_pushdown.sh
@@ -161,6 +161,73 @@ run_test "nonint_history_filter_correct" \
 
 rm -f "$DB2"
 
+DB_COLLATION=/tmp/test_pushdown_collation_$$.db
+rm -f "$DB_COLLATION"
+echo "CREATE TABLE Foo(id INTEGER PRIMARY KEY, v TEXT);
+CREATE VIEW MyView AS SELECT * FROM Foo;
+INSERT INTO Foo VALUES(1,'a');
+SELECT dolt_commit('-A','-m','Seed');
+SELECT dolt_branch('Feature');
+SELECT dolt_tag('Release');
+SELECT dolt_remote('add','Origin','file:///tmp/origin');
+UPDATE Foo SET v='b' WHERE id=1;" | $DOLTLITE "$DB_COLLATION" > /dev/null 2>&1
+
+run_test_match "binary_name_equality_still_pushes" \
+  "EXPLAIN QUERY PLAN SELECT * FROM dolt_branches WHERE name='main';" \
+  "VIRTUAL TABLE INDEX 1" "$DB_COLLATION"
+run_test_match "nocase_name_equality_scans" \
+  "EXPLAIN QUERY PLAN SELECT * FROM dolt_branches WHERE name COLLATE NOCASE='MAIN';" \
+  "VIRTUAL TABLE INDEX 0" "$DB_COLLATION"
+run_test "branches_nocase_equality" \
+  "SELECT name FROM dolt_branches WHERE name COLLATE NOCASE='MAIN';" \
+  "main" "$DB_COLLATION"
+run_test "branches_rtrim_equality" \
+  "SELECT name FROM dolt_branches WHERE name COLLATE RTRIM='main   ';" \
+  "main" "$DB_COLLATION"
+run_test "tags_nocase_equality" \
+  "SELECT tag_name FROM dolt_tags WHERE tag_name COLLATE NOCASE='release';" \
+  "Release" "$DB_COLLATION"
+run_test "remotes_nocase_equality" \
+  "SELECT name FROM dolt_remotes WHERE name COLLATE NOCASE='origin';" \
+  "Origin" "$DB_COLLATION"
+run_test "status_table_nocase_equality" \
+  "SELECT table_name FROM dolt_status WHERE table_name COLLATE NOCASE='foo';" \
+  "Foo" "$DB_COLLATION"
+
+COLLATION_DIFF_COUNT=$(echo "SELECT count(*) FROM dolt_diff WHERE (table_name||'') COLLATE NOCASE='foo';" | $DOLTLITE "$DB_COLLATION")
+run_test "diff_table_nocase_equality" \
+  "SELECT count(*) FROM dolt_diff WHERE table_name COLLATE NOCASE='foo';" \
+  "$COLLATION_DIFF_COUNT" "$DB_COLLATION"
+run_test "schemas_name_nocase_equality" \
+  "SELECT name FROM dolt_schemas WHERE name COLLATE NOCASE='myview';" \
+  "MyView" "$DB_COLLATION"
+run_test "schemas_type_nocase_equality" \
+  "SELECT type FROM dolt_schemas WHERE type COLLATE NOCASE='VIEW';" \
+  "view" "$DB_COLLATION"
+run_test "patch_type_nocase_equality" \
+  "SELECT count(*) FROM dolt_patch('HEAD','WORKING') WHERE diff_type COLLATE NOCASE='DATA';" \
+  "1" "$DB_COLLATION"
+run_test "log_binary_uppercase_hash_rechecked" \
+  "SELECT count(*) FROM dolt_log WHERE commit_hash=upper((SELECT commit_hash FROM dolt_log LIMIT 1));" \
+  "0" "$DB_COLLATION"
+run_test "log_nocase_uppercase_hash" \
+  "SELECT count(*) FROM dolt_log WHERE commit_hash COLLATE NOCASE=upper((SELECT commit_hash FROM dolt_log LIMIT 1));" \
+  "1" "$DB_COLLATION"
+run_test "history_binary_uppercase_hash_rechecked" \
+  "SELECT count(*) FROM dolt_history_Foo WHERE commit_hash=upper((SELECT commit_hash FROM dolt_log LIMIT 1));" \
+  "0" "$DB_COLLATION"
+run_test "history_nocase_uppercase_hash" \
+  "SELECT count(*) FROM dolt_history_Foo WHERE commit_hash COLLATE NOCASE=upper((SELECT commit_hash FROM dolt_log LIMIT 1));" \
+  "1" "$DB_COLLATION"
+run_test "ancestors_binary_uppercase_hash_rechecked" \
+  "SELECT count(*) FROM dolt_commit_ancestors WHERE commit_hash=upper((SELECT commit_hash FROM dolt_log LIMIT 1));" \
+  "0" "$DB_COLLATION"
+run_test "ancestors_nocase_uppercase_hash" \
+  "SELECT count(*) FROM dolt_commit_ancestors WHERE commit_hash COLLATE NOCASE=upper((SELECT commit_hash FROM dolt_log LIMIT 1));" \
+  "1" "$DB_COLLATION"
+
+rm -f "$DB_COLLATION"
+
 # sqlite3_value_int64 reads NULL as 0; the pk=0 row is what would match by accident.
 DB3=/tmp/test_pushdown_null_$$.db
 rm -f "$DB3"


### PR DESCRIPTION
## Summary

- only push visible string equality constraints when SQLite reports BINARY collation
- keep BINARY fast paths while allowing SQLite to recheck their predicates
- fall back to SQLite evaluation for NOCASE and RTRIM across shared and bespoke VC metadata filters
- add fail-before coverage for branches, tags, remotes, status, diff, schemas, patch, log, history, and commit ancestors

## Validation

- `make -B -C build doltlite`
- `make lint`
- `bash test/doltlite_dolt_table_pushdown.sh build/doltlite` (66 passed)
- affected native branch/tag/diff/log/history suites (209 passed)
- affected Dolt oracle suites for branches, tags, remotes, status, schemas, log, history, commit ancestors, diff, and patch
- `test/run_doltlite_tests.sh` (113/113 suites; 310,930/310,930 C regression assertions)

Co-Authored-By: OpenAI Codex <noreply@openai.com>
