### PR TITLE
A table rename merges as a rename, not a drop plus a create

### DIFF
--- a/src/doltlite_merge_predetect.c
+++ b/src/doltlite_merge_predetect.c
@@ -781,7 +781,7 @@ static int mergePreNormalizeTableRename(
       SchemaEntry *pAncT = &aAncSchema[t];
       SchemaEntry *pNewT = 0;
       char *azPair[2];
-      int nCand = 0, bTrigger = 0;
+      int nCand = 0;
 
       if( !pAncT->zType || strcmp(pAncT->zType, "table")!=0 ) continue;
       if( !pAncT->zName || !pAncT->zSql ) continue;
@@ -807,17 +807,28 @@ static int mergePreNormalizeTableRename(
       }
       if( nCand!=1 || !pNewT ) continue;
 
-      /* Only a trigger the non-renaming side holds on the old name forces
-      ** this; everything else already merges as a drop plus a create. */
-      for(i=0; i<nOther && !bTrigger; i++){
-        if( aOther[i].zType && strcmp(aOther[i].zType, "trigger")==0
-         && aOther[i].zTblName
-         && sqlite3_stricmp(aOther[i].zTblName, pAncT->zName)==0
-         && !findSchemaEntry(aAncSchema, nAncSchema, aOther[i].zName) ){
-          bTrigger = 1;
+      /* The pairing must be bijective. If the new table's text also matches
+      ** another ancestor table this side no longer has, tables with equal
+      ** column lists make the rename ambiguous — a dropped table could be
+      ** claimed by an unrelated rename — so it stays a drop plus a create. */
+      {
+        int bAmbiguous = 0;
+        for(i=0; i<nAncSchema && !bAmbiguous; i++){
+          char *azProbe[2];
+          SchemaEntry *pOtherAnc = &aAncSchema[i];
+          if( pOtherAnc==pAncT ) continue;
+          if( !pOtherAnc->zType || strcmp(pOtherAnc->zType, "table")!=0 ) continue;
+          if( !pOtherAnc->zName || !pOtherAnc->zSql ) continue;
+          if( findSchemaEntry(aSide, nSide, pOtherAnc->zName) ) continue;
+          azProbe[0] = pOtherAnc->zName;
+          azProbe[1] = pNewT->zName;
+          if( mergeTextsEqualModuloRenames(pOtherAnc->zSql, pNewT->zSql,
+                                           azProbe, 2) ){
+            bAmbiguous = 1;
+          }
         }
+        if( bAmbiguous ) continue;
       }
-      if( !bTrigger ) continue;
 
       azPair[0] = pAncT->zName;
       azPair[1] = pNewT->zName;

--- a/test/doltlite_schema_merge.sh
+++ b/test/doltlite_schema_merge.sh
@@ -1589,7 +1589,8 @@ EOF
   rm -f "$DB"
 done
 
-# Ancestor trigger rides the rename; this conflict is table-rename vs row-change, not a trigger refusal.
+# A table rename composes with the other side's row change: the rows land
+# in the renamed table and the ancestor trigger rides along.
 DB=/tmp/test_merge_trig_ancestor_$$.db; rm -f "$DB"
 cat <<'EOF' | $DOLTLITE "$DB" > /dev/null 2>&1
 CREATE TABLE t(k INTEGER PRIMARY KEY, a TEXT, n INTEGER);
@@ -1604,8 +1605,12 @@ SELECT dolt_checkout('main');
 ALTER TABLE t RENAME TO t2;
 SELECT dolt_commit('-Am','main renames');
 EOF
-run_test_match "merge_ancestor_trigger_not_refused_for_rename" \
-  "SELECT dolt_merge('feat');" "conflicts detected" "$DB"
+run_test_match "merge_ancestor_trigger_rename_composes" \
+  "SELECT dolt_merge('feat');" "^[0-9a-f]{40}$" "$DB"
+run_test "merge_ancestor_trigger_rename_rows" \
+  "SELECT group_concat(k) FROM (SELECT k FROM t2 ORDER BY k);" "1,7" "$DB"
+run_test "merge_ancestor_trigger_rename_trigger" \
+  "SELECT tbl_name FROM sqlite_master WHERE type='trigger';" "t2" "$DB"
 rm -f "$DB"
 
 # View over a renamed table stays as text; catalog still loads.
@@ -2262,5 +2267,97 @@ EOF
      SELECT count(*) FROM sqlite_master WHERE type='trigger';" "0" "$DB"
   rm -f "$DB"
 done
+
+# A pure table rename is a rename, not a drop plus a create: the other
+# side's row and schema changes land in the renamed table. Dolt conflicts
+# here (it sees a drop), a deliberate divergence.
+for dir in ours theirs; do
+  DB=/tmp/test_merge_ren_tbl_rows_${dir}_$$.db; rm -f "$DB"
+  if [ "$dir" = ours ]; then MAIN="ALTER TABLE t RENAME TO t9;"; FEAT="UPDATE t SET n=11 WHERE k=1; INSERT INTO t VALUES(2,'b',20);"
+  else MAIN="UPDATE t SET n=11 WHERE k=1; INSERT INTO t VALUES(2,'b',20);"; FEAT="ALTER TABLE t RENAME TO t9;"; fi
+  cat <<EOF | $DOLTLITE "$DB" > /dev/null 2>&1
+CREATE TABLE t(k INTEGER PRIMARY KEY, a TEXT, n INTEGER);
+INSERT INTO t VALUES(1,'a1',10);
+SELECT dolt_commit('-Am','base');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+$FEAT
+SELECT dolt_commit('-Am','feat side');
+SELECT dolt_checkout('main');
+$MAIN
+SELECT dolt_commit('-Am','main side');
+EOF
+  run_test_match "merge_table_rename_composes_rows_${dir}_merges" \
+    "SELECT dolt_merge('feat');" "^[0-9a-f]{40}$" "$DB"
+  run_test "merge_table_rename_composes_rows_${dir}_data" \
+    "SELECT group_concat(k||':'||n) FROM (SELECT k,n FROM t9 ORDER BY k);" \
+    "1:11,2:20" "$DB"
+  run_test "merge_table_rename_composes_rows_${dir}_integrity" \
+    "PRAGMA integrity_check;" "ok" "$DB"
+  rm -f "$DB"
+done
+
+# Rename plus row edit on one side, row insert on the other: full compose.
+DB=/tmp/test_merge_ren_tbl_bothedit_$$.db; rm -f "$DB"
+cat <<'EOF' | $DOLTLITE "$DB" > /dev/null 2>&1
+CREATE TABLE t(k INTEGER PRIMARY KEY, a TEXT, n INTEGER);
+INSERT INTO t VALUES(1,'a1',10);
+SELECT dolt_commit('-Am','base');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+INSERT INTO t VALUES(3,'c',30);
+SELECT dolt_commit('-Am','feat inserts');
+SELECT dolt_checkout('main');
+ALTER TABLE t RENAME TO t9;
+UPDATE t9 SET a='x1' WHERE k=1;
+SELECT dolt_commit('-Am','main renames and edits');
+EOF
+run_test_match "merge_table_rename_and_edit_composes" \
+  "SELECT dolt_merge('feat');" "^[0-9a-f]{40}$" "$DB"
+run_test "merge_table_rename_and_edit_data" \
+  "SELECT group_concat(k||':'||a) FROM (SELECT k,a FROM t9 ORDER BY k);" \
+  "1:x1,3:c" "$DB"
+rm -f "$DB"
+
+# Schema changes compose across the rename too.
+DB=/tmp/test_merge_ren_tbl_addcol_$$.db; rm -f "$DB"
+cat <<'EOF' | $DOLTLITE "$DB" > /dev/null 2>&1
+CREATE TABLE t(k INTEGER PRIMARY KEY, a TEXT, n INTEGER);
+INSERT INTO t VALUES(1,'a1',10);
+SELECT dolt_commit('-Am','base');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+ALTER TABLE t ADD COLUMN x TEXT;
+SELECT dolt_commit('-Am','feat adds column');
+SELECT dolt_checkout('main');
+ALTER TABLE t RENAME TO t9;
+SELECT dolt_commit('-Am','main renames');
+EOF
+run_test_match "merge_table_rename_addcol_composes" \
+  "SELECT dolt_merge('feat');" "^[0-9a-f]{40}$" "$DB"
+run_test "merge_table_rename_addcol_schema" \
+  "SELECT group_concat(name) FROM pragma_table_info('t9');" "k,a,n,x" "$DB"
+rm -f "$DB"
+
+# Renames to two different names stay a drop plus two creates, as before.
+DB=/tmp/test_merge_dual_tbl_rename_$$.db; rm -f "$DB"
+cat <<'EOF' | $DOLTLITE "$DB" > /dev/null 2>&1
+CREATE TABLE t(k INTEGER PRIMARY KEY, a TEXT, n INTEGER);
+INSERT INTO t VALUES(1,'a1',10);
+SELECT dolt_commit('-Am','base');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+ALTER TABLE t RENAME TO t8;
+SELECT dolt_commit('-Am','feat renames to t8');
+SELECT dolt_checkout('main');
+ALTER TABLE t RENAME TO t9;
+SELECT dolt_commit('-Am','main renames to t9');
+EOF
+run_test_match "merge_dual_table_rename_merges" \
+  "SELECT dolt_merge('feat');" "^[0-9a-f]{40}$" "$DB"
+run_test "merge_dual_table_rename_objects" \
+  "SELECT group_concat(name) FROM (SELECT name FROM sqlite_master WHERE type='table' ORDER BY name);" \
+  "t8,t9" "$DB"
+rm -f "$DB"
 
 dltest_finish

--- a/test/vc_oracle_correct_schema_merge_matrix_test.sh
+++ b/test/vc_oracle_correct_schema_merge_matrix_test.sh
@@ -24,6 +24,64 @@ REFUSE_WHERE_DOLT_MERGES="
 MERGE_WHERE_DOLT_REFUSES="
 "
 
+# Merge while Dolt conflicts, by decree: a pure table rename is a rename,
+# not a drop plus a create, so the other side's changes compose with it.
+# Dolt cannot tell the two apart (dolthub/dolt#2016-class) and conflicts.
+MERGE_WHERE_DOLT_CONFLICTS_BY_DECREE="
+add_d:ren_tbl:a table rename composes with the other side, where Dolt sees a drop and conflicts
+bidx:drop_b:ren_tbl:a table rename composes with the other side, where Dolt sees a drop and conflicts
+bidx:ren_a:ren_tbl:a table rename composes with the other side, where Dolt sees a drop and conflicts
+bidx:ren_b:ren_tbl:a table rename composes with the other side, where Dolt sees a drop and conflicts
+bidx:ren_tbl:drop_b:a table rename composes with the other side, where Dolt sees a drop and conflicts
+bidx:ren_tbl:ren_a:a table rename composes with the other side, where Dolt sees a drop and conflicts
+bidx:ren_tbl:ren_b:a table rename composes with the other side, where Dolt sees a drop and conflicts
+bidx:ren_tbl:rows:a table rename composes with the other side, where Dolt sees a drop and conflicts
+bidx:rows:ren_tbl:a table rename composes with the other side, where Dolt sees a drop and conflicts
+btrig:drop_b:ren_tbl:a table rename composes with the other side, where Dolt sees a drop and conflicts
+btrig:idx_a:ren_tbl:a table rename composes with the other side, where Dolt sees a drop and conflicts
+btrig:ren_a:ren_tbl:a table rename composes with the other side, where Dolt sees a drop and conflicts
+btrig:ren_b:ren_tbl:a table rename composes with the other side, where Dolt sees a drop and conflicts
+btrig:ren_tbl:drop_b:a table rename composes with the other side, where Dolt sees a drop and conflicts
+btrig:ren_tbl:idx_a:a table rename composes with the other side, where Dolt sees a drop and conflicts
+btrig:ren_tbl:ren_a:a table rename composes with the other side, where Dolt sees a drop and conflicts
+btrig:ren_tbl:ren_b:a table rename composes with the other side, where Dolt sees a drop and conflicts
+btrig:ren_tbl:rows:a table rename composes with the other side, where Dolt sees a drop and conflicts
+btrig:rows:ren_tbl:a table rename composes with the other side, where Dolt sees a drop and conflicts
+bview:drop_b:ren_tbl:a table rename composes with the other side, where Dolt sees a drop and conflicts
+bview:idx_a:ren_tbl:a table rename composes with the other side, where Dolt sees a drop and conflicts
+bview:ren_a:ren_tbl:a table rename composes with the other side, where Dolt sees a drop and conflicts
+bview:ren_b:ren_tbl:a table rename composes with the other side, where Dolt sees a drop and conflicts
+bview:ren_tbl:drop_b:a table rename composes with the other side, where Dolt sees a drop and conflicts
+bview:ren_tbl:idx_a:a table rename composes with the other side, where Dolt sees a drop and conflicts
+bview:ren_tbl:ren_a:a table rename composes with the other side, where Dolt sees a drop and conflicts
+bview:ren_tbl:ren_b:a table rename composes with the other side, where Dolt sees a drop and conflicts
+bview:ren_tbl:rows:a table rename composes with the other side, where Dolt sees a drop and conflicts
+bview:rows:ren_tbl:a table rename composes with the other side, where Dolt sees a drop and conflicts
+drop_a:ren_tbl:a table rename composes with the other side, where Dolt sees a drop and conflicts
+drop_b_with_index:ren_tbl:a table rename composes with the other side, where Dolt sees a drop and conflicts
+drop_b:ren_tbl:a table rename composes with the other side, where Dolt sees a drop and conflicts
+idx_a:ren_tbl:a table rename composes with the other side, where Dolt sees a drop and conflicts
+idx_b:ren_tbl:a table rename composes with the other side, where Dolt sees a drop and conflicts
+ins:ren_tbl:a table rename composes with the other side, where Dolt sees a drop and conflicts
+ren_a:ren_tbl:a table rename composes with the other side, where Dolt sees a drop and conflicts
+ren_b_view:ren_tbl:a table rename composes with the other side, where Dolt sees a drop and conflicts
+ren_b:ren_tbl:a table rename composes with the other side, where Dolt sees a drop and conflicts
+ren_tbl:add_d:a table rename composes with the other side, where Dolt sees a drop and conflicts
+ren_tbl:drop_a:a table rename composes with the other side, where Dolt sees a drop and conflicts
+ren_tbl:drop_b:a table rename composes with the other side, where Dolt sees a drop and conflicts
+ren_tbl:drop_b_with_index:a table rename composes with the other side, where Dolt sees a drop and conflicts
+ren_tbl:idx_a:a table rename composes with the other side, where Dolt sees a drop and conflicts
+ren_tbl:idx_b:a table rename composes with the other side, where Dolt sees a drop and conflicts
+ren_tbl:ins:a table rename composes with the other side, where Dolt sees a drop and conflicts
+ren_tbl:ren_a:a table rename composes with the other side, where Dolt sees a drop and conflicts
+ren_tbl:ren_b:a table rename composes with the other side, where Dolt sees a drop and conflicts
+ren_tbl:ren_b_view:a table rename composes with the other side, where Dolt sees a drop and conflicts
+ren_tbl:rows:a table rename composes with the other side, where Dolt sees a drop and conflicts
+ren_tbl:uniq_b:a table rename composes with the other side, where Dolt sees a drop and conflicts
+rows:ren_tbl:a table rename composes with the other side, where Dolt sees a drop and conflicts
+uniq_b:ren_tbl:a table rename composes with the other side, where Dolt sees a drop and conflicts
+"
+
 # "disk image is malformed" is never an acceptable refusal; listed so rot is visible.
 CORRUPT_TODAY="
 "
@@ -271,6 +329,11 @@ EOF
   fi
 
   if [ "$dl_ok" = 1 ] && [ "$dt_ok" = 0 ]; then
+    reason=$(printf '%s\n' "$MERGE_WHERE_DOLT_CONFLICTS_BY_DECREE" | grep "^$key:" | cut -d: -f3-)
+    if [ -n "$reason" ]; then
+      pass_name "$name (merges by decree: $reason)"
+      return
+    fi
     reason=$(printf '%s\n' "$MERGE_WHERE_DOLT_REFUSES" | grep "^$key:" | cut -d: -f3-)
     if [ -n "$reason" ]; then
       gaps=$((gaps+1)); GAP_NAMES="$GAP_NAMES $name"
@@ -284,6 +347,10 @@ EOF
   if [ "$dl_ok" = 0 ] && [ "$dt_ok" = 0 ]; then
     if printf '%s\n' "$MERGE_WHERE_DOLT_REFUSES" | grep -q "^$key:"; then
       fail_name "$name (listed as a gap but we no longer merge -- delete the entry)"
+      return
+    fi
+    if printf '%s\n' "$MERGE_WHERE_DOLT_CONFLICTS_BY_DECREE" | grep -q "^$key:"; then
+      fail_name "$name (listed as merging by decree but refuses -- delete the entry)"
       return
     fi
     pass_name "$name (both refuse)"
@@ -306,6 +373,10 @@ EOF
   fi
   if printf '%s\n' "$MERGE_WHERE_DOLT_REFUSES" | grep -q "^$key:"; then
     fail_name "$name (listed as a gap but Dolt merges it too -- delete the entry)"
+    return
+  fi
+  if printf '%s\n' "$MERGE_WHERE_DOLT_CONFLICTS_BY_DECREE" | grep -q "^$key:"; then
+    fail_name "$name (listed as merging by decree but Dolt merges it too -- delete the entry)"
     return
   fi
 


### PR DESCRIPTION
The second dangler: the un-rename-and-replay path from #2363 ran only when a trigger forced it. Every other table rename merged as a drop plus a create, so the other side's changes died in a spurious conflict. This removes the gate: **every pure table rename now composes** — row edits and inserts from the other side land in the renamed table, column adds/renames carry across, and indexes, views and triggers follow, in both directions.

```
base:   t(k,a,n) = {1}          base:   t(k,a,n) with trigger, index
ours:   RENAME t TO t9, edit    ours:   RENAME t TO t9
theirs: INSERT row 3            theirs: DROP COLUMN b / ADD COLUMN / edit rows
→ t9 with both changes          → t9 with the schema change composed, dependents following
```

## Deliberate divergence, at its strongest

Dolt cannot tell a rename from a drop (dolthub/dolt#2016-class) and **conflicts on every such pair** — so did we, until now. 52 matrix pairs move to a new `MERGE_WHERE_DOLT_CONFLICTS_BY_DECREE` list: scored as passes with the reason printed, policed for staleness in both directions like the other lists. This is the git model: a rename composes with content edits.

## The hazard the gate was masking

Widening the detection exposed a real pairing bug: with tables of identical column lists (`a(id,payload)` and `c(id,payload)`), a **dropped** table could be text-matched as the rename source of an unrelated new table, silently swallowing the conflict that was protecting it — caught by `index_on_excluded_rename_is_not_adopted` in the index-conflict suite. The pairing is now **bijective**: a new table whose text matches more than one vanished ancestor table stays a drop plus a create. Fail-before/pass-after on that suite (33/34 → 34/34).

Unchanged on purpose: renames to two different names still merge as one drop and two creates (verified byte-identical to master), rename-vs-drop likewise, and replays are untouched (the pass only runs where action plumbing exists).

## Verification

| check | result |
| --- | --- |
| `vc_oracle_correct_schema_merge_matrix_test.sh` vs Dolt | **264 passed, 0 failed, 0 gaps, 0 differing, 0 corrupting**; all 52 decree entries exercised |
| `doltlite_schema_merge.sh` | 386 passed, 0 failed (new: composes-rows both directions, rename+edit compose, addcol compose, dual-rename control) |
| `doltlite_merge_index_conflict.sh` | 34 passed (the suite that caught the pairing hazard) |
| `doltlite_index_vc_matrix.sh` | 49 passed |
| `run_doltlite_tests.sh` | 112 suites passed |
| stateful vc fuzzer | seed 1787347777, 2683 steps clean |
| lint / amalgamation | pass; compiles under CI's warning flags |

Also verified along the way: the "resurrection" my first spot-check appeared to find was a harness artifact — stock SQLite refuses `DROP COLUMN` on an indexed column, so the setup had silently failed; the matrix's setup-rejection detector already handles that class correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)