### PR TITLE
Preserve SQLite affinity in staged filters

### DIFF
--- a/src/doltlite_at.c
+++ b/src/doltlite_at.c
@@ -22,7 +22,8 @@ static char *atBuildSchema(const DoltliteColInfo *ci){
   char *z;
   if( !pStr ) return 0;
   sqlite3_str_appendall(pStr, "CREATE TABLE x(");
-  if( doltliteAppendQuotedColumnList(pStr, ci->azName, ci->nCol, 0, 0)!=SQLITE_OK ){
+  if( doltliteAppendIntegerPkColumnList(pStr, ci->azName, ci->nCol,
+                                        ci->iPkCol)!=SQLITE_OK ){
     sqlite3_str_reset(pStr);
     return 0;
   }

--- a/src/doltlite_blame.c
+++ b/src/doltlite_blame.c
@@ -202,9 +202,15 @@ static void blameFreePkColumns(char **azNames, int *aColIdx, int nCols){
 static char *blameBuildSchema(BlameVtab *v){
   sqlite3_str *pStr = sqlite3_str_new(0);
   char *z;
+  int i;
+  int iIntPk = -1;
   if( !pStr ) return 0;
+  for(i=0; i<v->nPkCols; i++){
+    if( v->aPkColIdx[i]==v->intPkCid ) iIntPk = i;
+  }
   sqlite3_str_appendall(pStr, "CREATE TABLE x(");
-  if( doltliteAppendQuotedColumnList(pStr, v->azPkNames, v->nPkCols, 0, 0)!=SQLITE_OK ){
+  if( doltliteAppendIntegerPkColumnList(pStr, v->azPkNames, v->nPkCols,
+                                        iIntPk)!=SQLITE_OK ){
     sqlite3_str_reset(pStr);
     return 0;
   }

--- a/src/doltlite_history.c
+++ b/src/doltlite_history.c
@@ -12,7 +12,8 @@ static char *htBuildSchema(const DoltliteColInfo *ci){
   char *z;
   if( !pStr ) return 0;
   sqlite3_str_appendall(pStr, "CREATE TABLE x(");
-  if( doltliteAppendQuotedColumnList(pStr, ci->azName, ci->nCol, 0, 0)!=SQLITE_OK ){
+  if( doltliteAppendIntegerPkColumnList(pStr, ci->azName, ci->nCol,
+                                        ci->iPkCol)!=SQLITE_OK ){
     sqlite3_str_reset(pStr);
     return 0;
   }

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -392,7 +392,7 @@ static SQLITE_INLINE int doltliteBestIndexIntPkRange(
   return SQLITE_OK;
 }
 
-static SQLITE_INLINE int doltlitePkRangeIntArg(
+static SQLITE_INLINE int doltliteExactInt64Arg(
   sqlite3_value *pArg,
   i64 *pValue
 ){
@@ -420,7 +420,7 @@ static SQLITE_INLINE void doltlitePkRangeFromArgs(
 
   if( idxNum & idxEq ){
     if( iArg < argc ){
-      eArg = doltlitePkRangeIntArg(argv[iArg++], &v);
+      eArg = doltliteExactInt64Arg(argv[iArg++], &v);
       if( eArg<0 ){
         pRange->isEmpty = 1;
         return;
@@ -433,7 +433,7 @@ static SQLITE_INLINE void doltlitePkRangeFromArgs(
   }else{
     if( idxNum & idxGe ){
       if( iArg < argc ){
-        eArg = doltlitePkRangeIntArg(argv[iArg++], &v);
+        eArg = doltliteExactInt64Arg(argv[iArg++], &v);
         if( eArg<0 ){
           pRange->isEmpty = 1;
           return;
@@ -447,7 +447,7 @@ static SQLITE_INLINE void doltlitePkRangeFromArgs(
     }
     if( idxNum & idxGt ){
       if( iArg < argc ){
-        eArg = doltlitePkRangeIntArg(argv[iArg++], &v);
+        eArg = doltliteExactInt64Arg(argv[iArg++], &v);
         if( eArg<0 ){
           pRange->isEmpty = 1;
           return;
@@ -463,7 +463,7 @@ static SQLITE_INLINE void doltlitePkRangeFromArgs(
     }
     if( idxNum & idxLe ){
       if( iArg < argc ){
-        eArg = doltlitePkRangeIntArg(argv[iArg++], &v);
+        eArg = doltliteExactInt64Arg(argv[iArg++], &v);
         if( eArg<0 ){
           pRange->isEmpty = 1;
           return;
@@ -477,7 +477,7 @@ static SQLITE_INLINE void doltlitePkRangeFromArgs(
     }
     if( idxNum & idxLt ){
       if( iArg < argc ){
-        eArg = doltlitePkRangeIntArg(argv[iArg++], &v);
+        eArg = doltliteExactInt64Arg(argv[iArg++], &v);
         if( eArg<0 ){
           pRange->isEmpty = 1;
           return;

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -622,6 +622,21 @@ static SQLITE_INLINE int doltliteAppendQuotedColumnList(
   return sqlite3_str_errcode(pStr);
 }
 
+static SQLITE_INLINE int doltliteAppendIntegerPkColumnList(
+  sqlite3_str *pStr,
+  char *const *azName,
+  int nName,
+  int iIntegerPk
+){
+  int i;
+  for(i=0; i<nName; i++){
+    if( i>0 ) sqlite3_str_appendall(pStr, ", ");
+    sqlite3_str_appendf(pStr, "\"%w\"%s", azName[i],
+                        i==iIntegerPk ? " INTEGER" : "");
+  }
+  return sqlite3_str_errcode(pStr);
+}
+
 static SQLITE_INLINE void doltliteFreeStringArray(char **az, int n){
   int i;
   if( !az ) return;

--- a/src/doltlite_status.c
+++ b/src/doltlite_status.c
@@ -1133,6 +1133,8 @@ static int statusFilter(sqlite3_vtab_cursor *pCursor,
   int headLoaded = 0;
   int stagedLoaded = 0;
   int workingLoaded = 0;
+  int eStagedArg;
+  i64 stagedArg;
   (void)idxStr;
 
   statusFreeRows(pCur);
@@ -1143,10 +1145,12 @@ static int statusFilter(sqlite3_vtab_cursor *pCursor,
   memset(&baseCatHash, 0, sizeof(baseCatHash));
   if( idxNum & STATUS_IDX_STAGED_EQ ){
     if( iArg>=argc ) return SQLITE_OK;
-    /* NULL sqlite3_value_int is 0, which would become staged=0 for an impossible constraint. */
-    if( sqlite3_value_type(argv[iArg])==SQLITE_NULL ) return SQLITE_OK;
-    iStagedOnly = sqlite3_value_int(argv[iArg++]);
-    if( iStagedOnly!=0 && iStagedOnly!=1 ) return SQLITE_OK;
+    eStagedArg = doltliteExactInt64Arg(argv[iArg++], &stagedArg);
+    if( eStagedArg<0 ) return SQLITE_OK;
+    if( eStagedArg>0 ){
+      if( stagedArg!=0 && stagedArg!=1 ) return SQLITE_OK;
+      iStagedOnly = (int)stagedArg;
+    }
   }
   if( idxNum & STATUS_IDX_TABLE_EQ ){
     if( iArg>=argc ) return SQLITE_OK;
@@ -1288,7 +1292,7 @@ static int statusBestIndex(sqlite3_vtab *pVtab, sqlite3_index_info *pInfo){
 
   if( iStagedEq>=0 ){
     pInfo->aConstraintUsage[iStagedEq].argvIndex = argvIdx++;
-    pInfo->aConstraintUsage[iStagedEq].omit = 1;
+    pInfo->aConstraintUsage[iStagedEq].omit = 0;
     idxNum |= STATUS_IDX_STAGED_EQ;
   }
   if( iTableEq>=0 ){

--- a/src/doltlite_workspace.c
+++ b/src/doltlite_workspace.c
@@ -428,6 +428,8 @@ static int wsFilter(sqlite3_vtab_cursor *cur,
   WorkspaceCursor *c = (WorkspaceCursor*)cur;
   WorkspaceVtab *p = (WorkspaceVtab*)cur->pVtab;
   int rc;
+  int eStagedArg;
+  i64 stagedArg;
   (void)idxStr;
   wsCloseIter(c);
   wsClearSides(c);
@@ -445,11 +447,12 @@ static int wsFilter(sqlite3_vtab_cursor *cur,
   c->stagedOnly = -1;
   if( idxNum & WS_IDX_STAGED_EQ ){
     if( argc<1 ) return SQLITE_OK;
-    c->stagedOnly = sqlite3_value_int(argv[0]);
-    if( c->stagedOnly!=0 && c->stagedOnly!=1 ){
+    eStagedArg = doltliteExactInt64Arg(argv[0], &stagedArg);
+    if( eStagedArg<0 || (eStagedArg>0 && stagedArg!=0 && stagedArg!=1) ){
       c->eof = 1;
       return SQLITE_OK;
     }
+    if( eStagedArg>0 ) c->stagedOnly = (int)stagedArg;
   }
   rc = wsInitCursorRoots(c, p);
   if( rc!=SQLITE_OK ) return rc;

--- a/test/doltlite_dolt_table_pushdown.sh
+++ b/test/doltlite_dolt_table_pushdown.sh
@@ -232,12 +232,16 @@ rm -f "$DB_COLLATION"
 DB3=/tmp/test_pushdown_null_$$.db
 rm -f "$DB3"
 echo "CREATE TABLE t(pk INTEGER PRIMARY KEY, v TEXT);
+CREATE TABLE s(pk INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(0,'zero');
 INSERT INTO t VALUES(1,'one');
+INSERT INTO s VALUES(1,'one');
 SELECT dolt_commit('-A','-m','init');
 UPDATE t SET v='changed' WHERE pk=1;
 SELECT dolt_commit('-A','-m','c2');
-UPDATE t SET v='dirty' WHERE pk=0;" | $DOLTLITE "$DB3" > /dev/null 2>&1
+UPDATE t SET v='dirty' WHERE pk=0;
+UPDATE s SET v='staged' WHERE pk=1;
+SELECT dolt_add('s');" | $DOLTLITE "$DB3" > /dev/null 2>&1
 
 run_test "null_pk_eq_at_empty" \
   "SELECT count(*) FROM dolt_at_t WHERE commit_ref='HEAD' AND pk=NULL;" "0" "$DB3"
@@ -266,6 +270,26 @@ run_test "pk_ge_zero_still_matches" \
   "SELECT count(*) FROM dolt_history_t WHERE pk>=0;" "4" "$DB3"
 run_test "staged_zero_still_matches" \
   "SELECT count(*) FROM dolt_status WHERE staged=0;" "1" "$DB3"
+run_test "staged_one_still_matches" \
+  "SELECT count(*) FROM dolt_status WHERE staged=1;" "1" "$DB3"
+run_test "staged_numeric_text_zero_matches" \
+  "SELECT table_name FROM dolt_status WHERE staged='0';" "t" "$DB3"
+run_test "staged_numeric_text_one_matches" \
+  "SELECT table_name FROM dolt_status WHERE staged='1';" "s" "$DB3"
+run_test "staged_integral_real_zero_matches" \
+  "SELECT table_name FROM dolt_status WHERE staged=0.0;" "t" "$DB3"
+run_test "staged_integral_real_one_matches" \
+  "SELECT table_name FROM dolt_status WHERE staged=1.0;" "s" "$DB3"
+run_test "staged_nonnumeric_text_empty" \
+  "SELECT count(*) FROM dolt_status WHERE staged='abc';" "0" "$DB3"
+run_test "staged_fractional_zero_side_empty" \
+  "SELECT count(*) FROM dolt_status WHERE staged=0.5;" "0" "$DB3"
+run_test "staged_fractional_one_side_empty" \
+  "SELECT count(*) FROM dolt_status WHERE staged=1.5;" "0" "$DB3"
+run_test "staged_blob_empty" \
+  "SELECT count(*) FROM dolt_status WHERE staged=x'00';" "0" "$DB3"
+run_test "staged_out_of_domain_empty" \
+  "SELECT count(*) FROM dolt_status WHERE staged=2;" "0" "$DB3"
 run_test "table_name_named_still_matches" \
   "SELECT count(*) FROM dolt_diff WHERE table_name='t';" "3" "$DB3"
 

--- a/test/doltlite_dolt_table_pushdown.sh
+++ b/test/doltlite_dolt_table_pushdown.sh
@@ -409,11 +409,20 @@ run_test "history_numeric_text_range_still_matches" \
 run_test "history_integral_real_equality_matches" \
   "SELECT group_concat(pk, ',') FROM dolt_history_t WHERE pk=5.0;" \
   "5" "$DB6"
+run_test "history_numeric_text_equality_matches" \
+  "SELECT group_concat(pk, ',') FROM dolt_history_t WHERE pk='5';" \
+  "5" "$DB6"
 run_test "blame_integral_real_equality_matches" \
   "SELECT group_concat(pk, ',') FROM dolt_blame_t WHERE pk=5.0;" \
   "5" "$DB6"
+run_test "blame_numeric_text_equality_matches" \
+  "SELECT group_concat(pk, ',') FROM dolt_blame_t WHERE pk='5';" \
+  "5" "$DB6"
 run_test "at_integral_real_equality_matches" \
   "SELECT group_concat(pk, ',') FROM dolt_at_t WHERE commit_ref='HEAD' AND pk=5.0;" \
+  "5" "$DB6"
+run_test "at_numeric_text_equality_matches" \
+  "SELECT group_concat(pk, ',') FROM dolt_at_t WHERE commit_ref='HEAD' AND pk='5';" \
   "5" "$DB6"
 
 rm -f "$DB6"

--- a/test/doltlite_workspace.sh
+++ b/test/doltlite_workspace.sh
@@ -212,6 +212,32 @@ run_test "workspace_stage_one_row" \
   "UPDATE dolt_workspace_t SET staged=1 WHERE id=1;
    SELECT group_concat(id || ':' || staged, ' ') FROM dolt_workspace_t;" \
   "1:1 2:0 3:0" "$MC_DB"
+run_test "workspace_staged_numeric_text_zero" \
+  "SELECT group_concat(to_pk || ':' || staged, ' ')
+     FROM (SELECT to_pk, staged FROM dolt_workspace_t WHERE staged='0' ORDER BY to_pk);" \
+  "2:0 3:0" "$MC_DB"
+run_test "workspace_staged_numeric_text_one" \
+  "SELECT group_concat(to_pk || ':' || staged, ' ')
+     FROM (SELECT to_pk, staged FROM dolt_workspace_t WHERE staged='1' ORDER BY to_pk);" \
+  "1:1" "$MC_DB"
+run_test "workspace_staged_integral_real_zero" \
+  "SELECT group_concat(to_pk || ':' || staged, ' ')
+     FROM (SELECT to_pk, staged FROM dolt_workspace_t WHERE staged=0.0 ORDER BY to_pk);" \
+  "2:0 3:0" "$MC_DB"
+run_test "workspace_staged_integral_real_one" \
+  "SELECT group_concat(to_pk || ':' || staged, ' ')
+     FROM (SELECT to_pk, staged FROM dolt_workspace_t WHERE staged=1.0 ORDER BY to_pk);" \
+  "1:1" "$MC_DB"
+run_test "workspace_staged_nonnumeric_text_empty" \
+  "SELECT count(*) FROM dolt_workspace_t WHERE staged='abc';" "0" "$MC_DB"
+run_test "workspace_staged_fractional_zero_side_empty" \
+  "SELECT count(*) FROM dolt_workspace_t WHERE staged=0.5;" "0" "$MC_DB"
+run_test "workspace_staged_fractional_one_side_empty" \
+  "SELECT count(*) FROM dolt_workspace_t WHERE staged=1.5;" "0" "$MC_DB"
+run_test "workspace_staged_blob_empty" \
+  "SELECT count(*) FROM dolt_workspace_t WHERE staged=x'00';" "0" "$MC_DB"
+run_test "workspace_staged_null_empty" \
+  "SELECT count(*) FROM dolt_workspace_t WHERE staged=NULL;" "0" "$MC_DB"
 run_test "workspace_delete_via_filtered_rowid" \
   "DELETE FROM dolt_workspace_t
      WHERE id=(SELECT id FROM dolt_workspace_t WHERE staged=0 LIMIT 1);


### PR DESCRIPTION
## Summary

- share exact integer argument classification between primary-key and staged-value pushdown
- narrow `dolt_status` and `dolt_workspace_*` scans only for exact `0` and `1` values
- keep SQLite's equality recheck so fractional, nonnumeric text, and BLOB constraints cannot fabricate matches
- preserve INTEGER affinity for true integer-primary-key aliases in `dolt_history_*`, `dolt_at_*`, and `dolt_blame_*`
- cover staged filters and historical numeric-text lookups with regressions

## Fail-before

An unstaged `dolt_status` row was incorrectly returned for `staged='abc'`, `staged=0.5`, and `staged=x'00'`; the equivalent one-side fractional case also failed for a staged row.

Ito additionally found that `id='1'` missed rows returned by `id=1` in historical views. The generated virtual schemas lacked the INTEGER affinity needed by SQLite's residual equality recheck.

## Validation

- `make -B -C build doltlite`
- `make lint`
- `test/doltlite_dolt_table_pushdown.sh` (90 passed)
- native history, point-in-time, and workspace suites (141 passed)
- Dolt history, point-in-time, blame, status, and workspace oracles (173 passed)
- `test/run_doltlite_tests.sh` (113/113 suites; 310,930/310,930 C regression assertions)

Co-Authored-By: OpenAI Codex <noreply@openai.com>
