### PR TITLE
Honor sqlite_dbpage schema selection

### DIFF
--- a/src/doltlite_dbpage.c
+++ b/src/doltlite_dbpage.c
@@ -121,24 +121,25 @@ static int dlDbpageBestIndex(sqlite3_vtab *pVtab, sqlite3_index_info *pInfo){
   (void)pVtab;
 
   for(i=0; i<pInfo->nConstraint; i++){
-    if( !pInfo->aConstraint[i].usable ) continue;
     if( pInfo->aConstraint[i].op!=SQLITE_INDEX_CONSTRAINT_EQ ) continue;
-    if( pInfo->aConstraint[i].iColumn==0 && iPgno<0 ){
+    if( pInfo->aConstraint[i].iColumn==2 ){
+      if( !pInfo->aConstraint[i].usable ) return SQLITE_CONSTRAINT;
+      if( iSchema<0 ) iSchema = i;
+    }else if( pInfo->aConstraint[i].usable
+           && pInfo->aConstraint[i].iColumn==0 && iPgno<0 ){
       iPgno = i;
-    }else if( pInfo->aConstraint[i].iColumn==2 && iSchema<0 ){
-      iSchema = i;
     }
   }
 
-  if( iPgno>=0 ){
-    pInfo->aConstraintUsage[iPgno].argvIndex = ++nArg;
-    pInfo->aConstraintUsage[iPgno].omit = 1;
-    idxNum |= 1;
-  }
   if( iSchema>=0 ){
     pInfo->aConstraintUsage[iSchema].argvIndex = ++nArg;
     pInfo->aConstraintUsage[iSchema].omit = 1;
     idxNum |= 2;
+  }
+  if( iPgno>=0 ){
+    pInfo->aConstraintUsage[iPgno].argvIndex = ++nArg;
+    pInfo->aConstraintUsage[iPgno].omit = 1;
+    idxNum |= 1;
   }
 
   pInfo->idxNum = idxNum;
@@ -162,6 +163,11 @@ static int dlDbpageFilter(sqlite3_vtab_cursor *pCursor,
   pCur->iRow = 0;
   pCur->hasRow = 0;
 
+  if( idxNum & 2 ){
+    const char *zSchema = (const char*)sqlite3_value_text(argv[iArg++]);
+    if( sqlite3FindDbName(pVtab->db, zSchema)!=0 ) return SQLITE_OK;
+  }
+
   if( idxNum & 1 ){
     sqlite3_int64 pgno = sqlite3_value_int64(argv[iArg++]);
     if( pgno!=1 ){
@@ -171,10 +177,6 @@ static int dlDbpageFilter(sqlite3_vtab_cursor *pCursor,
         "(content-addressed chunk store has no page layout)");
       return SQLITE_ERROR;
     }
-  }
-
-  if( idxNum & 2 ){
-    iArg++;
   }
 
   synthesizeHeader(pVtab->db, pCur->aPage);
@@ -205,6 +207,8 @@ static int dlDbpageColumn(sqlite3_vtab_cursor *pCursor,
                           SQLITE_TRANSIENT);
       break;
     case 2:
+      sqlite3_result_text(ctx, "main", -1, SQLITE_STATIC);
+      break;
     default:
       sqlite3_result_null(ctx);
       break;

--- a/test/doltlite_dbpage.sh
+++ b/test/doltlite_dbpage.sh
@@ -47,6 +47,34 @@ run_test_match "page99_rejected" "SELECT length(data) FROM sqlite_dbpage WHERE p
 
 run_test "full_scan_count" "SELECT count(*) FROM sqlite_dbpage;" "1" "$DB"
 
+run_test "default_schema" \
+  "SELECT quote(schema) FROM sqlite_dbpage WHERE pgno=1;" "'main'" "$DB"
+
+run_test "main_schema" \
+  "SELECT count(*) FROM sqlite_dbpage WHERE pgno=1 AND schema='main';" "1" "$DB"
+
+run_test "main_schema_argument" \
+  "SELECT count(*) FROM sqlite_dbpage('main') WHERE pgno=1;" "1" "$DB"
+
+run_test "main_schema_case_insensitive" \
+  "SELECT count(*) FROM sqlite_dbpage('MAIN') WHERE pgno=1;" "1" "$DB"
+
+run_test "unknown_schema" \
+  "SELECT count(*) FROM sqlite_dbpage WHERE pgno=1 AND schema='nosuch';" "0" "$DB"
+
+run_test "unknown_schema_argument" \
+  "SELECT count(*) FROM sqlite_dbpage('nosuch') WHERE pgno=1;" "0" "$DB"
+
+run_test "null_schema" \
+  "SELECT count(*) FROM sqlite_dbpage(NULL) WHERE pgno=1;" "0" "$DB"
+
+run_test "attached_schema_unsupported" \
+  "ATTACH ':memory:' AS aux;
+SELECT count(*) FROM sqlite_dbpage('aux') WHERE pgno=1;" "0" "$DB"
+
+run_test "unknown_schema_precedes_page_check" \
+  "SELECT count(*) FROM sqlite_dbpage('nosuch') WHERE pgno=99;" "0" "$DB"
+
 db_rm "$DB"
 
 echo ""

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -1212,7 +1212,6 @@ dbpage dbpage-200 class=unsupported issue=947  # sqlite_dbpage raw page access; 
 dbpage dbpage-210 class=unsupported issue=947  # sqlite_dbpage raw page access; chunk store has no SQLite pages
 dbpage dbpage-220 class=unsupported issue=947  # sqlite_dbpage raw page access; chunk store has no SQLite pages
 dbpage dbpage-230 class=unsupported issue=947  # sqlite_dbpage raw page access; chunk store has no SQLite pages
-dbpage dbpage-240 class=unsupported issue=947  # sqlite_dbpage raw page access; chunk store has no SQLite pages
 dbpage dbpage-241 class=unsupported issue=947  # sqlite_dbpage raw page access; chunk store has no SQLite pages
 dbpage dbpage-250 class=unsupported issue=947  # sqlite_dbpage raw page access; chunk store has no SQLite pages
 dbpage dbpage-260 class=unsupported issue=947  # sqlite_dbpage raw page access; chunk store has no SQLite pages

--- a/test/known_testfixture_exception_ratchet.txt
+++ b/test/known_testfixture_exception_ratchet.txt
@@ -6,8 +6,8 @@
 # Counts are per gate -- one divergent assertion, or one expected crash.
 # Lowering a number is the point. Raising one is a deliberate act that belongs
 # in a PR description.
-gates 4795
+gates 4794
 intentional 3448
-unsupported 1186
+unsupported 1185
 harness 11
 engine-gap 150


### PR DESCRIPTION
## Summary

- resolve `sqlite_dbpage`'s hidden `schema` argument before page lookup
- synthesize page 1 only for `main`; return no rows for unknown, NULL, or attached schemas
- report `main` through the hidden output column
- cover default, explicit, case-insensitive, unknown, NULL, attached, and page-error ordering cases
- retire inherited `dbpage-240` from the unsupported inventory now that it passes

## Fail-before

`schema='nosuch'`, `sqlite_dbpage(NULL)`, and an attached schema all returned the synthesized main page. The hidden output column was NULL, and an unsupported schema paired with `pgno=99` raised the page-layout error instead of returning no rows.

## Validation

- `make -C build doltlite testfixture`
- `make lint`
- `test/doltlite_dbpage.sh` (14 passed)
- inherited `dbpage` in default and coverage variants (10 passed; 24 existing documented divergences)
- `doltlite_recover_rawformat_3` (102 passed)
- stock-file open and SQLite oracle suites (205 passed)
- `test/run_doltlite_tests.sh` (113/113 suites; 310,930/310,930 C regression assertions)

Co-Authored-By: OpenAI Codex <noreply@openai.com>
