### PR TITLE
Avoid false table rename on dual add

### DIFF
--- a/src/doltlite_merge_predetect.c
+++ b/src/doltlite_merge_predetect.c
@@ -806,6 +806,7 @@ static int mergePreNormalizeTableRename(
         nCand++;
       }
       if( nCand!=1 || !pNewT ) continue;
+      if( findSchemaEntry(aOther, nOther, pNewT->zName) ) continue;
 
       /* The pairing must be bijective. If the new table's text also matches
       ** another ancestor table this side no longer has, tables with equal

--- a/test/doltlite_merge.sh
+++ b/test/doltlite_merge.sh
@@ -615,5 +615,67 @@ run_test_match "constraint_detector_sql_error_merge_errors" "SELECT dolt_merge('
 run_test "constraint_detector_sql_error_restores_rows" "SELECT count(*) FROM t;" "0" "$DB40"
 run_test "constraint_detector_sql_error_preserves_head" "SELECT message FROM dolt_log LIMIT 1;" "add json check" "$DB40"
 
-rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8" "$DB8B" "$DB9" "$DB10" "$DB11" "$DB11D" "$DB11E" "$DB11F" "$DB12" "$DB13" "$DB14" "$DB15" "$DB16" "$DB17" "$DB18" "$DB19" "$DB20" "$DB20B" "$DB21" "$DB22" "$DB23" "$DB24" "$DB25" "$DB40"
+DB41=/tmp/test_merge41_$$.db; rm -f "$DB41"
+run_test_match "same_added_table_with_peer_drop_merge" "
+CREATE TABLE p(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO p VALUES(1,'a');
+SELECT dolt_commit('-A','-m','base');
+SELECT dolt_branch('feature');
+CREATE TABLE q(id INTEGER PRIMARY KEY, v TEXT);
+SELECT dolt_commit('-A','-m','main');
+SELECT dolt_checkout('feature');
+CREATE TABLE q(id INTEGER PRIMARY KEY, v TEXT);
+DROP TABLE p;
+SELECT dolt_commit('-A','-m','feature');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feature');
+SELECT 'RESULT|' || group_concat(name, ',') FROM (
+  SELECT name FROM sqlite_master
+  WHERE type='table' AND name NOT LIKE 'dolt_%' ORDER BY name
+);" "^RESULT\|q$" "$DB41"
+run_test "same_added_table_with_peer_drop_schema" "SELECT group_concat(name, ',') FROM (SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'dolt_%' ORDER BY name);" "q" "$DB41"
+run_test "same_added_table_with_peer_drop_integrity" "PRAGMA integrity_check;" "ok" "$DB41"
+
+DB42=/tmp/test_merge42_$$.db; rm -f "$DB42"
+run_test_match "same_added_table_with_our_drop_merge" "
+CREATE TABLE p(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO p VALUES(1,'a');
+SELECT dolt_commit('-A','-m','base');
+SELECT dolt_branch('feature');
+CREATE TABLE q(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO q VALUES(1,'main');
+DROP TABLE p;
+SELECT dolt_commit('-A','-m','main');
+SELECT dolt_checkout('feature');
+CREATE TABLE q(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO q VALUES(2,'feature');
+SELECT dolt_commit('-A','-m','feature');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feature');
+SELECT 'RESULT|' || group_concat(id || ':' || v, ',') FROM (
+  SELECT id,v FROM q ORDER BY id
+);" "^RESULT\|1:main,2:feature$" "$DB42"
+run_test "same_added_table_with_our_drop_schema" "SELECT group_concat(name, ',') FROM (SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'dolt_%' ORDER BY name);" "q" "$DB42"
+run_test "same_added_table_with_our_drop_integrity" "PRAGMA integrity_check;" "ok" "$DB42"
+
+DB43=/tmp/test_merge43_$$.db; rm -f "$DB43"
+run_test_match "same_empty_added_table_with_peer_drop_merge" "
+CREATE TABLE p(id INTEGER PRIMARY KEY, v TEXT);
+SELECT dolt_commit('-A','-m','base');
+SELECT dolt_branch('feature');
+CREATE TABLE q(id INTEGER PRIMARY KEY, v TEXT);
+SELECT dolt_commit('-A','-m','main');
+SELECT dolt_checkout('feature');
+CREATE TABLE q(id INTEGER PRIMARY KEY, v TEXT);
+DROP TABLE p;
+SELECT dolt_commit('-A','-m','feature');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feature');
+SELECT 'RESULT|' || group_concat(name, ',') FROM (
+  SELECT name FROM sqlite_master
+  WHERE type='table' AND name NOT LIKE 'dolt_%' ORDER BY name
+);" "^RESULT\|q$" "$DB43"
+run_test "same_empty_added_table_with_peer_drop_integrity" "PRAGMA integrity_check;" "ok" "$DB43"
+
+rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8" "$DB8B" "$DB9" "$DB10" "$DB11" "$DB11D" "$DB11E" "$DB11F" "$DB12" "$DB13" "$DB14" "$DB15" "$DB16" "$DB17" "$DB18" "$DB19" "$DB20" "$DB20B" "$DB21" "$DB22" "$DB23" "$DB24" "$DB25" "$DB40" "$DB41" "$DB42" "$DB43"
 dltest_finish

--- a/test/vc_oracle_merge_test.sh
+++ b/test/vc_oracle_merge_test.sh
@@ -1740,6 +1740,22 @@ SELECT dolt_merge('feat');
 echo ""
 echo "--- add/add matching schema ---"
 
+oracle_error_poststate "dual_add_same_table_with_peer_drop" "
+CREATE TABLE p(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO p VALUES (1, 'a');
+SELECT dolt_commit('-Am', 'base');
+SELECT dolt_branch('feat');
+CREATE TABLE q(id INTEGER PRIMARY KEY, v TEXT);
+SELECT dolt_commit('-Am', 'main adds q');
+SELECT dolt_checkout('feat');
+CREATE TABLE q(id INTEGER PRIMARY KEY, v TEXT);
+DROP TABLE p;
+SELECT dolt_commit('-Am', 'feat adds q and drops p');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feat');
+" "SELECT group_concat(name, ',') FROM (SELECT name FROM sqlite_master WHERE type='table' AND name IN ('p','q') ORDER BY name)" \
+"SELECT GROUP_CONCAT(TABLE_NAME ORDER BY TABLE_NAME SEPARATOR ',') FROM information_schema.tables WHERE TABLE_SCHEMA=DATABASE() AND TABLE_NAME IN ('p','q')"
+
 oracle_error_poststate "dual_add_table_same_schema_union" "
 SELECT dolt_commit('-Am', 'init empty');
 SELECT dolt_branch('feat');


### PR DESCRIPTION
## Summary

- skip table-rename normalization when its target already exists on the other merge side
- let ordinary drop and matching dual-add semantics resolve the catalogs
- cover the reported sequence, reverse direction, empty tables, row union, integrity, and Dolt parity

## Testing

- `bash test/run_doltlite_tests.sh build/doltlite`
- `bash test/run_c_tests.sh`
- `bash test/vc_oracle_merge_test.sh build/doltlite dolt`
- `bash test/vc_oracle_correct_schema_merge_matrix_test.sh build/doltlite dolt`
- `make lint`

Fixes #2380

Co-Authored-By: OpenAI Codex <noreply@openai.com>