### PR TITLE
Keep watchdogs quiet when a step-level reporter already spoke

### DIFF
--- a/.github/workflows/nightly-fuzz.yml
+++ b/.github/workflows/nightly-fuzz.yml
@@ -315,7 +315,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+    - name: Skip when a step-level reporter already covered this run
+      id: sibling
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        LABEL_PREFIXES: "fuzz-crash- sql-differential-divergence"
+      run: |
+        started=$(gh api "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}" --jq .run_started_at)
+        covered=0
+        for prefix in fuzz-crash- sql-differential-divergence; do
+          n=$(gh api -X GET "repos/${{ github.repository }}/issues" \
+                -f state=all -f per_page=50 -f sort=updated -f direction=desc \
+              | jq --arg p "$prefix" --arg t "$started" --arg w "nightly-fuzz-watchdog" \
+                  '[.[] | select([.labels[].name] | any(startswith($p) and . != $w)) | select(.updated_at >= $t)] | length')
+          [ "${n:-0}" -gt 0 ] && covered=1
+        done
+        echo "covered=$covered" >> "$GITHUB_OUTPUT"
+        echo "sibling reporter coverage since $started: covered=$covered"
     - name: Describe the incident
+      if: steps.sibling.outputs.covered != '1'
       run: |
         {
           echo "The scheduled nightly-fuzz run did not finish green and no step-level reporter covered it."
@@ -325,6 +343,7 @@ jobs:
           echo "If a more specific issue (fuzz crash, stress failure) was filed for this night, triage there; this entry exists so no red nightly is silent."
         } > "$RUNNER_TEMP/watchdog-body.md"
     - uses: ./.github/actions/report-failure-issue
+      if: steps.sibling.outputs.covered != '1'
       with:
         label: nightly-fuzz-watchdog
         title: "Nightly fuzz run did not finish"

--- a/.github/workflows/nightly-performance.yml
+++ b/.github/workflows/nightly-performance.yml
@@ -431,7 +431,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+    - name: Skip when a step-level reporter already covered this run
+      id: sibling
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        LABEL_PREFIXES: "nightly-performance-regression"
+      run: |
+        started=$(gh api "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}" --jq .run_started_at)
+        covered=0
+        for prefix in nightly-performance-regression; do
+          n=$(gh api -X GET "repos/${{ github.repository }}/issues" \
+                -f state=all -f per_page=50 -f sort=updated -f direction=desc \
+              | jq --arg p "$prefix" --arg t "$started" --arg w "nightly-performance-watchdog" \
+                  '[.[] | select([.labels[].name] | any(startswith($p) and . != $w)) | select(.updated_at >= $t)] | length')
+          [ "${n:-0}" -gt 0 ] && covered=1
+        done
+        echo "covered=$covered" >> "$GITHUB_OUTPUT"
+        echo "sibling reporter coverage since $started: covered=$covered"
     - name: Describe the incident
+      if: steps.sibling.outputs.covered != '1'
       run: |
         {
           echo "The scheduled nightly-performance run did not finish green and no step-level reporter covered it."
@@ -441,6 +459,7 @@ jobs:
           echo "If a more specific issue (fuzz crash, stress failure) was filed for this night, triage there; this entry exists so no red nightly is silent."
         } > "$RUNNER_TEMP/watchdog-body.md"
     - uses: ./.github/actions/report-failure-issue
+      if: steps.sibling.outputs.covered != '1'
       with:
         label: nightly-performance-watchdog
         title: "Nightly performance run did not finish"

--- a/.github/workflows/nightly-scale.yml
+++ b/.github/workflows/nightly-scale.yml
@@ -194,7 +194,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+    - name: Skip when a step-level reporter already covered this run
+      id: sibling
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        LABEL_PREFIXES: "nightly-scale-large-full"
+      run: |
+        started=$(gh api "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}" --jq .run_started_at)
+        covered=0
+        for prefix in nightly-scale-large-full; do
+          n=$(gh api -X GET "repos/${{ github.repository }}/issues" \
+                -f state=all -f per_page=50 -f sort=updated -f direction=desc \
+              | jq --arg p "$prefix" --arg t "$started" --arg w "nightly-scale-watchdog" \
+                  '[.[] | select([.labels[].name] | any(startswith($p) and . != $w)) | select(.updated_at >= $t)] | length')
+          [ "${n:-0}" -gt 0 ] && covered=1
+        done
+        echo "covered=$covered" >> "$GITHUB_OUTPUT"
+        echo "sibling reporter coverage since $started: covered=$covered"
     - name: Describe the incident
+      if: steps.sibling.outputs.covered != '1'
       run: |
         {
           echo "The scheduled nightly-scale run did not finish green and no step-level reporter covered it."
@@ -204,6 +222,7 @@ jobs:
           echo "If a more specific issue (fuzz crash, stress failure) was filed for this night, triage there; this entry exists so no red nightly is silent."
         } > "$RUNNER_TEMP/watchdog-body.md"
     - uses: ./.github/actions/report-failure-issue
+      if: steps.sibling.outputs.covered != '1'
       with:
         label: nightly-scale-watchdog
         title: "Nightly scale run did not finish"

--- a/.github/workflows/nightly-stress.yml
+++ b/.github/workflows/nightly-stress.yml
@@ -389,7 +389,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+    - name: Skip when a step-level reporter already covered this run
+      id: sibling
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        LABEL_PREFIXES: "nightly-stress-"
+      run: |
+        started=$(gh api "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}" --jq .run_started_at)
+        covered=0
+        for prefix in nightly-stress-; do
+          n=$(gh api -X GET "repos/${{ github.repository }}/issues" \
+                -f state=all -f per_page=50 -f sort=updated -f direction=desc \
+              | jq --arg p "$prefix" --arg t "$started" --arg w "nightly-stress-watchdog" \
+                  '[.[] | select([.labels[].name] | any(startswith($p) and . != $w)) | select(.updated_at >= $t)] | length')
+          [ "${n:-0}" -gt 0 ] && covered=1
+        done
+        echo "covered=$covered" >> "$GITHUB_OUTPUT"
+        echo "sibling reporter coverage since $started: covered=$covered"
     - name: Describe the incident
+      if: steps.sibling.outputs.covered != '1'
       run: |
         {
           echo "The scheduled nightly-stress run did not finish green and no step-level reporter covered it."
@@ -399,6 +417,7 @@ jobs:
           echo "If a more specific issue (fuzz crash, stress failure) was filed for this night, triage there; this entry exists so no red nightly is silent."
         } > "$RUNNER_TEMP/watchdog-body.md"
     - uses: ./.github/actions/report-failure-issue
+      if: steps.sibling.outputs.covered != '1'
       with:
         label: nightly-stress-watchdog
         title: "Nightly stress run did not finish"


### PR DESCRIPTION
Last night one bad run produced duplicate issues: the stress vc-fuzzer reporter filed #2384 and the watchdog filed #2385 for the same run; likewise #2382 (differential) and #2383. The watchdog's job is *"no red night is silent"* — not *"every red night is reported twice."*

Each watchdog now checks, before filing, whether any issue carrying its workflow's step-level reporter labels (`fuzz-crash-*`/`sql-differential-divergence`, `nightly-stress-*`, `nightly-scale-large-full`, `nightly-performance-regression`) was created or updated since `run_started_at`, and skips if so. Its own tracking label is excluded so an old watchdog issue can't suppress a genuine new report. Cancellations and reporter-less failures (e.g. build breakage) still file — that coverage is the reason the watchdogs exist.

**Validated against the real incident**: the exact step body, executed against last night's stress run (`32622225727`), returns `covered=1` — with this gate, #2385 and #2383 would not have been filed while #2384 and #2382 still would.

Query uses `jq --arg` piped from `gh api` (no shell-escaping games), and all four workflow files parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)