### PR TITLE
Merged index rows keep our rootpage when both sides hold the name

### DIFF
--- a/src/doltlite_merge_rebuild.c
+++ b/src/doltlite_merge_rebuild.c
@@ -360,7 +360,32 @@ int rebuildDisjointSchemaRows(
         continue;
       }
     }
-    iRootpage = remapSchemaRootpage(aRemap, nRemap, pSe->iRootpage);
+    /* Rootpage numbers are per-branch: once histories renumber, theirs'
+    ** number can be a different object here. The remap table records where
+    ** pass 2 actually placed their entry, so a mapping is authoritative.
+    ** Without one, an index we also hold by name was adopted by pass 1
+    ** into our-numbered entry, so the row must carry our number; theirs'
+    ** raw number is only trustworthy when neither side relocated it. */
+    {
+      int bMapped = 0;
+      int j;
+      for(j=0; j<nRemap; j++){
+        if( aRemap[j].oldPg==pSe->iRootpage ){
+          iRootpage = aRemap[j].newPg;
+          bMapped = 1;
+          break;
+        }
+      }
+      if( !bMapped ){
+        SchemaEntry *pOurSe = findSchemaEntry(aOursSchema, nOursSchema,
+                                              pSe->zName);
+        if( pOurSe && pOurSe->zType && strcmp(pOurSe->zType, "index")==0 ){
+          iRootpage = pOurSe->iRootpage;
+        }else{
+          iRootpage = pSe->iRootpage;
+        }
+      }
+    }
     rc = appendMergedSchemaCatalogRecord(db, &root, pMaster->flags, iNextRowid++,
                                          pSe, iRootpage);
     if( rc!=SQLITE_OK ) return rc;

--- a/test/doltlite_schema_merge.sh
+++ b/test/doltlite_schema_merge.sh
@@ -2360,4 +2360,38 @@ run_test "merge_dual_table_rename_objects" \
   "t8,t9" "$DB"
 rm -f "$DB"
 
+# Rootpage numbers are per-branch once histories renumber. Theirs recreates
+# an index we also hold while our side's numbering has shifted; the merged
+# row must carry our entry's number, not theirs' (which is another object
+# here). Used to assemble two rows on one rootpage: disk image is malformed.
+DB=/tmp/test_merge_renumbered_index_$$.db; rm -f "$DB"
+cat <<'EOF2' | $DOLTLITE "$DB" > /dev/null 2>&1
+CREATE TABLE ma(id INTEGER PRIMARY KEY, v TEXT);
+CREATE TABLE zz(id INTEGER PRIMARY KEY, v TEXT);
+CREATE INDEX iz ON zz(v);
+INSERT INTO zz VALUES(1,'x');
+SELECT dolt_commit('-Am','base');
+SELECT dolt_branch('feat');
+CREATE TABLE aa(id INTEGER PRIMARY KEY, v TEXT);
+SELECT dolt_commit('-Am','ours adds aa, renumbering everything after it');
+SELECT dolt_checkout('feat');
+DROP INDEX iz;
+CREATE INDEX iz ON zz(id);
+SELECT dolt_commit('-Am','theirs recreates iz under its own numbering');
+SELECT dolt_checkout('main');
+EOF2
+run_test_match "merge_renumbered_index_merges" "SELECT dolt_merge('feat');" \
+  "^[0-9a-f]{40}$" "$DB"
+run_test "merge_renumbered_index_takes_theirs" \
+  "SELECT sql FROM sqlite_master WHERE name='iz';" \
+  "CREATE INDEX iz ON zz(id)" "$DB"
+run_test "merge_renumbered_index_distinct_pages" \
+  "SELECT count(DISTINCT rootpage) = count(*) FROM sqlite_master WHERE rootpage > 0;" \
+  "1" "$DB"
+run_test "merge_renumbered_index_reopen" \
+  "SELECT v FROM zz WHERE id=1; PRAGMA integrity_check;" \
+  "x
+ok" "$DB"
+rm -f "$DB"
+
 dltest_finish


### PR DESCRIPTION
Fixes #2384.

## Root cause

Rootpage numbers are per-branch: canonical-by-sorted-name renumbering means the same number can name different objects on branches with different create/drop histories. In `rebuildDisjointSchemaRows`, the theirs-changed-index loop stamped merged rows with **theirs' branch-local rootpage**, corrected only by pass 2's remap table. But when *we also hold the index by name*, pass 1 adopts their content into our-numbered entry and pass 2 never creates a remap entry — so the row kept theirs' number, which under divergent numbering is a different object on our side. The nightly soak produced a merged catalog with two index rows sharing rootpage 122 (`aux_idx_6519` ours@122 vs `aux_idx_8288` theirs@122 unremapped) → `database disk image is malformed`.

This is pre-existing (a pre-#2360 build fails the same golden replay); the nightly's random seed window just found it now.

## Fix

When ours holds an index of the same name, the merged row carries our entry's rootpage; the remap table remains authoritative only for entries pass 2 adopted from their side.

## Repro (fails on master, passes here)

```sql
CREATE TABLE ma(id INTEGER PRIMARY KEY, v TEXT);
CREATE TABLE zz(id INTEGER PRIMARY KEY, v TEXT);
CREATE INDEX iz ON zz(v);
INSERT INTO zz VALUES(1,'x');
SELECT dolt_commit('-Am','base'); SELECT dolt_branch('f');
CREATE TABLE aa(id INTEGER PRIMARY KEY, v TEXT);  -- ours: shifts canonical numbering
SELECT dolt_commit('-Am','ours');
-- on f: DROP INDEX iz; CREATE INDEX iz ON zz(id);  -- theirs: recreates iz under its own numbering
SELECT dolt_merge('f');  -- master: database disk image is malformed
```

Dolt merges this shape cleanly (adopts theirs' recreated index) — we now match.

## Validation

- Minimal repro: fail-before on master build, pass-after here (merged catalog has distinct rootpages, theirs' index text adopted, integrity_check ok)
- Golden nightly asset (seed 1787465601 pre-merge state): 3/3 deterministic successful merges; result accepted by a DOLTLITE_PROLLY_CHECK=1 binary
- Regression test added to test/doltlite_schema_merge.sh (390/390)
- Full soak of seed 1787465601 on the fixed build
- test/run_doltlite_tests.sh full suite
- Amalgamation compiles with the fix included; lint_layers clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
