### PR TITLE
Restore RETURNING and NEW.rowid on clustered primary keys

### DIFF
--- a/src/delete.c
+++ b/src/delete.c
@@ -831,6 +831,11 @@ void sqlite3GenerateRowDelete(
 
     /* Populate the OLD.* pseudo-table register array. These values will be
     ** used by any BEFORE and AFTER triggers that exist.  */
+#ifdef DOLTLITE_PROLLY
+    if( VisibleRowid(pTab) && !HasRowid(pTab) ){
+      sqlite3VdbeAddOp2(v, OP_Rowid, iDataCur, iOld);
+    }else
+#endif
     sqlite3VdbeAddOp2(v, OP_Copy, iPk, iOld);
     for(iCol=0; iCol<pTab->nCol; iCol++){
       testcase( mask!=0xffffffff && iCol==31 );

--- a/src/delete.c
+++ b/src/delete.c
@@ -832,7 +832,7 @@ void sqlite3GenerateRowDelete(
     /* Populate the OLD.* pseudo-table register array. These values will be
     ** used by any BEFORE and AFTER triggers that exist.  */
 #ifdef DOLTLITE_PROLLY
-    if( VisibleRowid(pTab) && !HasRowid(pTab) ){
+    if( VisibleRowid(pTab) && !HasRowid(pTab) && pTrigger ){
       sqlite3VdbeAddOp2(v, OP_Rowid, iDataCur, iOld);
     }else
 #endif

--- a/src/insert.c
+++ b/src/insert.c
@@ -2872,6 +2872,11 @@ void sqlite3CompleteInsertion(
                          aRegIdx[i]+1,
                          pIdx->uniqNotNull ? pIdx->nKeyCol: pIdx->nColumn);
     sqlite3VdbeChangeP5(v, pik_flags);
+#ifdef DOLTLITE_PROLLY
+    if( IsPrimaryKeyIndex(pIdx) && VisibleRowid(pTab) && !HasRowid(pTab) ){
+      sqlite3VdbeAddOp3(v, OP_Rowid, iIdxCur+i, regNewData, aRegIdx[i]);
+    }
+#endif
   }
   if( !HasRowid(pTab) ) return;
   if( pParse->nested ){

--- a/src/insert.c
+++ b/src/insert.c
@@ -1621,6 +1621,18 @@ void sqlite3Insert(
   }
 
   if( pTrigger ){
+#ifdef DOLTLITE_PROLLY
+    if( !isView && !IsVirtual(pTab) && VisibleRowid(pTab) && withoutRowid ){
+      int ii;
+      Index *pPkIdx;
+      for(ii=0, pPkIdx=pTab->pIndex; pPkIdx; pPkIdx=pPkIdx->pNext, ii++){
+        if( IsPrimaryKeyIndex(pPkIdx) && aRegIdx[ii] ){
+          sqlite3VdbeAddOp3(v, OP_Rowid, iIdxCur+ii, regRowid, aRegIdx[ii]);
+          break;
+        }
+      }
+    }
+#endif
     /* Code AFTER triggers */
     sqlite3CodeRowTrigger(pParse, pTrigger, TK_INSERT, 0, TRIGGER_AFTER,
         pTab, regData-2-pTab->nCol, onError, endOfLoop);
@@ -2872,11 +2884,6 @@ void sqlite3CompleteInsertion(
                          aRegIdx[i]+1,
                          pIdx->uniqNotNull ? pIdx->nKeyCol: pIdx->nColumn);
     sqlite3VdbeChangeP5(v, pik_flags);
-#ifdef DOLTLITE_PROLLY
-    if( IsPrimaryKeyIndex(pIdx) && VisibleRowid(pTab) && !HasRowid(pTab) ){
-      sqlite3VdbeAddOp3(v, OP_Rowid, iIdxCur+i, regNewData, aRegIdx[i]);
-    }
-#endif
   }
   if( !HasRowid(pTab) ) return;
   if( pParse->nested ){

--- a/src/update.c
+++ b/src/update.c
@@ -920,6 +920,12 @@ void sqlite3Update(
 #endif
       sqlite3VdbeAddOp2(v, OP_Copy, regOldRowid, regNewRowid);
     }
+#ifdef DOLTLITE_PROLLY
+    else if( VisibleRowid(pTab) && pPk!=0 ){
+      sqlite3VdbeAddOp2(v, OP_Rowid, iDataCur, regOldRowid);
+      sqlite3VdbeAddOp2(v, OP_Copy, regOldRowid, regNewRowid);
+    }
+#endif
   }
 
   /* Populate the array of registers beginning at regNew with the new

--- a/src/update.c
+++ b/src/update.c
@@ -921,7 +921,7 @@ void sqlite3Update(
       sqlite3VdbeAddOp2(v, OP_Copy, regOldRowid, regNewRowid);
     }
 #ifdef DOLTLITE_PROLLY
-    else if( VisibleRowid(pTab) && pPk!=0 ){
+    else if( VisibleRowid(pTab) && pPk!=0 && pTrigger ){
       sqlite3VdbeAddOp2(v, OP_Rowid, iDataCur, regOldRowid);
       sqlite3VdbeAddOp2(v, OP_Copy, regOldRowid, regNewRowid);
     }

--- a/src/update.c
+++ b/src/update.c
@@ -1121,6 +1121,18 @@ void sqlite3Update(
   }
 
   if( pTrigger ){
+#ifdef DOLTLITE_PROLLY
+    if( !isView && VisibleRowid(pTab) && pPk!=0 ){
+      int ii;
+      Index *pPkIdx;
+      for(ii=0, pPkIdx=pTab->pIndex; pPkIdx; pPkIdx=pPkIdx->pNext, ii++){
+        if( IsPrimaryKeyIndex(pPkIdx) && aRegIdx[ii] ){
+          sqlite3VdbeAddOp3(v, OP_Rowid, iIdxCur+ii, regNewRowid, aRegIdx[ii]);
+          break;
+        }
+      }
+    }
+#endif
     sqlite3CodeRowTrigger(pParse, pTrigger, TK_UPDATE, pChanges,
         TRIGGER_AFTER, pTab, regOldRowid, onError, labelContinue);
   }

--- a/src/vdbe.c
+++ b/src/vdbe.c
@@ -7046,7 +7046,6 @@ case OP_IdxInsert: {        /* in2 */
   pC->cacheStatus = CACHE_STALE;
   if( rc) goto abort_due_to_error;
 #ifdef DOLTLITE_PROLLY
-  pC->nullRow = 0;
   if( (pOp->p5 & OPFLAG_LASTROWID)!=0 && (pIn2->flags & MEM_Blob)!=0 ){
     db->lastRowid = doltliteSyntheticRowidFromRecord(
         (const u8*)pIn2->z, pIn2->n, pC->pKeyInfo);

--- a/src/vdbe.c
+++ b/src/vdbe.c
@@ -6563,7 +6563,7 @@ case OP_RowData: {
   break;
 }
 
-/* Opcode: Rowid P1 P2 * * *
+/* Opcode: Rowid P1 P2 P3 * *
 ** Synopsis: r[P2]=PX rowid of P1
 **
 ** Store in register P2 an integer which is the key of the table entry that
@@ -6572,6 +6572,11 @@ case OP_RowData: {
 ** P1 can be either an ordinary table or a virtual table.  There used to
 ** be a separate OP_VRowid opcode for use with virtual tables, but this
 ** one opcode now works for both table types.
+**
+** If P3 is non-zero, P1 is used only for KeyInfo and r[P2] is the SQL
+** rowid of the index record in r[P3]. Clustered PRIMARY KEY RETURNING
+** and NEW.rowid use that form because the PK cursor is still a null row
+** after OP_IdxInsert.
 */
 case OP_Rowid: {                 /* out2, ncycle */
   VdbeCursor *pC;
@@ -6583,6 +6588,22 @@ case OP_Rowid: {                 /* out2, ncycle */
   assert( pOp->p1>=0 && pOp->p1<p->nCursor );
   pC = p->apCsr[pOp->p1];
   assert( pC!=0 );
+#ifdef DOLTLITE_PROLLY
+  if( pOp->p3 ){
+    Mem *pRec = &aMem[pOp->p3];
+    assert( pC->eCurType==CURTYPE_BTREE );
+    rc = ExpandBlob(pRec);
+    if( rc ) goto abort_due_to_error;
+    if( (pRec->flags & MEM_Blob)==0 ){
+      pOut->flags = MEM_Null;
+      break;
+    }
+    v = doltliteSyntheticRowidFromRecord(
+        (const u8*)pRec->z, pRec->n, pC->pKeyInfo);
+    pOut->u.i = v;
+    break;
+  }
+#endif
   assert( pC->eCurType!=CURTYPE_PSEUDO || pC->nullRow );
   if( pC->nullRow ){
     pOut->flags = MEM_Null;
@@ -7025,6 +7046,7 @@ case OP_IdxInsert: {        /* in2 */
   pC->cacheStatus = CACHE_STALE;
   if( rc) goto abort_due_to_error;
 #ifdef DOLTLITE_PROLLY
+  pC->nullRow = 0;
   if( (pOp->p5 & OPFLAG_LASTROWID)!=0 && (pIn2->flags & MEM_Blob)!=0 ){
     db->lastRowid = doltliteSyntheticRowidFromRecord(
         (const u8*)pIn2->z, pIn2->n, pC->pKeyInfo);

--- a/test/doltlite_rowid_returning.sh
+++ b/test/doltlite_rowid_returning.sh
@@ -1,0 +1,153 @@
+#!/bin/bash
+. "$(dirname "$0")/lib/doltlite_test_common.sh"
+
+echo "=== DoltLite clustered-PK RETURNING and NEW.rowid ==="
+echo ""
+
+DB=/tmp/test_doltlite_rowid_returning_$$.db
+rm -f "$DB"
+trap 'rm -f "$DB"' EXIT
+
+run_test "insert_returning_matches_select" "
+CREATE TABLE t(k TEXT PRIMARY KEY, v INT);
+INSERT INTO t VALUES('a',1) RETURNING rowid = last_insert_rowid();
+SELECT rowid = last_insert_rowid() FROM t;
+" "1
+1" "$DB"
+
+rm -f "$DB"
+run_test "insert_returning_typeof_integer" "
+CREATE TABLE t(k TEXT PRIMARY KEY, v INT);
+INSERT INTO t VALUES('a',1) RETURNING typeof(rowid), k;
+" "integer|a" "$DB"
+
+rm -f "$DB"
+run_test "delete_returning_typeof_integer" "
+CREATE TABLE t(k TEXT PRIMARY KEY, v INT);
+INSERT INTO t VALUES('a',1);
+DELETE FROM t RETURNING typeof(rowid), k;
+SELECT count(*) FROM t;
+" "integer|a
+0" "$DB"
+
+rm -f "$DB"
+printf '%s\n' "CREATE TABLE t(k TEXT PRIMARY KEY, v INT); INSERT INTO t VALUES('a',1);" \
+  | "$DOLTLITE" "$DB" >/dev/null
+OLD=$(dltest_run_sql "SELECT rowid FROM t;" "$DB")
+run_test "delete_returning_matches_prior_select" "
+DELETE FROM t RETURNING rowid, k;
+" "$OLD|a" "$DB"
+
+rm -f "$DB"
+run_test "update_returning_unchanged_pk" "
+CREATE TABLE t(k TEXT PRIMARY KEY, v INT);
+INSERT INTO t VALUES('a',1);
+UPDATE t SET v=2 RETURNING rowid = last_insert_rowid(), k, v;
+SELECT rowid = last_insert_rowid(), v FROM t;
+" "1|a|2
+1|2" "$DB"
+
+rm -f "$DB"
+printf '%s\n' "CREATE TABLE t(k TEXT PRIMARY KEY, v INT); INSERT INTO t VALUES('a',1);" \
+  | "$DOLTLITE" "$DB" >/dev/null
+RET=$(dltest_run_sql "UPDATE t SET k='b' RETURNING rowid;" "$DB")
+SEL=$(dltest_run_sql "SELECT rowid FROM t;" "$DB")
+if [ -n "$RET" ] && [ "$RET" = "$SEL" ]; then
+  dltest_pass
+else
+  dltest_fail "update_pk_returning_matches_new_select" \
+    "  returning: $RET
+  select:     $SEL"
+fi
+
+rm -f "$DB"
+run_test "after_insert_new_rowid" "
+CREATE TABLE t(k TEXT PRIMARY KEY, v INT);
+CREATE TABLE log(kind TEXT, r);
+CREATE TRIGGER tr AFTER INSERT ON t BEGIN
+  INSERT INTO log VALUES(typeof(new.rowid), new.rowid);
+END;
+INSERT INTO t VALUES('a',1);
+SELECT kind FROM log;
+SELECT r = (SELECT rowid FROM t) FROM log;
+" "integer
+1" "$DB"
+
+rm -f "$DB"
+printf '%s\n' "
+CREATE TABLE t(k TEXT PRIMARY KEY, v INT);
+CREATE TABLE log(kind TEXT, r);
+INSERT INTO t VALUES('a',1);
+CREATE TRIGGER tr AFTER DELETE ON t BEGIN
+  INSERT INTO log VALUES(typeof(old.rowid), old.rowid);
+END;
+" | "$DOLTLITE" "$DB" >/dev/null
+OLD=$(dltest_run_sql "SELECT rowid FROM t;" "$DB")
+run_test "after_delete_old_rowid" "
+DELETE FROM t;
+SELECT kind, r FROM log;
+" "integer|$OLD" "$DB"
+
+rm -f "$DB"
+run_test "after_update_pk_new_differs_from_old" "
+CREATE TABLE t(k TEXT PRIMARY KEY, v INT);
+CREATE TABLE log(same INT, new_ok INT);
+INSERT INTO t VALUES('a',1);
+CREATE TRIGGER tr AFTER UPDATE ON t BEGIN
+  INSERT INTO log VALUES(old.rowid = new.rowid,
+                         new.rowid = (SELECT rowid FROM t));
+END;
+UPDATE t SET k='b';
+SELECT * FROM log;
+" "0|1" "$DB"
+
+rm -f "$DB"
+run_test "after_update_old_and_new_rowid" "
+CREATE TABLE t(k TEXT PRIMARY KEY, v INT);
+CREATE TABLE log(okind TEXT, nkind TEXT, same INT);
+INSERT INTO t VALUES('a',1);
+CREATE TRIGGER tr AFTER UPDATE ON t BEGIN
+  INSERT INTO log VALUES(typeof(old.rowid), typeof(new.rowid),
+                         old.rowid = new.rowid);
+END;
+UPDATE t SET v=2;
+SELECT * FROM log;
+" "integer|integer|1" "$DB"
+
+rm -f "$DB"
+run_test "int_pk_returning_is_the_pk" "
+CREATE TABLE t(id INT PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(10,'a') RETURNING rowid, id;
+UPDATE t SET v='b' RETURNING rowid;
+DELETE FROM t RETURNING rowid, id;
+" "10|10
+10
+10|10" "$DB"
+
+rm -f "$DB"
+run_test "integer_pk_returning_unchanged" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t(v) VALUES('a') RETURNING rowid, id;
+" "1|1" "$DB"
+
+rm -f "$DB"
+run_test_match "explicit_without_rowid_returning_rejected" "
+CREATE TABLE t(k TEXT PRIMARY KEY, v TEXT) WITHOUT ROWID;
+INSERT INTO t VALUES('a','one') RETURNING rowid;
+" "no such column: rowid" "$DB"
+
+rm -f "$DB"
+run_test "oid_and_rowid_alias" "
+CREATE TABLE t(k TEXT PRIMARY KEY);
+INSERT INTO t VALUES('a') RETURNING oid = rowid, _rowid_ = rowid;
+" "1|1" "$DB"
+
+rm -f "$DB"
+run_test "composite_pk_returning_matches_select" "
+CREATE TABLE t(a INT, b TEXT, PRIMARY KEY(a, b));
+INSERT INTO t VALUES(1,'x') RETURNING rowid = last_insert_rowid();
+SELECT rowid = last_insert_rowid() FROM t;
+" "1
+1" "$DB"
+
+dltest_finish

--- a/test/lib/doltlite_suite_manifest.sh
+++ b/test/lib/doltlite_suite_manifest.sh
@@ -62,6 +62,7 @@ doltlite_delete_or.sh
 doltlite_autoinc_schema.sh
 doltlite_rowid_identity.sh
 doltlite_pk_clustered_notnull.sh
+doltlite_rowid_returning.sh
 doltlite_nocase_index.sh
 doltlite_update_replace_trigger.sh
 doltlite_unique_index_delete.sh


### PR DESCRIPTION
## Summary

Fixes #2391. `SELECT rowid` / `last_insert_rowid()` already work on auto-clustered (non-`INTEGER PRIMARY KEY`) tables. `RETURNING rowid` and trigger `NEW.rowid` / `OLD.rowid` did not: they read the NEW/OLD rowid register.

- `INSERT … RETURNING rowid` and `NEW.rowid` were NULL.
- `UPDATE … RETURNING rowid` was NULL; `NEW.rowid` was NULL.
- `DELETE … RETURNING rowid` was the PK sort-key blob (e.g. `020F61` for `'a'`).

SQLite returns the integer rowid in all of those places.

After a clustered PK `OP_IdxInsert`, hash that index record into the rowid register (`OP_Rowid` with P3 = the record). DELETE copies `OP_Rowid` from the positioned PK cursor. Explicit `WITHOUT ROWID` still has no rowid. `INTEGER PRIMARY KEY` is unchanged.

No extra stored column. No `CHUNK_STORE_VERSION` bump. Guarded by `DOLTLITE_PROLLY`.

## Tests

`test/doltlite_rowid_returning.sh` (15 cases): INSERT/UPDATE/DELETE RETURNING, AFTER INSERT/UPDATE/DELETE triggers, INT PK, INTEGER PK control, explicit WITHOUT ROWID, oid/`_rowid_` aliases, composite PK, PK-changing UPDATE.

Local: that suite and `doltlite_rowid_identity.sh` green.

## Agent notes

- Branch is off current `master` (not stacked on #2395).
- Staged by explicit path.
- Never deleted a test.

Co-Authored-By: Grok 4.6 <noreply@x.ai>