### PR TITLE
Hash a bounded window of large mutmap keys

### DIFF
--- a/src/prolly_mutmap.c
+++ b/src/prolly_mutmap.c
@@ -69,12 +69,26 @@ static int compareEntryToKey(
   return prollyKeyCmp(e->pKey, e->nKey, pKey, nKey);
 }
 
+/* Hash-table filter only: every consumer re-checks with a full key compare,
+** so a large key hashes a head+tail window instead of all of it. Bulk index
+** builds carry multi-KB keys and the full scan dominated their insert cost. */
 static u32 hashKey(const u8 *pKey, int nKey){
   u32 h = 2166136261u;
   int i;
-  for(i=0; i<nKey; i++){
-    h ^= pKey[i];
-    h *= 16777619u;
+  if( nKey > 128 ){
+    for(i=0; i<64; i++){
+      h ^= pKey[i];
+      h *= 16777619u;
+    }
+    for(i=nKey-64; i<nKey; i++){
+      h ^= pKey[i];
+      h *= 16777619u;
+    }
+  }else{
+    for(i=0; i<nKey; i++){
+      h ^= pKey[i];
+      h *= 16777619u;
+    }
   }
   h ^= (u32)nKey;
   h *= 16777619u;


### PR DESCRIPTION
Speeds up the bigsort path (#2397 context): `CREATE INDEX` over rows with multi-KB payloads.

## What was slow

Profiling bigsort's `CREATE INDEX` (100k×10KB rows) showed ~25% of statement CPU in `hashKey` — a byte-at-a-time FNV loop over the **entire** key, run on every mutmap insert (`copyEntryData`) and every lazy lookup probe. With 10KB sort keys that's a serialized-multiply scan of the whole key per row.

## Why the fix is safe

The hash is purely an in-memory hash-table filter: `hashEntryMatches` confirms with a full `memcmp` (or `keyPrefix64` for int keys ≤8 bytes, unaffected), and `prollyMutMapMerge` copies hashes between maps so the function stays the single source of truth. Nothing persistent derives from it — chunk boundaries (xxh32) and chunk hashes (BLAKE3) are untouched. Worst case for an adversarial key set is longer probe chains, never wrong results.

Keys ≤128 bytes hash exactly as before; larger keys hash a 64-byte head + 64-byte tail + length.

## Measured

| rows | CREATE INDEX before | after |
|---|---|---|
| 100k | 13.7s | 10.6s |
| 200k | 29.9s | 22.3s |

Statement user CPU 7.2s → 6.0s at 100k; `appendEntry`/hash scan gone from the profile (remaining top: BLAKE3 ~30%, pwrite ~21% — content addressing and IO).

## Validation

- Schema-merge battery 390/390; full shell suite 114/114
- Stateful vc fuzzer seed 1787465601 on a DOLTLITE_PROLLY_CHECK build (running locally; CI vc-fuzz covers this too)
- Amalgamation compiles with the change; lint clean
- `prolly_mutmap.c` is DOLTLITE_PROLLY-gated; stock build untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)