### PR TITLE
Honor collation and INDEXED BY in COUNT BETWEEN

### DIFF
--- a/src/select.c
+++ b/src/select.c
@@ -5560,14 +5560,22 @@ static int exprColumnOfTable(Expr *pExpr, Table *pTab){
   return -2;
 }
 
-static Index *findSingleColumnIndex(Table *pTab, int iColumn){
+static Index *findSingleColumnIndex(
+  SrcItem *pSrc,
+  Table *pTab,
+  int iColumn,
+  const char *zColl
+){
   Index *pIdx;
-  for(pIdx=pTab->pIndex; pIdx; pIdx=pIdx->pNext){
+  if( pSrc->fg.notIndexed ) return 0;
+  pIdx = pSrc->fg.isIndexedBy ? pSrc->u2.pIBIndex : pTab->pIndex;
+  for(; pIdx; pIdx=pSrc->fg.isIndexedBy ? 0 : pIdx->pNext){
     if( pIdx->pPartIdxWhere==0
      && pIdx->bUnordered==0
      && pIdx->nKeyCol>=1
      && pIdx->aiColumn[0]==iColumn
      && (pIdx->aSortOrder==0 || pIdx->aSortOrder[0]==0)
+     && sqlite3StrICmp(pIdx->azColl[0], zColl)==0
     ){
       return pIdx;
     }
@@ -5660,6 +5668,8 @@ static Index *isSimpleIndexRangeCount(
   ExprList *pArgs;
   SrcItem *pSrc;
   Index *pIdx;
+  CollSeq *pColl;
+  CollSeq *pCollHigh;
   int iColumn;
   int iArgColumn;
 
@@ -5696,7 +5706,12 @@ static Index *isSimpleIndexRangeCount(
   ){
     return 0;
   }
-  pIdx = findSingleColumnIndex(pTab, iColumn);
+  pColl = sqlite3BinaryCompareCollSeq(pParse, p->pWhere->pLeft, *ppLow);
+  pCollHigh = sqlite3BinaryCompareCollSeq(pParse, p->pWhere->pLeft, *ppHigh);
+  if( pColl==0 ) pColl = pParse->db->pDfltColl;
+  if( pCollHigh==0 ) pCollHigh = pParse->db->pDfltColl;
+  if( sqlite3StrICmp(pColl->zName, pCollHigh->zName) ) return 0;
+  pIdx = findSingleColumnIndex(pSrc, pTab, iColumn, pColl->zName);
   if( !pIdx ) return 0;
 
   pExpr = p->pEList->a[0].pExpr;

--- a/test/doltlite_count_index_collation.sh
+++ b/test/doltlite_count_index_collation.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+. "$(dirname "$0")/lib/doltlite_test_common.sh"
+
+echo "=== COUNT(*) BETWEEN honors collation and INDEXED BY ==="
+echo ""
+
+DB=/tmp/test_doltlite_count_index_collation_$$.db
+rm -f "$DB"
+trap 'rm -f "$DB"' EXIT
+
+run_test "nocase_index_binary_column" "
+CREATE TABLE t(k TEXT);
+CREATE INDEX t_nocase ON t(k COLLATE NOCASE);
+INSERT INTO t VALUES('A');
+SELECT count(*) FROM t WHERE k BETWEEN 'a' AND 'z';
+SELECT count(*) FROM (SELECT k FROM t WHERE k BETWEEN 'a' AND 'z');
+SELECT count(*) FROM t NOT INDEXED WHERE k BETWEEN 'a' AND 'z';
+" "0
+0
+0" "$DB"
+
+rm -f "$DB"
+run_test "indexed_by_binary_skips_nocase" "
+CREATE TABLE t(k TEXT);
+CREATE INDEX t_nocase ON t(k COLLATE NOCASE);
+CREATE INDEX t_bin ON t(k);
+INSERT INTO t VALUES('A');
+SELECT count(*) FROM t INDEXED BY t_bin WHERE k BETWEEN 'a' AND 'z';
+" "0" "$DB"
+
+rm -f "$DB"
+run_test "binary_index_on_nocase_column" "
+CREATE TABLE t(k TEXT COLLATE NOCASE);
+CREATE INDEX t_bin ON t(k COLLATE BINARY);
+INSERT INTO t VALUES('A'),('b');
+SELECT count(*) FROM t WHERE k BETWEEN 'a' AND 'z';
+" "2" "$DB"
+
+rm -f "$DB"
+run_test "integer_between_still_counts" "
+CREATE TABLE t(v INT);
+CREATE INDEX t_v ON t(v);
+INSERT INTO t VALUES(1),(2),(3),(10);
+SELECT count(*) FROM t WHERE v BETWEEN 1 AND 3;
+" "3" "$DB"
+
+rm -f "$DB"
+run_test_match "integer_between_uses_covering_index" "
+CREATE TABLE t(v INT);
+CREATE INDEX t_v ON t(v);
+INSERT INTO t VALUES(1),(2),(3);
+EXPLAIN QUERY PLAN SELECT count(*) FROM t WHERE v BETWEEN 1 AND 3;
+" "SEARCH t USING COVERING INDEX t_v" "$DB"
+
+dltest_finish

--- a/test/lib/doltlite_suite_manifest.sh
+++ b/test/lib/doltlite_suite_manifest.sh
@@ -115,6 +115,7 @@ doltlite_index_prefix.sh
 doltlite_txn_seek_visibility.sh
 doltlite_txn_seek_prefix_contract.sh
 doltlite_count_numeric_range.sh
+doltlite_count_index_collation.sh
 doltlite_row_count_estimate.sh
 doltlite_regression_test_c.sh
 review_regression_test.sh


### PR DESCRIPTION
## Summary

Fixes #2392. `SELECT count(*) FROM t WHERE col BETWEEN lo AND hi` used `OP_CountIndexRange` on the first non-partial ASC index on `col`. It did not check collation or `INDEXED BY` / `NOT INDEXED`.

A `COLLATE NOCASE` index then counted rows that a BINARY comparison would reject, and `INDEXED BY` could not force the BINARY index.

Require the index collation to match the BETWEEN comparison (same rule `where.c` uses). If `INDEXED BY x`, only that index. If `NOT INDEXED`, skip the shortcut. Prefer skipping over a wrong count.

Integer `BETWEEN` with one matching index still uses the fast path.

No `CHUNK_STORE_VERSION` bump.

## Tests

`test/doltlite_count_index_collation.sh`: NOCASE index on BINARY column, `INDEXED BY` BINARY index, BINARY index on NOCASE column, integer BETWEEN still correct and still `COVERING INDEX`.

## Agent notes

- Branch is off current `master`.
- Staged by explicit path.
- Never deleted a test.

Co-Authored-By: Grok 4.6 <noreply@x.ai>