### PR TITLE
Theirs-changed-index rows adopt ours' number only on a name+table match

### DIFF
--- a/src/doltlite_merge_rebuild.c
+++ b/src/doltlite_merge_rebuild.c
@@ -377,9 +377,15 @@ int rebuildDisjointSchemaRows(
         }
       }
       if( !bMapped ){
+        /* Mirror pass 2's adoption test: it declines theirs' entry only
+        ** when ours holds the same object by name AND table, so a
+        ** same-named index on a different table stays pass-2-installed
+        ** at theirs' own number. */
         SchemaEntry *pOurSe = findSchemaEntry(aOursSchema, nOursSchema,
                                               pSe->zName);
-        if( pOurSe && pOurSe->zType && strcmp(pOurSe->zType, "index")==0 ){
+        if( pOurSe && pOurSe->zType && strcmp(pOurSe->zType, "index")==0
+         && pOurSe->zTblName && pSe->zTblName
+         && strcmp(pOurSe->zTblName, pSe->zTblName)==0 ){
           iRootpage = pOurSe->iRootpage;
         }else{
           iRootpage = pSe->iRootpage;

--- a/test/doltlite_schema_merge.sh
+++ b/test/doltlite_schema_merge.sh
@@ -2394,4 +2394,29 @@ run_test "merge_renumbered_index_reopen" \
 ok" "$DB"
 rm -f "$DB"
 
+# Reverting a table rename makes theirs' index share a name with ours' index
+# on a DIFFERENT table; pass 2 installs theirs' entry at its own number, so
+# the merged row must not be redirected to ours' number (which shifted with
+# the extra table and matches no merged entry). Used to fail the revert.
+DB=/tmp/test_revert_renamed_index_$$.db; rm -f "$DB"
+cat <<'EOF2' | $DOLTLITE "$DB" > /dev/null 2>&1
+CREATE TABLE t(a INTEGER PRIMARY KEY, v TEXT);
+CREATE INDEX ix ON t(v);
+INSERT INTO t VALUES(1,'x');
+SELECT dolt_commit('-Am','base');
+ALTER TABLE t RENAME TO t2;
+CREATE TABLE a0(id INTEGER PRIMARY KEY);
+SELECT dolt_commit('-Am','rename plus new table');
+EOF2
+run_test_match "revert_renamed_index_succeeds" "SELECT dolt_revert('HEAD');" \
+  "^[0-9a-f]{40}$" "$DB"
+run_test "revert_renamed_index_follows_back" \
+  "SELECT name, tbl_name FROM sqlite_master WHERE type='index';" \
+  "ix|t" "$DB"
+run_test "revert_renamed_index_intact" \
+  "SELECT v FROM t WHERE v='x'; PRAGMA integrity_check;" \
+  "x
+ok" "$DB"
+rm -f "$DB"
+
 dltest_finish


### PR DESCRIPTION
Fixes #2405 — a regression I introduced in #2389 that broke `dolt_revert` (both recent vc-fuzz reds: seeds 1787527244 step 1710 and 1787583757 step 2954, both op=revert).

## Root cause

#2389's override gave a theirs-changed-index row ours' rootpage whenever ours held an index of the same **name**. But pass 2 declines installing theirs' entry only when ours holds the same object by name **and table** (`doltlite_merge_pass2.c` `findCatalogEntryBySchemaObject`). Reverting a table rename creates exactly the mismatch: theirs' index shares a name with ours' index on a *different* table, pass 2 installs theirs' entry at theirs' own number, and the override then pointed the row at ours' shifted number — which matches no merged entry. The loader dropped the row and the post-merge `REINDEX` of the now-missing index failed the revert (`unable to identify the object to be reindexed`).

## Fix

The override now requires same name AND same table — mirroring pass 2's adoption test exactly. Remap mappings stay authoritative; otherwise theirs' own number stands.

## Repro (fails on master, passes here)

```sql
CREATE TABLE t(a INTEGER PRIMARY KEY, v TEXT);
CREATE INDEX ix ON t(v);
INSERT INTO t VALUES(1,'x');
SELECT dolt_commit('-Am','base');
ALTER TABLE t RENAME TO t2;             -- ix follows the rename
CREATE TABLE a0(id INTEGER PRIMARY KEY); -- shifts ours' canonical numbering
SELECT dolt_commit('-Am','rename plus new table');
SELECT dolt_revert('HEAD');  -- master: revert of "HEAD" failed
```

## Validation

- Fail-before/pass-after on the repro; regression tests added (battery 393/393)
- The fuzzer's preserved failing state replays clean; #2384's golden asset and minimal repro still pass (this preserves #2389's fix)
- Seed 1787527244 clean for 2374 steps (past the failing 1710) on a DOLTLITE_PROLLY_CHECK build; seeds 1787583757 / 1787465601 confirmations in flight, CI vc-fuzz covers independently
- Full shell suite green (one count-perf timing flake under fuzz load; 15/15 solo)
- Amalgamation compiles; lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)