### PR TITLE
Open sqlite3_blob on clustered PRIMARY KEY tables

### DIFF
--- a/src/prolly_btree_mutation.c
+++ b/src/prolly_btree_mutation.c
@@ -1522,13 +1522,8 @@ int prollyBtCursorPutData(BtCursor *pCur, u32 offset, u32 amt, void *pBuf){
     payload.pData = pNew;
     payload.nData = nVal;
   } else {
-    const u8 *pKey;
-    int nKey;
-    prollyCursorKey(&pCur->pCur, &pKey, &nKey);
-    payload.pKey = pKey;
-    payload.nKey = nKey;
-    payload.pData = pNew;
-    payload.nData = nVal;
+    payload.pKey = pNew;
+    payload.nKey = nVal;
   }
 
   rc = sqlite3BtreeInsert(pCur, &payload, 0, 0);

--- a/src/vdbeblob.c
+++ b/src/vdbeblob.c
@@ -178,6 +178,12 @@ int sqlite3_blob_open(
       pTab = 0;
       sqlite3ErrorMsg(&sParse, "cannot open virtual table: %s", zTable);
     }
+#ifndef SQLITE_OMIT_VIEW
+    if( pTab && IsView(pTab) ){
+      pTab = 0;
+      sqlite3ErrorMsg(&sParse, "cannot open view: %s", zTable);
+    }
+#endif
 #ifdef DOLTLITE_PROLLY
     if( pTab && !VisibleRowid(pTab) ){
 #else
@@ -191,12 +197,6 @@ int sqlite3_blob_open(
       sqlite3ErrorMsg(&sParse, "cannot open table with generated columns: %s",
                       zTable);
     }
-#ifndef SQLITE_OMIT_VIEW
-    if( pTab && IsView(pTab) ){
-      pTab = 0;
-      sqlite3ErrorMsg(&sParse, "cannot open view: %s", zTable);
-    }
-#endif
     if( pTab==0
      || ((iDb = sqlite3SchemaToIndex(db, pTab->pSchema))==1 &&
          sqlite3OpenTempDatabase(&sParse))
@@ -336,7 +336,7 @@ int sqlite3_blob_open(
         sqlite3VdbeAddOp2(v, OP_Next, 0, addrRowid);
         addrMiss = sqlite3VdbeAddOp0(v, OP_Halt);
         addrFound = sqlite3VdbeAddOp3(v, OP_Column, 0, iStore, 3);
-        sqlite3VdbeAddOp2(v, OP_ResultRow, 3, 1);
+        sqlite3VdbeAddOp2(v, OP_ResultRow, 1, 0);
         sqlite3VdbeAddOp0(v, OP_Halt);
         if( db->mallocFailed==0 ){
           sqlite3VdbeChangeP2(v, addrRewind, addrMiss);

--- a/src/vdbeblob.c
+++ b/src/vdbeblob.c
@@ -67,7 +67,11 @@ static int blobSeekToRow(Incrblob *p, sqlite3_int64 iRow, char **pzErr){
   ** counter is faster. */
   if( v->pc>4 ){
     v->pc = 4;
-    assert( v->aOp[v->pc].opcode==OP_NotExists );
+    assert( v->aOp[v->pc].opcode==OP_NotExists
+#ifdef DOLTLITE_PROLLY
+         || v->aOp[v->pc].opcode==OP_Rewind
+#endif
+    );
     rc = sqlite3VdbeExec(v);
   }else{
     rc = sqlite3_step(p->pStmt);
@@ -174,7 +178,11 @@ int sqlite3_blob_open(
       pTab = 0;
       sqlite3ErrorMsg(&sParse, "cannot open virtual table: %s", zTable);
     }
+#ifdef DOLTLITE_PROLLY
+    if( pTab && !VisibleRowid(pTab) ){
+#else
     if( pTab && !HasRowid(pTab) ){
+#endif
       pTab = 0;
       sqlite3ErrorMsg(&sParse, "cannot open table without rowid: %s", zTable);
     }
@@ -294,6 +302,53 @@ int sqlite3_blob_open(
                            pTab->pSchema->iGeneration);
       sqlite3VdbeChangeP5(v, 1);
       assert( sqlite3VdbeCurrentAddr(v)==2 || db->mallocFailed );
+#ifdef DOLTLITE_PROLLY
+      if( !HasRowid(pTab) ){
+        Index *pPk = sqlite3PrimaryKeyIndex(pTab);
+        int iStore;
+        int addrRewind, addrRowid, addrEq, addrMiss, addrFound;
+
+        sqlite3VdbeUsesBtree(v, iDb);
+        iStore = pPk ? sqlite3TableColumnToIndex(pPk, iCol) : -1;
+        if( iStore<0 ){
+          sqlite3DbFree(db, zErr);
+          zErr = sqlite3MPrintf(db, "no such column: \"%s\"", zColumn);
+          rc = SQLITE_ERROR;
+          sqlite3BtreeLeaveAll(db);
+          goto blob_open_out;
+        }
+        pBlob->iCol = (u16)iStore;
+#ifdef SQLITE_OMIT_SHARED_CACHE
+        sqlite3VdbeAddOp0(v, OP_Noop);
+#else
+        sqlite3VdbeAddOp3(v, OP_TableLock, iDb, pTab->tnum, wrFlag);
+        sqlite3VdbeChangeP4(v, 2, pTab->zName, P4_TRANSIENT);
+#endif
+        sqlite3VdbeAddOp3(v, wrFlag ? OP_OpenWrite : OP_OpenRead,
+                          0, pPk->tnum, iDb);
+        sqlite3VdbeSetP4KeyInfo(&sParse, pPk);
+        /* blobSeekToRow() restarts at addr 4 (OP_Rewind). */
+        assert( sqlite3VdbeCurrentAddr(v)==4 || db->mallocFailed );
+        addrRewind = sqlite3VdbeAddOp2(v, OP_Rewind, 0, 0);
+        addrRowid = sqlite3VdbeAddOp2(v, OP_Rowid, 0, 2);
+        addrEq = sqlite3VdbeAddOp3(v, OP_Eq, 1, 0, 2);
+        sqlite3VdbeChangeP5(v, SQLITE_AFF_NUMERIC|SQLITE_NULLEQ);
+        sqlite3VdbeAddOp2(v, OP_Next, 0, addrRowid);
+        addrMiss = sqlite3VdbeAddOp0(v, OP_Halt);
+        addrFound = sqlite3VdbeAddOp3(v, OP_Column, 0, iStore, 3);
+        sqlite3VdbeAddOp2(v, OP_ResultRow, 3, 1);
+        sqlite3VdbeAddOp0(v, OP_Halt);
+        if( db->mallocFailed==0 ){
+          sqlite3VdbeChangeP2(v, addrRewind, addrMiss);
+          sqlite3VdbeChangeP2(v, addrEq, addrFound);
+          sParse.nVar = 0;
+          sParse.nMem = 3;
+          sParse.nTab = 1;
+          sqlite3VdbeMakeReady(v, &sParse);
+        }
+      }else
+#endif
+      {
       aOp = sqlite3VdbeAddOpList(v, ArraySize(openBlob), openBlob, iLn);
 
       /* Make sure a mutex is held on the table to be accessed */
@@ -335,9 +390,16 @@ int sqlite3_blob_open(
         sParse.nTab = 1;
         sqlite3VdbeMakeReady(v, &sParse);
       }
+      }
     }
    
+#ifdef DOLTLITE_PROLLY
+    if( HasRowid(pTab) ){
+      pBlob->iCol = iCol;
+    }
+#else
     pBlob->iCol = iCol;
+#endif
     pBlob->db = db;
     sqlite3BtreeLeaveAll(db);
     if( db->mallocFailed ){

--- a/test/doltlite_recover_incrblob.test
+++ b/test/doltlite_recover_incrblob.test
@@ -19,26 +19,41 @@ do_execsql_test 1.0 {
 } {}
 
 do_test 1.1 {
-  set rc [catch {db incrblob pk b 1} msg]
-  list $rc $msg [sqlite3_errmsg db]
-} {1 {cannot open table without rowid: pk} {cannot open table without rowid: pk}}
+  set rowid [db one {SELECT rowid FROM pk}]
+  set blob [db incrblob pk b $rowid]
+  fconfigure $blob -translation binary
+  binary scan [read $blob] H* h
+  close $blob
+  set h
+} {0102030405060708090a}
 
 do_test 1.2 {
-  set rc [catch {db incrblob -readonly pk b 1} msg]
-  list $rc $msg [sqlite3_errmsg db]
-} {1 {cannot open table without rowid: pk} {cannot open table without rowid: pk}}
+  set rowid [db one {SELECT rowid FROM pk}]
+  set blob [db incrblob -readonly pk b $rowid]
+  fconfigure $blob -translation binary
+  binary scan [read $blob] H* h
+  close $blob
+  set h
+} {0102030405060708090a}
 
 do_test 1.3 {
   unset -nocomplain B
-  set rc [catch {sqlite3_blob_open db main pk b 1 0 B} msg]
-  list $rc $msg [sqlite3_errmsg db]
-} {1 SQLITE_ERROR {cannot open table without rowid: pk}}
+  set rowid [db one {SELECT rowid FROM pk}]
+  sqlite3_blob_open db main pk b $rowid 0 B
+  set n [sqlite3_blob_bytes $B]
+  binary scan [sqlite3_blob_read $B 0 $n] H* h
+  sqlite3_blob_close $B
+  list $n $h
+} {10 0102030405060708090a}
 
 do_test 1.4 {
   unset -nocomplain B
-  set rc [catch {sqlite3_blob_open db main pk b 1 1 B} msg]
-  list $rc $msg [sqlite3_errmsg db]
-} {1 SQLITE_ERROR {cannot open table without rowid: pk}}
+  set rowid [db one {SELECT rowid FROM pk}]
+  sqlite3_blob_open db main pk b $rowid 1 B
+  sqlite3_blob_write $B 0 ABCDEFGHIJ
+  sqlite3_blob_close $B
+  db eval {SELECT hex(b) FROM pk}
+} {4142434445464748494A}
 
 do_test 1.5 {
   set blob [db incrblob ipk b 1]
@@ -60,7 +75,7 @@ do_execsql_test 1.7 {
   SELECT a, hex(b) FROM pk;
   SELECT id, hex(b) FROM ipk;
   PRAGMA integrity_check;
-} {one 0102030405060708090A 1 0102030405060708090A ok}
+} {one 4142434445464748494A 1 0102030405060708090A ok}
 
 do_ioerr_test 2 -count 20 -cksum 1 -sqlprep {
   CREATE TABLE blobs(k INTEGER PRIMARY KEY, v BLOB);

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -85,6 +85,17 @@ static const char *queryScalarText(sqlite3 *db, const char *sql){
   return gBuf;
 }
 
+static sqlite3_int64 queryInt64(sqlite3 *db, const char *sql){
+  sqlite3_stmt *stmt = 0;
+  sqlite3_int64 v = 0;
+  if( sqlite3_prepare_v2(db, sql, -1, &stmt, 0)==SQLITE_OK
+   && sqlite3_step(stmt)==SQLITE_ROW ){
+    v = sqlite3_column_int64(stmt, 0);
+  }
+  sqlite3_finalize(stmt);
+  return v;
+}
+
 static int execSql(sqlite3 *db, const char *sql){
   char *err = 0;
   int rc = sqlite3_exec(db, sql, 0, 0, &err);
@@ -12232,6 +12243,116 @@ static void run_rowid_named_pk_keeps_rowid_table(void){
   removeDbFiles(dbpath);
 }
 
+/* Clustered TEXT PK tables expose SQL rowid; sqlite3_blob_open must seek by that
+** rowid. Explicit WITHOUT ROWID stays rejected. */
+static void run_clustered_pk_blob_open(void){
+  char dbpath[512];
+  sqlite3 *db = 0;
+  sqlite3_blob *pBlob = 0;
+  sqlite3_int64 rowid;
+  sqlite3_int64 rowid2;
+  unsigned char buf[8];
+  int rc;
+
+  printf("=== Clustered PK Blob Open Test ===\n\n");
+  make_dbpath(dbpath, sizeof(dbpath), "test_clustered_pk_blob_open");
+  removeDbFiles(dbpath);
+
+  rc = sqlite3_open(dbpath, &db);
+  check("cpk_blob_open_db", rc==SQLITE_OK);
+  if( !db ) return;
+
+  check("cpk_blob_setup", execSql(db,
+      "CREATE TABLE cpk(k TEXT PRIMARY KEY, b BLOB);"
+      "INSERT INTO cpk VALUES('k', x'0102');")==SQLITE_OK);
+  rowid = queryInt64(db, "SELECT rowid FROM cpk");
+  check("cpk_blob_sql_rowid_nonzero", rowid!=0);
+
+  rc = sqlite3_blob_open(db, "main", "cpk", "b", rowid, 0, &pBlob);
+  check("cpk_blob_open_read", rc==SQLITE_OK);
+  if( rc!=SQLITE_OK ){
+    fprintf(stderr, "  cpk_blob_open_read: %s\n", sqlite3_errmsg(db));
+  }
+  if( pBlob ){
+    memset(buf, 0, sizeof(buf));
+    check("cpk_blob_bytes", sqlite3_blob_bytes(pBlob)==2);
+    check("cpk_blob_read",
+          sqlite3_blob_read(pBlob, buf, 2, 0)==SQLITE_OK
+          && buf[0]==0x01 && buf[1]==0x02);
+    sqlite3_blob_close(pBlob);
+    pBlob = 0;
+  }
+
+  rc = sqlite3_blob_open(db, "main", "cpk", "b", rowid, 1, &pBlob);
+  check("cpk_blob_open_write", rc==SQLITE_OK);
+  if( pBlob ){
+    check("cpk_blob_write", sqlite3_blob_write(pBlob, "AB", 2, 0)==SQLITE_OK);
+    sqlite3_blob_close(pBlob);
+    pBlob = 0;
+  }
+  check("cpk_blob_write_landed",
+        strcmp(queryScalarText(db, "SELECT hex(b) FROM cpk"), "4142")==0);
+
+  sqlite3_close(db);
+  db = 0;
+  rc = sqlite3_open(dbpath, &db);
+  check("cpk_blob_reopen_db", rc==SQLITE_OK);
+  if( db ){
+    check("cpk_blob_write_persisted",
+          strcmp(queryScalarText(db, "SELECT hex(b) FROM cpk"), "4142")==0);
+  }
+
+  check("cpk_blob_blob_first_col", execSql(db,
+      "CREATE TABLE cpk2(b BLOB, k TEXT PRIMARY KEY);"
+      "INSERT INTO cpk2 VALUES(x'aa', 'x');"
+      "INSERT INTO cpk2 VALUES(x'bb', 'y');")==SQLITE_OK);
+  rowid = queryInt64(db, "SELECT rowid FROM cpk2 WHERE k='x'");
+  rowid2 = queryInt64(db, "SELECT rowid FROM cpk2 WHERE k='y'");
+  rc = sqlite3_blob_open(db, "main", "cpk2", "b", rowid, 0, &pBlob);
+  check("cpk_blob_open_non_leading_pk", rc==SQLITE_OK);
+  if( pBlob ){
+    memset(buf, 0, sizeof(buf));
+    check("cpk_blob_read_non_leading_pk",
+          sqlite3_blob_read(pBlob, buf, 1, 0)==SQLITE_OK && buf[0]==0xaa);
+    check("cpk_blob_reopen_other_row",
+          sqlite3_blob_reopen(pBlob, rowid2)==SQLITE_OK);
+    memset(buf, 0, sizeof(buf));
+    check("cpk_blob_reopen_read",
+          sqlite3_blob_read(pBlob, buf, 1, 0)==SQLITE_OK && buf[0]==0xbb);
+    sqlite3_blob_close(pBlob);
+    pBlob = 0;
+  }
+
+  check("ipk_blob_setup", execSql(db,
+      "CREATE TABLE ipk(id INTEGER PRIMARY KEY, b BLOB);"
+      "INSERT INTO ipk VALUES(1, x'0102');")==SQLITE_OK);
+  rc = sqlite3_blob_open(db, "main", "ipk", "b", 1, 0, &pBlob);
+  check("ipk_blob_open", rc==SQLITE_OK);
+  if( pBlob ){
+    memset(buf, 0, sizeof(buf));
+    check("ipk_blob_read",
+          sqlite3_blob_read(pBlob, buf, 2, 0)==SQLITE_OK
+          && buf[0]==0x01 && buf[1]==0x02);
+    sqlite3_blob_close(pBlob);
+    pBlob = 0;
+  }
+
+  check("wor_blob_setup", execSql(db,
+      "CREATE TABLE wor(k TEXT PRIMARY KEY, b BLOB) WITHOUT ROWID;"
+      "INSERT INTO wor VALUES('k', x'0102');")==SQLITE_OK);
+  rc = sqlite3_blob_open(db, "main", "wor", "b", 1, 0, &pBlob);
+  check("wor_blob_open_rejected", rc==SQLITE_ERROR);
+  check("wor_blob_open_msg",
+        strstr(sqlite3_errmsg(db), "cannot open table without rowid")!=0);
+  if( pBlob ){
+    sqlite3_blob_close(pBlob);
+    pBlob = 0;
+  }
+
+  sqlite3_close(db);
+  removeDbFiles(dbpath);
+}
+
 /* Untrusted refs blob: bound each u32 count; oversized counts are corrupt, not a wrapped alloc. */
 static void run_refs_deserialize_overflow_guard(void){
   printf("=== Refs Deserialize Overflow Guard Test ===\n\n");
@@ -13082,6 +13203,7 @@ static const RegressionCase aCases[] = {
   { "incrblob_legacy_engine_write", "Incrblob Legacy Engine Write Test", run_incrblob_legacy_engine_write },
   { "incrblob_chunked_and_multihandle", "Incrblob Chunked Record And Multi-Handle Test", run_incrblob_chunked_and_multihandle },
   { "rowid_named_pk_keeps_rowid_table", "Rowid-Named PK Keeps Rowid Table Test", run_rowid_named_pk_keeps_rowid_table },
+  { "clustered_pk_blob_open", "Clustered PK Blob Open Test", run_clustered_pk_blob_open },
   { "diff_side_schema_custom_function", "Diff Side Schema Custom Function Test", run_diff_side_schema_custom_function },
   { "rollback_persist_failure_ends_txn", "Rollback Persist Failure Ends Write Txn Test", run_rollback_persist_failure_ends_txn },
   { "blob_restore_mutmap_keeps_scan", "Blob Restore MutMap Keeps Scan Test", run_blob_restore_mutmap_keeps_scan },

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -216,7 +216,6 @@ collate4 collate4-1.2.13 class=intentional
 fkey1 fkey1-4.2 class=intentional  # table_info notnull=1 on the TEXT PK column (PK-clustered; matches stock WITHOUT ROWID), not FK-related
 
 # ── fkey2 ──
-fkey2 fkey2-5.2 class=intentional issue=1840  # FK + rowid interaction
 fkey2 fkey2-5.3 class=intentional issue=1840
 fkey2 fkey2-5.4 class=intentional issue=1840
 fkey2 fkey2-13.1.2.1 class=intentional issue=1840

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -1839,7 +1839,6 @@ dbstatus2 dbstatus2-1.2 class=intentional  # DBSTATUS cache stats zero under chu
 dbstatus2 dbstatus2-1.3 class=intentional  # DBSTATUS cache stats zero under chunk store; dbstat on WITHOUT ROWID
 dbstatus2 dbstatus2-1.4 class=intentional  # DBSTATUS cache stats zero under chunk store; dbstat on WITHOUT ROWID
 dbstatus2 dbstatus2-1.5 class=intentional  # DBSTATUS cache stats zero under chunk store; dbstat on WITHOUT ROWID
-dbstatus2 dbstatus2-1.7 class=intentional  # DBSTATUS cache stats zero under chunk store; dbstat on WITHOUT ROWID
 dbstatus2 dbstatus2-1.8 class=intentional  # DBSTATUS cache stats zero under chunk store; dbstat on WITHOUT ROWID
 dbstatus2 dbstatus2-1.9 class=intentional  # DBSTATUS cache stats zero under chunk store; dbstat on WITHOUT ROWID
 dbstatus2 dbstatus2-2.2 class=intentional  # DBSTATUS cache stats zero under chunk store; dbstat on WITHOUT ROWID
@@ -3110,13 +3109,9 @@ e_blobclose e_blobclose-3.3 class=intentional
 e_blobclose e_blobclose-3.4 class=intentional
 e_blobclose e_blobclose-3.5 class=intentional
 
-# All 4.8.* tests call sqlite3_blob_open on t3(a PRIMARY KEY, b, c, d, e, f,
-# UNIQUE(e,f)) — an explicit-PK table that doltlite stores without a rowid,
-# so blob_open fails "cannot open table without rowid: t3" (rowid-on-PK
-# class). The 4.8.1.* read-access opens that stock allows fail outright, and
-# the 4.8.2.* cases that expect "cannot open indexed column for writing"
-# get the without-rowid message instead. Every blob_open test on genuine
-# rowid tables (sections 1-4.7, 4.9+) passes.
+# t3 is clustered TEXT PK. blob_open is allowed, but iRow=1 is not the
+# hashed SQL rowid of 'aaaa', so 4.8.1.* reads and 4.8.2.3/4 writes that
+# stock allows still fail. Indexed-column write guards now match stock.
 e_blobopen e_blobopen-4.8.1.1.1 class=intentional
 e_blobopen e_blobopen-4.8.1.1.2 class=intentional
 e_blobopen e_blobopen-4.8.1.1.3 class=intentional
@@ -3141,8 +3136,6 @@ e_blobopen e_blobopen-4.8.1.6.1 class=intentional
 e_blobopen e_blobopen-4.8.1.6.2 class=intentional
 e_blobopen e_blobopen-4.8.1.6.3 class=intentional
 e_blobopen e_blobopen-4.8.1.6.4 class=intentional
-e_blobopen e_blobopen-4.8.2.1.3 class=intentional
-e_blobopen e_blobopen-4.8.2.2.3 class=intentional
 e_blobopen e_blobopen-4.8.2.3.1 class=intentional
 e_blobopen e_blobopen-4.8.2.3.2 class=intentional
 e_blobopen e_blobopen-4.8.2.3.3 class=intentional
@@ -3151,8 +3144,6 @@ e_blobopen e_blobopen-4.8.2.4.1 class=intentional
 e_blobopen e_blobopen-4.8.2.4.2 class=intentional
 e_blobopen e_blobopen-4.8.2.4.3 class=intentional
 e_blobopen e_blobopen-4.8.2.4.4 class=intentional
-e_blobopen e_blobopen-4.8.2.5.3 class=intentional
-e_blobopen e_blobopen-4.8.2.6.3 class=intentional
 
 # e_reindex-1.3 hides the indexes via writable_schema, mutates the table,
 # restores the index rows, and checks integrity_check output. doltlite

--- a/test/known_testfixture_exception_ratchet.txt
+++ b/test/known_testfixture_exception_ratchet.txt
@@ -6,8 +6,8 @@
 # Counts are per gate -- one divergent assertion, or one expected crash.
 # Lowering a number is the point. Raising one is a deliberate act that belongs
 # in a PR description.
-gates 4732
-intentional 3409
+gates 4727
+intentional 3404
 unsupported 1166
 harness 11
 engine-gap 146

--- a/test/known_testfixture_exception_ratchet.txt
+++ b/test/known_testfixture_exception_ratchet.txt
@@ -6,8 +6,8 @@
 # Counts are per gate -- one divergent assertion, or one expected crash.
 # Lowering a number is the point. Raising one is a deliberate act that belongs
 # in a PR description.
-gates 4733
-intentional 3410
+gates 4732
+intentional 3409
 unsupported 1166
 harness 11
 engine-gap 146


### PR DESCRIPTION
Fixes #2394.

## Problem

PR #2368 restored SQL `rowid` / `last_insert_rowid()` on auto-clustered (non-INTEGER PRIMARY KEY) tables (`VisibleRowid`). `sqlite3_blob_open` still used `HasRowid` and rejected those tables:

```
cannot open table without rowid: cpk
```

Stock SQLite opens a blob by the integer rowid on any rowid table, including `TEXT PRIMARY KEY`. INTEGER PRIMARY KEY already worked. Explicit `WITHOUT ROWID` should keep failing.

## Fix

- Allow `sqlite3_blob_open` when `VisibleRowid(pTab)`, even if `!HasRowid`.
- For clustered tables, open the PK index with KeyInfo and scan for the SQL rowid (`OP_Rowid` / `sqlite3BtreeSqlRowid`), the same mapping as `SELECT rowid` / `WHERE rowid=?`. `blobSeekToRow` restarts at `OP_Rewind` (addr 4).
- Map the blob column through `sqlite3TableColumnToIndex` so a non-leading PK still reads the right field.
- `sqlite3_blob_write` on a blobkey cursor now reinserts the patched sqlite record as `pKey` (the clustered insert path), not a sort key.

Do not store an extra rowid column. Do not bump `CHUNK_STORE_VERSION`. `DOLTLITE_PROLLY=0` keeps stock `HasRowid` blob_open.

## Tests

Fail-before / pass-after in `test/doltlite_regression_test_c.c` (`clustered_pk_blob_open`):

| case | unfixed | fixed |
|---|---|---|
| TEXT PK + BLOB `sqlite3_blob_open` read/write/persist | `cannot open table without rowid` | pass |
| BLOB before TEXT PK + `sqlite3_blob_reopen` | fail | pass |
| INTEGER PRIMARY KEY | pass | pass |
| explicit `WITHOUT ROWID` | `cannot open table without rowid` | same |

Existing incrblob cases still pass: `incrblob_legacy_engine_write` 12/12, `incrblob_chunked_and_multihandle` 39/39, `rowid_named_pk_keeps_rowid_table` 20/20.

Co-Authored-By: Grok 4.6 <noreply@x.ai>