### PR TITLE
Cover nightly revert index regression

### DIFF
--- a/test/doltlite_schema_merge.sh
+++ b/test/doltlite_schema_merge.sh
@@ -2419,4 +2419,39 @@ run_test "revert_renamed_index_intact" \
 ok" "$DB"
 rm -f "$DB"
 
+DB=/tmp/test_revert_renumbered_indexes_$$.db; rm -f "$DB"
+cat <<'EOF' | $DOLTLITE "$DB" > /dev/null 2>&1
+CREATE TABLE a(id INTEGER PRIMARY KEY, payload TEXT);
+CREATE TABLE b(id INTEGER PRIMARY KEY);
+INSERT INTO a VALUES(1,'one'),(2,'two');
+CREATE INDEX i1 ON a(payload);
+CREATE INDEX i2 ON a(payload);
+CREATE INDEX i3 ON a(payload);
+SELECT dolt_commit('-Am','base');
+ALTER TABLE a RENAME TO c;
+CREATE TABLE d(id INTEGER PRIMARY KEY);
+INSERT INTO c VALUES(3,'three');
+SELECT dolt_commit('-Am','rename and add');
+EOF
+run_test_match "revert_renumbered_indexes_hash" "SELECT dolt_revert('HEAD');" \
+  "^[0-9a-f]{40}$" "$DB"
+run_test "revert_renumbered_indexes_tables" \
+  "SELECT group_concat(name) FROM (SELECT name FROM sqlite_master WHERE type='table' ORDER BY name);" \
+  "a,b" "$DB"
+run_test "revert_renumbered_indexes_owners" \
+  "SELECT group_concat(name || ':' || tbl_name) FROM (SELECT name,tbl_name FROM sqlite_master WHERE type='index' ORDER BY name);" \
+  "i1:a,i2:a,i3:a" "$DB"
+run_test "revert_renumbered_indexes_rows" \
+  "SELECT id FROM a INDEXED BY i1 WHERE payload='two';
+   SELECT id FROM a INDEXED BY i2 WHERE payload='two';
+   SELECT id FROM a INDEXED BY i3 WHERE payload='two';" \
+  "2
+2
+2" "$DB"
+run_test "revert_renumbered_indexes_distinct_pages" \
+  "SELECT count(DISTINCT rootpage) = count(*) FROM sqlite_master WHERE rootpage > 0;" \
+  "1" "$DB"
+run_test "revert_renumbered_indexes_reopen" "PRAGMA integrity_check;" "ok" "$DB"
+rm -f "$DB"
+
 dltest_finish

--- a/test/vc_oracle_revert_cherrypick_test.sh
+++ b/test/vc_oracle_revert_cherrypick_test.sh
@@ -993,6 +993,38 @@ SELECT dolt_revert('HEAD');
 " "SELECT 'Q|' || (SELECT count(*) FROM sqlite_master WHERE name = 'idx') || '|' || (SELECT group_concat(id, ',') FROM (SELECT id FROM t WHERE v = 10 ORDER BY id))" \
 "SELECT concat('Q|', (SELECT count(*) FROM information_schema.statistics WHERE table_name = 't' AND index_name = 'idx'), '|', (SELECT group_concat(id ORDER BY id SEPARATOR ',') FROM t WHERE v = 10))"
 
+oracle_dual_poststate "revert_renumbered_indexes" "
+CREATE TABLE a(id INTEGER PRIMARY KEY, payload TEXT);
+CREATE TABLE b(id INTEGER PRIMARY KEY);
+INSERT INTO a VALUES (1, 'one'), (2, 'two');
+CREATE INDEX i1 ON a(payload);
+CREATE INDEX i2 ON a(payload);
+CREATE INDEX i3 ON a(payload);
+SELECT dolt_commit('-Am', 'base');
+ALTER TABLE a RENAME TO c;
+CREATE TABLE d(id INTEGER PRIMARY KEY);
+INSERT INTO c VALUES (3, 'three');
+SELECT dolt_commit('-Am', 'rename and add');
+SELECT dolt_revert('HEAD');
+" "
+CREATE TABLE a(id INT PRIMARY KEY, payload VARCHAR(100));
+CREATE TABLE b(id INT PRIMARY KEY);
+INSERT INTO a VALUES (1, 'one'), (2, 'two');
+CREATE INDEX i1 ON a(payload);
+CREATE INDEX i2 ON a(payload);
+CREATE INDEX i3 ON a(payload);
+SELECT dolt_commit('-Am', 'base');
+ALTER TABLE a RENAME TO c;
+CREATE TABLE d(id INT PRIMARY KEY);
+INSERT INTO c VALUES (3, 'three');
+SELECT dolt_commit('-Am', 'rename and add');
+SELECT dolt_revert('HEAD');
+" "SELECT 'Q|' ||
+       (SELECT group_concat(name, ',') FROM (SELECT name FROM sqlite_master WHERE type='table' ORDER BY name)) || '|' ||
+       (SELECT group_concat(name, ',') FROM (SELECT name FROM sqlite_master WHERE type='index' ORDER BY name)) || '|' ||
+       (SELECT group_concat(id, ',') FROM (SELECT id FROM a ORDER BY id))" \
+"SELECT concat('Q|', (SELECT group_concat(table_name ORDER BY table_name SEPARATOR ',') FROM information_schema.tables WHERE table_name IN ('a','b','c','d')), '|', (SELECT group_concat(index_name ORDER BY index_name SEPARATOR ',') FROM information_schema.statistics WHERE index_name IN ('i1','i2','i3')), '|', (SELECT group_concat(id ORDER BY id SEPARATOR ',') FROM a))"
+
 oracle_error "revert_view_add_after_modify_conflicts" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
 SELECT dolt_commit('-Am', 'base');


### PR DESCRIPTION
## Summary

- reproduce stateful VC seed 1787552356 against its preserved 10,926-step database
- add a compact three-index regression for the rename/revert rootpage mismatch
- add Dolt oracle coverage for the same post-revert schema and rows

The engine correction landed in #2406 while this failure was being diagnosed. This PR preserves the fuller multi-index shape found by the nightly fuzzer and closes the original report.

## Validation

- original nightly database: revert succeeds, 86 indexes restored, integrity check passes
- `DOLTLITE=build/doltlite bash test/doltlite_schema_merge.sh` (399/399)
- `bash test/vc_oracle_revert_cherrypick_test.sh build/doltlite dolt` (61/61)
- `make lint`

Fixes #2402