### PR TITLE
Failed CREATE VIRTUAL TABLE aborts its statement, not the transaction

### DIFF
--- a/src/vdbe.c
+++ b/src/vdbe.c
@@ -8838,7 +8838,7 @@ case OP_VBegin: {
 case OP_VCreate: {
   Mem sMem;          /* For storing the record being decoded */
   const char *zTab;  /* Name of the virtual table */
-#ifdef DOLTLITE_PROLLY
+#if defined(DOLTLITE_PROLLY) && defined(SQLITE_TEST)
   int bUnknownTokenizer = 0;
 #endif
 
@@ -8853,7 +8853,7 @@ case OP_VCreate: {
   zTab = (const char*)sqlite3_value_text(&sMem);
   assert( zTab || db->mallocFailed );
   if( zTab ){
-#ifdef DOLTLITE_PROLLY
+#if defined(DOLTLITE_PROLLY) && defined(SQLITE_TEST)
     Table *pTab = sqlite3FindTable(db, zTab, db->aDb[pOp->p1].zDbSName);
     if( pTab && IsVirtual(pTab) ){
       int ii;
@@ -8876,9 +8876,6 @@ case OP_VCreate: {
     rc = sqlite3VtabCallCreate(db, pOp->p1, zTab, &p->zErrMsg);
 #ifdef DOLTLITE_PROLLY
     if( rc ){
-      if( !db->mallocFailed ){
-        (void)sqlite3BtreeRollback(db->aDb[pOp->p1].pBt, SQLITE_OK, 0);
-      }
       assert( resetSchemaOnFault==0 || resetSchemaOnFault==pOp->p1+1 );
       resetSchemaOnFault = pOp->p1+1;
     }
@@ -8886,7 +8883,9 @@ case OP_VCreate: {
     if( rc && db->mallocFailed ){
       rc = SQLITE_NOMEM_BKPT;
     }
-#ifdef DOLTLITE_PROLLY
+#if defined(DOLTLITE_PROLLY) && defined(SQLITE_TEST)
+    /* The generic constructor message only replaces the tokenizer error
+    ** when allocating that error failed; the OOM harness expects NOMEM. */
     else if( rc && bUnknownTokenizer && p->zErrMsg
            && sqlite3_strnicmp(p->zErrMsg, "vtable constructor failed:", 26)==0 ){
       sqlite3DbFree(db, p->zErrMsg);

--- a/test/doltlite_fts_stmt_savepoint.test
+++ b/test/doltlite_fts_stmt_savepoint.test
@@ -55,4 +55,48 @@ do_execsql_test 3.0 {
          (SELECT md5sum(term, docid, col, pos) FROM t2check);
 } {1}
 
+# A failed CREATE VIRTUAL TABLE must abort only its own statement. It used
+# to roll back the whole btree transaction: earlier DML in an open BEGIN
+# vanished while SQL still believed the transaction was open.
+do_execsql_test 3.0 {
+  CREATE TABLE keepme(a INTEGER PRIMARY KEY, b TEXT);
+  BEGIN;
+  INSERT INTO keepme VALUES(1, 'keep');
+}
+do_catchsql_test 3.1 {
+  CREATE VIRTUAL TABLE vbad USING fts3(x, tokenize nosuch);
+} {1 {unknown tokenizer: nosuch}}
+do_test 3.2 { sqlite3_get_autocommit db } {0}
+do_execsql_test 3.3 { SELECT a, b FROM keepme } {1 keep}
+do_execsql_test 3.4 {
+  SELECT count(*) FROM sqlite_master WHERE name='vbad';
+} {0}
+do_execsql_test 3.5 { COMMIT }
+do_execsql_test 3.6 { SELECT a, b FROM keepme } {1 keep}
+
+# Control: the same failure outside a transaction leaves the database
+# usable and records nothing.
+do_catchsql_test 3.7 {
+  CREATE VIRTUAL TABLE vbad2 USING fts3(x, tokenize nosuch);
+} {1 {unknown tokenizer: nosuch}}
+do_test 3.8 { sqlite3_get_autocommit db } {1}
+do_execsql_test 3.9 {
+  CREATE TABLE alive(a);
+  INSERT INTO alive VALUES(7);
+  SELECT a FROM alive;
+} {7}
+do_execsql_test 3.10 {
+  SELECT count(*) FROM sqlite_master WHERE name LIKE 'vbad%';
+} {0}
+do_execsql_test 3.11 {
+  BEGIN;
+  INSERT INTO keepme VALUES(2, 'more');
+}
+do_catchsql_test 3.12 {
+  CREATE VIRTUAL TABLE vbad3 USING fts3(x, tokenize nosuch);
+} {1 {unknown tokenizer: nosuch}}
+do_execsql_test 3.13 { ROLLBACK }
+do_test 3.14 { sqlite3_get_autocommit db } {1}
+do_execsql_test 3.15 { SELECT a, b FROM keepme } {1 keep}
+
 finish_test


### PR DESCRIPTION
Fixes #2393.

## Root cause

`OP_VCreate`'s doltlite failure arm called `sqlite3BtreeRollback` on the whole btree, so a failed constructor (e.g. `tokenize nosuch`) destroyed every earlier write in an open `BEGIN` while `sqlite3_get_autocommit()` stayed 0 — the SQL layer believed the transaction was still open, `SELECT` returned nothing, and `COMMIT` persisted nothing.

The rollback dates to the June FTS3 OOM cleanup (5667285b27), before which a targeted schema-entry delete was used. The prolly layer has since had real statement savepoints (`prollyBtreeBeginStmt`/`prollyBtreeSavepoint`), so plain statement abort — stock's behavior — unwinds the half-written catalog row on its own.

## Changes

- Drop the whole-btree rollback; keep `resetSchemaOnFault` (still needed to drop the in-memory Table). Statement abort handles the catalog row.
- Move the unknown-tokenizer → `SQLITE_NOMEM` remap (and its argument scan) under `SQLITE_TEST`: it only fires when allocating the constructor's real error message failed, exists for the OOM harness, and production now keeps the constructor's own error.

## Validation

- New regressions in `test/doltlite_fts_stmt_savepoint.test` (in-txn survival + autocommit state, no leftover `sqlite_master` row, outside-txn control, ROLLBACK path): old binary fails exactly the three data-loss assertions, fixed binary 30/30.
- The June commit's own guards hold: `doltlite_fts3_oom` leftover-row checks pass; `fts3malloc` 12,495 OOM injections pass. (`doltlite_fts3_oom-2.2.1` fails identically on unmodified master locally on macOS — pre-existing local artifact, not this change; verified against a master-build control.)
- `doltlite_recover_vtab1`, `doltlite_recover_fts3_optimize`, `doltlite_fts_reverse_pending_delete` green; full shell suite 117/117; amalgamation compiles in both prolly and stock modes; lint clean.

Note: #2393 asked for a `Grok 4.6` trailer; as with #2378, the commit carries my own trailer since I authored the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)