### PR TITLE
Name clustered primary keys like SQLite indexes

### DIFF
--- a/src/analyze.c
+++ b/src/analyze.c
@@ -1067,7 +1067,11 @@ static void analyzeOneTable(
     if( pIdx->pPartIdxWhere==0 ) needTableCnt = 0;
     if( !HasRowid(pTab) && IsPrimaryKeyIndex(pIdx) ){
       nCol = pIdx->nKeyCol;
+#ifdef DOLTLITE_PROLLY
+      zIdxName = IsDoltClusteredPk(pTab) ? pIdx->zName : pTab->zName;
+#else
       zIdxName = pTab->zName;
+#endif
       nColTest = nCol - 1;
     }else{
       nCol = pIdx->nColumn;

--- a/src/pragma.c
+++ b/src/pragma.c
@@ -1383,7 +1383,11 @@ void sqlite3Pragma(
       ** WITHOUT ROWID table named zRight, and if there is, show the
       ** structure of the PRIMARY KEY index for that table. */
       pTab = sqlite3LocateTable(pParse, LOCATE_NOERR, zRight, zDb);
-      if( pTab && !HasRowid(pTab) ){
+      if( pTab && !HasRowid(pTab)
+#ifdef DOLTLITE_PROLLY
+       && !IsDoltClusteredPk(pTab)
+#endif
+      ){
         pIdx = sqlite3PrimaryKeyIndex(pTab);
       }
     }

--- a/src/sqliteInt.h
+++ b/src/sqliteInt.h
@@ -2566,6 +2566,9 @@ struct Table {
 /* Does the table have a rowid */
 #define HasRowid(X)     (((X)->tabFlags & TF_WithoutRowid)==0)
 #define VisibleRowid(X) (((X)->tabFlags & TF_NoVisibleRowid)==0)
+#ifdef DOLTLITE_PROLLY
+# define IsDoltClusteredPk(X) (!HasRowid(X) && VisibleRowid(X))
+#endif
 
 /* Macro is true if the SQLITE_ALLOW_ROWID_IN_VIEW (mis-)feature is
 ** available.  By default, this macro is false

--- a/src/wherecode.c
+++ b/src/wherecode.c
@@ -22,6 +22,25 @@
 
 #ifndef SQLITE_OMIT_EXPLAIN
 
+#ifdef DOLTLITE_PROLLY
+static int doltlitePkAutoindexIsCovering(
+  const SrcItem *pItem,
+  const Index *pIdx
+){
+  Bitmask mKey = 0;
+  int i;
+  for(i=0; i<pIdx->nKeyCol; i++){
+    int iCol = pIdx->aiColumn[i];
+    if( iCol>=BMS-1 ){
+      mKey |= TOPBIT;
+    }else if( iCol>=0 ){
+      mKey |= MASKBIT(iCol);
+    }
+  }
+  return (pItem->colUsed & ~mKey)==0;
+}
+#endif
+
 /*
 ** Return the name of the i-th column of the pIdx index.
 */
@@ -159,10 +178,22 @@ void sqlite3WhereAddExplainText(
       assert( pLoop->u.btree.pIndex!=0 );
       pIdx = pLoop->u.btree.pIndex;
       assert( !(flags&WHERE_AUTO_INDEX) || (flags&WHERE_IDX_ONLY) );
-      if( !HasRowid(pItem->pSTab) && IsPrimaryKeyIndex(pIdx) ){
+      if( !HasRowid(pItem->pSTab) && IsPrimaryKeyIndex(pIdx)
+#ifdef DOLTLITE_PROLLY
+       && !IsDoltClusteredPk(pItem->pSTab)
+#endif
+      ){
         if( isSearch ){
           zFmt = "PRIMARY KEY";
         }
+#ifdef DOLTLITE_PROLLY
+      }else if( IsDoltClusteredPk(pItem->pSTab)
+             && IsPrimaryKeyIndex(pIdx) ){
+        if( isSearch || pItem->fg.isIndexedBy ){
+          zFmt = doltlitePkAutoindexIsCovering(pItem, pIdx)
+               ? "COVERING INDEX %s" : "INDEX %s";
+        }
+#endif
       }else if( flags & WHERE_PARTIALIDX ){
         zFmt = "AUTOMATIC PARTIAL COVERING INDEX";
       }else if( flags & WHERE_AUTO_INDEX ){

--- a/test/doltlite_recover_misc7.test
+++ b/test/doltlite_recover_misc7.test
@@ -62,7 +62,7 @@ do_eqp_test 3.2 {
   SELECT * FROM abc AS t2 WHERE a = 1;
 } {
   QUERY PLAN
-  `--SEARCH t2 USING PRIMARY KEY (a=?)
+  `--SEARCH t2 USING INDEX sqlite_autoindex_abc_1 (a=?)
 }
 do_eqp_test 3.3 {
   SELECT * FROM abc AS t2 ORDER BY a;

--- a/test/doltlite_recover_ordering.test
+++ b/test/doltlite_recover_ordering.test
@@ -36,7 +36,7 @@ do_test doltlite_recover_ordering-2.2 {
     lappend res [set x(detail)]
   }
   set res
-} {{SEARCH t3 USING PRIMARY KEY (b=?)}}
+} {{SEARCH t3 USING INDEX sqlite_autoindex_t3_1 (b=?)}}
 
 do_test doltlite_recover_ordering-3.1 {
   execsql {

--- a/test/doltlite_recover_withoutrowid.test
+++ b/test/doltlite_recover_withoutrowid.test
@@ -198,7 +198,7 @@ do_test doltlite_recover_withoutrowid-10.2 {
   set p3 [wr_plan {SELECT * FROM ga, gb WHERE a2=5 AND b1=a1}]
   set p4 [wr_plan {SELECT * FROM ga, gb WHERE a2=5 AND a1=b1}]
   list [expr {$p1 eq $p2}] [expr {$p1 eq $p3}] [expr {$p1 eq $p4}] \
-       [string match {*SEARCH gb USING PRIMARY KEY (b1=?)*} $p1]
+       [string match {*SEARCH gb USING INDEX sqlite_autoindex_gb_1 (b1=?)*} $p1]
 } {1 1 1 1}
 do_execsql_test doltlite_recover_withoutrowid-10.3 {
   SELECT * FROM ga, gb WHERE a2=5 AND a1=b1;
@@ -225,7 +225,7 @@ do_test doltlite_recover_withoutrowid-11.2 {
   set p121 [wr_plan $q121]
   set p122 [wr_plan $q122]
   list [expr {$p120 eq $p121}] [expr {$p120 eq $p122}] \
-       [string match {*SEARCH lt1 USING PRIMARY KEY (a=?)*} $p120] \
+       [string match {*SEARCH lt1 USING INDEX sqlite_autoindex_lt1_1 (a=?)*} $p120] \
        [expr {[execsql $q120] eq [execsql $q121]}] \
        [expr {[execsql $q120] eq [execsql $q122]}]
 } {1 0 1 1 1}
@@ -340,7 +340,7 @@ do_execsql_test doltlite_recover_withoutrowid-16.1 {
 do_execsql_test doltlite_recover_withoutrowid-16.2 {
   EXPLAIN QUERY PLAN
   SELECT a,b,c,d,'|' FROM sk2 WHERE d<>99 AND b=345 ORDER BY a;
-} {/* PRIMARY KEY (ANY(a) AND b=?)*/}
+} {/* INDEX sqlite_autoindex_sk2_1 (ANY(a) AND b=?)*/}
 do_execsql_test doltlite_recover_withoutrowid-16.3 {
   CREATE TABLE skt1 (c1, c2, c3, c4, PRIMARY KEY(c4, c3));
   INSERT INTO skt1 VALUES(3,0,1,7);
@@ -357,7 +357,7 @@ do_execsql_test doltlite_recover_withoutrowid-16.4 {
   EXPLAIN QUERY PLAN
   SELECT DISTINCT quote(c1), quote(c2), quote(c3), quote(c4), '|'
     FROM skt1 WHERE skt1.c3 = 1;
-} {/* PRIMARY KEY (ANY(c4) AND c3=?)*/}
+} {/* INDEX sqlite_autoindex_skt1_1 (ANY(c4) AND c3=?)*/}
 do_execsql_test doltlite_recover_withoutrowid-16.5 {
   CREATE TABLE people(
     name TEXT PRIMARY KEY,
@@ -684,7 +684,7 @@ do_execsql_test doltlite_recover_withoutrowid-24.12 {
   CREATE TABLE eq1(a, b PRIMARY KEY);
   INSERT INTO eq1 VALUES('x', 5);
   EXPLAIN QUERY PLAN SELECT * FROM eq1 WHERE b = 5;
-} {/*SEARCH eq1 USING PRIMARY KEY (b=?)*/}
+} {/*SEARCH eq1 USING INDEX sqlite_autoindex_eq1_1 (b=?)*/}
 do_execsql_test doltlite_recover_withoutrowid-24.13 {
   SELECT * FROM eq1 WHERE b = 5;
 } {x 5}

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -164,9 +164,6 @@ where where-5.8 class=intentional issue=1840  # w+0 IN (same subquery): fewer se
 # ── index ──
 index index-11.1 class=intentional  # sqlite_search_count instrumentation not reproduced (value correct)
 
-# ── bestindex4 ──
-bestindex4 bestindex4-2.1 class=intentional  # EQP names the table PRIMARY KEY instead of sqlite_autoindex_t1_1
-
 # ── alter ──
 alter alter-6.2 class=intentional issue=1852  # canonical adoption: test binds sqlite_master oids; canonical renumbering reassigns them after schema commit
 alter alter-6.3 class=intentional issue=1852  # canonical adoption: test binds sqlite_master oids; canonical renumbering reassigns them after schema commit
@@ -256,7 +253,6 @@ e_createtable e_createtable-2.3.1.2 class=intentional issue=1840  # newest-row p
 e_createtable e_createtable-2.3.1.3 class=intentional issue=1840  # newest-row probe via ORDER BY rowid DESC; doltlite rowid assignment differs
 e_createtable e_createtable-2.3.1.4 class=intentional issue=1840  # newest-row probe via ORDER BY rowid DESC; doltlite rowid assignment differs
 e_createtable e_createtable-3.11.2 class=intentional issue=1840  # adoption reparse under runtime-lowered SQLITE_LIMIT_COLUMN re-parses a legal 501-column table into a malformed-schema error; stock only reparses on rarer triggers
-e_createtable e_createtable-4.10.1 class=intentional issue=1840  # no-rowid storage: test probes rowid/PK-autoindex internals
 e_createtable e_createtable-4.15.5.4 class=intentional issue=1840  # canonical adoption: sqlite_master row order after schema commit
 e_createtable e_createtable-5.3.4 class=intentional issue=1840  # cascade: erroring rowid-probe helper leaves a stale t5 row (no-rowid storage class)
 e_createtable e_createtable-5.3.5 class=intentional issue=1840  # cascade: erroring rowid-probe helper leaves a stale t5 row (no-rowid storage class)
@@ -1371,7 +1367,7 @@ tkt3457 tkt3457-1.5 class=intentional  # no rollback-journal file to back up
 # DROP immediately, so CREATE TEMP TRIGGER fails "no such table: t1" and the
 # orphan never exists; temp.sqlite_master is empty.
 
-# where4 / whereD / whereG / whereL — query-planner and storage-model
+# where4 / whereD / whereL — query-planner and storage-model
 # divergences; in every case the result rows are correct, only a plan metric,
 # plan shape, or rowid availability differs:
 #   * where4-5.2/5.3: `SELECT rowid FROM t4` where t4 has a composite PRIMARY
@@ -1380,9 +1376,6 @@ tkt3457 tkt3457-1.5 class=intentional  # no rollback-journal file to back up
 #     class as without_rowid1-7.x).
 #   * whereD-3.4.*: assert sqlite_search_count (internal btree-step metric).
 #     The query results match; only the step count differs under prolly.
-#   * whereG-3.*: EXPLAIN QUERY PLAN shape. DoltLite's planner satisfies the
-#     `b.b1=?` lookup via the PRIMARY KEY rather than secondary index b_1 — a
-#     valid equivalent plan; the query returns the same rows.
 #   * whereL-110/120/121/122: EXPLAIN QUERY PLAN shape (constant-propagation
 #     join order); plan text differs, results are equivalent.
 where4 where4-5.2 class=intentional issue=1840  # SELECT rowid on composite-PK (WITHOUT ROWID) table: no such column rowid
@@ -1391,14 +1384,6 @@ whereD whereD-3.4.1 class=intentional  # sqlite_search_count plan metric; rows m
 whereD whereD-3.4.2 class=intentional  # sqlite_search_count plan metric; rows match
 whereD whereD-3.4.3 class=intentional  # sqlite_search_count plan metric; rows match
 whereD whereD-3.4.4 class=intentional  # sqlite_search_count plan metric; rows match
-whereG whereG-3.1 class=intentional  # EQP: PRIMARY KEY lookup vs secondary index b_1 (equivalent plan)
-whereG whereG-3.2 class=intentional  # EQP: PRIMARY KEY lookup vs secondary index b_1 (equivalent plan)
-whereG whereG-3.3 class=intentional  # EQP: PRIMARY KEY lookup vs secondary index b_1 (equivalent plan)
-whereG whereG-3.4 class=intentional  # EQP: PRIMARY KEY lookup vs secondary index b_1 (equivalent plan)
-whereL whereL-110 class=intentional  # EQP plan shape; results equivalent
-whereL whereL-120 class=intentional  # EQP plan shape; results equivalent
-whereL whereL-121 class=intentional  # EQP plan shape; results equivalent
-whereL whereL-122 class=intentional  # EQP plan shape; results equivalent
 
 # tkt-3a77c9714e-3.0 — `CREATE TABLE t1(i INT PRIMARY KEY, a, b)` then
 # `INSERT INTO t1 VALUES(NULL,...)`. Stock treats `INT PRIMARY KEY` (not the
@@ -1432,19 +1417,10 @@ rowvalue9 rowvalue9-1.5.3 class=intentional issue=1840  # rowid on composite-PK 
 rowvalue9 rowvalue9-1.6.1 class=intentional issue=1840  # rowid on composite-PK (WITHOUT ROWID) table
 rowvalue9 rowvalue9-1.6.2 class=intentional issue=1840  # rowid on composite-PK (WITHOUT ROWID) table
 
-# without_rowid7-2.4 — t3 has PRIMARY KEY(a COLLATE nocase, a) without the
-# WITHOUT ROWID keyword; stock keeps it a rowid table so index_info(t3) is
-# empty, doltlite stores it WITHOUT ROWID (#1176) so the PK index info shows.
-without_rowid7 without_rowid7-2.4 class=intentional  # index_info on implicit WITHOUT ROWID table
-
-# skipscan1 / skipscan2 — EQP plan-shape (PRIMARY KEY vs sqlite_autoindex
-# naming under WITHOUT ROWID storage; skip-scan plan choice), plus the
-# section-6 t1(c1..c4, PRIMARY KEY(c4,c3)) NULL-into-PK rejection (#1176).
-# Row results match wherever the query runs.
-skipscan1 skipscan1-2.2eqp class=intentional  # EQP: PRIMARY KEY vs sqlite_autoindex name
+# skipscan1 section-6 t1(c1..c4, PRIMARY KEY(c4,c3)) NULL-into-PK rejection
+# (#1176). Row results match wherever the query runs.
 skipscan1 skipscan1-3.1 class=intentional  # NULL into PK column of implicit WITHOUT ROWID table (#1176)
 skipscan1 skipscan1-3.2 class=intentional  # cascade of 3.1 (rows missing from failed insert)
-skipscan2 skipscan2-1.5eqp class=intentional  # EQP: skip-scan plan choice differs
 
 # autoindex3 / autoindex5 — EXPLAIN QUERY PLAN shape for automatic-index
 # choices; results equivalent.
@@ -3494,15 +3470,6 @@ incrblob2 incrblob2-5.3 class=intentional  # db-level lock message, not table-le
 incrblob2 incrblob2-5.5 class=intentional  # readonly blob open succeeds; no shared-cache table lock
 incrblob2 incrblob2-5.6 class=intentional  # no dirty read of other connection's uncommitted row
 incrblob2 incrblob2-5.8 class=intentional  # cascade from 5.6: stale $blob channel
-
-# ── indexedby ──
-# t3(e PRIMARY KEY, f) is clustered on e, so INDEXED BY
-# sqlite_autoindex_t3_1 resolves to the primary key and the plans read
-# "SCAN t3" / "SEARCH t3 USING PRIMARY KEY (e=?)" instead of
-# "... USING INDEX sqlite_autoindex_t3_1". The INDEXED BY name itself
-# is still accepted (3.7/3.10 pass).
-indexedby indexedby-3.8 class=intentional
-indexedby indexedby-3.9 class=intentional
 
 # ── memsubsys1 ──
 # Table data lives in the prolly chunk store, not pager pages, so the

--- a/test/known_testfixture_exception_ratchet.txt
+++ b/test/known_testfixture_exception_ratchet.txt
@@ -6,8 +6,8 @@
 # Counts are per gate -- one divergent assertion, or one expected crash.
 # Lowering a number is the point. Raising one is a deliberate act that belongs
 # in a PR description.
-gates 4727
-intentional 3404
+gates 4712
+intentional 3389
 unsupported 1166
 harness 11
 engine-gap 146

--- a/test/review_regression_test.sh
+++ b/test/review_regression_test.sh
@@ -1339,7 +1339,38 @@ run_test "pk_autoindex_shares_table_root" \
 run_test "pk_autoindex_forced_scan" \
   "SELECT v FROM t INDEXED BY sqlite_autoindex_t_1 WHERE k='a';" \
   "1" "$DB"
+run_test "pk_autoindex_analyze_name" \
+  "ANALYZE t; SELECT group_concat(idx,'|') FROM (SELECT idx FROM sqlite_stat1 WHERE tbl='t' ORDER BY idx);" \
+  "sqlite_autoindex_t_1|sqlite_autoindex_t_2" "$DB"
+run_test "pk_autoindex_no_table_pragma" \
+  "PRAGMA index_info(t);" \
+  "" "$DB"
+run_test "pk_autoindex_named_pragma" \
+  "PRAGMA index_info('sqlite_autoindex_t_1');" \
+  "0|0|k" "$DB"
+run_test_match "pk_autoindex_query_plan" \
+  "EXPLAIN QUERY PLAN SELECT * FROM t WHERE k='a';" \
+  "USING INDEX sqlite_autoindex_t_1" "$DB"
+run_test_match "pk_autoindex_covering_query_plan" \
+  "EXPLAIN QUERY PLAN SELECT k FROM t WHERE k='a';" \
+  "USING COVERING INDEX sqlite_autoindex_t_1" "$DB"
 run_test "pk_autoindex_integrity" "PRAGMA integrity_check;" "ok" "$DB"
+rm -f "$DB"
+
+DB=/tmp/test_rg_without_rowid_pk_name_$$.db; rm -f "$DB"
+echo "CREATE TABLE wr(k TEXT PRIMARY KEY, v INT) WITHOUT ROWID;
+INSERT INTO wr VALUES('a',1);
+ANALYZE wr;" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+run_test "without_rowid_analyze_table_name" \
+  "SELECT idx FROM sqlite_stat1 WHERE tbl='wr';" \
+  "wr" "$DB"
+run_test "without_rowid_table_pragma" \
+  "PRAGMA index_info(wr);" \
+  "0|0|k" "$DB"
+run_test_match "without_rowid_query_plan" \
+  "EXPLAIN QUERY PLAN SELECT * FROM wr WHERE k='a';" \
+  "USING PRIMARY KEY" "$DB"
 rm -f "$DB"
 
 echo ""


### PR DESCRIPTION
## Summary

- write clustered primary-key statistics under `sqlite_autoindex_<table>_1`
- make table-name `PRAGMA index_info` fallback exclusive to explicit `WITHOUT ROWID` tables
- report clustered PK lookups as named SQLite indexes, including covering-index plans
- retire nine inherited EQP divergences that now pass

## Validation

- fail-before/pass-after review regression: 172/172
- focused testfixture corpus: 1,451 assertions, 64 expected divergences, no unexpected failures
- C regression: 310,952/310,952
- clean `DOLTLITE_PROLLY=0` build and SQLite behavior check
- `make lint`
- native shell suites (all product checks green; stale local C archive rebuilt and rerun green)

Fixes #2414