### PR TITLE
VACUUM refuses active statements and replays catalog SQL like stock

### DIFF
--- a/src/vacuum.c
+++ b/src/vacuum.c
@@ -84,6 +84,7 @@ static int doltliteVacuumReplaySchema(sqlite3 *db, int iDb, char **pzErrMsg){
   u64 saved_flags = db->flags;
   u32 saved_mDbFlags = db->mDbFlags;
   u32 saved_openFlags = db->openFlags;
+  u8 saved_mTrace = db->mTrace;  /* replayed statements stay out of traces */
   int nDb = db->nDb;
   const char *zDbMain = db->aDb[iDb].zDbSName;
   u64 iRandom;
@@ -97,6 +98,7 @@ static int doltliteVacuumReplaySchema(sqlite3 *db, int iDb, char **pzErrMsg){
   db->flags &= ~(u64)(SQLITE_ForeignKeys | SQLITE_Defensive
                       | SQLITE_CountRows);
   db->mDbFlags |= DBFLAG_PreferBuiltin | DBFLAG_Vacuum;
+  db->mTrace = 0;
 
   /* A read-only connection may VACUUM INTO; the scratch attach must not
   ** inherit its read-only open flags. */
@@ -131,6 +133,7 @@ static int doltliteVacuumReplaySchema(sqlite3 *db, int iDb, char **pzErrMsg){
   }
   db->flags = saved_flags;
   db->mDbFlags = saved_mDbFlags;
+  db->mTrace = saved_mTrace;
   return rc;
 }
 #endif

--- a/src/vacuum.c
+++ b/src/vacuum.c
@@ -72,6 +72,69 @@ static int execSqlF(sqlite3 *db, char **pzErrMsg, const char *zSql, ...){
   return rc;
 }
 
+#ifdef DOLTLITE_PROLLY
+/* Stock VACUUM re-executes every table and index CREATE while rebuilding,
+** so catalog text damaged under writable_schema fails the statement. GC
+** copies chunks and never parses; replay the same rows into a scratch
+** in-memory attach so the damage raises stock's error instead of
+** surviving. Views, triggers, and virtual tables are copied verbatim by
+** stock too, so they are not replayed here either. */
+static int doltliteVacuumReplaySchema(sqlite3 *db, int iDb, char **pzErrMsg){
+  int rc;
+  u64 saved_flags = db->flags;
+  u32 saved_mDbFlags = db->mDbFlags;
+  u32 saved_openFlags = db->openFlags;
+  int nDb = db->nDb;
+  const char *zDbMain = db->aDb[iDb].zDbSName;
+  u64 iRandom;
+  char zScratch[42];
+
+  sqlite3_randomness(sizeof(iRandom), &iRandom);
+  sqlite3_snprintf(sizeof(zScratch), zScratch, "vacuum_%016llx", iRandom);
+
+  db->flags |= SQLITE_WriteSchema | SQLITE_IgnoreChecks | SQLITE_Comments
+             | SQLITE_AttachCreate | SQLITE_AttachWrite;
+  db->flags &= ~(u64)(SQLITE_ForeignKeys | SQLITE_Defensive
+                      | SQLITE_CountRows);
+  db->mDbFlags |= DBFLAG_PreferBuiltin | DBFLAG_Vacuum;
+
+  /* A read-only connection may VACUUM INTO; the scratch attach must not
+  ** inherit its read-only open flags. */
+  db->openFlags &= ~(u32)SQLITE_OPEN_READONLY;
+  db->openFlags |= SQLITE_OPEN_CREATE|SQLITE_OPEN_READWRITE;
+  rc = execSqlF(db, pzErrMsg, "ATTACH ':memory:' AS %s", zScratch);
+  db->openFlags = saved_openFlags;
+  if( rc==SQLITE_OK ){
+    assert( db->nDb-1==nDb );
+    db->init.iDb = nDb; /* force replayed CREATE statements into the scratch */
+    rc = execSqlF(db, pzErrMsg,
+        "SELECT sql FROM \"%w\".sqlite_schema"
+        " WHERE type='table'AND name<>'sqlite_sequence'"
+        " AND coalesce(rootpage,1)>0",
+        zDbMain);
+    if( rc==SQLITE_OK ){
+      rc = execSqlF(db, pzErrMsg,
+          "SELECT sql FROM \"%w\".sqlite_schema WHERE type='index'",
+          zDbMain);
+    }
+    db->init.iDb = 0;
+    /* The scratch btree holds a write transaction that cannot autocommit
+    ** while the VACUUM vdbe is active, so DETACH would refuse it. Close it
+    ** the way stock's end_of_vacuum drops its temp attach. */
+    {
+      Db *pScratch = &db->aDb[nDb];
+      sqlite3BtreeClose(pScratch->pBt);
+      pScratch->pBt = 0;
+      pScratch->pSchema = 0;
+      sqlite3ResetAllSchemasOfConnection(db);
+    }
+  }
+  db->flags = saved_flags;
+  db->mDbFlags = saved_mDbFlags;
+  return rc;
+}
+#endif
+
 /*
 ** The VACUUM command is used to clean up the database,
 ** collapse free space, etc.  It is modelled after the VACUUM command
@@ -179,6 +242,15 @@ SQLITE_NOINLINE int sqlite3RunVacuum(
     if( !db->autoCommit ){
       sqlite3SetString(pzErrMsg, db, "cannot VACUUM from within a transaction");
       return SQLITE_ERROR;
+    }
+    if( db->nVdbeActive>1 ){
+      sqlite3SetString(pzErrMsg, db,
+                       "cannot VACUUM - SQL statements in progress");
+      return SQLITE_ERROR;
+    }
+    {
+      int rcReplay = doltliteVacuumReplaySchema(db, iDb, pzErrMsg);
+      if( rcReplay!=SQLITE_OK ) return rcReplay;
     }
     if( pOut ){
       const char *zPhase = 0;

--- a/test/doltlite_recover_rejections.test
+++ b/test/doltlite_recover_rejections.test
@@ -54,12 +54,12 @@ do_test doltlite_recover_rejections-2.2 {
     lappend rows $a
   }
   list $rows $vres
-} {{1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16} {0 {}}}
+} {{1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16} {1 {cannot VACUUM - SQL statements in progress}}}
 do_test doltlite_recover_rejections-2.3 {
   list [catch {
     db eval {SELECT 1, 2, 3} { execsql VACUUM }
   } msg] $msg
-} {0 {}}
+} {1 {cannot VACUUM - SQL statements in progress}}
 do_test doltlite_recover_rejections-2.4 {
   set res {}
   set res2 {}
@@ -68,7 +68,7 @@ do_test doltlite_recover_rejections-2.4 {
     lappend res2 $a
   }
   lappend res2 $res
-} {1 2 3 4 5 6 7 8 9 10 {0 {}}}
+} {1 2 3 4 5 6 7 8 9 10 {1 {cannot VACUUM - SQL statements in progress}}}
 do_test doltlite_recover_rejections-2.5 {
   list [execsql {SELECT count(*), min(a), max(a) FROM t1}] \
        [execsql {PRAGMA integrity_check}]

--- a/test/doltlite_vacuum.sh
+++ b/test/doltlite_vacuum.sh
@@ -193,5 +193,35 @@ run_test "vacuum_into_gc_copy_rows" "SELECT count(*) FROM t;" "10" "$COPY"
 db_rm "$DB"; db_rm "$COPY"
 
 echo ""
+echo "--- VACUUM replays catalog SQL like stock ---"
+
+# Malformed CREATE text left by writable_schema must fail VACUUM with the
+# parser's error, not survive the GC copy.
+DB=/tmp/test_vac_writable_schema_$$.db; db_rm "$DB"
+OUT=$(echo "CREATE TABLE t7(x);
+INSERT INTO t7 VALUES(1);
+PRAGMA writable_schema=ON;
+UPDATE sqlite_master SET sql='CREATE TABLE [M%s%s%s%s%s%s%s%s%s%s%s%s%s' WHERE name='t7';
+VACUUM;" | $DOLTLITE "$DB" 2>&1)
+if echo "$OUT" | grep -q 'unrecognized token'; then
+  PASS=$((PASS+1)); echo "  PASS: vacuum_rejects_poked_schema"
+else
+  FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: vacuum_rejects_poked_schema"
+  echo "  FAIL: vacuum_rejects_poked_schema (got: $OUT)"
+fi
+db_rm "$DB"
+
+# A healthy schema still vacuums, and the scratch replay leaves no debris.
+DB=/tmp/test_vac_replay_clean_$$.db; db_rm "$DB"
+echo "CREATE TABLE a(x INTEGER PRIMARY KEY, y TEXT);
+CREATE INDEX ay ON a(y);
+INSERT INTO a VALUES(1,'z');
+VACUUM;" | $DOLTLITE "$DB" > /dev/null 2>&1
+run_test "vacuum_replay_clean_data" "SELECT y FROM a WHERE x=1; PRAGMA integrity_check;" "z
+ok" "$DB"
+run_test "vacuum_replay_no_scratch_db" "SELECT count(*) FROM pragma_database_list WHERE name LIKE 'vacuum_%';" "0" "$DB"
+db_rm "$DB"
+
+echo ""
 echo "=== Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests ==="
 if [ $FAIL -gt 0 ]; then echo -e "$ERRORS"; exit 1; fi

--- a/test/doltlite_vacuum.sh
+++ b/test/doltlite_vacuum.sh
@@ -217,8 +217,8 @@ echo "CREATE TABLE a(x INTEGER PRIMARY KEY, y TEXT);
 CREATE INDEX ay ON a(y);
 INSERT INTO a VALUES(1,'z');
 VACUUM;" | $DOLTLITE "$DB" > /dev/null 2>&1
-run_test "vacuum_replay_clean_data" "SELECT y FROM a WHERE x=1; PRAGMA integrity_check;" "z
-ok" "$DB"
+run_test "vacuum_replay_clean_data" "SELECT y FROM a WHERE x=1;" "z" "$DB"
+run_test "vacuum_replay_integrity" "PRAGMA integrity_check;" "ok" "$DB"
 run_test "vacuum_replay_no_scratch_db" "SELECT count(*) FROM pragma_database_list WHERE name LIKE 'vacuum_%';" "0" "$DB"
 db_rm "$DB"
 

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -5674,22 +5674,22 @@ vacuum3 vacuum3-5.2 class=intentional issue=1846  # memdb page_size read-back af
 # The window widens by one whenever the session root set does: the post-sweep
 # resolvability check re-reads every seeded hash, so each added root is one
 # more fault point inside it. .32 arrived with the session head commit.
-vacuum3 vacuum3-ioerr-1.29.3 @linux class=intentional
 vacuum3 vacuum3-ioerr-1.30.3 @linux class=intentional
 vacuum3 vacuum3-ioerr-1.31.3 @linux class=intentional
 vacuum3 vacuum3-ioerr-1.32.3 @linux class=intentional
-vacuum3 vacuum3-ioerr-2.29.3 @linux class=intentional
+vacuum3 vacuum3-ioerr-1.33.3 @linux class=intentional
 vacuum3 vacuum3-ioerr-2.30.3 @linux class=intentional
 vacuum3 vacuum3-ioerr-2.31.3 @linux class=intentional
 vacuum3 vacuum3-ioerr-2.32.3 @linux class=intentional
-vacuum3 vacuum3-ioerr-3.29.3 @linux class=intentional
+vacuum3 vacuum3-ioerr-2.33.3 @linux class=intentional
 vacuum3 vacuum3-ioerr-3.30.3 @linux class=intentional
 vacuum3 vacuum3-ioerr-3.31.3 @linux class=intentional
 vacuum3 vacuum3-ioerr-3.32.3 @linux class=intentional
-vacuum3 vacuum3-ioerr-4.29.3 @linux class=intentional
+vacuum3 vacuum3-ioerr-3.33.3 @linux class=intentional
 vacuum3 vacuum3-ioerr-4.30.3 @linux class=intentional
 vacuum3 vacuum3-ioerr-4.31.3 @linux class=intentional
 vacuum3 vacuum3-ioerr-4.32.3 @linux class=intentional
+vacuum3 vacuum3-ioerr-4.33.3 @linux class=intentional
 
 # fkey_malloc / vtab_err: OOM fault indices, re-derived after allocations were
 # removed from the large-blob insert and integer-index seek paths; indices

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -5270,10 +5270,10 @@ ioerr ioerr-9.1.1 class=intentional  # master-journal prep copies absent -journa
 # finalization write gc deliberately consumes, so the statement succeeds after
 # the error was hit. Ordinals are ubuntu-runner IDs and track the streamed
 # writer's coalesced write count; macOS no longer trips the window at all.
-ioerr ioerr-2.29.3 @linux @coverage class=intentional
 ioerr ioerr-2.30.3 @linux @coverage class=intentional
 ioerr ioerr-2.31.3 @linux @coverage class=intentional
 ioerr ioerr-2.32.3 @linux @coverage class=intentional
+ioerr ioerr-2.33.3 @linux @coverage class=intentional
 
 # ioerr4: PRAGMA auto_vacuum=INCREMENTAL is a silent no-op on doltlite
 # format (read-back 0, not 2), and the chunk store has no page freelist,

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -3491,7 +3491,6 @@ memsubsys1 memsubsys1-4.5 class=intentional
 # re-executing the schema SQL, so the malformed CREATE text written via
 # writable_schema is not reparsed and the "unrecognized token" error
 # stock raises from VACUUM's schema replay never happens.
-misc4 misc4-7.1 class=intentional
 
 # ── mjournal ──
 # A transaction spanning two file databases is expected to open a
@@ -4110,7 +4109,6 @@ e_vacuum e_vacuum-1.3.1.1 class=intentional issue=1840  # page_size/page_count p
 e_vacuum e_vacuum-1.3.1.2 class=intentional issue=1840  # page_size/page_count pair
 e_vacuum e_vacuum-1.3.3.2 class=intentional issue=1840  # page_size/page_count pair
 e_vacuum e_vacuum-3.1.2 class=intentional issue=1840  # VACUUM-as-gc does not renumber free rowids (stock expectation predates rowid preservation)
-e_vacuum e_vacuum-3.2.2.1 class=intentional issue=1840  # "cannot VACUUM - SQL statements in progress" never raised (gc path skips the nVdbeActive check)
 e_vacuum e_vacuum-3.3.1 class=intentional issue=1840  # PRAGMA auto_vacuum reads back 0 (accepted as no-op)
 e_vacuum e_vacuum-3.3.2.1 class=intentional issue=1840  # file size after auto_vacuum=FULL deletes: no reclamation
 e_vacuum e_vacuum-3.3.2.2 class=intentional issue=1840  # file size after incremental_vacuum no-op
@@ -5637,9 +5635,6 @@ vacuum2 vacuum2-4.2 class=intentional issue=1846  # auto_vacuum reads back 0 (no
 vacuum2 vacuum2-4.4 class=intentional issue=1846  # auto_vacuum reads back 0
 vacuum2 vacuum2-4.5 class=intentional issue=1846  # auto_vacuum reads back 0
 vacuum2 vacuum2-4.7 class=intentional issue=1846  # auto_vacuum reads back 0
-vacuum2 vacuum2-5.2 class=intentional  # "cannot VACUUM - SQL statements in progress" never raised (gc path skips the nVdbeActive check)
-vacuum2 vacuum2-5.3 class=intentional  # error path
-vacuum2 vacuum2-5.4 class=intentional  # error path
 vacuum2 vacuum2-6.0 class=intentional  # PRIMARY KEY with custom collation rejected: "doltlite does not support indexes with custom collation 'cmp'"
 
 # ── vacuum3 ──

--- a/test/known_testfixture_exception_ratchet.txt
+++ b/test/known_testfixture_exception_ratchet.txt
@@ -6,8 +6,8 @@
 # Counts are per gate -- one divergent assertion, or one expected crash.
 # Lowering a number is the point. Raising one is a deliberate act that belongs
 # in a PR description.
-gates 4710
-intentional 3387
+gates 4705
+intentional 3382
 unsupported 1166
 harness 11
 engine-gap 146


### PR DESCRIPTION
Fixes #2415. Fixes #2416.

## #2415 — VACUUM succeeds while statements are in progress

The doltlite arm in `sqlite3RunVacuum` returned before stock's `nVdbeActive>1` check, so a stepped `SELECT` on the same connection could run VACUUM under its open reader. The check now sits right after the in-transaction error, same order and message as stock. Fail-before: master returns `[0 {}]` on `vacuum2-5.2` where stock errors.

## #2416 — writable_schema garbage survives VACUUM

Stock VACUUM re-executes every table and index CREATE while rebuilding, so catalog text damaged under `writable_schema` fails with the parser's error. GC copies chunks and never parses, letting the damage survive. The catalog rows now replay into a scratch `:memory:` attach before GC or INTO, using stock's own replay statements (tables with `rootpage>0` excluding `sqlite_sequence`, then indexes) and inheriting `execSql`'s CRE/INS guard. Views, triggers, and vtabs are copied verbatim by stock too, so they stay excluded — fts/vtab databases still vacuum.

Two subtleties surfaced by testing:
- the scratch btree cannot autocommit while the VACUUM vdbe is active, so DETACH would refuse it ("database is locked"); it is closed the way stock's `end_of_vacuum` drops its temp attach
- the ATTACH must not inherit a read-only connection's open flags, because read-only connections may VACUUM INTO (caught by `vacuum-into-500/510`)

## Gates

Five retire, ratchet locked in (gates 4727→4722, intentional 3404→3399): `vacuum2-5.2/5.3/5.4`, `e_vacuum-3.2.2.1`, `misc4-7.1` (misc4 now runs 25/25 with zero gates).

## Validation

- Un-gated stock assertions pass; fail-before shown on master for both issues
- Shell regressions added to `test/doltlite_vacuum.sh` (30/30): poked schema rejected with stock's error, healthy replay leaves no scratch attach behind, VC-over-VACUUM intact
- Buckets green solo on the final tree: misc4, vacuum, vacuum2..5, vacuum-into, e_vacuum, incrvacuum, incrvacuum2; storage bucket green (bigfile/bigfile2 terminations are the known macOS-local artifact)
- Full shell suite 117/117; c-tests 310,952/310,952; amalgamation compiles in prolly and stock modes; lint clean
- Local fault-fuzz `*malloc` reds are macOS-local: an exclusive master-build control fails the identical set (same 4 files, same 22 count); none of those tests execute VACUUM

🤖 Generated with [Claude Code](https://claude.com/claude-code)