### PR TITLE
Abort clustered incrblob handles after SQL writes

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -1479,6 +1479,11 @@ int prollyBtCursorCloseCursor(BtCursor *pCur){
   pBt = pCur->pBt;
   if( !pBt ) return SQLITE_OK;
 
+  if( pCur->curFlags & BTCF_Incrblob ){
+    assert( pBt->nIncrblobCur>0 );
+    pBt->nIncrblobCur--;
+  }
+
   if( pCur->pMutMap && pCur->flushSeekEdits ){
     struct TableEntry *pTE = findTable(pCur->pBtree, pCur->pgnoRoot);
     if( pTE ){

--- a/src/prolly_btree_catalog.c
+++ b/src/prolly_btree_catalog.c
@@ -151,6 +151,7 @@ static void faultIncrblobCursor(BtCursor *p){
 void prollyInvalidateIncrblobCursors(BtShared *pBt, Pgno pgnoRoot,
                                       i64 iRow, int isClearTable){
   BtCursor *p;
+  if( pBt->nIncrblobCur==0 ) return;
   for(p=pBt->pCursor; p; p=p->pNext){
     if( (p->curFlags & BTCF_Incrblob)==0 || p->pgnoRoot!=pgnoRoot ) continue;
     if( !isClearTable ){
@@ -167,6 +168,7 @@ void prollyInvalidateIncrblobCursors(BtShared *pBt, Pgno pgnoRoot,
 void prollyInvalidateIncrblobCursorsByKey(BtShared *pBt, Pgno pgnoRoot,
                                            const u8 *pKey, int nKey){
   BtCursor *p;
+  if( pBt->nIncrblobCur==0 ) return;
   for(p=pBt->pCursor; p; p=p->pNext){
     const u8 *pCursorKey = 0;
     int nCursorKey = 0;

--- a/src/prolly_btree_catalog.c
+++ b/src/prolly_btree_catalog.c
@@ -137,6 +137,16 @@ void invalidateCursors(BtShared *pBt, Pgno iTable, int errCode){
   }
 }
 
+static void faultIncrblobCursor(BtCursor *p){
+  p->eState = CURSOR_FAULT;
+  p->skipNext = SQLITE_ABORT;
+  p->mmActive = 0;
+  p->mmPhysActive = 0;
+  p->mmIdx = -1;
+  p->mmPhysIdx = -1;
+  prollyCursorReleaseAll(&p->pCur);
+}
+
 /* Abort incrblob handles on this row; skip when the writer is itself incrblob. */
 void prollyInvalidateIncrblobCursors(BtShared *pBt, Pgno pgnoRoot,
                                       i64 iRow, int isClearTable){
@@ -150,13 +160,34 @@ void prollyInvalidateIncrblobCursors(BtShared *pBt, Pgno pgnoRoot,
         if( p->cachedIntKey!=iRow ) continue;
       }
     }
-    p->eState = CURSOR_FAULT;
-    p->skipNext = SQLITE_ABORT;
-    p->mmActive = 0;
-    p->mmPhysActive = 0;
-    p->mmIdx = -1;
-    p->mmPhysIdx = -1;
-    prollyCursorReleaseAll(&p->pCur);
+    faultIncrblobCursor(p);
+  }
+}
+
+void prollyInvalidateIncrblobCursorsByKey(BtShared *pBt, Pgno pgnoRoot,
+                                           const u8 *pKey, int nKey){
+  BtCursor *p;
+  for(p=pBt->pCursor; p; p=p->pNext){
+    const u8 *pCursorKey = 0;
+    int nCursorKey = 0;
+    if( (p->curFlags & BTCF_Incrblob)==0
+     || p->pgnoRoot!=pgnoRoot
+     || p->curIntKey ){
+      continue;
+    }
+    if( p->eState==CURSOR_REQUIRESEEK ){
+      pCursorKey = (const u8*)p->pKey;
+      nCursorKey = (int)p->nKey;
+    }else if( prollyCursorIsValid(&p->pCur) ){
+      prollyCursorKey(&p->pCur, &pCursorKey, &nCursorKey);
+    }else{
+      continue;
+    }
+    if( nCursorKey!=nKey
+     || (nKey>0 && memcmp(pCursorKey, pKey, nKey)!=0) ){
+      continue;
+    }
+    faultIncrblobCursor(p);
   }
 }
 

--- a/src/prolly_btree_int.h
+++ b/src/prolly_btree_int.h
@@ -739,6 +739,7 @@ int deserializeCatalog(Btree*, const u8*, int);
 void initDefaultMeta(Btree*);
 void resetConnectionSchema(Btree*);
 void prollyInvalidateIncrblobCursors(BtShared*, Pgno, i64, int);
+void prollyInvalidateIncrblobCursorsByKey(BtShared*, Pgno, const u8*, int);
 void refreshCursorRoot(BtCursor*);
 int applyMutMapToTableRoot(BtShared*, struct TableEntry*, ProllyMutMap*);
 int flushAllPending(Btree*, BtShared*, Pgno);

--- a/src/prolly_btree_int.h
+++ b/src/prolly_btree_int.h
@@ -185,6 +185,7 @@ struct BtShared {
   u32 pageSize;
   u32 iWorkingStateVersion;
   int nRef;
+  int nIncrblobCur;
   u8 inCatalogSerialize;
 };
 

--- a/src/prolly_btree_mutation.c
+++ b/src/prolly_btree_mutation.c
@@ -1559,7 +1559,10 @@ int sqlite3BtreePutData(BtCursor *pCur, u32 offset, u32 amt, void *pBuf){
 }
 
 void prollyBtCursorIncrblobCursor(BtCursor *pCur){
-  pCur->curFlags |= BTCF_Incrblob;
+  if( !(pCur->curFlags & BTCF_Incrblob) ){
+    pCur->curFlags |= BTCF_Incrblob;
+    pCur->pBt->nIncrblobCur++;
+  }
 }
 void sqlite3BtreeIncrblobCursor(BtCursor *pCur){
   pCur->pCurOps->xIncrblobCursor(pCur);

--- a/src/prolly_btree_mutation.c
+++ b/src/prolly_btree_mutation.c
@@ -888,6 +888,10 @@ int prollyBtCursorInsert(
       pSortKey = pCur->pSeekSortKey;
     }
     if( rc==SQLITE_OK ){
+      if( !(pCur->curFlags & BTCF_Incrblob) ){
+        prollyInvalidateIncrblobCursorsByKey(
+            pCur->pBt, pCur->pgnoRoot, pSortKey, nSortKey);
+      }
       if( pCur->mmExactMiss
        && pCur->pMutMap
        && pCur->mmMissGeneration==pCur->pMutMap->generation
@@ -1241,6 +1245,9 @@ int prollyBtCursorDelete(BtCursor *pCur, u8 flags){
 
   if( pCur->curIntKey && hasSavedKey ){
     prollyInvalidateIncrblobCursors(pCur->pBt, pCur->pgnoRoot, savedIntKey, 0);
+  }else if( !pCur->curIntKey && hasSavedKey ){
+    prollyInvalidateIncrblobCursorsByKey(
+        pCur->pBt, pCur->pgnoRoot, pSavedDelKey, nSavedDelKey);
   }
 
   rc = ensureMutMap(pCur);

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -12249,6 +12249,7 @@ static void run_clustered_pk_blob_open(void){
   char dbpath[512];
   sqlite3 *db = 0;
   sqlite3_blob *pBlob = 0;
+  sqlite3_blob *pOther = 0;
   sqlite3_int64 rowid;
   sqlite3_int64 rowid2;
   unsigned char buf[8];
@@ -12319,6 +12320,122 @@ static void run_clustered_pk_blob_open(void){
     memset(buf, 0, sizeof(buf));
     check("cpk_blob_reopen_read",
           sqlite3_blob_read(pBlob, buf, 1, 0)==SQLITE_OK && buf[0]==0xbb);
+    sqlite3_blob_close(pBlob);
+    pBlob = 0;
+  }
+
+  check("cpk_blob_abort_setup", execSql(db,
+      "CREATE TABLE cpk_abort(k TEXT PRIMARY KEY, n INT, b BLOB);"
+      "INSERT INTO cpk_abort VALUES('a', 1, x'0102');"
+      "INSERT INTO cpk_abort VALUES('b', 2, x'0304');")==SQLITE_OK);
+  rowid = queryInt64(db, "SELECT rowid FROM cpk_abort WHERE k='a'");
+  rowid2 = queryInt64(db, "SELECT rowid FROM cpk_abort WHERE k='b'");
+  check("cpk_blob_abort_open_same",
+        sqlite3_blob_open(db, "main", "cpk_abort", "b", rowid, 0,
+                          &pBlob)==SQLITE_OK);
+  check("cpk_blob_abort_open_other",
+        sqlite3_blob_open(db, "main", "cpk_abort", "b", rowid2, 0,
+                          &pOther)==SQLITE_OK);
+  check("cpk_blob_abort_sql_update", execSql(db,
+      "UPDATE cpk_abort SET b=x'ffff' WHERE k='a'")==SQLITE_OK);
+  if( pBlob ){
+    check("cpk_blob_abort_update_read",
+          sqlite3_blob_read(pBlob, buf, 2, 0)==SQLITE_ABORT);
+    check("cpk_blob_abort_update_msg",
+          strcmp(sqlite3_errmsg(db), "query aborted")==0);
+    sqlite3_blob_close(pBlob);
+    pBlob = 0;
+  }
+  if( pOther ){
+    memset(buf, 0, sizeof(buf));
+    check("cpk_blob_other_row_survives",
+          sqlite3_blob_read(pOther, buf, 2, 0)==SQLITE_OK
+          && buf[0]==0x03 && buf[1]==0x04);
+    sqlite3_blob_close(pOther);
+    pOther = 0;
+  }
+
+  check("cpk_blob_abort_open_nonblob_update",
+        sqlite3_blob_open(db, "main", "cpk_abort", "b", rowid, 0,
+                          &pBlob)==SQLITE_OK);
+  check("cpk_blob_abort_nonblob_update", execSql(db,
+      "UPDATE cpk_abort SET n=n+1 WHERE k='a'")==SQLITE_OK);
+  if( pBlob ){
+    check("cpk_blob_abort_nonblob_read",
+          sqlite3_blob_read(pBlob, buf, 2, 0)==SQLITE_ABORT);
+    sqlite3_blob_close(pBlob);
+    pBlob = 0;
+  }
+
+  check("cpk_blob_abort_open_different_update",
+        sqlite3_blob_open(db, "main", "cpk_abort", "b", rowid, 0,
+                          &pBlob)==SQLITE_OK);
+  check("cpk_blob_abort_different_update", execSql(db,
+      "UPDATE cpk_abort SET b=x'eeee' WHERE k='b'")==SQLITE_OK);
+  if( pBlob ){
+    memset(buf, 0, sizeof(buf));
+    check("cpk_blob_different_update_survives",
+          sqlite3_blob_read(pBlob, buf, 2, 0)==SQLITE_OK
+          && buf[0]==0xff && buf[1]==0xff);
+    sqlite3_blob_close(pBlob);
+    pBlob = 0;
+  }
+
+  check("cpk_blob_abort_open_delete",
+        sqlite3_blob_open(db, "main", "cpk_abort", "b", rowid, 0,
+                          &pBlob)==SQLITE_OK);
+  check("cpk_blob_abort_delete", execSql(db,
+      "DELETE FROM cpk_abort WHERE k='a'")==SQLITE_OK);
+  if( pBlob ){
+    check("cpk_blob_abort_delete_read",
+          sqlite3_blob_read(pBlob, buf, 2, 0)==SQLITE_ABORT);
+    sqlite3_blob_close(pBlob);
+    pBlob = 0;
+  }
+
+  check("cpk_blob_abort_write_setup", execSql(db,
+      "INSERT INTO cpk_abort VALUES('c', 3, x'0506')")==SQLITE_OK);
+  rowid = queryInt64(db, "SELECT rowid FROM cpk_abort WHERE k='c'");
+  check("cpk_blob_abort_open_write",
+        sqlite3_blob_open(db, "main", "cpk_abort", "b", rowid, 1,
+                          &pBlob)==SQLITE_OK);
+  check("cpk_blob_abort_write_sql_update", execSql(db,
+      "UPDATE cpk_abort SET n=4 WHERE k='c'")==SQLITE_OK);
+  if( pBlob ){
+    check("cpk_blob_abort_write",
+          sqlite3_blob_write(pBlob, "ZZ", 2, 0)==SQLITE_ABORT);
+    sqlite3_blob_close(pBlob);
+    pBlob = 0;
+  }
+
+  check("cpk_blob_abort_int_setup", execSql(db,
+      "CREATE TABLE cpk_int(k INT PRIMARY KEY, b BLOB);"
+      "INSERT INTO cpk_int VALUES(7, x'0708')")==SQLITE_OK);
+  rowid = queryInt64(db, "SELECT rowid FROM cpk_int");
+  check("cpk_blob_abort_int_open",
+        sqlite3_blob_open(db, "main", "cpk_int", "b", rowid, 0,
+                          &pBlob)==SQLITE_OK);
+  check("cpk_blob_abort_int_update", execSql(db,
+      "UPDATE cpk_int SET b=x'090a' WHERE k=7")==SQLITE_OK);
+  if( pBlob ){
+    check("cpk_blob_abort_int_read",
+          sqlite3_blob_read(pBlob, buf, 2, 0)==SQLITE_ABORT);
+    sqlite3_blob_close(pBlob);
+    pBlob = 0;
+  }
+
+  check("cpk_blob_abort_composite_setup", execSql(db,
+      "CREATE TABLE cpk_comp(a TEXT, k INT, b BLOB, PRIMARY KEY(a,k));"
+      "INSERT INTO cpk_comp VALUES('x', 9, x'0b0c')")==SQLITE_OK);
+  rowid = queryInt64(db, "SELECT rowid FROM cpk_comp");
+  check("cpk_blob_abort_composite_open",
+        sqlite3_blob_open(db, "main", "cpk_comp", "b", rowid, 0,
+                          &pBlob)==SQLITE_OK);
+  check("cpk_blob_abort_composite_update", execSql(db,
+      "UPDATE cpk_comp SET b=x'0d0e' WHERE a='x' AND k=9")==SQLITE_OK);
+  if( pBlob ){
+    check("cpk_blob_abort_composite_read",
+          sqlite3_blob_read(pBlob, buf, 2, 0)==SQLITE_ABORT);
     sqlite3_blob_close(pBlob);
     pBlob = 0;
   }


### PR DESCRIPTION
## Summary

- invalidate clustered-PK incremental blob handles by canonical sort key after SQL UPDATE or DELETE of their row
- leave handles on other rows usable and preserve incremental-blob self-writes
- cover TEXT, INT, and composite clustered keys, same-row non-BLOB updates, deletes, reads, writes, and neighboring handles

## Validation

- fail-before: 6 new UPDATE assertions failed on the unfixed engine
- pass-after: clustered-PK blob regression 50/50
- focused incrblob testfixture corpus: 1,082 passing assertions, 5 expected divergences
- full C gate: 29/29 binaries passed, 0 failed or stale
- make lint

Fixes #2418