### PR TITLE
Advance persists its own catalog when no working catalog is given

### DIFF
--- a/src/doltlite_config.c
+++ b/src/doltlite_config.c
@@ -220,7 +220,14 @@ int doltliteMaybeSeedRepo(sqlite3 *db){
       "Initialize data repository", NULL, NULL, 0, 0, &seedHash);
   if( rc!=SQLITE_OK ) return rc;
 
-  return doltliteAdvanceBranch(db, &seedHash, &emptyCatalog, 0);
+  /* Tables created before the seed live only in the session; the working
+  ** set must carry them, not the seed's empty catalog. */
+  {
+    ProllyHash liveCatalog;
+    rc = doltliteFlushCatalogToHash(db, &liveCatalog);
+    if( rc!=SQLITE_OK ) return rc;
+    return doltliteAdvanceBranch(db, &seedHash, &emptyCatalog, &liveCatalog);
+  }
 }
 
 int doltliteConfigRegister(sqlite3 *db){

--- a/src/doltlite_core.c
+++ b/src/doltlite_core.c
@@ -722,7 +722,13 @@ static int doltliteAdvanceBranchWithState(
     }
   }
 
-  rc = doltlitePersistWorkingSetWithHash(db, pWorkingCatHash);
+  /* A null working catalog used to flush the live session here, but the
+  ** head confirm can have reloaded that session from a peer's freshly
+  ** written working set: the persist then binds the peer's content to the
+  ** new head and the staleness gate waves it through. Advancing with no
+  ** explicit working catalog means the working set IS the new catalog. */
+  rc = doltlitePersistWorkingSetWithHash(
+      db, pWorkingCatHash ? pWorkingCatHash : pCatalogHash);
   if( rc!=SQLITE_OK ){
     return doltliteRestoreTxnStateOnFailure(db, pSaved, rc);
   }


### PR DESCRIPTION
Fixes #2433.

## Root cause — captured live with instrumented CI soaks

The nightly's `merge_race_feat_rows_present` flake is silent data loss in a fast-forward merge racing a concurrent commit, cross-process:

1. The writer's INSERT persists main's working set (base + its row, no feat) bound to the base head — landing between the merger's dirty-check and its head-confirm.
2. The merger's FF has already switched its live catalog to feat's — but `RefreshAndConfirmHead` sees the store changed and **reloads the live session from disk, silently replacing the merge content with the writer's working set**.
3. The head CAS still passes (tip unmoved), the FF advances main onto feat's commit — and `PersistWorkingSetWithHash(NULL)` flushes the **clobbered** live session: the writer's stale content gets bound to the new head. The staleness gate accepts it.
4. The writer's retry loads that poisoned working set and commits it on top — feat's rows are gone from every subsequent commit while both processes report success.

The instrumented capture shows the poisoned write directly: `[ws] br=main cat=2ae6 commit=a9b6` — writer content, feat-head binding — followed by the writer's `[cmt] expected=a9b6 cat=2ae6` advancing over it. The preserved store has `feat work` in main's ancestry with zero feat rows.

## Fix

`AdvanceBranchWithState` with no explicit working catalog now persists **the catalog being advanced to** instead of the reload-vulnerable live session — advancing with no working catalog means the working set is the new catalog. Covers FF, the merge-commit path, cherry-pick, and rebase finalize. One caller depended on the old live-flush: seed-init keeps a user's pre-seed tables in the working set, and now passes the flushed live catalog explicitly.

## Verification

- **Fail-before**: unfixed builds reproduced twice in instrumented CI soaks (loop 318 and lane d1), plus the original nightly at run 211. Local macOS never reproduces (1050+ loops) — the window needs Linux timing.
- **Pass-after**: three CI soak runs on the fixed build — 12 nightly-warmup lanes, 7,200 total loops — zero failures (unfixed rate predicts ~24).
- Local: multi-process merge/rebase test 3×46/46, full shell suite 118/118, c-tests 311,071/311,071, stateful fuzz seed clean for 2,563 steps (merge/refs path — fuzz applies), amalgamation compiles, lint clean.
- The temporary soak rig lives only on `soak/mp-merge-race-2433` (never to merge; I'll delete it after this lands). The nightly stress soak remains the ongoing sentinel — the race needs hundreds of Linux runs to fire, so no deterministic CI test can gate it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)