### PR TITLE
Differential generator totalizes quote()-keyed picks

### DIFF
--- a/test/sql_differential_fuzzer.py
+++ b/test/sql_differential_fuzzer.py
@@ -186,8 +186,10 @@ class Gen:
     def child_write(self):
         """Child write. ORDER BY is load-bearing: LIMIT 1 without it is plan-dependent."""
         if self.r.random() < 0.7:
+            # quote() collapses embedded NULs, so distinct keys can tie and
+            # LIMIT 1 would pick by scan order; the raw key totalizes it.
             self.emit("INSERT OR IGNORE INTO ch(cid, fk, note) "
-                      "SELECT %d, k, %s FROM t WHERE %s ORDER BY %s LIMIT 1;"
+                      "SELECT %d, k, %s FROM t WHERE %s ORDER BY %s, k LIMIT 1;"
                       % (self.r.randint(1, 60), self.text_val(), self.pred(),
                          Q % "k"))
         else:
@@ -294,11 +296,13 @@ class Gen:
         if self.shape == "composite_pk":
             sel = "k + %d, coalesce(quote(j),'x'), a, b" % self.r.randint(1, 50)
             order = ", ".join(Q % col for col in ("k", "j", "a", "b"))
+            order += ", k, j, a, b"
         else:
             base = "coalesce(quote(k),'x') || 'x'" if self.key_kind == "text" \
                 else "k + %d" % self.r.randint(1, 50)
             sel = "%s, a, b" % base
             order = ", ".join(Q % col for col in ("k", "a", "b"))
+            order += ", k, a, b"
         self.emit("INSERT OR IGNORE INTO t(%s, a, b) "
                   "SELECT %s FROM t WHERE %s ORDER BY %s;"
                   % (kc, sel, self.pred(), order))


### PR DESCRIPTION
Fixes #2437.

## Not an engine bug

Seed 4702898686's divergence traces to an under-determined generated query, not doltlite. `quote()` collapses text at an embedded NUL — `quote('a'||char(0)||'b')` renders `'a'`, identically on both engines — so two distinct keys tie under `ORDER BY coalesce(quote(k),'N')`. The generator's child-write pick then does `LIMIT 1` on that tie, and tie order follows scan order, which legitimately differs between a prolly tree and a b-tree after REPLACE churn. Hex-tracing showed both engines agree on every deterministic statement in the script; adding the raw key as a tiebreaker makes them pick the same row.

The same-table `INSERT OR IGNORE ... SELECT ... ORDER BY quote-cols` site has the same latent tie (insert order decides the OR IGNORE winner); both sites now append raw columns.

## Validation

- Seed 4702898686 regenerates deterministic and both engines agree
- 30,000-seed local sweep spanning the failing window: 30,000/30,000, zero divergences
- The isolated FK/NUL-key behaviors the script exercises (SET NULL on DELETE and on REPLACE-conflict, NUL-key ordering, quote truncation) were each verified identical on both engines while ruling the engine out

🤖 Generated with [Claude Code](https://claude.com/claude-code)