### PR TITLE
The ALTER materialize helper becomes an internal-only function

### DIFF
--- a/src/doltlite_config.c
+++ b/src/doltlite_config.c
@@ -253,6 +253,15 @@ int doltliteConfigRegister(sqlite3 *db){
       "doltlite_internal_materialize_default_column",
       3, DOLTLITE_COMMAND_FUNC_FLAGS, 0,
       doltliteInternalMaterializeDefaultColumnFunc, 0, 0);
+  if( rc==SQLITE_OK ){
+    /* ALTER's codegen resolves this FuncDef directly; user SQL must not.
+    ** SQLITE_FUNC_INTERNAL is stock's mechanism for exactly that split:
+    ** name resolution reports no such function and PRAGMA function_list
+    ** hides it, same as stock's own internal helpers. */
+    FuncDef *pDef = sqlite3FindFunction(db,
+        "doltlite_internal_materialize_default_column", 3, SQLITE_UTF8, 0);
+    if( pDef ) pDef->funcFlags |= SQLITE_FUNC_INTERNAL;
+  }
   return rc;
 }
 

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -12797,7 +12797,7 @@ static void run_directonly_dolt_functions(void){
     "'dolt_connect_branch','dolt_creds','dolt_creds_new',"
     "'dolt_default_branch','dolt_fetch','dolt_gc','dolt_merge','dolt_pull',"
     "'dolt_push','dolt_rebase','dolt_remote','dolt_reset','dolt_revert',"
-    "'dolt_tag','doltlite_internal_materialize_default_column'";
+    "'dolt_tag'";
   sqlite3 *db = 0;
   char dbpath[256];
   char *zSql;
@@ -12818,8 +12818,34 @@ static void run_directonly_dolt_functions(void){
   if( zSql ){
     zResult = queryScalarText(db, zSql);
     check("all_command_functions_are_directonly",
-          strcmp(zResult, "23|23")==0);
+          strcmp(zResult, "22|22")==0);
     sqlite3_free(zSql);
+  }
+
+  /* The ALTER materialize helper is internal-only: hidden from the
+  ** function list and unresolvable from user SQL, like stock's own
+  ** internal helpers. ALTER's codegen resolves the FuncDef directly. */
+  zResult = queryScalarText(db,
+    "SELECT count(*) FROM pragma_function_list "
+    "WHERE name='doltlite_internal_materialize_default_column'");
+  check("materialize_helper_not_listed", strcmp(zResult, "0")==0);
+  {
+    sqlite3_stmt *pStmt = 0;
+    rc = sqlite3_prepare_v2(db,
+      "SELECT doltlite_internal_materialize_default_column('main','t','c')",
+      -1, &pStmt, 0);
+    check("materialize_helper_unresolvable", rc==SQLITE_ERROR
+          && strstr(sqlite3_errmsg(db), "no such function")!=0);
+    sqlite3_finalize(pStmt);
+  }
+  {
+    const char *zB;
+    check("materialize_alter_setup", execSql(db,
+      "CREATE TABLE mat_t(a INTEGER PRIMARY KEY);"
+      "INSERT INTO mat_t VALUES(1);"
+      "ALTER TABLE mat_t ADD COLUMN b TEXT DEFAULT 'z';")==SQLITE_OK);
+    zB = queryScalarText(db, "SELECT b FROM mat_t WHERE a=1");
+    check("materialize_alter_still_fills_default", strcmp(zB, "z")==0);
   }
 
   zSql = sqlite3_mprintf(


### PR DESCRIPTION
Fixes #2441.

#2428's ADD COLUMN DEFAULT rewrite helper (`doltlite_internal_materialize_default_column`) was registered as an ordinary SQL function: `PRAGMA function_list` advertised it, and any top-level statement could run a silent full-table rewrite with the authorizer cleared and `changes()` suppressed.

ALTER's codegen resolves the FuncDef via `sqlite3FindFunction` and calls it directly — the name never needed user-scope resolution. The fix ORs `SQLITE_FUNC_INTERNAL` into the FuncDef after registration, which is stock's own mechanism for this split (used by its internal helpers): resolve.c reports `no such function` for user SQL (nested parses and the codegen lookup unaffected), and `PRAGMA function_list` hides it unless the internal-functions test-control is active — identical behavior to stock's internals.

#2428's semantics are preserved: ALTER ADD COLUMN DEFAULT still materializes without firing user authorizers, triggers, or `sqlite3_changes()`.

## Validation

- Stock parity on the issue's repro: `function_list` shows nothing, top-level call errors `no such function`, and `ALTER TABLE t ADD COLUMN b TEXT DEFAULT 'z'` still fills existing rows
- c-test updated (the DIRECTONLY census no longer counts the hidden helper) plus four new checks: not listed, unresolvable, ALTER setup, default materialized — 311,094/311,094
- alter/alterauth/altercol/altertab/func testfixture buckets green (alter2's silence is its gated expected termination); full shell suite 118/118; amalgamation compiles; lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)