### PR TITLE
Keep table merges separate from same-number indexes

### DIFF
--- a/src/doltlite_merge_pass1.c
+++ b/src/doltlite_merge_pass1.c
@@ -263,9 +263,12 @@ static int mergePass1ResolveOursEntry(
       }
       pTheirsByNo = doltliteFindTableByNumber(
           c->aTheirs, c->nTheirs, c->aOurs[iOurs].iTable);
-      if( pTheirsByNo && pTheirsByNo->zName
-       && strcmp(pTheirsByNo->zName, pByNo->zName)!=0
-       && strcmp(pTheirsByNo->zName, zName)!=0 ){
+      if( pTheirsByNo && !pTheirsByNo->zName ){
+        pTheirsByNo = 0;
+        pByNo = 0;
+      }else if( pTheirsByNo
+             && strcmp(pTheirsByNo->zName, pByNo->zName)!=0
+             && strcmp(pTheirsByNo->zName, zName)!=0 ){
         pTheirsByNo = 0;
         pByNo = 0;
       }

--- a/test/vc_oracle_merge_test.sh
+++ b/test/vc_oracle_merge_test.sh
@@ -1818,6 +1818,33 @@ SELECT dolt_merge('feat');
 " "SELECT (SELECT count(*) FROM dolt_schema_conflicts) || '|' || (SELECT group_concat(id || ':' || k, ',') FROM (SELECT id, k FROM t ORDER BY id)) || '|' || (SELECT group_concat(id || ':' || k, ',') FROM (SELECT id, k FROM t INDEXED BY tk WHERE k >= 10 ORDER BY k))" \
 "SELECT CONCAT((SELECT COUNT(*) FROM dolt_schema_conflicts), '|', (SELECT GROUP_CONCAT(CONCAT(id, ':', k) ORDER BY id SEPARATOR ',') FROM t), '|', (SELECT GROUP_CONCAT(CONCAT(id, ':', k) ORDER BY k SEPARATOR ',') FROM t WHERE k >= 10))"
 
+oracle_reopen_state "table_index_rootpage_collision" "
+CREATE TABLE parent(id INTEGER PRIMARY KEY, payload VARCHAR(20));
+CREATE TABLE old_table(id INTEGER PRIMARY KEY, payload TEXT);
+INSERT INTO parent VALUES (1, 'one');
+SELECT dolt_commit('-Am', 'base');
+SELECT dolt_branch('feat');
+DROP TABLE old_table;
+CREATE TABLE added_table(id INTEGER PRIMARY KEY, payload TEXT);
+INSERT INTO added_table VALUES (1, 'ours');
+SELECT dolt_commit('-Am', 'ours');
+SELECT dolt_checkout('feat');
+DROP TABLE old_table;
+CREATE INDEX parent_payload ON parent(payload);
+SELECT dolt_commit('-Am', 'theirs');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feat');
+" "SELECT 'Q' || char(9) ||
+          (SELECT count(*) FROM sqlite_master WHERE type='table' AND name='old_table') || '|' ||
+          (SELECT count(*) FROM added_table) || '|' ||
+          (SELECT count(*) FROM sqlite_master WHERE type='index' AND name='parent_payload') || '|' ||
+          (SELECT count(*) FROM parent INDEXED BY parent_payload WHERE payload='one');" \
+"SELECT CONCAT('Q', char(9),
+          (SELECT COUNT(*) FROM information_schema.tables WHERE TABLE_SCHEMA=DATABASE() AND TABLE_NAME='old_table'), '|',
+          (SELECT COUNT(*) FROM added_table), '|',
+          (SELECT COUNT(*) FROM information_schema.statistics WHERE TABLE_SCHEMA=DATABASE() AND TABLE_NAME='parent' AND INDEX_NAME='parent_payload'), '|',
+          (SELECT COUNT(*) FROM parent WHERE payload='one'));"
+
 echo ""
 echo "=== Results: $pass passed, $fail failed ==="
 if [ $fail -gt 0 ]; then


### PR DESCRIPTION
## Summary

- stop treating an unnamed index as the same merge object as a named table when branch-local catalog numbers collide
- let the normal merge remapping preserve both independently added objects
- add a Dolt oracle covering a dropped table whose number is reused by a table on one branch and an index on the other

The bad pairing synthesized `ALTER TABLE ... DROP COLUMN id`, leaked a bare `SQLITE_ERROR`, and could leave a partially installed working catalog. The corrected pairing produces a clean merge matching Dolt.

## Tests

- exact preserved seed-1787839780 failure state: merge no longer leaks `SQL logic error`; post-state remains clean
- `bash test/vc_oracle_merge_test.sh build/doltlite dolt` (89 passed)
- `bash test/doltlite_schema_merge.sh build/doltlite` (399 passed)
- `bash test/doltlite_unknown_sql_function.sh build/doltlite` (6 passed)
- `bash test/run_c_tests.sh` (30/30 gated suites)
- `make lint`

Fixes #2446

Co-Authored-By: Codex <noreply@openai.com>