### PR TITLE
EXPLAIN comments compile into the library build

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -408,7 +408,10 @@ jobs:
         cd build-coverage
         set -o pipefail
         {
-          make -j2 DOLTLITE_PROLLY_CHECK=1 \
+          # DOLTLITE_CLI_OBJECTS: the coverage report needs the CLI to
+          # drive per-source objects; an embedded amalgamation attributes
+          # everything to sqlite3.c and the report loses it.
+          make -j2 DOLTLITE_PROLLY_CHECK=1 DOLTLITE_CLI_OBJECTS=1 \
             doltlite doltlite-remotesrv doltlite-lib testfixture \
             doltlite-c-tests-build doltlite-regression-test-c-build
           make DOLTLITE_PROLLY=0 sqlite3

--- a/main.mk
+++ b/main.mk
@@ -2664,9 +2664,29 @@ sqlite3d$(T.exe):	shell.c $(LIBOBJS0)
 shell_renamed.c: shell.c
 	sed 's/^int SQLITE_CDECL main(/int SQLITE_CDECL sqlite3_shell_main(/' shell.c > $@
 
-doltlite$(T.exe):	shell_renamed.c $(TOP)/src/shell_wrapper.c $(LIBOBJS0)
+# The CLI embeds the amalgamation, stock's own model for its shell:
+# EXPLAIN comments change the Op struct layout, so the flag must cover
+# the whole engine in one translation unit and cannot mix with the
+# canonical library objects, which stay without the documented ~5%
+# comment-recording cost. The engine unit compiles WITHOUT SHELL_OPT:
+# its DQS and subtype flags would change SQL semantics that doltlite
+# code and tests assume, so they stay confined to the shell unit.
+#
+# DOLTLITE_CLI_OBJECTS=1 links the canonical objects instead (and loses
+# the comment column): clang's coverage mapping attributes an embedded
+# amalgamation to sqlite3.c, so the instrumented build must drive the
+# per-source objects for the report to see them.
+DOLTLITE_CLI_OBJECTS ?= 0
+doltlite-cli-engine.0 = sqlite3-cli.o
+doltlite-cli-engine.1 = $(LIBOBJS0)
+DOLTLITE_CLI_COMMENT_FLAG ?= -DSQLITE_ENABLE_EXPLAIN_COMMENTS
+sqlite3-cli.o:	sqlite3.c
+	$(T.cc.sqlite) $(DOLTLITE_CLI_COMMENT_FLAG) \
+		-c sqlite3.c -o $@
+doltlite$(T.exe):	shell_renamed.c $(TOP)/src/shell_wrapper.c $(doltlite-cli-engine.$(DOLTLITE_CLI_OBJECTS))
 	$(T.link) -o $@ \
-		shell_renamed.c $(TOP)/src/shell_wrapper.c $(LIBOBJS0) \
+		shell_renamed.c $(TOP)/src/shell_wrapper.c \
+		$(doltlite-cli-engine.$(DOLTLITE_CLI_OBJECTS)) \
 		$(CFLAGS.readline) $(SHELL_OPT) \
 		$(LDFLAGS.libsqlite3) $(LDFLAGS.readline)
 

--- a/test/doltlite_explain_comments.sh
+++ b/test/doltlite_explain_comments.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+source "$(dirname "$0")/lib/doltlite_test_common.sh"
+
+echo "=== EXPLAIN comment column ==="
+echo ""
+
+DB=:memory:
+
+# The coverage build links the canonical objects (DOLTLITE_CLI_OBJECTS=1)
+# and has no comment column by design; the suite only applies to the
+# amalgamation-embedded CLI.
+HAS_FLAG=$(echo "SELECT count(*) FROM pragma_compile_options WHERE compile_options='ENABLE_EXPLAIN_COMMENTS';" | $DOLTLITE "$DB" 2>/dev/null)
+if [ "$HAS_FLAG" != "1" ]; then
+  echo "  SKIP: CLI built without EXPLAIN comments (object-linked build)"
+  dltest_finish
+  exit 0
+fi
+
+run_test "explain_comments_compile_option" \
+  "SELECT compile_options FROM pragma_compile_options WHERE compile_options='ENABLE_EXPLAIN_COMMENTS';" \
+  "ENABLE_EXPLAIN_COMMENTS" \
+  "$DB"
+
+run_test_match "explain_init_comment" \
+  "EXPLAIN SELECT abs(-1);" \
+  "Start at " \
+  "$DB"
+
+run_test_match "explain_integer_comment" \
+  "EXPLAIN SELECT abs(-1);" \
+  "r\\[[0-9]+\\]=-1" \
+  "$DB"
+
+# The comments annotate the stream; the opcodes themselves are unchanged.
+run_test_match "explain_opcodes_unchanged_init" \
+  "EXPLAIN SELECT abs(-1);" \
+  "Init" \
+  "$DB"
+
+run_test_match "explain_opcodes_unchanged_function" \
+  "EXPLAIN SELECT abs(-1);" \
+  "Function" \
+  "$DB"
+
+dltest_finish

--- a/test/lib/doltlite_suite_manifest.sh
+++ b/test/lib/doltlite_suite_manifest.sh
@@ -109,6 +109,7 @@ doltlite_snapshot_isolation.sh
 doltlite_storage_locking.sh
 doltlite_unknown_table_cursor.sh
 doltlite_unknown_sql_function.sh
+doltlite_explain_comments.sh
 doltlite_behavior.sh
 doltlite_branch_edge.sh
 doltlite_diff_alter.sh


### PR DESCRIPTION
Fixes #2449 — scoped to the CLI per review direction, not library-wide.

## Design

`SQLITE_ENABLE_EXPLAIN_COMMENTS` changes the VDBE `Op` struct layout, so it cannot cover only some library objects — it is whole-engine-or-nothing per binary. Library-wide would put upstream's documented ~5% comment-recording cost into libdoltlite. The scoping follows stock's own model (its shell embeds the amalgamation precisely because "the shell needs features … not appropriate for the canonical library"):

- **libdoltlite / testfixture / c-tests**: canonical objects, no flag, no cost — verified: testfixture's `compile_options` does not list it
- **doltlite CLI**: embeds the amalgamation as a dedicated engine unit (`sqlite3-cli.o`) compiled with the feature flags plus `EXPLAIN_COMMENTS` — and deliberately **without** `SHELL_OPT`, whose `DQS=0`/`STRICT_SUBTYPE` flags change SQL semantics doltlite keeps out of the engine (an intermediate iteration leaked them in and five suites failed: diff, persistence, structural, perf, count_perf — all recovered on the split)

A side benefit: every shell-suite run now exercises the amalgamation build continuously, the same class the compile-the-amalgamation CI gate covers.

## Validation

- CLI: `EXPLAIN SELECT abs(-1)` shows `Start at 7` / `r[N]=-1`, `compile_options` lists the flag, opcode stream unchanged; new 5-test suite registered
- Library lineage: testfixture flag-free; c-tests 311,107/311,107
- Full shell suite 120/120 against the amalgamation-embedded CLI; eqp buckets green; lint clean

Note: #2449 asked for a `Grok 4.6` trailer; the commit carries my own since I authored the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)