### PR TITLE
Accept WORKING and STAGED in dolt_hashof_db and dolt_hashof_table

### DIFF
--- a/src/doltlite_hashof.c
+++ b/src/doltlite_hashof.c
@@ -581,7 +581,7 @@ static int hashofDbInCatalog(
   return SQLITE_OK;
 }
 
-/* Resolve ref-spec to catalog hash. Empty/failure sets the SQL result and
+/* Resolve ref-spec to catalog hash. NULL/failure sets the SQL result and
 ** returns 1. */
 static int hashofResolveRefCatalog(
   sqlite3_context *ctx,
@@ -603,6 +603,16 @@ static int hashofResolveRefCatalog(
   if( !zRef ){
     sqlite3_result_null(ctx);
     return 1;
+  }
+  if( zRef[0]==0 || doltliteRefIsWorking(zRef) || doltliteRefIsStaged(zRef) ){
+    rc = doltliteResolveCatalogHashForRef(db, zRef[0] ? zRef : "WORKING",
+                                          pCatHash);
+    if( rc!=SQLITE_OK ){
+      sqlite3_snprintf(sizeof(zErr), zErr, "%s: invalid ref spec", zFn);
+      sqlite3_result_error(ctx, zErr, -1);
+      return 1;
+    }
+    return 0;
   }
   rc = doltliteResolveRef(db, zRef, &commitHash);
   if( rc==SQLITE_NOTFOUND ){

--- a/test/doltlite_hashof_refs.sh
+++ b/test/doltlite_hashof_refs.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+source "$(dirname "$0")/lib/doltlite_test_common.sh"
+
+echo "=== dolt_hashof WORKING/STAGED refs ==="
+echo ""
+
+DB=:memory:
+
+dirty() {
+  printf "%s" \
+    "CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES(1,1);
+SELECT dolt_commit('-A','-m','c');
+INSERT INTO t VALUES(2,2);
+$1"
+}
+
+run_test_lastline "hashof_db_working_equals_noarg" \
+  "$(dirty "SELECT dolt_hashof_db('WORKING') = dolt_hashof_db();")" \
+  "1" \
+  "$DB"
+
+run_test_lastline "hashof_db_empty_equals_working" \
+  "$(dirty "SELECT dolt_hashof_db('') = dolt_hashof_db('WORKING');")" \
+  "1" \
+  "$DB"
+
+run_test_lastline "hashof_db_working_case_insensitive" \
+  "$(dirty "SELECT dolt_hashof_db('working') = dolt_hashof_db('WORKING');")" \
+  "1" \
+  "$DB"
+
+run_test_lastline "hashof_db_staged_equals_head_before_add" \
+  "$(dirty "SELECT dolt_hashof_db('STAGED') = dolt_hashof_db('HEAD');")" \
+  "1" \
+  "$DB"
+
+run_test_lastline "hashof_db_working_differs_from_head_when_dirty" \
+  "$(dirty "SELECT dolt_hashof_db('WORKING') != dolt_hashof_db('HEAD');")" \
+  "1" \
+  "$DB"
+
+run_test_lastline "hashof_table_working_equals_noarg" \
+  "$(dirty "SELECT dolt_hashof_table('t','WORKING') = dolt_hashof_table('t');")" \
+  "1" \
+  "$DB"
+
+run_test_lastline "hashof_table_working_differs_from_head" \
+  "$(dirty "SELECT dolt_hashof_table('t','WORKING') != dolt_hashof_table('t','HEAD');")" \
+  "1" \
+  "$DB"
+
+run_test_lastline "hashof_catalog_working_equals_noarg" \
+  "$(dirty "SELECT dolt_hashof_catalog('WORKING') = dolt_hashof_catalog();")" \
+  "1" \
+  "$DB"
+
+run_test_lastline "hashof_db_staged_equals_working_after_add" \
+  "$(dirty "SELECT dolt_add('t');
+SELECT dolt_hashof_db('STAGED') = dolt_hashof_db('WORKING');")" \
+  "1" \
+  "$DB"
+
+run_test_lastline "hashof_db_staged_differs_from_head_after_add" \
+  "$(dirty "SELECT dolt_add('t');
+SELECT dolt_hashof_db('STAGED') != dolt_hashof_db('HEAD');")" \
+  "1" \
+  "$DB"
+
+run_test_match "hashof_working_still_errors" \
+  "$(dirty "SELECT dolt_hashof('WORKING');")" \
+  "invalid ref spec" \
+  "$DB"
+
+run_test_match "hashof_staged_still_errors" \
+  "$(dirty "SELECT dolt_hashof('STAGED');")" \
+  "invalid ref spec" \
+  "$DB"
+
+dltest_finish

--- a/test/lib/doltlite_suite_manifest.sh
+++ b/test/lib/doltlite_suite_manifest.sh
@@ -9,6 +9,7 @@ storage_format_contract_test.sh
 doltlite_parity.sh
 doltlite_commit.sh
 doltlite_commit_date.sh
+doltlite_hashof_refs.sh
 doltlite_staging.sh
 doltlite_workspace.sh
 doltlite_docs.sh
@@ -157,6 +158,7 @@ storage_format_contract_test.sh
 doltlite_parity.sh
 doltlite_commit.sh
 doltlite_commit_date.sh
+doltlite_hashof_refs.sh
 doltlite_staging.sh
 doltlite_workspace.sh
 doltlite_docs.sh

--- a/test/vc_oracle_hashof_test.sh
+++ b/test/vc_oracle_hashof_test.sh
@@ -495,18 +495,33 @@ H_HEAD_COMMITTED=$(run_hash_on "$DB" "SELECT dolt_hashof('HEAD');")
 exec_pair "$DB" "INSERT INTO t VALUES (2, 'b');"
 H_T_WORKING=$(run_hash_on "$DB" "SELECT dolt_hashof_table('t');")
 H_DB_WORKING=$(run_hash_on "$DB" "SELECT dolt_hashof_db();")
+H_DB_NAMED_WORKING=$(run_hash_on "$DB" "SELECT dolt_hashof_db('WORKING');")
+H_DB_EMPTY=$(run_hash_on "$DB" "SELECT dolt_hashof_db('');")
+H_DB_STAGED_BEFORE=$(run_hash_on "$DB" "SELECT dolt_hashof_db('STAGED');")
+H_DB_HEAD_NAMED=$(run_hash_on "$DB" "SELECT dolt_hashof_db('HEAD');")
 H_HEAD_WORKING=$(run_hash_on "$DB" "SELECT dolt_hashof('HEAD');")
 different "working_change_updates_table_hash" "$H_T_COMMITTED" "$H_T_WORKING"
 different "working_change_updates_db_hash" "$H_DB_COMMITTED" "$H_DB_WORKING"
 same "working_change_does_not_move_HEAD" "$H_HEAD_COMMITTED" "$H_HEAD_WORKING"
+same "named_working_equals_noarg_db" "$H_DB_WORKING" "$H_DB_NAMED_WORKING"
+same "empty_ref_equals_working_db" "$H_DB_EMPTY" "$H_DB_NAMED_WORKING"
+same "staged_equals_head_before_add" "$H_DB_STAGED_BEFORE" "$H_DB_HEAD_NAMED"
+different "named_working_differs_from_head_when_dirty" "$H_DB_NAMED_WORKING" "$H_DB_HEAD_NAMED"
+both_error "hashof_working_is_commit_only" "$DB" "SELECT dolt_hashof('WORKING');"
+both_error "hashof_staged_is_commit_only" "$DB" "SELECT dolt_hashof('STAGED');"
 
 exec_pair "$DB" "SELECT dolt_add('-A');"
 H_T_STAGED=$(run_hash_on "$DB" "SELECT dolt_hashof_table('t');")
 H_DB_STAGED=$(run_hash_on "$DB" "SELECT dolt_hashof_db();")
+H_DB_STAGED_NAMED=$(run_hash_on "$DB" "SELECT dolt_hashof_db('STAGED');")
+H_DB_WORKING_AFTER=$(run_hash_on "$DB" "SELECT dolt_hashof_db('WORKING');")
+H_DB_HEAD_AFTER=$(run_hash_on "$DB" "SELECT dolt_hashof_db('HEAD');")
 H_HEAD_STAGED=$(run_hash_on "$DB" "SELECT dolt_hashof('HEAD');")
 same "staging_keeps_working_table_hash" "$H_T_WORKING" "$H_T_STAGED"
 same "staging_keeps_working_db_hash" "$H_DB_WORKING" "$H_DB_STAGED"
 same "staging_does_not_move_HEAD" "$H_HEAD_COMMITTED" "$H_HEAD_STAGED"
+same "named_staged_equals_working_after_add" "$H_DB_STAGED_NAMED" "$H_DB_WORKING_AFTER"
+different "named_staged_differs_from_head_after_add" "$H_DB_STAGED_NAMED" "$H_DB_HEAD_AFTER"
 
 echo ""
 


### PR DESCRIPTION
Fixes #2454.

`dolt_hashof_db` / `dolt_hashof_table` / `dolt_hashof_catalog` with a ref argument resolved through `doltliteResolveRef`, which is commit-only, so `WORKING` and `STAGED` returned `invalid ref spec`. Empty, `WORKING`, and `STAGED` now go through `doltliteResolveCatalogHashForRef`; commit-ish refs stay on the existing path. `dolt_hashof()` remains commit-only.

Validation:
- fail-before: 10 of 12 `doltlite_hashof_refs.sh` assertions failed
- pass-after: 12 of 12
- `test/vc_oracle_hashof_test.sh`: 43 of 43 vs Dolt 2.2.2
- `test/vc_oracle_hashof_errors_test.sh`: 4 of 4
- make lint

Co-Authored-By: Grok 4.6 <noreply@x.ai>