### PR TITLE
Reject attached-schema Dolt VC vtabs

### DIFF
--- a/src/select.c
+++ b/src/select.c
@@ -6304,6 +6304,28 @@ static int selectExpander(Walker *pWalker, Select *p){
       assert( pFrom->pSTab==0 );
       pFrom->pSTab = pTab = sqlite3LocateTableItem(pParse, 0, pFrom);
       if( pTab==0 ) return WRC_Abort;
+#ifdef DOLTLITE_PROLLY
+      if( IsVirtual(pTab)
+       && pTab->u.vtab.nArg>0
+       && pTab->u.vtab.azArg[0]
+       && sqlite3StrNICmp(pTab->u.vtab.azArg[0], "dolt_", 5)==0
+      ){
+        const char *zDb;
+        if( pFrom->fg.fixedSchema ){
+          int iDb = sqlite3SchemaToIndex(db, pFrom->u4.pSchema);
+          assert( iDb>=0 && iDb<db->nDb );
+          zDb = db->aDb[iDb].zDbSName;
+        }else{
+          zDb = pFrom->u4.zDatabase;
+        }
+        if( zDb && sqlite3StrICmp(zDb, "main")!=0 ){
+          sqlite3ErrorMsg(pParse, "%s is only available in the main database",
+                          pTab->zName);
+          pFrom->pSTab = 0;
+          return WRC_Abort;
+        }
+      }
+#endif
       if( pTab->nTabRef>=0xffff ){
         sqlite3ErrorMsg(pParse, "too many references to \"%s\": max 65535",
            pTab->zName);

--- a/test/doltlite_attach_write_matrix.sh
+++ b/test/doltlite_attach_write_matrix.sh
@@ -17,6 +17,17 @@ want_eq() {
   fi
 }
 
+want_contains() {
+  local name="$1" got="$2" want="$3"
+  case "$got" in
+    *"$want"*) PASS=$((PASS+1)) ;;
+    *)
+      FAIL=$((FAIL+1))
+      ERRORS="$ERRORS\n  FAIL: $name\n    want substring: $(printf %q "$want")\n    got:  $(printf %q "$got")"
+      ;;
+  esac
+}
+
 dl_last() { printf '%s\n' "$1" | $DOLTLITE "$2" 2>&1 | tail -1; }
 dl_all()  { printf '%s\n' "$1" | $DOLTLITE "$2" 2>&1; }
 sq_last() { printf '%s\n' "$1" | $SQLITE3 "$2" 2>&1 | tail -1; }
@@ -224,6 +235,23 @@ else
   R=$(dl_last "ATTACH '$STOCK_ATT' AS x; BEGIN; INSERT INTO t VALUES(1); INSERT INTO x.u VALUES(1); COMMIT; SELECT (SELECT count(*) FROM t) || '/' || (SELECT count(*) FROM x.u);" "$STOCK_MAIN")
   want_eq "stock_file__stock_file/T2_explicit_txn_both_commit" "$R" "1/1"
 fi
+
+VC_MAIN="$TMP/vtab_main.db"
+VC_ATT="$TMP/vtab_att.db"
+dl_all "CREATE TABLE t(id INTEGER PRIMARY KEY);
+  SELECT dolt_commit('-Am','main init');
+  SELECT dolt_branch('main_only_branch');" "$VC_MAIN" >/dev/null
+dl_all "CREATE TABLE u(id INTEGER PRIMARY KEY);
+  INSERT INTO u VALUES(1);
+  SELECT dolt_commit('-Am','attached init');
+  INSERT INTO u VALUES(2);" "$VC_ATT" >/dev/null
+for surface in dolt_branches dolt_log dolt_status; do
+  R=$(dl_all "ATTACH '$VC_ATT' AS x; SELECT * FROM x.$surface;" "$VC_MAIN")
+  want_contains "attached_vtab/$surface" "$R" \
+    "$surface is only available in the main database"
+done
+R=$(dl_last "SELECT group_concat(name,',') FROM dolt_branches;" "$VC_MAIN")
+want_eq "main_vtab_still_available" "$R" "main,main_only_branch"
 
 echo ""
 echo "============================="


### PR DESCRIPTION
## Summary

- reject schema-qualified Dolt VC virtual tables outside main instead of silently reading main state
- identify DoltLite system vtabs by their dolt_ module name during FROM-clause expansion
- preserve ordinary attached tables, main VC surfaces, sqlite_dbpage, and stock SQLite behavior

SQLite creates eponymous virtual tables in main before invoking xConnect, so the vtab callback cannot recover an explicit attached-schema qualifier. The resolver still has that qualifier and can fail closed before execution.

## Tests

- bash test/doltlite_attach_write_matrix.sh build/doltlite /tmp/doltlite-stock-review.JzI834/sqlite3 (105 passed)
- bash test/run_doltlite_tests.sh (118 suites passed; the sole stale-library failure passed after rebuilding doltlite-lib)
- bash test/doltlite_regression_test_c.sh (311137 passed)
- make lint
- make DOLTLITE_PROLLY=0 sqlite3
- git diff --check

Fixes #2462

Co-Authored-By: Codex <noreply@openai.com>