### PR TITLE
Refuse cherry-pick of merge commits and empty already-applied patches

### DIFF
--- a/src/doltlite_cherry_pick.c
+++ b/src/doltlite_cherry_pick.c
@@ -437,6 +437,14 @@ static void doltliteCherryPickFunc(
     sqlite3_result_error(context, "failed to load HEAD commit", -1);
     return;
   }
+  if( doltliteCommitParentCount(&pickCommit)>1 ){
+    doltliteCommitClear(&pickCommit);
+    doltliteCommitClear(&parentCommit);
+    doltliteCommitClear(&ourCommit);
+    sqlite3_result_error(context,
+      "cherry-picking a merge commit is not supported", -1);
+    return;
+  }
 
   {
     const char *zMsg = pickCommit.zMessage;

--- a/src/doltlite_cherry_pick.c
+++ b/src/doltlite_cherry_pick.c
@@ -456,7 +456,7 @@ static void doltliteCherryPickFunc(
 
     rc = applyMergedCatalogAndCommit(db, context,
         &parentCommit.catalogHash, &ourCommit.catalogHash,
-        &pickCommit.catalogHash, &ourHead, 0, zMsg, 0, 0, &nConflicts, 0,
+        &pickCommit.catalogHash, &ourHead, 0, zMsg, 0, 1, &nConflicts, 0,
         &zApplyErr, hexBuf);
   }
 
@@ -467,6 +467,11 @@ static void doltliteCherryPickFunc(
   if( rc==SQLITE_BUSY ){
     sqlite3_free(zApplyErr);
     doltliteCmdResultPeerBranchBusy(context, "cherry-pick");
+    return;
+  }
+  if( rc==SQLITE_DONE ){
+    sqlite3_free(zApplyErr);
+    sqlite3_result_error(context, "no changes were made, nothing to commit", -1);
     return;
   }
   if( rc!=SQLITE_OK ){

--- a/test/doltlite_cherry_pick.sh
+++ b/test/doltlite_cherry_pick.sh
@@ -134,6 +134,58 @@ run_test_match "cp_err_initial" \
 
 rm -f "$DB"
 
+DB=/tmp/test_cp_merge_$$.db; rm -f "$DB"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES(1,1);
+SELECT dolt_commit('-A','-m','b');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+INSERT INTO t VALUES(2,2);
+SELECT dolt_commit('-A','-m','f');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES(3,3);
+SELECT dolt_commit('-A','-m','m');
+SELECT dolt_merge('feat','--no-ff','-m','mf');
+SELECT dolt_branch('other');
+SELECT dolt_checkout('other');
+SELECT dolt_reset('--hard','HEAD~1');" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+run_test_match "cp_err_merge_commit" \
+  "SELECT dolt_checkout('other');
+SELECT dolt_cherry_pick('main');" \
+  "cherry-picking a merge commit is not supported" "$DB"
+
+run_test_lastline "cp_err_merge_commit_rows_unchanged" \
+  "SELECT dolt_checkout('other');
+SELECT dolt_cherry_pick('main');
+SELECT group_concat(id) FROM (SELECT id FROM t ORDER BY id);" \
+  "1,3" "$DB"
+
+rm -f "$DB"
+
+DB=/tmp/test_rv_merge_$$.db; rm -f "$DB"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES(1,1);
+SELECT dolt_commit('-A','-m','b');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+INSERT INTO t VALUES(2,2);
+SELECT dolt_commit('-A','-m','f');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES(3,3);
+SELECT dolt_commit('-A','-m','m');
+SELECT dolt_merge('feat','--no-ff','-m','mf');" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+run_test_match "rv_merge_commit_hash" \
+  "SELECT dolt_revert('HEAD');" \
+  "^[0-9a-f]{40}$" "$DB"
+
+run_test "rv_merge_commit_first_parent_rows" \
+  "SELECT group_concat(id) FROM (SELECT id FROM t ORDER BY id);" \
+  "1,3" "$DB"
+
+rm -f "$DB"
+
 DB=/tmp/test_cp_persist_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'init');

--- a/test/doltlite_cherry_pick.sh
+++ b/test/doltlite_cherry_pick.sh
@@ -186,6 +186,27 @@ run_test "rv_merge_commit_first_parent_rows" \
 
 rm -f "$DB"
 
+DB=/tmp/test_cp_empty_$$.db; rm -f "$DB"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES(1,1);
+SELECT dolt_commit('-A','-m','c1');
+INSERT INTO t VALUES(2,2);
+SELECT dolt_commit('-A','-m','c2');" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+run_test_match "cp_err_already_applied" \
+  "SELECT dolt_cherry_pick(dolt_hashof('HEAD~1'));" \
+  "no changes were made, nothing to commit" "$DB"
+
+run_test "cp_err_already_applied_log_unchanged" \
+  "SELECT count(*) FROM dolt_log;" \
+  "3" "$DB"
+
+run_test "cp_err_already_applied_rows_unchanged" \
+  "SELECT group_concat(id) FROM (SELECT id FROM t ORDER BY id);" \
+  "1,2" "$DB"
+
+rm -f "$DB"
+
 DB=/tmp/test_cp_persist_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'init');

--- a/test/doltlite_feature_deep.sh
+++ b/test/doltlite_feature_deep.sh
@@ -45,7 +45,7 @@ run_test "cp_twice_first" "SELECT count(*) FROM t;" "2" "$DB"
 
 run_test_match "cp_twice_second" \
   "SELECT dolt_cherry_pick('feat');" \
-  "^[0-9a-f]{40}$" "$DB"
+  "no changes were made, nothing to commit" "$DB"
 run_test "cp_twice_still2" "SELECT count(*) FROM t;" "2" "$DB"
 
 db_rm "$DB"

--- a/test/vc_oracle_revert_cherrypick_test.sh
+++ b/test/vc_oracle_revert_cherrypick_test.sh
@@ -718,6 +718,45 @@ $SEED
 SELECT dolt_cherry_pick((SELECT commit_hash FROM dolt_log WHERE message = 'Initialize data repository'));
 "
 
+oracle_error "cherry_pick_merge_commit" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'b');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+INSERT INTO t VALUES (2, 2);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'f');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES (3, 3);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'm');
+SELECT dolt_merge('feat', '--no-ff', '-m', 'mf');
+SELECT dolt_branch('other');
+SELECT dolt_checkout('other');
+SELECT dolt_reset('--hard', 'HEAD~1');
+SELECT dolt_cherry_pick('main');
+"
+
+oracle "revert_merge_commit_first_parent" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'b');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+INSERT INTO t VALUES (2, 2);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'f');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES (3, 3);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'm');
+SELECT dolt_merge('feat', '--no-ff', '-m', 'mf');
+SELECT dolt_revert('HEAD');
+"
+
 oracle_error_poststate "cherry_pick_constraint_violation_rolls_back" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, u INT UNIQUE, v TEXT);
 INSERT INTO t VALUES (1,1,'base1'),(2,2,'base2');

--- a/test/vc_oracle_revert_cherrypick_test.sh
+++ b/test/vc_oracle_revert_cherrypick_test.sh
@@ -718,6 +718,17 @@ $SEED
 SELECT dolt_cherry_pick((SELECT commit_hash FROM dolt_log WHERE message = 'Initialize data repository'));
 "
 
+oracle_error "cherry_pick_already_applied" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+INSERT INTO t VALUES (2, 2);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c2');
+SELECT dolt_cherry_pick(dolt_hashof('HEAD~1'));
+"
+
 oracle_error "cherry_pick_merge_commit" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
 INSERT INTO t VALUES (1, 1);

--- a/test/vc_stateful_fuzzer.py
+++ b/test/vc_stateful_fuzzer.py
@@ -568,6 +568,7 @@ def cherry_pick_branch(doltlite, db_path, branches, model, rng, step):
             "nothing to commit",
             "already exists",
             "cherry-pick of",
+            "cherry-picking a merge commit",
         ),
     )
     sync_vc_result(doltlite, db_path, target, model)


### PR DESCRIPTION
Fixes #2455. Fixes #2456.

Dolt refuses two cherry-pick cases that DoltLite used to apply:

- A merge commit: Dolt errors `cherry-picking a merge commit is not supported`. DoltLite applied the first-parent diff. Reject a picked commit with more than one parent. `dolt_revert` of a merge is unchanged (first parent).
- An already-applied patch: Dolt errors `no changes were made, nothing to commit`. DoltLite wrote a new commit with the same message and an empty diff. Reuse revert's `bRejectUnchanged` path so a no-op cherry-pick does not advance HEAD.

Validation:
- fail-before: merge-commit cherry-pick applied feat's insert (`1,2,3`); `HEAD~1` after `c2` created a second `c1` commit
- pass-after: `test/doltlite_cherry_pick.sh` 134 of 134
- `test/vc_oracle_revert_cherrypick_test.sh` 64 of 64 vs Dolt 2.2.2
- make lint

Co-Authored-By: Grok 4.6 <noreply@x.ai>