### PR TITLE
Preserve explicit Unix epoch commit dates

### DIFF
--- a/src/doltlite_commit_cmd.c
+++ b/src/doltlite_commit_cmd.c
@@ -625,7 +625,7 @@ static int doltliteCommitCreateObject(
 
   rc = doltliteCreateAndStoreCommitWithTime(db, &parentHash, pCatalogHash,
       zMessage, zParsedName, zParsedEmail, aExtraParents, nExtraParents,
-      opts->explicitTimestamp, pCommitHashOut);
+      opts->zDate!=0, opts->explicitTimestamp, pCommitHashOut);
   sqlite3_free(zParsedName);
   sqlite3_free(zParsedEmail);
   if( rc!=SQLITE_OK ){

--- a/src/doltlite_core.c
+++ b/src/doltlite_core.c
@@ -519,6 +519,7 @@ static int doltliteCreateAndStoreCommitOnStore(
   const char *zAuthorEmail,
   const ProllyHash *aExtraParents,
   int nExtraParents,
+  int hasExplicitTimestamp,
   i64 explicitTimestamp,
   ProllyHash *pCommitHash
 );
@@ -535,7 +536,8 @@ int doltliteCreateAndStoreCommit(
   ProllyHash *pCommitHash
 ){
   return doltliteCreateAndStoreCommitWithTime(db, pParent, pCatalog, zMessage,
-      zAuthorName, zAuthorEmail, aExtraParents, nExtraParents, 0, pCommitHash);
+      zAuthorName, zAuthorEmail, aExtraParents, nExtraParents, 0, 0,
+      pCommitHash);
 }
 
 static int doltliteCreateAndStoreCommitOnStore(
@@ -548,6 +550,7 @@ static int doltliteCreateAndStoreCommitOnStore(
   const char *zAuthorEmail,
   const ProllyHash *aExtraParents,
   int nExtraParents,
+  int hasExplicitTimestamp,
   i64 explicitTimestamp,
   ProllyHash *pCommitHash
 ){
@@ -562,7 +565,7 @@ static int doltliteCreateAndStoreCommitOnStore(
   memset(&c, 0, sizeof(c));
   memcpy(&c.parentHash, pParent, sizeof(ProllyHash));
   memcpy(&c.catalogHash, pCatalog, sizeof(ProllyHash));
-  c.timestamp = explicitTimestamp ? explicitTimestamp : (i64)time(0);
+  c.timestamp = hasExplicitTimestamp ? explicitTimestamp : (i64)time(0);
   c.zName  = sqlite3_mprintf("%s", zAuthorName  ? zAuthorName  : doltliteGetAuthorName(db));
   if( c.zName==0 ){
     rc = SQLITE_NOMEM;
@@ -605,6 +608,7 @@ int doltliteCreateAndStoreCommitWithTime(
   const char *zAuthorEmail,
   const ProllyHash *aExtraParents,
   int nExtraParents,
+  int hasExplicitTimestamp,
   i64 explicitTimestamp,
   ProllyHash *pCommitHash
 ){
@@ -612,7 +616,7 @@ int doltliteCreateAndStoreCommitWithTime(
   assert( cs!=0 );
   return doltliteCreateAndStoreCommitOnStore(db, cs, pParent, pCatalog,
       zMessage, zAuthorName, zAuthorEmail, aExtraParents, nExtraParents,
-      explicitTimestamp, pCommitHash);
+      hasExplicitTimestamp, explicitTimestamp, pCommitHash);
 }
 
 int doltliteSeedStoreIfNeeded(
@@ -655,7 +659,7 @@ int doltliteSeedStoreIfNeeded(
 
   memset(&empty, 0, sizeof(empty));
   rc = doltliteCreateAndStoreCommitOnStore(db, cs, &empty, &empty,
-      "Initialize data repository", 0, 0, 0, 0, 0, pSeedHash);
+      "Initialize data repository", 0, 0, 0, 0, 0, 0, pSeedHash);
   if( rc==SQLITE_OK ){
     if( nBranches==0 ){
       rc = chunkStoreAddBranch(cs, zBranch, pSeedHash);

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -911,6 +911,7 @@ int doltliteCreateAndStoreCommitWithTime(
   const char *zAuthorEmail,
   const ProllyHash *aExtraParents,
   int nExtraParents,
+  int hasExplicitTimestamp,
   i64 explicitTimestamp,
   ProllyHash *pCommitHash
 );

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -3525,11 +3525,11 @@ static void run_ancestor_criss_cross_single_walk(void){
 
   rc = doltliteCreateAndStoreCommitWithTime(db, &rootHash,
       &rootCommit.catalogHash, "left-0", "test", "test@example.com", 0, 0,
-      1000, &left);
+      1, 1000, &left);
   if( rc==SQLITE_OK ){
     rc = doltliteCreateAndStoreCommitWithTime(db, &rootHash,
         &rootCommit.catalogHash, "right-0", "test", "test@example.com", 0, 0,
-        1001, &right);
+        1, 1001, &right);
   }
   for(i=1; rc==SQLITE_OK && i<=CRISS_CROSS_DEPTH; i++){
     ProllyHash nextLeft;
@@ -3539,12 +3539,12 @@ static void run_ancestor_criss_cross_single_walk(void){
     snprintf(zMessage, sizeof(zMessage), "left-%d", i);
     rc = doltliteCreateAndStoreCommitWithTime(db, &previousLeft,
         &rootCommit.catalogHash, zMessage, "test", "test@example.com",
-        &previousRight, 1, 1000 + i*2, &nextLeft);
+        &previousRight, 1, 1, 1000 + i*2, &nextLeft);
     if( rc==SQLITE_OK ){
       snprintf(zMessage, sizeof(zMessage), "right-%d", i);
       rc = doltliteCreateAndStoreCommitWithTime(db, &previousRight,
           &rootCommit.catalogHash, zMessage, "test", "test@example.com",
-          &previousLeft, 1, 1001 + i*2, &nextRight);
+          &previousLeft, 1, 1, 1001 + i*2, &nextRight);
     }
     left = nextLeft;
     right = nextRight;

--- a/test/vc_oracle_commit_test.sh
+++ b/test/vc_oracle_commit_test.sh
@@ -413,6 +413,24 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'bad', '--date', '2024-01-15T10:00:00junk');
 "
 
+oracle_query "commit_with_epoch_date" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 10);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'epoch', '--date', '1970-01-01T00:00:00Z');
+" \
+"SELECT 'R|' || unixepoch(date) FROM dolt_log WHERE message='epoch';" \
+"SELECT CONCAT('R|', TIMESTAMPDIFF(SECOND, '1970-01-01 00:00:00', date)) FROM dolt_log WHERE message='epoch';"
+
+oracle_query "commit_with_pre_epoch_date" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 10);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'pre-epoch', '--date', '1969-12-31T23:59:59Z');
+" \
+"SELECT 'R|' || unixepoch(date) FROM dolt_log WHERE message='pre-epoch';" \
+"SELECT CONCAT('R|', TIMESTAMPDIFF(SECOND, '1970-01-01 00:00:00', date)) FROM dolt_log WHERE message='pre-epoch';"
+
 echo "--- schema edge commits ---"
 
 oracle "commit_renamed_and_modified_table" "


### PR DESCRIPTION
## Summary

- carry explicit-date presence separately from the parsed Unix timestamp
- preserve timestamp zero as 1970-01-01T00:00:00Z
- keep omitted dates on wall-clock time and preserve negative pre-epoch timestamps
- add timezone-independent Dolt oracle coverage for epoch zero and minus one

The commit creation path previously used timestamp truthiness to distinguish an omitted date. That made valid Unix timestamp zero indistinguishable from no --date value.

## Tests

- bash test/vc_oracle_commit_test.sh build/doltlite dolt (50 passed)
- bash test/doltlite_commit.sh build/doltlite (82 passed)
- bash test/run_doltlite_regression_case.sh ancestor_criss_cross_single_walk (7 passed)
- bash test/run_doltlite_tests.sh (119 suites passed)
- C regression bucket within the full run (311137 passed)
- make lint
- git diff --check

No storage format change is required; the commit timestamp encoding is unchanged.

Fixes #2467

Co-Authored-By: Grok 4.6 <noreply@x.ai>