### PR TITLE
Refuse checkout when a tag shares the branch name

### DIFF
--- a/src/doltlite_checkout.c
+++ b/src/doltlite_checkout.c
@@ -1151,6 +1151,12 @@ static void doltCheckoutParsedFunc(
       doltliteVcResultError(ctx, db, "no current branch");
       return;
     }
+    if( chunkStoreFindTag(cs, zBranch, &probe)==SQLITE_OK
+     && !prollyHashIsEmpty(&probe) ){
+      doltliteVcResultError(ctx, db,
+          "dolt does not support a detached head state");
+      return;
+    }
     if( chunkStoreFindBranch(cs, zBranch, &probe)!=SQLITE_OK ){
       if( doltliteResolveRef(db, zBranch, &probe)==SQLITE_OK ){
         doltliteVcResultError(ctx, db,
@@ -1214,6 +1220,16 @@ static void doltCheckoutParsedFunc(
       return;
     }
     isCreateAndSwitch = 1;
+  }
+
+  if( !createBranch && argc==1 ){
+    ProllyHash tagHash;
+    if( chunkStoreFindTag(cs, zBranch, &tagHash)==SQLITE_OK
+     && !prollyHashIsEmpty(&tagHash) ){
+      doltliteVcResultError(ctx, db,
+          "dolt does not support a detached head state");
+      return;
+    }
   }
 
   if( !doltliteIsDetached(db)

--- a/test/doltlite_tag.sh
+++ b/test/doltlite_tag.sh
@@ -90,5 +90,62 @@ echo "SELECT dolt_tag('one'); SELECT dolt_tag('two');" | $DOLTLITE "$DB4" > /dev
 run_test_match "delete_multiple_tags_missing_is_atomic" "SELECT dolt_tag('-d','one','missing','two');" "not found" "$DB4"
 run_test "delete_multiple_tags_missing_keeps_tags" "SELECT count(*) FROM dolt_tags;" "2" "$DB4"
 
-rm -f "$DB" "$DB2" "$DB3" "$DB4"
+DB5=/tmp/test_tag_collide_$$.db; rm -f "$DB5"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES(1);
+SELECT dolt_commit('-A','-m','c');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+INSERT INTO t VALUES(2);
+SELECT dolt_commit('-A','-m','later');
+SELECT dolt_checkout('main');
+SELECT dolt_tag('feat');" | $DOLTLITE "$DB5" > /dev/null 2>&1
+
+run_test_match "checkout_colliding_name_is_tag" \
+  "SELECT dolt_checkout('feat');" \
+  "does not support a detached head state" "$DB5"
+
+run_test "hashof_colliding_name_equals_branch" \
+  "SELECT dolt_hashof('feat') = (SELECT hash FROM dolt_branches WHERE name='feat');" \
+  "1" "$DB5"
+
+run_test "hashof_colliding_name_not_tag" \
+  "SELECT dolt_hashof('feat') = (SELECT tag_hash FROM dolt_tags WHERE tag_name='feat');" \
+  "0" "$DB5"
+
+run_test "checkout_unique_branch_still_works" \
+  "SELECT dolt_checkout('main'); SELECT active_branch();" \
+  "0
+main" "$DB5"
+
+run_test_lastline "checkout_b_from_colliding_name_uses_branch" \
+  "SELECT dolt_checkout('-b','fromtag','feat');
+SELECT active_branch();" \
+  "fromtag" "$DB5"
+
+run_test "checkout_b_from_colliding_name_at_branch_tip" \
+  "SELECT (SELECT hash FROM dolt_branches WHERE name='fromtag')
+          = (SELECT hash FROM dolt_branches WHERE name='feat');" \
+  "1" "$DB5"
+
+DB6=/tmp/test_tag_collide_onbranch_$$.db; rm -f "$DB6"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES(1);
+SELECT dolt_commit('-A','-m','c');
+SELECT dolt_branch('feat');" | $DOLTLITE "$DB6" > /dev/null 2>&1
+
+run_test_lastline "checkout_colliding_name_stays_on_branch" \
+  "SELECT dolt_checkout('feat');
+SELECT dolt_tag('feat');
+SELECT dolt_checkout('feat');
+SELECT active_branch();" \
+  "feat" "$DB6"
+
+run_test_match "checkout_colliding_name_errors_while_on_branch" \
+  "SELECT dolt_checkout('feat');
+SELECT dolt_tag('feat');
+SELECT dolt_checkout('feat');" \
+  "does not support a detached head state" "$DB6"
+
+rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6"
 dltest_finish

--- a/test/vc_oracle_hashof_test.sh
+++ b/test/vc_oracle_hashof_test.sh
@@ -556,6 +556,29 @@ H_ID_OUT=$(query_pair_separate "$DB" \
   "SELECT dolt_hashof('$(pair_dt "$H_HEAD")');")
 same "commit_hash_is_identity_on_hashof" "$H_HEAD" "$H_ID_OUT"
 
+COLLIDE_SEED="
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1, 'a');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+INSERT INTO t VALUES (2, 'b');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'later');
+SELECT dolt_checkout('main');
+SELECT dolt_tag('feat');
+"
+
+DB="tag_branch_collide"
+setup_pair "$DB" "$COLLIDE_SEED"
+H_TAG=$(run_hash_on "$DB" "SELECT tag_hash FROM dolt_tags WHERE tag_name='feat';")
+H_BRANCH=$(run_hash_on "$DB" "SELECT hash FROM dolt_branches WHERE name='feat';")
+H_NAME=$(run_hash_on "$DB" "SELECT dolt_hashof('feat');")
+same "hashof_colliding_name_equals_branch" "$H_BRANCH" "$H_NAME"
+different "hashof_colliding_name_differs_from_tag" "$H_TAG" "$H_NAME"
+both_error "checkout_colliding_name_is_tag" "$DB" "SELECT dolt_checkout('feat');"
+
 echo ""
 
 echo "--- 10. Engine-specific shape conformance ---"

--- a/test/vc_oracle_tags_test.sh
+++ b/test/vc_oracle_tags_test.sh
@@ -318,6 +318,16 @@ SELECT dolt_commit('-m', 'first');
 SELECT dolt_tag('bad name');
 "
 
+oracle_error "checkout_colliding_tag_is_detached" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES (1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c');
+SELECT dolt_branch('feat');
+SELECT dolt_tag('feat');
+SELECT dolt_checkout('feat');
+"
+
 echo "--- savepoint parity ---"
 
 oracle_savepoint_tag_poststate "tag_inside_savepoint_releases_savepoint" "


### PR DESCRIPTION
Fixes #2457.

Git prefers the branch for both `git checkout feat` and `git rev-parse feat` when `refs/heads/feat` exists. Dolt SQL does not: bare `CALL dolt_checkout('feat')` treats a colliding name as a tag and errors `dolt does not support a detached head state`. `HASHOF('feat')`, `dolt_merge('feat')`, and `dolt_checkout('-b', new, 'feat')` still resolve the branch. Verified on Dolt 2.2.2; the issue's hashof-equals-tag row does not match that oracle.

Bare `dolt_checkout('feat')` now looks up the tag first and refuses instead of switching to the branch, including when the session is already on that branch. `doltliteResolveRef` stays branch-then-tag, so hashof / merge / `-b` start points match Dolt. URI `$DB/same` stays branch-first (`doltliteOpenRevisionBase`).

Validation:
- fail-before: `checkout_colliding_name_is_tag` switched to the branch
- pass-after: `test/doltlite_tag.sh` 38/38
- `test/doltlite_open_branch.sh` 42/42 (`branch_wins_over_tag` URI unchanged)
- `test/doltlite_branch.sh` 72/72
- `test/vc_oracle_tags_test.sh` 24/24 vs Dolt 2.2.2
- `test/vc_oracle_hashof_test.sh` 46/46 vs Dolt 2.2.2 (`hashof_colliding_name_equals_branch`)
- `make lint`

Co-Authored-By: Grok 4.6 <noreply@x.ai>