### PR TITLE
Serialize ATTACHed schemas with uncommitted writes

### DIFF
--- a/src/doltlite_core.c
+++ b/src/doltlite_core.c
@@ -258,19 +258,34 @@ int doltliteHasUncommittedChanges(sqlite3 *db, int *pDirty){
   }
 }
 
-int doltliteUpdateSchemaHashes(sqlite3 *db){
+int doltliteUpdateSchemaHashesForBtree(Btree *pBtree){
+  sqlite3 *db;
   sqlite3_stmt *pStmt = 0;
+  char *zSql = 0;
+  const char *zSchema = 0;
+  int i;
   int rc;
   int rc2;
   /* One sqlite_master scan for tables and indexes, keyed by rootpage.
   ** Virtual tables have rootpage 0 and no catalog entry. */
+  if( !pBtree ) return SQLITE_MISUSE;
+  db = pBtree->db;
   if( !db ) return SQLITE_MISUSE;
-  rc = sqlite3_prepare_v2(
-      db,
+  for(i=0; i<db->nDb; i++){
+    if( db->aDb[i].pBt==pBtree ){
+      zSchema = db->aDb[i].zDbSName;
+      break;
+    }
+  }
+  if( !zSchema ) zSchema = "main";
+  zSql = sqlite3_mprintf(
       "SELECT name, rootpage, sql "
-      "FROM main.sqlite_master "
+      "FROM \"%w\".sqlite_master "
       "WHERE type IN ('table','index') AND sql IS NOT NULL AND rootpage>0",
-      -1, &pStmt, 0);
+      zSchema);
+  if( !zSql ) return SQLITE_NOMEM;
+  rc = sqlite3_prepare_v2(db, zSql, -1, &pStmt, 0);
+  sqlite3_free(zSql);
   if( rc!=SQLITE_OK ){
     sqlite3_finalize(pStmt);
     return rc;
@@ -281,6 +296,8 @@ int doltliteUpdateSchemaHashes(sqlite3 *db){
     const char *zCreate = (const char*)sqlite3_column_text(pStmt, 2);
     ProllyHash h;
     char *zCanon;
+    int j;
+    int found = 0;
     if( !zName || !zCreate ){
       rc = db->mallocFailed ? SQLITE_NOMEM : SQLITE_CORRUPT;
       break;
@@ -300,7 +317,14 @@ int doltliteUpdateSchemaHashes(sqlite3 *db){
     }
     prollyHashCompute(zCanon, (int)strlen(zCanon), &h);
     sqlite3_free(zCanon);
-    rc = doltliteSetTableSchemaHash(db, (Pgno)iRoot, &h);
+    for(j=0; j<pBtree->cat.n; j++){
+      if( pBtree->cat.a[j].iTable==(Pgno)iRoot ){
+        memcpy(&pBtree->cat.a[j].schemaHash, &h, sizeof(ProllyHash));
+        found = 1;
+        break;
+      }
+    }
+    rc = found ? SQLITE_OK : SQLITE_NOTFOUND;
     if( rc==SQLITE_NOTFOUND ){
       rc = SQLITE_CORRUPT;
     }
@@ -312,6 +336,11 @@ int doltliteUpdateSchemaHashes(sqlite3 *db){
   rc2 = sqlite3_finalize(pStmt);
   if( rc==SQLITE_OK ) rc = rc2;
   return rc;
+}
+
+int doltliteUpdateSchemaHashes(sqlite3 *db){
+  if( !db || db->nDb<=0 || !db->aDb[0].pBt ) return SQLITE_MISUSE;
+  return doltliteUpdateSchemaHashesForBtree(db->aDb[0].pBt);
 }
 
 int doltliteLoadLiveSchemaSql(
@@ -457,16 +486,25 @@ int doltliteMutateRefs(sqlite3 *db, DoltliteRefsMutation xMutate, void *pArg){
   return doltliteMutateRefsExpected(db, 0, 0, xMutate, pArg);
 }
 
-int doltliteFlushCatalogToHash(sqlite3 *db, ProllyHash *pHash){
-  ChunkStore *cs = doltliteGetChunkStore(db);
+static int doltliteFlushBtreeCatalogToHash(Btree *pBtree, ProllyHash *pHash){
+  ChunkStore *cs = doltliteBtreeChunkStore(pBtree);
   u8 *catData = 0;
   int nCatData = 0;
   int rc;
-  rc = doltliteFlushAndSerializeCatalog(db, &catData, &nCatData);
-  if( rc!=SQLITE_OK ) return rc;
+  if( !cs ) return SQLITE_ERROR;
+  rc = doltliteFlushAndSerializeBtreeCatalog(pBtree, &catData, &nCatData);
+  if( rc!=SQLITE_OK ){
+    sqlite3_free(catData);
+    return rc;
+  }
   rc = chunkStorePut(cs, catData, nCatData, pHash);
   sqlite3_free(catData);
   return rc;
+}
+
+int doltliteFlushCatalogToHash(sqlite3 *db, ProllyHash *pHash){
+  if( !db || db->nDb<=0 || !db->aDb[0].pBt ) return SQLITE_ERROR;
+  return doltliteFlushBtreeCatalogToHash(db->aDb[0].pBt, pHash);
 }
 
 int doltliteSerializeDb(sqlite3 *db, Btree *pBt,
@@ -474,10 +512,11 @@ int doltliteSerializeDb(sqlite3 *db, Btree *pBt,
   const char *zBranch = 0;
   ProllyHash liveHash;
   const void *pLive = 0;
-  if( db && db->nDb>0 && db->aDb[0].pBt==pBt ){
-    int rc = doltliteFlushCatalogToHash(db, &liveHash);
+  UNUSED_PARAMETER(db);
+  if( pBt && sqlite3BtreeIsDoltliteFormat(pBt) ){
+    int rc = doltliteFlushBtreeCatalogToHash(pBt, &liveHash);
     if( rc!=SQLITE_OK ) return rc;
-    zBranch = doltliteGetSessionBranch(db);
+    zBranch = pBt->zBranch ? pBt->zBranch : "main";
     pLive = &liveHash;
   }
   return doltliteBtreeSerialize(pBt, zBranch, pLive, ppData, pnData);

--- a/src/prolly_btree_catalog.c
+++ b/src/prolly_btree_catalog.c
@@ -2030,13 +2030,13 @@ int deserializeCatalog(Btree *pBtree, const u8 *data, int nData){
 }
 
 
-int doltliteFlushAndSerializeCatalog(sqlite3 *db, u8 **ppOut, int *pnOut){
-  BtShared *pBt = doltliteGetBtShared(db);
-  Btree *pBtree;
+int doltliteFlushAndSerializeBtreeCatalog(Btree *pBtree, u8 **ppOut, int *pnOut){
+  BtShared *pBt;
   int rc;
-  if( !pBt ) return SQLITE_ERROR;
-  if( !db || db->nDb<=0 || !db->aDb[0].pBt ) return SQLITE_ERROR;
-  pBtree = db->aDb[0].pBt;
+  if( !pBtree || !sqlite3BtreeIsDoltliteFormat(pBtree) || !pBtree->pBt ){
+    return SQLITE_ERROR;
+  }
+  pBt = pBtree->pBt;
   if( pBtree->inTrans==TRANS_WRITE ){
     rc = flushAllPending(pBtree, pBt, 0);
     if( rc!=SQLITE_OK ) return rc;
@@ -2047,10 +2047,15 @@ int doltliteFlushAndSerializeCatalog(sqlite3 *db, u8 **ppOut, int *pnOut){
 
   /* Fresh connections have only runtime sqlite_master; skip hash refresh. */
   if( pBtree->cat.n>1 ){
-    rc = doltliteUpdateSchemaHashes(db);
+    rc = doltliteUpdateSchemaHashesForBtree(pBtree);
     if( rc!=SQLITE_OK ) return rc;
   }
-  return serializeCatalog(db->aDb[0].pBt, ppOut, pnOut);
+  return serializeCatalog(pBtree, ppOut, pnOut);
+}
+
+int doltliteFlushAndSerializeCatalog(sqlite3 *db, u8 **ppOut, int *pnOut){
+  if( !db || db->nDb<=0 || !db->aDb[0].pBt ) return SQLITE_ERROR;
+  return doltliteFlushAndSerializeBtreeCatalog(db->aDb[0].pBt, ppOut, pnOut);
 }
 
 int doltliteDeserializeCatalogForTest(sqlite3 *db, const u8 *data, int nData){

--- a/src/prolly_btree_int.h
+++ b/src/prolly_btree_int.h
@@ -42,6 +42,7 @@
 void doltliteGetSessionHead(sqlite3 *db, ProllyHash *pHead);
 char *doltliteCanonicalizeSchemaSql(const char *zSql, const char *zName);
 int doltliteUpdateSchemaHashes(sqlite3 *db);
+int doltliteUpdateSchemaHashesForBtree(Btree *pBtree);
 int doltliteLoadLiveSchemaSql(sqlite3 *db, const char *zType,
                               const char *zDb,
                               const char *zName, const char *zTblName,
@@ -735,6 +736,7 @@ void freeSavepointTables(struct SavepointTableState*);
 int snapshotPendingForFlush(Btree*, Pgno, ProllyMutMap**, ProllyMutMap**, int*);
 void btreeDiscardAllSavepoints(Btree*);
 int serializeCatalog(Btree*, u8**, int*);
+int doltliteFlushAndSerializeBtreeCatalog(Btree*, u8**, int*);
 int serializeCatalogForCommit(Btree*, u8**, int*);
 int deserializeCatalog(Btree*, const u8*, int);
 void initDefaultMeta(Btree*);

--- a/test/serialize_pending_test.c
+++ b/test/serialize_pending_test.c
@@ -122,6 +122,159 @@ static void createOnlyCase(const char *zPath){
   unlink(zPath);
 }
 
+static void unlinkDb(const char *zPath){
+  char zLock[512];
+  unlink(zPath);
+  snprintf(zLock, sizeof(zLock), "%s-lock", zPath);
+  unlink(zLock);
+}
+
+static void attachedDirtyTxnCase(const char *zMain, const char *zAux){
+  sqlite3 *db = 0;
+  sqlite3 *db2 = 0;
+  unsigned char *p = 0;
+  sqlite3_int64 n = 0;
+  char *z;
+  char zSql[700];
+
+  unlinkDb(zMain);
+  unlinkDb(zAux);
+  check(sqlite3_open(zMain, &db)==SQLITE_OK, "open attached source");
+  snprintf(zSql, sizeof(zSql), "ATTACH '%s' AS aux;", zAux);
+  check(sqlite3_exec(db, zSql, 0, 0, 0)==SQLITE_OK, "attach aux");
+  check(sqlite3_exec(db,
+      "CREATE TABLE aux.t(a INTEGER PRIMARY KEY, b TEXT);"
+      "INSERT INTO aux.t VALUES(1,'committed');"
+      "BEGIN;"
+      "INSERT INTO aux.t VALUES(2,'dirty');"
+      "CREATE TABLE aux.u(x INT);"
+      "INSERT INTO aux.u VALUES(9);", 0, 0, 0)==SQLITE_OK,
+      "populate attached + dirty txn");
+
+  p = sqlite3_serialize(db, "aux", &n, 0);
+  check(p!=0 && n>0, "serialize attached returns image");
+
+  db2 = deserializeInto(p, n);
+  check(db2!=0, "deserialize attached image");
+  p = 0;
+  if( db2 ){
+    z = oneText(db2,
+        "SELECT group_concat(name) FROM sqlite_master"
+        " WHERE type='table' ORDER BY name");
+    check(z && strstr(z,"t") && strstr(z,"u"),
+          "attached image has both tables");
+    free(z);
+    z = oneText(db2, "SELECT group_concat(b) FROM t");
+    check(z && strstr(z,"committed") && strstr(z,"dirty"),
+          "attached image has committed and dirty rows");
+    free(z);
+    z = oneText(db2, "SELECT x FROM u");
+    check(z && strcmp(z,"9")==0, "attached image has dirty-only table");
+    free(z);
+    sqlite3_close(db2);
+  }
+
+  check(sqlite3_get_autocommit(db)==0, "attached source still in transaction");
+  check(sqlite3_exec(db, "COMMIT", 0, 0, 0)==SQLITE_OK,
+        "attached source commit after serialize");
+  z = oneText(db, "SELECT group_concat(b) FROM aux.t");
+  check(z && strstr(z,"committed") && strstr(z,"dirty"),
+        "attached commit keeps dirty row");
+  free(z);
+  sqlite3_close(db);
+  unlinkDb(zMain);
+  unlinkDb(zAux);
+}
+
+static void attachedCreateOnlyCase(const char *zMain, const char *zAux){
+  sqlite3 *db = 0;
+  sqlite3 *db2 = 0;
+  unsigned char *p = 0;
+  sqlite3_int64 n = 0;
+  char *z;
+  char zSql[700];
+
+  unlinkDb(zMain);
+  unlinkDb(zAux);
+  check(sqlite3_open(zMain, &db)==SQLITE_OK, "open attached fresh source");
+  snprintf(zSql, sizeof(zSql), "ATTACH '%s' AS aux;", zAux);
+  check(sqlite3_exec(db, zSql, 0, 0, 0)==SQLITE_OK, "attach fresh aux");
+  check(sqlite3_exec(db,
+      "BEGIN; CREATE TABLE aux.only_dirty(x INT);"
+      "INSERT INTO aux.only_dirty VALUES(7);", 0, 0, 0)==SQLITE_OK,
+      "attached create-only dirty txn");
+  p = sqlite3_serialize(db, "aux", &n, 0);
+  check(p!=0 && n>0, "attached fresh-db serialize returns image");
+  db2 = deserializeInto(p, n);
+  check(db2!=0, "attached fresh-db image deserializes");
+  if( db2 ){
+    z = oneText(db2, "SELECT x FROM only_dirty");
+    check(z && strcmp(z,"7")==0,
+          "attached image has create-only table and row");
+    free(z);
+    sqlite3_close(db2);
+  }
+  sqlite3_close(db);
+  unlinkDb(zMain);
+  unlinkDb(zAux);
+}
+
+static void attachedDoesNotLeakIntoMain(const char *zMain, const char *zAux){
+  sqlite3 *db = 0;
+  sqlite3 *db2 = 0;
+  unsigned char *p = 0;
+  sqlite3_int64 n = 0;
+  char *z;
+  char zSql[700];
+
+  unlinkDb(zMain);
+  unlinkDb(zAux);
+  check(sqlite3_open(zMain, &db)==SQLITE_OK, "open crosstalk source");
+  snprintf(zSql, sizeof(zSql), "ATTACH '%s' AS aux;", zAux);
+  check(sqlite3_exec(db, zSql, 0, 0, 0)==SQLITE_OK, "attach crosstalk aux");
+  check(sqlite3_exec(db,
+      "CREATE TABLE t(a INTEGER PRIMARY KEY, b TEXT);"
+      "INSERT INTO t VALUES(1,'main-committed');"
+      "CREATE TABLE aux.t(a INTEGER PRIMARY KEY, b TEXT);"
+      "INSERT INTO aux.t VALUES(1,'aux-committed');"
+      "BEGIN;"
+      "INSERT INTO t VALUES(2,'main-dirty');"
+      "INSERT INTO aux.t VALUES(2,'aux-dirty');", 0, 0, 0)==SQLITE_OK,
+      "populate main and aux dirty txns");
+
+  p = sqlite3_serialize(db, "main", &n, 0);
+  check(p!=0 && n>0, "serialize main with aux attached");
+  db2 = deserializeInto(p, n);
+  check(db2!=0, "deserialize main image");
+  p = 0;
+  if( db2 ){
+    z = oneText(db2, "SELECT group_concat(b) FROM t");
+    check(z && strstr(z,"main-committed") && strstr(z,"main-dirty")
+          && strstr(z,"aux-dirty")==0,
+          "main image has main dirty rows only");
+    free(z);
+    sqlite3_close(db2);
+  }
+
+  p = sqlite3_serialize(db, "aux", &n, 0);
+  check(p!=0 && n>0, "serialize aux with main dirty");
+  db2 = deserializeInto(p, n);
+  check(db2!=0, "deserialize aux image");
+  p = 0;
+  if( db2 ){
+    z = oneText(db2, "SELECT group_concat(b) FROM t");
+    check(z && strstr(z,"aux-committed") && strstr(z,"aux-dirty")
+          && strstr(z,"main-dirty")==0,
+          "aux image has aux dirty rows only");
+    free(z);
+    sqlite3_close(db2);
+  }
+
+  sqlite3_close(db);
+  unlinkDb(zMain);
+  unlinkDb(zAux);
+}
+
 static void nocopyCase(const char *zPath){
   sqlite3 *db = 0;
   unsigned char *p = 0;
@@ -149,6 +302,12 @@ static void nocopyCase(const char *zPath){
 int main(void){
   dirtyTxnCase("serialize_pending_test.db");
   createOnlyCase("serialize_pending_fresh_test.db");
+  attachedDirtyTxnCase("serialize_pending_attach_main.db",
+                       "serialize_pending_attach_aux.db");
+  attachedCreateOnlyCase("serialize_pending_attach_fresh_main.db",
+                         "serialize_pending_attach_fresh_aux.db");
+  attachedDoesNotLeakIntoMain("serialize_pending_crosstalk_main.db",
+                              "serialize_pending_crosstalk_aux.db");
   nocopyCase("serialize_pending_nocopy_test.db");
   if( failures ){
     fprintf(stderr, "%d failure(s)\n", failures);


### PR DESCRIPTION
Fixes #2460.

`sqlite3_serialize` of an ATTACHed schema copied the committed store only: a dirty row vanished and an uncommitted `CREATE TABLE` was missing from the image, with no error. Stock captures both. Main already did the right thing after #2430; attached schemas still hit the `aDb[0]` gate in `doltliteSerializeDb`.

The named schema's btree now takes the same live path as main:

1. Flush pending mutmaps on that btree
2. Hash the live catalog into that btree's store
3. Bind the image working set to that catalog on that btree's branch

Main and aux images stay isolated when both are dirty in the same transaction. Source `COMMIT` after serialize still lands the dirty writes.

## Validation

- `test/serialize_pending_test.c` extended with attached dirty txn, attached create-only txn, and main/aux isolation. Fail-before on unfixed engine (5 failures); pass-after with the fix.
- Existing main serialize cases still pass
- `catalog_serialize_determinism_test` 80/80
- `doltlite_regression_test_c serialize_deserialize` 54/54
- `make lint` clean

Co-Authored-By: Grok 4.6 <noreply@x.ai>