### PR TITLE
Merge deletes across defaulted column additions

### DIFF
--- a/src/doltlite_merge_int.h
+++ b/src/doltlite_merge_int.h
@@ -327,6 +327,7 @@ int normalizeSideToMergedLayout(
   const char *zAncSql,
   const char *zOursSql,
   const char *zTheirsSql,
+  int bFillSharedDefaults,
   ProllyHash *pOutRoot
 );
 

--- a/src/doltlite_merge_pass1.c
+++ b/src/doltlite_merge_pass1.c
@@ -589,6 +589,7 @@ static int mergePass1RelayoutToMergedSchema(
   const ProllyHash *pMergedRoot,
   const ProllyHash *pOtherRoot,
   const ProllyHash *pAncRoot,
+  int bFillSharedDefaults,
   ProllyHash *pOtherOut,
   ProllyHash *pAncOut,
   int *pbRelaid
@@ -600,13 +601,51 @@ static int mergePass1RelayoutToMergedSchema(
 
   rc = normalizeSideToMergedLayout(c->db, zName, pMergedRoot, pOtherRoot,
                                    flags, zAncSql,
-                                   zMergedSql, zOtherSql, pOtherOut);
+                                   zMergedSql, zOtherSql,
+                                   bFillSharedDefaults, pOtherOut);
   if( rc!=SQLITE_OK ) return rc;
   rc = normalizeSideToMergedLayout(c->db, zName, pMergedRoot, pAncRoot,
                                    flags, zAncSql,
-                                   zMergedSql, zAncSql, pAncOut);
+                                   zMergedSql, zAncSql,
+                                   bFillSharedDefaults, pAncOut);
   if( rc!=SQLITE_OK ) return rc;
   *pbRelaid = 1;
+  return SQLITE_OK;
+}
+
+static int mergePass1SchemaAppendsColumns(
+  const char *zAncSql,
+  const char *zSideSql,
+  int *pbAppends
+){
+  ParsedColumn *aAnc = 0;
+  ParsedColumn *aSide = 0;
+  int nAnc = 0;
+  int nSide = 0;
+  int i;
+  int rc;
+
+  *pbAppends = 0;
+  if( !zAncSql || !zSideSql ) return SQLITE_OK;
+  rc = parseColumns(zAncSql, &aAnc, &nAnc);
+  if( rc!=SQLITE_OK ) return rc;
+  rc = parseColumns(zSideSql, &aSide, &nSide);
+  if( rc!=SQLITE_OK ){
+    freeColumns(aAnc, nAnc);
+    return rc;
+  }
+  if( nSide>nAnc ){
+    *pbAppends = 1;
+    for(i=0; i<nAnc; i++){
+      if( sqlite3_stricmp(aAnc[i].zName, aSide[i].zName)!=0
+       || !parsedColumnDefinitionsMatch(&aAnc[i], &aSide[i]) ){
+        *pbAppends = 0;
+        break;
+      }
+    }
+  }
+  freeColumns(aAnc, nAnc);
+  freeColumns(aSide, nSide);
   return SQLITE_OK;
 }
 
@@ -625,9 +664,16 @@ static int mergePass1RelayoutOneSidedSchema(
   SchemaEntry *ourSE = findSchemaEntry(c->aOursSchema, c->nOursSchema, zName);
   SchemaEntry *theirSE = findSchemaEntry(c->aTheirsSchema, c->nTheirsSchema, zName);
   SchemaEntry *ancSE = findSchemaEntry(c->aAncSchema, c->nAncSchema, zName);
+  int bFillSharedDefaults = 0;
+  int rc;
 
   *pbRelaid = 0;
   if( !ancSE || !ourSE || !theirSE ) return SQLITE_OK;
+
+  rc = mergePass1SchemaAppendsColumns(
+      ancSE->zSql, bMergedIsOurs ? ourSE->zSql : theirSE->zSql,
+      &bFillSharedDefaults);
+  if( rc!=SQLITE_OK ) return rc;
 
   return mergePass1RelayoutToMergedSchema(c, zName, ancSE->zSql,
       bMergedIsOurs ? ourSE->zSql : theirSE->zSql,
@@ -635,7 +681,8 @@ static int mergePass1RelayoutOneSidedSchema(
       pOurs->flags,
       bMergedIsOurs ? &pOurs->root : &pTheirs->root,
       bMergedIsOurs ? &pTheirs->root : &pOurs->root,
-      &pAnc->root, pOtherOut, pAncOut, pbRelaid);
+      &pAnc->root, bFillSharedDefaults,
+      pOtherOut, pAncOut, pbRelaid);
 }
 
 static int mergePass1BothSides(
@@ -751,6 +798,7 @@ static int mergePass1BothSides(
                                            &theirsEntry->root,
                                            c->aOurs[iOurs].flags, ancSE->zSql,
                                            ourSE->zSql, theirSE->zSql,
+                                           0,
                                            &theirsNormRoot);
         if( rc!=SQLITE_OK ) return rc;
         rc = normalizeSideToMergedLayout(c->db, zName,
@@ -758,6 +806,7 @@ static int mergePass1BothSides(
                                            &ancEntry->root,
                                            c->aOurs[iOurs].flags, ancSE->zSql,
                                            ourSE->zSql, ancSE->zSql,
+                                           0,
                                            &ancNormRoot);
         if( rc!=SQLITE_OK ) return rc;
         ancAdj = *ancEntry;
@@ -804,6 +853,7 @@ static int mergePass1BothSides(
       rc = mergePass1RelayoutToMergedSchema(c, zName, ancSE->zSql,
           mergedSE->zSql, zOursPrevSql, c->aOurs[iOurs].flags,
           &theirsEntry->root, &c->aOurs[iOurs].root, &ancEntry->root,
+          0,
           &otherNormRoot, &ancNormRoot, &bRelaid);
       if( rc!=SQLITE_OK ){
         sqlite3_free(zOursPrevSql);
@@ -832,6 +882,7 @@ static int mergePass1BothSides(
       rc = mergePass1RelayoutToMergedSchema(c, zName, ancSE->zSql,
           ourSE->zSql, theirSE->zSql, c->aOurs[iOurs].flags,
           &c->aOurs[iOurs].root, &theirsEntry->root, &ancEntry->root,
+          0,
           &otherNormRoot, &ancNormRoot, &bRelaid);
       if( rc!=SQLITE_OK ) return rc;
     }

--- a/src/doltlite_merge_schema.c
+++ b/src/doltlite_merge_schema.c
@@ -1077,7 +1077,7 @@ int mergeColDefaultsLoad(
   if( rc!=SQLITE_OK ) goto done;
 
   zQuery = sqlite3_mprintf(
-      "SELECT cid, dflt_value FROM pragma_table_info(%Q) ORDER BY cid",
+      "SELECT cid, dflt_value, type FROM pragma_table_info(%Q) ORDER BY cid",
       zTable);
   if( !zQuery ){ rc = SQLITE_NOMEM; goto done; }
   rc = sqlite3_prepare_v2(tmp, zQuery, -1, &pStmt, 0);
@@ -1101,6 +1101,7 @@ int mergeColDefaultsLoad(
   while( (rc = sqlite3_step(pStmt))==SQLITE_ROW ){
     int cid = sqlite3_column_int(pStmt, 0);
     const char *zDflt = (const char*)sqlite3_column_text(pStmt, 1);
+    const char *zType = (const char*)sqlite3_column_text(pStmt, 2);
     sqlite3_stmt *pEval = 0;
     char *zEval;
     if( !zDflt || !zDflt[0] || cid<0 || cid>=pOut->nCol ) continue;
@@ -1109,22 +1110,25 @@ int mergeColDefaultsLoad(
     if( sqlite3_prepare_v2(tmp, zEval, -1, &pEval, 0)==SQLITE_OK
      && sqlite3_step(pEval)==SQLITE_ROW ){
       DoltliteSerialValue *m = &pOut->aVal[cid];
-      switch( sqlite3_column_type(pEval, 0) ){
+      sqlite3_value *pVal = sqlite3_column_value(pEval, 0);
+      sqlite3ValueApplyAffinity(
+          pVal, sqlite3AffinityType(zType ? zType : "", 0), SQLITE_UTF8);
+      switch( sqlite3_value_type(pVal) ){
         case SQLITE_INTEGER:
           m->eType = SQLITE_INTEGER;
-          m->i = sqlite3_column_int64(pEval, 0);
+          m->i = sqlite3_value_int64(pVal);
           break;
         case SQLITE_FLOAT:
           m->eType = SQLITE_FLOAT;
-          m->r = sqlite3_column_double(pEval, 0);
+          m->r = sqlite3_value_double(pVal);
           break;
         case SQLITE_TEXT:
         case SQLITE_BLOB: {
-          int isText = sqlite3_column_type(pEval, 0)==SQLITE_TEXT;
+          int isText = sqlite3_value_type(pVal)==SQLITE_TEXT;
           const void *p = isText
-              ? (const void*)sqlite3_column_text(pEval, 0)
-              : sqlite3_column_blob(pEval, 0);
-          int n = sqlite3_column_bytes(pEval, 0);
+              ? (const void*)sqlite3_value_text(pVal)
+              : sqlite3_value_blob(pVal);
+          int n = sqlite3_value_bytes(pVal);
           u8 *pCopy = 0;
           if( n>0 ){
             pCopy = sqlite3_malloc(n);

--- a/src/doltlite_merge_schema.c
+++ b/src/doltlite_merge_schema.c
@@ -1169,6 +1169,7 @@ int normalizeSideToMergedLayout(
   const char *zAncSql,
   const char *zOursSql,
   const char *zTheirsSql,
+  int bFillSharedDefaults,
   ProllyHash *pOutRoot
 ){
   ChunkStore *cs = doltliteGetChunkStore(db);
@@ -1245,7 +1246,7 @@ int normalizeSideToMergedLayout(
   if( nMerged > DOLTLITE_MAX_RECORD_FIELDS ){ rc = SQLITE_ERROR; goto done; }
 
   /* Already at merged positions; trailing adds read as absent anyway. */
-  if( nDropped==0 ){
+  if( nDropped==0 && !bFillSharedDefaults ){
     int bSamePositions = 1;
     for(j=0; j<nTheirs; j++){
       if( aMap[j]!=j ){ bSamePositions = 0; break; }
@@ -1292,8 +1293,8 @@ int normalizeSideToMergedLayout(
       prollyCursorKey(&cur, &pKey, &nKey);
     }
 
-    /* Defaults only for rows theirs uniquely has. Filling our column
-    ** on a shared row would look like their change and conflict. */
+    /* Dual-schema relayout fills defaults only for rows unique to this side.
+    ** A one-sided append projects every row into the wider logical layout. */
     rowOnlyTheirs = 0;
     if( oursCurInit ){
       int oursRes = 0;
@@ -1312,11 +1313,11 @@ int normalizeSideToMergedLayout(
     for(k=0; k<nMerged; k++){
       memset(&aMem[k], 0, sizeof(aMem[k]));
       aMem[k].eType = SQLITE_NULL;
-      if( rowOnlyTheirs && k<oursDefaults.nCol ){
+      if( (rowOnlyTheirs || bFillSharedDefaults) && k<oursDefaults.nCol ){
         aMem[k] = oursDefaults.aVal[k];
       }
     }
-    if( rowOnlyTheirs ){
+    if( rowOnlyTheirs || bFillSharedDefaults ){
       for(j=0; j<nTheirs; j++){
         if( aMap[j]>=nOurs && j<theirsDefaults.nCol ){
           aMem[aMap[j]] = theirsDefaults.aVal[j];

--- a/test/doltlite_merge.sh
+++ b/test/doltlite_merge.sh
@@ -687,9 +687,9 @@ run_test "delete_vs_add_column_default_rows" "SELECT group_concat(id || ':' || a
 DB45=/tmp/test_merge45_$$.db; rm -f "$DB45"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); CREATE INDEX tv ON t(v); INSERT INTO t VALUES(1,'one'),(2,'two'),(3,'three'); SELECT dolt_commit('-A','-m','base'); SELECT dolt_branch('feature');" | $DOLTLITE "$DB45" > /dev/null 2>&1
 echo "DELETE FROM t WHERE id=2; SELECT dolt_commit('-A','-m','delete row');" | $DOLTLITE "$DB45/feature" > /dev/null 2>&1
-echo "ALTER TABLE t ADD COLUMN added TEXT NOT NULL DEFAULT 'dd'; SELECT dolt_commit('-A','-m','add col');" | $DOLTLITE "$DB45" > /dev/null 2>&1
+echo "ALTER TABLE t ADD COLUMN added TEXT NOT NULL DEFAULT 7; SELECT dolt_commit('-A','-m','add col');" | $DOLTLITE "$DB45" > /dev/null 2>&1
 run_test_match "add_column_default_vs_delete_merges" "SELECT dolt_merge('feature');" "^[0-9a-f]{40}$" "$DB45"
-run_test "add_column_default_vs_delete_rows" "SELECT group_concat(id || ':' || added, ',') FROM (SELECT id,added FROM t INDEXED BY tv ORDER BY v);" "1:dd,3:dd" "$DB45"
+run_test "add_column_default_vs_delete_rows" "SELECT group_concat(id || ':' || quote(added), ',') FROM (SELECT id,added FROM t INDEXED BY tv ORDER BY v);" "1:'7',3:'7'" "$DB45"
 run_test "add_column_default_vs_delete_integrity" "PRAGMA integrity_check;" "ok" "$DB45"
 
 DB46=/tmp/test_merge46_$$.db; rm -f "$DB46"

--- a/test/doltlite_merge.sh
+++ b/test/doltlite_merge.sh
@@ -677,5 +677,26 @@ SELECT 'RESULT|' || group_concat(name, ',') FROM (
 );" "^RESULT\|q$" "$DB43"
 run_test "same_empty_added_table_with_peer_drop_integrity" "PRAGMA integrity_check;" "ok" "$DB43"
 
-rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8" "$DB8B" "$DB9" "$DB10" "$DB11" "$DB11D" "$DB11E" "$DB11F" "$DB12" "$DB13" "$DB14" "$DB15" "$DB16" "$DB17" "$DB18" "$DB19" "$DB20" "$DB20B" "$DB21" "$DB22" "$DB23" "$DB24" "$DB25" "$DB40" "$DB41" "$DB42" "$DB43"
+DB44=/tmp/test_merge44_$$.db; rm -f "$DB44"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'one'),(2,'two'),(3,'three'); SELECT dolt_commit('-A','-m','base'); SELECT dolt_branch('feature');" | $DOLTLITE "$DB44" > /dev/null 2>&1
+echo "ALTER TABLE t ADD COLUMN added TEXT DEFAULT 'dd'; SELECT dolt_commit('-A','-m','add col');" | $DOLTLITE "$DB44/feature" > /dev/null 2>&1
+echo "DELETE FROM t WHERE id=2; SELECT dolt_commit('-A','-m','delete row');" | $DOLTLITE "$DB44" > /dev/null 2>&1
+run_test_match "delete_vs_add_column_default_merges" "SELECT dolt_merge('feature');" "^[0-9a-f]{40}$" "$DB44"
+run_test "delete_vs_add_column_default_rows" "SELECT group_concat(id || ':' || added, ',') FROM (SELECT id,added FROM t ORDER BY id);" "1:dd,3:dd" "$DB44"
+
+DB45=/tmp/test_merge45_$$.db; rm -f "$DB45"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); CREATE INDEX tv ON t(v); INSERT INTO t VALUES(1,'one'),(2,'two'),(3,'three'); SELECT dolt_commit('-A','-m','base'); SELECT dolt_branch('feature');" | $DOLTLITE "$DB45" > /dev/null 2>&1
+echo "DELETE FROM t WHERE id=2; SELECT dolt_commit('-A','-m','delete row');" | $DOLTLITE "$DB45/feature" > /dev/null 2>&1
+echo "ALTER TABLE t ADD COLUMN added TEXT NOT NULL DEFAULT 'dd'; SELECT dolt_commit('-A','-m','add col');" | $DOLTLITE "$DB45" > /dev/null 2>&1
+run_test_match "add_column_default_vs_delete_merges" "SELECT dolt_merge('feature');" "^[0-9a-f]{40}$" "$DB45"
+run_test "add_column_default_vs_delete_rows" "SELECT group_concat(id || ':' || added, ',') FROM (SELECT id,added FROM t INDEXED BY tv ORDER BY v);" "1:dd,3:dd" "$DB45"
+run_test "add_column_default_vs_delete_integrity" "PRAGMA integrity_check;" "ok" "$DB45"
+
+DB46=/tmp/test_merge46_$$.db; rm -f "$DB46"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'one'),(2,'two'); SELECT dolt_commit('-A','-m','base'); SELECT dolt_branch('feature');" | $DOLTLITE "$DB46" > /dev/null 2>&1
+echo "ALTER TABLE t ADD COLUMN added TEXT DEFAULT 'dd'; UPDATE t SET v='edited' WHERE id=2; SELECT dolt_commit('-A','-m','add col and edit');" | $DOLTLITE "$DB46/feature" > /dev/null 2>&1
+echo "DELETE FROM t WHERE id=2; SELECT dolt_commit('-A','-m','delete row');" | $DOLTLITE "$DB46" > /dev/null 2>&1
+run_test_match "delete_vs_real_edit_with_add_column_conflicts" "SELECT dolt_merge('feature');" "conflict" "$DB46"
+
+rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8" "$DB8B" "$DB9" "$DB10" "$DB11" "$DB11D" "$DB11E" "$DB11F" "$DB12" "$DB13" "$DB14" "$DB15" "$DB16" "$DB17" "$DB18" "$DB19" "$DB20" "$DB20B" "$DB21" "$DB22" "$DB23" "$DB24" "$DB25" "$DB40" "$DB41" "$DB42" "$DB43" "$DB44" "$DB45" "$DB46"
 dltest_finish

--- a/test/vc_oracle_merge_test.sh
+++ b/test/vc_oracle_merge_test.sh
@@ -1642,6 +1642,37 @@ SELECT dolt_merge('feature');
 " "SELECT id || '|' || Name || '|' || Score || '|' || coalesce(MainNote,'~') || '|' || coalesce(FeatNote,'~') FROM t" \
 "SELECT CONCAT(id, '|', Name, '|', Score, '|', coalesce(MainNote,'~'), '|', coalesce(FeatNote,'~')) FROM t"
 
+oracle_error_poststate "delete_vs_add_column_default" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1, 'one'), (2, 'two'), (3, 'three');
+SELECT dolt_commit('-Am', 'base');
+SELECT dolt_branch('feat');
+DELETE FROM t WHERE id = 2;
+SELECT dolt_commit('-Am', 'delete row');
+SELECT dolt_checkout('feat');
+ALTER TABLE t ADD COLUMN added TEXT DEFAULT 'dd';
+SELECT dolt_commit('-Am', 'add col');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feat');
+" "SELECT group_concat(id || ':' || added, ',') FROM (SELECT id, added FROM t ORDER BY id)" \
+"SELECT GROUP_CONCAT(CONCAT(id, ':', added) ORDER BY id SEPARATOR ',') FROM t"
+
+oracle_error_poststate "add_column_not_null_default_vs_indexed_delete" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+CREATE INDEX tv ON t(v);
+INSERT INTO t VALUES (1, 'one'), (2, 'two'), (3, 'three');
+SELECT dolt_commit('-Am', 'base');
+SELECT dolt_branch('feat');
+ALTER TABLE t ADD COLUMN added TEXT NOT NULL DEFAULT 'dd';
+SELECT dolt_commit('-Am', 'add col');
+SELECT dolt_checkout('feat');
+DELETE FROM t WHERE id = 2;
+SELECT dolt_commit('-Am', 'delete row');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feat');
+" "SELECT group_concat(id || ':' || added, ',') FROM (SELECT id, added FROM t ORDER BY id)" \
+"SELECT GROUP_CONCAT(CONCAT(id, ':', added) ORDER BY id SEPARATOR ',') FROM t"
+
 # Concluding a conflicted merge must still record the second parent.
 oracle "conflict_resolved_commit_keeps_merged_branch_in_log" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);


### PR DESCRIPTION
Fixes #2461.

A one-sided ADD COLUMN with a DEFAULT rewrites stored row payloads. Merge relayout left the ancestor and unchanged-schema side in their shorter encodings, so a concurrent delete was incorrectly classified as delete-vs-modify.

For strictly append-only schema changes, relayout now projects shared rows through the wider schema defaults on both the ancestor and unchanged-layout side. The scope check requires every ancestor column to retain its ordinal, name, and definition. Real edits to existing columns continue to conflict with deletes.

Regression coverage includes both merge directions, DEFAULT and NOT NULL DEFAULT, an indexed base table, a real delete-vs-edit negative control, and Dolt oracle comparisons.

Validation:
- doltlite_merge.sh: 151/151
- vc_oracle_merge_test.sh: 91/91 against Dolt
- run_doltlite_tests.sh: all 121 suites pass (failed C archive rebuilt, then 311164/311164)
- make lint

Co-Authored-By: Grok 4.6 <noreply@x.ai>