### PR TITLE
Drop empty rebase picks the way Dolt drops them

### DIFF
--- a/src/doltlite_rebase.c
+++ b/src/doltlite_rebase.c
@@ -491,12 +491,17 @@ static int doltliteRebaseLinearReplay(
         &replayCommit.catalogHash,
         &curHead, 0,
         replayCommit.zMessage ? replayCommit.zMessage : "",
-        0, 0, &nConflicts, &nViolations, &zApplyErr, hexBuf);
+        0, 1, &nConflicts, &nViolations, &zApplyErr, hexBuf);
 
     doltliteCommitClear(&replayCommit);
     doltliteCommitClear(&parentCommit);
     doltliteCommitClear(&curHeadCommit);
 
+    if( rc==SQLITE_DONE ){
+      sqlite3_free(zApplyErr);
+      zApplyErr = 0;
+      continue;
+    }
     if( rc!=SQLITE_OK ) goto rollback;
     if( nConflicts>0 ){ bConflict = 1; rc = SQLITE_ERROR; goto rollback; }
     /* Finish rolled this replay back and returned OK; stop or the loop
@@ -1058,9 +1063,11 @@ static int rebaseReplayPlanGroup(
   int *piNext
 ){
   char *combinedMsg = 0;
+  ProllyHash startCat;
   int rc;
   int j;
 
+  startCat = *pCurCat;
   rc = rebaseApplyPlanRowCatalog(db, &aPlan[iStart], pCurCat, pCurCat);
   if( rc!=SQLITE_OK ) return rc;
 
@@ -1092,6 +1099,12 @@ static int rebaseReplayPlanGroup(
       if( !combinedMsg ) return SQLITE_NOMEM;
     }
     j++;
+  }
+
+  if( prollyHashCompare(pCurCat, &startCat)==0 ){
+    sqlite3_free(combinedMsg);
+    *piNext = j;
+    return SQLITE_OK;
   }
 
   {

--- a/test/doltlite_rebase.sh
+++ b/test/doltlite_rebase.sh
@@ -718,7 +718,96 @@ else
 fi
 rm -f "$DB13"
 
-rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB5_SHORT" "$DB6" "$DB7" "$DB8" "$DB9"
+DBE=/tmp/test_rebase_empty_pick_$$.db; rm -f "$DBE"
+cat <<'SQL' | "$DOLTLITE" "$DBE" >/dev/null 2>&1
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1, 'base');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'base');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+INSERT INTO t VALUES (2, 'same');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'feat_add_2');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES (2, 'same');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'main_add_2');
+SELECT dolt_checkout('feat');
+SELECT dolt_rebase('main');
+SQL
+run_test "empty_pick_dropped_log" \
+  "SELECT dolt_checkout('feat');
+   SELECT group_concat(message, ',') FROM dolt_log WHERE message NOT LIKE 'Initialize%';" \
+  "0
+main_add_2,base" \
+  "$DBE"
+run_test "empty_pick_not_duplicate_catalog" \
+  "SELECT dolt_checkout('feat');
+   SELECT dolt_hashof_db('HEAD') = dolt_hashof_db('HEAD~1');" \
+  "0
+0" \
+  "$DBE"
+run_test "empty_pick_lands_on_onto" \
+  "SELECT dolt_checkout('feat');
+   SELECT dolt_hashof('HEAD') = dolt_hashof('main');" \
+  "0
+1" \
+  "$DBE"
+
+DBE2=/tmp/test_rebase_empty_then_real_$$.db; rm -f "$DBE2"
+cat <<'SQL' | "$DOLTLITE" "$DBE2" >/dev/null 2>&1
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1, 'base');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'base');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+INSERT INTO t VALUES (2, 'same');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'feat_same');
+INSERT INTO t VALUES (3, 'feat_only');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'feat_only');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES (2, 'same');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'main_same');
+SELECT dolt_checkout('feat');
+SELECT dolt_rebase('main');
+SQL
+run_test "empty_then_real_log" \
+  "SELECT dolt_checkout('feat');
+   SELECT group_concat(message, ',') FROM dolt_log WHERE message NOT LIKE 'Initialize%';" \
+  "0
+feat_only,main_same,base" \
+  "$DBE2"
+run_test "empty_then_real_rows" \
+  "SELECT dolt_checkout('feat');
+   SELECT group_concat(id || ':' || v, ',') FROM t;" \
+  "0
+1:base,2:same,3:feat_only" \
+  "$DBE2"
+
+DBE3=/tmp/test_rebase_interactive_empty_$$.db; rm -f "$DBE3"
+cat <<'SQL' | "$DOLTLITE" "$DBE3" >/dev/null 2>&1
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1, 'base');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'base');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+INSERT INTO t VALUES (2, 'same');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'feat_add_2');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES (2, 'same');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'main_add_2');
+SELECT dolt_checkout('feat');
+SQL
+run_test "interactive_empty_pick_dropped_log" \
+  "SELECT dolt_checkout('feat');
+   SELECT dolt_rebase('-i','main');
+   SELECT dolt_rebase('--continue');
+   SELECT group_concat(message, ',') FROM dolt_log WHERE message NOT LIKE 'Initialize%';" \
+  "0
+interactive rebase started on branch dolt_rebase_feat; adjust the rebase plan in the dolt_rebase table, then continue rebasing by calling dolt_rebase('--continue')
+Successfully rebased and updated refs/heads/feat
+main_add_2,base" \
+  "$DBE3"
+
+rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB5_SHORT" "$DB6" "$DB7" "$DB8" "$DB9" "$DBE" "$DBE2" "$DBE3"
 echo ""
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"
 if [ $FAIL -gt 0 ]; then echo -e "$ERRORS"; exit 1; fi

--- a/test/vc_oracle_rebase_test.sh
+++ b/test/vc_oracle_rebase_test.sh
@@ -256,6 +256,54 @@ SELECT dolt_rebase('main');
 oracle "descendant_log_order" "$DESCEND_SETUP" \
   "SELECT CONCAT('LOG|', message) FROM dolt_log;"
 
+echo "--- rebase drops a pick whose patch is already on upstream ---"
+
+EMPTY_PICK_SETUP="
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1, 'base');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'base');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+INSERT INTO t VALUES (2, 'same');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'feat_add_2');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES (2, 'same');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'main_add_2');
+SELECT dolt_checkout('feat');
+SELECT dolt_rebase('main');
+SELECT dolt_checkout('feat');
+"
+
+oracle "empty_pick_dropped_log" "$EMPTY_PICK_SETUP" \
+  "SELECT CONCAT('LOG|', message) FROM dolt_log WHERE message NOT LIKE 'Initialize%';"
+
+oracle "empty_pick_table" "$EMPTY_PICK_SETUP" \
+  "SELECT CONCAT('LOG|', id, '=', v) FROM t ORDER BY id;"
+
+EMPTY_THEN_REAL_SETUP="
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1, 'base');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'base');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+INSERT INTO t VALUES (2, 'same');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'feat_same');
+INSERT INTO t VALUES (3, 'feat_only');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'feat_only');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES (2, 'same');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'main_same');
+SELECT dolt_checkout('feat');
+SELECT dolt_rebase('main');
+SELECT dolt_checkout('feat');
+"
+
+oracle "empty_then_real_log" "$EMPTY_THEN_REAL_SETUP" \
+  "SELECT CONCAT('LOG|', message) FROM dolt_log WHERE message NOT LIKE 'Initialize%';"
+
+oracle "empty_then_real_table" "$EMPTY_THEN_REAL_SETUP" \
+  "SELECT CONCAT('LOG|', id, '=', v) FROM t ORDER BY id;"
+
 echo "--- rebase with multi-commit chain preserving order ---"
 
 MULTI_SETUP="


### PR DESCRIPTION
Fixes #2478.

Linear rebase replay passed `bRejectUnchanged=0` into `applyMergedCatalogAndCommit`, so a pick whose patch was already on upstream still wrote a commit with the same catalog as `HEAD~1`. Cherry-pick already refuses that case (`SQLITE_DONE`). Linear rebase now uses `bRejectUnchanged=1` and continues to the next pick on `SQLITE_DONE`. Interactive `--continue` skips `CreateAndStoreCommit` when the applied plan group does not change the catalog.

`--empty=keep` is still unknown; default matches Dolt `--empty=drop`.

## Validation

- fail-before: 5 of 6 new `doltlite_rebase.sh` assertions failed (empty pick kept in the log; `hashof_db('HEAD')==hashof_db('HEAD~1')`)
- pass-after: `doltlite_rebase.sh` 65/65
- `vc_oracle_rebase_test.sh` 56/56 vs Dolt 2.2.2 (includes `empty_pick_dropped_log` / `empty_then_real_*`)
- `doltlite_rebase_schema.sh` 25/25
- `doltlite_cherry_pick.sh` 134/134
- `make lint` clean

Co-Authored-By: Grok 4.6 <noreply@x.ai>