### PR TITLE
Fix checkout from raw commit hashes

### DIFF
--- a/src/doltlite_checkout.c
+++ b/src/doltlite_checkout.c
@@ -1116,11 +1116,19 @@ static int doltliteCheckoutTables(
   return rc;
 }
 
+static void checkoutDetachedHeadError(sqlite3_context *ctx, sqlite3 *db){
+  doltliteVcResultError(ctx, db,
+      "dolt does not support a detached head state. To create a branch at "
+      "this commit instead, run SELECT dolt_checkout(<start_point>, '-b', "
+      "<new_branch_name>)");
+}
+
 static void doltCheckoutParsedFunc(
   sqlite3_context *ctx,
   int argc,
   sqlite3_value **argv,
-  int createBranch
+  int createBranch,
+  int startFirst
 ){
   sqlite3 *db = sqlite3_context_db_handle(ctx);
   ChunkStore *cs = doltliteGetChunkStore(db);
@@ -1153,14 +1161,12 @@ static void doltCheckoutParsedFunc(
     }
     if( chunkStoreFindTag(cs, zBranch, &probe)==SQLITE_OK
      && !prollyHashIsEmpty(&probe) ){
-      doltliteVcResultError(ctx, db,
-          "dolt does not support a detached head state");
+      checkoutDetachedHeadError(ctx, db);
       return;
     }
     if( chunkStoreFindBranch(cs, zBranch, &probe)!=SQLITE_OK ){
       if( doltliteResolveRef(db, zBranch, &probe)==SQLITE_OK ){
-        doltliteVcResultError(ctx, db,
-            "dolt does not support a detached head state");
+        checkoutDetachedHeadError(ctx, db);
       }else{
         char *zErr = sqlite3_mprintf("no such branch or table: %s", zBranch);
         doltliteVcResultError(ctx, db,
@@ -1186,9 +1192,12 @@ static void doltCheckoutParsedFunc(
   }
 
   if( createBranch ){
+    int iBranch = startFirst ? 1 : 0;
+    int iStart = startFirst ? 0 : 1;
     if( argc<1 ){ doltliteVcResultError(ctx, db, "branch name required after -b"); return; }
+    if( startFirst && argc<2 ){ doltliteVcResultError(ctx, db, "branch name required after -b"); return; }
     if( argc>2 ){ doltliteVcResultError(ctx, db, "too many arguments"); return; }
-    zBranch = (const char*)sqlite3_value_text(argv[0]);
+    zBranch = (const char*)sqlite3_value_text(argv[iBranch]);
     if( branchNameEmpty(zBranch) ){ doltliteVcResultError(ctx, db, "branch name required after -b"); return; }
     if( !doltliteUserRefNameIsValid(zBranch) ){
       doltliteVcResultError(ctx, db, "invalid branch name");
@@ -1196,7 +1205,7 @@ static void doltCheckoutParsedFunc(
     }
 
     if( argc>=2 ){
-      const char *zStart = (const char*)sqlite3_value_text(argv[1]);
+      const char *zStart = (const char*)sqlite3_value_text(argv[iStart]);
       if( !zStart ){
         doltliteVcResultError(ctx, db, "start point not found");
         return;
@@ -1223,11 +1232,15 @@ static void doltCheckoutParsedFunc(
   }
 
   if( !createBranch && argc==1 ){
-    ProllyHash tagHash;
-    if( chunkStoreFindTag(cs, zBranch, &tagHash)==SQLITE_OK
-     && !prollyHashIsEmpty(&tagHash) ){
-      doltliteVcResultError(ctx, db,
-          "dolt does not support a detached head state");
+    ProllyHash probe;
+    if( chunkStoreFindTag(cs, zBranch, &probe)==SQLITE_OK
+     && !prollyHashIsEmpty(&probe) ){
+      checkoutDetachedHeadError(ctx, db);
+      return;
+    }
+    if( chunkStoreFindBranch(cs, zBranch, &probe)!=SQLITE_OK
+     && doltliteResolveRef(db, zBranch, &probe)==SQLITE_OK ){
+      checkoutDetachedHeadError(ctx, db);
       return;
     }
   }
@@ -1392,16 +1405,39 @@ checkout_done:
   sqlite3_result_int(ctx, 0);
 }
 
+static int checkoutStartPointBeforeDashB(
+  int argc,
+  sqlite3_value **argv
+){
+  int i;
+  int seenPositional = 0;
+  int endOptions = 0;
+  for(i=0; i<argc; i++){
+    const char *zArg = (const char*)sqlite3_value_text(argv[i]);
+    if( !zArg ) continue;
+    if( !endOptions && strcmp(zArg, "--")==0 ){
+      endOptions = 1;
+      continue;
+    }
+    if( !endOptions && strcmp(zArg, "-b")==0 ){
+      return seenPositional;
+    }
+    seenPositional = 1;
+  }
+  return 0;
+}
+
 void doltCheckoutFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   DoltliteCmdArgs args;
   int createBranch = 0;
+  int startFirst = 0;
   DoltliteCmdOption aOption[] = {
     { 0, 'b', DOLTLITE_CMD_OPTION_FLAG, &createBranch, 0 }
   };
   int rc;
 
   if( argc==0 ){
-    doltCheckoutParsedFunc(ctx, argc, argv, createBranch);
+    doltCheckoutParsedFunc(ctx, argc, argv, createBranch, startFirst);
     return;
   }
   rc = doltliteCmdParseArgs(ctx, argc, argv, aOption, ArraySize(aOption),
@@ -1410,8 +1446,11 @@ void doltCheckoutFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
     (void)doltliteVcSealSavepointError(sqlite3_context_db_handle(ctx));
     return;
   }
+  if( createBranch ){
+    startFirst = checkoutStartPointBeforeDashB(argc, argv);
+  }
   doltCheckoutParsedFunc(ctx, args.nPositional, args.apPositional,
-                         createBranch);
+                         createBranch, startFirst);
   doltliteCmdArgsClear(&args);
 }
 

--- a/test/doltlite_branch.sh
+++ b/test/doltlite_branch.sh
@@ -163,6 +163,12 @@ echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'ba
 run_test "branch_from_first_parent_ref_persists_across_reopen" "SELECT count(*) FROM t;" "2" "$DB13/from_p1"
 run_test "branch_from_second_parent_ref_persists_across_reopen" "SELECT count(*) FROM t;" "2" "$DB13/from_p2"
 run_test "branch_from_second_parent_hash_persists_across_reopen" "SELECT count(*) FROM t;" "2" "$DB13/from_hash"
+run_test_match "checkout_raw_hash_refuses_detached_head" "SELECT dolt_checkout(dolt_hashof('HEAD^2'));" "does not support a detached head state" "$DB13"
+run_test_match "checkout_raw_hash_suggests_branch" "SELECT dolt_checkout(dolt_hashof('HEAD^2'));" "To create a branch at this commit instead" "$DB13"
+run_test "checkout_b_raw_hash_documented_order" "SELECT dolt_checkout(dolt_hashof('HEAD^2'),'-b','checkout_from_hash');" "0" "$DB13"
+run_test "checkout_b_raw_hash_documented_order_rows" "SELECT count(*) FROM t;" "2" "$DB13/checkout_from_hash"
+run_test "checkout_b_raw_hash_flag_first" "SELECT dolt_checkout('-b','checkout_from_hash_flag_first',dolt_hashof('HEAD^1'));" "0" "$DB13"
+run_test "checkout_b_raw_hash_flag_first_rows" "SELECT count(*) FROM t;" "2" "$DB13/checkout_from_hash_flag_first"
 
 DB14=/tmp/test_branch14_$$.db; rm -f "$DB14"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'base'); SELECT dolt_commit('-A','-m','init'); SELECT dolt_branch('feature'); SELECT dolt_checkout('feature'); UPDATE t SET v='working' WHERE id=1; SELECT dolt_checkout('main');" | $DOLTLITE "$DB14" > /dev/null 2>&1

--- a/test/vc_oracle_checkout_test.sh
+++ b/test/vc_oracle_checkout_test.sh
@@ -261,6 +261,14 @@ SELECT dolt_checkout('main');
 SELECT dolt_checkout('-b', 'newfeat', 'feature');
 "
 
+oracle "dash_b_from_raw_hash_documented_order" "
+$SEED
+INSERT INTO t VALUES (2, 'main_b');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c2');
+SELECT dolt_checkout(dolt_hashof('HEAD~1'), '-b', 'from_c1');
+"
+
 echo "--- per-table checkout ---"
 
 oracle "revert_single_table_working" "
@@ -487,6 +495,14 @@ echo "--- error paths ---"
 oracle_error "checkout_nonexistent" "
 $SEED
 SELECT dolt_checkout('nope');
+"
+
+oracle_error "checkout_raw_hash_refuses_detached_head" "
+$SEED
+INSERT INTO t VALUES (2, 'main_b');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c2');
+SELECT dolt_checkout(dolt_hashof('HEAD~1'));
 "
 
 oracle_error "dash_b_existing_branch" "


### PR DESCRIPTION
Fixes #2473.

Bare commit hashes now resolve before branch/table fallback, so DoltLite refuses the detached-HEAD state and directs the caller to create a branch. Table checkout from a commit ref remains unchanged when table names follow.

Checkout now retains whether the start point appeared before or after `-b`. This supports Dolt's documented `dolt_checkout(start, '-b', name)` order while preserving the existing `dolt_checkout('-b', name, start)` form.

Regression coverage proves the original failures, both argument orders, historical row state, detached-head guidance, and Dolt oracle parity.

Validation:
- doltlite_branch.sh: 78/78
- vc_oracle_checkout_test.sh: 71/71 against Dolt
- run_doltlite_tests.sh: all 121 suites pass (311164/311164 regression assertions)
- make lint
- make doltlite-lib

Co-Authored-By: Grok 4.6 <noreply@x.ai>