### PR TITLE
dolt_add learns -f/--force to stage ignored tables

### DIFF
--- a/src/doltlite_add.c
+++ b/src/doltlite_add.c
@@ -288,7 +288,8 @@ static int addStageAllTables(
   sqlite3 *db,
   sqlite3_context *context,
   ChunkStore *cs,
-  const ProllyHash *pWorkingHash
+  const ProllyHash *pWorkingHash,
+  int bForce
 ){
   struct TableEntry *aWorking = 0;
   struct TableEntry *aStaged = 0;
@@ -330,7 +331,7 @@ static int addStageAllTables(
   for(k=0; k<nWorking; k++){
     const char *zName = aWorking[k].zName;
     struct TableEntry *pUse = &aWorking[k];
-    if( aWorking[k].iTable>1 && zName ){
+    if( aWorking[k].iTable>1 && zName && !bForce ){
       int ignored = 0;
       rc = addCheckIgnore(db, context, zName, &ignored);
       if( rc!=SQLITE_OK ){
@@ -358,6 +359,8 @@ static int addStageAllTables(
     const char *zName = aStaged[k].zName;
     if( aStaged[k].iTable<=1 || !zName ) continue;
     if( addNameIndexFind(&workingIdx, zName) ) continue;
+    /* Force stages the deletion of an ignored table like any other. */
+    if( bForce ) continue;
     {
       int ignored = 0;
       rc = addCheckIgnore(db, context, zName, &ignored);
@@ -569,7 +572,8 @@ int doltliteStageNamedTables(
   ChunkStore *cs,
   const ProllyHash *pWorkingHash,
   int argc,
-  sqlite3_value **argv
+  sqlite3_value **argv,
+  int bForce
 ){
   struct TableEntry *aWorking = 0;
   struct TableEntry *aStaged = 0;
@@ -644,7 +648,7 @@ int doltliteStageNamedTables(
     int j;
     if( !zTable || strcmp(zTable, ".")==0 ) continue;
 
-    {
+    if( !bForce ){
       int ignored = 0;
       rc = addCheckIgnore(db, context, zTable, &ignored);
       if( rc!=SQLITE_OK ){
@@ -897,7 +901,8 @@ static int doltliteStageArgsAndPersist(
   ChunkStore *cs,
   int argc,
   sqlite3_value **argv,
-  int stageAll
+  int stageAll,
+  int bForce
 ){
   ProllyHash workingHash;
   ProllyHash savedStaged;
@@ -918,9 +923,10 @@ static int doltliteStageArgsAndPersist(
   }
 
   if( stageAll ){
-    rc = addStageAllTables(db, context, cs, &workingHash);
+    rc = addStageAllTables(db, context, cs, &workingHash, bForce);
   }else{
-    rc = doltliteStageNamedTables(db, context, cs, &workingHash, argc, argv);
+    rc = doltliteStageNamedTables(db, context, cs, &workingHash, argc, argv,
+                                  bForce);
   }
   if( rc!=SQLITE_OK ) return rc;
 
@@ -942,9 +948,11 @@ static void doltliteAddFunc(
   ChunkStore *cs = doltliteGetChunkStore(db);
   int sealTopLevel = doltliteSavepointIsTopLevelTxn(db);
   int stageAll = 0;
+  int force = 0;
   DoltliteCmdArgs args;
   DoltliteCmdOption aOption[] = {
-    { "all", 'A', DOLTLITE_CMD_OPTION_FLAG, &stageAll, 0 }
+    { "all", 'A', DOLTLITE_CMD_OPTION_FLAG, &stageAll, 0 },
+    { "force", 'f', DOLTLITE_CMD_OPTION_FLAG, &force, 0 }
   };
   int rc;
   int i;
@@ -981,7 +989,7 @@ static void doltliteAddFunc(
 
   parsed = 1;
   opRc = doltliteStageArgsAndPersist(
-      db, context, cs, nTables, args.apPositional, stageAll);
+      db, context, cs, nTables, args.apPositional, stageAll, force);
   if( opRc!=SQLITE_OK ) goto add_cleanup;
 
   sqlite3_result_int(context, 0);
@@ -991,7 +999,7 @@ add_cleanup:
     rc = doltliteVcSealTopLevelSavepointTxn(db);
     if( rc==SQLITE_OK && parsed && opRc==SQLITE_OK ){
       rc = doltliteStageArgsAndPersist(
-          db, context, cs, nTables, args.apPositional, stageAll);
+          db, context, cs, nTables, args.apPositional, stageAll, force);
       if( rc!=SQLITE_OK ){
         opRc = rc;
       }

--- a/src/doltlite_checkout.c
+++ b/src/doltlite_checkout.c
@@ -1101,7 +1101,7 @@ static int doltliteCheckoutTables(
     /* Checking a table out of a ref stages only that table. */
     if( rc==SQLITE_OK && zSourceRef ){
       rc = doltliteStageNamedTables(db, context, cs, &newWorkingHash,
-                                    nNames, argv+iFirstName);
+                                    nNames, argv+iFirstName, 0);
     }
     if( rc==SQLITE_OK ){
       rc = doltlitePersistWorkingSet(db);

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -1038,7 +1038,8 @@ int addAppendIndexEntriesOfTable(
 );
 int doltliteStageNamedTables(
   sqlite3 *db, sqlite3_context *context, ChunkStore *cs,
-  const ProllyHash *pWorkingHash, int argc, sqlite3_value **argv
+  const ProllyHash *pWorkingHash, int argc, sqlite3_value **argv,
+  int bForce
 );
 int doltliteCatalogRenameMate(
   sqlite3 *db,

--- a/test/doltlite_ignore.sh
+++ b/test/doltlite_ignore.sh
@@ -113,6 +113,61 @@ run_test_match "incomparable_patterns_conflict" \
    SELECT dolt_add('-A');" \
   "matches conflicting patterns" "$DB3"
 
-rm -f "$DB" "$DB2" "$DB3" "$DB4"
+DB5=/tmp/test_ignore_force_$$.db
+rm -f "$DB5"
+
+run_test "force_add_named_ignored" \
+  "INSERT INTO dolt_ignore VALUES('tmp_*', 1);
+   CREATE TABLE tmp_secret(id INTEGER PRIMARY KEY);
+   CREATE TABLE keep(id INTEGER PRIMARY KEY);
+   SELECT dolt_add('-f', 'tmp_secret');
+   SELECT table_name, staged, status FROM dolt_status ORDER BY table_name;" \
+  "0
+dolt_ignore|0|new table
+keep|0|new table
+tmp_secret|1|new table" "$DB5"
+
+run_test "force_added_table_commits" \
+  "SELECT dolt_add('dolt_ignore', 'keep');
+   SELECT dolt_commit('-m','forced') IS NOT NULL;
+   SELECT count(*) FROM dolt_status;
+   INSERT INTO tmp_secret VALUES(1);
+   SELECT table_name, staged, status FROM dolt_status ORDER BY table_name;" \
+  "0
+1
+0
+tmp_secret|0|modified" "$DB5"
+
+DB6=/tmp/test_ignore_force_all_$$.db
+rm -f "$DB6"
+
+run_test "force_add_all_stages_ignored" \
+  "INSERT INTO dolt_ignore VALUES('tmp_*', 1);
+   CREATE TABLE tmp_secret(id INTEGER PRIMARY KEY);
+   CREATE TABLE keep(id INTEGER PRIMARY KEY);
+   SELECT dolt_add('-A', '-f');
+   SELECT table_name, staged, status FROM dolt_status ORDER BY table_name;" \
+  "0
+dolt_ignore|1|new table
+keep|1|new table
+tmp_secret|1|new table" "$DB6"
+
+DB7=/tmp/test_ignore_force_dot_$$.db
+rm -f "$DB7"
+
+run_test "force_add_dot_stages_ignored" \
+  "INSERT INTO dolt_ignore VALUES('tmp_*', 1);
+   CREATE TABLE tmp_secret(id INTEGER PRIMARY KEY);
+   SELECT dolt_add('--force', '.');
+   SELECT table_name, staged, status FROM dolt_status ORDER BY table_name;" \
+  "0
+dolt_ignore|1|new table
+tmp_secret|1|new table" "$DB7"
+
+run_test_match "force_requires_name" \
+  "SELECT dolt_add('-f');" \
+  "requires table name" "$DB7"
+
+rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7"
 
 dltest_finish

--- a/test/vc_oracle_ignore_test.sh
+++ b/test/vc_oracle_ignore_test.sh
@@ -244,6 +244,35 @@ CREATE TABLE keep(x INT PRIMARY KEY);
 SELECT dolt_add('keep');
 "
 
+echo "--- dolt_add -f ---"
+
+oracle "add_force_explicit_ignored" "
+INSERT INTO dolt_ignore VALUES ('tmp_*', 1);
+CREATE TABLE tmp_foo(x INT PRIMARY KEY);
+CREATE TABLE keep(x INT PRIMARY KEY);
+SELECT dolt_add('-f', 'tmp_foo');
+"
+
+oracle "add_force_long_option" "
+INSERT INTO dolt_ignore VALUES ('tmp_*', 1);
+CREATE TABLE tmp_foo(x INT PRIMARY KEY);
+SELECT dolt_add('--force', 'tmp_foo');
+"
+
+oracle "add_force_dash_A_stages_ignored" "
+INSERT INTO dolt_ignore VALUES ('tmp_*', 1);
+CREATE TABLE tmp_foo(x INT PRIMARY KEY);
+CREATE TABLE keep(x INT PRIMARY KEY);
+SELECT dolt_add('-A', '-f');
+"
+
+oracle "add_force_dot_stages_ignored" "
+INSERT INTO dolt_ignore VALUES ('tmp_*', 1);
+CREATE TABLE tmp_foo(x INT PRIMARY KEY);
+CREATE TABLE keep(x INT PRIMARY KEY);
+SELECT dolt_add('-f', '.');
+"
+
 echo "--- dolt_commit -A ---"
 
 oracle "commit_A_skips_ignored" "


### PR DESCRIPTION
Fixes #2475.

## Problem

`dolt_add` parsed only `--all`/`-A`, so `dolt_add('-f','secrets')` errored `unknown option -f` and a table matched by `dolt_ignore` could not be staged at all. Dolt 2.2.2 force-stages it.

## Fix

Adds `-f`/`--force` to `dolt_add`'s option table and threads the flag through both staging paths (`addStageAllTables`, `doltliteStageNamedTables`). Semantics oracled against Dolt 2.2.2 case by case:

- `dolt_add('-f','secrets')` stages just the named ignored table (others stay unstaged).
- `dolt_add('-A','-f')` and `dolt_add('-f','.')` stage everything including ignored tables, and stage the deletion of a previously staged ignored table.
- Bare `dolt_add('-f')` still errors (Dolt: "Nothing specified"; doltlite keeps its existing "requires table name or '-A'" message).
- `dolt_checkout(ref, table)`'s internal staging keeps the ignore filter (passes force=0).

## Testing

- `test/doltlite_ignore.sh`: five new cases (named force, force-all, force-dot via `--force`, commit round-trip of a force-added table, bare `-f` error). Fail-before on the unfixed engine: all 5 fail with `unknown option`; pass-after: 21/21.
- `test/vc_oracle_ignore_test.sh`: four new cases oracled live against Dolt 2.2.2 (named `-f`, `--force` long form, `-A -f`, `-f .`): 50/50.
- `test/vc_oracle_add_test.sh` regression: 43/43.
- Full regression C battery 311,164/311,164; shell battery 121/121; amalgamation regenerated and testfixture compiled cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)