### PR TITLE
Accept dolt_merge --no-commit and --squash

### DIFF
--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -1052,14 +1052,17 @@ int doltliteCatalogRenameMate(
 int mergeAbortInPlace(sqlite3 *db);
 int mergeFastForward(
   sqlite3 *db, sqlite3_context *context, ChunkStore *cs,
-  const ProllyHash *pOurHead, const ProllyHash *pTheirHead
+  const ProllyHash *pOurHead, const ProllyHash *pTheirHead,
+  int squash
 );
 int doltliteMergeRef(
   sqlite3 *db,
   sqlite3_context *context,
   const char *zBranch,
   const char *zMessage,
-  int noFastForward
+  int noFastForward,
+  int noCommit,
+  int squash
 );
 
 int doltliteAddRegister(sqlite3 *db);

--- a/src/doltlite_merge_cmd.c
+++ b/src/doltlite_merge_cmd.c
@@ -42,7 +42,8 @@ int mergeFastForward(
   sqlite3_context *context,
   ChunkStore *cs,
   const ProllyHash *pOurHead,
-  const ProllyHash *pTheirHead
+  const ProllyHash *pTheirHead,
+  int squash
 ){
   DoltliteCommit theirCommit;
   DoltliteTxnState savedState;
@@ -65,13 +66,28 @@ int mergeFastForward(
     return rc;
   }
   rc = doltliteSwitchCatalog(db, &theirCommit.catalogHash);
-  if( rc==SQLITE_OK ){
-    rc = doltliteUpdateBranchWorkingState(db, doltliteGetSessionBranch(db),
-                                          &theirCommit.catalogHash, NULL);
-  }
-  if( rc==SQLITE_OK ){
-    rc = doltliteCompareAndAdvanceBranch(
-        db, pOurHead, pTheirHead, &theirCommit.catalogHash, 0);
+  if( squash ){
+    if( rc==SQLITE_OK ){
+      rc = doltliteSetSessionStaged(db, &theirCommit.catalogHash);
+    }
+    if( rc==SQLITE_OK ){
+      rc = doltliteRefreshAndConfirmHead(db, cs, pOurHead);
+    }
+    if( rc==SQLITE_OK ){
+      int persistRc = doltlitePersistWorkingSetWithHash(
+          db, &theirCommit.catalogHash);
+      chunkStoreUnlock(cs);
+      rc = persistRc;
+    }
+  }else{
+    if( rc==SQLITE_OK ){
+      rc = doltliteUpdateBranchWorkingState(db, doltliteGetSessionBranch(db),
+                                            &theirCommit.catalogHash, NULL);
+    }
+    if( rc==SQLITE_OK ){
+      rc = doltliteCompareAndAdvanceBranch(
+          db, pOurHead, pTheirHead, &theirCommit.catalogHash, 0);
+    }
   }
   if( rc!=SQLITE_OK ){
     doltliteCommitClear(&theirCommit);
@@ -371,7 +387,8 @@ static int mergeRefCreateMergeCommit(
   const ProllyHash *pTheirHead,
   const ProllyHash *pMergedCat,
   const char *zBranch,
-  const char *zMessage
+  const char *zMessage,
+  int nExtraParents
 ){
   ProllyHash commitHash;
   char hexBuf[PROLLY_HASH_SIZE*2+1];
@@ -392,7 +409,8 @@ static int mergeRefCreateMergeCommit(
              zBranch, doltliteGetSessionBranch(db));
   }
   rc = doltliteCreateAndStoreCommit(db, pOurHead, pMergedCat,
-      msg, NULL, NULL, pTheirHead, 1, &commitHash);
+      msg, NULL, NULL, nExtraParents ? pTheirHead : NULL, nExtraParents,
+      &commitHash);
   if( rc!=SQLITE_OK ){
     /* Catalog is already live; leaving it lets dolt_commit drop theirHead
     ** from ancestry. Restore first. */
@@ -425,12 +443,69 @@ static int mergeRefCreateMergeCommit(
   return SQLITE_OK;
 }
 
+static int mergeRefLeaveUncommitted(
+  sqlite3 *db,
+  sqlite3_context *context,
+  DoltliteTxnState *pSaved,
+  const ProllyHash *pOurHead,
+  const ProllyHash *pTheirHead,
+  const ProllyHash *pMergedCat,
+  const char *zBranch,
+  int bSetMergeState
+){
+  ChunkStore *cs = doltliteGetChunkStore(db);
+  ProllyHash empty;
+  int rc;
+
+  memset(&empty, 0, sizeof(empty));
+  if( bSetMergeState ){
+    rc = doltliteSetSessionMergeState(db, 1, pTheirHead, &empty);
+    if( rc==SQLITE_OK ){
+      (void)doltliteSetSessionMergeSourceSpec(db, zBranch, pTheirHead);
+    }
+    if( rc!=SQLITE_OK ){
+      sqlite3_result_error_code(context,
+          doltliteRestoreTxnStateOnFailure(db, pSaved, rc));
+      return SQLITE_ERROR;
+    }
+  }
+
+  rc = doltliteRefreshAndConfirmHead(db, cs, pOurHead);
+  if( rc==SQLITE_BUSY ){
+    doltliteCmdResultPeerBranchBusy(context, "merge");
+    doltliteRestoreTxnStateOnFailure(db, pSaved, rc);
+    return SQLITE_ERROR;
+  }
+  if( rc!=SQLITE_OK ){
+    sqlite3_result_error_code(context,
+        doltliteRestoreTxnStateOnFailure(db, pSaved, rc));
+    return SQLITE_ERROR;
+  }
+  rc = doltlitePersistWorkingSetWithHash(db, pMergedCat);
+  chunkStoreUnlock(cs);
+  if( rc!=SQLITE_OK ){
+    sqlite3_result_error_code(context,
+        doltliteRestoreTxnStateOnFailure(db, pSaved, rc));
+    return SQLITE_ERROR;
+  }
+  rc = doltliteVcSealEnclosingTxn(db);
+  if( rc!=SQLITE_OK ){
+    sqlite3_result_error_code(context, rc);
+    return SQLITE_ERROR;
+  }
+  doltliteTxnStateClear(pSaved);
+  sqlite3_result_int(context, 0);
+  return SQLITE_OK;
+}
+
 int doltliteMergeRef(
   sqlite3 *db,
   sqlite3_context *context,
   const char *zBranch,
   const char *zMessage,
-  int noFastForward
+  int noFastForward,
+  int noCommit,
+  int squash
 ){
   ChunkStore *cs = doltliteGetChunkStore(db);
   ProllyHash ourHead, theirHead, ancestorHash;
@@ -514,7 +589,7 @@ int doltliteMergeRef(
   }
 
   if( prollyHashCompare(&ancestorHash, &ourHead)==0 && !noFastForward ){
-    return mergeFastForward(db, context, cs, &ourHead, &theirHead);
+    return mergeFastForward(db, context, cs, &ourHead, &theirHead, squash);
   }
 
   rc = mergeRefLoadCatalogs(db, &ourHead, &theirHead, &ancestorHash,
@@ -620,9 +695,14 @@ int doltliteMergeRef(
     return SQLITE_ERROR;
   }
 
+  if( noCommit ){
+    return mergeRefLeaveUncommitted(
+        db, context, &savedState, &ourHead, &theirHead, &mergedCatHash,
+        zBranch, !squash);
+  }
   return mergeRefCreateMergeCommit(
       db, context, &savedState, &ourHead, &theirHead, &mergedCatHash,
-      zBranch, zMessage);
+      zBranch, zMessage, squash ? 0 : 1);
 
 merge_fail:
   if( graphLocked ){
@@ -665,9 +745,13 @@ static void doltliteMergeFunc(
   DoltliteCmdArgs args;
   int isAbort = 0;
   int noFastForward = 0;
+  int noCommit = 0;
+  int squash = 0;
   DoltliteCmdOption aOption[] = {
     { "abort", 0, DOLTLITE_CMD_OPTION_FLAG, &isAbort, 0 },
     { "no-ff", 0, DOLTLITE_CMD_OPTION_FLAG, &noFastForward, 0 },
+    { "no-commit", 0, DOLTLITE_CMD_OPTION_FLAG, &noCommit, 0 },
+    { "squash", 0, DOLTLITE_CMD_OPTION_FLAG, &squash, 0 },
     { "message", 'm', DOLTLITE_CMD_OPTION_VALUE, 0, &zMessage }
   };
   u8 isMerging = 0;
@@ -694,7 +778,7 @@ static void doltliteMergeFunc(
   if( args.nPositional==1 ) zBranch = args.azPositional[0];
 
   if( isAbort ){
-    if( zBranch || zMessage || noFastForward ){
+    if( zBranch || zMessage || noFastForward || noCommit || squash ){
       sqlite3_result_error(context,
         "--abort does not take other arguments", -1);
       doltliteCmdArgsClear(&args);
@@ -717,7 +801,15 @@ static void doltliteMergeFunc(
     return;
   }
 
-  (void)doltliteMergeRef(db, context, zBranch, zMessage, noFastForward);
+  if( squash && noFastForward ){
+    doltliteCmdArgsClear(&args);
+    sqlite3_result_error(context,
+      "flags '--squash' and '--no-ff' cannot be used together", -1);
+    return;
+  }
+
+  (void)doltliteMergeRef(db, context, zBranch, zMessage, noFastForward,
+                         noCommit, squash);
   doltliteCmdArgsClear(&args);
 }
 

--- a/src/doltlite_remote_sql.c
+++ b/src/doltlite_remote_sql.c
@@ -629,7 +629,7 @@ static void doltPullFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
         sqlite3_result_error_nomem(ctx);
         return;
       }
-      rc = doltliteMergeRef(db, ctx, zTrackingRef, 0, 0);
+      rc = doltliteMergeRef(db, ctx, zTrackingRef, 0, 0, 0, 0);
       sqlite3_free(zTrackingRef);
       if( rc!=SQLITE_OK ){
         return;

--- a/test/doltlite_merge.sh
+++ b/test/doltlite_merge.sh
@@ -698,5 +698,168 @@ echo "ALTER TABLE t ADD COLUMN added TEXT DEFAULT 'dd'; UPDATE t SET v='edited' 
 echo "DELETE FROM t WHERE id=2; SELECT dolt_commit('-A','-m','delete row');" | $DOLTLITE "$DB46" > /dev/null 2>&1
 run_test_match "delete_vs_real_edit_with_add_column_conflicts" "SELECT dolt_merge('feature');" "conflict" "$DB46"
 
-rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8" "$DB8B" "$DB9" "$DB10" "$DB11" "$DB11D" "$DB11E" "$DB11F" "$DB12" "$DB13" "$DB14" "$DB15" "$DB16" "$DB17" "$DB18" "$DB19" "$DB20" "$DB20B" "$DB21" "$DB22" "$DB23" "$DB24" "$DB25" "$DB40" "$DB41" "$DB42" "$DB43" "$DB44" "$DB45" "$DB46"
+DB47=/tmp/test_merge47_$$.db; rm -f "$DB47"
+cat <<'EOF' | $DOLTLITE "$DB47" > /dev/null 2>&1
+CREATE TABLE t(i INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'b');
+SELECT dolt_commit('-Am','b');
+SELECT dolt_branch('f');
+SELECT dolt_checkout('f');
+INSERT INTO t VALUES(2,'f');
+SELECT dolt_commit('-Am','f');
+SELECT dolt_checkout('main');
+EOF
+run_test_match "ff_nocommit_still_ff" "SELECT dolt_merge('--no-commit','f');" "^[0-9a-f]{40}$" "$DB47"
+run_test "ff_nocommit_count" "SELECT count(*) FROM t;" "2" "$DB47"
+run_test "ff_nocommit_log" "SELECT message FROM dolt_log LIMIT 1;" "f" "$DB47"
+run_test "ff_nocommit_status" "SELECT count(*) FROM dolt_status;" "0" "$DB47"
+run_test "ff_nocommit_merging" "SELECT is_merging FROM dolt_merge_status;" "0" "$DB47"
+
+DB48=/tmp/test_merge48_$$.db; rm -f "$DB48"
+cat <<'EOF' | $DOLTLITE "$DB48" > /dev/null 2>&1
+CREATE TABLE t(i INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'b');
+SELECT dolt_commit('-Am','b');
+SELECT dolt_branch('f');
+SELECT dolt_checkout('f');
+INSERT INTO t VALUES(2,'f');
+SELECT dolt_commit('-Am','f');
+SELECT dolt_checkout('main');
+EOF
+run_test_match "ff_squash_hash" "SELECT dolt_merge('--squash','f');" "^[0-9a-f]{40}$" "$DB48"
+run_test "ff_squash_count" "SELECT count(*) FROM t;" "2" "$DB48"
+run_test "ff_squash_log" "SELECT message FROM dolt_log LIMIT 1;" "b" "$DB48"
+run_test "ff_squash_status" \
+  "SELECT table_name || '|' || staged || '|' || status FROM dolt_status;" \
+  "t|1|modified" "$DB48"
+run_test "ff_squash_merging" "SELECT is_merging FROM dolt_merge_status;" "0" "$DB48"
+run_test_match "ff_squash_abort_none" "SELECT dolt_merge('--abort');" "no merge in progress" "$DB48"
+
+DB49=/tmp/test_merge49_$$.db; rm -f "$DB49"
+cat <<'EOF' | $DOLTLITE "$DB49" > /dev/null 2>&1
+CREATE TABLE t(i INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'b');
+SELECT dolt_commit('-Am','b');
+SELECT dolt_branch('f');
+INSERT INTO t VALUES(3,'m');
+SELECT dolt_commit('-Am','m');
+SELECT dolt_checkout('f');
+INSERT INTO t VALUES(2,'f');
+SELECT dolt_commit('-Am','f');
+SELECT dolt_checkout('main');
+EOF
+run_test "threeway_nocommit_ret" "SELECT dolt_merge('--no-commit','f');" "0" "$DB49"
+run_test "threeway_nocommit_count" "SELECT count(*) FROM t;" "3" "$DB49"
+run_test "threeway_nocommit_log" "SELECT message FROM dolt_log LIMIT 1;" "m" "$DB49"
+run_test "threeway_nocommit_status" \
+  "SELECT table_name || '|' || staged || '|' || status FROM dolt_status;" \
+  "t|1|modified" "$DB49"
+run_test "threeway_nocommit_merging" "SELECT is_merging FROM dolt_merge_status;" "1" "$DB49"
+run_test_match "threeway_nocommit_blocks_second" \
+  "SELECT dolt_merge('f');" "uncommitted" "$DB49"
+run_test_match "threeway_nocommit_finish" \
+  "SELECT dolt_commit('-m','finished merge');" "^[0-9a-f]{40}$" "$DB49"
+run_test "threeway_nocommit_after_log" \
+  "SELECT message FROM dolt_log LIMIT 1;" "finished merge" "$DB49"
+run_test "threeway_nocommit_feat_ancestor" \
+  "SELECT count(*) FROM dolt_log WHERE message='f';" "1" "$DB49"
+run_test "threeway_nocommit_after_merging" \
+  "SELECT is_merging FROM dolt_merge_status;" "0" "$DB49"
+run_test "threeway_nocommit_after_status" "SELECT count(*) FROM dolt_status;" "0" "$DB49"
+
+DB50=/tmp/test_merge50_$$.db; rm -f "$DB50"
+cat <<'EOF' | $DOLTLITE "$DB50" > /dev/null 2>&1
+CREATE TABLE t(i INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'b');
+SELECT dolt_commit('-Am','b');
+SELECT dolt_branch('f');
+INSERT INTO t VALUES(3,'m');
+SELECT dolt_commit('-Am','m');
+SELECT dolt_checkout('f');
+INSERT INTO t VALUES(2,'f');
+SELECT dolt_commit('-Am','f');
+SELECT dolt_checkout('main');
+EOF
+run_test_match "threeway_squash_hash" \
+  "SELECT dolt_merge('--squash','f');" "^[0-9a-f]{40}$" "$DB50"
+run_test "threeway_squash_count" "SELECT count(*) FROM t;" "3" "$DB50"
+run_test "threeway_squash_log" \
+  "SELECT message FROM dolt_log LIMIT 1;" "Merge branch 'f' into main" "$DB50"
+run_test "threeway_squash_feat_absent" \
+  "SELECT count(*) FROM dolt_log WHERE message='f';" "0" "$DB50"
+run_test "threeway_squash_status" "SELECT count(*) FROM dolt_status;" "0" "$DB50"
+run_test "threeway_squash_merging" "SELECT is_merging FROM dolt_merge_status;" "0" "$DB50"
+
+DB51=/tmp/test_merge51_$$.db; rm -f "$DB51"
+cat <<'EOF' | $DOLTLITE "$DB51" > /dev/null 2>&1
+CREATE TABLE t(i INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'b');
+SELECT dolt_commit('-Am','b');
+SELECT dolt_branch('f');
+INSERT INTO t VALUES(3,'m');
+SELECT dolt_commit('-Am','m');
+SELECT dolt_checkout('f');
+INSERT INTO t VALUES(2,'f');
+SELECT dolt_commit('-Am','f');
+SELECT dolt_checkout('main');
+EOF
+run_test "threeway_squash_nocommit_ret" \
+  "SELECT dolt_merge('--squash','--no-commit','f');" "0" "$DB51"
+run_test "threeway_squash_nocommit_count" "SELECT count(*) FROM t;" "3" "$DB51"
+run_test "threeway_squash_nocommit_log" \
+  "SELECT message FROM dolt_log LIMIT 1;" "m" "$DB51"
+run_test "threeway_squash_nocommit_status" \
+  "SELECT table_name || '|' || staged || '|' || status FROM dolt_status;" \
+  "t|1|modified" "$DB51"
+run_test "threeway_squash_nocommit_merging" \
+  "SELECT is_merging FROM dolt_merge_status;" "0" "$DB51"
+run_test_match "threeway_squash_nocommit_commit" \
+  "SELECT dolt_commit('-m','squashed');" "^[0-9a-f]{40}$" "$DB51"
+run_test "threeway_squash_nocommit_after_log" \
+  "SELECT message FROM dolt_log LIMIT 1;" "squashed" "$DB51"
+run_test "threeway_squash_nocommit_feat_absent" \
+  "SELECT count(*) FROM dolt_log WHERE message='f';" "0" "$DB51"
+
+DB52=/tmp/test_merge52_$$.db; rm -f "$DB52"
+cat <<'EOF' | $DOLTLITE "$DB52" > /dev/null 2>&1
+CREATE TABLE t(i INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'b');
+SELECT dolt_commit('-Am','b');
+SELECT dolt_branch('f');
+SELECT dolt_checkout('f');
+INSERT INTO t VALUES(2,'f');
+SELECT dolt_commit('-Am','f');
+SELECT dolt_checkout('main');
+EOF
+run_test_match "squash_noff_rejected" \
+  "SELECT dolt_merge('--squash','--no-ff','f');" \
+  "cannot be used together" "$DB52"
+run_test "squash_noff_unchanged" "SELECT count(*) FROM t;" "1" "$DB52"
+
+DB53=/tmp/test_merge53_$$.db; rm -f "$DB53"
+cat <<'EOF' | $DOLTLITE "$DB53" > /dev/null 2>&1
+CREATE TABLE t(i INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'b');
+SELECT dolt_commit('-Am','b');
+SELECT dolt_branch('f');
+SELECT dolt_checkout('f');
+INSERT INTO t VALUES(2,'f');
+SELECT dolt_commit('-Am','f');
+SELECT dolt_checkout('main');
+EOF
+run_test "ff_nocommit_noff_ret" \
+  "SELECT dolt_merge('--no-commit','--no-ff','f');" "0" "$DB53"
+run_test "ff_nocommit_noff_count" "SELECT count(*) FROM t;" "2" "$DB53"
+run_test "ff_nocommit_noff_log" "SELECT message FROM dolt_log LIMIT 1;" "b" "$DB53"
+run_test "ff_nocommit_noff_status" \
+  "SELECT table_name || '|' || staged || '|' || status FROM dolt_status;" \
+  "t|1|modified" "$DB53"
+run_test "ff_nocommit_noff_merging" \
+  "SELECT is_merging FROM dolt_merge_status;" "1" "$DB53"
+run_test "ff_nocommit_noff_abort" "SELECT dolt_merge('--abort');" "0" "$DB53"
+run_test "ff_nocommit_noff_abort_count" "SELECT count(*) FROM t;" "1" "$DB53"
+run_test "ff_nocommit_noff_abort_merging" \
+  "SELECT is_merging FROM dolt_merge_status;" "0" "$DB53"
+
+rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8" "$DB8B" "$DB9" "$DB10" "$DB11" "$DB11D" "$DB11E" "$DB11F" "$DB12" "$DB13" "$DB14" "$DB15" "$DB16" "$DB17" "$DB18" "$DB19" "$DB20" "$DB20B" "$DB21" "$DB22" "$DB23" "$DB24" "$DB25" "$DB40" "$DB41" "$DB42" "$DB43" "$DB44" "$DB45" "$DB46" "$DB47" "$DB48" "$DB49" "$DB50" "$DB51" "$DB52" "$DB53"
 dltest_finish

--- a/test/vc_oracle_merge_test.sh
+++ b/test/vc_oracle_merge_test.sh
@@ -358,6 +358,88 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feature', '--no-ff');
 "
 
+echo "--- --no-commit / --squash ---"
+
+oracle_reopen_state "ff_squash_applies_without_commit" "
+$SEED
+SELECT dolt_checkout('feature');
+INSERT INTO t VALUES (2, 20);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feat1');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('--squash', 'feature');
+" "SELECT 'Q' || char(9) || count(*) FROM t;
+SELECT 'Q' || char(9) || message FROM dolt_log LIMIT 1;
+SELECT 'Q' || char(9) || count(*) FROM dolt_status;" \
+"SELECT concat('Q', char(9), count(*)) FROM t;
+SELECT concat('Q', char(9), message) FROM dolt_log ORDER BY commit_order DESC LIMIT 1;
+SELECT concat('Q', char(9), count(*)) FROM dolt_status;"
+
+oracle "ff_nocommit_still_fast_forwards" "
+$SEED
+SELECT dolt_checkout('feature');
+INSERT INTO t VALUES (2, 20);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feat1');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('--no-commit', 'feature');
+"
+
+oracle_reopen_state "three_way_nocommit_applies_without_commit" "
+$SEED
+INSERT INTO t VALUES (10, 100);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'main2');
+SELECT dolt_checkout('feature');
+INSERT INTO t VALUES (20, 200);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feat1');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('--no-commit', 'feature');
+" "SELECT 'Q' || char(9) || count(*) FROM t;
+SELECT 'Q' || char(9) || message FROM dolt_log LIMIT 1;
+SELECT 'Q' || char(9) || count(*) FROM dolt_status;" \
+"SELECT concat('Q', char(9), count(*)) FROM t;
+SELECT concat('Q', char(9), message) FROM dolt_log ORDER BY commit_order DESC LIMIT 1;
+SELECT concat('Q', char(9), count(*)) FROM dolt_status;"
+
+oracle "three_way_squash" "
+$SEED
+INSERT INTO t VALUES (10, 100);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'main2');
+SELECT dolt_checkout('feature');
+INSERT INTO t VALUES (20, 200);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feat1');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('--squash', 'feature');
+"
+
+oracle "three_way_squash_nocommit_then_commit" "
+$SEED
+INSERT INTO t VALUES (10, 100);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'main2');
+SELECT dolt_checkout('feature');
+INSERT INTO t VALUES (20, 200);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feat1');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('--squash', '--no-commit', 'feature');
+SELECT dolt_commit('-m', 'squashed');
+"
+
+oracle_error "squash_and_no_ff_rejected" "
+$SEED
+SELECT dolt_checkout('feature');
+INSERT INTO t VALUES (2, 20);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feat1');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('--squash', '--no-ff', 'feature');
+"
+
 echo "--- custom message ---"
 
 oracle "merge_with_custom_message" "


### PR DESCRIPTION
## Summary

`dolt_merge('--no-commit', …)` and `dolt_merge('--squash', …)` were unknown options. Dolt 2.2.2 accepts both.

- **`--squash`** on a fast-forward applies the incoming rows to working/staged, leaves HEAD unmoved, and does **not** set `dolt_merge_status.IS_MERGING`.
- **`--no-commit`** on a fast-forward still fast-forwards (same as Dolt: use `--no-ff --no-commit` to stop before a commit).
- **`--no-commit`** on a three-way (or `--no-ff`) stages the merge, sets `IS_MERGING`, and leaves `dolt_commit` to create the merge commit.
- **`--squash`** on a three-way writes a single-parent commit unless `--no-commit` is also set.
- **`--squash --no-ff`** is rejected, matching Dolt.

Fail-before: both flags error `unknown option` and leave `count(*)=1`. Pass-after: squash FF has `count(*)=2`, `t|1|modified`, log still at the pre-merge commit.

## Test plan

- [x] Repro from #2474 fail-before / pass-after
- [x] `DOLTLITE=build/doltlite bash test/doltlite_merge.sh` (197 passed)
- [x] `bash test/vc_oracle_merge_test.sh build/doltlite dolt` (97 passed)
- [x] `test/doltlite_merge_status.sh` and `vc_oracle_merge_status_test.sh`
- [x] `bash test/run_doltlite_tests.sh`
- [x] `make lint`

Fixes #2474

Co-Authored-By: Grok 4.6 <noreply@x.ai>