### PR TITLE
Implement dolt_clean

### DIFF
--- a/doltlite.mk
+++ b/doltlite.mk
@@ -57,7 +57,7 @@ PROLLY_OBJS = \
               prolly_mutate.o prolly_check.o prolly_diff.o prolly_three_way_diff.o prolly_three_way_merge.o \
               prolly_btree.o prolly_btree_catalog.o prolly_btree_cursor.o prolly_btree_cursor_seek.o prolly_btree_cursor_payload.o prolly_btree_cursor_count.o prolly_btree_mutation.o \
               prolly_btree_orig.o prolly_btree_state.o prolly_btree_txn.o pager_shim.o sortkey.o \
-              doltlite.o doltlite_core.o doltlite_cmd.o doltlite_add.o doltlite_commit_cmd.o doltlite_reset.o doltlite_merge_cmd.o doltlite_cherry_pick.o doltlite_revert.o doltlite_rebase.o doltlite_config.o doltlite_commit.o doltlite_ref.o doltlite_log.o doltlite_commit_ancestors.o doltlite_status.o doltlite_merge_status.o \
+              doltlite.o doltlite_core.o doltlite_cmd.o doltlite_add.o doltlite_clean.o doltlite_commit_cmd.o doltlite_reset.o doltlite_merge_cmd.o doltlite_cherry_pick.o doltlite_revert.o doltlite_rebase.o doltlite_config.o doltlite_commit.o doltlite_ref.o doltlite_log.o doltlite_commit_ancestors.o doltlite_status.o doltlite_merge_status.o \
               doltlite_diff.o doltlite_diff_table.o doltlite_workspace.o doltlite_branch.o doltlite_branches.o doltlite_checkout.o doltlite_tag.o doltlite_ancestor.o doltlite_merge.o doltlite_merge_pass1.o doltlite_merge_pass2.o doltlite_merge_predetect.o doltlite_merge_rebuild.o doltlite_merge_rows.o doltlite_merge_schema.o doltlite_conflicts.o \
               doltlite_gc.o doltlite_chunk_walk.o doltlite_history.o doltlite_at.o doltlite_blame.o doltlite_schema_diff.o doltlite_patch.o doltlite_schemas.o doltlite_diff_stat.o doltlite_record.o \
               doltlite_ignore.o doltlite_docs.o doltlite_tests.o doltlite_hashof.o \

--- a/main.mk
+++ b/main.mk
@@ -1482,6 +1482,9 @@ doltlite_cmd.o:	$(TOP)/src/doltlite_cmd.c $(DEPS_OBJ_COMMON)
 doltlite_add.o:	$(TOP)/src/doltlite_add.c $(DEPS_OBJ_COMMON)
 	$(T.cc.sqlite) -c $(TOP)/src/doltlite_add.c
 
+doltlite_clean.o:	$(TOP)/src/doltlite_clean.c $(DEPS_OBJ_COMMON)
+	$(T.cc.sqlite) -c $(TOP)/src/doltlite_clean.c
+
 doltlite_commit_cmd.o:	$(TOP)/src/doltlite_commit_cmd.c $(DEPS_OBJ_COMMON)
 	$(T.cc.sqlite) -c $(TOP)/src/doltlite_commit_cmd.c
 

--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -31,6 +31,7 @@ int doltliteRegister(sqlite3 *db){
   int rc;
   if( (rc = doltliteCommitCmdRegister(db))!=SQLITE_OK ) return rc;
   if( (rc = doltliteAddRegister(db))!=SQLITE_OK ) return rc;
+  if( (rc = doltliteCleanRegister(db))!=SQLITE_OK ) return rc;
   if( (rc = doltliteResetRegister(db))!=SQLITE_OK ) return rc;
   if( (rc = doltliteMergeCmdRegister(db))!=SQLITE_OK ) return rc;
   if( (rc = doltliteCherryPickRegister(db))!=SQLITE_OK ) return rc;

--- a/src/doltlite_clean.c
+++ b/src/doltlite_clean.c
@@ -1,0 +1,254 @@
+#ifdef DOLTLITE_PROLLY
+
+#include "sqliteInt.h"
+#include "chunk_store.h"
+#include "doltlite_internal.h"
+
+#include <string.h>
+
+typedef struct CleanNames CleanNames;
+struct CleanNames {
+  char **az;
+  int n;
+  int nAlloc;
+};
+
+static void cleanNamesClear(CleanNames *pNames){
+  int i;
+  for(i=0; i<pNames->n; i++) sqlite3_free(pNames->az[i]);
+  sqlite3_free(pNames->az);
+  memset(pNames, 0, sizeof(*pNames));
+}
+
+static int cleanNamesContains(const CleanNames *pNames, const char *zName){
+  int i;
+  for(i=0; i<pNames->n; i++){
+    if( sqlite3_stricmp(pNames->az[i], zName)==0 ) return 1;
+  }
+  return 0;
+}
+
+static int cleanNamesAppend(CleanNames *pNames, const char *zName){
+  char *zCopy;
+  int rc;
+  if( cleanNamesContains(pNames, zName) ) return SQLITE_OK;
+  rc = DOLTLITE_GROW_ARRAY(&pNames->az, &pNames->nAlloc, pNames->n+1, 8);
+  if( rc!=SQLITE_OK ) return rc;
+  zCopy = sqlite3_mprintf("%s", zName);
+  if( !zCopy ) return SQLITE_NOMEM;
+  pNames->az[pNames->n++] = zCopy;
+  return SQLITE_OK;
+}
+
+static int cleanIsSystemName(const char *zName){
+  return sqlite3_strnicmp(zName, "sqlite_", 7)==0
+      || sqlite3_strnicmp(zName, "dolt_", 5)==0;
+}
+
+static int cleanLoadStagedNames(
+  sqlite3 *db,
+  ChunkStore *cs,
+  CleanNames *pStaged
+){
+  ProllyHash stagedHash;
+  SchemaEntry *aSchema = 0;
+  int nSchema = 0;
+  int i;
+  int rc;
+
+  doltliteGetSessionStaged(db, &stagedHash);
+  if( prollyHashIsEmpty(&stagedHash) ){
+    rc = doltliteGetHeadCatalogHash(db, &stagedHash);
+    if( rc!=SQLITE_OK ) return rc;
+  }
+  if( prollyHashIsEmpty(&stagedHash) ) return SQLITE_OK;
+
+  rc = loadSchemaFromCatalog(db, cs, doltliteGetCache(db), &stagedHash,
+                             &aSchema, &nSchema);
+  for(i=0; rc==SQLITE_OK && i<nSchema; i++){
+    if( aSchema[i].zType && strcmp(aSchema[i].zType, "table")==0
+     && aSchema[i].zName && !cleanIsSystemName(aSchema[i].zName) ){
+      rc = cleanNamesAppend(pStaged, aSchema[i].zName);
+    }
+  }
+  freeSchemaEntries(aSchema, nSchema);
+  return rc;
+}
+
+static int cleanResolveLiveName(
+  sqlite3 *db,
+  const char *zName,
+  char **pzResolved
+){
+  sqlite3_stmt *pStmt = 0;
+  int rc;
+  *pzResolved = 0;
+  if( !zName || cleanIsSystemName(zName) ) return SQLITE_NOTFOUND;
+  rc = sqlite3_prepare_v2(db,
+      "SELECT name FROM pragma_table_list "
+      "WHERE schema='main' AND name=? COLLATE NOCASE "
+      "AND type IN ('table','virtual')",
+      -1, &pStmt, 0);
+  if( rc==SQLITE_OK ) rc = sqlite3_bind_text(pStmt, 1, zName, -1, SQLITE_STATIC);
+  if( rc==SQLITE_OK ){
+    rc = sqlite3_step(pStmt);
+    if( rc==SQLITE_ROW ){
+      const char *zFound = (const char*)sqlite3_column_text(pStmt, 0);
+      *pzResolved = zFound ? sqlite3_mprintf("%s", zFound) : 0;
+      rc = *pzResolved ? SQLITE_OK : SQLITE_NOMEM;
+    }else if( rc==SQLITE_DONE ){
+      rc = SQLITE_NOTFOUND;
+    }
+  }
+  {
+    int rc2 = sqlite3_finalize(pStmt);
+    if( rc==SQLITE_OK ) rc = rc2;
+  }
+  return rc;
+}
+
+static int cleanLoadAllLiveNames(sqlite3 *db, CleanNames *pNames){
+  sqlite3_stmt *pStmt = 0;
+  int rc = sqlite3_prepare_v2(db,
+      "SELECT name FROM pragma_table_list "
+      "WHERE schema='main' AND type IN ('table','virtual') "
+      "AND substr(name,1,7)!='sqlite_' AND substr(name,1,5)!='dolt_' "
+      "ORDER BY name",
+      -1, &pStmt, 0);
+  while( rc==SQLITE_OK && (rc = sqlite3_step(pStmt))==SQLITE_ROW ){
+    const char *zName = (const char*)sqlite3_column_text(pStmt, 0);
+    if( zName && !cleanIsSystemName(zName) ){
+      rc = cleanNamesAppend(pNames, zName);
+    }
+  }
+  if( rc==SQLITE_DONE ) rc = SQLITE_OK;
+  {
+    int rc2 = sqlite3_finalize(pStmt);
+    if( rc==SQLITE_OK ) rc = rc2;
+  }
+  return rc;
+}
+
+static int cleanDropTables(sqlite3 *db, const CleanNames *pNames){
+  int i;
+  int rc = SQLITE_OK;
+  int fkeys = 0;
+  int ignored = 0;
+  rc = sqlite3_db_config(db, SQLITE_DBCONFIG_ENABLE_FKEY, -1, &fkeys);
+  if( rc==SQLITE_OK && fkeys ){
+    rc = sqlite3_db_config(db, SQLITE_DBCONFIG_ENABLE_FKEY, 0, &ignored);
+  }
+  for(i=pNames->n-1; rc==SQLITE_OK && i>=0; i--){
+    char *zSql = sqlite3_mprintf("DROP TABLE \"%w\"", pNames->az[i]);
+    if( !zSql ){
+      rc = SQLITE_NOMEM;
+      break;
+    }
+    rc = sqlite3_exec(db, zSql, 0, 0, 0);
+    sqlite3_free(zSql);
+  }
+  if( fkeys ){
+    int rc2 = sqlite3_db_config(db, SQLITE_DBCONFIG_ENABLE_FKEY, 1, &ignored);
+    if( rc==SQLITE_OK ) rc = rc2;
+  }
+  return rc;
+}
+
+static void doltliteCleanFunc(
+  sqlite3_context *context,
+  int argc,
+  sqlite3_value **argv
+){
+  sqlite3 *db = sqlite3_context_db_handle(context);
+  ChunkStore *cs = doltliteGetChunkStore(db);
+  DoltliteCmdArgs args;
+  CleanNames staged;
+  CleanNames selected;
+  CleanNames untracked;
+  int dryRun = 0;
+  DoltliteCmdOption aOption[] = {
+    { "dry-run", 0, DOLTLITE_CMD_OPTION_FLAG, &dryRun, 0 }
+  };
+  int i;
+  int rc;
+
+  memset(&args, 0, sizeof(args));
+  memset(&staged, 0, sizeof(staged));
+  memset(&selected, 0, sizeof(selected));
+  memset(&untracked, 0, sizeof(untracked));
+
+  if( doltliteCmdRejectDetached(context) ) return;
+  if( !cs ){
+    sqlite3_result_error(context, doltliteVcUnavailableMessage(db), -1);
+    return;
+  }
+  for(i=0; i<argc; i++){
+    if( sqlite3_value_type(argv[i])==SQLITE_NULL ){
+      sqlite3_result_error(context,
+                           "failed to clean; table not found: ''", -1);
+      goto clean_done;
+    }
+  }
+  rc = doltliteCmdParseArgs(context, argc, argv, aOption, ArraySize(aOption),
+                            0, &args);
+  if( rc!=SQLITE_OK ) goto clean_done;
+
+  if( args.nPositional ){
+    for(i=0; i<args.nPositional; i++){
+      char *zResolved = 0;
+      rc = cleanResolveLiveName(db, args.azPositional[i], &zResolved);
+      if( rc==SQLITE_NOTFOUND ){
+        char *zErr = sqlite3_mprintf("failed to clean; table not found: '%s'",
+                                     args.azPositional[i]);
+        sqlite3_result_error(context, zErr ? zErr : "table not found", -1);
+        sqlite3_free(zErr);
+        goto clean_done;
+      }
+      if( rc!=SQLITE_OK ){
+        sqlite3_free(zResolved);
+        goto clean_error;
+      }
+      rc = cleanNamesAppend(&selected, zResolved);
+      sqlite3_free(zResolved);
+      if( rc!=SQLITE_OK ) goto clean_error;
+    }
+  }else{
+    rc = cleanLoadAllLiveNames(db, &selected);
+    if( rc!=SQLITE_OK ) goto clean_error;
+  }
+
+  rc = cleanLoadStagedNames(db, cs, &staged);
+  if( rc!=SQLITE_OK ) goto clean_error;
+  for(i=0; i<selected.n; i++){
+    if( !cleanNamesContains(&staged, selected.az[i]) ){
+      rc = cleanNamesAppend(&untracked, selected.az[i]);
+      if( rc!=SQLITE_OK ) goto clean_error;
+    }
+  }
+
+  if( !dryRun ){
+    rc = cleanDropTables(db, &untracked);
+    if( rc!=SQLITE_OK ) goto clean_error;
+    rc = doltlitePersistWorkingSet(db);
+    if( rc!=SQLITE_OK ) goto clean_error;
+  }
+  sqlite3_result_int(context, 0);
+  goto clean_done;
+
+clean_error:
+  sqlite3_result_error(context, sqlite3_errmsg(db), -1);
+  sqlite3_result_error_code(context, rc);
+clean_done:
+  cleanNamesClear(&untracked);
+  cleanNamesClear(&selected);
+  cleanNamesClear(&staged);
+  doltliteCmdArgsClear(&args);
+}
+
+int doltliteCleanRegister(sqlite3 *db){
+  return sqlite3_create_function(db, "dolt_clean", -1,
+                                 DOLTLITE_COMMAND_FUNC_FLAGS, 0,
+                                 doltliteCleanFunc, 0, 0);
+}
+
+#endif

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -1063,6 +1063,7 @@ int doltliteMergeRef(
 );
 
 int doltliteAddRegister(sqlite3 *db);
+int doltliteCleanRegister(sqlite3 *db);
 int doltliteCommitCmdRegister(sqlite3 *db);
 int doltliteResetRegister(sqlite3 *db);
 int doltliteMergeCmdRegister(sqlite3 *db);

--- a/test/doltlite_clean.sh
+++ b/test/doltlite_clean.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+. "$(dirname "$0")/lib/doltlite_test_common.sh"
+
+echo "=== Doltlite Clean Tests ==="
+
+DB=/tmp/test_clean_$$.db; rm -f "$DB"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'tracked'); SELECT dolt_commit('-Am','base'); CREATE TABLE u(id INTEGER PRIMARY KEY); CREATE TABLE v(id INTEGER PRIMARY KEY);" | $DOLTLITE "$DB" >/dev/null 2>&1
+
+run_test "clean_named" "SELECT dolt_clean('u');" "0" "$DB"
+run_test "clean_named_drops_target" "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='u';" "0" "$DB"
+run_test "clean_named_keeps_other_untracked" "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='v';" "1" "$DB"
+run_test "clean_named_keeps_tracked" "SELECT v FROM t;" "tracked" "$DB"
+run_test "clean_all" "SELECT dolt_clean();" "0" "$DB"
+run_test "clean_all_drops_untracked" "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='v';" "0" "$DB"
+
+echo "CREATE TABLE sqlitex(id INTEGER PRIMARY KEY); CREATE TABLE doltx(id INTEGER PRIMARY KEY);" | $DOLTLITE "$DB" >/dev/null 2>&1
+run_test "clean_prefix_names" "SELECT dolt_clean();" "0" "$DB"
+run_test "clean_prefix_names_dropped" "SELECT count(*) FROM sqlite_master WHERE type='table' AND name IN ('sqlitex','doltx');" "0" "$DB"
+
+echo "CREATE TABLE dry_run(id INTEGER PRIMARY KEY);" | $DOLTLITE "$DB" >/dev/null 2>&1
+run_test "clean_dry_run" "SELECT dolt_clean('--dry-run');" "0" "$DB"
+run_test "clean_dry_run_keeps_table" "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='dry_run';" "1" "$DB"
+run_test "clean_named_dry_run" "SELECT dolt_clean('dry_run','--dry-run');" "0" "$DB"
+run_test "clean_named_dry_run_keeps_table" "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='dry_run';" "1" "$DB"
+
+run_test_match "clean_unknown" "SELECT dolt_clean('missing');" "table not found" "$DB"
+run_test_match "clean_unknown_is_atomic" "SELECT dolt_clean('dry_run','missing');" "table not found" "$DB"
+run_test "clean_unknown_keeps_valid_target" "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='dry_run';" "1" "$DB"
+run_test_match "clean_null_rejected" "SELECT dolt_clean(NULL);" "table not found" "$DB"
+run_test "clean_null_keeps_untracked" "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='dry_run';" "1" "$DB"
+run_test_match "clean_unknown_option" "SELECT dolt_clean('--unknown');" "unknown option" "$DB"
+
+echo "CREATE TABLE staged_new(id INTEGER PRIMARY KEY); SELECT dolt_add('staged_new'); CREATE TABLE unstaged_new(id INTEGER PRIMARY KEY);" | $DOLTLITE "$DB" >/dev/null 2>&1
+run_test "clean_keeps_staged_new" "SELECT dolt_clean();" "0" "$DB"
+run_test "clean_staged_new_exists" "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='staged_new';" "1" "$DB"
+run_test "clean_unstaged_new_gone" "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='unstaged_new';" "0" "$DB"
+run_test "clean_staged_state_unchanged" "SELECT staged || ':' || status FROM dolt_status WHERE table_name='staged_new';" "1:new table" "$DB"
+
+echo "INSERT INTO t VALUES(2,'working');" | $DOLTLITE "$DB" >/dev/null 2>&1
+run_test "clean_named_tracked" "SELECT dolt_clean('T');" "0" "$DB"
+run_test "clean_named_tracked_keeps_changes" "SELECT group_concat(v, ',') FROM t ORDER BY id;" "tracked,working" "$DB"
+
+DB2=/tmp/test_clean_rename_$$.db; rm -f "$DB2"
+echo "CREATE TABLE old_name(id INTEGER PRIMARY KEY); INSERT INTO old_name VALUES(1); SELECT dolt_commit('-Am','base'); ALTER TABLE old_name RENAME TO new_name;" | $DOLTLITE "$DB2" >/dev/null 2>&1
+run_test "clean_unstaged_rename" "SELECT dolt_clean();" "0" "$DB2"
+run_test "clean_unstaged_rename_drops_new_name" "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='new_name';" "0" "$DB2"
+run_test "clean_unstaged_rename_reports_old_deleted" "SELECT table_name || ':' || status FROM dolt_status;" "old_name:deleted" "$DB2"
+
+DB3=/tmp/test_clean_vtab_$$.db; rm -f "$DB3"
+echo "CREATE VIRTUAL TABLE docs USING fts5(body); INSERT INTO docs VALUES('x');" | $DOLTLITE "$DB3" >/dev/null 2>&1
+run_test "clean_untracked_vtab" "SELECT dolt_clean();" "0" "$DB3"
+run_test "clean_untracked_vtab_shadows" "SELECT count(*) FROM sqlite_master WHERE name='docs' OR name GLOB 'docs_*';" "0" "$DB3"
+echo "CREATE VIRTUAL TABLE tracked_docs USING fts5(body); INSERT INTO tracked_docs VALUES('x'); SELECT dolt_add('tracked_docs');" | $DOLTLITE "$DB3" >/dev/null 2>&1
+run_test "clean_keeps_staged_vtab" "SELECT dolt_clean();" "0" "$DB3"
+run_test "clean_keeps_staged_vtab_shadows" "SELECT count(*) FROM sqlite_master WHERE name='tracked_docs' OR name GLOB 'tracked_docs_*';" "6" "$DB3"
+
+DB4=/tmp/test_clean_fresh_$$.db; rm -f "$DB4"
+echo "CREATE TABLE fresh(id INTEGER PRIMARY KEY);" | $DOLTLITE "$DB4" >/dev/null 2>&1
+run_test "clean_fresh_repo" "SELECT dolt_clean();" "0" "$DB4"
+run_test "clean_fresh_repo_drops_table" "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='fresh';" "0" "$DB4"
+
+DB5=/tmp/test_clean_fk_$$.db; rm -f "$DB5"
+echo "PRAGMA foreign_keys=ON; CREATE TABLE z_parent(id INTEGER PRIMARY KEY); CREATE TABLE a_child(id INTEGER PRIMARY KEY, parent_id INTEGER REFERENCES z_parent(id)); INSERT INTO z_parent VALUES(1); INSERT INTO a_child VALUES(1,1); SELECT dolt_clean();" | $DOLTLITE "$DB5" >/dev/null 2>&1
+run_test "clean_untracked_fk_pair" "SELECT count(*) FROM sqlite_master WHERE type='table' AND name IN ('a_child','z_parent');" "0" "$DB5"
+
+DB6=/tmp/test_clean_fk_blocked_$$.db; rm -f "$DB6"
+echo "PRAGMA foreign_keys=ON; CREATE TABLE parent(id INTEGER PRIMARY KEY); CREATE TABLE child(id INTEGER PRIMARY KEY, parent_id INTEGER REFERENCES parent(id)); SELECT dolt_commit('-Am','base'); ALTER TABLE parent RENAME TO renamed_parent;" | $DOLTLITE "$DB6" >/dev/null 2>&1
+run_test "clean_referenced_table_dry_run" "PRAGMA foreign_keys=ON; SELECT dolt_clean('--dry-run');" "0" "$DB6"
+run_test "clean_referenced_table_dry_run_keeps_parent" "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='renamed_parent';" "1" "$DB6"
+run_test "clean_referenced_table" "PRAGMA foreign_keys=ON; SELECT dolt_clean();" "0" "$DB6"
+run_test "clean_referenced_table_dropped" "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='renamed_parent';" "0" "$DB6"
+run_test "clean_referenced_table_reports_old_deleted" "SELECT table_name || ':' || status FROM dolt_status WHERE table_name='parent';" "parent:deleted" "$DB6"
+
+DB7=/tmp/test_clean_tracked_fk_$$.db; rm -f "$DB7"
+echo "CREATE TABLE parent(id INTEGER PRIMARY KEY); CREATE TABLE child(id INTEGER PRIMARY KEY, parent_id INTEGER REFERENCES parent(id)); SELECT dolt_commit('-Am','base');" | $DOLTLITE "$DB7" >/dev/null 2>&1
+run_test "clean_with_only_tracked_fk_tables" "SELECT dolt_clean();" "0" "$DB7"
+run_test "clean_with_only_tracked_fk_tables_keeps_both" "SELECT count(*) FROM sqlite_master WHERE type='table' AND name IN ('child','parent');" "2" "$DB7"
+
+rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7"
+dltest_finish

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -1480,11 +1480,11 @@ attach2 attach2-4.12 class=intentional issue=1846  # PRAGMA lock_status: doltlit
 # shifting every entry by +25. The dolt_tests and dolt_test_run module
 # registrations add four more. The dolt_ignore module registration adds
 # two more. Checkpoint discovery adds the remaining build-dependent shifts.
-attachmalloc attachmalloc-1.transient.505 class=unsupported issue=1839  # OOM fault-point shift (parent probe)
-attachmalloc attachmalloc-1.transient.933 @no-coverage class=unsupported issue=1839  # OOM fault-point shift (ATTACH seed)
-attachmalloc attachmalloc-1.transient.1429 @no-coverage class=unsupported issue=1839  # OOM fault-point shift (ATTACH seed)
-attachmalloc attachmalloc-1.transient.938 @coverage class=unsupported issue=1839  # OOM fault-point shift (ATTACH seed)
-attachmalloc attachmalloc-1.transient.1440 @coverage class=unsupported issue=1839  # OOM fault-point shift (ATTACH seed)
+attachmalloc attachmalloc-1.transient.507 class=unsupported issue=1839  # OOM fault-point shift (parent probe)
+attachmalloc attachmalloc-1.transient.932 @no-coverage class=unsupported issue=1839  # OOM fault-point shift (ATTACH seed)
+attachmalloc attachmalloc-1.transient.1426 @no-coverage class=unsupported issue=1839  # OOM fault-point shift (ATTACH seed)
+attachmalloc attachmalloc-1.transient.940 @coverage class=unsupported issue=1839  # OOM fault-point shift (ATTACH seed)
+attachmalloc attachmalloc-1.transient.1442 @coverage class=unsupported issue=1839  # OOM fault-point shift (ATTACH seed)
 
 # temptable2 section 8 — page_count is a chunk-store metric, not SQLite
 # pages; backup_init needs the page-image backup API, unsupported on prolly.

--- a/test/lib/doltlite_suite_manifest.sh
+++ b/test/lib/doltlite_suite_manifest.sh
@@ -11,6 +11,7 @@ doltlite_commit.sh
 doltlite_commit_date.sh
 doltlite_hashof_refs.sh
 doltlite_staging.sh
+doltlite_clean.sh
 doltlite_workspace.sh
 doltlite_docs.sh
 doltlite_tests.sh
@@ -160,6 +161,7 @@ doltlite_commit.sh
 doltlite_commit_date.sh
 doltlite_hashof_refs.sh
 doltlite_staging.sh
+doltlite_clean.sh
 doltlite_workspace.sh
 doltlite_docs.sh
 doltlite_tests.sh

--- a/test/oracle-buckets/refs-workspace.txt
+++ b/test/oracle-buckets/refs-workspace.txt
@@ -4,6 +4,7 @@ vc_oracle_ancestor_spec_test.sh
 vc_oracle_branch_test.sh
 vc_oracle_branches_test.sh
 vc_oracle_checkout_test.sh
+vc_oracle_clean_test.sh
 vc_oracle_commit_ancestors_test.sh
 vc_oracle_commit_test.sh
 vc_oracle_connection_branch_test.sh

--- a/test/vc_oracle_clean_test.sh
+++ b/test/vc_oracle_clean_test.sh
@@ -1,0 +1,146 @@
+#!/bin/bash
+
+set -u
+set -o pipefail
+
+DOLTLITE="${1:-./doltlite}"
+DOLT="${2:-dolt}"
+TMPROOT=$(mktemp -d)
+trap "rm -rf $TMPROOT" EXIT
+pass=0; fail=0
+FAILED_NAMES=""
+source "$(dirname "$0")/lib/vc_oracle_common.sh"
+
+normalize_status() {
+  tr -d '\r"' \
+    | awk -F'\t' 'NF >= 4 && $1 == "S" { print }' \
+    | sort -t$'\t' -k2,2 -k3,3 -k4,4
+}
+
+oracle() {
+  local name="$1" setup="$2"
+  local dir="$TMPROOT/$name"
+  mkdir -p "$dir/dl" "$dir/dt" "$dir/dt.rows"
+
+  local dl_status dl_rows
+  dl_status=$(printf "%s\n.headers off\n.mode list\n.separator '\t'\nSELECT 'S' || char(9) || table_name || char(9) || staged || char(9) || status FROM dolt_status;\n" "$setup" \
+    | "$DOLTLITE" "$dir/dl/db" 2>"$dir/dl.err" | normalize_status)
+  dl_rows=$(printf "%s\nSELECT count(*) FROM t;\n" "$setup" \
+    | "$DOLTLITE" "$dir/dl.rows" 2>>"$dir/dl.err" | tail -1)
+
+  local dolt_setup dt_status dt_rows
+  dolt_setup=$(vc_oracle_translate_for_dolt "$setup")
+  (
+    cd "$dir/dt" || exit 1
+    vc_oracle_init_repo
+    printf '%s\n' "$dolt_setup" | "$DOLT" sql -c >/dev/null 2>"$dir/dt.err"
+    "$DOLT" sql -r csv -q "SELECT concat('S', char(9), table_name, char(9), staged, char(9), status) FROM dolt_status;" 2>>"$dir/dt.err"
+  ) >"$dir/dt.status"
+  dt_status=$(tail -n +2 "$dir/dt.status" | normalize_status)
+  (
+    cd "$dir/dt.rows" || exit 1
+    vc_oracle_init_repo
+    printf '%s\n' "$dolt_setup" | "$DOLT" sql -c >/dev/null 2>"$dir/dt.rows.err"
+    "$DOLT" sql -r csv -q "SELECT count(*) FROM t;" 2>>"$dir/dt.rows.err"
+  ) >"$dir/dt.rows.out"
+  dt_rows=$(tail -n +2 "$dir/dt.rows.out" | tr -d '\r"')
+
+  vc_oracle_assert_match "$name" "$dl_status|$dl_rows" "$dt_status|$dt_rows"
+}
+
+oracle_error() {
+  local name="$1" setup="$2"
+  local dir="$TMPROOT/${name}_err"
+  mkdir -p "$dir/dl" "$dir/dt"
+  local dl_rc dt_rc dolt_setup
+  vc_oracle_run_doltlite_script "$dir/dl/db" "$dir/dl.out" "$dir/dl.err" "$setup"
+  dl_rc=$?
+  dolt_setup=$(vc_oracle_translate_for_dolt "$setup")
+  vc_oracle_run_dolt_script_for_error "$dir/dt" "$dir/dt.out" "$dir/dt.err" "$dolt_setup"
+  dt_rc=$?
+  if vc_oracle_is_clean_error "$dl_rc" && vc_oracle_is_clean_error "$dt_rc"; then
+    pass=$((pass+1))
+  else
+    fail=$((fail+1))
+    FAILED_NAMES="$FAILED_NAMES $name"
+    echo "  FAIL: $name (expected both to error; doltlite=$dl_rc dolt=$dt_rc)"
+  fi
+}
+
+SEED="
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1, 'base');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'base');
+"
+
+echo "=== Version Control Oracle Tests: dolt_clean ==="
+
+oracle "clean_named" "
+$SEED
+CREATE TABLE u(id INTEGER PRIMARY KEY);
+CREATE TABLE v(id INTEGER PRIMARY KEY);
+SELECT dolt_clean('u');
+"
+
+oracle "clean_all" "
+$SEED
+CREATE TABLE u(id INTEGER PRIMARY KEY);
+CREATE TABLE v(id INTEGER PRIMARY KEY);
+SELECT dolt_clean();
+"
+
+oracle "clean_dry_run" "
+$SEED
+CREATE TABLE u(id INTEGER PRIMARY KEY);
+SELECT dolt_clean('--dry-run');
+"
+
+oracle "clean_keeps_staged_new" "
+$SEED
+CREATE TABLE staged_new(id INTEGER PRIMARY KEY);
+SELECT dolt_add('staged_new');
+CREATE TABLE unstaged_new(id INTEGER PRIMARY KEY);
+SELECT dolt_clean();
+"
+
+oracle "clean_named_tracked_keeps_changes" "
+$SEED
+INSERT INTO t VALUES (2, 'working');
+SELECT dolt_clean('t');
+"
+
+oracle "clean_unstaged_rename" "
+$SEED
+ALTER TABLE t RENAME TO renamed_t;
+SELECT dolt_clean();
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+"
+
+oracle "clean_untracked_foreign_key_pair" "
+$SEED
+CREATE TABLE z_parent(id INTEGER PRIMARY KEY);
+CREATE TABLE a_child(id INTEGER PRIMARY KEY, parent_id INTEGER REFERENCES z_parent(id));
+INSERT INTO z_parent VALUES (1);
+INSERT INTO a_child VALUES (1, 1);
+SELECT dolt_clean();
+"
+
+oracle_error "clean_unknown" "
+$SEED
+CREATE TABLE u(id INTEGER PRIMARY KEY);
+SELECT dolt_clean('missing');
+"
+
+oracle_error "clean_null" "
+$SEED
+CREATE TABLE u(id INTEGER PRIMARY KEY);
+SELECT dolt_clean(NULL);
+"
+
+echo ""
+echo "=== Results: $pass passed, $fail failed ==="
+if [ "$fail" -gt 0 ]; then
+  echo "Failed:$FAILED_NAMES"
+  exit 1
+fi

--- a/tool/mksqlite3c.tcl
+++ b/tool/mksqlite3c.tcl
@@ -833,7 +833,7 @@ proc emit_doltlite_engine_block {} {
     prolly_btree_mutation.c prolly_btree_orig.c prolly_btree_state.c
     prolly_btree_txn.c pager_shim.c sortkey.c
     doltlite_creds.c doltlite_tls.c
-    doltlite.c doltlite_core.c doltlite_cmd.c doltlite_add.c doltlite_commit_cmd.c
+    doltlite.c doltlite_core.c doltlite_cmd.c doltlite_add.c doltlite_clean.c doltlite_commit_cmd.c
     doltlite_reset.c doltlite_merge_cmd.c doltlite_cherry_pick.c
     doltlite_revert.c doltlite_rebase.c doltlite_config.c
     doltlite_commit.c doltlite_ref.c doltlite_log.c


### PR DESCRIPTION
## Summary

- implement dolt_clean for named tables and all untracked tables
- preserve staged and tracked tables, including virtual tables
- support --dry-run, atomic argument validation, case-insensitive names, renames, and foreign-key table groups
- register the command in regular and amalgamation builds

## Validation

- DOLTLITE=build/doltlite bash test/doltlite_clean.sh (41 passed)
- bash test/vc_oracle_clean_test.sh build/doltlite dolt (9 passed)
- bash test/run_doltlite_tests.sh (122 suites passed; 311,164 regression assertions)
- make lint
- make doltlite-lib
- make sqlite3.c && make sqlite3.o

Fixes #2477

Co-Authored-By: Grok 4.6 <noreply@x.ai>