### PR TITLE
dolt_diff_<t> resolves revision specs in from_commit/to_commit filters

### DIFF
--- a/src/doltlite_diff_table.c
+++ b/src/doltlite_diff_table.c
@@ -104,9 +104,11 @@ struct DiffTblCursor {
   i64 iRowid;
 };
 
-#define DT_IDX_TO_COMMIT_EQ  0x01
-#define DT_IDX_SLICE         0x02
-#define DT_IDX_RANGE_SPEC    0x04
+#define DT_IDX_TO_COMMIT_EQ   0x01
+#define DT_IDX_SLICE          0x02
+#define DT_IDX_RANGE_SPEC     0x04
+#define DT_IDX_FROM_TO_COMMIT 0x08
+#define DT_IDX_FROM_COMMIT_EQ 0x10
 
 static void clearAuditRow(AuditRow *r){
   sqlite3_free(r->pKeyRec);
@@ -975,10 +977,12 @@ static int dtBestIndex(sqlite3_vtab *pVtab, sqlite3_index_info *pInfo){
   DiffTblVtab *p = (DiffTblVtab*)pVtab;
   int i;
   int iToCommitEq = -1;
+  int iFromCommitEq = -1;
   int iFromRefEq = -1;
   int iToRefEq = -1;
   int nUser = p->cols.nCol;
   int toCommitCol = nUser;
+  int fromCommitCol = 2*nUser + 2;
   int fromRefCol  = 2*nUser + 5;
   int toRefCol    = 2*nUser + 6;
 
@@ -987,6 +991,8 @@ static int dtBestIndex(sqlite3_vtab *pVtab, sqlite3_index_info *pInfo){
     if( pInfo->aConstraint[i].op!=SQLITE_INDEX_CONSTRAINT_EQ ) continue;
     if( pInfo->aConstraint[i].iColumn==toCommitCol ){
       iToCommitEq = i;
+    }else if( pInfo->aConstraint[i].iColumn==fromCommitCol ){
+      iFromCommitEq = i;
     }else if( pInfo->aConstraint[i].iColumn==fromRefCol ){
       iFromRefEq = i;
     }else if( pInfo->aConstraint[i].iColumn==toRefCol ){
@@ -1006,10 +1012,26 @@ static int dtBestIndex(sqlite3_vtab *pVtab, sqlite3_index_info *pInfo){
     pInfo->aConstraintUsage[iFromRefEq].argvIndex = 1;
     pInfo->aConstraintUsage[iFromRefEq].omit = 1;
     pInfo->estimatedCost = 10.0;
+  }else if( iFromCommitEq>=0 && iToCommitEq>=0 ){
+    /* Both ends named: the arbitrary-pair diff, same as the function
+    ** form. Constraints are consumed after ref resolution, so revision
+    ** specs never face a text recheck against the rendered hash. */
+    pInfo->idxNum = DT_IDX_FROM_TO_COMMIT;
+    pInfo->aConstraintUsage[iFromCommitEq].argvIndex = 1;
+    pInfo->aConstraintUsage[iFromCommitEq].omit = 1;
+    pInfo->aConstraintUsage[iToCommitEq].argvIndex = 2;
+    pInfo->aConstraintUsage[iToCommitEq].omit = 1;
+    pInfo->estimatedCost = 10.0;
   }else if( iToCommitEq>=0 ){
     pInfo->idxNum = DT_IDX_TO_COMMIT_EQ;
     pInfo->aConstraintUsage[iToCommitEq].argvIndex = 1;
+    pInfo->aConstraintUsage[iToCommitEq].omit = 1;
     pInfo->estimatedCost = 100.0;
+  }else if( iFromCommitEq>=0 ){
+    pInfo->idxNum = DT_IDX_FROM_COMMIT_EQ;
+    pInfo->aConstraintUsage[iFromCommitEq].argvIndex = 1;
+    pInfo->aConstraintUsage[iFromCommitEq].omit = 1;
+    pInfo->estimatedCost = 500.0;
   }else{
     pInfo->idxNum = 0;
     pInfo->estimatedCost = 10000.0;
@@ -1079,12 +1101,46 @@ static int dtFilter(sqlite3_vtab_cursor *cur,
           "dolt_diff_%s: invalid revision range '%s'",
           pVtab->zTableName, zSpec ? zSpec : "");
     }
+  }else if( (idxNum & DT_IDX_FROM_TO_COMMIT)!=0 && argc>=2 ){
+    const char *zFrom = (const char*)sqlite3_value_text(argv[0]);
+    const char *zTo = (const char*)sqlite3_value_text(argv[1]);
+    rc = buildSliceDiffPair(c, db, pVtab->zTableName, zFrom, zTo);
   }else if( (idxNum & DT_IDX_TO_COMMIT_EQ)!=0 && argc>=1 ){
     const char *zToCommit = (const char*)sqlite3_value_text(argv[0]);
     if( zToCommit && sqlite3_stricmp(zToCommit, "WORKING")==0 ){
       rc = buildWorkingDiffPair(c, db, pVtab->zTableName);
+    }else if( zToCommit && sqlite3_stricmp(zToCommit, "STAGED")==0 ){
+      rc = buildSliceDiffPair(c, db, pVtab->zTableName, "HEAD", "STAGED");
     }else{
       rc = buildCommitDiffPair(c, db, pVtab->zTableName, zToCommit);
+    }
+  }else if( (idxNum & DT_IDX_FROM_COMMIT_EQ)!=0 && argc>=1 ){
+    /* Resolve the ref once, then keep only history pairs departing it. */
+    const char *zFrom = (const char*)sqlite3_value_text(argv[0]);
+    char zLabel[PROLLY_HASH_SIZE*2+1];
+    rc = SQLITE_OK;
+    zLabel[0] = 0;
+    if( zFrom && (sqlite3_stricmp(zFrom, "WORKING")==0
+               || sqlite3_stricmp(zFrom, "STAGED")==0) ){
+      sqlite3_snprintf(sizeof(zLabel), zLabel, "%s", zFrom);
+    }else if( zFrom ){
+      ProllyHash fromHash;
+      if( doltliteResolveRef(db, zFrom, &fromHash)==SQLITE_OK ){
+        doltliteHashToHex(&fromHash, zLabel);
+      }
+    }
+    if( zLabel[0] ){
+      rc = buildDiffPairs(c, db, pVtab->zTableName);
+      if( rc==SQLITE_OK ){
+        int iKeep = 0;
+        int iScan;
+        for(iScan=0; iScan<c->nPairs; iScan++){
+          if( sqlite3_stricmp(c->aPairs[iScan].zFromCommit, zLabel)==0 ){
+            c->aPairs[iKeep++] = c->aPairs[iScan];
+          }
+        }
+        c->nPairs = iKeep;
+      }
     }
   }else{
 

--- a/test/doltlite_diff_table.sh
+++ b/test/doltlite_diff_table.sh
@@ -348,4 +348,57 @@ run_test "gencol_nonleading_pk_diff" \
 
 rm -f "$DBG1" "$DBG2" "$DBG3"
 
+# Revision specs in from_commit/to_commit constraints resolve like the
+# function form; both-ends-named is the arbitrary-pair diff.
+DBRS=/tmp/test_dt_revspec_$$.db; rm -f "$DBRS"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'a'),(2,'b');
+SELECT dolt_commit('-A','-m','c1');
+UPDATE t SET v='A' WHERE id=1;
+SELECT dolt_commit('-A','-m','c2');
+UPDATE t SET v='B' WHERE id=2;
+SELECT dolt_commit('-A','-m','c3');" | $DOLTLITE "$DBRS" > /dev/null 2>&1
+
+run_test "revspec_from_to_adjacent" \
+  "SELECT count(*) FROM dolt_diff_t WHERE from_commit='HEAD~1' AND to_commit='HEAD';" \
+  "1" "$DBRS"
+run_test "revspec_from_to_nonadjacent_slice" \
+  "SELECT count(*) FROM dolt_diff_t WHERE from_commit='HEAD~2' AND to_commit='HEAD';" \
+  "2" "$DBRS"
+run_test "revspec_to_only" \
+  "SELECT count(*) FROM dolt_diff_t WHERE to_commit='HEAD';" \
+  "1" "$DBRS"
+run_test "revspec_from_only" \
+  "SELECT count(*) FROM dolt_diff_t WHERE from_commit='HEAD~1';" \
+  "1" "$DBRS"
+run_test "revspec_from_only_row" \
+  "SELECT diff_type || ':' || to_v FROM dolt_diff_t WHERE from_commit='HEAD~1';" \
+  "modified:B" "$DBRS"
+run_test "revspec_hash_pair_still_works" \
+  "SELECT count(*) FROM dolt_diff_t WHERE from_commit=(SELECT commit_hash FROM dolt_log WHERE message='c2') AND to_commit=(SELECT commit_hash FROM dolt_log WHERE message='c3');" \
+  "1" "$DBRS"
+run_test "revspec_garbage_from_matches_nothing" \
+  "SELECT count(*) FROM dolt_diff_t WHERE from_commit='nosuchref' AND to_commit='HEAD';" \
+  "0" "$DBRS"
+run_test "revspec_garbage_to_matches_nothing" \
+  "SELECT count(*) FROM dolt_diff_t WHERE to_commit='garbage';" \
+  "0" "$DBRS"
+run_test "revspec_to_working" \
+  "INSERT INTO t VALUES(3,'dirty');
+   SELECT count(*) FROM dolt_diff_t WHERE to_commit='WORKING';" \
+  "1" "$DBRS"
+run_test "revspec_from_head_to_working" \
+  "SELECT count(*) FROM dolt_diff_t WHERE from_commit='HEAD' AND to_commit='WORKING';" \
+  "1" "$DBRS"
+run_test "revspec_to_staged" \
+  "SELECT dolt_add('t');
+   SELECT count(*) FROM dolt_diff_t WHERE to_commit='STAGED';" \
+  "0
+1" "$DBRS"
+run_test "revspec_unconstrained_unchanged" \
+  "SELECT count(*) FROM dolt_diff_t;" \
+  "5" "$DBRS"
+
+rm -f "$DBRS"
+
 dltest_finish


### PR DESCRIPTION
Found in the pre-beta review: `SELECT ... FROM dolt_diff_t WHERE from_commit='HEAD~1' AND to_commit='HEAD'` silently returned **zero rows** — the constraint text was re-checked against the rendered hex hash after pushdown (`to_commit`), or never pushed at all (`from_commit`). Anyone constraining a diff with a ref name got nothing, and fell through to the O(commits × table) unconstrained walk.

## Semantics (deliberate consolidation, noted in-code)

- `from_commit` + `to_commit` both constrained → the arbitrary-pair diff, identical to the documented `dolt_diff_<t>(from, to)` function form. Dolt splits this surface into `dolt_commit_diff_<t>`; doltlite documents `dolt_diff_<t>(from,to)` as its replacement, so the WHERE form now matches it (Dolt 2.3.1 oracled: its `dolt_commit_diff_<t>` resolves specs and non-adjacent pairs the same way).
- `to_commit` alone → the parent→commit pair; `WORKING` and `STAGED` handled (`STAGED` previously returned nothing).
- `from_commit` alone → history pairs departing the resolved commit.
- Unresolvable refs still match nothing; raw-hash constraints behave exactly as before (consumed constraints are now omitted from the recheck).

## Testing

- 12 new cases in `test/doltlite_diff_table.sh` (spec pairs, non-adjacent slice, from-only, to-only, WORKING/STAGED, garbage refs, hash-pair and unconstrained behavior preserved): the 7 spec-dependent ones fail on the unfixed engine, 71/71 with the fix.
- `vc_oracle_diff_test.sh` vs Dolt 2.3.1: 68/68.
- Full regression C battery 311,164/311,164; shell battery 122/122; amalgamation compiled clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)