### PR TITLE
Preserve rowid suffix in merged index entries

### DIFF
--- a/src/doltlite_merge_rows.c
+++ b/src/doltlite_merge_rows.c
@@ -326,7 +326,6 @@ static int doltliteBuildIndexEntryWithExpr(
   int nIdxRec = 0;
   int nOut = 0;
   int nAlloc;
-  int iPKeyUsed = 0;
   int hasRowid;
   int storePayload = 0;
   int i, rc;
@@ -356,13 +355,11 @@ static int doltliteBuildIndexEntryWithExpr(
     }else if( col==XN_ROWID || col==iPKey ){
       aMem[nOut].eType = SQLITE_INTEGER;
       aMem[nOut].i = intKey;
-      iPKeyUsed = 1;
       nOut++;
     }else if( col>=0 && col<info.nField ){
       if( iPKey>=0 && col==iPKey ){
         aMem[nOut].eType = SQLITE_INTEGER;
         aMem[nOut].i = intKey;
-        iPKeyUsed = 1;
       }else{
         rc = serialValueFromRecordField(pRec, nRec, &info, col, &aMem[nOut]);
         if( rc!=SQLITE_OK ) goto expr_fail;
@@ -370,7 +367,8 @@ static int doltliteBuildIndexEntryWithExpr(
       nOut++;
     }
   }
-  if( hasRowid && !iPKeyUsed ){
+  /* SQLite appends rowid even when an IPK is already an index term. */
+  if( hasRowid ){
     aMem[nOut].eType = SQLITE_INTEGER;
     aMem[nOut].i = intKey;
     nOut++;
@@ -477,15 +475,11 @@ static int doltliteBuildIndexEntry(
     int nTotal;
     u8 *p;
 
-    int nOutField = info.nField;
-    int *aFieldOrder = sqlite3_malloc(nOutField * sizeof(int));
-    u8 *aUsed = sqlite3_malloc(info.nField);
-    if( !aFieldOrder || !aUsed ){
-      sqlite3_free(aFieldOrder);
-      sqlite3_free(aUsed);
+    int nOutField;
+    int *aFieldOrder = sqlite3_malloc((nIdxCol + 1) * sizeof(int));
+    if( !aFieldOrder ){
       return SQLITE_NOMEM;
     }
-    memset(aUsed, 0, info.nField);
 
     {
       int out = 0;
@@ -493,13 +487,10 @@ static int doltliteBuildIndexEntry(
         int col = aiColumn[i];
         if( col>=0 && col<info.nField ){
           aFieldOrder[out++] = col;
-          aUsed[col] = 1;
         }
       }
-      /* IPK is the secondary-index tie-breaker. */
-      if( iPKey>=0 && iPKey<info.nField && !aUsed[iPKey] ){
+      if( iPKey>=0 && iPKey<info.nField ){
         aFieldOrder[out++] = iPKey;
-        aUsed[iPKey] = 1;
       }
       nOutField = out;
     }
@@ -522,7 +513,6 @@ static int doltliteBuildIndexEntry(
     pIdxRec = sqlite3_malloc(nTotal);
     if( !pIdxRec ){
       sqlite3_free(aFieldOrder);
-      sqlite3_free(aUsed);
       return SQLITE_NOMEM;
     }
 
@@ -560,7 +550,6 @@ static int doltliteBuildIndexEntry(
     }
     nIdxRec = (int)(p - pIdxRec);
     sqlite3_free(aFieldOrder);
-    sqlite3_free(aUsed);
   }
 
   storePayload = indexKeyInfoNeedsPayload(pKeyInfo, pIdxRec, nIdxRec);

--- a/test/doltlite_merge_index_conflict.sh
+++ b/test/doltlite_merge_index_conflict.sh
@@ -101,6 +101,38 @@ check "clean_merge_iv_complete" "1|1
 2|20
 3|30" "$out"
 
+DB="$TMPROOT/explicit_ipk_index.db"
+"$DOLTLITE" "$DB" <<'EOF' >/dev/null 2>&1
+CREATE TABLE t(id INTEGER PRIMARY KEY, score INT NOT NULL);
+CREATE INDEX score_id ON t(score,id);
+CREATE INDEX id_score ON t(id,score);
+CREATE UNIQUE INDEX unique_score_id ON t(score,id);
+CREATE INDEX expression_id ON t((score+1),id);
+INSERT INTO t VALUES(1,1),(2,2),(3,3);
+SELECT dolt_commit('-Am','base');
+SELECT dolt_checkout('-b','feature');
+UPDATE t SET score=101 WHERE id=1;
+DELETE FROM t WHERE id=3;
+INSERT INTO t VALUES(4,104);
+SELECT dolt_commit('-Am','feature');
+SELECT dolt_checkout('main');
+UPDATE t SET score=202 WHERE id=2;
+SELECT dolt_commit('-Am','main');
+SELECT dolt_merge('feature');
+EOF
+out=$("$DOLTLITE" "$DB" "SELECT group_concat(id || ':' || score, ',') FROM (SELECT * FROM t NOT INDEXED ORDER BY id);")
+check "explicit_ipk_table_rows" "1:101,2:202,4:104" "$out"
+out=$("$DOLTLITE" "$DB" "SELECT group_concat(id || ':' || score, ',') FROM (SELECT * FROM t INDEXED BY score_id WHERE score>0 ORDER BY score,id);")
+check "explicit_ipk_score_index_rows" "1:101,4:104,2:202" "$out"
+out=$("$DOLTLITE" "$DB" "SELECT group_concat(id || ':' || score, ',') FROM (SELECT * FROM t INDEXED BY id_score WHERE id>0 ORDER BY id,score);")
+check "explicit_ipk_leading_index_rows" "1:101,2:202,4:104" "$out"
+out=$("$DOLTLITE" "$DB" "SELECT group_concat(id || ':' || score, ',') FROM (SELECT * FROM t INDEXED BY unique_score_id WHERE score>0 ORDER BY score,id);")
+check "explicit_ipk_unique_index_rows" "1:101,4:104,2:202" "$out"
+out=$("$DOLTLITE" "$DB" "SELECT group_concat(id || ':' || score, ',') FROM (SELECT * FROM t INDEXED BY expression_id WHERE score+1>0 ORDER BY score+1,id);")
+check "explicit_ipk_expression_index_rows" "1:101,4:104,2:202" "$out"
+out=$("$DOLTLITE" "$DB" "PRAGMA integrity_check;")
+check "explicit_ipk_index_integrity" "ok" "$out"
+
 DB="$TMPROOT/twoidx.db"
 "$DOLTLITE" "$DB" <<'EOF' >/dev/null 2>&1
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT, w INT);


### PR DESCRIPTION
## Summary

- preserve SQLite’s appended rowid in merge-built secondary-index records even when the INTEGER PRIMARY KEY is already an explicit index term
- remove the deduplication that caused merge deletes to miss old keys and inserts to create truncated keys
- cover incoming updates, deletes, and inserts across ordinary, unique, reversed-column, and expression indexes

Fixes #2489.

## Validation

- fail-before: forced `score,id` index scan returned the stale and updated row, and `PRAGMA integrity_check` reported `row 1 missing from index idx_score`
- `bash test/doltlite_merge_index_conflict.sh build/doltlite` — 40 passed
- `bash test/run_doltlite_tests.sh` — 122 suites passed
- `bash test/vc_oracle_merge_test.sh build/doltlite dolt` — 97 passed
- `make lint`
- `git diff --check`

Co-Authored-By: OpenAI Codex <noreply@openai.com>