### PR TITLE
Support dolt_cherry_pick --abort

### DIFF
--- a/src/doltlite_cherry_pick.c
+++ b/src/doltlite_cherry_pick.c
@@ -366,6 +366,11 @@ static void doltliteCherryPickFunc(
   const char *zRef;
   ProllyHash pickHash, ourHead;
   DoltliteCommit pickCommit, parentCommit, ourCommit;
+  DoltliteCmdArgs args;
+  int isAbort = 0;
+  DoltliteCmdOption aOption[] = {
+    { "abort", 0, DOLTLITE_CMD_OPTION_FLAG, &isAbort, 0 }
+  };
   int nConflicts = 0;
   int dirty = 0;
   int rc;
@@ -382,17 +387,41 @@ static void doltliteCherryPickFunc(
     sqlite3_result_error(context, "usage: dolt_cherry_pick('commit_hash')", -1);
     return;
   }
-  if( argc>1 ){
+
+  rc = doltliteCmdParseArgs(context, argc, argv, aOption, ArraySize(aOption),
+                            0, &args);
+  if( rc!=SQLITE_OK ) return;
+  if( args.nPositional>1 ){
+    doltliteCmdArgsClear(&args);
     sqlite3_result_error(context,
       "cherry-picking multiple commits is not supported yet.", -1);
     return;
   }
+  if( isAbort ){
+    u8 isMerging = 0;
+    doltliteGetSessionMergeState(db, &isMerging, 0, 0);
+    if( !isMerging && !doltliteSessionHasPendingReplayCommit(db) ){
+      doltliteCmdArgsClear(&args);
+      sqlite3_result_error(context, "no cherry-pick in progress", -1);
+      return;
+    }
+    rc = mergeAbortInPlace(db);
+    doltliteCmdArgsClear(&args);
+    if( rc!=SQLITE_OK ){
+      sqlite3_result_error_code(context, rc);
+      return;
+    }
+    sqlite3_result_int(context, 0);
+    return;
+  }
 
-  zRef = (const char*)sqlite3_value_text(argv[0]);
+  zRef = args.nPositional==1 ? args.azPositional[0] : 0;
   if( !zRef ){
+    doltliteCmdArgsClear(&args);
     sqlite3_result_error(context, "commit hash required", -1);
     return;
   }
+  doltliteCmdArgsClear(&args);
 
   rc = doltliteHasUncommittedChanges(db, &dirty);
   if( rc!=SQLITE_OK ){

--- a/src/doltlite_cherry_pick.c
+++ b/src/doltlite_cherry_pick.c
@@ -398,9 +398,7 @@ static void doltliteCherryPickFunc(
     return;
   }
   if( isAbort ){
-    u8 isMerging = 0;
-    doltliteGetSessionMergeState(db, &isMerging, 0, 0);
-    if( !isMerging && !doltliteSessionHasPendingReplayCommit(db) ){
+    if( !doltliteSessionHasPendingReplayCommit(db) ){
       doltliteCmdArgsClear(&args);
       sqlite3_result_error(context, "no cherry-pick in progress", -1);
       return;

--- a/src/doltlite_merge_cmd.c
+++ b/src/doltlite_merge_cmd.c
@@ -26,6 +26,7 @@ int mergeAbortInPlace(sqlite3 *db){
   if( rc!=SQLITE_OK ) return rc;
   rc = doltliteSetSessionStaged(db, &headCatHash);
   if( rc==SQLITE_OK ) rc = doltliteClearSessionMergeState(db);
+  if( rc==SQLITE_OK ) rc = doltliteSetSessionPendingReplayCommit(db, 0);
   if( rc==SQLITE_OK ){
     extern int doltliteClearAllConstraintViolations(sqlite3*);
     if( doltliteSessionHasConstraintViolations(db) ){

--- a/test/doltlite_cherry_pick.sh
+++ b/test/doltlite_cherry_pick.sh
@@ -743,6 +743,40 @@ M" \
   "$DB"
 rm -f "$DB"
 
+DB=/tmp/test_cp_abort_merge_$$.db; rm -f "$DB"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'a');
+SELECT dolt_commit('-A','-m','init');
+SELECT dolt_checkout('-b','feat');
+UPDATE t SET v='F';
+SELECT dolt_commit('-A','-m','f');
+SELECT dolt_checkout('main');
+UPDATE t SET v='M';
+SELECT dolt_commit('-A','-m','m');" | $DOLTLITE "$DB" > /dev/null 2>&1
+run_test "cp_abort_preserves_merge" \
+  "BEGIN;
+   SELECT dolt_merge('feat');
+   SELECT dolt_cherry_pick('--abort');
+   SELECT count(*) FROM dolt_conflicts;
+   SELECT is_merging FROM dolt_merge_status;
+   SELECT v FROM t;
+   SELECT dolt_merge('--abort');
+   SELECT count(*) FROM dolt_conflicts;
+   SELECT is_merging FROM dolt_merge_status;
+   SELECT v FROM t;
+   COMMIT;" \
+  "Error near line 2: Merge has 1 conflict(s). Resolve and then commit with dolt_commit.
+Error near line 3: no cherry-pick in progress
+1
+1
+M
+0
+0
+0
+M" \
+  "$DB"
+rm -f "$DB"
+
 # --ours can leave the tree identical to HEAD; still create a single-parent commit.
 DB=/tmp/test_cp_conflict_ours_commit_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);

--- a/test/doltlite_cherry_pick.sh
+++ b/test/doltlite_cherry_pick.sh
@@ -700,6 +700,49 @@ Error near line 6: no merge in progress" \
   "$DB"
 rm -f "$DB"
 
+DB=/tmp/test_cp_abort_$$.db; rm -f "$DB"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'a');
+SELECT dolt_commit('-A','-m','init');
+SELECT dolt_checkout('-b','feat');
+UPDATE t SET v='F';
+SELECT dolt_commit('-A','-m','f');
+SELECT dolt_checkout('main');
+UPDATE t SET v='M';
+SELECT dolt_commit('-A','-m','m');" | $DOLTLITE "$DB" > /dev/null 2>&1
+run_test "cp_abort_conflict" \
+  "BEGIN;
+   SELECT dolt_cherry_pick('feat');
+   SELECT dolt_cherry_pick('--abort');
+   SELECT count(*) FROM dolt_conflicts;
+   SELECT count(*) FROM dolt_status;
+   SELECT v FROM t;
+   COMMIT;" \
+  "Error near line 2: Cherry-pick has 1 conflict(s). Resolve and then commit with dolt_commit.
+0
+0
+0
+M" \
+  "$DB"
+run_test_match "cp_abort_without_active" \
+  "SELECT dolt_cherry_pick('--abort');" \
+  "no cherry-pick in progress" "$DB"
+run_test "cp_abort_after_resolve" \
+  "BEGIN;
+   SELECT dolt_cherry_pick('feat');
+   SELECT dolt_conflicts_resolve('--ours','t');
+   SELECT dolt_cherry_pick('--abort');
+   SELECT count(*) FROM dolt_conflicts;
+   SELECT v FROM t;
+   COMMIT;" \
+  "Error near line 2: Cherry-pick has 1 conflict(s). Resolve and then commit with dolt_commit.
+0
+0
+0
+M" \
+  "$DB"
+rm -f "$DB"
+
 # --ours can leave the tree identical to HEAD; still create a single-parent commit.
 DB=/tmp/test_cp_conflict_ours_commit_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);

--- a/test/oracle-buckets/merge-replay-schema.txt
+++ b/test/oracle-buckets/merge-replay-schema.txt
@@ -1,3 +1,4 @@
+vc_oracle_cherry_pick_abort_test.sh
 vc_oracle_conflicts_resolve_test.sh
 vc_oracle_conflicts_table_test.sh
 vc_oracle_conflicts_test.sh

--- a/test/vc_oracle_cherry_pick_abort_test.sh
+++ b/test/vc_oracle_cherry_pick_abort_test.sh
@@ -1,0 +1,178 @@
+#!/bin/bash
+
+set -u
+set -o pipefail
+
+DOLTLITE="${1:-./doltlite}"
+DOLT="${2:-dolt}"
+TMPROOT=$(mktemp -d)
+trap "rm -rf $TMPROOT" EXIT
+pass=0
+fail=0
+FAILED_NAMES=""
+source "$(dirname "$0")/lib/vc_oracle_common.sh"
+
+state_sqlite() {
+  local label="$1"
+  if [ "$label" = BEFORE ]; then
+    printf "%s" "SELECT '$label|' ||
+      (SELECT count(*) FROM dolt_conflicts) || '|' ||
+      (SELECT count(*) FROM dolt_constraint_violations) || '|' ||
+      coalesce((SELECT group_concat(id || ':' || v, ',') FROM
+        (SELECT id,v FROM t ORDER BY id)), '') || '|' ||
+      (SELECT message FROM dolt_log LIMIT 1) || '|' ||
+      (SELECT count(*) FROM dolt_log);"
+  else
+    printf "%s" "SELECT '$label|' ||
+      (SELECT count(*) FROM dolt_conflicts) || '|' ||
+      (SELECT count(*) FROM dolt_constraint_violations) || '|' ||
+      (SELECT count(*) FROM dolt_status) || '|' ||
+      coalesce((SELECT group_concat(id || ':' || v, ',') FROM
+        (SELECT id,v FROM t ORDER BY id)), '') || '|' ||
+      (SELECT message FROM dolt_log LIMIT 1) || '|' ||
+      (SELECT count(*) FROM dolt_log);"
+  fi
+}
+
+state_dolt() {
+  local label="$1"
+  if [ "$label" = BEFORE ]; then
+    printf "%s" "SELECT CONCAT('$label|',
+      (SELECT COUNT(*) FROM dolt_conflicts), '|',
+      (SELECT COUNT(*) FROM dolt_constraint_violations), '|',
+      COALESCE((SELECT GROUP_CONCAT(CONCAT(id, ':', v) ORDER BY id SEPARATOR ',')
+        FROM t), ''), '|',
+      (SELECT message FROM dolt_log LIMIT 1), '|',
+      (SELECT COUNT(*) FROM dolt_log));"
+  else
+    printf "%s" "SELECT CONCAT('$label|',
+      (SELECT COUNT(*) FROM dolt_conflicts), '|',
+      (SELECT COUNT(*) FROM dolt_constraint_violations), '|',
+      (SELECT COUNT(*) FROM dolt_status), '|',
+      COALESCE((SELECT GROUP_CONCAT(CONCAT(id, ':', v) ORDER BY id SEPARATOR ',')
+        FROM t), ''), '|',
+      (SELECT message FROM dolt_log LIMIT 1), '|',
+      (SELECT COUNT(*) FROM dolt_log));"
+  fi
+}
+
+abort_oracle() {
+  local name="$1" setup="$2" pick_ref="$3" abort_args="$4"
+  local dir="$TMPROOT/$name"
+  local dl_out dt_out dolt_setup
+  mkdir -p "$dir/dl" "$dir/dt"
+
+  {
+    printf '%s\n' "$setup"
+    printf '%s\n' "BEGIN;"
+    printf "SELECT dolt_cherry_pick('%s');\n" "$pick_ref"
+    state_sqlite BEFORE
+    printf '\nSELECT dolt_cherry_pick(%s);\n' "$abort_args"
+    state_sqlite AFTER
+    printf '\nCOMMIT;\n'
+  } | "$DOLTLITE" "$dir/dl/db" >"$dir/dl.out" 2>"$dir/dl.err" || true
+  dl_out=$(tr -d '\r' < "$dir/dl.out" | grep -E '^(BEFORE|AFTER)\|' || true)
+
+  dolt_setup=$(vc_oracle_translate_for_dolt "$setup")
+  (
+    cd "$dir/dt" || exit 1
+    vc_oracle_init_repo
+    {
+      printf '%s\n' "$dolt_setup"
+      printf '%s\n' "START TRANSACTION;"
+      printf "CALL dolt_cherry_pick('%s');\n" "$pick_ref"
+      state_dolt BEFORE
+      printf '\nCALL dolt_cherry_pick(%s);\n' "$abort_args"
+      state_dolt AFTER
+      printf '\nCOMMIT;\n'
+    } | "$DOLT" sql -c -r csv >"$dir/dt.out" 2>"$dir/dt.err"
+  ) || true
+  dt_out=$(tr -d '"\r' < "$dir/dt.out" | grep -E '^(BEFORE|AFTER)\|' || true)
+
+  vc_oracle_assert_match "$name" "$dl_out" "$dt_out"
+}
+
+error_oracle() {
+  local name="$1" setup="$2"
+  local dir="$TMPROOT/$name"
+  local dl_rc dt_rc dolt_setup
+  mkdir -p "$dir/dl" "$dir/dt"
+
+  vc_oracle_run_doltlite_script \
+    "$dir/dl/db" "$dir/dl.out" "$dir/dl.err" "$setup"
+  dl_rc=$?
+  dolt_setup=$(vc_oracle_translate_for_dolt "$setup")
+  vc_oracle_run_dolt_script_for_error \
+    "$dir/dt" "$dir/dt.out" "$dir/dt.err" "$dolt_setup"
+  dt_rc=$?
+
+  if vc_oracle_is_clean_error "$dl_rc" && vc_oracle_is_clean_error "$dt_rc"; then
+    pass=$((pass+1))
+  else
+    fail=$((fail+1))
+    FAILED_NAMES="$FAILED_NAMES $name"
+    echo "  FAIL: $name (expected both to error)"
+    echo "    doltlite rc: $dl_rc"
+    echo "    dolt rc:     $dt_rc"
+  fi
+}
+
+echo "=== Version Control Oracle Tests: dolt_cherry_pick --abort ==="
+echo ""
+
+CONFLICT_SETUP="
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1, 'base');
+SELECT dolt_commit('-Am', 'base');
+SELECT dolt_checkout('-b', 'feature');
+UPDATE t SET v='feature' WHERE id=1;
+SELECT dolt_commit('-Am', 'feature edit');
+SELECT dolt_checkout('main');
+UPDATE t SET v='main' WHERE id=1;
+SELECT dolt_commit('-Am', 'main edit');
+"
+
+abort_oracle "cherry_pick_abort_conflict" \
+  "$CONFLICT_SETUP" "feature" "'--abort'"
+
+abort_oracle "cherry_pick_abort_ignores_one_positional" \
+  "$CONFLICT_SETUP" "feature" "'--abort', 'HEAD'"
+
+CV_SETUP="
+CREATE TABLE t(id INTEGER PRIMARY KEY, u INT UNIQUE, v TEXT);
+INSERT INTO t VALUES(1,1,'base1'),(2,2,'base2');
+SELECT dolt_commit('-Am','base');
+SELECT dolt_checkout('-b','feature');
+UPDATE t SET u=9, v='feature' WHERE id=2;
+SELECT dolt_commit('-Am','feature unique');
+SELECT dolt_checkout('main');
+UPDATE t SET u=9, v='main' WHERE id=1;
+SELECT dolt_commit('-Am','main unique');
+"
+
+abort_oracle "cherry_pick_abort_constraint_violation" \
+  "$CV_SETUP" "feature" "'--abort'"
+
+error_oracle "cherry_pick_abort_without_active_operation" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+SELECT dolt_commit('-Am','base');
+SELECT dolt_cherry_pick('--abort');
+"
+
+error_oracle "cherry_pick_abort_after_clean_pick" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+SELECT dolt_commit('-Am','base');
+SELECT dolt_checkout('-b','feature');
+INSERT INTO t VALUES(1,'feature');
+SELECT dolt_commit('-Am','feature');
+SELECT dolt_checkout('main');
+SELECT dolt_cherry_pick('feature');
+SELECT dolt_cherry_pick('--abort');
+"
+
+echo ""
+echo "Results: $pass passed, $fail failed out of $((pass+fail)) tests"
+if [ "$fail" -ne 0 ]; then
+  echo "FAILED:$FAILED_NAMES"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- add `--abort` handling to `dolt_cherry_pick`
- restore HEAD, staging, conflicts, constraint violations, and replay state without ending the transaction
- add five direct Dolt 2.3.1 oracles covering conflicts, constraint violations, resolved conflicts, argument handling, and inactive aborts

## Validation

- `bash test/run_doltlite_tests.sh` (122/122 suites)
- `bash test/vc_oracle_cherry_pick_abort_test.sh build/doltlite dolt` (5/5)
- `bash test/vc_oracle_revert_cherrypick_test.sh build/doltlite dolt` (64/64)
- `make lint`

Fixes #2501

Co-Authored-By: OpenAI Codex <noreply@openai.com>