### PR TITLE
Add dolthub/doltlite-php: Composer package over PHP FFI

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -197,6 +197,14 @@ jobs:
       run: cd build && bash ../test/windows_path_smoke.sh ./doltlite.exe
       timeout-minutes: 2
 
+    - name: Set up PHP
+      if: matrix.platform != 'windows'
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: '8.3'
+        extensions: ffi
+        tools: composer
+
     - name: Smoke test the dolthub/doltlite-php Composer package
       if: matrix.platform != 'windows'
       run: |

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -197,6 +197,13 @@ jobs:
       run: cd build && bash ../test/windows_path_smoke.sh ./doltlite.exe
       timeout-minutes: 2
 
+    - name: Smoke test the dolthub/doltlite-php Composer package
+      if: matrix.platform != 'windows'
+      run: |
+        chmod +x packaging/composer/assemble.sh packaging/composer/test-package.sh
+        bash packaging/composer/test-package.sh build
+      timeout-minutes: 5
+
     - name: GC smoke tests
       if: matrix.platform != 'windows'
       run: |

--- a/packaging/composer/README.md
+++ b/packaging/composer/README.md
@@ -1,0 +1,64 @@
+# dolthub/doltlite-php
+
+[DoltLite](https://github.com/dolthub/doltlite) for PHP: SQLite with Git-style
+version control — branch, commit, merge, and diff your relational data. The
+binding runs over PHP's FFI extension against the `libdoltlite` shared library
+bundled with this package, and mirrors the shape of PHP's built-in `SQLite3`
+classes so existing code ports by search-and-replace.
+
+## Requirements
+
+- PHP >= 8.1 with the `ffi` extension enabled (`php -m | grep FFI`). On
+  hardened hosts check `ffi.enable`; the CLI default allows FFI.
+- Linux (x86_64/arm64) or macOS (x86_64/arm64). The package bundles a
+  prebuilt `libdoltlite` per platform; `DOLTLITE_PHP_LIB=/path/to/lib`
+  overrides resolution for anything else.
+
+## Install
+
+```sh
+composer require dolthub/doltlite-php
+```
+
+## Use
+
+The API is `SQLite3` with the prefix swapped: `Doltlite3`, `Doltlite3Stmt`,
+`Doltlite3Result`, and `DOLTLITE3_*` constants. Errors always raise
+`Doltlite\Exception`.
+
+```php
+use Doltlite\Doltlite3;
+
+$db = new Doltlite3('app.db');
+$db->exec('CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT)');
+
+$stmt = $db->prepare('INSERT INTO users(name) VALUES (:name)');
+$stmt->bindValue(':name', 'Ada');
+$stmt->execute();
+
+// Version control is plain SQL on the same connection.
+$db->querySingle("SELECT dolt_commit('-A', '-m', 'add ada')");
+$db->querySingle("SELECT dolt_checkout('-b', 'experiment')");
+$db->exec("UPDATE users SET name = 'Grace' WHERE id = 1");
+$db->querySingle("SELECT dolt_commit('-A', '-m', 'rename')");
+$db->querySingle("SELECT dolt_checkout('main')");
+$db->querySingle("SELECT dolt_merge('experiment')");
+
+$log = $db->query('SELECT commit_hash, message FROM dolt_log');
+while (($commit = $log->fetchArray(DOLTLITE3_ASSOC)) !== false) {
+    echo "{$commit['commit_hash']} {$commit['message']}\n";
+}
+```
+
+Every DoltLite feature — branches, merges, diffs (`dolt_diff`, `dolt_log`,
+`dolt_branches` tables), remotes (`dolt_push`/`dolt_pull`/`dolt_clone`) — is
+reachable through SQL; no binding-specific API is needed. See the
+[DoltLite documentation](https://github.com/dolthub/doltlite) for the SQL
+surface.
+
+## Differences from SQLite3
+
+- Errors always throw `Doltlite\Exception`; there is no warnings mode
+  (matching where PHP itself is headed with `SQLite3`).
+- `openBlob`, `createFunction`, `createAggregate`, `createCollation`, and
+  `setAuthorizer` are not implemented. File an issue if you need them.

--- a/packaging/composer/assemble.sh
+++ b/packaging/composer/assemble.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+#
+# Stage the dolthub/doltlite-php Composer package into an output directory.
+# Copies this directory's composer.json/src/README alongside the shared
+# library `make doltlite-lib` produced (placed under lib/<os>-<arch>/ where
+# src/Lib.php resolves it), stamps the version, and drops in the repo LICENSE.
+# A release merges the lib/ trees of per-platform runs of this script.
+#
+# Usage: assemble.sh <version> <out_dir> <build_dir>
+#   version    release version without the leading "v" (e.g. 0.11.15)
+#   out_dir    directory to create and populate (e.g. dist/composer)
+#   build_dir  build directory containing libdoltlite.{so,dylib,dll}
+
+set -euo pipefail
+
+VERSION="${1:?usage: assemble.sh <version> <out_dir> <build_dir>}"
+OUT_DIR="${2:?usage: assemble.sh <version> <out_dir> <build_dir>}"
+BUILD_DIR="${3:?usage: assemble.sh <version> <out_dir> <build_dir>}"
+
+PKG_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$PKG_DIR/../.." && pwd)"
+
+case "$(uname -s)" in
+  Darwin) OS=darwin; EXT=dylib ;;
+  MINGW*|MSYS*|CYGWIN*) OS=windows; EXT=dll ;;
+  *) OS=linux; EXT=so ;;
+esac
+case "$(uname -m)" in
+  arm64|aarch64) ARCH=arm64 ;;
+  x86_64|amd64) ARCH=x86_64 ;;
+  *) ARCH="$(uname -m)" ;;
+esac
+
+LIB="$BUILD_DIR/libdoltlite.$EXT"
+if [ ! -f "$LIB" ]; then
+  echo "ERROR: missing shared library: $LIB (did 'make doltlite-lib' run?)" >&2
+  exit 1
+fi
+
+rm -rf "$OUT_DIR"
+mkdir -p "$OUT_DIR/lib/$OS-$ARCH"
+
+cp -R "$PKG_DIR/src" "$OUT_DIR/src"
+cp "$PKG_DIR/README.md" "$OUT_DIR/README.md"
+cp "$ROOT/LICENSE.md" "$OUT_DIR/LICENSE.md"
+cp "$LIB" "$OUT_DIR/lib/$OS-$ARCH/libdoltlite.$EXT"
+
+# Stamp the version into the staged composer.json without depending on jq.
+php -r '
+  $src = $argv[1]; $dst = $argv[2]; $v = $argv[3];
+  $j = json_decode(file_get_contents($src), true, 512, JSON_THROW_ON_ERROR);
+  $j["version"] = $v;
+  file_put_contents($dst, json_encode($j,
+      JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n");
+' "$PKG_DIR/composer.json" "$OUT_DIR/composer.json" "$VERSION"
+
+echo "Staged dolthub/doltlite-php@$VERSION ($OS-$ARCH) in $OUT_DIR:"
+ls -laR "$OUT_DIR" | head -30

--- a/packaging/composer/composer.json
+++ b/packaging/composer/composer.json
@@ -1,0 +1,18 @@
+{
+  "name": "dolthub/doltlite-php",
+  "description": "DoltLite for PHP: SQLite with Git-style version control (branch, commit, merge, diff), bound over FFI with the SQLite3-class API shape.",
+  "type": "library",
+  "license": "Apache-2.0",
+  "keywords": ["doltlite", "dolt", "sqlite", "database", "version-control", "ffi"],
+  "homepage": "https://github.com/dolthub/doltlite",
+  "require": {
+    "php": ">=8.1",
+    "ext-ffi": "*"
+  },
+  "autoload": {
+    "psr-4": {
+      "Doltlite\\": "src/"
+    },
+    "files": ["src/constants.php"]
+  }
+}

--- a/packaging/composer/smoke-test.php
+++ b/packaging/composer/smoke-test.php
@@ -1,0 +1,121 @@
+<?php
+
+/*
+** Package-level smoke test for dolthub/doltlite-php. Runs from a consumer
+** project against the installed package (vendor/autoload.php), covering the
+** binding surface end to end: DDL/DML, prepared statements across every
+** value type, result modes, error paths, and a version-control round trip
+** (commit, branch, checkout, merge, dolt_log/dolt_diff reads).
+*/
+
+declare(strict_types=1);
+
+require __DIR__ . '/vendor/autoload.php';
+
+use Doltlite\Doltlite3;
+use Doltlite\Exception as DoltliteException;
+
+$failures = 0;
+
+function check(string $name, mixed $got, mixed $want): void
+{
+    global $failures;
+    if ($got === $want) {
+        echo "  PASS: $name\n";
+    } else {
+        $failures++;
+        echo "  FAIL: $name\n    want: " . var_export($want, true)
+            . "\n    got:  " . var_export($got, true) . "\n";
+    }
+}
+
+$dir = sys_get_temp_dir() . '/doltlite-php-smoke-' . getmypid();
+@mkdir($dir);
+$dbPath = "$dir/smoke.db";
+@unlink($dbPath);
+
+$db = new Doltlite3($dbPath);
+
+$v = Doltlite3::version();
+check('version reports a string', is_string($v['versionString']) && $v['versionString'] !== '', true);
+
+// exec: multi-statement, then simple reads.
+$db->exec("
+    CREATE TABLE t(pk INTEGER PRIMARY KEY, s TEXT, f REAL, b BLOB);
+    INSERT INTO t(pk, s, f, b) VALUES (1, 'one', 1.5, x'00ff10');
+");
+check('changes after insert', $db->changes(), 1);
+check('lastInsertRowID', $db->lastInsertRowID(), 1);
+
+// Prepared statements: every bind type, named and positional.
+$stmt = $db->prepare('INSERT INTO t(pk, s, f, b) VALUES (:pk, :s, :f, :b)');
+check('paramCount', $stmt->paramCount(), 4);
+$stmt->bindValue(':pk', 2);
+$stmt->bindValue('s', 'twö');
+$stmt->bindValue(':f', 2.25);
+$stmt->bindValue(':b', "\x01\x00\x02", DOLTLITE3_BLOB);
+$stmt->execute()->finalize();
+$stmt->reset();
+$stmt->clear();
+$stmt->bindValue(1, 3);
+$stmt->bindValue(2, null);
+$stmt->bindValue(3, 3);
+$stmt->bindValue(4, null);
+$stmt->execute()->finalize();
+$stmt->close();
+
+// Result modes and typed round trips.
+$row = $db->querySingle('SELECT s, f, b FROM t WHERE pk = 2', true);
+check('text round trip (utf8)', $row['s'], 'twö');
+check('float round trip', $row['f'], 2.25);
+check('blob round trip (embedded nul)', $row['b'], "\x01\x00\x02");
+check('null round trip', $db->querySingle('SELECT s FROM t WHERE pk = 3'), null);
+check('int is int', $db->querySingle('SELECT pk FROM t WHERE pk = 1'), 1);
+check('querySingle no rows', $db->querySingle('SELECT s FROM t WHERE pk = 99'), null);
+check('querySingle no rows (row mode)', $db->querySingle('SELECT * FROM t WHERE pk = 99', true), []);
+
+$res = $db->query('SELECT pk, s FROM t ORDER BY pk');
+check('numColumns', $res->numColumns(), 2);
+check('columnName', $res->columnName(1), 's');
+$first = $res->fetchArray(DOLTLITE3_NUM);
+check('fetch NUM', [$first[0], $first[1]], [1, 'one']);
+$res->reset();
+$again = $res->fetchArray(DOLTLITE3_ASSOC);
+check('reset refetches', $again['pk'], 1);
+$n = 1;
+while ($res->fetchArray() !== false) {
+    $n++;
+}
+check('row count', $n, 3);
+$res->finalize();
+
+// Error paths raise Doltlite\Exception with the engine message.
+try {
+    $db->exec('SELECT * FROM missing_table');
+    check('bad SQL throws', 'no exception', 'exception');
+} catch (DoltliteException $e) {
+    check('bad SQL throws', str_contains($e->getMessage(), 'missing_table'), true);
+    check('lastErrorCode set', $db->lastErrorCode() !== 0, true);
+}
+
+// Version control is plain SQL through the same connection.
+check('dolt_commit', $db->querySingle("SELECT dolt_commit('-A', '-m', 'first commit')") !== '', true);
+check('dolt_branch', $db->querySingle("SELECT dolt_branch('feature')"), 0);
+check('dolt_checkout feature', $db->querySingle("SELECT dolt_checkout('feature')"), 0);
+$db->exec("UPDATE t SET s = 'branched' WHERE pk = 1");
+check('dolt_commit on branch', $db->querySingle("SELECT dolt_commit('-A', '-m', 'feature work')") !== '', true);
+check('dolt_checkout main', $db->querySingle("SELECT dolt_checkout('main')"), 0);
+check('main unchanged', $db->querySingle('SELECT s FROM t WHERE pk = 1'), 'one');
+$merge = $db->querySingle("SELECT dolt_merge('feature')", true);
+check('dolt_merge fast-forwards', $db->querySingle('SELECT s FROM t WHERE pk = 1'), 'branched');
+check('dolt_log sees both commits',
+    $db->querySingle('SELECT count(*) FROM dolt_log') >= 2, true);
+
+$db->close();
+check('close idempotent', $db->close(), true);
+
+@unlink($dbPath);
+@rmdir($dir);
+
+echo $failures === 0 ? "smoke-test: all checks passed\n" : "smoke-test: $failures failure(s)\n";
+exit($failures === 0 ? 0 : 1);

--- a/packaging/composer/src/Doltlite3.php
+++ b/packaging/composer/src/Doltlite3.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doltlite;
+
+/**
+ * A DoltLite database connection with the shape of PHP's SQLite3 class.
+ * Errors always raise Doltlite\Exception; there is no warnings mode.
+ * DoltLite's version-control surface is plain SQL — e.g.
+ * $db->querySingle("SELECT dolt_commit('-A', '-m', 'message')").
+ */
+class Doltlite3
+{
+    private ?\FFI\CData $db = null;
+
+    public function __construct(
+        string $filename,
+        int $flags = DOLTLITE3_OPEN_READWRITE | DOLTLITE3_OPEN_CREATE,
+    ) {
+        $ffi = Lib::get();
+        $pDb = $ffi->new('sqlite3*[1]');
+        $rc = $ffi->sqlite3_open_v2($filename, $pDb, $flags, null);
+        if ($rc !== Lib::OK) {
+            $msg = $pDb[0] !== null ? $ffi->sqlite3_errmsg($pDb[0]) : "open failed ($rc)";
+            if ($pDb[0] !== null) {
+                $ffi->sqlite3_close_v2($pDb[0]);
+            }
+            throw new Exception("Unable to open database: $msg", $rc);
+        }
+        $this->db = $pDb[0];
+    }
+
+    public function __destruct()
+    {
+        $this->close();
+    }
+
+    public function close(): bool
+    {
+        if ($this->db !== null) {
+            Lib::get()->sqlite3_close_v2($this->db);
+            $this->db = null;
+        }
+        return true;
+    }
+
+    /** Runs one or more semicolon-separated statements, discarding rows. */
+    public function exec(string $query): bool
+    {
+        $ffi = Lib::get();
+        $handle = $this->handle();
+        $sql = $query;
+        while (trim($sql) !== '') {
+            $pStmt = $ffi->new('sqlite3_stmt*[1]');
+            $pTail = $ffi->new('const char*[1]');
+            $rc = $ffi->sqlite3_prepare_v2($handle, $sql, -1, $pStmt, $pTail);
+            if ($rc !== Lib::OK) {
+                throw $this->error();
+            }
+            $tail = $pTail[0];
+            $consumed = is_string($tail) ? $tail
+                : ($tail === null ? '' : \FFI::string($tail));
+            if ($pStmt[0] !== null) {
+                do {
+                    $rc = $ffi->sqlite3_step($pStmt[0]);
+                } while ($rc === Lib::ROW);
+                $ffi->sqlite3_finalize($pStmt[0]);
+                if ($rc !== Lib::DONE) {
+                    throw $this->error();
+                }
+            }
+            $sql = $consumed;
+        }
+        return true;
+    }
+
+    public function prepare(string $query): Doltlite3Stmt
+    {
+        return new Doltlite3Stmt($this, $query);
+    }
+
+    public function query(string $query): Doltlite3Result
+    {
+        return new Doltlite3Result($this, $this->prepare($query), true);
+    }
+
+    /**
+     * First column of the first row (null when there are no rows), or with
+     * $entireRow the whole first row as an associative array ([] when empty).
+     */
+    public function querySingle(string $query, bool $entireRow = false): mixed
+    {
+        $result = $this->query($query);
+        $row = $result->fetchArray($entireRow ? DOLTLITE3_ASSOC : DOLTLITE3_NUM);
+        $result->finalize();
+        if ($row === false) {
+            return $entireRow ? [] : null;
+        }
+        return $entireRow ? $row : $row[0];
+    }
+
+    public function lastInsertRowID(): int
+    {
+        return Lib::get()->sqlite3_last_insert_rowid($this->handle());
+    }
+
+    public function changes(): int
+    {
+        return Lib::get()->sqlite3_changes($this->handle());
+    }
+
+    public function lastErrorCode(): int
+    {
+        return $this->db === null ? 0 : Lib::get()->sqlite3_errcode($this->db);
+    }
+
+    public function lastErrorMsg(): string
+    {
+        return $this->db === null ? '' : Lib::get()->sqlite3_errmsg($this->db);
+    }
+
+    public function busyTimeout(int $milliseconds): bool
+    {
+        return Lib::get()->sqlite3_busy_timeout($this->handle(), $milliseconds) === Lib::OK;
+    }
+
+    public static function escapeString(string $value): string
+    {
+        return str_replace("'", "''", $value);
+    }
+
+    /** @return array{versionString: string, versionNumber: int} */
+    public static function version(): array
+    {
+        $ffi = Lib::get();
+        return [
+            'versionString' => $ffi->sqlite3_libversion(),
+            'versionNumber' => $ffi->sqlite3_libversion_number(),
+        ];
+    }
+
+    /** @internal */
+    public function handle(): \FFI\CData
+    {
+        if ($this->db === null) {
+            throw new Exception('Database is closed');
+        }
+        return $this->db;
+    }
+
+    /** @internal */
+    public function error(): Exception
+    {
+        return new Exception($this->lastErrorMsg(), $this->lastErrorCode());
+    }
+}

--- a/packaging/composer/src/Doltlite3Result.php
+++ b/packaging/composer/src/Doltlite3Result.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doltlite;
+
+class Doltlite3Result
+{
+    private Doltlite3 $db;
+    /** Kept as an object reference so the statement outlives query(). */
+    private ?Doltlite3Stmt $stmt;
+    /** Results from query() own their statement; execute()'s do not. */
+    private bool $ownsStmt;
+    /** A row produced by the eager first step, not yet fetched. */
+    private bool $pendingRow;
+    private bool $done;
+
+    /** @internal use Doltlite3::query() or Doltlite3Stmt::execute() */
+    public function __construct(Doltlite3 $db, Doltlite3Stmt $stmt, bool $ownsStmt)
+    {
+        $this->db = $db;
+        $this->stmt = $stmt;
+        $this->ownsStmt = $ownsStmt;
+        // Step eagerly so writes run even if the caller never fetches.
+        $rc = Lib::get()->sqlite3_step($stmt->cHandle());
+        if ($rc !== Lib::ROW && $rc !== Lib::DONE) {
+            Lib::get()->sqlite3_reset($stmt->cHandle());
+            throw $db->error();
+        }
+        $this->pendingRow = ($rc === Lib::ROW);
+        $this->done = ($rc === Lib::DONE);
+    }
+
+    /** @return array<int|string, mixed>|false */
+    public function fetchArray(int $mode = DOLTLITE3_BOTH): array|false
+    {
+        $ffi = Lib::get();
+        $stmt = $this->handle();
+        if ($this->pendingRow) {
+            $this->pendingRow = false;
+        } else {
+            if ($this->done) {
+                return false;
+            }
+            $rc = $ffi->sqlite3_step($stmt);
+            if ($rc === Lib::DONE) {
+                $this->done = true;
+                return false;
+            }
+            if ($rc !== Lib::ROW) {
+                throw $this->db->error();
+            }
+        }
+
+        $row = [];
+        $n = $ffi->sqlite3_column_count($stmt);
+        for ($i = 0; $i < $n; $i++) {
+            $value = $this->columnValue($i);
+            if ($mode & DOLTLITE3_NUM) {
+                $row[$i] = $value;
+            }
+            if ($mode & DOLTLITE3_ASSOC) {
+                $row[$ffi->sqlite3_column_name($stmt, $i)] = $value;
+            }
+        }
+        return $row;
+    }
+
+    public function numColumns(): int
+    {
+        return Lib::get()->sqlite3_column_count($this->handle());
+    }
+
+    public function columnName(int $column): string
+    {
+        return Lib::get()->sqlite3_column_name($this->handle(), $column);
+    }
+
+    public function columnType(int $column): int
+    {
+        return Lib::get()->sqlite3_column_type($this->handle(), $column);
+    }
+
+    /** Rewinds so the rows can be fetched again. */
+    public function reset(): bool
+    {
+        $stmt = $this->handle();
+        Lib::get()->sqlite3_reset($stmt);
+        $rc = Lib::get()->sqlite3_step($stmt);
+        if ($rc !== Lib::ROW && $rc !== Lib::DONE) {
+            throw $this->db->error();
+        }
+        $this->pendingRow = ($rc === Lib::ROW);
+        $this->done = ($rc === Lib::DONE);
+        return true;
+    }
+
+    public function finalize(): bool
+    {
+        if ($this->stmt !== null) {
+            if ($this->ownsStmt) {
+                $this->stmt->close();
+            } else {
+                Lib::get()->sqlite3_reset($this->stmt->cHandle());
+            }
+            $this->stmt = null;
+        }
+        return true;
+    }
+
+    public function __destruct()
+    {
+        $this->finalize();
+    }
+
+    private function columnValue(int $i): mixed
+    {
+        $ffi = Lib::get();
+        $stmt = $this->handle();
+        return match ($ffi->sqlite3_column_type($stmt, $i)) {
+            DOLTLITE3_NULL => null,
+            DOLTLITE3_INTEGER => $ffi->sqlite3_column_int64($stmt, $i),
+            DOLTLITE3_FLOAT => $ffi->sqlite3_column_double($stmt, $i),
+            DOLTLITE3_BLOB => $this->bytes($ffi->sqlite3_column_blob($stmt, $i), $i),
+            default => $this->bytes($ffi->sqlite3_column_text($stmt, $i), $i),
+        };
+    }
+
+    private function bytes(?\FFI\CData $ptr, int $i): string
+    {
+        $len = Lib::get()->sqlite3_column_bytes($this->handle(), $i);
+        if ($ptr === null || $len === 0) {
+            return '';
+        }
+        return \FFI::string($ptr, $len);
+    }
+
+    private function handle(): \FFI\CData
+    {
+        if ($this->stmt === null) {
+            throw new Exception('Result is finalized');
+        }
+        return $this->stmt->cHandle();
+    }
+}

--- a/packaging/composer/src/Doltlite3Stmt.php
+++ b/packaging/composer/src/Doltlite3Stmt.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doltlite;
+
+class Doltlite3Stmt
+{
+    private Doltlite3 $db;
+    private ?\FFI\CData $stmt = null;
+
+    /** @internal use Doltlite3::prepare() */
+    public function __construct(Doltlite3 $db, string $query)
+    {
+        $ffi = Lib::get();
+        $pStmt = $ffi->new('sqlite3_stmt*[1]');
+        $rc = $ffi->sqlite3_prepare_v2($db->handle(), $query, -1, $pStmt, null);
+        if ($rc !== Lib::OK) {
+            throw $db->error();
+        }
+        if ($pStmt[0] === null) {
+            throw new Exception('Query contains no SQL statement');
+        }
+        $this->db = $db;
+        $this->stmt = $pStmt[0];
+    }
+
+    public function __destruct()
+    {
+        $this->close();
+    }
+
+    public function bindValue(string|int $param, mixed $value, ?int $type = null): bool
+    {
+        $ffi = Lib::get();
+        $stmt = $this->handle();
+        $index = $this->paramIndex($param);
+
+        if ($type === null) {
+            $type = match (true) {
+                $value === null => DOLTLITE3_NULL,
+                is_int($value), is_bool($value) => DOLTLITE3_INTEGER,
+                is_float($value) => DOLTLITE3_FLOAT,
+                default => DOLTLITE3_TEXT,
+            };
+        }
+        $rc = match ($type) {
+            DOLTLITE3_NULL => $ffi->sqlite3_bind_null($stmt, $index),
+            DOLTLITE3_INTEGER => $ffi->sqlite3_bind_int64($stmt, $index, (int) $value),
+            DOLTLITE3_FLOAT => $ffi->sqlite3_bind_double($stmt, $index, (float) $value),
+            DOLTLITE3_BLOB => $ffi->sqlite3_bind_blob(
+                $stmt, $index, (string) $value, strlen((string) $value), Lib::TRANSIENT),
+            default => $ffi->sqlite3_bind_text(
+                $stmt, $index, (string) $value, strlen((string) $value), Lib::TRANSIENT),
+        };
+        if ($rc !== Lib::OK) {
+            throw $this->db->error();
+        }
+        return true;
+    }
+
+    public function execute(): Doltlite3Result
+    {
+        Lib::get()->sqlite3_reset($this->handle());
+        return new Doltlite3Result($this->db, $this, false);
+    }
+
+    public function reset(): bool
+    {
+        Lib::get()->sqlite3_reset($this->handle());
+        return true;
+    }
+
+    public function clear(): bool
+    {
+        Lib::get()->sqlite3_clear_bindings($this->handle());
+        return true;
+    }
+
+    public function paramCount(): int
+    {
+        return Lib::get()->sqlite3_bind_parameter_count($this->handle());
+    }
+
+    public function close(): bool
+    {
+        if ($this->stmt !== null) {
+            Lib::get()->sqlite3_finalize($this->stmt);
+            $this->stmt = null;
+        }
+        return true;
+    }
+
+    private function paramIndex(string|int $param): int
+    {
+        if (is_int($param)) {
+            return $param;
+        }
+        $ffi = Lib::get();
+        $index = $ffi->sqlite3_bind_parameter_index($this->handle(), $param);
+        if ($index === 0 && $param !== '' && $param[0] !== ':' && $param[0] !== '@') {
+            $index = $ffi->sqlite3_bind_parameter_index($this->handle(), ':' . $param);
+        }
+        if ($index === 0) {
+            throw new Exception("Unknown parameter: $param");
+        }
+        return $index;
+    }
+
+    /** @internal */
+    public function cHandle(): \FFI\CData
+    {
+        return $this->handle();
+    }
+
+    private function handle(): \FFI\CData
+    {
+        if ($this->stmt === null) {
+            throw new Exception('Statement is closed');
+        }
+        return $this->stmt;
+    }
+}

--- a/packaging/composer/src/Exception.php
+++ b/packaging/composer/src/Exception.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doltlite;
+
+class Exception extends \Exception
+{
+}

--- a/packaging/composer/src/Lib.php
+++ b/packaging/composer/src/Lib.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doltlite;
+
+/**
+ * Process-wide FFI handle to libdoltlite. The library keeps SQLite's C API
+ * under SQLite's own symbol names, so the declarations below are the plain
+ * sqlite3_* subset the classes in this package call.
+ */
+final class Lib
+{
+    private static ?\FFI $ffi = null;
+
+    /** SQLITE_TRANSIENT: the library copies bound text/blobs immediately. */
+    public const TRANSIENT = -1;
+
+    public const OK = 0;
+    public const ROW = 100;
+    public const DONE = 101;
+
+    private const CDEF = <<<'C'
+        typedef struct sqlite3 sqlite3;
+        typedef struct sqlite3_stmt sqlite3_stmt;
+        int sqlite3_open_v2(const char *filename, sqlite3 **ppDb, int flags,
+                            const char *zVfs);
+        int sqlite3_close_v2(sqlite3 *db);
+        int sqlite3_prepare_v2(sqlite3 *db, const char *zSql, int nByte,
+                               sqlite3_stmt **ppStmt, const char **pzTail);
+        int sqlite3_step(sqlite3_stmt *pStmt);
+        int sqlite3_reset(sqlite3_stmt *pStmt);
+        int sqlite3_finalize(sqlite3_stmt *pStmt);
+        int sqlite3_clear_bindings(sqlite3_stmt *pStmt);
+        int sqlite3_bind_parameter_count(sqlite3_stmt *pStmt);
+        int sqlite3_bind_parameter_index(sqlite3_stmt *pStmt, const char *zName);
+        int sqlite3_bind_int64(sqlite3_stmt *pStmt, int i, int64_t v);
+        int sqlite3_bind_double(sqlite3_stmt *pStmt, int i, double v);
+        int sqlite3_bind_null(sqlite3_stmt *pStmt, int i);
+        int sqlite3_bind_text(sqlite3_stmt *pStmt, int i, const char *z, int n,
+                              intptr_t destructor);
+        int sqlite3_bind_blob(sqlite3_stmt *pStmt, int i, const void *p, int n,
+                              intptr_t destructor);
+        int sqlite3_column_count(sqlite3_stmt *pStmt);
+        const char *sqlite3_column_name(sqlite3_stmt *pStmt, int i);
+        int sqlite3_column_type(sqlite3_stmt *pStmt, int i);
+        int64_t sqlite3_column_int64(sqlite3_stmt *pStmt, int i);
+        double sqlite3_column_double(sqlite3_stmt *pStmt, int i);
+        const unsigned char *sqlite3_column_text(sqlite3_stmt *pStmt, int i);
+        const void *sqlite3_column_blob(sqlite3_stmt *pStmt, int i);
+        int sqlite3_column_bytes(sqlite3_stmt *pStmt, int i);
+        const char *sqlite3_errmsg(sqlite3 *db);
+        int sqlite3_errcode(sqlite3 *db);
+        int64_t sqlite3_last_insert_rowid(sqlite3 *db);
+        int sqlite3_changes(sqlite3 *db);
+        int sqlite3_busy_timeout(sqlite3 *db, int ms);
+        const char *sqlite3_libversion(void);
+        int sqlite3_libversion_number(void);
+        C;
+
+    public static function get(): \FFI
+    {
+        if (self::$ffi === null) {
+            self::$ffi = \FFI::cdef(self::CDEF, self::resolveLibrary());
+        }
+        return self::$ffi;
+    }
+
+    /**
+     * Resolution order: explicit override, the binary bundled with this
+     * package for the current platform, then the system search path.
+     */
+    private static function resolveLibrary(): string
+    {
+        $override = getenv('DOLTLITE_PHP_LIB');
+        if ($override !== false && $override !== '') {
+            return $override;
+        }
+
+        $ext = match (PHP_OS_FAMILY) {
+            'Darwin' => 'dylib',
+            'Windows' => 'dll',
+            default => 'so',
+        };
+        $os = strtolower(PHP_OS_FAMILY);
+        $machine = strtolower(php_uname('m'));
+        $arch = match ($machine) {
+            'arm64', 'aarch64' => 'arm64',
+            'x86_64', 'amd64' => 'x86_64',
+            default => $machine,
+        };
+
+        $bundled = dirname(__DIR__) . "/lib/$os-$arch/libdoltlite.$ext";
+        if (is_file($bundled)) {
+            return $bundled;
+        }
+        return "libdoltlite.$ext";
+    }
+}

--- a/packaging/composer/src/constants.php
+++ b/packaging/composer/src/constants.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+** Same names and values as PHP's built-in SQLite3 constants with the prefix
+** swapped, so code ports by search-and-replace.
+*/
+
+declare(strict_types=1);
+
+if (!defined('DOLTLITE3_ASSOC')) {
+    define('DOLTLITE3_ASSOC', 1);
+    define('DOLTLITE3_NUM', 2);
+    define('DOLTLITE3_BOTH', 3);
+
+    define('DOLTLITE3_INTEGER', 1);
+    define('DOLTLITE3_FLOAT', 2);
+    define('DOLTLITE3_TEXT', 3);
+    define('DOLTLITE3_BLOB', 4);
+    define('DOLTLITE3_NULL', 5);
+
+    define('DOLTLITE3_OPEN_READONLY', 1);
+    define('DOLTLITE3_OPEN_READWRITE', 2);
+    define('DOLTLITE3_OPEN_CREATE', 4);
+}

--- a/packaging/composer/test-package.sh
+++ b/packaging/composer/test-package.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+#
+# Package-level smoke test for dolthub/doltlite-php. Stages the package from
+# a build directory's shared library, installs it into a throwaway consumer
+# project through Composer (path repository, offline), and runs
+# smoke-test.php against the installed package. This exercises the real
+# package metadata -- autoload map, bundled library resolution -- not just
+# the raw source files.
+#
+# Usage: test-package.sh [build_dir]   (default: ./build)
+
+set -euo pipefail
+
+PKG_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$PKG_DIR/../.." && pwd)"
+BUILD_DIR="$(cd "${1:-$ROOT/build}" && pwd)"
+
+command -v php >/dev/null || { echo "ERROR: php is required" >&2; exit 1; }
+command -v composer >/dev/null || { echo "ERROR: composer is required" >&2; exit 1; }
+php -r 'exit(extension_loaded("ffi") ? 0 : 1);' \
+  || { echo "ERROR: the php ffi extension is required" >&2; exit 1; }
+
+STAGE="$(mktemp -d)"
+CONSUMER="$(mktemp -d)"
+trap 'rm -rf "$STAGE" "$CONSUMER"' EXIT
+
+bash "$PKG_DIR/assemble.sh" "0.0.0" "$STAGE/pkg" "$BUILD_DIR"
+
+cd "$CONSUMER"
+cat > composer.json <<EOF
+{
+  "repositories": [
+    { "type": "path", "url": "$STAGE/pkg", "options": { "symlink": false } },
+    { "packagist.org": false }
+  ],
+  "require": { "dolthub/doltlite-php": "0.0.0" }
+}
+EOF
+composer install --no-interaction --quiet
+
+cp "$PKG_DIR/smoke-test.php" .
+php -d ffi.enable=1 smoke-test.php


### PR DESCRIPTION
PHP bindings, shipped as a Composer package over PHP FFI — option (2) of the binding routes: no per-PHP-version native builds, one bundled `libdoltlite` per platform, installable with `composer require dolthub/doltlite-php`.

## Shape

- `Doltlite3` / `Doltlite3Stmt` / `Doltlite3Result` / `DOLTLITE3_*` mirror PHP's built-in SQLite3 classes, so existing code ports by search-and-replace. Errors always raise `Doltlite\Exception`.
- The FFI layer (`src/Lib.php`) declares the ~30-call sqlite3_* subset the classes use and resolves the library as: `DOLTLITE_PHP_LIB` override → bundled `lib/<os>-<arch>/` binary → system search path. `make doltlite-lib` already produces the artifact.
- Version control is plain SQL on the same connection (`SELECT dolt_commit(...)`, `dolt_log`, …) — no binding-specific API needed.
- Binary-safe TEXT/BLOB round trips (columns are read by `sqlite3_column_bytes`, binds use SQLITE_TRANSIENT).

## Packaging and tests

`packaging/composer/` follows the `packaging/npm` precedent: `assemble.sh` stages the package with the platform library and stamps the version; `test-package.sh` installs the staged package into a throwaway consumer project through a Composer path repository (packagist disabled, fully offline) and runs `smoke-test.php` against the installed package — DDL/DML, every bind/column type including blobs with embedded NULs and UTF-8 text, result modes/reset, error paths, and a commit → branch → checkout → merge → dolt_log round trip. Build-Test runs it on ubuntu and macos from the checked build.

## Out of scope, deliberately

- `openBlob`, `createFunction`/`createAggregate`/`createCollation`, `setAuthorizer` (need FFI callbacks; demand-driven).
- Windows staging is handled by `assemble.sh` but untested in CI.
- Publishing: Packagist tracks a git repository rather than uploaded artifacts, so publishing needs a read-only split repo (e.g. `dolthub/doltlite-php`) that release wiring pushes staged packages to — left for a follow-up decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)