### PR TITLE
Push the Composer package to doltlite-php on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -741,6 +741,93 @@ jobs:
   # triggered by release-bindings), the wasm "binding" is pure build output:
   # the JS API lives in ext/wasm/api and is assembled by the build, so there
   # is no separate repo to maintain. We publish @dolthub/doltlite-wasm straight
+  # ── Publish the PHP Composer package ─────────────────────
+  # Packagist tracks the dolthub/doltlite-php git repository, so publishing
+  # means pushing a snapshot there: the package source from packaging/composer
+  # plus the per-platform shared libraries extracted from this release's
+  # doltlite-lib-*.zip assets, committed and tagged to match. Packagist picks
+  # the tag up through its GitHub webhook.
+  release-php:
+    if: github.event_name != 'workflow_dispatch'
+    needs: release
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN }}
+      VERSION: ${{ github.ref_name }}
+    steps:
+    - name: Check release bot token
+      run: |
+        if [ -z "${GH_TOKEN}" ]; then
+          echo "RELEASE_BOT_TOKEN is required to push commits and tags to doltlite-php"
+          exit 1
+        fi
+        gh auth status
+        gh auth setup-git
+
+    - uses: actions/checkout@v4
+
+    - name: Configure git identity
+      run: |
+        git config --global user.name "DoltHub Release Bot"
+        git config --global user.email "releases@dolthub.com"
+
+    - name: Release doltlite-php
+      run: |
+        set -euo pipefail
+        version="${VERSION#v}"
+
+        if gh api "repos/dolthub/doltlite-php/git/ref/tags/${VERSION}" >/dev/null 2>&1; then
+          echo "doltlite-php ${VERSION} already exists; skipping"
+          exit 0
+        fi
+
+        # release target -> package platform dir : library extension
+        stage="$(mktemp -d)"
+        for spec in \
+          "linux-x64 linux-x86_64 so" \
+          "linux-arm64 linux-arm64 so" \
+          "osx-arm64 darwin-arm64 dylib" \
+          "osx-x64 darwin-x86_64 dylib" \
+          "win-x64 windows-x86_64 dll"; do
+          read -r target platdir ext <<<"$spec"
+          gh release download "${VERSION}" --repo dolthub/doltlite \
+            --pattern "doltlite-lib-${target}-${version}.zip" --dir "$stage"
+          unzip -q "$stage/doltlite-lib-${target}-${version}.zip" -d "$stage"
+          lib="$stage/doltlite-lib-${target}-${version}/libdoltlite.$ext"
+          if [ ! -f "$lib" ]; then
+            # The lib zips copy the shared library best-effort; Windows is
+            # untested for this package, so its absence must not block the
+            # release. The Unix platforms are the product.
+            if [ "$target" = "win-x64" ]; then
+              echo "warning: no libdoltlite.dll in the win-x64 assets; packaging without it"
+              continue
+            fi
+            echo "ERROR: missing libdoltlite.$ext in doltlite-lib-${target}-${version}.zip"
+            exit 1
+          fi
+          mkdir -p "$stage/pkg/lib/$platdir"
+          cp "$lib" "$stage/pkg/lib/$platdir/libdoltlite.$ext"
+        done
+
+        cp -R packaging/composer/src "$stage/pkg/src"
+        cp packaging/composer/README.md "$stage/pkg/README.md"
+        cp LICENSE.md "$stage/pkg/LICENSE.md"
+        jq --arg v "$version" '.version = $v' packaging/composer/composer.json \
+          > "$stage/pkg/composer.json"
+
+        gh repo clone dolthub/doltlite-php "$stage/doltlite-php"
+        cd "$stage/doltlite-php"
+        git checkout main
+        find . -mindepth 1 -maxdepth 1 -not -name .git -exec rm -rf {} +
+        cp -R "$stage/pkg/." .
+        git add -A
+        if ! git diff --cached --quiet; then
+          git commit -m "doltlite ${VERSION}"
+          git push origin main
+        fi
+        git tag "${VERSION}"
+        git push origin "${VERSION}"
+
   # from here — build the canonical npm distributables (make -C ext/wasm npm),
   # stage them with packaging/npm, and npm publish. Requires the NPM_TOKEN
   # secret: an npm automation token with publish rights to the @dolthub scope.

--- a/packaging/composer/README.md
+++ b/packaging/composer/README.md
@@ -1,5 +1,12 @@
 # dolthub/doltlite-php
 
+> The installable package is distributed through
+> [dolthub/doltlite-php](https://github.com/dolthub/doltlite-php), whose
+> contents — including the prebuilt `lib/` binaries — are pushed by
+> [dolthub/doltlite](https://github.com/dolthub/doltlite)'s release workflow
+> on every tagged release. The package source lives in that repository under
+> `packaging/composer/`; send issues and pull requests there.
+
 [DoltLite](https://github.com/dolthub/doltlite) for PHP: SQLite with Git-style
 version control — branch, commit, merge, and diff your relational data. The
 binding runs over PHP's FFI extension against the `libdoltlite` shared library


### PR DESCRIPTION
Follow-up to #2510: release wiring for the PHP package.

Adds a `release-php` job mirroring `release-bindings`/`release-swift`: on each tagged release it stages `packaging/composer` with the per-platform shared libraries extracted from the release's own `doltlite-lib-*.zip` assets (linux x86_64/arm64, darwin x86_64/arm64; win-x64 included best-effort), stamps the version into `composer.json`, and pushes the snapshot plus a matching `vX.Y.Z` tag to [dolthub/doltlite-php](https://github.com/dolthub/doltlite-php). Idempotent on re-runs via the existing tag-exists check. Uses `RELEASE_BOT_TOKEN`, which needs Contents-write on `dolthub/doltlite-php` (same grant shape as doltlite-node/-python/-swift).

The package README now carries the distribution-repo note so release pushes keep it.

Remaining manual step after this merges: submit `github.com/dolthub/doltlite-php` on Packagist so tags publish automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)