### PR TITLE
Add PHP to the bindings table

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ functions, subject to the [storage-engine exceptions](#sqlite-compatibility).
 | Python | `pip install doltlite` | [dolthub/doltlite-python](https://github.com/dolthub/doltlite-python) |
 | Ruby | `gem install doltlite` | [dolthub/doltlite-ruby](https://github.com/dolthub/doltlite-ruby) |
 | Node.js / Bun | `npm install @dolthub/doltlite` | [dolthub/doltlite-node](https://github.com/dolthub/doltlite-node) |
+| PHP | `composer require dolthub/doltlite-php` | this repo ([`packaging/composer`](packaging/composer)), distributed via [dolthub/doltlite-php](https://github.com/dolthub/doltlite-php) |
 | Browser / WASM | `npm install @dolthub/doltlite-wasm` | this repo ([`packaging/npm`](packaging/npm), built from [`ext/wasm`](ext/wasm)) |
 | Swift (iOS / macOS) | SwiftPM: `https://github.com/dolthub/doltlite-swift` | [dolthub/doltlite-swift](https://github.com/dolthub/doltlite-swift) (XCFramework built by [`packaging/swift`](packaging/swift)) |
 | Android | Gradle: `com.dolthub:doltlite-android` | [dolthub/doltlite-android](https://github.com/dolthub/doltlite-android) (AAR + JNA) |


### PR DESCRIPTION
Follow-up to #2510: list `composer require dolthub/doltlite-php` in the README bindings table, pointing at `packaging/composer` and the [dolthub/doltlite-php](https://github.com/dolthub/doltlite-php) distribution repo (live on [Packagist](https://packagist.org/packages/dolthub/doltlite-php)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)