### PR TITLE
Add DoltHub.Doltlite: NuGet package over SQLitePCLRaw

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -212,6 +212,13 @@ jobs:
         bash packaging/composer/test-package.sh build
       timeout-minutes: 5
 
+    - name: Smoke test the DoltHub.Doltlite NuGet package
+      shell: bash
+      run: |
+        chmod +x packaging/nuget/assemble.sh packaging/nuget/test-package.sh
+        bash packaging/nuget/test-package.sh build
+      timeout-minutes: 10
+
     - name: GC smoke tests
       if: matrix.platform != 'windows'
       run: |

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ functions, subject to the [storage-engine exceptions](#sqlite-compatibility).
 | Ruby | `gem install doltlite` | [dolthub/doltlite-ruby](https://github.com/dolthub/doltlite-ruby) |
 | Node.js / Bun | `npm install @dolthub/doltlite` | [dolthub/doltlite-node](https://github.com/dolthub/doltlite-node) |
 | PHP | `composer require dolthub/doltlite-php` | this repo ([`packaging/composer`](packaging/composer)), distributed via [dolthub/doltlite-php](https://github.com/dolthub/doltlite-php) |
+| .NET | `dotnet add package DoltHub.Doltlite` | this repo ([`packaging/nuget`](packaging/nuget)); works under Microsoft.Data.Sqlite.Core, EF Core, Dapper |
 | Browser / WASM | `npm install @dolthub/doltlite-wasm` | this repo ([`packaging/npm`](packaging/npm), built from [`ext/wasm`](ext/wasm)) |
 | Swift (iOS / macOS) | SwiftPM: `https://github.com/dolthub/doltlite-swift` | [dolthub/doltlite-swift](https://github.com/dolthub/doltlite-swift) (XCFramework built by [`packaging/swift`](packaging/swift)) |
 | Android | Gradle: `com.dolthub:doltlite-android` | [dolthub/doltlite-android](https://github.com/dolthub/doltlite-android) (AAR + JNA) |

--- a/main.mk
+++ b/main.mk
@@ -2939,13 +2939,19 @@ LDFLAGS.libdoltlite.exports = $(if $(libdoltlite.exports.file),-Wl$(libdoltlite.
 # export table also settles what an unfiltered MinGW link only guesses at:
 # its auto-export heuristic is disabled by any one dllexport anywhere in the
 # link, which silently produced a DLL that dlopen'd but resolved no symbols.
+# Data exports (sqlite3_version, sqlite3_temp_directory) carry the DATA
+# keyword: without it the import library hands a consumer the address of the
+# indirection slot instead of the variable.
 libdoltlite.def: $(LIBOBJS0)
 	echo EXPORTS > $@
 	nm -g --defined-only $(LIBOBJS0) \
-		| sed -n 's/^.*[[:space:]][TRD][[:space:]]_\{0,1\}\(sqlite3_[A-Za-z0-9_]*\)$$/\1/p' \
+		| sed -n 's/^.*[[:space:]]T[[:space:]]_\{0,1\}\(sqlite3_[A-Za-z0-9_]*\)$$/\1/p' \
 		| sort -u >> $@
 	nm -g --defined-only $(LIBOBJS0) \
-		| sed -n 's/^.*[[:space:]][TRD][[:space:]]_\{0,1\}\(doltliteServe[A-Za-z0-9_]*\)$$/\1/p' \
+		| sed -n 's/^.*[[:space:]][RDB][[:space:]]_\{0,1\}\(sqlite3_[A-Za-z0-9_]*\)$$/\1 DATA/p' \
+		| sort -u >> $@
+	nm -g --defined-only $(LIBOBJS0) \
+		| sed -n 's/^.*[[:space:]]T[[:space:]]_\{0,1\}\(doltliteServe[A-Za-z0-9_]*\)$$/\1/p' \
 		| sort -u >> $@
 
 libdoltlite.deffile = $(if $(filter .dll,$(T.dll)),libdoltlite.def,)

--- a/main.mk
+++ b/main.mk
@@ -2933,8 +2933,25 @@ libdoltlite.exports.file = $(if $(filter .so,$(T.dll)),$(TOP)/src/libdoltlite.ma
 libdoltlite.exports.flag = $(if $(filter .so,$(T.dll)),--version-script,$(if $(filter .dylib,$(T.dll)),-exported_symbols_list,))
 LDFLAGS.libdoltlite.exports = $(if $(libdoltlite.exports.file),-Wl$(libdoltlite.comma)$(libdoltlite.exports.flag)$(libdoltlite.comma)$(libdoltlite.exports.file),)
 
-libdoltlite$(T.dll):	$(LIBOBJS0) $(libdoltlite.exports.file)
-	$(T.link.shared) -o $@ $(LIBOBJS0) $(LDFLAGS.libsqlite3) \
+# PE has no version-script equivalent, and the export lists above are globs
+# that a .def cannot express, so the same export set is resolved against the
+# objects here -- upstream generates sqlite3.def the same way. Naming an
+# export table also settles what an unfiltered MinGW link only guesses at:
+# its auto-export heuristic is disabled by any one dllexport anywhere in the
+# link, which silently produced a DLL that dlopen'd but resolved no symbols.
+libdoltlite.def: $(LIBOBJS0)
+	echo EXPORTS > $@
+	nm -g --defined-only $(LIBOBJS0) \
+		| sed -n 's/^.*[[:space:]][TRD][[:space:]]_\{0,1\}\(sqlite3_[A-Za-z0-9_]*\)$$/\1/p' \
+		| sort -u >> $@
+	nm -g --defined-only $(LIBOBJS0) \
+		| sed -n 's/^.*[[:space:]][TRD][[:space:]]_\{0,1\}\(doltliteServe[A-Za-z0-9_]*\)$$/\1/p' \
+		| sort -u >> $@
+
+libdoltlite.deffile = $(if $(filter .dll,$(T.dll)),libdoltlite.def,)
+
+libdoltlite$(T.dll):	$(LIBOBJS0) $(libdoltlite.exports.file) $(libdoltlite.deffile)
+	$(T.link.shared) -o $@ $(libdoltlite.deffile) $(LIBOBJS0) $(LDFLAGS.libsqlite3) \
 		$(LDFLAGS.libdoltlite.os-specific) $(LDFLAGS.libdoltlite.soname) \
 		$(LDFLAGS.libdoltlite.exports)
 	$(if $(filter .so,$(T.dll)),ln -sf libdoltlite$(T.dll) libdoltlite$(T.dll).0)

--- a/packaging/nuget/DoltHub.Doltlite.csproj
+++ b/packaging/nuget/DoltHub.Doltlite.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <RootNamespace>DoltHub.Doltlite</RootNamespace>
+    <AssemblyName>DoltHub.Doltlite</AssemblyName>
+
+    <PackageId>DoltHub.Doltlite</PackageId>
+    <Description>DoltLite for .NET: SQLite with Git-style version control (branch, commit, merge, diff). Plugs the bundled libdoltlite engine into SQLitePCLRaw, so Microsoft.Data.Sqlite.Core, EF Core, and Dapper work unchanged on top.</Description>
+    <Authors>DoltHub</Authors>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/dolthub/doltlite</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/dolthub/doltlite</RepositoryUrl>
+    <PackageTags>doltlite;dolt;sqlite;database;version-control</PackageTags>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <IncludeSymbols>false</IncludeSymbols>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="SQLitePCLRaw.core" Version="2.1.10" />
+    <PackageReference Include="SQLitePCLRaw.provider.dynamic_cdecl" Version="2.1.10" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="/" />
+    <None Include="runtimes/**" Pack="true" PackagePath="runtimes/" />
+  </ItemGroup>
+
+</Project>

--- a/packaging/nuget/README.md
+++ b/packaging/nuget/README.md
@@ -1,0 +1,61 @@
+# DoltHub.Doltlite
+
+[DoltLite](https://github.com/dolthub/doltlite) for .NET: SQLite with
+Git-style version control — branch, commit, merge, and diff your relational
+data. This package bundles the `libdoltlite` native engine per platform and
+plugs it into [SQLitePCLRaw](https://github.com/ericsink/SQLitePCL.raw), the
+layer the .NET SQLite ecosystem already builds on — so
+`Microsoft.Data.Sqlite.Core`, EF Core's Sqlite provider, and Dapper work
+unchanged on top of it.
+
+## Install
+
+```sh
+dotnet add package DoltHub.Doltlite
+dotnet add package Microsoft.Data.Sqlite.Core
+```
+
+Use `Microsoft.Data.Sqlite.Core`, not `Microsoft.Data.Sqlite`: the non-Core
+package pins SQLitePCLRaw to its own bundled stock engine.
+
+## Use
+
+```csharp
+using DoltHub.Doltlite;
+using Microsoft.Data.Sqlite;
+
+Doltlite.Init(); // once at startup, before the first connection
+
+using var conn = new SqliteConnection("Data Source=app.db");
+conn.Open();
+
+var create = conn.CreateCommand();
+create.CommandText = "CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT)";
+create.ExecuteNonQuery();
+
+// Version control is plain SQL on the same connection.
+var commit = conn.CreateCommand();
+commit.CommandText = "SELECT dolt_commit('-A', '-m', 'add users table')";
+commit.ExecuteScalar();
+```
+
+With EF Core, configure the provider as usual
+(`options.UseSqlite("Data Source=app.db")`) after calling `Doltlite.Init()`,
+and reach version control through
+`db.Database.ExecuteSqlRaw("SELECT dolt_commit(...)")`. Every DoltLite
+feature — branches, merges, the `dolt_log`/`dolt_diff`/`dolt_branches`
+tables, remotes — is reachable through SQL; see the
+[DoltLite documentation](https://github.com/dolthub/doltlite).
+
+## Requirements
+
+- .NET 6.0 or later.
+- Bundled native engines: `linux-x64`, `linux-arm64`, `osx-x64`, `osx-arm64`,
+  `win-x64`. For anything else, set `DOLTLITE_NET_LIB` to the path of a
+  `libdoltlite` shared library built from source.
+
+## Source
+
+The package source lives in
+[dolthub/doltlite](https://github.com/dolthub/doltlite) under
+`packaging/nuget/`; send issues and pull requests there.

--- a/packaging/nuget/assemble.sh
+++ b/packaging/nuget/assemble.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+#
+# Stage and pack the DoltHub.Doltlite NuGet package. Copies this directory's
+# csproj/src/README alongside the shared library `make doltlite-lib` produced
+# (placed under runtimes/<rid>/native/ where NativeLibrary.Load resolves it)
+# and runs `dotnet pack` with the version. A release merges the runtimes/
+# trees of per-platform runs before the final pack.
+#
+# Usage: assemble.sh <version> <out_dir> <build_dir>
+#   version    release version without the leading "v" (e.g. 0.11.57)
+#   out_dir    directory to create and populate; the .nupkg lands in it
+#   build_dir  build directory containing libdoltlite.{so,dylib,dll}
+
+set -euo pipefail
+
+VERSION="${1:?usage: assemble.sh <version> <out_dir> <build_dir>}"
+OUT_DIR="${2:?usage: assemble.sh <version> <out_dir> <build_dir>}"
+BUILD_DIR="${3:?usage: assemble.sh <version> <out_dir> <build_dir>}"
+
+PKG_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+case "$(uname -s)" in
+  Darwin) OS=osx; SRC_LIB=libdoltlite.dylib; DST_LIB=libdoltlite.dylib ;;
+  MINGW*|MSYS*|CYGWIN*) OS=win; SRC_LIB=libdoltlite.dll; DST_LIB=doltlite.dll ;;
+  *) OS=linux; SRC_LIB=libdoltlite.so; DST_LIB=libdoltlite.so ;;
+esac
+case "$(uname -m)" in
+  arm64|aarch64) ARCH=arm64 ;;
+  *) ARCH=x64 ;;
+esac
+RID="$OS-$ARCH"
+
+LIB="$BUILD_DIR/$SRC_LIB"
+if [ ! -f "$LIB" ]; then
+  echo "ERROR: missing shared library: $LIB (did 'make doltlite-lib' run?)" >&2
+  exit 1
+fi
+
+rm -rf "$OUT_DIR"
+mkdir -p "$OUT_DIR/pkg/runtimes/$RID/native"
+
+cp "$PKG_DIR/DoltHub.Doltlite.csproj" "$OUT_DIR/pkg/"
+cp -R "$PKG_DIR/src" "$OUT_DIR/pkg/src"
+cp "$PKG_DIR/README.md" "$OUT_DIR/pkg/README.md"
+cp "$LIB" "$OUT_DIR/pkg/runtimes/$RID/native/$DST_LIB"
+
+dotnet pack "$OUT_DIR/pkg/DoltHub.Doltlite.csproj" \
+  -p:Version="$VERSION" -c Release -o "$OUT_DIR" --nologo -v quiet
+
+echo "Packed DoltHub.Doltlite $VERSION ($RID) into $OUT_DIR:"
+ls -la "$OUT_DIR"/*.nupkg

--- a/packaging/nuget/smoke-test/Program.cs
+++ b/packaging/nuget/smoke-test/Program.cs
@@ -24,6 +24,30 @@ void Check(string name, object? got, object? want)
     }
 }
 
+// A library that loads but is not an engine must say so, not fail as a null
+// dereference inside the provider. Runs before Init() since the provider is
+// process-wide and set once; the harness builds the decoy.
+string? decoy = Environment.GetEnvironmentVariable("DOLTLITE_TEST_DECOY");
+if (string.IsNullOrEmpty(decoy))
+{
+    Console.WriteLine("  SKIP: non-engine library is rejected (no decoy built)");
+}
+else
+{
+    Environment.SetEnvironmentVariable("DOLTLITE_NET_LIB", decoy);
+    try
+    {
+        Doltlite.Init();
+        Check("non-engine library is rejected", "no exception", "exception");
+    }
+    catch (EntryPointNotFoundException e)
+    {
+        Check("non-engine library is rejected",
+            e.Message.Contains("does not export"), true);
+    }
+    Environment.SetEnvironmentVariable("DOLTLITE_NET_LIB", null);
+}
+
 Doltlite.Init();
 
 string dbPath = Path.Combine(

--- a/packaging/nuget/smoke-test/Program.cs
+++ b/packaging/nuget/smoke-test/Program.cs
@@ -1,0 +1,115 @@
+// Package-level smoke test for DoltHub.Doltlite. Runs from a consumer
+// project against the installed package, covering the surface end to end:
+// provider init, DDL/DML through Microsoft.Data.Sqlite.Core, parameters and
+// column values across every type, error paths, and a version-control round
+// trip (commit, branch, checkout, merge, dolt_log reads).
+
+using DoltHub.Doltlite;
+using Microsoft.Data.Sqlite;
+
+int failures = 0;
+
+void Check(string name, object? got, object? want)
+{
+    bool ok = Equals(got, want) ||
+        (got is byte[] g && want is byte[] w && g.AsSpan().SequenceEqual(w));
+    if (ok)
+    {
+        Console.WriteLine($"  PASS: {name}");
+    }
+    else
+    {
+        failures++;
+        Console.WriteLine($"  FAIL: {name}\n    want: {want}\n    got:  {got}");
+    }
+}
+
+Doltlite.Init();
+
+string dbPath = Path.Combine(
+    Path.GetTempPath(), $"doltlite-net-smoke-{Environment.ProcessId}.db");
+foreach (string f in new[] { dbPath, $"{dbPath}-lock" })
+{
+    File.Delete(f);
+}
+
+using (var conn = new SqliteConnection($"Data Source={dbPath}"))
+{
+    conn.Open();
+
+    object? Scalar(string sql)
+    {
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = sql;
+        return cmd.ExecuteScalar();
+    }
+    int Exec(string sql)
+    {
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = sql;
+        return cmd.ExecuteNonQuery();
+    }
+
+    Check("engine version reports", ((string?)Scalar("SELECT sqlite_version()"))?.Length > 0, true);
+
+    Exec("CREATE TABLE t(pk INTEGER PRIMARY KEY, s TEXT, f REAL, b BLOB)");
+    Check("insert changes", Exec("INSERT INTO t(pk, s, f, b) VALUES (1, 'one', 1.5, x'00ff10')"), 1);
+
+    using (var ins = conn.CreateCommand())
+    {
+        ins.CommandText = "INSERT INTO t(pk, s, f, b) VALUES ($pk, $s, $f, $b)";
+        ins.Parameters.AddWithValue("$pk", 2);
+        ins.Parameters.AddWithValue("$s", "twö");
+        ins.Parameters.AddWithValue("$f", 2.25);
+        ins.Parameters.AddWithValue("$b", new byte[] { 1, 0, 2 });
+        Check("parameterized insert", ins.ExecuteNonQuery(), 1);
+    }
+    using (var ins = conn.CreateCommand())
+    {
+        ins.CommandText = "INSERT INTO t(pk, s) VALUES ($pk, $s)";
+        ins.Parameters.AddWithValue("$pk", 3);
+        ins.Parameters.AddWithValue("$s", DBNull.Value);
+        ins.ExecuteNonQuery();
+    }
+
+    using (var sel = conn.CreateCommand())
+    {
+        sel.CommandText = "SELECT s, f, b FROM t WHERE pk = 2";
+        using var r = sel.ExecuteReader();
+        Check("row exists", r.Read(), true);
+        Check("text round trip (utf8)", r.GetString(0), "twö");
+        Check("float round trip", r.GetDouble(1), 2.25);
+        Check("blob round trip", (byte[])r.GetValue(2), new byte[] { 1, 0, 2 });
+    }
+    Check("null round trip", Scalar("SELECT s FROM t WHERE pk = 3"), DBNull.Value);
+    Check("int round trip", Scalar("SELECT pk FROM t WHERE pk = 1"), 1L);
+
+    try
+    {
+        Scalar("SELECT * FROM missing_table");
+        Check("bad SQL throws", "no exception", "exception");
+    }
+    catch (SqliteException e)
+    {
+        Check("bad SQL throws", e.Message.Contains("missing_table"), true);
+    }
+
+    // Version control is plain SQL through the same connection.
+    Check("dolt_commit", ((string?)Scalar("SELECT dolt_commit('-A', '-m', 'first commit')"))?.Length > 0, true);
+    Check("dolt_branch", Scalar("SELECT dolt_branch('feature')"), 0L);
+    Check("dolt_checkout feature", Scalar("SELECT dolt_checkout('feature')"), 0L);
+    Exec("UPDATE t SET s = 'branched' WHERE pk = 1");
+    Check("dolt_commit on branch", ((string?)Scalar("SELECT dolt_commit('-A', '-m', 'feature work')"))?.Length > 0, true);
+    Check("dolt_checkout main", Scalar("SELECT dolt_checkout('main')"), 0L);
+    Check("main unchanged", Scalar("SELECT s FROM t WHERE pk = 1"), "one");
+    Scalar("SELECT dolt_merge('feature')");
+    Check("dolt_merge fast-forwards", Scalar("SELECT s FROM t WHERE pk = 1"), "branched");
+    Check("dolt_log sees both commits", (long)Scalar("SELECT count(*) FROM dolt_log")! >= 2, true);
+}
+
+File.Delete(dbPath);
+
+Console.WriteLine(failures == 0
+    ? "smoke-test: all checks passed"
+    : $"smoke-test: {failures} failure(s)");
+return failures == 0 ? 0 : 1;

--- a/packaging/nuget/smoke-test/Program.cs
+++ b/packaging/nuget/smoke-test/Program.cs
@@ -52,10 +52,26 @@ Doltlite.Init();
 
 string dbPath = Path.Combine(
     Path.GetTempPath(), $"doltlite-net-smoke-{Environment.ProcessId}.db");
-foreach (string f in new[] { dbPath, $"{dbPath}-lock" })
+string[] dbFiles = { dbPath, $"{dbPath}-lock" };
+
+void Cleanup()
 {
-    File.Delete(f);
+    // Disposing a SqliteConnection returns it to the pool rather than
+    // closing the handle, and Windows refuses to delete a file still open.
+    SqliteConnection.ClearAllPools();
+    foreach (string f in dbFiles)
+    {
+        try
+        {
+            File.Delete(f);
+        }
+        catch (IOException)
+        {
+        }
+    }
 }
+
+Cleanup();
 
 using (var conn = new SqliteConnection($"Data Source={dbPath}"))
 {
@@ -131,7 +147,7 @@ using (var conn = new SqliteConnection($"Data Source={dbPath}"))
     Check("dolt_log sees both commits", (long)Scalar("SELECT count(*) FROM dolt_log")! >= 2, true);
 }
 
-File.Delete(dbPath);
+Cleanup();
 
 Console.WriteLine(failures == 0
     ? "smoke-test: all checks passed"

--- a/packaging/nuget/smoke-test/smoke-test.csproj
+++ b/packaging/nuget/smoke-test/smoke-test.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="DoltHub.Doltlite" Version="0.0.0-ci" />
+    <PackageReference Include="Microsoft.Data.Sqlite.Core" Version="8.0.8" />
+  </ItemGroup>
+
+</Project>

--- a/packaging/nuget/src/Doltlite.cs
+++ b/packaging/nuget/src/Doltlite.cs
@@ -17,6 +17,16 @@ namespace DoltHub.Doltlite
         private static readonly object Gate = new object();
         private static bool _initialized;
 
+        /// <summary>
+        /// Proves the loaded library is doltlite with a working export table.
+        /// Deliberately not a sqlite3_* name: a stock SQLite satisfies those,
+        /// so pointing DOLTLITE_NET_LIB at one would pass here and then fail
+        /// far away on the first dolt_ function. This symbol is doltlite's, is
+        /// defined whether or not the build has remote support, and is covered
+        /// by the export filter on every platform.
+        /// </summary>
+        private const string Marker = "doltliteServerPort";
+
         public static void Init()
         {
             lock (Gate)
@@ -25,18 +35,17 @@ namespace DoltHub.Doltlite
                 {
                     return;
                 }
-                IntPtr lib = LoadNativeLibrary();
-                // A library that loads but exports nothing usable otherwise
-                // surfaces as a NullReferenceException from deep inside the
-                // provider, naming neither the library nor the symbol.
-                if (!NativeLibrary.TryGetExport(
-                        lib, "sqlite3_libversion_number", out IntPtr _))
+                string source;
+                IntPtr lib = LoadNativeLibrary(out source);
+                // Without this, a library that loads but cannot back the API
+                // fails as a null dereference inside the provider, naming
+                // neither the library nor what was missing.
+                if (!NativeLibrary.TryGetExport(lib, Marker, out IntPtr _))
                 {
-                    throw new DllNotFoundException(
-                        "The doltlite native library loaded but does not export " +
-                        "the SQLite C API (sqlite3_libversion_number is missing). " +
-                        "It is likely not a doltlite build, or was built without " +
-                        "an export table.");
+                    throw new EntryPointNotFoundException(
+                        $"The native library loaded from {source} does not " +
+                        $"export {Marker}, so it is not a doltlite build or " +
+                        "was built without an export table.");
                 }
                 SQLite3Provider_dynamic_cdecl.Setup("doltlite", new Exports(lib));
                 raw.SetProvider(new SQLite3Provider_dynamic_cdecl());
@@ -44,17 +53,19 @@ namespace DoltHub.Doltlite
             }
         }
 
-        private static IntPtr LoadNativeLibrary()
+        private static IntPtr LoadNativeLibrary(out string source)
         {
             string? overridePath =
                 Environment.GetEnvironmentVariable("DOLTLITE_NET_LIB");
             if (!string.IsNullOrEmpty(overridePath))
             {
+                source = $"DOLTLITE_NET_LIB ({overridePath})";
                 return NativeLibrary.Load(overridePath);
             }
             // Probes the platform name variants (libdoltlite.so/.dylib,
             // doltlite.dll) through the assembly's package context, which
             // includes this package's runtimes/<rid>/native payload.
+            source = "this package's bundled runtimes";
             return NativeLibrary.Load(
                 "doltlite", typeof(Doltlite).Assembly, null);
         }

--- a/packaging/nuget/src/Doltlite.cs
+++ b/packaging/nuget/src/Doltlite.cs
@@ -26,6 +26,18 @@ namespace DoltHub.Doltlite
                     return;
                 }
                 IntPtr lib = LoadNativeLibrary();
+                // A library that loads but exports nothing usable otherwise
+                // surfaces as a NullReferenceException from deep inside the
+                // provider, naming neither the library nor the symbol.
+                if (!NativeLibrary.TryGetExport(
+                        lib, "sqlite3_libversion_number", out IntPtr _))
+                {
+                    throw new DllNotFoundException(
+                        "The doltlite native library loaded but does not export " +
+                        "the SQLite C API (sqlite3_libversion_number is missing). " +
+                        "It is likely not a doltlite build, or was built without " +
+                        "an export table.");
+                }
                 SQLite3Provider_dynamic_cdecl.Setup("doltlite", new Exports(lib));
                 raw.SetProvider(new SQLite3Provider_dynamic_cdecl());
                 _initialized = true;

--- a/packaging/nuget/src/Doltlite.cs
+++ b/packaging/nuget/src/Doltlite.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Runtime.InteropServices;
+using SQLitePCL;
+
+namespace DoltHub.Doltlite
+{
+    /// <summary>
+    /// Plugs the bundled libdoltlite engine into SQLitePCLRaw. Call
+    /// <see cref="Init"/> once at startup, before the first connection;
+    /// everything layered on SQLitePCLRaw (Microsoft.Data.Sqlite.Core,
+    /// EF Core's Sqlite provider, Dapper) then runs on DoltLite unchanged.
+    /// DoltLite's version control is plain SQL on the connection, e.g.
+    /// <c>SELECT dolt_commit('-A', '-m', 'message')</c>.
+    /// </summary>
+    public static class Doltlite
+    {
+        private static readonly object Gate = new object();
+        private static bool _initialized;
+
+        public static void Init()
+        {
+            lock (Gate)
+            {
+                if (_initialized)
+                {
+                    return;
+                }
+                IntPtr lib = LoadNativeLibrary();
+                SQLite3Provider_dynamic_cdecl.Setup("doltlite", new Exports(lib));
+                raw.SetProvider(new SQLite3Provider_dynamic_cdecl());
+                _initialized = true;
+            }
+        }
+
+        private static IntPtr LoadNativeLibrary()
+        {
+            string? overridePath =
+                Environment.GetEnvironmentVariable("DOLTLITE_NET_LIB");
+            if (!string.IsNullOrEmpty(overridePath))
+            {
+                return NativeLibrary.Load(overridePath);
+            }
+            // Probes the platform name variants (libdoltlite.so/.dylib,
+            // doltlite.dll) through the assembly's package context, which
+            // includes this package's runtimes/<rid>/native payload.
+            return NativeLibrary.Load(
+                "doltlite", typeof(Doltlite).Assembly, null);
+        }
+
+        private sealed class Exports : IGetFunctionPointer
+        {
+            private readonly IntPtr _lib;
+
+            internal Exports(IntPtr lib)
+            {
+                _lib = lib;
+            }
+
+            public IntPtr GetFunctionPointer(string name)
+            {
+                return NativeLibrary.TryGetExport(_lib, name, out IntPtr p)
+                    ? p
+                    : IntPtr.Zero;
+            }
+        }
+    }
+}

--- a/packaging/nuget/test-package.sh
+++ b/packaging/nuget/test-package.sh
@@ -22,6 +22,12 @@ STAGE="$(mktemp -d)"
 CONSUMER="$(mktemp -d)"
 trap 'rm -rf "$STAGE" "$CONSUMER"' EXIT
 
+# Per-run package cache. The staged package always carries the same version,
+# and NuGet keys its global cache on id+version alone -- without this it
+# restores whatever 0.0.0-ci it extracted first and silently ignores the
+# package built from the current tree.
+export NUGET_PACKAGES="$CONSUMER/.nuget"
+
 bash "$PKG_DIR/assemble.sh" "0.0.0-ci" "$STAGE/feed" "$BUILD_DIR"
 
 cp "$PKG_DIR/smoke-test/smoke-test.csproj" "$CONSUMER/"
@@ -43,6 +49,23 @@ cat > "$CONSUMER/nuget.config" <<EOF
   </packageSources>
 </configuration>
 EOF
+
+# A library that loads but is not an engine, for the rejection check. Built
+# rather than borrowed from the system: what a system library resolves varies
+# by platform (on macOS the system SQLite is reachable through libSystem).
+case "$(uname -s)" in
+  Darwin) DECOY_EXT=dylib ;;
+  MINGW*|MSYS*|CYGWIN*) DECOY_EXT=dll ;;
+  *) DECOY_EXT=so ;;
+esac
+printf 'int doltlite_decoy(void){ return 0; }\n' > "$CONSUMER/decoy.c"
+if cc -shared -o "$CONSUMER/decoy.$DECOY_EXT" "$CONSUMER/decoy.c" 2>/dev/null; then
+  DECOY="$CONSUMER/decoy.$DECOY_EXT"
+  if command -v cygpath >/dev/null 2>&1; then
+    DECOY="$(cygpath -w "$DECOY")"
+  fi
+  export DOLTLITE_TEST_DECOY="$DECOY"
+fi
 
 cd "$CONSUMER"
 dotnet run -c Release --nologo

--- a/packaging/nuget/test-package.sh
+++ b/packaging/nuget/test-package.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+#
+# Package-level smoke test for DoltHub.Doltlite. Packs the package from a
+# build directory's shared library, installs it into a throwaway consumer
+# project from a local NuGet feed, and runs the smoke test against the
+# installed package. This exercises the real package payload -- the managed
+# init assembly and the runtimes/<rid>/native library resolution -- not just
+# the raw source files. Dependencies (SQLitePCLRaw, Microsoft.Data.Sqlite.Core)
+# restore from nuget.org.
+#
+# Usage: test-package.sh [build_dir]   (default: ./build)
+
+set -euo pipefail
+
+PKG_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$PKG_DIR/../.." && pwd)"
+BUILD_DIR="$(cd "${1:-$ROOT/build}" && pwd)"
+
+command -v dotnet >/dev/null || { echo "ERROR: dotnet is required" >&2; exit 1; }
+
+STAGE="$(mktemp -d)"
+CONSUMER="$(mktemp -d)"
+trap 'rm -rf "$STAGE" "$CONSUMER"' EXIT
+
+bash "$PKG_DIR/assemble.sh" "0.0.0-ci" "$STAGE/feed" "$BUILD_DIR"
+
+cp "$PKG_DIR/smoke-test/smoke-test.csproj" "$CONSUMER/"
+cp "$PKG_DIR/smoke-test/Program.cs" "$CONSUMER/"
+cat > "$CONSUMER/nuget.config" <<EOF
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="local" value="$STAGE/feed" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>
+EOF
+
+cd "$CONSUMER"
+dotnet run -c Release --nologo

--- a/packaging/nuget/test-package.sh
+++ b/packaging/nuget/test-package.sh
@@ -26,11 +26,19 @@ bash "$PKG_DIR/assemble.sh" "0.0.0-ci" "$STAGE/feed" "$BUILD_DIR"
 
 cp "$PKG_DIR/smoke-test/smoke-test.csproj" "$CONSUMER/"
 cp "$PKG_DIR/smoke-test/Program.cs" "$CONSUMER/"
+
+# NuGet reads the source as a literal path, and under Git Bash a shell path
+# like /tmp/x resolves to C:\tmp\x for the native dotnet. Hand it the OS path.
+FEED="$STAGE/feed"
+if command -v cygpath >/dev/null 2>&1; then
+  FEED="$(cygpath -w "$FEED")"
+fi
+
 cat > "$CONSUMER/nuget.config" <<EOF
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <add key="local" value="$STAGE/feed" />
+    <add key="local" value="$FEED" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
.NET bindings via the ecosystem's own engine-swap hook: SQLitePCLRaw's dynamic-cdecl provider. `Doltlite.Init()` loads the bundled `libdoltlite` (which keeps SQLite's exported symbol names) and sets it as the SQLitePCLRaw provider — everything layered on it (`Microsoft.Data.Sqlite.Core`, EF Core's Sqlite provider, Dapper) then runs on DoltLite unchanged. No ADO.NET provider fork needed.

## Shape

- `packaging/nuget/`: net6.0 managed init assembly (`DoltHub.Doltlite`), per-platform natives under `runtimes/<rid>/native/` (linux-x64/arm64, osx-x64/arm64, win-x64), deps on `SQLitePCLRaw.core` + `SQLitePCLRaw.provider.dynamic_cdecl`.
- Library resolution: `DOLTLITE_NET_LIB` override → package `runtimes/` payload via `NativeLibrary.Load` → system.
- Version control is plain SQL on the connection; no binding-specific API.

## Tests

`test-package.sh` packs from a build directory's shared library, installs the package into a throwaway consumer from a local NuGet feed, and runs the smoke test against the installed package through `Microsoft.Data.Sqlite.Core`: every parameter/column type (UTF-8 text, blobs, null, int64, real), error paths, and a commit → branch → checkout → merge → `dolt_log` round trip. Green locally on macOS arm64.

Build-Test runs it on **all three platforms** — deliberately including Windows, making this the first CI exercise of the win-x64 `libdoltlite.dll` that the checked build already produces.

## Follow-ups (separate PRs)

- Release wiring: `release-nuget` job assembling all five RIDs from the release's `doltlite-lib-*.zip` assets and pushing to nuget.org — needs a `NUGET_TOKEN` secret (nuget.org API key for the DoltHub account); no split repo required since NuGet takes uploaded artifacts.
- Optional sugar package later (extension methods like `conn.DoltCommit(...)`) if demand shows up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)