### PR TITLE
Announce DoltLite beta in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ on the [DoltHub blog](https://www.dolthub.com/blog/?tags=doltlite). DoltLite is
 the proud product of 
 [agentic engineering](https://www.dolthub.com/blog/2026-08-17-top-5-agent-engineered-open-source-projects/).
 
+[DoltLite is Beta](https://www.dolthub.com/blog/2026-08-31-doltlite-beta/).
+
 ## Install
 
 Prebuilt binaries: [github.com/dolthub/doltlite/releases](https://github.com/dolthub/doltlite/releases).


### PR DESCRIPTION
Adds a short beta announcement at the end of the README introduction and links to the release blog.

Documentation-only change.

Co-Authored-By: OpenAI Codex <noreply@openai.com>