### PR TITLE
Refresh regression archive before local runs

### DIFF
--- a/test/build_artifacts_guard_test.sh
+++ b/test/build_artifacts_guard_test.sh
@@ -155,7 +155,8 @@ done
 exit 43
 EOF
 chmod +x "$WRAPPER_TMP/cc-stub"
-if DOLTLITE_BUILD_DIR="$WRAPPER_TMP" \
+if DOLTLITE_REGRESSION_PREBUILT=0 \
+   DOLTLITE_BUILD_DIR="$WRAPPER_TMP" \
    DOLTLITE_TEST_ARCHIVE="$WRAPPER_TMP/libdoltlite.a" \
    CC="$WRAPPER_TMP/cc-stub" \
    bash "$HERE/run_doltlite_regression_case.sh" all >/dev/null 2>&1; then

--- a/test/build_artifacts_guard_test.sh
+++ b/test/build_artifacts_guard_test.sh
@@ -131,6 +131,41 @@ else
   echo "  (skipping sanitizer probes: set DOLTLITE_SAN_ARCHIVE to an instrumented libdoltlite.a)"
 fi
 
+WRAPPER_TMP=$(mktemp -d)
+printf 'stale\n' > "$WRAPPER_TMP/libdoltlite.a"
+cat > "$WRAPPER_TMP/Makefile" <<'EOF'
+.PHONY: libdoltlite.a
+libdoltlite.a:
+	@printf 'refreshed\n' > libdoltlite.a
+EOF
+cat > "$WRAPPER_TMP/cc-stub" <<'EOF'
+#!/bin/sh
+if ! grep -qx refreshed "$DOLTLITE_TEST_ARCHIVE"; then
+  exit 42
+fi
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = -o ]; then
+    shift
+    printf '#!/bin/sh\nexit 0\n' > "$1"
+    chmod +x "$1"
+    exit 0
+  fi
+  shift
+done
+exit 43
+EOF
+chmod +x "$WRAPPER_TMP/cc-stub"
+if DOLTLITE_BUILD_DIR="$WRAPPER_TMP" \
+   DOLTLITE_TEST_ARCHIVE="$WRAPPER_TMP/libdoltlite.a" \
+   CC="$WRAPPER_TMP/cc-stub" \
+   bash "$HERE/run_doltlite_regression_case.sh" all >/dev/null 2>&1; then
+  ok
+else
+  bad "regression_wrapper_refreshes_archive" \
+      "regression wrapper linked without refreshing libdoltlite.a"
+fi
+rm -rf "$WRAPPER_TMP"
+
 echo
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"
 if [ "$FAIL" -gt 0 ]; then

--- a/test/run_doltlite_regression_case.sh
+++ b/test/run_doltlite_regression_case.sh
@@ -18,6 +18,7 @@ esac
 
 if [ "${DOLTLITE_REGRESSION_PREBUILT:-0}" != "1" ]; then
   source "$script_dir/lib/build_artifacts.sh"
+  make -C "$build_dir" libdoltlite.a
   dl_check_archive_flags "$build_dir/libdoltlite.a" "${CFLAGS:-"-g"}"
   "${CC:-cc}" ${CFLAGS:-"-g"} -I"$build_dir" -I"$repo_root/src" \
     -o "$build_dir/doltlite_regression_test_c" \


### PR DESCRIPTION
## Summary

- rebuild libdoltlite.a through the configured Makefile before linking local C regression cases
- cover the wrapper with a fake stale archive that must be refreshed before compilation
- preserve the prebuilt CI path for coverage and sanitizer artifacts

## Testing

- bash test/build_artifacts_guard_test.sh
- bash test/run_doltlite_regression_case.sh peer_commit_keeps_statements
- bash test/run_doltlite_regression_case.sh all
- make lint

Co-Authored-By: OpenAI Codex <noreply@openai.com>