### PR TITLE
Update agent guidance for DoltLite Beta

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -279,6 +279,21 @@ conflict durability, update the TSV and keep the multiproc C suites green
 The version-control correctness invariants above remain load-bearing for
 implementors even when a claim is also listed in the contract.
 
+## SQLite compatibility contract
+
+The user-facing SQLite compatibility contract lives in the README **SQLite
+Compatibility** section; claims and evidence live in
+`test/sqlite_compatibility_contract.tsv`. Update the README, contract row, and
+its evidence together when observable compatibility behavior changes.
+
+Do not infer poor SQLite compatibility from an intentional storage-engine
+adaptation. DoltLite uses chunks rather than pages, has no SQLite WAL or
+rollback journal, and cannot use an anonymous rowid as a version-controlled
+key because identity must be history-independent. Classify inherited-suite
+exceptions through `test/known_testfixture_divergences.txt`: `engine-gap` is a
+bug to fix, while `intentional`, `unsupported`, and `harness` entries describe
+known boundaries. SQLLogicTest remains a zero-divergence correctness gate.
+
 ## Storage format version
 
 Chunk-store version **12** is the beta format freeze. User-facing rules live in
@@ -297,8 +312,22 @@ Any incompatible change to a nested write format, including working sets,
 catalogs, refs, commits, prolly nodes, or key encoding, must bump
 `CHUNK_STORE_VERSION`. Do not silently reinterpret another version.
 
-## Move fast
+The release workflow also runs `test/doltlite_compat_test.sh` against prior
+releases. Run it when changing format recognition, readers, writers, or version
+handling; version-12 databases already created by Beta users are compatibility
+fixtures, not disposable test data.
 
-External integration tests and remaining pre-beta docs freezes are deprioritized
-when they are not on the beta path. Prefer fixing the engine and proving it with
-tests; format and concurrency contracts that already ship must stay accurate.
+## Beta release surfaces
+
+DoltLite is public Beta. Move quickly on engine fixes, but treat documented
+behavior, version-12 data, the compatibility and concurrency contracts, public
+C headers and exports, release packages, and binding inputs as shipped
+surfaces. A change under `packaging/`, the install/export rules, amalgamation
+generation, or `.github/workflows/release.yml` must run the relevant package or
+artifact smoke test; core engine tests alone do not validate a distributed
+artifact.
+
+External integration and documentation work is no longer a pre-Beta
+deprioritized category. Scope validation to the surface being changed, preserve
+the published contracts, and fix the engine with fail-before/pass-after
+evidence when behavior is wrong.

--- a/src/doltlite_docs.c
+++ b/src/doltlite_docs.c
@@ -32,8 +32,8 @@ static const char *zDocsAgentName = "AGENT.md";
 static const char *zDocsAgentDefault =
   "# AGENT.md - DoltLite Database Operations Guide\n"
   "\n"
-  "This database is a DoltLite database: SQLite-compatible SQL with\n"
-  "Dolt-style version control (commits, branches, diffs, merges) built in.\n"
+  "This is a DoltLite database: SQLite-compatible SQL with Dolt-style\n"
+  "version control (commits, branches, diffs, merges) built in.\n"
   "Version control operations are SQL function calls, not stored\n"
   "procedures: use `SELECT dolt_commit(...)`, never `CALL dolt_commit(...)`.\n"
   "\n"
@@ -61,6 +61,15 @@ static const char *zDocsAgentDefault =
   "Each branch has its own working state; uncommitted changes are\n"
   "per-branch.\n"
   "\n"
+  "## Remotes\n"
+  "\n"
+  "```sql\n"
+  "SELECT dolt_remote('add', 'origin', 'file:///path/to/remote.db');\n"
+  "SELECT dolt_push('origin', 'main');\n"
+  "SELECT dolt_pull('origin', 'main');\n"
+  "SELECT dolt_clone('file:///path/to/source.db');\n"
+  "```\n"
+  "\n"
   "## Diffs and History\n"
   "\n"
   "```sql\n"
@@ -85,6 +94,10 @@ static const char *zDocsAgentDefault =
   "SELECT dolt_commit('-m', 'merged');\n"
   "```\n"
   "\n"
+  "Constraint violations may persist after merges. Inspect\n"
+  "`dolt_constraint_violations` and `dolt_constraint_violations_<t>`, then\n"
+  "run `SELECT dolt_verify_constraints('--all')` after repairs.\n"
+  "\n"
   "## Undoing Changes\n"
   "\n"
   "```sql\n"
@@ -98,8 +111,12 @@ static const char *zDocsAgentDefault =
   "- `dolt_docs` (this table) stores versioned documents keyed by name;\n"
   "  `dolt_ignore` holds patterns for tables `dolt_add` should skip. Both\n"
   "  commit, diff, branch and merge like ordinary tables.\n"
-  "- Standard SQLite applies everywhere else: `.tables`, `PRAGMA`, ATTACH,\n"
-  "  triggers, views, FTS5, R-Tree.\n";
+  "- Beta storage format version 12 is not SQLite's page format; stock SQLite\n"
+  "  cannot open it, and no SQLite journal, `-wal`, or `-shm` sidecars exist.\n"
+  "- ATTACH works, but one transaction may write only one file-backed database.\n"
+  "- Most SQLite SQL features remain available, including triggers, views,\n"
+  "  FTS5, and R-Tree. For storage-coupled API and PRAGMA differences, see\n"
+  "  https://github.com/dolthub/doltlite#sqlite-compatibility.\n";
 
 static int docsConnect(sqlite3 *db, void *pAux, int argc,
     const char *const*argv, sqlite3_vtab **ppVtab, char **pzErr){

--- a/test/doltlite_docs.sh
+++ b/test/doltlite_docs.sh
@@ -10,6 +10,15 @@ run_test "fresh_select_shows_default_agent" \
   "SELECT doc_name, length(doc_text) > 500 FROM dolt_docs;" \
   "AGENT.md|1" "$DB"
 
+run_test "fresh_agent_documents_beta_contracts" \
+  "SELECT instr(doc_text, 'storage format version 12') > 0,
+          instr(doc_text, 'dolt_push') > 0,
+          instr(doc_text, 'dolt_constraint_violations') > 0,
+          instr(doc_text, 'one transaction may write only one file-backed') > 0,
+          instr(doc_text, 'Standard SQLite applies everywhere else') = 0
+     FROM dolt_docs WHERE doc_name='AGENT.md';" \
+  "1|1|1|1|1" "$DB"
+
 run_test "fresh_no_status_row" \
   "SELECT count(*) FROM dolt_status;" \
   "0" "$DB"


### PR DESCRIPTION
## Summary

- replace the stale pre-Beta prioritization guidance with rules for shipped compatibility, packaging, and binding surfaces
- document how to classify SQLite storage adaptations separately from engine compatibility gaps
- add the prior-release compatibility gate to the storage-format workflow
- expand the embedded `dolt_docs` `AGENT.md` with concise remotes, constraint-violation, version-12, sidecar, ATTACH, and compatibility guidance
- remove the blanket claim that standard SQLite behavior applies everywhere

## Testing

- fail-before: `fresh_agent_documents_beta_contracts` returned `0|0|0|0|0`
- pass-after: `DOLTLITE=build/doltlite bash test/doltlite_docs.sh` — 35 passed
- `bash test/vc_oracle_docs_test.sh build/doltlite dolt` — 47 passed
- `DOLTLITE_BUILD_DIR="$PWD/build" bash test/run_doltlite_tests.sh` — passed
- `make lint` — passed
- `bash -n test/doltlite_docs.sh`
- `git diff --check`

Co-Authored-By: OpenAI Codex <noreply@openai.com>
