### PR TITLE
Omit sqlite3.h from the curl installer

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -8,6 +8,7 @@
 #   DOLTLITE_INSTALL_DIR — target directory (default /usr/local/bin)
 #   DOLTLITE_VERSION     — pin to a specific version, e.g. v0.10.3
 #                          (default: the latest GitHub release)
+#   DOLTLITE_BASE_URL    — override the release asset URL (tests)
 
 set -euo pipefail
 
@@ -96,7 +97,7 @@ esac
 
 TOOLS_ZIP="doltlite-tools-${TARGET}-${VERSION_NUM}.zip"
 LIB_ZIP="doltlite-lib-${TARGET}-${VERSION_NUM}.zip"
-BASE_URL="https://github.com/dolthub/doltlite/releases/download/${VERSION}"
+BASE_URL="${DOLTLITE_BASE_URL:-https://github.com/dolthub/doltlite/releases/download/${VERSION}}"
 
 TMP_DIR="$(mktemp -d -t doltlite-install-XXXXXX)"
 trap 'rm -rf "$TMP_DIR"' EXIT
@@ -123,7 +124,9 @@ for bin in doltlite doltlite-remotesrv; do
   echo "Installed ${INSTALL_DIR}/${bin}"
 done
 
-for hdr in sqlite3.h doltlite.h doltlite_remotesrv.h; do
+# Deb and Homebrew install doltlite.h only. sqlite3.h collides with
+# system SQLite headers; skip it even if a lib zip still contains it.
+for hdr in doltlite.h doltlite_remotesrv.h; do
   if [ -f "${LIB_SRC_DIR}/${hdr}" ]; then
     install -m 0644 "${LIB_SRC_DIR}/${hdr}" "${INCLUDE_DIR}/${hdr}"
     echo "Installed ${INCLUDE_DIR}/${hdr}"

--- a/test/install_sh_layout_test.sh
+++ b/test/install_sh_layout_test.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# install.sh must match Deb/Homebrew: doltlite.h and doltlite_remotesrv.h,
+# never sqlite3.h. A lib zip that still contains sqlite3.h is the
+# regression — older releases did, and copying it collides with system
+# SQLite. Uses DOLTLITE_BASE_URL so this does not hit the network.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+INSTALL_SH="$REPO_ROOT/install.sh"
+
+if [ ! -x "$INSTALL_SH" ] && [ ! -f "$INSTALL_SH" ]; then
+  echo "FAIL: $INSTALL_SH not found"
+  exit 1
+fi
+
+for cmd in curl unzip zip; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "SKIP: $cmd is required to exercise install.sh"
+    exit 0
+  fi
+done
+
+OS="$(uname -s)"
+case "$OS" in
+  Linux)  PLATFORM="linux" ;;
+  Darwin) PLATFORM="osx" ;;
+  *) echo "SKIP: install.sh does not support OS '$OS'"; exit 0 ;;
+esac
+
+ARCH="$(uname -m)"
+case "$ARCH" in
+  x86_64|amd64) PKG_ARCH="x64" ;;
+  arm64|aarch64) PKG_ARCH="arm64" ;;
+  *) echo "SKIP: install.sh does not support architecture '$ARCH'"; exit 0 ;;
+esac
+TARGET="${PLATFORM}-${PKG_ARCH}"
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/doltlite-install-sh.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+pass=0
+fail=0
+ok()  { echo "  PASS: $1"; pass=$((pass+1)); }
+bad() { echo "  FAIL: $1"; fail=$((fail+1)); }
+
+VERSION="v0.0.0-test"
+VERSION_NUM="${VERSION#v}"
+ASSETS="$TMP/assets"
+PREFIX="$TMP/prefix"
+TOOLS_NAME="doltlite-tools-${TARGET}-${VERSION_NUM}"
+LIB_NAME="doltlite-lib-${TARGET}-${VERSION_NUM}"
+TOOLS_DIR="$ASSETS/$TOOLS_NAME"
+LIB_DIR="$ASSETS/$LIB_NAME"
+
+mkdir -p "$TOOLS_DIR" "$LIB_DIR"
+printf '#!/bin/sh\necho dummy\n' >"$TOOLS_DIR/doltlite"
+printf '#!/bin/sh\necho dummy\n' >"$TOOLS_DIR/doltlite-remotesrv"
+chmod +x "$TOOLS_DIR/doltlite" "$TOOLS_DIR/doltlite-remotesrv"
+
+printf 'SQLITE3_COLLISION\n' >"$LIB_DIR/sqlite3.h"
+printf 'DOLTLITE_HEADER\n' >"$LIB_DIR/doltlite.h"
+printf 'REMOTESRV_HEADER\n' >"$LIB_DIR/doltlite_remotesrv.h"
+printf 'static\n' >"$LIB_DIR/libdoltlite.a"
+case "$PLATFORM" in
+  linux) printf 'shared\n' >"$LIB_DIR/libdoltlite.so" ;;
+  osx)   printf 'shared\n' >"$LIB_DIR/libdoltlite.dylib" ;;
+esac
+
+( cd "$ASSETS" && zip -qr "${TOOLS_NAME}.zip" "$TOOLS_NAME" \
+  && zip -qr "${LIB_NAME}.zip" "$LIB_NAME" ) || {
+  echo "FAIL: could not write fixture zips"
+  exit 1
+}
+
+echo "=== install.sh layout (${TARGET}) ==="
+if ! DOLTLITE_INSTALL_DIR="$PREFIX/bin" \
+     DOLTLITE_VERSION="$VERSION" \
+     DOLTLITE_BASE_URL="file://${ASSETS}" \
+     bash "$INSTALL_SH" >"$TMP/install.log" 2>&1; then
+  echo "FAIL: install.sh exited non-zero"
+  sed 's/^/    /' "$TMP/install.log" | head -40
+  exit 1
+fi
+
+have() { if [ -e "$2" ]; then ok "$1"; else bad "$1 (missing $2)"; fi; }
+absent() { if [ -e "$2" ]; then bad "$1 (unexpected $2)"; else ok "$1"; fi; }
+
+have "bin/doltlite"                 "$PREFIX/bin/doltlite"
+have "bin/doltlite-remotesrv"       "$PREFIX/bin/doltlite-remotesrv"
+have "include/doltlite.h"           "$PREFIX/include/doltlite.h"
+have "include/doltlite_remotesrv.h" "$PREFIX/include/doltlite_remotesrv.h"
+have "lib/libdoltlite.a"            "$PREFIX/lib/libdoltlite.a"
+case "$PLATFORM" in
+  linux) have "lib/libdoltlite.so"    "$PREFIX/lib/libdoltlite.so" ;;
+  osx)   have "lib/libdoltlite.dylib" "$PREFIX/lib/libdoltlite.dylib" ;;
+esac
+absent "include/sqlite3.h is not installed" "$PREFIX/include/sqlite3.h"
+
+if [ -f "$PREFIX/include/doltlite.h" ]; then
+  got="$(cat "$PREFIX/include/doltlite.h")"
+  if [ "$got" = "DOLTLITE_HEADER" ]; then
+    ok "include/doltlite.h is the DoltLite header, not sqlite3.h"
+  else
+    bad "include/doltlite.h is the DoltLite header, not sqlite3.h (got: $got)"
+  fi
+fi
+
+echo ""
+echo "======================================="
+echo "Results: $pass passed, $fail failed"
+echo "======================================="
+[ "$fail" -eq 0 ] && exit 0 || exit 1

--- a/test/lib/doltlite_suite_manifest.sh
+++ b/test/lib/doltlite_suite_manifest.sh
@@ -3,6 +3,7 @@
 doltlite_all_suites() {
   cat <<'EOF'
 build_artifacts_guard_test.sh
+install_sh_layout_test.sh
 sqlite_compatibility_contract_test.sh
 concurrency_contract_test.sh
 storage_format_contract_test.sh


### PR DESCRIPTION
Deb and Homebrew already install the embedding header as `doltlite.h` only, so they do not collide with system SQLite. The curl installer (`install.sh`) still copied `sqlite3.h` into `$PREFIX/include` whenever the lib zip contained it.

Skip `sqlite3.h` even if an older zip still has it. `DOLTLITE_BASE_URL` lets the new layout test feed fixture zips over `file://` without hitting GitHub.

`test/install_sh_layout_test.sh` builds a zip that contains both headers and asserts `sqlite3.h` is not installed.

Co-Authored-By: Grok 4.6 <noreply@x.ai>