### PR TITLE
Document pointing an existing SQLite binding at DoltLite

### DIFF
--- a/doc/doltlite/using-existing-sqlite-bindings.md
+++ b/doc/doltlite/using-existing-sqlite-bindings.md
@@ -13,7 +13,7 @@ documented way to be handed a different one. Where that hook exists, adopting
 DoltLite is a configuration change rather than a port.
 
 If your language has a
-[packaged binding](../README.md#bindings), use it — it bundles the engine and
+[packaged binding](../../README.md#bindings), use it — it bundles the engine and
 needs none of this. This document is for everything else.
 
 ## What you need
@@ -54,7 +54,7 @@ cargo build
 ```
 
 Do not enable its `bundled` feature — that compiles its own copy of SQLite and
-ignores yours. There is also a [`doltlite` crate](../packaging/rust) that
+ignores yours. There is also a [`doltlite` crate](../../packaging/rust) that
 vendors the engine if you would rather not manage the library.
 
 ## Go (mattn/go-sqlite3)
@@ -101,7 +101,7 @@ carry the native library.
 
 ## .NET
 
-Covered by the [`DoltHub.Doltlite`](../packaging/nuget) package: it plugs the
+Covered by the [`DoltHub.Doltlite`](../../packaging/nuget) package: it plugs the
 engine into SQLitePCLRaw, under `Microsoft.Data.Sqlite.Core`, EF Core, and
 Dapper. Use `Microsoft.Data.Sqlite.Core` rather than `Microsoft.Data.Sqlite`,
 which pins its own bundled engine.
@@ -109,7 +109,7 @@ which pins its own bundled engine.
 ## Python, PHP, Node, Ruby
 
 All have packaged bindings — see the
-[bindings table](../README.md#bindings). Python additionally works with the
+[bindings table](../../README.md#bindings). Python additionally works with the
 stdlib `sqlite3` module when the interpreter links a shared `libsqlite3`; the
 [`doltlite`](https://github.com/dolthub/doltlite-python) package handles that
 for you.
@@ -140,7 +140,7 @@ this work?" in a few seconds before committing to a real integration.
 ## What changes, and what does not
 
 The SQL surface, the C API, and your queries stay the same, with the
-[storage-engine exceptions](../README.md#sqlite-compatibility) — those are
+[storage-engine exceptions](../../README.md#sqlite-compatibility) — those are
 about page-level and journaling APIs, not about SQL. What you gain is that
 every write can be committed, branched, diffed, and merged.
 

--- a/doc/using-existing-sqlite-bindings.md
+++ b/doc/using-existing-sqlite-bindings.md
@@ -1,0 +1,151 @@
+# Pointing an existing SQLite binding at DoltLite
+
+DoltLite exports the SQLite C API under SQLite's own symbol names, so a
+program that already talks to SQLite can be pointed at DoltLite instead of
+being rewritten. Your queries keep working, and the `dolt_*` functions and
+version-control tables become available through whatever query API you
+already use.
+
+This matters because the layer people assume is the engine usually is not.
+`Microsoft.Data.Sqlite`, `rusqlite`, `sqlite3` for Dart, and PHP's `pdo_sqlite`
+are all *bindings* that call a native SQLite library, and most of them have a
+documented way to be handed a different one. Where that hook exists, adopting
+DoltLite is a configuration change rather than a port.
+
+If your language has a
+[packaged binding](../README.md#bindings), use it — it bundles the engine and
+needs none of this. This document is for everything else.
+
+## What you need
+
+A DoltLite shared library, from a
+[release](https://github.com/dolthub/doltlite/releases) (`doltlite-lib-*.zip`,
+or the `.deb` packages) or built from source:
+
+```sh
+cd build && ../configure && make doltlite-lib
+# → libdoltlite.{so,dylib}, libdoltlite.a, and SQLite-named copies
+#   (libsqlite3.*) of the same engine
+```
+
+The SQLite-named artifacts exist precisely for this: bindings that hardcode
+`-lsqlite3` link them without knowing the difference.
+
+## Confirming you got DoltLite
+
+Whatever the mechanism, verify it took effect rather than assuming:
+
+```sql
+SELECT doltlite_engine();   -- prolly
+```
+
+Stock SQLite fails that query with "no such function", which is the signal
+you are still on the old engine. `SELECT sqlite_version()` is *not* a useful
+check — DoltLite reports the SQLite version it is derived from.
+
+## Rust (rusqlite)
+
+`libsqlite3-sys` links an external SQLite when told where it is:
+
+```sh
+SQLITE3_LIB_DIR=/path/to/doltlite/build \
+SQLITE3_INCLUDE_DIR=/path/to/doltlite/build \
+cargo build
+```
+
+Do not enable its `bundled` feature — that compiles its own copy of SQLite and
+ignores yours. There is also a [`doltlite` crate](../packaging/rust) that
+vendors the engine if you would rather not manage the library.
+
+## Go (mattn/go-sqlite3)
+
+The `libsqlite3` build tag links a system library through `pkg-config` instead
+of compiling the bundled amalgamation:
+
+```sh
+sudo make install        # the shipped sqlite3.pc resolves against the
+                         # install prefix, not the build directory
+go build -tags libsqlite3 ./...
+```
+
+Note that Go already has a better option for most cases: Dolt itself embeds
+in-process via [`github.com/dolthub/driver`](https://github.com/dolthub/driver),
+in pure Go with no cgo and the full Dolt feature set. Reach for DoltLite when
+you specifically need SQLite dialect compatibility for an existing SQLite
+application, or a small C library rather than Dolt's dependency tree.
+
+## Dart / Flutter (`sqlite3` package)
+
+The package takes an explicit override:
+
+```dart
+import 'dart:ffi';
+import 'package:sqlite3/open.dart';
+import 'package:sqlite3/sqlite3.dart';
+
+void main() {
+  open.overrideFor(
+    OperatingSystem.linux,
+    () => DynamicLibrary.open('libdoltlite.so'),
+  );
+  final db = sqlite3.open('app.db');
+  db.select("SELECT dolt_commit('-A', '-m', 'checkpoint')");
+}
+```
+
+Register the override before the first `sqlite3` use, once per platform you
+ship. For Android and iOS specifically, prefer the packaged
+[Android](https://github.com/dolthub/doltlite-android) and
+[Swift](https://github.com/dolthub/doltlite-swift) bindings, which already
+carry the native library.
+
+## .NET
+
+Covered by the [`DoltHub.Doltlite`](../packaging/nuget) package: it plugs the
+engine into SQLitePCLRaw, under `Microsoft.Data.Sqlite.Core`, EF Core, and
+Dapper. Use `Microsoft.Data.Sqlite.Core` rather than `Microsoft.Data.Sqlite`,
+which pins its own bundled engine.
+
+## Python, PHP, Node, Ruby
+
+All have packaged bindings — see the
+[bindings table](../README.md#bindings). Python additionally works with the
+stdlib `sqlite3` module when the interpreter links a shared `libsqlite3`; the
+[`doltlite`](https://github.com/dolthub/doltlite-python) package handles that
+for you.
+
+## Any language with a C FFI
+
+If your binding has no override hook, two general mechanisms remain.
+
+**Load the library directly.** Anything that can `dlopen` and call C functions
+can drive DoltLite: open `libdoltlite`, then call `sqlite3_open_v2`,
+`sqlite3_prepare_v2`, `sqlite3_step`, and friends. That is exactly how the PHP
+binding works.
+
+**Substitute it at load time.** Where a binding hardcodes a library name, the
+dynamic linker can be told to resolve those symbols from DoltLite first:
+
+```sh
+LD_PRELOAD=/path/to/libdoltlite.so ./your-program              # Linux
+DYLD_INSERT_LIBRARIES=/path/to/libdoltlite.dylib ./your-program # macOS
+```
+
+Treat this as a last resort and a development aid rather than a deployment
+strategy: it applies process-wide, so every component that uses SQLite gets
+DoltLite, and on macOS it additionally requires the library's install name to
+match what the program looked for. It is genuinely useful for answering "would
+this work?" in a few seconds before committing to a real integration.
+
+## What changes, and what does not
+
+The SQL surface, the C API, and your queries stay the same, with the
+[storage-engine exceptions](../README.md#sqlite-compatibility) — those are
+about page-level and journaling APIs, not about SQL. What you gain is that
+every write can be committed, branched, diffed, and merged.
+
+Two practical notes. `PRAGMA journal_mode` is inert: the chunk store has its
+own durability mechanism, so on a file database the pragma always reports
+`wal` and setting it changes nothing. And a DoltLite database is not a SQLite
+file — existing `.db` files must be migrated by dumping and reloading, not
+opened in place.


### PR DESCRIPTION
One page answering the question that came up twice this week in different languages: *"the SQLite binding is the engine — how do I swap it?"*

It isn't, usually. `Microsoft.Data.Sqlite`, `rusqlite`, Dart's `sqlite3`, and `pdo_sqlite` all call a native library and most expose a documented way to be handed a different one. Since DoltLite exports the SQLite C API under SQLite's own names, that makes adoption a configuration change rather than a port — worth writing down once rather than answering per language.

Covers: rusqlite (`SQLITE3_LIB_DIR`), mattn/go-sqlite3 (`-tags libsqlite3`), Dart (`open.overrideFor`), .NET (points at the package), and the generic `dlopen` / `LD_PRELOAD` routes for anything with a C FFI. Points at the packaged bindings first, and is honest that **Go should usually use embedded Dolt** (`github.com/dolthub/driver`, pure Go, full feature set) unless they need SQLite dialect compatibility for an existing application.

Also documents how to confirm the swap actually took effect — `SELECT doltlite_engine()` returns `prolly`, and notes that `sqlite_version()` is not a useful check since DoltLite reports the SQLite version it derives from.

Claims were verified against a real build rather than inferred, which caught two of my own errors before they shipped: `journal_mode` reports `wal` on a file database and setting it is inert (I had written "a fixed value" after testing only `:memory:`, which reports `memory`), and the shipped `sqlite3.pc` resolves against the install prefix — so the Go instructions say `make install` rather than pointing `PKG_CONFIG_PATH` at the build directory, which would have silently linked the wrong library.

🤖 Generated with [Claude Code](https://claude.com/claude-code)