### PR TITLE
Compare the file, not the filesystem, in the replacement guard

### DIFF
--- a/test/doltlite_readonly_file_replacement.sh
+++ b/test/doltlite_readonly_file_replacement.sh
@@ -14,6 +14,14 @@ echo ""
 ROOT=$(mktemp -d /tmp/dl_ro_repl_XXXXXX)
 trap 'chmod -R u+w "$ROOT" 2>/dev/null; rm -rf "$ROOT"' EXIT
 
+# GNU stat spells the format -c and uses -f for filesystem info; BSD stat is
+# the reverse. Probing -c first keeps the Linux path from capturing statfs
+# output, whose free-block counters any concurrent write perturbs -- the file
+# signature then compares unequal even though the file never changed.
+file_signature() {
+  stat -c "%s-%a-%i-%h" "$1" 2>/dev/null || stat -f "%z-%Lp-%i-%l" "$1"
+}
+
 seed_db() {
   rm -f "$1"
   echo "CREATE TABLE t(a INTEGER PRIMARY KEY, b TEXT);
@@ -26,9 +34,9 @@ for op in "VACUUM;" "PRAGMA wal_checkpoint;" "SELECT dolt_gc();"; do
   seed_db "$DB"
   ln "$DB" "$ROOT/link.db"
   chmod 0444 "$DB"
-  before=$(stat -f "%z-%Lp-%i-%l" "$DB" 2>/dev/null || stat -c "%s-%a-%i-%h" "$DB")
+  before=$(file_signature "$DB")
   $DOLTLITE "file:$DB?mode=ro" "$op" > /dev/null 2>&1
-  after=$(stat -f "%z-%Lp-%i-%l" "$DB" 2>/dev/null || stat -c "%s-%a-%i-%h" "$DB")
+  after=$(file_signature "$DB")
   label=$(echo "$op" | tr -cd '[:alnum:]_')
   if [ "$before" = "$after" ]; then
     dltest_pass "readonly_untouched_$label"


### PR DESCRIPTION
`doltlite_readonly_file_replacement.sh` failed on a coverage run for `readonly_untouched_SELECTdolt_gc`. The engine was fine — the test was comparing the wrong thing on Linux.

The signature probes BSD `stat` first:

```sh
before=$(stat -f "%z-%Lp-%i-%l" "$DB" 2>/dev/null || stat -c "%s-%a-%i-%h" "$DB")
```

but GNU `stat` spells the format `-c` and uses `-f` for `--file-system`, which takes no format argument. On Linux that captures **statfs output** — total/free blocks and inodes for the whole volume — with the real signature appended after it. Any write anywhere on the filesystem between the two probes moves the free counters and fails the comparison.

The failing run shows exactly that. Free blocks went `22210379 → 22210378`, one block, while the file signature itself — `3639-444-7378430-2` (size-mode-inode-links) — is **identical on both sides**. The read-only handle never touched the database; only the volume's free space moved, most likely the coverage runtime writing a `.profraw`.

That also explains why it has essentially never been seen: it needs a write to land on the same filesystem inside the window between two adjacent `stat` calls, which a busy coverage runner makes far more likely than a normal one.

Fix probes `-c` first and keeps the BSD spelling as the fallback. Verified both ways: macOS still passes 9/9 (falls back to `-f`), and in a Linux container the old pattern returns statfs text where the new one returns a proper `3-644-1966113-1` signature.

Found while investigating a red on #2523, which touches no engine or test code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)