### PR TITLE
Publish the doltlite crate to crates.io on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -906,6 +906,66 @@ jobs:
           --source https://api.nuget.org/v3/index.json \
           --skip-duplicate
 
+  # ── Publish the Rust crate ───────────────────────────────
+  # crates.io takes uploaded source, so there is no split repo: stage the
+  # crate with this build's amalgamation vendored into it and publish.
+  # Verification is left on -- cargo builds the packaged crate before
+  # uploading -- because a crates.io publish is permanent: there is no
+  # delete and no unlist, only `cargo yank`, which still serves the files.
+  #
+  # Authentication is a stored token only because trusted publishing is
+  # configured per crate and the crate has to exist first. Once the first
+  # version is up, register this workflow on the crate and swap the token
+  # for rust-lang/crates-io-auth-action with id-token: write, matching how
+  # release-nuget authenticates.
+  release-crates:
+    if: github.event_name != 'workflow_dispatch'
+    needs: release
+    runs-on: ubuntu-latest
+    env:
+      VERSION: ${{ github.ref_name }}
+    steps:
+    - name: Check crates.io token
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      run: |
+        if [ -z "${CARGO_REGISTRY_TOKEN}" ]; then
+          echo "CARGO_REGISTRY_TOKEN is required to publish the doltlite crate"
+          exit 1
+        fi
+
+    - uses: actions/checkout@v4
+
+    - name: Install dependencies
+      run: bash .github/scripts/install-apt-deps.sh build-essential zlib1g-dev tcl
+
+    - name: Build the amalgamation
+      run: |
+        mkdir -p build && cd build
+        ../configure
+        make sqlite3.c sqlite3.h
+
+    - name: Stage the crate
+      run: |
+        version="${VERSION#v}"
+        bash packaging/rust/assemble.sh "$version" dist/crate build
+
+    - name: Publish to crates.io
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      run: |
+        set -euo pipefail
+        version="${VERSION#v}"
+        # Idempotent: a re-run of the release workflow must not fail on a
+        # version crates.io already has.
+        if curl -sf -H "User-Agent: doltlite-release" \
+             "https://crates.io/api/v1/crates/doltlite/${version}" >/dev/null; then
+          echo "doltlite ${version} already published; skipping"
+          exit 0
+        fi
+        cd dist/crate
+        cargo publish --allow-dirty
+
   # from here — build the canonical npm distributables (make -C ext/wasm npm),
   # stage them with packaging/npm, and npm publish. Requires the NPM_TOKEN
   # secret: an npm automation token with publish rights to the @dolthub scope.


### PR DESCRIPTION
Follow-up to #2523: release wiring for the Rust crate.

On each tagged release, `release-crates` builds the amalgamation, stages `packaging/rust` with it vendored via `assemble.sh`, and publishes to crates.io. No split repo — crates.io takes uploaded source directly.

Two deliberate choices:

**cargo's verification stays enabled.** It builds the packaged crate before uploading, which costs a few minutes but is worth it here: a crates.io publish is *permanent*. There is no delete and no unlist, only `cargo yank`, which stops new dependents from resolving the version but keeps serving the files forever. Publishing something broken can't be walked back.

**Token auth, for now.** crates.io trusted publishing is configured per crate on the crate's own settings page, so the crate has to exist before it can be registered — the first publish needs `CARGO_REGISTRY_TOKEN` regardless. The job comment records the intended follow-up: register this workflow on the crate, swap to `rust-lang/crates-io-auth-action` with `id-token: write` (matching how `release-nuget` authenticates), and delete the secret.

Idempotent on re-runs: it queries crates.io for the version first and skips if present, matching the other publish jobs.

After the first successful publish, two manual steps: run `cargo owner --add github:dolthub:<team>` so the crate belongs to a team rather than the publishing account, and register trusted publishing so the token can be retired. I'll verify the published crate installs from crates.io with a version-control round trip, as with the PHP and .NET packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)