### PR TITLE
Assert read-only maintenance operation results

### DIFF
--- a/test/doltlite_readonly_file_replacement.sh
+++ b/test/doltlite_readonly_file_replacement.sh
@@ -22,6 +22,14 @@ file_signature() {
   stat -c "%s-%a-%i-%h" "$1" 2>/dev/null || stat -f "%z-%Lp-%i-%l" "$1"
 }
 
+readonly_result_ok() {
+  if [ "$1" = "PRAGMA wal_checkpoint;" ]; then
+    [ "$2" -eq 0 ] && echo "$3" | grep -qE '^[0-9]+\|'
+  else
+    [ "$2" -ne 0 ] && echo "$3" | grep -q "readonly"
+  fi
+}
+
 seed_db() {
   rm -f "$1"
   echo "CREATE TABLE t(a INTEGER PRIMARY KEY, b TEXT);
@@ -35,14 +43,18 @@ for op in "VACUUM;" "PRAGMA wal_checkpoint;" "SELECT dolt_gc();"; do
   ln "$DB" "$ROOT/link.db"
   chmod 0444 "$DB"
   before=$(file_signature "$DB")
-  $DOLTLITE "file:$DB?mode=ro" "$op" > /dev/null 2>&1
+  out=$($DOLTLITE "file:$DB?mode=ro" "$op" 2>&1)
+  rc=$?
   after=$(file_signature "$DB")
   label=$(echo "$op" | tr -cd '[:alnum:]_')
-  if [ "$before" = "$after" ]; then
+  if [ "$before" != "$after" ]; then
+    dltest_fail "readonly_untouched_$label" \
+      "  file changed: $before -> $after (size-mode-inode-links)"
+  elif readonly_result_ok "$op" "$rc" "$out"; then
     dltest_pass "readonly_untouched_$label"
   else
     dltest_fail "readonly_untouched_$label" \
-      "  file changed: $before -> $after (size-mode-inode-links)"
+      "  unexpected result (status $rc): $out"
   fi
   chmod u+w "$DB"; rm -f "$DB" "$ROOT/link.db"
 done


### PR DESCRIPTION
## Summary

- require read-only `VACUUM` and `dolt_gc()` to return the expected read-only refusal
- require read-only `wal_checkpoint` to succeed with checkpoint output
- continue asserting that every operation leaves the database file identity and metadata unchanged

Follow-up to #2525 and the additional Ito finding.

## Testing

- fail-before: an injected checkpoint exit 42 incorrectly produced 9/9 passes
- pass-after guard: the same injection produces the expected 8/9 result and reports status 42
- real `test/doltlite_readonly_file_replacement.sh`: 9/9 passed
- `bash -n test/doltlite_readonly_file_replacement.sh`
- `make lint`

Co-Authored-By: OpenAI Codex <noreply@openai.com>