### PR TITLE
Add doltlite-go: a database/sql driver with the engine vendored

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -212,6 +212,14 @@ jobs:
         bash packaging/composer/test-package.sh build
       timeout-minutes: 5
 
+    - name: Smoke test the doltlite-go module
+      if: matrix.platform != 'windows'
+      shell: bash
+      run: |
+        chmod +x packaging/go/assemble.sh packaging/go/test-package.sh
+        bash packaging/go/test-package.sh build
+      timeout-minutes: 20
+
     - name: Smoke test the doltlite Rust crate
       if: matrix.platform != 'windows'
       shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,5 @@ state.json
 .compat-cache/
 packaging/rust/vendor/
 packaging/rust/target/
+packaging/go/doltlite.c
+packaging/go/doltlite.h

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ functions, subject to the [storage-engine exceptions](#sqlite-compatibility).
 | PHP | `composer require dolthub/doltlite-php` | this repo ([`packaging/composer`](packaging/composer)), distributed via [dolthub/doltlite-php](https://github.com/dolthub/doltlite-php) |
 | .NET | `dotnet add package DoltHub.Doltlite` | this repo ([`packaging/nuget`](packaging/nuget)); works under Microsoft.Data.Sqlite.Core, EF Core, Dapper |
 | Rust | `cargo add doltlite` | this repo ([`packaging/rust`](packaging/rust)); engine vendored, or point `rusqlite` at a build with `SQLITE3_LIB_DIR` |
+| Go | `go get github.com/dolthub/doltlite-go` | this repo ([`packaging/go`](packaging/go)); `database/sql` driver, engine vendored |
 | Browser / WASM | `npm install @dolthub/doltlite-wasm` | this repo ([`packaging/npm`](packaging/npm), built from [`ext/wasm`](ext/wasm)) |
 | Swift (iOS / macOS) | SwiftPM: `https://github.com/dolthub/doltlite-swift` | [dolthub/doltlite-swift](https://github.com/dolthub/doltlite-swift) (XCFramework built by [`packaging/swift`](packaging/swift)) |
 | Android | Gradle: `com.dolthub:doltlite-android` | [dolthub/doltlite-android](https://github.com/dolthub/doltlite-android) (AAR + JNA) |

--- a/packaging/go/README.md
+++ b/packaging/go/README.md
@@ -1,0 +1,70 @@
+# doltlite-go
+
+[DoltLite](https://github.com/dolthub/doltlite) for Go: SQLite with Git-style
+version control — branch, commit, merge, and diff your relational data,
+exposed as a `database/sql` driver. The engine is compiled into the package
+from a vendored amalgamation, so there is no system library to install.
+
+## Install
+
+```sh
+go get github.com/dolthub/doltlite-go
+```
+
+Requires cgo (`CGO_ENABLED=1`, the default when a C compiler is present) and
+zlib. The first build compiles the engine and is then cached.
+
+## Use
+
+```go
+import (
+    "database/sql"
+    _ "github.com/dolthub/doltlite-go"
+)
+
+db, err := sql.Open("doltlite", "app.db")
+if err != nil { return err }
+defer db.Close()
+
+if _, err := db.Exec(`CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT)`); err != nil {
+    return err
+}
+if _, err := db.Exec(`INSERT INTO users(name) VALUES (?)`, "Ada"); err != nil {
+    return err
+}
+
+// Version control is plain SQL on the same connection.
+var commit string
+if err := db.QueryRow(`SELECT dolt_commit('-A', '-m', ?)`, "add ada").Scan(&commit); err != nil {
+    return err
+}
+
+rows, err := db.Query(`SELECT commit_hash, message FROM dolt_log`)
+```
+
+Every DoltLite feature — branches, merges, `dolt_log`/`dolt_diff`/`dolt_branches`,
+remotes — is reachable through SQL; there is no separate API. See the
+[DoltLite documentation](https://github.com/dolthub/doltlite).
+
+## Why not embedded Dolt?
+
+If you want versioned SQL in a new Go program, prefer
+[`github.com/dolthub/driver`](https://github.com/dolthub/driver): it embeds
+Dolt itself in pure Go, needs no cgo, and gives you the full Dolt feature set
+with MySQL dialect.
+
+Use this package when you specifically need **DoltLite databases** — a
+single-file chunk store that embedded Dolt cannot open — or SQLite dialect
+compatibility for an existing SQLite application, or a small C library rather
+than Dolt's dependency tree.
+
+## Platforms
+
+Linux and macOS. Windows is not supported yet: the build links the platform's
+zlib, which the MSVC toolchain does not provide.
+
+## Source
+
+The package source lives in
+[dolthub/doltlite](https://github.com/dolthub/doltlite) under `packaging/go/`;
+send issues and pull requests there.

--- a/packaging/go/assemble.sh
+++ b/packaging/go/assemble.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+#
+# Stage the doltlite-go module into an output directory ready to push to the
+# distribution repo. Copies this directory's module source and vendors the
+# amalgamation the build produced (build/sqlite3.c is genuinely doltlite --
+# mksqlite3c.tcl --doltlite weaves the prolly engine and version control into
+# it), which cgo compiles as part of the package.
+#
+# Usage: assemble.sh <version> <out_dir> <build_dir>
+#   version    release version without the leading "v" (e.g. 0.50.2)
+#   out_dir    directory to create and populate
+#   build_dir  build directory containing sqlite3.c and sqlite3.h
+
+set -euo pipefail
+
+VERSION="${1:?usage: assemble.sh <version> <out_dir> <build_dir>}"
+OUT_DIR="${2:?usage: assemble.sh <version> <out_dir> <build_dir>}"
+BUILD_DIR="${3:?usage: assemble.sh <version> <out_dir> <build_dir>}"
+
+PKG_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$PKG_DIR/../.." && pwd)"
+
+for f in sqlite3.c sqlite3.h; do
+  if [ ! -f "$BUILD_DIR/$f" ]; then
+    echo "ERROR: missing $BUILD_DIR/$f (did 'make sqlite3.c sqlite3.h' run?)" >&2
+    exit 1
+  fi
+done
+
+rm -rf "$OUT_DIR"
+mkdir -p "$OUT_DIR"
+
+cp "$PKG_DIR/doltlite.go" "$OUT_DIR/doltlite.go"
+cp "$PKG_DIR/go.mod"      "$OUT_DIR/go.mod"
+cp "$PKG_DIR/README.md"   "$OUT_DIR/README.md"
+cp "$ROOT/LICENSE.md"     "$OUT_DIR/LICENSE.md"
+cp "$BUILD_DIR/sqlite3.c" "$OUT_DIR/doltlite.c"
+cp "$BUILD_DIR/sqlite3.h" "$OUT_DIR/doltlite.h"
+
+# Go modules take their version from the repository tag, not from go.mod, so
+# there is nothing to stamp -- record it for the pushing side instead.
+echo "$VERSION" > "$OUT_DIR/.version"
+
+echo "Staged doltlite-go $VERSION in $OUT_DIR:"
+ls -la "$OUT_DIR"

--- a/packaging/go/doltlite.go
+++ b/packaging/go/doltlite.go
@@ -1,0 +1,316 @@
+// Package doltlite registers a database/sql driver for DoltLite: SQLite with
+// Git-style version control. Version control is plain SQL on the connection,
+// e.g. SELECT dolt_commit('-A', '-m', 'message').
+//
+// The engine is compiled from the amalgamation vendored alongside this file,
+// so no system library is required.
+package doltlite
+
+/*
+#cgo CFLAGS: -DDOLTLITE_PROLLY=1 -DSQLITE_THREADSAFE=1
+#cgo CFLAGS: -DSQLITE_ENABLE_MATH_FUNCTIONS -DSQLITE_ENABLE_FTS5
+#cgo CFLAGS: -DSQLITE_ENABLE_RTREE -DSQLITE_ENABLE_DBSTAT_VTAB
+#cgo CFLAGS: -DSQLITE_ENABLE_COLUMN_METADATA -w
+#cgo LDFLAGS: -lz -lm
+#cgo linux LDFLAGS: -lpthread
+
+#include <stdlib.h>
+#include <string.h>
+#include "doltlite.h"
+
+// The engine copies bound text and blobs rather than borrowing them, which
+// cgo requires: Go memory must not be retained by C after the call returns.
+static int dl_bind_text(sqlite3_stmt *s, int i, const char *p, int n) {
+  return sqlite3_bind_text(s, i, p, n, SQLITE_TRANSIENT);
+}
+static int dl_bind_blob(sqlite3_stmt *s, int i, const void *p, int n) {
+  return sqlite3_bind_blob(s, i, p, n, SQLITE_TRANSIENT);
+}
+*/
+import "C"
+
+import (
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"fmt"
+	"io"
+	"sync"
+	"unsafe"
+)
+
+func init() {
+	sql.Register("doltlite", Driver{})
+}
+
+// Version reports the SQLite version the bundled engine derives from.
+func Version() string {
+	return C.GoString(C.sqlite3_libversion())
+}
+
+// Error is an engine error carrying its result code.
+type Error struct {
+	Code int
+	Msg  string
+}
+
+func (e *Error) Error() string { return fmt.Sprintf("doltlite: %s (code %d)", e.Msg, e.Code) }
+
+// Driver implements driver.Driver.
+type Driver struct{}
+
+func (Driver) Open(name string) (driver.Conn, error) {
+	cname := C.CString(name)
+	defer C.free(unsafe.Pointer(cname))
+
+	var db *C.sqlite3
+	rc := C.sqlite3_open_v2(cname, &db,
+		C.SQLITE_OPEN_READWRITE|C.SQLITE_OPEN_CREATE, nil)
+	if rc != C.SQLITE_OK {
+		msg := "unable to open database"
+		if db != nil {
+			msg = C.GoString(C.sqlite3_errmsg(db))
+			C.sqlite3_close_v2(db)
+		}
+		return nil, &Error{Code: int(rc), Msg: msg}
+	}
+	return &conn{db: db}, nil
+}
+
+type conn struct {
+	mu     sync.Mutex
+	db     *C.sqlite3
+	closed bool
+}
+
+func (c *conn) err(rc C.int) error {
+	code := C.sqlite3_extended_errcode(c.db)
+	if code == 0 {
+		code = rc
+	}
+	return &Error{Code: int(code), Msg: C.GoString(C.sqlite3_errmsg(c.db))}
+}
+
+func (c *conn) Close() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed {
+		return nil
+	}
+	c.closed = true
+	C.sqlite3_close_v2(c.db)
+	return nil
+}
+
+func (c *conn) Prepare(query string) (driver.Stmt, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed {
+		return nil, driver.ErrBadConn
+	}
+	cq := C.CString(query)
+	defer C.free(unsafe.Pointer(cq))
+
+	var st *C.sqlite3_stmt
+	if rc := C.sqlite3_prepare_v2(c.db, cq, -1, &st, nil); rc != C.SQLITE_OK {
+		return nil, c.err(rc)
+	}
+	if st == nil {
+		return nil, errors.New("doltlite: query contains no statement")
+	}
+	return &stmt{c: c, st: st, nInput: int(C.sqlite3_bind_parameter_count(st))}, nil
+}
+
+func (c *conn) Begin() (driver.Tx, error) {
+	if err := c.exec("BEGIN"); err != nil {
+		return nil, err
+	}
+	return &tx{c: c}, nil
+}
+
+// exec runs a statement that takes no parameters and returns no rows.
+func (c *conn) exec(query string) error {
+	s, err := c.Prepare(query)
+	if err != nil {
+		return err
+	}
+	defer s.Close()
+	_, err = s.(*stmt).Exec(nil)
+	return err
+}
+
+type tx struct{ c *conn }
+
+func (t *tx) Commit() error   { return t.c.exec("COMMIT") }
+func (t *tx) Rollback() error { return t.c.exec("ROLLBACK") }
+
+type stmt struct {
+	c      *conn
+	st     *C.sqlite3_stmt
+	nInput int
+	closed bool
+}
+
+func (s *stmt) Close() error {
+	if s.closed {
+		return nil
+	}
+	s.closed = true
+	s.c.mu.Lock()
+	defer s.c.mu.Unlock()
+	C.sqlite3_finalize(s.st)
+	return nil
+}
+
+func (s *stmt) NumInput() int { return s.nInput }
+
+func (s *stmt) bind(args []driver.Value) error {
+	C.sqlite3_reset(s.st)
+	C.sqlite3_clear_bindings(s.st)
+	for i, a := range args {
+		idx := C.int(i + 1)
+		var rc C.int
+		switch v := a.(type) {
+		case nil:
+			rc = C.sqlite3_bind_null(s.st, idx)
+		case int64:
+			rc = C.sqlite3_bind_int64(s.st, idx, C.sqlite3_int64(v))
+		case float64:
+			rc = C.sqlite3_bind_double(s.st, idx, C.double(v))
+		case bool:
+			n := C.sqlite3_int64(0)
+			if v {
+				n = 1
+			}
+			rc = C.sqlite3_bind_int64(s.st, idx, n)
+		case string:
+			// An empty string still needs a valid pointer for the bind.
+			if len(v) == 0 {
+				rc = C.dl_bind_text(s.st, idx, (*C.char)(unsafe.Pointer(&[]byte{0}[0])), 0)
+			} else {
+				b := []byte(v)
+				rc = C.dl_bind_text(s.st, idx,
+					(*C.char)(unsafe.Pointer(&b[0])), C.int(len(b)))
+			}
+		case []byte:
+			if len(v) == 0 {
+				rc = C.dl_bind_blob(s.st, idx, unsafe.Pointer(&[]byte{0}[0]), 0)
+			} else {
+				rc = C.dl_bind_blob(s.st, idx, unsafe.Pointer(&v[0]), C.int(len(v)))
+			}
+		default:
+			return fmt.Errorf("doltlite: unsupported argument type %T", a)
+		}
+		if rc != C.SQLITE_OK {
+			return s.c.err(rc)
+		}
+	}
+	return nil
+}
+
+func (s *stmt) Exec(args []driver.Value) (driver.Result, error) {
+	s.c.mu.Lock()
+	defer s.c.mu.Unlock()
+	if err := s.bind(args); err != nil {
+		return nil, err
+	}
+	for {
+		rc := C.sqlite3_step(s.st)
+		if rc == C.SQLITE_ROW {
+			continue
+		}
+		if rc != C.SQLITE_DONE {
+			C.sqlite3_reset(s.st)
+			return nil, s.c.err(rc)
+		}
+		break
+	}
+	res := result{
+		lastID:  int64(C.sqlite3_last_insert_rowid(s.c.db)),
+		changes: int64(C.sqlite3_changes(s.c.db)),
+	}
+	C.sqlite3_reset(s.st)
+	return res, nil
+}
+
+func (s *stmt) Query(args []driver.Value) (driver.Rows, error) {
+	s.c.mu.Lock()
+	defer s.c.mu.Unlock()
+	if err := s.bind(args); err != nil {
+		return nil, err
+	}
+	n := int(C.sqlite3_column_count(s.st))
+	cols := make([]string, n)
+	for i := 0; i < n; i++ {
+		cols[i] = C.GoString(C.sqlite3_column_name(s.st, C.int(i)))
+	}
+	return &rows{s: s, cols: cols}, nil
+}
+
+type result struct {
+	lastID  int64
+	changes int64
+}
+
+func (r result) LastInsertId() (int64, error) { return r.lastID, nil }
+func (r result) RowsAffected() (int64, error) { return r.changes, nil }
+
+type rows struct {
+	s      *stmt
+	cols   []string
+	closed bool
+}
+
+func (r *rows) Columns() []string { return r.cols }
+
+func (r *rows) Close() error {
+	if r.closed {
+		return nil
+	}
+	r.closed = true
+	r.s.c.mu.Lock()
+	defer r.s.c.mu.Unlock()
+	C.sqlite3_reset(r.s.st)
+	return nil
+}
+
+func (r *rows) Next(dest []driver.Value) error {
+	r.s.c.mu.Lock()
+	defer r.s.c.mu.Unlock()
+
+	rc := C.sqlite3_step(r.s.st)
+	if rc == C.SQLITE_DONE {
+		return io.EOF
+	}
+	if rc != C.SQLITE_ROW {
+		return r.s.c.err(rc)
+	}
+	for i := range dest {
+		idx := C.int(i)
+		switch C.sqlite3_column_type(r.s.st, idx) {
+		case C.SQLITE_NULL:
+			dest[i] = nil
+		case C.SQLITE_INTEGER:
+			dest[i] = int64(C.sqlite3_column_int64(r.s.st, idx))
+		case C.SQLITE_FLOAT:
+			dest[i] = float64(C.sqlite3_column_double(r.s.st, idx))
+		case C.SQLITE_BLOB:
+			dest[i] = columnBytes(r.s.st, idx, C.sqlite3_column_blob(r.s.st, idx))
+		default:
+			// Text: copied by length rather than as a C string, since a value
+			// may contain embedded NULs.
+			b := columnBytes(r.s.st, idx,
+				unsafe.Pointer(C.sqlite3_column_text(r.s.st, idx)))
+			dest[i] = string(b)
+		}
+	}
+	return nil
+}
+
+func columnBytes(st *C.sqlite3_stmt, idx C.int, p unsafe.Pointer) []byte {
+	n := C.sqlite3_column_bytes(st, idx)
+	if p == nil || n == 0 {
+		return []byte{}
+	}
+	return C.GoBytes(p, n)
+}

--- a/packaging/go/go.mod
+++ b/packaging/go/go.mod
@@ -1,0 +1,3 @@
+module github.com/dolthub/doltlite-go
+
+go 1.21

--- a/packaging/go/smoke-test/go.mod
+++ b/packaging/go/smoke-test/go.mod
@@ -1,0 +1,5 @@
+module doltlite-smoke-test
+
+go 1.21
+
+require github.com/dolthub/doltlite-go v0.0.0

--- a/packaging/go/smoke-test/main.go
+++ b/packaging/go/smoke-test/main.go
@@ -1,0 +1,159 @@
+// Package-level smoke test for doltlite-go. Runs from a consumer module
+// against the staged package, covering the driver surface end to end: every
+// value type, transactions, error paths, and a version-control round trip
+// (commit, branch, checkout, merge, dolt_log reads).
+package main
+
+import (
+	"bytes"
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	doltlite "github.com/dolthub/doltlite-go"
+)
+
+var failures int
+
+func check(name string, got, want any) {
+	ok := fmt.Sprint(got) == fmt.Sprint(want)
+	if b1, k1 := got.([]byte); k1 {
+		if b2, k2 := want.([]byte); k2 {
+			ok = bytes.Equal(b1, b2)
+		}
+	}
+	if ok {
+		fmt.Printf("  PASS: %s\n", name)
+		return
+	}
+	failures++
+	fmt.Printf("  FAIL: %s\n    want: %v\n    got:  %v\n", name, want, got)
+}
+
+func main() {
+	dir := os.TempDir()
+	dbPath := filepath.Join(dir, fmt.Sprintf("doltlite-go-smoke-%d.db", os.Getpid()))
+	cleanup := func() {
+		os.Remove(dbPath)
+		os.Remove(filepath.Join(dir, "."+filepath.Base(dbPath)+"-lock"))
+	}
+	cleanup()
+	defer cleanup()
+
+	check("engine version reports", doltlite.Version() != "", true)
+
+	db, err := sql.Open("doltlite", dbPath)
+	must(err)
+	defer db.Close()
+
+	_, err = db.Exec(`CREATE TABLE t(pk INTEGER PRIMARY KEY, s TEXT, f REAL, b BLOB)`)
+	must(err)
+
+	res, err := db.Exec(`INSERT INTO t(pk, s, f, b) VALUES (?, ?, ?, ?)`,
+		1, "one", 1.5, []byte{0, 255, 16})
+	must(err)
+	n, err := res.RowsAffected()
+	must(err)
+	check("insert rows affected", n, int64(1))
+	id, err := res.LastInsertId()
+	must(err)
+	check("last insert id", id, int64(1))
+
+	_, err = db.Exec(`INSERT INTO t(pk, s, f, b) VALUES (?, ?, ?, ?)`,
+		2, "twö", 2.25, []byte{1, 0, 2})
+	must(err)
+	_, err = db.Exec(`INSERT INTO t(pk, s) VALUES (?, ?)`, 3, nil)
+	must(err)
+
+	var s string
+	var f float64
+	var b []byte
+	must(db.QueryRow(`SELECT s, f, b FROM t WHERE pk = 2`).Scan(&s, &f, &b))
+	check("text round trip (utf8)", s, "twö")
+	check("float round trip", f, 2.25)
+	check("blob round trip", b, []byte{1, 0, 2})
+
+	var ns sql.NullString
+	must(db.QueryRow(`SELECT s FROM t WHERE pk = 3`).Scan(&ns))
+	check("null round trip", ns.Valid, false)
+
+	var empty string
+	must(db.QueryRow(`SELECT ''`).Scan(&empty))
+	check("empty string binds", empty, "")
+
+	err = db.QueryRow(`SELECT s FROM t WHERE pk = 99`).Scan(&s)
+	check("no rows is ErrNoRows", err == sql.ErrNoRows, true)
+
+	rows, err := db.Query(`SELECT pk, s FROM t ORDER BY pk`)
+	must(err)
+	cols, err := rows.Columns()
+	must(err)
+	check("column names", fmt.Sprint(cols), "[pk s]")
+	count := 0
+	for rows.Next() {
+		count++
+	}
+	must(rows.Err())
+	rows.Close()
+	check("row count", count, 3)
+
+	_, err = db.Query(`SELECT * FROM missing_table`)
+	check("bad SQL errors", err != nil, true)
+
+	// Transactions.
+	tx, err := db.Begin()
+	must(err)
+	_, err = tx.Exec(`INSERT INTO t(pk, s) VALUES (?, ?)`, 4, "rolled back")
+	must(err)
+	must(tx.Rollback())
+	var c int
+	must(db.QueryRow(`SELECT count(*) FROM t WHERE pk = 4`).Scan(&c))
+	check("rollback discards", c, 0)
+
+	tx, err = db.Begin()
+	must(err)
+	_, err = tx.Exec(`INSERT INTO t(pk, s) VALUES (?, ?)`, 5, "committed")
+	must(err)
+	must(tx.Commit())
+	must(db.QueryRow(`SELECT count(*) FROM t WHERE pk = 5`).Scan(&c))
+	check("commit persists", c, 1)
+
+	// Version control is plain SQL on the same connection.
+	var commit string
+	must(db.QueryRow(`SELECT dolt_commit('-A', '-m', ?)`, "first commit").Scan(&commit))
+	check("dolt_commit", commit != "", true)
+
+	scalar := func(q string) string {
+		var v sql.NullString
+		must(db.QueryRow(q).Scan(&v))
+		return v.String
+	}
+	check("dolt_branch", scalar(`SELECT dolt_branch('feature')`), "0")
+	check("dolt_checkout feature", scalar(`SELECT dolt_checkout('feature')`), "0")
+	_, err = db.Exec(`UPDATE t SET s = 'branched' WHERE pk = 1`)
+	must(err)
+	check("dolt_commit on branch",
+		scalar(`SELECT dolt_commit('-A', '-m', 'feature work')`) != "", true)
+	check("dolt_checkout main", scalar(`SELECT dolt_checkout('main')`), "0")
+	check("main unchanged", scalar(`SELECT s FROM t WHERE pk = 1`), "one")
+	scalar(`SELECT dolt_merge('feature')`)
+	check("dolt_merge fast-forwards", scalar(`SELECT s FROM t WHERE pk = 1`), "branched")
+	var logCount int
+	must(db.QueryRow(`SELECT count(*) FROM dolt_log`).Scan(&logCount))
+	check("dolt_log sees both commits", logCount >= 2, true)
+
+	if failures == 0 {
+		fmt.Println("smoke-test: all checks passed")
+		return
+	}
+	fmt.Printf("smoke-test: %d failure(s)\n", failures)
+	os.Exit(1)
+}
+
+func must(err error) {
+	if err != nil {
+		fmt.Println("fatal:", err)
+		os.Exit(1)
+	}
+}

--- a/packaging/go/test-package.sh
+++ b/packaging/go/test-package.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+#
+# Package-level smoke test for doltlite-go. Stages the module, then builds the
+# smoke test against the staged copy through a module replace, so the test
+# exercises what would actually be pushed -- notably whether the vendored
+# amalgamation is present -- rather than the working tree.
+#
+# Usage: test-package.sh [build_dir]   (default: ./build)
+
+set -euo pipefail
+
+PKG_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$PKG_DIR/../.." && pwd)"
+BUILD_DIR="$(cd "${1:-$ROOT/build}" && pwd)"
+
+command -v go >/dev/null || { echo "ERROR: go is required" >&2; exit 1; }
+
+STAGE="$(mktemp -d)"
+CONSUMER="$(mktemp -d)"
+trap 'chmod -R u+w "$STAGE" "$CONSUMER" 2>/dev/null; rm -rf "$STAGE" "$CONSUMER"' EXIT
+
+bash "$PKG_DIR/assemble.sh" "0.0.0" "$STAGE/pkg" "$BUILD_DIR"
+
+[ -f "$STAGE/pkg/doltlite.c" ] || {
+  echo "ERROR: staged module has no vendored amalgamation" >&2; exit 1; }
+
+cp "$PKG_DIR/smoke-test/main.go" "$CONSUMER/"
+cp "$PKG_DIR/smoke-test/go.mod"  "$CONSUMER/"
+cd "$CONSUMER"
+go mod edit -replace "github.com/dolthub/doltlite-go=$STAGE/pkg"
+go mod tidy >/dev/null 2>&1 || true
+CGO_ENABLED=1 go run .


### PR DESCRIPTION
Go bindings as a `database/sql` driver — `sql.Open("doltlite", path)` — over cgo, with the amalgamation vendored into the package so there's no system library to install.

## Why a Go binding, given embedded Dolt exists

I argued earlier in this repo's history that Go didn't need one, because [`github.com/dolthub/driver`](https://github.com/dolthub/driver) embeds Dolt in pure Go with no cgo. That reasoning holds for *new* programs wanting versioned SQL — but it doesn't cover the case that motivated this: **embedded Dolt speaks Dolt's on-disk format and cannot open a DoltLite database**, which is a single-file chunk store. Anything that has to read DoltLite files from Go — the DoltHub API, for instance — needs a real binding.

The README states this plainly and sends new Go programs to embedded Dolt instead, so the packages don't compete for the same use case.

## Shape

- Full driver set: `Driver`, `Conn`, `Stmt`, `Rows`, `Tx`, `Result` — so `database/sql` and everything layered on it works unchanged.
- Version control is plain SQL on the connection; no binding-specific API.
- Binds text and blobs with `SQLITE_TRANSIENT`, which cgo requires (C must not retain Go memory past the call), and reads text by length rather than as a C string so embedded NULs survive.
- Empty strings and empty blobs bind through a valid pointer rather than nil.

## Tests

`test-package.sh` stages the module and builds the smoke test against the **staged copy** via a `replace` directive, so a missing vendored amalgamation fails the test instead of shipping. 22 checks pass locally: every value type (UTF-8 text, blobs with embedded NULs, null, int64, real, empty string), `ErrNoRows`, column names, error paths, commit/rollback transactions, and a commit → branch → checkout → merge → `dolt_log` round trip. `gofmt` and `go vet` clean.

Build-Test runs it on ubuntu and macos. Windows is excluded and documented, same as the Rust crate: the build links the platform's zlib, which MSVC doesn't provide.

## Distribution needs a repo

Go modules resolve from a VCS path, so publishing needs a **`dolthub/doltlite-go`** repository (same pattern as `doltlite-php`) that release wiring pushes the staged module and a matching tag into. Could you create it when convenient? I'll wire `release-go` once it exists.

Until then this is usable directly with a `replace` directive pointing at `packaging/go`, which is what the DoltHub API side could do immediately if it's in a hurry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)