### PR TITLE
Gate WAL checkpoint threshold behind SQLITE_TEST

### DIFF
--- a/src/chunk_wal.c
+++ b/src/chunk_wal.c
@@ -132,11 +132,13 @@ void csStampWalCheckpoint(const ChunkStore *cs, u8 *aManifest){
 
 static i64 csWalCheckpointThreshold(void){
   i64 n = 64*1024*1024;
+#if defined(SQLITE_TEST) || defined(DOLTLITE_MECH_REPRO)
   const char *z = getenv("DOLTLITE_WAL_CHECKPOINT_THRESHOLD");
   if( z && z[0] ){
     i64 v = (i64)strtoll(z, 0, 10);
     if( v>0 ) n = v;
   }
+#endif
   return n;
 }
 

--- a/test/doltlite_checkpoint_threshold_env.sh
+++ b/test/doltlite_checkpoint_threshold_env.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# The CLI and libdoltlite are not SQLITE_TEST builds. Production must ignore
+# DOLTLITE_WAL_CHECKPOINT_THRESHOLD; testfixture still honors it.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/doltlite_test_common.sh"
+DOLTLITE="${1:-./doltlite}"
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "SKIP: python3 required to read checkpoint stamps"
+  exit 0
+fi
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/doltlite-ckpt-env.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+DB="$TMP/t.db"
+
+checkpoint_magic() {
+  python3 -c '
+import struct, sys
+path = sys.argv[1]
+with open(path, "rb") as f:
+    f.seek(0, 2)
+    n = f.tell()
+    if n < 169:
+        print(0)
+        raise SystemExit
+    f.seek(n - 169)
+    rec = f.read(169)
+print(struct.unpack_from("<I", rec, 1 + 8)[0])
+' "$1"
+}
+
+echo "=== WAL checkpoint threshold env is test-only ==="
+
+export DOLTLITE_WAL_CHECKPOINT_THRESHOLD=1
+"$DOLTLITE" "$DB" \
+  "CREATE TABLE t(id INTEGER PRIMARY KEY, b BLOB);
+   INSERT INTO t VALUES(1, randomblob(8192));
+   SELECT dolt_commit('-A','-m','env-threshold');" >/dev/null
+magic="$(checkpoint_magic "$DB")"
+if [ "$magic" = "0" ]; then
+  dltest_pass
+else
+  dltest_fail "cli_ignores_checkpoint_threshold_env" \
+    "  expected checkpoint magic 0 (64MiB default), got $magic"
+fi
+
+dltest_finish

--- a/test/lib/doltlite_suite_manifest.sh
+++ b/test/lib/doltlite_suite_manifest.sh
@@ -83,6 +83,7 @@ doltlite_feature_deep.sh
 doltlite_deep_history.sh
 doltlite_open_perf.sh
 doltlite_checkpoint_perf.sh
+doltlite_checkpoint_threshold_env.sh
 doltlite_perf.sh
 doltlite_count_perf.sh
 doltlite_demo.sh


### PR DESCRIPTION
Beta review item 5: `DOLTLITE_WAL_CHECKPOINT_THRESHOLD` was a live `getenv` in production. A process environment could drop the checkpoint interval to 1 byte (or skip checkpoints) and force full WAL replay on every open.

Match `DOLTLITE_CHUNK_PENDING_DRAIN_LIMIT`: honor the env only under `SQLITE_TEST` or `DOLTLITE_MECH_REPRO`. Release CLI/libdoltlite stay on the 64MiB default.

`testfixture` still sees the knob (`doltlite_recover_corruption.test`). `doltlite_checkpoint_perf.sh` uses the CLI with the same 64MiB default, so it is unchanged.

`test/doltlite_checkpoint_threshold_env.sh` fails on an ungated CLI (env=1 stamps a checkpoint on an 8KiB commit) and passes after the gate.

Co-Authored-By: Grok 4.6 <noreply@x.ai>