### PR TITLE
Respect dolt_ignore in clean and add all

### DIFF
--- a/src/doltlite_add.c
+++ b/src/doltlite_add.c
@@ -235,6 +235,59 @@ static int addWriteStagedCatalog(
   return rc;
 }
 
+static int addComposeStageAllMaster(
+  sqlite3 *db,
+  sqlite3_context *context,
+  struct TableEntry *aWorking,
+  int nWorking,
+  struct TableEntry *aStaged,
+  int nStaged,
+  struct TableEntry *aNew,
+  int nNew
+){
+  const char **azTouched = 0;
+  struct TableEntry *pWorkingMaster;
+  struct TableEntry *pStagedMaster;
+  struct TableEntry *pNewMaster;
+  ProllyHash composedRoot;
+  int nTouched = 0;
+  int i;
+  int rc = SQLITE_OK;
+
+  if( nWorking>0 ){
+    azTouched = sqlite3_malloc64((sqlite3_uint64)nWorking * sizeof(*azTouched));
+    if( !azTouched ){
+      sqlite3_result_error_nomem(context);
+      return SQLITE_NOMEM;
+    }
+  }
+  for(i=0; i<nWorking; i++){
+    int ignored = 0;
+    if( aWorking[i].iTable<=1 || !aWorking[i].zName ) continue;
+    rc = addCheckIgnore(db, context, aWorking[i].zName, &ignored);
+    if( rc!=SQLITE_OK ) break;
+    if( !ignored ) azTouched[nTouched++] = aWorking[i].zName;
+  }
+  pWorkingMaster = doltliteFindTableByNumber(aWorking, nWorking, 1);
+  pStagedMaster = doltliteFindTableByNumber(aStaged, nStaged, 1);
+  pNewMaster = doltliteFindTableByNumber(aNew, nNew, 1);
+  if( rc==SQLITE_OK && (!pWorkingMaster || !pNewMaster) ) rc = SQLITE_CORRUPT;
+  if( rc==SQLITE_OK && pWorkingMaster && pNewMaster ){
+    rc = doltliteBuildNamedStageMasterRoot(db,
+            &pWorkingMaster->root, pWorkingMaster->flags,
+            pStagedMaster ? &pStagedMaster->root : 0,
+            pStagedMaster ? pStagedMaster->flags : 0,
+            azTouched, nTouched, aNew, nNew, 1, &composedRoot);
+    if( rc==SQLITE_OK ){
+      pNewMaster->root = composedRoot;
+      pNewMaster->schemaHash = pWorkingMaster->schemaHash;
+      pNewMaster->flags = pWorkingMaster->flags;
+    }
+  }
+  sqlite3_free(azTouched);
+  return rc;
+}
+
 /* True when the catalogs' index schema rows for zTable differ. Index
 ** changes have no named catalog entry, so status/diff use this. */
 int doltliteIndexSchemaRowsDifferForTable(
@@ -386,7 +439,13 @@ static int addStageAllTables(
     rc = doltliteSetSessionStaged(db, pWorkingHash);
   }else{
     doltliteAlignStagedEntriesToWorking(aWorking, nWorking, aNew, nNew);
-    rc = addWriteStagedCatalog(db, cs, aNew, nNew);
+    doltliteRenumberStaleStagedEntries(aNew, nNew, aWorking, nWorking);
+    rc = addComposeStageAllMaster(db, context,
+                                  aWorking, nWorking, aStaged, nStaged,
+                                  aNew, nNew);
+    if( rc==SQLITE_OK ){
+      rc = addWriteStagedCatalog(db, cs, aNew, nNew);
+    }
   }
   if( workingIdxInit ) addNameIndexFree(&workingIdx);
   if( stagedIdxInit ) addNameIndexFree(&stagedIdx);

--- a/src/doltlite_clean.c
+++ b/src/doltlite_clean.c
@@ -3,6 +3,7 @@
 #include "sqliteInt.h"
 #include "chunk_store.h"
 #include "doltlite_internal.h"
+#include "doltlite_ignore.h"
 
 #include <string.h>
 
@@ -154,6 +155,23 @@ static int cleanDropTables(sqlite3 *db, const CleanNames *pNames){
   return rc;
 }
 
+static int cleanCheckIgnore(
+  sqlite3 *db,
+  sqlite3_context *context,
+  const char *zName,
+  int *pIgnored
+){
+  char *zErr = 0;
+  int rc = doltliteCheckIgnore(db, zName, pIgnored, &zErr);
+  if( rc==SQLITE_CONSTRAINT ){
+    sqlite3_result_error(context, zErr ? zErr : "dolt_ignore conflict", -1);
+  }else if( rc!=SQLITE_OK ){
+    sqlite3_result_error_code(context, rc);
+  }
+  sqlite3_free(zErr);
+  return rc;
+}
+
 static void doltliteCleanFunc(
   sqlite3_context *context,
   int argc,
@@ -221,6 +239,12 @@ static void doltliteCleanFunc(
   if( rc!=SQLITE_OK ) goto clean_error;
   for(i=0; i<selected.n; i++){
     if( !cleanNamesContains(&staged, selected.az[i]) ){
+      if( args.nPositional==0 ){
+        int ignored = 0;
+        rc = cleanCheckIgnore(db, context, selected.az[i], &ignored);
+        if( rc!=SQLITE_OK ) goto clean_done;
+        if( ignored ) continue;
+      }
       rc = cleanNamesAppend(&untracked, selected.az[i]);
       if( rc!=SQLITE_OK ) goto clean_error;
     }

--- a/test/doltlite_clean.sh
+++ b/test/doltlite_clean.sh
@@ -76,5 +76,15 @@ echo "CREATE TABLE parent(id INTEGER PRIMARY KEY); CREATE TABLE child(id INTEGER
 run_test "clean_with_only_tracked_fk_tables" "SELECT dolt_clean();" "0" "$DB7"
 run_test "clean_with_only_tracked_fk_tables_keeps_both" "SELECT count(*) FROM sqlite_master WHERE type='table' AND name IN ('child','parent');" "2" "$DB7"
 
-rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7"
+DB8=/tmp/test_clean_ignore_$$.db; rm -f "$DB8"
+echo "CREATE TABLE tracked(id INTEGER PRIMARY KEY); SELECT dolt_commit('-Am','base'); INSERT INTO dolt_ignore VALUES('ig_%', 1); CREATE TABLE ig_temp(id INTEGER PRIMARY KEY); CREATE TABLE untracked(id INTEGER PRIMARY KEY);" | $DOLTLITE "$DB8" >/dev/null 2>&1
+run_test "clean_all_respects_ignore" "SELECT dolt_clean();" "0" "$DB8"
+run_test "clean_all_keeps_ignored" "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='ig_temp';" "1" "$DB8"
+run_test "clean_all_drops_non_ignored" "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='untracked';" "0" "$DB8"
+echo "CREATE TABLE ig_named(id INTEGER PRIMARY KEY); CREATE TABLE other(id INTEGER PRIMARY KEY);" | $DOLTLITE "$DB8" >/dev/null 2>&1
+run_test "clean_named_overrides_ignore" "SELECT dolt_clean('ig_named');" "0" "$DB8"
+run_test "clean_named_drops_ignored_target" "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='ig_named';" "0" "$DB8"
+run_test "clean_named_keeps_other_untracked" "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='other';" "1" "$DB8"
+
+rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8"
 dltest_finish

--- a/test/doltlite_ignore.sh
+++ b/test/doltlite_ignore.sh
@@ -168,6 +168,49 @@ run_test_match "force_requires_name" \
   "SELECT dolt_add('-f');" \
   "requires table name" "$DB7"
 
-rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7"
+DB8=/tmp/test_ignore_dropped_$$.db
+rm -f "$DB8"
+
+run_test "add_all_preserves_dropped_ignored_table" \
+  "CREATE TABLE tracked(id INT PRIMARY KEY);
+   INSERT INTO tracked VALUES(1);
+   SELECT dolt_add('-A');
+   SELECT dolt_commit('-m','base') IS NOT NULL;
+   INSERT INTO dolt_ignore VALUES('ig_*',1);
+   CREATE TABLE ig_one(id INT);
+   SELECT dolt_add('-f','ig_one');
+   SELECT dolt_add('dolt_ignore');
+   SELECT dolt_commit('-m','forced') IS NOT NULL;
+   DROP TABLE ig_one;
+   SELECT dolt_add('-A');
+   SELECT table_name, staged, status FROM dolt_status ORDER BY table_name, staged;" \
+  "0
+1
+0
+0
+1
+0
+ig_one|0|deleted" "$DB8"
+
+run_test "dropped_ignored_state_survives_reopen" \
+  "SELECT table_name, staged, status FROM dolt_status ORDER BY table_name, staged;" \
+  "ig_one|0|deleted" "$DB8"
+
+run_test "commit_after_preserved_ignored_drop" \
+  "UPDATE tracked SET id=2;
+   SELECT dolt_add('-A');
+   SELECT dolt_commit('-m','tracked update') IS NOT NULL;
+   SELECT table_name, staged, status FROM dolt_status ORDER BY table_name, staged;" \
+  "0
+1
+ig_one|0|deleted" "$DB8"
+
+run_test "force_add_all_stages_dropped_ignored_table" \
+  "SELECT dolt_add('-A','-f');
+   SELECT table_name, staged, status FROM dolt_status ORDER BY table_name, staged;" \
+  "0
+ig_one|1|deleted" "$DB8"
+
+rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8"
 
 dltest_finish

--- a/test/vc_oracle_add_test.sh
+++ b/test/vc_oracle_add_test.sh
@@ -482,6 +482,47 @@ SELECT concat('Q|', group_concat(concat(column_name, ':', replace(lower(column_t
  WHERE table_schema = database() AND table_name = 'a';
 SELECT concat('Q|', k, '|', n) FROM a;"
 
+oracle_reopen "add_all_preserves_dropped_ignored_table" "
+CREATE TABLE tracked(id INT PRIMARY KEY);
+INSERT INTO tracked VALUES (1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'base');
+INSERT INTO dolt_ignore VALUES ('ig_*', 1);
+CREATE TABLE ig_one(id INT);
+SELECT dolt_add('-f', 'ig_one');
+SELECT dolt_add('dolt_ignore');
+SELECT dolt_commit('-m', 'forced');
+DROP TABLE ig_one;
+SELECT dolt_add('-A');
+" "SELECT 'Q|' || table_name || '|' || staged || '|' || status
+     FROM dolt_status
+    ORDER BY table_name, staged, status;" \
+"SELECT concat('Q|', table_name, '|', staged, '|', status)
+   FROM dolt_status
+  ORDER BY table_name, staged, status;"
+
+oracle_reopen "commit_after_preserved_ignored_drop" "
+CREATE TABLE tracked(id INT PRIMARY KEY);
+INSERT INTO tracked VALUES (1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'base');
+INSERT INTO dolt_ignore VALUES ('ig_*', 1);
+CREATE TABLE ig_one(id INT);
+SELECT dolt_add('-f', 'ig_one');
+SELECT dolt_add('dolt_ignore');
+SELECT dolt_commit('-m', 'forced');
+DROP TABLE ig_one;
+SELECT dolt_add('-A');
+UPDATE tracked SET id=2;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'tracked update');
+" "SELECT 'Q|' || table_name || '|' || staged || '|' || status
+     FROM dolt_status
+    ORDER BY table_name, staged, status;" \
+"SELECT concat('Q|', table_name, '|', staged, '|', status)
+   FROM dolt_status
+  ORDER BY table_name, staged, status;"
+
 echo "--- noop and clean states ---"
 
 oracle "all_on_empty_repo" "

--- a/test/vc_oracle_clean_test.sh
+++ b/test/vc_oracle_clean_test.sh
@@ -11,20 +11,22 @@ pass=0; fail=0
 FAILED_NAMES=""
 source "$(dirname "$0")/lib/vc_oracle_common.sh"
 
-normalize_status() {
+normalize_state() {
   tr -d '\r"' \
-    | awk -F'\t' 'NF >= 4 && $1 == "S" { print }' \
-    | sort -t$'\t' -k2,2 -k3,3 -k4,4
+    | awk -F'\t' 'NF >= 4 && $1 == "S" { print }
+        NF >= 2 && $1 == "T" && $2 !~ /^(dolt_|sqlite_)/ { print }' \
+    | sort
 }
 
 oracle() {
   local name="$1" setup="$2"
+  local compare="${3:-all}"
   local dir="$TMPROOT/$name"
   mkdir -p "$dir/dl" "$dir/dt" "$dir/dt.rows"
 
   local dl_status dl_rows
-  dl_status=$(printf "%s\n.headers off\n.mode list\n.separator '\t'\nSELECT 'S' || char(9) || table_name || char(9) || staged || char(9) || status FROM dolt_status;\n" "$setup" \
-    | "$DOLTLITE" "$dir/dl/db" 2>"$dir/dl.err" | normalize_status)
+  dl_status=$(printf "%s\n.headers off\n.mode list\n.separator '\t'\nSELECT 'S' || char(9) || table_name || char(9) || staged || char(9) || status FROM dolt_status;\nSELECT 'T' || char(9) || name FROM pragma_table_list WHERE schema='main' AND type IN ('table','virtual');\n" "$setup" \
+    | "$DOLTLITE" "$dir/dl/db" 2>"$dir/dl.err" | normalize_state)
   dl_rows=$(printf "%s\nSELECT count(*) FROM t;\n" "$setup" \
     | "$DOLTLITE" "$dir/dl.rows" 2>>"$dir/dl.err" | tail -1)
 
@@ -35,8 +37,13 @@ oracle() {
     vc_oracle_init_repo
     printf '%s\n' "$dolt_setup" | "$DOLT" sql -c >/dev/null 2>"$dir/dt.err"
     "$DOLT" sql -r csv -q "SELECT concat('S', char(9), table_name, char(9), staged, char(9), status) FROM dolt_status;" 2>>"$dir/dt.err"
+    "$DOLT" sql -r csv -q "SELECT concat('T', char(9), table_name) FROM information_schema.tables WHERE table_schema=database() AND table_type='BASE TABLE';" 2>>"$dir/dt.err"
   ) >"$dir/dt.status"
-  dt_status=$(tail -n +2 "$dir/dt.status" | normalize_status)
+  dt_status=$(tail -n +2 "$dir/dt.status" | normalize_state)
+  if [ "$compare" = "tables" ]; then
+    dl_status=$(printf '%s\n' "$dl_status" | awk -F'\t' '$1 == "T"')
+    dt_status=$(printf '%s\n' "$dt_status" | awk -F'\t' '$1 == "T"')
+  fi
   (
     cd "$dir/dt.rows" || exit 1
     vc_oracle_init_repo
@@ -89,6 +96,22 @@ CREATE TABLE u(id INTEGER PRIMARY KEY);
 CREATE TABLE v(id INTEGER PRIMARY KEY);
 SELECT dolt_clean();
 "
+
+oracle "clean_all_preserves_ignored" "
+$SEED
+INSERT INTO dolt_ignore VALUES ('ig_%', 1);
+CREATE TABLE ig_temp(id INTEGER PRIMARY KEY);
+CREATE TABLE u(id INTEGER PRIMARY KEY);
+SELECT dolt_clean();
+" tables
+
+oracle "clean_named_overrides_ignore" "
+$SEED
+INSERT INTO dolt_ignore VALUES ('ig_%', 1);
+CREATE TABLE ig_temp(id INTEGER PRIMARY KEY);
+CREATE TABLE u(id INTEGER PRIMARY KEY);
+SELECT dolt_clean('ig_temp');
+" tables
 
 oracle "clean_dry_run" "
 $SEED


### PR DESCRIPTION
## Summary

- preserve ignored untracked tables during parameterless `dolt_clean()`
- preserve dropped ignored tables during `dolt_add(-A)` without corrupting neighboring staged state
- retain explicit-name and `-f` override behavior

## Validation

- `DOLTLITE=build/doltlite bash test/doltlite_clean.sh` (47 passed)
- `DOLTLITE=build/doltlite bash test/doltlite_ignore.sh` (25 passed)
- `bash test/vc_oracle_clean_test.sh build/doltlite dolt` (11 passed)
- `bash test/vc_oracle_add_test.sh build/doltlite dolt` (45 passed)
- `bash test/run_doltlite_tests.sh build/doltlite` (125 suites passed)
- `make lint`

Fixes #2535
Fixes #2536

Co-Authored-By: OpenAI Codex <noreply@openai.com>