### PR TITLE
Emit every merge parent from dolt_diff to_commit filters

### DIFF
--- a/src/doltlite_diff_table.c
+++ b/src/doltlite_diff_table.c
@@ -559,6 +559,9 @@ static int buildCommitDiffPair(
   char zFromLabel[PROLLY_HASH_SIZE*2+1];
   char zToLabel[PROLLY_HASH_SIZE*2+1];
   const ProllyHash *pParent;
+  int nParents;
+  int nIter;
+  int i;
   int rc;
 
   if( !zToCommit ) return SQLITE_OK;
@@ -602,42 +605,60 @@ static int buildCommitDiffPair(
     return rc;
   }
 
-  pParent = doltliteCommitParentHash(&toCommit, 0);
-  if( pParent && !prollyHashIsEmpty(pParent) ){
-    DoltliteCommit fromCommit;
-    memset(&fromCommit, 0, sizeof(fromCommit));
-    fromHash = *pParent;
-    rc = doltliteLoadCommit(db, &fromHash, &fromCommit);
-    if( rc==SQLITE_OK ){
-      memcpy(&fromCatHash, &fromCommit.catalogHash, sizeof(ProllyHash));
-      fromDate = fromCommit.timestamp;
-      rc = doltliteLoadTableRootByNameOrEmpty(db, &fromCatHash, zTableName,
-                                              &fromTblRoot, &fromFlags,
-                                              &fromSchemaHash);
+  nParents = doltliteCommitParentCount(&toCommit);
+  nIter = nParents>0 ? nParents : 1;
+  doltliteHashToHex(&toHash, zToLabel);
+  for(i=0; i<nIter; i++){
+    u8 pairFromFlags;
+    u8 pairToFlags;
+
+    memset(&fromHash, 0, sizeof(fromHash));
+    memset(&fromTblRoot, 0, sizeof(fromTblRoot));
+    memset(&fromCatHash, 0, sizeof(fromCatHash));
+    memset(&fromSchemaHash, 0, sizeof(fromSchemaHash));
+    fromFlags = 0;
+    fromDate = 0;
+
+    if( nParents>0 ){
+      DoltliteCommit fromCommit;
+      pParent = doltliteCommitParentHash(&toCommit, i);
+      if( !pParent || prollyHashIsEmpty(pParent) ) continue;
+      memset(&fromCommit, 0, sizeof(fromCommit));
+      fromHash = *pParent;
+      rc = doltliteLoadCommit(db, &fromHash, &fromCommit);
+      if( rc==SQLITE_OK ){
+        memcpy(&fromCatHash, &fromCommit.catalogHash, sizeof(ProllyHash));
+        fromDate = fromCommit.timestamp;
+        rc = doltliteLoadTableRootByNameOrEmpty(db, &fromCatHash, zTableName,
+                                                &fromTblRoot, &fromFlags,
+                                                &fromSchemaHash);
+      }
+      doltliteCommitClear(&fromCommit);
+      if( rc!=SQLITE_OK ){
+        doltliteCommitClear(&toCommit);
+        return rc;
+      }
     }
-    doltliteCommitClear(&fromCommit);
+
+    if( prollyHashCompare(&fromTblRoot, &toTblRoot)==0
+     && prollyHashCompare(&fromSchemaHash, &toSchemaHash)==0 ){
+      continue;
+    }
+
+    pairFromFlags = fromFlags ? fromFlags : toFlags;
+    pairToFlags = toFlags ? toFlags : fromFlags;
+    doltliteHashToHex(&fromHash, zFromLabel);
+    rc = pairsAppend(pCur, zFromLabel, &fromTblRoot, &fromCatHash,
+                     &fromSchemaHash, pairFromFlags, fromDate,
+                     zToLabel, &toTblRoot, &toCatHash, &toSchemaHash,
+                     pairToFlags, toCommit.timestamp);
     if( rc!=SQLITE_OK ){
       doltliteCommitClear(&toCommit);
       return rc;
     }
   }
-
-  if( prollyHashCompare(&fromTblRoot, &toTblRoot)==0
-   && prollyHashCompare(&fromSchemaHash, &toSchemaHash)==0 ){
-    doltliteCommitClear(&toCommit);
-    return SQLITE_OK;
-  }
-
-  if( !fromFlags ) fromFlags = toFlags;
-  if( !toFlags ) toFlags = fromFlags;
-  doltliteHashToHex(&fromHash, zFromLabel);
-  doltliteHashToHex(&toHash, zToLabel);
-  rc = pairsAppend(pCur, zFromLabel, &fromTblRoot, &fromCatHash,
-                   &fromSchemaHash, fromFlags, fromDate,
-                   zToLabel, &toTblRoot, &toCatHash, &toSchemaHash,
-                   toFlags, toCommit.timestamp);
   doltliteCommitClear(&toCommit);
-  return rc;
+  return SQLITE_OK;
 }
 
 typedef struct DtSliceEnd DtSliceEnd;

--- a/test/doltlite_diff_table.sh
+++ b/test/doltlite_diff_table.sh
@@ -98,8 +98,50 @@ SELECT dolt_merge('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 run_test_match "merge_count" "SELECT count(*) FROM dolt_diff_t;" "^[3-9]" "$DB"
 run_test_match "merge_has_merge_commit" "SELECT count(DISTINCT to_commit) FROM dolt_diff_t;" "^[3-9]" "$DB"
+run_test "merge_to_commit_eq_count" \
+  "SELECT count(*) FROM dolt_diff_t WHERE to_commit=(SELECT commit_hash FROM dolt_log LIMIT 1);" \
+  "2" "$DB"
+run_test "merge_to_commit_eq_matches_plus" \
+  "SELECT (SELECT count(*) FROM dolt_diff_t WHERE to_commit=(SELECT commit_hash FROM dolt_log LIMIT 1)) = (SELECT count(*) FROM dolt_diff_t WHERE +to_commit=(SELECT commit_hash FROM dolt_log LIMIT 1));" \
+  "1" "$DB"
+run_test "merge_to_commit_head_count" \
+  "SELECT count(*) FROM dolt_diff_t WHERE to_commit='HEAD';" \
+  "2" "$DB"
+run_test "merge_to_commit_distinct_parents" \
+  "SELECT count(DISTINCT from_commit) FROM dolt_diff_t WHERE to_commit='HEAD';" \
+  "2" "$DB"
+run_test "merge_to_commit_head_ids" \
+  "SELECT group_concat(coalesce(to_id, from_id), ',') FROM (SELECT to_id, from_id FROM dolt_diff_t WHERE to_commit='HEAD' ORDER BY coalesce(to_id, from_id));" \
+  "2,3" "$DB"
 
 rm -f "$DB"
+
+# Two-parent merge whose parents each change a different row: the to_commit
+# EQ pushdown must emit both parent pairs, matching the unconstrained scan.
+DBMTC=/tmp/test_dt_merge_to_commit_$$.db; rm -f "$DBMTC"
+echo "CREATE TABLE t(k INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(100,'a'),(200,'b');
+SELECT dolt_commit('-Am','base');
+SELECT dolt_branch('side');
+UPDATE t SET v='main' WHERE k=100;
+SELECT dolt_commit('-Am','mainc');
+SELECT dolt_checkout('side');
+UPDATE t SET v='side' WHERE k=200;
+SELECT dolt_commit('-Am','sidec');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('side');" | $DOLTLITE "$DBMTC" > /dev/null 2>&1
+
+run_test "merge_to_commit_both_rows" \
+  "SELECT count(*) FROM dolt_diff_t WHERE to_commit=(SELECT commit_hash FROM dolt_log LIMIT 1);" \
+  "2" "$DBMTC"
+run_test "merge_to_commit_both_keys" \
+  "SELECT group_concat(coalesce(to_k, from_k), ',') FROM (SELECT to_k, from_k FROM dolt_diff_t WHERE to_commit='HEAD' ORDER BY coalesce(to_k, from_k));" \
+  "100,200" "$DBMTC"
+run_test "merge_to_commit_plus_agrees" \
+  "SELECT (SELECT count(*) FROM dolt_diff_t WHERE to_commit=(SELECT commit_hash FROM dolt_log LIMIT 1)) = (SELECT count(*) FROM dolt_diff_t WHERE +to_commit=(SELECT commit_hash FROM dolt_log LIMIT 1));" \
+  "1" "$DBMTC"
+
+rm -f "$DBMTC"
 
 DB=/tmp/test_dt_cp_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);

--- a/test/vc_oracle_diff_tvf_test.sh
+++ b/test/vc_oracle_diff_tvf_test.sh
@@ -303,6 +303,20 @@ SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'feat_commit');
 SELECT dolt_checkout('main');
 " "SELECT CONCAT('R|', count(*)) FROM dolt_diff_t WHERE to_commit=(SELECT commit_hash FROM dolt_log('feat') LIMIT 1);"
 
+oracle "to_commit_merge_emits_all_parents" "
+CREATE TABLE t(k INTEGER PRIMARY KEY, v VARCHAR(32));
+INSERT INTO t VALUES(100,'a'),(200,'b');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','base');
+SELECT dolt_branch('side');
+UPDATE t SET v='main' WHERE k=100;
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','mainc');
+SELECT dolt_checkout('side');
+UPDATE t SET v='side' WHERE k=200;
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','sidec');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('side');
+" "SELECT CONCAT('R|', IFNULL(to_k,''), '|', IFNULL(from_v,''), '|', IFNULL(to_v,''), '|', diff_type, '|', IFNULL(log_from.message, from_commit)) FROM dolt_diff_t dt LEFT JOIN dolt_log log_from ON log_from.commit_hash = dt.from_commit WHERE to_commit=(SELECT commit_hash FROM dolt_log LIMIT 1);"
+
 echo ""
 echo "=== Results: $pass passed, $fail failed ==="
 if [ $fail -gt 0 ]; then


### PR DESCRIPTION
Fixes #2538.

`WHERE to_commit = <hash of a merge commit>` (and `to_commit='HEAD'` when HEAD is a merge) went through `buildCommitDiffPair`, which built a single pair from parent 0. The unconstrained `dolt_diff_<t>` scan already emits one pair per parent, and Dolt 2.3.1 returns both under the same hash filter. Unary `+to_commit` blocked the EQ pushdown and showed the true count; `omit=1` on the constraint meant the missing parent never came back via a recheck.

Loop every parent in the pushdown path, skipping a parent only when that parent's table/schema roots match the merge. Root commits still emit one empty-from pair.

`test/doltlite_diff_table.sh` is the issue repro: filtered count matches `+to_commit`, both keys appear, `to_commit='HEAD'` resolves both parents. `vc_oracle_diff_tvf_test.sh` pins Dolt 2.3.1 on the hash filter.

Co-Authored-By: Grok 4.6 <noreply@x.ai>