### PR TITLE
Add origin-backed lazy clones

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,8 +137,8 @@ an Emscripten-compatible socket transport or proxy; see
 [`examples/wa-sqlite-clone.mjs`](examples/wa-sqlite-clone.mjs) for a public
 clone request that exercises the client.
 
-`DOLTLITE_ENABLE_CHUNK_SOURCE=0` omits host-provided lazy chunk fetching. The
-feature is enabled by default.
+`DOLTLITE_ENABLE_CHUNK_SOURCE=0` omits host-provided and origin-backed lazy
+chunk fetching. The feature is enabled by default.
 
 ## Using as a C Library
 
@@ -653,10 +653,25 @@ Git-like push / fetch / pull / clone between databases.
 SELECT dolt_remote('add', 'origin', 'file:///path/to/remote.doltlite');
 SELECT dolt_push('origin', 'main');
 SELECT dolt_clone('file:///path/to/source.doltlite');
+SELECT dolt_clone('--lazy', 'file:///path/to/source.doltlite');
 SELECT dolt_fetch('origin', 'main');
 SELECT dolt_pull('origin', 'main');   -- fetch, then fast-forward or merge
 SELECT * FROM dolt_remotes;
 ```
+
+A lazy clone installs refs and records `origin` without copying the reachable
+chunk graph. It enables origin-backed reads on its current connection. To
+reopen the clone in another process, opt in before the B-tree opens:
+
+```sh
+doltlite 'file:/path/to/lazy.db?lazy_origin=1'
+```
+
+Missing chunks are fetched and cached as queries need them. Fetch and
+fast-forward pull remain refs-only while the connection is origin-enabled. A
+divergent lazy pull is refused until the store is fully materialized.
+Opening without `lazy_origin=1` leaves cached chunks available, but an
+uncached miss fails with a hash-named error instead of contacting `origin`.
 
 `dolt_pull` fetches, then fast-forwards if the local branch is an ancestor
 of the remote tip. If the current branch has diverged, it three-way merges
@@ -671,6 +686,7 @@ Same ops as filesystem remotes; the URL includes the database name:
 SELECT dolt_remote('add', 'origin', 'http://myserver:8080/mydb.db');
 SELECT dolt_push('origin', 'main');
 SELECT dolt_clone('http://myserver:8080/mydb.db');
+SELECT dolt_clone('--lazy', 'http://myserver:8080/mydb.db');
 ```
 
 ##### Remote Server (`doltlite-remotesrv`)

--- a/src/doltlite_chunk_source.c
+++ b/src/doltlite_chunk_source.c
@@ -1,10 +1,16 @@
 #ifndef DOLTLITE_ENABLE_CHUNK_SOURCE
 # define DOLTLITE_ENABLE_CHUNK_SOURCE 1
 #endif
+#ifndef DOLTLITE_ENABLE_REMOTES
+# define DOLTLITE_ENABLE_REMOTES 1
+#endif
 
 #ifdef DOLTLITE_PROLLY
 
 #include "prolly_btree_int.h"
+#if DOLTLITE_ENABLE_REMOTES
+#include "doltlite_remote.h"
+#endif
 
 #if DOLTLITE_ENABLE_CHUNK_SOURCE
 
@@ -13,6 +19,7 @@
 #define CS_SOURCE_CACHE_MAX_BYTES (16*1024*1024)
 #define CS_SOURCE_BUSY_RETRY_COUNT 200
 #define CS_SOURCE_BUSY_RETRY_US 5000
+#define CS_SOURCE_REMOTE_BATCH_SIZE 256
 
 typedef struct DoltliteChunkSourceEntry DoltliteChunkSourceEntry;
 struct DoltliteChunkSourceEntry {
@@ -25,7 +32,8 @@ struct DoltliteChunkSourceEntry {
 };
 
 struct DoltliteChunkSourceState {
-  doltlite_chunk_source *pSource;
+  doltlite_chunk_source *pHostSource;
+  doltlite_chunk_source originSource;
   sqlite3 *db;
   DoltliteChunkSourceEntry *aHash[CS_SOURCE_CACHE_BUCKETS];
   DoltliteChunkSourceEntry *pLruHead;
@@ -35,9 +43,127 @@ struct DoltliteChunkSourceState {
   ChunkStore writer;
   u8 writerOpen;
   u8 memoryOnly;
+  u8 originEnabled;
   int errRc;
   char *zErr;
 };
+
+static int csSourceHasOrigin(ChunkStore *cs){
+  const char *zUrl = 0;
+  return chunkStoreFindRemote(cs, "origin", &zUrl)==SQLITE_OK
+      && zUrl && zUrl[0];
+}
+
+static doltlite_chunk_source *csSourceActive(DoltliteChunkSourceState *p){
+  if( p->pHostSource ) return p->pHostSource;
+  if( p->originEnabled
+   && csSourceHasOrigin((ChunkStore*)p->originSource.pCtx) ){
+    return &p->originSource;
+  }
+  return 0;
+}
+
+#if DOLTLITE_ENABLE_REMOTES
+static int SQLITE_CALLBACK csOriginGetMany(
+  void *pCtx,
+  int nHash,
+  const unsigned char *aHash,
+  unsigned char **apBytes,
+  int *anBytes
+){
+  ChunkStore *cs = (ChunkStore*)pCtx;
+  DoltliteRemote *pRemote = 0;
+  const char *zUrl = 0;
+  int any = 0;
+  int i;
+  int offset;
+  int rc;
+
+  for(i=0; i<nHash; i++){
+    apBytes[i] = 0;
+    anBytes[i] = 0;
+  }
+  if( nHash<=0 ) return DOLTLITE_SOURCE_OK;
+  rc = chunkStoreFindRemote(cs, "origin", &zUrl);
+  if( rc!=SQLITE_OK || !zUrl ) return DOLTLITE_SOURCE_IOERR;
+  pRemote = doltliteRemoteOpenReadOnly(chunkFileGetVfs(&cs->file), zUrl);
+  if( !pRemote ) return DOLTLITE_SOURCE_IOERR;
+
+  for(offset=0; offset<nHash; offset += CS_SOURCE_REMOTE_BATCH_SIZE){
+    ProllyHash aBatch[CS_SOURCE_REMOTE_BATCH_SIZE];
+    int nBatch = nHash - offset;
+    if( nBatch>CS_SOURCE_REMOTE_BATCH_SIZE ){
+      nBatch = CS_SOURCE_REMOTE_BATCH_SIZE;
+    }
+    for(i=0; i<nBatch; i++){
+      memcpy(aBatch[i].data,
+             aHash + (offset+i)*PROLLY_HASH_SIZE, PROLLY_HASH_SIZE);
+    }
+    if( pRemote->xGetChunks ){
+      rc = pRemote->xGetChunks(pRemote, aBatch, nBatch,
+                               (u8**)&apBytes[offset], &anBytes[offset]);
+      if( rc!=SQLITE_OK ){
+        pRemote->xClose(pRemote);
+        return DOLTLITE_SOURCE_IOERR;
+      }
+    }else{
+      for(i=0; i<nBatch; i++){
+        int iOut = offset + i;
+        rc = pRemote->xGetChunk(
+            pRemote, &aBatch[i], (u8**)&apBytes[iOut], &anBytes[iOut]);
+        if( rc==SQLITE_NOTFOUND ){
+          sqlite3_free(apBytes[iOut]);
+          apBytes[iOut] = 0;
+          anBytes[iOut] = 0;
+          continue;
+        }
+        if( rc!=SQLITE_OK ){
+          pRemote->xClose(pRemote);
+          return DOLTLITE_SOURCE_IOERR;
+        }
+      }
+    }
+  }
+  pRemote->xClose(pRemote);
+  for(i=0; i<nHash; i++){
+    if( apBytes[i] ){
+      any = 1;
+      break;
+    }
+  }
+  return any ? DOLTLITE_SOURCE_OK : DOLTLITE_SOURCE_NOTFOUND;
+}
+#else
+static int SQLITE_CALLBACK csOriginGetMany(
+  void *pCtx,
+  int nHash,
+  const unsigned char *aHash,
+  unsigned char **apBytes,
+  int *anBytes
+){
+  int i;
+  UNUSED_PARAMETER(pCtx);
+  UNUSED_PARAMETER(aHash);
+  for(i=0; i<nHash; i++){
+    apBytes[i] = 0;
+    anBytes[i] = 0;
+  }
+  return DOLTLITE_SOURCE_IOERR;
+}
+#endif
+
+static int SQLITE_CALLBACK csOriginGet(
+  void *pCtx,
+  const unsigned char aHash[PROLLY_HASH_SIZE],
+  unsigned char **ppBytes,
+  int *pnBytes
+){
+  int rc = csOriginGetMany(pCtx, 1, aHash, ppBytes, pnBytes);
+  if( rc==DOLTLITE_SOURCE_OK && !*ppBytes ){
+    rc = DOLTLITE_SOURCE_NOTFOUND;
+  }
+  return rc;
+}
 
 static unsigned int csSourceBucket(const ProllyHash *pHash){
   return ((unsigned int)pHash->data[0]
@@ -194,6 +320,23 @@ static void csSourceSetHashError(
   p->zErr = sqlite3_mprintf("%s %s", zPrefix, zHash);
 }
 
+static int csSourceSetModeError(
+  ChunkStore *cs,
+  const ProllyHash *pHash
+){
+  DoltliteChunkSourceState *p = cs->pChunkSource;
+  if( !p ){
+    p = (DoltliteChunkSourceState*)sqlite3_malloc(sizeof(*p));
+    if( !p ) return SQLITE_NOMEM;
+    memset(p, 0, sizeof(*p));
+    cs->pChunkSource = p;
+  }
+  csSourceSetHashError(p, SQLITE_NOTFOUND,
+      "origin chunk source is not enabled; reopen with lazy_origin=1 for",
+      pHash);
+  return SQLITE_NOTFOUND;
+}
+
 static int csSourceGraphLockHeld(
   ChunkStore *cs,
   DoltliteChunkSourceState *p
@@ -344,13 +487,17 @@ int chunkStoreSourceGet(
   int *pnData
 ){
   DoltliteChunkSourceState *p = cs->pChunkSource;
+  doltlite_chunk_source *pSource;
   u8 *pData = 0;
   u8 *apData[1];
   int nData = 0;
   int anData[1];
   int sourceRc;
   int rc;
-  if( !p ) return SQLITE_NOTFOUND;
+  if( !p ){
+    if( csSourceHasOrigin(cs) ) return csSourceSetModeError(cs, pHash);
+    return SQLITE_NOTFOUND;
+  }
   csSourceClearError(p);
   rc = csSourceCacheGet(p, pHash, ppData, pnData);
   if( rc!=SQLITE_NOTFOUND ) return rc;
@@ -367,13 +514,19 @@ int chunkStoreSourceGet(
     }
     if( rc!=SQLITE_NOTFOUND ) return rc;
   }
+  pSource = csSourceActive(p);
+  if( !pSource ){
+    if( csSourceHasOrigin(cs) && !p->originEnabled ){
+      return csSourceSetModeError(cs, pHash);
+    }
+    return SQLITE_NOTFOUND;
+  }
   if( csSourceGraphLockHeld(cs, p) ){
     csSourceSetHashError(p, SQLITE_BUSY,
       "chunk source fetch blocked by active graph lock for", pHash);
     return SQLITE_BUSY;
   }
-  sourceRc = p->pSource->xGet(p->pSource->pCtx, pHash->data,
-                              &pData, &nData);
+  sourceRc = pSource->xGet(pSource->pCtx, pHash->data, &pData, &nData);
   if( sourceRc==DOLTLITE_SOURCE_NOTFOUND ){
     sqlite3_free(pData);
     csSourceSetHashError(
@@ -411,6 +564,7 @@ int chunkStoreSourcePrefetchMany(
   int nHash
 ){
   DoltliteChunkSourceState *p = cs->pChunkSource;
+  doltlite_chunk_source *pSource;
   u8 *aPresent = 0;
   ProllyHash *aMissing = 0;
   u8 **apData = 0;
@@ -422,6 +576,8 @@ int chunkStoreSourcePrefetchMany(
 
   if( !p || nHash==0 ) return SQLITE_OK;
   if( nHash<0 ) return SQLITE_MISUSE;
+  pSource = csSourceActive(p);
+  if( !pSource ) return SQLITE_OK;
   csSourceClearError(p);
 
   aPresent = (u8*)sqlite3_malloc64((sqlite3_uint64)nHash);
@@ -455,8 +611,8 @@ int chunkStoreSourcePrefetchMany(
   memset(apData, 0, (size_t)nMissing * sizeof(u8*));
   memset(anData, 0, (size_t)nMissing * sizeof(int));
 
-  sourceRc = p->pSource->xGetMany(
-      p->pSource->pCtx, nMissing, (const u8*)aMissing, apData, anData);
+  sourceRc = pSource->xGetMany(
+      pSource->pCtx, nMissing, (const u8*)aMissing, apData, anData);
   if( sourceRc==DOLTLITE_SOURCE_NOTFOUND ) goto prefetch_done;
   if( sourceRc!=DOLTLITE_SOURCE_OK ){
     int iErr = 0;
@@ -518,21 +674,17 @@ void chunkStoreSourceClose(ChunkStore *cs){
   sqlite3_free(p);
 }
 
-int chunkStoreSourceSet(
+static int csSourceCreate(
   ChunkStore *cs,
   sqlite3 *db,
-  doltlite_chunk_source *pSource,
+  DoltliteChunkSourceState **ppState,
   int *pChanged
 ){
   DoltliteChunkSourceState *p;
-  int rc = SQLITE_OK;
-  if( pChanged ) *pChanged = 0;
-  chunkStoreSourceClose(cs);
-  if( !pSource ) return chunkStoreRefreshIfChanged(cs, pChanged);
+  int rc;
   p = (DoltliteChunkSourceState*)sqlite3_malloc(sizeof(*p));
   if( !p ) return SQLITE_NOMEM;
   memset(p, 0, sizeof(*p));
-  p->pSource = pSource;
   p->db = db;
   rc = csSourceOpenWriter(cs, p, pChanged);
   if( rc!=SQLITE_OK ){
@@ -541,7 +693,81 @@ int chunkStoreSourceSet(
     return rc;
   }
   cs->pChunkSource = p;
+  *ppState = p;
   return SQLITE_OK;
+}
+
+int chunkStoreSourceSet(
+  ChunkStore *cs,
+  sqlite3 *db,
+  doltlite_chunk_source *pSource,
+  int *pChanged
+){
+  DoltliteChunkSourceState *p = cs->pChunkSource;
+  int openChanged = 0;
+  int refreshChanged = 0;
+  int rc = SQLITE_OK;
+  if( pChanged ) *pChanged = 0;
+  if( pSource ){
+    if( !p ){
+      rc = csSourceCreate(cs, db, &p, pChanged);
+      if( rc!=SQLITE_OK ) return rc;
+    }else{
+      rc = csSourceOpenWriter(cs, p, &openChanged);
+      if( rc==SQLITE_OK ){
+        rc = chunkStoreRefreshIfChanged(cs, &refreshChanged);
+      }
+      if( pChanged ) *pChanged = openChanged || refreshChanged;
+      if( rc!=SQLITE_OK ) return rc;
+      p->db = db;
+    }
+    p->pHostSource = pSource;
+    return SQLITE_OK;
+  }
+  if( p ){
+    p->pHostSource = 0;
+  }
+  rc = chunkStoreRefreshIfChanged(cs, pChanged);
+  if( rc==SQLITE_OK && p && !p->originEnabled ){
+    chunkStoreSourceClose(cs);
+  }
+  return rc;
+}
+
+int doltliteOriginSourceEnable(
+  ChunkStore *cs,
+  sqlite3 *db,
+  int *pChanged
+){
+  DoltliteChunkSourceState *p = cs->pChunkSource;
+  int rc;
+  if( pChanged ) *pChanged = 0;
+  if( !p ){
+    rc = csSourceCreate(cs, db, &p, pChanged);
+    if( rc!=SQLITE_OK ) return rc;
+  }else{
+    rc = csSourceOpenWriter(cs, p, pChanged);
+    if( rc!=SQLITE_OK ) return rc;
+  }
+  p->db = db;
+  p->originSource.iVersion = 1;
+  p->originSource.pCtx = cs;
+  p->originSource.xGet = csOriginGet;
+  p->originSource.xGetMany = csOriginGetMany;
+  p->originEnabled = 1;
+  return SQLITE_OK;
+}
+
+int chunkStoreOriginSourceEnabled(ChunkStore *cs){
+  DoltliteChunkSourceState *p = cs->pChunkSource;
+  return p && p->originEnabled && csSourceHasOrigin(cs);
+}
+
+static void csSourceDropHost(ChunkStore *cs){
+  DoltliteChunkSourceState *p = cs->pChunkSource;
+  if( !p ) return;
+  p->pHostSource = 0;
+  if( !p->originEnabled ) chunkStoreSourceClose(cs);
 }
 
 static char *csSourceTakeError(
@@ -628,23 +854,25 @@ SQLITE_API int SQLITE_APICALL doltlite_set_chunk_source(
       pBtree->iLoadedWorkingStateVersion =
           pBtree->pBt->iWorkingStateVersion - 1;
     }
-    if( rc==SQLITE_OK && pSource ){
-      installed = 1;
+    if( rc==SQLITE_OK && cs->pChunkSource
+     && csSourceActive(cs->pChunkSource) ){
+      installed = pSource!=0;
       rc = doltliteBtreeHydrateDeferred(pBtree);
     }
     if( rc!=SQLITE_OK && installed ){
       zSourceErr = chunkStoreSourceTakeError(cs, 0);
-      chunkStoreSourceClose(cs);
+      csSourceDropHost(cs);
     }
     sqlite3BtreeLeave(pBtree);
-    if( rc==SQLITE_OK && pSource
+    if( rc==SQLITE_OK && cs->pChunkSource
+     && csSourceActive(cs->pChunkSource)
      && pBtree==sqlite3DbNameToBtree(db, 0)
      && pBtree->bDeferredRegister ){
       rc = doltliteRegister(db);
       if( rc!=SQLITE_OK ){
         sqlite3BtreeEnter(pBtree);
         zSourceErr = chunkStoreSourceTakeError(cs, 0);
-        chunkStoreSourceClose(cs);
+        if( installed ) csSourceDropHost(cs);
         sqlite3BtreeLeave(pBtree);
       }
     }
@@ -716,11 +944,14 @@ SQLITE_API int SQLITE_APICALL doltlite_init_lazy(
       doltliteBtreeInstallBackupBranch(pBtree, zPreparedBranch);
       zPreparedBranch = 0;
     }
-    if( rc==SQLITE_OK && cs->pChunkSource ){
+    if( rc==SQLITE_OK && cs->pChunkSource
+     && csSourceActive(cs->pChunkSource) ){
       rc = doltliteBtreeHydrateDeferred(pBtree);
     }
     sqlite3BtreeLeave(pBtree);
-    if( rc==SQLITE_OK && cs->pChunkSource && pBtree->bDeferredRegister ){
+    if( rc==SQLITE_OK && cs->pChunkSource
+     && csSourceActive(cs->pChunkSource)
+     && pBtree->bDeferredRegister ){
       rc = doltliteRegister(db);
     }
     if( rc==SQLITE_OK ) sqlite3Error(db, SQLITE_OK);
@@ -734,6 +965,55 @@ SQLITE_API int SQLITE_APICALL doltlite_init_lazy(
 
 #else
 
+struct DoltliteChunkSourceState {
+  u8 originEnabled;
+  int errRc;
+  char *zErr;
+};
+
+static int csDisabledEnsureState(ChunkStore *cs){
+  DoltliteChunkSourceState *p;
+  if( cs->pChunkSource ) return SQLITE_OK;
+  p = (DoltliteChunkSourceState*)sqlite3_malloc(sizeof(*p));
+  if( !p ) return SQLITE_NOMEM;
+  memset(p, 0, sizeof(*p));
+  cs->pChunkSource = p;
+  return SQLITE_OK;
+}
+
+static int csDisabledHasOrigin(ChunkStore *cs){
+  const char *zUrl = 0;
+  return chunkStoreFindRemote(cs, "origin", &zUrl)==SQLITE_OK
+      && zUrl && zUrl[0];
+}
+
+static int csDisabledSetHashError(
+  ChunkStore *cs,
+  const ProllyHash *pHash,
+  const char *zPrefix,
+  int errRc
+){
+  static const char zHex[] = "0123456789abcdef";
+  DoltliteChunkSourceState *p;
+  char zHash[PROLLY_HASH_SIZE*2 + 1];
+  int rc;
+  int i;
+  rc = csDisabledEnsureState(cs);
+  if( rc!=SQLITE_OK ) return rc;
+  p = cs->pChunkSource;
+  sqlite3_free(p->zErr);
+  p->zErr = 0;
+  for(i=0; i<PROLLY_HASH_SIZE; i++){
+    zHash[i*2] = zHex[pHash->data[i] >> 4];
+    zHash[i*2 + 1] = zHex[pHash->data[i] & 0x0f];
+  }
+  zHash[PROLLY_HASH_SIZE*2] = 0;
+  p->zErr = sqlite3_mprintf("%s %s", zPrefix, zHash);
+  if( !p->zErr ) return SQLITE_NOMEM;
+  p->errRc = errRc;
+  return errRc;
+}
+
 int chunkStoreSourceHas(ChunkStore *cs, const ProllyHash *pHash, int *pHas){
   UNUSED_PARAMETER(cs);
   UNUSED_PARAMETER(pHash);
@@ -743,38 +1023,101 @@ int chunkStoreSourceHas(ChunkStore *cs, const ProllyHash *pHash, int *pHas){
 
 int chunkStoreSourceGet(ChunkStore *cs, const ProllyHash *pHash,
                         u8 **ppData, int *pnData){
-  UNUSED_PARAMETER(cs);
-  UNUSED_PARAMETER(pHash);
-  UNUSED_PARAMETER(ppData);
-  UNUSED_PARAMETER(pnData);
-  return SQLITE_NOTFOUND;
+  *ppData = 0;
+  *pnData = 0;
+  if( !csDisabledHasOrigin(cs) ) return SQLITE_NOTFOUND;
+  if( chunkStoreOriginSourceEnabled(cs) ){
+    return csDisabledSetHashError(
+        cs, pHash, "DoltLite chunk source support is disabled for",
+        SQLITE_IOERR_CHUNK_SOURCE);
+  }
+  return csDisabledSetHashError(
+      cs, pHash,
+      "origin chunk source is not enabled; reopen with lazy_origin=1 for",
+      SQLITE_NOTFOUND);
 }
 
 int chunkStoreSourcePrefetchMany(ChunkStore *cs, const ProllyHash *aHash,
                                  int nHash){
-  UNUSED_PARAMETER(cs);
-  UNUSED_PARAMETER(aHash);
-  UNUSED_PARAMETER(nHash);
-  return SQLITE_OK;
+  int errRc;
+  int i;
+  int rc;
+  if( nHash<0 ) return SQLITE_MISUSE;
+  if( nHash==0 || !chunkStoreOriginSourceEnabled(cs) ) return SQLITE_OK;
+  for(i=0; i<nHash; i++){
+    int has = 0;
+    rc = chunkStoreHas(cs, &aHash[i], &has);
+    if( rc!=SQLITE_OK ) return rc;
+    if( !has ) break;
+  }
+  if( i==nHash ) return SQLITE_OK;
+  errRc = SQLITE_IOERR_CHUNK_SOURCE;
+  return csDisabledSetHashError(
+      cs, &aHash[i], "DoltLite chunk source support is disabled for", errRc);
 }
 
 int chunkStoreSourceSet(ChunkStore *cs, sqlite3 *db,
                         doltlite_chunk_source *pSource, int *pChanged){
-  UNUSED_PARAMETER(cs);
+  DoltliteChunkSourceState *p = cs->pChunkSource;
   UNUSED_PARAMETER(db);
   if( pChanged ) *pChanged = 0;
+  if( !pSource && (!p || !p->originEnabled) ){
+    chunkStoreSourceClose(cs);
+  }
   return pSource ? SQLITE_NOTFOUND : SQLITE_OK;
 }
 
-void chunkStoreSourceClose(ChunkStore *cs){ UNUSED_PARAMETER(cs); }
+int doltliteOriginSourceEnable(ChunkStore *cs, sqlite3 *db, int *pChanged){
+  DoltliteChunkSourceState *p;
+  int rc;
+  UNUSED_PARAMETER(db);
+  if( pChanged ) *pChanged = 0;
+  rc = csDisabledEnsureState(cs);
+  if( rc!=SQLITE_OK ) return rc;
+  p = cs->pChunkSource;
+  p->originEnabled = 1;
+  return SQLITE_OK;
+}
+
+int chunkStoreOriginSourceEnabled(ChunkStore *cs){
+  DoltliteChunkSourceState *p = cs->pChunkSource;
+  return p && p->originEnabled && csDisabledHasOrigin(cs);
+}
+
+void chunkStoreSourceClose(ChunkStore *cs){
+  DoltliteChunkSourceState *p = cs->pChunkSource;
+  if( !p ) return;
+  cs->pChunkSource = 0;
+  sqlite3_free(p->zErr);
+  sqlite3_free(p);
+}
 char *chunkStoreSourceTakeError(ChunkStore *cs, int *pRc){
-  UNUSED_PARAMETER(cs);
-  if( pRc ) *pRc = SQLITE_OK;
-  return 0;
+  DoltliteChunkSourceState *p = cs->pChunkSource;
+  char *zErr = 0;
+  int rc = SQLITE_OK;
+  if( p ){
+    zErr = p->zErr;
+    rc = p->errRc;
+    p->zErr = 0;
+    p->errRc = SQLITE_OK;
+  }
+  if( pRc ) *pRc = rc;
+  return zErr;
 }
 char *doltliteTakeChunkSourceError(sqlite3 *db, int *pRc){
-  UNUSED_PARAMETER(db);
+  int i;
   if( pRc ) *pRc = SQLITE_OK;
+  for(i=0; i<db->nDb; i++){
+    ChunkStore *cs = doltliteBtreeChunkStore(db->aDb[i].pBt);
+    char *zErr;
+    int rc;
+    if( !cs ) continue;
+    zErr = chunkStoreSourceTakeError(cs, &rc);
+    if( zErr || rc!=SQLITE_OK ){
+      if( pRc ) *pRc = rc;
+      return zErr;
+    }
+  }
   return 0;
 }
 

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -20,6 +20,8 @@ typedef struct DoltliteTxnState DoltliteTxnState;
 typedef struct DoltlitePkRange DoltlitePkRange;
 typedef struct DoltliteCommitQueue DoltliteCommitQueue;
 
+int chunkStoreOriginSourceEnabled(ChunkStore*);
+
 #define DOLTLITE_RANGE_NONE      0
 #define DOLTLITE_RANGE_TWO_DOT   2
 #define DOLTLITE_RANGE_THREE_DOT 3

--- a/src/doltlite_remote.c
+++ b/src/doltlite_remote.c
@@ -514,10 +514,13 @@ static void fsClose(DoltliteRemote *pRemote){
   sqlite3_free(p);
 }
 
-DoltliteRemote *doltliteFsRemoteOpen(sqlite3_vfs *pVfs, const char *zPath){
+static DoltliteRemote *fsRemoteOpen(
+  sqlite3_vfs *pVfs,
+  const char *zPath,
+  int flags
+){
   FsRemote *p;
   int rc;
-  int flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_MAIN_DB;
 
   p = sqlite3_malloc(sizeof(FsRemote));
   if( !p ) return 0;
@@ -540,6 +543,25 @@ DoltliteRemote *doltliteFsRemoteOpen(sqlite3_vfs *pVfs, const char *zPath){
   }
 
   return &p->base;
+}
+
+DoltliteRemote *doltliteFsRemoteOpen(sqlite3_vfs *pVfs, const char *zPath){
+  return fsRemoteOpen(pVfs, zPath,
+      SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_MAIN_DB);
+}
+
+DoltliteRemote *doltliteRemoteOpenReadOnly(
+  sqlite3_vfs *pVfs,
+  const char *zUrl
+){
+  if( strncmp(zUrl, "file://", 7)==0 ){
+    return fsRemoteOpen(pVfs, zUrl + 7,
+                        SQLITE_OPEN_READONLY | SQLITE_OPEN_MAIN_DB);
+  }
+  if( strncmp(zUrl, "http://", 7)==0 || strncmp(zUrl, "https://", 8)==0 ){
+    return doltliteHttpRemoteOpen(zUrl);
+  }
+  return 0;
 }
 
 ChunkStore *doltliteFsRemoteStoreForTest(DoltliteRemote *pRemote){

--- a/src/doltlite_remote.c
+++ b/src/doltlite_remote.c
@@ -1143,7 +1143,8 @@ static int installFetchedRefs(
   ChunkStore *pRemoteRefs,
   const char *zRemoteName,
   const char *zBranch,
-  const ProllyHash *pRemoteCommit
+  const ProllyHash *pRemoteCommit,
+  int bSkipGraphValidation
 ){
   ChunkStore nextRefs;
   SavedRefsState savedRefs;
@@ -1168,7 +1169,11 @@ static int installFetchedRefs(
     locked = 1;
     rc = chunkStoreForceRefresh(pLocal);
   }
-  if( rc==SQLITE_OK ){
+  if( rc==SQLITE_OK && bSkipGraphValidation
+   && !chunkStoreOriginSourceEnabled(pLocal) ){
+    bSkipGraphValidation = 0;
+  }
+  if( rc==SQLITE_OK && !bSkipGraphValidation ){
     /* Nothing roots synced chunks until this tracking ref lands. A gc in that
     ** window collects the fetch; installing then wedges later connections. */
     ProllyHash aRoots[1];
@@ -1241,11 +1246,14 @@ int doltliteFetch(
   ProllyHash trackingCommit;
   DoltliteRemote *pLocalDst = 0;
   ChunkStore remoteRefs;
+  int bLazyOrigin;
   int rc;
 
   memset(&remoteCommit, 0, sizeof(remoteCommit));
   memset(&trackingCommit, 0, sizeof(trackingCommit));
   memset(&remoteRefs, 0, sizeof(remoteRefs));
+  bLazyOrigin = chunkStoreOriginSourceEnabled(pLocal)
+             && strcmp(zRemoteName, "origin")==0;
 
   rc = pRemote->xGetRefs(pRemote, &refsData, &nRefsData);
   if( rc!=SQLITE_OK ) return rc;
@@ -1284,20 +1292,25 @@ int doltliteFetch(
     return rc;
   }
 
-  pLocalDst = doltliteLocalAsRemote(pLocal);
-  if( !pLocalDst ){
-    chunkStoreClose(&remoteRefs);
-    return SQLITE_NOMEM;
+  if( !bLazyOrigin ){
+    pLocalDst = doltliteLocalAsRemote(pLocal);
+    if( !pLocalDst ){
+      chunkStoreClose(&remoteRefs);
+      return SQLITE_NOMEM;
+    }
+
+    rc = doltliteSyncChunks(pRemote, pLocalDst, &remoteCommit, 1);
+
+    if( rc==SQLITE_OK ) rc = pLocalDst->xCommit(pLocalDst);
+    pLocalDst->xClose(pLocalDst);
+  }else{
+    rc = SQLITE_OK;
   }
-
-  rc = doltliteSyncChunks(pRemote, pLocalDst, &remoteCommit, 1);
-
-  if( rc==SQLITE_OK ) rc = pLocalDst->xCommit(pLocalDst);
-  pLocalDst->xClose(pLocalDst);
   if( rc==SQLITE_OK ){
     doltliteTestRunBeforeRefInstallHook();
     rc = installFetchedRefs(
-        pLocal, &remoteRefs, zRemoteName, zBranch, &remoteCommit);
+        pLocal, &remoteRefs, zRemoteName, zBranch, &remoteCommit,
+        bLazyOrigin);
   }
 
   chunkStoreClose(&remoteRefs);

--- a/src/doltlite_remote.c
+++ b/src/doltlite_remote.c
@@ -1304,6 +1304,97 @@ int doltliteFetch(
   return rc;
 }
 
+int doltliteCloneLazy(
+  ChunkStore *pLocal,
+  DoltliteRemote *pRemote,
+  const char *zUrl
+){
+  ChunkStore refsView;
+  ChunkStoreRefsSnapshot snapshot;
+  const BranchRef *aBranch = 0;
+  ProllyHash defaultCommit;
+  ProllyHash emptyWs;
+  u8 *pRemoteRefs = 0;
+  u8 *pLocalRefs = 0;
+  int nRemoteRefs = 0;
+  int nLocalRefs = 0;
+  int nBranch = 0;
+  int haveSnapshot = 0;
+  int locked = 0;
+  int rc;
+  int i;
+
+  memset(&refsView, 0, sizeof(refsView));
+  memset(&snapshot, 0, sizeof(snapshot));
+  memset(&defaultCommit, 0, sizeof(defaultCommit));
+  memset(&emptyWs, 0, sizeof(emptyWs));
+  if( !zUrl ) return SQLITE_MISUSE;
+
+  rc = pRemote->xGetRefs(pRemote, &pRemoteRefs, &nRemoteRefs);
+  if( rc==SQLITE_OK ){
+    rc = chunkStoreLoadRefsFromBlob(&refsView, pRemoteRefs, nRemoteRefs);
+  }
+  sqlite3_free(pRemoteRefs);
+  if( rc!=SQLITE_OK ) goto lazy_clone_done;
+
+  refsTableGetBranches(&refsView.refs, &nBranch, &aBranch);
+  if( nBranch>0 ){
+    rc = chunkStoreFindBranch(
+        &refsView, chunkStoreGetDefaultBranch(&refsView), &defaultCommit);
+    if( rc!=SQLITE_OK || prollyHashIsEmpty(&defaultCommit) ){
+      rc = SQLITE_ERROR;
+      goto lazy_clone_done;
+    }
+  }
+
+  rc = chunkStoreDeleteRemote(&refsView, "origin");
+  if( rc==SQLITE_NOTFOUND ) rc = SQLITE_OK;
+  if( rc==SQLITE_OK ) rc = chunkStoreAddRemote(&refsView, "origin", zUrl);
+  for(i=0; i<nBranch && rc==SQLITE_OK; i++){
+    rc = chunkStoreSetBranchWorkingSet(
+        &refsView, aBranch[i].zName, &emptyWs);
+    if( rc==SQLITE_OK ){
+      rc = chunkStoreUpdateTracking(
+          &refsView, "origin", aBranch[i].zName, &aBranch[i].commitHash);
+    }
+  }
+  if( rc==SQLITE_OK ){
+    rc = chunkStoreSerializeRefsToBlob(
+        &refsView, &pLocalRefs, &nLocalRefs);
+  }
+  if( rc!=SQLITE_OK ) goto lazy_clone_done;
+
+  rc = chunkStoreLockAndRefresh(pLocal);
+  if( rc==SQLITE_OK ){
+    locked = 1;
+    rc = chunkStoreForceRefresh(pLocal);
+  }
+  if( rc==SQLITE_OK ){
+    rc = chunkStoreSnapshotRefs(pLocal, &snapshot);
+    if( rc==SQLITE_OK ) haveSnapshot = 1;
+  }
+  if( rc==SQLITE_OK ){
+    rc = chunkStoreInstallRefsBlob(pLocal, pLocalRefs, nLocalRefs);
+  }
+  if( rc==SQLITE_OK ){
+    rc = chunkStoreCommit(pLocal);
+  }
+  if( haveSnapshot ){
+    if( rc==SQLITE_OK ){
+      chunkStoreDiscardRefsSnapshot(&snapshot);
+    }else{
+      chunkStoreRollback(pLocal);
+      chunkStoreRestoreRefsSnapshot(pLocal, &snapshot);
+    }
+  }
+  if( locked ) chunkStoreUnlock(pLocal);
+
+lazy_clone_done:
+  chunkStoreClose(&refsView);
+  sqlite3_free(pLocalRefs);
+  return rc;
+}
+
 int doltliteClone(ChunkStore *pLocal, DoltliteRemote *pRemote){
   u8 *refsData = 0;
   int nRefsData = 0;

--- a/src/doltlite_remote.h
+++ b/src/doltlite_remote.h
@@ -61,6 +61,9 @@ int doltliteClone(ChunkStore *pLocal, DoltliteRemote *pRemote);
 
 DoltliteRemote *doltliteFsRemoteOpen(sqlite3_vfs *pVfs, const char *zPath);
 
+DoltliteRemote *doltliteRemoteOpenReadOnly(sqlite3_vfs *pVfs,
+                                           const char *zUrl);
+
 DoltliteRemote *doltliteLocalAsRemote(ChunkStore *pLocal);
 
 DoltliteRemote *doltliteHttpRemoteOpen(const char *zUrl);

--- a/src/doltlite_remote.h
+++ b/src/doltlite_remote.h
@@ -59,6 +59,9 @@ int doltliteFetch(ChunkStore *pLocal, DoltliteRemote *pRemote,
 
 int doltliteClone(ChunkStore *pLocal, DoltliteRemote *pRemote);
 
+int doltliteCloneLazy(ChunkStore *pLocal, DoltliteRemote *pRemote,
+                      const char *zUrl);
+
 DoltliteRemote *doltliteFsRemoteOpen(sqlite3_vfs *pVfs, const char *zPath);
 
 DoltliteRemote *doltliteRemoteOpenReadOnly(sqlite3_vfs *pVfs,

--- a/src/doltlite_remote_sql.c
+++ b/src/doltlite_remote_sql.c
@@ -623,6 +623,14 @@ static void doltPullFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
           "cannot pull non-current branch without fast-forward");
         return;
       }
+      if( strcmp(zRemoteName, "origin")==0
+       && chunkStoreOriginSourceEnabled(cs) ){
+        remoteSqlRestoreAndReport(
+          ctx, db, cs, &savedState, SQLITE_ERROR,
+          "cannot merge a non-fast-forward pull in a lazy store; "
+          "materialize the store first");
+        return;
+      }
       /* Merge owns txn save/restore; drop pull's snapshot first. */
       doltliteTxnStateClear(&savedState);
       zTrackingRef = sqlite3_mprintf("%s/%s", zRemoteName, zBranch);

--- a/src/doltlite_remote_sql.c
+++ b/src/doltlite_remote_sql.c
@@ -9,6 +9,7 @@
 #include "doltlite_commit.h"
 #include "doltlite_internal.h"
 #include "doltlite_creds.h"
+#include "prolly_btree_int.h"
 #include <string.h>
 #include <stdlib.h>
 
@@ -698,26 +699,41 @@ static void doltCloneFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   sqlite3 *db = sqlite3_context_db_handle(ctx);
   ChunkStore *cs = doltliteGetChunkStore(db);
   DoltliteRemote *pRemote = 0;
+  DoltliteCmdArgs args;
+  DoltliteCmdOption aOption[] = {
+    { "lazy", 0, DOLTLITE_CMD_OPTION_FLAG, 0, 0 }
+  };
   const char *zUrl;
   DoltliteTxnState savedState;
+  int bLazy = 0;
   int dirty = 0;
   int rc;
 
   if( !cs ){ doltliteVcResultError(ctx, db, "no database"); return; }
   if( argc<1 ){
-    doltliteVcResultError(ctx, db, "usage: dolt_clone(url)");
+    doltliteVcResultError(ctx, db, "usage: dolt_clone(['--lazy'], url)");
     return;
   }
 
-  zUrl = (const char*)sqlite3_value_text(argv[0]);
-  if( !zUrl ){
+  aOption[0].pSeen = &bLazy;
+  rc = doltliteCmdParseArgs(ctx, argc, argv, aOption, ArraySize(aOption),
+                            0, &args);
+  if( rc!=SQLITE_OK ){
+    (void)doltliteVcSealSavepointError(db);
+    return;
+  }
+  if( args.nPositional<1 ){
+    doltliteCmdArgsClear(&args);
     doltliteVcResultError(ctx, db, "url required");
     return;
   }
-  if( argc>1 ){
+  if( args.nPositional>1 ){
+    doltliteCmdArgsClear(&args);
     doltliteVcResultError(ctx, db, "too many arguments");
     return;
   }
+  zUrl = args.azPositional[0];
+  doltliteCmdArgsClear(&args);
   memset(&savedState, 0, sizeof(savedState));
 
   rc = doltliteHasUncommittedChanges(db, &dirty);
@@ -780,7 +796,17 @@ static void doltCloneFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
     return;
   }
 
-  rc = doltliteClone(cs, pRemote);
+  if( bLazy ){
+    rc = doltliteOriginSourceEnable(cs, db, 0);
+    if( rc!=SQLITE_OK ){
+      pRemote->xClose(pRemote);
+      remoteSqlRestoreAndReport(ctx, db, cs, &savedState, rc,
+                                "failed to initialize lazy clone");
+      return;
+    }
+  }
+  rc = bLazy ? doltliteCloneLazy(cs, pRemote, zUrl)
+             : doltliteClone(cs, pRemote);
   if( rc!=SQLITE_OK ){
     const char *zMsg = remoteSqlRemoteMsg(pRemote, rc);
     char *zOwned;
@@ -795,6 +821,32 @@ static void doltCloneFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
     return;
   }
   pRemote->xClose(pRemote);
+
+  if( bLazy ){
+    Btree *pBtree = sqlite3DbNameToBtree(db, 0);
+    char *zPreparedBranch = 0;
+    if( !pBtree || !sqlite3BtreeIsDoltliteFormat(pBtree) ){
+      remoteSqlRestoreAndReport(ctx, db, cs, &savedState, SQLITE_ERROR,
+                                "failed to initialize lazy clone");
+      return;
+    }
+    pBtree->bDeferredOpen = 1;
+    rc = doltliteBtreePrepareBackupBranch(
+        pBtree, cs, &zPreparedBranch);
+    if( rc==SQLITE_OK && zPreparedBranch ){
+      doltliteBtreeInstallBackupBranch(pBtree, zPreparedBranch);
+      zPreparedBranch = 0;
+    }
+    sqlite3_free(zPreparedBranch);
+    if( rc!=SQLITE_OK ){
+      remoteSqlRestoreAndReport(ctx, db, cs, &savedState, rc,
+                                "failed to initialize lazy clone");
+      return;
+    }
+    remoteSqlExpireCurrentStatement(db);
+    remoteSqlClearAndSucceed(ctx, &savedState);
+    return;
+  }
 
   rc = chunkStoreAddRemote(cs, "origin", zUrl);
   if( rc!=SQLITE_OK ){

--- a/src/main.c
+++ b/src/main.c
@@ -3698,6 +3698,9 @@ static int openDatabase(
     if( rc==SQLITE_IOERR_NOMEM ){
       rc = SQLITE_NOMEM_BKPT;
     }
+#ifdef DOLTLITE_PROLLY
+    if( rc!=SQLITE_IOERR_CHUNK_SOURCE )
+#endif
     sqlite3Error(db, rc);
     goto opendb_out;
   }

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -11,6 +11,24 @@ static void btreeClearCatalogCache(Btree *p){
 
 static int registerDoltiteFunctions(sqlite3 *db);
 
+static int btreeApplyChunkSourceError(
+  sqlite3 *db,
+  ChunkStore *cs,
+  int rc
+){
+  char *zErr;
+  int sourceRc = SQLITE_OK;
+  zErr = chunkStoreSourceTakeError(cs, &sourceRc);
+  if( sourceRc!=SQLITE_OK ) rc = sourceRc;
+  if( zErr ){
+    sqlite3ErrorWithMsg(db, rc, "%s", zErr);
+    sqlite3_free(zErr);
+  }else if( sourceRc!=SQLITE_OK ){
+    sqlite3Error(db, rc);
+  }
+  return rc;
+}
+
 
 #define PROLLY_MUTMAP_PENDING_FLUSH_LIMIT 65536
 
@@ -540,6 +558,7 @@ int sqlite3BtreeOpen(
   BtShared *pBt = 0;
   int rc = SQLITE_OK;
   int useOrig;
+  int useOriginSource = 0;
   int hasMainBtree;
   u8 poisonAfterOpen = 0;
   char *zStoreFilename = 0;
@@ -561,6 +580,7 @@ int sqlite3BtreeOpen(
   ** under-read. */
   if( !useOrig && (vfsFlags & SQLITE_OPEN_MAIN_DB)!=0 ){
     const char *zEngine = sqlite3_uri_parameter(zFilename, "doltlite_engine");
+    useOriginSource = sqlite3_uri_boolean(zFilename, "lazy_origin", 0);
     if( zEngine && sqlite3StrICmp(zEngine, "sqlite")==0 ){
       int hasContent = 1;
       rc = doltliteFileHasContent(pVfs, zFilename, &hasContent);
@@ -636,6 +656,16 @@ int sqlite3BtreeOpen(
     sqlite3_free(p);
     return rc;
   }
+  if( useOriginSource ){
+    rc = doltliteOriginSourceEnable(&pBt->store, db, 0);
+    if( rc!=SQLITE_OK ){
+      chunkStoreClose(&pBt->store);
+      sqlite3_free(zStoreFilename);
+      sqlite3_free(pBt);
+      sqlite3_free(p);
+      return rc;
+    }
+  }
   /* Serve the recovered prefix to open-time catalog reads, then re-arm. */
   poisonAfterOpen = pBt->store.corruptMidStream;
   pBt->store.corruptMidStream = 0;
@@ -702,15 +732,18 @@ int sqlite3BtreeOpen(
       rc = doltliteResolveOpenRevision(&pBt->store, zDef, &branchCommit,
                                        &revisionCatalog, &isBranchRevision);
 #if DOLTLITE_ENABLE_CHUNK_SOURCE
-      if( rc==SQLITE_NOTFOUND && isBranchRevision ){
+      if( rc==SQLITE_NOTFOUND && isBranchRevision
+       && !chunkStoreOriginSourceEnabled(&pBt->store) ){
         bDeferredOpen = 1;
         rc = SQLITE_OK;
       }
 #endif
     }
     if( zBranchFromPath && rc!=SQLITE_OK ){
-      int openRc = rc==SQLITE_NOMEM || rc==SQLITE_IOERR_NOMEM
-                 ? rc : SQLITE_ERROR;
+      int openRc;
+      rc = btreeApplyChunkSourceError(db, &pBt->store, rc);
+      openRc = rc==SQLITE_NOMEM || rc==SQLITE_IOERR_NOMEM
+             || rc==SQLITE_IOERR_CHUNK_SOURCE ? rc : SQLITE_ERROR;
       if( openRc==SQLITE_ERROR ){
         sqlite3ErrorWithMsg(db, SQLITE_ERROR,
                             "unable to select branch \"%s\"", zDef);
@@ -733,13 +766,15 @@ int sqlite3BtreeOpen(
     }else{
       rc = btreeLoadBranchState(&pBt->store, zDef, 1, &state);
 #if DOLTLITE_ENABLE_CHUNK_SOURCE
-      if( rc==SQLITE_NOTFOUND ){
+      if( rc==SQLITE_NOTFOUND
+       && !chunkStoreOriginSourceEnabled(&pBt->store) ){
         bDeferredOpen = 1;
         rc = SQLITE_OK;
       }
 #endif
     }
     if( rc!=SQLITE_OK ){
+      rc = btreeApplyChunkSourceError(db, &pBt->store, rc);
       pagerShimDestroy(pBt->pPagerShim);
       prollyCacheFree(&pBt->cache);
       chunkStoreClose(&pBt->store);
@@ -768,12 +803,14 @@ int sqlite3BtreeOpen(
       }else{
         sqlite3_free(catData);
 #if DOLTLITE_ENABLE_CHUNK_SOURCE
-        if( rc==SQLITE_NOTFOUND && !p->isDetached ){
+        if( rc==SQLITE_NOTFOUND && !p->isDetached
+         && !chunkStoreOriginSourceEnabled(&pBt->store) ){
           bDeferredOpen = 1;
           rc = SQLITE_OK;
         }
 #endif
         if( rc!=SQLITE_OK ){
+          rc = btreeApplyChunkSourceError(db, &pBt->store, rc);
           btreeClearBranchState(&state);
           pagerShimDestroy(pBt->pPagerShim);
           prollyCacheFree(&pBt->cache);
@@ -867,6 +904,9 @@ int sqlite3BtreeOpen(
     sqlite3_free(zStoreFilename);
     sqlite3BtreeClose(p);
     return rc;
+  }
+  if( rc!=SQLITE_OK && chunkStoreOriginSourceEnabled(&pBt->store) ){
+    p->bDeferredRegister = 1;
   }
 
   sqlite3_free(zStoreFilename);

--- a/src/prolly_btree_int.h
+++ b/src/prolly_btree_int.h
@@ -731,6 +731,8 @@ int btreeRefreshFromDisk(Btree*);
 int btreeRefreshSharedWorkingState(Btree*);
 int btreeReloadBranchWorkingStateInto(Btree*, int, ProllyHash*);
 int doltliteBtreeHydrateDeferred(Btree*);
+int doltliteOriginSourceEnable(ChunkStore*, sqlite3*, int*);
+int chunkStoreOriginSourceEnabled(ChunkStore*);
 int doltliteBtreeRunDeferredWork(sqlite3*);
 void doltliteBtreeRegistrationDone(sqlite3*);
 void btreeStoreCommittedFromCurrent(Btree*, const ProllyHash*);

--- a/src/sqlite.h.in
+++ b/src/sqlite.h.in
@@ -11228,11 +11228,14 @@ int sqlite3_snapshot_recover(sqlite3 *db, const char *zDb);
 ** in the database file when it is writable, or in a bounded connection-local
 ** memory cache when it is read-only. The callback object and its context must
 ** outlive a successful registration. A failed registration does not retain
-** pSource. Passing NULL clears the registration.
+** pSource. A host registration takes precedence over an origin-backed source
+** selected for the current database open. Passing NULL clears the host
+** registration and restores that built-in source when present.
+** The built-in source is selected with the lazy_origin=1 database URI
+** parameter and is inert until the store records an origin remote.
 **
 ** zDbName selects one attached database and follows SQLite database-name
-** conventions; NULL selects "main". This seam is also intended for a future
-** built-in source backed by the recorded origin remote.
+** conventions; NULL selects "main".
 */
 typedef struct doltlite_chunk_source doltlite_chunk_source;
 struct doltlite_chunk_source {

--- a/test/amalgamation_chunk_source_probe.c
+++ b/test/amalgamation_chunk_source_probe.c
@@ -1,4 +1,5 @@
 #include "sqlite3.h"
+#include <ctype.h>
 #include <stdio.h>
 #include <string.h>
 
@@ -38,7 +39,57 @@ static int sourceGetMany(
   return DOLTLITE_SOURCE_OK;
 }
 
-int main(void){
+#if !DOLTLITE_ENABLE_CHUNK_SOURCE
+static int containsHash(const char *z){
+  int nHex = 0;
+  while( z && *z ){
+    if( isxdigit((unsigned char)*z) ){
+      nHex++;
+      if( nHex>=40 ) return 1;
+    }else{
+      nHex = 0;
+    }
+    z++;
+  }
+  return 0;
+}
+
+static int checkDisabledLazy(const char *zPath){
+  sqlite3 *db = 0;
+  sqlite3_stmt *pStmt = 0;
+  char *zUri;
+  const char *zErr;
+  int extendedRc;
+  int rc;
+
+  zUri = sqlite3_mprintf("file:%s?lazy_origin=1", zPath);
+  if( !zUri ) return 1;
+  rc = sqlite3_open_v2(zUri, &db,
+      SQLITE_OPEN_READWRITE | SQLITE_OPEN_URI, 0);
+  sqlite3_free(zUri);
+  if( rc==SQLITE_OK ){
+    rc = sqlite3_prepare_v2(
+        db, "SELECT count(*) FROM users", -1, &pStmt, 0);
+  }
+  if( rc==SQLITE_OK ) rc = sqlite3_step(pStmt);
+  extendedRc = db ? sqlite3_extended_errcode(db) : rc;
+  zErr = db ? sqlite3_errmsg(db) : "";
+  if( extendedRc!=SQLITE_IOERR_CHUNK_SOURCE
+   || !strstr(zErr, "chunk source support is disabled")
+   || !containsHash(zErr) ){
+    fprintf(stderr, "unexpected disabled lazy-store error rc=%d: %s\n",
+            extendedRc, zErr);
+    sqlite3_finalize(pStmt);
+    sqlite3_close(db);
+    return 1;
+  }
+  sqlite3_finalize(pStmt);
+  sqlite3_close(db);
+  return 0;
+}
+#endif
+
+int main(int argc, char **argv){
   doltlite_chunk_source source;
   sqlite3 *db = 0;
   int rc;
@@ -62,6 +113,11 @@ int main(void){
     return 1;
   }
 #else
+  if( argc!=2 ){
+    fprintf(stderr, "usage: %s LAZY_DB\n", argv[0]);
+    sqlite3_close(db);
+    return 1;
+  }
   if( rc!=SQLITE_NOTFOUND
    || !strstr(sqlite3_errmsg(db), "chunk source support is disabled") ){
     fprintf(stderr, "unexpected disabled registration: %s\n",
@@ -80,5 +136,11 @@ int main(void){
     return 1;
   }
   sqlite3_close(db);
+#if !DOLTLITE_ENABLE_CHUNK_SOURCE
+  if( checkDisabledLazy(argv[1]) ) return 1;
+#else
+  (void)argc;
+  (void)argv;
+#endif
   return 0;
 }

--- a/test/amalgamation_http_probe.c
+++ b/test/amalgamation_http_probe.c
@@ -39,15 +39,17 @@ int main(int argc, char **argv){
   char *zSql;
   const char *zSrc;
   const char *zClone;
+  const char *zLazy = 0;
   const char *zUrl;
 
-  if( argc!=4 ){
-    fprintf(stderr, "usage: %s SRC_DB CLONE_DB HTTP_URL\n", argv[0]);
+  if( argc!=4 && argc!=5 ){
+    fprintf(stderr, "usage: %s SRC_DB CLONE_DB HTTP_URL [LAZY_DB]\n", argv[0]);
     return 1;
   }
   zSrc = argv[1];
   zClone = argv[2];
   zUrl = argv[3];
+  if( argc==5 ) zLazy = argv[4];
 
   if( doltliteInstallAutoExt()!=SQLITE_OK ){
     fprintf(stderr, "doltliteInstallAutoExt failed\n");
@@ -81,6 +83,21 @@ int main(int argc, char **argv){
   }
   sqlite3_free(zSql);
   sqlite3_close(db);
+
+  if( zLazy ){
+    if( sqlite3_open(zLazy, &db)!=SQLITE_OK ){
+      fprintf(stderr, "%s\n", db ? sqlite3_errmsg(db) : "sqlite3_open failed");
+      return 1;
+    }
+    zSql = sqlite3_mprintf("SELECT dolt_clone('--lazy',%Q);", zUrl);
+    if( !zSql || exec_sql(db, zSql) ){
+      sqlite3_free(zSql);
+      sqlite3_close(db);
+      return 1;
+    }
+    sqlite3_free(zSql);
+    sqlite3_close(db);
+  }
 
   if( sqlite3_open(zClone, &db)!=SQLITE_OK ){
     fprintf(stderr, "%s\n", db ? sqlite3_errmsg(db) : "sqlite3_open failed");

--- a/test/amalgamation_http_remote_test.sh
+++ b/test/amalgamation_http_remote_test.sh
@@ -101,7 +101,8 @@ if [ -z "$port" ]; then
 fi
 
 DOLTLITE_CREDS_DIR="$tmp/creds" \
-  "$probe" "$tmp/src.db" "$tmp/clone.db" "http://127.0.0.1:$port/repo.db"
+  "$probe" "$tmp/src.db" "$tmp/clone.db" "http://127.0.0.1:$port/repo.db" \
+  "$tmp/lazy-off.db"
 
 offline_probe="$tmp/amalg_remotes_disabled_probe"
 case "$(uname -s)" in
@@ -127,7 +128,7 @@ esac
 "$cc_bin" -Wno-comment -DDOLTLITE_ENABLE_CHUNK_SOURCE=0 -I. \
   ../test/amalgamation_chunk_source_probe.c ./sqlite3.c \
   "${probe_libs[@]}" -o "$chunk_source_off_probe"
-"$chunk_source_off_probe"
+"$chunk_source_off_probe" "$tmp/lazy-off.db"
 
 if nm "$offline_probe" | grep -Eq \
     'doltlite(HttpRemoteOpen|CredsGenerate|TlsClientNew)|mbedtls_ssl_tls13'; then

--- a/test/chunk_source_test.c
+++ b/test/chunk_source_test.c
@@ -488,12 +488,36 @@ static int createLazyFile(
   return rc;
 }
 
+static int createOriginLazyFile(const char *zPath, const char *zSource){
+  sqlite3 *db = 0;
+  char *zUrl = 0;
+  char *zSql = 0;
+  int rc;
+  removeStore(zPath);
+  rc = openDb(zPath, SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE, &db);
+  if( rc==SQLITE_OK ){
+    zUrl = sqlite3_mprintf("file://%s", zSource);
+    zSql = zUrl ? sqlite3_mprintf(
+        "SELECT dolt_clone('--lazy',%Q)", zUrl) : 0;
+    if( !zSql ) rc = SQLITE_NOMEM;
+  }
+  if( rc==SQLITE_OK ) rc = execSql(db, zSql);
+  sqlite3_free(zSql);
+  sqlite3_free(zUrl);
+  if( db ){
+    int crc = sqlite3_close(db);
+    if( rc==SQLITE_OK && crc!=SQLITE_OK ) rc = crc;
+  }
+  return rc;
+}
+
 static int collectMissingHashes(
   ChunkStore *pDest,
   const ChunkIndexEntry *aEntry,
   int nEntry,
   ProllyHash *aOut,
   int nWant,
+  int bIncludeSource,
   int *pnOut
 ){
   int rc = SQLITE_OK;
@@ -502,16 +526,21 @@ static int collectMissingHashes(
     int has = 0;
     rc = chunkStoreHas(pDest, &aEntry[i].hash, &has);
     if( rc!=SQLITE_OK ) return rc;
+    if( !has && bIncludeSource ){
+      rc = chunkStoreSourceHas(pDest, &aEntry[i].hash, &has);
+      if( rc!=SQLITE_OK ) return rc;
+    }
     if( !has ) aOut[(*pnOut)++] = aEntry[i].hash;
   }
   return SQLITE_OK;
 }
 
-static int findMissingHashes(
+static int findMissingHashesImpl(
   sqlite3 *db,
   SourceCtx *pCtx,
   ProllyHash *aOut,
-  int nWant
+  int nWant,
+  int bIncludeSource
 ){
   Btree *pBtree = db->aDb[0].pBt;
   ChunkStore *pDest;
@@ -529,22 +558,40 @@ static int findMissingHashes(
   if( rc==SQLITE_OK ){
     chunkIndexGetEntries(&pCtx->store.index, &nEntry, &aEntry);
     rc = collectMissingHashes(
-        pDest, aEntry, nEntry, aOut, nWant, &nOut);
+        pDest, aEntry, nEntry, aOut, nWant, bIncludeSource, &nOut);
   }
   if( rc==SQLITE_OK && nOut<nWant ){
     chunkStagingGetRecent(&pCtx->store.staging, &nEntry, &aEntry);
     rc = collectMissingHashes(
-        pDest, aEntry, nEntry, aOut, nWant, &nOut);
+        pDest, aEntry, nEntry, aOut, nWant, bIncludeSource, &nOut);
   }
   if( rc==SQLITE_OK && nOut<nWant ){
     chunkStagingGetPending(&pCtx->store.staging, &nEntry, &aEntry);
     rc = collectMissingHashes(
-        pDest, aEntry, nEntry, aOut, nWant, &nOut);
+        pDest, aEntry, nEntry, aOut, nWant, bIncludeSource, &nOut);
   }
   sqlite3BtreeLeave(pBtree);
   sqlite3_mutex_leave(db->mutex);
   if( rc==SQLITE_OK && nOut<nWant ) rc = SQLITE_NOTFOUND;
   return rc;
+}
+
+static int findMissingHashes(
+  sqlite3 *db,
+  SourceCtx *pCtx,
+  ProllyHash *aOut,
+  int nWant
+){
+  return findMissingHashesImpl(db, pCtx, aOut, nWant, 0);
+}
+
+static int findUncachedHashes(
+  sqlite3 *db,
+  SourceCtx *pCtx,
+  ProllyHash *aOut,
+  int nWant
+){
+  return findMissingHashesImpl(db, pCtx, aOut, nWant, 1);
 }
 
 static int getDbChunk(
@@ -615,6 +662,124 @@ static void hashHex(const unsigned char *aHash, char zOut[41]){
     zOut[i*2+1] = zHex[aHash[i] & 0x0f];
   }
   zOut[40] = 0;
+}
+
+static void testOriginPrecedenceAndReuse(
+  const char *zPath,
+  const char *zSource,
+  const char *zSourceAway,
+  SourceCtx *pCtx,
+  doltlite_chunk_source *pApi
+){
+  sqlite3 *db = 0;
+  ProllyHash aMissing[3];
+  unsigned char *pData = 0;
+  int nData = 0;
+  int nHostRequest = 0;
+  int sourceMoved = 0;
+  int sourceErrRc = SQLITE_OK;
+  sqlite3_int64 value = 0;
+  char zHash[41];
+  char *zErr = 0;
+  char *zUri = 0;
+  int rc;
+
+  removeStore(zPath);
+  removeStore(zSourceAway);
+  rc = createOriginLazyFile(zPath, zSource);
+  check("create origin-backed lazy clone", rc==SQLITE_OK);
+  if( rc!=SQLITE_OK ) goto origin_done;
+  zUri = sqlite3_mprintf(
+      "file:%s?lazy_origin=1", zPath);
+  rc = zUri ? openDb(
+      zUri, SQLITE_OPEN_READWRITE | SQLITE_OPEN_URI, &db) : SQLITE_NOMEM;
+  sqlite3_free(zUri);
+  zUri = 0;
+  check("reopen lazy clone with origin chunk source URI", rc==SQLITE_OK);
+  if( rc!=SQLITE_OK ) goto origin_done;
+
+  sourceResetCounters(pCtx);
+  pCtx->mode = SOURCE_NORMAL;
+  rc = doltlite_set_chunk_source(db, "main", pApi);
+  check("host source overrides built-in source", rc==SQLITE_OK);
+  if( rc!=SQLITE_OK ) goto origin_done;
+  sourceResetCounters(pCtx);
+  rc = findUncachedHashes(db, pCtx, aMissing, 3);
+  check("find distinct uncached chunks for source precedence", rc==SQLITE_OK);
+  if( rc!=SQLITE_OK ) goto origin_done;
+
+  rc = rename(zSource, zSourceAway);
+  check("make built-in origin unavailable under host override", rc==0);
+  if( rc!=0 ) goto origin_done;
+  sourceMoved = 1;
+  rc = getDbChunk(db, &aMissing[0], &pData, &nData);
+  check("host callback serves miss while built-in is offline",
+        rc==SQLITE_OK && pData!=0 && nData>0 && pCtx->nRequest>0);
+  sqlite3_free(pData);
+  pData = 0;
+  nData = 0;
+  nHostRequest = pCtx->nRequest;
+  rc = rename(zSourceAway, zSource);
+  check("restore built-in origin after host override", rc==0);
+  if( rc!=0 ) goto origin_done;
+  sourceMoved = 0;
+
+  rc = doltlite_set_chunk_source(db, "main", 0);
+  check("clear host source falls back to built-in", rc==SQLITE_OK);
+  if( rc!=SQLITE_OK ) goto origin_done;
+  rc = getDbChunk(db, &aMissing[1], &pData, &nData);
+  check("built-in source serves distinct miss after host clear",
+        rc==SQLITE_OK && pData!=0 && nData>0);
+  check("built-in fallback does not call cleared host",
+        pCtx->nRequest==nHostRequest);
+  sqlite3_free(pData);
+  pData = 0;
+  nData = 0;
+
+  rc = rename(zSource, zSourceAway);
+  check("make built-in origin unavailable", rc==0);
+  if( rc!=0 ) goto origin_done;
+  sourceMoved = 1;
+  rc = getDbChunk(db, &aMissing[2], &pData, &nData);
+  check("offline built-in miss returns chunk-source IOERR",
+        rc==SQLITE_IOERR_CHUNK_SOURCE);
+  sqlite3_free(pData);
+  pData = 0;
+  nData = 0;
+  zErr = doltliteTakeChunkSourceError(db, &sourceErrRc);
+  hashHex(aMissing[2].data, zHash);
+  check("offline built-in IOERR names requested hash",
+        sourceErrRc==SQLITE_IOERR_CHUNK_SOURCE
+        && zErr && strstr(zErr, zHash)!=0);
+  sqlite3_free(zErr);
+  zErr = 0;
+
+  rc = rename(zSourceAway, zSource);
+  check("restore built-in origin after IOERR", rc==0);
+  if( rc!=0 ) goto origin_done;
+  sourceMoved = 0;
+  rc = queryInt64(db, "SELECT 42", &value);
+  check("connection remains usable after built-in IOERR",
+        rc==SQLITE_OK && value==42);
+  rc = getDbChunk(db, &aMissing[2], &pData, &nData);
+  check("same connection retries built-in miss after origin recovers",
+        rc==SQLITE_OK && pData!=0 && nData>0);
+  check("recovered built-in source still bypasses cleared host",
+        pCtx->nRequest==nHostRequest);
+
+origin_done:
+  sqlite3_free(pData);
+  sqlite3_free(zErr);
+  sqlite3_free(zUri);
+  if( sourceMoved ){
+    rc = rename(zSourceAway, zSource);
+    check("restore origin during precedence cleanup", rc==0);
+  }
+  if( db ){
+    (void)doltlite_set_chunk_source(db, "main", 0);
+    sqlite3_close(db);
+  }
+  pCtx->mode = SOURCE_NORMAL;
 }
 
 static void runOracleComparisons(sqlite3 *a, sqlite3 *b){
@@ -2251,6 +2416,8 @@ int main(void){
   char zScalarIoerr[192];
   char zPrepareIoerr[192];
   char zIntegrity[192];
+  char zOriginLazy[192];
+  char zOriginAway[208];
   int rc;
 
   sqlite3_initialize();
@@ -2279,6 +2446,8 @@ int main(void){
   snprintf(zPrepareIoerr, sizeof(zPrepareIoerr),
            "%s_prepare_ioerr.db", zPrefix);
   snprintf(zIntegrity, sizeof(zIntegrity), "%s_integrity.db", zPrefix);
+  snprintf(zOriginLazy, sizeof(zOriginLazy), "%s_origin_lazy.db", zPrefix);
+  snprintf(zOriginAway, sizeof(zOriginAway), "%s_source.db.offline", zPrefix);
 
   printf("DoltLite host chunk source test\n");
   printf("===============================\n");
@@ -2301,6 +2470,9 @@ int main(void){
   if( !pNewRefs ) goto test_done;
   rc = queryInt64(sourceDb, "SELECT count(*) FROM items", &expectedRows);
   check("count advanced source rows", rc==SQLITE_OK && expectedRows>BASE_ROWS);
+
+  testOriginPrecedenceAndReuse(
+      zOriginLazy, zSource, zOriginAway, &source, &api);
 
   sourceResetCounters(&source);
   source.mode = SOURCE_NORMAL;
@@ -2360,6 +2532,8 @@ test_done:
   removeStore(zScalarIoerr);
   removeStore(zPrepareIoerr);
   removeStore(zIntegrity);
+  removeStore(zOriginLazy);
+  removeStore(zOriginAway);
   sqlite3_shutdown();
   printf("\n%d passed, %d failed\n", nPass, nFail);
   return nFail ? 1 : 0;

--- a/test/remote_test.sh
+++ b/test/remote_test.sh
@@ -778,6 +778,142 @@ check "dirty row stays in the source working set" "0
 dirty-uncommitted
 1" "$result"
 
+echo "=== Lazy file clone faults data in and survives reopen ==="
+"$DB" "$TMPDIR/lazy_origin.db" <<'ENDSQL' > /dev/null
+CREATE TABLE lazy_rows(id INTEGER PRIMARY KEY, v TEXT, payload BLOB);
+CREATE TABLE lazy_cold(id INTEGER PRIMARY KEY, payload BLOB);
+WITH RECURSIVE seq(i) AS (
+  VALUES(1) UNION ALL SELECT i + 1 FROM seq WHERE i < 800
+)
+INSERT INTO lazy_rows SELECT i, printf('row-%04d', i), randomblob(2048) FROM seq;
+WITH RECURSIVE seq(i) AS (
+  VALUES(1) UNION ALL SELECT i + 1 FROM seq WHERE i < 100
+)
+INSERT INTO lazy_cold SELECT i, randomblob(4096) FROM seq;
+SELECT dolt_commit('-Am','lazy base');
+UPDATE lazy_rows SET v='changed' WHERE id=1;
+INSERT INTO lazy_rows VALUES(801,'added',randomblob(2048));
+SELECT dolt_commit('-am','lazy update');
+SELECT dolt_branch('feature');
+.quit
+ENDSQL
+
+lazy_parity_sql="
+SELECT count(*) || '|' || sum(id) || '|' || sum(length(payload)) FROM lazy_rows;
+SELECT count(*) || '|' || max(message='lazy update') FROM dolt_log;
+SELECT group_concat(name || ':' || dirty, ',') FROM (SELECT name, dirty FROM dolt_branches ORDER BY name);
+SELECT rows_added || '|' || rows_deleted || '|' || rows_modified || '|' || old_row_count || '|' || new_row_count FROM dolt_diff_stat('HEAD~1','HEAD','lazy_rows');
+SELECT count(*) || '|' || sum(id) FROM dolt_at_lazy_rows('HEAD~1');
+SELECT group_concat(id || ':' || v, ',') FROM (SELECT id, v FROM lazy_rows WHERE id IN (1,400,801) ORDER BY id);
+"
+lazy_expected=$("$DB" "$TMPDIR/lazy_origin.db" "$lazy_parity_sql")
+lazy_origin_size=$(file_size "$TMPDIR/lazy_origin.db")
+
+result=$("$DB" "$TMPDIR/lazy_bad_option.db" "SELECT dolt_clone('--unknown','$R/lazy_origin.db');" 2>&1)
+check_match "lazy clone rejects unknown option" "unknown option" "$result"
+
+result=$("$DB" "$TMPDIR/lazy_extra_arg.db" "SELECT dolt_clone('--lazy','$R/lazy_origin.db','extra');" 2>&1)
+check_match "lazy clone rejects an extra URL" "too many arguments" "$result"
+
+lazy_bootstrap_uri="file:$TMPDIR/lazy_bootstrap.db?lazy_origin=1"
+result=$("$DB" "$lazy_bootstrap_uri" \
+  "SELECT dolt_clone('--lazy','$R/lazy_origin.db'); SELECT count(*) || '|' || sum(id) FROM lazy_rows;")
+check "lazy URI bootstraps and queries in the clone connection" "0
+801|321201" "$result"
+
+lazy_clone_uri="file:$TMPDIR/lazy_clone.db?lazy_origin=1"
+result=$("$DB" "$lazy_clone_uri" "SELECT dolt_clone('--lazy','$R/lazy_origin.db');")
+check "lazy clone succeeds" "0" "$result"
+
+lazy_size_before=$(file_size "$TMPDIR/lazy_clone.db")
+if [ "$lazy_size_before" -lt "$lazy_origin_size" ] &&
+   [ $((lazy_size_before * 4)) -lt "$lazy_origin_size" ]; then
+  lazy_refs_sized=1
+else
+  lazy_refs_sized=0
+fi
+check "lazy clone is refs-sized before use" "1" "$lazy_refs_sized"
+
+lazy_actual=$("$DB" "$lazy_clone_uri" "$lazy_parity_sql")
+check "lazy clone matches rows, log, branches, diff stat, historical rows, and full scan" "$lazy_expected" "$lazy_actual"
+
+lazy_size_after_rows=$(file_size "$TMPDIR/lazy_clone.db")
+if [ "$lazy_size_after_rows" -gt "$lazy_size_before" ]; then
+  lazy_rows_grew=1
+else
+  lazy_rows_grew=0
+fi
+check "lazy clone grows when rows are read" "1" "$lazy_rows_grew"
+
+lazy_cold_expected=$("$DB" "$TMPDIR/lazy_origin.db" \
+  "SELECT count(*) || '|' || sum(id) || '|' || sum(length(payload)) FROM lazy_cold;")
+lazy_cold_actual=$("$DB" "$lazy_clone_uri" \
+  "SELECT count(*) || '|' || sum(id) || '|' || sum(length(payload)) FROM lazy_cold;")
+check "fresh-process reopen faults in an unread table" "$lazy_cold_expected" "$lazy_cold_actual"
+
+lazy_size_after_reopen=$(file_size "$TMPDIR/lazy_clone.db")
+if [ "$lazy_size_after_reopen" -gt "$lazy_size_after_rows" ]; then
+  lazy_reopen_grew=1
+else
+  lazy_reopen_grew=0
+fi
+check "reopened lazy clone persists newly fetched chunks" "1" "$lazy_reopen_grew"
+
+"$DB" "$TMPDIR/lazy_origin.db" <<'ENDSQL' > /dev/null
+INSERT INTO lazy_rows VALUES(802,'after-fetch',randomblob(1048576));
+SELECT dolt_commit('-am','lazy refresh');
+.quit
+ENDSQL
+lazy_origin_head=$("$DB" "$TMPDIR/lazy_origin.db" "SELECT hash FROM dolt_branches WHERE name='main';")
+lazy_size_before_fetch=$(file_size "$TMPDIR/lazy_clone.db")
+result=$("$DB" "$lazy_clone_uri" "SELECT dolt_fetch('origin');")
+check "fetch on a lazy clone succeeds" "0" "$result"
+lazy_size_after_fetch=$(file_size "$TMPDIR/lazy_clone.db")
+lazy_tracking_head=$("$DB" "$lazy_clone_uri" \
+  "SELECT hash FROM dolt_remote_branches WHERE name='remotes/origin/main';")
+check "lazy fetch advances the origin tracking ref" "$lazy_origin_head" "$lazy_tracking_head"
+
+lazy_fetch_growth=$((lazy_size_after_fetch - lazy_size_before_fetch))
+if [ "$lazy_fetch_growth" -ge 0 ] && [ "$lazy_fetch_growth" -lt 262144 ]; then
+  lazy_fetch_refs_only=1
+else
+  lazy_fetch_refs_only=0
+fi
+check "lazy fetch installs refs without bulk chunk transfer" "1" "$lazy_fetch_refs_only"
+
+result=$("$DB" "$lazy_clone_uri" \
+  "SELECT length(payload) FROM dolt_at_lazy_rows('remotes/origin/main') WHERE id=802;")
+check "new remote data faults in after fetch" "1048576" "$result"
+lazy_size_after_refresh_read=$(file_size "$TMPDIR/lazy_clone.db")
+if [ "$lazy_size_after_refresh_read" -gt "$lazy_size_after_fetch" ]; then
+  lazy_refresh_grew=1
+else
+  lazy_refresh_grew=0
+fi
+check "reading newly fetched history grows the lazy store" "1" "$lazy_refresh_grew"
+
+"$DB" "$TMPDIR/lazy_origin.db" <<'ENDSQL' > /dev/null
+INSERT INTO lazy_rows VALUES(803,'cached-offline',randomblob(524288));
+INSERT INTO lazy_cold VALUES(101,randomblob(1048576));
+SELECT dolt_commit('-am','lazy offline');
+.quit
+ENDSQL
+"$DB" "$lazy_clone_uri" "SELECT dolt_fetch('origin');" > /dev/null
+result=$("$DB" "$lazy_clone_uri" \
+  "SELECT length(payload) FROM dolt_at_lazy_rows('remotes/origin/main') WHERE id=803;")
+check "selected remote data is cached before going offline" "524288" "$result"
+
+mv "$TMPDIR/lazy_origin.db" "$TMPDIR/lazy_origin.offline.db"
+result=$("$DB" "$TMPDIR/lazy_clone.db" \
+  "SELECT length(payload) FROM dolt_at_lazy_rows('remotes/origin/main') WHERE id=803;")
+check "cached lazy data remains readable without the URI parameter" "524288" "$result"
+
+result=$("$DB" "$TMPDIR/lazy_clone.db" \
+  "SELECT length(payload) FROM dolt_at_lazy_cold('remotes/origin/main') WHERE id=101;" 2>&1)
+check_match "uncached lazy data fails without the URI parameter with its chunk hash" "[0-9a-f]{40}" "$result"
+check "uncached no-parameter failure is not reported as corruption" "0" \
+  "$(echo "$result" | grep -Eic 'corrupt|malformed|database disk image')"
+
 echo ""
 echo "======================================="
 echo "Results: $pass passed, $fail failed"

--- a/test/remotesrv_http_test.sh
+++ b/test/remotesrv_http_test.sh
@@ -331,6 +331,29 @@ SQL
 result=$("$DB" "$A" "SELECT dolt_push('origin','main');" 2>&1)
 check "initial push returns 0" "0" "$result"
 
+echo "--- 1b. lazy clone faults chunks over http after reopen ---"
+LAZY="$TMP/lazy.db"
+LAZY_URI="file:$LAZY?lazy_origin=1"
+before_chunk_posts=$(grep -ac "^POST chunks$" "$TMP/counts.log")
+before_chunk_fetches=$(grep -Eac "^(GET chunk|POST get-chunks)$" "$TMP/counts.log")
+result=$("$DB" "$LAZY" "SELECT dolt_clone('--lazy','$URL');" 2>&1)
+after_clone_chunk_posts=$(grep -ac "^POST chunks$" "$TMP/counts.log")
+after_clone_chunk_fetches=$(grep -Eac "^(GET chunk|POST get-chunks)$" "$TMP/counts.log")
+check "lazy clone returns 0" "0" "$result"
+check "lazy clone posts no chunk payloads" "$before_chunk_posts" "$after_clone_chunk_posts"
+check "lazy clone fetches refs without chunk data" "$before_chunk_fetches" "$after_clone_chunk_fetches"
+
+result=$("$DB" "$LAZY_URI" "SELECT count(*)||'|'||sum(age) FROM users; SELECT sum(length(data)) FROM blobs;" 2>&1)
+after_reopen_chunk_fetches=$(grep -Eac "^(GET chunk|POST get-chunks)$" "$TMP/counts.log")
+check "reopened lazy clone reads origin-backed rows" "3|90
+2097152" "$result"
+if [ "$after_reopen_chunk_fetches" -gt "$after_clone_chunk_fetches" ]; then
+  echo "  PASS: reopened lazy clone fetched chunks on demand"; pass=$((pass+1))
+else
+  echo "  FAIL: reopened lazy clone did not fetch chunks on demand"
+  fail=$((fail+1))
+fi
+
 echo "--- 2. clone over http, full parity ---"
 result=$("$DB" "$B" "SELECT dolt_clone('$URL');" 2>&1)
 check "clone returns 0" "0" "$result"


### PR DESCRIPTION
Depends on #2551 and uses its chunk-source seam as the engine-owned executor.

## Summary

- add a built-in source backed by the recorded `origin` remote, reusing the existing file and HTTP(S) remote clients
- add `dolt_clone('--lazy', url)` to install refs, origin, and tracking refs without transferring the reachable chunk graph
- enable origin-backed misses per open with `file:...?lazy_origin=1`, including bootstrap and query in one connection
- keep origin fetch and fast-forward pull refs-only while demand reads fault verified chunks into the local cache

## Phase 0 / design

- Activation is per-open configuration, not persisted state. `lazy_origin=1` is inert until an origin exists, so it activates immediately after `dolt_clone('--lazy', ...)` records origin. This makes no file-format, manifest, WAL, or version change.
- A host-registered callback takes precedence. Clearing it restores the built-in origin source for that connection.
- The source reuses the existing remote client and its 256-hash `xGetChunks` batches, credential resolution, and TLS behavior. Version 1 opens a client per callback; file remotes are opened read-only.
- Source callbacks inherit the seam's graph-lock rule, common hash verification, bounded memory cache, and verified write-through path. No network request runs under the graph lock.
- On an origin-enabled connection, `dolt_fetch('origin')` updates tracking refs without bulk transfer. Fast-forward pull remains lazy. A divergent pull fails with a materialization requirement because merge would otherwise need source reads while graph-locked.
- Without `lazy_origin=1`, cached chunks remain readable and an uncached miss reports `NOTFOUND` with the requested hash and activation remedy. With activation, unreachable-origin transport reports a hash-named chunk-source I/O error rather than corruption.

## Validation

- `./build/chunk_source_test`: 311/311
- file remote suite: 133/133
- HTTP remotesrv suite: 42/42 across 156 validated requests
- regression assertions: 311177/311177
- amalgamation enabled/disabled probes
- fresh `DOLTLITE_ENABLE_CHUNK_SOURCE=0` build
- lint and native DoltLite suites

## Deferred follow-ups

- durable lazy activation with an explicit format/version gate before an auto-enabled end-user CLI mode
- full materialization command
- remote client and HTTP connection pooling
- richer prefetch tuning and WASM host plumbing

Co-Authored-By: OpenAI Codex <noreply@openai.com>


