### PR TITLE
Fix delete merges across appended defaults

### DIFF
--- a/src/doltlite_merge_int.h
+++ b/src/doltlite_merge_int.h
@@ -135,6 +135,7 @@ struct MergeRowPolicy {
   int nRenameOverDrop;
   const char **azDualRename;
   int nDualRename;
+  int nDeleteCompareFields;
 };
 
 int mergeTableRows(
@@ -167,6 +168,7 @@ int parsedColumnDefinitionsMatch(
   const ParsedColumn *pA,
   const ParsedColumn *pB
 );
+int parsedColumnIsVirtual(const ParsedColumn *pCol);
 
 int trySchemaColumnMerge(
   const char *zAncSql,

--- a/src/doltlite_merge_pass1.c
+++ b/src/doltlite_merge_pass1.c
@@ -47,6 +47,53 @@ static void mergePass1FreeIdxInfo(MergeIndexInfo *aIdxInfo, int nIdxInfo){
   sqlite3_free(aIdxInfo);
 }
 
+static int mergePass1SchemaPrefixInfo(
+  const char *zAncSql,
+  const char *zSideSql,
+  int *pbPrefix,
+  int *pnAnc,
+  int *pnSide,
+  int *pnAncRecord
+){
+  ParsedColumn *aAnc = 0;
+  ParsedColumn *aSide = 0;
+  int nAnc = 0;
+  int nSide = 0;
+  int i;
+  int rc;
+
+  *pbPrefix = 0;
+  *pnAnc = 0;
+  *pnSide = 0;
+  if( pnAncRecord ) *pnAncRecord = 0;
+  if( !zAncSql || !zSideSql ) return SQLITE_OK;
+  rc = parseColumns(zAncSql, &aAnc, &nAnc);
+  if( rc!=SQLITE_OK ) return rc;
+  rc = parseColumns(zSideSql, &aSide, &nSide);
+  if( rc!=SQLITE_OK ){
+    freeColumns(aAnc, nAnc);
+    return rc;
+  }
+  if( nSide>=nAnc ){
+    *pbPrefix = 1;
+    for(i=0; i<nAnc; i++){
+      if( sqlite3_stricmp(aAnc[i].zName, aSide[i].zName)!=0
+       || !parsedColumnDefinitionsMatch(&aAnc[i], &aSide[i]) ){
+        *pbPrefix = 0;
+        break;
+      }
+    }
+  }
+  *pnAnc = nAnc;
+  *pnSide = nSide;
+  for(i=0; pnAncRecord && i<nAnc; i++){
+    if( !parsedColumnIsVirtual(&aAnc[i]) ) (*pnAncRecord)++;
+  }
+  freeColumns(aAnc, nAnc);
+  freeColumns(aSide, nSide);
+  return SQLITE_OK;
+}
+
 static int mergePass1CollectIndexes(
   MergePass1Ctx *c,
   const char *zName,
@@ -144,8 +191,40 @@ static int mergePass1MergeTableData(
   DoltliteConflictRow *aConflictRows = 0;
   MergeIndexInfo *aIdxInfo = 0;
   int nIdxInfo = 0;
+  MergeRowPolicy rowPolicy;
+  const MergeRowPolicy *pRowPolicy = 0;
   int rc;
   int handled = 0;
+
+  memset(&rowPolicy, 0, sizeof(rowPolicy));
+
+  if( zName && (ourSchemaChanged || theirSchemaChanged) ){
+    SchemaEntry *pAncSe = findSchemaEntry(c->aAncSchema, c->nAncSchema, zName);
+    SchemaEntry *pOurSe = findSchemaEntry(c->aOursSchema, c->nOursSchema, zName);
+    SchemaEntry *pTheirSe = findSchemaEntry(
+        c->aTheirsSchema, c->nTheirsSchema, zName);
+    int bOurPrefix = 0, bTheirPrefix = 0;
+    int nAncOur = 0, nAncTheir = 0;
+    int nOur = 0, nTheir = 0;
+    int nAncOurRecord = 0, nAncTheirRecord = 0;
+    if( pAncSe && pOurSe && pTheirSe ){
+      rc = mergePass1SchemaPrefixInfo(
+          pAncSe->zSql, pOurSe->zSql, &bOurPrefix,
+          &nAncOur, &nOur, &nAncOurRecord);
+      if( rc==SQLITE_OK ){
+        rc = mergePass1SchemaPrefixInfo(
+            pAncSe->zSql, pTheirSe->zSql,
+            &bTheirPrefix, &nAncTheir, &nTheir, &nAncTheirRecord);
+      }
+      if( rc!=SQLITE_OK ) return rc;
+      if( bOurPrefix && bTheirPrefix && nAncOur==nAncTheir
+       && nAncOurRecord==nAncTheirRecord
+       && (nOur>nAncOur || nTheir>nAncTheir) ){
+        rowPolicy.nDeleteCompareFields = nAncOurRecord;
+        pRowPolicy = &rowPolicy;
+      }
+    }
+  }
 
   rc = mergePass1CollectIndexes(c, zName, &aIdxInfo, &nIdxInfo);
   if( rc!=SQLITE_OK ) return rc;
@@ -166,7 +245,7 @@ static int mergePass1MergeTableData(
                         pTheirsRoot, pOurs->flags,
                         pAnc->flags, pTheirsEntry->flags,
                         &mergedTableRoot, &nConflicts, &aConflictRows,
-                        aIdxInfo, nIdxInfo, 0);
+                        aIdxInfo, nIdxInfo, pRowPolicy);
     if( rc!=SQLITE_OK ){
       mergePass1FreeIdxInfo(aIdxInfo, nIdxInfo);
       return rc;
@@ -575,6 +654,12 @@ static int mergePass1CheckPrimaryKeysMatch(
   return SQLITE_ERROR;
 }
 
+static int mergePass1SchemaAppendsColumns(
+  const char *zAncSql,
+  const char *zSideSql,
+  int *pbAppends
+);
+
 /* Cell merge is by merged column position. Relayout the unmerged side
 ** first or dropped columns shift later values and the ancestor looks
 ** changed. zOtherSql is that side's layout, not always the schema array
@@ -589,15 +674,19 @@ static int mergePass1RelayoutToMergedSchema(
   const ProllyHash *pMergedRoot,
   const ProllyHash *pOtherRoot,
   const ProllyHash *pAncRoot,
-  int bFillSharedDefaults,
   ProllyHash *pOtherOut,
   ProllyHash *pAncOut,
   int *pbRelaid
 ){
+  int bFillSharedDefaults = 0;
   int rc;
 
   *pbRelaid = 0;
   if( !zAncSql || !zMergedSql || !zOtherSql ) return SQLITE_OK;
+
+  rc = mergePass1SchemaAppendsColumns(
+      zAncSql, zMergedSql, &bFillSharedDefaults);
+  if( rc!=SQLITE_OK ) return rc;
 
   rc = normalizeSideToMergedLayout(c->db, zName, pMergedRoot, pOtherRoot,
                                    flags, zAncSql,
@@ -618,35 +707,15 @@ static int mergePass1SchemaAppendsColumns(
   const char *zSideSql,
   int *pbAppends
 ){
-  ParsedColumn *aAnc = 0;
-  ParsedColumn *aSide = 0;
-  int nAnc = 0;
-  int nSide = 0;
-  int i;
+  int bPrefix = 0;
+  int nAnc = 0, nSide = 0;
   int rc;
 
   *pbAppends = 0;
-  if( !zAncSql || !zSideSql ) return SQLITE_OK;
-  rc = parseColumns(zAncSql, &aAnc, &nAnc);
-  if( rc!=SQLITE_OK ) return rc;
-  rc = parseColumns(zSideSql, &aSide, &nSide);
-  if( rc!=SQLITE_OK ){
-    freeColumns(aAnc, nAnc);
-    return rc;
-  }
-  if( nSide>nAnc ){
-    *pbAppends = 1;
-    for(i=0; i<nAnc; i++){
-      if( sqlite3_stricmp(aAnc[i].zName, aSide[i].zName)!=0
-       || !parsedColumnDefinitionsMatch(&aAnc[i], &aSide[i]) ){
-        *pbAppends = 0;
-        break;
-      }
-    }
-  }
-  freeColumns(aAnc, nAnc);
-  freeColumns(aSide, nSide);
-  return SQLITE_OK;
+  rc = mergePass1SchemaPrefixInfo(
+      zAncSql, zSideSql, &bPrefix, &nAnc, &nSide, 0);
+  if( rc==SQLITE_OK ) *pbAppends = bPrefix && nSide>nAnc;
+  return rc;
 }
 
 /* One side changed columns: that layout wins; move the other and ancestor. */
@@ -664,16 +733,9 @@ static int mergePass1RelayoutOneSidedSchema(
   SchemaEntry *ourSE = findSchemaEntry(c->aOursSchema, c->nOursSchema, zName);
   SchemaEntry *theirSE = findSchemaEntry(c->aTheirsSchema, c->nTheirsSchema, zName);
   SchemaEntry *ancSE = findSchemaEntry(c->aAncSchema, c->nAncSchema, zName);
-  int bFillSharedDefaults = 0;
-  int rc;
 
   *pbRelaid = 0;
   if( !ancSE || !ourSE || !theirSE ) return SQLITE_OK;
-
-  rc = mergePass1SchemaAppendsColumns(
-      ancSE->zSql, bMergedIsOurs ? ourSE->zSql : theirSE->zSql,
-      &bFillSharedDefaults);
-  if( rc!=SQLITE_OK ) return rc;
 
   return mergePass1RelayoutToMergedSchema(c, zName, ancSE->zSql,
       bMergedIsOurs ? ourSE->zSql : theirSE->zSql,
@@ -681,7 +743,7 @@ static int mergePass1RelayoutOneSidedSchema(
       pOurs->flags,
       bMergedIsOurs ? &pOurs->root : &pTheirs->root,
       bMergedIsOurs ? &pTheirs->root : &pOurs->root,
-      &pAnc->root, bFillSharedDefaults,
+      &pAnc->root,
       pOtherOut, pAncOut, pbRelaid);
 }
 
@@ -793,21 +855,12 @@ static int mergePass1BothSides(
       SchemaEntry *ancSE = findSchemaEntry(c->aAncSchema, c->nAncSchema, zName);
       if( ancSE && ancSE->zSql && ourSE && ourSE->zSql
        && theirSE && theirSE->zSql ){
-        rc = normalizeSideToMergedLayout(c->db, zName,
-                                           &c->aOurs[iOurs].root,
-                                           &theirsEntry->root,
-                                           c->aOurs[iOurs].flags, ancSE->zSql,
-                                           ourSE->zSql, theirSE->zSql,
-                                           0,
-                                           &theirsNormRoot);
-        if( rc!=SQLITE_OK ) return rc;
-        rc = normalizeSideToMergedLayout(c->db, zName,
-                                           &c->aOurs[iOurs].root,
-                                           &ancEntry->root,
-                                           c->aOurs[iOurs].flags, ancSE->zSql,
-                                           ourSE->zSql, ancSE->zSql,
-                                           0,
-                                           &ancNormRoot);
+        int bRelaid = 0;
+        rc = mergePass1RelayoutToMergedSchema(c, zName,
+            ancSE->zSql, ourSE->zSql, theirSE->zSql,
+            c->aOurs[iOurs].flags, &c->aOurs[iOurs].root,
+            &theirsEntry->root, &ancEntry->root,
+            &theirsNormRoot, &ancNormRoot, &bRelaid);
         if( rc!=SQLITE_OK ) return rc;
         ancAdj = *ancEntry;
         memcpy(&ancAdj.root, &ancNormRoot, sizeof(ProllyHash));
@@ -853,7 +906,6 @@ static int mergePass1BothSides(
       rc = mergePass1RelayoutToMergedSchema(c, zName, ancSE->zSql,
           mergedSE->zSql, zOursPrevSql, c->aOurs[iOurs].flags,
           &theirsEntry->root, &c->aOurs[iOurs].root, &ancEntry->root,
-          0,
           &otherNormRoot, &ancNormRoot, &bRelaid);
       if( rc!=SQLITE_OK ){
         sqlite3_free(zOursPrevSql);
@@ -882,7 +934,6 @@ static int mergePass1BothSides(
       rc = mergePass1RelayoutToMergedSchema(c, zName, ancSE->zSql,
           ourSE->zSql, theirSE->zSql, c->aOurs[iOurs].flags,
           &c->aOurs[iOurs].root, &theirsEntry->root, &ancEntry->root,
-          0,
           &otherNormRoot, &ancNormRoot, &bRelaid);
       if( rc!=SQLITE_OK ) return rc;
     }
@@ -1110,6 +1161,7 @@ static void mergePass1FreeRowPolicy(MergeRowPolicy *pPolicy){
   pPolicy->azDualRename = 0;
   pPolicy->nRenameOverDrop = 0;
   pPolicy->nDualRename = 0;
+  pPolicy->nDeleteCompareFields = 0;
 }
 
 static int mergePass1IsAuxSchemaType(const char *zType){

--- a/src/doltlite_merge_rows.c
+++ b/src/doltlite_merge_rows.c
@@ -803,12 +803,45 @@ static int catalogRowNamedByDualRename(
       pPolicy->azDualRename, pPolicy->nDualRename, pBase, nBase);
 }
 
-static int fieldEquals(const u8 *pRecA, RecField *fA,
-                       const u8 *pRecB, RecField *fB){
+static int fieldEquals(const u8 *pRecA, const RecField *fA,
+                       const u8 *pRecB, const RecField *fB){
   if(fA->st != fB->st) return 1;
   if(fA->len != fB->len) return 1;
   if(fA->len==0) return 0;
   return memcmp(pRecA + fA->off, pRecB + fB->off, fA->len);
+}
+
+static int recordsEqualPrefix(
+  const u8 *pA,
+  int nA,
+  const u8 *pB,
+  int nB,
+  int nField,
+  int *pbEqual
+){
+  static const RecField nullField = { 0, 0, 0 };
+  RecField *aA = 0, *aB = 0;
+  int nFieldA = 0, nFieldB = 0;
+  int i;
+
+  *pbEqual = 0;
+  if( parseRecordFields(pA, nA, &aA, &nFieldA)<0 ) return SQLITE_CORRUPT;
+  if( parseRecordFields(pB, nB, &aB, &nFieldB)<0 ){
+    sqlite3_free(aA);
+    return SQLITE_CORRUPT;
+  }
+  *pbEqual = 1;
+  for(i=0; i<nField; i++){
+    const RecField *pFieldA = i<nFieldA ? &aA[i] : &nullField;
+    const RecField *pFieldB = i<nFieldB ? &aB[i] : &nullField;
+    if( fieldEquals(pA, pFieldA, pB, pFieldB)!=0 ){
+      *pbEqual = 0;
+      break;
+    }
+  }
+  sqlite3_free(aA);
+  sqlite3_free(aB);
+  return SQLITE_OK;
 }
 
 typedef struct MergeWinner MergeWinner;
@@ -1066,6 +1099,37 @@ static int rowMergeCallback(void *pCtx, const ThreeWayChange *pChange){
     }
     deliberate_fall_through
     case THREE_WAY_CONFLICT_DM: {
+
+      if( pChange->type==THREE_WAY_CONFLICT_DM && ctx->pPolicy
+       && ctx->pPolicy->nDeleteCompareFields>0 ){
+        const u8 *pSurv = pChange->pOurVal ? pChange->pOurVal
+                                           : pChange->pTheirVal;
+        int nSurv = pChange->pOurVal ? pChange->nOurVal : pChange->nTheirVal;
+        int bSharedEqual = 0;
+        rc = recordsEqualPrefix(
+            pChange->pBaseVal, pChange->nBaseVal,
+            pSurv, nSurv, ctx->pPolicy->nDeleteCompareFields,
+            &bSharedEqual);
+        if( rc!=SQLITE_OK ) return rc;
+        if( bSharedEqual ){
+          if( pChange->pOurVal && !pChange->pTheirVal ){
+            rc = prollyMutMapDelete(ctx->pEdits,
+                pChange->pKey, pChange->nKey, pChange->intKey);
+            if( rc==SQLITE_OK && ctx->nIndexes>0 ){
+              int ix;
+              for(ix=0; ix<ctx->nIndexes && rc==SQLITE_OK; ix++){
+                MergeIndexInfo *mi = &ctx->aIndexes[ix];
+                rc = doltliteIndexMutMapRowDelta(
+                    ctx->db, mi->pIdx, mi->pEdits,
+                    mi->aiColumn, mi->nColumn, mi->pKeyInfo, mi->iPKey,
+                    pChange->intKey, pChange->pKey, pChange->nKey,
+                    pChange->pOurVal, pChange->nOurVal, 0, 0);
+              }
+            }
+          }
+          break;
+        }
+      }
 
       /* Policy-named catalog row (rename vs drop): rename wins, as Dolt.
       ** Inferring here would also pick a winner for a dual rename. */

--- a/src/doltlite_merge_schema.c
+++ b/src/doltlite_merge_schema.c
@@ -211,12 +211,13 @@ static int schemaTokenTextIs(const char *z, int n, const char *zText){
   return n==nText && sqlite3_strnicmp(z, zText, n)==0;
 }
 
-static const char *schemaGeneratedTailStart(const char *zDef){
+static const char *schemaGeneratedTailStart(const char *zDef, int *pbVirtual){
   const char *zEnd = zDef + strlen(zDef);
   const char *zGenerated;
   const char *zAs;
   const char *p;
   int type, n;
+  int bVirtual = 1;
 
   zGenerated = schemaFindToken(zDef, zEnd, "GENERATED", 9);
   if( zGenerated ){
@@ -243,11 +244,20 @@ static const char *schemaGeneratedTailStart(const char *zDef){
   if( p<zEnd ){
     if( schemaGetToken(p, zEnd, &type, &n)!=SQLITE_OK ) return 0;
     if( type==TK_VIRTUAL || schemaTokenTextIs(p, n, "STORED") ){
+      if( schemaTokenTextIs(p, n, "STORED") ) bVirtual = 0;
       p += n;
     }
   }
   p = schemaSkipTrivia(p, zEnd);
-  return p==zEnd ? (zGenerated ? zGenerated : zAs) : 0;
+  if( p!=zEnd ) return 0;
+  if( pbVirtual ) *pbVirtual = bVirtual;
+  return zGenerated ? zGenerated : zAs;
+}
+
+int parsedColumnIsVirtual(const ParsedColumn *pCol){
+  int bVirtual = 0;
+  if( !pCol || !pCol->zDef ) return 0;
+  return schemaGeneratedTailStart(pCol->zDef, &bVirtual) && bVirtual;
 }
 
 static int schemaColumnsMergeEquivalent(
@@ -260,8 +270,8 @@ static int schemaColumnsMergeEquivalent(
   int nTheirs;
 
   if( schemaDefinitionsEquivalent(zOurs, zTheirs) ) return 1;
-  zOurTail = schemaGeneratedTailStart(zOurs);
-  zTheirTail = schemaGeneratedTailStart(zTheirs);
+  zOurTail = schemaGeneratedTailStart(zOurs, 0);
+  zTheirTail = schemaGeneratedTailStart(zTheirs, 0);
   if( !zOurTail && !zTheirTail ) return 0;
   nOurs = zOurTail ? (int)(zOurTail-zOurs) : (int)strlen(zOurs);
   nTheirs = zTheirTail ? (int)(zTheirTail-zTheirs) : (int)strlen(zTheirs);
@@ -1077,7 +1087,7 @@ int mergeColDefaultsLoad(
   if( rc!=SQLITE_OK ) goto done;
 
   zQuery = sqlite3_mprintf(
-      "SELECT cid, dflt_value, type FROM pragma_table_info(%Q) ORDER BY cid",
+      "SELECT cid, dflt_value, type FROM pragma_table_xinfo(%Q) ORDER BY cid",
       zTable);
   if( !zQuery ){ rc = SQLITE_NOMEM; goto done; }
   rc = sqlite3_prepare_v2(tmp, zQuery, -1, &pStmt, 0);
@@ -1181,7 +1191,11 @@ int normalizeSideToMergedLayout(
   ParsedColumn *aAnc = 0, *aOurs = 0, *aTheirs = 0;
   int nAnc = 0, nOurs = 0, nTheirs = 0;
   int *aMap = 0;
+  int *aMergedRecord = 0;
+  int *aTheirsRecord = 0;
   int nMerged;
+  int nMergedRecord = 0;
+  int nTheirsRecord = 0;
   int nDropped = 0;
   ProllyMutMap mm;
   int mmInit = 0;
@@ -1211,11 +1225,24 @@ int normalizeSideToMergedLayout(
 
   nMerged = nOurs;
   aMap = sqlite3_malloc((nTheirs>0 ? nTheirs : 1) * (int)sizeof(int));
-  if( !aMap ){ rc = SQLITE_NOMEM; goto done; }
+  aMergedRecord = sqlite3_malloc(
+      (nOurs+nTheirs>0 ? nOurs+nTheirs : 1) * (int)sizeof(int));
+  aTheirsRecord = sqlite3_malloc(
+      (nTheirs>0 ? nTheirs : 1) * (int)sizeof(int));
+  if( !aMap || !aMergedRecord || !aTheirsRecord ){
+    rc = SQLITE_NOMEM;
+    goto done;
+  }
+  for(j=0; j<nOurs; j++){
+    aMergedRecord[j] = parsedColumnIsVirtual(&aOurs[j])
+        ? -1 : nMergedRecord++;
+  }
   for(j=0; j<nTheirs; j++){
     int found = parsedColumnIndexByName(
         aOurs, nOurs, aTheirs[j].zName);
     int bInAnc = 0;
+    aTheirsRecord[j] = parsedColumnIsVirtual(&aTheirs[j])
+        ? -1 : nTheirsRecord++;
     if( found<0 ){
       int ai = parsedColumnIndexByName(
           aAnc, nAnc, aTheirs[j].zName);
@@ -1244,10 +1271,16 @@ int normalizeSideToMergedLayout(
       aMap[j] = -1;
       nDropped++;
     }else{
-      aMap[j] = nMerged++;
+      aMap[j] = nMerged;
+      aMergedRecord[nMerged] = parsedColumnIsVirtual(&aTheirs[j])
+          ? -1 : nMergedRecord++;
+      nMerged++;
     }
   }
-  if( nMerged > DOLTLITE_MAX_RECORD_FIELDS ){ rc = SQLITE_ERROR; goto done; }
+  if( nMergedRecord > DOLTLITE_MAX_RECORD_FIELDS ){
+    rc = SQLITE_ERROR;
+    goto done;
+  }
 
   /* Already at merged positions; trailing adds read as absent anyway. */
   if( nDropped==0 && !bFillSharedDefaults ){
@@ -1314,26 +1347,33 @@ int normalizeSideToMergedLayout(
     }
 
     doltliteParseRecord(pVal, nVal, &info);
-    for(k=0; k<nMerged; k++){
+    for(k=0; k<nMergedRecord; k++){
       memset(&aMem[k], 0, sizeof(aMem[k]));
       aMem[k].eType = SQLITE_NULL;
-      if( (rowOnlyTheirs || bFillSharedDefaults) && k<oursDefaults.nCol ){
-        aMem[k] = oursDefaults.aVal[k];
-      }
     }
     if( rowOnlyTheirs || bFillSharedDefaults ){
+      for(k=0; k<nOurs && k<oursDefaults.nCol; k++){
+        int tgt = aMergedRecord[k];
+        if( tgt>=0 ) aMem[tgt] = oursDefaults.aVal[k];
+      }
       for(j=0; j<nTheirs; j++){
         if( aMap[j]>=nOurs && j<theirsDefaults.nCol ){
-          aMem[aMap[j]] = theirsDefaults.aVal[j];
+          int tgt = aMergedRecord[aMap[j]];
+          if( tgt>=0 ) aMem[tgt] = theirsDefaults.aVal[j];
         }
       }
     }
-    for(j=0; j<info.nField && j<nTheirs; j++){
-      int tgt = aMap[j];
-      int st = info.aType[j];
-      const u8 *body = pVal + info.aOffset[j];
+    for(j=0; j<nTheirs; j++){
+      int src = aTheirsRecord[j];
+      int tgt;
+      int st;
+      const u8 *body;
       DoltliteSerialValue *m;
+      if( src<0 || src>=info.nField || aMap[j]<0 ) continue;
+      tgt = aMergedRecord[aMap[j]];
       if( tgt<0 ) continue;
+      st = info.aType[src];
+      body = pVal + info.aOffset[src];
       m = &aMem[tgt];
       memset(m, 0, sizeof(*m));
       m->eType = SQLITE_NULL;
@@ -1358,7 +1398,7 @@ int normalizeSideToMergedLayout(
       }
       if( m->eType!=SQLITE_NULL && tgt+1>nEmit ) nEmit = tgt+1;
     }
-    for(k=0; k<nMerged; k++){
+    for(k=0; k<nMergedRecord; k++){
       if( aMem[k].eType!=SQLITE_NULL && k+1>nEmit ) nEmit = k+1;
     }
 
@@ -1393,6 +1433,8 @@ done:
   if( curInit ) prollyCursorClose(&cur);
   if( mmInit ) prollyMutMapFree(&mm);
   sqlite3_free(aMap);
+  sqlite3_free(aMergedRecord);
+  sqlite3_free(aTheirsRecord);
   freeColumns(aAnc, nAnc);
   freeColumns(aOurs, nOurs);
   freeColumns(aTheirs, nTheirs);

--- a/test/doltlite_merge.sh
+++ b/test/doltlite_merge.sh
@@ -913,5 +913,75 @@ SELECT dolt_merge('bogus');
 SELECT dolt_merge('b2');" | $DOLTLITE "$DB55" > /dev/null 2>&1
 run_test "refuse_does_not_undo_prior_merge" "SELECT count(*) FROM t;" "3" "$DB55"
 
-rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8" "$DB8B" "$DB9" "$DB10" "$DB11" "$DB11D" "$DB11E" "$DB11F" "$DB12" "$DB13" "$DB14" "$DB15" "$DB16" "$DB17" "$DB18" "$DB19" "$DB20" "$DB20B" "$DB21" "$DB22" "$DB23" "$DB24" "$DB25" "$DB40" "$DB41" "$DB42" "$DB43" "$DB44" "$DB45" "$DB46" "$DB47" "$DB48" "$DB49" "$DB50" "$DB51" "$DB52" "$DB53" "$DB54" "$DB55"
+DB56=/tmp/test_merge56_$$.db; rm -f "$DB56"
+echo "CREATE TABLE t(a INT PRIMARY KEY, b INT); CREATE INDEX tb ON t(b); INSERT INTO t VALUES(1,1),(2,2),(3,3),(4,4); SELECT dolt_commit('-Am','base'); SELECT dolt_branch('feature');" | $DOLTLITE "$DB56" > /dev/null 2>&1
+echo "ALTER TABLE t ADD COLUMN d TEXT DEFAULT 'x'; DELETE FROM t WHERE a=2; UPDATE t SET b=30 WHERE a=3; SELECT dolt_commit('-Am','feature');" | $DOLTLITE "$DB56/feature" > /dev/null 2>&1
+echo "ALTER TABLE t ADD COLUMN c INT DEFAULT 7; UPDATE t SET c=8 WHERE a=2; DELETE FROM t WHERE a=4; SELECT dolt_commit('-Am','main');" | $DOLTLITE "$DB56" > /dev/null 2>&1
+run_test_match "dual_defaults_and_opposite_deletes_merge" \
+  "SELECT dolt_merge('feature');" "^[0-9a-f]{40}$" "$DB56"
+run_test "dual_defaults_and_opposite_deletes_rows" \
+  "SELECT group_concat(a || ':' || b || ':' || c || ':' || d, ',') FROM (SELECT a,b,c,d FROM t ORDER BY a);" \
+  "1:1:7:x,3:30:7:x" "$DB56"
+run_test "dual_defaults_and_opposite_deletes_index" \
+  "SELECT group_concat(a || ':' || b, ',') FROM (SELECT a,b FROM t INDEXED BY tb ORDER BY b);" \
+  "1:1,3:30" "$DB56"
+run_test "dual_defaults_and_opposite_deletes_clean" \
+  "SELECT (SELECT count(*) FROM dolt_conflicts) || ':' || (SELECT count(*) FROM dolt_constraint_violations) || ':' || (SELECT integrity_check FROM pragma_integrity_check);" \
+  "0:0:ok" "$DB56"
+run_test "dual_defaults_and_opposite_deletes_reopen" \
+  "SELECT group_concat(a || ':' || b || ':' || c || ':' || d, ',') FROM (SELECT a,b,c,d FROM t ORDER BY a);" \
+  "1:1:7:x,3:30:7:x" "$DB56"
+
+DB57=/tmp/test_merge57_$$.db; rm -f "$DB57"
+echo "CREATE TABLE t(a INT, b INT, v INT, PRIMARY KEY(a,b)); CREATE INDEX tv ON t(v); INSERT INTO t VALUES(1,1,10),(2,2,20),(3,3,30),(4,4,40); SELECT dolt_commit('-Am','base'); SELECT dolt_branch('feature');" | $DOLTLITE "$DB57" > /dev/null 2>&1
+echo "ALTER TABLE t ADD COLUMN d TEXT NOT NULL DEFAULT 9; ALTER TABLE t ADD COLUMN e INT DEFAULT 11; DELETE FROM t WHERE a=2; UPDATE t SET v=31 WHERE a=3; SELECT dolt_commit('-Am','feature');" | $DOLTLITE "$DB57/feature" > /dev/null 2>&1
+echo "ALTER TABLE t ADD COLUMN c TEXT NOT NULL DEFAULT 7; ALTER TABLE t ADD COLUMN f TEXT DEFAULT 'y'; DELETE FROM t WHERE a=4; SELECT dolt_commit('-Am','main');" | $DOLTLITE "$DB57" > /dev/null 2>&1
+run_test_match "dual_multi_defaults_composite_pk_merge" \
+  "SELECT dolt_merge('feature');" "^[0-9a-f]{40}$" "$DB57"
+run_test "dual_multi_defaults_composite_pk_rows" \
+  "SELECT group_concat(a || ':' || b || ':' || v || ':' || quote(c) || ':' || f || ':' || quote(d) || ':' || e, ',') FROM (SELECT a,b,v,c,f,d,e FROM t ORDER BY a,b);" \
+  "1:1:10:'7':y:'9':11,3:3:31:'7':y:'9':11" "$DB57"
+run_test "dual_multi_defaults_composite_pk_index" \
+  "SELECT group_concat(a || ':' || b || ':' || v, ',') FROM (SELECT a,b,v FROM t INDEXED BY tv ORDER BY v);" \
+  "1:1:10,3:3:31" "$DB57"
+run_test "dual_multi_defaults_composite_pk_clean" \
+  "SELECT (SELECT count(*) FROM dolt_conflicts) || ':' || (SELECT count(*) FROM dolt_constraint_violations) || ':' || (SELECT integrity_check FROM pragma_integrity_check);" \
+  "0:0:ok" "$DB57"
+
+DB58=/tmp/test_merge58_$$.db; rm -f "$DB58"
+echo "CREATE TABLE t(a INT PRIMARY KEY, b INT); INSERT INTO t VALUES(1,1),(2,2); SELECT dolt_commit('-Am','base'); SELECT dolt_branch('feature');" | $DOLTLITE "$DB58" > /dev/null 2>&1
+echo "ALTER TABLE t ADD COLUMN d TEXT DEFAULT 'x'; DELETE FROM t WHERE a=2; SELECT dolt_commit('-Am','feature');" | $DOLTLITE "$DB58/feature" > /dev/null 2>&1
+echo "ALTER TABLE t ADD COLUMN c INT DEFAULT 7; UPDATE t SET b=20 WHERE a=2; SELECT dolt_commit('-Am','main');" | $DOLTLITE "$DB58" > /dev/null 2>&1
+run_test_match "dual_defaults_delete_vs_base_edit_conflicts" \
+  "SELECT dolt_merge('feature');" "conflict" "$DB58"
+run_test "dual_defaults_delete_vs_base_edit_rolls_back" \
+  "SELECT a || ':' || b || ':' || c FROM t WHERE a=2;" "2:20:7" "$DB58"
+run_test "dual_defaults_delete_vs_base_edit_not_persisted" \
+  "SELECT count(*) FROM dolt_conflicts;" "0" "$DB58"
+
+DB59=/tmp/test_merge59_$$.db; rm -f "$DB59"
+echo "CREATE TABLE t(a INT PRIMARY KEY, b INT); INSERT INTO t VALUES(1,1),(2,2),(3,3); SELECT dolt_commit('-Am','base'); SELECT dolt_branch('feature');" | $DOLTLITE "$DB59" > /dev/null 2>&1
+echo "ALTER TABLE t ADD COLUMN c INT DEFAULT 7; UPDATE t SET c=8 WHERE a=2; SELECT dolt_commit('-Am','feature');" | $DOLTLITE "$DB59/feature" > /dev/null 2>&1
+echo "DELETE FROM t WHERE a=2; SELECT dolt_commit('-Am','main');" | $DOLTLITE "$DB59" > /dev/null 2>&1
+run_test_match "one_sided_default_edit_vs_delete_merges" \
+  "SELECT dolt_merge('feature');" "^[0-9a-f]{40}$" "$DB59"
+run_test "one_sided_default_edit_vs_delete_rows" \
+  "SELECT group_concat(a || ':' || b || ':' || c, ',') FROM (SELECT a,b,c FROM t ORDER BY a);" \
+  "1:1:7,3:3:7" "$DB59"
+run_test "one_sided_default_edit_vs_delete_integrity" \
+  "PRAGMA integrity_check;" "ok" "$DB59"
+
+DB60=/tmp/test_merge60_$$.db; rm -f "$DB60"
+echo "CREATE TABLE t(a INTEGER PRIMARY KEY, b INT, gs INT GENERATED ALWAYS AS (b+10) STORED, gv INT GENERATED ALWAYS AS (b*2) VIRTUAL); INSERT INTO t(a,b) VALUES(1,1),(2,2),(3,3); SELECT dolt_commit('-Am','base'); SELECT dolt_branch('feature');" | $DOLTLITE "$DB60" > /dev/null 2>&1
+echo "ALTER TABLE t ADD COLUMN d INT DEFAULT 9; DELETE FROM t WHERE a=2; SELECT dolt_commit('-Am','feature');" | $DOLTLITE "$DB60/feature" > /dev/null 2>&1
+echo "ALTER TABLE t ADD COLUMN c INT DEFAULT 7; UPDATE t SET c=8 WHERE a=2; SELECT dolt_commit('-Am','main');" | $DOLTLITE "$DB60" > /dev/null 2>&1
+run_test_match "dual_defaults_after_generated_columns_merge" \
+  "SELECT dolt_merge('feature');" "^[0-9a-f]{40}$" "$DB60"
+run_test "dual_defaults_after_generated_columns_rows" \
+  "SELECT group_concat(a || ':' || b || ':' || gs || ':' || gv || ':' || c || ':' || d, ',') FROM (SELECT a,b,gs,gv,c,d FROM t ORDER BY a);" \
+  "1:1:11:2:7:9,3:3:13:6:7:9" "$DB60"
+run_test "dual_defaults_after_generated_columns_integrity" \
+  "PRAGMA integrity_check;" "ok" "$DB60"
+
+rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8" "$DB8B" "$DB9" "$DB10" "$DB11" "$DB11D" "$DB11E" "$DB11F" "$DB12" "$DB13" "$DB14" "$DB15" "$DB16" "$DB17" "$DB18" "$DB19" "$DB20" "$DB20B" "$DB21" "$DB22" "$DB23" "$DB24" "$DB25" "$DB40" "$DB41" "$DB42" "$DB43" "$DB44" "$DB45" "$DB46" "$DB47" "$DB48" "$DB49" "$DB50" "$DB51" "$DB52" "$DB53" "$DB54" "$DB55" "$DB56" "$DB57" "$DB58" "$DB59" "$DB60"
 dltest_finish

--- a/test/vc_oracle_merge_test.sh
+++ b/test/vc_oracle_merge_test.sh
@@ -1755,6 +1755,96 @@ SELECT dolt_merge('feat');
 " "SELECT group_concat(id || ':' || added, ',') FROM (SELECT id, added FROM t ORDER BY id)" \
 "SELECT GROUP_CONCAT(CONCAT(id, ':', added) ORDER BY id SEPARATOR ',') FROM t"
 
+oracle_error_poststate "dual_defaults_opposite_deletes_and_surviving_edit" "
+CREATE TABLE t(a INT PRIMARY KEY, b INT);
+INSERT INTO t VALUES (1, 1), (2, 2), (3, 3), (4, 4);
+SELECT dolt_commit('-Am', 'base');
+SELECT dolt_branch('feature');
+SELECT dolt_checkout('feature');
+ALTER TABLE t ADD COLUMN d TEXT DEFAULT 'x';
+DELETE FROM t WHERE a = 2;
+UPDATE t SET b = 30 WHERE a = 3;
+SELECT dolt_commit('-Am', 'feature');
+SELECT dolt_checkout('main');
+ALTER TABLE t ADD COLUMN c INT DEFAULT 7;
+UPDATE t SET c = 8 WHERE a = 2;
+DELETE FROM t WHERE a = 4;
+SELECT dolt_commit('-Am', 'main');
+SELECT dolt_merge('feature');
+" "SELECT group_concat(a || ':' || b || ':' || c || ':' || d, ',') FROM (SELECT a, b, c, d FROM t ORDER BY a)" \
+"SELECT GROUP_CONCAT(CONCAT(a, ':', b, ':', c, ':', d) ORDER BY a SEPARATOR ',') FROM t"
+
+oracle_error_poststate "dual_multi_defaults_composite_pk_deletes" "
+CREATE TABLE t(a INT, b INT, v INT, PRIMARY KEY(a, b));
+CREATE INDEX tv ON t(v);
+INSERT INTO t VALUES (1, 1, 10), (2, 2, 20), (3, 3, 30), (4, 4, 40);
+SELECT dolt_commit('-Am', 'base');
+SELECT dolt_branch('feature');
+SELECT dolt_checkout('feature');
+ALTER TABLE t ADD COLUMN d TEXT NOT NULL DEFAULT 9;
+ALTER TABLE t ADD COLUMN e INT DEFAULT 11;
+DELETE FROM t WHERE a = 2;
+UPDATE t SET v = 31 WHERE a = 3;
+SELECT dolt_commit('-Am', 'feature');
+SELECT dolt_checkout('main');
+ALTER TABLE t ADD COLUMN c TEXT NOT NULL DEFAULT 7;
+ALTER TABLE t ADD COLUMN f TEXT DEFAULT 'y';
+DELETE FROM t WHERE a = 4;
+SELECT dolt_commit('-Am', 'main');
+SELECT dolt_merge('feature');
+" "SELECT group_concat(a || ':' || b || ':' || v || ':' || c || ':' || f || ':' || d || ':' || e, ',') FROM (SELECT a, b, v, c, f, d, e FROM t ORDER BY a, b)" \
+"SELECT GROUP_CONCAT(CONCAT(a, ':', b, ':', v, ':', c, ':', f, ':', d, ':', e) ORDER BY a, b SEPARATOR ',') FROM t"
+
+oracle_error_poststate "one_sided_default_column_edit_vs_delete" "
+CREATE TABLE t(a INT PRIMARY KEY, b INT);
+INSERT INTO t VALUES (1, 1), (2, 2), (3, 3);
+SELECT dolt_commit('-Am', 'base');
+SELECT dolt_branch('feature');
+SELECT dolt_checkout('feature');
+ALTER TABLE t ADD COLUMN c INT DEFAULT 7;
+UPDATE t SET c = 8 WHERE a = 2;
+SELECT dolt_commit('-Am', 'feature');
+SELECT dolt_checkout('main');
+DELETE FROM t WHERE a = 2;
+SELECT dolt_commit('-Am', 'main');
+SELECT dolt_merge('feature');
+" "SELECT group_concat(a || ':' || b || ':' || c, ',') FROM (SELECT a, b, c FROM t ORDER BY a)" \
+"SELECT GROUP_CONCAT(CONCAT(a, ':', b, ':', c) ORDER BY a SEPARATOR ',') FROM t"
+
+oracle_error "dual_defaults_delete_vs_ancestor_column_edit" "
+CREATE TABLE t(a INT PRIMARY KEY, b INT);
+INSERT INTO t VALUES (1, 1), (2, 2);
+SELECT dolt_commit('-Am', 'base');
+SELECT dolt_branch('feature');
+SELECT dolt_checkout('feature');
+ALTER TABLE t ADD COLUMN d TEXT DEFAULT 'x';
+DELETE FROM t WHERE a = 2;
+SELECT dolt_commit('-Am', 'feature');
+SELECT dolt_checkout('main');
+ALTER TABLE t ADD COLUMN c INT DEFAULT 7;
+UPDATE t SET b = 20 WHERE a = 2;
+SELECT dolt_commit('-Am', 'main');
+SELECT dolt_merge('feature');
+"
+
+oracle_error_poststate "dual_defaults_after_virtual_generated_column" "
+CREATE TABLE t(a INTEGER PRIMARY KEY, b INT,
+  gv INT GENERATED ALWAYS AS (b * 2) VIRTUAL);
+INSERT INTO t(a, b) VALUES (1, 1), (2, 2), (3, 3);
+SELECT dolt_commit('-Am', 'base');
+SELECT dolt_branch('feature');
+SELECT dolt_checkout('feature');
+ALTER TABLE t ADD COLUMN d INT DEFAULT 9;
+DELETE FROM t WHERE a = 2;
+SELECT dolt_commit('-Am', 'feature');
+SELECT dolt_checkout('main');
+ALTER TABLE t ADD COLUMN c INT DEFAULT 7;
+UPDATE t SET c = 8 WHERE a = 2;
+SELECT dolt_commit('-Am', 'main');
+SELECT dolt_merge('feature');
+" "SELECT group_concat(a || ':' || b || ':' || gv || ':' || c || ':' || d, ',') FROM (SELECT a, b, gv, c, d FROM t ORDER BY a)" \
+"SELECT GROUP_CONCAT(CONCAT(a, ':', b, ':', gv, ':', c, ':', d) ORDER BY a SEPARATOR ',') FROM t"
+
 # Concluding a conflicted merge must still record the second parent.
 oracle "conflict_resolved_commit_keeps_merged_branch_in_log" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);


### PR DESCRIPTION
## Summary
- normalize defaulted appended columns on every schema-relayout path
- let deletes win over changes confined to newly appended columns while preserving conflicts for ancestor-column edits
- keep secondary indexes and generated-column record layouts correct in both deletion directions
- add native and Dolt-oracle coverage for dual defaults, opposite deletes, composite keys, indexes, affinity, and generated columns

## Validation
- `make -C build lint`
- `bash test/run_doltlite_tests.sh build/doltlite` — 125 suites passed
- `bash test/vc_oracle_merge_test.sh build/doltlite dolt` — 102 passed
- `DOLTLITE=build/doltlite bash test/vc_oracle_schema_merge_test.sh` — 123 passed
- `bash test/oracle_generated_columns_vc_test.sh build/doltlite` — 24 passed

Fixes #2537

Co-Authored-By: OpenAI Codex <noreply@openai.com>