### PR TITLE
Reject extra arguments to dolt_cherry_pick --abort

### DIFF
--- a/src/doltlite_cherry_pick.c
+++ b/src/doltlite_cherry_pick.c
@@ -391,13 +391,13 @@ static void doltliteCherryPickFunc(
   rc = doltliteCmdParseArgs(context, argc, argv, aOption, ArraySize(aOption),
                             0, &args);
   if( rc!=SQLITE_OK ) return;
-  if( args.nPositional>1 ){
-    doltliteCmdArgsClear(&args);
-    sqlite3_result_error(context,
-      "cherry-picking multiple commits is not supported yet.", -1);
-    return;
-  }
   if( isAbort ){
+    if( args.nPositional>0 ){
+      doltliteCmdArgsClear(&args);
+      sqlite3_result_error(context,
+        "--abort does not take other arguments", -1);
+      return;
+    }
     if( !doltliteSessionHasPendingReplayCommit(db) ){
       doltliteCmdArgsClear(&args);
       sqlite3_result_error(context, "no cherry-pick in progress", -1);
@@ -410,6 +410,12 @@ static void doltliteCherryPickFunc(
       return;
     }
     sqlite3_result_int(context, 0);
+    return;
+  }
+  if( args.nPositional>1 ){
+    doltliteCmdArgsClear(&args);
+    sqlite3_result_error(context,
+      "cherry-picking multiple commits is not supported yet.", -1);
     return;
   }
 

--- a/test/doltlite_cherry_pick.sh
+++ b/test/doltlite_cherry_pick.sh
@@ -727,6 +727,25 @@ M" \
 run_test_match "cp_abort_without_active" \
   "SELECT dolt_cherry_pick('--abort');" \
   "no cherry-pick in progress" "$DB"
+run_test_match "cp_abort_extra_args" \
+  "SELECT dolt_cherry_pick('--abort', 'extra');" \
+  "--abort does not take other arguments" "$DB"
+run_test "cp_abort_extra_preserves_conflict" \
+  "BEGIN;
+   SELECT dolt_cherry_pick('feat');
+   SELECT dolt_cherry_pick('--abort', 'HEAD');
+   SELECT count(*) FROM dolt_conflicts;
+   SELECT v FROM t;
+   SELECT dolt_cherry_pick('--abort');
+   SELECT count(*) FROM dolt_conflicts;
+   COMMIT;" \
+  "Error near line 2: Cherry-pick has 1 conflict(s). Resolve and then commit with dolt_commit.
+Error near line 3: --abort does not take other arguments
+1
+M
+0
+0" \
+  "$DB"
 run_test "cp_abort_after_resolve" \
   "BEGIN;
    SELECT dolt_cherry_pick('feat');

--- a/test/vc_oracle_cherry_pick_abort_test.sh
+++ b/test/vc_oracle_cherry_pick_abort_test.sh
@@ -135,8 +135,11 @@ SELECT dolt_commit('-Am', 'main edit');
 abort_oracle "cherry_pick_abort_conflict" \
   "$CONFLICT_SETUP" "feature" "'--abort'"
 
-abort_oracle "cherry_pick_abort_ignores_one_positional" \
-  "$CONFLICT_SETUP" "feature" "'--abort', 'HEAD'"
+error_oracle "cherry_pick_abort_rejects_extra_args" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+SELECT dolt_commit('-Am','base');
+SELECT dolt_cherry_pick('--abort', 'extra');
+"
 
 CV_SETUP="
 CREATE TABLE t(id INTEGER PRIMARY KEY, u INT UNIQUE, v TEXT);


### PR DESCRIPTION
Fixes #2554.

`dolt_cherry_pick('--abort', 'extra')` silently discarded the extra argument and aborted. `dolt_merge('--abort', 'x')` and `dolt_rebase('--abort', 'x')` already refuse with `--abort does not take other arguments`.

`--abort` now rejects any positional argument with that same error and does not call `mergeAbortInPlace`, so an in-progress cherry-pick stays in place until a bare `--abort`.

`test/doltlite_cherry_pick.sh` covers the idle error and a conflicted pick that remains conflicted through the refused abort. `vc_oracle_cherry_pick_abort_test.sh` expects both engines to error on extra args when no cherry-pick is active.

Co-Authored-By: Grok 4.6 <noreply@x.ai>