### PR TITLE
Reject unresolved diff refs consistently

### DIFF
--- a/src/doltlite_diff_stat.c
+++ b/src/doltlite_diff_stat.c
@@ -645,6 +645,21 @@ static void dsFilterCtxClear(DsFilterCtx *pCtx){
   memset(pCtx, 0, sizeof(*pCtx));
 }
 
+static int dsRefError(
+  sqlite3_vtab *pVtab,
+  const char *zName,
+  const char *zRef,
+  int rc
+){
+  const char *zKind;
+  if( rc!=SQLITE_NOTFOUND && rc!=SQLITE_ERROR ) return rc;
+  zKind = rc==SQLITE_NOTFOUND ? "ref not found" : "invalid ref";
+  sqlite3_free(pVtab->zErrMsg);
+  pVtab->zErrMsg = sqlite3_mprintf(
+      "%s: %s: %s", zName, zKind, zRef ? zRef : "");
+  return pVtab->zErrMsg ? SQLITE_ERROR : SQLITE_NOMEM;
+}
+
 static int dsFilterInit(
   sqlite3 *db,
   sqlite3_vtab *pVtab,
@@ -672,9 +687,11 @@ static int dsFilterInit(
   }
 
   rc = doltliteResolveCatalogHashForRef(db, pCtx->zFromRef, &pCtx->fromCat);
-  if( rc!=SQLITE_OK ) return rc;
+  if( rc!=SQLITE_OK ) return dsRefError(
+      pVtab, zName, pCtx->zFromRef, rc);
   rc = doltliteResolveCatalogHashForRef(db, pCtx->zToRef, &pCtx->toCat);
-  if( rc!=SQLITE_OK ) return rc;
+  if( rc!=SQLITE_OK ) return dsRefError(
+      pVtab, zName, pCtx->zToRef, rc);
   if( pCtx->zTblFilter ){
     pCtx->azNames = sqlite3_malloc((int)sizeof(char*));
     if( !pCtx->azNames ) return SQLITE_NOMEM;

--- a/src/doltlite_diff_table.c
+++ b/src/doltlite_diff_table.c
@@ -110,6 +110,16 @@ struct DiffTblCursor {
 #define DT_IDX_FROM_TO_COMMIT 0x08
 #define DT_IDX_FROM_COMMIT_EQ 0x10
 
+static int dtRefError(DiffTblVtab *pVtab, const char *zRef, int rc){
+  const char *zKind;
+  if( rc!=SQLITE_NOTFOUND && rc!=SQLITE_ERROR ) return rc;
+  zKind = rc==SQLITE_NOTFOUND ? "ref not found" : "invalid ref";
+  sqlite3_free(pVtab->base.zErrMsg);
+  pVtab->base.zErrMsg = sqlite3_mprintf(
+      "dolt_diff_%s: %s: %s", pVtab->zTableName, zKind, zRef ? zRef : "");
+  return pVtab->base.zErrMsg ? SQLITE_ERROR : SQLITE_NOMEM;
+}
+
 static void clearAuditRow(AuditRow *r){
   sqlite3_free(r->pKeyRec);
   sqlite3_free(r->pOldKeyRec);
@@ -545,7 +555,8 @@ static int buildCommitDiffPair(
   DiffTblCursor *pCur,
   sqlite3 *db,
   const char *zTableName,
-  const char *zToCommit
+  const char *zToCommit,
+  int *pbRefError
 ){
   ProllyHash toHash;
   ProllyHash fromHash;
@@ -561,6 +572,7 @@ static int buildCommitDiffPair(
   const ProllyHash *pParent;
   int rc;
 
+  *pbRefError = 0;
   if( !zToCommit ) return SQLITE_OK;
 
   memset(&toHash, 0, sizeof(toHash));
@@ -575,7 +587,10 @@ static int buildCommitDiffPair(
   memset(zToLabel, 0, sizeof(zToLabel));
 
   rc = doltliteResolveRef(db, zToCommit, &toHash);
-  if( rc!=SQLITE_OK ) return SQLITE_OK;
+  if( rc!=SQLITE_OK ){
+    *pbRefError = 1;
+    return rc;
+  }
 
   /* to_commit filter only walks the session head's ancestry; unreachable commits yield no rows. */
   {
@@ -650,15 +665,19 @@ struct DtSliceEnd {
   char zLabel[PROLLY_HASH_SIZE*2+1];
 };
 
-/* SQLITE_NOTFOUND for an unresolvable ref so the caller yields no rows. */
 static int dtResolveSliceEnd(
-  sqlite3 *db, const char *zRef, const char *zTableName, DtSliceEnd *pEnd
+  sqlite3 *db, const char *zRef, const char *zTableName, DtSliceEnd *pEnd,
+  int *pbRefError
 ){
   int rc;
+  *pbRefError = 0;
   memset(pEnd, 0, sizeof(*pEnd));
 
   rc = doltliteResolveCatalogHashForRef(db, zRef, &pEnd->catHash);
-  if( rc!=SQLITE_OK ) return rc;
+  if( rc!=SQLITE_OK ){
+    *pbRefError = 1;
+    return rc;
+  }
 
   if( doltliteRefIsWorking(zRef) ){
     rc = doltliteGetWorkingTableState(db, zTableName, &pEnd->tblRoot,
@@ -684,7 +703,10 @@ static int dtResolveSliceEnd(
     DoltliteCommit commit;
     memset(&commit, 0, sizeof(commit));
     rc = doltliteResolveRef(db, zRef, &commitHash);
-    if( rc!=SQLITE_OK ) return rc;
+    if( rc!=SQLITE_OK ){
+      *pbRefError = 1;
+      return rc;
+    }
     rc = doltliteLoadCommit(db, &commitHash, &commit);
     if( rc!=SQLITE_OK ) return rc;
     pEnd->date = commit.timestamp;
@@ -699,18 +721,21 @@ static int buildSliceDiffPair(
   sqlite3 *db,
   const char *zTableName,
   const char *zFromRef,
-  const char *zToRef
+  const char *zToRef,
+  const char **pzBadRef
 ){
   DtSliceEnd from, to;
+  int bRefError = 0;
   int rc;
 
+  *pzBadRef = 0;
   if( !zFromRef || !zToRef ) return SQLITE_OK;
 
-  rc = dtResolveSliceEnd(db, zFromRef, zTableName, &from);
-  if( rc==SQLITE_NOTFOUND ) return SQLITE_OK;
+  rc = dtResolveSliceEnd(db, zFromRef, zTableName, &from, &bRefError);
+  if( bRefError ) *pzBadRef = zFromRef;
   if( rc!=SQLITE_OK ) return rc;
-  rc = dtResolveSliceEnd(db, zToRef, zTableName, &to);
-  if( rc==SQLITE_NOTFOUND ) return SQLITE_OK;
+  rc = dtResolveSliceEnd(db, zToRef, zTableName, &to, &bRefError);
+  if( bRefError ) *pzBadRef = zToRef;
   if( rc!=SQLITE_OK ) return rc;
 
   if( prollyHashCompare(&from.tblRoot, &to.tblRoot)==0
@@ -734,6 +759,7 @@ static int buildRangeSpecDiffPair(
 ){
   char *zLeft = 0;
   char *zRight = 0;
+  const char *zBadRef = 0;
   int rangeType = DOLTLITE_RANGE_NONE;
   int rc;
 
@@ -750,10 +776,12 @@ static int buildRangeSpecDiffPair(
     }
     if( rc==SQLITE_OK ){
       doltliteHashToHex(&ancestor, zAncestor);
-      rc = buildSliceDiffPair(pCur, db, zTableName, zAncestor, zRight);
+      rc = buildSliceDiffPair(
+          pCur, db, zTableName, zAncestor, zRight, &zBadRef);
     }
   }else{
-    rc = buildSliceDiffPair(pCur, db, zTableName, zLeft, zRight);
+    rc = buildSliceDiffPair(
+        pCur, db, zTableName, zLeft, zRight, &zBadRef);
   }
   sqlite3_free(zLeft);
   sqlite3_free(zRight);
@@ -1086,7 +1114,10 @@ static int dtFilter(sqlite3_vtab_cursor *cur,
   if( (idxNum & DT_IDX_SLICE)!=0 && argc>=2 ){
     const char *zFromRef = (const char*)sqlite3_value_text(argv[0]);
     const char *zToRef = (const char*)sqlite3_value_text(argv[1]);
-    rc = buildSliceDiffPair(c, db, pVtab->zTableName, zFromRef, zToRef);
+    const char *zBadRef = 0;
+    rc = buildSliceDiffPair(
+        c, db, pVtab->zTableName, zFromRef, zToRef, &zBadRef);
+    if( zBadRef ) rc = dtRefError(pVtab, zBadRef, rc);
   }else if( (idxNum & DT_IDX_RANGE_SPEC)!=0 && argc>=1 ){
     const char *zSpec = (const char*)sqlite3_value_text(argv[0]);
     rc = buildRangeSpecDiffPair(c, db, pVtab->zTableName, zSpec);
@@ -1095,24 +1126,34 @@ static int dtFilter(sqlite3_vtab_cursor *cur,
       pVtab->base.zErrMsg = sqlite3_mprintf(
           "dolt_diff_%s requires a '..' or '...' revision range",
           pVtab->zTableName);
-    }else if( rc==SQLITE_ERROR ){
+    }else if( rc==SQLITE_ERROR || rc==SQLITE_NOTFOUND ){
       sqlite3_free(pVtab->base.zErrMsg);
       pVtab->base.zErrMsg = sqlite3_mprintf(
           "dolt_diff_%s: invalid revision range '%s'",
           pVtab->zTableName, zSpec ? zSpec : "");
+      rc = pVtab->base.zErrMsg ? SQLITE_ERROR : SQLITE_NOMEM;
     }
   }else if( (idxNum & DT_IDX_FROM_TO_COMMIT)!=0 && argc>=2 ){
     const char *zFrom = (const char*)sqlite3_value_text(argv[0]);
     const char *zTo = (const char*)sqlite3_value_text(argv[1]);
-    rc = buildSliceDiffPair(c, db, pVtab->zTableName, zFrom, zTo);
+    const char *zBadRef = 0;
+    rc = buildSliceDiffPair(
+        c, db, pVtab->zTableName, zFrom, zTo, &zBadRef);
+    if( zBadRef ) rc = dtRefError(pVtab, zBadRef, rc);
   }else if( (idxNum & DT_IDX_TO_COMMIT_EQ)!=0 && argc>=1 ){
     const char *zToCommit = (const char*)sqlite3_value_text(argv[0]);
     if( zToCommit && sqlite3_stricmp(zToCommit, "WORKING")==0 ){
       rc = buildWorkingDiffPair(c, db, pVtab->zTableName);
     }else if( zToCommit && sqlite3_stricmp(zToCommit, "STAGED")==0 ){
-      rc = buildSliceDiffPair(c, db, pVtab->zTableName, "HEAD", "STAGED");
+      const char *zBadRef = 0;
+      rc = buildSliceDiffPair(
+          c, db, pVtab->zTableName, "HEAD", "STAGED", &zBadRef);
+      if( zBadRef ) rc = dtRefError(pVtab, zBadRef, rc);
     }else{
-      rc = buildCommitDiffPair(c, db, pVtab->zTableName, zToCommit);
+      int bRefError = 0;
+      rc = buildCommitDiffPair(
+          c, db, pVtab->zTableName, zToCommit, &bRefError);
+      if( bRefError ) rc = dtRefError(pVtab, zToCommit, rc);
     }
   }else if( (idxNum & DT_IDX_FROM_COMMIT_EQ)!=0 && argc>=1 ){
     /* Resolve the ref once, then keep only history pairs departing it. */
@@ -1125,8 +1166,11 @@ static int dtFilter(sqlite3_vtab_cursor *cur,
       sqlite3_snprintf(sizeof(zLabel), zLabel, "%s", zFrom);
     }else if( zFrom ){
       ProllyHash fromHash;
-      if( doltliteResolveRef(db, zFrom, &fromHash)==SQLITE_OK ){
+      rc = doltliteResolveRef(db, zFrom, &fromHash);
+      if( rc==SQLITE_OK ){
         doltliteHashToHex(&fromHash, zLabel);
+      }else{
+        rc = dtRefError(pVtab, zFrom, rc);
       }
     }
     if( zLabel[0] ){

--- a/test/doltlite_diff.sh
+++ b/test/doltlite_diff.sh
@@ -59,7 +59,7 @@ run_test_match "diff_stat_no_such_table" \
 
 run_test_match "diff_bad_ref_errors" \
   "SELECT count(*) FROM dolt_diff_stat('definitely_not_a_ref', (SELECT commit_hash FROM dolt_log LIMIT 1), 't');" \
-  "Error" "$DB"
+  "dolt_diff_stat: ref not found: definitely_not_a_ref" "$DB"
 
 DB2=/tmp/test_diff2_$$.db; rm -f "$DB2"
 echo "CREATE TABLE t(x); SELECT dolt_commit('-A','-m','empty');" | $DOLTLITE "$DB2" > /dev/null 2>&1

--- a/test/doltlite_diff_table.sh
+++ b/test/doltlite_diff_table.sh
@@ -377,12 +377,39 @@ run_test "revspec_from_only_row" \
 run_test "revspec_hash_pair_still_works" \
   "SELECT count(*) FROM dolt_diff_t WHERE from_commit=(SELECT commit_hash FROM dolt_log WHERE message='c2') AND to_commit=(SELECT commit_hash FROM dolt_log WHERE message='c3');" \
   "1" "$DBRS"
-run_test "revspec_garbage_from_matches_nothing" \
+run_test_match "revspec_garbage_from_rejected" \
   "SELECT count(*) FROM dolt_diff_t WHERE from_commit='nosuchref' AND to_commit='HEAD';" \
-  "0" "$DBRS"
-run_test "revspec_garbage_to_matches_nothing" \
+  "dolt_diff_t: ref not found: nosuchref" "$DBRS"
+run_test_match "revspec_garbage_to_rejected" \
   "SELECT count(*) FROM dolt_diff_t WHERE to_commit='garbage';" \
-  "0" "$DBRS"
+  "dolt_diff_t: ref not found: garbage" "$DBRS"
+run_test_match "revspec_garbage_from_only_rejected" \
+  "SELECT count(*) FROM dolt_diff_t WHERE from_commit='nosuchref';" \
+  "dolt_diff_t: ref not found: nosuchref" "$DBRS"
+run_test_match "revspec_invalid_ancestor_from_only_rejected" \
+  "SELECT count(*) FROM dolt_diff_t WHERE from_commit='HEAD~99';" \
+  "dolt_diff_t: invalid ref: HEAD~99" "$DBRS"
+run_test_match "revspec_invalid_ancestor_to_only_rejected" \
+  "SELECT count(*) FROM dolt_diff_t WHERE to_commit='HEAD~99';" \
+  "dolt_diff_t: invalid ref: HEAD~99" "$DBRS"
+run_test_match "revspec_tvf_garbage_from_rejected" \
+  "SELECT count(*) FROM dolt_diff_t('nosuchref','HEAD');" \
+  "dolt_diff_t: ref not found: nosuchref" "$DBRS"
+run_test_match "revspec_tvf_garbage_to_rejected" \
+  "SELECT count(*) FROM dolt_diff_t('HEAD','nosuchref');" \
+  "dolt_diff_t: ref not found: nosuchref" "$DBRS"
+run_test_match "revspec_tvf_hash_prefix_rejected" \
+  "SELECT count(*) FROM dolt_diff_t('abc123','HEAD');" \
+  "dolt_diff_t: ref not found: abc123" "$DBRS"
+run_test_match "revspec_tvf_invalid_ancestor_rejected" \
+  "SELECT count(*) FROM dolt_diff_t('HEAD~99','HEAD');" \
+  "dolt_diff_t: invalid ref: HEAD~99" "$DBRS"
+run_test_match "diff_stat_garbage_ref_descriptive" \
+  "SELECT count(*) FROM dolt_diff_stat('nosuchref','HEAD','t');" \
+  "dolt_diff_stat: ref not found: nosuchref" "$DBRS"
+run_test_match "diff_stat_invalid_ancestor_descriptive" \
+  "SELECT count(*) FROM dolt_diff_stat('HEAD~99','HEAD','t');" \
+  "dolt_diff_stat: invalid ref: HEAD~99" "$DBRS"
 run_test "revspec_to_working" \
   "INSERT INTO t VALUES(3,'dirty');
    SELECT count(*) FROM dolt_diff_t WHERE to_commit='WORKING';" \

--- a/test/doltlite_diff_table_range.sh
+++ b/test/doltlite_diff_table_range.sh
@@ -49,6 +49,14 @@ run_test_match "three_dot_missing_right_rejected" \
   "SELECT count(*) FROM dolt_diff_t('feature...');" \
   "invalid revision range" "$DB"
 
+run_test_match "two_dot_unknown_ref_rejected" \
+  "SELECT count(*) FROM dolt_diff_t('nosuchref..feature');" \
+  "invalid revision range" "$DB"
+
+run_test_match "three_dot_invalid_ancestor_rejected" \
+  "SELECT count(*) FROM dolt_diff_t('HEAD~99...feature');" \
+  "invalid revision range" "$DB"
+
 run_test "three_dot_feature" \
   "SELECT coalesce(from_id,to_id) || ':' || diff_type
      FROM dolt_diff_t('main...feature');" "2:added" "$DB"

--- a/test/vc_oracle_diff_stat_test.sh
+++ b/test/vc_oracle_diff_stat_test.sh
@@ -413,6 +413,16 @@ $SEED
 SELECT * FROM dolt_diff_stat('HEAD', 'definitely_not_a_ref', 't');
 "
 
+oracle_error "diff_stat_invalid_from_ancestor" "
+$SEED
+SELECT * FROM dolt_diff_stat('HEAD~99', 'HEAD', 't');
+"
+
+oracle_error "diff_stat_invalid_to_ancestor" "
+$SEED
+SELECT * FROM dolt_diff_stat('HEAD', 'HEAD~99', 't');
+"
+
 oracle_summary "diff_summary_missing_table" "
 $SEED
 " "HEAD" "HEAD" "doesnotexist" "EXPECT_EMPTY"

--- a/test/vc_oracle_diff_tvf_test.sh
+++ b/test/vc_oracle_diff_tvf_test.sh
@@ -234,6 +234,21 @@ oracle_error "diff_three_dot_missing_left" "$SETUP_DIVERGENT" \
 oracle_error "diff_three_dot_missing_right" "$SETUP_DIVERGENT" \
   "SELECT count(*) FROM dolt_diff_t('feature...');"
 
+oracle_error "diff_slice_unknown_from_ref" "$SETUP_DIVERGENT" \
+  "SELECT count(*) FROM dolt_diff_t('nosuchref', 'feature');"
+
+oracle_error "diff_slice_unknown_to_ref" "$SETUP_DIVERGENT" \
+  "SELECT count(*) FROM dolt_diff_t('feature', 'nosuchref');"
+
+oracle_error "diff_slice_unknown_hash_prefix" "$SETUP_DIVERGENT" \
+  "SELECT count(*) FROM dolt_diff_t('abc123', 'feature');"
+
+oracle_error "diff_slice_invalid_ancestor" "$SETUP_DIVERGENT" \
+  "SELECT count(*) FROM dolt_diff_t('HEAD~99', 'feature');"
+
+oracle_error "diff_range_unknown_ref" "$SETUP_DIVERGENT" \
+  "SELECT count(*) FROM dolt_diff_t('nosuchref..feature');"
+
 oracle_error "log_two_dot_missing_left" "$SETUP_DIVERGENT" \
   "SELECT count(*) FROM dolt_log('..feature');"
 


### PR DESCRIPTION
## Summary
- reject unresolved refs across every `dolt_diff_<table>` query plan instead of silently returning zero rows
- report distinct descriptive errors for missing refs and invalid ancestor specs
- make `dolt_diff_stat` use the same error domain
- cover TVF, WHERE-filter, hash-prefix, from-only, to-only, and revision-range forms against Dolt

## Validation
- `make -C build lint`
- `bash test/run_doltlite_tests.sh build/doltlite` — 125 suites passed
- focused native diff suites — 156 passed
- focused Dolt oracle suites — 243 passed

Fixes #2540

Co-Authored-By: OpenAI Codex <noreply@openai.com>
