### PR TITLE
Keep the Homebrew formula on the current release tarball

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,12 +96,17 @@ jobs:
         tar czf doltlite-autoconf-${VERSION}.tar.gz \
           --transform "s,^,doltlite-autoconf-${VERSION}/," \
           configure Makefile.in Makefile.linux-generic Makefile.msc main.mk \
+          doltlite.mk \
           auto.def VERSION manifest manifest.tags manifest.uuid \
           pragma.h magic.txt lempar.c \
           sqlite3.pc.in sqlite.pc.in \
           src/ ext/ tool/ autosetup/ autoconf/ \
           sqlite3.c sqlite3.h sqlite3ext.h sqlite3session.h \
           .dolt_release_version
+        prefix="doltlite-autoconf-${VERSION}"
+        for req in configure main.mk doltlite.mk auto.def sqlite3.c sqlite3.h; do
+          tar tzf doltlite-autoconf-${VERSION}.tar.gz | grep -qx "${prefix}/${req}"
+        done
         rm .dolt_release_version
 
     - name: Package wasm distribution
@@ -1292,6 +1297,9 @@ jobs:
     if: github.event_name != 'workflow_dispatch'
     needs: release
     runs-on: ubuntu-latest
+    concurrency:
+      group: doltlite-homebrew-formula
+      cancel-in-progress: false
     env:
       GH_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN }}
       VERSION: ${{ github.ref_name }}
@@ -1323,11 +1331,38 @@ jobs:
         gh release download "${VERSION}" --repo dolthub/doltlite \
           --pattern "${asset}" --dir /tmp
         sha256=$(sha256sum "/tmp/${asset}" | awk '{print $1}')
-        bash packaging/homebrew/bump-formula.sh "${version}" "${sha256}"
-        if git diff --quiet -- packaging/homebrew/doltlite.rb; then
-          echo "Homebrew formula already at ${version}"
-          exit 0
-        fi
-        git add packaging/homebrew/doltlite.rb
-        git commit -m "Bump Homebrew formula to ${version}"
-        git push origin master
+
+        formula_ver() {
+          sed -n 's|.*/doltlite-autoconf-\([^"]*\)\.tar\.gz.*|\1|p' \
+            packaging/homebrew/doltlite.rb | head -1
+        }
+        should_skip() {
+          local current="$1"
+          [ "$current" = "$version" ] && return 0
+          [ -n "$current" ] || return 1
+          [ "$(printf '%s\n%s\n' "$current" "$version" | sort -V | tail -1)" != "$version" ]
+        }
+
+        for attempt in 1 2 3 4 5; do
+          git fetch origin master
+          git reset --hard origin/master
+          current="$(formula_ver)"
+          if should_skip "$current"; then
+            echo "Homebrew formula already at ${current}; not writing ${version}"
+            exit 0
+          fi
+          bash packaging/homebrew/bump-formula.sh "${version}" "${sha256}"
+          if git diff --quiet -- packaging/homebrew/doltlite.rb; then
+            echo "Homebrew formula already at ${version}"
+            exit 0
+          fi
+          git add packaging/homebrew/doltlite.rb
+          git commit -m "Bump Homebrew formula to ${version}"
+          if git push origin master; then
+            exit 0
+          fi
+          echo "push rejected (attempt ${attempt}); retrying"
+          sleep $((attempt * 2))
+        done
+        echo "failed to push Homebrew formula bump after retries"
+        exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1282,3 +1282,52 @@ jobs:
         git pull --ff-only origin main
         git tag "${VERSION}"
         git push origin "${VERSION}"
+
+  # ── Bump the in-repo Homebrew formula ────────────────────
+  # packaging/homebrew/doltlite.rb is the source-of-truth copy until
+  # homebrew-core accepts a submission. Pinning a stale tarball ships a
+  # pre-format-freeze engine. After the autoconf tarball is on the GitHub
+  # release, rewrite url/sha256 and push to master.
+  release-homebrew:
+    if: github.event_name != 'workflow_dispatch'
+    needs: release
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN }}
+      VERSION: ${{ github.ref_name }}
+    steps:
+    - name: Check release bot token
+      run: |
+        if [ -z "${GH_TOKEN}" ]; then
+          echo "RELEASE_BOT_TOKEN is required to push Homebrew formula bumps to doltlite"
+          exit 1
+        fi
+        gh auth status
+        gh auth setup-git
+
+    - name: Configure git identity
+      run: |
+        git config --global user.name "DoltHub Release Bot"
+        git config --global user.email "releases@dolthub.com"
+
+    - uses: actions/checkout@v4
+      with:
+        ref: master
+        token: ${{ secrets.RELEASE_BOT_TOKEN }}
+
+    - name: Bump Homebrew formula to this release
+      run: |
+        set -euo pipefail
+        version="${VERSION#v}"
+        asset="doltlite-autoconf-${version}.tar.gz"
+        gh release download "${VERSION}" --repo dolthub/doltlite \
+          --pattern "${asset}" --dir /tmp
+        sha256=$(sha256sum "/tmp/${asset}" | awk '{print $1}')
+        bash packaging/homebrew/bump-formula.sh "${version}" "${sha256}"
+        if git diff --quiet -- packaging/homebrew/doltlite.rb; then
+          echo "Homebrew formula already at ${version}"
+          exit 0
+        fi
+        git add packaging/homebrew/doltlite.rb
+        git commit -m "Bump Homebrew formula to ${version}"
+        git push origin master

--- a/packaging/homebrew/bump-formula.sh
+++ b/packaging/homebrew/bump-formula.sh
@@ -33,6 +33,10 @@ if [ -z "$VERSION" ] || [ -z "$SHA256" ]; then
 fi
 VERSION="${VERSION#v}"
 
+if ! printf '%s' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+  echo "version must be X.Y.Z (got ${VERSION})" >&2
+  exit 2
+fi
 if ! printf '%s' "$SHA256" | grep -Eq '^[0-9a-f]{64}$'; then
   echo "sha256 must be 64 lowercase hex characters" >&2
   exit 2
@@ -57,21 +61,15 @@ path = pathlib.Path(sys.argv[1])
 url = sys.argv[2]
 sha256 = sys.argv[3]
 text = path.read_text()
-text, n_url = re.subn(
-    r'url "https://github.com/dolthub/doltlite/releases/download/v[^"]+"',
-    f'url "{url}"',
-    text,
-    count=1,
-)
-text, n_sha = re.subn(
-    r'sha256 "[0-9a-fA-F]+"',
-    f'sha256 "{sha256}"',
-    text,
-    count=1,
-)
+url_pat = r'url "https://github.com/dolthub/doltlite/releases/download/v[^"]+"'
+sha_pat = r'sha256 "[0-9a-fA-F]+"'
+n_url = len(re.findall(url_pat, text))
+n_sha = len(re.findall(sha_pat, text))
 if n_url != 1 or n_sha != 1:
     raise SystemExit(
-        f"expected one url and one sha256 to rewrite, got url={n_url} sha256={n_sha}"
+        f"expected exactly one url and one sha256, got url={n_url} sha256={n_sha}"
     )
+text = re.sub(url_pat, f'url "{url}"', text, count=1)
+text = re.sub(sha_pat, f'sha256 "{sha256}"', text, count=1)
 path.write_text(text)
 PY

--- a/packaging/homebrew/bump-formula.sh
+++ b/packaging/homebrew/bump-formula.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Rewrite url and sha256 in the Homebrew formula for a doltlite release.
+# Usage: bump-formula.sh [--file PATH] VERSION SHA256
+
+set -euo pipefail
+
+FORMULA=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --file)
+      FORMULA="${2:?}"
+      shift 2
+      ;;
+    --)
+      shift
+      break
+      ;;
+    -*)
+      echo "usage: bump-formula.sh [--file PATH] VERSION SHA256" >&2
+      exit 2
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
+VERSION="${1:-}"
+SHA256="${2:-}"
+if [ -z "$VERSION" ] || [ -z "$SHA256" ]; then
+  echo "usage: bump-formula.sh [--file PATH] VERSION SHA256" >&2
+  exit 2
+fi
+VERSION="${VERSION#v}"
+
+if ! printf '%s' "$SHA256" | grep -Eq '^[0-9a-f]{64}$'; then
+  echo "sha256 must be 64 lowercase hex characters" >&2
+  exit 2
+fi
+
+if [ -z "$FORMULA" ]; then
+  FORMULA="$(cd "$(dirname "$0")" && pwd)/doltlite.rb"
+fi
+if [ ! -f "$FORMULA" ]; then
+  echo "formula not found: $FORMULA" >&2
+  exit 1
+fi
+
+URL="https://github.com/dolthub/doltlite/releases/download/v${VERSION}/doltlite-autoconf-${VERSION}.tar.gz"
+
+python3 - "$FORMULA" "$URL" "$SHA256" <<'PY'
+import pathlib
+import re
+import sys
+
+path = pathlib.Path(sys.argv[1])
+url = sys.argv[2]
+sha256 = sys.argv[3]
+text = path.read_text()
+text, n_url = re.subn(
+    r'url "https://github.com/dolthub/doltlite/releases/download/v[^"]+"',
+    f'url "{url}"',
+    text,
+    count=1,
+)
+text, n_sha = re.subn(
+    r'sha256 "[0-9a-fA-F]+"',
+    f'sha256 "{sha256}"',
+    text,
+    count=1,
+)
+if n_url != 1 or n_sha != 1:
+    raise SystemExit(
+        f"expected one url and one sha256 to rewrite, got url={n_url} sha256={n_sha}"
+    )
+path.write_text(text)
+PY

--- a/packaging/homebrew/doltlite.rb
+++ b/packaging/homebrew/doltlite.rb
@@ -1,13 +1,20 @@
 # Homebrew formula for doltlite. Held in this repo as the source-of-truth
 # copy until the project clears homebrew-core's notability threshold for
 # new third-party submissions (≥30 forks, ≥30 watchers, ≥75 stars).
+# release.yml rewrites url/sha256 on each tag so this tracks the latest
+# release rather than a pinned pre-freeze tarball.
 class Doltlite < Formula
   desc "SQLite fork with Git-style version control via prolly trees"
   homepage "https://github.com/dolthub/doltlite"
-  url "https://github.com/dolthub/doltlite/releases/download/v0.10.6/doltlite-autoconf-0.10.6.tar.gz"
-  sha256 "816ecedc369dd61fd06a0759985d5fbfbdf9fadcd1096cc1c35cc7f09447e7c3"
+  url "https://github.com/dolthub/doltlite/releases/download/v0.50.2/doltlite-autoconf-0.50.2.tar.gz"
+  sha256 "186742c40a2cc72183b6e626232d84d8f1223b1212be0e974de47d9374fb1b1e"
   license "Apache-2.0"
   head "https://github.com/dolthub/doltlite.git", branch: "master"
+
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
 
   uses_from_macos "zlib"
 

--- a/test/homebrew_formula_test.sh
+++ b/test/homebrew_formula_test.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# The in-repo Homebrew formula must not pin a pre-freeze tarball, and
+# bump-formula.sh must rewrite url/sha256 the way the release job does.
+. "$(dirname "$0")/lib/doltlite_test_common.sh"
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+FORMULA="$ROOT/packaging/homebrew/doltlite.rb"
+BUMP="$ROOT/packaging/homebrew/bump-formula.sh"
+RELEASE_YML="$ROOT/.github/workflows/release.yml"
+
+if [ ! -f "$FORMULA" ]; then
+  echo "FAIL: missing $FORMULA"
+  exit 1
+fi
+if [ ! -f "$BUMP" ]; then
+  echo "FAIL: missing $BUMP"
+  exit 1
+fi
+
+formula_url() {
+  grep -E '^[[:space:]]*url "' "$1" | head -1
+}
+
+if grep -q 'v0\.10\.6' "$FORMULA"; then
+  dltest_fail "formula_not_pre_freeze_0_10_6" "  formula still pins v0.10.6"
+else
+  dltest_pass
+fi
+
+if echo "$(formula_url "$FORMULA")" | grep -Eq 'doltlite-autoconf-[0-9]+\.[0-9]+\.[0-9]+\.tar\.gz'; then
+  dltest_pass
+else
+  dltest_fail "formula_url_is_autoconf_tarball" "  $(formula_url "$FORMULA")"
+fi
+
+url_ver=$(formula_url "$FORMULA" | sed -n 's|.*/v\([^/]*\)/doltlite-autoconf-.*|\1|p')
+tarball_ver=$(formula_url "$FORMULA" | sed -n 's|.*/doltlite-autoconf-\([^"]*\)\.tar\.gz.*|\1|p')
+if [ -n "$url_ver" ] && [ "$url_ver" = "$tarball_ver" ]; then
+  dltest_pass
+else
+  dltest_fail "formula_url_version_matches_tarball" "  url=$url_ver tarball=$tarball_ver"
+fi
+
+if grep -q 'release-homebrew:' "$RELEASE_YML" \
+   && grep -q 'packaging/homebrew/bump-formula.sh' "$RELEASE_YML"; then
+  dltest_pass
+else
+  dltest_fail "release_yml_has_homebrew_bump" "  missing release-homebrew job or bump-formula.sh"
+fi
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/doltlite-homebrew.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+cp "$FORMULA" "$TMP/doltlite.rb"
+if bash "$BUMP" --file "$TMP/doltlite.rb" 9.9.9 \
+     "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" \
+   && formula_url "$TMP/doltlite.rb" | grep -q 'v9.9.9/doltlite-autoconf-9.9.9.tar.gz' \
+   && grep -q 'sha256 "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"' \
+        "$TMP/doltlite.rb"; then
+  dltest_pass
+else
+  dltest_fail "bump_formula_rewrites_url_and_sha256" "  $(formula_url "$TMP/doltlite.rb")"
+fi
+
+if bash "$BUMP" --file "$TMP/doltlite.rb" 1.0.0 not-a-hash >/dev/null 2>&1; then
+  dltest_fail "bump_formula_rejects_bad_sha256" "  accepted a non-hex sha256"
+else
+  dltest_pass
+fi
+
+dltest_finish

--- a/test/homebrew_formula_test.sh
+++ b/test/homebrew_formula_test.sh
@@ -67,4 +67,36 @@ else
   dltest_pass
 fi
 
+cp "$FORMULA" "$TMP/path.rb"
+cp "$TMP/path.rb" "$TMP/path-before.rb"
+if bash "$BUMP" --file "$TMP/path.rb" '9.9/../../evil' \
+     "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" \
+     >/dev/null 2>&1; then
+  dltest_fail "bump_formula_rejects_path_version" "  accepted a path-like version"
+elif ! cmp -s "$TMP/path.rb" "$TMP/path-before.rb"; then
+  dltest_fail "bump_formula_rejects_path_version" "  mutated the formula on invalid version"
+else
+  dltest_pass
+fi
+
+cp "$FORMULA" "$TMP/dup.rb"
+grep -E '^[[:space:]]*url "' "$TMP/dup.rb" | head -1 >> "$TMP/dup.rb"
+cp "$TMP/dup.rb" "$TMP/dup-before.rb"
+if bash "$BUMP" --file "$TMP/dup.rb" 9.9.9 \
+     "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" \
+     >/dev/null 2>&1; then
+  dltest_fail "bump_formula_rejects_duplicate_url" "  rewrote a formula with two urls"
+elif ! cmp -s "$TMP/dup.rb" "$TMP/dup-before.rb"; then
+  dltest_fail "bump_formula_rejects_duplicate_url" "  mutated the formula before rejecting"
+else
+  dltest_pass
+fi
+
+if grep -E 'tar czf doltlite-autoconf' -A6 "$RELEASE_YML" | grep -q 'doltlite.mk'; then
+  dltest_pass
+else
+  dltest_fail "autoconf_tarball_includes_doltlite_mk" \
+    "  release.yml tarball file list is missing doltlite.mk"
+fi
+
 dltest_finish

--- a/test/lib/doltlite_suite_manifest.sh
+++ b/test/lib/doltlite_suite_manifest.sh
@@ -4,6 +4,7 @@ doltlite_all_suites() {
   cat <<'EOF'
 build_artifacts_guard_test.sh
 install_sh_layout_test.sh
+homebrew_formula_test.sh
 sqlite_compatibility_contract_test.sh
 concurrency_contract_test.sh
 storage_format_contract_test.sh


### PR DESCRIPTION
Fixes #2542.

`packaging/homebrew/doltlite.rb` pinned `v0.10.6`, which predates the beta format freeze. Homebrew-core will not accept the formula until notability, but this in-repo copy is the source of truth and was shipping a stale engine to anyone who used it.

The formula now points at the `v0.50.2` autoconf tarball. `packaging/homebrew/bump-formula.sh` rewrites `url`/`sha256`. A `release-homebrew` job runs after the GitHub release has the tarball, hashes it, and pushes the bump to `master`.

`test/homebrew_formula_test.sh` rejects a `v0.10.6` pin, checks url/tarball versions agree, and exercises the bump script.

Co-Authored-By: Grok 4.6 <noreply@x.ai>