### PR TITLE
Ship the license and the real version in the doltlite crate

### DIFF
--- a/packaging/rust/Cargo.toml
+++ b/packaging/rust/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/dolthub/doltlite"
 keywords = ["doltlite", "dolt", "sqlite", "database", "version-control"]
 categories = ["database", "database-implementations"]
 readme = "README.md"
-include = ["src/**", "build.rs", "vendor/doltlite.c", "vendor/doltlite.h", "README.md", "Cargo.toml"]
+include = ["src/**", "build.rs", "vendor/doltlite.c", "vendor/doltlite.h", "README.md", "LICENSE.md", "Cargo.toml"]
 
 [build-dependencies]
 cc = "1.0"

--- a/packaging/rust/build.rs
+++ b/packaging/rust/build.rs
@@ -2,10 +2,18 @@ fn main() {
     println!("cargo:rerun-if-changed=vendor/doltlite.c");
     println!("cargo:rerun-if-changed=vendor/doltlite.h");
 
+    // assemble.sh stamps the crate version from the release tag, so it is also
+    // the engine version; unset, the amalgamation falls back to a placeholder.
+    let version = format!(
+        "\"v{}\"",
+        std::env::var("CARGO_PKG_VERSION").expect("cargo sets CARGO_PKG_VERSION")
+    );
+
     let mut build = cc::Build::new();
     build
         .file("vendor/doltlite.c")
         .flag_if_supported("-w")
+        .define("DOLTLITE_VERSION", version.as_str())
         .define("DOLTLITE_PROLLY", "1")
         .define("SQLITE_THREADSAFE", "1")
         .define("SQLITE_ENABLE_MATH_FUNCTIONS", None)

--- a/packaging/rust/smoke-test/src/main.rs
+++ b/packaging/rust/smoke-test/src/main.rs
@@ -148,6 +148,16 @@ fn main() -> std::process::ExitCode {
             })
             .unwrap_or_default()
     };
+    let engine_version = scalar("SELECT dolt_version()");
+    check(
+        "dolt_version is stamped, not the amalgamation placeholder",
+        (engine_version.starts_with('v') && engine_version != "doltlite-amalgamation").to_string(),
+        "true".into(),
+    );
+    if let Ok(want) = std::env::var("DOLTLITE_EXPECT_VERSION") {
+        check("dolt_version matches the crate version", engine_version, want);
+    }
+
     check("dolt_branch", scalar("SELECT dolt_branch('feature')"), "0".into());
     check(
         "dolt_checkout feature",

--- a/packaging/rust/test-package.sh
+++ b/packaging/rust/test-package.sh
@@ -31,6 +31,10 @@ tar -xzf "$TARBALL" -C "$STAGE/extracted"
 EXTRACTED="$STAGE/extracted/doltlite-0.0.0"
 [ -f "$EXTRACTED/vendor/doltlite.c" ] || {
   echo "ERROR: packaged crate has no vendored amalgamation" >&2; exit 1; }
+# The vendored amalgamation carries mbedtls/ed25519/BLAKE3, whose notices live
+# in LICENSE.md.
+[ -f "$EXTRACTED/LICENSE.md" ] || {
+  echo "ERROR: packaged crate has no LICENSE.md" >&2; exit 1; }
 
 cp -R "$PKG_DIR/smoke-test/." "$CONSUMER/"
 # Point the consumer at the extracted package rather than crates.io.
@@ -38,4 +42,4 @@ sed -i.bak "s|^doltlite = .*|doltlite = { path = \"$EXTRACTED\" }|" \
   "$CONSUMER/Cargo.toml"
 rm -f "$CONSUMER/Cargo.toml.bak"
 cd "$CONSUMER"
-cargo run --release --quiet
+DOLTLITE_EXPECT_VERSION="v0.0.0" cargo run --release --quiet


### PR DESCRIPTION
Fixes #2543.

Two defects in the published `doltlite` crate, both confirmed against the live crates.io 0.50.2 artifact.

**No license text.** `assemble.sh` stages `LICENSE.md` into the crate, but `Cargo.toml`'s `include` list omitted it, and `license = "Apache-2.0"` is an SPDX expression rather than `license-file`, so cargo excluded it from the package. The vendored amalgamation embeds mbedtls, ed25519 and BLAKE3, whose notices live in that file. Adding `LICENSE.md` to `include` ships it.

**No engine version.** `DOLTLITE_VERSION` reaches ordinary builds as a `-D` flag from `doltlite.mk` and is never baked into the amalgamation text, so the crate compiled against the `#ifndef` fallback and `dolt_version()` answered `"doltlite-amalgamation"`. `build.rs` now defines it from `CARGO_PKG_VERSION`, which `assemble.sh` stamps from the release tag — so the crate reports the same string as the tag it was published from.

## Evidence

`test-package.sh` gains both assertions — it packages the crate exactly as `cargo publish` would, extracts that tarball, and builds the smoke test against the extracted copy:

- the extracted package must contain `LICENSE.md`
- `dolt_version()` must be stamped (not the placeholder), and must equal the crate version

Fail-before / pass-after, run locally against a freshly regenerated amalgamation:

| state | result |
|---|---|
| both fixes reverted | `ERROR: packaged crate has no LICENSE.md` |
| license fixed, version reverted | `FAIL: dolt_version is stamped...` + `FAIL: dolt_version matches the crate version` |
| both applied | 21/21 PASS |

Also verified the real-release path rather than only the `0.0.0` staging version: assembling at `0.50.2` produces a tarball containing `LICENSE.md`, and `dolt_version()` returns exactly `v0.50.2`. Run under cargo 1.68.1, which is the crate's declared MSRV.

🤖 Generated with [Claude Code](https://claude.com/claude-code)