### PR TITLE
Correct rusqlite source build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ functions, subject to the [storage-engine exceptions](#sqlite-compatibility).
 | Node.js / Bun | `npm install @dolthub/doltlite` | [dolthub/doltlite-node](https://github.com/dolthub/doltlite-node) |
 | PHP | `composer require dolthub/doltlite-php` | this repo ([`packaging/composer`](packaging/composer)), distributed via [dolthub/doltlite-php](https://github.com/dolthub/doltlite-php) |
 | .NET | `dotnet add package DoltHub.Doltlite` | this repo ([`packaging/nuget`](packaging/nuget)); works under Microsoft.Data.Sqlite.Core, EF Core, Dapper |
-| Rust | `cargo add doltlite` | this repo ([`packaging/rust`](packaging/rust)); engine vendored, or point `rusqlite` at a build with `SQLITE3_LIB_DIR` |
+| Rust | `cargo add doltlite` | this repo ([`packaging/rust`](packaging/rust)); engine vendored, or run the full default build and point `rusqlite` at it with `SQLITE3_LIB_DIR` |
 | Browser / WASM | `npm install @dolthub/doltlite-wasm` | this repo ([`packaging/npm`](packaging/npm), built from [`ext/wasm`](ext/wasm)) |
 | Swift (iOS / macOS) | SwiftPM: `https://github.com/dolthub/doltlite-swift` | [dolthub/doltlite-swift](https://github.com/dolthub/doltlite-swift) (XCFramework built by [`packaging/swift`](packaging/swift)) |
 | Android | Gradle: `com.dolthub:doltlite-android` | [dolthub/doltlite-android](https://github.com/dolthub/doltlite-android) (AAR + JNA) |

--- a/doc/doltlite/using-existing-sqlite-bindings.md
+++ b/doc/doltlite/using-existing-sqlite-bindings.md
@@ -20,16 +20,19 @@ needs none of this. This document is for everything else.
 
 A DoltLite shared library, from a
 [release](https://github.com/dolthub/doltlite/releases) (`doltlite-lib-*.zip`,
-or the `.deb` packages) or built from source:
+or the `.deb` packages) or built from source. Bindings that require the
+library to be named `libsqlite3` need the full source build:
 
 ```sh
-cd build && ../configure && make doltlite-lib
+cd build && ../configure && make
 # → libdoltlite.{so,dylib}, libdoltlite.a, and SQLite-named copies
 #   (libsqlite3.*) of the same engine
 ```
 
-The SQLite-named artifacts exist precisely for this: bindings that hardcode
-`-lsqlite3` link them without knowing the difference.
+The full `make` target creates the SQLite-named artifacts so bindings that
+hardcode `-lsqlite3` can link them without knowing the difference.
+`make doltlite-lib` creates only the DoltLite-named libraries, and release
+packages omit the aliases to avoid colliding with system SQLite.
 
 ## Confirming you got DoltLite
 

--- a/packaging/rust/README.md
+++ b/packaging/rust/README.md
@@ -49,9 +49,14 @@ learn. See the [DoltLite documentation](https://github.com/dolthub/doltlite).
 
 If you would rather use [`rusqlite`](https://crates.io/crates/rusqlite) and its
 ecosystem, you do not need this crate: point `libsqlite3-sys` at a DoltLite
-build, which installs SQLite-named artifacts for exactly this purpose.
+source build. The full default build creates the SQLite-named artifacts that
+`libsqlite3-sys` expects; `make doltlite-lib` alone does not.
 
 ```sh
+cd /path/to/doltlite/build
+../configure
+make
+cd /path/to/rust/project
 SQLITE3_LIB_DIR=/path/to/doltlite/build \
 SQLITE3_INCLUDE_DIR=/path/to/doltlite/build \
 cargo build


### PR DESCRIPTION
Closes #2544

Document that bindings which link libsqlite3 require the full default source build. Clarify that make doltlite-lib only creates DoltLite-named libraries and that release packages intentionally omit SQLite-named aliases. Update the rusqlite recipe and bindings table consistently.

Tests: docs-only change; git diff --check

Co-Authored-By: OpenAI Codex <noreply@openai.com>