### PR TITLE
Pair catalog rows to entries by identity, not number alone

### DIFF
--- a/src/prolly_btree_catalog.c
+++ b/src/prolly_btree_catalog.c
@@ -1362,10 +1362,13 @@ static int doltliteSerializeCatalogEntriesForBtreeImpl(
       iTblPg = schemaCatalogTableOldPg(aRows, nRows, aRows[i].zTblName);
       if( !iTblPg || aRows[i].oldPg==iTblPg ) continue;
       for(j=0; j<nTables; j++){
-        if( aTables[j].iTable==aRows[i].oldPg ){
-          bPhys = 1;
-          break;
-        }
+        if( aTables[j].iTable!=aRows[i].oldPg ) continue;
+        /* Only an unnamed entry can be this index's own; a named one claiming
+        ** the number belongs to another domain, not proof of a physical
+        ** index. Live entry names may be stale after RENAME. */
+        if( aTables!=pBtree->cat.a && aTables[j].zName ) continue;
+        bPhys = 1;
+        break;
       }
       if( !bPhys ) aRows[i].oldPg = iTblPg;
     }
@@ -1446,11 +1449,19 @@ static int doltliteSerializeCatalogEntriesForBtreeImpl(
                                         aRows[i].zSql, &nRec);
       }
       if( !schemaCatalogRowIsClusteredPrimaryKey(aRows, nRows, i) ){
+        int bLiveCatalog = (aTables==pBtree->cat.a);
         for(j=0; j<nTables; j++){
-          if( aTables[j].iTable==aRows[i].oldPg ){
-            aTables[j].schemaHash = h;
-            break;
+          if( aTables[j].iTable!=aRows[i].oldPg ) continue;
+          /* Constructed catalogs mix numbering domains, so a number match
+          ** alone can land on a different object; an index row carrying a
+          ** stale number would then zero a table's schema hash. Live names
+          ** may be stale after RENAME, so only names are checked here. */
+          if( !bLiveCatalog && aTables[j].zName && aRows[i].zName
+           && strcmp(aTables[j].zName, aRows[i].zName)!=0 ){
+            continue;
           }
+          aTables[j].schemaHash = h;
+          break;
         }
       }
       if( !pRec ){


### PR DESCRIPTION
Follow-up to #2548, which fixed the phantom-status half of #2535. This fixes the residual I found re-verifying that issue ([details](https://github.com/dolthub/doltlite/issues/2535#issuecomment-5502813249)).

## Symptom

After #2548, `dolt_status` correctly reports a dropped ignored table as **unstaged** — matching Dolt exactly — but `dolt_add('-A')` still wrote the deletion into the staged catalog, so the next `dolt_commit` committed the drop. Dolt refuses that commit. The two sources of truth disagreed, and the original user-visible complaint (an ignored table's drop reaching history without `-f`) still happened.

```
                                    before              after            Dolt 2.3.1
dolt_status after -A                ig_one|0|deleted    same             ig_one|0|deleted
dolt_diff_summary('HEAD','STAGED')  ig_one modified     (empty)          --
dolt_commit('-m','x')               <hash>              nothing to commit   nothing to commit
```

## Root cause

Serializing a *constructed* catalog paired schema rows to entries on the entry number alone. Numbers are canonical-by-sorted-name, and constructed arrays mix staged/working/HEAD domains, so one number can name a different object in each. Two pairings landed on the wrong object:

1. **Schema-hash writeback** stamped whichever entry held the row's number. Autoindex rows carry no SQL, so their hash is zero — a stale number let one zero an unrelated table's schema hash. Caught in the act:

   ```
   row(index:sqlite_autoindex_tracked_1 oldPg=3) -> entry(ig_one pg=3) hash=ZERO
   ```

2. **Autoindex normalization** treated *any* entry holding the number as proof of a physical index and skipped folding the index onto its table. Index entries are unnamed, so a named entry is never that proof; a clustered PK's autoindex took `newPg=5` instead of sharing its table's `4`, changing the master root.

Each left a staged catalog that no longer matched HEAD byte-for-byte despite describing the same schema — and the commit's empty check compares catalog hashes (`doltlite_commit_cmd.c:823`).

The fix pairs on identity instead: only an unnamed entry can own an index row, and a row never stamps an entry named for something else. Live catalogs keep matching on number, where names legitimately go stale across RENAME — the same `bLiveCatalog` distinction the entry→row pairing 90 lines below already makes.

## Verification

Diagnosed by dumping and decoding the serialized catalog blobs and hashing every emitted record; after the fix all five records and the master root match HEAD exactly.

- The #2535 repro now ends in `nothing to commit`, matching Dolt 2.3.1 step for step.
- `dolt_add('-A','-f')` still stages the deletion and commits it (override preserved).
- `test/run_doltlite_tests.sh`: **125/125 suites, 172/172 guards**.
- `test/vc_oracle_add_test.sh` vs Dolt 2.3.1: **45/45**.

No test added here — flagging for CI per request.

**One pre-existing failure, not from this change:** `doltlite_ignore.sh` / `force_add_all_stages_dropped_ignored_table` fails with ``unknown option `-f` ``. I confirmed it reproduces identically on unmodified master in the same rig (stashed this diff, rebuilt, re-ran), and the same suite passes inside `run_doltlite_tests.sh`, so it looks like a standalone-invocation issue in the suite rather than an engine bug. Worth a look separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)