### PR TITLE
Harden random-kill crash recovery assertions

### DIFF
--- a/test/crash_recovery_test.c
+++ b/test/crash_recovery_test.c
@@ -492,7 +492,12 @@ static void test_07_five_commits_random_kill(void){
 
       if( nLog>0 ){
         int nRows = queryScalarInt(db, "SELECT count(*) FROM t", -1);
-        check("test_07: row count matches commit count", nRows==nLog);
+        int nHeadRows = queryScalarInt(db,
+          "SELECT count(*) FROM dolt_at_t('HEAD')", -1);
+        check("test_07: committed row count matches commit count",
+              nHeadRows==nLog);
+        check("test_07: working rows match commits or next insert",
+              nRows==nLog || (nLog<5 && nRows==nLog+1));
       }
     }
     sqlite3_close(db);


### PR DESCRIPTION
The randomized crash-recovery test can kill after an autocommitted INSERT but before its following dolt_commit. In that valid state, the durable working set has one more row than the user commit count. This is the same race already handled by tests 10 and 28.

Accept that bounded working-set state in test 07 while separately asserting that the committed HEAD snapshot contains exactly one row per durable user commit. This keeps the durability check strict and prevents the CI flake observed on PR #2565.

Tests:
- crash_recovery_test (124/124, twice)
- warning-free rebuild with -Werror
- git diff --check

Co-Authored-By: OpenAI Codex <noreply@openai.com>