### PR TITLE
Split the slow feature-interaction oracle shard

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -190,6 +190,7 @@ jobs:
           - refs-workspace
           - diff-history-data
           - merge-replay-schema
+          - feature-interaction
           - remotes-recovery
           - sql
 

--- a/test/oracle-buckets/feature-interaction.txt
+++ b/test/oracle-buckets/feature-interaction.txt
@@ -1,0 +1,1 @@
+vc_oracle_feature_interaction_test.sh

--- a/test/oracle-buckets/remotes-recovery.txt
+++ b/test/oracle-buckets/remotes-recovery.txt
@@ -1,5 +1,4 @@
 vc_oracle_error_recovery_test.sh
-vc_oracle_feature_interaction_test.sh
 vc_oracle_fetch_pull_convergence_test.sh
 vc_oracle_model_test.sh
 vc_oracle_push_default_branch_test.sh


### PR DESCRIPTION
The remotes/recovery oracle job on PR #2565 timed out after 18 minutes despite every completed suite passing. Its feature-interaction suite consumed roughly 12 minutes under coverage, leaving too little time for the remaining six suites.

Move feature interaction into its own parallel oracle bucket. This preserves every test and keeps both resulting jobs comfortably within the existing timeout instead of weakening the timeout guard.

Tests:
- check_oracle_buckets.sh
- workflow YAML/matrix parse
- git diff --check

Co-Authored-By: OpenAI Codex <noreply@openai.com>