### PR TITLE
Rebuild WASM library after source changes

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -829,6 +829,7 @@ jobs:
           make doltlite
           cd ..
           make -C ext/wasm fiddle npm
+          bash test/wasm_incremental_build_test.sh
           mkdir -p ci-wasm-runtime
           cp -a ext/wasm/jswasm/. ci-wasm-runtime/
           make -C ext/wasm dist

--- a/ext/wasm/GNUmakefile
+++ b/ext/wasm/GNUmakefile
@@ -1228,12 +1228,13 @@ sqlite3-wasm.c.in += $(doltlite.wasm.lib)
 endif
 
 ifeq (1,$(DOLTLITE_WASM))
-$(dir.doltlite.build)/Makefile: $(dir.top)/Makefile
+.PHONY: doltlite.wasm.sync
+doltlite.wasm.sync:
 	@mkdir -p $(dir.doltlite.build)
-	@cp $(dir.top)/Makefile $(dir.doltlite.build)/Makefile
-	@find $(dir.top) -maxdepth 1 \( -name '*.h' -o -name '*.c' \) -exec cp {} $(dir.doltlite.build) \;
+	@cp -f -p $(dir.top)/Makefile $(dir.doltlite.build)/Makefile
+	@find $(dir.top) -maxdepth 1 \( -name '*.h' -o -name '*.c' \) -exec cp -f -p {} $(dir.doltlite.build) \;
 
-$(doltlite.wasm.lib): $(dir.doltlite.build)/Makefile
+$(doltlite.wasm.lib): doltlite.wasm.sync
 	@echo "[$(emo.tool) doltlite] building wasm libdoltlite.a"
 	@$(MAKE) -C $(dir.doltlite.build) libdoltlite.a \
 		CC='$(bin.emcc)' AR=emar \
@@ -1279,6 +1280,10 @@ $(bin.mkwb): $(bin.mkwb).c $(MAKEFILE)
 -include .wasmbuilds.make
 endif
 CLEAN_FILES += .wasmbuilds.make $(bin.mkwb)
+
+ifeq (1,$(DOLTLITE_WASM))
+$(dir.dout)/sqlite3-node.mjs: $(dir.dout)/sqlite3.wasm
+endif
 
 #
 # $(sqlite3.ext.js) = API-related files which are standalone

--- a/test/wasm_incremental_build_test.sh
+++ b/test/wasm_incremental_build_test.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source_file="$repo_dir/src/prolly_xxhash.c"
+header_file="$repo_dir/sqlite3.h"
+object_file="$repo_dir/ext/wasm/bld/doltlite-build/prolly_xxhash.o"
+library_file="$repo_dir/ext/wasm/bld/doltlite-build/libdoltlite.a"
+wasm_file="$repo_dir/ext/wasm/jswasm/sqlite3.wasm"
+copied_header="$repo_dir/ext/wasm/bld/doltlite-build/sqlite3.h"
+tmp="$(mktemp -d "${TMPDIR:-/tmp}/doltlite-wasm-incremental.XXXXXX")"
+cleanup() {
+  if [ -f "$tmp/source.timestamp" ]; then
+    touch -r "$tmp/source.timestamp" "$source_file"
+  fi
+  if [ -f "$tmp/header.timestamp" ]; then
+    touch -r "$tmp/header.timestamp" "$header_file"
+  fi
+  if [ -f "$tmp/copied-header.timestamp" ]; then
+    touch -r "$tmp/copied-header.timestamp" "$copied_header"
+  fi
+  rm -rf "$tmp"
+}
+trap cleanup EXIT
+
+for artifact in "$object_file" "$library_file" "$wasm_file" "$copied_header"; do
+  if [ ! -f "$artifact" ]; then
+    echo "FAIL: missing initial WASM artifact: $artifact"
+    exit 1
+  fi
+done
+
+touch -r "$source_file" "$tmp/source.timestamp"
+touch -r "$header_file" "$tmp/header.timestamp"
+touch -r "$copied_header" "$tmp/copied-header.timestamp"
+touch -r "$object_file" "$tmp/object.timestamp"
+touch -r "$library_file" "$tmp/library.timestamp"
+touch -r "$wasm_file" "$tmp/wasm.timestamp"
+
+sleep 1
+touch "$header_file"
+make -C "$repo_dir/ext/wasm" doltlite.wasm.sync
+if [ ! "$copied_header" -nt "$tmp/copied-header.timestamp" ]; then
+  echo "FAIL: updated WASM build header was not copied"
+  exit 1
+fi
+touch -r "$tmp/header.timestamp" "$header_file"
+touch -r "$tmp/copied-header.timestamp" "$copied_header"
+
+sleep 1
+touch "$source_file"
+
+make -C "$repo_dir/ext/wasm" emcc_opt=-Oz jswasm/sqlite3-node.mjs
+
+if [ ! "$object_file" -nt "$tmp/object.timestamp" ]; then
+  echo "FAIL: WASM object was not rebuilt after its source changed"
+  exit 1
+fi
+if [ ! "$library_file" -nt "$tmp/library.timestamp" ]; then
+  echo "FAIL: WASM libdoltlite.a was not rebuilt after its source changed"
+  exit 1
+fi
+if [ ! "$wasm_file" -nt "$tmp/wasm.timestamp" ]; then
+  echo "FAIL: Node entry point's WASM binary was not rebuilt after its source changed"
+  exit 1
+fi
+
+echo "WASM incremental rebuild test passed"


### PR DESCRIPTION
Make the outer WASM build always invoke the nested DoltLite make dependency graph, which remains a no-op when its inputs are unchanged. Also make the published Node entry point depend on its canonical `sqlite3.wasm` partner so an incremental build cannot pair outputs from different builds.

Add a CI regression that touches a DoltLite C source and verifies the object, archive, and Node entry point's WASM binary all rebuild.

Validation:
- fail-before reproduction left `prolly_xxhash.o` and `libdoltlite.a` unchanged
- incremental rebuild regression passes
- WASM smoke, write E2E, and native export roundtrip tests pass

Fixes #2574

Co-Authored-By: OpenAI Codex <noreply@openai.com>