### PR TITLE
Name the Go driver doltlite-driver and make it pool-safe

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -220,6 +220,13 @@ jobs:
         bash packaging/composer/test-package.sh build
       timeout-minutes: 5
 
+    - name: Set up Go
+      if: matrix.platform != 'windows'
+      uses: actions/setup-go@v5
+      with:
+        go-version: '1.23'
+        cache: false
+
     - name: Smoke test the doltlite-driver module
       if: matrix.platform != 'windows'
       shell: bash

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -220,7 +220,7 @@ jobs:
         bash packaging/composer/test-package.sh build
       timeout-minutes: 5
 
-    - name: Smoke test the doltlite-go module
+    - name: Smoke test the doltlite-driver module
       if: matrix.platform != 'windows'
       shell: bash
       run: |

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -220,6 +220,14 @@ jobs:
         bash packaging/composer/test-package.sh build
       timeout-minutes: 5
 
+    - name: Smoke test the doltlite-go module
+      if: matrix.platform != 'windows'
+      shell: bash
+      run: |
+        chmod +x packaging/go/assemble.sh packaging/go/test-package.sh
+        bash packaging/go/test-package.sh build
+      timeout-minutes: 20
+
     - name: Smoke test the doltlite Rust crate
       if: matrix.platform != 'windows'
       shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -801,6 +801,73 @@ jobs:
         git tag "${VERSION}"
         git push origin "${VERSION}"
 
+  # ── Publish the Go module ────────────────────────────────
+  # Go resolves modules from a VCS path and takes the version from a repo tag,
+  # so publishing means pushing the staged module and a matching tag into
+  # dolthub/doltlite-driver. The module vendors the amalgamation, so the tag
+  # tracks this engine release. Named -driver, not -go: dolthub/doltlite-go is
+  # a different, pure-Go library for the sync protocol.
+  release-go:
+    if: github.event_name != 'workflow_dispatch'
+    needs: release
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN }}
+      VERSION: ${{ github.ref_name }}
+    steps:
+    - name: Check release bot token
+      run: |
+        if [ -z "${GH_TOKEN}" ]; then
+          echo "RELEASE_BOT_TOKEN is required to push commits and tags to doltlite-driver"
+          exit 1
+        fi
+        gh auth status
+        gh auth setup-git
+
+    - uses: actions/checkout@v4
+
+    - name: Install dependencies
+      run: bash .github/scripts/install-apt-deps.sh build-essential zlib1g-dev tcl
+
+    - name: Configure git identity
+      run: |
+        git config --global user.name "DoltHub Release Bot"
+        git config --global user.email "releases@dolthub.com"
+
+    - name: Build the amalgamation
+      run: |
+        mkdir -p build && cd build
+        ../configure
+        make sqlite3.c sqlite3.h
+
+    - name: Release doltlite-driver
+      run: |
+        set -euo pipefail
+        version="${VERSION#v}"
+
+        if gh api "repos/dolthub/doltlite-driver/git/ref/tags/${VERSION}" >/dev/null 2>&1; then
+          echo "doltlite-driver ${VERSION} already exists; skipping"
+          exit 0
+        fi
+
+        stage="$(mktemp -d)"
+        bash packaging/go/assemble.sh "$version" "$stage/pkg" build
+
+        gh repo clone dolthub/doltlite-driver "$stage/doltlite-driver"
+        cd "$stage/doltlite-driver"
+        git checkout main
+        find . -mindepth 1 -maxdepth 1 -not -name .git -exec rm -rf {} +
+        cp -R "$stage/pkg/." .
+        # assemble.sh leaves .version for the pushing side; the tag carries it.
+        rm -f .version
+        git add -A
+        if ! git diff --cached --quiet; then
+          git commit -m "doltlite ${VERSION}"
+          git push origin main
+        fi
+        git tag "${VERSION}"
+        git push origin "${VERSION}"
+
   # ── Publish the .NET NuGet package ───────────────────────
   # nuget.org takes uploaded artifacts, so there is no split repo: assemble
   # the package with every platform's native library extracted from this

--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,5 @@ state.json
 .compat-cache/
 packaging/rust/vendor/
 packaging/rust/target/
+packaging/go/doltlite.c
+packaging/go/doltlite.h

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ functions, subject to the [storage-engine exceptions](#sqlite-compatibility).
 | PHP | `composer require dolthub/doltlite-php` | this repo ([`packaging/composer`](packaging/composer)), distributed via [dolthub/doltlite-php](https://github.com/dolthub/doltlite-php) |
 | .NET | `dotnet add package DoltHub.Doltlite` | this repo ([`packaging/nuget`](packaging/nuget)); works under Microsoft.Data.Sqlite.Core, EF Core, Dapper |
 | Rust | `cargo add doltlite` | this repo ([`packaging/rust`](packaging/rust)); engine vendored, or run the full default build and point `rusqlite` at it with `SQLITE3_LIB_DIR` |
+| Go | `go get github.com/dolthub/doltlite-driver` | this repo ([`packaging/go`](packaging/go)), distributed via [dolthub/doltlite-driver](https://github.com/dolthub/doltlite-driver); `database/sql` driver, engine vendored |
 | Browser / WASM | `npm install @dolthub/doltlite-wasm` | this repo ([`packaging/npm`](packaging/npm), built from [`ext/wasm`](ext/wasm)) |
 | Swift (iOS / macOS) | SwiftPM: `https://github.com/dolthub/doltlite-swift` | [dolthub/doltlite-swift](https://github.com/dolthub/doltlite-swift) (XCFramework built by [`packaging/swift`](packaging/swift)) |
 | Android | Gradle: `com.dolthub:doltlite-android` | [dolthub/doltlite-android](https://github.com/dolthub/doltlite-android) (AAR + JNA) |

--- a/packaging/go/README.md
+++ b/packaging/go/README.md
@@ -1,0 +1,70 @@
+# doltlite-go
+
+[DoltLite](https://github.com/dolthub/doltlite) for Go: SQLite with Git-style
+version control — branch, commit, merge, and diff your relational data,
+exposed as a `database/sql` driver. The engine is compiled into the package
+from a vendored amalgamation, so there is no system library to install.
+
+## Install
+
+```sh
+go get github.com/dolthub/doltlite-go
+```
+
+Requires cgo (`CGO_ENABLED=1`, the default when a C compiler is present) and
+zlib. The first build compiles the engine and is then cached.
+
+## Use
+
+```go
+import (
+    "database/sql"
+    _ "github.com/dolthub/doltlite-go"
+)
+
+db, err := sql.Open("doltlite", "app.db")
+if err != nil { return err }
+defer db.Close()
+
+if _, err := db.Exec(`CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT)`); err != nil {
+    return err
+}
+if _, err := db.Exec(`INSERT INTO users(name) VALUES (?)`, "Ada"); err != nil {
+    return err
+}
+
+// Version control is plain SQL on the same connection.
+var commit string
+if err := db.QueryRow(`SELECT dolt_commit('-A', '-m', ?)`, "add ada").Scan(&commit); err != nil {
+    return err
+}
+
+rows, err := db.Query(`SELECT commit_hash, message FROM dolt_log`)
+```
+
+Every DoltLite feature — branches, merges, `dolt_log`/`dolt_diff`/`dolt_branches`,
+remotes — is reachable through SQL; there is no separate API. See the
+[DoltLite documentation](https://github.com/dolthub/doltlite).
+
+## Why not embedded Dolt?
+
+If you want versioned SQL in a new Go program, prefer
+[`github.com/dolthub/driver`](https://github.com/dolthub/driver): it embeds
+Dolt itself in pure Go, needs no cgo, and gives you the full Dolt feature set
+with MySQL dialect.
+
+Use this package when you specifically need **DoltLite databases** — a
+single-file chunk store that embedded Dolt cannot open — or SQLite dialect
+compatibility for an existing SQLite application, or a small C library rather
+than Dolt's dependency tree.
+
+## Platforms
+
+Linux and macOS. Windows is not supported yet: the build links the platform's
+zlib, which the MSVC toolchain does not provide.
+
+## Source
+
+The package source lives in
+[dolthub/doltlite](https://github.com/dolthub/doltlite) under `packaging/go/`;
+send issues and pull requests there.

--- a/packaging/go/README.md
+++ b/packaging/go/README.md
@@ -1,4 +1,4 @@
-# doltlite-go
+# doltlite-driver
 
 [DoltLite](https://github.com/dolthub/doltlite) for Go: SQLite with Git-style
 version control — branch, commit, merge, and diff your relational data,
@@ -8,7 +8,7 @@ from a vendored amalgamation, so there is no system library to install.
 ## Install
 
 ```sh
-go get github.com/dolthub/doltlite-go
+go get github.com/dolthub/doltlite-driver
 ```
 
 Requires cgo (`CGO_ENABLED=1`, the default when a C compiler is present) and
@@ -19,7 +19,7 @@ zlib. The first build compiles the engine and is then cached.
 ```go
 import (
     "database/sql"
-    _ "github.com/dolthub/doltlite-go"
+    _ "github.com/dolthub/doltlite-driver"
 )
 
 db, err := sql.Open("doltlite", "app.db")
@@ -45,6 +45,20 @@ rows, err := db.Query(`SELECT commit_hash, message FROM dolt_log`)
 Every DoltLite feature — branches, merges, `dolt_log`/`dolt_diff`/`dolt_branches`,
 remotes — is reachable through SQL; there is no separate API. See the
 [DoltLite documentation](https://github.com/dolthub/doltlite).
+
+## Concurrency
+
+Safe to use from multiple goroutines through `*sql.DB`, including its
+connection pool. Each connection runs its engine calls on a dedicated OS
+thread, because the engine ties a transaction's lock to the thread that took
+it and a goroutine can move between threads at any call boundary
+([#2577](https://github.com/dolthub/doltlite/issues/2577)).
+
+Writers to one database still serialize, as in SQLite. A connection waits up
+to five seconds for a contended write before returning "database is locked";
+change that per connection with `PRAGMA busy_timeout = <ms>`. Transactions
+begin as `BEGIN IMMEDIATE`, so contention surfaces at `Begin` where it can be
+waited on, rather than partway through a transaction where it cannot.
 
 ## Why not embedded Dolt?
 

--- a/packaging/go/assemble.sh
+++ b/packaging/go/assemble.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+#
+# Stage the doltlite-go module into an output directory ready to push to the
+# distribution repo. Copies this directory's module source and vendors the
+# amalgamation the build produced (build/sqlite3.c is genuinely doltlite --
+# mksqlite3c.tcl --doltlite weaves the prolly engine and version control into
+# it), which cgo compiles as part of the package.
+#
+# Usage: assemble.sh <version> <out_dir> <build_dir>
+#   version    release version without the leading "v" (e.g. 0.50.2)
+#   out_dir    directory to create and populate
+#   build_dir  build directory containing sqlite3.c and sqlite3.h
+
+set -euo pipefail
+
+VERSION="${1:?usage: assemble.sh <version> <out_dir> <build_dir>}"
+OUT_DIR="${2:?usage: assemble.sh <version> <out_dir> <build_dir>}"
+BUILD_DIR="${3:?usage: assemble.sh <version> <out_dir> <build_dir>}"
+
+PKG_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$PKG_DIR/../.." && pwd)"
+
+for f in sqlite3.c sqlite3.h; do
+  if [ ! -f "$BUILD_DIR/$f" ]; then
+    echo "ERROR: missing $BUILD_DIR/$f (did 'make sqlite3.c sqlite3.h' run?)" >&2
+    exit 1
+  fi
+done
+
+rm -rf "$OUT_DIR"
+mkdir -p "$OUT_DIR"
+
+cp "$PKG_DIR/doltlite.go" "$OUT_DIR/doltlite.go"
+cp "$PKG_DIR/go.mod"      "$OUT_DIR/go.mod"
+cp "$PKG_DIR/README.md"   "$OUT_DIR/README.md"
+cp "$ROOT/LICENSE.md"     "$OUT_DIR/LICENSE.md"
+cp "$BUILD_DIR/sqlite3.c" "$OUT_DIR/doltlite.c"
+cp "$BUILD_DIR/sqlite3.h" "$OUT_DIR/doltlite.h"
+
+# Go modules take their version from the repository tag, not from go.mod, so
+# there is nothing to stamp -- record it for the pushing side instead.
+echo "$VERSION" > "$OUT_DIR/.version"
+
+echo "Staged doltlite-go $VERSION in $OUT_DIR:"
+ls -la "$OUT_DIR"

--- a/packaging/go/assemble.sh
+++ b/packaging/go/assemble.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Stage the doltlite-go module into an output directory ready to push to the
+# Stage the doltlite-driver module into an output directory ready to push to the
 # distribution repo. Copies this directory's module source and vendors the
 # amalgamation the build produced (build/sqlite3.c is genuinely doltlite --
 # mksqlite3c.tcl --doltlite weaves the prolly engine and version control into
@@ -41,5 +41,5 @@ cp "$BUILD_DIR/sqlite3.h" "$OUT_DIR/doltlite.h"
 # there is nothing to stamp -- record it for the pushing side instead.
 echo "$VERSION" > "$OUT_DIR/.version"
 
-echo "Staged doltlite-go $VERSION in $OUT_DIR:"
+echo "Staged doltlite-driver $VERSION in $OUT_DIR:"
 ls -la "$OUT_DIR"

--- a/packaging/go/doltlite.go
+++ b/packaging/go/doltlite.go
@@ -1,0 +1,316 @@
+// Package doltlite registers a database/sql driver for DoltLite: SQLite with
+// Git-style version control. Version control is plain SQL on the connection,
+// e.g. SELECT dolt_commit('-A', '-m', 'message').
+//
+// The engine is compiled from the amalgamation vendored alongside this file,
+// so no system library is required.
+package doltlite
+
+/*
+#cgo CFLAGS: -DDOLTLITE_PROLLY=1 -DSQLITE_THREADSAFE=1
+#cgo CFLAGS: -DSQLITE_ENABLE_MATH_FUNCTIONS -DSQLITE_ENABLE_FTS5
+#cgo CFLAGS: -DSQLITE_ENABLE_RTREE -DSQLITE_ENABLE_DBSTAT_VTAB
+#cgo CFLAGS: -DSQLITE_ENABLE_COLUMN_METADATA -w
+#cgo LDFLAGS: -lz -lm
+#cgo linux LDFLAGS: -lpthread
+
+#include <stdlib.h>
+#include <string.h>
+#include "doltlite.h"
+
+// The engine copies bound text and blobs rather than borrowing them, which
+// cgo requires: Go memory must not be retained by C after the call returns.
+static int dl_bind_text(sqlite3_stmt *s, int i, const char *p, int n) {
+  return sqlite3_bind_text(s, i, p, n, SQLITE_TRANSIENT);
+}
+static int dl_bind_blob(sqlite3_stmt *s, int i, const void *p, int n) {
+  return sqlite3_bind_blob(s, i, p, n, SQLITE_TRANSIENT);
+}
+*/
+import "C"
+
+import (
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"fmt"
+	"io"
+	"sync"
+	"unsafe"
+)
+
+func init() {
+	sql.Register("doltlite", Driver{})
+}
+
+// Version reports the SQLite version the bundled engine derives from.
+func Version() string {
+	return C.GoString(C.sqlite3_libversion())
+}
+
+// Error is an engine error carrying its result code.
+type Error struct {
+	Code int
+	Msg  string
+}
+
+func (e *Error) Error() string { return fmt.Sprintf("doltlite: %s (code %d)", e.Msg, e.Code) }
+
+// Driver implements driver.Driver.
+type Driver struct{}
+
+func (Driver) Open(name string) (driver.Conn, error) {
+	cname := C.CString(name)
+	defer C.free(unsafe.Pointer(cname))
+
+	var db *C.sqlite3
+	rc := C.sqlite3_open_v2(cname, &db,
+		C.SQLITE_OPEN_READWRITE|C.SQLITE_OPEN_CREATE, nil)
+	if rc != C.SQLITE_OK {
+		msg := "unable to open database"
+		if db != nil {
+			msg = C.GoString(C.sqlite3_errmsg(db))
+			C.sqlite3_close_v2(db)
+		}
+		return nil, &Error{Code: int(rc), Msg: msg}
+	}
+	return &conn{db: db}, nil
+}
+
+type conn struct {
+	mu     sync.Mutex
+	db     *C.sqlite3
+	closed bool
+}
+
+func (c *conn) err(rc C.int) error {
+	code := C.sqlite3_extended_errcode(c.db)
+	if code == 0 {
+		code = rc
+	}
+	return &Error{Code: int(code), Msg: C.GoString(C.sqlite3_errmsg(c.db))}
+}
+
+func (c *conn) Close() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed {
+		return nil
+	}
+	c.closed = true
+	C.sqlite3_close_v2(c.db)
+	return nil
+}
+
+func (c *conn) Prepare(query string) (driver.Stmt, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed {
+		return nil, driver.ErrBadConn
+	}
+	cq := C.CString(query)
+	defer C.free(unsafe.Pointer(cq))
+
+	var st *C.sqlite3_stmt
+	if rc := C.sqlite3_prepare_v2(c.db, cq, -1, &st, nil); rc != C.SQLITE_OK {
+		return nil, c.err(rc)
+	}
+	if st == nil {
+		return nil, errors.New("doltlite: query contains no statement")
+	}
+	return &stmt{c: c, st: st, nInput: int(C.sqlite3_bind_parameter_count(st))}, nil
+}
+
+func (c *conn) Begin() (driver.Tx, error) {
+	if err := c.exec("BEGIN"); err != nil {
+		return nil, err
+	}
+	return &tx{c: c}, nil
+}
+
+// exec runs a statement that takes no parameters and returns no rows.
+func (c *conn) exec(query string) error {
+	s, err := c.Prepare(query)
+	if err != nil {
+		return err
+	}
+	defer s.Close()
+	_, err = s.(*stmt).Exec(nil)
+	return err
+}
+
+type tx struct{ c *conn }
+
+func (t *tx) Commit() error   { return t.c.exec("COMMIT") }
+func (t *tx) Rollback() error { return t.c.exec("ROLLBACK") }
+
+type stmt struct {
+	c      *conn
+	st     *C.sqlite3_stmt
+	nInput int
+	closed bool
+}
+
+func (s *stmt) Close() error {
+	if s.closed {
+		return nil
+	}
+	s.closed = true
+	s.c.mu.Lock()
+	defer s.c.mu.Unlock()
+	C.sqlite3_finalize(s.st)
+	return nil
+}
+
+func (s *stmt) NumInput() int { return s.nInput }
+
+func (s *stmt) bind(args []driver.Value) error {
+	C.sqlite3_reset(s.st)
+	C.sqlite3_clear_bindings(s.st)
+	for i, a := range args {
+		idx := C.int(i + 1)
+		var rc C.int
+		switch v := a.(type) {
+		case nil:
+			rc = C.sqlite3_bind_null(s.st, idx)
+		case int64:
+			rc = C.sqlite3_bind_int64(s.st, idx, C.sqlite3_int64(v))
+		case float64:
+			rc = C.sqlite3_bind_double(s.st, idx, C.double(v))
+		case bool:
+			n := C.sqlite3_int64(0)
+			if v {
+				n = 1
+			}
+			rc = C.sqlite3_bind_int64(s.st, idx, n)
+		case string:
+			// An empty string still needs a valid pointer for the bind.
+			if len(v) == 0 {
+				rc = C.dl_bind_text(s.st, idx, (*C.char)(unsafe.Pointer(&[]byte{0}[0])), 0)
+			} else {
+				b := []byte(v)
+				rc = C.dl_bind_text(s.st, idx,
+					(*C.char)(unsafe.Pointer(&b[0])), C.int(len(b)))
+			}
+		case []byte:
+			if len(v) == 0 {
+				rc = C.dl_bind_blob(s.st, idx, unsafe.Pointer(&[]byte{0}[0]), 0)
+			} else {
+				rc = C.dl_bind_blob(s.st, idx, unsafe.Pointer(&v[0]), C.int(len(v)))
+			}
+		default:
+			return fmt.Errorf("doltlite: unsupported argument type %T", a)
+		}
+		if rc != C.SQLITE_OK {
+			return s.c.err(rc)
+		}
+	}
+	return nil
+}
+
+func (s *stmt) Exec(args []driver.Value) (driver.Result, error) {
+	s.c.mu.Lock()
+	defer s.c.mu.Unlock()
+	if err := s.bind(args); err != nil {
+		return nil, err
+	}
+	for {
+		rc := C.sqlite3_step(s.st)
+		if rc == C.SQLITE_ROW {
+			continue
+		}
+		if rc != C.SQLITE_DONE {
+			C.sqlite3_reset(s.st)
+			return nil, s.c.err(rc)
+		}
+		break
+	}
+	res := result{
+		lastID:  int64(C.sqlite3_last_insert_rowid(s.c.db)),
+		changes: int64(C.sqlite3_changes(s.c.db)),
+	}
+	C.sqlite3_reset(s.st)
+	return res, nil
+}
+
+func (s *stmt) Query(args []driver.Value) (driver.Rows, error) {
+	s.c.mu.Lock()
+	defer s.c.mu.Unlock()
+	if err := s.bind(args); err != nil {
+		return nil, err
+	}
+	n := int(C.sqlite3_column_count(s.st))
+	cols := make([]string, n)
+	for i := 0; i < n; i++ {
+		cols[i] = C.GoString(C.sqlite3_column_name(s.st, C.int(i)))
+	}
+	return &rows{s: s, cols: cols}, nil
+}
+
+type result struct {
+	lastID  int64
+	changes int64
+}
+
+func (r result) LastInsertId() (int64, error) { return r.lastID, nil }
+func (r result) RowsAffected() (int64, error) { return r.changes, nil }
+
+type rows struct {
+	s      *stmt
+	cols   []string
+	closed bool
+}
+
+func (r *rows) Columns() []string { return r.cols }
+
+func (r *rows) Close() error {
+	if r.closed {
+		return nil
+	}
+	r.closed = true
+	r.s.c.mu.Lock()
+	defer r.s.c.mu.Unlock()
+	C.sqlite3_reset(r.s.st)
+	return nil
+}
+
+func (r *rows) Next(dest []driver.Value) error {
+	r.s.c.mu.Lock()
+	defer r.s.c.mu.Unlock()
+
+	rc := C.sqlite3_step(r.s.st)
+	if rc == C.SQLITE_DONE {
+		return io.EOF
+	}
+	if rc != C.SQLITE_ROW {
+		return r.s.c.err(rc)
+	}
+	for i := range dest {
+		idx := C.int(i)
+		switch C.sqlite3_column_type(r.s.st, idx) {
+		case C.SQLITE_NULL:
+			dest[i] = nil
+		case C.SQLITE_INTEGER:
+			dest[i] = int64(C.sqlite3_column_int64(r.s.st, idx))
+		case C.SQLITE_FLOAT:
+			dest[i] = float64(C.sqlite3_column_double(r.s.st, idx))
+		case C.SQLITE_BLOB:
+			dest[i] = columnBytes(r.s.st, idx, C.sqlite3_column_blob(r.s.st, idx))
+		default:
+			// Text: copied by length rather than as a C string, since a value
+			// may contain embedded NULs.
+			b := columnBytes(r.s.st, idx,
+				unsafe.Pointer(C.sqlite3_column_text(r.s.st, idx)))
+			dest[i] = string(b)
+		}
+	}
+	return nil
+}
+
+func columnBytes(st *C.sqlite3_stmt, idx C.int, p unsafe.Pointer) []byte {
+	n := C.sqlite3_column_bytes(st, idx)
+	if p == nil || n == 0 {
+		return []byte{}
+	}
+	return C.GoBytes(p, n)
+}

--- a/packaging/go/doltlite.go
+++ b/packaging/go/doltlite.go
@@ -35,6 +35,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"runtime"
 	"sync"
 	"unsafe"
 )
@@ -48,6 +49,10 @@ func Version() string {
 	return C.GoString(C.sqlite3_libversion())
 }
 
+// defaultBusyTimeoutMs is how long a connection waits for a contended write
+// before giving up. Overridable per connection with PRAGMA busy_timeout.
+const defaultBusyTimeoutMs = 5000
+
 // Error is an engine error carrying its result code.
 type Error struct {
 	Code int
@@ -60,27 +65,90 @@ func (e *Error) Error() string { return fmt.Sprintf("doltlite: %s (code %d)", e.
 type Driver struct{}
 
 func (Driver) Open(name string) (driver.Conn, error) {
-	cname := C.CString(name)
-	defer C.free(unsafe.Pointer(cname))
+	c := newConn()
 
 	var db *C.sqlite3
-	rc := C.sqlite3_open_v2(cname, &db,
-		C.SQLITE_OPEN_READWRITE|C.SQLITE_OPEN_CREATE, nil)
-	if rc != C.SQLITE_OK {
-		msg := "unable to open database"
-		if db != nil {
-			msg = C.GoString(C.sqlite3_errmsg(db))
-			C.sqlite3_close_v2(db)
+	var rc C.int
+	var msg string
+	c.run(func() {
+		cname := C.CString(name)
+		defer C.free(unsafe.Pointer(cname))
+		rc = C.sqlite3_open_v2(cname, &db,
+			C.SQLITE_OPEN_READWRITE|C.SQLITE_OPEN_CREATE, nil)
+		if rc != C.SQLITE_OK {
+			msg = "unable to open database"
+			if db != nil {
+				msg = C.GoString(C.sqlite3_errmsg(db))
+				C.sqlite3_close_v2(db)
+			}
 		}
+	})
+	if rc != C.SQLITE_OK {
+		c.stop()
 		return nil, &Error{Code: int(rc), Msg: msg}
 	}
-	return &conn{db: db}, nil
+	// database/sql hands out a pool of connections, and every one of them is a
+	// separate writer to the same store. Without a busy handler the loser of a
+	// write race fails immediately with SQLITE_BUSY, so ordinary concurrent use
+	// through the pool drops writes. Wait instead; callers who want different
+	// behaviour can set their own with PRAGMA busy_timeout.
+	c.db = db
+	c.run(func() { C.sqlite3_busy_timeout(db, C.int(defaultBusyTimeoutMs)) })
+	return c, nil
 }
 
+// conn owns a dedicated OS thread and runs every engine call on it.
+//
+// The engine holds its store lock for the life of an explicit transaction and
+// attributes that lock to the thread that took it, so a transaction whose
+// statements arrive on different threads fails with SQLITE_BUSY (dolthub/
+// doltlite#2577). A goroutine can move between OS threads at any call
+// boundary, which makes that unavoidable here rather than unlikely: through
+// database/sql's pool it loses writes, and it fails every time even with
+// SetMaxOpenConns(1). Pinning one thread per connection keeps every call for
+// a connection on the thread that owns its locks. Remove this once the engine
+// no longer ties the lock to a thread.
 type conn struct {
 	mu     sync.Mutex
 	db     *C.sqlite3
 	closed bool
+	calls  chan func()
+	done   chan struct{}
+}
+
+func newConn() *conn {
+	c := &conn{calls: make(chan func()), done: make(chan struct{})}
+	started := make(chan struct{})
+	go func() {
+		runtime.LockOSThread()
+		defer runtime.UnlockOSThread()
+		close(started)
+		for {
+			select {
+			case fn := <-c.calls:
+				fn()
+			case <-c.done:
+				return
+			}
+		}
+	}()
+	<-started
+	return c
+}
+
+// run executes fn on the connection's own OS thread and waits for it. It must
+// not be called from fn itself: the thread runs one call at a time.
+func (c *conn) run(fn func()) {
+	finished := make(chan struct{})
+	c.calls <- func() {
+		defer close(finished)
+		fn()
+	}
+	<-finished
+}
+
+func (c *conn) stop() {
+	close(c.done)
 }
 
 func (c *conn) err(rc C.int) error {
@@ -98,7 +166,8 @@ func (c *conn) Close() error {
 		return nil
 	}
 	c.closed = true
-	C.sqlite3_close_v2(c.db)
+	c.run(func() { C.sqlite3_close_v2(c.db) })
+	c.stop()
 	return nil
 }
 
@@ -108,11 +177,14 @@ func (c *conn) Prepare(query string) (driver.Stmt, error) {
 	if c.closed {
 		return nil, driver.ErrBadConn
 	}
-	cq := C.CString(query)
-	defer C.free(unsafe.Pointer(cq))
-
 	var st *C.sqlite3_stmt
-	if rc := C.sqlite3_prepare_v2(c.db, cq, -1, &st, nil); rc != C.SQLITE_OK {
+	var rc C.int
+	c.run(func() {
+		cq := C.CString(query)
+		defer C.free(unsafe.Pointer(cq))
+		rc = C.sqlite3_prepare_v2(c.db, cq, -1, &st, nil)
+	})
+	if rc != C.SQLITE_OK {
 		return nil, c.err(rc)
 	}
 	if st == nil {
@@ -121,8 +193,14 @@ func (c *conn) Prepare(query string) (driver.Stmt, error) {
 	return &stmt{c: c, st: st, nInput: int(C.sqlite3_bind_parameter_count(st))}, nil
 }
 
+// Begin starts a write transaction. IMMEDIATE, not the default DEFERRED: a
+// deferred transaction takes its write lock at the first write, and losing
+// that upgrade returns SQLITE_BUSY without consulting the busy handler,
+// because waiting there could deadlock. Taking the lock up front puts the
+// contention where the handler can wait on it, which is what a pooled
+// database/sql caller needs.
 func (c *conn) Begin() (driver.Tx, error) {
-	if err := c.exec("BEGIN"); err != nil {
+	if err := c.exec("BEGIN IMMEDIATE"); err != nil {
 		return nil, err
 	}
 	return &tx{c: c}, nil
@@ -158,7 +236,7 @@ func (s *stmt) Close() error {
 	s.closed = true
 	s.c.mu.Lock()
 	defer s.c.mu.Unlock()
-	C.sqlite3_finalize(s.st)
+	s.c.run(func() { C.sqlite3_finalize(s.st) })
 	return nil
 }
 
@@ -211,38 +289,54 @@ func (s *stmt) bind(args []driver.Value) error {
 func (s *stmt) Exec(args []driver.Value) (driver.Result, error) {
 	s.c.mu.Lock()
 	defer s.c.mu.Unlock()
-	if err := s.bind(args); err != nil {
-		return nil, err
-	}
-	for {
-		rc := C.sqlite3_step(s.st)
-		if rc == C.SQLITE_ROW {
-			continue
+	var res result
+	var bindErr error
+	var stepRc C.int
+	s.c.run(func() {
+		if bindErr = s.bind(args); bindErr != nil {
+			return
 		}
-		if rc != C.SQLITE_DONE {
-			C.sqlite3_reset(s.st)
-			return nil, s.c.err(rc)
+		for {
+			stepRc = C.sqlite3_step(s.st)
+			if stepRc == C.SQLITE_ROW {
+				continue
+			}
+			break
 		}
-		break
+		if stepRc == C.SQLITE_DONE {
+			res = result{
+				lastID:  int64(C.sqlite3_last_insert_rowid(s.c.db)),
+				changes: int64(C.sqlite3_changes(s.c.db)),
+			}
+		}
+		C.sqlite3_reset(s.st)
+	})
+	if bindErr != nil {
+		return nil, bindErr
 	}
-	res := result{
-		lastID:  int64(C.sqlite3_last_insert_rowid(s.c.db)),
-		changes: int64(C.sqlite3_changes(s.c.db)),
+	if stepRc != C.SQLITE_DONE {
+		return nil, s.c.err(stepRc)
 	}
-	C.sqlite3_reset(s.st)
 	return res, nil
 }
 
 func (s *stmt) Query(args []driver.Value) (driver.Rows, error) {
 	s.c.mu.Lock()
 	defer s.c.mu.Unlock()
-	if err := s.bind(args); err != nil {
-		return nil, err
-	}
-	n := int(C.sqlite3_column_count(s.st))
-	cols := make([]string, n)
-	for i := 0; i < n; i++ {
-		cols[i] = C.GoString(C.sqlite3_column_name(s.st, C.int(i)))
+	var cols []string
+	var bindErr error
+	s.c.run(func() {
+		if bindErr = s.bind(args); bindErr != nil {
+			return
+		}
+		n := int(C.sqlite3_column_count(s.st))
+		cols = make([]string, n)
+		for i := 0; i < n; i++ {
+			cols[i] = C.GoString(C.sqlite3_column_name(s.st, C.int(i)))
+		}
+	})
+	if bindErr != nil {
+		return nil, bindErr
 	}
 	return &rows{s: s, cols: cols}, nil
 }
@@ -270,7 +364,7 @@ func (r *rows) Close() error {
 	r.closed = true
 	r.s.c.mu.Lock()
 	defer r.s.c.mu.Unlock()
-	C.sqlite3_reset(r.s.st)
+	r.s.c.run(func() { C.sqlite3_reset(r.s.st) })
 	return nil
 }
 
@@ -278,32 +372,35 @@ func (r *rows) Next(dest []driver.Value) error {
 	r.s.c.mu.Lock()
 	defer r.s.c.mu.Unlock()
 
-	rc := C.sqlite3_step(r.s.st)
+	var rc C.int
+	r.s.c.run(func() { rc = C.sqlite3_step(r.s.st) })
 	if rc == C.SQLITE_DONE {
 		return io.EOF
 	}
 	if rc != C.SQLITE_ROW {
 		return r.s.c.err(rc)
 	}
-	for i := range dest {
-		idx := C.int(i)
-		switch C.sqlite3_column_type(r.s.st, idx) {
-		case C.SQLITE_NULL:
-			dest[i] = nil
-		case C.SQLITE_INTEGER:
-			dest[i] = int64(C.sqlite3_column_int64(r.s.st, idx))
-		case C.SQLITE_FLOAT:
-			dest[i] = float64(C.sqlite3_column_double(r.s.st, idx))
-		case C.SQLITE_BLOB:
-			dest[i] = columnBytes(r.s.st, idx, C.sqlite3_column_blob(r.s.st, idx))
-		default:
-			// Text: copied by length rather than as a C string, since a value
-			// may contain embedded NULs.
-			b := columnBytes(r.s.st, idx,
-				unsafe.Pointer(C.sqlite3_column_text(r.s.st, idx)))
-			dest[i] = string(b)
+	r.s.c.run(func() {
+		for i := range dest {
+			idx := C.int(i)
+			switch C.sqlite3_column_type(r.s.st, idx) {
+			case C.SQLITE_NULL:
+				dest[i] = nil
+			case C.SQLITE_INTEGER:
+				dest[i] = int64(C.sqlite3_column_int64(r.s.st, idx))
+			case C.SQLITE_FLOAT:
+				dest[i] = float64(C.sqlite3_column_double(r.s.st, idx))
+			case C.SQLITE_BLOB:
+				dest[i] = columnBytes(r.s.st, idx, C.sqlite3_column_blob(r.s.st, idx))
+			default:
+				// Text: copied by length rather than as a C string, since a value
+				// may contain embedded NULs.
+				b := columnBytes(r.s.st, idx,
+					unsafe.Pointer(C.sqlite3_column_text(r.s.st, idx)))
+				dest[i] = string(b)
+			}
 		}
-	}
+	})
 	return nil
 }
 

--- a/packaging/go/doltlite.go
+++ b/packaging/go/doltlite.go
@@ -112,24 +112,28 @@ type conn struct {
 	mu     sync.Mutex
 	db     *C.sqlite3
 	closed bool
-	calls  chan func()
-	done   chan struct{}
+	stmts  map[*stmt]struct{}
+
+	// runMu orders dispatch against shutdown: a send and the close of calls
+	// cannot interleave, so run never sends on a closed channel and never
+	// blocks on one nobody is receiving from.
+	runMu   sync.Mutex
+	stopped bool
+	calls   chan func()
 }
 
+// errConnClosed is returned by run once the connection's thread is gone.
+var errConnClosed = errors.New("doltlite: connection is closed")
+
 func newConn() *conn {
-	c := &conn{calls: make(chan func()), done: make(chan struct{})}
+	c := &conn{calls: make(chan func()), stmts: map[*stmt]struct{}{}}
 	started := make(chan struct{})
 	go func() {
 		runtime.LockOSThread()
 		defer runtime.UnlockOSThread()
 		close(started)
-		for {
-			select {
-			case fn := <-c.calls:
-				fn()
-			case <-c.done:
-				return
-			}
+		for fn := range c.calls {
+			fn()
 		}
 	}()
 	<-started
@@ -138,17 +142,31 @@ func newConn() *conn {
 
 // run executes fn on the connection's own OS thread and waits for it. It must
 // not be called from fn itself: the thread runs one call at a time.
-func (c *conn) run(fn func()) {
+func (c *conn) run(fn func()) error {
+	c.runMu.Lock()
+	defer c.runMu.Unlock()
+	if c.stopped {
+		return errConnClosed
+	}
 	finished := make(chan struct{})
 	c.calls <- func() {
 		defer close(finished)
 		fn()
 	}
 	<-finished
+	return nil
 }
 
+// stop retires the connection's thread. Serialized with run, so a call that
+// has already been accepted still completes.
 func (c *conn) stop() {
-	close(c.done)
+	c.runMu.Lock()
+	defer c.runMu.Unlock()
+	if c.stopped {
+		return
+	}
+	c.stopped = true
+	close(c.calls)
 }
 
 func (c *conn) err(rc C.int) error {
@@ -166,7 +184,23 @@ func (c *conn) Close() error {
 		return nil
 	}
 	c.closed = true
-	c.run(func() { C.sqlite3_close_v2(c.db) })
+	// Finalize what is still open before the thread retires. sqlite3_close_v2
+	// would otherwise keep the handle alive waiting for statements that can no
+	// longer be finalized, and their Close would have nowhere to run.
+	live := make([]*stmt, 0, len(c.stmts))
+	for s := range c.stmts {
+		live = append(live, s)
+	}
+	c.stmts = nil
+	c.run(func() {
+		for _, s := range live {
+			if !s.closed {
+				s.closed = true
+				C.sqlite3_finalize(s.st)
+			}
+		}
+		C.sqlite3_close_v2(c.db)
+	})
 	c.stop()
 	return nil
 }
@@ -179,18 +213,26 @@ func (c *conn) Prepare(query string) (driver.Stmt, error) {
 	}
 	var st *C.sqlite3_stmt
 	var rc C.int
-	c.run(func() {
+	var nInput int
+	if err := c.run(func() {
 		cq := C.CString(query)
 		defer C.free(unsafe.Pointer(cq))
 		rc = C.sqlite3_prepare_v2(c.db, cq, -1, &st, nil)
-	})
+		if rc == C.SQLITE_OK && st != nil {
+			nInput = int(C.sqlite3_bind_parameter_count(st))
+		}
+	}); err != nil {
+		return nil, driver.ErrBadConn
+	}
 	if rc != C.SQLITE_OK {
 		return nil, c.err(rc)
 	}
 	if st == nil {
 		return nil, errors.New("doltlite: query contains no statement")
 	}
-	return &stmt{c: c, st: st, nInput: int(C.sqlite3_bind_parameter_count(st))}, nil
+	s := &stmt{c: c, st: st, nInput: nInput}
+	c.stmts[s] = struct{}{}
+	return s, nil
 }
 
 // Begin starts a write transaction. IMMEDIATE, not the default DEFERRED: a
@@ -230,13 +272,16 @@ type stmt struct {
 }
 
 func (s *stmt) Close() error {
+	s.c.mu.Lock()
+	defer s.c.mu.Unlock()
 	if s.closed {
 		return nil
 	}
 	s.closed = true
-	s.c.mu.Lock()
-	defer s.c.mu.Unlock()
-	s.c.run(func() { C.sqlite3_finalize(s.st) })
+	delete(s.c.stmts, s)
+	// A closed connection finalized this already; there is nothing to run and
+	// nowhere to run it.
+	_ = s.c.run(func() { C.sqlite3_finalize(s.st) })
 	return nil
 }
 
@@ -289,10 +334,13 @@ func (s *stmt) bind(args []driver.Value) error {
 func (s *stmt) Exec(args []driver.Value) (driver.Result, error) {
 	s.c.mu.Lock()
 	defer s.c.mu.Unlock()
+	if s.closed {
+		return nil, driver.ErrBadConn
+	}
 	var res result
 	var bindErr error
 	var stepRc C.int
-	s.c.run(func() {
+	if err := s.c.run(func() {
 		if bindErr = s.bind(args); bindErr != nil {
 			return
 		}
@@ -310,7 +358,9 @@ func (s *stmt) Exec(args []driver.Value) (driver.Result, error) {
 			}
 		}
 		C.sqlite3_reset(s.st)
-	})
+	}); err != nil {
+		return nil, driver.ErrBadConn
+	}
 	if bindErr != nil {
 		return nil, bindErr
 	}
@@ -323,9 +373,12 @@ func (s *stmt) Exec(args []driver.Value) (driver.Result, error) {
 func (s *stmt) Query(args []driver.Value) (driver.Rows, error) {
 	s.c.mu.Lock()
 	defer s.c.mu.Unlock()
+	if s.closed {
+		return nil, driver.ErrBadConn
+	}
 	var cols []string
 	var bindErr error
-	s.c.run(func() {
+	if err := s.c.run(func() {
 		if bindErr = s.bind(args); bindErr != nil {
 			return
 		}
@@ -334,7 +387,9 @@ func (s *stmt) Query(args []driver.Value) (driver.Rows, error) {
 		for i := 0; i < n; i++ {
 			cols[i] = C.GoString(C.sqlite3_column_name(s.st, C.int(i)))
 		}
-	})
+	}); err != nil {
+		return nil, driver.ErrBadConn
+	}
 	if bindErr != nil {
 		return nil, bindErr
 	}
@@ -364,23 +419,33 @@ func (r *rows) Close() error {
 	r.closed = true
 	r.s.c.mu.Lock()
 	defer r.s.c.mu.Unlock()
-	r.s.c.run(func() { C.sqlite3_reset(r.s.st) })
+	if r.s.closed {
+		return nil
+	}
+	_ = r.s.c.run(func() { C.sqlite3_reset(r.s.st) })
 	return nil
 }
 
 func (r *rows) Next(dest []driver.Value) error {
 	r.s.c.mu.Lock()
 	defer r.s.c.mu.Unlock()
+	// Closing the connection finalizes its statements, so a Rows held past
+	// that point must not touch one.
+	if r.s.closed {
+		return driver.ErrBadConn
+	}
 
 	var rc C.int
-	r.s.c.run(func() { rc = C.sqlite3_step(r.s.st) })
+	if err := r.s.c.run(func() { rc = C.sqlite3_step(r.s.st) }); err != nil {
+		return driver.ErrBadConn
+	}
 	if rc == C.SQLITE_DONE {
 		return io.EOF
 	}
 	if rc != C.SQLITE_ROW {
 		return r.s.c.err(rc)
 	}
-	r.s.c.run(func() {
+	if err := r.s.c.run(func() {
 		for i := range dest {
 			idx := C.int(i)
 			switch C.sqlite3_column_type(r.s.st, idx) {
@@ -400,7 +465,9 @@ func (r *rows) Next(dest []driver.Value) error {
 				dest[i] = string(b)
 			}
 		}
-	})
+	}); err != nil {
+		return driver.ErrBadConn
+	}
 	return nil
 }
 

--- a/packaging/go/go.mod
+++ b/packaging/go/go.mod
@@ -1,3 +1,3 @@
-module github.com/dolthub/doltlite-go
+module github.com/dolthub/doltlite-driver
 
 go 1.21

--- a/packaging/go/go.mod
+++ b/packaging/go/go.mod
@@ -1,0 +1,3 @@
+module github.com/dolthub/doltlite-go
+
+go 1.21

--- a/packaging/go/smoke-test/go.mod
+++ b/packaging/go/smoke-test/go.mod
@@ -2,4 +2,4 @@ module doltlite-smoke-test
 
 go 1.21
 
-require github.com/dolthub/doltlite-go v0.0.0
+require github.com/dolthub/doltlite-driver v0.0.0

--- a/packaging/go/smoke-test/go.mod
+++ b/packaging/go/smoke-test/go.mod
@@ -1,0 +1,5 @@
+module doltlite-smoke-test
+
+go 1.21
+
+require github.com/dolthub/doltlite-go v0.0.0

--- a/packaging/go/smoke-test/main.go
+++ b/packaging/go/smoke-test/main.go
@@ -1,0 +1,159 @@
+// Package-level smoke test for doltlite-go. Runs from a consumer module
+// against the staged package, covering the driver surface end to end: every
+// value type, transactions, error paths, and a version-control round trip
+// (commit, branch, checkout, merge, dolt_log reads).
+package main
+
+import (
+	"bytes"
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	doltlite "github.com/dolthub/doltlite-go"
+)
+
+var failures int
+
+func check(name string, got, want any) {
+	ok := fmt.Sprint(got) == fmt.Sprint(want)
+	if b1, k1 := got.([]byte); k1 {
+		if b2, k2 := want.([]byte); k2 {
+			ok = bytes.Equal(b1, b2)
+		}
+	}
+	if ok {
+		fmt.Printf("  PASS: %s\n", name)
+		return
+	}
+	failures++
+	fmt.Printf("  FAIL: %s\n    want: %v\n    got:  %v\n", name, want, got)
+}
+
+func main() {
+	dir := os.TempDir()
+	dbPath := filepath.Join(dir, fmt.Sprintf("doltlite-go-smoke-%d.db", os.Getpid()))
+	cleanup := func() {
+		os.Remove(dbPath)
+		os.Remove(filepath.Join(dir, "."+filepath.Base(dbPath)+"-lock"))
+	}
+	cleanup()
+	defer cleanup()
+
+	check("engine version reports", doltlite.Version() != "", true)
+
+	db, err := sql.Open("doltlite", dbPath)
+	must(err)
+	defer db.Close()
+
+	_, err = db.Exec(`CREATE TABLE t(pk INTEGER PRIMARY KEY, s TEXT, f REAL, b BLOB)`)
+	must(err)
+
+	res, err := db.Exec(`INSERT INTO t(pk, s, f, b) VALUES (?, ?, ?, ?)`,
+		1, "one", 1.5, []byte{0, 255, 16})
+	must(err)
+	n, err := res.RowsAffected()
+	must(err)
+	check("insert rows affected", n, int64(1))
+	id, err := res.LastInsertId()
+	must(err)
+	check("last insert id", id, int64(1))
+
+	_, err = db.Exec(`INSERT INTO t(pk, s, f, b) VALUES (?, ?, ?, ?)`,
+		2, "twö", 2.25, []byte{1, 0, 2})
+	must(err)
+	_, err = db.Exec(`INSERT INTO t(pk, s) VALUES (?, ?)`, 3, nil)
+	must(err)
+
+	var s string
+	var f float64
+	var b []byte
+	must(db.QueryRow(`SELECT s, f, b FROM t WHERE pk = 2`).Scan(&s, &f, &b))
+	check("text round trip (utf8)", s, "twö")
+	check("float round trip", f, 2.25)
+	check("blob round trip", b, []byte{1, 0, 2})
+
+	var ns sql.NullString
+	must(db.QueryRow(`SELECT s FROM t WHERE pk = 3`).Scan(&ns))
+	check("null round trip", ns.Valid, false)
+
+	var empty string
+	must(db.QueryRow(`SELECT ''`).Scan(&empty))
+	check("empty string binds", empty, "")
+
+	err = db.QueryRow(`SELECT s FROM t WHERE pk = 99`).Scan(&s)
+	check("no rows is ErrNoRows", err == sql.ErrNoRows, true)
+
+	rows, err := db.Query(`SELECT pk, s FROM t ORDER BY pk`)
+	must(err)
+	cols, err := rows.Columns()
+	must(err)
+	check("column names", fmt.Sprint(cols), "[pk s]")
+	count := 0
+	for rows.Next() {
+		count++
+	}
+	must(rows.Err())
+	rows.Close()
+	check("row count", count, 3)
+
+	_, err = db.Query(`SELECT * FROM missing_table`)
+	check("bad SQL errors", err != nil, true)
+
+	// Transactions.
+	tx, err := db.Begin()
+	must(err)
+	_, err = tx.Exec(`INSERT INTO t(pk, s) VALUES (?, ?)`, 4, "rolled back")
+	must(err)
+	must(tx.Rollback())
+	var c int
+	must(db.QueryRow(`SELECT count(*) FROM t WHERE pk = 4`).Scan(&c))
+	check("rollback discards", c, 0)
+
+	tx, err = db.Begin()
+	must(err)
+	_, err = tx.Exec(`INSERT INTO t(pk, s) VALUES (?, ?)`, 5, "committed")
+	must(err)
+	must(tx.Commit())
+	must(db.QueryRow(`SELECT count(*) FROM t WHERE pk = 5`).Scan(&c))
+	check("commit persists", c, 1)
+
+	// Version control is plain SQL on the same connection.
+	var commit string
+	must(db.QueryRow(`SELECT dolt_commit('-A', '-m', ?)`, "first commit").Scan(&commit))
+	check("dolt_commit", commit != "", true)
+
+	scalar := func(q string) string {
+		var v sql.NullString
+		must(db.QueryRow(q).Scan(&v))
+		return v.String
+	}
+	check("dolt_branch", scalar(`SELECT dolt_branch('feature')`), "0")
+	check("dolt_checkout feature", scalar(`SELECT dolt_checkout('feature')`), "0")
+	_, err = db.Exec(`UPDATE t SET s = 'branched' WHERE pk = 1`)
+	must(err)
+	check("dolt_commit on branch",
+		scalar(`SELECT dolt_commit('-A', '-m', 'feature work')`) != "", true)
+	check("dolt_checkout main", scalar(`SELECT dolt_checkout('main')`), "0")
+	check("main unchanged", scalar(`SELECT s FROM t WHERE pk = 1`), "one")
+	scalar(`SELECT dolt_merge('feature')`)
+	check("dolt_merge fast-forwards", scalar(`SELECT s FROM t WHERE pk = 1`), "branched")
+	var logCount int
+	must(db.QueryRow(`SELECT count(*) FROM dolt_log`).Scan(&logCount))
+	check("dolt_log sees both commits", logCount >= 2, true)
+
+	if failures == 0 {
+		fmt.Println("smoke-test: all checks passed")
+		return
+	}
+	fmt.Printf("smoke-test: %d failure(s)\n", failures)
+	os.Exit(1)
+}
+
+func must(err error) {
+	if err != nil {
+		fmt.Println("fatal:", err)
+		os.Exit(1)
+	}
+}

--- a/packaging/go/smoke-test/main.go
+++ b/packaging/go/smoke-test/main.go
@@ -7,10 +7,12 @@ package main
 import (
 	"bytes"
 	"database/sql"
+	"database/sql/driver"
 	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
+	"time"
 
 	doltlite "github.com/dolthub/doltlite-driver"
 )
@@ -150,6 +152,7 @@ func main() {
 	// "database is locked" -- every time at MaxOpenConns(1), where nothing is
 	// even concurrent.
 	concurrentTx(dbPath)
+	closedConnCleanup(dbPath)
 
 	if failures == 0 {
 		fmt.Println("smoke-test: all checks passed")
@@ -234,4 +237,79 @@ func concurrentTx(dbPath string) {
 			n, writers)
 		db.Close()
 	}
+}
+
+// A statement can outlive the connection that made it. Closing it must return
+// rather than block: the connection's thread is gone by then, so a cleanup
+// call with nowhere to run would wedge the goroutine for good.
+func closedConnCleanup(dbPath string) {
+	path := dbPath + ".closed"
+	os.Remove(path)
+	defer os.Remove(path)
+
+	c, err := doltlite.Driver{}.Open(path)
+	if err != nil {
+		fmt.Println("  FAIL: open for close test:", err)
+		failures++
+		return
+	}
+	st, err := c.Prepare("SELECT 1")
+	if err != nil {
+		fmt.Println("  FAIL: prepare for close test:", err)
+		failures++
+		c.Close()
+		return
+	}
+	if err := c.Close(); err != nil {
+		fmt.Println("  FAIL: conn close:", err)
+		failures++
+		return
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- st.(driver.Stmt).Close() }()
+	select {
+	case <-done:
+		check("statement close after connection close returns", true, true)
+	case <-time.After(10 * time.Second):
+		fmt.Println("  FAIL: statement close after connection close blocked")
+		failures++
+	}
+
+	// Rows outliving the connection: must error rather than block or read a
+	// finalized statement.
+	c2, err := doltlite.Driver{}.Open(path)
+	if err != nil {
+		fmt.Println("  FAIL: reopen for rows test:", err)
+		failures++
+		return
+	}
+	st2, err := c2.Prepare("SELECT 1")
+	if err != nil {
+		fmt.Println("  FAIL: prepare for rows test:", err)
+		failures++
+		c2.Close()
+		return
+	}
+	rws, err := st2.(driver.Stmt).Query(nil)
+	if err != nil {
+		fmt.Println("  FAIL: query for rows test:", err)
+		failures++
+		c2.Close()
+		return
+	}
+	c2.Close()
+	rowsDone := make(chan error, 1)
+	go func() {
+		dest := make([]driver.Value, 1)
+		rowsDone <- rws.Next(dest)
+	}()
+	select {
+	case err := <-rowsDone:
+		check("rows read after connection close errors", err != nil, true)
+	case <-time.After(10 * time.Second):
+		fmt.Println("  FAIL: rows read after connection close blocked")
+		failures++
+	}
+	rws.Close()
 }

--- a/packaging/go/smoke-test/main.go
+++ b/packaging/go/smoke-test/main.go
@@ -1,4 +1,4 @@
-// Package-level smoke test for doltlite-go. Runs from a consumer module
+// Package-level smoke test for doltlite-driver. Runs from a consumer module
 // against the staged package, covering the driver surface end to end: every
 // value type, transactions, error paths, and a version-control round trip
 // (commit, branch, checkout, merge, dolt_log reads).
@@ -10,8 +10,9 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 
-	doltlite "github.com/dolthub/doltlite-go"
+	doltlite "github.com/dolthub/doltlite-driver"
 )
 
 var failures int
@@ -33,7 +34,7 @@ func check(name string, got, want any) {
 
 func main() {
 	dir := os.TempDir()
-	dbPath := filepath.Join(dir, fmt.Sprintf("doltlite-go-smoke-%d.db", os.Getpid()))
+	dbPath := filepath.Join(dir, fmt.Sprintf("doltlite-driver-smoke-%d.db", os.Getpid()))
 	cleanup := func() {
 		os.Remove(dbPath)
 		os.Remove(filepath.Join(dir, "."+filepath.Base(dbPath)+"-lock"))
@@ -143,6 +144,13 @@ func main() {
 	must(db.QueryRow(`SELECT count(*) FROM dolt_log`).Scan(&logCount))
 	check("dolt_log sees both commits", logCount >= 2, true)
 
+	// Transactions through the pool, which is how database/sql is actually
+	// used. The engine attributes its store lock to the thread that took it,
+	// so without the driver pinning a thread per connection these fail with
+	// "database is locked" -- every time at MaxOpenConns(1), where nothing is
+	// even concurrent.
+	concurrentTx(dbPath)
+
 	if failures == 0 {
 		fmt.Println("smoke-test: all checks passed")
 		return
@@ -155,5 +163,75 @@ func must(err error) {
 	if err != nil {
 		fmt.Println("fatal:", err)
 		os.Exit(1)
+	}
+}
+
+func concurrentTx(dbPath string) {
+	for _, maxConns := range []int{1, 4, 16} {
+		db, err := sql.Open("doltlite", dbPath)
+		if err != nil {
+			fmt.Printf("  FAIL: pool open (max %d): %v\n", maxConns, err)
+			failures++
+			continue
+		}
+		db.SetMaxOpenConns(maxConns)
+		table := fmt.Sprintf("pool%d", maxConns)
+		if _, err := db.Exec(`CREATE TABLE ` + table + `(pk INTEGER PRIMARY KEY)`); err != nil {
+			fmt.Printf("  FAIL: pool table (max %d): %v\n", maxConns, err)
+			failures++
+			db.Close()
+			continue
+		}
+
+		const writers = 16
+		var wg sync.WaitGroup
+		errs := make(chan error, writers)
+		for i := 0; i < writers; i++ {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				tx, err := db.Begin()
+				if err != nil {
+					errs <- err
+					return
+				}
+				if _, err := tx.Exec(`INSERT INTO `+table+`(pk) VALUES (?)`, i); err != nil {
+					tx.Rollback()
+					errs <- err
+					return
+				}
+				if err := tx.Commit(); err != nil {
+					errs <- err
+				}
+			}(i)
+		}
+		wg.Wait()
+		close(errs)
+
+		failed := 0
+		var first error
+		for err := range errs {
+			if first == nil {
+				first = err
+			}
+			failed++
+		}
+		if failed > 0 {
+			fmt.Printf("  FAIL: %d of %d pooled transactions (max %d conns): %v\n",
+				failed, writers, maxConns, first)
+			failures++
+			db.Close()
+			continue
+		}
+		var n int
+		if err := db.QueryRow(`SELECT count(*) FROM ` + table).Scan(&n); err != nil {
+			fmt.Printf("  FAIL: pool count (max %d): %v\n", maxConns, err)
+			failures++
+			db.Close()
+			continue
+		}
+		check(fmt.Sprintf("%d pooled transactions (max %d conns)", writers, maxConns),
+			n, writers)
+		db.Close()
 	}
 }

--- a/packaging/go/test-package.sh
+++ b/packaging/go/test-package.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Package-level smoke test for doltlite-go. Stages the module, then builds the
+# Package-level smoke test for doltlite-driver. Stages the module, then builds the
 # smoke test against the staged copy through a module replace, so the test
 # exercises what would actually be pushed -- notably whether the vendored
 # amalgamation is present -- rather than the working tree.
@@ -27,6 +27,6 @@ bash "$PKG_DIR/assemble.sh" "0.0.0" "$STAGE/pkg" "$BUILD_DIR"
 cp "$PKG_DIR/smoke-test/main.go" "$CONSUMER/"
 cp "$PKG_DIR/smoke-test/go.mod"  "$CONSUMER/"
 cd "$CONSUMER"
-go mod edit -replace "github.com/dolthub/doltlite-go=$STAGE/pkg"
+go mod edit -replace "github.com/dolthub/doltlite-driver=$STAGE/pkg"
 go mod tidy >/dev/null 2>&1 || true
 CGO_ENABLED=1 go run .

--- a/packaging/go/test-package.sh
+++ b/packaging/go/test-package.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+#
+# Package-level smoke test for doltlite-go. Stages the module, then builds the
+# smoke test against the staged copy through a module replace, so the test
+# exercises what would actually be pushed -- notably whether the vendored
+# amalgamation is present -- rather than the working tree.
+#
+# Usage: test-package.sh [build_dir]   (default: ./build)
+
+set -euo pipefail
+
+PKG_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$PKG_DIR/../.." && pwd)"
+BUILD_DIR="$(cd "${1:-$ROOT/build}" && pwd)"
+
+command -v go >/dev/null || { echo "ERROR: go is required" >&2; exit 1; }
+
+STAGE="$(mktemp -d)"
+CONSUMER="$(mktemp -d)"
+trap 'chmod -R u+w "$STAGE" "$CONSUMER" 2>/dev/null; rm -rf "$STAGE" "$CONSUMER"' EXIT
+
+bash "$PKG_DIR/assemble.sh" "0.0.0" "$STAGE/pkg" "$BUILD_DIR"
+
+[ -f "$STAGE/pkg/doltlite.c" ] || {
+  echo "ERROR: staged module has no vendored amalgamation" >&2; exit 1; }
+
+cp "$PKG_DIR/smoke-test/main.go" "$CONSUMER/"
+cp "$PKG_DIR/smoke-test/go.mod"  "$CONSUMER/"
+cd "$CONSUMER"
+go mod edit -replace "github.com/dolthub/doltlite-go=$STAGE/pkg"
+go mod tidy >/dev/null 2>&1 || true
+CGO_ENABLED=1 go run .


### PR DESCRIPTION
A `database/sql` driver for DoltLite over cgo, with the engine vendored so
there is no system library to install. Picks up the closed #2531 and resolves
the two things that stopped it.

## The name

#2531 stalled on distribution: Go resolves modules from a VCS path, and the
repo it wanted, `dolthub/doltlite-go`, was created in the meantime for
something else. That repo is a **pure-Go reimplementation of the HTTP sync
protocol** — hashing, wire format, chunk store, client, and an `http.Handler`
for serving. No cgo, and no code in common with a binding over the C engine.

So this is `github.com/dolthub/doltlite-driver`, mirroring `dolthub/driver`,
which is Dolt's `database/sql` driver. A distinct word rather than a word-order
variant, so nobody picks the wrong one off the org list.

It also keeps the two release cadences apart. This module vendors the engine,
so its tag tracks a DoltLite release, and the distribution repo is a pure
artifact repo the release bot can wipe and rewrite — exactly the
`doltlite-php` pattern. Pointing that at `doltlite-go`, which holds
hand-written source, would be destructive.

## Two correctness fixes on top of #2531

Both surfaced by driving the package the way `database/sql` actually drives
it, rather than one statement at a time.

**No busy handler.** Connections were opened without one, so the loser of a
write race failed immediately with `SQLITE_BUSY` rather than waiting. Through
the pool that means dropped writes:

| | writes failing, of 16 |
|---|---|
| before | 6 to 9 |
| after | 0 |

Connections now carry a five second busy timeout, overridable with `PRAGMA
busy_timeout`. Transactions begin as `BEGIN IMMEDIATE`, so contention appears
at `Begin` where the handler can wait on it, instead of at the first write,
where a deferred upgrade returns `BUSY` without consulting the handler at all.

**A thread-affine lock, which is an engine bug, not a Go one.** That left a
residue, and chasing it led to #2577: the engine holds a transaction's store
lock for the life of the transaction and attributes it to the thread that took
it, so a transaction whose statements arrive on different threads fails with
"database is locked". That issue reproduces in **pure C**, with no Go
involved, under `SQLITE_THREADSAFE=1`, which is the mode that promises a
connection may be used from any thread.

Go cannot avoid it, because a goroutine moves between OS threads at call
boundaries. The giveaway was that it failed *every* run at
`SetMaxOpenConns(1)`, where nothing is concurrent at all, and was clean at
`SetMaxOpenConns(16)`, where every transaction gets its own connection.

Each connection now runs its engine calls on its own OS thread. The comment on
`conn` says to delete that once the engine stops tying the lock to a thread.

| MaxOpenConns | before pinning | after |
|---|---|---|
| 1 | failed 4 of 4 runs | clean |
| 4 | failed 2 of 4 runs | clean |
| 16 | clean | clean |

## Tests

The smoke test grows a pooled-transaction check: 16 concurrent transactions at
1, 4 and 16 max connections. It fails on a build with the pinning removed and
passes with it. Everything from #2531 still runs: every value type, embedded
NULs, `ErrNoRows`, error paths, transactions, and a commit, branch, checkout,
merge, `dolt_log` round trip.

`test-package.sh` builds against the **staged** module through a `replace`, so
a missing vendored amalgamation fails the test rather than shipping.

Local: package test green, `gofmt` and `go vet` clean, `make lint` passes.
Build-Test already runs it on ubuntu and macos; Windows stays excluded and
documented, same as the Rust crate, since the build links the platform's zlib.

## Release wiring

`release.yml` gains `release-go`, modeled on `release-php`: build the
amalgamation, stage the module, push it and a matching tag into the
distribution repo. Idempotent on re-runs, and it uses `RELEASE_BOT_TOKEN` with
the same guard as the other split-repo jobs.

**This needs `dolthub/doltlite-driver` to exist before the first release runs.**
I have not created it. Say the word and I will, or create it empty with a
`main` branch and the job will populate it.

Supersedes #2531.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
