### PR TITLE
Hide ALTER ADD COLUMN DEFAULT from sqlite3_update_hook

### DIFF
--- a/src/doltlite_config.c
+++ b/src/doltlite_config.c
@@ -171,23 +171,8 @@ static void doltliteInternalMaterializeDefaultColumnFunc(
     int bWasSet = (db->mDbFlags & DBFLAG_InternalDml)!=0;
     i64 nChange = db->nChange;
     i64 nTotalChange = db->nTotalChange;
-    void (*xUpdateCallback)(void*,int,const char*,const char*,sqlite_int64);
-    void *pUpdateArg;
-#ifdef SQLITE_ENABLE_PREUPDATE_HOOK
-    void (*xPreUpdateCallback)(void*,sqlite3*,int,char const*,char const*,
-                               sqlite3_int64,sqlite3_int64);
-    void *pPreUpdateArg;
-#endif
 #ifndef SQLITE_OMIT_AUTHORIZATION
     sqlite3_xauth xAuth = db->xAuth;
-#endif
-    xUpdateCallback = db->xUpdateCallback;
-    pUpdateArg = db->pUpdateArg;
-    db->xUpdateCallback = 0;
-#ifdef SQLITE_ENABLE_PREUPDATE_HOOK
-    xPreUpdateCallback = db->xPreUpdateCallback;
-    pPreUpdateArg = db->pPreUpdateArg;
-    db->xPreUpdateCallback = 0;
 #endif
     db->mDbFlags |= DBFLAG_InternalDml;
 #ifndef SQLITE_OMIT_AUTHORIZATION
@@ -196,12 +181,6 @@ static void doltliteInternalMaterializeDefaultColumnFunc(
     rc = sqlite3_exec(db, zSql, 0, 0, 0);
 #ifndef SQLITE_OMIT_AUTHORIZATION
     db->xAuth = xAuth;
-#endif
-    db->xUpdateCallback = xUpdateCallback;
-    db->pUpdateArg = pUpdateArg;
-#ifdef SQLITE_ENABLE_PREUPDATE_HOOK
-    db->xPreUpdateCallback = xPreUpdateCallback;
-    db->pPreUpdateArg = pPreUpdateArg;
 #endif
     /* Clear this bit only: restoring the word would undo flags set by prepare. */
     if( !bWasSet ) db->mDbFlags &= ~DBFLAG_InternalDml;

--- a/src/doltlite_config.c
+++ b/src/doltlite_config.c
@@ -165,13 +165,29 @@ static void doltliteInternalMaterializeDefaultColumnFunc(
     return;
   }
 
-  /* Stock ALTER exposes no row DML to triggers, counters, or authorizers. */
+  /* Stock ALTER exposes no row DML to triggers, counters, authorizers,
+  ** or update/preupdate hooks. */
   {
     int bWasSet = (db->mDbFlags & DBFLAG_InternalDml)!=0;
     i64 nChange = db->nChange;
     i64 nTotalChange = db->nTotalChange;
+    void (*xUpdateCallback)(void*,int,const char*,const char*,sqlite_int64);
+    void *pUpdateArg;
+#ifdef SQLITE_ENABLE_PREUPDATE_HOOK
+    void (*xPreUpdateCallback)(void*,sqlite3*,int,char const*,char const*,
+                               sqlite3_int64,sqlite3_int64);
+    void *pPreUpdateArg;
+#endif
 #ifndef SQLITE_OMIT_AUTHORIZATION
     sqlite3_xauth xAuth = db->xAuth;
+#endif
+    xUpdateCallback = db->xUpdateCallback;
+    pUpdateArg = db->pUpdateArg;
+    db->xUpdateCallback = 0;
+#ifdef SQLITE_ENABLE_PREUPDATE_HOOK
+    xPreUpdateCallback = db->xPreUpdateCallback;
+    pPreUpdateArg = db->pPreUpdateArg;
+    db->xPreUpdateCallback = 0;
 #endif
     db->mDbFlags |= DBFLAG_InternalDml;
 #ifndef SQLITE_OMIT_AUTHORIZATION
@@ -180,6 +196,12 @@ static void doltliteInternalMaterializeDefaultColumnFunc(
     rc = sqlite3_exec(db, zSql, 0, 0, 0);
 #ifndef SQLITE_OMIT_AUTHORIZATION
     db->xAuth = xAuth;
+#endif
+    db->xUpdateCallback = xUpdateCallback;
+    db->pUpdateArg = pUpdateArg;
+#ifdef SQLITE_ENABLE_PREUPDATE_HOOK
+    db->xPreUpdateCallback = xPreUpdateCallback;
+    db->pPreUpdateArg = pPreUpdateArg;
 #endif
     /* Clear this bit only: restoring the word would undo flags set by prepare. */
     if( !bWasSet ) db->mDbFlags &= ~DBFLAG_InternalDml;

--- a/src/vdbe.c
+++ b/src/vdbe.c
@@ -112,9 +112,17 @@ static void updateMaxBlobsize(Mem *p){
 ** hook are enabled for database connect DB.
 */
 #ifdef SQLITE_ENABLE_PREUPDATE_HOOK
-# define HAS_UPDATE_HOOK(DB) ((DB)->xPreUpdateCallback||(DB)->xUpdateCallback)
+# define HAS_UPDATE_HOOK_CB(DB) ((DB)->xPreUpdateCallback||(DB)->xUpdateCallback)
 #else
-# define HAS_UPDATE_HOOK(DB) ((DB)->xUpdateCallback)
+# define HAS_UPDATE_HOOK_CB(DB) ((DB)->xUpdateCallback)
+#endif
+#ifdef DOLTLITE_PROLLY
+  /* Internal DML must not fire hooks. Do not clear xPreUpdateCallback:
+  ** the session module stores its object list in pPreUpdateArg. */
+# define HAS_UPDATE_HOOK(DB) \
+    (HAS_UPDATE_HOOK_CB(DB) && ((DB)->mDbFlags & DBFLAG_InternalDml)==0)
+#else
+# define HAS_UPDATE_HOOK(DB) HAS_UPDATE_HOOK_CB(DB)
 #endif
 
 /*
@@ -7174,7 +7182,8 @@ case OP_IdxInsert: {        /* in2 */
       db->lastRowid = iRowid;
       bRowid = 1;
     }
-    if( pOp->p4type==P4_TABLE && db->xUpdateCallback!=0 ){
+    if( pOp->p4type==P4_TABLE && db->xUpdateCallback!=0
+     && (db->mDbFlags & DBFLAG_InternalDml)==0 ){
       Table *pTab = pOp->p4.pTab;
       if( pTab && pTab->aCol && VisibleRowid(pTab) && pC->iDb>=0 ){
         if( !bRowid ){

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -2331,6 +2331,75 @@ static void run_alter_default_update_hook(void){
   removeDbFiles(dbpath);
 }
 
+#if defined(SQLITE_ENABLE_SESSION) && defined(SQLITE_ENABLE_PREUPDATE_HOOK)
+static void run_alter_default_session_changeset(void){
+  sqlite3 *db = 0;
+  sqlite3_session *s1 = 0;
+  sqlite3_session *s2 = 0;
+  char dbpath[256];
+  int n = 0;
+  void *p = 0;
+
+  printf("=== ALTER Default Session Changeset Test ===\n\n");
+  make_dbpath(dbpath, sizeof(dbpath), "test_alter_default_session_changeset");
+  removeDbFiles(dbpath);
+  check("alter_default_session_open", open_db(dbpath, &db)==SQLITE_OK);
+  if( !db ) return;
+
+  check("alter_default_session_setup", execSql(db,
+      "CREATE TABLE t(id INTEGER PRIMARY KEY);"
+      "INSERT INTO t VALUES(1),(2),(3);")==SQLITE_OK);
+
+  check("alter_default_session_create_before",
+      sqlite3session_create(db, "main", &s1)==SQLITE_OK);
+  check("alter_default_session_attach_before",
+      sqlite3session_attach(s1, "t")==SQLITE_OK);
+  check("alter_default_session_baseline",
+      sqlite3session_changeset(s1, &n, &p)==SQLITE_OK);
+  check("alter_default_session_baseline_empty", n==0);
+  sqlite3_free(p);
+  p = 0;
+  n = 0;
+
+  check("alter_default_session_alter", execSql(db,
+      "ALTER TABLE t ADD COLUMN v INTEGER DEFAULT 7")==SQLITE_OK);
+  check("alter_default_session_values",
+        strcmp(queryScalarText(db,
+          "SELECT group_concat(id||':'||v,',') FROM t"),
+          "1:7,2:7,3:7")==0);
+  check("alter_default_session_live_after_alter",
+      sqlite3session_changeset(s1, &n, &p)==SQLITE_OK);
+  check("alter_default_session_live_empty", n==0);
+  sqlite3_free(p);
+  p = 0;
+  n = 0;
+  sqlite3session_delete(s1);
+  s1 = 0;
+
+  check("alter_default_session_create_after",
+      sqlite3session_create(db, "main", &s2)==SQLITE_OK);
+  check("alter_default_session_attach_after",
+      sqlite3session_attach(s2, "t")==SQLITE_OK);
+  check("alter_default_session_changeset_after",
+      sqlite3session_changeset(s2, &n, &p)==SQLITE_OK);
+  check("alter_default_session_changeset_empty", n==0);
+  sqlite3_free(p);
+
+  check("alter_default_session_real_update",
+      execSql(db, "UPDATE t SET v=8 WHERE id=1")==SQLITE_OK);
+  n = 0;
+  p = 0;
+  check("alter_default_session_real_changeset",
+      sqlite3session_changeset(s2, &n, &p)==SQLITE_OK);
+  check("alter_default_session_real_changeset_nonempty", n>0);
+  sqlite3_free(p);
+  sqlite3session_delete(s2);
+
+  sqlite3_close(db);
+  removeDbFiles(dbpath);
+}
+#endif
+
 static void run_schema_hash_error_propagation(void){
   sqlite3 *db = 0;
   char dbpath[256];
@@ -14030,6 +14099,9 @@ static const RegressionCase aCases[] = {
   { "refs_deserialize_overflow_guard", "Refs Deserialize Overflow Guard Test", run_refs_deserialize_overflow_guard },
   { "alter_default_authorizer", "ALTER Default Authorizer Test", run_alter_default_authorizer },
   { "alter_default_update_hook", "ALTER Default Update Hook Test", run_alter_default_update_hook },
+#if defined(SQLITE_ENABLE_SESSION) && defined(SQLITE_ENABLE_PREUPDATE_HOOK)
+  { "alter_default_session_changeset", "ALTER Default Session Changeset Test", run_alter_default_session_changeset },
+#endif
   { "backup_safety", "Backup Safety Test", run_backup_safety },
   { "backup_source_write_busy", "Backup Source Write Busy Test", run_backup_source_write_busy },
   { "backup_dest_missing_branch", "Backup Dest Missing Branch Test", run_backup_dest_missing_branch },

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -2264,6 +2264,73 @@ static void run_alter_default_authorizer(void){
   removeDbFiles(auxpath);
 }
 
+static int nAlterDefaultUpdateHook;
+
+static void countAlterDefaultUpdateHook(
+  void *p,
+  int op,
+  const char *zDb,
+  const char *zTbl,
+  sqlite3_int64 rowid
+){
+  (void)p;
+  (void)zDb;
+  (void)zTbl;
+  (void)rowid;
+  if( op==SQLITE_UPDATE ) nAlterDefaultUpdateHook++;
+}
+
+static void run_alter_default_update_hook(void){
+  sqlite3 *db = 0;
+  char dbpath[256];
+
+  printf("=== ALTER Default Update Hook Test ===\n\n");
+  make_dbpath(dbpath, sizeof(dbpath), "test_alter_default_update_hook");
+  removeDbFiles(dbpath);
+  check("alter_default_hook_open", open_db(dbpath, &db)==SQLITE_OK);
+  if( !db ) return;
+
+  check("alter_default_hook_empty_setup", execSql(db,
+      "CREATE TABLE t0(id INTEGER PRIMARY KEY);")==SQLITE_OK);
+  nAlterDefaultUpdateHook = 0;
+  sqlite3_update_hook(db, countAlterDefaultUpdateHook, 0);
+  check("alter_default_hook_empty_alter", execSql(db,
+      "ALTER TABLE t0 ADD COLUMN v INT DEFAULT 7")==SQLITE_OK);
+  check("alter_default_hook_empty_count", nAlterDefaultUpdateHook==0);
+  check("alter_default_hook_empty_value",
+        strcmp(queryScalarText(db, "SELECT count(*) FROM t0"), "0")==0);
+
+  check("alter_default_hook_one_setup", execSql(db,
+      "CREATE TABLE t1(id INTEGER PRIMARY KEY);"
+      "INSERT INTO t1 VALUES(1);")==SQLITE_OK);
+  nAlterDefaultUpdateHook = 0;
+  check("alter_default_hook_one_alter", execSql(db,
+      "ALTER TABLE t1 ADD COLUMN v INT DEFAULT 7")==SQLITE_OK);
+  check("alter_default_hook_one_count", nAlterDefaultUpdateHook==0);
+  check("alter_default_hook_one_value",
+        strcmp(queryScalarText(db, "SELECT v FROM t1"), "7")==0);
+
+  check("alter_default_hook_multi_setup", execSql(db,
+      "CREATE TABLE t3(id INTEGER PRIMARY KEY);"
+      "INSERT INTO t3 VALUES(1),(2),(3);")==SQLITE_OK);
+  nAlterDefaultUpdateHook = 0;
+  check("alter_default_hook_multi_alter", execSql(db,
+      "ALTER TABLE t3 ADD COLUMN v INT DEFAULT 7")==SQLITE_OK);
+  check("alter_default_hook_multi_count", nAlterDefaultUpdateHook==0);
+  check("alter_default_hook_multi_value",
+        strcmp(queryScalarText(db,
+          "SELECT group_concat(id||':'||v,',') FROM t3"),
+          "1:7,2:7,3:7")==0);
+
+  nAlterDefaultUpdateHook = 0;
+  check("alter_default_hook_real_update", execSql(db,
+      "UPDATE t3 SET v=8 WHERE id=1")==SQLITE_OK);
+  check("alter_default_hook_real_update_count", nAlterDefaultUpdateHook==1);
+
+  sqlite3_close(db);
+  removeDbFiles(dbpath);
+}
+
 static void run_schema_hash_error_propagation(void){
   sqlite3 *db = 0;
   char dbpath[256];
@@ -13962,6 +14029,7 @@ static const RegressionCase aCases[] = {
   { "directonly_dolt_functions", "Direct-Only Dolt Functions Test", run_directonly_dolt_functions },
   { "refs_deserialize_overflow_guard", "Refs Deserialize Overflow Guard Test", run_refs_deserialize_overflow_guard },
   { "alter_default_authorizer", "ALTER Default Authorizer Test", run_alter_default_authorizer },
+  { "alter_default_update_hook", "ALTER Default Update Hook Test", run_alter_default_update_hook },
   { "backup_safety", "Backup Safety Test", run_backup_safety },
   { "backup_source_write_busy", "Backup Source Write Busy Test", run_backup_source_write_busy },
   { "backup_dest_missing_branch", "Backup Dest Missing Branch Test", run_backup_dest_missing_branch },


### PR DESCRIPTION
Fixes #2581.

Adding a column with a non-NULL default materializes the default by rewriting rows. That internal UPDATE was already hidden from triggers, `changes()`, and the authorizer, but `sqlite3_update_hook()` still saw one UPDATE per existing row. Stock SQLite emits none.

The rewrite now sets `DBFLAG_InternalDml` so VDBE skips update/preupdate hooks without clearing `xPreUpdateCallback`. The session module keeps its object list in `pPreUpdateArg`; zeroing the callback (the first version of this PR) was not session-safe.

`test/doltlite_regression_test_c.c` covers zero rows, one row, three rows, a real UPDATE after the ALTER, and (when built with `SQLITE_ENABLE_SESSION`) a post-ALTER `sqlite3session_changeset`.

Co-Authored-By: Grok 4.6 <noreply@x.ai>