### PR TITLE
Harden bearer token time validation

### DIFF
--- a/doc/doltlite/auth.md
+++ b/doc/doltlite/auth.md
@@ -39,10 +39,13 @@ The remotesrv verifier checks:
 - `kid` is present and the matching public JWK is in `--auth-keys`
 - Ed25519 signature over the JWT signing input
 - `iss`, `sub`, and `aud` as above
-- `exp` is present and strictly in the future (`now >= exp` is rejected)
-
-It does not check `iat` or `nbf`, and it does not apply a clock-skew
-window other than the `exp` comparison.
+- `exp` is present and the token is within a 60-second clock-skew window
+- optional `iat` and `nbf` claims are valid integers and no more than 60 seconds
+  ahead of the server clock
+- `exp` is not before `iat` or `nbf`, and an `iat`-bearing token has at most the
+  30-second lifetime DoltLite mints
+- a token without `iat` has no more than 90 seconds until `exp`, preserving
+  compatibility with Dolt credentials while rejecting far-future expirations
 
 The `Authorization` scheme must be the six characters `Bearer ` (capital
 B, one space). `bearer` is rejected. Extra spaces after `Bearer ` are

--- a/src/doltlite_creds.c
+++ b/src/doltlite_creds.c
@@ -239,6 +239,7 @@ void doltliteCredsSign(const DoltliteCreds *c, const unsigned char *msg,
 #define JWT_SUBJECT_PREFIX "doltClientCredentials/"
 #define JWT_TOKEN_VERSION "2023.01"
 #define JWT_TTL_SECONDS   30
+#define JWT_CLOCK_SKEW_SECONDS 60
 
 static char *b64urlRaw(const unsigned char *in, size_t len) {
   char *s = doltliteBase64UrlEncode(in, len);
@@ -450,8 +451,7 @@ static char *jsonFindString(const char *json, const char *key) {
   return jsonDupQuoted(credsJsonObjectValue(json, key));
 }
 
-static int jsonFindLong(const char *json, const char *key, long *out) {
-  const char *p = credsJsonObjectValue(json, key);
+static int jsonParseLong(const char *p, long *out) {
   const char *end;
   uint64_t v;
   if( !p || !out ) return 0;
@@ -464,6 +464,21 @@ static int jsonFindLong(const char *json, const char *key, long *out) {
   if( *end!=',' && *end!='}' ) return 0;
   *out = (long)v;
   return 1;
+}
+
+static int jsonFindLong(const char *json, const char *key, long *out) {
+  return jsonParseLong(credsJsonObjectValue(json, key), out);
+}
+
+static int jsonFindOptionalLong(
+  const char *json,
+  const char *key,
+  long *out,
+  int *present
+) {
+  const char *p = credsJsonObjectValue(json, key);
+  *present = p != 0;
+  return !p || jsonParseLong(p, out);
 }
 
 static int jsonAudienceMatches(const char *json, const char *expected){
@@ -1065,12 +1080,14 @@ int doltliteCredsVerifyBearer(const char *authValue, const char *expectedAudienc
   unsigned char *sig = NULL;
   size_t siglen = 0;
   unsigned char pub[DOLTLITE_PUBKEY_LEN];
-  long exp = 0;
+  long exp = 0, iat = 0, nbf = 0;
+  int hasIat = 0, hasNbf = 0;
   int rc = 1;
 
   if (kidOut) *kidOut = NULL;
   if (!authValue) return 1;
   if (!expectedAudience || !expectedAudience[0]) return 1;
+  if (now < 0) return 1;
 
   jwt = authValue;
   if (strncmp(jwt, "Bearer ", 7) == 0) jwt += 7;
@@ -1116,7 +1133,20 @@ int doltliteCredsVerifyBearer(const char *authValue, const char *expectedAudienc
   if (!jsonAudienceMatches(claims, expectedAudience)) goto done;
 
   if (!jsonFindLong(claims, "exp", &exp)) goto done;
-  if (now >= exp) goto done;
+  if (!jsonFindOptionalLong(claims, "iat", &iat, &hasIat)) goto done;
+  if (!jsonFindOptionalLong(claims, "nbf", &nbf, &hasNbf)) goto done;
+  if (now > exp && now - exp > JWT_CLOCK_SKEW_SECONDS) goto done;
+  if (exp > now && exp - now > JWT_TTL_SECONDS + JWT_CLOCK_SKEW_SECONDS) {
+    goto done;
+  }
+  if (hasIat) {
+    if (iat > now && iat - now > JWT_CLOCK_SKEW_SECONDS) goto done;
+    if (exp < iat || exp - iat > JWT_TTL_SECONDS) goto done;
+  }
+  if (hasNbf) {
+    if (nbf > now && nbf - now > JWT_CLOCK_SKEW_SECONDS) goto done;
+    if (nbf > exp) goto done;
+  }
 
   rc = 0;
   if (kidOut) {

--- a/test/creds_verify_kat.c
+++ b/test/creds_verify_kat.c
@@ -32,10 +32,12 @@ static char *encodeRaw(const unsigned char *p, size_t n) {
   return z;
 }
 
-static char *tokenWithAudJson(
+static char *tokenWithClaims(
   const DoltliteCreds *c,
   const char *kid,
   const char *audJson,
+  const char *iat,
+  const char *nbf,
   const char *exp
 ) {
   char *header = NULL, *claims = NULL, *h64 = NULL, *c64 = NULL;
@@ -49,14 +51,18 @@ static char *tokenWithAudJson(
   snprintf(header, n,
            "{\"alg\":\"EdDSA\",\"kid\":\"%s\",\"dolt_token_version\":\"2023.01\"}",
            kid);
-  n = strlen(kid) * 2 + strlen(audJson) + strlen(exp) + 160;
+  n = strlen(kid) * 2 + strlen(audJson) +
+      (iat ? strlen(iat) : 0) + (nbf ? strlen(nbf) : 0) +
+      (exp ? strlen(exp) : 0) + 192;
   claims = (char *)malloc(n);
   if (!claims) goto done;
   snprintf(claims, n,
            "{\"iss\":\"dolt-client.dolthub.com\","
-           "\"sub\":\"doltClientCredentials/%s\",\"aud\":%s,"
-           "\"iat\":%ld,\"exp\":%s}",
-           kid, audJson, IAT, exp);
+           "\"sub\":\"doltClientCredentials/%s\",\"aud\":%s%s%s%s%s%s%s}",
+           kid, audJson,
+           iat ? ",\"iat\":" : "", iat ? iat : "",
+           nbf ? ",\"nbf\":" : "", nbf ? nbf : "",
+           exp ? ",\"exp\":" : "", exp ? exp : "");
   h64 = encodeRaw((const unsigned char *)header, strlen(header));
   c64 = encodeRaw((const unsigned char *)claims, strlen(claims));
   if (!h64 || !c64) goto done;
@@ -79,6 +85,15 @@ done:
   free(input);
   sqlite3_free(s64);
   return token;
+}
+
+static char *tokenWithAudJson(
+  const DoltliteCreds *c,
+  const char *kid,
+  const char *audJson,
+  const char *exp
+) {
+  return tokenWithClaims(c, kid, audJson, "1700000000", NULL, exp);
 }
 
 static char *tokenForKid(
@@ -177,6 +192,81 @@ int main(int argc, char **argv) {
 
   check("expired token rejected",
         doltliteCredsVerifyBearer(jwt, AUD, authDir, LATE, NULL) != 0);
+
+  check("iat at positive clock-skew boundary accepted",
+        doltliteCredsVerifyBearer(jwt, AUD, authDir, IAT - 60, NULL) == 0);
+  check("iat beyond positive clock-skew boundary rejected",
+        doltliteCredsVerifyBearer(jwt, AUD, authDir, IAT - 61, NULL) != 0);
+  check("token accepted at exp",
+        doltliteCredsVerifyBearer(jwt, AUD, authDir, IAT + 30, NULL) == 0);
+  check("token accepted at negative clock-skew boundary",
+        doltliteCredsVerifyBearer(jwt, AUD, authDir, IAT + 90, NULL) == 0);
+  check("token rejected beyond negative clock-skew boundary",
+        doltliteCredsVerifyBearer(jwt, AUD, authDir, IAT + 91, NULL) != 0);
+
+  {
+    char *missingIat = tokenWithClaims(c, kid, "\"" AUD "\"", NULL, NULL,
+                                       "1700000030");
+    char *futureNbf = tokenWithClaims(c, kid, "\"" AUD "\"", NULL,
+                                      "1700000060", "1700000090");
+    char *tooFutureNbf = tokenWithClaims(c, kid, "\"" AUD "\"", NULL,
+                                         "1700000061", "1700000090");
+    char *invalidIat = tokenWithClaims(c, kid, "\"" AUD "\"",
+                                       "1700000000x", NULL, "1700000030");
+    char *invalidNbf = tokenWithClaims(c, kid, "\"" AUD "\"", NULL,
+                                       "1700000000x", "1700000030");
+    char *longTtl = tokenWithClaims(c, kid, "\"" AUD "\"", "1700000000",
+                                    NULL, "1700000031");
+    char *reversed = tokenWithClaims(c, kid, "\"" AUD "\"", "1700000000",
+                                     NULL, "1699999999");
+    char *longRemaining = tokenWithClaims(c, kid, "\"" AUD "\"", NULL,
+                                          NULL, "1700000091");
+    char *nbfAfterExp = tokenWithClaims(c, kid, "\"" AUD "\"", NULL,
+                                        "1700000031", "1700000030");
+    char *missingExp = tokenWithClaims(c, kid, "\"" AUD "\"",
+                                       "1700000000", NULL, NULL);
+    check("missing iat accepted for Dolt compatibility",
+          missingIat &&
+              doltliteCredsVerifyBearer(missingIat, AUD, authDir, MID, NULL) == 0);
+    check("nbf at positive clock-skew boundary accepted",
+          futureNbf &&
+              doltliteCredsVerifyBearer(futureNbf, AUD, authDir, IAT, NULL) == 0);
+    check("nbf beyond positive clock-skew boundary rejected",
+          tooFutureNbf &&
+              doltliteCredsVerifyBearer(tooFutureNbf, AUD, authDir, IAT, NULL) != 0);
+    check("malformed iat rejected",
+          invalidIat &&
+              doltliteCredsVerifyBearer(invalidIat, AUD, authDir, MID, NULL) != 0);
+    check("malformed nbf rejected",
+          invalidNbf &&
+              doltliteCredsVerifyBearer(invalidNbf, AUD, authDir, MID, NULL) != 0);
+    check("token lifetime above 30 seconds rejected",
+          longTtl &&
+              doltliteCredsVerifyBearer(longTtl, AUD, authDir, MID, NULL) != 0);
+    check("exp before iat rejected",
+          reversed &&
+              doltliteCredsVerifyBearer(reversed, AUD, authDir, MID, NULL) != 0);
+    check("missing-iat token above maximum remaining lifetime rejected",
+          longRemaining &&
+              doltliteCredsVerifyBearer(longRemaining, AUD, authDir, IAT, NULL) != 0);
+    check("nbf after exp rejected",
+          nbfAfterExp &&
+              doltliteCredsVerifyBearer(nbfAfterExp, AUD, authDir, IAT, NULL) != 0);
+    check("missing exp rejected",
+          missingExp &&
+              doltliteCredsVerifyBearer(missingExp, AUD, authDir, MID, NULL) != 0);
+    free(missingIat);
+    free(futureNbf);
+    free(tooFutureNbf);
+    free(invalidIat);
+    free(invalidNbf);
+    free(longTtl);
+    free(reversed);
+    free(longRemaining);
+    free(nbfAfterExp);
+    free(missingExp);
+  }
+
   check("wrong audience rejected",
         doltliteCredsVerifyBearer(jwt, "evil.example.com", authDir, MID, NULL) != 0);
   check("unknown key (empty authorized dir) rejected",


### PR DESCRIPTION
## Summary

- enforce Dolt-compatible 60-second clock skew for `exp`, `iat`, and `nbf`
- reject malformed or inconsistent time claims and cap token lifetimes
- preserve compatibility with Dolt credentials that omit `iat`
- add boundary KAT coverage and document the verifier policy

## Testing

- `bash test/creds_kat_test.sh`
- `bash test/creds_verify_test.sh`
- standalone verifier build with `-Wall -Wextra -Werror`
- `bash test/remote_https_auth_test.sh build/doltlite build/doltlite-remotesrv`
- `make -C build lint`

Fixes #2583

Co-Authored-By: OpenAI Codex <noreply@openai.com>