### PR TITLE
State both halves of the licence in the Homebrew formula

### DIFF
--- a/packaging/homebrew/doltlite.rb
+++ b/packaging/homebrew/doltlite.rb
@@ -8,7 +8,10 @@ class Doltlite < Formula
   homepage "https://github.com/dolthub/doltlite"
   url "https://github.com/dolthub/doltlite/releases/download/v0.50.2/doltlite-autoconf-0.50.2.tar.gz"
   sha256 "186742c40a2cc72183b6e626232d84d8f1223b1212be0e974de47d9374fb1b1e"
-  license "Apache-2.0"
+  # Composite, and both halves are real: the DoltLite extensions are
+  # Apache-2.0, the SQLite code they are built on is public domain. Stating
+  # only the first would misdescribe the tarball this formula builds.
+  license all_of: ["Apache-2.0", :public_domain]
   head "https://github.com/dolthub/doltlite.git", branch: "master"
 
   livecheck do


### PR DESCRIPTION
The formula claimed `Apache-2.0`. The tarball it builds is a composite: the
DoltLite extensions are Apache-2.0, and the SQLite code underneath is public
domain. `LICENSE.md` has always said both.

```ruby
license all_of: ["Apache-2.0", :public_domain]
```

brew resolves that to `Apache-2.0 AND LicenseRef-Homebrew-public-domain`.

## Why nothing caught it

Nothing could. GitHub reports the repository licence as `NOASSERTION`, because
`LICENSE.md` is a composite document rather than a recognised licence text, so
brew's licence audit has no reference to compare against and skips silently.

I confirmed that by setting the formula's licence to `MIT`, an outright lie,
and running `brew audit --new --online --strict`: it passed. The audit itself
is live, which I checked separately by breaking the `desc` and watching it get
rejected on two counts.

A homebrew-core reviewer will not skip the licensing question on a
self-submission, and an undeterminable licence is the wrong thing to present
when asking to be accepted.

## Checks

| check | result |
|---|---|
| `brew audit --new --online --strict` (Homebrew 6.0.21) | clean |
| `brew info --json` licence resolution | `Apache-2.0 AND LicenseRef-Homebrew-public-domain` |
| `test/homebrew_formula_test.sh` | 9 of 9 |
| `make lint` | pass |

Formula-only change; no engine code touched.

Toward #2590. That issue's real blocker is separate and already fixed on
master: v0.50.2's autoconf tarball omits `doltlite.mk`, so it cannot build,
which a4634d27f1 corrected after the tag. Submission waits on a release cut
from master, and I verified a master-built tarball installs and passes
`brew test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
