### PR TITLE
Exercise the Rust crate on the version it advertises

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -243,6 +243,28 @@ jobs:
         bash packaging/rust/test-package.sh build
       timeout-minutes: 25
 
+    # The step above runs on whatever stable the runner ships, which cannot
+    # tell us whether the crate still builds on the version it advertises.
+    # Read the MSRV out of the manifest so this leg cannot drift away from
+    # what the crate promises, and let the consumer resolve dependencies
+    # from scratch, so a dependency raising its own MSRV fails here rather
+    # than after publication.
+    - name: Smoke test the doltlite Rust crate on its declared MSRV
+      if: matrix.platform == 'ubuntu'
+      shell: bash
+      run: |
+        msrv=$(sed -n 's/^rust-version = "\(.*\)"/\1/p' packaging/rust/Cargo.toml)
+        if [ -z "$msrv" ]; then
+          echo "::error::packaging/rust/Cargo.toml declares no rust-version"
+          exit 1
+        fi
+        rustup toolchain install "$msrv" --profile minimal --no-self-update
+        export RUSTUP_TOOLCHAIN="$msrv"
+        echo "declared MSRV $msrv -> $(rustc --version)"
+        chmod +x packaging/rust/assemble.sh packaging/rust/test-package.sh
+        bash packaging/rust/test-package.sh build
+      timeout-minutes: 25
+
     - name: Smoke test the DoltHub.Doltlite NuGet package
       shell: bash
       run: |


### PR DESCRIPTION
The crate declares `rust-version = "1.68"`, but CI built it with whatever
stable the runner shipped, so nothing checked the claim. Crate code or an
unconstrained dependency could raise the real floor and we would find out from
a consumer.

One added leg, ubuntu only. It reads the MSRV out of the manifest rather than
repeating it, so the two cannot drift apart:

```bash
msrv=$(sed -n 's/^rust-version = "\(.*\)"/\1/p' packaging/rust/Cargo.toml)
rustup toolchain install "$msrv" --profile minimal --no-self-update
export RUSTUP_TOOLCHAIN="$msrv"
bash packaging/rust/test-package.sh build
```

`rustup` resolves `1.68` to the newest 1.68.x, and the smoke test's consumer
has no lockfile, so dependencies resolve the way a new consumer's would. A
dependency that raises its own MSRV fails here rather than after publication,
which is the drift the issue is about. The existing stable leg stays; the goal
is to cover both ends, not to move the floor.

## It has teeth

Checked rather than assumed, by adding a `std::sync::OnceLock` item to the
crate. `OnceLock` stabilized in 1.70, so it must build on stable and fail on
the declared MSRV:

| toolchain | with the 1.70-only item | real code |
|---|---|---|
| stable, 1.98.0 | passes, so today's leg misses it | passes |
| declared MSRV, resolved to 1.68.2 | fails, `error[E0658]` | passes |

The MSRV run also passes from a clean `CARGO_HOME`, so the current
dependency set genuinely resolves and builds on 1.68 today; this leg is not
red on arrival.

If the manifest ever loses its `rust-version`, the step fails with an explicit
error rather than silently testing nothing.

Fixes #2584.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
