### PR TITLE
Open the Homebrew bump as a pull request

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1374,26 +1374,30 @@ jobs:
           [ "$(printf '%s\n%s\n' "$current" "$version" | sort -V | tail -1)" != "$version" ]
         }
 
-        for attempt in 1 2 3 4 5; do
-          git fetch origin master
-          git reset --hard origin/master
-          current="$(formula_ver)"
-          if should_skip "$current"; then
-            echo "Homebrew formula already at ${current}; not writing ${version}"
-            exit 0
-          fi
-          bash packaging/homebrew/bump-formula.sh "${version}" "${sha256}"
-          if git diff --quiet -- packaging/homebrew/doltlite.rb; then
-            echo "Homebrew formula already at ${version}"
-            exit 0
-          fi
-          git add packaging/homebrew/doltlite.rb
-          git commit -m "Bump Homebrew formula to ${version}"
-          if git push origin master; then
-            exit 0
-          fi
-          echo "push rejected (attempt ${attempt}); retrying"
-          sleep $((attempt * 2))
-        done
-        echo "failed to push Homebrew formula bump after retries"
-        exit 1
+        git fetch origin master
+        git reset --hard origin/master
+        current="$(formula_ver)"
+        if should_skip "$current"; then
+          echo "Homebrew formula already at ${current}; not writing ${version}"
+          exit 0
+        fi
+        bash packaging/homebrew/bump-formula.sh "${version}" "${sha256}"
+        if git diff --quiet -- packaging/homebrew/doltlite.rb; then
+          echo "Homebrew formula already at ${version}"
+          exit 0
+        fi
+
+        # master requires status checks, so the bump arrives as a pull request
+        # rather than a push. A branch per version keeps re-runs idempotent.
+        branch="automation/homebrew-${version}"
+        if gh api "repos/dolthub/doltlite/git/ref/heads/${branch}" >/dev/null 2>&1; then
+          echo "branch ${branch} already exists; nothing to open"
+          exit 0
+        fi
+        git checkout -b "${branch}"
+        git add packaging/homebrew/doltlite.rb
+        git commit -m "Bump Homebrew formula to ${version}"
+        git push origin "${branch}"
+        gh pr create --base master --head "${branch}" \
+          --title "Bump Homebrew formula to ${version}" \
+          --body "Points the formula at the ${VERSION} release tarball. Opened by the release workflow."

--- a/packaging/homebrew/doltlite.rb
+++ b/packaging/homebrew/doltlite.rb
@@ -6,8 +6,8 @@
 class Doltlite < Formula
   desc "SQLite fork with Git-style version control via prolly trees"
   homepage "https://github.com/dolthub/doltlite"
-  url "https://github.com/dolthub/doltlite/releases/download/v0.50.2/doltlite-autoconf-0.50.2.tar.gz"
-  sha256 "186742c40a2cc72183b6e626232d84d8f1223b1212be0e974de47d9374fb1b1e"
+  url "https://github.com/dolthub/doltlite/releases/download/v0.50.3/doltlite-autoconf-0.50.3.tar.gz"
+  sha256 "fbe66215a3f214d92d1edab82d7125df8257690844541f9a75a3bc6435c2d714"
   # Composite, and both halves are real: the DoltLite extensions are
   # Apache-2.0, the SQLite code they are built on is public domain. Stating
   # only the first would misdescribe the tarball this formula builds.


### PR DESCRIPTION
`release-homebrew` failed on v0.50.3, which was its first release. It has never
worked.

The job pushed the formula bump straight to `master`, retrying five times when
the push was rejected:

```
remote: error: GH013: Repository rule violations found for refs/heads/master.
error: failed to push some refs to 'https://github.com/dolthub/doltlite'
```

`master` carries an active ruleset requiring status checks, so a direct push
is refused. The retry loop was written for a lost race against a concurrent
push; a policy rejection is not a race, so repeating it five times just failed
five times.

## The change

The bump now arrives the way every other change to this repo does, as a pull
request off a per-version branch. That also makes re-runs idempotent without
the loop: if `automation/homebrew-<version>` already exists, there is nothing
to open.

I have carried the v0.50.3 bump in this PR too, since the job could not land
it. The next release skips it, because the formula already names that version.

## Verified against the real release

The v0.50.3 tarball contains `doltlite.mk`, which v0.50.2's did not; that
missing file is why the previous release's tarball could not build at all.

| check, against `releases/download/v0.50.3/...` | result |
|---|---|
| `brew install --build-from-source` | succeeds, built in 14s |
| `brew test` | passes |
| `brew audit --new --online --strict` | clean |
| installed binary | reports `v0.50.3`, engine `prolly` |
| commit, branch, commit, checkout, merge through the installed binary | 2 rows, 3 log entries |
| `test/homebrew_formula_test.sh` | 9 of 9 |
| `make lint` | passes |

Toward #2590. With this the formula is submittable to homebrew-core; the
remaining blocker for that issue is gone.

## Separately, and not fixed here

`release-go` failed on the same run for an unrelated reason:

```
remote: Permission to dolthub/doltlite-driver.git denied to timsehn.
```

The release bot could not push to the newly created repo. @timsehn has since
added `doltlite-driver` to the token's scope, so that job needs a re-run once
the release workflow finishes; it cannot be re-run while the run is still in
progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
