### PR TITLE
Recover missing Homebrew bump pull requests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1387,17 +1387,4 @@ jobs:
           exit 0
         fi
 
-        # master requires status checks, so the bump arrives as a pull request
-        # rather than a push. A branch per version keeps re-runs idempotent.
-        branch="automation/homebrew-${version}"
-        if gh api "repos/dolthub/doltlite/git/ref/heads/${branch}" >/dev/null 2>&1; then
-          echo "branch ${branch} already exists; nothing to open"
-          exit 0
-        fi
-        git checkout -b "${branch}"
-        git add packaging/homebrew/doltlite.rb
-        git commit -m "Bump Homebrew formula to ${version}"
-        git push origin "${branch}"
-        gh pr create --base master --head "${branch}" \
-          --title "Bump Homebrew formula to ${version}" \
-          --body "Points the formula at the ${VERSION} release tarball. Opened by the release workflow."
+        bash packaging/homebrew/open-bump-pr.sh "$version" "$VERSION"

--- a/packaging/homebrew/open-bump-pr.sh
+++ b/packaging/homebrew/open-bump-pr.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+set -euo pipefail
+
+if [ "$#" -ne 2 ]; then
+  echo "usage: $0 VERSION RELEASE_TAG" >&2
+  exit 2
+fi
+
+version="$1"
+release_tag="$2"
+repository="dolthub/doltlite"
+branch="automation/homebrew-${version}"
+
+find_open_pr() {
+  gh pr list --repo "$repository" --base master --head "$branch" \
+    --state open --json number --jq '.[0].number'
+}
+
+open_pr="$(find_open_pr)"
+if [ -n "$open_pr" ]; then
+  echo "Homebrew bump pull request #${open_pr} already exists"
+  exit 0
+fi
+
+if ! gh api "repos/${repository}/git/ref/heads/${branch}" >/dev/null 2>&1; then
+  git checkout -b "$branch"
+  git add packaging/homebrew/doltlite.rb
+  git commit -m "Bump Homebrew formula to ${version}"
+  git push origin "$branch"
+fi
+
+if gh pr create --repo "$repository" --base master --head "$branch" \
+  --title "Bump Homebrew formula to ${version}" \
+  --body "Points the formula at the ${release_tag} release tarball. Opened by the release workflow."; then
+  exit 0
+fi
+
+open_pr="$(find_open_pr)"
+if [ -n "$open_pr" ]; then
+  echo "Homebrew bump pull request #${open_pr} already exists"
+  exit 0
+fi
+exit 1

--- a/test/homebrew_formula_test.sh
+++ b/test/homebrew_formula_test.sh
@@ -6,6 +6,7 @@
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 FORMULA="$ROOT/packaging/homebrew/doltlite.rb"
 BUMP="$ROOT/packaging/homebrew/bump-formula.sh"
+OPEN_PR="$ROOT/packaging/homebrew/open-bump-pr.sh"
 RELEASE_YML="$ROOT/.github/workflows/release.yml"
 
 if [ ! -f "$FORMULA" ]; then
@@ -14,6 +15,10 @@ if [ ! -f "$FORMULA" ]; then
 fi
 if [ ! -f "$BUMP" ]; then
   echo "FAIL: missing $BUMP"
+  exit 1
+fi
+if [ ! -f "$OPEN_PR" ]; then
+  echo "FAIL: missing $OPEN_PR"
   exit 1
 fi
 
@@ -42,10 +47,11 @@ else
 fi
 
 if grep -q 'release-homebrew:' "$RELEASE_YML" \
-   && grep -q 'packaging/homebrew/bump-formula.sh' "$RELEASE_YML"; then
+   && grep -q 'packaging/homebrew/bump-formula.sh' "$RELEASE_YML" \
+   && grep -q 'packaging/homebrew/open-bump-pr.sh' "$RELEASE_YML"; then
   dltest_pass
 else
-  dltest_fail "release_yml_has_homebrew_bump" "  missing release-homebrew job or bump-formula.sh"
+  dltest_fail "release_yml_has_homebrew_bump" "  missing release-homebrew job or helper"
 fi
 
 TMP="$(mktemp -d "${TMPDIR:-/tmp}/doltlite-homebrew.XXXXXX")"
@@ -97,6 +103,54 @@ if grep -E 'tar czf doltlite-autoconf' -A6 "$RELEASE_YML" | grep -q 'doltlite.mk
 else
   dltest_fail "autoconf_tarball_includes_doltlite_mk" \
     "  release.yml tarball file list is missing doltlite.mk"
+fi
+
+mkdir "$TMP/bin"
+cat > "$TMP/bin/gh" <<'EOF'
+#!/bin/bash
+printf 'gh %s\n' "$*" >> "$CALLS"
+if [ "$1 $2" = "pr list" ]; then
+  printf '%s\n' "$MOCK_OPEN_PR"
+elif [ "$1" = "api" ]; then
+  [ "$MOCK_BRANCH_EXISTS" = "1" ]
+fi
+EOF
+cat > "$TMP/bin/git" <<'EOF'
+#!/bin/bash
+printf 'git %s\n' "$*" >> "$CALLS"
+EOF
+chmod +x "$TMP/bin/gh" "$TMP/bin/git"
+
+run_open_pr() {
+  : > "$TMP/calls"
+  PATH="$TMP/bin:$PATH" CALLS="$TMP/calls" \
+    MOCK_OPEN_PR="$1" MOCK_BRANCH_EXISTS="$2" \
+    bash "$OPEN_PR" 9.9.9 v9.9.9 >/dev/null
+}
+
+if run_open_pr "" 1 \
+   && grep -q '^gh pr create ' "$TMP/calls" \
+   && ! grep -q '^git ' "$TMP/calls"; then
+  dltest_pass
+else
+  dltest_fail "homebrew_existing_branch_opens_missing_pr" "$(sed 's/^/  /' "$TMP/calls")"
+fi
+
+if run_open_pr 2596 1 \
+   && ! grep -q '^gh pr create ' "$TMP/calls" \
+   && ! grep -q '^git ' "$TMP/calls"; then
+  dltest_pass
+else
+  dltest_fail "homebrew_existing_pr_is_idempotent" "$(sed 's/^/  /' "$TMP/calls")"
+fi
+
+if run_open_pr "" 0 \
+   && grep -q '^git checkout -b automation/homebrew-9.9.9$' "$TMP/calls" \
+   && grep -q '^git push origin automation/homebrew-9.9.9$' "$TMP/calls" \
+   && grep -q '^gh pr create ' "$TMP/calls"; then
+  dltest_pass
+else
+  dltest_fail "homebrew_missing_branch_pushes_and_opens_pr" "$(sed 's/^/  /' "$TMP/calls")"
 fi
 
 dltest_finish


### PR DESCRIPTION
If the Homebrew bump branch exists after a failed `gh pr create`, a release retry now checks for the open pull request and creates it when missing. An existing open pull request remains an idempotent success.

The helper also rechecks after a failed create to tolerate the request succeeding remotely before the command reports failure.

Testing: `bash test/homebrew_formula_test.sh` (12/12)

Co-Authored-By: OpenAI Codex <noreply@openai.com>