### PR TITLE
packaging/go: enable SQLITE_OPEN_URI in driver Open

### DIFF
--- a/packaging/go/doltlite.go
+++ b/packaging/go/doltlite.go
@@ -73,7 +73,7 @@ func (Driver) Open(name string) (driver.Conn, error) {
 		cname := C.CString(name)
 		defer C.free(unsafe.Pointer(cname))
 		rc = C.sqlite3_open_v2(cname, &db,
-			C.SQLITE_OPEN_READWRITE|C.SQLITE_OPEN_CREATE, nil)
+			C.SQLITE_OPEN_READWRITE|C.SQLITE_OPEN_CREATE|C.SQLITE_OPEN_URI, nil)
 		if rc != C.SQLITE_OK {
 			msg = "unable to open database"
 			if db != nil {


### PR DESCRIPTION
Open databases with `SQLITE_OPEN_URI` so a `file:` DSN can carry query parameters.

This lets callers pass DoltLite URI options through `database/sql`, most importantly `file:app.db?lazy_origin=1` to open a lazily-hydrated repository (fetch missing chunks from the recorded `origin` remote on demand rather than requiring a full local database).

Backward compatible: a plain path without a `file:` scheme is still treated as a literal filename, so existing DSNs are unaffected. This matches how the standard Go SQLite drivers (e.g. mattn/go-sqlite3) open by default.

Verified the lazy path works end to end through the driver with this change — `sql.Open("doltlite", "file:x.db?lazy_origin=1")` + `SELECT dolt_clone('--lazy', <url>)` lazily browses a hosted repo over plain `database/sql`.