### PR TITLE
Reject NULL version-control arguments

### DIFF
--- a/src/doltlite_at.c
+++ b/src/doltlite_at.c
@@ -484,8 +484,14 @@ static int atFilter(sqlite3_vtab_cursor *cur,
   if(!pBt) return SQLITE_OK;
   pCache=doltliteGetCache(db);
 
+  if( sqlite3_value_type(argv[0])==SQLITE_NULL ){
+    sqlite3_free(cur->pVtab->zErrMsg);
+    cur->pVtab->zErrMsg = sqlite3_mprintf(
+        "dolt_at_%s: invalid argument: NULL", v->zTableName);
+    return cur->pVtab->zErrMsg ? SQLITE_ERROR : SQLITE_NOMEM;
+  }
   zRef=(const char*)sqlite3_value_text(argv[0]);
-  if(!zRef) return SQLITE_OK;
+  if(!zRef) return SQLITE_NOMEM;
   c->zCommitRef = sqlite3_mprintf("%s", zRef);
   if( !c->zCommitRef ) return SQLITE_NOMEM;
 

--- a/src/doltlite_cmd.c
+++ b/src/doltlite_cmd.c
@@ -139,7 +139,12 @@ int doltliteCmdParseArgs(
       doltliteCmdArgsClear(pArgs);
       return rc;
     }
-    if( !zArg ) continue;
+    if( !zArg ){
+      if( flags & DOLTLITE_CMD_PARSE_IGNORE_NULLS ) continue;
+      sqlite3_result_error(ctx, "invalid empty argument", -1);
+      doltliteCmdArgsClear(pArgs);
+      return SQLITE_ERROR;
+    }
     if( !endOptions && strcmp(zArg, "--")==0 ){
       endOptions = 1;
       continue;

--- a/src/doltlite_diff_stat.c
+++ b/src/doltlite_diff_stat.c
@@ -295,6 +295,21 @@ static int dsRequireRefs(sqlite3_vtab *pVtab, int idxNum, const char *zName){
   return SQLITE_OK;
 }
 
+static int dsArgText(
+  sqlite3_vtab *pVtab,
+  sqlite3_value *pValue,
+  const char *zName,
+  const char **pzValue
+){
+  if( sqlite3_value_type(pValue)==SQLITE_NULL ){
+    sqlite3_free(pVtab->zErrMsg);
+    pVtab->zErrMsg = sqlite3_mprintf("%s: invalid argument: NULL", zName);
+    return pVtab->zErrMsg ? SQLITE_ERROR : SQLITE_NOMEM;
+  }
+  *pzValue = (const char*)sqlite3_value_text(pValue);
+  return *pzValue ? SQLITE_OK : SQLITE_NOMEM;
+}
+
 static int dsComputeTableStats(
   sqlite3 *db,
   const char *zFromName,
@@ -677,13 +692,16 @@ static int dsFilterInit(
   if( rc!=SQLITE_OK ) return rc;
 
   if( (idxNum & 1) && argIdx<argc ){
-    pCtx->zFromRef = (const char*)sqlite3_value_text(argv[argIdx++]);
+    rc = dsArgText(pVtab, argv[argIdx++], zName, &pCtx->zFromRef);
+    if( rc!=SQLITE_OK ) return rc;
   }
   if( (idxNum & 2) && argIdx<argc ){
-    pCtx->zToRef = (const char*)sqlite3_value_text(argv[argIdx++]);
+    rc = dsArgText(pVtab, argv[argIdx++], zName, &pCtx->zToRef);
+    if( rc!=SQLITE_OK ) return rc;
   }
   if( (idxNum & 4) && argIdx<argc ){
-    pCtx->zTblFilter = (const char*)sqlite3_value_text(argv[argIdx++]);
+    rc = dsArgText(pVtab, argv[argIdx++], zName, &pCtx->zTblFilter);
+    if( rc!=SQLITE_OK ) return rc;
   }
 
   rc = doltliteResolveCatalogHashForRef(db, pCtx->zFromRef, &pCtx->fromCat);

--- a/src/doltlite_diff_table.c
+++ b/src/doltlite_diff_table.c
@@ -156,6 +156,21 @@ static int dtRefError(DiffTblVtab *pVtab, const char *zRef, int rc){
   return pVtab->base.zErrMsg ? SQLITE_ERROR : SQLITE_NOMEM;
 }
 
+static int dtArgText(
+  DiffTblVtab *pVtab,
+  sqlite3_value *pValue,
+  const char **pzValue
+){
+  if( sqlite3_value_type(pValue)==SQLITE_NULL ){
+    sqlite3_free(pVtab->base.zErrMsg);
+    pVtab->base.zErrMsg = sqlite3_mprintf(
+        "dolt_diff_%s: invalid argument: NULL", pVtab->zTableName);
+    return pVtab->base.zErrMsg ? SQLITE_ERROR : SQLITE_NOMEM;
+  }
+  *pzValue = (const char*)sqlite3_value_text(pValue);
+  return *pzValue ? SQLITE_OK : SQLITE_NOMEM;
+}
+
 static void clearAuditRow(AuditRow *r){
   sqlite3_free(r->pKeyRec);
   sqlite3_free(r->pOldKeyRec);
@@ -1177,11 +1192,15 @@ static int dtFilter(sqlite3_vtab_cursor *cur,
   }
 
   if( (idxNum & DT_IDX_SLICE)!=0 && argc>=2 ){
-    const char *zFromRef = (const char*)sqlite3_value_text(argv[0]);
-    const char *zToRef = (const char*)sqlite3_value_text(argv[1]);
+    const char *zFromRef;
+    const char *zToRef;
     const char *zBadRef = 0;
-    rc = buildSliceDiffPair(
-        c, db, pVtab->zTableName, zFromRef, zToRef, &zBadRef);
+    rc = dtArgText(pVtab, argv[0], &zFromRef);
+    if( rc==SQLITE_OK ) rc = dtArgText(pVtab, argv[1], &zToRef);
+    if( rc==SQLITE_OK ){
+      rc = buildSliceDiffPair(
+          c, db, pVtab->zTableName, zFromRef, zToRef, &zBadRef);
+    }
     if( zBadRef ) rc = dtRefError(pVtab, zBadRef, rc);
   }else if( (idxNum & DT_IDX_RANGE_SPEC)!=0 && argc>=1 ){
     const char *zSpec = (const char*)sqlite3_value_text(argv[0]);

--- a/src/doltlite_history.c
+++ b/src/doltlite_history.c
@@ -368,9 +368,16 @@ static int htFilter(sqlite3_vtab_cursor *cur,
   if( c->singleCommit ){
     head = startHash;
   }else if( idxNum & HIST_IDX_START_REF ){
-    const char *zRef = iArg<argc
-                     ? (const char*)sqlite3_value_text(argv[iArg]) : 0;
-    if( !zRef ) return SQLITE_OK;
+    const char *zRef;
+    if( iArg>=argc ) return SQLITE_OK;
+    if( sqlite3_value_type(argv[iArg])==SQLITE_NULL ){
+      sqlite3_free(cur->pVtab->zErrMsg);
+      cur->pVtab->zErrMsg = sqlite3_mprintf(
+          "dolt_history_%s: invalid argument: NULL", v->zTableName);
+      return cur->pVtab->zErrMsg ? SQLITE_ERROR : SQLITE_NOMEM;
+    }
+    zRef = (const char*)sqlite3_value_text(argv[iArg]);
+    if( !zRef ) return SQLITE_NOMEM;
     rc = doltliteResolveRef(v->db, zRef, &head);
     if( rc==SQLITE_NOTFOUND ){
       sqlite3_free(cur->pVtab->zErrMsg);

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -936,6 +936,7 @@ int doltlitePersistOrSaveWorkingSet(sqlite3 *db);
 #define DOLTLITE_CMD_OPTION_FLAG 0
 #define DOLTLITE_CMD_OPTION_VALUE 1
 #define DOLTLITE_CMD_PARSE_SHORT_GROUPS 0x01
+#define DOLTLITE_CMD_PARSE_IGNORE_NULLS 0x02
 
 typedef struct DoltliteCmdOption DoltliteCmdOption;
 struct DoltliteCmdOption {

--- a/src/doltlite_reset.c
+++ b/src/doltlite_reset.c
@@ -485,6 +485,7 @@ static void doltliteResetFunc(
   int nPaths = 0;
   int rc;
   int i;
+  int nNullArgs = 0;
   int graphLocked = 0;
   u8 isMerging = 0;
   int bSucceeded = 0;
@@ -506,9 +507,22 @@ static void doltliteResetFunc(
     havePreResetHead = 1;
   }
 
+  for(i=0; i<argc; i++){
+    if( sqlite3_value_type(argv[i])==SQLITE_NULL ) nNullArgs++;
+  }
   rc = doltliteCmdParseArgs(context, argc, argv, aOption, ArraySize(aOption),
-                            0, &args);
+                            DOLTLITE_CMD_PARSE_IGNORE_NULLS, &args);
   if( rc!=SQLITE_OK ) goto reset_cleanup;
+  if( argc==1 && nNullArgs==1 ){
+    sqlite3_result_error(context, "commit not found", -1);
+    goto reset_cleanup;
+  }
+  if( (isHard || isSoft) && args.nPositional+nNullArgs>1 ){
+    sqlite3_result_error(context,
+      isHard ? "--hard supports at most one additional param"
+             : "--soft supports at most one additional param", -1);
+    goto reset_cleanup;
+  }
   azPaths = (const char**)sqlite3_malloc(
       sizeof(char*) * (args.nPositional>0 ? args.nPositional : 1));
   if( !azPaths ){ sqlite3_result_error_nomem(context); goto reset_cleanup; }

--- a/src/doltlite_revert.c
+++ b/src/doltlite_revert.c
@@ -190,9 +190,13 @@ static void doltliteRevertFunc(
     return;
   }
 
+  if( sqlite3_value_type(argv[0])==SQLITE_NULL ){
+    sqlite3_result_error(context, "invalid commit hash", -1);
+    return;
+  }
   zRef = (const char*)sqlite3_value_text(argv[0]);
   if( !zRef ){
-    sqlite3_result_int(context, 0);
+    sqlite3_result_error_nomem(context);
     return;
   }
 

--- a/src/doltlite_schema_diff.c
+++ b/src/doltlite_schema_diff.c
@@ -846,15 +846,25 @@ static int sdParseArgs(
   const char *zFromRef = 0;
   const char *zToRef = 0;
   const char *zTableFilter = 0;
+  sqlite3_value *pArg;
 
   if( (idxNum & 1) && argIdx<argc ){
-    zFromRef = (const char*)sqlite3_value_text(argv[argIdx++]);
+    pArg = argv[argIdx++];
+    if( sqlite3_value_type(pArg)==SQLITE_NULL ) goto null_arg;
+    zFromRef = (const char*)sqlite3_value_text(pArg);
+    if( !zFromRef ) return SQLITE_NOMEM;
   }
   if( (idxNum & 2) && argIdx<argc ){
-    zToRef = (const char*)sqlite3_value_text(argv[argIdx++]);
+    pArg = argv[argIdx++];
+    if( sqlite3_value_type(pArg)==SQLITE_NULL ) goto null_arg;
+    zToRef = (const char*)sqlite3_value_text(pArg);
+    if( !zToRef ) return SQLITE_NOMEM;
   }
   if( (idxNum & 4) && argIdx<argc ){
-    zTableFilter = (const char*)sqlite3_value_text(argv[argIdx++]);
+    pArg = argv[argIdx++];
+    if( sqlite3_value_type(pArg)==SQLITE_NULL ) goto null_arg;
+    zTableFilter = (const char*)sqlite3_value_text(pArg);
+    if( !zTableFilter ) return SQLITE_NOMEM;
   }
 
   if( zFromRef && !zToRef ){
@@ -906,6 +916,12 @@ static int sdParseArgs(
   *pzToRef = zToRef;
   *pzTableFilter = zTableFilter;
   return SQLITE_OK;
+
+null_arg:
+  sqlite3_free(pVtab->zErrMsg);
+  pVtab->zErrMsg = sqlite3_mprintf(
+      "dolt_schema_diff: invalid argument: NULL");
+  return pVtab->zErrMsg ? SQLITE_ERROR : SQLITE_NOMEM;
 }
 
 static int sdFilter(sqlite3_vtab_cursor *cur,

--- a/test/oracle-buckets/diff-history-data.txt
+++ b/test/oracle-buckets/diff-history-data.txt
@@ -6,6 +6,7 @@ vc_oracle_diff_stat_test.sh
 vc_oracle_diff_test.sh
 vc_oracle_diff_tvf_test.sh
 vc_oracle_history_test.sh
+vc_oracle_null_args_test.sh
 vc_oracle_patch_test.sh
 vc_oracle_pk_edge_values_test.sh
 vc_oracle_pk_only_tables_test.sh

--- a/test/vc_oracle_diff_stat_test.sh
+++ b/test/vc_oracle_diff_stat_test.sh
@@ -381,6 +381,36 @@ SELECT dolt_commit('-m', 'c2');
 
 echo "--- missing table filter (match Dolt) ---"
 
+oracle_error "diff_stat_null_from_ref" "
+$SEED
+SELECT * FROM dolt_diff_stat(NULL, 'HEAD~1', 't');
+"
+
+oracle_error "diff_stat_null_to_ref" "
+$SEED
+SELECT * FROM dolt_diff_stat('HEAD~1', NULL, 't');
+"
+
+oracle_error "diff_stat_null_table" "
+$SEED
+SELECT * FROM dolt_diff_stat('HEAD~1', 'HEAD', NULL);
+"
+
+oracle_error "diff_summary_null_from_ref" "
+$SEED
+SELECT * FROM dolt_diff_summary(NULL, 'HEAD~1', 't');
+"
+
+oracle_error "diff_summary_null_to_ref" "
+$SEED
+SELECT * FROM dolt_diff_summary('HEAD~1', NULL, 't');
+"
+
+oracle_error "diff_summary_null_table" "
+$SEED
+SELECT * FROM dolt_diff_summary('HEAD~1', 'HEAD', NULL);
+"
+
 oracle_error "diff_stat_missing_table" "
 $SEED
 SELECT * FROM dolt_diff_stat('HEAD', 'HEAD', 'doesnotexist');

--- a/test/vc_oracle_diff_tvf_test.sh
+++ b/test/vc_oracle_diff_tvf_test.sh
@@ -246,6 +246,12 @@ oracle_error "diff_slice_unknown_hash_prefix" "$SETUP_DIVERGENT" \
 oracle_error "diff_slice_invalid_ancestor" "$SETUP_DIVERGENT" \
   "SELECT count(*) FROM dolt_diff_t('HEAD~99', 'feature');"
 
+oracle_error "diff_slice_null_from_ref" "$SETUP_DIVERGENT" \
+  "SELECT count(*) FROM dolt_diff_t(NULL, 'feature');"
+
+oracle_error "diff_slice_null_to_ref" "$SETUP_DIVERGENT" \
+  "SELECT count(*) FROM dolt_diff_t('main', NULL);"
+
 oracle_error "diff_range_unknown_ref" "$SETUP_DIVERGENT" \
   "SELECT count(*) FROM dolt_diff_t('nosuchref..feature');"
 

--- a/test/vc_oracle_null_args_test.sh
+++ b/test/vc_oracle_null_args_test.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+
+set -u
+
+DOLTLITE="${1:-./doltlite}"
+DOLT="${2:-dolt}"
+TMPROOT=$(mktemp -d)
+trap "rm -rf $TMPROOT" EXIT
+pass=0; fail=0
+FAILED_NAMES=""
+source "$(dirname "$0")/lib/vc_oracle_common.sh"
+
+oracle_error() {
+  local name="$1" setup="$2" dl_query="$3" dt_query="$4"
+  local dir="$TMPROOT/$name"
+  local dl_rc dt_rc dt_setup
+  mkdir -p "$dir/dl" "$dir/dt"
+
+  vc_oracle_run_doltlite_script "$dir/dl/db" "$dir/dl.out" \
+    "$dir/dl.err" "$(printf '%s\n%s\n' "$setup" "$dl_query")"
+  dl_rc=$?
+
+  dt_setup=$(vc_oracle_translate_for_dolt "$setup")
+  vc_oracle_run_dolt_script_for_error "$dir/dt" "$dir/dt.out" \
+    "$dir/dt.err" "$(printf '%s\n%s\n' "$dt_setup" "$dt_query")"
+  dt_rc=$?
+
+  if vc_oracle_is_clean_error "$dl_rc" && vc_oracle_is_clean_error "$dt_rc"; then
+    pass=$((pass+1))
+  else
+    fail=$((fail+1))
+    FAILED_NAMES="$FAILED_NAMES $name"
+    echo "  FAIL: $name (doltlite rc=$dl_rc, dolt rc=$dt_rc)"
+  fi
+}
+
+BASE="
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'base');
+SELECT dolt_commit('-A','-m','base');
+SELECT dolt_branch('feature');
+SELECT dolt_checkout('feature');
+INSERT INTO t VALUES(2,'feature');
+SELECT dolt_commit('-A','-m','feature');
+SELECT dolt_checkout('main');
+"
+
+DIRTY="$BASE
+INSERT INTO t VALUES(3,'dirty');
+"
+
+STAGED="$DIRTY
+SELECT dolt_add('t');
+"
+
+echo "=== Version Control Oracle Tests: NULL arguments ==="
+
+oracle_error "at_null_ref" "$BASE" \
+  "SELECT count(*) FROM dolt_at_t(NULL);" \
+  "SELECT count(*) FROM t AS OF NULL;"
+
+oracle_error "history_null_ref" "$BASE" \
+  "SELECT count(*) FROM dolt_history_t(NULL);" \
+  "SELECT count(*) FROM dolt_history_t AS OF NULL;"
+
+oracle_error "schema_diff_null_table" "$BASE" \
+  "SELECT count(*) FROM dolt_schema_diff('HEAD~1','HEAD',NULL);" \
+  "SELECT count(*) FROM dolt_schema_diff('HEAD~1','HEAD',NULL);"
+
+oracle_error "revert_null_ref" "$BASE" \
+  "SELECT dolt_revert(NULL);" \
+  "CALL dolt_revert(NULL);"
+
+oracle_error "reset_null_ref" "$STAGED" \
+  "SELECT dolt_reset(NULL);" \
+  "CALL dolt_reset(NULL);"
+
+oracle_error "reset_hard_null_and_ref" "$STAGED" \
+  "SELECT dolt_reset(NULL,'--hard','HEAD');" \
+  "CALL dolt_reset(NULL,'--hard','HEAD');"
+
+oracle_error "add_drops_null_arg" "$DIRTY" \
+  "SELECT dolt_add(NULL,'t');" \
+  "CALL dolt_add(NULL,'t');"
+
+oracle_error "branch_drops_null_arg" "$BASE" \
+  "SELECT dolt_branch(NULL,'newbranch');" \
+  "CALL dolt_branch(NULL,'newbranch');"
+
+oracle_error "checkout_drops_null_arg" "$BASE" \
+  "SELECT dolt_checkout(NULL,'main');" \
+  "CALL dolt_checkout(NULL,'main');"
+
+oracle_error "commit_drops_null_arg" "$DIRTY" \
+  "SELECT dolt_commit(NULL,'-A','-m','commit');" \
+  "CALL dolt_commit(NULL,'-A','-m','commit');"
+
+oracle_error "tag_drops_null_arg" "$BASE" \
+  "SELECT dolt_tag(NULL,'newtag');" \
+  "CALL dolt_tag(NULL,'newtag');"
+
+oracle_error "merge_drops_null_arg" "$BASE" \
+  "SELECT dolt_merge(NULL,'feature');" \
+  "CALL dolt_merge(NULL,'feature');"
+
+oracle_error "cherry_pick_drops_null_arg" "$BASE" \
+  "SELECT dolt_cherry_pick(NULL,dolt_hashof('feature'));" \
+  "CALL dolt_cherry_pick(NULL,dolt_hashof('feature'));"
+
+echo ""
+echo "=== Results: $pass passed, $fail failed ==="
+if [ "$fail" -ne 0 ]; then
+  echo "Failed:$FAILED_NAMES"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- reject explicit SQL NULL revision arguments and table filters across diff-stat, table-diff, schema-diff, historical-table, revert, and reset surfaces
- stop the shared command parser from dropping NULL positional arguments and accidentally reinterpreting later arguments as valid calls
- preserve the unusual NULL reset forms that Dolt accepts while rejecting the forms Dolt rejects
- add Dolt oracle coverage for 21 affected argument positions and call shapes

## Root cause

Several argument parsers converted SQL NULL values to null C pointers. Downstream code then treated those pointers as omitted arguments, HEAD, absent filters, empty diffs, or shifted later positional arguments left. Explicit NULL values now produce errors wherever Dolt does, without changing ordinary SQL NULL predicate behavior or APIs with deliberate NULL semantics.

## Validation

- comprehensive NULL oracle fail-before: 0 passed, 13 expected failures
- comprehensive NULL oracle pass-after: 13 passed, 0 failed
- diff-stat oracle fail-before: 111 passed, 6 expected failures
- diff-stat oracle pass-after: 117 passed, 0 failed
- table-diff oracle fail-before: 35 passed, 2 expected failures
- table-diff oracle pass-after: 37 passed, 0 failed
- affected existing Dolt oracle suites: 683 passed, 0 failed
- full native suite: 126 passed, 0 failed; 311207 regression assertions passed
- make lint

Co-Authored-By: OpenAI Codex <noreply@openai.com>