### PR TITLE
Allow lazy chunk fetches under graph locks

### DIFF
--- a/src/chunk_store.h
+++ b/src/chunk_store.h
@@ -311,6 +311,7 @@ int chunkStoreSourcePrefetchMany(ChunkStore *cs, const ProllyHash *aHash,
                                  int nHash);
 int chunkStoreSourceSet(ChunkStore *cs, sqlite3 *db,
                         doltlite_chunk_source *pSource, int *pChanged);
+void chunkStoreSourceCloseWriter(ChunkStore *cs);
 void chunkStoreSourceClose(ChunkStore *cs);
 char *chunkStoreSourceTakeError(ChunkStore *cs, int *pRc);
 

--- a/src/doltlite_chunk_source.c
+++ b/src/doltlite_chunk_source.c
@@ -521,11 +521,6 @@ int chunkStoreSourceGet(
     }
     return SQLITE_NOTFOUND;
   }
-  if( csSourceGraphLockHeld(cs, p) ){
-    csSourceSetHashError(p, SQLITE_BUSY,
-      "chunk source fetch blocked by active graph lock for", pHash);
-    return SQLITE_BUSY;
-  }
   sourceRc = pSource->xGet(pSource->pCtx, pHash->data, &pData, &nData);
   if( sourceRc==DOLTLITE_SOURCE_NOTFOUND ){
     sqlite3_free(pData);
@@ -547,7 +542,9 @@ int chunkStoreSourceGet(
   }
   apData[0] = pData;
   anData[0] = nData;
-  rc = csSourcePersistMany(cs, p, pHash, apData, anData, 1);
+  if( !csSourceGraphLockHeld(cs, p) ){
+    rc = csSourcePersistMany(cs, p, pHash, apData, anData, 1);
+  }
   if( rc==SQLITE_OK ) rc = csSourceCachePut(p, pHash, pData, nData);
   if( rc!=SQLITE_OK ){
     sqlite3_free(pData);
@@ -593,13 +590,6 @@ int chunkStoreSourcePrefetchMany(
     if( !aPresent[i] ) aMissing[nMissing++] = aHash[i];
   }
   if( nMissing==0 ) goto prefetch_done;
-  if( csSourceGraphLockHeld(cs, p) ){
-    csSourceSetHashError(p, SQLITE_BUSY,
-      "chunk source fetch blocked by active graph lock for", &aMissing[0]);
-    rc = SQLITE_BUSY;
-    goto prefetch_done;
-  }
-
   apData = (u8**)sqlite3_malloc64(
       (sqlite3_uint64)nMissing * sizeof(u8*));
   anData = (int*)sqlite3_malloc64(
@@ -645,7 +635,9 @@ int chunkStoreSourcePrefetchMany(
     }
   }
 
-  rc = csSourcePersistMany(cs, p, aMissing, apData, anData, nMissing);
+  if( !csSourceGraphLockHeld(cs, p) ){
+    rc = csSourcePersistMany(cs, p, aMissing, apData, anData, nMissing);
+  }
   if( rc!=SQLITE_OK ) goto prefetch_done;
   for(i=0; i<nMissing; i++){
     if( !apData[i] ) continue;

--- a/src/doltlite_chunk_source.c
+++ b/src/doltlite_chunk_source.c
@@ -666,6 +666,13 @@ void chunkStoreSourceClose(ChunkStore *cs){
   sqlite3_free(p);
 }
 
+void chunkStoreSourceCloseWriter(ChunkStore *cs){
+  DoltliteChunkSourceState *p = cs->pChunkSource;
+  if( !p || !p->writerOpen ) return;
+  chunkStoreClose(&p->writer);
+  p->writerOpen = 0;
+}
+
 static int csSourceCreate(
   ChunkStore *cs,
   sqlite3 *db,
@@ -1082,6 +1089,9 @@ void chunkStoreSourceClose(ChunkStore *cs){
   cs->pChunkSource = 0;
   sqlite3_free(p->zErr);
   sqlite3_free(p);
+}
+void chunkStoreSourceCloseWriter(ChunkStore *cs){
+  UNUSED_PARAMETER(cs);
 }
 char *chunkStoreSourceTakeError(ChunkStore *cs, int *pRc){
   DoltliteChunkSourceState *p = cs->pChunkSource;

--- a/src/doltlite_gc.c
+++ b/src/doltlite_gc.c
@@ -1008,6 +1008,7 @@ static int gcRun(
     return SQLITE_BUSY;
   }
 
+  chunkStoreSourceCloseWriter(cs);
   rc = gcLockAndRefresh(db, cs, bBusyRetry);
   if( rc!=SQLITE_OK ){
     *pzPhase = "failed to acquire lock for gc";

--- a/test/chunk_source_test.c
+++ b/test/chunk_source_test.c
@@ -1138,7 +1138,7 @@ other_ws_done:
   pCtx->mode = SOURCE_NORMAL;
 }
 
-static void testGraphLockMiss(
+static void testGraphLockFetch(
   const char *zPath,
   const char *zAuxPath,
   SourceCtx *pCtx,
@@ -1182,18 +1182,18 @@ static void testGraphLockMiss(
   inTxn = 1;
   sourceResetCounters(pCtx);
   rc = getDbChunk(db, &missing, &pData, &nData);
-  check("graph-lock miss returns busy", (rc & 0xff)==SQLITE_BUSY);
-  check("graph-lock miss does not invoke callback",
-        pCtx->nGet==0 && pCtx->nGetMany==0 && pCtx->nRequest==0);
+  check("graph-lock miss fetches into memory", rc==SQLITE_OK);
+  check("graph-lock miss invokes callback", pCtx->nRequest>0);
   sqlite3_free(pData);
   pData = 0;
   rc = execSql(db, "ROLLBACK");
   check("rollback graph-lock transaction", rc==SQLITE_OK);
   if( rc==SQLITE_OK ) inTxn = 0;
   if( rc!=SQLITE_OK ) goto graph_lock_done;
+  sourceResetCounters(pCtx);
   rc = getDbChunk(db, &missing, &pData, &nData);
-  check("source miss succeeds after graph-lock rollback", rc==SQLITE_OK);
-  check("post-rollback miss invokes source", pCtx->nRequest>0);
+  check("graph-lock fetch remains cached after rollback", rc==SQLITE_OK);
+  check("post-rollback cache hit skips callback", pCtx->nRequest==0);
   sqlite3_free(pData);
   pData = 0;
   zAttach = sqlite3_mprintf("ATTACH %Q AS aux", zAuxPath);
@@ -1217,10 +1217,8 @@ static void testGraphLockMiss(
   if( rc!=SQLITE_OK ) goto graph_lock_done;
   sourceResetCounters(pCtx);
   rc = getDbChunk(db, &missing, &pData, &nData);
-  check("cross-database graph-lock miss returns busy",
-        (rc & 0xff)==SQLITE_BUSY);
-  check("cross-database graph lock suppresses callback",
-        pCtx->nGet==0 && pCtx->nGetMany==0 && pCtx->nRequest==0);
+  check("cross-database graph-lock miss fetches into memory", rc==SQLITE_OK);
+  check("cross-database graph-lock miss invokes callback", pCtx->nRequest>0);
 
 graph_lock_done:
   sqlite3_free(pData);
@@ -2497,7 +2495,7 @@ int main(void){
       zWorkingSetMiss, &source, &api, pNewRefs, nNewRefs);
   testOtherBranchWorkingSetNotFound(
       zOtherWorkingSetMiss, &source, &api, pNewRefs, nNewRefs);
-  testGraphLockMiss(
+  testGraphLockFetch(
       zGraphLock, zGraphAux, &source, &api, pNewRefs, nNewRefs);
   testSourcePersistenceBusyRetry(
       zBusyRetry, sourceDb, &source, &api, pNewRefs, nNewRefs);

--- a/test/remote_test.sh
+++ b/test/remote_test.sh
@@ -868,7 +868,12 @@ lazy_gc_uri="file:$TMPDIR/lazy_gc.db?lazy_origin=1"
   "SELECT dolt_clone('--lazy','$R/lazy_origin.db');" > /dev/null
 result=$("$DB" "$lazy_gc_uri" "SELECT dolt_gc();" 2>&1)
 lazy_gc_rc=$?
-check "gc faults in uncached lazy chunks" "0" "$lazy_gc_rc"
+if [ "$lazy_gc_rc" -eq 0 ]; then
+  lazy_gc_status=0
+else
+  lazy_gc_status="$lazy_gc_rc: $result"
+fi
+check "gc faults in uncached lazy chunks" "0" "$lazy_gc_status"
 result=$("$DB" "$lazy_gc_uri" \
   "SELECT count(*) || '|' || sum(id) FROM lazy_rows;" 2>&1)
 check "lazy data remains intact after gc" "801|321201" "$result"

--- a/test/remote_test.sh
+++ b/test/remote_test.sh
@@ -834,6 +834,45 @@ else
 fi
 check "lazy clone is refs-sized before use" "1" "$lazy_refs_sized"
 
+lazy_write_uri="file:$TMPDIR/lazy_write.db?lazy_origin=1"
+"$DB" "$lazy_write_uri" \
+  "SELECT dolt_clone('--lazy','$R/lazy_origin.db');" > /dev/null
+result=$("$DB" "$lazy_write_uri" \
+  "INSERT INTO lazy_cold VALUES(102,zeroblob(4096)); SELECT count(*) || '|' || max(id) FROM lazy_cold;" 2>&1)
+check "first write to an uncached lazy table succeeds" "101|102" "$result"
+
+"$DB" "$TMPDIR/lazy_merge_origin.db" <<'ENDSQL' > /dev/null
+CREATE TABLE merge_rows(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO merge_rows VALUES(1,'base');
+SELECT dolt_commit('-Am','base');
+.quit
+ENDSQL
+lazy_merge_uri="file:$TMPDIR/lazy_merge.db?lazy_origin=1"
+"$DB" "$lazy_merge_uri" \
+  "SELECT dolt_clone('--lazy','$R/lazy_merge_origin.db');" > /dev/null
+"$DB" "$lazy_merge_uri" \
+  "SELECT count(*) FROM merge_rows; INSERT INTO merge_rows VALUES(3,'local'); SELECT dolt_commit('-am','local');" > /dev/null
+"$DB" "$TMPDIR/lazy_merge_origin.db" \
+  "INSERT INTO merge_rows VALUES(2,'origin'); SELECT dolt_commit('-am','origin');" > /dev/null
+"$DB" "$lazy_merge_uri" "SELECT dolt_fetch('origin');" > /dev/null
+result=$("$DB" "$lazy_merge_uri" \
+  "SELECT dolt_merge('origin/main');" 2>&1)
+lazy_merge_rc=$?
+check "merge faults in uncached lazy table data" "0" "$lazy_merge_rc"
+result=$("$DB" "$lazy_merge_uri" \
+  "SELECT group_concat(id, ',') FROM (SELECT id FROM merge_rows ORDER BY id);" 2>&1)
+check "lazy merge keeps both branches' rows" "1,2,3" "$result"
+
+lazy_gc_uri="file:$TMPDIR/lazy_gc.db?lazy_origin=1"
+"$DB" "$lazy_gc_uri" \
+  "SELECT dolt_clone('--lazy','$R/lazy_origin.db');" > /dev/null
+result=$("$DB" "$lazy_gc_uri" "SELECT dolt_gc();" 2>&1)
+lazy_gc_rc=$?
+check "gc faults in uncached lazy chunks" "0" "$lazy_gc_rc"
+result=$("$DB" "$lazy_gc_uri" \
+  "SELECT count(*) || '|' || sum(id) FROM lazy_rows;" 2>&1)
+check "lazy data remains intact after gc" "801|321201" "$result"
+
 lazy_actual=$("$DB" "$lazy_clone_uri" "$lazy_parity_sql")
 check "lazy clone matches rows, log, branches, diff stat, historical rows, and full scan" "$lazy_expected" "$lazy_actual"
 


### PR DESCRIPTION
## Summary

- allow lazy-origin chunks to be fetched and verified while a graph lock is active
- cache locked fetches in the connection instead of opening the competing persistence writer
- close the auxiliary source writer before GC file replacement, preserving source registration and the memory cache
- preserve durable source caching when no graph lock is held
- cover first writes to uncached tables, fetched-tip merges, GC, and cross-database graph locks

## Fail-before evidence

On master, the new lazy-clone regression failed its first uncached write with chunk source fetch blocked by active graph lock and left the table unchanged. The fresh lazy-clone GC regression also exited with an error. Both pass with this change.

The first CI run exposed the remaining platform-specific case: Windows passed lazy writes and merges but failed lazy GC because its open auxiliary persistence handle prevented database-file replacement. GC now closes that handle before acquiring and refreshing under the graph lock; this also avoids retaining a stale pre-GC inode on Unix.

## Validation

- remote suite: 138 passed, 0 failed
- host chunk-source test: 313 passed, 0 failed
- focused GC suites: 77 passed, 0 failed
- multiprocess GC test: 101 passed, 0 failed
- gated C tests: 33 passed, 0 failed
- native DoltLite suites: 126 passed, 0 failed; 311207 regression assertions passed
- make lint

Closes #2607

Co-Authored-By: OpenAI Codex <noreply@openai.com>