### PR TITLE
Keep clone remotes local to the clone

### DIFF
--- a/src/doltlite_remote.c
+++ b/src/doltlite_remote.c
@@ -1317,6 +1317,23 @@ int doltliteFetch(
   return rc;
 }
 
+static int remotePrepareCloneRefs(ChunkStore *pStore, const char *zUrl){
+  const BranchRef *aBranch;
+  int nBranch;
+  int rc;
+  int i;
+
+  csFreeRemotes(pStore);
+  csFreeTracking(pStore);
+  rc = chunkStoreAddRemote(pStore, "origin", zUrl);
+  refsTableGetBranches(&pStore->refs, &nBranch, &aBranch);
+  for(i=0; i<nBranch && rc==SQLITE_OK; i++){
+    rc = chunkStoreUpdateTracking(
+        pStore, "origin", aBranch[i].zName, &aBranch[i].commitHash);
+  }
+  return rc;
+}
+
 int doltliteCloneLazy(
   ChunkStore *pLocal,
   DoltliteRemote *pRemote,
@@ -1360,17 +1377,11 @@ int doltliteCloneLazy(
     }
   }
 
-  rc = chunkStoreDeleteRemote(&refsView, "origin");
-  if( rc==SQLITE_NOTFOUND ) rc = SQLITE_OK;
-  if( rc==SQLITE_OK ) rc = chunkStoreAddRemote(&refsView, "origin", zUrl);
   for(i=0; i<nBranch && rc==SQLITE_OK; i++){
     rc = chunkStoreSetBranchWorkingSet(
         &refsView, aBranch[i].zName, &emptyWs);
-    if( rc==SQLITE_OK ){
-      rc = chunkStoreUpdateTracking(
-          &refsView, "origin", aBranch[i].zName, &aBranch[i].commitHash);
-    }
   }
+  if( rc==SQLITE_OK ) rc = remotePrepareCloneRefs(&refsView, zUrl);
   if( rc==SQLITE_OK ){
     rc = chunkStoreSerializeRefsToBlob(
         &refsView, &pLocalRefs, &nLocalRefs);
@@ -1408,7 +1419,11 @@ lazy_clone_done:
   return rc;
 }
 
-int doltliteClone(ChunkStore *pLocal, DoltliteRemote *pRemote){
+int doltliteClone(
+  ChunkStore *pLocal,
+  DoltliteRemote *pRemote,
+  const char *zUrl
+){
   u8 *refsData = 0;
   int nRefsData = 0;
   ProllyHash *aRoots = 0;
@@ -1427,6 +1442,7 @@ int doltliteClone(ChunkStore *pLocal, DoltliteRemote *pRemote){
          sizeof(ProllyHash));
   memset(&savedRefs, 0, sizeof(savedRefs));
   oldRefsStale = pLocal->bRefsStale;
+  if( !zUrl ) return SQLITE_MISUSE;
 
   rc = pRemote->xGetRefs(pRemote, &refsData, &nRefsData);
   if( rc!=SQLITE_OK ) return rc;
@@ -1497,6 +1513,7 @@ int doltliteClone(ChunkStore *pLocal, DoltliteRemote *pRemote){
         rc = chunkStoreSetBranchWorkingSet(pLocal, aBr[i].zName, &emptyWs);
       }
     }
+    if( rc==SQLITE_OK ) rc = remotePrepareCloneRefs(pLocal, zUrl);
     if( rc==SQLITE_OK ){
       rc = chunkStoreSerializeRefs(pLocal);
     }

--- a/src/doltlite_remote.h
+++ b/src/doltlite_remote.h
@@ -57,7 +57,8 @@ int doltliteValidateRefsTargetGraph(ChunkStore *pStore, const u8 *pBlob,
 int doltliteFetch(ChunkStore *pLocal, DoltliteRemote *pRemote,
                   const char *zRemoteName, const char *zBranch);
 
-int doltliteClone(ChunkStore *pLocal, DoltliteRemote *pRemote);
+int doltliteClone(ChunkStore *pLocal, DoltliteRemote *pRemote,
+                  const char *zUrl);
 
 int doltliteCloneLazy(ChunkStore *pLocal, DoltliteRemote *pRemote,
                       const char *zUrl);

--- a/src/doltlite_remote_sql.c
+++ b/src/doltlite_remote_sql.c
@@ -814,7 +814,7 @@ static void doltCloneFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
     }
   }
   rc = bLazy ? doltliteCloneLazy(cs, pRemote, zUrl)
-             : doltliteClone(cs, pRemote);
+             : doltliteClone(cs, pRemote, zUrl);
   if( rc!=SQLITE_OK ){
     const char *zMsg = remoteSqlRemoteMsg(pRemote, rc);
     char *zOwned;
@@ -854,29 +854,6 @@ static void doltCloneFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
     remoteSqlExpireCurrentStatement(db);
     remoteSqlClearAndSucceed(ctx, &savedState);
     return;
-  }
-
-  rc = chunkStoreAddRemote(cs, "origin", zUrl);
-  if( rc!=SQLITE_OK ){
-    remoteSqlRestoreAndReport(ctx, db, cs, &savedState, SQLITE_ERROR,
-                              "failed to add origin remote");
-    return;
-  }
-
-  {
-    int i;
-    int nBr;
-    const BranchRef *aBr;
-    refsTableGetBranches(&cs->refs, &nBr, &aBr);
-    for(i=0; i<nBr; i++){
-      rc = chunkStoreUpdateTracking(
-          cs, "origin", aBr[i].zName, &aBr[i].commitHash);
-      if( rc!=SQLITE_OK ){
-        remoteSqlRestoreAndReport(ctx, db, cs, &savedState, rc,
-                                  "failed to add origin tracking refs");
-        return;
-      }
-    }
   }
 
   {

--- a/test/remote_test.sh
+++ b/test/remote_test.sh
@@ -125,6 +125,34 @@ check "clone has origin" "origin" "$result"
 result=$("$DB" "$TMPDIR/clone.db" "SELECT message FROM dolt_log LIMIT 1;")
 check "clone has commit history" "initial: two tables with data" "$result"
 
+"$DB" "$TMPDIR/clone_chain_source.db" \
+  "SELECT dolt_clone('$R/remote.db'); SELECT dolt_remote('add','other','$R/remote.db'); SELECT dolt_fetch('other','main');" > /dev/null
+
+result=$("$DB" "$TMPDIR/clone_chain.db" \
+  "SELECT dolt_clone('$R/clone_chain_source.db');" 2>&1)
+check "clone of clone succeeds" "0" "$result"
+result=$("$DB" "$TMPDIR/clone_chain.db" \
+  "SELECT name, url FROM dolt_remotes ORDER BY name;")
+check "clone of clone keeps only its immediate origin" \
+  "origin|$R/clone_chain_source.db" "$result"
+result=$("$DB" "$TMPDIR/clone_chain.db" \
+  "SELECT name FROM dolt_remote_branches ORDER BY name;")
+check "clone of clone rebuilds only origin tracking refs" \
+  "remotes/origin/main" "$result"
+
+lazy_chain_uri="file:$TMPDIR/lazy_clone_chain.db?lazy_origin=1"
+result=$("$DB" "$lazy_chain_uri" \
+  "SELECT dolt_clone('--lazy','$R/clone_chain_source.db');" 2>&1)
+check "lazy clone of clone succeeds" "0" "$result"
+result=$("$DB" "$lazy_chain_uri" \
+  "SELECT name, url FROM dolt_remotes ORDER BY name;")
+check "lazy clone of clone keeps only its immediate origin" \
+  "origin|$R/clone_chain_source.db" "$result"
+result=$("$DB" "$lazy_chain_uri" \
+  "SELECT name FROM dolt_remote_branches ORDER BY name;")
+check "lazy clone of clone rebuilds only origin tracking refs" \
+  "remotes/origin/main" "$result"
+
 "$DB" "$TMPDIR/noop_clone.db" "SELECT dolt_clone('$R/remote.db'); SELECT dolt_fetch('origin','main');" > /dev/null
 clone_size_before=$(file_size "$TMPDIR/noop_clone.db")
 result=$("$DB" "$TMPDIR/noop_clone.db" "SELECT dolt_fetch('origin','main');")


### PR DESCRIPTION
Summary

- discard source remote and tracking metadata for both full and lazy clones
- create origin for the immediate source and rebuild branch tracking before cloned refs are committed
- cover full and lazy clone-of-clone behavior when the source has multiple remotes and tracking refs

Fail-before evidence

The new remote regression produced 139 passes and 5 failures on the unfixed engine: full clone failed after installing refs, full clone retained both source remotes and tracking refs, and lazy clone retained the extra source remote and tracking ref.

Validation

- remote suite: 144 passed, 0 failed
- gated C tests: 33 passed, 0 failed
- native DoltLite suites: 126 passed, 0 failed; 311207 regression assertions passed
- make lint

Closes #2608

Co-Authored-By: OpenAI Codex <noreply@openai.com>