### PR TITLE
Compare empty value records as different, not corrupt

### DIFF
--- a/src/doltlite_diff_stat.c
+++ b/src/doltlite_diff_stat.c
@@ -208,6 +208,52 @@ static void dsCountChangedCells(
   *pnModified = nModified;
 }
 
+/* A row whose primary key covers every column stores an empty record, so its
+** values must come back from the key before the sides can be compared. */
+static int dsCountModifiedRow(
+  sqlite3 *db,
+  const ProllyDiffChange *pChange,
+  const DoltliteColInfo *pFromCi,
+  const DoltliteColInfo *pToCi,
+  const DsColMap *pColMap,
+  int *pnDiffer,
+  int *pnModified
+){
+  const u8 *pOld = pChange->pOldVal;
+  const u8 *pNew = pChange->pNewVal;
+  int nOld = pChange->nOldVal;
+  int nNew = pChange->nNewVal;
+  u8 *pOldOwned = 0;
+  u8 *pNewOwned = 0;
+  int nOwned = 0;
+  int rc = SQLITE_OK;
+
+  *pnDiffer = 0;
+  *pnModified = 0;
+  if( nOld==0 ){
+    rc = doltliteRecordFromClusteredKeyCols(db, pFromCi, pChange->pKey,
+                                            pChange->nKey, &pOldOwned, &nOwned);
+    if( rc==SQLITE_OK && pOldOwned ){
+      pOld = pOldOwned;
+      nOld = nOwned;
+    }
+  }
+  if( rc==SQLITE_OK && nNew==0 ){
+    rc = doltliteRecordFromClusteredKeyCols(db, pToCi, pChange->pKey,
+                                            pChange->nKey, &pNewOwned, &nOwned);
+    if( rc==SQLITE_OK && pNewOwned ){
+      pNew = pNewOwned;
+      nNew = nOwned;
+    }
+  }
+  if( rc==SQLITE_OK ){
+    dsCountChangedCells(pOld, nOld, pNew, nNew, pColMap, pnDiffer, pnModified);
+  }
+  sqlite3_free(pOldOwned);
+  sqlite3_free(pNewOwned);
+  return rc;
+}
+
 typedef struct DsStatRow DsStatRow;
 struct DsStatRow {
   char *zTableName;
@@ -383,6 +429,7 @@ static int dsComputeTableStats(
     ProllyDiffChange *pChange = 0;
     u8 ff = fromFlags ? fromFlags : toFlags;
     u8 tf = toFlags ? toFlags : fromFlags;
+    int rcRow = SQLITE_OK;
     if( !cs || !pCache ){
       rc = SQLITE_ERROR;
       goto done;
@@ -401,19 +448,22 @@ static int dsComputeTableStats(
           break;
         case PROLLY_DIFF_MODIFY: {
           int nDiffer = 0, nModified = 0;
-          dsCountChangedCells(
-              pChange->pOldVal, pChange->nOldVal,
-              pChange->pNewVal, pChange->nNewVal,
-              &colMap, &nDiffer, &nModified);
-          if( nDiffer>0 ){
+          rcRow = dsCountModifiedRow(db, pChange, &fromCi, &toCi,
+                                     &colMap, &nDiffer, &nModified);
+          if( rcRow==SQLITE_OK && nDiffer>0 ){
             rowsMod++;
             cellsMod += nModified;
           }
           break;
         }
       }
+      if( rcRow!=SQLITE_OK ) break;
     }
     prollyDiffIterClose(&iter);
+    if( rcRow!=SQLITE_OK ){
+      rc = rcRow;
+      goto done;
+    }
     if( rc!=SQLITE_DONE && rc!=SQLITE_ROW ) goto done;
     rc = SQLITE_OK;
   }
@@ -1056,9 +1106,9 @@ static int dssDataActuallyChanged(
       changed = 1;
       break;
     }
-    dsCountChangedCells(pChange->pOldVal, pChange->nOldVal,
-                        pChange->pNewVal, pChange->nNewVal,
-                        &colMap, &nDiffer, &nModified);
+    rc = dsCountModifiedRow(db, pChange, &fromCi, &toCi,
+                            &colMap, &nDiffer, &nModified);
+    if( rc!=SQLITE_OK ) goto done;
     if( nDiffer>0 ){
       changed = 1;
       break;

--- a/src/doltlite_merge_schema.c
+++ b/src/doltlite_merge_schema.c
@@ -1174,6 +1174,35 @@ done:
 }
 
 
+static void relayoutFieldValue(
+  const u8 *pRec,
+  const DoltliteRecordInfo *pInfo,
+  int src,
+  DoltliteSerialValue *m
+){
+  int st = pInfo->aType[src];
+  const u8 *body = pRec + pInfo->aOffset[src];
+  memset(m, 0, sizeof(*m));
+  m->eType = SQLITE_NULL;
+  if( st==0 ) return;
+  if( dlSerialIsInt(st) ){
+    m->eType = SQLITE_INTEGER;
+    if( st==8 ) m->i = 0;
+    else if( st==9 ) m->i = 1;
+    else m->i = dlReadIntBytes(body, dlSerialTypeLen((u64)st));
+  }else if( st==7 ){
+    u64 bits = (u64)dlReadIntBytes(body, 8);
+    double d;
+    memcpy(&d, &bits, sizeof(d));
+    m->eType = SQLITE_FLOAT;
+    m->r = d;
+  }else if( st>=12 ){
+    m->eType = (st & 1) ? SQLITE_TEXT : SQLITE_BLOB;
+    m->p = body;
+    m->n = dlSerialTypeLen((u64)st);
+  }
+}
+
 int normalizeSideToMergedLayout(
   sqlite3 *db,
   const char *zTable,
@@ -1204,12 +1233,16 @@ int normalizeSideToMergedLayout(
   int isIntKey = (flags & PROLLY_NODE_INTKEY) ? 1 : 0;
   MergeColDefaults oursDefaults;
   MergeColDefaults theirsDefaults;
+  DoltliteColInfo sideCi;
+  int sideCiInit = 0;
+  u8 *pKeyRec = 0;
   ProllyCursor oursCur;
   int oursCurInit = 0;
   int rc, res, j;
 
   memset(&oursDefaults, 0, sizeof(oursDefaults));
   memset(&theirsDefaults, 0, sizeof(theirsDefaults));
+  memset(&sideCi, 0, sizeof(sideCi));
 
   memset(pOutRoot, 0, sizeof(*pOutRoot));
   rc = parseColumns(zAncSql, &aAnc, &nAnc);
@@ -1300,6 +1333,16 @@ int normalizeSideToMergedLayout(
   rc = mergeColDefaultsLoad(zTheirsSql, zTable, &theirsDefaults);
   if( rc!=SQLITE_OK ) goto done;
 
+  if( !isIntKey ){
+    sqlite3 *tmp = 0;
+    rc = sqlite3_open(":memory:", &tmp);
+    if( rc==SQLITE_OK ) rc = sqlite3_exec(tmp, zTheirsSql, 0, 0, 0);
+    if( rc==SQLITE_OK ) rc = doltliteGetColumnNames(tmp, zTable, &sideCi);
+    if( tmp ) sqlite3_close(tmp);
+    if( rc!=SQLITE_OK ) goto done;
+    sideCiInit = 1;
+  }
+
   rc = prollyMutMapInit(&mm, (u8)isIntKey);
   if( rc!=SQLITE_OK ) goto done;
   mmInit = 1;
@@ -1366,40 +1409,40 @@ int normalizeSideToMergedLayout(
     for(j=0; j<nTheirs; j++){
       int src = aTheirsRecord[j];
       int tgt;
-      int st;
-      const u8 *body;
       DoltliteSerialValue *m;
       if( src<0 || src>=info.nField || aMap[j]<0 ) continue;
       tgt = aMergedRecord[aMap[j]];
       if( tgt<0 ) continue;
-      st = info.aType[src];
-      body = pVal + info.aOffset[src];
       m = &aMem[tgt];
-      memset(m, 0, sizeof(*m));
-      m->eType = SQLITE_NULL;
-      if( st==0 ){
-        m->eType = SQLITE_NULL;
+      relayoutFieldValue(pVal, &info, src, m);
+      if( m->eType==SQLITE_NULL ){
         if( rowOnlyTheirs && tgt+1>nEmit ) nEmit = tgt+1;
-      }else if( dlSerialIsInt(st) ){
-        m->eType = SQLITE_INTEGER;
-        if( st==8 ) m->i = 0;
-        else if( st==9 ) m->i = 1;
-        else m->i = dlReadIntBytes(body, dlSerialTypeLen((u64)st));
-      }else if( st==7 ){
-        u64 bits = (u64)dlReadIntBytes(body, 8);
-        double d;
-        memcpy(&d, &bits, sizeof(d));
-        m->eType = SQLITE_FLOAT;
-        m->r = d;
-      }else if( st>=12 ){
-        m->eType = (st & 1) ? SQLITE_TEXT : SQLITE_BLOB;
-        m->p = body;
-        m->n = dlSerialTypeLen((u64)st);
+      }else if( tgt+1>nEmit ){
+        nEmit = tgt+1;
       }
-      if( m->eType!=SQLITE_NULL && tgt+1>nEmit ) nEmit = tgt+1;
     }
     for(k=0; k<nMergedRecord; k++){
       if( aMem[k].eType!=SQLITE_NULL && k+1>nEmit ) nEmit = k+1;
+    }
+
+    /* A PK-covering row stores an empty record; once a filled default
+    ** makes the record non-empty its key columns must be spelled out too. */
+    if( nEmit>0 && nVal==0 && sideCiInit ){
+      DoltliteRecordInfo kinfo;
+      int nKeyRec = 0;
+      rc = doltliteRecordFromClusteredKeyCols(db, &sideCi, pKey, nKey,
+                                              &pKeyRec, &nKeyRec);
+      if( rc!=SQLITE_OK ) goto done;
+      doltliteParseRecord(pKeyRec, nKeyRec, &kinfo);
+      for(j=0; j<nTheirs; j++){
+        int src = aTheirsRecord[j];
+        int tgt;
+        if( src<0 || src>=kinfo.nField || aMap[j]<0 ) continue;
+        tgt = aMergedRecord[aMap[j]];
+        if( tgt<0 ) continue;
+        relayoutFieldValue(pKeyRec, &kinfo, src, &aMem[tgt]);
+        if( aMem[tgt].eType!=SQLITE_NULL && tgt+1>nEmit ) nEmit = tgt+1;
+      }
     }
 
     if( nEmit>0 ){
@@ -1408,6 +1451,8 @@ int normalizeSideToMergedLayout(
     }
     rc = prollyMutMapInsert(&mm, pKey, nKey, intKey, pNew, nNew);
     sqlite3_free(pNew);
+    sqlite3_free(pKeyRec);
+    pKeyRec = 0;
     if( rc!=SQLITE_OK ) goto done;
 
     rc = prollyCursorNext(&cur);
@@ -1429,6 +1474,8 @@ int normalizeSideToMergedLayout(
 done:
   mergeColDefaultsFree(&oursDefaults);
   mergeColDefaultsFree(&theirsDefaults);
+  if( sideCiInit ) doltliteFreeColInfo(&sideCi);
+  sqlite3_free(pKeyRec);
   if( oursCurInit ) prollyCursorClose(&oursCur);
   if( curInit ) prollyCursorClose(&cur);
   if( mmInit ) prollyMutMapFree(&mm);

--- a/src/prolly_diff.c
+++ b/src/prolly_diff.c
@@ -146,7 +146,12 @@ static int diffRecordsEqualFieldwise(
   int rc;
 
   *pEqual = 0;
-  if( nA < 1 || nB < 1 ) return SQLITE_CORRUPT;
+  /* PK-covering rows store an empty record until ADD COLUMN rewrites them,
+  ** so empty and non-empty shapes coexist in one table and simply differ. */
+  if( nA < 1 || nB < 1 ){
+    *pEqual = (nA < 1 && nB < 1);
+    return SQLITE_OK;
+  }
 
   rc = doltliteParseRecordStrict(pA, nA, &aInfo);
   if( rc!=SQLITE_OK ) return rc;

--- a/test/doltlite_diff_alter.sh
+++ b/test/doltlite_diff_alter.sh
@@ -123,6 +123,64 @@ run_test_match "diff_after_merge_works" \
   "SELECT coalesce(sum(rows_added + rows_deleted + rows_modified), 0) FROM dolt_diff_stat((SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 1), (SELECT commit_hash FROM dolt_log LIMIT 1), 't');" \
   "^[0-9]+$" "$DB5"
 
-rm -f "$DB1" "$DB2" "$DB3" "$DB4" "$DB5"
+DB6=/tmp/test_diff_alter6_$$.db; rm -f "$DB6"
+
+echo "CREATE TABLE t(a TEXT, b INT, PRIMARY KEY(a,b));
+INSERT INTO t VALUES('x',1),('y',2);
+SELECT dolt_commit('-A','-m','base');
+SELECT dolt_branch('feat');
+INSERT INTO t VALUES('m',9);
+SELECT dolt_commit('-A','-m','main2');
+SELECT dolt_checkout('feat');
+ALTER TABLE t ADD COLUMN c TEXT;
+UPDATE t SET c='z' WHERE a='x';
+SELECT dolt_commit('-A','-m','feat2');" | $DOLTLITE "$DB6" > /dev/null 2>&1
+
+run_test "pk_covering_add_col_diff_row" \
+  "SELECT dolt_checkout('feat'); SELECT from_a || '|' || from_b || '|' || coalesce(from_c,'NULL') || ' -> ' || to_a || '|' || to_b || '|' || to_c || ' ' || diff_type FROM dolt_diff_t('HEAD~1','HEAD');" \
+  "0
+x|1|NULL -> x|1|z modified" "$DB6"
+
+run_test "pk_covering_add_col_diff_stat" \
+  "SELECT dolt_checkout('feat'); SELECT rows_modified FROM dolt_diff_stat('HEAD~1','HEAD','t');" \
+  "0
+1" "$DB6"
+
+run_test "pk_covering_add_col_diff_summary" \
+  "SELECT dolt_checkout('feat'); SELECT diff_type || '|' || data_change FROM dolt_diff_summary('HEAD~1','HEAD');" \
+  "0
+modified|1" "$DB6"
+
+run_test_match "pk_covering_add_col_patch_emits_update" \
+  "SELECT dolt_checkout('feat'); SELECT statement FROM dolt_patch('HEAD~1','HEAD');" \
+  "^UPDATE \"t\" SET \"c\"='z' WHERE \"a\"='x' AND \"b\"=1;$" "$DB6"
+
+run_test "pk_covering_add_col_merge" \
+  "SELECT length(dolt_merge('feat')); SELECT a || '|' || b || '|' || coalesce(c,'NULL') FROM t ORDER BY a;" \
+  "40
+m|9|NULL
+x|1|z
+y|2|NULL" "$DB6"
+
+DB7=/tmp/test_diff_alter7_$$.db; rm -f "$DB7"
+
+echo "CREATE TABLE t(a TEXT PRIMARY KEY) WITHOUT ROWID;
+INSERT INTO t VALUES('x'),('y');
+SELECT dolt_commit('-A','-m','base');
+SELECT dolt_branch('feat');
+INSERT INTO t VALUES('m');
+SELECT dolt_commit('-A','-m','main2');
+SELECT dolt_checkout('feat');
+ALTER TABLE t ADD COLUMN c INT DEFAULT 7;
+SELECT dolt_commit('-A','-m','feat2');" | $DOLTLITE "$DB7" > /dev/null 2>&1
+
+run_test "pk_covering_add_col_default_cherry_pick" \
+  "SELECT length(dolt_cherry_pick('feat')); SELECT a || '|' || c FROM t ORDER BY a;" \
+  "40
+m|7
+x|7
+y|7" "$DB7"
+
+rm -f "$DB1" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7"
 
 dltest_finish

--- a/test/vc_oracle_diff_test.sh
+++ b/test/vc_oracle_diff_test.sh
@@ -632,6 +632,26 @@ ALTER TABLE t ADD COLUMN extra INT;
 UPDATE t SET extra = 42 WHERE id = 1;
 "
 
+oracle "diff_pk_covering_add_col_and_update_working_set" "
+CREATE TABLE pk_all(id INT, k VARCHAR(10), PRIMARY KEY(id, k));
+INSERT INTO pk_all VALUES (1, 'x'), (2, 'y');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+ALTER TABLE pk_all ADD COLUMN c VARCHAR(10);
+UPDATE pk_all SET c = 'z' WHERE id = 1;
+" "pk_all"
+
+oracle "diff_pk_covering_add_col_across_commits" "
+CREATE TABLE pk_all(id INT, k VARCHAR(10), PRIMARY KEY(id, k));
+INSERT INTO pk_all VALUES (1, 'x'), (2, 'y');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+ALTER TABLE pk_all ADD COLUMN c VARCHAR(10);
+UPDATE pk_all SET c = 'z' WHERE id = 1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c2');
+" "pk_all"
+
 echo ""
 echo "--- summary form: dolt_diff (no args) ---"
 

--- a/test/vc_oracle_merge_test.sh
+++ b/test/vc_oracle_merge_test.sh
@@ -1039,6 +1039,37 @@ SELECT 'Q' || char(9) ||
   "SET @@foreign_key_checks = 1;
 SELECT CONCAT('Q', CHAR(9), (SELECT COUNT(*) FROM gp), '|', (SELECT COUNT(*) FROM p), '|', (SELECT COUNT(*) FROM c))"
 
+oracle_reopen_state "pk_covering_add_col_merge_applies" "
+CREATE TABLE pk_all(id INT, k VARCHAR(10), PRIMARY KEY(id, k));
+INSERT INTO pk_all VALUES (1, 'x'), (2, 'y');
+SELECT dolt_commit('-Am', 'base');
+SELECT dolt_branch('feature');
+INSERT INTO pk_all VALUES (9, 'm');
+SELECT dolt_commit('-Am', 'main2');
+SELECT dolt_checkout('feature');
+ALTER TABLE pk_all ADD COLUMN c VARCHAR(10);
+UPDATE pk_all SET c = 'z' WHERE id = 1;
+SELECT dolt_commit('-Am', 'feat2');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feature');
+" "SELECT 'Q' || char(9) || id || char(9) || k || char(9) || coalesce(c,'NULL') FROM pk_all ORDER BY id;" \
+"SELECT concat('Q', char(9), id, char(9), k, char(9), coalesce(c,'NULL')) FROM pk_all ORDER BY id;"
+
+oracle_reopen_state "pk_covering_add_col_default_merge_applies" "
+CREATE TABLE pk_all(id INT, k VARCHAR(10), PRIMARY KEY(id, k));
+INSERT INTO pk_all VALUES (1, 'x'), (2, 'y');
+SELECT dolt_commit('-Am', 'base');
+SELECT dolt_branch('feature');
+INSERT INTO pk_all VALUES (9, 'm');
+SELECT dolt_commit('-Am', 'main2');
+SELECT dolt_checkout('feature');
+ALTER TABLE pk_all ADD COLUMN c INT DEFAULT 7;
+SELECT dolt_commit('-Am', 'feat2');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feature');
+" "SELECT 'Q' || char(9) || id || char(9) || k || char(9) || coalesce(c,'NULL') FROM pk_all ORDER BY id;" \
+"SELECT concat('Q', char(9), id, char(9), k, char(9), coalesce(c,'NULL')) FROM pk_all ORDER BY id;"
+
 echo "--- non-branch merge sources ---"
 
 oracle "merge_from_tag" "


### PR DESCRIPTION
Fixes #2604.

A row whose primary key covers every column stores an **empty** value record. `ALTER TABLE ... ADD COLUMN` gives the rewritten rows a non-empty one, so both shapes coexist in a single table, and `diffRecordsEqualFieldwise` treated an empty record as corruption.

Every value comparison over such a table failed as soon as an appended column was populated on a pre-existing row:

- `dolt_diff_<t>`, the diff TVF, `dolt_diff_stat`, `dolt_diff_summary`, `dolt_patch` → `database disk image is malformed`
- `dolt_merge` / `dolt_cherry_pick` of the appending commit → `merge failed`, the change silently lost

Empty and non-empty records simply differ; only two empty ones are equal.

Fixing the comparator exposed two consumers that need the values the empty record does not hold:

- **`dolt_diff_stat`** counted the row as unmodified, because `dsCountChangedCells` gives up when a side is absent. It now rebuilds that side from the key, the way the diff vtable already does, and reports the same numbers as Dolt.
- **The merge relayout** wrote a record holding only the filled default and dropped the key columns a non-empty record must spell out, which surfaced as a NOT NULL constraint violation on the primary key. It now fills them from the key as well.

## Verification

Fail-before / pass-after against a `master` build of the same tree:

| suite | master | this branch |
|---|---|---|
| `test/doltlite_diff_alter.sh` | 15 passed, **6 failed** | **21 passed, 0 failed** |
| `test/vc_oracle_diff_test.sh` | 68 passed, **2 failed** | **70 passed, 0 failed** |
| `test/vc_oracle_merge_test.sh` | 102 passed, **2 failed** | **104 passed, 0 failed** |

The two oracle suites compare identical SQL against Dolt 2.3.1; the new cases cover the PK-covering ADD COLUMN diff (working set and across commits) and the merge of an appending branch with and without a column default. `dolt_diff_stat` now matches Dolt cell for cell (`1,0,0,1,2,0,1`).

Also green: `test/run_doltlite_tests.sh` 126/126, `vc_oracle_diff_stat` 111/0, `vc_oracle_patch` 85/0, `vc_oracle_schema_merge` 123/0, `vc_oracle_correct_schema_merge_matrix` 264/0. The new tests also pass under an AddressSanitizer build with no sanitizer reports.