### PR TITLE
Drop staged new tables on hard reset

### DIFF
--- a/src/doltlite_reset.c
+++ b/src/doltlite_reset.c
@@ -278,12 +278,12 @@ done:
 static int doltlitePreserveUntrackedTablesOnHardReset(
   sqlite3 *db,
   ChunkStore *cs,
-  const ProllyHash *pPreResetHeadCatHash,
+  const ProllyHash *pPreResetStagedCatHash,
   ProllyHash *pTargetCatHash
 ){
-  struct TableEntry *aHead = 0;
+  struct TableEntry *aStaged = 0;
   SchemaEntry *aTargetSchema = 0;
-  int nHead = 0;
+  int nStaged = 0;
   int nTargetSchema = 0;
   int nUntracked = 0;
   char **azUntracked = 0;
@@ -291,7 +291,8 @@ static int doltlitePreserveUntrackedTablesOnHardReset(
   int j, k;
   int rc;
 
-  rc = doltliteLoadCatalog(db, pPreResetHeadCatHash, &aHead, &nHead, 0);
+  rc = doltliteLoadCatalog(
+      db, pPreResetStagedCatHash, &aStaged, &nStaged, 0);
   if( rc==SQLITE_OK ){
     rc = sqlite3_prepare_v2(db,
         "SELECT m.name FROM sqlite_master AS m WHERE m.type='table' "
@@ -304,15 +305,15 @@ static int doltlitePreserveUntrackedTablesOnHardReset(
   if( rc==SQLITE_OK ){
     while( sqlite3_step(pStmt)==SQLITE_ROW ){
       const char *zName = (const char*)sqlite3_column_text(pStmt, 0);
-      int inHead = 0;
+      int inStaged = 0;
       if( !zName ) continue;
-      for(k=0; k<nHead; k++){
-        if( aHead[k].zName && strcmp(aHead[k].zName, zName)==0 ){
-          inHead = 1;
+      for(k=0; k<nStaged; k++){
+        if( aStaged[k].zName && strcmp(aStaged[k].zName, zName)==0 ){
+          inStaged = 1;
           break;
         }
       }
-      if( !inHead ){
+      if( !inStaged ){
         char **aNew = sqlite3_realloc(azUntracked,
             (nUntracked+1)*(int)sizeof(char*));
         if( !aNew ){ rc = SQLITE_NOMEM; break; }
@@ -456,7 +457,7 @@ static int doltlitePreserveUntrackedTablesOnHardReset(
   if( pStmt ) sqlite3_finalize(pStmt);
   for(j=0; j<nUntracked; j++) sqlite3_free(azUntracked[j]);
   sqlite3_free(azUntracked);
-  doltliteFreeCatalog(aHead, nHead);
+  doltliteFreeCatalog(aStaged, nStaged);
   freeSchemaEntries(aTargetSchema, nTargetSchema);
   return rc;
 }
@@ -471,6 +472,7 @@ static void doltliteResetFunc(
   ProllyHash targetCatHash;
   ProllyHash targetCommit;
   ProllyHash preResetHeadCatHash;
+  ProllyHash preResetStagedCatHash;
   ProllyHash sessionHeadBeforeLock;
   int havePreResetHead = 0;
   int isHard = 0;
@@ -505,6 +507,11 @@ static void doltliteResetFunc(
     goto reset_cleanup;
   }else if( rc==SQLITE_OK && !prollyHashIsEmpty(&preResetHeadCatHash) ){
     havePreResetHead = 1;
+    doltliteGetSessionStaged(db, &preResetStagedCatHash);
+    if( prollyHashIsEmpty(&preResetStagedCatHash) ){
+      memcpy(&preResetStagedCatHash, &preResetHeadCatHash,
+             sizeof(ProllyHash));
+    }
   }
 
   for(i=0; i<argc; i++){
@@ -692,7 +699,7 @@ static void doltliteResetFunc(
 
     if( havePreResetHead ){
       rc = doltlitePreserveUntrackedTablesOnHardReset(
-        db, cs, &preResetHeadCatHash, &targetCatHash
+        db, cs, &preResetStagedCatHash, &targetCatHash
       );
       if( rc!=SQLITE_OK ){
         sqlite3_result_error_code(context, rc);

--- a/test/doltlite_reset.sh
+++ b/test/doltlite_reset.sh
@@ -293,6 +293,27 @@ run_test "hard_reset_drops_tracked_rename" \
 run_test "hard_reset_tracked_rename_integrity" \
   "PRAGMA integrity_check;" "ok" "$DB12"
 
-rm -f "$DB" "$DB2" "$DB3" "$DB3B" "$DB3C" "$DB4" "$DB5" "$DB5B" "$DB5C" "$DB5C.hash" "$DB6" "$DB7" "$DB8" "$DB9" "$DB10" "$DB11" "$DB12"
+DB13=/tmp/test_reset13_$$.db; rm -f "$DB13"
+$DOLTLITE "$DB13" > /dev/null 2>&1 <<'SQL'
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES(1);
+SELECT dolt_commit('-A','-m','base');
+CREATE TABLE s(id INTEGER PRIMARY KEY);
+INSERT INTO s VALUES(2);
+SELECT dolt_add('s');
+CREATE TABLE u(id INTEGER PRIMARY KEY);
+INSERT INTO u VALUES(3);
+SELECT dolt_reset('--hard');
+SQL
+run_test "hard_reset_drops_staged_new_table" \
+  "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='s';" \
+  "0" "$DB13"
+run_test "hard_reset_preserves_only_untracked_new_table" \
+  "SELECT table_name || ':' || staged || ':' || status FROM dolt_status;" \
+  "u:0:new table" "$DB13"
+run_test "hard_reset_mixed_new_tables_integrity" \
+  "PRAGMA integrity_check;" "ok" "$DB13"
+
+rm -f "$DB" "$DB2" "$DB3" "$DB3B" "$DB3C" "$DB4" "$DB5" "$DB5B" "$DB5C" "$DB5C.hash" "$DB6" "$DB7" "$DB8" "$DB9" "$DB10" "$DB11" "$DB12" "$DB13"
 
 dltest_finish

--- a/test/vc_oracle_reset_test.sh
+++ b/test/vc_oracle_reset_test.sh
@@ -881,6 +881,16 @@ oracle_same_session "reset_hard_preserves_untracked_contents" "$UNTRACKED_SEED" 
 SELECT concat('Q|s|', id, '|', v) FROM s;
 SELECT concat('Q|u|', x, '|', w) FROM u;"
 
+oracle "reset_hard_drops_staged_new_table" "
+$SEED
+CREATE TABLE s(id INTEGER PRIMARY KEY);
+INSERT INTO s VALUES (2);
+SELECT dolt_add('s');
+CREATE TABLE u(id INTEGER PRIMARY KEY);
+INSERT INTO u VALUES (3);
+SELECT dolt_reset('--hard');
+"
+
 echo "--- table takes precedence over a same-named ref ---"
 
 oracle "reset_path_prefers_table_over_same_named_branch" "


### PR DESCRIPTION
## Summary

- snapshot the staged catalog before a hard reset
- preserve only tables absent from that staged catalog
- add native and Dolt-oracle coverage for mixed staged and untracked new tables

## Fail-before evidence

- `hard_reset_drops_staged_new_table` returned 1 instead of 0
- `hard_reset_preserves_only_untracked_new_table` reported both the staged table and the genuinely untracked table
- the new oracle case disagreed with Dolt for the same scenario

## Validation

- `make doltlite`
- `make lint`
- `bash test/doltlite_reset.sh build/doltlite` (62/62)
- `bash test/run_doltlite_tests.sh build/doltlite` (126/126 suites; 311,207/311,207 regression assertions)
- `bash test/run_c_tests.sh` (33/33 gated tests)
- `bash test/vc_oracle_reset_test.sh build/doltlite dolt`: the new issue case passes; the full local run retains the pre-existing `reset_soft_to_previous_commit` mismatch with the installed Dolt version

Closes #2609

Co-Authored-By: OpenAI Codex <noreply@openai.com>