### PR TITLE
Keep untracked dolt_-prefixed tables through a hard reset

### DIFF
--- a/src/doltlite_reset.c
+++ b/src/doltlite_reset.c
@@ -296,7 +296,7 @@ static int doltlitePreserveUntrackedTablesOnHardReset(
   if( rc==SQLITE_OK ){
     rc = sqlite3_prepare_v2(db,
         "SELECT m.name FROM sqlite_master AS m WHERE m.type='table' "
-        "AND m.name NOT LIKE 'sqlite_%' AND m.name NOT LIKE 'dolt_%' "
+        "AND m.name NOT LIKE 'sqlite_%' "
         "AND NOT EXISTS (SELECT 1 FROM dolt_status AS s "
         "WHERE s.status='renamed' AND "
         "substr(s.table_name, -(length(m.name)+4))=' -> ' || m.name)",

--- a/test/doltlite_reset.sh
+++ b/test/doltlite_reset.sh
@@ -314,6 +314,39 @@ run_test "hard_reset_preserves_only_untracked_new_table" \
 run_test "hard_reset_mixed_new_tables_integrity" \
   "PRAGMA integrity_check;" "ok" "$DB13"
 
-rm -f "$DB" "$DB2" "$DB3" "$DB3B" "$DB3C" "$DB4" "$DB5" "$DB5B" "$DB5C" "$DB5C.hash" "$DB6" "$DB7" "$DB8" "$DB9" "$DB10" "$DB11" "$DB12" "$DB13"
+DB14=/tmp/test_reset14_$$.db; rm -f "$DB14"
+$DOLTLITE "$DB14" > /dev/null 2>&1 <<'SQL'
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+SELECT dolt_commit('-A','-m','base');
+INSERT INTO dolt_ignore VALUES('scratch_%',1);
+INSERT INTO dolt_docs VALUES('README.md','hello');
+INSERT INTO dolt_tests VALUES('t1','g','SELECT 1','expected_single_value','==','1');
+CREATE TABLE newt(id INTEGER PRIMARY KEY);
+CREATE TABLE dolt_custom(a INTEGER PRIMARY KEY);
+INSERT INTO dolt_custom VALUES(7);
+SELECT dolt_reset('--hard');
+SQL
+run_test "hard_reset_keeps_untracked_lazy_system_tables" \
+  "SELECT group_concat(table_name,'|') FROM (SELECT table_name FROM dolt_status ORDER BY table_name);" \
+  "dolt_custom|dolt_docs|dolt_ignore|dolt_tests|newt" "$DB14"
+run_test "hard_reset_keeps_untracked_lazy_system_table_rows" \
+  "SELECT (SELECT count(*) FROM dolt_ignore) || '|' || (SELECT count(*) FROM dolt_docs WHERE doc_name='README.md') || '|' || (SELECT count(*) FROM dolt_tests) || '|' || (SELECT count(*) FROM dolt_custom);" \
+  "1|1|1|1" "$DB14"
+
+DB15=/tmp/test_reset15_$$.db; rm -f "$DB15"
+$DOLTLITE "$DB15" > /dev/null 2>&1 <<'SQL'
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO dolt_ignore VALUES('keep_%',1);
+INSERT INTO dolt_docs VALUES('README.md','committed');
+SELECT dolt_commit('-A','-m','base');
+INSERT INTO dolt_ignore VALUES('extra_%',0);
+UPDATE dolt_docs SET doc_text='edited' WHERE doc_name='README.md';
+SELECT dolt_reset('--hard');
+SQL
+run_test "hard_reset_reverts_tracked_lazy_system_tables" \
+  "SELECT (SELECT count(*) FROM dolt_ignore) || '|' || (SELECT doc_text FROM dolt_docs WHERE doc_name='README.md') || '|' || (SELECT count(*) FROM dolt_status);" \
+  "1|committed|0" "$DB15"
+
+rm -f "$DB" "$DB2" "$DB3" "$DB3B" "$DB3C" "$DB4" "$DB5" "$DB5B" "$DB5C" "$DB5C.hash" "$DB6" "$DB7" "$DB8" "$DB9" "$DB10" "$DB11" "$DB12" "$DB13" "$DB14" "$DB15"
 
 dltest_finish

--- a/test/vc_oracle_reset_test.sh
+++ b/test/vc_oracle_reset_test.sh
@@ -997,6 +997,33 @@ SELECT dolt_reset('t');
 SELECT dolt_commit('-m', 'nothing is staged');
 "
 
+oracle "reset_hard_keeps_untracked_dolt_ignore" "
+$SEED
+INSERT INTO dolt_ignore VALUES ('scratch_%', 1);
+CREATE TABLE newt(id INTEGER PRIMARY KEY);
+SELECT dolt_reset('--hard');
+"
+
+oracle_same_session "reset_hard_keeps_untracked_dolt_ignore_rows" "
+$SEED
+INSERT INTO dolt_ignore VALUES ('scratch_%', 1);
+SELECT dolt_reset('--hard');
+" "SELECT 'Q|' || count(*) || '|' || coalesce(group_concat(pattern),'none') FROM dolt_ignore;" \
+"$SEED
+INSERT INTO dolt_ignore VALUES ('scratch_%', 1);
+SELECT dolt_reset('--hard');
+" "SELECT concat('Q|', count(*), '|', coalesce(group_concat(pattern),'none')) FROM dolt_ignore;"
+
+oracle "reset_hard_reverts_tracked_dolt_ignore" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 10);
+INSERT INTO dolt_ignore VALUES ('keep_%', 1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+INSERT INTO dolt_ignore VALUES ('extra_%', 0);
+SELECT dolt_reset('--hard');
+"
+
 oracle "reset_end_options_dash_table" "
 CREATE TABLE \`--hard\`(id INTEGER PRIMARY KEY, v INT);
 INSERT INTO \`--hard\` VALUES (1, 10);


### PR DESCRIPTION
Fixes #2610.

`dolt_reset('--hard')` preserves untracked tables, matching git, but the scan that finds them skipped every name beginning with `dolt_`:

```sql
AND m.name NOT LIKE 'sqlite_%' AND m.name NOT LIKE 'dolt_%'
```

The lazy user-space system tables are ordinary tables once a write materializes them, so rows a user had just written to `dolt_ignore`, `dolt_docs` or `dolt_tests` were destroyed and the tables de-materialized, while a neighbouring untracked table survived untouched. Dolt preserves all of them. A user table that happens to start with `dolt_` was lost the same way.

No `dolt_` module can be instantiated as an explicit virtual table (`CREATE VIRTUAL TABLE ... USING dolt_log` fails with "no such module"), so every `dolt_`-prefixed `sqlite_master` row with `type='table'` is a real user-space table. The prefix test only ever excluded tables that should have been kept, so it is dropped. Membership in the pre-reset HEAD catalog already decides what is tracked: a materialized system table that HEAD *does* carry still resets to its committed contents, verified by a new test in both directions.

## Verification

Fail-before / pass-after against a `master` build of the same tree:

| suite | master | this branch |
|---|---|---|
| `test/doltlite_reset.sh` | 60 passed, **2 failed** | **62 passed, 0 failed** |
| `test/vc_oracle_reset_test.sh` | 58 passed, **2 failed** | **60 passed, 0 failed** |

The oracle cases run identical SQL against Dolt 2.3.1: untracked `dolt_ignore` survives `--hard` with its rows and shows as a new table in `dolt_status`, and a *tracked* `dolt_ignore` still reverts to its committed rows. Behaviour matches Dolt exactly, including the `dolt_tests` row that a bare `DELETE FROM dolt_tests` materializes.

Also green: `test/run_doltlite_tests.sh` 126/126, and the `ignore` (50), `docs` (47), `tests` (35), `clean` (11), `status` (41), `state_transitions` (19) and `checkout` (71) oracle suites, all with 0 failures.