### PR TITLE
Emit dolt_log in commit-height order

### DIFF
--- a/src/doltlite_log.c
+++ b/src/doltlite_log.c
@@ -13,6 +13,304 @@
 #define LOG_IDX_HASH_EQ 0x01
 #define LOG_IDX_REVISION 0x02
 
+/* Dolt emits commits by height (its commit_order) descending, breaking ties on
+** date descending and then on the order a parent was reached. Height needs the
+** ancestor walk, so keys are computed only once more than one commit is
+** pending: a linear history never pays for them. */
+typedef struct LogHeightMap LogHeightMap;
+struct LogHeightMap {
+  ProllyHash *aKey;
+  i64 *aVal;
+  u8 *aUsed;
+  int nSlot;
+  int nUsed;
+};
+
+static void logHeightMapFree(LogHeightMap *p){
+  sqlite3_free(p->aKey);
+  sqlite3_free(p->aVal);
+  sqlite3_free(p->aUsed);
+  memset(p, 0, sizeof(*p));
+}
+
+static unsigned logHashSlot(const ProllyHash *pHash, int nSlot){
+  unsigned h = ((unsigned)pHash->data[0])
+             | ((unsigned)pHash->data[1] << 8)
+             | ((unsigned)pHash->data[2] << 16)
+             | ((unsigned)pHash->data[3] << 24);
+  return h & (unsigned)(nSlot - 1);
+}
+
+static int logHeightMapFind(LogHeightMap *p, const ProllyHash *pHash, i64 *pVal){
+  unsigned i;
+  if( p->nSlot==0 ) return 0;
+  i = logHashSlot(pHash, p->nSlot);
+  while( p->aUsed[i] ){
+    if( memcmp(&p->aKey[i], pHash, sizeof(ProllyHash))==0 ){
+      *pVal = p->aVal[i];
+      return 1;
+    }
+    i = (i + 1) & (unsigned)(p->nSlot - 1);
+  }
+  return 0;
+}
+
+static int logHeightMapPut(LogHeightMap *p, const ProllyHash *pHash, i64 val){
+  unsigned i;
+  if( p->nSlot==0 || p->nUsed*10 >= p->nSlot*7 ){
+    int nNew = p->nSlot ? p->nSlot * 2 : 256;
+    LogHeightMap grown;
+    int j;
+    memset(&grown, 0, sizeof(grown));
+    grown.aKey = sqlite3_malloc64((sqlite3_int64)nNew * sizeof(ProllyHash));
+    grown.aVal = sqlite3_malloc64((sqlite3_int64)nNew * sizeof(i64));
+    grown.aUsed = sqlite3_malloc64((sqlite3_int64)nNew);
+    if( !grown.aKey || !grown.aVal || !grown.aUsed ){
+      logHeightMapFree(&grown);
+      return SQLITE_NOMEM;
+    }
+    memset(grown.aUsed, 0, (size_t)nNew);
+    grown.nSlot = nNew;
+    for(j=0; j<p->nSlot; j++){
+      if( p->aUsed[j] ) logHeightMapPut(&grown, &p->aKey[j], p->aVal[j]);
+    }
+    logHeightMapFree(p);
+    *p = grown;
+  }
+  i = logHashSlot(pHash, p->nSlot);
+  while( p->aUsed[i] ){
+    if( memcmp(&p->aKey[i], pHash, sizeof(ProllyHash))==0 ){
+      p->aVal[i] = val;
+      return SQLITE_OK;
+    }
+    i = (i + 1) & (unsigned)(p->nSlot - 1);
+  }
+  p->aKey[i] = *pHash;
+  p->aVal[i] = val;
+  p->aUsed[i] = 1;
+  p->nUsed++;
+  return SQLITE_OK;
+}
+
+/* height(c) = 1 + max(height(parents)), matching Dolt's commit_order. Walked
+** iteratively: a deep history must not consume the C stack. */
+static int logCommitHeight(
+  sqlite3 *db,
+  LogHeightMap *pMap,
+  const ProllyHash *pHash,
+  i64 *pOut
+){
+  ProllyHash *aStack = 0;
+  int nStack = 0, nAlloc = 0;
+  int rc = SQLITE_OK;
+
+  if( logHeightMapFind(pMap, pHash, pOut) ) return SQLITE_OK;
+  aStack = sqlite3_malloc64(16 * sizeof(ProllyHash));
+  if( !aStack ) return SQLITE_NOMEM;
+  nAlloc = 16;
+  aStack[nStack++] = *pHash;
+
+  while( nStack>0 ){
+    ProllyHash cur = aStack[nStack-1];
+    DoltliteCommit commit;
+    i64 best = 0;
+    int nPending = 0;
+    int i, nParent;
+    i64 ignored;
+
+    if( logHeightMapFind(pMap, &cur, &ignored) ){
+      nStack--;
+      continue;
+    }
+    memset(&commit, 0, sizeof(commit));
+    rc = doltliteLoadCommit(db, &cur, &commit);
+    if( rc!=SQLITE_OK ){
+      doltliteCommitClear(&commit);
+      break;
+    }
+    nParent = doltliteCommitParentCount(&commit);
+    for(i=0; i<nParent; i++){
+      const ProllyHash *pParent = doltliteCommitParentHash(&commit, i);
+      i64 h = 0;
+      if( !pParent || prollyHashIsEmpty(pParent) ) continue;
+      if( logHeightMapFind(pMap, pParent, &h) ){
+        if( h>best ) best = h;
+        continue;
+      }
+      if( nStack+nPending >= nAlloc ){
+        i64 nNew = (i64)nAlloc * 2;
+        ProllyHash *tmp;
+        if( nNew > (i64)0x7fffffff/(i64)sizeof(ProllyHash) ){
+          rc = SQLITE_NOMEM;
+          break;
+        }
+        tmp = sqlite3_realloc64(aStack, (sqlite3_uint64)nNew * sizeof(ProllyHash));
+        if( !tmp ){ rc = SQLITE_NOMEM; break; }
+        aStack = tmp;
+        nAlloc = (int)nNew;
+      }
+      aStack[nStack + nPending] = *pParent;
+      nPending++;
+    }
+    doltliteCommitClear(&commit);
+    if( rc!=SQLITE_OK ) break;
+    if( nPending>0 ){
+      nStack += nPending;
+      continue;
+    }
+    rc = logHeightMapPut(pMap, &cur, best + 1);
+    if( rc!=SQLITE_OK ) break;
+    nStack--;
+  }
+
+  sqlite3_free(aStack);
+  if( rc!=SQLITE_OK ) return rc;
+  if( !logHeightMapFind(pMap, pHash, pOut) ) return SQLITE_CORRUPT;
+  return SQLITE_OK;
+}
+
+typedef struct LogFrontier LogFrontier;
+struct LogFrontier {
+  ProllyHash *aPend;
+  i64 *aHeight;
+  i64 *aDate;
+  u8 *aHaveKey;
+  int nPend;
+  int nAlloc;
+  ProllyHashSet visited;
+  ProllyHashSet queued;
+  int setsInit;
+  LogHeightMap heights;
+};
+
+static void logFrontierClear(LogFrontier *f){
+  sqlite3_free(f->aPend);
+  sqlite3_free(f->aHeight);
+  sqlite3_free(f->aDate);
+  sqlite3_free(f->aHaveKey);
+  if( f->setsInit ){
+    prollyHashSetFree(&f->visited);
+    prollyHashSetFree(&f->queued);
+  }
+  logHeightMapFree(&f->heights);
+  memset(f, 0, sizeof(*f));
+}
+
+static int logFrontierEnqueue(LogFrontier *f, const ProllyHash *pHash){
+  if( !pHash || prollyHashIsEmpty(pHash) ) return SQLITE_OK;
+  if( prollyHashSetContains(&f->visited, pHash) ) return SQLITE_OK;
+  if( prollyHashSetContains(&f->queued, pHash) ) return SQLITE_OK;
+  if( f->nPend >= f->nAlloc ){
+    i64 nNew = f->nAlloc ? (i64)f->nAlloc * 2 : (i64)8;
+    ProllyHash *aP;
+    i64 *aH; i64 *aD; u8 *aK;
+    if( nNew > (i64)0x7fffffff/(i64)sizeof(ProllyHash) ) return SQLITE_NOMEM;
+    aP = sqlite3_realloc64(f->aPend, (sqlite3_uint64)nNew * sizeof(ProllyHash));
+    if( !aP ) return SQLITE_NOMEM;
+    f->aPend = aP;
+    aH = sqlite3_realloc64(f->aHeight, (sqlite3_uint64)nNew * sizeof(i64));
+    if( !aH ) return SQLITE_NOMEM;
+    f->aHeight = aH;
+    aD = sqlite3_realloc64(f->aDate, (sqlite3_uint64)nNew * sizeof(i64));
+    if( !aD ) return SQLITE_NOMEM;
+    f->aDate = aD;
+    aK = sqlite3_realloc64(f->aHaveKey, (sqlite3_uint64)nNew);
+    if( !aK ) return SQLITE_NOMEM;
+    f->aHaveKey = aK;
+    f->nAlloc = (int)nNew;
+  }
+  f->aPend[f->nPend] = *pHash;
+  f->aHeight[f->nPend] = 0;
+  f->aDate[f->nPend] = 0;
+  f->aHaveKey[f->nPend] = 0;
+  f->nPend++;
+  return prollyHashSetAdd(&f->queued, pHash);
+}
+
+static int logFrontierInit(LogFrontier *f, const ProllyHash *pHead){
+  int rc;
+  logFrontierClear(f);
+  rc = prollyHashSetInit(&f->visited, 64);
+  if( rc!=SQLITE_OK ) return rc;
+  rc = prollyHashSetInit(&f->queued, 64);
+  if( rc!=SQLITE_OK ){
+    prollyHashSetFree(&f->visited);
+    memset(f, 0, sizeof(*f));
+    return rc;
+  }
+  f->setsInit = 1;
+  rc = logFrontierEnqueue(f, pHead);
+  if( rc!=SQLITE_OK ) logFrontierClear(f);
+  return rc;
+}
+
+static int logFrontierEnqueueParents(LogFrontier *f, const DoltliteCommit *pCommit){
+  int i, rc;
+  for(i=0; i<doltliteCommitParentCount(pCommit); i++){
+    rc = logFrontierEnqueue(f, doltliteCommitParentHash(pCommit, i));
+    if( rc!=SQLITE_OK ) return rc;
+  }
+  return SQLITE_OK;
+}
+
+static int logFrontierKey(LogFrontier *f, sqlite3 *db, int i){
+  DoltliteCommit commit;
+  int rc;
+  if( f->aHaveKey[i] ) return SQLITE_OK;
+  rc = logCommitHeight(db, &f->heights, &f->aPend[i], &f->aHeight[i]);
+  if( rc!=SQLITE_OK ) return rc;
+  memset(&commit, 0, sizeof(commit));
+  rc = doltliteLoadCommit(db, &f->aPend[i], &commit);
+  if( rc==SQLITE_OK ) f->aDate[i] = commit.timestamp;
+  doltliteCommitClear(&commit);
+  if( rc!=SQLITE_OK ) return rc;
+  f->aHaveKey[i] = 1;
+  return SQLITE_OK;
+}
+
+static int logFrontierNext(
+  LogFrontier *f,
+  sqlite3 *db,
+  ProllyHash *pHash,
+  int *pHas
+){
+  int rc;
+  *pHas = 0;
+  while( f->nPend>0 ){
+    int iBest = 0;
+    ProllyHash cur;
+    if( f->nPend>1 ){
+      int i;
+      for(i=0; i<f->nPend; i++){
+        rc = logFrontierKey(f, db, i);
+        if( rc!=SQLITE_OK ) return rc;
+      }
+      for(i=1; i<f->nPend; i++){
+        if( f->aHeight[i] > f->aHeight[iBest]
+         || (f->aHeight[i]==f->aHeight[iBest] && f->aDate[i] > f->aDate[iBest]) ){
+          iBest = i;
+        }
+      }
+    }
+    cur = f->aPend[iBest];
+    if( iBest < f->nPend-1 ){
+      int nMove = f->nPend - iBest - 1;
+      memmove(&f->aPend[iBest], &f->aPend[iBest+1], (size_t)nMove * sizeof(ProllyHash));
+      memmove(&f->aHeight[iBest], &f->aHeight[iBest+1], (size_t)nMove * sizeof(i64));
+      memmove(&f->aDate[iBest], &f->aDate[iBest+1], (size_t)nMove * sizeof(i64));
+      memmove(&f->aHaveKey[iBest], &f->aHaveKey[iBest+1], (size_t)nMove);
+    }
+    f->nPend--;
+    if( prollyHashSetContains(&f->visited, &cur) ) continue;
+    rc = prollyHashSetAdd(&f->visited, &cur);
+    if( rc!=SQLITE_OK ) return rc;
+    *pHash = cur;
+    *pHas = 1;
+    return SQLITE_OK;
+  }
+  return SQLITE_OK;
+}
+
 typedef struct DoltliteLogVtab DoltliteLogVtab;
 struct DoltliteLogVtab {
   sqlite3_vtab base;
@@ -22,7 +320,7 @@ struct DoltliteLogVtab {
 typedef struct DoltliteLogCursor DoltliteLogCursor;
 struct DoltliteLogCursor {
   sqlite3_vtab_cursor base;
-  DoltliteCommitQueue queue;
+  LogFrontier frontier;
   ProllyHashSet excluded;
   int excludedInit;
   char zHex[PROLLY_HASH_SIZE*2+1];
@@ -84,7 +382,7 @@ static int doltliteLogOpen(sqlite3_vtab *pVtab, sqlite3_vtab_cursor **ppCursor){
 static void logCursorReset(DoltliteLogCursor *pCur){
   doltliteCommitClear(&pCur->curCommit);
   memset(&pCur->curCommit, 0, sizeof(pCur->curCommit));
-  doltliteCommitQueueClear(&pCur->queue);
+  logFrontierClear(&pCur->frontier);
   if( pCur->excludedInit ){
     prollyHashSetFree(&pCur->excluded);
     pCur->excludedInit = 0;
@@ -110,7 +408,7 @@ static int logAdvance(DoltliteLogCursor *pCur, sqlite3 *db){
 
   for(;;){
     ProllyHash cur;
-    rc = doltliteCommitQueueNext(&pCur->queue, &cur, &hasHash);
+    rc = logFrontierNext(&pCur->frontier, db, &cur, &hasHash);
     if( rc!=SQLITE_OK ) return rc;
     if( !hasHash ) break;
     if( pCur->excludedInit
@@ -134,7 +432,7 @@ static int logAdvance(DoltliteLogCursor *pCur, sqlite3 *db){
 
     if( pCur->singleCommit ) return SQLITE_OK;
 
-    rc = doltliteCommitQueueEnqueueParents(&pCur->queue, &pCur->curCommit);
+    rc = logFrontierEnqueueParents(&pCur->frontier, &pCur->curCommit);
     if( rc!=SQLITE_OK ) return rc;
     return SQLITE_OK;
   }
@@ -301,10 +599,10 @@ static int doltliteLogFilter(
     if( prollyHashIsEmpty(&head) ) return SQLITE_OK;
   }
 
-  rc = doltliteCommitQueueInit(&pCur->queue, &head);
+  rc = logFrontierInit(&pCur->frontier, &head);
   if( rc!=SQLITE_OK ) return rc;
   if( useSecondHead ){
-    rc = doltliteCommitQueueEnqueue(&pCur->queue, &secondHead);
+    rc = logFrontierEnqueue(&pCur->frontier, &secondHead);
     if( rc!=SQLITE_OK ) return rc;
   }
 

--- a/test/doltlite_log.sh
+++ b/test/doltlite_log.sh
@@ -27,5 +27,45 @@ run_test "hash_filter_matches_unpushed_predicate" "SELECT count(*) FROM dolt_log
 run_test "hash_filter_includes_reachable_commit" "SELECT count(*) FROM dolt_log WHERE commit_hash=dolt_hashof('main');" "1" "$DB4"
 run_test "hash_filter_honors_explicit_revision" "SELECT count(*) FROM dolt_log('feat') WHERE commit_hash=dolt_hashof('feat');" "1" "$DB4"
 
-rm -f "$DB1" "$DB2" "$DB3" "$DB4"
+DB5=/tmp/test_log5_$$.db; rm -f "$DB5"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES(1);
+SELECT dolt_commit('-Am','c1','--date','2020-01-01T00:00:00');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO t VALUES(2);
+SELECT dolt_commit('-Am','feat1','--date','2020-01-02T00:00:00');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES(3);
+SELECT dolt_commit('-Am','main1','--date','2020-01-03T00:00:00');
+SELECT dolt_checkout('feat');
+INSERT INTO t VALUES(4);
+SELECT dolt_commit('-Am','feat2','--date','2020-01-04T00:00:00');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feat');" | $DOLTLITE "$DB5" > /dev/null 2>&1
+run_test "log_merge_orders_by_height_then_date" \
+  "SELECT group_concat(message,'|') FROM (SELECT message FROM dolt_log);" \
+  "Merge branch 'feat' into main|feat2|main1|feat1|c1|Initialize data repository" "$DB5"
+run_test "log_merge_order_limit_takes_newest" \
+  "SELECT group_concat(message,'|') FROM (SELECT message FROM dolt_log LIMIT 3);" \
+  "Merge branch 'feat' into main|feat2|main1" "$DB5"
+
+DB6=/tmp/test_log6_$$.db; rm -f "$DB6"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES(1);
+SELECT dolt_commit('-Am','c1','--date','2020-01-01T00:00:00');
+SELECT dolt_branch('feat');
+INSERT INTO t VALUES(2);
+SELECT dolt_commit('-Am','main1','--date','2020-01-02T00:00:00');
+INSERT INTO t VALUES(3);
+SELECT dolt_commit('-Am','main2','--date','2020-01-03T00:00:00');
+SELECT dolt_checkout('feat');
+INSERT INTO t VALUES(9);
+SELECT dolt_commit('-Am','feat_dated_2030','--date','2030-06-01T00:00:00');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feat');" | $DOLTLITE "$DB6" > /dev/null 2>&1
+run_test "log_height_outranks_a_later_date" \
+  "SELECT group_concat(message,'|') FROM (SELECT message FROM dolt_log);" \
+  "Merge branch 'feat' into main|main2|feat_dated_2030|main1|c1|Initialize data repository" "$DB6"
+
+rm -f "$DB1" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6"
 dltest_finish

--- a/test/vc_oracle_log_test.sh
+++ b/test/vc_oracle_log_test.sh
@@ -354,6 +354,53 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'post_merge');
 "
 
+oracle "merge_order_branch_commit_is_newer" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 10);
+SELECT dolt_commit('-Am', 'c1', '--date', '2020-01-01T00:00:00');
+SELECT dolt_checkout('-b', 'feature');
+INSERT INTO t VALUES (2, 20);
+SELECT dolt_commit('-Am', 'feat1', '--date', '2020-01-02T00:00:00');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES (3, 30);
+SELECT dolt_commit('-Am', 'main1', '--date', '2020-01-03T00:00:00');
+SELECT dolt_checkout('feature');
+INSERT INTO t VALUES (4, 40);
+SELECT dolt_commit('-Am', 'feat2', '--date', '2020-01-04T00:00:00');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feature');
+"
+
+oracle "merge_order_height_outranks_date" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 10);
+SELECT dolt_commit('-Am', 'c1', '--date', '2020-01-01T00:00:00');
+SELECT dolt_branch('feature');
+INSERT INTO t VALUES (2, 20);
+SELECT dolt_commit('-Am', 'main1', '--date', '2020-01-02T00:00:00');
+INSERT INTO t VALUES (3, 30);
+SELECT dolt_commit('-Am', 'main2', '--date', '2020-01-03T00:00:00');
+SELECT dolt_checkout('feature');
+INSERT INTO t VALUES (9, 90);
+SELECT dolt_commit('-Am', 'feat_dated_2030', '--date', '2030-06-01T00:00:00');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feature');
+"
+
+oracle "merge_order_equal_height_breaks_on_date" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 10);
+SELECT dolt_commit('-Am', 'c1', '--date', '2020-01-01T00:00:00');
+SELECT dolt_branch('feature');
+INSERT INTO t VALUES (2, 20);
+SELECT dolt_commit('-Am', 'main_dated_2025', '--date', '2025-01-02T00:00:00');
+SELECT dolt_checkout('feature');
+INSERT INTO t VALUES (9, 90);
+SELECT dolt_commit('-Am', 'feat_dated_2021', '--date', '2021-01-01T00:00:00');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feature');
+"
+
 echo "--- tags and branches ---"
 
 oracle "tag_does_not_add_commit" "


### PR DESCRIPTION
Fixes #2612.

`dolt_log` walked the commit graph with a FIFO queue, so once history contained a merge the rows came out in breadth-first parent order instead of the order Dolt reports. The row set was right and so was the first row, but everything after a merge could interleave the branches wrongly, and `LIMIT` handed back different commits than Dolt.

## What Dolt actually orders by

Not date. Dolt orders by `commit_order`, its commit height, descending, and breaks ties on date descending. Verified against Dolt 2.3.1 with deliberately skewed dates:

```
LOG,message,date,commit_order
LOG,Merge branch 'feat' into main,2026-09-04 15:48:28.252,5
LOG,m2,2020-01-03 00:00:00.000,4
LOG,f1_LATEST_DATE,2030-06-01 00:00:00.000,3     <- newest date, still below m2
LOG,m1,2020-01-02 00:00:00.000,3
LOG,c1,2020-01-01 00:00:00.000,2
LOG,Initialize data repository,2026-09-04 15:48:27.968,1
```

So a fix that simply sorted by date would have been wrong. The walk now orders by the same key. Height is not stored in a commit record, so it is derived as `1 + max(parent heights)` with an iterative walk (a deep history must not consume the C stack) and memoised per cursor.

## Cost

Deriving a height reads the ancestors behind a commit, so keys are computed **only once more than one commit is pending**. A linear history never pays for them, and neither does `LIMIT 1` on any history. Measured on a 2122-commit history with 40 real merge commits, five runs each:

| query | before | after |
|---|---|---|
| `LIMIT 1` | 52.4 ms | 51.8 ms |
| `LIMIT 5` | 52.6 ms | 58.5 ms |
| `LIMIT 100` | 52.4 ms | 57.5 ms |

Most of that is process startup; the height walk adds roughly 6 ms once per cursor that pops past a merge.

The walk keeps its own frontier rather than the shared commit queue, so `dolt_at`, `dolt_diff` and `dolt_history` keep exactly the traversal they had.

## Verification

Fail-before / pass-after against a build of the same tree without the fix:

| suite | before | after |
|---|---|---|
| `test/doltlite_log.sh` | 12 passed, **2 failed** | **14 passed, 0 failed** |
| `test/vc_oracle_log_test.sh` | 23 passed, **1 failed** | **24 passed, 0 failed** |

Three new oracle cases run identical SQL against Dolt: a merge whose branch commit is newer, a branch commit dated 2030 that must still sort below a higher-height commit, and an equal-height pair broken by date. The last two pass on the old engine as well; they are there to pin the rule so a future date-only implementation cannot slip in.

Also green: `test/run_doltlite_tests.sh` 126/126, and the `history` (31), `blame` (25), `ancestor_spec` (27), `commit_ancestors` (9), `merge` (104) and `branch` (48) oracle suites.