### PR TITLE
Keep added implicit NULL columns hash-stable

### DIFF
--- a/src/alter.c
+++ b/src/alter.c
@@ -499,7 +499,7 @@ void sqlite3AlterFinishAddColumn(Parse *pParse, Token *pColDef){
     }
 
 #ifdef DOLTLITE_PROLLY
-    if( pDflt && (pCol->colFlags & COLFLAG_GENERATED)==0 ){
+    if( (pCol->colFlags & COLFLAG_GENERATED)==0 ){
       FuncDef *pFunc = sqlite3FindFunction(
           db, "doltlite_internal_materialize_default_column", 3, ENC(db), 0);
       if( pFunc ){

--- a/src/alter.c
+++ b/src/alter.c
@@ -499,7 +499,7 @@ void sqlite3AlterFinishAddColumn(Parse *pParse, Token *pColDef){
     }
 
 #ifdef DOLTLITE_PROLLY
-    if( (pCol->colFlags & COLFLAG_GENERATED)==0 ){
+    if( pDflt && (pCol->colFlags & COLFLAG_GENERATED)==0 ){
       FuncDef *pFunc = sqlite3FindFunction(
           db, "doltlite_internal_materialize_default_column", 3, ENC(db), 0);
       if( pFunc ){

--- a/src/doltlite_blame.c
+++ b/src/doltlite_blame.c
@@ -5,6 +5,7 @@
 #include "prolly_hash.h"
 #include "prolly_cursor.h"
 #include "prolly_cache.h"
+#include "prolly_diff.h"
 #include "chunk_store.h"
 #include "doltlite_commit.h"
 #include "doltlite_record.h"
@@ -415,15 +416,6 @@ static int blameCursorCompareRowKey(
   }
 }
 
-static int blameRowValueEqual(const u8 *pA, int nA, const u8 *pB, int nB){
-  int isA = (pA && nA>0);
-  int isB = (pB && nB>0);
-  if( !isA && !isB ) return 1;
-  if( !isA || !isB ) return 0;
-  if( nA != nB ) return 0;
-  return memcmp(pA, pB, nA)==0;
-}
-
 static int blameAssign(
   BlameRow *pRow,
   const ProllyHash *pCommitHash,
@@ -503,6 +495,7 @@ static int blameCompareAgainstRef(
     u8 *pRefRebuilt = 0;
     const u8 *pRefEff;
     int nRefEff;
+    int equal;
     if( r->blamed ) continue;
 
     if( haveRef ){
@@ -540,7 +533,13 @@ static int blameCompareAgainstRef(
       nRefEff = nR;
     }
 
-    if( !blameRowValueEqual(r->pCurVal, r->nCurVal, pRefEff, nRefEff) ){
+    rc = prollyValuesEqual(r->pCurVal, r->nCurVal,
+                           pRefEff, nRefEff, &equal);
+    if( rc!=SQLITE_OK ){
+      sqlite3_free(pRefRebuilt);
+      goto blame_compare_done;
+    }
+    if( !equal ){
       rc = blameAssign(r, pCommitHash, pCommit);
       if( rc!=SQLITE_OK ){ sqlite3_free(pRefRebuilt); goto blame_compare_done; }
       pCur->nUnresolved--;

--- a/src/prolly_btree_mutation.c
+++ b/src/prolly_btree_mutation.c
@@ -1,6 +1,7 @@
 #ifdef DOLTLITE_PROLLY
 
 #include "prolly_btree_int.h"
+#include "prolly_diff.h"
 
 static int keyInfoHasLossyCollation(const KeyInfo *pKeyInfo){
   int i;
@@ -807,6 +808,36 @@ int prollyBtCursorInsert(
     if( nData<0 || pPayload->nZero<0 || nTotal64 > 0x7fffffff ){
       return SQLITE_TOOBIG;
     }
+    if( (pCur->pBtree->db->mDbFlags & DBFLAG_InternalDml)==0
+     && pPayload->nZero==0 && pCur->eState==CURSOR_VALID
+     && !pCur->deferredMergedSeek ){
+      const u8 *pOld;
+      int nOld;
+      int equal;
+      int sameKey = 0;
+      if( pCur->mmActive
+       && (pCur->mergeSrc==MERGE_SRC_MUT
+           || pCur->mergeSrc==MERGE_SRC_BOTH) ){
+        ProllyMutMapEntry *pEntry;
+        rc = currentMutMapEntry(pCur, &pEntry);
+        if( rc!=SQLITE_OK ) return rc;
+        sameKey = prollyMutMapEntryIntKey(pEntry)==pPayload->nKey;
+      }else if( prollyCursorIsValid(&pCur->pCur) ){
+        sameKey = cursorCurrentTreeIntKey(pCur)==pPayload->nKey;
+      }else if( pCur->curFlags & BTCF_ValidNKey ){
+        sameKey = pCur->cachedIntKey==pPayload->nKey;
+      }
+      if( sameKey ){
+        rc = getCursorPayload(pCur, &pOld, &nOld);
+        if( rc!=SQLITE_OK ) return rc;
+        rc = prollyValuesEqual(pOld, nOld, pData, nData, &equal);
+        if( rc!=SQLITE_OK ) return rc;
+        if( equal ){
+          pData = pOld;
+          nData = nOld;
+        }
+      }
+    }
     pInsertedPayload = pData;
     nInsertedPayload = nData;
 
@@ -848,6 +879,8 @@ int prollyBtCursorInsert(
     int splitKey = 0;
     int storePayload = 0;
     int isIndex = 0;
+    const u8 *pStoredPayload = (const u8*)pPayload->pKey;
+    int nStoredPayload = (int)pPayload->nKey;
     if( pCur->pKeyInfo ){
       struct TableEntry *pTE = findTable(pCur->pBtree, pCur->pgnoRoot);
       int rcRoot = SQLITE_OK;
@@ -888,6 +921,42 @@ int prollyBtCursorInsert(
       pSortKey = pCur->pSeekSortKey;
     }
     if( rc==SQLITE_OK ){
+      const u8 *pCurrentKey = 0;
+      int nCurrentKey = 0;
+      if( pCur->eState==CURSOR_VALID ){
+        if( pCur->mmActive
+         && (pCur->mergeSrc==MERGE_SRC_MUT
+             || pCur->mergeSrc==MERGE_SRC_BOTH) ){
+          ProllyMutMapEntry *pEntry;
+          rc = currentMutMapEntry(pCur, &pEntry);
+          if( rc==SQLITE_OK ){
+            pCurrentKey = pEntry->pKey;
+            nCurrentKey = pEntry->nKey;
+          }
+        }else if( prollyCursorIsValid(&pCur->pCur) ){
+          prollyCursorKey(&pCur->pCur, &pCurrentKey, &nCurrentKey);
+        }
+      }
+      if( rc==SQLITE_OK
+       && (pCur->pBtree->db->mDbFlags & DBFLAG_InternalDml)==0
+       && storePayload && pCurrentKey
+       && nCurrentKey==nSortKey
+       && memcmp(pCurrentKey, pSortKey, nSortKey)==0 ){
+        const u8 *pOld;
+        int nOld;
+        int equal;
+        rc = getCursorPayload(pCur, &pOld, &nOld);
+        if( rc==SQLITE_OK ){
+          rc = prollyValuesEqual(
+              pOld, nOld, pStoredPayload, nStoredPayload, &equal);
+        }
+        if( rc==SQLITE_OK && equal ){
+          pStoredPayload = pOld;
+          nStoredPayload = nOld;
+        }
+      }
+    }
+    if( rc==SQLITE_OK ){
       if( !(pCur->curFlags & BTCF_Incrblob) ){
         prollyInvalidateIncrblobCursorsByKey(
             pCur->pBt, pCur->pgnoRoot, pSortKey, nSortKey);
@@ -899,12 +968,12 @@ int prollyBtCursorInsert(
        && memcmp(pCur->aSeekSortKey, pSortKey, nSortKey)==0 ){
         rc = prollyMutMapInsertAbsent(
             pCur->pMutMap, pSortKey, nSortKey, 0,
-            storePayload ? (const u8*)pPayload->pKey : NULL,
-            storePayload ? (int)pPayload->nKey : 0);
+            storePayload ? pStoredPayload : NULL,
+            storePayload ? nStoredPayload : 0);
       }else if( storePayload ){
         rc = prollyMutMapInsert(pCur->pMutMap,
                                  pSortKey, nSortKey, 0,
-                                 (const u8*)pPayload->pKey, (int)pPayload->nKey);
+                                 pStoredPayload, nStoredPayload);
       }else{
         rc = prollyMutMapInsert(pCur->pMutMap,
                                  pSortKey, nSortKey, 0,

--- a/src/prolly_diff.c
+++ b/src/prolly_diff.c
@@ -142,14 +142,28 @@ static int diffRecordsEqualFieldwise(
 ){
   DoltliteRecordInfo aInfo;
   DoltliteRecordInfo bInfo;
+  int nField;
   int i;
   int rc;
 
   *pEqual = 0;
-  /* PK-covering rows store an empty record until ADD COLUMN rewrites them,
-  ** so empty and non-empty shapes coexist in one table and simply differ. */
   if( nA < 1 || nB < 1 ){
-    *pEqual = (nA < 1 && nB < 1);
+    DoltliteRecordInfo *pInfo;
+    const u8 *pRec;
+    int nRec;
+    if( nA < 1 && nB < 1 ){
+      *pEqual = 1;
+      return SQLITE_OK;
+    }
+    pRec = nA < 1 ? pB : pA;
+    nRec = nA < 1 ? nB : nA;
+    pInfo = nA < 1 ? &bInfo : &aInfo;
+    rc = doltliteParseRecordStrict(pRec, nRec, pInfo);
+    if( rc!=SQLITE_OK ) return rc;
+    for(i=0; i<pInfo->nField; i++){
+      if( pInfo->aType[i]!=0 ) return SQLITE_OK;
+    }
+    *pEqual = 1;
     return SQLITE_OK;
   }
 
@@ -158,20 +172,19 @@ static int diffRecordsEqualFieldwise(
   rc = doltliteParseRecordStrict(pB, nB, &bInfo);
   if( rc!=SQLITE_OK ) return rc;
 
-  if( aInfo.nField != bInfo.nField ) return SQLITE_OK;
-
-  for(i=0; i<aInfo.nField; i++){
-    int stA = aInfo.aType[i];
-    int stB = bInfo.aType[i];
+  nField = aInfo.nField > bInfo.nField ? aInfo.nField : bInfo.nField;
+  for(i=0; i<nField; i++){
+    int stA = i<aInfo.nField ? aInfo.aType[i] : 0;
+    int stB = i<bInfo.nField ? bInfo.aType[i] : 0;
     int szA;
     int szB;
 
     if( stA != stB ){
       if( dlSerialIsInt(stA) && dlSerialIsInt(stB) ){
         i64 vA = dlDecodeSerialInt(stA, pA + aInfo.aOffset[i],
-                                nA - aInfo.aOffset[i]);
+                                   nA - aInfo.aOffset[i]);
         i64 vB = dlDecodeSerialInt(stB, pB + bInfo.aOffset[i],
-                                nB - bInfo.aOffset[i]);
+                                   nB - bInfo.aOffset[i]);
         if( vA != vB ) return SQLITE_OK;
         continue;
       }

--- a/test/doltlite_diff_alter.sh
+++ b/test/doltlite_diff_alter.sh
@@ -181,6 +181,67 @@ m|7
 x|7
 y|7" "$DB7"
 
-rm -f "$DB1" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7"
+DB8=/tmp/test_diff_alter8_$$.db; rm -f "$DB8"
+
+echo "CREATE TABLE rowid_t(id INTEGER PRIMARY KEY, v TEXT);
+CREATE TABLE text_pk_t(id TEXT PRIMARY KEY, v TEXT);
+CREATE TABLE clustered_t(a TEXT, b INT, v TEXT, PRIMARY KEY(a,b)) WITHOUT ROWID;
+INSERT INTO rowid_t VALUES(1,'a'),(2,'b');
+INSERT INTO text_pk_t VALUES('a','a'),('b','b');
+INSERT INTO clustered_t VALUES('a',1,'a'),('b',2,'b');
+SELECT dolt_commit('-A','-m','base');
+ALTER TABLE rowid_t ADD COLUMN added INT;
+ALTER TABLE text_pk_t ADD COLUMN added INT;
+ALTER TABLE clustered_t ADD COLUMN added INT;
+SELECT dolt_commit('-A','-m','add columns');" | $DOLTLITE "$DB8" > /dev/null 2>&1
+
+run_test "added_null_rowid_hash_stable" \
+  "CREATE TEMP TABLE h AS SELECT dolt_hashof_table('rowid_t') AS v;
+   UPDATE rowid_t SET added=NULL WHERE id=2;
+   SELECT v=dolt_hashof_table('rowid_t') FROM h;" \
+  "1" "$DB8"
+
+run_test "added_null_text_pk_hash_stable" \
+  "CREATE TEMP TABLE h AS SELECT dolt_hashof_table('text_pk_t') AS v;
+   UPDATE text_pk_t SET added=NULL WHERE id='b';
+   SELECT v=dolt_hashof_table('text_pk_t') FROM h;" \
+  "1" "$DB8"
+
+run_test "added_null_clustered_hash_stable" \
+  "CREATE TEMP TABLE h AS SELECT dolt_hashof_table('clustered_t') AS v;
+   UPDATE clustered_t SET added=NULL WHERE a='b' AND b=2;
+   SELECT v=dolt_hashof_table('clustered_t') FROM h;" \
+  "1" "$DB8"
+
+run_test "added_null_status_clean" \
+  "SELECT count(*) FROM dolt_status;" \
+  "0" "$DB8"
+
+run_test "added_null_diff_empty" \
+  "SELECT (SELECT count(*) FROM dolt_diff_rowid_t('HEAD','WORKING'))
+        + (SELECT count(*) FROM dolt_diff_text_pk_t('HEAD','WORKING'))
+        + (SELECT count(*) FROM dolt_diff_clustered_t('HEAD','WORKING'));" \
+  "0" "$DB8"
+
+run_test "added_null_diff_stat_empty" \
+  "SELECT coalesce(sum(rows_added + rows_deleted + rows_modified), 0)
+     FROM dolt_diff_stat('HEAD','WORKING');" \
+  "0" "$DB8"
+
+run_test "added_null_patch_empty" \
+  "SELECT count(*) FROM dolt_patch('HEAD','WORKING');" \
+  "0" "$DB8"
+
+run_test "added_null_blame_unchanged" \
+  "SELECT group_concat(message, ',') FROM (
+     SELECT message FROM dolt_blame_rowid_t ORDER BY id
+   );" \
+  "base,base" "$DB8"
+
+run_test_match "added_null_cannot_commit" \
+  "SELECT dolt_commit('-A','-m','content-free');" \
+  "nothing to commit" "$DB8"
+
+rm -f "$DB1" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8"
 
 dltest_finish

--- a/test/vc_oracle_hashof_test.sh
+++ b/test/vc_oracle_hashof_test.sh
@@ -244,7 +244,29 @@ same "net_vs_delete_reinsert" "$H_NET" "$H_DR"
 
 echo ""
 
-echo "--- 3b. Oversized singleton leaf vs one-shot insert ---"
+echo "--- 3b. Setting an added column to its implicit NULL is a no-op ---"
+
+ADDED_NULL="
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1, 'a'), (2, 'b');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'base');
+ALTER TABLE t ADD COLUMN added INTEGER;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'add column');
+"
+
+DB="added_null"
+setup_pair "$DB" "$ADDED_NULL"
+H_ADDED_NULL_BEFORE=$(run_hash_on "$DB" "SELECT dolt_hashof_table('t');")
+exec_pair "$DB" "UPDATE t SET added=NULL WHERE id=2;"
+H_ADDED_NULL_AFTER=$(run_hash_on "$DB" "SELECT dolt_hashof_table('t');")
+same "added_implicit_null_update_keeps_table_hash" \
+  "$H_ADDED_NULL_BEFORE" "$H_ADDED_NULL_AFTER"
+
+echo ""
+
+echo "--- 3c. Oversized singleton leaf vs one-shot insert ---"
 
 SMALL_TWO="
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);


### PR DESCRIPTION
## Summary

- treat absent trailing record fields as SQL NULL during semantic comparisons
- retain the existing encoded payload for semantically unchanged rowid and clustered-table updates, preserving version-12 table roots
- use semantic row equality in blame while preserving schema-only ALTER behavior
- cover rowid, text-primary-key, and clustered tables across hash, status, diff, patch, blame, and commit surfaces, with Dolt oracle parity

## Testing

- make lint
- DOLTLITE="$PWD/build/doltlite" bash test/run_doltlite_tests.sh (126 suites passed)
- bash test/run_c_tests.sh (33 gated binaries passed)
- bash test/vc_oracle_diff_test.sh build/doltlite dolt (70 passed)
- bash test/vc_oracle_hashof_test.sh build/doltlite dolt (47 passed)
- bash test/vc_oracle_blame_test.sh build/doltlite dolt (25 passed)
- bash test/run_testfixture.sh "SQLite regression e_fkey" 600 e_fkey (916 passing, 15 established divergences)

Fixes #2611

Co-Authored-By: OpenAI Codex <noreply@openai.com>