### PR TITLE
Reject connection control in dolt_test_run

### DIFF
--- a/src/doltlite_tests.c
+++ b/src/doltlite_tests.c
@@ -590,6 +590,12 @@ static int testAuthorizer(void *pArg, int action, const char *z1,
       p->hasCommand = 1;
     }
   }
+  if( rc==SQLITE_OK && (action==SQLITE_ATTACH
+      || action==SQLITE_DETACH
+      || action==SQLITE_TRANSACTION
+      || action==SQLITE_SAVEPOINT) ){
+    p->hasCommand = 1;
+  }
   if( rc==SQLITE_OK && action==SQLITE_PRAGMA ){
     p->hasPragma = 1;
     rc = SQLITE_DENY;

--- a/test/doltlite_tests.sh
+++ b/test/doltlite_tests.sh
@@ -157,6 +157,37 @@ zero_rows|FAIL|expected_single_value expects exactly one cell. Received 0 rows
 0
 1" "$DB"
 
+CONTROL_FILE="${DB}.injected"
+rm -f "$CONTROL_FILE"
+run_test "runner_connection_control_rejected" \
+  "CREATE TABLE transaction_guard(i INT);
+   ATTACH ':memory:' AS caller_aux;
+   INSERT INTO dolt_tests VALUES
+     ('attach','connection_control','ATTACH ''$CONTROL_FILE'' AS injected','expected_rows','==','0'),
+     ('detach','connection_control','DETACH caller_aux','expected_rows','==','0'),
+     ('rollback','connection_control','ROLLBACK','expected_rows','==','0'),
+     ('savepoint','connection_control','SAVEPOINT injected_savepoint','expected_rows','==','0');
+   BEGIN;
+   INSERT INTO transaction_guard VALUES(1);
+   SELECT test_name, status, message FROM dolt_test_run('connection_control');
+   SELECT count(*) FROM pragma_database_list WHERE name='caller_aux';
+   SELECT count(*) FROM pragma_database_list WHERE name='injected';
+   SELECT count(*) FROM transaction_guard;
+   COMMIT;" \
+  "attach|FAIL|Cannot execute write queries
+detach|FAIL|Cannot execute write queries
+rollback|FAIL|Cannot execute write queries
+savepoint|FAIL|Cannot execute write queries
+1
+0
+1" "$DB"
+
+if [ -e "$CONTROL_FILE" ]; then
+  dltest_fail "runner_attach_no_file" "  created: $CONTROL_FILE"
+else
+  dltest_pass
+fi
+
 run_test "runner_query_error" \
   "INSERT INTO dolt_tests VALUES
      ('query_error','errors','SELECT * FROM absent','expected_rows','==','0');
@@ -178,7 +209,7 @@ run_test "drop_materialized_table" \
   "0
 0" "$DB"
 
-rm -f "$DB"
+rm -f "$DB" "$CONTROL_FILE"
 DB=/tmp/test_dolt_tests_zero_$$.db
 rm -f "$DB"
 

--- a/test/vc_oracle_tests_test.sh
+++ b/test/vc_oracle_tests_test.sh
@@ -227,6 +227,13 @@ INSERT INTO dolt_tests VALUES
  ('write','validation','CREATE TABLE nope(x INT)','expected_rows','==','1');
 " "'validation'"
 
+oracle_query results "attach_rejected" "
+INSERT INTO dolt_tests VALUES
+ ('attach',NULL,'ATTACH '':memory:'' AS aux','expected_rows','==','0');
+" \
+  "SELECT 'R|' || test_name || '|' || status FROM dolt_test_run('attach');" \
+  "SELECT concat('R|', test_name, '|', status) FROM dolt_test_run('attach');"
+
 oracle_results "non_integer_counts" "
 INSERT INTO dolt_tests VALUES
  ('bad_cols','bad_int','SELECT 1','expected_columns','==','0.5'),


### PR DESCRIPTION
## Summary

- reject ATTACH and DETACH in stored test queries before they can change the caller connection or create files
- reject transaction and savepoint control so tests cannot commit, roll back, or otherwise alter caller transaction state
- add native regression coverage and a Dolt status oracle for ATTACH rejection

## Testing

- make lint
- DOLTLITE="$PWD/build/doltlite" bash test/run_doltlite_tests.sh (126 suites passed; 311,207 C assertions passed)
- DOLTLITE="$PWD/doltlite" bash ../test/doltlite_tests.sh from build/ (31 tests passed)
- new attach_rejected oracle matches Dolt 2.3.1 (the full local oracle script retains its unrelated DECIMAL formatting mismatch against that older Dolt version)

Fixes #2613

Co-Authored-By: OpenAI Codex <noreply@openai.com>