### PR TITLE
Refuse branch names that differ only by case

### DIFF
--- a/src/doltlite_branch.c
+++ b/src/doltlite_branch.c
@@ -72,6 +72,28 @@ static int resetBranchRef(sqlite3 *db, ChunkStore *cs, const char *zName,
   return rc;
 }
 
+/* Dolt refuses to create a branch whose name differs from an existing one only
+** by case, while every lookup stays exact. An exact match is left to the
+** caller's own duplicate handling, and a rename may re-case its own name. */
+static int branchNameTakenIgnoringCase(
+  ChunkStore *cs,
+  const char *zName,
+  const char *zSelf
+){
+  const BranchRef *aBranch = 0;
+  int nBranch = 0;
+  int i;
+  refsTableGetBranches(&cs->refs, &nBranch, &aBranch);
+  for(i=0; i<nBranch; i++){
+    const char *zHave = aBranch[i].zName;
+    if( !zHave ) continue;
+    if( strcmp(zHave, zName)==0 ) continue;
+    if( zSelf && strcmp(zHave, zSelf)==0 ) continue;
+    if( sqlite3_stricmp(zHave, zName)==0 ) return 1;
+  }
+  return 0;
+}
+
 int mutateBranchRef(sqlite3 *db, ChunkStore *cs, void *pArg){
   BranchMutationCtx *p = (BranchMutationCtx*)pArg;
 
@@ -86,6 +108,7 @@ int mutateBranchRef(sqlite3 *db, ChunkStore *cs, void *pArg){
   if( p->force && chunkStoreFindBranch(cs, p->zName, 0)==SQLITE_OK ){
     return resetBranchRef(db, cs, p->zName, &p->head);
   }
+  if( branchNameTakenIgnoringCase(cs, p->zName, 0) ) return SQLITE_ERROR;
   return chunkStoreAddBranch(cs, p->zName, &p->head);
 }
 
@@ -110,6 +133,7 @@ static int mutateBranchCopy(sqlite3 *db, ChunkStore *cs, void *pArg){
       return resetBranchRef(db, cs, p->zDest, &srcCommit);
     }
   }
+  if( branchNameTakenIgnoringCase(cs, p->zDest, 0) ) return SQLITE_ERROR;
   return chunkStoreAddBranch(cs, p->zDest, &srcCommit);
 }
 
@@ -131,6 +155,7 @@ static int mutateBranchMove(sqlite3 *db, ChunkStore *cs, void *pArg){
   if( !doltliteUserRefNameIsValid(p->zDest) ) return SQLITE_CONSTRAINT;
   rc = chunkStoreFindBranch(cs, p->zSrc, &srcCommit);
   if( rc!=SQLITE_OK ) return rc;
+  if( branchNameTakenIgnoringCase(cs, p->zDest, p->zSrc) ) return SQLITE_ERROR;
   zDefault = chunkStoreGetDefaultBranch(cs);
   srcIsDefault = zDefault && strcmp(p->zSrc, zDefault)==0;
   rc = chunkStoreGetBranchWorkingSet(cs, p->zSrc, &srcWorkingSet);

--- a/test/doltlite_branch.sh
+++ b/test/doltlite_branch.sh
@@ -190,5 +190,29 @@ echo "SELECT dolt_checkout('one'); INSERT INTO t VALUES(2); SELECT dolt_commit('
 run_test "force_delete_multiple_branches" "SELECT dolt_branch('-D','one','two');" "0" "$DB15"
 run_test "force_delete_multiple_branches_removed" "SELECT count(*) FROM dolt_branches WHERE name IN ('one','two');" "0" "$DB15"
 
-rm -f "$DB" "$DB2" "$DB2B" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8" "$DB9" "$DB10" "$DB11" "$DB12" "$DB13" "$DB14" "$DB15"
+DB16=/tmp/test_branch16_$$.db; rm -f "$DB16"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY); INSERT INTO t VALUES(1); SELECT dolt_commit('-A','-m','init'); SELECT dolt_branch('feat');" | $DOLTLITE "$DB16" > /dev/null 2>&1
+run_test_match "create_case_variant_refused" "SELECT dolt_branch('Feat');" "already exists" "$DB16"
+run_test_match "copy_to_case_variant_refused" "SELECT dolt_branch('-c','main','MAIN');" "already exists" "$DB16"
+run_test_match "force_create_case_variant_refused" "SELECT dolt_branch('-f','Main','main');" "already exists" "$DB16"
+run_test_match "checkout_b_case_variant_refused" "SELECT dolt_checkout('-b','MAIN');" "already exists" "$DB16"
+run_test_match "move_onto_case_variant_refused" "SELECT dolt_branch('-m','feat','MAIN');" "already exists" "$DB16"
+run_test_match "force_move_onto_case_variant_refused" "SELECT dolt_branch('-m','-f','feat','MAIN');" "already exists" "$DB16"
+run_test "case_variant_attempts_created_nothing" \
+  "SELECT group_concat(name,'|') FROM (SELECT name FROM dolt_branches ORDER BY name);" \
+  "feat|main" "$DB16"
+run_test "distinct_name_still_creates" "SELECT dolt_branch('feature2');" "0" "$DB16"
+
+DB17=/tmp/test_branch17_$$.db; rm -f "$DB17"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY); INSERT INTO t VALUES(1); SELECT dolt_commit('-A','-m','init'); SELECT dolt_branch('feat');" | $DOLTLITE "$DB17" > /dev/null 2>&1
+run_test "move_recases_own_name" "SELECT dolt_branch('-m','feat','FEAT');" "0" "$DB17"
+run_test "move_recased_branch_listed_once" \
+  "SELECT group_concat(name,'|') FROM (SELECT name FROM dolt_branches ORDER BY name);" \
+  "FEAT|main" "$DB17"
+run_test "move_recases_default_branch" "SELECT dolt_branch('-m','main','MAIN');" "0" "$DB17"
+run_test "recased_default_branch_listed_once" \
+  "SELECT group_concat(name,'|') FROM (SELECT name FROM dolt_branches ORDER BY name);" \
+  "FEAT|MAIN" "$DB17"
+
+rm -f "$DB" "$DB2" "$DB2B" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8" "$DB9" "$DB10" "$DB11" "$DB12" "$DB13" "$DB14" "$DB15" "$DB16" "$DB17"
 dltest_finish

--- a/test/vc_oracle_branch_test.sh
+++ b/test/vc_oracle_branch_test.sh
@@ -517,6 +517,54 @@ oracle_error "no_args" "
 SELECT dolt_branch();
 "
 
+SEED_CASE="
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 10);
+SELECT dolt_commit('-Am', 'c1');
+SELECT dolt_branch('feat');
+"
+
+oracle_error "create_case_variant_of_existing_branch" "
+$SEED_CASE
+SELECT dolt_branch('Feat');
+"
+
+oracle_error "create_case_variant_of_default_branch" "
+$SEED_CASE
+SELECT dolt_branch('MAIN');
+"
+
+oracle_error "copy_to_case_variant" "
+$SEED_CASE
+SELECT dolt_branch('-c', 'main', 'MAIN');
+"
+
+oracle_error "force_create_case_variant" "
+$SEED_CASE
+SELECT dolt_branch('-f', 'Main', 'main');
+"
+
+oracle_error "checkout_b_case_variant" "
+$SEED_CASE
+SELECT dolt_checkout('-b', 'MAIN');
+"
+
+oracle_error "move_onto_case_variant_of_other_branch" "
+$SEED_CASE
+SELECT dolt_branch('-m', 'feat', 'MAIN');
+"
+
+oracle "move_recases_own_name" "
+$SEED_CASE
+SELECT dolt_branch('-m', 'feat', 'FEAT');
+"
+
+oracle "case_distinct_names_still_create" "
+$SEED_CASE
+SELECT dolt_branch('feature2');
+SELECT dolt_branch('-c', 'main', 'mainline');
+"
+
 echo ""
 echo "=== Results: $pass passed, $fail failed ==="
 if [ $fail -gt 0 ]; then


### PR DESCRIPTION
Fixes #2615.

Creating a branch checked for an exact name match, so `main` and `MAIN` could both exist in one database. Dolt refuses. I ran the whole matrix against Dolt 2.3.1 first, because the rule is narrower than "branch names are case-insensitive":

| operation | Dolt |
|---|---|
| `dolt_branch('Feat')` with `feat` present | error, names the existing branch |
| `dolt_branch('-c','main','MAIN')` | error |
| `dolt_branch('-c','-f','main','MAIN')` | error, force does not bypass |
| `dolt_branch('-f','Main','main')` | error |
| `dolt_checkout('-b','MAIN')` | error |
| `dolt_branch('-m','feat','MAIN')` | error, with or without `-f` |
| `dolt_branch('-m','feat','FEAT')` | **allowed**, a branch may re-case its own name |
| `dolt_branch('-d','feat')` when `FEAT` exists | branch not found, lookups stay exact |
| `dolt_checkout('feat')` when `FEAT` exists | not found |
| `dolt_branch('zz','MAIN')` when `main` exists | start point not resolved |
| `dolt_tag('v1')` then `dolt_tag('V1')` | **both allowed**, tags are a case-sensitive namespace |

So the rule is case-insensitive uniqueness on branch *creation* only, with a self-rename exemption. Everything else stays exact, and tags are untouched. DoltLite now matches every row of that table.

Two details worth calling out:

- **Force does not bypass the check.** Confirmed directly against Dolt for both `-f` create and `-c -f` copy, so the check runs before the force-reset path, which still resets an *exact* match as before.
- **ASCII folding is sufficient.** Dolt rejects a branch name containing non-ASCII letters outright (`fatal: 'FEÄT' is an invalid branch name.`), so a Unicode-aware fold can never be reached.

The check lives in the branch command's create, copy and rename paths rather than in the ref store, so rebase working branches, fetch and clone still install whatever names the commit graph carries.

## Verification

Fail-before / pass-after against a build of the same tree without the fix:

| suite | before | after |
|---|---|---|
| `test/doltlite_branch.sh` | 85 passed, **5 failed** | **90 passed, 0 failed** |
| `test/vc_oracle_branch_test.sh` | 50 passed, **6 failed** | **56 passed, 0 failed** |

The oracle cases run identical SQL against Dolt and assert both engines reject, plus two positive cases: a branch re-casing its own name, and ordinary distinct names still creating.

Also green: `test/run_doltlite_tests.sh` 126/126, and the `checkout` (71), `branches` (15), `active_branch` (4) and `connection_branch` (29) oracle suites.