### PR TITLE
Propagate tags through remotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -653,6 +653,8 @@ Git-like push / fetch / pull / clone between databases.
 ```sql
 SELECT dolt_remote('add', 'origin', 'file:///path/to/remote.doltlite');
 SELECT dolt_push('origin', 'main');
+SELECT dolt_push('origin', 'v1.0');       -- push one tag
+SELECT dolt_push('origin', '--tags');     -- push all tags
 SELECT dolt_clone('file:///path/to/source.doltlite');
 SELECT dolt_clone('--lazy', 'file:///path/to/source.doltlite');
 SELECT dolt_fetch('origin', 'main');
@@ -677,7 +679,8 @@ uncached miss fails with a hash-named error instead of contacting `origin`.
 `dolt_pull` fetches, then fast-forwards if the local branch is an ancestor
 of the remote tip. If the current branch has diverged, it three-way merges
 like `dolt_merge`. A non-current branch that is not a fast-forward is
-refused.
+refused. Fetch and pull also install remote tags whose commits have been
+fetched, without replacing same-named local tags.
 
 ##### HTTP Remotes
 

--- a/README.md
+++ b/README.md
@@ -680,7 +680,7 @@ uncached miss fails with a hash-named error instead of contacting `origin`.
 of the remote tip. If the current branch has diverged, it three-way merges
 like `dolt_merge`. A non-current branch that is not a fast-forward is
 refused. Fetch and pull also install remote tags whose commits have been
-fetched, without replacing same-named local tags.
+fetched, replacing same-named local tags when the remote value differs.
 
 ##### HTTP Remotes
 

--- a/src/doltlite_docs.c
+++ b/src/doltlite_docs.c
@@ -66,6 +66,8 @@ static const char *zDocsAgentDefault =
   "```sql\n"
   "SELECT dolt_remote('add', 'origin', 'file:///path/to/remote.db');\n"
   "SELECT dolt_push('origin', 'main');\n"
+  "SELECT dolt_push('origin', 'v1');\n"
+  "SELECT dolt_push('origin', '--tags');\n"
   "SELECT dolt_pull('origin', 'main');\n"
   "SELECT dolt_clone('file:///path/to/source.db');\n"
   "```\n"

--- a/src/doltlite_remote.c
+++ b/src/doltlite_remote.c
@@ -77,6 +77,14 @@ static int remoteFindBranchFromRefsBlob(
   return rc;
 }
 
+#define REMOTE_TAG_SCOPE_PREFIX "tag:"
+
+static const char *remoteScopedTagName(const char *zRef){
+  int nPrefix = (int)sizeof(REMOTE_TAG_SCOPE_PREFIX) - 1;
+  if( !zRef || strncmp(zRef, REMOTE_TAG_SCOPE_PREFIX, nPrefix)!=0 ) return 0;
+  return zRef[nPrefix] ? zRef + nPrefix : 0;
+}
+
 static int remoteCollectRootsFromRefsBlob(
   const u8 *pData, int nData, ProllyHash **paRoots, int *pnRoots
 ){
@@ -202,21 +210,36 @@ int doltliteValidateRefsTargetGraph(
   ChunkStore *pStore,
   const u8 *pBlob,
   int nBlob,
-  const char *zBranch
+  const char *zRef
 ){
   ChunkStore refsView;
   ProllyHash aRoots[2];
   const BranchRef *aBranch;
+  const TagRef *aTag;
+  const char *zTag = remoteScopedTagName(zRef);
   int nBranch;
+  int nTag;
   int rc;
   int i;
 
   rc = remoteLoadRefsView(pBlob, nBlob, &refsView);
   if( rc!=SQLITE_OK ) return rc;
+  if( zTag ){
+    refsTableGetTags(&refsView.refs, &nTag, &aTag);
+    rc = SQLITE_NOTFOUND;
+    for(i=0; i<nTag; i++){
+      if( strcmp(aTag[i].zName, zTag)==0 ){
+        rc = remoteValidateGraph(pStore, &aTag[i].commitHash, 1);
+        break;
+      }
+    }
+    chunkStoreClose(&refsView);
+    return rc;
+  }
   refsTableGetBranches(&refsView.refs, &nBranch, &aBranch);
   rc = SQLITE_NOTFOUND;
   for(i=0; i<nBranch; i++){
-    if( strcmp(aBranch[i].zName, zBranch)==0 ){
+    if( strcmp(aBranch[i].zName, zRef)==0 ){
       aRoots[0] = aBranch[i].commitHash;
       aRoots[1] = aBranch[i].workingSetHash;
       rc = remoteValidateGraph(pStore, aRoots, 2);
@@ -807,6 +830,24 @@ static int scopedTagsMatch(const TagRef *aCur, int nCur,
   return 1;
 }
 
+static int scopedBranchesMatch(const BranchRef *aCur, int nCur,
+                               const BranchRef *aInc, int nInc){
+  int i, j;
+  if( nCur!=nInc ) return 0;
+  for(i=0; i<nCur; i++){
+    for(j=0; j<nInc; j++){
+      if( scopedSameText(aInc[j].zName, aCur[i].zName) ) break;
+    }
+    if( j>=nInc
+     || prollyHashCompare(&aInc[j].commitHash, &aCur[i].commitHash)!=0
+     || prollyHashCompare(&aInc[j].workingSetHash,
+                          &aCur[i].workingSetHash)!=0 ){
+      return 0;
+    }
+  }
+  return 1;
+}
+
 static int scopedRemotesMatch(const RemoteRef *aCur, int nCur,
                               const RemoteRef *aInc, int nInc){
   int i, j;
@@ -853,11 +894,24 @@ static int scopedSequencesOnlyAdvance(const SequenceRef *aCur, int nCur,
   return 1;
 }
 
+static int scopedSequencesMatch(const SequenceRef *aCur, int nCur,
+                                const SequenceRef *aInc, int nInc){
+  int i, j;
+  if( nCur!=nInc ) return 0;
+  for(i=0; i<nCur; i++){
+    for(j=0; j<nInc; j++){
+      if( scopedSameText(aInc[j].zTableName, aCur[i].zTableName) ) break;
+    }
+    if( j>=nInc || aInc[j].iSeq!=aCur[i].iSeq ) return 0;
+  }
+  return 1;
+}
+
 int doltliteValidateScopedRefsUpdate(
   ChunkStore *pStore,
   const u8 *pBlob,
   int nBlob,
-  const char *zBranch,
+  const char *zRef,
   int bForce
 ){
   ChunkStore inc;
@@ -866,6 +920,7 @@ int doltliteValidateScopedRefsUpdate(
   const RemoteRef *aCurRem = 0, *aIncRem = 0;
   const TrackingBranch *aCurTrk = 0, *aIncTrk = 0;
   const SequenceRef *aCurSeq = 0, *aIncSeq = 0;
+  const char *zTag = remoteScopedTagName(zRef);
   int nCur = 0, nInc = 0, nCurTag = 0, nIncTag = 0;
   int nCurRem = 0, nIncRem = 0, nCurTrk = 0, nIncTrk = 0;
   int nCurSeq = 0, nIncSeq = 0;
@@ -873,7 +928,7 @@ int doltliteValidateScopedRefsUpdate(
   int rc;
   int i, j;
 
-  if( !zBranch || !zBranch[0] ) return SQLITE_MISUSE;
+  if( !zRef || !zRef[0] ) return SQLITE_MISUSE;
   memset(&inc, 0, sizeof(inc));
   rc = csDeserializeRefsIntoTemp(&inc, pBlob, nBlob);
   if( rc!=SQLITE_OK ){
@@ -901,9 +956,48 @@ int doltliteValidateScopedRefsUpdate(
     goto done;
   }
 
+  if( zTag ){
+    const TagRef *incTag = 0;
+    if( !scopedBranchesMatch(aCur, nCur, aInc, nInc)
+     || !scopedRemotesMatch(aCurRem, nCurRem, aIncRem, nIncRem)
+     || !scopedTrackingMatch(aCurTrk, nCurTrk, aIncTrk, nIncTrk)
+     || !scopedSequencesMatch(aCurSeq, nCurSeq, aIncSeq, nIncSeq)
+     || !scopedSameText(scopedDefaultBranch(&pStore->refs),
+                        scopedDefaultBranch(&inc.refs)) ){
+      rc = SQLITE_CONSTRAINT;
+      goto done;
+    }
+    for(i=0; i<nCurTag; i++){
+      if( strcmp(aCurTag[i].zName, zTag)==0 ) continue;
+      for(j=0; j<nIncTag; j++){
+        if( strcmp(aIncTag[j].zName, aCurTag[i].zName)==0 ) break;
+      }
+      if( j>=nIncTag
+       || !scopedTagsMatch(&aCurTag[i], 1, &aIncTag[j], 1) ){
+        rc = SQLITE_CONSTRAINT;
+        goto done;
+      }
+    }
+    for(j=0; j<nIncTag; j++){
+      if( strcmp(aIncTag[j].zName, zTag)==0 ){
+        incTag = &aIncTag[j];
+        continue;
+      }
+      for(i=0; i<nCurTag; i++){
+        if( strcmp(aCurTag[i].zName, aIncTag[j].zName)==0 ) break;
+      }
+      if( i>=nCurTag ){
+        rc = SQLITE_CONSTRAINT;
+        goto done;
+      }
+    }
+    rc = incTag ? SQLITE_OK : SQLITE_CONSTRAINT;
+    goto done;
+  }
+
   /* Every other current branch must survive unchanged (name, commit, working set). */
   for(i=0; i<nCur; i++){
-    if( strcmp(aCur[i].zName, zBranch)==0 ) continue;
+    if( strcmp(aCur[i].zName, zRef)==0 ) continue;
     for(j=0; j<nInc; j++){
       if( strcmp(aInc[j].zName, aCur[i].zName)==0 ) break;
     }
@@ -917,7 +1011,7 @@ int doltliteValidateScopedRefsUpdate(
 
   /* Push may not introduce any branch other than the declared one. */
   for(j=0; j<nInc; j++){
-    if( strcmp(aInc[j].zName, zBranch)==0 ) continue;
+    if( strcmp(aInc[j].zName, zRef)==0 ) continue;
     for(i=0; i<nCur; i++){
       if( strcmp(aCur[i].zName, aInc[j].zName)==0 ) break;
     }
@@ -939,17 +1033,17 @@ int doltliteValidateScopedRefsUpdate(
   /* Push may not repoint the default branch (clone checkout / GET /root).
   ** An empty target may adopt the pushed branch. */
   if( !scopedSameText(scopedDefaultBranch(&inc.refs),
-                      nCur==0 ? zBranch : scopedDefaultBranch(&pStore->refs)) ){
+                      nCur==0 ? zRef : scopedDefaultBranch(&pStore->refs)) ){
     rc = SQLITE_CONSTRAINT;
     goto done;
   }
 
   /* Declared branch may be created; an existing one must fast-forward unless forced. */
   for(i=0; i<nCur; i++){
-    if( strcmp(aCur[i].zName, zBranch)==0 ){ curB = &aCur[i]; break; }
+    if( strcmp(aCur[i].zName, zRef)==0 ){ curB = &aCur[i]; break; }
   }
   for(j=0; j<nInc; j++){
-    if( strcmp(aInc[j].zName, zBranch)==0 ){ incB = &aInc[j]; break; }
+    if( strcmp(aInc[j].zName, zRef)==0 ){ incB = &aInc[j]; break; }
   }
   /* Push creates or advances the declared branch, never deletes it. */
   if( !incB ){
@@ -988,6 +1082,57 @@ static int remoteSequencesWouldAdvance(
      && aRemSeq[iSeq].iSeq >
         chunkStoreGetSequenceValue(pLocal, aRemSeq[iSeq].zTableName) ){
       *pWouldAdvance = 1;
+      break;
+    }
+  }
+  return SQLITE_OK;
+}
+
+static int remoteTagTargetAvailable(
+  ChunkStore *pLocal,
+  const ProllyHash *pCommit,
+  int *pAvailable
+){
+  u8 *pData = 0;
+  int nData = 0;
+  int rc;
+
+  *pAvailable = 0;
+  rc = chunkStoreGet(pLocal, pCommit, &pData, &nData);
+  if( rc==SQLITE_NOTFOUND ) return SQLITE_OK;
+  if( rc==SQLITE_OK ){
+    if( doltliteClassifyChunk(pData, nData)!=CHUNK_COMMIT ){
+      rc = SQLITE_CORRUPT;
+    }else{
+      *pAvailable = 1;
+    }
+  }
+  sqlite3_free(pData);
+  return rc;
+}
+
+static int remoteTagsWouldInstall(
+  ChunkStore *pLocal,
+  ChunkStore *pRemoteRefs,
+  int *pWouldInstall
+){
+  const TagRef *aRemoteTag = 0;
+  int nRemoteTag = 0;
+  int i;
+  int rc;
+
+  *pWouldInstall = 0;
+  refsTableGetTags(&pRemoteRefs->refs, &nRemoteTag, &aRemoteTag);
+  for(i=0; i<nRemoteTag; i++){
+    int available = 0;
+    if( chunkStoreFindTag(pLocal, aRemoteTag[i].zName, 0)==SQLITE_OK ){
+      continue;
+    }
+    rc = remoteTagTargetAvailable(
+        pLocal, &aRemoteTag[i].commitHash, &available);
+    if( rc!=SQLITE_OK ) return rc;
+    if( available ){
+      *pWouldInstall = 1;
       break;
     }
   }
@@ -1138,6 +1283,118 @@ int doltlitePush(
   return rc;
 }
 
+int doltlitePushTag(
+  ChunkStore *pLocal,
+  DoltliteRemote *pRemote,
+  const char *zTag
+){
+  const TagRef *aLocalTag = 0;
+  const TagRef *pLocalTag = 0;
+  ProllyHash expectedRefsHash;
+  u8 *refsData = 0;
+  int nRefsData = 0;
+  int nLocalTag = 0;
+  int rc;
+  int i;
+
+  refsTableGetTags(&pLocal->refs, &nLocalTag, &aLocalTag);
+  for(i=0; i<nLocalTag; i++){
+    if( strcmp(aLocalTag[i].zName, zTag)==0 ){
+      pLocalTag = &aLocalTag[i];
+      break;
+    }
+  }
+  if( !pLocalTag ) return SQLITE_NOTFOUND;
+
+  memset(&expectedRefsHash, 0, sizeof(expectedRefsHash));
+  rc = pRemote->xGetRefs(pRemote, &refsData, &nRefsData);
+  if( rc==SQLITE_OK && refsData ){
+    ChunkStore refsView;
+    const TagRef *aRemoteTag = 0;
+    int nRemoteTag = 0;
+    prollyHashCompute(refsData, nRefsData, &expectedRefsHash);
+    memset(&refsView, 0, sizeof(refsView));
+    rc = chunkStoreLoadRefsFromBlob(&refsView, refsData, nRefsData);
+    if( rc==SQLITE_OK ){
+      refsTableGetTags(&refsView.refs, &nRemoteTag, &aRemoteTag);
+      for(i=0; i<nRemoteTag; i++){
+        if( strcmp(aRemoteTag[i].zName, zTag)==0
+         && scopedTagsMatch(pLocalTag, 1, &aRemoteTag[i], 1) ){
+          chunkStoreClose(&refsView);
+          sqlite3_free(refsData);
+          return SQLITE_OK;
+        }
+      }
+    }
+    chunkStoreClose(&refsView);
+  }else if( rc==SQLITE_NOTFOUND ){
+    rc = SQLITE_OK;
+  }
+  sqlite3_free(refsData);
+  refsData = 0;
+  if( rc!=SQLITE_OK ) return rc;
+
+  {
+    DoltliteRemote *pLocalSrc = doltliteLocalAsRemote(pLocal);
+    if( !pLocalSrc ) return SQLITE_NOMEM;
+    rc = doltliteSyncChunks(
+        pLocalSrc, pRemote, &pLocalTag->commitHash, 1);
+    pLocalSrc->xClose(pLocalSrc);
+  }
+  if( rc!=SQLITE_OK ) return rc;
+
+  rc = pRemote->xGetRefs(pRemote, &refsData, &nRefsData);
+  if( rc==SQLITE_NOTFOUND ){
+    refsData = 0;
+    nRefsData = 0;
+    rc = SQLITE_OK;
+  }
+  if( rc==SQLITE_OK ){
+    ChunkStore nextRefs;
+    u8 *newRefs = 0;
+    char *zScope = 0;
+    int nNewRefs = 0;
+
+    memset(&nextRefs, 0, sizeof(nextRefs));
+    if( refsData && nRefsData>0 ){
+      rc = chunkStoreLoadRefsFromBlob(&nextRefs, refsData, nRefsData);
+    }
+    if( rc==SQLITE_OK
+     && chunkStoreFindTag(&nextRefs, zTag, 0)==SQLITE_OK ){
+      rc = chunkStoreDeleteTag(&nextRefs, zTag);
+    }
+    if( rc==SQLITE_OK ){
+      rc = chunkStoreAddTagFull(
+          &nextRefs, zTag, &pLocalTag->commitHash,
+          pLocalTag->zTagger, pLocalTag->zEmail,
+          pLocalTag->timestamp, pLocalTag->zMessage);
+    }
+    if( rc==SQLITE_OK ){
+      rc = chunkStoreSerializeRefsToBlob(&nextRefs, &newRefs, &nNewRefs);
+    }
+    if( rc==SQLITE_OK ){
+      zScope = sqlite3_mprintf("%s%s", REMOTE_TAG_SCOPE_PREFIX, zTag);
+      if( !zScope ) rc = SQLITE_NOMEM;
+    }
+    if( rc==SQLITE_OK ){
+      if( pRemote->xSetRefsIf ){
+        rc = pRemote->xSetRefsIf(
+            pRemote, &expectedRefsHash, zScope, 1, newRefs, nNewRefs);
+      }else{
+        rc = pRemote->xSetRefs(pRemote, zScope, 1, newRefs, nNewRefs);
+      }
+    }
+    sqlite3_free(zScope);
+    sqlite3_free(newRefs);
+    chunkStoreClose(&nextRefs);
+  }
+  sqlite3_free(refsData);
+  if( rc!=SQLITE_OK ) return rc;
+
+  doltliteTestCrashFinalize("push");
+  return pRemote->xCommit(pRemote);
+}
+
 static int installFetchedRefs(
   ChunkStore *pLocal,
   ChunkStore *pRemoteRefs,
@@ -1155,7 +1412,9 @@ static int installFetchedRefs(
   int nCurrentData = 0;
   int nNextData = 0;
   const SequenceRef *aRemSeq = 0;
+  const TagRef *aRemTag = 0;
   int nRemSeq = 0;
+  int nRemTag = 0;
   int refsDetached = 0;
   int locked = 0;
   int i;
@@ -1195,6 +1454,23 @@ static int installFetchedRefs(
       if( aRemSeq[i].zTableName ){
         rc = chunkStoreBumpSequence(
             &nextRefs, aRemSeq[i].zTableName, aRemSeq[i].iSeq);
+      }
+    }
+  }
+  if( rc==SQLITE_OK ){
+    refsTableGetTags(&pRemoteRefs->refs, &nRemTag, &aRemTag);
+    for(i=0; i<nRemTag && rc==SQLITE_OK; i++){
+      int available = 0;
+      if( chunkStoreFindTag(&nextRefs, aRemTag[i].zName, 0)==SQLITE_OK ){
+        continue;
+      }
+      rc = remoteTagTargetAvailable(
+          pLocal, &aRemTag[i].commitHash, &available);
+      if( rc==SQLITE_OK && available ){
+        rc = chunkStoreAddTagFull(
+            &nextRefs, aRemTag[i].zName, &aRemTag[i].commitHash,
+            aRemTag[i].zTagger, aRemTag[i].zEmail,
+            aRemTag[i].timestamp, aRemTag[i].zMessage);
       }
     }
   }
@@ -1277,12 +1553,18 @@ int doltliteFetch(
   if( rc==SQLITE_OK ){
     if( prollyHashCompare(&trackingCommit, &remoteCommit)==0 ){
       int seqWouldAdvance = 0;
+      int tagWouldInstall = 0;
       rc = remoteSequencesWouldAdvance(pLocal, &remoteRefs, &seqWouldAdvance);
       if( rc!=SQLITE_OK ){
         chunkStoreClose(&remoteRefs);
         return rc;
       }
-      if( !seqWouldAdvance ){
+      rc = remoteTagsWouldInstall(pLocal, &remoteRefs, &tagWouldInstall);
+      if( rc!=SQLITE_OK ){
+        chunkStoreClose(&remoteRefs);
+        return rc;
+      }
+      if( !seqWouldAdvance && !tagWouldInstall ){
         chunkStoreClose(&remoteRefs);
         return SQLITE_OK;
       }

--- a/src/doltlite_remote.c
+++ b/src/doltlite_remote.c
@@ -1116,18 +1116,24 @@ static int remoteTagsWouldInstall(
   ChunkStore *pRemoteRefs,
   int *pWouldInstall
 ){
+  const TagRef *aLocalTag = 0;
   const TagRef *aRemoteTag = 0;
+  int nLocalTag = 0;
   int nRemoteTag = 0;
   int i;
   int rc;
 
   *pWouldInstall = 0;
+  refsTableGetTags(&pLocal->refs, &nLocalTag, &aLocalTag);
   refsTableGetTags(&pRemoteRefs->refs, &nRemoteTag, &aRemoteTag);
   for(i=0; i<nRemoteTag; i++){
     int available = 0;
-    if( chunkStoreFindTag(pLocal, aRemoteTag[i].zName, 0)==SQLITE_OK ){
-      continue;
+    int j;
+    for(j=0; j<nLocalTag; j++){
+      if( strcmp(aLocalTag[j].zName, aRemoteTag[i].zName)==0 ) break;
     }
+    if( j<nLocalTag
+     && scopedTagsMatch(&aLocalTag[j], 1, &aRemoteTag[i], 1) ) continue;
     rc = remoteTagTargetAvailable(
         pLocal, &aRemoteTag[i].commitHash, &available);
     if( rc!=SQLITE_OK ) return rc;
@@ -1336,9 +1342,11 @@ int doltlitePushTag(
 
   {
     DoltliteRemote *pLocalSrc = doltliteLocalAsRemote(pLocal);
+    ProllyHash tagCommit;
     if( !pLocalSrc ) return SQLITE_NOMEM;
+    memcpy(&tagCommit, &pLocalTag->commitHash, sizeof(tagCommit));
     rc = doltliteSyncChunks(
-        pLocalSrc, pRemote, &pLocalTag->commitHash, 1);
+        pLocalSrc, pRemote, &tagCommit, 1);
     pLocalSrc->xClose(pLocalSrc);
   }
   if( rc!=SQLITE_OK ) return rc;
@@ -1461,11 +1469,22 @@ static int installFetchedRefs(
     refsTableGetTags(&pRemoteRefs->refs, &nRemTag, &aRemTag);
     for(i=0; i<nRemTag && rc==SQLITE_OK; i++){
       int available = 0;
-      if( chunkStoreFindTag(&nextRefs, aRemTag[i].zName, 0)==SQLITE_OK ){
-        continue;
+      const TagRef *aLocalTag = 0;
+      int nLocalTag = 0;
+      int j;
+      refsTableGetTags(&nextRefs.refs, &nLocalTag, &aLocalTag);
+      for(j=0; j<nLocalTag; j++){
+        if( strcmp(aLocalTag[j].zName, aRemTag[i].zName)==0 ) break;
       }
+      if( j<nLocalTag
+       && scopedTagsMatch(&aLocalTag[j], 1, &aRemTag[i], 1) ) continue;
       rc = remoteTagTargetAvailable(
           pLocal, &aRemTag[i].commitHash, &available);
+      if( rc==SQLITE_OK && available ){
+        if( j<nLocalTag ){
+          rc = chunkStoreDeleteTag(&nextRefs, aRemTag[i].zName);
+        }
+      }
       if( rc==SQLITE_OK && available ){
         rc = chunkStoreAddTagFull(
             &nextRefs, aRemTag[i].zName, &aRemTag[i].commitHash,

--- a/src/doltlite_remote.h
+++ b/src/doltlite_remote.h
@@ -45,14 +45,16 @@ int doltliteSyncChunks(
 int doltlitePush(ChunkStore *pLocal, DoltliteRemote *pRemote,
                  const char *zBranch, int bForce);
 
-/* Allow only create/advance of zBranch (FF unless bForce); other branches
-** and tags must match pStore. */
+int doltlitePushTag(ChunkStore *pLocal, DoltliteRemote *pRemote,
+                    const char *zTag);
+
+/* Allow only the declared branch or tag update; every other ref must match. */
 int doltliteValidateScopedRefsUpdate(ChunkStore *pStore, const u8 *pBlob,
-                                     int nBlob, const char *zBranch,
+                                     int nBlob, const char *zRef,
                                      int bForce);
 
 int doltliteValidateRefsTargetGraph(ChunkStore *pStore, const u8 *pBlob,
-                                    int nBlob, const char *zBranch);
+                                    int nBlob, const char *zRef);
 
 int doltliteFetch(ChunkStore *pLocal, DoltliteRemote *pRemote,
                   const char *zRemoteName, const char *zBranch);

--- a/src/doltlite_remote_sql.c
+++ b/src/doltlite_remote_sql.c
@@ -278,8 +278,9 @@ static void doltRemoteFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv)
 static void doltPushParsedFunc(
   sqlite3_context *ctx,
   const char *zRemoteName,
-  const char *zBranch,
-  int bForce
+  const char *zRef,
+  int bForce,
+  int bTags
 ){
   sqlite3 *db = sqlite3_context_db_handle(ctx);
   ChunkStore *cs = doltliteGetChunkStore(db);
@@ -292,12 +293,27 @@ static void doltPushParsedFunc(
   rc = remoteSqlOpenNamedRemote(cs, zRemoteName, &zUrl, &pRemote);
   if( remoteSqlReportOpenError(ctx, db, rc, 0) ) return;
 
-  rc = doltlitePush(cs, pRemote, zBranch, bForce);
+  if( bTags ){
+    const TagRef *aTag = 0;
+    int nTag = 0;
+    int i;
+    refsTableGetTags(&cs->refs, &nTag, &aTag);
+    rc = SQLITE_OK;
+    for(i=0; i<nTag && rc==SQLITE_OK; i++){
+      rc = doltlitePushTag(cs, pRemote, aTag[i].zName);
+    }
+  }else if( chunkStoreFindBranch(cs, zRef, 0)==SQLITE_OK ){
+    rc = doltlitePush(cs, pRemote, zRef, bForce);
+  }else{
+    rc = doltlitePushTag(cs, pRemote, zRef);
+  }
   if( rc!=SQLITE_OK ){
     const char *zMsg = remoteSqlRemoteMsg(pRemote, rc);
     char *zOwned;
     if( !zMsg && rc==SQLITE_ERROR ){
       zMsg = "push failed (not a fast-forward?)";
+    }else if( !zMsg && rc==SQLITE_NOTFOUND ){
+      zMsg = "push failed: branch or tag not found";
     }
     zOwned = zMsg ? sqlite3_mprintf("%s", zMsg) : 0;
     pRemote->xClose(pRemote);
@@ -314,14 +330,17 @@ static void doltPushFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   sqlite3 *db = sqlite3_context_db_handle(ctx);
   DoltliteCmdArgs args;
   int bForce = 0;
+  int bTags = 0;
   DoltliteCmdOption aOption[] = {
-    { "force", 0, DOLTLITE_CMD_OPTION_FLAG, &bForce, 0 }
+    { "force", 0, DOLTLITE_CMD_OPTION_FLAG, &bForce, 0 },
+    { "tags", 0, DOLTLITE_CMD_OPTION_FLAG, &bTags, 0 }
   };
   int rc;
 
   if( argc<2 ){
     doltliteVcResultError(ctx, db,
-        "usage: dolt_push(remote, branch [, '--force'])");
+        "usage: dolt_push(remote, branch [, '--force']) or "
+        "dolt_push(remote, '--tags')");
     return;
   }
   rc = doltliteCmdParseArgs(ctx, argc, argv, aOption, ArraySize(aOption),
@@ -330,17 +349,21 @@ static void doltPushFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
     (void)doltliteVcSealSavepointError(db);
     return;
   }
-  if( args.nPositional<2 ){
+  if( args.nPositional<(bTags ? 1 : 2) ){
     doltliteCmdArgsClear(&args);
-    doltliteVcResultError(ctx, db, "remote and branch required");
+    doltliteVcResultError(ctx, db,
+        bTags ? "remote required" : "remote and branch required");
     return;
   }
-  if( args.nPositional>2 ){
+  if( args.nPositional>(bTags ? 1 : 2) ){
     doltliteCmdArgsClear(&args);
-    doltliteVcResultError(ctx, db, "too many arguments");
+    doltliteVcResultError(ctx, db,
+        bTags ? "--tags cannot be combined with a branch"
+              : "too many arguments");
     return;
   }
-  doltPushParsedFunc(ctx, args.azPositional[0], args.azPositional[1], bForce);
+  doltPushParsedFunc(ctx, args.azPositional[0],
+                     bTags ? 0 : args.azPositional[1], bForce, bTags);
   doltliteCmdArgsClear(&args);
 }
 

--- a/test/oracle-buckets/remotes-recovery.txt
+++ b/test/oracle-buckets/remotes-recovery.txt
@@ -3,4 +3,5 @@ vc_oracle_fetch_pull_convergence_test.sh
 vc_oracle_model_test.sh
 vc_oracle_push_default_branch_test.sh
 vc_oracle_remote_branches_test.sh
+vc_oracle_remote_tags_test.sh
 vc_oracle_remotes_test.sh

--- a/test/remote_test.sh
+++ b/test/remote_test.sh
@@ -412,6 +412,61 @@ check "clone into seeded dirty db keeps local rows" "1" "$result"
 result=$("$DB" "$TMPDIR/seeded_dirty.db" "SELECT count(*) FROM dolt_remotes;")
 check "clone into seeded dirty db keeps remotes empty" "0" "$result"
 
+echo "=== 15b. Tag push and fetch ==="
+"$DB" "$TMPDIR/tag_src.db" <<ENDSQL
+CREATE TABLE tag_rows(id INTEGER PRIMARY KEY);
+INSERT INTO tag_rows VALUES(1);
+SELECT dolt_commit('-Am','tag c1');
+SELECT dolt_tag('v1','-m','first release');
+SELECT dolt_remote('add','origin','$R/tag_remote.db');
+SELECT dolt_push('origin','main');
+.quit
+ENDSQL
+
+result=$("$DB" "$TMPDIR/tag_remote.db" "SELECT count(*) FROM dolt_tags;")
+check "branch push does not implicitly push tags" "0" "$result"
+
+result=$("$DB" "$TMPDIR/tag_src.db" "SELECT dolt_push('origin','v1');")
+check "named tag push returns 0" "0" "$result"
+result=$("$DB" "$TMPDIR/tag_remote.db" \
+  "SELECT tag_name || '|' || message FROM dolt_tags;")
+check "named tag push preserves metadata" "v1|first release" "$result"
+
+"$DB" "$TMPDIR/tag_clone.db" "SELECT dolt_clone('$R/tag_remote.db');" >/dev/null
+"$DB" "$TMPDIR/tag_src.db" <<'ENDSQL' >/dev/null
+INSERT INTO tag_rows VALUES(2);
+SELECT dolt_commit('-Am','tag c2');
+SELECT dolt_tag('v2','-m','second release');
+SELECT dolt_push('origin','main');
+SELECT dolt_push('origin','--tags');
+ENDSQL
+result=$("$DB" "$TMPDIR/tag_remote.db" \
+  "SELECT group_concat(tag_name, ',') FROM (SELECT tag_name FROM dolt_tags ORDER BY tag_name);")
+check "--tags pushes every local tag" "v1,v2" "$result"
+
+result=$("$DB" "$TMPDIR/tag_clone.db" \
+  "SELECT dolt_fetch('origin','main'); SELECT group_concat(tag_name, ',') FROM (SELECT tag_name FROM dolt_tags ORDER BY tag_name);")
+check "fetch follows tags on fetched commits" $'0\nv1,v2' "$result"
+
+"$DB" "$TMPDIR/tag_remote.db" \
+  "SELECT dolt_tag('remote-only','-m','made remotely'); SELECT dolt_tag('collision','-m','remote value');" >/dev/null
+"$DB" "$TMPDIR/tag_clone.db" \
+  "SELECT dolt_tag('collision','-m','local value');" >/dev/null
+result=$("$DB" "$TMPDIR/tag_clone.db" \
+  "SELECT dolt_fetch('origin','main'); SELECT group_concat(tag_name, ',') FROM (SELECT tag_name FROM dolt_tags ORDER BY tag_name); SELECT message FROM dolt_tags WHERE tag_name='collision';")
+check "fetch adds remote tags and preserves local collisions" \
+  $'0\ncollision,remote-only,v1,v2\nlocal value' "$result"
+
+"$DB" "$TMPDIR/tag_src.db" \
+  "SELECT dolt_tag('replace-me','HEAD~1','-m','local replacement');" >/dev/null
+"$DB" "$TMPDIR/tag_remote.db" \
+  "SELECT dolt_tag('replace-me','-m','remote original');" >/dev/null
+result=$("$DB" "$TMPDIR/tag_src.db" "SELECT dolt_push('origin','replace-me');")
+check "named tag push replaces the same remote tag" "0" "$result"
+result=$("$DB" "$TMPDIR/tag_remote.db" \
+  "SELECT message FROM dolt_tags WHERE tag_name='replace-me';")
+check "remote tag replacement preserves local metadata" "local replacement" "$result"
+
 echo "=== 16. Error cases ==="
 result=$("$DB" "$TMPDIR/src.db" "SELECT dolt_push('nonexistent','main');" 2>&1)
 check "push to unknown remote errors" "1" "$(echo "$result" | grep -c 'remote not found')"

--- a/test/remote_test.sh
+++ b/test/remote_test.sh
@@ -454,8 +454,8 @@ check "fetch follows tags on fetched commits" $'0\nv1,v2' "$result"
   "SELECT dolt_tag('collision','-m','local value');" >/dev/null
 result=$("$DB" "$TMPDIR/tag_clone.db" \
   "SELECT dolt_fetch('origin','main'); SELECT group_concat(tag_name, ',') FROM (SELECT tag_name FROM dolt_tags ORDER BY tag_name); SELECT message FROM dolt_tags WHERE tag_name='collision';")
-check "fetch adds remote tags and preserves local collisions" \
-  $'0\ncollision,remote-only,v1,v2\nlocal value' "$result"
+check "fetch adds remote tags and replaces local collisions" \
+  $'0\ncollision,remote-only,v1,v2\nremote value' "$result"
 
 "$DB" "$TMPDIR/tag_src.db" \
   "SELECT dolt_tag('replace-me','HEAD~1','-m','local replacement');" >/dev/null
@@ -466,6 +466,34 @@ check "named tag push replaces the same remote tag" "0" "$result"
 result=$("$DB" "$TMPDIR/tag_remote.db" \
   "SELECT message FROM dolt_tags WHERE tag_name='replace-me';")
 check "remote tag replacement preserves local metadata" "local replacement" "$result"
+
+"$DB" "$TMPDIR/tag_src.db" \
+  "SELECT dolt_tag('v3','-m','must not leak');" >/dev/null
+result=$("$DB" "$TMPDIR/tag_src.db" \
+  "SELECT dolt_push('origin','--tags','main');" 2>&1)
+check_match "--tags rejects a branch argument" \
+  "tags cannot be combined with a branch|ERROR" "$result"
+result=$("$DB" "$TMPDIR/tag_remote.db" \
+  "SELECT count(*) FROM dolt_tags WHERE tag_name='v3';")
+check "failed --tags leaves remote tags unchanged" "0" "$result"
+
+result=$("$DB" "$TMPDIR/tag_src.db" \
+  "SELECT dolt_push('missing','--tags');" 2>&1)
+check_match "--tags to unknown remote errors" "remote not found|ERROR" "$result"
+result=$("$DB" "$TMPDIR/tag_src.db" \
+  "SELECT count(*) FROM dolt_tags WHERE tag_name='v3';")
+check "failed --tags preserves local tags" "1" "$result"
+
+"$DB" "$TMPDIR/no_tag_src.db" <<ENDSQL >/dev/null
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES(1);
+SELECT dolt_commit('-Am','no tags');
+SELECT dolt_remote('add','origin','$R/no_tag_remote.db');
+SELECT dolt_push('origin','main');
+ENDSQL
+result=$("$DB" "$TMPDIR/no_tag_src.db" \
+  "SELECT dolt_push('origin','--tags');")
+check "--tags with no local tags is a no-op" "0" "$result"
 
 echo "=== 16. Error cases ==="
 result=$("$DB" "$TMPDIR/src.db" "SELECT dolt_push('nonexistent','main');" 2>&1)

--- a/test/remotesrv_http_test.sh
+++ b/test/remotesrv_http_test.sh
@@ -363,6 +363,14 @@ check "clone content and history match source" "$src_state" "$cln_state"
 result=$("$DB" "$B" "SELECT count(*) FROM users WHERE age>26;")
 check "clone index query works" "2" "$result"
 
+echo "--- 2b. tag push and fetch over http ---"
+result=$("$DB" "$A" \
+  "SELECT dolt_tag('http-v1','-m','http release'); SELECT dolt_push('origin','http-v1');" 2>&1 | tail -1)
+check "tag push over http returns 0" "0" "$result"
+result=$("$DB" "$B" \
+  "SELECT dolt_fetch('origin','main'); SELECT tag_name || '|' || message FROM dolt_tags WHERE tag_name='http-v1';" 2>&1)
+check "fetch over http installs the remote tag" $'0\nhttp-v1|http release' "$result"
+
 echo "--- 3. malformed has-chunks responses stop push before refs update ---"
 "$DB" "$A" "INSERT INTO users VALUES(99,'protocol',99); SELECT dolt_commit('-am','protocol response');" >/dev/null
 for mode in short long invalid; do

--- a/test/scoped_refs_push_test.c
+++ b/test/scoped_refs_push_test.c
@@ -282,6 +282,33 @@ int main(void){
 
     rc = doltliteValidateScopedRefsUpdate(&tagged, blob, n, "foo", 0);
     check("reject rewriting a tag message", rc==SQLITE_CONSTRAINT);
+    rc = doltliteValidateScopedRefsUpdate(&tagged, blob, n, "tag:v1", 0);
+    check("allow rewriting only the declared tag", rc==SQLITE_OK);
+    rc = doltliteValidateScopedRefsUpdate(&tagged, blob, n, "tag:v2", 1);
+    check("reject rewriting an undeclared tag", rc==SQLITE_CONSTRAINT);
+
+    memset(&tmp, 0, sizeof(tmp));
+    chunkStoreLoadRefsFromBlob(&tmp, blob, n);
+    sqlite3_free(blob);
+    blob = 0;
+    chunkStoreAddTagFull(&tmp, "v2", &Hb, "t", "t@e", 2, "other");
+    chunkStoreSerializeRefsToBlob(&tmp, &blob, &n);
+    chunkStoreClose(&tmp);
+    rc = doltliteValidateScopedRefsUpdate(&tagged, blob, n, "tag:v1", 1);
+    check("reject adding a second tag in the same update",
+          rc==SQLITE_CONSTRAINT);
+
+    memset(&tmp, 0, sizeof(tmp));
+    chunkStoreLoadRefsFromBlob(&tmp, tagBlob, nTag);
+    chunkStoreDeleteTag(&tmp, "v1");
+    chunkStoreAddTagFull(&tmp, "v1", &Ha, "t", "t@e", 1, "rewritten");
+    chunkStoreUpdateBranch(&tmp, "foo", &Hc);
+    sqlite3_free(blob);
+    blob = 0;
+    chunkStoreSerializeRefsToBlob(&tmp, &blob, &n);
+    chunkStoreClose(&tmp);
+    rc = doltliteValidateScopedRefsUpdate(&tagged, blob, n, "tag:v1", 1);
+    check("tag update cannot rewrite a branch", rc==SQLITE_CONSTRAINT);
 
     /* And the same tag, untouched, stays in scope. */
     rc = doltliteValidateScopedRefsUpdate(&tagged, tagBlob, nTag, "foo", 0);

--- a/test/vc_oracle_remote_tags_test.sh
+++ b/test/vc_oracle_remote_tags_test.sh
@@ -1,0 +1,355 @@
+#!/bin/bash
+
+set -u
+set -o pipefail
+
+DOLTLITE="${1:-./doltlite}"
+DOLT="${2:-dolt}"
+TMPROOT=$(mktemp -d)
+trap 'rm -rf "$TMPROOT"' EXIT
+pass=0; fail=0
+FAILED_NAMES=""
+source "$(dirname "$0")/lib/vc_oracle_common.sh"
+
+record_failure() {
+  local name="$1"
+  fail=$((fail+1))
+  FAILED_NAMES="$FAILED_NAMES $name"
+  echo "  FAIL: $name"
+}
+
+remote_tag_flow() {
+  local name="$1" seed="$2" advance="$3" consume="$4"
+  local dl_query="$5" dt_query="$6"
+  local dir="$TMPROOT/$name"
+  local dl_remote="file://$dir/remote.db"
+  local dl_src="$dir/src.db" dl_con="$dir/con.db"
+  local dl_seed_rc dl_clone_rc dl_advance_rc dl_consume_rc dl_query_rc
+  local dt_seed_rc dt_clone_rc dt_advance_rc dt_consume_rc dt_query_rc
+  local dl_out dt_out dt_seed dt_advance dt_consume dt_q
+  mkdir -p "$dir"
+
+  printf '%s\n' "${seed//@REMOTE@/$dl_remote}" \
+    | "$DOLTLITE" "$dl_src" >"$dir/dl_seed.out" 2>"$dir/dl_seed.err"
+  dl_seed_rc=$?
+  printf "SELECT dolt_clone('%s');\n" "$dl_remote" \
+    | "$DOLTLITE" "$dl_con" >"$dir/dl_clone.out" 2>"$dir/dl_clone.err"
+  dl_clone_rc=$?
+  printf '%s\n' "${advance//@REMOTE@/$dl_remote}" \
+    | "$DOLTLITE" "$dl_src" >"$dir/dl_advance.out" 2>"$dir/dl_advance.err"
+  dl_advance_rc=$?
+  printf '%s\n' "$consume" \
+    | "$DOLTLITE" "$dl_con" >"$dir/dl_consume.out" 2>"$dir/dl_consume.err"
+  dl_consume_rc=$?
+  dl_out=$(printf '.headers off\n.mode list\n%s\n' "$dl_query" \
+    | "$DOLTLITE" "$dl_con" 2>"$dir/dl_query.err" \
+    | tr -d '\r' | grep '^R|' | sort)
+  dl_query_rc=$?
+
+  dt_seed=$(vc_oracle_translate_for_dolt "${seed//@REMOTE@/file://$dir/dt_remote}")
+  dt_advance=$(vc_oracle_translate_for_dolt "${advance//@REMOTE@/file://$dir/dt_remote}")
+  dt_consume=$(vc_oracle_translate_for_dolt "$consume")
+  dt_q=$(vc_oracle_translate_for_dolt "$dt_query")
+  mkdir -p "$dir/dsrc" "$dir/dt_remote"
+  (cd "$dir/dsrc" && vc_oracle_init_repo)
+  (cd "$dir/dsrc" && printf '%s\n' "$dt_seed" \
+    | "$DOLT" sql -c >"$dir/dt_seed.out" 2>"$dir/dt_seed.err")
+  dt_seed_rc=$?
+  (cd "$dir" && "$DOLT" clone "file://$dir/dt_remote" dcon \
+    >"$dir/dt_clone.out" 2>"$dir/dt_clone.err")
+  dt_clone_rc=$?
+  (cd "$dir/dsrc" && printf '%s\n' "$dt_advance" \
+    | "$DOLT" sql -c >"$dir/dt_advance.out" 2>"$dir/dt_advance.err")
+  dt_advance_rc=$?
+  (cd "$dir/dcon" && printf '%s\n' "$dt_consume" \
+    | "$DOLT" sql -c >"$dir/dt_consume.out" 2>"$dir/dt_consume.err")
+  dt_consume_rc=$?
+  (cd "$dir/dcon" && printf '%s\n' "$dt_q" \
+    | "$DOLT" sql -r csv 2>"$dir/dt_query.err") >"$dir/dt.raw"
+  dt_query_rc=$?
+  dt_out=$(tr -d '"\r' <"$dir/dt.raw" | grep '^R|' | sort)
+
+  if [ "$dl_seed_rc" -ne 0 ] || [ "$dl_clone_rc" -ne 0 ] \
+     || [ "$dl_advance_rc" -ne 0 ] || [ "$dl_consume_rc" -ne 0 ] \
+     || [ "$dl_query_rc" -ne 0 ] || [ "$dt_seed_rc" -ne 0 ] \
+     || [ "$dt_clone_rc" -ne 0 ] || [ "$dt_advance_rc" -ne 0 ] \
+     || [ "$dt_consume_rc" -ne 0 ] || [ "$dt_query_rc" -ne 0 ]; then
+    record_failure "$name"
+    echo "    doltlite rc: $dl_seed_rc/$dl_clone_rc/$dl_advance_rc/$dl_consume_rc/$dl_query_rc"
+    echo "    dolt rc:     $dt_seed_rc/$dt_clone_rc/$dt_advance_rc/$dt_consume_rc/$dt_query_rc"
+    return
+  fi
+  vc_oracle_assert_match "$name" "$dl_out" "$dt_out"
+}
+
+remote_tag_error_flow() {
+  local name="$1" side="$2" seed="$3" action="$4" after="$5"
+  local dl_query="$6" dt_query="$7"
+  local dir="$TMPROOT/$name"
+  local dl_remote="file://$dir/remote.db"
+  local dl_src="$dir/src.db" dl_con="$dir/con.db" dl_action_db
+  local dl_seed_rc dl_clone_rc dl_action_rc dl_after_rc dl_query_rc
+  local dt_seed_rc dt_clone_rc dt_action_rc dt_after_rc dt_query_rc
+  local dl_out dt_out dt_seed dt_action dt_after dt_q dt_action_dir
+  mkdir -p "$dir"
+
+  printf '%s\n' "${seed//@REMOTE@/$dl_remote}" \
+    | "$DOLTLITE" "$dl_src" >"$dir/dl_seed.out" 2>"$dir/dl_seed.err"
+  dl_seed_rc=$?
+  printf "SELECT dolt_clone('%s');\n" "$dl_remote" \
+    | "$DOLTLITE" "$dl_con" >"$dir/dl_clone.out" 2>"$dir/dl_clone.err"
+  dl_clone_rc=$?
+  if [ "$side" = "src" ]; then dl_action_db="$dl_src"; else dl_action_db="$dl_con"; fi
+  printf '%s\n' "$action" | "$DOLTLITE" "$dl_action_db" \
+    >"$dir/dl_action.out" 2>"$dir/dl_action.err"
+  dl_action_rc=$?
+  printf '%s\n' "$after" | "$DOLTLITE" "$dl_con" \
+    >"$dir/dl_after.out" 2>"$dir/dl_after.err"
+  dl_after_rc=$?
+  dl_out=$(printf '.headers off\n.mode list\n%s\n' "$dl_query" \
+    | "$DOLTLITE" "$dl_con" 2>"$dir/dl_query.err" \
+    | tr -d '\r' | grep '^R|' | sort)
+  dl_query_rc=$?
+
+  dt_seed=$(vc_oracle_translate_for_dolt "${seed//@REMOTE@/file://$dir/dt_remote}")
+  dt_action=$(vc_oracle_translate_for_dolt "$action")
+  dt_after=$(vc_oracle_translate_for_dolt "$after")
+  dt_q=$(vc_oracle_translate_for_dolt "$dt_query")
+  mkdir -p "$dir/dsrc" "$dir/dt_remote"
+  (cd "$dir/dsrc" && vc_oracle_init_repo)
+  (cd "$dir/dsrc" && printf '%s\n' "$dt_seed" \
+    | "$DOLT" sql -c >"$dir/dt_seed.out" 2>"$dir/dt_seed.err")
+  dt_seed_rc=$?
+  (cd "$dir" && "$DOLT" clone "file://$dir/dt_remote" dcon \
+    >"$dir/dt_clone.out" 2>"$dir/dt_clone.err")
+  dt_clone_rc=$?
+  if [ "$side" = "src" ]; then dt_action_dir="$dir/dsrc"; else dt_action_dir="$dir/dcon"; fi
+  (cd "$dt_action_dir" && printf '%s\n' "$dt_action" \
+    | "$DOLT" sql >"$dir/dt_action.out" 2>"$dir/dt_action.err")
+  dt_action_rc=$?
+  (cd "$dir/dcon" && printf '%s\n' "$dt_after" \
+    | "$DOLT" sql -c >"$dir/dt_after.out" 2>"$dir/dt_after.err")
+  dt_after_rc=$?
+  (cd "$dir/dcon" && printf '%s\n' "$dt_q" \
+    | "$DOLT" sql -r csv 2>"$dir/dt_query.err") >"$dir/dt.raw"
+  dt_query_rc=$?
+  dt_out=$(tr -d '"\r' <"$dir/dt.raw" | grep '^R|' | sort)
+
+  if [ "$dl_seed_rc" -ne 0 ] || [ "$dl_clone_rc" -ne 0 ] \
+     || ! vc_oracle_is_clean_error "$dl_action_rc" \
+     || [ "$dl_after_rc" -ne 0 ] || [ "$dl_query_rc" -ne 0 ] \
+     || [ "$dt_seed_rc" -ne 0 ] || [ "$dt_clone_rc" -ne 0 ] \
+     || ! vc_oracle_is_clean_error "$dt_action_rc" \
+     || [ "$dt_after_rc" -ne 0 ] || [ "$dt_query_rc" -ne 0 ]; then
+    record_failure "$name"
+    echo "    doltlite rc: $dl_seed_rc/$dl_clone_rc/$dl_action_rc/$dl_after_rc/$dl_query_rc"
+    echo "    dolt rc:     $dt_seed_rc/$dt_clone_rc/$dt_action_rc/$dt_after_rc/$dt_query_rc"
+    return
+  fi
+  vc_oracle_assert_match "$name" "$dl_out" "$dt_out"
+}
+
+BASE_SEED="
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1,'one');
+SELECT dolt_commit('-Am','c1');
+SELECT dolt_tag('v1','-m','first release');
+SELECT dolt_remote('add','origin','@REMOTE@');
+SELECT dolt_push('origin','main');
+"
+
+echo "=== Version Control Oracle Tests: remote tags ==="
+echo ""
+echo "--- push and fetch ---"
+
+remote_tag_flow "branch_push_excludes_tags" "$BASE_SEED" "" "" \
+  "SELECT 'R|'||count(*) FROM dolt_tags;" \
+  "SELECT CONCAT('R|',count(*)) FROM dolt_tags;"
+
+remote_tag_flow "named_tag_push_fetches_on_unchanged_branch" "$BASE_SEED" \
+  "SELECT dolt_push('origin','v1');" \
+  "SELECT dolt_fetch('origin','main');" \
+  "SELECT 'R|'||tag_name||'|'||message FROM dolt_tags;
+   SELECT 'R|rows|'||count(*) FROM dolt_at_t WHERE commit_ref='v1';" \
+  "SELECT CONCAT('R|',tag_name,'|',message) FROM dolt_tags;
+   SELECT CONCAT('R|rows|',count(*)) FROM t AS OF 'v1';"
+
+remote_tag_flow "annotated_tag_metadata_survives_push" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES (1);
+SELECT dolt_commit('-Am','c1');
+SELECT dolt_tag('release','--author','Alice Example <alice@example.com>','-m','annotated release');
+SELECT dolt_remote('add','origin','@REMOTE@');
+SELECT dolt_push('origin','main');
+" "SELECT dolt_push('origin','release');" \
+  "SELECT dolt_fetch('origin','main');" \
+  "SELECT 'R|'||tag_name||'|'||tagger||'|'||email||'|'||message FROM dolt_tags;" \
+  "SELECT CONCAT('R|',tag_name,'|',tagger,'|',email,'|',message) FROM dolt_tags;"
+
+remote_tag_flow "fetch_follows_multiple_reachable_tags" "$BASE_SEED" "
+INSERT INTO t VALUES (2,'two');
+SELECT dolt_commit('-Am','c2');
+SELECT dolt_tag('v2','-m','second release');
+SELECT dolt_push('origin','main');
+SELECT dolt_push('origin','v1');
+SELECT dolt_push('origin','v2');
+" "SELECT dolt_fetch('origin','main');" \
+  "SELECT 'R|'||tag_name||'|'||message FROM dolt_tags ORDER BY tag_name;
+   SELECT 'R|v1-rows|'||count(*) FROM dolt_at_t WHERE commit_ref='v1';
+   SELECT 'R|v2-rows|'||count(*) FROM dolt_at_t WHERE commit_ref='v2';" \
+  "SELECT CONCAT('R|',tag_name,'|',message) FROM dolt_tags ORDER BY tag_name;
+   SELECT CONCAT('R|v1-rows|',count(*)) FROM t AS OF 'v1';
+   SELECT CONCAT('R|v2-rows|',count(*)) FROM t AS OF 'v2';"
+
+remote_tag_flow "fetch_replaces_same_named_local_tag" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1,'one');
+SELECT dolt_commit('-Am','c1');
+SELECT dolt_tag('v1','-m','remote old');
+SELECT dolt_remote('add','origin','@REMOTE@');
+SELECT dolt_push('origin','main');
+SELECT dolt_push('origin','v1');
+" "
+INSERT INTO t VALUES (2,'two');
+SELECT dolt_commit('-Am','c2');
+SELECT dolt_tag('-d','v1');
+SELECT dolt_tag('v1','-m','remote replacement');
+SELECT dolt_push('origin','main');
+SELECT dolt_push('origin','v1');
+" "
+SELECT dolt_tag('-d','v1');
+SELECT dolt_tag('v1','-m','local collision');
+SELECT dolt_fetch('origin','main');
+" "SELECT 'R|'||message FROM dolt_tags WHERE tag_name='v1';
+   SELECT 'R|rows|'||count(*) FROM dolt_at_t WHERE commit_ref='v1';" \
+  "SELECT CONCAT('R|',message) FROM dolt_tags WHERE tag_name='v1';
+   SELECT CONCAT('R|rows|',count(*)) FROM t AS OF 'v1';"
+
+remote_tag_flow "fetch_replaces_metadata_on_unchanged_target" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES (1);
+SELECT dolt_commit('-Am','c1');
+SELECT dolt_tag('v1','-m','old message');
+SELECT dolt_remote('add','origin','@REMOTE@');
+SELECT dolt_push('origin','main');
+SELECT dolt_push('origin','v1');
+" "
+SELECT dolt_tag('-d','v1');
+SELECT dolt_tag('v1','-m','new message');
+SELECT dolt_push('origin','v1');
+" "SELECT dolt_fetch('origin','main');" \
+  "SELECT 'R|'||message FROM dolt_tags WHERE tag_name='v1';" \
+  "SELECT CONCAT('R|',message) FROM dolt_tags WHERE tag_name='v1';"
+
+remote_tag_flow "fetch_skips_tag_with_unfetched_target" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES (1);
+SELECT dolt_commit('-Am','main c1');
+SELECT dolt_remote('add','origin','@REMOTE@');
+SELECT dolt_push('origin','main');
+" "
+SELECT dolt_checkout('-b','private');
+INSERT INTO t VALUES (2);
+SELECT dolt_commit('-Am','private c2');
+SELECT dolt_tag('private-tag','-m','not reachable from main');
+SELECT dolt_push('origin','private-tag');
+" "SELECT dolt_fetch('origin','main');" \
+  "SELECT 'R|tags|'||count(*) FROM dolt_tags;
+   SELECT 'R|rows|'||count(*) FROM t;" \
+  "SELECT CONCAT('R|tags|',count(*)) FROM dolt_tags;
+   SELECT CONCAT('R|rows|',count(*)) FROM t;"
+
+remote_tag_flow "fetch_installs_older_reachable_tag" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES (1);
+SELECT dolt_commit('-Am','c1');
+SELECT dolt_tag('v1','HEAD','-m','historical');
+INSERT INTO t VALUES (2);
+SELECT dolt_commit('-Am','c2');
+SELECT dolt_remote('add','origin','@REMOTE@');
+SELECT dolt_push('origin','main');
+" "SELECT dolt_push('origin','v1');" \
+  "SELECT dolt_fetch('origin','main');" \
+  "SELECT 'R|head|'||count(*) FROM t;
+   SELECT 'R|tag|'||count(*) FROM dolt_at_t WHERE commit_ref='v1';" \
+  "SELECT CONCAT('R|head|',count(*)) FROM t;
+   SELECT CONCAT('R|tag|',count(*)) FROM t AS OF 'v1';"
+
+remote_tag_flow "pull_installs_tag_and_target_commit" "$BASE_SEED" "
+INSERT INTO t VALUES (2,'two');
+SELECT dolt_commit('-Am','c2');
+SELECT dolt_tag('v2','-m','pulled release');
+SELECT dolt_push('origin','main');
+SELECT dolt_push('origin','v2');
+" "SELECT dolt_pull('origin','main');" \
+  "SELECT 'R|rows|'||count(*) FROM t;
+   SELECT 'R|'||tag_name||'|'||message FROM dolt_tags;" \
+  "SELECT CONCAT('R|rows|',count(*)) FROM t;
+   SELECT CONCAT('R|',tag_name,'|',message) FROM dolt_tags;"
+
+remote_tag_flow "forced_tag_push_is_idempotent" "$BASE_SEED" \
+  "SELECT dolt_push('origin','v1','--force');
+   SELECT dolt_push('origin','v1','--force');" \
+  "SELECT dolt_fetch('origin','main');
+   SELECT dolt_fetch('origin','main');" \
+  "SELECT 'R|'||count(*)||'|'||max(message) FROM dolt_tags;" \
+  "SELECT CONCAT('R|',count(*),'|',max(message)) FROM dolt_tags;"
+
+echo "--- failure recovery ---"
+
+remote_tag_error_flow "push_missing_ref_preserves_remote" "src" "$BASE_SEED" \
+  "SELECT dolt_push('origin','missing-tag');" \
+  "SELECT dolt_fetch('origin','main');" \
+  "SELECT 'R|tags|'||count(*) FROM dolt_tags;
+   SELECT 'R|rows|'||count(*) FROM t;" \
+  "SELECT CONCAT('R|tags|',count(*)) FROM dolt_tags;
+   SELECT CONCAT('R|rows|',count(*)) FROM t;"
+
+remote_tag_error_flow "push_tag_to_missing_remote_preserves_clone" "src" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES (1);
+SELECT dolt_commit('-Am','c1');
+SELECT dolt_tag('v1','-m','release');
+SELECT dolt_remote('add','origin','@REMOTE@');
+SELECT dolt_push('origin','main');
+SELECT dolt_push('origin','v1');
+" "SELECT dolt_push('missing','v1');" "" \
+  "SELECT 'R|'||count(*)||'|'||max(message) FROM dolt_tags;
+   SELECT 'R|rows|'||count(*) FROM dolt_at_t WHERE commit_ref='v1';" \
+  "SELECT CONCAT('R|',count(*),'|',max(message)) FROM dolt_tags;
+   SELECT CONCAT('R|rows|',count(*)) FROM t AS OF 'v1';"
+
+remote_tag_error_flow "fetch_missing_branch_preserves_tags" "con" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES (1);
+SELECT dolt_commit('-Am','c1');
+SELECT dolt_tag('v1','-m','release');
+SELECT dolt_remote('add','origin','@REMOTE@');
+SELECT dolt_push('origin','main');
+SELECT dolt_push('origin','v1');
+" "SELECT dolt_fetch('origin','missing-branch');" "" \
+  "SELECT 'R|'||count(*)||'|'||max(message) FROM dolt_tags;
+   SELECT 'R|rows|'||count(*) FROM t;" \
+  "SELECT CONCAT('R|',count(*),'|',max(message)) FROM dolt_tags;
+   SELECT CONCAT('R|rows|',count(*)) FROM t;"
+
+remote_tag_error_flow "pull_missing_branch_preserves_tags" "con" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES (1);
+SELECT dolt_commit('-Am','c1');
+SELECT dolt_tag('v1','-m','release');
+SELECT dolt_remote('add','origin','@REMOTE@');
+SELECT dolt_push('origin','main');
+SELECT dolt_push('origin','v1');
+" "SELECT dolt_pull('origin','missing-branch');" "" \
+  "SELECT 'R|'||count(*)||'|'||max(message) FROM dolt_tags;
+   SELECT 'R|rows|'||count(*) FROM t;" \
+  "SELECT CONCAT('R|',count(*),'|',max(message)) FROM dolt_tags;
+   SELECT CONCAT('R|rows|',count(*)) FROM t;"
+
+echo ""
+echo "=== Results: $pass passed, $fail failed ==="
+if [ -n "$FAILED_NAMES" ]; then
+  echo "Failed:$FAILED_NAMES"
+fi
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
## Summary

- support pushing a named tag or every local tag with `--tags`
- install remote tags during fetch and pull when their commits are available locally
- match Dolt by replacing same-named local tags when the fetched remote value differs
- extend scoped-ref validation so a tag push can change only its declared tag
- preserve tag metadata across file and HTTP remotes
- document the remote tag behavior

`--tags` is a DoltLite extension; current Dolt rejects that option, so its success and failure cases stay in the native remote suite. Named tag push and fetch/pull behavior are covered by the Dolt oracle.

## Validation

- fail-before remote-tag oracle: 12 passed, 2 failed (target and metadata replacement)
- `bash test/vc_oracle_remote_tags_test.sh build/doltlite dolt` — 14 passed
- `bash test/run_doltlite_tests.sh build/doltlite` — 126 suites passed, including 311,207 C regression assertions
- `bash test/remote_test.sh build/doltlite` — 157 passed
- `bash test/remotesrv_http_test.sh build/doltlite build/doltlite-remotesrv` — 44 passed, 162 requests protocol-checked
- `build/scoped_refs_push_test` — 32 passed
- `bash test/check_oracle_buckets.sh`
- `make lint`

Fixes #2616

Co-Authored-By: OpenAI Codex <noreply@openai.com>
