### PR TITLE
Remove unused DoltLite helpers and close dead-code gate gaps

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -1017,3 +1017,6 @@ jobs:
 
     - name: Dead-code gate
       run: bash test/dead_code_check.sh
+
+    - name: Dead-code gate self-test
+      run: bash test/dead_code_check_selftest.sh

--- a/src/doltlite_add.c
+++ b/src/doltlite_add.c
@@ -975,12 +975,6 @@ static int doltliteStageArgsAndPersist(
 
   doltliteGetSessionStaged(db, &savedStaged);
 
-  rc = doltlitePrepareCatalogForPersistence(db);
-  if( rc!=SQLITE_OK ){
-    sqlite3_result_error(context, "failed to prepare catalog", -1);
-    return rc;
-  }
-
   rc = doltliteFlushCatalogToHash(db, &workingHash);
   if( rc!=SQLITE_OK ){
     sqlite3_result_error(context, "failed to flush", -1);

--- a/src/doltlite_cherry_pick.c
+++ b/src/doltlite_cherry_pick.c
@@ -99,9 +99,33 @@ static int cherryPickRestoreAndPersist(
   int opRc
 ){
   ProllyHash restoredCat = pSaved->sessionCatalogHash;
-  int restoreRc = doltliteRestoreTxnStateOnFailure(db, pSaved, opRc);
+  ProllyHash savedHead = pSaved->sessionHead;
+  ProllyHash diskHead;
+  ProllyHash sessionHead;
+  ChunkStore *cs = doltliteGetChunkStore(db);
+  int found = 0;
+  int restoreRc;
+  int persistRc;
+
+  /* CompareAndAdvanceBranch can return an error after the new tip is already
+  ** on disk with a matching working set. Restoring the pre-op working set
+  ** then binds working-commit to the old tip; reopen discards that blob
+  ** (working-commit != HEAD) and leaves staged empty. */
+  memset(&diskHead, 0, sizeof(diskHead));
+  doltliteGetSessionHead(db, &sessionHead);
+  if( cs
+   && chunkStoreReadDiskBranchTip(
+        cs, doltliteGetSessionBranch(db), &diskHead, &found)==SQLITE_OK
+   && found
+   && prollyHashCompare(&diskHead, &savedHead)!=0
+   && prollyHashCompare(&diskHead, &sessionHead)==0 ){
+    doltliteTxnStateClear(pSaved);
+    return opRc;
+  }
+
+  restoreRc = doltliteRestoreTxnStateOnFailure(db, pSaved, opRc);
   if( restoreRc==opRc && !prollyHashIsEmpty(&restoredCat) ){
-    int persistRc = doltlitePersistWorkingSetWithHash(db, &restoredCat);
+    persistRc = doltlitePersistWorkingSetWithHash(db, &restoredCat);
     if( persistRc!=SQLITE_OK && persistRc!=SQLITE_NOMEM ) restoreRc = persistRc;
   }
   return restoreRc;

--- a/src/doltlite_cherry_pick.c
+++ b/src/doltlite_cherry_pick.c
@@ -93,6 +93,20 @@ static int applyRestoreOriginalBranch(
   return rc==SQLITE_OK ? opRc : rc;
 }
 
+static int cherryPickRestoreAndPersist(
+  sqlite3 *db,
+  DoltliteTxnState *pSaved,
+  int opRc
+){
+  ProllyHash restoredCat = pSaved->sessionCatalogHash;
+  int restoreRc = doltliteRestoreTxnStateOnFailure(db, pSaved, opRc);
+  if( restoreRc==opRc && !prollyHashIsEmpty(&restoredCat) ){
+    int persistRc = doltlitePersistWorkingSetWithHash(db, &restoredCat);
+    if( persistRc!=SQLITE_OK && persistRc!=SQLITE_NOMEM ) restoreRc = persistRc;
+  }
+  return restoreRc;
+}
+
 int applyMergedCatalogAndCommit(
   sqlite3 *db,
   sqlite3_context *context,
@@ -201,42 +215,10 @@ int applyMergedCatalogAndCommit(
 
   {
     int nViolations = 0;
-    int nUnique = 0;
-    int nCheck = 0;
-    int nNotNull = 0;
-    int nStrict = 0;
     char *zDetectErrMsg = 0;
 
-    rc = doltliteConstraintViolationBatchBegin(db);
-    if( rc==SQLITE_OK ){
-      rc = doltliteDetectMergeFkViolations(db, ancCatHash,
-                                           &zDetectErrMsg, &nViolations,
-                                           0, 0);
-    }
-    if( rc==SQLITE_OK ){
-      rc = doltliteDetectMergeUniqueViolations(db, ancCatHash,
-                                               &zDetectErrMsg, &nUnique,
-                                               0, 0);
-    }
-    if( rc==SQLITE_OK ){
-      rc = doltliteDetectMergeCheckViolations(db, ancCatHash,
-                                              &zDetectErrMsg, &nCheck,
-                                              0, 0);
-    }
-    if( rc==SQLITE_OK ){
-      rc = doltliteDetectMergeNotNullViolations(db, ancCatHash,
-                                               &zDetectErrMsg, &nNotNull,
-                                               0, 0);
-    }
-    if( rc==SQLITE_OK ){
-      rc = doltliteDetectMergeStrictViolations(db, ancCatHash,
-                                              &zDetectErrMsg, &nStrict,
-                                              0, 0);
-    }
-    {
-      int erc = doltliteConstraintViolationBatchEnd(db, rc==SQLITE_OK);
-      if( rc==SQLITE_OK ) rc = erc;
-    }
+    rc = doltliteDetectConstraintViolationsFiltered(
+        db, ancCatHash, 0, 0, 1, &nViolations, &zDetectErrMsg);
     if( rc!=SQLITE_OK ){
       if( zDetectErrMsg ){
         sqlite3_result_error(context, zDetectErrMsg, -1);
@@ -246,9 +228,9 @@ int applyMergedCatalogAndCommit(
     }
     sqlite3_free(zDetectErrMsg);
 
-    if( nViolations + nUnique + nCheck + nNotNull + nStrict > 0 ){
+    if( nViolations > 0 ){
       if( pnViolations ){
-        *pnViolations = nViolations + nUnique + nCheck + nNotNull + nStrict;
+        *pnViolations = nViolations;
       }
       if( *pnConflicts > 0 ){
         return doltliteCmdFinishWithConflictsAndConstraintViolations(
@@ -303,18 +285,11 @@ int applyMergedCatalogAndCommit(
     const ProllyHash *pHeadCat = pCommitOurCatHash
         ? pCommitOurCatHash : ourCatHash;
     if( prollyHashCompare(&commitCatHash, pHeadCat)==0 ){
-      ProllyHash restoredCat = savedState.sessionCatalogHash;
-      int restoreRc;
       if( graphLocked ){
         chunkStoreUnlock(cs);
         graphLocked = 0;
       }
-      restoreRc = doltliteRestoreTxnStateOnFailure(db, &savedState, SQLITE_DONE);
-      if( restoreRc==SQLITE_DONE && !prollyHashIsEmpty(&restoredCat) ){
-        int persistRc = doltlitePersistWorkingSetWithHash(db, &restoredCat);
-        if( persistRc!=SQLITE_OK && persistRc!=SQLITE_NOMEM ) return persistRc;
-      }
-      return restoreRc;
+      return cherryPickRestoreAndPersist(db, &savedState, SQLITE_DONE);
     }
   }
 
@@ -344,30 +319,7 @@ apply_rollback:
   if( graphLocked ){
     chunkStoreUnlock(cs);
   }
-  {
-    ProllyHash restoredCat = savedState.sessionCatalogHash;
-    int restoreRc = doltliteRestoreTxnStateOnFailure(db, &savedState, rc);
-    if( restoreRc==rc && !prollyHashIsEmpty(&restoredCat) ){
-      int persistRc = doltlitePersistWorkingSetWithHash(db, &restoredCat);
-      if( persistRc!=SQLITE_OK && persistRc!=SQLITE_NOMEM ) restoreRc = persistRc;
-    }
-    return restoreRc;
-  }
-}
-
-static int cherryPickSourceResultError(
-  sqlite3_context *context,
-  ChunkStore *cs,
-  int rc
-){
-  int pendingRc = SQLITE_OK;
-  char *zErr = chunkStoreSourceTakeError(cs, &pendingRc);
-  if( !zErr && pendingRc==SQLITE_OK ) return 0;
-  if( zErr ) sqlite3_result_error(context, zErr, -1);
-  sqlite3_result_error_code(
-      context, pendingRc!=SQLITE_OK ? pendingRc : rc);
-  sqlite3_free(zErr);
-  return 1;
+  return cherryPickRestoreAndPersist(db, &savedState, rc);
 }
 
 static void doltliteCherryPickFunc(
@@ -420,7 +372,7 @@ static void doltliteCherryPickFunc(
     rc = mergeAbortInPlace(db);
     doltliteCmdArgsClear(&args);
     if( rc!=SQLITE_OK ){
-      if( !cherryPickSourceResultError(context, cs, rc) ){
+      if( !doltliteCmdSourceResultError(context, cs, &rc) ){
         sqlite3_result_error_code(context, rc);
       }
       return;
@@ -445,7 +397,7 @@ static void doltliteCherryPickFunc(
 
   rc = doltliteHasUncommittedChanges(db, &dirty);
   if( rc!=SQLITE_OK ){
-    if( !cherryPickSourceResultError(context, cs, rc) ){
+    if( !doltliteCmdSourceResultError(context, cs, &rc) ){
       sqlite3_result_error_code(context, rc);
     }
     return;
@@ -458,7 +410,7 @@ static void doltliteCherryPickFunc(
 
   rc = doltliteResolveRef(db,zRef, &pickHash);
   if( rc!=SQLITE_OK ){
-    if( !cherryPickSourceResultError(context, cs, rc) ){
+    if( !doltliteCmdSourceResultError(context, cs, &rc) ){
       if( rc==SQLITE_NOTFOUND || rc==SQLITE_ERROR ){
         sqlite3_result_error(context, "invalid commit hash", -1);
       }else{
@@ -475,7 +427,7 @@ static void doltliteCherryPickFunc(
     doltliteCommitClear(&pickCommit);
     doltliteCommitClear(&parentCommit);
     doltliteCommitClear(&ourCommit);
-    if( !cherryPickSourceResultError(context, cs, rc) ){
+    if( !doltliteCmdSourceResultError(context, cs, &rc) ){
       sqlite3_result_error(context, "commit not found", -1);
     }
     return;
@@ -495,7 +447,7 @@ static void doltliteCherryPickFunc(
     doltliteCommitClear(&pickCommit);
     doltliteCommitClear(&parentCommit);
     doltliteCommitClear(&ourCommit);
-    if( !cherryPickSourceResultError(context, cs, rc) ){
+    if( !doltliteCmdSourceResultError(context, cs, &rc) ){
       sqlite3_result_error_code(context, rc);
     }
     return;
@@ -529,7 +481,7 @@ static void doltliteCherryPickFunc(
 
   if( rc==SQLITE_BUSY ){
     sqlite3_free(zApplyErr);
-    if( !cherryPickSourceResultError(context, cs, rc) ){
+    if( !doltliteCmdSourceResultError(context, cs, &rc) ){
       doltliteCmdResultPeerBranchBusy(context, "cherry-pick");
     }
     return;
@@ -540,7 +492,7 @@ static void doltliteCherryPickFunc(
     return;
   }
   if( rc!=SQLITE_OK ){
-    if( !cherryPickSourceResultError(context, cs, rc) ){
+    if( !doltliteCmdSourceResultError(context, cs, &rc) ){
       if( zApplyErr ){
         sqlite3_result_error(context, zApplyErr, -1);
       }else{

--- a/src/doltlite_cmd.c
+++ b/src/doltlite_cmd.c
@@ -309,79 +309,91 @@ static int markPendingReplayIfNotMerging(sqlite3 *db){
   return doltliteSetSessionPendingReplayCommit(db, 1);
 }
 
-int doltliteReportConflicts(
+static int persistPendingAndError(
+  sqlite3 *db,
+  sqlite3_context *ctx,
+  int bRegisterConflicts,
+  const char *zMsg
+){
+  int rc;
+  if( bRegisterConflicts ){
+    rc = doltliteRegisterConflictTables(db);
+    if( rc!=SQLITE_OK ) return rc;
+  }
+  rc = doltlitePersistOrSaveWorkingSet(db);
+  if( rc!=SQLITE_OK ) return rc;
+  rc = markPendingReplayIfNotMerging(db);
+  if( rc!=SQLITE_OK ) return rc;
+  sqlite3_result_error(ctx, zMsg, -1);
+  return SQLITE_OK;
+}
+
+static int cmdReportConflicts(
   sqlite3 *db,
   sqlite3_context *ctx,
   int nConflicts,
   const char *zOp
 ){
   char msg[256];
-  int rc;
-  rc = doltliteRegisterConflictTables(db);
-  if( rc!=SQLITE_OK ) return rc;
-  rc = doltlitePersistOrSaveWorkingSet(db);
-  if( rc!=SQLITE_OK ) return rc;
-  rc = markPendingReplayIfNotMerging(db);
-  if( rc!=SQLITE_OK ) return rc;
   sqlite3_snprintf(sizeof(msg), msg,
     "%s has %d conflict(s). Resolve and then commit with dolt_commit.",
     zOp, nConflicts);
-  sqlite3_result_error(ctx, msg, -1);
-  return SQLITE_OK;
+  return persistPendingAndError(db, ctx, 1, msg);
 }
 
-int doltliteReportConstraintViolations(
+static int cmdReportConstraintViolations(
   sqlite3 *db,
   sqlite3_context *ctx,
   const char *zOp
 ){
   char msg[256];
-  int rc;
-  rc = doltlitePersistOrSaveWorkingSet(db);
-  if( rc!=SQLITE_OK ) return rc;
-  rc = markPendingReplayIfNotMerging(db);
-  if( rc!=SQLITE_OK ) return rc;
   sqlite3_snprintf(sizeof(msg), msg,
     "%s resulted in constraint violations. Resolve the rows in "
     "dolt_constraint_violations and then commit with dolt_commit.",
     zOp);
-  sqlite3_result_error(ctx, msg, -1);
-  return SQLITE_OK;
+  return persistPendingAndError(db, ctx, 0, msg);
 }
 
-int doltliteReportConflictsAndConstraintViolations(
+static int cmdReportConflictsAndConstraintViolations(
   sqlite3 *db,
   sqlite3_context *ctx,
   int nConflicts,
   const char *zOp
 ){
   char msg[384];
-  int rc;
-  rc = doltliteRegisterConflictTables(db);
-  if( rc!=SQLITE_OK ) return rc;
-  rc = doltlitePersistOrSaveWorkingSet(db);
-  if( rc!=SQLITE_OK ) return rc;
-  rc = markPendingReplayIfNotMerging(db);
-  if( rc!=SQLITE_OK ) return rc;
   sqlite3_snprintf(sizeof(msg), msg,
     "%s has %d conflict(s) and constraint violations. Resolve "
     "dolt_conflicts and dolt_constraint_violations, then commit with "
     "dolt_commit.",
     zOp ? zOp : "Operation", nConflicts);
-  sqlite3_result_error(ctx, msg, -1);
+  return persistPendingAndError(db, ctx, 1, msg);
+}
+
+static int cmdFinishPlainAfterReport(
+  sqlite3 *db,
+  sqlite3_context *ctx,
+  DoltliteTxnState *pSaved,
+  int reportRc,
+  int bSealOnPlain
+){
+  if( reportRc!=SQLITE_OK ){
+    sqlite3_result_error_code(ctx,
+        doltliteRestoreTxnStateOnFailure(db, pSaved, reportRc));
+    return reportRc;
+  }
+  if( bSealOnPlain ){
+    int rc = doltliteVcSealActiveSavepoints(db);
+    if( rc!=SQLITE_OK ){
+      sqlite3_result_error_code(ctx,
+          doltliteRestoreTxnStateOnFailure(db, pSaved, rc));
+      return rc;
+    }
+  }
+  doltliteTxnStateClear(pSaved);
   return SQLITE_OK;
 }
 
-void doltliteReportAutocommitConflictRollback(sqlite3_context *ctx){
-  sqlite3_result_error(ctx,
-    "cannot merge: conflicts detected, autocommit transaction rolled back. "
-    "Run the merge inside BEGIN/COMMIT to inspect dolt_conflicts and "
-    "dolt_schema_conflicts, resolve with dolt_conflicts_resolve(), then commit "
-    "with dolt_commit(). Conflicts are never committed as conflicts",
-    -1);
-}
-
-int doltliteRollbackAutocommitConflict(
+static int cmdRollbackAutocommitConflict(
   sqlite3 *db,
   sqlite3_context *ctx,
   DoltliteTxnState *pSaved
@@ -410,7 +422,12 @@ int doltliteRollbackAutocommitConflict(
     rc = doltliteVcSealTopLevelSavepointTxn(db);
   }
   if( rc==SQLITE_OK ){
-    doltliteReportAutocommitConflictRollback(ctx);
+    sqlite3_result_error(ctx,
+      "cannot merge: conflicts detected, autocommit transaction rolled back. "
+      "Run the merge inside BEGIN/COMMIT to inspect dolt_conflicts and "
+      "dolt_schema_conflicts, resolve with dolt_conflicts_resolve(), then commit "
+      "with dolt_commit(). Conflicts are never committed as conflicts",
+      -1);
   }
   return rc;
 }
@@ -471,26 +488,12 @@ int doltliteCmdFinishWithConflicts(
   int rc;
   switch( doltliteVcTxnMode(db) ){
   case DOLTLITE_VC_TXN_AUTOCOMMIT_LIKE:
-    rc = doltliteRollbackAutocommitConflict(db, ctx, pSaved);
+    rc = cmdRollbackAutocommitConflict(db, ctx, pSaved);
     if( rc!=SQLITE_OK ) sqlite3_result_error_code(ctx, rc);
     return rc==SQLITE_OK ? SQLITE_OK : rc;
   case DOLTLITE_VC_TXN_PLAIN:
-    rc = doltliteReportConflicts(db, ctx, nConflicts, zOp);
-    if( rc!=SQLITE_OK ){
-      sqlite3_result_error_code(ctx,
-          doltliteRestoreTxnStateOnFailure(db, pSaved, rc));
-      return rc;
-    }
-    if( bSealOnPlain ){
-      rc = doltliteVcSealActiveSavepoints(db);
-      if( rc!=SQLITE_OK ){
-        sqlite3_result_error_code(ctx,
-            doltliteRestoreTxnStateOnFailure(db, pSaved, rc));
-        return rc;
-      }
-    }
-    doltliteTxnStateClear(pSaved);
-    return SQLITE_OK;
+    return cmdFinishPlainAfterReport(db, ctx, pSaved,
+        cmdReportConflicts(db, ctx, nConflicts, zOp), bSealOnPlain);
   case DOLTLITE_VC_TXN_NESTED_SAVEPOINT:
     rc = doltliteRestoreTxnStateOnFailure(db, pSaved, SQLITE_OK);
     if( rc!=SQLITE_OK ){
@@ -522,22 +525,8 @@ int doltliteCmdFinishWithConstraintViolations(
   case DOLTLITE_VC_TXN_AUTOCOMMIT_LIKE:
     return cmdRollbackAutocommitConstraintViolations(db, ctx, pSaved);
   case DOLTLITE_VC_TXN_PLAIN:
-    rc = doltliteReportConstraintViolations(db, ctx, zOp);
-    if( rc!=SQLITE_OK ){
-      sqlite3_result_error_code(ctx,
-          doltliteRestoreTxnStateOnFailure(db, pSaved, rc));
-      return rc;
-    }
-    if( bSealOnPlain ){
-      rc = doltliteVcSealActiveSavepoints(db);
-      if( rc!=SQLITE_OK ){
-        sqlite3_result_error_code(ctx,
-            doltliteRestoreTxnStateOnFailure(db, pSaved, rc));
-        return rc;
-      }
-    }
-    doltliteTxnStateClear(pSaved);
-    return SQLITE_OK;
+    return cmdFinishPlainAfterReport(db, ctx, pSaved,
+        cmdReportConstraintViolations(db, ctx, zOp), bSealOnPlain);
   case DOLTLITE_VC_TXN_NESTED_SAVEPOINT:
     rc = doltliteRestoreTxnStateOnFailure(db, pSaved, SQLITE_OK);
     if( rc!=SQLITE_OK ){
@@ -601,23 +590,10 @@ int doltliteCmdFinishWithConflictsAndConstraintViolations(
     return cmdRollbackAutocommitConflictsAndCVs(
         db, ctx, pSaved, nConflicts, zOp);
   case DOLTLITE_VC_TXN_PLAIN:
-    rc = doltliteReportConflictsAndConstraintViolations(
-        db, ctx, nConflicts, zOp);
-    if( rc!=SQLITE_OK ){
-      sqlite3_result_error_code(ctx,
-          doltliteRestoreTxnStateOnFailure(db, pSaved, rc));
-      return rc;
-    }
-    if( bSealOnPlain ){
-      rc = doltliteVcSealActiveSavepoints(db);
-      if( rc!=SQLITE_OK ){
-        sqlite3_result_error_code(ctx,
-            doltliteRestoreTxnStateOnFailure(db, pSaved, rc));
-        return rc;
-      }
-    }
-    doltliteTxnStateClear(pSaved);
-    return SQLITE_OK;
+    return cmdFinishPlainAfterReport(db, ctx, pSaved,
+        cmdReportConflictsAndConstraintViolations(
+            db, ctx, nConflicts, zOp),
+        bSealOnPlain);
   case DOLTLITE_VC_TXN_NESTED_SAVEPOINT:
     rc = doltliteRestoreTxnStateOnFailure(db, pSaved, SQLITE_OK);
     if( rc!=SQLITE_OK ){

--- a/src/doltlite_cmd.c
+++ b/src/doltlite_cmd.c
@@ -617,4 +617,19 @@ int doltliteCmdFinishWithConflictsAndConstraintViolations(
   return SQLITE_OK;
 }
 
+int doltliteCmdSourceResultError(
+  sqlite3_context *ctx,
+  ChunkStore *cs,
+  int *pRc
+){
+  int pendingRc = SQLITE_OK;
+  char *zErr = chunkStoreSourceTakeError(cs, &pendingRc);
+  if( !zErr && pendingRc==SQLITE_OK ) return 0;
+  if( zErr ) sqlite3_result_error(ctx, zErr, -1);
+  if( pendingRc!=SQLITE_OK ) *pRc = pendingRc;
+  sqlite3_result_error_code(ctx, *pRc);
+  sqlite3_free(zErr);
+  return 1;
+}
+
 #endif

--- a/src/doltlite_commit_cmd.c
+++ b/src/doltlite_commit_cmd.c
@@ -756,12 +756,6 @@ static void doltliteCommitFunc(
     }
   }
 
-  rc = doltlitePrepareCatalogForPersistence(db);
-  if( rc!=SQLITE_OK ){
-    sqlite3_result_error(context, "failed to prepare catalog", -1);
-    return;
-  }
-
   if( addAll ){
 
     rc = doltliteFlushCatalogToHash(db, &catalogHash);

--- a/src/doltlite_conflicts.c
+++ b/src/doltlite_conflicts.c
@@ -398,13 +398,13 @@ static int storeConflictBytes(
     rc = doltliteSetSessionConflictsCatalog(db, &newHash);
   }
   if( rc!=SQLITE_OK ) return rc;
+  rc = doltlitePersistOrSaveWorkingSet(db);
+  if( rc!=SQLITE_OK ) return rc;
   mode = doltliteVcTxnMode(db);
   if( mode==DOLTLITE_VC_TXN_AUTOCOMMIT_LIKE ){
-    rc = doltlitePersistWorkingSet(db);
-    if( rc!=SQLITE_OK ) return rc;
     return doltliteVcSealActiveSavepoints(db);
   }
-  return doltliteSaveWorkingSet(db);
+  return SQLITE_OK;
 }
 
 static int deleteConflictRowFromCatalog(

--- a/src/doltlite_constraint_violations.c
+++ b/src/doltlite_constraint_violations.c
@@ -356,10 +356,7 @@ static int storeUpdatedViolations(
     rc = doltliteSetSessionConstraintViolationsCatalog(db, &newHash);
   }
   if( rc!=SQLITE_OK ) return rc;
-  if( doltliteVcTxnMode(db)==DOLTLITE_VC_TXN_AUTOCOMMIT_LIKE ){
-    return doltlitePersistWorkingSet(db);
-  }
-  return doltliteSaveWorkingSet(db);
+  return doltlitePersistOrSaveWorkingSet(db);
 }
 
 static int storeViolationBytes(
@@ -380,10 +377,7 @@ static int storeViolationBytes(
     rc = doltliteSetSessionConstraintViolationsCatalog(db, &newHash);
   }
   if( rc!=SQLITE_OK ) return rc;
-  if( doltliteVcTxnMode(db)==DOLTLITE_VC_TXN_AUTOCOMMIT_LIKE ){
-    return doltlitePersistWorkingSet(db);
-  }
-  return doltliteSaveWorkingSet(db);
+  return doltlitePersistOrSaveWorkingSet(db);
 }
 
 static int deleteViolationRowFromCatalog(
@@ -675,10 +669,7 @@ int doltliteClearAllConstraintViolations(sqlite3 *db){
   static const ProllyHash emptyHash = {{0}};
   int rc = doltliteSetSessionConstraintViolationsCatalog(db, &emptyHash);
   if( rc!=SQLITE_OK ) return rc;
-  if( doltliteVcTxnMode(db)==DOLTLITE_VC_TXN_AUTOCOMMIT_LIKE ){
-    return doltlitePersistWorkingSet(db);
-  }
-  return doltliteSaveWorkingSet(db);
+  return doltlitePersistOrSaveWorkingSet(db);
 }
 
 typedef struct CvSumVtab CvSumVtab;

--- a/src/doltlite_core.c
+++ b/src/doltlite_core.c
@@ -859,15 +859,6 @@ int doltlitePersistOrSaveWorkingSet(sqlite3 *db){
   return doltliteSaveWorkingSet(db);
 }
 
-int doltliteDetectPostMergeConstraintViolations(
-  sqlite3 *db,
-  const ProllyHash *pAncCatHash,
-  int *pnViolations
-){
-  return doltliteDetectConstraintViolationsFiltered(
-      db, pAncCatHash, 0, 0, 1, pnViolations);
-}
-
 int doltliteDetectConstraintViolationsFiltered(
   sqlite3 *db,
   const ProllyHash *pAncCatHash,

--- a/src/doltlite_core.c
+++ b/src/doltlite_core.c
@@ -522,11 +522,6 @@ int doltliteSerializeDb(sqlite3 *db, Btree *pBt,
   return doltliteBtreeSerialize(pBt, zBranch, pLive, ppData, pnData);
 }
 
-int doltlitePrepareCatalogForPersistence(sqlite3 *db){
-  UNUSED_PARAMETER(db);
-  return SQLITE_OK;
-}
-
 void freeSchemaMergeActions(SchemaMergeAction *a, int n){
   int i, j;
   for(i=0; i<n; i++){
@@ -865,7 +860,8 @@ int doltliteDetectConstraintViolationsFiltered(
   const char **azTables,
   int nTables,
   int bPersist,
-  int *pnViolations
+  int *pnViolations,
+  char **pzErr
 ){
   int nViolations = 0;
   int nUnique = 0;
@@ -876,6 +872,8 @@ int doltliteDetectConstraintViolationsFiltered(
   int rc;
   sqlite3_stmt *pStmt = 0;
   int needsDetection = 0;
+
+  if( pzErr ) *pzErr = 0;
 
   rc = sqlite3_prepare_v2(db,
       "SELECT 1 "
@@ -943,7 +941,11 @@ int doltliteDetectConstraintViolationsFiltered(
         db, rc==SQLITE_OK && bPersist);
     if( rc==SQLITE_OK ) rc = erc;
   }
-  sqlite3_free(zDetectErrMsg);
+  if( pzErr ){
+    *pzErr = zDetectErrMsg;
+  }else{
+    sqlite3_free(zDetectErrMsg);
+  }
   if( rc!=SQLITE_OK ) return rc;
 
   if( pnViolations ){

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -10,7 +10,6 @@
 #include "chunk_store.h"
 #include "doltlite_catalog_types.h"
 #include <time.h>
-#include <ctype.h>
 #include <limits.h>
 
 typedef struct BtShared BtShared;
@@ -607,21 +606,6 @@ static SQLITE_INLINE int doltliteResolveBranchEffectiveCatalog(
   return SQLITE_OK;
 }
 
-/* True if the trimmed CREATE TABLE segment is a table-level constraint. */
-static SQLITE_INLINE int doltliteSegmentIsTableConstraint(const char *s, int len){
-  if( len>=11 && sqlite3_strnicmp(s, "PRIMARY KEY", 11)==0
-      && (len==11 || !isalnum((unsigned char)s[11])) ) return 1;
-  if( len>=6 && sqlite3_strnicmp(s, "UNIQUE", 6)==0
-      && (len==6 || s[6]=='(' || isspace((unsigned char)s[6])) ) return 1;
-  if( len>=5 && sqlite3_strnicmp(s, "CHECK", 5)==0
-      && (len==5 || s[5]=='(' || isspace((unsigned char)s[5])) ) return 1;
-  if( len>=11 && sqlite3_strnicmp(s, "FOREIGN KEY", 11)==0
-      && (len==11 || !isalnum((unsigned char)s[11])) ) return 1;
-  if( len>=10 && sqlite3_strnicmp(s, "CONSTRAINT", 10)==0
-      && (len==10 || isspace((unsigned char)s[10])) ) return 1;
-  return 0;
-}
-
 static SQLITE_INLINE int doltliteAppendQuotedColumnList(
   sqlite3_str *pStr,
   char *const *azName,
@@ -676,23 +660,6 @@ int doltliteLoadCatalog(sqlite3 *db, const ProllyHash *catHash,
                         struct TableEntry **ppTables, int *pnTables,
                         Pgno *piNextTable);
 void doltliteFreeCatalog(struct TableEntry *a, int n);
-
-static SQLITE_INLINE int doltliteFindTableRootByName(
-  struct TableEntry *a, int n, const char *zName,
-  ProllyHash *pRoot, u8 *pFlags, ProllyHash *pSchemaHash
-){
-  struct TableEntry *e = doltliteFindTableByName(a, n, zName);
-  if( e ){
-    memcpy(pRoot, &e->root, sizeof(ProllyHash));
-    if( pFlags ) *pFlags = e->flags;
-    if( pSchemaHash ) memcpy(pSchemaHash, &e->schemaHash, sizeof(ProllyHash));
-    return SQLITE_OK;
-  }
-  memset(pRoot, 0, sizeof(ProllyHash));
-  if( pFlags ) *pFlags = 0;
-  if( pSchemaHash ) memset(pSchemaHash, 0, sizeof(ProllyHash));
-  return SQLITE_NOTFOUND;
-}
 
 int doltliteLoadTableRootByName(
   sqlite3 *db,
@@ -984,18 +951,6 @@ int doltliteCmdFinishWithConflictsAndConstraintViolations(
   const char *zNestedMsg
 );
 
-int doltliteReportConflicts(
-  sqlite3 *db, sqlite3_context *ctx, int nConflicts, const char *zOp
-);
-int doltliteReportConstraintViolations(
-  sqlite3 *db, sqlite3_context *ctx, const char *zOp
-);
-int doltliteReportConflictsAndConstraintViolations(
-  sqlite3 *db, sqlite3_context *ctx, int nConflicts, const char *zOp
-);
-int doltliteDetectPostMergeConstraintViolations(
-  sqlite3 *db, const ProllyHash *pAncCatHash, int *pnViolations
-);
 int doltliteDetectConstraintViolationsFiltered(
   sqlite3 *db,
   const ProllyHash *pAncCatHash,
@@ -1012,10 +967,6 @@ int doltliteRestoreTxnStateOnFailure(
   sqlite3 *db, DoltliteTxnState *pSaved, int opRc
 );
 int doltlitePrimeSchemaCache(sqlite3 *db);
-void doltliteReportAutocommitConflictRollback(sqlite3_context *ctx);
-int doltliteRollbackAutocommitConflict(
-  sqlite3 *db, sqlite3_context *ctx, DoltliteTxnState *pSaved
-);
 int doltliteSavepointIsTopLevelTxn(sqlite3 *db);
 int doltliteVcSealTopLevelSavepointTxn(sqlite3 *db);
 
@@ -1405,12 +1356,6 @@ int doltliteTableSchemaConflictDetail(const char *zAncestorSql,
 int doltliteSessionHasSchemaConflicts(sqlite3 *db, int *pHas);
 int doltliteForEachSchemaConflict(sqlite3 *db,
     int (*xConflict)(void*, const char*), void *pCtx);
-
-static SQLITE_INLINE int doltliteAppendQuotedIdent(sqlite3_str *pStr,
-                                                   const char *zName){
-  sqlite3_str_appendf(pStr, "\"%w\"", zName ? zName : "");
-  return sqlite3_str_errcode(pStr);
-}
 
 static SQLITE_INLINE const char *doltliteVcUnavailableMessage(sqlite3 *db){
   if( doltliteIsStockSqliteDb(db) ){

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -861,7 +861,6 @@ int doltliteDeserializeConstraintViolationsForTest(
   const u8 *data, int nData
 );
 int doltliteFlushCatalogToHash(sqlite3 *db, ProllyHash *pHash);
-int doltlitePrepareCatalogForPersistence(sqlite3 *db);
 int doltliteCreateAndStoreCommit(
   sqlite3 *db,
   const ProllyHash *pParent,
@@ -937,6 +936,9 @@ int doltliteCmdParseAuthor(
   char **pzName, char **pzEmail
 );
 void doltliteCmdResultPeerBranchBusy(sqlite3_context *ctx, const char *zOp);
+int doltliteCmdSourceResultError(
+  sqlite3_context *ctx, ChunkStore *cs, int *pRc
+);
 int doltliteCmdFinishWithConflicts(
   sqlite3 *db, sqlite3_context *ctx, DoltliteTxnState *pSaved,
   int nConflicts, const char *zOp, int bSealOnPlain
@@ -957,7 +959,8 @@ int doltliteDetectConstraintViolationsFiltered(
   const char **azTables,
   int nTables,
   int bPersist,
-  int *pnViolations
+  int *pnViolations,
+  char **pzErr
 );
 int doltliteVerifyConstraintsRegister(sqlite3 *db);
 int doltliteRefreshAndConfirmHead(

--- a/src/doltlite_merge_cmd.c
+++ b/src/doltlite_merge_cmd.c
@@ -336,7 +336,6 @@ static int mergeRefDetectConstraintViolations(
   int *pnViolations,
   char **pzErr
 ){
-  int nFk = 0, nUnique = 0, nCheck = 0, nNotNull = 0, nStrict = 0;
   int vrc;
   int erc;
   int bOwnTxn = 0;
@@ -350,32 +349,11 @@ static int mergeRefDetectConstraintViolations(
     if( vrc!=SQLITE_OK ) return vrc;
     bOwnTxn = 1;
   }
-  vrc = doltliteConstraintViolationBatchBegin(db);
-  if( vrc==SQLITE_OK ){
-    vrc = doltliteDetectMergeFkViolations(db, pAncCat, pzErr, &nFk, 0, 0);
-  }
-  if( vrc==SQLITE_OK ){
-    vrc = doltliteDetectMergeUniqueViolations(db, pAncCat, pzErr, &nUnique, 0, 0);
-  }
-  if( vrc==SQLITE_OK ){
-    vrc = doltliteDetectMergeCheckViolations(db, pAncCat, pzErr, &nCheck, 0, 0);
-  }
-  if( vrc==SQLITE_OK ){
-    vrc = doltliteDetectMergeNotNullViolations(db, pAncCat, pzErr, &nNotNull,
-                                              0, 0);
-  }
-  if( vrc==SQLITE_OK ){
-    vrc = doltliteDetectMergeStrictViolations(db, pAncCat, pzErr, &nStrict,
-                                             0, 0);
-  }
-  erc = doltliteConstraintViolationBatchEnd(db, vrc==SQLITE_OK);
-  if( vrc==SQLITE_OK ) vrc = erc;
+  vrc = doltliteDetectConstraintViolationsFiltered(
+      db, pAncCat, 0, 0, 1, pnViolations, pzErr);
   if( bOwnTxn ){
     erc = sqlite3_exec(db, vrc==SQLITE_OK ? "COMMIT" : "ROLLBACK", 0, 0, 0);
     if( vrc==SQLITE_OK ) vrc = erc;
-  }
-  if( vrc==SQLITE_OK ){
-    *pnViolations = nFk + nUnique + nCheck + nNotNull + nStrict;
   }
   return vrc;
 }

--- a/src/doltlite_rebase.c
+++ b/src/doltlite_rebase.c
@@ -1008,9 +1008,8 @@ static int rebaseApplyPlanRowCatalog(
     doltliteFreeNameList(azReindex, nReindex);
   }
   if( rc==SQLITE_OK && nConflicts==0 ){
-    rc = doltliteDetectPostMergeConstraintViolations(db,
-                                                     &parentC.catalogHash,
-                                                     &nViolations);
+    rc = doltliteDetectConstraintViolationsFiltered(
+        db, &parentC.catalogHash, 0, 0, 1, &nViolations);
   }
   doltliteCommitClear(&parentC);
   doltliteCommitClear(&replayC);

--- a/src/doltlite_rebase.c
+++ b/src/doltlite_rebase.c
@@ -1009,7 +1009,7 @@ static int rebaseApplyPlanRowCatalog(
   }
   if( rc==SQLITE_OK && nConflicts==0 ){
     rc = doltliteDetectConstraintViolationsFiltered(
-        db, &parentC.catalogHash, 0, 0, 1, &nViolations);
+        db, &parentC.catalogHash, 0, 0, 1, &nViolations, 0);
   }
   doltliteCommitClear(&parentC);
   doltliteCommitClear(&replayC);

--- a/src/doltlite_reset.c
+++ b/src/doltlite_reset.c
@@ -31,21 +31,6 @@ static int resetFindTableIndex(struct TableEntry *aTables, int nTables,
   return -1;
 }
 
-static int resetSourceResultError(
-  sqlite3_context *context,
-  ChunkStore *cs,
-  int *pRc
-){
-  int pendingRc = SQLITE_OK;
-  char *zErr = chunkStoreSourceTakeError(cs, &pendingRc);
-  if( !zErr && pendingRc==SQLITE_OK ) return 0;
-  if( zErr ) sqlite3_result_error(context, zErr, -1);
-  if( pendingRc!=SQLITE_OK ) *pRc = pendingRc;
-  sqlite3_result_error_code(context, *pRc);
-  sqlite3_free(zErr);
-  return 1;
-}
-
 /* True when zName is a table in live schema, staged, or HEAD. A table
 ** beats a same-named ref: dolt_reset('x') must not rewind HEAD. */
 static int resetNameIsTablePath(
@@ -70,7 +55,7 @@ static int resetNameIsTablePath(
   if( !prollyHashIsEmpty(&hash) ){
     rc = doltliteLoadCatalog(db, &hash, &aCat, &nCat, 0);
     if( rc!=SQLITE_OK ){
-      if( resetSourceResultError(context, cs, &rc) ) return rc;
+      if( doltliteCmdSourceResultError(context, cs, &rc) ) return rc;
     }else{
       *pFound = resetFindTableIndex(aCat, nCat, zName)>=0;
       doltliteFreeCatalog(aCat, nCat);
@@ -81,13 +66,13 @@ static int resetNameIsTablePath(
   }
   rc = doltliteGetHeadCatalogHash(db, &hash);
   if( rc!=SQLITE_OK ){
-    if( resetSourceResultError(context, cs, &rc) ) return rc;
+    if( doltliteCmdSourceResultError(context, cs, &rc) ) return rc;
     return SQLITE_OK;
   }
   if( !prollyHashIsEmpty(&hash) ){
     rc = doltliteLoadCatalog(db, &hash, &aCat, &nCat, 0);
     if( rc!=SQLITE_OK ){
-      if( resetSourceResultError(context, cs, &rc) ) return rc;
+      if( doltliteCmdSourceResultError(context, cs, &rc) ) return rc;
     }else{
       *pFound = resetFindTableIndex(aCat, nCat, zName)>=0;
       doltliteFreeCatalog(aCat, nCat);
@@ -503,7 +488,7 @@ static void doltliteResetFunc(
   }
 
   rc = doltliteGetHeadCatalogHash(db, &preResetHeadCatHash);
-  if( rc!=SQLITE_OK && resetSourceResultError(context, cs, &rc) ){
+  if( rc!=SQLITE_OK && doltliteCmdSourceResultError(context, cs, &rc) ){
     goto reset_cleanup;
   }else if( rc==SQLITE_OK && !prollyHashIsEmpty(&preResetHeadCatHash) ){
     havePreResetHead = 1;
@@ -550,7 +535,7 @@ static void doltliteResetFunc(
           rc = doltliteResolveRef(db, arg, &probe);
           if( rc==SQLITE_OK ){
             zRef = arg;
-          }else if( resetSourceResultError(context, cs, &rc) ){
+          }else if( doltliteCmdSourceResultError(context, cs, &rc) ){
             goto reset_cleanup;
           }else{
             azPaths[nPaths++] = arg;

--- a/src/doltlite_revert.c
+++ b/src/doltlite_revert.c
@@ -136,21 +136,6 @@ done:
   return rc;
 }
 
-static int revertSourceResultError(
-  sqlite3_context *context,
-  ChunkStore *cs,
-  int rc
-){
-  int pendingRc = SQLITE_OK;
-  char *zErr = chunkStoreSourceTakeError(cs, &pendingRc);
-  if( !zErr && pendingRc==SQLITE_OK ) return 0;
-  if( zErr ) sqlite3_result_error(context, zErr, -1);
-  sqlite3_result_error_code(
-      context, pendingRc!=SQLITE_OK ? pendingRc : rc);
-  sqlite3_free(zErr);
-  return 1;
-}
-
 static void doltliteRevertFunc(
   sqlite3_context *context,
   int argc,
@@ -202,7 +187,7 @@ static void doltliteRevertFunc(
 
   rc = doltliteResolveRef(db,zRef, &revertHash);
   if( rc!=SQLITE_OK ){
-    if( !revertSourceResultError(context, cs, rc) ){
+    if( !doltliteCmdSourceResultError(context, cs, &rc) ){
       if( rc==SQLITE_NOTFOUND || rc==SQLITE_ERROR ){
         sqlite3_result_error(context, "invalid commit hash", -1);
       }else{
@@ -219,7 +204,7 @@ static void doltliteRevertFunc(
     doltliteCommitClear(&revertCommit);
     doltliteCommitClear(&parentCommit);
     doltliteCommitClear(&ourCommit);
-    if( !revertSourceResultError(context, cs, rc) ){
+    if( !doltliteCmdSourceResultError(context, cs, &rc) ){
       sqlite3_result_error(context, "commit not found", -1);
     }
     return;
@@ -239,7 +224,7 @@ static void doltliteRevertFunc(
     doltliteCommitClear(&revertCommit);
     doltliteCommitClear(&parentCommit);
     doltliteCommitClear(&ourCommit);
-    if( !revertSourceResultError(context, cs, rc) ){
+    if( !doltliteCmdSourceResultError(context, cs, &rc) ){
       sqlite3_result_error_code(context, rc);
     }
     return;
@@ -285,7 +270,7 @@ static void doltliteRevertFunc(
 
   if( rc==SQLITE_BUSY ){
     sqlite3_free(zApplyErr);
-    if( !revertSourceResultError(context, cs, rc) ){
+    if( !doltliteCmdSourceResultError(context, cs, &rc) ){
       doltliteCmdResultPeerBranchBusy(context, "revert");
     }
     return;
@@ -296,7 +281,7 @@ static void doltliteRevertFunc(
     return;
   }
   if( rc!=SQLITE_OK ){
-    if( !revertSourceResultError(context, cs, rc) ){
+    if( !doltliteCmdSourceResultError(context, cs, &rc) ){
       if( zApplyErr ){
         sqlite3_result_error(context, zApplyErr, -1);
       }else{
@@ -321,7 +306,7 @@ revert_error:
   doltliteCommitClear(&revertCommit);
   doltliteCommitClear(&parentCommit);
   doltliteCommitClear(&ourCommit);
-  if( !revertSourceResultError(context, cs, rc) ){
+  if( !doltliteCmdSourceResultError(context, cs, &rc) ){
     char *zMsg = sqlite3_mprintf("revert of \"%s\" failed", zRef);
     sqlite3_result_error(context, zMsg ? zMsg : "revert failed", -1);
     sqlite3_free(zMsg);

--- a/src/doltlite_verify_constraints.c
+++ b/src/doltlite_verify_constraints.c
@@ -319,7 +319,7 @@ static void doltVerifyConstraintsFunc(
   }
 
   rc = doltliteDetectConstraintViolationsFiltered(
-      db, pDetectAnc, azScan, nScan, !bOutputOnly, &nViolations);
+      db, pDetectAnc, azScan, nScan, !bOutputOnly, &nViolations, 0);
   if( rc!=SQLITE_OK ){
     sqlite3_result_error_code(context, rc);
     goto cleanup;

--- a/src/doltlite_vtab_util.h
+++ b/src/doltlite_vtab_util.h
@@ -81,12 +81,6 @@ static SQLITE_INLINE int doltliteVtabCommonCaptureRowSide(
   return SQLITE_OK;
 }
 
-static SQLITE_INLINE int doltliteVtabCommonCaptureRow(
-  DoltliteVtabCursorCommon *c, sqlite3 *db, const char *zTableName
-){
-  return doltliteVtabCommonCaptureRowSide(c, db, zTableName, 0);
-}
-
 static SQLITE_INLINE int doltliteVtabCommonDisconnect(
   sqlite3_vtab *pVtab
 ){

--- a/src/pager_shim.c
+++ b/src/pager_shim.c
@@ -851,6 +851,7 @@ sqlite3_file *sqlite3_database_file_object(const char *zName){
   return 0;
 }
 
+#if !defined(NDEBUG) || defined(SQLITE_TEST)
 Pgno sqlite3PagerPagenumber(DbPage *pPg){
   (void)pPg;
   return 0;
@@ -859,6 +860,9 @@ int sqlite3PagerIswriteable(DbPage *pPg){
   (void)pPg;
   return 1;
 }
+#endif
+
+#ifdef SQLITE_TEST
 int *sqlite3PagerStats(Pager *pPager){
   static int aStats[11];
   (void)pPager;
@@ -875,6 +879,7 @@ void disable_simulated_io_errors(void){
 }
 void enable_simulated_io_errors(void){
 }
+#endif
 
 ChunkStore *doltliteBtreeChunkStore(Btree *p);
 void doltliteBtreeBackupStart(Btree *p);

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -703,9 +703,6 @@ int sqlite3BtreeOpen(
   if( pBt->store.readOnly ){
     pBt->btsFlags |= BTS_READ_ONLY;
   }
-  if( chunkStoreIsEmpty(&pBt->store) ){
-    pBt->btsFlags |= BTS_INITIALLY_EMPTY;
-  }
 
   p->aMeta[BTREE_FREE_PAGE_COUNT] = 0;
   p->aMeta[BTREE_SCHEMA_VERSION] = 0;
@@ -1801,7 +1798,7 @@ void prollyBtCursorClearCursor(BtCursor *pCur){
   CLEAR_CACHED_PAYLOAD(pCur);
   clearMergeCursorState(pCur);
   pCur->eState = CURSOR_INVALID;
-  pCur->curFlags &= ~(BTCF_ValidNKey|BTCF_ValidOvfl|BTCF_AtLast);
+  pCur->curFlags &= ~(BTCF_ValidNKey|BTCF_AtLast);
   pCur->skipNext = 0;
 }
 void sqlite3BtreeClearCursor(BtCursor *pCur){

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -37,7 +37,7 @@ int mutMapShouldDrain(BtCursor *pCur){
       && prollyMutMapCount(pCur->pMutMap) >= PROLLY_MUTMAP_PENDING_FLUSH_LIMIT;
 }
 
-i64 prollyBtreeSyntheticPageCount(Btree *p){
+static i64 prollyBtreeSyntheticPageCount(Btree *p){
   ChunkStore *cs;
   i64 n;
   if( !p || !p->pBt ) return 0;

--- a/src/prolly_btree_int.h
+++ b/src/prolly_btree_int.h
@@ -87,15 +87,12 @@ u32 prollyBtreeGetU32LE(const u8 *p);
 
 #define BTCF_WriteFlag  0x01
 #define BTCF_ValidNKey  0x02
-#define BTCF_ValidOvfl  0x04
 #define BTCF_AtLast     0x08
 #define BTCF_Incrblob   0x10
-#define BTCF_Multiple   0x20
 #define BTCF_Pinned     0x40
 #define BTCF_DeleteKey  0x80
 
 #define BTS_READ_ONLY       0x0001
-#define BTS_INITIALLY_EMPTY 0x0010
 
 #define CLEAR_CACHED_PAYLOAD(pCsr) do{ \
   if( (pCsr)->cachedPayloadOwned && (pCsr)->pCachedPayload ){ \
@@ -440,9 +437,6 @@ struct TableEntry *catFind(Catalog *cat, Pgno iTable);
 struct TableEntry *catAdd(Catalog *cat, Pgno iTable, u8 flags);
 void catRemove(Catalog *cat, Pgno iTable);
 void catFree(Catalog *cat);
-int btreeLoadBranchHeadCatalog(ChunkStore *cs, const char *zBranch,
-                                      ProllyHash *pCatHash,
-                                      ProllyHash *pHeadCommit);
 
 static inline struct TableEntry *findTable(Btree *p, Pgno iTable){
   return catFind(&p->cat, iTable);
@@ -464,8 +458,6 @@ void refreshCursorMutMapAliases(Btree *pBtree, BtShared *pBt,
                                         Pgno iTable, ProllyMutMap *pNewMap);
 int getCursorPayload(BtCursor *pCur, const u8 **ppData, int *pnData);
 int flushIfNeeded(BtCursor *pCur);
-int flushAllPending(Btree *pBtree, BtShared *pBt, Pgno iTable);
-int applyMutMapToTableRoot(BtShared *pBt, struct TableEntry *pTE, ProllyMutMap *pMap);
 int flushPendingForTable(Btree *pBtree, BtShared *pBt,
                                 struct TableEntry *pTE, int clearInPlace);
 int cacheCursorPayloadCopy(BtCursor *pCur, const u8 *pData, int nData);

--- a/src/prolly_btree_mutation.c
+++ b/src/prolly_btree_mutation.c
@@ -523,7 +523,7 @@ void refreshCursorMutMapAliases(Btree *pBtree, BtShared *pBt,
   }
 }
 
-int ensureMutMap(BtCursor *pCur){
+static int ensureMutMap(BtCursor *pCur){
   int rc;
   struct TableEntry *pTE;
   ProllyMutMap *pMap;

--- a/src/prolly_btree_state.c
+++ b/src/prolly_btree_state.c
@@ -511,7 +511,7 @@ void btreeStoreCommittedFromCurrent(Btree *p, const ProllyHash *pCatHash){
   memcpy(p->committedAMeta, p->aMeta, sizeof(p->committedAMeta));
 }
 
-void btreeBumpExternalDataVersion(Btree *p){
+static void btreeBumpExternalDataVersion(Btree *p){
   assert( p!=0 && p->pBt!=0 );
   if( p->pBt->pPagerShim ){
     p->pBt->pPagerShim->iDataVersion++;

--- a/test/dead_code_check.sh
+++ b/test/dead_code_check.sh
@@ -9,9 +9,15 @@
 #           heuristic (an occurrence count of <=2 means a definition plus at
 #           most one declaration, i.e. no call site); intentional exports that
 #           legitimately have no in-tree caller are listed in ALLOW below.
+#   Part C: static inline helpers in headers that never appear outside their
+#           definition (the compiler will not warn; each TU that includes the
+#           header just omits the unused inline).
+#   Part D: non-static functions with no identifier occurrence outside the
+#           defining file. Those should be static so Part A can see them.
 #
 # Needs the generated headers, so run it after a configure+build (the build
-# dir defaults to ./build, override with DOLTLITE_BUILD_DIR).
+# dir defaults to ./build, override with DOLTLITE_BUILD_DIR). Point
+# DOLTLITE_SRC_ROOT at an alternate src/ tree for the self-test.
 
 set -uo pipefail
 
@@ -19,9 +25,18 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$ROOT"
 BUILD_DIR="${DOLTLITE_BUILD_DIR:-$ROOT/build}"
+SRC_ROOT="${DOLTLITE_SRC_ROOT:-$ROOT/src}"
 CC="${CC:-cc}"
 
-SRCS=(src/doltlite.c src/doltlite_*.c src/chunk_*.c src/prolly_*.c src/remotesrv_main.c)
+SRCS=(
+  "$SRC_ROOT"/doltlite.c
+  "$SRC_ROOT"/doltlite_*.c
+  "$SRC_ROOT"/chunk_*.c
+  "$SRC_ROOT"/prolly_*.c
+  "$SRC_ROOT"/remotesrv_main.c
+  "$SRC_ROOT"/pager_shim.c
+  "$SRC_ROOT"/sortkey.c
+)
 
 CFLAGS=(
   -DNDEBUG -O1 -g
@@ -29,7 +44,7 @@ CFLAGS=(
   -DDOLTLITE_PROLLY=1 -DDOLTLITE_VERSION='"dev"'
   -DSQLITE_ENABLE_FTS5 -DSQLITE_ENABLE_RTREE
   -D_HAVE_SQLITE_CONFIG_H -DBUILD_sqlite
-  "-I$BUILD_DIR" -Isrc -Iext/rtree -Iext/icu -Iext/fts3 -Iext/session
+  "-I$BUILD_DIR" "-I$SRC_ROOT" -Iext/rtree -Iext/icu -Iext/fts3 -Iext/session
   -Iext/misc -Iext/blake3 -Iext/ed25519 -Iext/mbedtls/include
 )
 
@@ -38,37 +53,52 @@ CFLAGS=(
 ALLOW="doltliteServe doltliteServeAsync doltliteServerStop"
 
 fail=0
+ERR=$(mktemp)
+FNS=$(mktemp)
+DEAD=$(mktemp)
+trap 'rm -f "$ERR" "$FNS" "$DEAD"' EXIT
 
 echo "== Part A: unused static functions / locals =="
-for f in "${SRCS[@]}"; do
-  # A real compile (not -fsyntax-only): GCC only runs its unused-function
-  # pass during code generation, so -fsyntax-only silently suppresses the
-  # warning under GCC (the CI compiler) while Clang still emits it. Compiling
-  # to /dev/null keeps the check compiler-portable.
-  if ! "$CC" "${CFLAGS[@]}" \
-        -Werror=unused-function -Werror=unused-variable \
-        -Werror=unused-but-set-variable -c -o /dev/null "$f" 2>/tmp/dc_err.$$; then
-    grep -iE 'error:' /tmp/dc_err.$$ | sed "s|^|  |"
-    fail=1
-  fi
-done
-rm -f /tmp/dc_err.$$
+if [ "${DEAD_CODE_SKIP_PART_A:-}" = 1 ]; then
+  echo "  (skipped)"
+else
+  for f in "${SRCS[@]}"; do
+    [ -f "$f" ] || continue
+    # A real compile (not -fsyntax-only): GCC only runs its unused-function
+    # pass during code generation, so -fsyntax-only silently suppresses the
+    # warning under GCC (the CI compiler) while Clang still emits it. Compiling
+    # to /dev/null keeps the check compiler-portable.
+    if ! "$CC" "${CFLAGS[@]}" \
+          -Werror=unused-function -Werror=unused-variable \
+          -Werror=unused-but-set-variable -c -o /dev/null "$f" 2>"$ERR"; then
+      grep -iE 'error:' "$ERR" | sed "s|^|  |"
+      fail=1
+    fi
+  done
+fi
 
 echo "== Part B: extern functions with no caller =="
 for f in "${SRCS[@]}"; do
+  [ -f "$f" ] || continue
   grep -nE '^[a-zA-Z_][a-zA-Z0-9_ ]*[ \*]([a-z][a-zA-Z0-9_]+)\(' "$f" \
     | grep -vE '^[0-9]+:(static|typedef|return|else|case|do|while|for|if|switch)\b' \
     | sed -nE 's/^[0-9]+:[a-zA-Z_][a-zA-Z0-9_ ]*[ \*]([a-z][a-zA-Z0-9_]+)\(.*/\1/p'
-done | sort -u > /tmp/dc_fns.$$
-: > /tmp/dc_dead.$$
+done | sort -u > "$FNS"
+: > "$DEAD"
 while read -r fn; do
   [ -z "$fn" ] && continue
   case " $ALLOW " in *" $fn "*) continue;; esac
-  cnt=$(grep -rhoE "\b$fn\b" src/*.c src/*.h ext/*/*.c ext/*/*.h test/*.c 2>/dev/null | wc -l | tr -d ' ')
-  [ "$cnt" -le 2 ] && echo "  dead (no caller): $fn" >> /tmp/dc_dead.$$
-done < /tmp/dc_fns.$$
-if [ -s /tmp/dc_dead.$$ ]; then cat /tmp/dc_dead.$$; fail=1; fi
-rm -f /tmp/dc_fns.$$ /tmp/dc_dead.$$
+  cnt=$(grep -rhoE "\b$fn\b" "$SRC_ROOT"/*.c "$SRC_ROOT"/*.h \
+          ext/*/*.c ext/*/*.h test/*.c 2>/dev/null | wc -l | tr -d ' ')
+  [ "$cnt" -le 2 ] && echo "  dead (no caller): $fn" >> "$DEAD"
+done < "$FNS"
+if [ -s "$DEAD" ]; then cat "$DEAD"; fail=1; fi
+
+echo "== Part C/D: unused header inlines / should-be-static =="
+if ! python3 "$SCRIPT_DIR/lib/dead_code_scan.py" --root "$ROOT" --src-root "$SRC_ROOT"
+then
+  fail=1
+fi
 
 if [ "$fail" != 0 ]; then
   echo "DEAD CODE GATE: FAIL"

--- a/test/dead_code_check_selftest.sh
+++ b/test/dead_code_check_selftest.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# Prove the dead-code gate still fails on planted unused/duplicate-export cases.
+# A clean-tree pass is the CI job's dead_code_check.sh run; this file only
+# checks that the detectors fire.
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/.." && pwd)"
+CHECK="$HERE/dead_code_check.sh"
+SCAN="$HERE/lib/dead_code_scan.py"
+BUILD_DIR="${DOLTLITE_BUILD_DIR:-$ROOT/build}"
+CC="${CC:-cc}"
+
+PASS=0
+FAIL=0
+ERRORS=""
+ok() { PASS=$((PASS+1)); }
+bad() { FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $1\n  $2"; }
+
+echo "=== dead_code_check self-test ==="
+
+if [ ! -f "$BUILD_DIR/sqlite_cfg.h" ]; then
+  echo "SETUP FAILED: $BUILD_DIR/sqlite_cfg.h missing; configure+build first" >&2
+  exit 2
+fi
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+mkdir -p "$WORK/src"
+
+expect_scan_hit() {
+  local name="$1" needle="$2" out rc
+  out=$(python3 "$SCAN" --root "$WORK" --src-root "$WORK/src" 2>&1)
+  rc=$?
+  if [ "$rc" -eq 0 ]; then
+    bad "$name" "scanner passed; expected a hit containing '$needle'"
+  elif ! printf '%s' "$out" | grep -q -- "$needle"; then
+    bad "$name" "exited $rc but never mentioned '$needle':
+$out"
+  else
+    ok
+  fi
+}
+
+# Part C: unused static inline in a header.
+cat > "$WORK/src/fixture.h" <<'EOF'
+#ifndef FIXTURE_H
+#define FIXTURE_H
+static SQLITE_INLINE int dead_code_gate_unused_inline(int x){ return x; }
+#endif
+EOF
+: > "$WORK/src/doltlite.c"
+expect_scan_hit "header_inline_is_rejected" "dead header inline: dead_code_gate_unused_inline"
+
+# Part D: non-static helper only referenced in its defining file.
+cat > "$WORK/src/doltlite.c" <<'EOF'
+int dead_code_gate_should_be_static(int x){
+  return x;
+}
+static int dead_code_gate_same_file_caller(int x){
+  return dead_code_gate_should_be_static(x);
+}
+EOF
+: > "$WORK/src/fixture.h"
+expect_scan_hit "should_be_static_is_rejected" "should be static: dead_code_gate_should_be_static"
+
+# Part A: unused static in a real translation unit (compiler-driven).
+cp "$ROOT/src/doltlite_add.c" "$WORK/src/doltlite_add.c"
+printf '\nstatic int dead_code_gate_unused_static(void){ return 0; }\n' \
+  >> "$WORK/src/doltlite_add.c"
+CFLAGS=(
+  -DNDEBUG -O1 -g
+  -DSQLITE_ENABLE_MATH_FUNCTIONS -DSQLITE_THREADSAFE=1
+  -DDOLTLITE_PROLLY=1 -DDOLTLITE_VERSION='"dev"'
+  -DSQLITE_ENABLE_FTS5 -DSQLITE_ENABLE_RTREE
+  -D_HAVE_SQLITE_CONFIG_H -DBUILD_sqlite
+  "-I$BUILD_DIR" "-I$ROOT/src" -I"$ROOT/ext/rtree" -I"$ROOT/ext/icu"
+  -I"$ROOT/ext/fts3" -I"$ROOT/ext/session" -I"$ROOT/ext/misc"
+  -I"$ROOT/ext/blake3" -I"$ROOT/ext/ed25519" -I"$ROOT/ext/mbedtls/include"
+)
+A_ERR=$WORK/part_a.err
+if "$CC" "${CFLAGS[@]}" -Werror=unused-function -Werror=unused-variable \
+      -Werror=unused-but-set-variable -c -o /dev/null \
+      "$WORK/src/doltlite_add.c" 2>"$A_ERR"; then
+  bad "unused_static_is_rejected" "compiler accepted an unused static function"
+elif ! grep -q 'dead_code_gate_unused_static' "$A_ERR"; then
+  bad "unused_static_is_rejected" "compiler failed but did not name the planted static:
+$(sed 's/^/    /' "$A_ERR")"
+else
+  ok
+fi
+
+# Part B: unused extern (definition, no caller) on a one-file src tree.
+mkdir -p "$WORK/tiny/src"
+printf 'int dead_code_gate_unused_extern(void){ return 0; }\n' \
+  > "$WORK/tiny/src/doltlite.c"
+B_OUT=$(
+  DEAD_CODE_SKIP_PART_A=1 \
+  DOLTLITE_SRC_ROOT="$WORK/tiny/src" \
+  DOLTLITE_BUILD_DIR="$BUILD_DIR" \
+  bash "$CHECK" 2>&1
+) || true
+if ! printf '%s' "$B_OUT" | grep -q 'dead (no caller): dead_code_gate_unused_extern'; then
+  bad "unused_extern_is_rejected" "gate did not flag planted extern:
+$B_OUT"
+else
+  ok
+fi
+
+echo
+echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"
+if [ "$FAIL" -gt 0 ]; then
+  printf '%b\n' "$ERRORS"
+  exit 1
+fi

--- a/test/lib/dead_code_scan.py
+++ b/test/lib/dead_code_scan.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Parts C/D of test/dead_code_check.sh.
+
+C: static inline in a header whose identifier never appears elsewhere.
+D: non-static function defined in DoltLite-owned .c with no identifier
+   occurrence outside that file (should be static, or it is dead).
+"""
+from __future__ import annotations
+
+import argparse
+import glob
+import os
+import re
+import sys
+from collections import Counter
+
+IDENT = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+INLINE = re.compile(
+    r"static\s+(?:SQLITE_INLINE|inline)\s+[^{;]*?\b([A-Za-z_][A-Za-z0-9_]*)\s*\(",
+    re.S,
+)
+DEF = re.compile(
+    r"^(?!\s)(?!static\b)(?!typedef\b)(?!#)"
+    r"(?:SQLITE_PRIVATE\s+|SQLITE_API\s+)?"
+    r".+?\b([A-Za-z_][A-Za-z0-9_]*)\s*\(",
+    re.M,
+)
+SKIP_DEF = {
+    "if",
+    "for",
+    "while",
+    "switch",
+    "return",
+    "sizeof",
+    "case",
+    "else",
+    "do",
+    "main",
+}
+SRC_GLOBS = (
+    "doltlite.c",
+    "doltlite_*.c",
+    "chunk_*.c",
+    "prolly_*.c",
+    "remotesrv_main.c",
+    "pager_shim.c",
+    "sortkey.c",
+)
+
+
+def expand(root: str, patterns: list[str]) -> list[str]:
+    out: set[str] = set()
+    for pat in patterns:
+        out.update(glob.glob(os.path.join(root, pat)))
+    return sorted(out)
+
+
+def strip_comments(text: str) -> str:
+    text = re.sub(r"/\*.*?\*/", "", text, flags=re.S)
+    return re.sub(r"//.*", "", text)
+
+
+def load_tokens(paths: list[str]) -> tuple[dict[str, str], dict[str, set[str]], dict[str, Counter]]:
+    texts: dict[str, str] = {}
+    idents: dict[str, set[str]] = {}
+    counts: dict[str, Counter] = {}
+    for path in paths:
+        try:
+            raw = open(path, errors="replace").read()
+        except OSError:
+            continue
+        texts[path] = raw
+        toks = IDENT.findall(strip_comments(raw))
+        idents[path] = set(toks)
+        counts[path] = Counter(toks)
+    return texts, idents, counts
+
+
+def scan_inlines(hdrs: list[str], corpus: list[str], texts: dict[str, str],
+                 idents: dict[str, set[str]], counts: dict[str, Counter]) -> list[str]:
+    dead: list[str] = []
+    for path in hdrs:
+        raw = texts.get(path)
+        if raw is None:
+            continue
+        for match in INLINE.finditer(strip_comments(raw)):
+            name = match.group(1)
+            others = [q for q in corpus if q != path and name in idents.get(q, ())]
+            if others:
+                continue
+            if counts.get(path, Counter())[name] <= 1:
+                dead.append(f"  dead header inline: {name} ({path})")
+    return dead
+
+
+def looks_like_def(line: str, name: str) -> bool:
+    before = line[: line.find(name)]
+    if not (re.search(r"[A-Za-z_][A-Za-z0-9_]*\s+\**$", before) or "*" in before):
+        return False
+    # Declarations end with ';' and have no body. One-line definitions have '{'.
+    if ";" in line and "{" not in line:
+        return False
+    return True
+
+
+def scan_should_be_static(src_files: list[str], corpus: list[str], texts: dict[str, str],
+                          idents: dict[str, set[str]]) -> list[str]:
+    dead: list[str] = []
+    for path in src_files:
+        raw = texts.get(path)
+        if raw is None:
+            continue
+        stripped = strip_comments(raw)
+        for match in DEF.finditer(stripped):
+            name = match.group(1)
+            if name in SKIP_DEF:
+                continue
+            if name.startswith("sqlite3") or name.startswith("orig_sqlite3"):
+                continue
+            if not looks_like_def(match.group(0), name):
+                continue
+            others = [q for q in corpus if q != path and name in idents.get(q, ())]
+            if others:
+                continue
+            line = stripped[: match.start()].count("\n") + 1
+            dead.append(f"  should be static: {name} ({path}:{line})")
+    return dead
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--root", required=True)
+    ap.add_argument("--src-root", default="")
+    args = ap.parse_args()
+    root = os.path.abspath(args.root)
+    src_root = os.path.abspath(args.src_root or os.path.join(root, "src"))
+
+    src_files = expand(src_root, list(SRC_GLOBS))
+    hdrs = expand(src_root, ["*.h"])
+    # Owned files are scanned for definitions; the whole src tree is searched
+    # for uses (sqliteInt.h / main.c / vdbe.c hold Register and btree entry
+    # points).
+    corpus = expand(src_root, ["*.c", "*.h"]) + expand(root, [
+        "test/*.c",
+        "test/c/*.c",
+        "ext/*/*.c",
+        "ext/*/*.h",
+    ])
+    corpus = sorted(set(corpus))
+    texts, idents, counts = load_tokens(corpus)
+
+    dead = scan_inlines(hdrs, corpus, texts, idents, counts)
+    dead += scan_should_be_static(src_files, corpus, texts, idents)
+    for line in dead:
+        print(line)
+    return 1 if dead else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- delete unused header `static inline` helpers the compiler never warns about (`doltliteFindTableRootByName`, `doltliteSegmentIsTableConstraint`, `doltliteAppendQuotedIdent`, `doltliteVtabCommonCaptureRow`) and the one-call wrapper `doltliteDetectPostMergeConstraintViolations`
- fold the duplicated conflict/CV persist-and-error path in `doltlite_cmd.c` into `persistPendingAndError` / `cmdFinishPlainAfterReport`
- make same-file-only `ensureMutMap`, `prollyBtreeSyntheticPageCount`, and `btreeBumpExternalDataVersion` static
- route merge and cherry-pick constraint detection through `doltliteDetectConstraintViolationsFiltered` (merge still owns its autocommit BEGIN/COMMIT wrap)
- replace persist/save copies in constraint-violations and conflicts with `doltlitePersistOrSaveWorkingSet`
- share chunk-source error reporting across cherry-pick, revert, and reset
- drop the no-op catalog-prepare hook, duplicate prolly header decls, unused prolly cursor-flag bits (`BTCF_ValidOvfl`, `BTCF_Multiple`, `BTS_INITIALLY_EMPTY`), and pager-shim test stubs from non-`SQLITE_TEST` builds
- extend the no-dead-code job to compile `pager_shim.c` and `sortkey.c`, flag unused header inlines and should-be-static functions, and plant each failure mode in a self-test

## Validation

- `bash test/dead_code_check.sh`: PASS
- `bash test/dead_code_check_selftest.sh`: 4 passed, 0 failed
- `make lint`: PASS
- `test/doltlite_conflicts.sh`: 54 passed, 0 failed
- `test/doltlite_merge.sh`: 219 passed, 0 failed
- `test/doltlite_rebase.sh`: 65 passed, 0 failed
- `test/doltlite_cherry_pick.sh`: 140 passed, 0 failed
- `test/doltlite_reset.sh`: 65 passed, 0 failed
- `test/doltlite_commit.sh`: 82 passed, 0 failed
- `test/doltlite_staging.sh`: 31 passed, 0 failed

Co-Authored-By: Grok 4.6 <noreply@x.ai>