### PR TITLE
Pull remote refs into the current branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -676,11 +676,12 @@ divergent lazy pull is refused until the store is fully materialized.
 Opening without `lazy_origin=1` leaves cached chunks available, but an
 uncached miss fails with a hash-named error instead of contacting `origin`.
 
-`dolt_pull` fetches, then fast-forwards if the local branch is an ancestor
-of the remote tip. If the current branch has diverged, it three-way merges
-like `dolt_merge`. A non-current branch that is not a fast-forward is
-refused. Fetch and pull also install remote tags whose commits have been
-fetched, replacing same-named local tags when the remote value differs.
+`dolt_pull` fetches the named remote branch, then integrates it into the
+current local branch. It fast-forwards when the current tip is an ancestor of
+the remote tip and otherwise three-way merges like `dolt_merge`. The branch
+name selects the remote ref; a same-named non-current local branch is neither
+created nor moved. Fetch and pull also install remote tags whose commits have
+been fetched, replacing same-named local tags when the remote value differs.
 
 ##### HTTP Remotes
 

--- a/src/doltlite_remote_sql.c
+++ b/src/doltlite_remote_sql.c
@@ -533,16 +533,14 @@ static void doltFetchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
 
 typedef struct PullAdvanceCtx PullAdvanceCtx;
 struct PullAdvanceCtx {
-  const char *zBranch;
+  const char *zLocalBranch;
   ProllyHash newTip;
-  int isCreate;
 };
 
 static int mutatePullAdvance(sqlite3 *db, ChunkStore *cs, void *pArg){
   PullAdvanceCtx *p = (PullAdvanceCtx*)pArg;
   (void)db;
-  if( p->isCreate ) return chunkStoreAddBranch(cs, p->zBranch, &p->newTip);
-  return chunkStoreUpdateBranch(cs, p->zBranch, &p->newTip);
+  return chunkStoreUpdateBranch(cs, p->zLocalBranch, &p->newTip);
 }
 
 static void doltPullFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
@@ -551,12 +549,14 @@ static void doltPullFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   DoltliteRemote *pRemote = 0;
   const char *zUrl = 0;
   const char *zRemoteName;
-  const char *zBranch;
+  const char *zRemoteBranch;
+  const char *zLocalBranch;
   ProllyHash trackingCommit, localCommit;
   DoltliteTxnState savedState;
   int dirty = 0;
   int rc;
 
+  if( doltliteCmdRejectDetached(ctx) ) return;
   if( !cs ){ doltliteVcResultError(ctx, db, "no database"); return; }
   if( argc<2 ){
     doltliteVcResultError(ctx, db, "usage: dolt_pull(remote, branch)");
@@ -564,8 +564,8 @@ static void doltPullFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   }
 
   zRemoteName = (const char*)sqlite3_value_text(argv[0]);
-  zBranch = (const char*)sqlite3_value_text(argv[1]);
-  if( !zRemoteName || !zBranch ){
+  zRemoteBranch = (const char*)sqlite3_value_text(argv[1]);
+  if( !zRemoteName || !zRemoteBranch ){
     doltliteVcResultError(ctx, db, "remote and branch required");
     return;
   }
@@ -585,7 +585,7 @@ static void doltPullFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   rc = remoteSqlOpenNamedRemote(cs, zRemoteName, &zUrl, &pRemote);
   if( remoteSqlReportOpenError(ctx, db, rc, &savedState) ) return;
 
-  rc = doltliteFetch(cs, pRemote, zRemoteName, zBranch);
+  rc = doltliteFetch(cs, pRemote, zRemoteName, zRemoteBranch);
   pRemote->xClose(pRemote);
   if( rc!=SQLITE_OK ){
     remoteSqlRestoreAndReport(ctx, db, cs, &savedState, rc,
@@ -593,36 +593,24 @@ static void doltPullFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
     return;
   }
 
-  rc = chunkStoreFindTracking(cs, zRemoteName, zBranch, &trackingCommit);
+  rc = chunkStoreFindTracking(
+      cs, zRemoteName, zRemoteBranch, &trackingCommit);
   if( rc!=SQLITE_OK || prollyHashIsEmpty(&trackingCommit) ){
     remoteSqlRestoreAndReport(ctx, db, cs, &savedState, SQLITE_ERROR,
                               "tracking branch not found after fetch");
     return;
   }
 
-  rc = chunkStoreFindBranch(cs, zBranch, &localCommit);
+  zLocalBranch = doltliteGetSessionBranch(db);
+  if( !zLocalBranch ){
+    remoteSqlRestoreAndReport(ctx, db, cs, &savedState, SQLITE_ERROR,
+                              "cannot pull in detached head");
+    return;
+  }
+  rc = chunkStoreFindBranch(cs, zLocalBranch, &localCommit);
   if( rc!=SQLITE_OK ){
-    /* Persist the new local branch under the lock; an unlocked in-memory
-    ** mutation would be clobbered or left unpersisted. */
-    DoltliteBranchExpectation exp;
-    PullAdvanceCtx adv;
-    exp.zBranch = zBranch;
-    exp.pTip = 0;
-    adv.zBranch = zBranch;
-    adv.newTip = trackingCommit;
-    adv.isCreate = 1;
-    rc = doltliteMutateRefsExpected(db, &exp, 1, mutatePullAdvance, &adv);
-    if( rc==SQLITE_BUSY ){
-      doltliteCmdResultPeerBranchBusy(ctx, "pull");
-      (void)doltliteRestoreTxnStateOnFailure(db, &savedState, rc);
-      return;
-    }
-    if( rc!=SQLITE_OK ){
-      remoteSqlRestoreAndReport(ctx, db, cs, &savedState, SQLITE_ERROR,
-                                "failed to create local branch");
-      return;
-    }
-    remoteSqlClearAndSucceed(ctx, &savedState);
+    remoteSqlRestoreAndReport(ctx, db, cs, &savedState, rc,
+                              "current branch not found after fetch");
     return;
   }
 
@@ -640,12 +628,6 @@ static void doltPullFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
     }
     if( prollyHashCompare(&ancestor, &localCommit)!=0 ){
       char *zTrackingRef;
-      if( strcmp(zBranch, doltliteGetSessionBranch(db))!=0 ){
-        remoteSqlRestoreAndReport(
-          ctx, db, cs, &savedState, SQLITE_ERROR,
-          "cannot pull non-current branch without fast-forward");
-        return;
-      }
       if( strcmp(zRemoteName, "origin")==0
        && chunkStoreOriginSourceEnabled(cs) ){
         remoteSqlRestoreAndReport(
@@ -656,7 +638,8 @@ static void doltPullFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
       }
       /* Merge owns txn save/restore; drop pull's snapshot first. */
       doltliteTxnStateClear(&savedState);
-      zTrackingRef = sqlite3_mprintf("%s/%s", zRemoteName, zBranch);
+      zTrackingRef = sqlite3_mprintf(
+          "%s/%s", zRemoteName, zRemoteBranch);
       if( !zTrackingRef ){
         sqlite3_result_error_nomem(ctx);
         return;
@@ -672,17 +655,15 @@ static void doltPullFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
     }
   }
 
-  if( strcmp(zBranch, doltliteGetSessionBranch(db))==0 ){
-    rc = doltliteHasUncommittedChanges(db, &dirty);
-    if( rc!=SQLITE_OK ){
-      remoteSqlRestoreAndReport(ctx, db, cs, &savedState, rc, 0);
-      return;
-    }
-    if( dirty ){
-      remoteSqlRestoreAndReport(ctx, db, cs, &savedState, SQLITE_ERROR,
-                                "cannot pull with uncommitted changes");
-      return;
-    }
+  rc = doltliteHasUncommittedChanges(db, &dirty);
+  if( rc!=SQLITE_OK ){
+    remoteSqlRestoreAndReport(ctx, db, cs, &savedState, rc, 0);
+    return;
+  }
+  if( dirty ){
+    remoteSqlRestoreAndReport(ctx, db, cs, &savedState, SQLITE_ERROR,
+                              "cannot pull with uncommitted changes");
+    return;
   }
 
   /* CAS-advance the branch: force-refresh under the graph lock, compare the
@@ -691,11 +672,10 @@ static void doltPullFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   {
     DoltliteBranchExpectation exp;
     PullAdvanceCtx adv;
-    exp.zBranch = zBranch;
+    exp.zBranch = zLocalBranch;
     exp.pTip = &localCommit;
-    adv.zBranch = zBranch;
+    adv.zLocalBranch = zLocalBranch;
     adv.newTip = trackingCommit;
-    adv.isCreate = 0;
     rc = doltliteMutateRefsExpected(db, &exp, 1, mutatePullAdvance, &adv);
   }
   if( rc!=SQLITE_OK ){
@@ -709,13 +689,11 @@ static void doltPullFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
     return;
   }
 
-  if( strcmp(zBranch, doltliteGetSessionBranch(db))==0 ){
-    rc = remoteSqlResetSessionToCommit(db, 0, &trackingCommit);
-    if( rc!=SQLITE_OK ){
-      remoteSqlRestoreAndReport(ctx, db, cs, &savedState, SQLITE_ERROR,
-                                "failed to update working tree from branch");
-      return;
-    }
+  rc = remoteSqlResetSessionToCommit(db, 0, &trackingCommit);
+  if( rc!=SQLITE_OK ){
+    remoteSqlRestoreAndReport(ctx, db, cs, &savedState, SQLITE_ERROR,
+                              "failed to update working tree from branch");
+    return;
   }
   doltliteTxnStateClear(&savedState);
   rc = doltliteVcSealBranchStyleTxn(db);

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -3965,8 +3965,7 @@ static void run_pull_persist_failure(void){
   removeDbFiles(remoteClientPath);
 }
 
-/* Pull of a missing local branch must create it via the atomic ref-mutation helper. */
-static void run_pull_new_branch_persists(void){
+static void run_pull_remote_branch_updates_current(void){
   sqlite3 *localDb = 0;
   sqlite3 *remoteDb = 0;
   sqlite3 *remoteClientDb = 0;
@@ -3976,11 +3975,11 @@ static void run_pull_new_branch_persists(void){
   char sql[1024];
   const char *res;
 
-  printf("=== Pull New Branch Persists Test ===\n\n");
-  make_dbpath(localPath, sizeof(localPath), "test_pull_new_branch_local");
-  make_dbpath(remotePath, sizeof(remotePath), "test_pull_new_branch_remote");
+  printf("=== Pull Remote Branch Updates Current Test ===\n\n");
+  make_dbpath(localPath, sizeof(localPath), "test_pull_remote_branch_local");
+  make_dbpath(remotePath, sizeof(remotePath), "test_pull_remote_branch_remote");
   make_dbpath(remoteClientPath, sizeof(remoteClientPath),
-              "test_pull_new_branch_client");
+              "test_pull_remote_branch_client");
   removeDbFiles(localPath);
   removeDbFiles(remotePath);
   removeDbFiles(remoteClientPath);
@@ -4010,21 +4009,23 @@ static void run_pull_new_branch_persists(void){
     "SELECT dolt_push('origin','feature');")==SQLITE_OK);
 
   res = queryScalarText(localDb, "SELECT dolt_pull('origin','feature')");
-  check("pull_new_branch_succeeds", strstr(res, "ERROR:")==0);
-  check("pulled_branch_visible_in_session",
+  check("pull_remote_branch_succeeds", strstr(res, "ERROR:")==0);
+  check("pull_remote_branch_keeps_main_active",
+    strcmp(queryScalarText(localDb, "SELECT active_branch()"), "main")==0);
+  check("pull_remote_branch_updates_current_rows",
+    strcmp(queryScalarText(localDb, "SELECT count(*) FROM t"), "2")==0);
+  check("pull_remote_branch_does_not_create_local_namesake",
     strcmp(queryScalarText(localDb,
-      "SELECT count(*) FROM dolt_branches WHERE name='feature'"), "1")==0);
+      "SELECT count(*) FROM dolt_branches WHERE name='feature'"), "0")==0);
 
   sqlite3_close(localDb);
   localDb = 0;
   check("reopen_local_after_pull", open_db(localPath, &localDb)==SQLITE_OK);
-  check("pulled_branch_persisted_across_reopen",
-    strcmp(queryScalarText(localDb,
-      "SELECT count(*) FROM dolt_branches WHERE name='feature'"), "1")==0);
-  check("pulled_branch_checkout_works", execSql(localDb,
-    "SELECT dolt_checkout('feature')")==SQLITE_OK);
-  check("pulled_branch_rows_present",
+  check("pulled_current_branch_persisted_across_reopen",
     strcmp(queryScalarText(localDb, "SELECT count(*) FROM t"), "2")==0);
+  check("pulled_remote_branch_still_not_local_after_reopen",
+    strcmp(queryScalarText(localDb,
+      "SELECT count(*) FROM dolt_branches WHERE name='feature'"), "0")==0);
 
   sqlite3_close(remoteClientDb);
   sqlite3_close(remoteDb);
@@ -14155,7 +14156,9 @@ static const RegressionCase aCases[] = {
   { "ancestor_criss_cross_single_walk", "Ancestor Criss-Cross Single Walk Test", run_ancestor_criss_cross_single_walk },
   { "pull_persist_failure", "Pull Persist Failure Test", run_pull_persist_failure },
   { "push_persist_failure", "Push Persist Failure Test", run_push_persist_failure },
-  { "pull_new_branch_persists", "Pull New Branch Persists Test", run_pull_new_branch_persists },
+  { "pull_remote_branch_updates_current",
+    "Pull Remote Branch Updates Current Test",
+    run_pull_remote_branch_updates_current },
   { "pull_dirty_working_set_fails", "Pull Dirty Working Set Fails Test", run_pull_dirty_working_set_fails },
   { "pull_staged_changes_fails", "Pull Staged Changes Fails Test", run_pull_staged_changes_fails },
   { "push_persist_failure", "Push Persist Failure Test", run_push_persist_failure },

--- a/test/remote_test.sh
+++ b/test/remote_test.sh
@@ -221,6 +221,19 @@ clone_head=$("$DB" "$TMPDIR/clone.db" "SELECT commit_hash FROM dolt_log LIMIT 1;
 result=$("$DB" "$TMPDIR/remote.db" "SELECT commit_hash FROM dolt_log LIMIT 1;")
 check "remote head matches clone push" "$clone_head" "$result"
 
+"$DB" "$TMPDIR/src.db" "SELECT dolt_fetch('origin','main');" >/dev/null
+detached_head=$("$DB" "$TMPDIR/src.db" "SELECT dolt_hashof('HEAD');")
+result=$("$DB" "$TMPDIR/src.db@$detached_head" \
+  "SELECT dolt_pull('origin','main');" 2>&1)
+check_match "pull from detached head reports detached session" \
+  "detached head" "$result"
+result=$("$DB" "$TMPDIR/src.db@$detached_head" \
+  "SELECT IFNULL(active_branch(),'NULL'); SELECT count(*) FROM users;")
+check "failed detached pull preserves snapshot" "NULL
+3" "$result"
+result=$("$DB" "$TMPDIR/src.db" "SELECT dolt_hashof('HEAD');")
+check "failed detached pull preserves main ref" "$detached_head" "$result"
+
 echo "=== 5. Fetch ==="
 result=$("$DB" "$TMPDIR/src.db" "SELECT dolt_fetch('origin','main');")
 check "fetch returns 0" "0" "$result"

--- a/test/vc_oracle_connection_branch_test.sh
+++ b/test/vc_oracle_connection_branch_test.sh
@@ -255,6 +255,58 @@ oracle_detached_command_success() {
   fi
 }
 
+oracle_detached_pull_error() {
+  local name="$1"
+  local dir="$TMPROOT/$name"
+  local parent repo_name dl_rc dt_rc dl_out dt_out
+
+  setup_pair "$dir"
+  run_dl "$dir/dl/remote.sqlite" \
+    "SELECT dolt_clone('file://$dir/dl/db.sqlite');" >/dev/null
+  run_dl "$dir/dl/db.sqlite" \
+    "SELECT dolt_remote('add','origin','file://$dir/dl/remote.sqlite');" \
+    >/dev/null
+  (
+    cd "$dir" || exit 1
+    "$DOLT" clone "file://$dir/dt" dt_remote >/dev/null 2>&1
+    cd "$dir/dt" || exit 1
+    printf "%s\n" \
+      "CALL dolt_remote('add','origin','file://$dir/dt_remote');" \
+      | "$DOLT" sql -c >/dev/null
+  )
+
+  run_dl "$dir/dl/db.sqlite/v1" "SELECT dolt_pull('origin','main');" \
+    >"$dir/dl.out" 2>"$dir/dl.err"
+  dl_rc=$?
+  parent=$(dirname "$dir/dt")
+  repo_name=$(basename "$dir/dt")
+  (
+    cd "$parent" || exit 1
+    printf "%s\n" "CALL dolt_pull('origin','main');" \
+      | "$DOLT" --use-db "$repo_name/v1" sql \
+          >"$dir/dt.out" 2>"$dir/dt.err"
+  )
+  dt_rc=$?
+
+  if vc_oracle_is_clean_error "$dl_rc" && vc_oracle_is_clean_error "$dt_rc"; then
+    pass=$((pass+1))
+  else
+    fail=$((fail+1))
+    FAILED_NAMES="$FAILED_NAMES $name"
+    echo "  FAIL: $name (expected both to error)"
+    echo "    doltlite rc: $dl_rc"
+    echo "    dolt rc:     $dt_rc"
+  fi
+
+  dl_out=$(run_dl "$dir/dl/db.sqlite/v1" \
+    "SELECT IFNULL(active_branch(),'NULL') || ':' || COUNT(*) FROM t;" \
+    2>>"$dir/dl.err" | tr -d '\r')
+  dt_out=$(run_dt "$dir/dt" "v1" \
+    "SELECT CONCAT(IFNULL(active_branch(),'NULL'),':',COUNT(*)) FROM t;" \
+    2>>"$dir/dt.err")
+  vc_oracle_assert_match "${name}_preserves_snapshot" "$dl_out" "$dt_out"
+}
+
 echo "=== Oracle Tests: Connection Branch Selection ==="
 echo ""
 
@@ -342,6 +394,7 @@ oracle_detached_command_error "detached_reset_is_rejected" \
   "SELECT dolt_reset('--hard');" "CALL dolt_reset('--hard');"
 oracle_detached_command_error "detached_merge_is_rejected" \
   "SELECT dolt_merge('main');" "CALL dolt_merge('main');"
+oracle_detached_pull_error "detached_pull_is_rejected"
 oracle_detached_command_error "checkout_tag_does_not_detach" \
   "SELECT dolt_checkout('v1');" "CALL dolt_checkout('v1');"
 oracle_error "attached_checkout_tag_does_not_detach" "" \

--- a/test/vc_oracle_fetch_pull_convergence_test.sh
+++ b/test/vc_oracle_fetch_pull_convergence_test.sh
@@ -122,6 +122,68 @@ remote_flow "nonmain_fetch_track_contents" "$NONMAIN_SEED" "$NONMAIN_ADVANCE" \
   "SELECT 'R|'||active_branch()||'|'||id||'|'||v FROM t;" \
   "SELECT CONCAT('R|',active_branch(),'|',id,'|',v) FROM t;"
 
+echo "--- pull remote branch into current branch ---"
+REMOTE_REF_SEED="
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1,'base');
+SELECT dolt_commit('-A','-m','base');
+SELECT dolt_remote('add','origin','@REMOTE@');
+SELECT dolt_push('origin','main');
+"
+REMOTE_REF_ADVANCE="
+SELECT dolt_checkout('-b','other');
+INSERT INTO t VALUES (2,'remote-other');
+SELECT dolt_commit('-A','-m','remote other');
+SELECT dolt_push('origin','other');
+"
+remote_flow "pull_remote_ref_without_local_branch" \
+  "$REMOTE_REF_SEED" "$REMOTE_REF_ADVANCE" \
+  "SELECT dolt_pull('origin','other');" \
+  "SELECT 'R|active|'||active_branch();
+   SELECT 'R|rows|'||group_concat(id||':'||v, ',') FROM (SELECT id,v FROM t ORDER BY id);
+   SELECT 'R|local-other|'||count(*) FROM dolt_branches WHERE name='other';" \
+  "SELECT CONCAT('R|active|',active_branch());
+   SELECT CONCAT('R|rows|',group_concat(CONCAT(id,':',v) ORDER BY id SEPARATOR ',')) FROM t;
+   SELECT CONCAT('R|local-other|',count(*)) FROM dolt_branches WHERE name='other';"
+
+remote_flow "pull_remote_ref_leaves_divergent_local_namesake" \
+  "$REMOTE_REF_SEED" "$REMOTE_REF_ADVANCE" \
+  "SELECT dolt_branch('other');
+   SELECT dolt_checkout('other');
+   INSERT INTO t VALUES (3,'local-other');
+   SELECT dolt_commit('-A','-m','local other');
+   SELECT dolt_checkout('main');
+   SELECT dolt_pull('origin','other');" \
+  "SELECT 'R|active|'||active_branch();
+   SELECT 'R|main|'||group_concat(id||':'||v, ',') FROM (SELECT id,v FROM t ORDER BY id);
+   SELECT 'R|other|'||group_concat(id||':'||v, ',') FROM (SELECT id,v FROM dolt_at_t WHERE commit_ref='other' ORDER BY id);" \
+  "SELECT CONCAT('R|active|',active_branch());
+   SELECT CONCAT('R|main|',group_concat(CONCAT(id,':',v) ORDER BY id SEPARATOR ',')) FROM t;
+   SELECT CONCAT('R|other|',group_concat(CONCAT(id,':',v) ORDER BY id SEPARATOR ',')) FROM t AS OF 'other';"
+
+remote_flow "pull_remote_ref_merges_into_divergent_current" \
+  "$REMOTE_REF_SEED" "$REMOTE_REF_ADVANCE" \
+  "INSERT INTO t VALUES (3,'local-main');
+   SELECT dolt_commit('-A','-m','local main');
+   SELECT dolt_pull('origin','other');" \
+  "SELECT 'R|active|'||active_branch();
+   SELECT 'R|rows|'||group_concat(id||':'||v, ',') FROM (SELECT id,v FROM t ORDER BY id);
+   SELECT 'R|local-other|'||count(*) FROM dolt_branches WHERE name='other';" \
+  "SELECT CONCAT('R|active|',active_branch());
+   SELECT CONCAT('R|rows|',group_concat(CONCAT(id,':',v) ORDER BY id SEPARATOR ',')) FROM t;
+   SELECT CONCAT('R|local-other|',count(*)) FROM dolt_branches WHERE name='other';"
+
+remote_flow "pull_remote_ref_dirty_current_fails_without_local_branch" \
+  "$REMOTE_REF_SEED" "$REMOTE_REF_ADVANCE" \
+  "INSERT INTO t VALUES (3,'dirty-main');
+   SELECT dolt_pull('origin','other');" \
+  "SELECT 'R|active|'||active_branch();
+   SELECT 'R|rows|'||group_concat(id||':'||v, ',') FROM (SELECT id,v FROM t ORDER BY id);
+   SELECT 'R|local-other|'||count(*) FROM dolt_branches WHERE name='other';" \
+  "SELECT CONCAT('R|active|',active_branch());
+   SELECT CONCAT('R|rows|',group_concat(CONCAT(id,':',v) ORDER BY id SEPARATOR ',')) FROM t;
+   SELECT CONCAT('R|local-other|',count(*)) FROM dolt_branches WHERE name='other';"
+
 echo "--- divergent pull from refreshed remote tracking branch ---"
 TOPIC_SEED="
 CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);


### PR DESCRIPTION
## Summary

- treat `dolt_pull(remote, branch)` branch argument as the remote ref to integrate
- fast-forward or merge that remote ref into the active local branch
- leave any same-named local branch untouched and do not create one when absent
- reject detached-session pulls before fetch or ref mutation
- retain the expected-tip CAS when advancing the active branch
- document both the corrected pull semantics and remote-tag propagation

## Oracle coverage

Added Dolt comparisons covering:

- fast-forward from a remote branch with no local namesake
- a divergent same-named local branch that must remain untouched
- a divergent current branch requiring a clean merge
- dirty-current-branch failure without accidental local branch creation
- detached pull rejection with a valid remote and unchanged snapshot

The original pull-branch cases fail 4 comparisons on the unfixed engine and pass all 33 after the fix. The detached boundary adds two passing Dolt comparisons, alongside a fail-before native error-message and state regression.

## Validation

- `bash test/vc_oracle_fetch_pull_convergence_test.sh build/doltlite dolt` — 33 passed
- `bash test/vc_oracle_connection_branch_test.sh build/doltlite dolt` — 31 passed
- `bash test/run_doltlite_tests.sh build/doltlite` — 126 suites passed, including 311,208 C regression assertions
- `bash test/remote_test.sh build/doltlite` — 160 passed
- targeted pull durability, dirty-working-set, and staged-change C cases — 48 passed
- `make lint`

Fixes #2617

Co-Authored-By: OpenAI Codex <noreply@openai.com>