### PR TITLE
Hash indexes, and show an index change on its table

### DIFF
--- a/README.md
+++ b/README.md
@@ -621,9 +621,13 @@ SELECT dolt_merge_base('abc123...', 'def456...');
 SELECT dolt_hashof('main');
 SELECT dolt_hashof('HEAD~2');
 
--- Table root (one-arg form includes uncommitted working edits)
+-- Table root and its indexes (one-arg form includes uncommitted working edits)
 SELECT dolt_hashof_table('users');
 SELECT dolt_hashof_table('users', 'main');
+
+-- One index on its own
+SELECT dolt_hashof_index('users_by_email');
+SELECT dolt_hashof_index('users_by_email', 'main');
 
 -- Whole catalog (moves when any table root or membership changes)
 SELECT dolt_hashof_db();
@@ -633,6 +637,14 @@ SELECT dolt_hashof_db('HEAD');
 Results are 40-char lowercase hex. `_table` / `_db` are history-independent:
 identical `(key, value)` sets hash the same regardless of insert order or
 branch. Property tests: `test/vc_oracle_hashof_test.sh`.
+
+An index is part of the table it indexes. `dolt_hashof_index` hashes one
+index, `dolt_hashof_table` folds in every index of that table, and a change to
+an index shows in `dolt_status` as a modification of the table it belongs to,
+never as a row of its own. `REINDEX` rewrites what the rows imply, so on a
+database whose indexes match its rows it changes no hash and leaves
+`dolt_status` clean; a hash that moves across `REINDEX` means the stored index
+did not match its rows.
 
 #### Garbage Collection
 

--- a/src/doltlite_hashof.c
+++ b/src/doltlite_hashof.c
@@ -991,16 +991,16 @@ int doltliteHashofRegister(sqlite3 *db){
                                  doltliteHashofCatalogFunc, 0, 0);
   }
   if( rc==SQLITE_OK ){
-    if( rc==SQLITE_OK ){
+    rc = sqlite3_create_function(db, "dolt_hashof_catalog", 1, SQLITE_UTF8, 0,
+                                 doltliteHashofCatalogFunc, 0, 0);
+  }
+  if( rc==SQLITE_OK ){
     rc = sqlite3_create_function(db, "dolt_hashof_index", 1, SQLITE_UTF8, 0,
                                  doltliteHashofIndexFunc, 0, 0);
   }
   if( rc==SQLITE_OK ){
     rc = sqlite3_create_function(db, "dolt_hashof_index", 2, SQLITE_UTF8, 0,
                                  doltliteHashofIndexFunc, 0, 0);
-  }
-  rc = sqlite3_create_function(db, "dolt_hashof_catalog", 1, SQLITE_UTF8, 0,
-                                 doltliteHashofCatalogFunc, 0, 0);
   }
   return rc;
 }

--- a/src/doltlite_hashof.c
+++ b/src/doltlite_hashof.c
@@ -46,6 +46,161 @@ static void doltliteHashofFunc(sqlite3_context *ctx, int argc, sqlite3_value **a
   sqlite3_result_text(ctx, hex, PROLLY_HASH_SIZE*2, SQLITE_TRANSIENT);
 }
 
+/* An index is part of the table it indexes: its root belongs in that table's
+** hash, and the index gets a hash of its own so a rebuild can be compared
+** without a constraint to walk it. Index catalog entries carry no name, so a
+** name resolves through the schema row's root page. */
+static int hashofIndexRootByName(
+  sqlite3 *db,
+  const ProllyHash *pCatHash,
+  const char *zIndex,
+  ProllyHash *pRoot,
+  ProllyHash *pSchemaHash,
+  char **pzTable
+){
+  ChunkStore *cs = doltliteGetChunkStore(db);
+  ProllyCache *cache = doltliteGetCache(db);
+  SchemaEntry *aSchema = 0;
+  struct TableEntry *aTables = 0;
+  int nSchema = 0, nTables = 0;
+  int rc, i;
+  int found = 0;
+  Pgno iRoot = 0;
+  char *zSql = 0;
+  char *zTable = 0;
+
+  if( pzTable ) *pzTable = 0;
+  if( !cs || !cache ) return SQLITE_ERROR;
+  rc = loadSchemaFromCatalog(db, cs, cache, pCatHash, &aSchema, &nSchema);
+  if( rc!=SQLITE_OK ) return rc;
+  for(i=0; i<nSchema; i++){
+    if( !aSchema[i].zName || !aSchema[i].zType ) continue;
+    if( sqlite3_stricmp(aSchema[i].zType, "index")!=0 ) continue;
+    if( sqlite3_stricmp(aSchema[i].zName, zIndex)!=0 ) continue;
+    iRoot = aSchema[i].iRootpage;
+    zSql = aSchema[i].zSql ? sqlite3_mprintf("%s", aSchema[i].zSql) : 0;
+    zTable = aSchema[i].zTblName ? sqlite3_mprintf("%s", aSchema[i].zTblName) : 0;
+    found = 1;
+    break;
+  }
+  freeSchemaEntries(aSchema, nSchema);
+  if( !found ) return SQLITE_NOTFOUND;
+
+  rc = doltliteLoadCatalog(db, pCatHash, &aTables, &nTables, 0);
+  if( rc!=SQLITE_OK ){
+    sqlite3_free(zSql);
+    sqlite3_free(zTable);
+    return rc;
+  }
+  memset(pRoot, 0, sizeof(*pRoot));
+  memset(pSchemaHash, 0, sizeof(*pSchemaHash));
+  found = 0;
+  for(i=0; i<nTables; i++){
+    if( aTables[i].iTable==iRoot ){
+      memcpy(pRoot, &aTables[i].root, sizeof(ProllyHash));
+      found = 1;
+      break;
+    }
+  }
+  doltliteFreeCatalog(aTables, nTables);
+  if( zSql ){
+    char *zCanon = doltliteCanonicalizeSchemaSql(zSql, zIndex);
+    if( zCanon ){
+      prollyHashCompute(zCanon, (int)strlen(zCanon), pSchemaHash);
+      sqlite3_free(zCanon);
+    }
+    sqlite3_free(zSql);
+  }
+  if( !found ){
+    sqlite3_free(zTable);
+    return SQLITE_NOTFOUND;
+  }
+  if( pzTable ){
+    *pzTable = zTable;
+  }else{
+    sqlite3_free(zTable);
+  }
+  return SQLITE_OK;
+}
+
+static int hashofIndexInCatalog(
+  sqlite3 *db,
+  const ProllyHash *pCatHash,
+  const char *zIndex,
+  char *pHex
+){
+  ProllyHash root, schemaHash, h;
+  u8 aBuf[PROLLY_HASH_SIZE*2];
+  int rc = hashofIndexRootByName(db, pCatHash, zIndex, &root, &schemaHash, 0);
+  if( rc!=SQLITE_OK ) return rc;
+  memcpy(aBuf, root.data, PROLLY_HASH_SIZE);
+  memcpy(aBuf + PROLLY_HASH_SIZE, schemaHash.data, PROLLY_HASH_SIZE);
+  prollyHashCompute(aBuf, sizeof(aBuf), &h);
+  doltliteHashToHex(&h, pHex);
+  return SQLITE_OK;
+}
+
+/* Fold every index of one table into a running hash, ordered by index name so
+** the result does not depend on catalog order. */
+static int hashofFoldTableIndexes(
+  sqlite3 *db,
+  const ProllyHash *pCatHash,
+  const char *zTable,
+  sqlite3_str *pStr
+){
+  ChunkStore *cs = doltliteGetChunkStore(db);
+  ProllyCache *cache = doltliteGetCache(db);
+  SchemaEntry *aSchema = 0;
+  int nSchema = 0;
+  char **azIndex = 0;
+  int nIndex = 0;
+  int rc, i, j;
+
+  if( !cs || !cache ) return SQLITE_ERROR;
+  rc = loadSchemaFromCatalog(db, cs, cache, pCatHash, &aSchema, &nSchema);
+  if( rc!=SQLITE_OK ) return rc;
+  for(i=0; i<nSchema; i++){
+    if( !aSchema[i].zName || !aSchema[i].zType || !aSchema[i].zTblName ) continue;
+    if( sqlite3_stricmp(aSchema[i].zType, "index")!=0 ) continue;
+    if( sqlite3_stricmp(aSchema[i].zTblName, zTable)!=0 ) continue;
+    azIndex = sqlite3_realloc64(azIndex, (sqlite3_uint64)(nIndex+1) * sizeof(char*));
+    if( !azIndex ){
+      freeSchemaEntries(aSchema, nSchema);
+      return SQLITE_NOMEM;
+    }
+    azIndex[nIndex] = sqlite3_mprintf("%s", aSchema[i].zName);
+    if( !azIndex[nIndex] ){
+      freeSchemaEntries(aSchema, nSchema);
+      for(j=0; j<nIndex; j++) sqlite3_free(azIndex[j]);
+      sqlite3_free(azIndex);
+      return SQLITE_NOMEM;
+    }
+    nIndex++;
+  }
+  freeSchemaEntries(aSchema, nSchema);
+
+  for(i=1; i<nIndex; i++){
+    char *zTmp = azIndex[i];
+    for(j=i; j>0 && strcmp(azIndex[j-1], zTmp)>0; j--) azIndex[j] = azIndex[j-1];
+    azIndex[j] = zTmp;
+  }
+
+  for(i=0; i<nIndex && rc==SQLITE_OK; i++){
+    char zIdxHex[PROLLY_HASH_SIZE*2+1];
+    rc = hashofIndexInCatalog(db, pCatHash, azIndex[i], zIdxHex);
+    if( rc==SQLITE_NOTFOUND ){
+      /* A schema row whose entry is gone contributes nothing. */
+      rc = SQLITE_OK;
+      continue;
+    }
+    if( rc!=SQLITE_OK ) break;
+    sqlite3_str_appendf(pStr, "|%s=%s", azIndex[i], zIdxHex);
+  }
+  for(i=0; i<nIndex; i++) sqlite3_free(azIndex[i]);
+  sqlite3_free(azIndex);
+  return rc;
+}
+
 static int hashofTableInCatalog(
   sqlite3 *db,
   const ProllyHash *pCatHash,
@@ -86,10 +241,43 @@ static int hashofTableInCatalog(
     sqlite3_free(zCanon);
   }
 
-  memcpy(aBuf, tableRoot.data, PROLLY_HASH_SIZE);
-  memcpy(aBuf + PROLLY_HASH_SIZE, schemaHash.data, PROLLY_HASH_SIZE);
-  prollyHashCompute(aBuf, sizeof(aBuf), &tableHash);
   clearSchemaEntry(&schemaEntry);
+
+  /* An index is part of the table's content, so its root belongs here. A table
+  ** without indexes keeps the original root-and-schema hash, so recorded
+  ** hashes stay valid where there is nothing new to fold in. Indexes fold in
+  ** by name, as hex: a hash byte may be zero and would truncate a raw
+  ** preimage. */
+  {
+    sqlite3_str *pStr = sqlite3_str_new(0);
+    char *zFold;
+    if( !pStr ) return SQLITE_NOMEM;
+    rc = hashofFoldTableIndexes(db, pCatHash, zTable, pStr);
+    zFold = sqlite3_str_finish(pStr);
+    if( rc!=SQLITE_OK ){
+      sqlite3_free(zFold);
+      return rc;
+    }
+    memcpy(aBuf, tableRoot.data, PROLLY_HASH_SIZE);
+    memcpy(aBuf + PROLLY_HASH_SIZE, schemaHash.data, PROLLY_HASH_SIZE);
+    if( !zFold || !zFold[0] ){
+      prollyHashCompute(aBuf, sizeof(aBuf), &tableHash);
+    }else{
+      char zRootHex[PROLLY_HASH_SIZE*2+1];
+      char zSchemaHex[PROLLY_HASH_SIZE*2+1];
+      char *zAll;
+      doltliteHashToHex(&tableRoot, zRootHex);
+      doltliteHashToHex(&schemaHash, zSchemaHex);
+      zAll = sqlite3_mprintf("%s|%s%s", zRootHex, zSchemaHex, zFold);
+      if( !zAll ){
+        sqlite3_free(zFold);
+        return SQLITE_NOMEM;
+      }
+      prollyHashCompute(zAll, (int)strlen(zAll), &tableHash);
+      sqlite3_free(zAll);
+    }
+    sqlite3_free(zFold);
+  }
   doltliteHashToHex(&tableHash, pHex);
   return SQLITE_OK;
 }
@@ -708,6 +896,50 @@ static void doltliteHashofDbFunc(sqlite3_context *ctx, int argc, sqlite3_value *
   sqlite3_result_text(ctx, hex, PROLLY_HASH_SIZE*2, SQLITE_TRANSIENT);
 }
 
+static void doltliteHashofIndexFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
+  sqlite3 *db;
+  const char *zIndex;
+  ProllyHash catHash;
+  char hex[PROLLY_HASH_SIZE*2+1];
+  int rc;
+
+  if( argc!=1 && argc!=2 ){
+    sqlite3_result_error(ctx, "dolt_hashof_index() takes 1 or 2 arguments", -1);
+    return;
+  }
+  if( sqlite3_value_type(argv[0])==SQLITE_NULL ){
+    sqlite3_result_null(ctx);
+    return;
+  }
+  zIndex = (const char*)sqlite3_value_text(argv[0]);
+  if( !zIndex || !*zIndex ){
+    sqlite3_result_error(ctx, "dolt_hashof_index: index not found", -1);
+    return;
+  }
+  db = sqlite3_context_db_handle(ctx);
+
+  if( argc==1 ){
+    rc = doltliteFlushCatalogToHash(db, &catHash);
+    if( rc!=SQLITE_OK ){
+      sqlite3_result_error(ctx, "dolt_hashof_index: catalog flush failed", -1);
+      return;
+    }
+  }else{
+    if( hashofResolveRefCatalog(ctx, db, argv[1], "dolt_hashof_index", &catHash) ) return;
+  }
+
+  rc = hashofIndexInCatalog(db, &catHash, zIndex, hex);
+  if( rc==SQLITE_NOTFOUND ){
+    sqlite3_result_error(ctx, "dolt_hashof_index: index not found", -1);
+    return;
+  }
+  if( rc!=SQLITE_OK ){
+    sqlite3_result_error(ctx, "dolt_hashof_index: index not found in catalog", -1);
+    return;
+  }
+  sqlite3_result_text(ctx, hex, PROLLY_HASH_SIZE*2, SQLITE_TRANSIENT);
+}
+
 static void doltliteHashofCatalogFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   sqlite3 *db;
   ProllyHash catHash;
@@ -759,7 +991,15 @@ int doltliteHashofRegister(sqlite3 *db){
                                  doltliteHashofCatalogFunc, 0, 0);
   }
   if( rc==SQLITE_OK ){
-    rc = sqlite3_create_function(db, "dolt_hashof_catalog", 1, SQLITE_UTF8, 0,
+    if( rc==SQLITE_OK ){
+    rc = sqlite3_create_function(db, "dolt_hashof_index", 1, SQLITE_UTF8, 0,
+                                 doltliteHashofIndexFunc, 0, 0);
+  }
+  if( rc==SQLITE_OK ){
+    rc = sqlite3_create_function(db, "dolt_hashof_index", 2, SQLITE_UTF8, 0,
+                                 doltliteHashofIndexFunc, 0, 0);
+  }
+  rc = sqlite3_create_function(db, "dolt_hashof_catalog", 1, SQLITE_UTF8, 0,
                                  doltliteHashofCatalogFunc, 0, 0);
   }
   return rc;

--- a/src/doltlite_status.c
+++ b/src/doltlite_status.c
@@ -414,6 +414,65 @@ static int statusIndexNameSetsMatch(
   return nACount==nBCount;
 }
 
+/* An index root is part of its table's content, so a rebuilt or diverging
+** index reads as the parent table being modified. Index catalog entries carry
+** no name; the schema row's root page pairs a name with its entry. */
+static int statusIndexRootFor(
+  SchemaEntry *aSchema, int nSchema,
+  struct TableEntry *aEnt, int nEnt,
+  const char *zTable, const char *zIndex,
+  ProllyHash *pOut,
+  int *pFound
+){
+  int i, j;
+  *pFound = 0;
+  memset(pOut, 0, sizeof(*pOut));
+  for(i=0; i<nSchema; i++){
+    if( !aSchema[i].zType || strcmp(aSchema[i].zType, "index")!=0 ) continue;
+    if( !aSchema[i].zTblName || strcmp(aSchema[i].zTblName, zTable)!=0 ) continue;
+    if( !aSchema[i].zName || strcmp(aSchema[i].zName, zIndex)!=0 ) continue;
+    for(j=0; j<nEnt; j++){
+      if( aEnt[j].iTable==aSchema[i].iRootpage ){
+        memcpy(pOut, &aEnt[j].root, sizeof(ProllyHash));
+        *pFound = 1;
+        return 1;
+      }
+    }
+    return 1;
+  }
+  return 0;
+}
+
+static int statusIndexRootsDifferForTable(
+  SchemaEntry *aFrom, int nFrom,
+  struct TableEntry *aFromEnt, int nFromEnt,
+  const char *zTblFrom,
+  SchemaEntry *aTo, int nTo,
+  struct TableEntry *aToEnt, int nToEnt,
+  const char *zTblTo
+){
+  int i;
+  for(i=0; i<nFrom; i++){
+    ProllyHash fromRoot, toRoot;
+    int haveFrom = 0, haveTo = 0;
+    if( !aFrom[i].zType || strcmp(aFrom[i].zType, "index")!=0 ) continue;
+    if( !aFrom[i].zTblName || strcmp(aFrom[i].zTblName, zTblFrom)!=0 ) continue;
+    if( !aFrom[i].zName ) continue;
+    if( !statusIndexRootFor(aFrom, nFrom, aFromEnt, nFromEnt,
+                            zTblFrom, aFrom[i].zName, &fromRoot, &haveFrom) ){
+      continue;
+    }
+    if( !statusIndexRootFor(aTo, nTo, aToEnt, nToEnt,
+                            zTblTo, aFrom[i].zName, &toRoot, &haveTo) ){
+      /* The index itself came or went; the name-set check owns that. */
+      continue;
+    }
+    if( !haveFrom || !haveTo ) continue;
+    if( prollyHashCompare(&fromRoot, &toRoot)!=0 ) return 1;
+  }
+  return 0;
+}
+
 static int statusCompareIndexSchemaObjects(
   DoltliteStatusCursor *pCur,
   sqlite3 *db,
@@ -493,7 +552,11 @@ static int statusCompareIndexSchemaObjects(
       }
     }
     if( doltliteIndexSchemaRowsDifferForTable(aFrom, nFrom, aTo, nTo,
-                                              pRow->zTblName) ){
+                                              pRow->zTblName)
+     || statusIndexRootsDifferForTable(aFrom, nFrom, aFromEnt, nFromEnt,
+                                       pRow->zTblName,
+                                       aTo, nTo, aToEnt, nToEnt,
+                                       pRow->zTblName) ){
       rc = statusMaybeAddParentSchemaChange(pCur, pRow->zTblName,
                                             staged, zFilter);
       if( rc!=SQLITE_OK ) goto index_schema_done;

--- a/test/doltlite_hashof_refs.sh
+++ b/test/doltlite_hashof_refs.sh
@@ -78,4 +78,61 @@ run_test_match "hashof_staged_still_errors" \
   "invalid ref spec" \
   "$DB"
 
+DBI=/tmp/test_hashof_index_$$.db; rm -f "$DBI"
+$DOLTLITE "$DBI" > /dev/null 2>&1 <<'SQL'
+CREATE TABLE child(id INTEGER PRIMARY KEY, parent_id INTEGER, grp INTEGER NOT NULL, name TEXT NOT NULL);
+CREATE INDEX child_grp ON child(grp);
+CREATE UNIQUE INDEX child_with_parent ON child(grp, parent_id, name) WHERE parent_id IS NOT NULL;
+INSERT INTO child VALUES(1, NULL, 1, 'a'), (2, 3, 1, 'b');
+SELECT dolt_commit('-Am','seed');
+SQL
+
+run_test_match "hashof_index_is_hex" \
+  "SELECT dolt_hashof_index('child_grp');" \
+  "^[0-9a-f]{40}$" "$DBI"
+run_test "hashof_index_is_stable" \
+  "SELECT dolt_hashof_index('child_grp') = dolt_hashof_index('child_grp');" \
+  "1" "$DBI"
+run_test "hashof_index_distinguishes_indexes" \
+  "SELECT dolt_hashof_index('child_grp') <> dolt_hashof_index('child_with_parent');" \
+  "1" "$DBI"
+run_test "hashof_index_accepts_a_ref" \
+  "SELECT dolt_hashof_index('child_grp') = dolt_hashof_index('child_grp','HEAD');" \
+  "1" "$DBI"
+run_test_match "hashof_index_unknown_name_errors" \
+  "SELECT dolt_hashof_index('nope');" \
+  "index not found" "$DBI"
+run_test "hashof_index_null_is_null" \
+  "SELECT coalesce(dolt_hashof_index(NULL),'NULL');" \
+  "NULL" "$DBI"
+HASHES_BEFORE_REINDEX=$($DOLTLITE "$DBI" \
+  "SELECT dolt_hashof_index('child_grp') || dolt_hashof_table('child') || dolt_hashof_db();" \
+  2>/dev/null)
+run_test "reindex_changes_no_hash" \
+  "REINDEX; SELECT dolt_hashof_index('child_grp') || dolt_hashof_table('child') || dolt_hashof_db();" \
+  "$HASHES_BEFORE_REINDEX" "$DBI"
+run_test "reindex_leaves_status_clean" \
+  "REINDEX; SELECT count(*) FROM dolt_status;" \
+  "0" "$DBI"
+
+echo "INSERT INTO child VALUES(9, 3, 1, 'z');" | $DOLTLITE "$DBI" > /dev/null 2>&1
+run_test "uncommitted_index_write_moves_index_hash" \
+  "SELECT dolt_hashof_index('child_with_parent') <> dolt_hashof_index('child_with_parent','HEAD');" \
+  "1" "$DBI"
+run_test "uncommitted_index_write_moves_table_hash" \
+  "SELECT dolt_hashof_table('child') <> dolt_hashof_table('child','HEAD');" \
+  "1" "$DBI"
+
+DBJ=/tmp/test_hashof_index2_$$.db; rm -f "$DBJ"
+$DOLTLITE "$DBJ" > /dev/null 2>&1 <<'SQL'
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'a');
+SELECT dolt_commit('-Am','seed');
+SQL
+run_test "table_without_indexes_keeps_root_schema_hash" \
+  "SELECT dolt_hashof_table('t') = dolt_hashof_table('t','HEAD');" \
+  "1" "$DBJ"
+
+rm -f "$DBI" "$DBJ"
+
 dltest_finish

--- a/test/vc_stateful_fuzzer.py
+++ b/test/vc_stateful_fuzzer.py
@@ -419,18 +419,46 @@ def assert_shadow_tables_consistent(doltlite, db_path, branch):
         )
 
 
+INDEX_NAMES = ("child_grp", "child_with_parent", "child_without_parent")
+
+
+def index_fingerprint(doltlite, db_path, branch):
+    """Hash of every index, the table that owns them, and the database."""
+    parts = ["dolt_hashof_index(%s)" % sql_quote(name) for name in INDEX_NAMES]
+    parts.append("dolt_hashof_table('child')")
+    parts.append("dolt_hashof_db()")
+    sql = "SELECT %s;" % " || '|' || ".join(parts)
+    return query_scalar(doltlite, db_path, branch, sql, "index_fingerprint")
+
+
 def assert_reindex_preserves_answers(doltlite, db_path, branch):
-    """Rebuilding every index must not change a single answer."""
+    """Rebuilding an index that is already right must change nothing.
+
+    REINDEX writes the index the engine believes the rows imply, so a hash that
+    moves means what was stored did not match the rows: an entry missing, or an
+    entry a partial predicate excludes. The answers a query returns are the
+    weaker half of this check, because a stale entry can hide behind a range
+    scan that never visits it.
+    """
     probe = (
         "SELECT coalesce(group_concat(id),'') FROM "
         "(SELECT id FROM child WHERE parent_id IS NOT NULL ORDER BY id);"
     )
-    before = query_scalar(doltlite, db_path, branch, probe, "reindex_before")
+    before_rows = query_scalar(doltlite, db_path, branch, probe, "reindex_before")
+    before_hash = index_fingerprint(doltlite, db_path, branch)
     run_sql(doltlite, db_for_branch(db_path, branch), "REINDEX;", "reindex_%s" % branch)
-    after = query_scalar(doltlite, db_path, branch, probe, "reindex_after")
-    if before != after:
+    after_rows = query_scalar(doltlite, db_path, branch, probe, "reindex_after")
+    after_hash = index_fingerprint(doltlite, db_path, branch)
+    if before_rows != after_rows:
         raise AssertionError(
-            "REINDEX changed answers on %s\nbefore=%r after=%r" % (branch, before, after)
+            "REINDEX changed answers on %s\nbefore=%r after=%r"
+            % (branch, before_rows, after_rows)
+        )
+    if before_hash != after_hash:
+        raise AssertionError(
+            "REINDEX changed an index hash on %s, so the stored index did not "
+            "match its rows\nbefore=%r\nafter=%r"
+            % (branch, before_hash, after_hash)
         )
 
 


### PR DESCRIPTION
Fixes #2637.

## What was actually missing

I measured the three surfaces before writing anything, using a database whose partial index holds rows the predicate excludes (the #2632 state) against a correct one with identical rows:

| surface | corrupt vs correct | verdict |
|---|---|---|
| `dolt_hashof_db()` | **differs** | already covers index roots, it walks every catalog entry |
| `dolt_hashof_catalog()` | **differs** | already covers them |
| `dolt_hashof_table('child')` | identical | blind to its own indexes |
| `dolt_status` | identical, and still clean after a `REINDEX` that changed `dolt_hashof_db()` | blind |

So the issue's "hash indexes into `hashof_db`" is already true. The real gaps were the table hash, status, and the missing per-index function. Also worth recording: `REINDEX` **does** repair, and moves the database hash to exactly the correct database's value, which is what makes it usable as an oracle.

## Changes

**`dolt_hashof_index(name[, ref])`.** Index catalog entries carry no name, so the name resolves through its schema row's root page. That works for a historical ref as well as the working set.

**`dolt_hashof_table` folds in every index of the table**, ordered by index name so catalog order cannot matter, hashed as hex because a raw hash byte may be zero and would truncate the preimage. A table with **no** indexes keeps exactly the hash it had, so recorded hashes stay valid where there is nothing new to fold in, and `test/chunker_boundary_golden.sh` keeps its pinned value untouched.

**`dolt_status` reports an index whose root differs as a modification of its parent table**, alongside the existing comparison of index definitions, never as a row of its own. This extends the function that already attributes index changes to the parent.

**The fuzzer** now asserts that `REINDEX` moves no index hash, no table hash and no database hash. That replaces comparing query answers, which a stale entry can hide from behind a range scan that never visits it.

## On what the tests can pin

`REINDEX` leaving hashes and status untouched on a healthy database is the case the tests pin, and it is the one that matters for false positives. The positive case needs an index that disagrees with its rows, which a correct engine will not produce, so I verified it by hand against a build from before #2635:

```
index  corrupt: 3dcc931324adaa8bee2328192cb02626c1daddf8
index  correct: 3404fc8367fcfa51471903f269bbbe61a4696710
after REINDEX:  3404fc8367fcfa51471903f269bbbe61a4696710   <- moves to the correct value
table  corrupt: c4678b89bda385b0038f9282672f3bfc9e29aa11
table  correct: 6c32fa70a2b7ef34f4fe4ea09054fce87d3adc13
status after the repairing REINDEX: child|0|modified       <- was empty before this change
```

## Verification

`test/doltlite_hashof_refs.sh` goes from 14 to 23 tests, covering the new function's shape, stability, ref argument, unknown name, NULL, that `REINDEX` moves nothing, that status stays clean after it, that an uncommitted index write moves both the index and the table hash, and that an index-free table keeps its old hash.

Green: `test/run_doltlite_tests.sh` 126/126, all C tests, and the `status` (41), `status_schema_objects` (18), `hashof` (47), `hashof_errors` (4), `merge_status` (11) and `diff_stat` (117) oracle suites, plus the index suites `index_vc_matrix` (49), `index_row_delta` (34), `oracle_index_merge` (43) and `oracle_reindex` (42). The stateful fuzzer runs clean on three seeds with the new hash invariant in place.