### PR TITLE
Fix staged index rootpage collisions in incremental dolt_add

### DIFF
--- a/src/doltlite_add.c
+++ b/src/doltlite_add.c
@@ -718,6 +718,11 @@ int doltliteStageNamedTables(
     Pgno iTable = 0;
     int j;
     if( !zTable || strcmp(zTable, ".")==0 ) continue;
+    for(j=0; j<i; j++){
+      const char *zPrior = (const char*)sqlite3_value_text(argv[j]);
+      if( zPrior && sqlite3_stricmp(zPrior, zTable)==0 ) break;
+    }
+    if( j<i ) continue;
 
     if( !bForce ){
       int ignored = 0;

--- a/src/doltlite_add.c
+++ b/src/doltlite_add.c
@@ -694,6 +694,18 @@ int doltliteStageNamedTables(
       rc = loadSchemaFromCatalog(db, cs, doltliteGetCache(db), &stagedSrc,
                                  &aStagedSchema, &nStagedSchema);
     }
+    if( rc==SQLITE_OK ){
+      Pgno offset;
+      rc = doltliteDisjoinCatalogEntries(db, aWorking, nWorking,
+                                         aStaged, nStaged, &offset);
+      if( rc==SQLITE_OK ){
+        for(i=0; i<nStagedSchema; i++){
+          if( aStagedSchema[i].iRootpage>1 ){
+            aStagedSchema[i].iRootpage += offset;
+          }
+        }
+      }
+    }
     if( rc!=SQLITE_OK ){
       ADDNAMED_FREE_ALL();
       sqlite3_result_error(context, "failed to load schema for staging", -1);

--- a/src/doltlite_commit_cmd.c
+++ b/src/doltlite_commit_cmd.c
@@ -189,6 +189,7 @@ static int doltliteCommitStageModifiedOnly(sqlite3 *db, sqlite3_context *context
   u8 *aRemoveStaged = 0;
   const char **azTouched = 0;
   int nTouched = 0;
+  Pgno stagedOffset = 0;
 
   memset(&workingIdx, 0, sizeof(workingIdx));
   memset(&headIdx, 0, sizeof(headIdx));
@@ -239,6 +240,14 @@ static int doltliteCommitStageModifiedOnly(sqlite3 *db, sqlite3_context *context
     return rc;
   }
 
+  rc = doltliteDisjoinCatalogEntries(db, aWorking, nWorking,
+                                     aStaged, nStaged, &stagedOffset);
+  if( rc!=SQLITE_OK ){
+    sqlite3_result_error_code(context, rc);
+    FREE_ADD_MODIFIED_CATALOGS();
+    return rc;
+  }
+
   nStagedAlloc = nStaged + nWorking + 1;
   if( nStagedAlloc>0 ){
     struct TableEntry *aNewStaged = sqlite3_realloc(
@@ -281,6 +290,7 @@ static int doltliteCommitStageModifiedOnly(sqlite3 *db, sqlite3_context *context
     int updated = 0;
     char *zDup;
     struct TableEntry *pStaged;
+    if( aWorking[j].iTable==1 ) continue;
     if( !addNameIndexFind(&headIdx, zName) ) continue;
 
     azTouched[nTouched++] = zName;
@@ -372,6 +382,12 @@ static int doltliteCommitStageModifiedOnly(sqlite3 *db, sqlite3_context *context
       sqlite3_result_error(context, "failed to load schema for staging", -1);
       FREE_ADD_MODIFIED_CATALOGS();
       return rc;
+    }
+
+    for(i2=0; i2<nOldSchema; i2++){
+      if( aOldSchema[i2].iRootpage>1 ){
+        aOldSchema[i2].iRootpage += stagedOffset;
+      }
     }
 
     for(k2=0; k2<nStaged; ){

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -1345,6 +1345,9 @@ int doltliteMergeCatalogs(sqlite3 *db,
 void doltliteFreeNameList(char **az, int n);
 int doltliteIndexSchemaRowsDifferForTable(SchemaEntry *aA, int nA,
     SchemaEntry *aB, int nB, const char *zTable);
+int doltliteDisjoinCatalogEntries(sqlite3 *db,
+  struct TableEntry *aWorking, int nWorking,
+  struct TableEntry *aStaged, int nStaged, Pgno *pOffset);
 int doltliteBuildNamedStageMasterRoot(sqlite3 *db,
     const ProllyHash *pWorkingMaster, u8 workingFlags,
     const ProllyHash *pOldMaster, u8 oldFlags,

--- a/src/prolly_btree_catalog.c
+++ b/src/prolly_btree_catalog.c
@@ -1139,6 +1139,75 @@ int doltliteSerializeCatalogEntries(
       db, aTables, nTables, 0, 0, ppOut, pnOut);
 }
 
+int doltliteDisjoinCatalogEntries(
+  sqlite3 *db,
+  struct TableEntry *aWorking, int nWorking,
+  struct TableEntry *aStaged, int nStaged,
+  Pgno *pOffset
+){
+  Btree *pBtree = db->aDb[0].pBt;
+  SchemaCatalogRow *aRows = 0;
+  struct TableEntry master;
+  struct TableEntry *pMaster = 0;
+  ProllyMutMap mm;
+  Pgno offset = 0;
+  int nRows = 0;
+  int i, rc;
+
+  *pOffset = 0;
+  for(i=0; i<nStaged; i++){
+    if( aStaged[i].iTable==1 ) pMaster = &aStaged[i];
+  }
+  if( !pMaster ) return SQLITE_OK;
+  for(i=0; i<nWorking; i++){
+    if( aWorking[i].iTable>offset ) offset = aWorking[i].iTable;
+  }
+  for(i=0; i<nStaged; i++){
+    if( aStaged[i].iTable>0xffffffff-offset ) return SQLITE_FULL;
+  }
+  master = *pMaster;
+  rc = loadSchemaCatalogRows(pBtree, aStaged, nStaged, &aRows, &nRows,
+                             &master.root, &master.flags);
+  if( rc!=SQLITE_OK ) return rc;
+  rc = prollyMutMapInit(&mm, 1);
+  if( rc!=SQLITE_OK ){
+    freeSchemaCatalogRows(aRows, nRows);
+    return rc;
+  }
+  for(i=0; i<nRows && rc==SQLITE_OK; i++){
+    Pgno pg = aRows[i].oldPg;
+    u8 *pRec;
+    int nRec;
+    if( pg>1 ){
+      if( pg>0xffffffff-offset ){
+        rc = SQLITE_FULL;
+        break;
+      }
+      pg += offset;
+    }
+    pRec = buildSchemaCatalogRecord(aRows[i].zType, aRows[i].zName,
+                                    aRows[i].zTblName, pg, aRows[i].zSql,
+                                    &nRec);
+    if( !pRec ){
+      rc = SQLITE_NOMEM;
+      break;
+    }
+    rc = prollyMutMapInsert(&mm, 0, 0, aRows[i].iRowid, pRec, nRec);
+    sqlite3_free(pRec);
+  }
+  if( rc==SQLITE_OK ) rc = applyMutMapToTableRoot(pBtree->pBt, &master, &mm);
+  prollyMutMapFree(&mm);
+  freeSchemaCatalogRows(aRows, nRows);
+  if( rc==SQLITE_OK ){
+    pMaster->root = master.root;
+    for(i=0; i<nStaged; i++){
+      if( aStaged[i].iTable>1 ) aStaged[i].iTable += offset;
+    }
+    *pOffset = offset;
+  }
+  return rc;
+}
+
 /* Named staging master: touched objects from working, the rest from staged. */
 int doltliteBuildNamedStageMasterRoot(
   sqlite3 *db,

--- a/test/doltlite_index_vc_matrix.sh
+++ b/test/doltlite_index_vc_matrix.sh
@@ -542,6 +542,31 @@ z
 ok" "$(echo "$result" | tail -n 4)"
 done
 
+scenario "duplicate named add arguments"
+newdb
+result=$(run_sql ".bail on
+CREATE TABLE t(id TEXT PRIMARY KEY, label TEXT UNIQUE);
+INSERT INTO t VALUES('t','label');
+CREATE VIRTUAL TABLE ft USING fts5(body);
+INSERT INTO ft VALUES('one doc');
+SELECT dolt_add('t','T','t');
+SELECT dolt_add('ft','FT','ft');
+SELECT dolt_commit('-m','duplicates');
+SELECT dolt_checkout('-b','snapshot');
+SELECT id FROM t INDEXED BY sqlite_autoindex_t_2 WHERE label='label';
+SELECT count(*) FROM ft WHERE ft MATCH 'doc';
+PRAGMA integrity_check;" "$DB")
+check "duplicate_named_add_exit" "0" "$?"
+check "duplicate_named_add_commit" "t
+1
+ok" "$(echo "$result" | tail -n 3)"
+result=$(run_sql "SELECT id FROM t INDEXED BY sqlite_autoindex_t_2 WHERE label='label';
+SELECT count(*) FROM ft WHERE ft MATCH 'doc';
+PRAGMA integrity_check;" "$DB@snapshot")
+check "duplicate_named_add_reopen" "t
+1
+ok" "$result"
+
 echo ""
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"
 if [ $FAIL -gt 0 ]; then

--- a/test/doltlite_index_vc_matrix.sh
+++ b/test/doltlite_index_vc_matrix.sh
@@ -445,6 +445,103 @@ ok
 ftok
 ok" "$result"
 
+scenario "new indexed tables staged individually"
+for count in 4 12 24; do
+  canonical_hash=""
+  for mode in all individual reverse; do
+    newdb
+    setup=""
+    stage=""
+    probes=""
+    expected=""
+    for ((i=0; i<count; i++)); do
+      setup="$setup CREATE TABLE items_$i(id TEXT PRIMARY KEY, label TEXT UNIQUE);
+INSERT INTO items_$i VALUES('base_$i','label_$i');"
+      if [ "$mode" = reverse ]; then
+        stage="SELECT dolt_add('items_$i'); $stage"
+      else
+        stage="$stage SELECT dolt_add('items_$i');"
+      fi
+      probes="$probes SELECT id FROM items_$i INDEXED BY sqlite_autoindex_items_${i}_2 WHERE label='label_$i';"
+      expected="${expected}base_$i
+"
+    done
+    if [ "$mode" = all ]; then stage="SELECT dolt_add('-A');"; fi
+    result=$(run_sql ".bail on
+$setup
+$stage
+SELECT dolt_commit('-m','initial');
+$probes
+SELECT dolt_branch('feature');
+SELECT dolt_checkout('feature');
+$probes
+PRAGMA integrity_check;" "$DB")
+    check "${mode}_${count}_exit" "0" "$?"
+    check "${mode}_${count}_checkout" "${expected}ok" "$(echo "$result" | tail -n $((count+1)))"
+    result=$(run_sql ".bail on
+$probes
+PRAGMA integrity_check;" "$DB@feature")
+    check "${mode}_${count}_reopen" "${expected}ok" "$result"
+    hash=$(run_sql "SELECT dolt_hashof_db('HEAD');" "$DB@feature")
+    if [ "$mode" = all ]; then canonical_hash="$hash"; fi
+    check "${mode}_${count}_canonical" "$canonical_hash" "$hash"
+    result=$(run_sql "INSERT INTO items_0 VALUES('duplicate','label_0');" "$DB@feature")
+    check "${mode}_${count}_unique_exit" "1" "$?"
+    case "$result" in
+      *"UNIQUE constraint failed"*) PASS=$((PASS+1));;
+      *) note_fail "${mode}_${count}_unique_error" "$result";;
+    esac
+    staged_hash=$(run_sql "SELECT dolt_hashof_db('STAGED');" "$DB@feature")
+    result=$(run_sql "SELECT dolt_add('items_0','missing_table');" "$DB@feature")
+    check "${mode}_${count}_missing_add_exit" "1" "$?"
+    check "${mode}_${count}_missing_add_atomic" "$staged_hash" \
+      "$(run_sql "SELECT dolt_hashof_db('STAGED');" "$DB@feature")"
+    REMOTE="file://$TDIR/incremental$N.db"
+    result=$(run_sql ".bail on
+SELECT dolt_remote('add','origin','$REMOTE');
+SELECT dolt_push('origin','feature');" "$DB@feature")
+    check "${mode}_${count}_push_exit" "0" "$?"
+    CLONE="$TDIR/incremental_clone$N.db"
+    result=$(run_sql ".bail on
+SELECT dolt_clone('$REMOTE');
+$probes
+PRAGMA integrity_check;" "$CLONE")
+    check "${mode}_${count}_clone_exit" "0" "$?"
+    check "${mode}_${count}_clone_indexes" "${expected}ok" \
+      "$(echo "$result" | tail -n $((count+1)))"
+  done
+done
+
+scenario "commit -am preserves staged-only indexes across numbering changes"
+setup=""
+for ((i=0; i<12; i++)); do
+  setup="$setup CREATE TABLE items_$i(id TEXT PRIMARY KEY, label TEXT UNIQUE);
+INSERT INTO items_$i VALUES('base_$i','label_$i');"
+done
+for staged in 0 10; do
+  newdb
+  result=$(run_sql ".bail on
+CREATE TABLE z(id TEXT PRIMARY KEY, label TEXT UNIQUE);
+INSERT INTO z VALUES('z','z');
+SELECT dolt_commit('-Am','base');
+$setup
+SELECT dolt_add('items_$staged');
+UPDATE items_$staged SET label='unstaged';
+UPDATE z SET label='zz';
+SELECT dolt_commit('-am','mixed');
+SELECT dolt_checkout('-b','snapshot');
+SELECT dolt_reset('--hard');
+SELECT id FROM items_$staged INDEXED BY sqlite_autoindex_items_${staged}_2 WHERE label='label_$staged';
+SELECT id FROM z INDEXED BY sqlite_autoindex_z_2 WHERE label='zz';
+SELECT count(*) FROM sqlite_master WHERE type='table' AND name LIKE 'items_%';
+PRAGMA integrity_check;" "$DB")
+  check "am_staged_${staged}_exit" "0" "$?"
+  check "am_staged_${staged}_indexes" "base_$staged
+z
+1
+ok" "$(echo "$result" | tail -n 4)"
+done
+
 echo ""
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"
 if [ $FAIL -gt 0 ]; then

--- a/test/doltlite_index_vc_matrix.sh
+++ b/test/doltlite_index_vc_matrix.sh
@@ -567,6 +567,155 @@ check "duplicate_named_add_reopen" "t
 1
 ok" "$result"
 
+scenario "mixed foreign keys, indexes, and shadow tables preserve staging boundary"
+newdb
+mixed_setup="PRAGMA foreign_keys=ON;
+CREATE TABLE parents(id TEXT PRIMARY KEY, code TEXT UNIQUE, label TEXT);
+CREATE INDEX parent_label_nocase ON parents(label COLLATE NOCASE);
+CREATE TABLE children(id TEXT PRIMARY KEY, parent_id TEXT NOT NULL,
+  slug TEXT UNIQUE, score INTEGER CHECK(score>=0),
+  FOREIGN KEY(parent_id) REFERENCES parents(id) ON UPDATE CASCADE ON DELETE CASCADE);
+CREATE INDEX child_parent_score ON children(parent_id,score DESC) WHERE score>=0;
+CREATE VIRTUAL TABLE notes USING fts5(body);
+CREATE VIRTUAL TABLE boxes USING rtree(id,x1,x2,y1,y2);
+INSERT INTO parents VALUES('p1','c1','Alpha'),('p2','c2','Beta');
+INSERT INTO children VALUES('k1','p1','s1',10),('k2','p2','s2',20);
+INSERT INTO notes VALUES('base document');
+INSERT INTO boxes VALUES(1,0,1,0,1);"
+mixed_stage="SELECT dolt_add('notes');
+SELECT dolt_add('children');
+SELECT dolt_add('boxes');
+SELECT dolt_add('parents');"
+for ((i=0; i<8; i++)); do
+  mixed_setup="$mixed_setup
+CREATE TABLE mix_$i(id TEXT PRIMARY KEY, label TEXT UNIQUE);
+INSERT INTO mix_$i VALUES('m$i','ml$i');"
+  mixed_stage="$mixed_stage SELECT dolt_add('mix_$((7-i))');"
+done
+result=$(run_sql ".bail on
+$mixed_setup
+$mixed_stage
+SELECT dolt_hashof_db('STAGED');" "$DB")
+check "mixed_stage_exit" "0" "$?"
+mixed_staged_hash=$(echo "$result" | tail -n 1)
+result=$(run_sql ".bail on
+PRAGMA foreign_keys=ON;
+UPDATE parents SET label='Working Alpha' WHERE id='p1';
+UPDATE children SET slug='working-s1' WHERE id='k1';
+INSERT INTO notes VALUES('working document');
+INSERT INTO boxes VALUES(2,2,3,2,3);
+UPDATE mix_3 SET label='working-ml3';
+CREATE TABLE extra(id TEXT PRIMARY KEY, label TEXT UNIQUE);
+INSERT INTO extra VALUES('e','extra');
+SELECT dolt_hashof_db('STAGED');" "$DB")
+check "mixed_working_mutation_exit" "0" "$?"
+check "mixed_staged_snapshot_stable" "$mixed_staged_hash" "$(echo "$result" | tail -n 1)"
+result=$(run_sql ".bail on
+SELECT dolt_commit('-m','staged snapshot');
+SELECT dolt_hashof_db('HEAD');
+SELECT dolt_checkout('-b','snapshot');
+PRAGMA foreign_keys=ON;
+SELECT label FROM parents INDEXED BY parent_label_nocase
+ WHERE label='alpha' COLLATE NOCASE;
+SELECT slug FROM children INDEXED BY sqlite_autoindex_children_2 WHERE slug='s1';
+SELECT score FROM children INDEXED BY child_parent_score
+ WHERE parent_id='p2' AND score>=0;
+SELECT count(*) FROM notes WHERE notes MATCH 'document';
+SELECT rtreecheck('main','boxes');
+SELECT count(*) FROM boxes WHERE x1>=0;
+SELECT label FROM mix_3 INDEXED BY sqlite_autoindex_mix_3_2 WHERE label='ml3';
+SELECT count(*) FROM sqlite_master WHERE type='table' AND name='extra';
+SELECT count(*) FROM pragma_foreign_key_check;
+PRAGMA integrity_check;" "$DB")
+check "mixed_commit_checkout_exit" "0" "$?"
+check "mixed_commit_matches_staged" "$mixed_staged_hash" \
+  "$(echo "$result" | grep -E '^[0-9a-f]{40}$' | tail -n 1)"
+check "mixed_commit_snapshot" "Alpha
+s1
+20
+1
+ok
+1
+ml3
+0
+0
+ok" "$(echo "$result" | tail -n 10)"
+mixed_snapshot_hash=$(run_sql "SELECT dolt_hashof_db('WORKING');" "$DB@snapshot")
+result=$(run_sql "PRAGMA foreign_keys=ON;
+INSERT INTO children VALUES('bad','missing','bad',1);" "$DB@snapshot")
+check "mixed_fk_failure_exit" "1" "$?"
+case "$result" in
+  *"FOREIGN KEY constraint failed"*) PASS=$((PASS+1));;
+  *) note_fail "mixed_fk_failure_error" "$result";;
+esac
+result=$(run_sql "INSERT INTO parents VALUES('p3','c1','Duplicate');" "$DB@snapshot")
+check "mixed_unique_failure_exit" "1" "$?"
+case "$result" in
+  *"UNIQUE constraint failed"*) PASS=$((PASS+1));;
+  *) note_fail "mixed_unique_failure_error" "$result";;
+esac
+result=$(run_sql "INSERT INTO boxes VALUES(9,5,4,0,1);" "$DB@snapshot")
+check "mixed_rtree_failure_exit" "1" "$?"
+case "$result" in
+  *"rtree constraint failed"*) PASS=$((PASS+1));;
+  *) note_fail "mixed_rtree_failure_error" "$result";;
+esac
+check "mixed_failures_leave_snapshot_unchanged" "$mixed_snapshot_hash" \
+  "$(run_sql "SELECT dolt_hashof_db('WORKING');" "$DB@snapshot")"
+result=$(run_sql ".bail on
+PRAGMA foreign_keys=ON;
+SELECT label FROM parents WHERE id='p1';
+SELECT slug FROM children WHERE id='k1';
+SELECT count(*) FROM notes;
+SELECT count(*) FROM boxes;
+SELECT label FROM mix_3 WHERE id='m3';
+SELECT count(*) FROM extra;" "$DB@main")
+check "mixed_working_after_staged_commit" "Working Alpha
+working-s1
+2
+2
+working-ml3
+1" "$result"
+result=$(run_sql ".bail on
+SELECT dolt_commit('-am','tracked working edits');
+SELECT dolt_checkout('-b','updated');
+PRAGMA foreign_keys=ON;
+SELECT label FROM parents WHERE id='p1';
+SELECT slug FROM children WHERE id='k1';
+SELECT count(*) FROM notes;
+SELECT rtreecheck('main','boxes');
+SELECT count(*) FROM boxes;
+SELECT label FROM mix_3 WHERE id='m3';
+SELECT count(*) FROM sqlite_master WHERE type='table' AND name='extra';
+SELECT count(*) FROM pragma_foreign_key_check;
+PRAGMA integrity_check;" "$DB@main")
+check "mixed_am_exit" "0" "$?"
+check "mixed_am_commit" "Working Alpha
+working-s1
+2
+ok
+2
+working-ml3
+0
+0
+ok" "$(echo "$result" | tail -n 9)"
+result=$(run_sql ".bail on
+PRAGMA foreign_keys=ON;
+SELECT label FROM parents INDEXED BY parent_label_nocase
+ WHERE label='working alpha' COLLATE NOCASE;
+SELECT slug FROM children INDEXED BY sqlite_autoindex_children_2
+ WHERE slug='working-s1';
+SELECT count(*) FROM notes WHERE notes MATCH 'working';
+SELECT rtreecheck('main','boxes');
+SELECT count(*) FROM pragma_foreign_key_check;
+PRAGMA integrity_check;" "$DB@updated")
+check "mixed_am_reopen" "Working Alpha
+working-s1
+1
+ok
+0
+ok" "$result"
+
 echo ""
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"
 if [ $FAIL -gt 0 ]; then

--- a/test/vc_oracle_commit_test.sh
+++ b/test/vc_oracle_commit_test.sh
@@ -766,6 +766,53 @@ SELECT dolt_checkout('-b','snapshot');
 " "SELECT 'R|' || id || '|' || label FROM t;" \
   "SELECT concat('R|', id, '|', label) FROM t;"
 
+MIXED_SCHEMA_SEED="
+CREATE TABLE parents(id VARCHAR(40) PRIMARY KEY, code VARCHAR(40) UNIQUE, label VARCHAR(40));
+CREATE INDEX parent_label_idx ON parents(label);
+CREATE TABLE children(id VARCHAR(40) PRIMARY KEY, parent_id VARCHAR(40) NOT NULL,
+  slug VARCHAR(40) UNIQUE, score INTEGER CHECK(score>=0),
+  FOREIGN KEY(parent_id) REFERENCES parents(id) ON UPDATE CASCADE ON DELETE CASCADE);
+CREATE INDEX child_parent_score ON children(parent_id,score);
+INSERT INTO parents VALUES('p1','c1','Alpha'),('p2','c2','Beta');
+INSERT INTO children VALUES('k1','p1','s1',10),('k2','p2','s2',20);
+SELECT dolt_add('children');
+SELECT dolt_add('parents');
+UPDATE parents SET label='Working Alpha' WHERE id='p1';
+UPDATE children SET slug='working-s1' WHERE id='k1';
+SELECT dolt_commit('-m','staged snapshot');
+SELECT dolt_reset('--hard');"
+
+oracle_query "mixed_fk_indexes_staged_snapshot" "$MIXED_SCHEMA_SEED" \
+  "SELECT 'R|p|' || id || '|' || label FROM parents WHERE label='Alpha';
+SELECT 'R|c|' || id || '|' || slug || '|' || score FROM children
+ WHERE parent_id='p2' AND score=20;" \
+  "SELECT concat('R|p|', id, '|', label) FROM parents WHERE label='Alpha';
+SELECT concat('R|c|', id, '|', slug, '|', score) FROM children
+ WHERE parent_id='p2' AND score=20;"
+
+oracle_query "mixed_fk_indexes_commit_am" "
+CREATE TABLE parents(id VARCHAR(40) PRIMARY KEY, code VARCHAR(40) UNIQUE, label VARCHAR(40));
+CREATE INDEX parent_label_idx ON parents(label);
+CREATE TABLE children(id VARCHAR(40) PRIMARY KEY, parent_id VARCHAR(40) NOT NULL,
+  slug VARCHAR(40) UNIQUE, score INTEGER CHECK(score>=0),
+  FOREIGN KEY(parent_id) REFERENCES parents(id) ON UPDATE CASCADE ON DELETE CASCADE);
+CREATE INDEX child_parent_score ON children(parent_id,score);
+INSERT INTO parents VALUES('p1','c1','Alpha'),('p2','c2','Beta');
+INSERT INTO children VALUES('k1','p1','s1',10),('k2','p2','s2',20);
+SELECT dolt_add('children');
+SELECT dolt_add('parents');
+UPDATE parents SET label='Working Alpha' WHERE id='p1';
+UPDATE children SET slug='working-s1' WHERE id='k1';
+SELECT dolt_commit('-m','staged snapshot');
+CREATE TABLE extra(id INTEGER PRIMARY KEY, label VARCHAR(40));
+INSERT INTO extra VALUES('e','extra');
+SELECT dolt_commit('-am','working edits');
+SELECT dolt_reset('--hard');
+" "SELECT 'R|p|' || id || '|' || label FROM parents WHERE id='p1';
+SELECT 'R|c|' || id || '|' || slug FROM children WHERE id='k1';" \
+  "SELECT concat('R|p|', id, '|', label) FROM parents WHERE id='p1';
+SELECT concat('R|c|', id, '|', slug) FROM children WHERE id='k1';"
+
 echo ""
 echo "=== Results: $pass passed, $fail failed ==="
 if [ $fail -gt 0 ]; then

--- a/test/vc_oracle_commit_test.sh
+++ b/test/vc_oracle_commit_test.sh
@@ -724,6 +724,39 @@ INSERT INTO a VALUES (9, 9);
 SELECT dolt_commit('-am', 'drop only');
 "
 
+echo "--- incremental staging of new indexed tables ---"
+for count in 12 24; do
+  for mode in all individual reverse; do
+    setup=""
+    stage=""
+    dl_query=""
+    dt_query=""
+    for ((i=0; i<count; i++)); do
+      setup="$setup
+CREATE TABLE items_$i(id VARCHAR(40) PRIMARY KEY, label VARCHAR(40) UNIQUE);
+INSERT INTO items_$i VALUES('base_$i','label_$i');"
+      if [ "$mode" = reverse ]; then
+        stage="SELECT dolt_add('items_$i'); $stage"
+      else
+        stage="$stage SELECT dolt_add('items_$i');"
+      fi
+      dl_query="$dl_query SELECT 'R|' || id FROM items_$i WHERE label='label_$i';"
+      dt_query="$dt_query SELECT concat('R|', id) FROM items_$i WHERE label='label_$i';"
+    done
+    if [ "$mode" = all ]; then stage="SELECT dolt_add('-A');"; fi
+    setup="$setup
+$stage
+SELECT dolt_commit('-m','initial');
+SELECT dolt_branch('feature');
+SELECT dolt_checkout('feature');"
+    oracle_query "indexed_${mode}_${count}" "$setup" "$dl_query" "$dt_query"
+    oracle_error "indexed_${mode}_${count}_duplicate" "$setup
+INSERT INTO items_0 VALUES('duplicate','label_0');"
+    oracle_error "indexed_${mode}_${count}_missing_add" "$setup
+SELECT dolt_add('items_0','missing_table');"
+  done
+done
+
 echo ""
 echo "=== Results: $pass passed, $fail failed ==="
 if [ $fail -gt 0 ]; then

--- a/test/vc_oracle_commit_test.sh
+++ b/test/vc_oracle_commit_test.sh
@@ -757,6 +757,15 @@ SELECT dolt_add('items_0','missing_table');"
   done
 done
 
+oracle_query "duplicate_named_add_arguments" "
+CREATE TABLE t(id VARCHAR(40) PRIMARY KEY, label VARCHAR(40) UNIQUE);
+INSERT INTO t VALUES('t','label');
+SELECT dolt_add('t','T','t');
+SELECT dolt_commit('-m','duplicates');
+SELECT dolt_checkout('-b','snapshot');
+" "SELECT 'R|' || id || '|' || label FROM t;" \
+  "SELECT concat('R|', id, '|', label) FROM t;"
+
 echo ""
 echo "=== Results: $pass passed, $fail failed ==="
 if [ $fail -gt 0 ]; then


### PR DESCRIPTION
## What happened

Rootpage numbers are local to each catalog. Each named add serializes a compact staged subset, then the next add mixes those renumbered entries with the full working catalog. Tables were reconciled by name, but unnamed index entries retained staged numbers that could collide with unrelated working entries. The live working schema remained readable; checkout exposed the corrupt committed schema.

Move the prior staged entries and their schema rootpages into a disjoint temporary range before overlaying working entries. Apply the same rule to commit -a and preserve its staged master until schema composition. Final serialization remains canonical: all-at-once, forward, and reverse staging produce identical database hashes. This prevents new corruption; it does not repair already-corrupt commits.

## Regression coverage

- 4, 12, and 24 newly created indexed tables; forward, reverse, and stage-all controls.
- Forced index lookups, checkout/reopen, unique failures, failed-add state, and file push/clone.
- Mixed commit -am preserves explicitly staged index contents and excludes unstaged tables.
- Dolt comparisons for indexed reads and duplicate/missing-table errors.

Unfixed master: 37 native assertions and four Dolt comparisons fail. Fixed: all pass. Existing index staging coverage started from an already-committed schema and missed incremental construction of new indexed catalogs.

## Validation

- Full native runner: 126 suites passed.
- Expanded index/VC matrix: 152 checks passed.
- Commit Dolt oracle: 71 cases passed.
- Rebuilt testfixture: nine SQLITE_TEST staging configurations pass checkout, reopen, indexed reads, and integrity checks.
- make -C build lint and git diff --check passed.

Separate finding during validation: hard reset while retaining untracked indexed tables can construct an invalid working schema. This remains outside the staging fix; the committed snapshot in that reproduction is readable on a fresh branch.

Fixes #2644

Co-Authored-By: OpenAI Codex <noreply@openai.com>
