### PR TITLE
Renumber an untracked table's index rows on hard reset

### DIFF
--- a/src/doltlite_reset.c
+++ b/src/doltlite_reset.c
@@ -369,6 +369,7 @@ static int doltlitePreserveUntrackedTablesOnHardReset(
     SchemaEntry *aWorkSchema = 0;
     int nWorking = 0, nTarget = 0, nWorkSchema = 0;
     Pgno iNextFree = 2;
+    Pgno iNextFreeBase = 2;
 
     rc = doltliteFlushCatalogToHash(db, &workingHash);
     if( rc==SQLITE_OK ){
@@ -388,23 +389,42 @@ static int doltlitePreserveUntrackedTablesOnHardReset(
       for(k=0; k<nTarget; k++){
         if( aTarget[k].iTable >= iNextFree ) iNextFree = aTarget[k].iTable + 1;
       }
+      for(k=0; k<nWorking; k++){
+        if( aWorking[k].iTable >= iNextFree ) iNextFree = aWorking[k].iTable + 1;
+      }
+      iNextFreeBase = iNextFree;
+      /* Every appended entry takes a fresh number, so the schema rows that
+      ** carried its working number must follow it: the serializer pairs an
+      ** index row to its entry by number alone, and only a table row can fall
+      ** back to its name. A clustered primary key's autoindex row shares its
+      ** table's number and needs no entry of its own. */
       for(j=0; j<nUntracked && rc==SQLITE_OK; j++){
         SchemaEntry *pSe = findSchemaEntry(aWorkSchema, nWorkSchema,
                                            azUntracked[j]);
         struct TableEntry *pWork = 0;
         struct TableEntry *aNew;
-        char *zDup;
+        char *zDup = 0;
+        Pgno iOldPg;
+        Pgno iNewPg;
+        int isIndex;
+        int m;
         if( !pSe || pSe->iRootpage<=1 ) continue;
+        iOldPg = pSe->iRootpage;
+        if( iOldPg >= iNextFreeBase ) continue;
         for(k=0; k<nWorking; k++){
-          if( aWorking[k].iTable==pSe->iRootpage ){
+          if( aWorking[k].iTable==iOldPg ){
             pWork = &aWorking[k];
             break;
           }
         }
         if( !pWork ) continue;
-        zDup = sqlite3_mprintf("%s", azUntracked[j]);
-        aNew = zDup ? sqlite3_realloc(aTarget,
-                        (nTarget+1)*(int)sizeof(struct TableEntry)) : 0;
+        isIndex = pSe->zType && strcmp(pSe->zType, "index")==0;
+        if( !isIndex ){
+          zDup = sqlite3_mprintf("%s", azUntracked[j]);
+          if( !zDup ){ rc = SQLITE_NOMEM; break; }
+        }
+        aNew = sqlite3_realloc(aTarget,
+                               (nTarget+1)*(int)sizeof(struct TableEntry));
         if( !aNew ){
           sqlite3_free(zDup);
           rc = SQLITE_NOMEM;
@@ -413,8 +433,12 @@ static int doltlitePreserveUntrackedTablesOnHardReset(
         aTarget = aNew;
         aTarget[nTarget] = *pWork;
         aTarget[nTarget].zName = zDup;
-        aTarget[nTarget].iTable = iNextFree++;
+        iNewPg = iNextFree++;
+        aTarget[nTarget].iTable = iNewPg;
         nTarget++;
+        for(m=0; m<nWorkSchema; m++){
+          if( aWorkSchema[m].iRootpage==iOldPg ) aWorkSchema[m].iRootpage = iNewPg;
+        }
       }
     }
     if( rc==SQLITE_OK ){

--- a/test/doltlite_reset.sh
+++ b/test/doltlite_reset.sh
@@ -347,6 +347,56 @@ run_test "hard_reset_reverts_tracked_lazy_system_tables" \
   "SELECT (SELECT count(*) FROM dolt_ignore) || '|' || (SELECT doc_text FROM dolt_docs WHERE doc_name='README.md') || '|' || (SELECT count(*) FROM dolt_status);" \
   "1|committed|0" "$DB15"
 
-rm -f "$DB" "$DB2" "$DB3" "$DB3B" "$DB3C" "$DB4" "$DB5" "$DB5B" "$DB5C" "$DB5C.hash" "$DB6" "$DB7" "$DB8" "$DB9" "$DB10" "$DB11" "$DB12" "$DB13" "$DB14" "$DB15"
+DB16=/tmp/test_reset16_$$.db; rm -f "$DB16"
+$DOLTLITE "$DB16" > /dev/null 2>&1 <<'SQL'
+CREATE TABLE tracked(id INTEGER PRIMARY KEY);
+INSERT INTO tracked VALUES(1);
+SELECT dolt_commit('-Am','base');
+CREATE TABLE untracked(id INTEGER PRIMARY KEY, label TEXT UNIQUE);
+INSERT INTO untracked VALUES(2,'label');
+SELECT dolt_reset('--hard');
+SQL
+run_test "hard_reset_untracked_unique_autoindex_tracked_intact" \
+  "SELECT * FROM tracked;" "1" "$DB16"
+run_test "hard_reset_untracked_unique_autoindex_indexed_read" \
+  "SELECT id FROM untracked WHERE label='label';" "2" "$DB16"
+run_test "hard_reset_untracked_unique_autoindex_integrity" \
+  "PRAGMA integrity_check;" "ok" "$DB16"
+run_test "hard_reset_untracked_unique_autoindex_status" \
+  "SELECT table_name || '|' || staged || '|' || status FROM dolt_status;" \
+  "untracked|0|new table" "$DB16"
+run_test_match "hard_reset_untracked_unique_still_enforced" \
+  "INSERT INTO untracked VALUES(3,'label');" "UNIQUE constraint failed" "$DB16"
+
+DB17=/tmp/test_reset17_$$.db; rm -f "$DB17"
+$DOLTLITE "$DB17" > /dev/null 2>&1 <<'SQL'
+CREATE TABLE tracked(id INTEGER PRIMARY KEY);
+INSERT INTO tracked VALUES(1);
+SELECT dolt_commit('-Am','base');
+CREATE TABLE u(k TEXT PRIMARY KEY, label TEXT UNIQUE);
+INSERT INTO u VALUES('a','x');
+CREATE TABLE w(k TEXT PRIMARY KEY, n INTEGER);
+CREATE INDEX w_n ON w(n);
+INSERT INTO w VALUES('b',7);
+CREATE TABLE p(id INTEGER PRIMARY KEY, a INTEGER, b INTEGER);
+CREATE UNIQUE INDEX p_ab ON p(a,b) WHERE b IS NOT NULL;
+INSERT INTO p VALUES(2,1,1),(3,1,NULL);
+SELECT dolt_reset('--hard');
+SQL
+run_test "hard_reset_untracked_text_pk_secondary_unique_read" \
+  "SELECT k FROM u WHERE label='x';" "a" "$DB17"
+run_test "hard_reset_untracked_explicit_index_read" \
+  "SELECT k FROM w WHERE n=7;" "b" "$DB17"
+run_test "hard_reset_untracked_partial_index_read" \
+  "SELECT count(*) FROM p WHERE a=1 AND b IS NOT NULL;" "1" "$DB17"
+run_test "hard_reset_multiple_untracked_indexed_integrity" \
+  "PRAGMA integrity_check;" "ok" "$DB17"
+run_test "hard_reset_multiple_untracked_indexed_status" \
+  "SELECT group_concat(table_name || '|' || staged || '|' || status, ' ') FROM (SELECT * FROM dolt_status ORDER BY table_name);" \
+  "p|0|new table u|0|new table w|0|new table" "$DB17"
+run_test "hard_reset_multiple_untracked_indexed_tracked_intact" \
+  "SELECT * FROM tracked;" "1" "$DB17"
+
+rm -f "$DB" "$DB2" "$DB3" "$DB3B" "$DB3C" "$DB4" "$DB5" "$DB5B" "$DB5C" "$DB5C.hash" "$DB6" "$DB7" "$DB8" "$DB9" "$DB10" "$DB11" "$DB12" "$DB13" "$DB14" "$DB15" "$DB16" "$DB17"
 
 dltest_finish

--- a/test/vc_oracle_reset_test.sh
+++ b/test/vc_oracle_reset_test.sh
@@ -1024,6 +1024,27 @@ INSERT INTO dolt_ignore VALUES ('extra_%', 0);
 SELECT dolt_reset('--hard');
 "
 
+oracle "reset_hard_keeps_untracked_unique_indexed_table" "
+$SEED
+CREATE TABLE untracked(id INTEGER PRIMARY KEY, label VARCHAR(40) UNIQUE);
+INSERT INTO untracked VALUES (2, 'label');
+SELECT dolt_reset('--hard');
+"
+
+oracle_same_session "reset_hard_untracked_unique_indexed_reads" "
+$SEED
+CREATE TABLE untracked(id INTEGER PRIMARY KEY, label VARCHAR(40) UNIQUE);
+INSERT INTO untracked VALUES (2, 'label');
+SELECT dolt_reset('--hard');
+" "SELECT 'Q|' || id FROM untracked WHERE label='label';
+SELECT 'Q|' || id FROM t;" \
+"$SEED
+CREATE TABLE untracked(id INTEGER PRIMARY KEY, label VARCHAR(40) UNIQUE);
+INSERT INTO untracked VALUES (2, 'label');
+SELECT dolt_reset('--hard');
+" "SELECT concat('Q|', id) FROM untracked WHERE label='label';
+SELECT concat('Q|', id) FROM t;"
+
 oracle "reset_end_options_dash_table" "
 CREATE TABLE \`--hard\`(id INTEGER PRIMARY KEY, v INT);
 INSERT INTO \`--hard\` VALUES (1, 10);


### PR DESCRIPTION
Fixes #2647.

Preserving an untracked table across `dolt_reset('--hard')` appends its catalog entries after the target's numbers, so each takes a fresh number. The schema rows for those objects, however, kept their working-set numbers. The catalog serializer pairs an **index** row to its entry by number alone and only lets a **table** row fall back to pairing by name, so a physical `UNIQUE` autoindex lost its entry and the reset persisted a schema whose row named a page nothing owned. Every query afterwards failed with `invalid rootpage`, including after reopening.

Naming the appended index entries made it worse: the serializer treats a *named* entry at an autoindex's number as another domain's table rather than proof the index is physical, and folded the row onto its table.

That is why an explicit `CREATE INDEX` happened to survive on master while a `UNIQUE` column or a TEXT primary key with a secondary `UNIQUE` did not.

## Fix

Move the schema rows with the entries:

- every row that carried an appended entry's working number takes the new number;
- index entries are appended **unnamed**, as the catalog keeps them;
- a clustered primary key's autoindex row, which shares its table's number, follows the table and gets no entry of its own;
- fresh numbers start past both the target and the working range, so a new number can never equal a working number a later row still carries.

## Verification

Fail-before / pass-after against a build of the same tree without the fix:

| suite | master | this branch |
|---|---|---|
| `test/doltlite_reset.sh` | 65 passed, **11 failed** | **76 passed, 0 failed** |
| `test/vc_oracle_reset_test.sh` | 61 passed, **2 failed** | **63 passed, 0 failed** |

The native tests cover exactly what the issue asks for: indexed reads before and after reset, retained untracked rows, unchanged committed data, `integrity_check`, the `UNIQUE` constraint still enforced afterwards, `dolt_status` showing the tables as untracked, and reopening (every `run_test` is a fresh process). Shapes: `UNIQUE` column autoindex, TEXT primary key plus secondary `UNIQUE`, explicit index, partial composite `UNIQUE` index, and three untracked indexed tables at once. The oracle cases run the same sequence against Dolt 2.3.1 and match on rows and status.

Also green: `test/run_doltlite_tests.sh` 126/126, all C tests, and the `status` (41), `state_transitions` (19), `checkout` (71), `clean` (11) and `ignore` (50) oracle suites.