### PR TITLE
Reject commits with missing foreign key parents

### DIFF
--- a/src/doltlite_commit_cmd.c
+++ b/src/doltlite_commit_cmd.c
@@ -635,6 +635,128 @@ static int doltliteCommitCreateObject(
   return SQLITE_OK;
 }
 
+static int doltliteCommitNextForeignKeyParent(
+  const char **pzSql,
+  char **pzParent
+){
+  const char *z = *pzSql;
+  int type;
+  int n;
+
+  *pzParent = 0;
+  while( *z ){
+    n = sqlite3GetToken((const u8*)z, &type);
+    if( n<=0 || type==TK_ILLEGAL ) return SQLITE_CORRUPT;
+    if( type!=TK_STRING && type!=TK_BLOB && type!=TK_COMMENT
+     && type!=TK_SPACE && n==10 && sqlite3_strnicmp(z, "REFERENCES", 10)==0 ){
+      z += n;
+      do{
+        if( !*z ) return SQLITE_CORRUPT;
+        n = sqlite3GetToken((const u8*)z, &type);
+        if( n<=0 || type==TK_ILLEGAL ) return SQLITE_CORRUPT;
+        if( type!=TK_SPACE && type!=TK_COMMENT ) break;
+        z += n;
+      }while( 1 );
+      *pzParent = sqlite3_mprintf("%.*s", n, z);
+      if( !*pzParent ) return SQLITE_NOMEM;
+      sqlite3Dequote(*pzParent);
+      *pzSql = z + n;
+      return SQLITE_ROW;
+    }
+    z += n;
+  }
+  *pzSql = z;
+  return SQLITE_DONE;
+}
+
+static int doltliteCommitFindMissingForeignKeyParent(
+  SchemaEntry *aSchema,
+  int nSchema,
+  char **pzChild,
+  char **pzParent
+){
+  int i;
+  *pzChild = 0;
+  *pzParent = 0;
+  for(i=0; i<nSchema; i++){
+    const char *z;
+    char *zParent = 0;
+    int rc;
+    if( !aSchema[i].zType || sqlite3_stricmp(aSchema[i].zType, "table")!=0
+     || !aSchema[i].zSql || !aSchema[i].zName ){
+      continue;
+    }
+    z = aSchema[i].zSql;
+    while( (rc = doltliteCommitNextForeignKeyParent(&z, &zParent))==SQLITE_ROW ){
+      int j;
+      int found = 0;
+      for(j=0; j<nSchema; j++){
+        if( aSchema[j].zType
+         && sqlite3_stricmp(aSchema[j].zType, "table")==0
+         && aSchema[j].zName
+         && sqlite3_stricmp(aSchema[j].zName, zParent)==0 ){
+          found = 1;
+          break;
+        }
+      }
+      if( !found ){
+        *pzChild = sqlite3_mprintf("%s", aSchema[i].zName);
+        if( !*pzChild ){
+          sqlite3_free(zParent);
+          return SQLITE_NOMEM;
+        }
+        *pzParent = zParent;
+        return SQLITE_OK;
+      }
+      sqlite3_free(zParent);
+      zParent = 0;
+    }
+    if( rc!=SQLITE_DONE ) return rc;
+  }
+  return SQLITE_OK;
+}
+
+static int doltliteCommitValidateForeignKeyParents(
+  sqlite3 *db,
+  sqlite3_context *context,
+  const ProllyHash *pCatalogHash
+){
+  SchemaEntry *aSchema = 0;
+  int nSchema = 0;
+  char *zChild = 0;
+  char *zParent = 0;
+  char *zErr;
+  int rc;
+
+  rc = loadSchemaFromCatalog(db, doltliteGetChunkStore(db),
+      doltliteGetCache(db), pCatalogHash, &aSchema, &nSchema);
+  if( rc==SQLITE_OK ){
+    rc = doltliteCommitFindMissingForeignKeyParent(
+        aSchema, nSchema, &zChild, &zParent);
+  }
+  freeSchemaEntries(aSchema, nSchema);
+  if( rc!=SQLITE_OK ){
+    sqlite3_free(zChild);
+    sqlite3_free(zParent);
+    sqlite3_result_error_code(context, rc);
+    return rc;
+  }
+  if( !zParent ) return SQLITE_OK;
+
+  zErr = sqlite3_mprintf(
+      "foreign key on table `%q` requires the referenced table `%q`",
+      zChild, zParent);
+  sqlite3_free(zChild);
+  sqlite3_free(zParent);
+  if( !zErr ){
+    sqlite3_result_error_code(context, SQLITE_NOMEM);
+    return SQLITE_NOMEM;
+  }
+  sqlite3_result_error(context, zErr, -1);
+  sqlite3_free(zErr);
+  return SQLITE_ERROR;
+}
+
 static void doltliteCommitFunc(
   sqlite3_context *context,
   int argc,
@@ -840,6 +962,11 @@ static void doltliteCommitFunc(
         }
       }
     }
+  }
+
+  if( !force ){
+    rc = doltliteCommitValidateForeignKeyParents(db, context, &catalogHash);
+    if( rc!=SQLITE_OK ) return;
   }
 
   rc = doltliteCommitCreateObject(db, context, &opts, &catalogHash, &commitHash);

--- a/test/doltlite_commit.sh
+++ b/test/doltlite_commit.sh
@@ -508,7 +508,159 @@ SELECT staged FROM dolt_status WHERE table_name='t';" \
   "0
 0" "$DB16"
 
-rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8" "$DB9" "$DB10" "$DB11" "$DB12" "$DB13" "$DB14" "$DB15" "$DB16"
+DB17=/tmp/test_dolt_commit_missing_fk_$$.db; rm -f "$DB17"
+
+run_test "missing_fk_empty_setup" \
+  "CREATE TABLE parents(id INTEGER PRIMARY KEY);
+CREATE TABLE children(id INTEGER PRIMARY KEY, parent_id INTEGER,
+  FOREIGN KEY(parent_id) REFERENCES parents(id));
+SELECT dolt_add('children');" \
+  "0" "$DB17"
+
+HEAD17=$(run_sql "SELECT dolt_hashof('HEAD');" "$DB17")
+STAGED17=$(run_sql "SELECT dolt_hashof('STAGED');" "$DB17")
+
+run_test_match "missing_fk_empty_rejected" \
+  "SELECT dolt_commit('-m','child only');" \
+  "foreign key.*children.*parents" "$DB17"
+
+run_test "missing_fk_failure_keeps_head" \
+  "SELECT dolt_hashof('HEAD');" "$HEAD17" "$DB17"
+
+run_test "missing_fk_failure_keeps_staged" \
+  "SELECT dolt_hashof('STAGED');" "$STAGED17" "$DB17"
+
+run_test "missing_fk_failure_survives_reopen" \
+  "SELECT table_name || '|' || staged || '|' || status
+   FROM dolt_status ORDER BY table_name, staged;" \
+  "children|1|new table
+parents|0|new table" "$DB17"
+
+run_test_match "missing_fk_child_then_parent_commits" \
+  "SELECT dolt_add('parents');
+SELECT dolt_commit('-m','both');" \
+  "[0-9a-f]{40}$" "$DB17"
+
+DB18=/tmp/test_dolt_commit_missing_fk_force_$$.db; rm -f "$DB18"
+
+run_test "missing_fk_populated_setup" \
+  "CREATE TABLE parents(id INTEGER PRIMARY KEY);
+CREATE TABLE children(id INTEGER PRIMARY KEY, parent_id INTEGER,
+  FOREIGN KEY(parent_id) REFERENCES parents(id));
+INSERT INTO parents VALUES(1);
+INSERT INTO children VALUES(1,1);
+SELECT dolt_add('children');" \
+  "0" "$DB18"
+
+run_test_match "missing_fk_populated_rejected" \
+  "SELECT dolt_commit('-m','child only');" \
+  "foreign key.*children.*parents" "$DB18"
+
+run_test_match "missing_fk_force_commits" \
+  "SELECT dolt_commit('--force','-m','child only');" \
+  "^[0-9a-f]{40}$" "$DB18"
+
+run_test "missing_fk_force_advances_head" \
+  "SELECT count(*) FROM dolt_log WHERE message='child only';" \
+  "1" "$DB18"
+
+DB19=/tmp/test_dolt_commit_fk_parent_first_$$.db; rm -f "$DB19"
+
+run_test_match "missing_fk_parent_then_child_commits" \
+  "CREATE TABLE parents(id INTEGER PRIMARY KEY);
+CREATE TABLE children(id INTEGER PRIMARY KEY, parent_id INTEGER,
+  FOREIGN KEY(parent_id) REFERENCES PaReNtS(id));
+SELECT dolt_add('parents');
+SELECT dolt_add('children');
+SELECT dolt_commit('-m','both');" \
+  "[0-9a-f]{40}$" "$DB19"
+
+DB20=/tmp/test_dolt_commit_fk_self_$$.db; rm -f "$DB20"
+
+run_test_match "missing_fk_quoted_self_reference_commits" \
+  "CREATE TABLE \"Node Table\"(id INTEGER PRIMARY KEY, parent_id INTEGER,
+  FOREIGN KEY(parent_id) REFERENCES \"Node Table\"(id));
+SELECT dolt_add('Node Table');
+SELECT dolt_commit('-m','self');" \
+  "[0-9a-f]{40}$" "$DB20"
+
+DB21=/tmp/test_dolt_commit_fk_drop_$$.db; rm -f "$DB21"
+
+run_test_match "missing_fk_drop_setup" \
+  "CREATE TABLE parents(id INTEGER PRIMARY KEY);
+CREATE TABLE children(id INTEGER PRIMARY KEY, parent_id INTEGER,
+  FOREIGN KEY(parent_id) REFERENCES parents(id));
+SELECT dolt_commit('-Am','base');" \
+  "^[0-9a-f]{40}$" "$DB21"
+
+run_test_match "missing_fk_dropped_parent_rejected" \
+  "PRAGMA foreign_keys=OFF;
+DROP TABLE parents;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','drop parent');" \
+  "foreign key.*children.*parents" "$DB21"
+
+run_test "missing_fk_dropped_parent_does_not_commit" \
+  "SELECT count(*) FROM dolt_log WHERE message='drop parent';" \
+  "0" "$DB21"
+
+DB22=/tmp/test_dolt_commit_fk_rename_$$.db; rm -f "$DB22"
+
+run_test_match "missing_fk_rename_setup" \
+  "CREATE TABLE parents(id INTEGER PRIMARY KEY);
+CREATE TABLE children(id INTEGER PRIMARY KEY, parent_id INTEGER,
+  FOREIGN KEY(parent_id) REFERENCES parents(id));
+SELECT dolt_commit('-Am','base');" \
+  "^[0-9a-f]{40}$" "$DB22"
+
+run_test "missing_fk_rename_stage" \
+  "ALTER TABLE parents RENAME TO parents_new;
+SELECT dolt_add('parents_new');" \
+  "0" "$DB22"
+
+HEAD22=$(run_sql "SELECT dolt_hashof('HEAD');" "$DB22")
+STATUS22=$(run_sql "SELECT table_name || '|' || staged || '|' || status
+  FROM dolt_status ORDER BY table_name, staged;" "$DB22")
+
+run_test_match "missing_fk_renamed_parent_rejected" \
+  "SELECT dolt_commit('-m','rename parent only');" \
+  "foreign key.*children.*parents" "$DB22"
+
+run_test "missing_fk_rename_failure_keeps_state" \
+  "SELECT dolt_hashof('HEAD');
+SELECT table_name || '|' || staged || '|' || status
+  FROM dolt_status ORDER BY table_name, staged;" \
+  "$HEAD22
+$STATUS22" "$DB22"
+
+DB23=/tmp/test_dolt_commit_fk_multiple_$$.db; rm -f "$DB23"
+
+run_test "missing_fk_multiple_setup" \
+  "CREATE TABLE present(id INTEGER PRIMARY KEY);
+CREATE TABLE children(id INTEGER PRIMARY KEY,
+  first_parent INTEGER REFERENCES present(id),
+  second_parent INTEGER,
+  CONSTRAINT second_fk FOREIGN KEY(second_parent) REFERENCES absent(id));
+SELECT dolt_add('present');
+SELECT dolt_add('children');" \
+  "0
+0" "$DB23"
+
+run_test_match "missing_fk_multiple_checks_every_reference" \
+  "SELECT dolt_commit('-m','two parents');" \
+  "foreign key.*children.*absent" "$DB23"
+
+DB24=/tmp/test_dolt_commit_fk_token_context_$$.db; rm -f "$DB24"
+
+run_test_match "missing_fk_ignores_comments_and_literals" \
+  "CREATE TABLE tokens(id INTEGER PRIMARY KEY,
+  note TEXT DEFAULT 'REFERENCES absent',
+  value INTEGER /* REFERENCES absent */);
+SELECT dolt_add('tokens');
+SELECT dolt_commit('-m','tokens');" \
+  "[0-9a-f]{40}$" "$DB24"
+
+rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8" "$DB9" "$DB10" "$DB11" "$DB12" "$DB13" "$DB14" "$DB15" "$DB16" "$DB17" "$DB18" "$DB19" "$DB20" "$DB21" "$DB22" "$DB23" "$DB24"
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"

--- a/test/vc_oracle_commit_test.sh
+++ b/test/vc_oracle_commit_test.sh
@@ -666,6 +666,62 @@ SELECT dolt_merge('feature');
 SELECT dolt_commit('-m', 'force-commit-with-conflict');
 "
 
+oracle_error "commit_missing_fk_parent_empty" "
+CREATE TABLE parents(id INTEGER PRIMARY KEY);
+CREATE TABLE children(id INTEGER PRIMARY KEY, parent_id INTEGER,
+  FOREIGN KEY(parent_id) REFERENCES parents(id));
+SELECT dolt_add('children');
+SELECT dolt_commit('-m', 'child only');
+"
+
+oracle_error "commit_missing_fk_parent_populated" "
+CREATE TABLE parents(id INTEGER PRIMARY KEY);
+CREATE TABLE children(id INTEGER PRIMARY KEY, parent_id INTEGER,
+  FOREIGN KEY(parent_id) REFERENCES parents(id));
+INSERT INTO parents VALUES(1);
+INSERT INTO children VALUES(1,1);
+SELECT dolt_add('children');
+SELECT dolt_commit('-m', 'child only');
+"
+
+oracle "commit_fk_child_then_parent" "
+CREATE TABLE parents(id INTEGER PRIMARY KEY);
+CREATE TABLE children(id INTEGER PRIMARY KEY, parent_id INTEGER,
+  FOREIGN KEY(parent_id) REFERENCES parents(id));
+SELECT dolt_add('children');
+SELECT dolt_add('parents');
+SELECT dolt_commit('-m', 'both');
+"
+
+oracle "commit_fk_parent_then_child" "
+CREATE TABLE parents(id INTEGER PRIMARY KEY);
+CREATE TABLE children(id INTEGER PRIMARY KEY, parent_id INTEGER,
+  FOREIGN KEY(parent_id) REFERENCES parents(id));
+SELECT dolt_add('parents');
+SELECT dolt_add('children');
+SELECT dolt_commit('-m', 'both');
+"
+
+oracle "commit_missing_fk_parent_force" "
+CREATE TABLE parents(id INTEGER PRIMARY KEY);
+CREATE TABLE children(id INTEGER PRIMARY KEY, parent_id INTEGER,
+  FOREIGN KEY(parent_id) REFERENCES parents(id));
+INSERT INTO parents VALUES(1);
+INSERT INTO children VALUES(1,1);
+SELECT dolt_add('children');
+SELECT dolt_commit('--force', '-m', 'child only');
+"
+
+oracle_error "commit_missing_fk_renamed_parent" "
+CREATE TABLE parents(id INTEGER PRIMARY KEY);
+CREATE TABLE children(id INTEGER PRIMARY KEY, parent_id INTEGER,
+  FOREIGN KEY(parent_id) REFERENCES parents(id));
+SELECT dolt_commit('-Am', 'base');
+ALTER TABLE parents RENAME TO parents_new;
+SELECT dolt_add('parents_new');
+SELECT dolt_commit('-m', 'rename parent only');
+"
+
 echo "--- commit -a leaves a working-tree rename in the working tree ---"
 
 COMMIT_A_RENAME_SEED="


### PR DESCRIPTION
## What happened

dolt_commit checked persisted row-level constraint violations, but did not validate foreign-key structure in the staged catalog. A child could therefore be staged and committed while its parent existed only in the working catalog, producing a commit with an unresolved REFERENCES target.

Validate every REFERENCES target against table entries in the final staged catalog before creating the commit object. The scan uses the SQLite tokenizer so comments and string literals do not look like constraints, handles quoted identifiers and multiple foreign keys, and keeps --force as the Dolt-compatible escape hatch.

## Regression coverage

- Empty and populated child-only staging failures.
- HEAD and staged-state preservation across failure and reopen.
- Parent/child staging in either order.
- Dropped and selectively renamed parents.
- Multiple references, quoted self-references, case-insensitive names, comments, and literals.
- --force success.
- Dolt oracle comparisons for rejection, success, rename, and force paths.

## Validation

- Full native runner: 126 suites passed.
- Focused commit suite: 104 checks passed.
- Dolt commit oracle: 59 cases passed.
- make lint and git diff --check passed.

Fixes #2648

Co-Authored-By: OpenAI Codex <noreply@openai.com>
