### PR TITLE
Resolve WORKING and STAGED in dolt_at tables

### DIFF
--- a/src/doltlite_at.c
+++ b/src/doltlite_at.c
@@ -495,7 +495,7 @@ static int atFilter(sqlite3_vtab_cursor *cur,
   c->zCommitRef = sqlite3_mprintf("%s", zRef);
   if( !c->zCommitRef ) return SQLITE_NOMEM;
 
-  rc=doltliteRefToCatalogHash(db,zRef,&catHash);
+  rc=doltliteResolveCatalogHashForRef(db,zRef,&catHash);
   if(rc==SQLITE_NOTFOUND){
     sqlite3_free(cur->pVtab->zErrMsg);
     cur->pVtab->zErrMsg = 0;

--- a/test/doltlite_at.sh
+++ b/test/doltlite_at.sh
@@ -372,4 +372,81 @@ run_test "at_namemap_old_commit" \
 
 rm -f "$DBA"
 
+DBWS=/tmp/test_at_working_staged_$$.db; rm -f "$DBWS"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'h1'),(2,'h2'),(3,'h3');
+SELECT dolt_commit('-Am','base');
+UPDATE t SET v='s' || id;
+SELECT dolt_add('t');
+UPDATE t SET v='w' || id;" | $DOLTLITE "$DBWS" > /dev/null 2>&1
+
+run_test "at_working_staged_head_rows" \
+  "SELECT group_concat(id || ':' || v, ',') FROM (
+    SELECT id, v FROM dolt_at_t('HEAD') ORDER BY id);" \
+  "1:h1,2:h2,3:h3" "$DBWS"
+
+run_test "at_working_staged_staged_rows" \
+  "SELECT group_concat(id || ':' || v, ',') FROM (
+    SELECT id, v FROM dolt_at_t('STAGED') ORDER BY id);" \
+  "1:s1,2:s2,3:s3" "$DBWS"
+
+run_test "at_working_staged_working_rows" \
+  "SELECT group_concat(id || ':' || v, ',') FROM (
+    SELECT id, v FROM dolt_at_t('WORKING') ORDER BY id);" \
+  "1:w1,2:w2,3:w3" "$DBWS"
+
+run_test "at_working_staged_case_insensitive" \
+  "SELECT v FROM dolt_at_t('staged') WHERE id=1;
+SELECT v FROM dolt_at_t('working') WHERE id=1;" \
+  "s1
+w1" "$DBWS"
+
+run_test "at_working_staged_pk_pushdown" \
+  "SELECT group_concat(id || ':' || v, ',') FROM (
+    SELECT id, v FROM dolt_at_t('STAGED') WHERE id>=2 ORDER BY id);
+SELECT group_concat(id || ':' || v, ',') FROM (
+    SELECT id, v FROM dolt_at_t('WORKING') WHERE id<3 ORDER BY id);" \
+  "2:s2,3:s3
+1:w1,2:w2" "$DBWS"
+
+run_test "at_working_staged_ref_labels" \
+  "SELECT DISTINCT commit_ref FROM dolt_at_t('STAGED');
+SELECT DISTINCT commit_ref FROM dolt_at_t('WORKING');" \
+  "STAGED
+WORKING" "$DBWS"
+
+run_test "at_working_sees_transaction_and_preserves_rollback" \
+  "BEGIN;
+UPDATE t SET v='txn' WHERE id=1;
+SELECT v FROM dolt_at_t('WORKING') WHERE id=1;
+ROLLBACK;
+SELECT v FROM t WHERE id=1;" \
+  "txn
+w1" "$DBWS"
+
+rm -f "$DBWS"
+
+DBWSS=/tmp/test_at_working_staged_schema_$$.db; rm -f "$DBWSS"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, keep TEXT, dropped TEXT);
+INSERT INTO t VALUES(1,'base','old');
+SELECT dolt_commit('-Am','base');
+ALTER TABLE t ADD COLUMN staged_col TEXT;
+UPDATE t SET staged_col='staged';
+SELECT dolt_add('t');
+ALTER TABLE t DROP COLUMN dropped;
+ALTER TABLE t ADD COLUMN working_col TEXT;
+UPDATE t SET working_col='working';" | $DOLTLITE "$DBWSS" > /dev/null 2>&1
+
+run_test "at_staged_with_working_schema_change" \
+  "SELECT id || '|' || keep || '|' || coalesce(staged_col,'NULL') || '|' ||
+          coalesce(working_col,'NULL') FROM dolt_at_t('STAGED');" \
+  "1|base|staged|NULL" "$DBWSS"
+
+run_test "at_working_with_working_schema_change" \
+  "SELECT id || '|' || keep || '|' || coalesce(staged_col,'NULL') || '|' ||
+          coalesce(working_col,'NULL') FROM dolt_at_t('WORKING');" \
+  "1|base|staged|working" "$DBWSS"
+
+rm -f "$DBWSS"
+
 dltest_finish

--- a/test/vc_oracle_at_test.sh
+++ b/test/vc_oracle_at_test.sh
@@ -325,7 +325,7 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'drop dropped table');
 " "dropped_only" "HEAD~1"
 
-echo "--- working set is NOT visible at any ref ---"
+echo "--- HEAD, STAGED, and WORKING isolation ---"
 
 oracle "at_head_excludes_working_modifications" "
 $SEED
@@ -337,6 +337,20 @@ $SEED
 UPDATE t SET v = 999 WHERE id = 1;
 SELECT dolt_add('-A');
 " "HEAD"
+
+WORKING_STAGED_SEED="
+CREATE TABLE t(id INT PRIMARY KEY, v VARCHAR(20));
+INSERT INTO t VALUES (1, 'h1'), (2, 'h2'), (3, 'h3');
+SELECT dolt_commit('-Am', 'base');
+UPDATE t SET v = concat('s', id);
+SELECT dolt_add('t');
+UPDATE t SET v = concat('w', id);
+"
+
+oracle "at_staged_rows" "$WORKING_STAGED_SEED" "STAGED"
+oracle "at_working_rows" "$WORKING_STAGED_SEED" "WORKING"
+oracle "at_staged_clean_falls_back_to_head" "$SEED" "STAGED"
+oracle "at_working_clean_matches_head" "$SEED" "WORKING"
 
 echo "--- post-merge ---"
 


### PR DESCRIPTION
## What happened

dolt_at_<table> resolved every argument as a commit ref, so the WORKING and STAGED pseudo-refs returned ref-not-found even though diff and hash surfaces already supported them.

Route the argument through the canonical catalog resolver. Existing commit, branch, tag, hash, and branch-effective behavior remains unchanged, while WORKING now reads live uncommitted rows and STAGED reads the staged catalog.

## Regression coverage

- Distinct HEAD, STAGED, and WORKING row snapshots.
- Function and hidden-column query forms through native and oracle coverage.
- Case-insensitive pseudo-ref names and commit_ref labels.
- Primary-key constraint pushdown.
- Staged and working schema divergence.
- In-transaction WORKING visibility with rollback preservation.
- Clean STAGED and WORKING fallback behavior.
- Dolt AS OF comparisons.

Before the fix, five native assertions and two Dolt oracle cases failed.

## Validation

- Full native runner: 126 suites passed.
- Focused dolt_at suite: 61 checks passed.
- Dolt dolt_at oracle: 30 cases passed.
- make lint and git diff --check passed.

Fixes #2651

Co-Authored-By: OpenAI Codex <noreply@openai.com>
