### PR TITLE
Unstage a table's schema on a per-table reset

### DIFF
--- a/src/doltlite_reset.c
+++ b/src/doltlite_reset.c
@@ -93,6 +93,8 @@ static int resetStageNamedPaths(
   int nHead = 0, nStaged = 0, nHeadSchema = 0, nStagedSchema = 0;
   ProllyHash headCatHash, stagedHash;
   Pgno iNextFree = 2;
+  const char **azReset = 0;
+  int nReset = 0;
   int p, k;
   int rc;
 
@@ -133,6 +135,13 @@ static int resetStageNamedPaths(
     if( iH<0 && iS<0 ){
       rc = SQLITE_NOTFOUND;
       goto done;
+    }
+    if( iH>=0 ){
+      const char **azNew = sqlite3_realloc(azReset,
+          (nReset+1)*(int)sizeof(const char*));
+      if( !azNew ){ rc = SQLITE_NOMEM; goto done; }
+      azReset = azNew;
+      azReset[nReset++] = zHeadTable;
     }
     if( iH<0 ){
       /* Staged-only: new table, or new name of a staged rename. Dolt keeps
@@ -231,6 +240,26 @@ static int resetStageNamedPaths(
     }
   }
 
+  /* The entries above now carry HEAD content, but the staged master still
+  ** spells the staged definition of each reset table: its CREATE TABLE text
+  ** and its index rows. Fallback rows only fill gaps, so compose the master
+  ** the way a named add does, with the reset tables' rows from HEAD and every
+  ** other row, views and triggers included, left as staged. */
+  if( rc==SQLITE_OK && nReset>0 ){
+    struct TableEntry *pHeadMaster = doltliteFindTableByNumber(aHead, nHead, 1);
+    struct TableEntry *pStagedMaster =
+        doltliteFindTableByNumber(aStaged, nStaged, 1);
+    if( pHeadMaster && pStagedMaster ){
+      ProllyHash composedRoot;
+      rc = doltliteBuildNamedStageMasterRoot(db,
+              &pHeadMaster->root, pHeadMaster->flags,
+              &pStagedMaster->root, pStagedMaster->flags,
+              azReset, nReset, aStaged, nStaged, 0, &composedRoot);
+      if( rc!=SQLITE_OK ) goto done;
+      pStagedMaster->root = composedRoot;
+    }
+  }
+
   {
     u8 *buf = 0;
     int nBuf = 0;
@@ -247,6 +276,7 @@ static int resetStageNamedPaths(
   }
 
 done:
+  sqlite3_free((void*)azReset);
   doltliteFreeCatalog(aHead, nHead);
   doltliteFreeCatalog(aStaged, nStaged);
   if( aHeadSchema ){

--- a/test/doltlite_reset.sh
+++ b/test/doltlite_reset.sh
@@ -397,6 +397,63 @@ run_test "hard_reset_multiple_untracked_indexed_status" \
 run_test "hard_reset_multiple_untracked_indexed_tracked_intact" \
   "SELECT * FROM tracked;" "1" "$DB17"
 
-rm -f "$DB" "$DB2" "$DB3" "$DB3B" "$DB3C" "$DB4" "$DB5" "$DB5B" "$DB5C" "$DB5C.hash" "$DB6" "$DB7" "$DB8" "$DB9" "$DB10" "$DB11" "$DB12" "$DB13" "$DB14" "$DB15" "$DB16" "$DB17"
+DB18=/tmp/test_reset18_$$.db; rm -f "$DB18"
+reset18_seed() {
+  rm -f "$DB18"
+  $DOLTLITE "$DB18" > /dev/null 2>&1 <<'SQL'
+CREATE TABLE child(id INTEGER PRIMARY KEY, grp INTEGER NOT NULL, body TEXT);
+CREATE INDEX cg ON child(grp);
+CREATE TABLE other(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO child VALUES(1,1,'a');
+INSERT INTO other VALUES(1,'o');
+SELECT dolt_commit('-Am','base');
+SQL
+}
+reset18_status() { echo "SELECT coalesce(group_concat(table_name||'|'||staged||'|'||status,' '),'clean') FROM (SELECT * FROM dolt_status ORDER BY table_name, staged);"; }
+
+reset18_seed
+echo "ALTER TABLE child ADD COLUMN x INT; SELECT dolt_add('child'); SELECT dolt_reset('child');" | $DOLTLITE "$DB18" > /dev/null 2>&1
+run_test "table_reset_unstages_add_column" "$(reset18_status)" "child|0|modified" "$DB18"
+run_test "table_reset_add_column_stays_in_working" \
+  "SELECT count(*) FROM pragma_table_info('child') WHERE name='x';" "1" "$DB18"
+
+reset18_seed
+echo "ALTER TABLE child RENAME COLUMN body TO body2; SELECT dolt_add('child'); SELECT dolt_reset('child');" | $DOLTLITE "$DB18" > /dev/null 2>&1
+run_test "table_reset_unstages_rename_column" "$(reset18_status)" "child|0|modified" "$DB18"
+
+reset18_seed
+echo "CREATE INDEX cb ON child(body); SELECT dolt_add('child'); SELECT dolt_reset('child');" | $DOLTLITE "$DB18" > /dev/null 2>&1
+run_test "table_reset_unstages_second_index" "$(reset18_status)" "child|0|modified" "$DB18"
+run_test "table_reset_second_index_absent_from_staged" \
+  "SELECT count(*) FROM dolt_diff_child('HEAD','STAGED');" "0" "$DB18"
+
+reset18_seed
+echo "CREATE INDEX cb ON child(body) WHERE body IS NOT NULL; SELECT dolt_add('child'); SELECT dolt_reset('child');" | $DOLTLITE "$DB18" > /dev/null 2>&1
+run_test "table_reset_unstages_partial_index" "$(reset18_status)" "child|0|modified" "$DB18"
+
+reset18_seed
+echo "DROP INDEX cg; SELECT dolt_add('child'); SELECT dolt_reset('child');" | $DOLTLITE "$DB18" > /dev/null 2>&1
+run_test "table_reset_unstages_drop_index" "$(reset18_status)" "child|0|modified" "$DB18"
+
+reset18_seed
+echo "CREATE INDEX cb ON child(body); INSERT INTO other VALUES(2,'p'); SELECT dolt_add('child','other'); SELECT dolt_reset('child','other');" | $DOLTLITE "$DB18" > /dev/null 2>&1
+run_test "table_reset_two_tables_one_call" "$(reset18_status)" "child|0|modified other|0|modified" "$DB18"
+
+reset18_seed
+echo "CREATE INDEX cb ON child(body); INSERT INTO child VALUES(2,2,'b'); SELECT dolt_add('child'); SELECT dolt_reset('child'); SELECT dolt_commit('-am','all');" | $DOLTLITE "$DB18" > /dev/null 2>&1
+run_test "table_reset_then_commit_am_takes_working_schema" \
+  "SELECT (SELECT count(*) FROM sqlite_master WHERE name='cb') || (SELECT count(*) FROM child) || length(dolt_hashof_index('cb','HEAD'));" \
+  "1240" "$DB18"
+
+reset18_seed
+echo "CREATE TABLE fresh(id TEXT PRIMARY KEY, label TEXT UNIQUE); INSERT INTO fresh VALUES('a','l'); CREATE INDEX cb ON child(body); SELECT dolt_add('-A'); SELECT dolt_reset('child'); SELECT dolt_commit('-m','fresh only'); SELECT dolt_branch('probe18');" | $DOLTLITE "$DB18" > /dev/null 2>&1
+run_test "table_reset_beside_staged_new_indexed_table_commit" \
+  "SELECT id FROM fresh WHERE label='l'; SELECT count(*) FROM sqlite_master WHERE name='cb'; PRAGMA integrity_check;" \
+  "a
+0
+ok" "$DB18/probe18"
+run_test "table_reset_beside_staged_new_indexed_table_status" "$(reset18_status)" "child|0|modified" "$DB18"
+
+rm -f "$DB" "$DB2" "$DB3" "$DB3B" "$DB3C" "$DB4" "$DB5" "$DB5B" "$DB5C" "$DB5C.hash" "$DB6" "$DB7" "$DB8" "$DB9" "$DB10" "$DB11" "$DB12" "$DB13" "$DB14" "$DB15" "$DB16" "$DB17" "$DB18"
 
 dltest_finish

--- a/test/vc_oracle_reset_test.sh
+++ b/test/vc_oracle_reset_test.sh
@@ -1044,6 +1044,34 @@ INSERT INTO untracked VALUES (2, 'label');
 SELECT dolt_reset('--hard');
 " "SELECT concat('Q|', id) FROM untracked WHERE label='label';
 SELECT concat('Q|', id) FROM t;"
+SEED_IDX="
+CREATE TABLE child(id INTEGER PRIMARY KEY, grp INTEGER NOT NULL, body VARCHAR(40));
+CREATE INDEX cg ON child(grp);
+INSERT INTO child VALUES (1, 1, 'a');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+"
+
+oracle "reset_table_unstages_add_column" "
+$SEED_IDX
+ALTER TABLE child ADD COLUMN x INT;
+SELECT dolt_add('child');
+SELECT dolt_reset('child');
+"
+
+oracle "reset_table_unstages_rename_column" "
+$SEED_IDX
+ALTER TABLE child RENAME COLUMN body TO body2;
+SELECT dolt_add('child');
+SELECT dolt_reset('child');
+"
+
+oracle "reset_table_unstages_second_index" "
+$SEED_IDX
+CREATE INDEX cb ON child(body);
+SELECT dolt_add('child');
+SELECT dolt_reset('child');
+"
 
 oracle "reset_end_options_dash_table" "
 CREATE TABLE \`--hard\`(id INTEGER PRIMARY KEY, v INT);


### PR DESCRIPTION
Fixes #2652.

`dolt_reset('<table>')` replaced the table's staged catalog **entries** with HEAD's, but the staged `sqlite_master` still spelled the staged definition: the `CREATE TABLE` text after an `ADD` or `RENAME COLUMN`, and the row for any index added to a table that already had one. The serializer's fallback rows only fill gaps, so those rows survived and `dolt_status` kept reporting the table as staged. That is also why the split was odd on master: a table's *first* new index unstaged, because dropping its entry left its row unpaired and filtered, while a *second* index paired to the sibling's table and stayed.

Dolt unstages the whole table, and so does `dolt_reset()` with no table, which adopts HEAD wholesale.

## Fix

Compose the staged master the way a named `dolt_add` already does, in the other direction. `doltliteBuildNamedStageMasterRoot` takes the reset tables' rows from the HEAD master and every other row from the staged master, leaving views and triggers as staged. Table rows pair to their kept staged number by name; index rows keep HEAD's numbers, which is exactly what the appended HEAD index entries carry.

## Verification

Fail-before / pass-after against a build of the same tree without the fix:

| suite | master | this branch |
|---|---|---|
| `test/doltlite_reset.sh` | 70 passed, **6 failed** | **76 passed, 0 failed** |
| `test/vc_oracle_reset_test.sh` | 61 passed, **3 failed** | **64 passed, 0 failed** |

Native shapes: `ADD COLUMN` (column stays in working), `RENAME COLUMN`, second plain index, second partial index, `DROP INDEX`, two tables in one call, reset then `commit -am` takes the working schema, and a reset beside a **staged new indexed table** that is then committed alone and read from a fresh branch, to smoke the numbering-collision class from #2644. The oracle cases run `ADD COLUMN`, `RENAME COLUMN` and second-index against Dolt 2.3.1 and match on status. (`DROP INDEX` cannot be expressed in one text for both dialects, so it is native-only.)

Also green: `test/run_doltlite_tests.sh` 126/126 and all C tests.

While isolating this I found a separate pre-existing artifact, filed as #2654: with a view staged, a per-table reset adds a spurious unstaged `dolt_schemas` row. It reproduces on master without this change and is not addressed here.