### PR TITLE
Compare views and triggers by content, not by master rowid

### DIFF
--- a/src/doltlite_diff.c
+++ b/src/doltlite_diff.c
@@ -137,7 +137,7 @@ int doltliteMasterViewTriggerRowsDiffer(
   if( rc==SQLITE_OK ){
     if( nOld!=nNew ){
       *pDiffer = 1;
-    }else{
+    }else if( nOld>0 ){
       qsort(azOld, nOld, sizeof(char*), masterRowStrCmp);
       qsort(azNew, nNew, sizeof(char*), masterRowStrCmp);
       for(i=0; i<nOld; i++){

--- a/src/doltlite_diff.c
+++ b/src/doltlite_diff.c
@@ -11,6 +11,7 @@
 
 #include "doltlite_record.h"
 #include "doltlite_internal.h"
+#include "prolly_record.h"
 #include "doltlite_name_index.h"
 #include <stddef.h>
 #include <string.h>
@@ -34,41 +35,130 @@ static int schemaRecordIsViewOrTrigger(const u8 *pRec, int nRec){
   return 0;
 }
 
+/* View and trigger rows are compared by content. The master keys its rows by
+** rowid, and a rowid is a position in the canonical row order, so adding or
+** dropping a table or index moves every view and trigger behind it; a rowid
+** diff would report them changed when nothing about them changed. */
+static int masterRowCanonical(const u8 *pRec, int nRec, char **pzOut){
+  DoltliteRecordInfo ri;
+  char *zType = 0, *zName = 0, *zTbl = 0, *zSql = 0;
+  int rc;
+  *pzOut = 0;
+  if( !pRec || nRec<=0 ) return SQLITE_OK;
+  doltliteParseRecord(pRec, nRec, &ri);
+  if( ri.nField<5 ) return SQLITE_OK;
+  rc = dlRecordTextField(pRec, nRec, &ri, 0, &zType);
+  if( rc==SQLITE_OK ) rc = dlRecordTextField(pRec, nRec, &ri, 1, &zName);
+  if( rc==SQLITE_OK ) rc = dlRecordTextField(pRec, nRec, &ri, 2, &zTbl);
+  if( rc==SQLITE_OK ) rc = dlRecordTextField(pRec, nRec, &ri, 4, &zSql);
+  if( rc==SQLITE_OK && zType
+   && (strcmp(zType, "view")==0 || strcmp(zType, "trigger")==0) ){
+    *pzOut = sqlite3_mprintf("%s\x01%s\x01%s\x01%s", zType,
+                             zName ? zName : "", zTbl ? zTbl : "",
+                             zSql ? zSql : "");
+    if( !*pzOut ) rc = SQLITE_NOMEM;
+  }
+  sqlite3_free(zType); sqlite3_free(zName); sqlite3_free(zTbl); sqlite3_free(zSql);
+  return rc;
+}
+
+static int masterCollectViewTriggerRows(
+  sqlite3 *db,
+  const ProllyHash *pRoot,
+  u8 flags,
+  char ***pazRows,
+  int *pnRows
+){
+  ChunkStore *cs = doltliteGetChunkStore(db);
+  ProllyCache *pCache = doltliteGetCache(db);
+  ProllyCursor cur;
+  char **az = 0;
+  int n = 0, nAlloc = 0;
+  int rc, res;
+  *pazRows = 0;
+  *pnRows = 0;
+  if( !cs || !pCache ) return SQLITE_ERROR;
+  if( prollyHashIsEmpty(pRoot) ) return SQLITE_OK;
+  prollyCursorInit(&cur, cs, pCache, pRoot, flags);
+  rc = prollyCursorFirst(&cur, &res);
+  if( rc!=SQLITE_OK || res ){
+    prollyCursorClose(&cur);
+    return rc;
+  }
+  while( prollyCursorIsValid(&cur) ){
+    const u8 *pVal; int nVal; char *z = 0;
+    prollyCursorValue(&cur, &pVal, &nVal);
+    rc = masterRowCanonical(pVal, nVal, &z);
+    if( rc!=SQLITE_OK ) break;
+    if( z ){
+      if( n>=nAlloc ){
+        int nNew = nAlloc ? nAlloc*2 : 8;
+        char **aNew = sqlite3_realloc(az, nNew*(int)sizeof(char*));
+        if( !aNew ){ sqlite3_free(z); rc = SQLITE_NOMEM; break; }
+        az = aNew; nAlloc = nNew;
+      }
+      az[n++] = z;
+    }
+    rc = prollyCursorNext(&cur);
+    if( rc!=SQLITE_OK ) break;
+  }
+  prollyCursorClose(&cur);
+  if( rc!=SQLITE_OK ){
+    int i;
+    for(i=0; i<n; i++) sqlite3_free(az[i]);
+    sqlite3_free(az);
+    return rc;
+  }
+  *pazRows = az;
+  *pnRows = n;
+  return SQLITE_OK;
+}
+
+static int masterRowStrCmp(const void *a, const void *b){
+  return strcmp(*(char*const*)a, *(char*const*)b);
+}
+
+int doltliteMasterViewTriggerRowsDiffer(
+  sqlite3 *db,
+  const ProllyHash *pOldRoot,
+  const ProllyHash *pNewRoot,
+  u8 flags,
+  int *pDiffer
+){
+  char **azOld = 0, **azNew = 0;
+  int nOld = 0, nNew = 0, i, rc;
+  *pDiffer = 0;
+  if( prollyHashCompare(pOldRoot, pNewRoot)==0 ) return SQLITE_OK;
+  rc = sqlite3FaultSim(957) ? SQLITE_IOERR
+     : masterCollectViewTriggerRows(db, pOldRoot, flags, &azOld, &nOld);
+  if( rc==SQLITE_OK ){
+    rc = masterCollectViewTriggerRows(db, pNewRoot, flags, &azNew, &nNew);
+  }
+  if( rc==SQLITE_OK ){
+    if( nOld!=nNew ){
+      *pDiffer = 1;
+    }else{
+      qsort(azOld, nOld, sizeof(char*), masterRowStrCmp);
+      qsort(azNew, nNew, sizeof(char*), masterRowStrCmp);
+      for(i=0; i<nOld; i++){
+        if( strcmp(azOld[i], azNew[i])!=0 ){ *pDiffer = 1; break; }
+      }
+    }
+  }
+  for(i=0; i<nOld; i++) sqlite3_free(azOld[i]);
+  for(i=0; i<nNew; i++) sqlite3_free(azNew[i]);
+  sqlite3_free(azOld);
+  sqlite3_free(azNew);
+  return rc;
+}
+
 static int schemaHasViewOrTriggerDiff(sqlite3 *db,
                                       const ProllyHash *pOldRoot,
                                       const ProllyHash *pNewRoot,
                                       u8 flags,
                                       int *pFound){
-  ChunkStore *cs = doltliteGetChunkStore(db);
-  ProllyCache *pCache = doltliteGetCache(db);
-  ProllyDiffIter iter;
-  ProllyDiffChange *pChange = 0;
-  int rc;
-  *pFound = 0;
-  if( !cs || !pCache ) return SQLITE_ERROR;
-  if( prollyHashCompare(pOldRoot, pNewRoot)==0 ) return SQLITE_OK;
-  memset(&iter, 0, sizeof(iter));
-  rc = sqlite3FaultSim(957) ? SQLITE_IOERR :
-       prollyDiffIterOpen(&iter, cs, pCache, pOldRoot, pNewRoot, flags,
-                          flags);
-  if( rc!=SQLITE_OK ){
-    prollyDiffIterClose(&iter);
-    return rc;
-  }
-  while( (rc = prollyDiffIterStep(&iter, &pChange))==SQLITE_ROW ){
-    if( !pChange ){
-      rc = SQLITE_CORRUPT;
-      break;
-    }
-    if( schemaRecordIsViewOrTrigger(pChange->pNewVal, pChange->nNewVal)
-     || schemaRecordIsViewOrTrigger(pChange->pOldVal, pChange->nOldVal) ){
-      *pFound = 1;
-      rc = SQLITE_OK;
-      break;
-    }
-  }
-  prollyDiffIterClose(&iter);
-  return rc==SQLITE_DONE ? SQLITE_OK : rc;
+  return doltliteMasterViewTriggerRowsDiffer(db, pOldRoot, pNewRoot, flags,
+                                             pFound);
 }
 
 static int schemaHasAnyViewOrTrigger(sqlite3 *db,

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -1168,6 +1168,9 @@ int doltliteSerializeConflicts(ChunkStore *cs,
 void doltliteIpkSerialType(i64 v, u32 *pType, u32 *pLen);
 void doltliteIpkWriteBE(u8 *p, i64 v, int n);
 KeyInfo *doltliteKeyInfoOfIndex(sqlite3 *db, Index *pIdx);
+int doltliteMasterViewTriggerRowsDiffer(sqlite3 *db, const ProllyHash *pOldRoot,
+                                        const ProllyHash *pNewRoot, u8 flags,
+                                        int *pDiffer);
 struct DoltlitePartialIndex;
 int doltliteIndexMutMapRowDelta(
   sqlite3 *db,

--- a/src/doltlite_status.c
+++ b/src/doltlite_status.c
@@ -237,26 +237,8 @@ static int statusSchemaHasViewOrTriggerDiff(sqlite3 *db,
                                             const ProllyHash *pNewRoot,
                                             u8 flags,
                                             int *pFound){
-  ChunkStore *cs = doltliteGetChunkStore(db);
-  ProllyCache *pCache = doltliteGetCache(db);
-  ProllyDiffIter iter;
-  ProllyDiffChange *pChange = 0;
-  int rc;
-  *pFound = 0;
-  if( !cs || !pCache ) return SQLITE_ERROR;
-  if( prollyHashCompare(pOldRoot, pNewRoot)==0 ) return SQLITE_OK;
-  rc = prollyDiffIterOpen(&iter, cs, pCache, pOldRoot, pNewRoot, flags,
-                          flags);
-  if( rc!=SQLITE_OK ) return rc;
-  while( (rc = prollyDiffIterStep(&iter, &pChange))==SQLITE_ROW && pChange ){
-    if( statusSchemaRecordIsViewOrTrigger(pChange->pNewVal, pChange->nNewVal)
-     || statusSchemaRecordIsViewOrTrigger(pChange->pOldVal, pChange->nOldVal) ){
-      *pFound = 1;
-      break;
-    }
-  }
-  prollyDiffIterClose(&iter);
-  return rc==SQLITE_ROW || rc==SQLITE_DONE ? SQLITE_OK : rc;
+  return doltliteMasterViewTriggerRowsDiffer(db, pOldRoot, pNewRoot, flags,
+                                             pFound);
 }
 
 static int statusCompareDoltSchemas(

--- a/test/doltlite_diff.sh
+++ b/test/doltlite_diff.sh
@@ -265,6 +265,39 @@ run_test "diff_empty_table_working" \
   "SELECT data_change || '|' || schema_change FROM dolt_diff WHERE commit_hash='WORKING' AND table_name='empty_working';" \
   "0|1" "$DB18"
 
-rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8" "$DB9" "$DB10" "$DB11" "$DB12" "$DB13" "$DB14" "$DB15" "$DB16" "$DB17" "$DB18"
+DB19=/tmp/test_diff19_$$.db; rm -f "$DB19"
+$DOLTLITE "$DB19" > /dev/null 2>&1 <<'SQL'
+CREATE TABLE t(id INTEGER PRIMARY KEY, x INT);
+INSERT INTO t VALUES(1,1);
+CREATE VIEW v1 AS SELECT id FROM t;
+SELECT dolt_commit('-Am','c1');
+CREATE TABLE newt(id INTEGER PRIMARY KEY);
+SELECT dolt_commit('-Am','c2 table only');
+CREATE INDEX tx ON t(x);
+SELECT dolt_commit('-Am','c3 index only');
+CREATE TRIGGER tr AFTER INSERT ON t BEGIN SELECT 1; END;
+SELECT dolt_commit('-Am','c4 trigger');
+DROP VIEW v1;
+CREATE VIEW v1 AS SELECT id, x FROM t;
+SELECT dolt_commit('-Am','c5 view changed');
+SQL
+run_test "diff_table_added_does_not_list_untouched_view" \
+  "SELECT group_concat(DISTINCT table_name) FROM dolt_diff WHERE commit_hash=dolt_hashof('HEAD~3');" \
+  "newt" "$DB19"
+run_test "diff_index_added_does_not_list_untouched_view" \
+  "SELECT group_concat(DISTINCT table_name) FROM dolt_diff WHERE commit_hash=dolt_hashof('HEAD~2');" \
+  "t" "$DB19"
+run_test "diff_trigger_added_lists_dolt_schemas" \
+  "SELECT group_concat(DISTINCT table_name) FROM dolt_diff WHERE commit_hash=dolt_hashof('HEAD~1');" \
+  "dolt_schemas" "$DB19"
+run_test "diff_view_changed_lists_dolt_schemas" \
+  "SELECT group_concat(DISTINCT table_name) FROM dolt_diff WHERE commit_hash=dolt_hashof('HEAD');" \
+  "dolt_schemas" "$DB19"
+echo "CREATE TABLE later(id INTEGER PRIMARY KEY);" | $DOLTLITE "$DB19" > /dev/null 2>&1
+run_test "status_table_added_does_not_list_untouched_view" \
+  "SELECT group_concat(table_name||'|'||staged||'|'||status) FROM dolt_status;" \
+  "later|0|new table" "$DB19"
+
+rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8" "$DB9" "$DB10" "$DB11" "$DB12" "$DB13" "$DB14" "$DB15" "$DB16" "$DB17" "$DB18" "$DB19"
 
 dltest_finish

--- a/test/vc_oracle_status_schema_objects_test.sh
+++ b/test/vc_oracle_status_schema_objects_test.sh
@@ -127,6 +127,50 @@ echo ""
 
 echo "--- indexes ---"
 
+oracle_status "view_committed_then_table_added_unstaged" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 10);
+CREATE VIEW v1 AS SELECT id FROM t;
+SELECT dolt_commit('-Am', 'base');
+CREATE TABLE newt(id INTEGER PRIMARY KEY);
+"
+
+oracle_status "view_committed_then_table_added_staged" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 10);
+CREATE VIEW v1 AS SELECT id FROM t;
+SELECT dolt_commit('-Am', 'base');
+CREATE TABLE newt(id INTEGER PRIMARY KEY);
+SELECT dolt_add('newt');
+"
+
+oracle_status "view_committed_then_index_added_unstaged" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 10);
+CREATE VIEW v1 AS SELECT id FROM t;
+SELECT dolt_commit('-Am', 'base');
+CREATE INDEX idx_t_v ON t(v);
+"
+
+oracle_status "view_staged_then_table_added_unstaged" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 10);
+SELECT dolt_commit('-Am', 'base');
+CREATE VIEW v1 AS SELECT id FROM t;
+SELECT dolt_add('-A');
+CREATE TABLE newt(id INTEGER PRIMARY KEY);
+"
+
+oracle_status "view_changed_beside_table_added" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 10);
+CREATE VIEW v1 AS SELECT id FROM t;
+SELECT dolt_commit('-Am', 'base');
+CREATE TABLE newt(id INTEGER PRIMARY KEY);
+DROP VIEW v1;
+CREATE VIEW v1 AS SELECT id, v FROM t;
+"
+
 oracle_status "create_index_unstaged" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
 INSERT INTO t VALUES (1, 10);


### PR DESCRIPTION
Fixes #2654, and turns out to be much broader than the per-table reset the issue described.

## What was wrong

`dolt_status` and `dolt_diff` decided whether `dolt_schemas` changed by diffing the two `sqlite_master` trees **row by row, keyed on rowid**. A master's rowids are positions in its canonical row order, and tables and indexes sort ahead of views and triggers. So adding or dropping *any* table or index moves every view and trigger to a new rowid, and the rowid diff reads each one as deleted-and-added.

The per-table reset in the issue was just one way to shift the rows. Every one of these reproduced on master, with a view that nobody touched:

| state | `dolt_status` on master | expected (Dolt 2.3.1) |
|---|---|---|
| committed view, unstaged new table | `dolt_schemas\|0\|modified`, `newt\|0\|new table` | `newt\|0\|new table` |
| committed view, staged new table | `dolt_schemas\|1\|modified`, `newt\|1\|new table` | `newt\|1\|new table` |
| committed view, unstaged new index | `dolt_schemas\|0\|modified`, `t\|0\|modified` | `t\|0\|modified` |
| staged view, unstaged new table | extra `dolt_schemas\|0\|modified` row | `dolt_schemas\|1\|new table`, `newt\|0\|new table` |

and `dolt_diff` for a commit that only added a table listed `dolt_schemas` alongside it. Any repository with a view saw phantom `dolt_schemas` changes on ordinary work.

## Fix

One helper collects the view and trigger rows of each master as (type, name, parent, text), sorts them, and compares the sets. Both surfaces call it. A view whose text changed, a view added, or a trigger added still reads as a change; a view that merely moved does not. The fault-injection point the diff path carried is kept.

## Verification

Fail-before / pass-after against a build of the same tree without the fix:

| suite | master | this branch |
|---|---|---|
| `test/doltlite_diff.sh` | 47 passed, **3 failed** | **50 passed, 0 failed** |
| `test/vc_oracle_status_schema_objects_test.sh` | 19 passed, **4 failed** | **23 passed, 0 failed** |

Native: `dolt_diff` over a five-commit history where only a table, only an index, a trigger, and a view change land in successive commits, asserting which commits list `dolt_schemas`; plus status with a table added beside a committed view. Oracle: four untouched-view shapes and one changed-view shape against Dolt, matching on status.

Also green: `test/run_doltlite_tests.sh` 126/126, all C tests, the `status` (41), `diff` (70) and `diff_stat` (117) oracle suites, and the DoltLite OOM recovery suites including the one that exercises status and diff under injected allocation failure.