### PR TITLE
Rebuild cleanly merged FTS shadow indexes

### DIFF
--- a/src/doltlite_merge.c
+++ b/src/doltlite_merge.c
@@ -1073,6 +1073,23 @@ int doltliteMergeCatalogs(
   }
   if( rc!=SQLITE_OK ) goto merge_cleanup;
 
+  if( totalConflicts==0 && pazRebuildVtabs ){
+    char *zRefuse = 0;
+    rc = mergeScheduleChangedDerivedShadows(db,
+        aAnc, nAnc, aOurs, nOurs, aTheirs, nTheirs,
+        pazRebuildVtabs, pnRebuildVtabs, &zRefuse);
+    if( rc==SQLITE_OK && zRefuse ){
+      if( pzErrMsg ){
+        sqlite3_free(*pzErrMsg);
+        *pzErrMsg = zRefuse;
+      }else{
+        sqlite3_free(zRefuse);
+      }
+      rc = SQLITE_ERROR;
+    }
+  }
+  if( rc!=SQLITE_OK ) goto merge_cleanup;
+
   /* Their schema would reinstall objects we deleted; drop those their
   ** side left alone. Tables/indexes are already excluded. A deletion
   ** racing their change keeps today's behaviour. */

--- a/src/doltlite_merge_int.h
+++ b/src/doltlite_merge_int.h
@@ -377,6 +377,11 @@ int mergeFilterDerivedShadowConflicts(sqlite3 *db,
     MergeConflictTable *aConflictTables, int *pnConflictTables,
     int *pTotalConflicts, char ***pazRebuild, int *pnRebuild,
     char **pzRefuse);
+int mergeScheduleChangedDerivedShadows(sqlite3 *db,
+    struct TableEntry *aAnc, int nAnc,
+    struct TableEntry *aOurs, int nOurs,
+    struct TableEntry *aTheirs, int nTheirs,
+    char ***pazRebuild, int *pnRebuild, char **pzRefuse);
 
 int mergeCatalogPass1(
   sqlite3 *db,

--- a/src/doltlite_merge_pass1.c
+++ b/src/doltlite_merge_pass1.c
@@ -5,7 +5,11 @@
 int mergeAppendReindexName(char ***paz, int *pn, const char *zName){
   char **azNew;
   char *zDup;
+  int i;
   if( !paz ) return SQLITE_OK;
+  for(i=0; i<*pn; i++){
+    if( strcmp((*paz)[i], zName)==0 ) return SQLITE_OK;
+  }
   azNew = sqlite3_realloc(*paz, (*pn+1)*(int)sizeof(char*));
   if( !azNew ) return SQLITE_NOMEM;
   *paz = azNew;

--- a/src/doltlite_merge_pass2.c
+++ b/src/doltlite_merge_pass2.c
@@ -647,6 +647,50 @@ static char *mergeDerivedShadowOwner(
   return 0;
 }
 
+int mergeScheduleChangedDerivedShadows(
+  sqlite3 *db,
+  struct TableEntry *aAnc, int nAnc,
+  struct TableEntry *aOurs, int nOurs,
+  struct TableEntry *aTheirs, int nTheirs,
+  char ***pazRebuild,
+  int *pnRebuild,
+  char **pzRefuse
+){
+  int i;
+  for(i=0; i<nAnc; i++){
+    struct TableEntry *pOurs;
+    struct TableEntry *pTheirs;
+    char *zOwner;
+    int bRebuildable;
+    int rc;
+    if( !aAnc[i].zName ) continue;
+    pOurs = doltliteFindTableByName(aOurs, nOurs, aAnc[i].zName);
+    pTheirs = doltliteFindTableByName(aTheirs, nTheirs, aAnc[i].zName);
+    if( !pOurs || !pTheirs
+     || prollyHashCompare(&aAnc[i].root, &pOurs->root)==0
+     || prollyHashCompare(&aAnc[i].root, &pTheirs->root)==0 ){
+      continue;
+    }
+    zOwner = mergeDerivedShadowOwner(db, aAnc[i].zName, &bRebuildable);
+    if( !zOwner ) continue;
+    if( !bRebuildable ){
+      if( pzRefuse && *pzRefuse==0 ){
+        *pzRefuse = sqlite3_mprintf(
+            "cannot merge: '%s' indexes data that cannot be rebuilt from the "
+            "merged rows, and both sides changed it. Merge on one branch, or "
+            "drop and recreate '%s' after merging",
+            zOwner, zOwner);
+      }
+      sqlite3_free(zOwner);
+      return SQLITE_OK;
+    }
+    rc = mergeAppendReindexName(pazRebuild, pnRebuild, zOwner);
+    sqlite3_free(zOwner);
+    if( rc!=SQLITE_OK ) return rc;
+  }
+  return SQLITE_OK;
+}
+
 /* If every conflict is a rebuildable derived shadow, drop them and
 ** return owners to rebuild. Any non-derived conflict keeps all loud. */
 int mergeFilterDerivedShadowConflicts(

--- a/test/doltlite_vtab_vc_matrix.sh
+++ b/test/doltlite_vtab_vc_matrix.sh
@@ -268,6 +268,26 @@ result=$(run_sql "INSERT INTO f5(f5) VALUES('integrity-check'); SELECT 'ok'; PRA
 check "merge_conflict_rebuilt_index_valid" "ok
 ok" "$result"
 
+scenario "clean fts5 shadow merge rebuilds from content"
+newdb
+run_sql "CREATE VIRTUAL TABLE docs USING fts5(body);
+INSERT INTO docs(rowid,body) VALUES(270203,'row b27 00868 doc');
+SELECT dolt_commit('-Am','base');
+SELECT dolt_checkout('-b','side');
+INSERT INTO docs(rowid,body) VALUES(610229,'row b61 01070 doc');
+INSERT INTO docs(docs) VALUES('rebuild');
+SELECT dolt_commit('-Am','side');
+SELECT dolt_checkout('main');
+INSERT INTO docs(rowid,body) VALUES(900212,'row b90 01626 doc');
+SELECT dolt_commit('-Am','main');
+SELECT dolt_merge('side');" "$DB" > /dev/null
+check "merge_clean_shadow_content" "3" \
+  "$(run_sql "SELECT count(*) FROM docs_content;" "$DB")"
+check "merge_clean_shadow_search" "610229,900212" \
+  "$(run_sql "SELECT group_concat(rowid) FROM (SELECT rowid FROM docs WHERE docs MATCH 'b61 OR b90' ORDER BY rowid);" "$DB")"
+check "merge_clean_shadow_integrity" "" \
+  "$(run_sql "INSERT INTO docs(docs) VALUES('integrity-check');" "$DB")"
+
 scenario "merge adopts a branch-added vtab of every flavor"
 newdb
 run_sql "CREATE TABLE plain(k INTEGER PRIMARY KEY, v TEXT); INSERT INTO plain VALUES(1,'p');

--- a/test/remote_test.sh
+++ b/test/remote_test.sh
@@ -904,7 +904,7 @@ dirty-uncommitted
 
 "$DB" "$TMPDIR/preopened_remote.db" "SELECT 1;" >/dev/null
 result=$("$DB" "$TMPDIR/preopened_src.db" \
-  "CREATE TABLE t(id INTEGER PRIMARY KEY); INSERT INTO t VALUES(1); SELECT dolt_commit('-Am','initial'); SELECT dolt_remote('add','origin','$R/preopened_remote.db'); SELECT dolt_push('origin','main');" 2>&1 | tail -1)
+  "SELECT dolt_clone('$R/preopened_remote.db'); CREATE TABLE t(id INTEGER PRIMARY KEY); INSERT INTO t VALUES(1); SELECT dolt_commit('-Am','initial'); SELECT dolt_push('origin','main');" 2>&1 | tail -1)
 check "clean pre-opened remote accepts initial push" "0" "$result"
 result=$("$DB" "$TMPDIR/preopened_remote.db" "SELECT id FROM t;")
 check "initial push lands in clean pre-opened remote" "1" "$result"


### PR DESCRIPTION
Fixes #2657.

## What was wrong

A three-way merge could combine disjoint FTS5 shadow-table changes without reporting a row conflict. The resulting structure record could not describe both segment layouts, so the merge committed an inverted index that FTS5 reported as malformed.

## Fix

Detect derived shadow tables changed on both sides even when their row merge is clean. Rebuild eligible virtual-table indexes from merged authoritative content, refuse indexes with no rebuild source, and deduplicate owners scheduled through multiple shadows.

The remote test also initialized its source and destination independently and relied on their timestamped empty commits hashing identically. It now clones the destination first, giving the push deterministic shared ancestry.

## Verification

- Exact seed 1788629437 reproduced the failure on master at step 1709
- Reduced regression fails before with database disk image is malformed
- Vtab VC matrix: 51/51 passed
- Remote suite: 170/170 passed
- Pre-opened push stress: 2/100 failures before, 0/100 after
- Lint passed

Co-Authored-By: OpenAI Codex <noreply@openai.com>