### PR TITLE
Use nightly benchmark summary in releases

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -150,6 +150,7 @@ jobs:
       run: |
         python3 test/benchmark_compare_test.py
         python3 test/benchmark_retry_test.py
+        python3 test/release_performance_summary_test.py
 
     - name: Generate relative performance report
       id: report

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -407,47 +407,6 @@ jobs:
         cc /tmp/doltlite-installed-probe.c -ldoltlite -lz -lpthread -lm -o /tmp/doltlite-installed-probe
         test "$(/tmp/doltlite-installed-probe)" = "prolly"
 
-  # ── Run benchmarks ────────────────────────────────────────
-  benchmark:
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    steps:
-    - uses: actions/checkout@v4
-
-    - name: Install dependencies
-      run: bash .github/scripts/install-apt-deps.sh tcl-dev build-essential zlib1g-dev python3
-
-    - name: Configure
-      run: |
-        mkdir -p build && cd build
-        TCL_CONFIG=$(find /usr/lib -name tclConfig.sh -print -quit 2>/dev/null)
-        if [ -n "$TCL_CONFIG" ]; then
-          ../configure --with-tcl=$(dirname $TCL_CONFIG)
-        else
-          ../configure
-        fi
-
-    - name: Build doltlite and stock SQLite
-      run: |
-        cd build
-        make doltlite
-        make doltlite-lib
-        cc -O2 -I. -I../src -o bench_timer_doltlite ../test/sysbench_timer.c libdoltlite.a -lpthread -lz -lm
-        bash ../test/build_stock_reference.sh ../build-stockref ./doltlite
-        cc -O2 -I../build-stockref -I../src -o bench_timer_sqlite ../test/sysbench_timer.c ../build-stockref/sqlite3.o -lpthread -lz -lm
-
-    - name: Run benchmarks
-      run: |
-        cd build
-        BENCH_ROWS=100000 BENCH_RUNS=5 BENCH_SECTION_MODE=wrapped bash ../test/sysbench_compare.sh > /tmp/bench_classic.md
-        sed -n '/### File-Backed/,/^_/p' /tmp/bench_classic.md > /tmp/bench_results.md
-
-    - name: Upload benchmark results
-      uses: actions/upload-artifact@v4
-      with:
-        name: benchmark
-        path: /tmp/bench_results.md
-
   # ── Cross-version compatibility gate ──────────────────────
   # Databases created by prior releases must open and pass feature smoke
   # tests when the on-disk format signature is unchanged, and must be
@@ -494,7 +453,7 @@ jobs:
   # ── Create GitHub release ─────────────────────────────────
   release:
     if: github.event_name != 'workflow_dispatch'
-    needs: [source, build, package-smoke-deb, benchmark, compat]
+    needs: [source, build, package-smoke-deb, compat]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -526,17 +485,21 @@ jobs:
         echo "Uploading: ${ASSETS}"
         gh release upload "${GITHUB_REF_NAME}" ${ASSETS} --clobber
 
-    - name: Append benchmark to release notes
+    - name: Append nightly performance summary to release notes
       env:
         GH_TOKEN: ${{ github.token }}
       run: |
-        BENCH="artifacts/benchmark/bench_results.md"
-        if [ -f "$BENCH" ]; then
-          EXISTING=$(gh release view "${GITHUB_REF_NAME}" --json body --jq .body)
-          APPEND=$(printf '\n## Benchmark / int-keys (100K rows, Linux x64)\n\n'; cat "$BENCH")
-          printf '%s\n%s' "$EXISTING" "$APPEND" > /tmp/release_body.md
-          gh release edit "${GITHUB_REF_NAME}" --notes-file /tmp/release_body.md
-        fi
+        SUMMARY="$RUNNER_TEMP/release-performance-summary.md"
+        NOTES="$RUNNER_TEMP/release-notes.md"
+        REPORT_URL="https://github.com/${GITHUB_REPOSITORY}/blob/${GITHUB_REF_NAME}/performance-report.md#sql-workload-summary"
+        python3 tool/release-performance-summary.py performance-report.md > "$SUMMARY"
+        EXISTING=$(gh release view "${GITHUB_REF_NAME}" --json body --jq .body)
+        {
+          printf '%s\n\n## Benchmark / SQL workload summary\n\n' "$EXISTING"
+          cat "$SUMMARY"
+          printf '\n_Full nightly results: [performance-report.md](%s)._\n' "$REPORT_URL"
+        } > "$NOTES"
+        gh release edit "${GITHUB_REF_NAME}" --notes-file "$NOTES"
 
   # ── Trigger binding releases ─────────────────────────────
   # The node and python bindings publish from tag pushes in their own

--- a/test/release_performance_summary_test.py
+++ b/test/release_performance_summary_test.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+
+import importlib.util
+import pathlib
+import unittest
+
+
+MODULE_PATH = (
+    pathlib.Path(__file__).parents[1]
+    / "tool"
+    / "release-performance-summary.py"
+)
+SPEC = importlib.util.spec_from_file_location(
+    "release_performance_summary", MODULE_PATH
+)
+summary = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(summary)
+
+
+REPORT = """# Performance
+
+## SQL workload summary
+
+### In-memory
+
+| Operation | SQLite median total | DoltLite median total | Ratio | Paired-ratio noise | Result |
+|---|---:|---:|---:|---:|---|
+| Reads | 10s | 11s | 1.1× | 1.4% | **PASS** |
+| Writes | 2s | 3s | 1.5× | 1.2% | **PASS** |
+
+### File-backed
+
+| Operation | SQLite median total | DoltLite median total | Ratio | Paired-ratio noise | Result |
+|---|---:|---:|---:|---:|---|
+| Reads | 12s | 11s | 0.9× | 1.5% | **PASS** |
+| Autocommit writes | 800ms | 3s | 3.8× | 6.3% | **PASS** |
+
+<details>
+"""
+
+
+class ReleasePerformanceSummaryTest(unittest.TestCase):
+    def test_keeps_summary_timings_and_ratio(self):
+        self.assertEqual(
+            summary.render_summary(REPORT),
+            """### In-memory
+
+| Operation | SQLite median total | DoltLite median total | Ratio |
+| --- | ---: | ---: | ---: |
+| Reads | 10s | 11s | 1.1× |
+| Writes | 2s | 3s | 1.5× |
+
+### File-backed
+
+| Operation | SQLite median total | DoltLite median total | Ratio |
+| --- | ---: | ---: | ---: |
+| Reads | 12s | 11s | 0.9× |
+| Autocommit writes | 800ms | 3s | 3.8× |
+""",
+        )
+
+    def test_requires_both_tables(self):
+        with self.assertRaisesRegex(ValueError, "File-backed"):
+            summary.render_summary(REPORT.replace("### File-backed", "### Disk"))
+
+    def test_rejects_changed_columns(self):
+        with self.assertRaisesRegex(ValueError, "unexpected columns"):
+            summary.render_summary(REPORT.replace(" | Result |", " | Status |", 1))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tool/release-performance-summary.py
+++ b/tool/release-performance-summary.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+
+import argparse
+import pathlib
+import sys
+
+
+HEADERS = (
+    "Operation",
+    "SQLite median total",
+    "DoltLite median total",
+    "Ratio",
+    "Paired-ratio noise",
+    "Result",
+)
+SECTIONS = ("### In-memory", "### File-backed")
+
+
+def cells(line):
+    line = line.strip()
+    if not line.startswith("|") or not line.endswith("|"):
+        raise ValueError("invalid markdown table row")
+    return [value.strip() for value in line[1:-1].split("|")]
+
+
+def render_table(lines, section):
+    try:
+        section_index = lines.index(section)
+    except ValueError as exc:
+        raise ValueError(f"missing {section} benchmark section") from exc
+
+    table_index = section_index + 1
+    while table_index < len(lines) and not lines[table_index].strip():
+        table_index += 1
+    if table_index + 2 >= len(lines):
+        raise ValueError(f"missing table under {section}")
+    if tuple(cells(lines[table_index])) != HEADERS:
+        raise ValueError(f"unexpected columns under {section}")
+
+    output = [section, ""]
+    row_index = table_index
+    while row_index < len(lines) and lines[row_index].lstrip().startswith("|"):
+        row = cells(lines[row_index])
+        if len(row) != len(HEADERS):
+            raise ValueError(f"unexpected row width under {section}")
+        output.append("| " + " | ".join(row[:4]) + " |")
+        row_index += 1
+    if len(output) < 5:
+        raise ValueError(f"missing results under {section}")
+    return output
+
+
+def render_summary(report):
+    lines = report.splitlines()
+    if "## SQL workload summary" not in lines:
+        raise ValueError("missing SQL workload summary")
+    output = []
+    for section in SECTIONS:
+        output.extend(render_table(lines, section))
+        output.append("")
+    return "\n".join(output)
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("report", type=pathlib.Path)
+    args = parser.parse_args(argv)
+    try:
+        report = args.report.read_text(encoding="utf-8")
+        sys.stdout.write(render_summary(report))
+    except (OSError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- remove the release-time benchmark job and dependency
- append the checked-in nightly SQL workload summary to release notes
- omit paired-ratio noise and result columns
- fail clearly if the report format changes

## Validation

- `python3 test/release_performance_summary_test.py`
- `bash test/homebrew_formula_test.sh`
- parsed both workflow files as YAML

Co-Authored-By: OpenAI Codex <noreply@openai.com>