### PR TITLE
Fold copied VC helpers and catch clones in the dead-code gate

### DIFF
--- a/src/doltlite_add.c
+++ b/src/doltlite_add.c
@@ -119,13 +119,7 @@ void addNameIndexFree(AddNameIndex *pIdx){
   doltliteNameIndexFree(pIdx);
 }
 
-struct TableEntry *addNameIndexFind(
-  const AddNameIndex *pIdx,
-  const char *zName
-){
-  int r = doltliteNameIndexFind(pIdx, zName);
-  return r<0 ? 0 : (struct TableEntry*)(pIdx->aBase + (size_t)r*pIdx->stride);
-}
+
 
 void doltliteAlignStagedEntriesToWorking(
   struct TableEntry *aWorking,

--- a/src/doltlite_ancestor.c
+++ b/src/doltlite_ancestor.c
@@ -378,14 +378,7 @@ static void doltMergeBaseFunc(
     sqlite3_result_text(ctx, hexBuf, -1, SQLITE_TRANSIENT);
   }else if( rc==SQLITE_NOTFOUND ){
     ChunkStore *cs = doltliteGetChunkStore(db);
-    int pendingRc = SQLITE_OK;
-    char *zErr = cs ? chunkStoreSourceTakeError(cs, &pendingRc) : 0;
-    if( zErr || pendingRc!=SQLITE_OK ){
-      if( zErr ) sqlite3_result_error(ctx, zErr, -1);
-      sqlite3_result_error_code(
-          ctx, pendingRc!=SQLITE_OK ? pendingRc : rc);
-      sqlite3_free(zErr);
-    }else{
+    if( !cs || !doltliteCmdSourceResultError(ctx, cs, &rc) ){
       sqlite3_result_null(ctx);
     }
   }else{

--- a/src/doltlite_at.c
+++ b/src/doltlite_at.c
@@ -320,13 +320,9 @@ static void atCursorReset(AtCursor *c){
 }
 
 static int atRowMatchesUpper(AtCursor *c){
-  i64 k;
   if( !c->pkRange.hasPkHi ) return 1;
-  k = prollyCursorIntKey(&c->common.tblCur);
-  if( c->pkRange.pkHiStrict ){
-    return k < c->pkRange.pkHi;
-  }
-  return k <= c->pkRange.pkHi;
+  return doltlitePkRangeMatchesUpper(
+      &c->pkRange, prollyCursorIntKey(&c->common.tblCur));
 }
 
 static int atConnect(sqlite3 *db, void *pAux, int argc,

--- a/src/doltlite_blame.c
+++ b/src/doltlite_blame.c
@@ -57,22 +57,7 @@ struct BlameCursor {
   int iRow;
 };
 
-static int blameMapChunkSourceError(
-  BlameCursor *pCur,
-  sqlite3 *db,
-  int sourceRc,
-  int mappedRc
-){
-  ChunkStore *cs = doltliteGetChunkStore(db);
-  int pendingRc = SQLITE_OK;
-  char *zErr = cs ? chunkStoreSourceTakeError(cs, &pendingRc) : 0;
-  if( !zErr && pendingRc==SQLITE_OK ) return mappedRc;
-  if( zErr ){
-    sqlite3_free(pCur->base.pVtab->zErrMsg);
-    pCur->base.pVtab->zErrMsg = zErr;
-  }
-  return pendingRc!=SQLITE_OK ? pendingRc : sourceRc;
-}
+
 
 static int blameIntPkEnabled(const BlameVtab *v){
   if( v->nPkCols != 1 ) return 0;
@@ -462,7 +447,7 @@ static int blameCompareAgainstRef(
                                      &refRoot, &refFlags, 0);
     if( rc==SQLITE_OK ) haveRef = 1;
     else if( rc==SQLITE_NOTFOUND ){
-      rc = blameMapChunkSourceError(pCur, db, rc, SQLITE_OK);
+      rc = doltliteVtabMapChunkSourceError(pCur->base.pVtab, db, rc, SQLITE_OK);
       if( rc!=SQLITE_OK ) return rc;
     }else{
       return rc;
@@ -583,7 +568,7 @@ static int blameFindAllParentMergeBase(
     memset(&nextBase, 0, sizeof(nextBase));
     rc = doltliteFindAncestor(db, &base, pParent, &nextBase);
     if( rc==SQLITE_NOTFOUND ){
-      rc = blameMapChunkSourceError(pCur, db, rc, SQLITE_OK);
+      rc = doltliteVtabMapChunkSourceError(pCur->base.pVtab, db, rc, SQLITE_OK);
       if( rc!=SQLITE_OK ) return rc;
       memset(&base, 0, sizeof(base));
       break;
@@ -625,7 +610,7 @@ static int blameWalk(
                                      &curTableRoot, &curFlags, 0);
     if( rc==SQLITE_OK ) haveCurTable = 1;
     else if( rc==SQLITE_NOTFOUND ){
-      rc = blameMapChunkSourceError(pCur, db, rc, SQLITE_OK);
+      rc = doltliteVtabMapChunkSourceError(pCur->base.pVtab, db, rc, SQLITE_OK);
       if( rc!=SQLITE_OK ){
         doltliteCommitClear(&commit);
         return rc;
@@ -854,7 +839,7 @@ static int bmFilter(sqlite3_vtab_cursor *pCursor,
   rc = doltliteLoadTableRootByName(db, &headCatHash, v->zTableName,
                                    &tableRoot, &tableFlags, 0);
   if( rc==SQLITE_NOTFOUND ){
-    rc = blameMapChunkSourceError(c, db, rc, SQLITE_OK);
+    rc = doltliteVtabMapChunkSourceError(c->base.pVtab, db, rc, SQLITE_OK);
   }
   if( rc!=SQLITE_OK ) return rc;
 

--- a/src/doltlite_cmd.c
+++ b/src/doltlite_cmd.c
@@ -632,4 +632,21 @@ int doltliteCmdSourceResultError(
   return 1;
 }
 
+int doltliteVtabMapChunkSourceError(
+  sqlite3_vtab *pVtab,
+  sqlite3 *db,
+  int sourceRc,
+  int mappedRc
+){
+  ChunkStore *cs = doltliteGetChunkStore(db);
+  int pendingRc = SQLITE_OK;
+  char *zErr = cs ? chunkStoreSourceTakeError(cs, &pendingRc) : 0;
+  if( !zErr && pendingRc==SQLITE_OK ) return mappedRc;
+  if( zErr ){
+    sqlite3_free(pVtab->zErrMsg);
+    pVtab->zErrMsg = zErr;
+  }
+  return pendingRc!=SQLITE_OK ? pendingRc : sourceRc;
+}
+
 #endif

--- a/src/doltlite_commit_ancestors.c
+++ b/src/doltlite_commit_ancestors.c
@@ -33,22 +33,6 @@ struct CommitAncestorsCursor {
   int singleCommit;
 };
 
-static int caMapChunkSourceError(
-  CommitAncestorsCursor *pCur,
-  sqlite3 *db,
-  int sourceRc,
-  int mappedRc
-){
-  ChunkStore *cs = doltliteGetChunkStore(db);
-  int pendingRc = SQLITE_OK;
-  char *zErr = cs ? chunkStoreSourceTakeError(cs, &pendingRc) : 0;
-  if( !zErr && pendingRc==SQLITE_OK ) return mappedRc;
-  if( zErr ){
-    sqlite3_free(pCur->base.pVtab->zErrMsg);
-    pCur->base.pVtab->zErrMsg = zErr;
-  }
-  return pendingRc!=SQLITE_OK ? pendingRc : sourceRc;
-}
 
 static const char *commitAncestorsSchema =
   "CREATE TABLE x("
@@ -123,7 +107,7 @@ static int caLoadNextCommit(CommitAncestorsCursor *pCur, sqlite3 *db){
     rc = doltliteLoadCommit(db, &cur, &pCur->curCommit);
     if( rc!=SQLITE_OK ){
       if( pCur->singleCommit ){
-        rc = caMapChunkSourceError(pCur, db, rc, SQLITE_OK);
+        rc = doltliteVtabMapChunkSourceError(pCur->base.pVtab, db, rc, SQLITE_OK);
         doltliteCommitClear(&pCur->curCommit);
         memset(&pCur->curCommit, 0, sizeof(pCur->curCommit));
         return rc;

--- a/src/doltlite_conflicts.c
+++ b/src/doltlite_conflicts.c
@@ -782,16 +782,7 @@ static void schemaConflictsFreeRows(SchemaConflictsCur *pCur){
   pCur->iRow = 0;
 }
 
-static int schemaEntrySame(const SchemaEntry *pA, const SchemaEntry *pB){
-  if( !pA && !pB ) return 1;
-  if( !pA || !pB ) return 0;
-  if( sqlite3_stricmp(pA->zType ? pA->zType : "",
-                      pB->zType ? pB->zType : "")!=0 ) return 0;
-  if( sqlite3_stricmp(pA->zTblName ? pA->zTblName : "",
-                      pB->zTblName ? pB->zTblName : "")!=0 ) return 0;
-  if( (pA->zSql==0)!=(pB->zSql==0) ) return 0;
-  return !pA->zSql || strcmp(pA->zSql, pB->zSql)==0;
-}
+
 
 static SchemaEntry *schemaTableEntry(
   SchemaEntry *aSchema,
@@ -865,9 +856,9 @@ static char *schemaConflictIndexDescription(
       pBase = findSchemaEntry(aBase, nBase, a[i].zName);
       pOurs = findSchemaEntry(aOurs, nOurs, a[i].zName);
       pTheirs = findSchemaEntry(aTheirs, nTheirs, a[i].zName);
-      oursChanged = !schemaEntrySame(pBase, pOurs);
-      theirsChanged = !schemaEntrySame(pBase, pTheirs);
-      if( !oursChanged || !theirsChanged || schemaEntrySame(pOurs, pTheirs) ){
+      oursChanged = !doltliteSchemaEntriesSame(pBase, pOurs);
+      theirsChanged = !doltliteSchemaEntriesSame(pBase, pTheirs);
+      if( !oursChanged || !theirsChanged || doltliteSchemaEntriesSame(pOurs, pTheirs) ){
         continue;
       }
       if( !pBase ){

--- a/src/doltlite_dbpage.c
+++ b/src/doltlite_dbpage.c
@@ -36,21 +36,7 @@ static void put4byteBE(unsigned char *p, unsigned int v){
   p[3] = (unsigned char)(v & 0xff);
 }
 
-static int dbpageMapChunkSourceError(
-  DbpageVtab *pVtab,
-  int sourceRc,
-  int mappedRc
-){
-  ChunkStore *cs = doltliteGetChunkStore(pVtab->db);
-  int pendingRc = SQLITE_OK;
-  char *zErr = cs ? chunkStoreSourceTakeError(cs, &pendingRc) : 0;
-  if( !zErr && pendingRc==SQLITE_OK ) return mappedRc;
-  if( zErr ){
-    sqlite3_free(pVtab->base.zErrMsg);
-    pVtab->base.zErrMsg = zErr;
-  }
-  return pendingRc!=SQLITE_OK ? pendingRc : sourceRc;
-}
+
 
 static int synthesizeHeader(DbpageVtab *pVtab, unsigned char *aPage){
   sqlite3 *db = pVtab->db;
@@ -88,14 +74,14 @@ static int synthesizeHeader(DbpageVtab *pVtab, unsigned char *aPage){
 
   rc = doltliteGetHeadCatalogHash(db, &catHash);
   if( rc!=SQLITE_OK ){
-    return dbpageMapChunkSourceError(pVtab, rc, SQLITE_OK);
+    return doltliteVtabMapChunkSourceError(&pVtab->base, pVtab->db, rc, SQLITE_OK);
   }
   if( !prollyHashIsEmpty(&catHash) ){
     int userTables = 0;
     rc = doltliteLoadCatalog(db, &catHash, &aTables, &nTables, &iNextTable);
     if( rc!=SQLITE_OK ){
       doltliteFreeCatalog(aTables, nTables);
-      return dbpageMapChunkSourceError(pVtab, rc, SQLITE_OK);
+      return doltliteVtabMapChunkSourceError(&pVtab->base, pVtab->db, rc, SQLITE_OK);
     }
     for(i=0; i<nTables; i++){
 

--- a/src/doltlite_diff.c
+++ b/src/doltlite_diff.c
@@ -17,23 +17,7 @@
 #include <string.h>
 #include <time.h>
 
-static int schemaRecordIsViewOrTrigger(const u8 *pRec, int nRec){
-  DoltliteRecordInfo ri;
-  int st, off, len;
-  const u8 *pBody;
-  if( !pRec || nRec<=0 ) return 0;
-  doltliteParseRecord(pRec, nRec, &ri);
-  if( ri.nField < 1 ) return 0;
-  st = ri.aType[0];
-  off = ri.aOffset[0];
-  if( st < 13 || (st & 1)==0 ) return 0;
-  len = (st - 13) / 2;
-  if( off < 0 || off + len > nRec ) return 0;
-  pBody = pRec + off;
-  if( len==4 && memcmp(pBody, "view", 4)==0 ) return 1;
-  if( len==7 && memcmp(pBody, "trigger", 7)==0 ) return 1;
-  return 0;
-}
+
 
 /* View and trigger rows are compared by content. The master keys its rows by
 ** rowid, and a rowid is a position in the canonical row order, so adding or
@@ -152,15 +136,6 @@ int doltliteMasterViewTriggerRowsDiffer(
   return rc;
 }
 
-static int schemaHasViewOrTriggerDiff(sqlite3 *db,
-                                      const ProllyHash *pOldRoot,
-                                      const ProllyHash *pNewRoot,
-                                      u8 flags,
-                                      int *pFound){
-  return doltliteMasterViewTriggerRowsDiffer(db, pOldRoot, pNewRoot, flags,
-                                             pFound);
-}
-
 static int schemaHasAnyViewOrTrigger(sqlite3 *db,
                                      const ProllyHash *pRoot,
                                      u8 flags,
@@ -181,7 +156,7 @@ static int schemaHasAnyViewOrTrigger(sqlite3 *db,
   while( prollyCursorIsValid(&cur) ){
     const u8 *pVal; int nVal;
     prollyCursorValue(&cur, &pVal, &nVal);
-    if( schemaRecordIsViewOrTrigger(pVal, nVal) ){
+    if( doltliteSchemaRecordIsViewOrTrigger(pVal, nVal) ){
       *pFound = 1;
       break;
     }
@@ -228,22 +203,7 @@ struct DoltliteDiffCursor {
   int pseudoFilter;   /* 0=STAGED+WORKING, 1=WORKING, 2=STAGED */
 };
 
-static int diffMapChunkSourceError(
-  DoltliteDiffCursor *pCur,
-  sqlite3 *db,
-  int sourceRc,
-  int mappedRc
-){
-  ChunkStore *cs = doltliteGetChunkStore(db);
-  int pendingRc = SQLITE_OK;
-  char *zErr = cs ? chunkStoreSourceTakeError(cs, &pendingRc) : 0;
-  if( !zErr && pendingRc==SQLITE_OK ) return mappedRc;
-  if( zErr ){
-    sqlite3_free(pCur->base.pVtab->zErrMsg);
-    pCur->base.pVtab->zErrMsg = zErr;
-  }
-  return pendingRc!=SQLITE_OK ? pendingRc : sourceRc;
-}
+
 
 static const char *diffSchema =
   "CREATE TABLE x("
@@ -282,13 +242,7 @@ static void diffNameIndexFree(DiffNameIndex *pIdx){
   doltliteNameIndexFree(pIdx);
 }
 
-static struct TableEntry *diffNameIndexFind(
-  const DiffNameIndex *pIdx,
-  const char *zName
-){
-  int r = doltliteNameIndexFind(pIdx, zName);
-  return r<0 ? 0 : (struct TableEntry*)(pIdx->aBase + (size_t)r*pIdx->stride);
-}
+
 
 static void freeBatch(DoltliteDiffCursor *pCur){
   int i;
@@ -390,7 +344,7 @@ static int diffFilteredTableRoots(
   rc = doltliteLoadTableRootByName(db, pChildCat, pCur->zFilterTable,
                                    &childRoot, 0, &childSchema);
   if( rc==SQLITE_NOTFOUND ){
-    rc = diffMapChunkSourceError(pCur, db, rc, SQLITE_OK);
+    rc = doltliteVtabMapChunkSourceError(pCur->base.pVtab, db, rc, SQLITE_OK);
     if( rc!=SQLITE_OK ) return rc;
     childFound = 0;
   }else{
@@ -405,7 +359,7 @@ static int diffFilteredTableRoots(
   rc = doltliteLoadTableRootByName(db, pParentCat, pCur->zFilterTable,
                                    &parentRoot, 0, &parentSchema);
   if( rc==SQLITE_NOTFOUND ){
-    rc = diffMapChunkSourceError(pCur, db, rc, SQLITE_OK);
+    rc = doltliteVtabMapChunkSourceError(pCur->base.pVtab, db, rc, SQLITE_OK);
     if( rc!=SQLITE_OK ) return rc;
     parentFound = 0;
   }else{
@@ -481,7 +435,7 @@ static int diffCatalogPairOne(
     if( !pNewMaster ) return SQLITE_OK;
 
     pOldRoot = pOldMaster ? &pOldMaster->root : &emptyRoot;
-    rc = schemaHasViewOrTriggerDiff(db, pOldRoot, &pNewMaster->root,
+    rc = doltliteMasterViewTriggerRowsDiffer(db, pOldRoot, &pNewMaster->root,
                                     pNewMaster->flags, &hasDiff);
     if( rc!=SQLITE_OK ) return rc;
     if( hasDiff ){
@@ -550,7 +504,7 @@ static int diffCatalogPair(
       memset(&emptyRoot, 0, sizeof(emptyRoot));
       pOldMaster = doltliteFindTableByNumber(aParent, nParent, 1);
       pOldRoot = pOldMaster ? &pOldMaster->root : &emptyRoot;
-      rc = schemaHasViewOrTriggerDiff(db, pOldRoot, &e->root, e->flags,
+      rc = doltliteMasterViewTriggerRowsDiffer(db, pOldRoot, &e->root, e->flags,
                                       &hasDiff);
       if( rc!=SQLITE_OK ) goto diff_done;
       if( hasDiff ){
@@ -562,7 +516,7 @@ static int diffCatalogPair(
       }
       continue;
     }
-    p = diffNameIndexFind(&parentIdx, e->zName);
+    p = addNameIndexFind(&parentIdx, e->zName);
     if( !p ){
       rc = diffRootHasRows(db, &e->root, &dataChange);
       if( rc!=SQLITE_OK ) goto diff_done;
@@ -584,7 +538,7 @@ static int diffCatalogPair(
     struct TableEntry *p = &aParent[i];
     u8 dataChange;
     if( !p->zName ) continue;
-    if( diffNameIndexFind(&childIdx, p->zName) ) continue;
+    if( addNameIndexFind(&childIdx, p->zName) ) continue;
     rc = diffRootHasRows(db, &p->root, &dataChange);
     if( rc!=SQLITE_OK ) goto diff_done;
     rc = batchAppend(pCur, zHex, p->zName, pCommit, dataChange, 1);

--- a/src/doltlite_diff_stat.c
+++ b/src/doltlite_diff_stat.c
@@ -309,13 +309,7 @@ static int dsNameIndexInit(
                                (int)offsetof(struct TableEntry, zName));
 }
 
-static struct TableEntry *dsNameIndexFind(
-  const DsNameIndex *pIdx,
-  const char *zName
-){
-  int r = doltliteNameIndexFind(pIdx, zName);
-  return r<0 ? 0 : (struct TableEntry*)(pIdx->aBase + (size_t)r*pIdx->stride);
-}
+
 
 static struct TableEntry *dsFindTableByNameNoCase(
   struct TableEntry *aCat,
@@ -641,7 +635,7 @@ static int dsAppendTableNames(
   for(i=0; i<nCat; i++){
     const char *zName = aCat[i].zName;
     if( !zName || aCat[i].iTable==1 ) continue;
-    if( pSkip && dsNameIndexFind(pSkip, zName) ) continue;
+    if( pSkip && addNameIndexFind(pSkip, zName) ) continue;
     if( *pn>=*pAlloc ){
       int newAlloc = *pAlloc ? *pAlloc*2 : 8;
       char **aNew = sqlite3_realloc(*paz, newAlloc*(int)sizeof(char*));
@@ -792,7 +786,7 @@ static struct TableEntry *dsRenamePartner(
   if( !pRef ) return 0;
   p = doltliteFindTableByNumber(aOther, nOther, pRef->iTable);
   if( !p || !p->zName ) return 0;
-  if( dsNameIndexFind(pRefSideIdx, p->zName) ) return 0;
+  if( addNameIndexFind(pRefSideIdx, p->zName) ) return 0;
   return p;
 }
 
@@ -818,8 +812,8 @@ static int dstAdvance(DstCursor *c, sqlite3 *db){
       if( pFromEntry ) zFromName = pFromEntry->zName;
       if( pToEntry ) zToName = pToEntry->zName;
     }else{
-      pFromEntry = dsNameIndexFind(&c->fromIdx, zName);
-      pToEntry = dsNameIndexFind(&c->toIdx, zName);
+      pFromEntry = addNameIndexFind(&c->fromIdx, zName);
+      pToEntry = addNameIndexFind(&c->toIdx, zName);
       if( pFromEntry && !pToEntry ){
         struct TableEntry *pRen =
             dsRenamePartner(c->aToCat, c->nToCat, pFromEntry, &c->fromIdx);
@@ -1206,8 +1200,8 @@ static int dssAdvance(DssCursor *c, sqlite3 *db){
       pFromEntry = dsFindTableByNameNoCase(c->aFromCat, c->nFromCat, zName);
       pToEntry = dsFindTableByNameNoCase(c->aToCat, c->nToCat, zName);
     }else{
-      pFromEntry = dsNameIndexFind(&c->fromIdx, zName);
-      pToEntry = dsNameIndexFind(&c->toIdx, zName);
+      pFromEntry = addNameIndexFind(&c->fromIdx, zName);
+      pToEntry = addNameIndexFind(&c->toIdx, zName);
       if( pFromEntry && !pToEntry ){
         struct TableEntry *pRen =
             dsRenamePartner(c->aToCat, c->nToCat, pFromEntry, &c->fromIdx);

--- a/src/doltlite_diff_table.c
+++ b/src/doltlite_diff_table.c
@@ -111,16 +111,10 @@ static int dtMapChunkSourceError(
   int sourceRc,
   int mappedRc
 ){
-  ChunkStore *cs = doltliteGetChunkStore(db);
-  int pendingRc = SQLITE_OK;
-  char *zErr = cs ? chunkStoreSourceTakeError(cs, &pendingRc) : 0;
-  if( !zErr && pendingRc==SQLITE_OK ) return mappedRc;
-  pCur->sourceError = 1;
-  if( zErr ){
-    sqlite3_free(pCur->base.pVtab->zErrMsg);
-    pCur->base.pVtab->zErrMsg = zErr;
-  }
-  return pendingRc!=SQLITE_OK ? pendingRc : sourceRc;
+  int rc = doltliteVtabMapChunkSourceError(
+      pCur->base.pVtab, db, sourceRc, mappedRc);
+  if( rc!=mappedRc ) pCur->sourceError = 1;
+  return rc;
 }
 
 static int dtLoadTableRootOrEmpty(

--- a/src/doltlite_docs.c
+++ b/src/doltlite_docs.c
@@ -144,11 +144,7 @@ static int docsOpen(sqlite3_vtab *pVtab, sqlite3_vtab_cursor **ppCursor){
   return doltliteVtabOpenCursor(ppCursor, sizeof(DocsCursor));
 }
 
-static int docsSetErrMsg(DocsVtab *p, int rc){
-  sqlite3_free(p->base.zErrMsg);
-  p->base.zErrMsg = sqlite3_mprintf("%s", sqlite3_errmsg(p->db));
-  return rc;
-}
+
 
 static int docsAdvance(DocsCursor *c){
   DocsVtab *p = (DocsVtab*)c->base.pVtab;
@@ -161,7 +157,7 @@ static int docsAdvance(DocsCursor *c){
   if( rc==SQLITE_ROW ) return SQLITE_OK;
   rc = sqlite3_finalize(c->pStmt);
   c->pStmt = 0;
-  if( rc!=SQLITE_OK ) return docsSetErrMsg(p, rc);
+  if( rc!=SQLITE_OK ) return doltliteVtabSetErrmsgFromDb(&p->base, p->db, rc);
   c->eof = 1;
   return SQLITE_OK;
 }
@@ -183,7 +179,7 @@ static int docsFilter(sqlite3_vtab_cursor *pCursor,
   rc = sqlite3_prepare_v3(p->db,
       "SELECT doc_name, doc_text FROM main.dolt_docs", -1,
       SQLITE_PREPARE_NO_VTAB, &c->pStmt, 0);
-  if( rc!=SQLITE_OK ) return docsSetErrMsg(p, rc);
+  if( rc!=SQLITE_OK ) return doltliteVtabSetErrmsgFromDb(&p->base, p->db, rc);
   return docsAdvance(c);
 }
 
@@ -227,33 +223,19 @@ static int docsClose(sqlite3_vtab_cursor *pCursor){
   return SQLITE_OK;
 }
 
-static int docsExecBound(DocsVtab *p, const char *zSql,
-                         sqlite3_value *pArg1, sqlite3_value *pArg2,
-                         sqlite3_value *pArg3){
-  sqlite3_stmt *pStmt = 0;
-  int rc = sqlite3_prepare_v3(p->db, zSql, -1,
-                              SQLITE_PREPARE_NO_VTAB, &pStmt, 0);
-  if( rc!=SQLITE_OK ) return docsSetErrMsg(p, rc);
-  if( pArg1 ) sqlite3_bind_value(pStmt, 1, pArg1);
-  if( pArg2 ) sqlite3_bind_value(pStmt, 2, pArg2);
-  if( pArg3 ) sqlite3_bind_value(pStmt, 3, pArg3);
-  sqlite3_step(pStmt);
-  rc = sqlite3_finalize(pStmt);
-  if( rc!=SQLITE_OK ) return docsSetErrMsg(p, rc);
-  return SQLITE_OK;
-}
+
 
 static int docsSeedAgent(DocsVtab *p){
   sqlite3_stmt *pStmt = 0;
   int rc = sqlite3_prepare_v3(p->db,
       "INSERT INTO main.dolt_docs(doc_name, doc_text) VALUES(?1, ?2)", -1,
       SQLITE_PREPARE_NO_VTAB, &pStmt, 0);
-  if( rc!=SQLITE_OK ) return docsSetErrMsg(p, rc);
+  if( rc!=SQLITE_OK ) return doltliteVtabSetErrmsgFromDb(&p->base, p->db, rc);
   sqlite3_bind_text(pStmt, 1, zDocsAgentName, -1, SQLITE_STATIC);
   sqlite3_bind_text(pStmt, 2, zDocsAgentDefault, -1, SQLITE_STATIC);
   sqlite3_step(pStmt);
   rc = sqlite3_finalize(pStmt);
-  if( rc!=SQLITE_OK ) return docsSetErrMsg(p, rc);
+  if( rc!=SQLITE_OK ) return doltliteVtabSetErrmsgFromDb(&p->base, p->db, rc);
   return SQLITE_OK;
 }
 
@@ -323,15 +305,15 @@ static int docsUpdate(sqlite3_vtab *pBase, int argc, sqlite3_value **argv,
   if( rc!=SQLITE_OK ) return rc;
 
   if( argc==1 ){
-    return docsExecBound(p,
+    return doltliteVtabExecBound(&p->base, p->db,
         "DELETE FROM main.dolt_docs WHERE doc_name=?1", argv[0], 0, 0);
   }
   if( sqlite3_value_type(argv[0])!=SQLITE_NULL ){
-    return docsExecBound(p,
+    return doltliteVtabExecBound(&p->base, p->db,
         docsUpdateSql(p->db), argv[2], argv[3], argv[0]);
   }
 
-  rc = docsExecBound(p, docsInsertSql(p->db), argv[2], argv[3], 0);
+  rc = doltliteVtabExecBound(&p->base, p->db, docsInsertSql(p->db), argv[2], argv[3], 0);
   if( rc!=SQLITE_OK ) return rc;
   if( pRowid ) *pRowid = sqlite3_last_insert_rowid(p->db);
   return SQLITE_OK;

--- a/src/doltlite_history.c
+++ b/src/doltlite_history.c
@@ -54,22 +54,7 @@ struct HistCursor {
   int singleCommit;
 };
 
-static int htMapChunkSourceError(
-  HistCursor *c,
-  sqlite3 *db,
-  int sourceRc,
-  int mappedRc
-){
-  ChunkStore *cs = doltliteGetChunkStore(db);
-  int pendingRc = SQLITE_OK;
-  char *zErr = cs ? chunkStoreSourceTakeError(cs, &pendingRc) : 0;
-  if( !zErr && pendingRc==SQLITE_OK ) return mappedRc;
-  if( zErr ){
-    sqlite3_free(c->common.base.pVtab->zErrMsg);
-    c->common.base.pVtab->zErrMsg = zErr;
-  }
-  return pendingRc!=SQLITE_OK ? pendingRc : sourceRc;
-}
+
 
 static void htCursorReset(HistCursor *c){
   doltliteVtabCommonReset(&c->common);
@@ -80,13 +65,9 @@ static void htCursorReset(HistCursor *c){
 }
 
 static int htRowMatchesUpper(HistCursor *c){
-  i64 k;
   if( !c->pkRange.hasPkHi ) return 1;
-  k = prollyCursorIntKey(&c->common.tblCur);
-  if( c->pkRange.pkHiStrict ){
-    return k < c->pkRange.pkHi;
-  }
-  return k <= c->pkRange.pkHi;
+  return doltlitePkRangeMatchesUpper(
+      &c->pkRange, prollyCursorIntKey(&c->common.tblCur));
 }
 
 static int htOpenTableAtCommit(HistCursor *c, sqlite3 *db,
@@ -131,7 +112,7 @@ static int htOpenTableAtCommit(HistCursor *c, sqlite3 *db,
   }
   doltliteCommitClear(&commit);
   if( rc==SQLITE_NOTFOUND ){
-    rc = htMapChunkSourceError(c, db, rc, SQLITE_OK);
+    rc = doltliteVtabMapChunkSourceError(c->common.base.pVtab, db, rc, SQLITE_OK);
   }
   if( rc!=SQLITE_OK ) return rc;
 

--- a/src/doltlite_ignore.c
+++ b/src/doltlite_ignore.c
@@ -320,11 +320,7 @@ static const char *zIgnoreCreate =
   "CREATE TABLE main.dolt_ignore("
   "pattern TEXT NOT NULL, ignored TINYINT NOT NULL, PRIMARY KEY(pattern))";
 
-static int ignoreSetErr(IgnoreVtab *p, int rc){
-  sqlite3_free(p->base.zErrMsg);
-  p->base.zErrMsg = sqlite3_mprintf("%s", sqlite3_errmsg(p->db));
-  return rc;
-}
+
 
 static int ignoreConnect(sqlite3 *db, void *pAux, int argc,
     const char *const*argv, sqlite3_vtab **ppVtab, char **pzErr){
@@ -397,21 +393,7 @@ static int ignoreBegin(sqlite3_vtab *pBase){
   return ignoreMaterialize((IgnoreVtab*)pBase);
 }
 
-static int ignoreExecBound(IgnoreVtab *p, const char *zSql,
-                           sqlite3_value *pArg1, sqlite3_value *pArg2,
-                           sqlite3_value *pArg3){
-  sqlite3_stmt *pStmt = 0;
-  int rc = sqlite3_prepare_v3(p->db, zSql, -1,
-                              SQLITE_PREPARE_NO_VTAB, &pStmt, 0);
-  if( rc!=SQLITE_OK ) return ignoreSetErr(p, rc);
-  if( pArg1 ) sqlite3_bind_value(pStmt, 1, pArg1);
-  if( pArg2 ) sqlite3_bind_value(pStmt, 2, pArg2);
-  if( pArg3 ) sqlite3_bind_value(pStmt, 3, pArg3);
-  sqlite3_step(pStmt);
-  rc = sqlite3_finalize(pStmt);
-  if( rc!=SQLITE_OK ) return ignoreSetErr(p, rc);
-  return SQLITE_OK;
-}
+
 
 static const char *ignoreInsertSql(sqlite3 *db){
   switch( sqlite3_vtab_on_conflict(db) ){
@@ -461,15 +443,15 @@ static int ignoreUpdate(sqlite3_vtab *pBase, int argc, sqlite3_value **argv,
   if( rc!=SQLITE_OK ) return rc;
 
   if( argc==1 ){
-    return ignoreExecBound(p,
+    return doltliteVtabExecBound(&p->base, p->db,
         "DELETE FROM main.dolt_ignore WHERE pattern=?1", argv[0], 0, 0);
   }
   if( sqlite3_value_type(argv[0])!=SQLITE_NULL ){
-    return ignoreExecBound(p,
+    return doltliteVtabExecBound(&p->base, p->db,
         ignoreUpdateSql(p->db), argv[2], argv[3], argv[0]);
   }
 
-  rc = ignoreExecBound(p, ignoreInsertSql(p->db), argv[2], argv[3], 0);
+  rc = doltliteVtabExecBound(&p->base, p->db, ignoreInsertSql(p->db), argv[2], argv[3], 0);
   if( rc!=SQLITE_OK ) return rc;
   if( pRowid ) *pRowid = sqlite3_last_insert_rowid(p->db);
   return SQLITE_OK;

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -77,6 +77,15 @@ struct DoltlitePkRange {
   int isEmpty;            /* NULL bound: scan matches nothing. */
 };
 
+static SQLITE_INLINE int doltlitePkRangeMatchesUpper(
+  const DoltlitePkRange *pRange,
+  i64 k
+){
+  if( !pRange->hasPkHi ) return 1;
+  if( pRange->pkHiStrict ) return k < pRange->pkHi;
+  return k <= pRange->pkHi;
+}
+
 struct DoltliteCommitQueue {
   ProllyHash *aQueue;
   int qHead, qTail, qAlloc;
@@ -949,6 +958,64 @@ void doltliteCmdResultPeerBranchBusy(sqlite3_context *ctx, const char *zOp);
 int doltliteCmdSourceResultError(
   sqlite3_context *ctx, ChunkStore *cs, int *pRc
 );
+int doltliteVtabMapChunkSourceError(
+  sqlite3_vtab *pVtab, sqlite3 *db, int sourceRc, int mappedRc
+);
+
+static SQLITE_INLINE int doltliteVtabSetErrmsgFromDb(
+  sqlite3_vtab *pVtab,
+  sqlite3 *db,
+  int rc
+){
+  sqlite3_free(pVtab->zErrMsg);
+  pVtab->zErrMsg = sqlite3_mprintf("%s", sqlite3_errmsg(db));
+  return rc;
+}
+
+static SQLITE_INLINE int doltliteVtabExecBound(
+  sqlite3_vtab *pVtab,
+  sqlite3 *db,
+  const char *zSql,
+  sqlite3_value *pArg1,
+  sqlite3_value *pArg2,
+  sqlite3_value *pArg3
+){
+  sqlite3_stmt *pStmt = 0;
+  int rc = sqlite3_prepare_v3(db, zSql, -1, SQLITE_PREPARE_NO_VTAB, &pStmt, 0);
+  if( rc!=SQLITE_OK ) return doltliteVtabSetErrmsgFromDb(pVtab, db, rc);
+  if( pArg1 ) sqlite3_bind_value(pStmt, 1, pArg1);
+  if( pArg2 ) sqlite3_bind_value(pStmt, 2, pArg2);
+  if( pArg3 ) sqlite3_bind_value(pStmt, 3, pArg3);
+  sqlite3_step(pStmt);
+  rc = sqlite3_finalize(pStmt);
+  if( rc!=SQLITE_OK ) return doltliteVtabSetErrmsgFromDb(pVtab, db, rc);
+  return SQLITE_OK;
+}
+
+static SQLITE_INLINE int doltliteTableEntryDiffers(
+  const struct TableEntry *a,
+  const struct TableEntry *b
+){
+  if( !a && !b ) return 0;
+  if( !a || !b ) return 1;
+  if( prollyHashCompare(&a->root, &b->root)!=0 ) return 1;
+  if( prollyHashCompare(&a->schemaHash, &b->schemaHash)!=0 ) return 1;
+  return 0;
+}
+
+static SQLITE_INLINE int doltliteSchemaEntriesSame(
+  const SchemaEntry *pA,
+  const SchemaEntry *pB
+){
+  if( !pA && !pB ) return 1;
+  if( !pA || !pB ) return 0;
+  if( sqlite3_stricmp(pA->zType ? pA->zType : "",
+                      pB->zType ? pB->zType : "")!=0 ) return 0;
+  if( sqlite3_stricmp(pA->zTblName ? pA->zTblName : "",
+                      pB->zTblName ? pB->zTblName : "")!=0 ) return 0;
+  if( (pA->zSql==0)!=(pB->zSql==0) ) return 0;
+  return !pA->zSql || strcmp(pA->zSql, pB->zSql)==0;
+}
 int doltliteCmdFinishWithConflicts(
   sqlite3 *db, sqlite3_context *ctx, DoltliteTxnState *pSaved,
   int nConflicts, const char *zOp, int bSealOnPlain
@@ -988,9 +1055,12 @@ int addNameIndexInit(
   AddNameIndex *pIdx, struct TableEntry *aEntry, int nEntry
 );
 void addNameIndexFree(AddNameIndex *pIdx);
-struct TableEntry *addNameIndexFind(
-  const AddNameIndex *pIdx, const char *zName
-);
+static SQLITE_INLINE struct TableEntry *addNameIndexFind(
+  const DoltliteNameIndex *pIdx, const char *zName
+){
+  int r = doltliteNameIndexFind(pIdx, zName);
+  return r<0 ? 0 : (struct TableEntry*)(pIdx->aBase + (size_t)r*(size_t)pIdx->stride);
+}
 int amTableStagedByName(
   struct TableEntry *aStaged, int nStaged, const char *zTbl
 );
@@ -1172,8 +1242,6 @@ int doltliteSerializeConflicts(ChunkStore *cs,
                                int nTables, ProllyHash *pHash);
 
 /* Index keys must match VDBE (NOCASE/RTRIM/DESC). */
-void doltliteIpkSerialType(i64 v, u32 *pType, u32 *pLen);
-void doltliteIpkWriteBE(u8 *p, i64 v, int n);
 KeyInfo *doltliteKeyInfoOfIndex(sqlite3 *db, Index *pIdx);
 int doltliteMasterViewTriggerRowsDiffer(sqlite3 *db, const ProllyHash *pOldRoot,
                                         const ProllyHash *pNewRoot, u8 flags,

--- a/src/doltlite_log.c
+++ b/src/doltlite_log.c
@@ -329,22 +329,7 @@ struct DoltliteLogCursor {
   int singleCommit;
 };
 
-static int logMapChunkSourceError(
-  DoltliteLogCursor *pCur,
-  sqlite3 *db,
-  int sourceRc,
-  int mappedRc
-){
-  ChunkStore *cs = doltliteGetChunkStore(db);
-  int pendingRc = SQLITE_OK;
-  char *zErr = cs ? chunkStoreSourceTakeError(cs, &pendingRc) : 0;
-  if( !zErr && pendingRc==SQLITE_OK ) return mappedRc;
-  if( zErr ){
-    sqlite3_free(pCur->base.pVtab->zErrMsg);
-    pCur->base.pVtab->zErrMsg = zErr;
-  }
-  return pendingRc!=SQLITE_OK ? pendingRc : sourceRc;
-}
+
 
 static const char *doltliteLogSchema =
   "CREATE TABLE x("
@@ -417,7 +402,7 @@ static int logAdvance(DoltliteLogCursor *pCur, sqlite3 *db){
     rc = doltliteLoadCommit(db, &cur, &pCur->curCommit);
     if( rc!=SQLITE_OK ){
       if( pCur->singleCommit ){
-        rc = logMapChunkSourceError(pCur, db, rc, SQLITE_OK);
+        rc = doltliteVtabMapChunkSourceError(pCur->base.pVtab, db, rc, SQLITE_OK);
         doltliteCommitClear(&pCur->curCommit);
         memset(&pCur->curCommit, 0, sizeof(pCur->curCommit));
         return rc;

--- a/src/doltlite_merge.c
+++ b/src/doltlite_merge.c
@@ -161,19 +161,7 @@ int hasAnySchemaConflict(
   return 0;
 }
 
-static int mergeSchemaEntriesSame(
-  const SchemaEntry *pA,
-  const SchemaEntry *pB
-){
-  if( !pA && !pB ) return 1;
-  if( !pA || !pB ) return 0;
-  if( sqlite3_stricmp(pA->zType ? pA->zType : "",
-                      pB->zType ? pB->zType : "")!=0 ) return 0;
-  if( sqlite3_stricmp(pA->zTblName ? pA->zTblName : "",
-                      pB->zTblName ? pB->zTblName : "")!=0 ) return 0;
-  if( (pA->zSql==0)!=(pB->zSql==0) ) return 0;
-  return !pA->zSql || strcmp(pA->zSql, pB->zSql)==0;
-}
+
 
 static int mergeIndexColListSame(const char *zA, const char *zB){
   if( !zA || !zB ) return zA==zB;
@@ -290,8 +278,8 @@ static int preDetectIndexSchemaConflicts(
       pAnc = findSchemaEntry(aAnc, nAnc, a[i].zName);
       pOurs = findSchemaEntry(aOurs, nOurs, a[i].zName);
       pTheirs = findSchemaEntry(aTheirs, nTheirs, a[i].zName);
-      oursChanged = !mergeSchemaEntriesSame(pAnc, pOurs);
-      theirsChanged = !mergeSchemaEntriesSame(pAnc, pTheirs);
+      oursChanged = !doltliteSchemaEntriesSame(pAnc, pOurs);
+      theirsChanged = !doltliteSchemaEntriesSame(pAnc, pTheirs);
       if( mergeIndexFollowsDualRename(
             aAnc, nAnc, aOurs, nOurs, aTheirs, nTheirs,
             pAnc, pOurs, pTheirs) ){
@@ -347,7 +335,7 @@ static int preDetectIndexSchemaConflicts(
         continue;
       }
       if( !oursChanged || !theirsChanged
-       || mergeSchemaEntriesSame(pOurs, pTheirs) ){
+       || doltliteSchemaEntriesSame(pOurs, pTheirs) ){
         continue;
       }
       /* Dolt keeps the modified index when the other branch drops it. */

--- a/src/doltlite_merge_constraints.c
+++ b/src/doltlite_merge_constraints.c
@@ -98,23 +98,14 @@ int fetchRowByBlobKey(
   return rc;
 }
 
-int tableEntryDiffers(
-  const struct TableEntry *a,
-  const struct TableEntry *b
-){
-  if( !a && !b ) return 0;
-  if( !a || !b ) return 1;
-  if( prollyHashCompare(&a->root, &b->root)!=0 ) return 1;
-  if( prollyHashCompare(&a->schemaHash, &b->schemaHash)!=0 ) return 1;
-  return 0;
-}
+
 
 int catalogTableChanged(
   struct TableEntry *aAnc, int nAnc,
   struct TableEntry *aCur, int nCur,
   const char *zTable
 ){
-  return tableEntryDiffers(
+  return doltliteTableEntryDiffers(
       doltliteFindTableByName(aAnc, nAnc, zTable),
       doltliteFindTableByName(aCur, nCur, zTable));
 }

--- a/src/doltlite_merge_constraints_int.h
+++ b/src/doltlite_merge_constraints_int.h
@@ -37,7 +37,6 @@ int fetchRowByBlobKey(
   ChunkStore *cs, ProllyCache *pCache, const ProllyHash *pRoot, u8 flags,
   const u8 *pKey, int nKey, u8 **ppKey, int *pnKey, u8 **ppVal, int *pnVal
 );
-int tableEntryDiffers(const struct TableEntry *a, const struct TableEntry *b);
 int catalogTableChanged(
   struct TableEntry *aAnc, int nAnc,
   struct TableEntry *aCur, int nCur,

--- a/src/doltlite_merge_rows.c
+++ b/src/doltlite_merge_rows.c
@@ -2,22 +2,7 @@
 
 #include "doltlite_merge_int.h"
 
-/* Serial type + body length for an i64, matching SQLite records. */
-void doltliteIpkSerialType(i64 v, u32 *pType, u32 *pLen){
-  if( v==0 ){ *pType = 8; *pLen = 0; return; }
-  if( v==1 ){ *pType = 9; *pLen = 0; return; }
-  if( v>=-128 && v<=127 ){ *pType = 1; *pLen = 1; return; }
-  if( v>=-32768 && v<=32767 ){ *pType = 2; *pLen = 2; return; }
-  if( v>=-8388608 && v<=8388607 ){ *pType = 3; *pLen = 3; return; }
-  if( v>=-2147483648LL && v<=2147483647LL ){ *pType = 4; *pLen = 4; return; }
-  if( v>=-140737488355328LL && v<=140737488355327LL ){ *pType = 5; *pLen = 6; return; }
-  *pType = 6; *pLen = 8;
-}
 
-void doltliteIpkWriteBE(u8 *p, i64 v, int n){
-  int i;
-  for(i=n-1; i>=0; i--){ p[i] = (u8)(v & 0xff); v >>= 8; }
-}
 
 /* KeyInfo without Parse. Matches sqlite3KeyInfoOfIndex so VC paths
 ** encode the same sort keys as VDBE. */
@@ -466,7 +451,7 @@ static int doltliteBuildIndexEntry(
     int st = info.aType[iPKey];
     if( st==0 || st==8 || st==9 ){
       useIpk = 1;
-      doltliteIpkSerialType(intKey, &ipkType, &ipkLen);
+      dlIpkSerialType(intKey, &ipkType, &ipkLen);
     }
   }
 
@@ -536,7 +521,7 @@ static int doltliteBuildIndexEntry(
         st = (int)ipkType;
         flen = (int)ipkLen;
         if( flen>0 ){
-          doltliteIpkWriteBE(p, intKey, flen);
+          dlIpkWriteBE(p, intKey, flen);
           p += flen;
         }
         continue;

--- a/src/doltlite_revert.c
+++ b/src/doltlite_revert.c
@@ -18,15 +18,7 @@
 #include <ctype.h>
 #include <time.h>
 
-static int doltliteTableEntryDiffers(
-  const struct TableEntry *a, const struct TableEntry *b
-){
-  if( !a && !b ) return 0;
-  if( !a || !b ) return 1;
-  if( prollyHashCompare(&a->root, &b->root)!=0 ) return 1;
-  if( prollyHashCompare(&a->schemaHash, &b->schemaHash)!=0 ) return 1;
-  return 0;
-}
+
 
 static int revertTouchesTable(
   struct TableEntry *aCommit, int nCommit,

--- a/src/doltlite_schema_diff.c
+++ b/src/doltlite_schema_diff.c
@@ -426,13 +426,7 @@ static int sdTableIndexInit(
                                (int)offsetof(struct TableEntry, zName));
 }
 
-static struct TableEntry *sdTableIndexFind(
-  const SdTableIndex *pIdx,
-  const char *zName
-){
-  int r = doltliteNameIndexFind(pIdx, zName);
-  return r<0 ? 0 : (struct TableEntry*)(pIdx->aBase + (size_t)r*pIdx->stride);
-}
+
 
 static int computeSchemaDiff(
   SdCursor *pCur,
@@ -483,7 +477,7 @@ static int computeSchemaDiff(
     fromEntry = sdSchemaIndexFind(&fromSchemaIdx, aTo[i].zName);
     if( fromEntry ) continue;
 
-    toTE = sdTableIndexFind(&toTableIdx, aTo[i].zName);
+    toTE = addNameIndexFind(&toTableIdx, aTo[i].zName);
     if( !toTE || toTE->iTable==0 ) continue;
 
     for(j=0; j<nFromTables; j++){
@@ -493,7 +487,7 @@ static int computeSchemaDiff(
       if( !aFromTables[j].zName ) continue;
       if( prollyHashCompare(&aFromTables[j].root, &toTE->root)!=0 ) break;
 
-      if( sdTableIndexFind(&toTableIdx, aFromTables[j].zName) ) break;
+      if( addNameIndexFind(&toTableIdx, aFromTables[j].zName) ) break;
 
       dropped = sdSchemaIndexFind(&fromSchemaIdx, aFromTables[j].zName);
       if( !dropped ) break;

--- a/src/doltlite_status.c
+++ b/src/doltlite_status.c
@@ -182,23 +182,7 @@ static int addRow(DoltliteStatusCursor *pCur, const char *zName,
   return SQLITE_OK;
 }
 
-static int statusSchemaRecordIsViewOrTrigger(const u8 *pRec, int nRec){
-  DoltliteRecordInfo ri;
-  int st, off, len;
-  const u8 *pBody;
-  if( !pRec || nRec<=0 ) return 0;
-  doltliteParseRecord(pRec, nRec, &ri);
-  if( ri.nField < 1 ) return 0;
-  st = ri.aType[0];
-  off = ri.aOffset[0];
-  if( st < 13 || (st & 1)==0 ) return 0;
-  len = (st - 13) / 2;
-  if( off < 0 || off + len > nRec ) return 0;
-  pBody = pRec + off;
-  if( len==4 && memcmp(pBody, "view", 4)==0 ) return 1;
-  if( len==7 && memcmp(pBody, "trigger", 7)==0 ) return 1;
-  return 0;
-}
+
 
 static int statusSchemaHasViewOrTrigger(sqlite3 *db,
                                         const ProllyHash *pRoot,
@@ -221,7 +205,7 @@ static int statusSchemaHasViewOrTrigger(sqlite3 *db,
     const u8 *pVal;
     int nVal;
     prollyCursorValue(&cur, &pVal, &nVal);
-    if( statusSchemaRecordIsViewOrTrigger(pVal, nVal) ){
+    if( doltliteSchemaRecordIsViewOrTrigger(pVal, nVal) ){
       *pFound = 1;
       break;
     }
@@ -232,14 +216,7 @@ static int statusSchemaHasViewOrTrigger(sqlite3 *db,
   return rc;
 }
 
-static int statusSchemaHasViewOrTriggerDiff(sqlite3 *db,
-                                            const ProllyHash *pOldRoot,
-                                            const ProllyHash *pNewRoot,
-                                            u8 flags,
-                                            int *pFound){
-  return doltliteMasterViewTriggerRowsDiffer(db, pOldRoot, pNewRoot, flags,
-                                             pFound);
-}
+
 
 static int statusCompareDoltSchemas(
   DoltliteStatusCursor *pCur,
@@ -273,7 +250,7 @@ static int statusCompareDoltSchemas(
   pNewRoot = pNewMaster ? &pNewMaster->root : &emptyRoot;
   flags = pNewMaster ? pNewMaster->flags : pOldMaster->flags;
 
-  rc = statusSchemaHasViewOrTriggerDiff(
+  rc = doltliteMasterViewTriggerRowsDiffer(
       db, pOldRoot, pNewRoot, flags, &changed);
   if( rc!=SQLITE_OK || !changed ) return rc;
 

--- a/src/doltlite_tests.c
+++ b/src/doltlite_tests.c
@@ -44,11 +44,7 @@ static const char *zTestsCreate =
   "CONSTRAINT assertion_comparator_check CHECK(assertion_comparator IN "
     "('==','!=','<','>','<=','>=')))";
 
-static int testsSetErr(TestsVtab *p, int rc){
-  sqlite3_free(p->base.zErrMsg);
-  p->base.zErrMsg = sqlite3_mprintf("%s", sqlite3_errmsg(p->db));
-  return rc;
-}
+
 
 static int testsConnect(sqlite3 *db, void *pAux, int argc,
     const char *const*argv, sqlite3_vtab **ppVtab, char **pzErr){
@@ -143,11 +139,11 @@ static int testsUpdate(sqlite3_vtab *pBase, int argc, sqlite3_value **argv,
       break;
   }
   rc = sqlite3_prepare_v2(p->db, zSql, -1, &pStmt, 0);
-  if( rc!=SQLITE_OK ) return testsSetErr(p, rc);
+  if( rc!=SQLITE_OK ) return doltliteVtabSetErrmsgFromDb(&p->base, p->db, rc);
   for(i=0; i<6; i++) sqlite3_bind_value(pStmt, i+1, argv[i+2]);
   sqlite3_step(pStmt);
   rc = sqlite3_finalize(pStmt);
-  if( rc!=SQLITE_OK ) return testsSetErr(p, rc);
+  if( rc!=SQLITE_OK ) return doltliteVtabSetErrmsgFromDb(&p->base, p->db, rc);
   if( pRowid ) *pRowid = sqlite3_last_insert_rowid(p->db);
   return SQLITE_OK;
 }

--- a/src/doltlite_workspace.c
+++ b/src/doltlite_workspace.c
@@ -64,22 +64,7 @@ struct WorkspaceCursor {
   WorkspaceRows *pRows;
 };
 
-static int wsMapChunkSourceError(
-  WorkspaceCursor *pCur,
-  WorkspaceVtab *pVtab,
-  int sourceRc,
-  int mappedRc
-){
-  ChunkStore *cs = doltliteGetChunkStore(pVtab->db);
-  int pendingRc = SQLITE_OK;
-  char *zErr = cs ? chunkStoreSourceTakeError(cs, &pendingRc) : 0;
-  if( !zErr && pendingRc==SQLITE_OK ) return mappedRc;
-  if( zErr ){
-    sqlite3_free(pCur->base.pVtab->zErrMsg);
-    pCur->base.pVtab->zErrMsg = zErr;
-  }
-  return pendingRc!=SQLITE_OK ? pendingRc : sourceRc;
-}
+
 
 static int wsLoadTableRootOrEmpty(
   WorkspaceCursor *pCur,
@@ -93,7 +78,7 @@ static int wsLoadTableRootOrEmpty(
       pVtab->db, pCatHash, pVtab->zTableName,
       pRoot, pFlags, pSchemaHash);
   if( rc==SQLITE_NOTFOUND ){
-    rc = wsMapChunkSourceError(pCur, pVtab, rc, SQLITE_OK);
+    rc = doltliteVtabMapChunkSourceError(&pVtab->base, pVtab->db, rc, SQLITE_OK);
   }
   return rc;
 }

--- a/src/prolly_record.h
+++ b/src/prolly_record.h
@@ -40,6 +40,22 @@ static inline int dlSerialTypeLen(u64 st){
   return 0;
 }
 
+static inline void dlIpkSerialType(i64 v, u32 *pType, u32 *pLen){
+  if( v==0 ){ *pType = 8; *pLen = 0; return; }
+  if( v==1 ){ *pType = 9; *pLen = 0; return; }
+  if( v>=-128 && v<=127 ){ *pType = 1; *pLen = 1; return; }
+  if( v>=-32768 && v<=32767 ){ *pType = 2; *pLen = 2; return; }
+  if( v>=-8388608 && v<=8388607 ){ *pType = 3; *pLen = 3; return; }
+  if( v>=-2147483648LL && v<=2147483647LL ){ *pType = 4; *pLen = 4; return; }
+  if( v>=-140737488355328LL && v<=140737488355327LL ){ *pType = 5; *pLen = 6; return; }
+  *pType = 6; *pLen = 8;
+}
+
+static inline void dlIpkWriteBE(u8 *p, i64 v, int n){
+  int i;
+  for(i=n-1; i>=0; i--){ p[i] = (u8)(v & 0xff); v >>= 8; }
+}
+
 static inline int dlSerialIsInt(int st){
   return st>=1 && st<=9 && st!=7;
 }
@@ -75,6 +91,24 @@ int doltliteParseRecordStrict(const u8 *pData, int nData,
                               DoltliteRecordInfo *pInfo);
 
 void doltliteParseRecord(const u8 *pData, int nData, DoltliteRecordInfo *pInfo);
+
+static inline int doltliteSchemaRecordIsViewOrTrigger(const u8 *pRec, int nRec){
+  DoltliteRecordInfo ri;
+  int st, off, len;
+  const u8 *pBody;
+  if( !pRec || nRec<=0 ) return 0;
+  doltliteParseRecord(pRec, nRec, &ri);
+  if( ri.nField < 1 ) return 0;
+  st = ri.aType[0];
+  off = ri.aOffset[0];
+  if( st < 13 || (st & 1)==0 ) return 0;
+  len = (st - 13) / 2;
+  if( off < 0 || off + len > nRec ) return 0;
+  pBody = pRec + off;
+  if( len==4 && memcmp(pBody, "view", 4)==0 ) return 1;
+  if( len==7 && memcmp(pBody, "trigger", 7)==0 ) return 1;
+  return 0;
+}
 
 static inline int dlRecordTextField(
   const u8 *pVal,

--- a/src/sortkey.c
+++ b/src/sortkey.c
@@ -3,6 +3,7 @@
 
 #include "sortkey.h"
 #include "vdbeInt.h"
+#include "prolly_record.h"
 #include <limits.h>
 #include <string.h>
 
@@ -49,9 +50,6 @@ static u8 serialTypeTag(u32 serialType){
 #define SORTKEY_COLL_BINARY 0
 #define SORTKEY_COLL_NOCASE 1
 #define SORTKEY_COLL_RTRIM  2
-
-static void intSerialType(i64 v, u32 *pType, u32 *pLen);
-static void writeIntBE(u8 *p, i64 v, int nByte);
 
 static int collFromKeyInfo(const KeyInfo *pKeyInfo, int iCol){
   const CollSeq *pColl;
@@ -473,11 +471,11 @@ static int sortKeyMemSerialType(Mem *pMem, u32 *pSerialType, u32 *pLen){
   }
   if( flags & MEM_IntReal ){
     /* Integer-valued REAL encodes as a true REAL of that value. */
-    intSerialType(pMem->u.i, pSerialType, pLen);
+    dlIpkSerialType(pMem->u.i, pSerialType, pLen);
     return SQLITE_OK;
   }
   if( flags & MEM_Int ){
-    intSerialType(pMem->u.i, pSerialType, pLen);
+    dlIpkSerialType(pMem->u.i, pSerialType, pLen);
     return SQLITE_OK;
   }
   if( flags & MEM_Real ){
@@ -529,7 +527,7 @@ static int sortKeyEncodeMemArray(
     pField = (const u8*)pMem->z;
 
     if( serialType <= 6 || serialType==8 || serialType==9 ){
-      writeIntBE(aNum, pMem->u.i, (int)fieldLen);
+      dlIpkWriteBE(aNum, pMem->u.i, (int)fieldLen);
       pField = aNum;
     }else if( serialType==7 ){
       u64 v;
@@ -728,30 +726,13 @@ int sortKeyFromInt64(i64 v, u8 *pOut, int *pnOut){
     return SQLITE_OK;
   }
 
-  intSerialType(v, &serialType, &nData);
-  writeIntBE(aData, v, (int)nData);
+  dlIpkSerialType(v, &serialType, &nData);
+  dlIpkWriteBE(aData, v, (int)nData);
   *pnOut = encodeNumeric(pOut, serialType, aData, nData, 0);
   return SQLITE_OK;
 }
 
-static void intSerialType(i64 v, u32 *pType, u32 *pLen){
-  if( v==0 ){ *pType = 8; *pLen = 0; return; }
-  if( v==1 ){ *pType = 9; *pLen = 0; return; }
-  if( v>=-128 && v<=127 ){ *pType = 1; *pLen = 1; return; }
-  if( v>=-32768 && v<=32767 ){ *pType = 2; *pLen = 2; return; }
-  if( v>=-8388608 && v<=8388607 ){ *pType = 3; *pLen = 3; return; }
-  if( v>=-2147483648LL && v<=2147483647LL ){ *pType = 4; *pLen = 4; return; }
-  if( v>=-140737488355328LL && v<=140737488355327LL ){ *pType = 5; *pLen = 6; return; }
-  *pType = 6; *pLen = 8;
-}
 
-static void writeIntBE(u8 *p, i64 v, int nByte){
-  int j;
-  for(j = nByte - 1; j >= 0; j--){
-    p[j] = (u8)(v & 0xFF);
-    v >>= 8;
-  }
-}
 
 static SQLITE_INLINE void decodeNumericSortKeyToRecord(
   const u8 *pIn,
@@ -771,8 +752,8 @@ static SQLITE_INLINE void decodeNumericSortKeyToRecord(
           | ((u64)pIn[13] << 24) | ((u64)pIn[14] << 16)
           | ((u64)pIn[15] << 8)  | (u64)pIn[16];
     i64 iv = (i64)(u ^ ((u64)1 << 63));
-    intSerialType(iv, pType, pLen);
-    writeIntBE(pOut, iv, (int)*pLen);
+    dlIpkSerialType(iv, pType, pLen);
+    dlIpkWriteBE(pOut, iv, (int)*pLen);
     return;
   }
 
@@ -792,8 +773,8 @@ static SQLITE_INLINE void decodeNumericSortKeyToRecord(
   {
     i64 iv = (i64)d;
     if( d >= -9223372036854775808.0 && d < 9223372036854775808.0 && (double)iv == d ){
-      intSerialType(iv, pType, pLen);
-      writeIntBE(pOut, iv, (int)*pLen);
+      dlIpkSerialType(iv, pType, pLen);
+      dlIpkWriteBE(pOut, iv, (int)*pLen);
     }else{
       *pType = 7;
       *pLen = 8;

--- a/test/dead_code_check.sh
+++ b/test/dead_code_check.sh
@@ -1,19 +1,23 @@
 #!/bin/bash
 #
 # Dead-code gate for the doltlite-specific sources. Fails CI if a function is
-# defined but never used:
+# defined but never used, or if the same function body is copied across files:
 #
 #   Part A: unused static functions and unused locals, detected exactly by the
 #           compiler (-Werror=unused-function / -unused-variable).
-#   Part B: extern functions with no caller anywhere in the tree. This is a
-#           heuristic (an occurrence count of <=2 means a definition plus at
-#           most one declaration, i.e. no call site); intentional exports that
-#           legitimately have no in-tree caller are listed in ALLOW below.
+#   Part B: extern functions with no caller in any other .c and no use in the
+#           defining file (a header declaration does not count as a caller).
+#           Intentional embeddable-API exports live in ALLOW_EXTERN in
+#           test/lib/dead_code_scan.py.
 #   Part C: static inline helpers in headers that never appear outside their
 #           definition (the compiler will not warn; each TU that includes the
 #           header just omits the unused inline).
 #   Part D: non-static functions with no identifier occurrence outside the
 #           defining file. Those should be static so Part A can see them.
+#   Part E: non-static prototypes in owned headers that never appear in any .c.
+#   Part F: #define names in owned headers that never appear elsewhere
+#           (include guards skipped).
+#   Part G: identical function bodies copied across owned .c files.
 #
 # Needs the generated headers, so run it after a configure+build (the build
 # dir defaults to ./build, override with DOLTLITE_BUILD_DIR). Point
@@ -48,15 +52,9 @@ CFLAGS=(
   -Iext/misc -Iext/blake3 -Iext/ed25519 -Iext/mbedtls/include
 )
 
-# Intentional exports that have no in-tree caller (documented/embeddable API,
-# or build-glue entry points reached from outside this tree).
-ALLOW="doltliteServe doltliteServeAsync doltliteServerStop"
-
 fail=0
 ERR=$(mktemp)
-FNS=$(mktemp)
-DEAD=$(mktemp)
-trap 'rm -f "$ERR" "$FNS" "$DEAD"' EXIT
+trap 'rm -f "$ERR"' EXIT
 
 echo "== Part A: unused static functions / locals =="
 if [ "${DEAD_CODE_SKIP_PART_A:-}" = 1 ]; then
@@ -77,24 +75,7 @@ else
   done
 fi
 
-echo "== Part B: extern functions with no caller =="
-for f in "${SRCS[@]}"; do
-  [ -f "$f" ] || continue
-  grep -nE '^[a-zA-Z_][a-zA-Z0-9_ ]*[ \*]([a-z][a-zA-Z0-9_]+)\(' "$f" \
-    | grep -vE '^[0-9]+:(static|typedef|return|else|case|do|while|for|if|switch)\b' \
-    | sed -nE 's/^[0-9]+:[a-zA-Z_][a-zA-Z0-9_ ]*[ \*]([a-z][a-zA-Z0-9_]+)\(.*/\1/p'
-done | sort -u > "$FNS"
-: > "$DEAD"
-while read -r fn; do
-  [ -z "$fn" ] && continue
-  case " $ALLOW " in *" $fn "*) continue;; esac
-  cnt=$(grep -rhoE "\b$fn\b" "$SRC_ROOT"/*.c "$SRC_ROOT"/*.h \
-          ext/*/*.c ext/*/*.h test/*.c 2>/dev/null | wc -l | tr -d ' ')
-  [ "$cnt" -le 2 ] && echo "  dead (no caller): $fn" >> "$DEAD"
-done < "$FNS"
-if [ -s "$DEAD" ]; then cat "$DEAD"; fail=1; fi
-
-echo "== Part C/D: unused header inlines / should-be-static =="
+echo "== Part B-G: unused externs / inlines / should-be-static / prototypes / macros / clones =="
 if ! python3 "$SCRIPT_DIR/lib/dead_code_scan.py" --root "$ROOT" --src-root "$SRC_ROOT"
 then
   fail=1

--- a/test/dead_code_check_selftest.sh
+++ b/test/dead_code_check_selftest.sh
@@ -44,14 +44,66 @@ $out"
 }
 
 # Part C: unused static inline in a header.
-cat > "$WORK/src/fixture.h" <<'EOF'
-#ifndef FIXTURE_H
-#define FIXTURE_H
+cat > "$WORK/src/doltlite_fixture.h" <<'EOF'
+#ifndef DOLTLITE_FIXTURE_H
+#define DOLTLITE_FIXTURE_H
 static SQLITE_INLINE int dead_code_gate_unused_inline(int x){ return x; }
 #endif
 EOF
 : > "$WORK/src/doltlite.c"
 expect_scan_hit "header_inline_is_rejected" "dead header inline: dead_code_gate_unused_inline"
+
+# Part E: unused header prototype.
+cat > "$WORK/src/doltlite_fixture.h" <<'EOF'
+#ifndef DOLTLITE_FIXTURE_H
+#define DOLTLITE_FIXTURE_H
+int dead_code_gate_unused_proto(void);
+#endif
+EOF
+: > "$WORK/src/doltlite.c"
+expect_scan_hit "header_prototype_is_rejected" "dead header prototype: dead_code_gate_unused_proto"
+
+# Part F: unused header macro.
+cat > "$WORK/src/doltlite_fixture.h" <<'EOF'
+#ifndef DOLTLITE_FIXTURE_H
+#define DOLTLITE_FIXTURE_H
+#define DEAD_CODE_GATE_UNUSED_MACRO 1
+#endif
+EOF
+: > "$WORK/src/doltlite.c"
+expect_scan_hit "header_macro_is_rejected" "dead header macro: DEAD_CODE_GATE_UNUSED_MACRO"
+
+# Part G: identical function bodies in two owned .c files.
+cat > "$WORK/src/doltlite_clone_a.c" <<'EOF'
+static int dead_code_gate_clone_left(int a, int b, int c){
+  int t;
+  if( a<0 ) a = -a;
+  if( b<0 ) b = -b;
+  if( c<0 ) c = -c;
+  t = a*b + b*c + c*a + a + b + c + 42;
+  if( t<0 ) t = -t;
+  t = t + a*a + b*b + c*c;
+  t = t + (a+1)*(b+1)*(c+1);
+  t = t + (a-1)*(b-1)*(c-1);
+  return t;
+}
+EOF
+cat > "$WORK/src/doltlite_clone_b.c" <<'EOF'
+static int dead_code_gate_clone_right(int a, int b, int c){
+  int t;
+  if( a<0 ) a = -a;
+  if( b<0 ) b = -b;
+  if( c<0 ) c = -c;
+  t = a*b + b*c + c*a + a + b + c + 42;
+  if( t<0 ) t = -t;
+  t = t + a*a + b*b + c*c;
+  t = t + (a+1)*(b+1)*(c+1);
+  t = t + (a-1)*(b-1)*(c-1);
+  return t;
+}
+EOF
+rm -f "$WORK/src/doltlite_fixture.h"
+expect_scan_hit "duplicate_body_is_rejected" "duplicate function body: dead_code_gate_clone_left"
 
 # Part D: non-static helper only referenced in its defining file.
 cat > "$WORK/src/doltlite.c" <<'EOF'
@@ -62,7 +114,6 @@ static int dead_code_gate_same_file_caller(int x){
   return dead_code_gate_should_be_static(x);
 }
 EOF
-: > "$WORK/src/fixture.h"
 expect_scan_hit "should_be_static_is_rejected" "should be static: dead_code_gate_should_be_static"
 
 # Part A: unused static in a real translation unit (compiler-driven).

--- a/test/lib/dead_code_scan.py
+++ b/test/lib/dead_code_scan.py
@@ -1,18 +1,26 @@
 #!/usr/bin/env python3
-"""Parts C/D of test/dead_code_check.sh.
+"""Dead/duplicate-code scan for DoltLite-owned sources.
 
+B: extern function defined in owned .c, never referenced from another .c and
+   never called in its defining file (header declaration does not count).
 C: static inline in a header whose identifier never appears elsewhere.
-D: non-static function defined in DoltLite-owned .c with no identifier
-   occurrence outside that file (should be static, or it is dead).
+D: non-static function with no identifier occurrence outside its .c
+   (should be static so Part A can see it).
+E: non-static prototype in an owned header that never appears in any .c.
+F: #define in an owned header whose identifier never appears elsewhere
+   (include guards skipped).
+G: two owned .c files contain functions with identical normalized bodies
+   (whitespace collapsed, length >= MIN_CLONE_BODY).
 """
 from __future__ import annotations
 
 import argparse
 import glob
+import hashlib
 import os
 import re
 import sys
-from collections import Counter
+from collections import Counter, defaultdict
 
 IDENT = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
 INLINE = re.compile(
@@ -20,11 +28,18 @@ INLINE = re.compile(
     re.S,
 )
 DEF = re.compile(
-    r"^(?!\s)(?!static\b)(?!typedef\b)(?!#)"
-    r"(?:SQLITE_PRIVATE\s+|SQLITE_API\s+)?"
+    r"^(?!\s)(?!typedef\b)(?!#)"
+    r"(?:static\s+)?(?:SQLITE_PRIVATE\s+|SQLITE_API\s+)?"
     r".+?\b([A-Za-z_][A-Za-z0-9_]*)\s*\(",
     re.M,
 )
+PROTO = re.compile(
+    r"^(?!\s)(?!static\b)(?!typedef\b)(?!#)"
+    r"(?:SQLITE_PRIVATE\s+|SQLITE_API\s+|SQLITE_EXTERN\s+)?"
+    r".+?\b([A-Za-z_][A-Za-z0-9_]*)\s*\([^;]*\)\s*;",
+    re.M,
+)
+MACRO = re.compile(r"^\s*#\s*define\s+([A-Za-z_][A-Za-z0-9_]*)", re.M)
 SKIP_DEF = {
     "if",
     "for",
@@ -37,6 +52,11 @@ SKIP_DEF = {
     "do",
     "main",
 }
+ALLOW_EXTERN = {
+    "doltliteServe",
+    "doltliteServeAsync",
+    "doltliteServerStop",
+}
 SRC_GLOBS = (
     "doltlite.c",
     "doltlite_*.c",
@@ -46,6 +66,15 @@ SRC_GLOBS = (
     "pager_shim.c",
     "sortkey.c",
 )
+OWNED_HDR_GLOBS = (
+    "doltlite*.h",
+    "chunk_*.h",
+    "prolly_*.h",
+    "pager_shim.h",
+    "sortkey.h",
+    "record_codec.h",
+)
+MIN_CLONE_BODY = 200
 
 
 def expand(root: str, patterns: list[str]) -> list[str]:
@@ -76,6 +105,19 @@ def load_tokens(paths: list[str]) -> tuple[dict[str, str], dict[str, set[str]], 
     return texts, idents, counts
 
 
+def looks_like_def(line: str, name: str) -> bool:
+    before = line[: line.find(name)]
+    if not (re.search(r"[A-Za-z_][A-Za-z0-9_]*\s+\**$", before) or "*" in before):
+        return False
+    if ";" in line and "{" not in line:
+        return False
+    return True
+
+
+def is_static_def(line: str) -> bool:
+    return bool(re.match(r"^(?:SQLITE_PRIVATE\s+|SQLITE_API\s+)?static\b", line))
+
+
 def scan_inlines(hdrs: list[str], corpus: list[str], texts: dict[str, str],
                  idents: dict[str, set[str]], counts: dict[str, Counter]) -> list[str]:
     dead: list[str] = []
@@ -93,37 +135,183 @@ def scan_inlines(hdrs: list[str], corpus: list[str], texts: dict[str, str],
     return dead
 
 
-def looks_like_def(line: str, name: str) -> bool:
-    before = line[: line.find(name)]
-    if not (re.search(r"[A-Za-z_][A-Za-z0-9_]*\s+\**$", before) or "*" in before):
-        return False
-    # Declarations end with ';' and have no body. One-line definitions have '{'.
-    if ";" in line and "{" not in line:
-        return False
-    return True
+def iter_defs(path: str, texts: dict[str, str]):
+    raw = texts.get(path)
+    if raw is None:
+        return
+    stripped = strip_comments(raw)
+    for match in DEF.finditer(stripped):
+        name = match.group(1)
+        if name in SKIP_DEF:
+            continue
+        if name.startswith("sqlite3") or name.startswith("orig_sqlite3"):
+            continue
+        line = match.group(0)
+        if not looks_like_def(line, name):
+            continue
+        lineno = stripped[: match.start()].count("\n") + 1
+        yield name, lineno, is_static_def(line), stripped, match
 
 
 def scan_should_be_static(src_files: list[str], corpus: list[str], texts: dict[str, str],
                           idents: dict[str, set[str]]) -> list[str]:
     dead: list[str] = []
     for path in src_files:
-        raw = texts.get(path)
-        if raw is None:
-            continue
-        stripped = strip_comments(raw)
-        for match in DEF.finditer(stripped):
-            name = match.group(1)
-            if name in SKIP_DEF:
-                continue
-            if name.startswith("sqlite3") or name.startswith("orig_sqlite3"):
-                continue
-            if not looks_like_def(match.group(0), name):
+        for name, line, is_static, stripped, match in iter_defs(path, texts):
+            if is_static:
                 continue
             others = [q for q in corpus if q != path and name in idents.get(q, ())]
             if others:
                 continue
-            line = stripped[: match.start()].count("\n") + 1
             dead.append(f"  should be static: {name} ({path}:{line})")
+    return dead
+
+
+def scan_unused_externs(src_files: list[str], corpus: list[str], texts: dict[str, str],
+                        idents: dict[str, set[str]], counts: dict[str, Counter]) -> list[str]:
+    """Definition in one .c, no other .c mentions it, defining file count==1."""
+    dead: list[str] = []
+    seen: set[str] = set()
+    for path in src_files:
+        for name, line, is_static, stripped, match in iter_defs(path, texts):
+            if is_static or name in ALLOW_EXTERN or name in seen:
+                continue
+            c_files = [q for q in corpus if q.endswith(".c") and name in idents.get(q, ())]
+            if len(c_files) != 1 or c_files[0] != path:
+                continue
+            if counts.get(path, Counter())[name] > 1:
+                continue
+            hdrs_with = [q for q in corpus if q.endswith(".h") and name in idents.get(q, ())]
+            proto = re.compile(
+                r"^(?!\s)(?:SQLITE_PRIVATE\s+|SQLITE_API\s+|SQLITE_EXTERN\s+)?"
+                r".+?\b" + re.escape(name) + r"\s*\([^;]*\)\s*;",
+                re.M,
+            )
+            used_from_header = False
+            for h in hdrs_with:
+                leftover = proto.sub("", strip_comments(texts[h]))
+                if name in IDENT.findall(leftover):
+                    used_from_header = True
+                    break
+            if used_from_header:
+                continue
+            seen.add(name)
+            dead.append(f"  dead (no caller): {name} ({path}:{line})")
+    return dead
+
+
+def scan_unused_prototypes(hdrs: list[str], corpus: list[str], texts: dict[str, str],
+                           idents: dict[str, set[str]]) -> list[str]:
+    dead: list[str] = []
+    seen: set[str] = set()
+    for path in hdrs:
+        raw = texts.get(path)
+        if raw is None:
+            continue
+        for match in PROTO.finditer(strip_comments(raw)):
+            name = match.group(1)
+            if name in SKIP_DEF or name in ALLOW_EXTERN:
+                continue
+            if name.startswith("sqlite3") or name.startswith("orig_sqlite3"):
+                continue
+            if name in seen:
+                continue
+            c_files = [q for q in corpus if q.endswith(".c") and name in idents.get(q, ())]
+            if c_files:
+                continue
+            seen.add(name)
+            dead.append(f"  dead header prototype: {name} ({path})")
+    return dead
+
+
+def scan_unused_macros(hdrs: list[str], corpus: list[str], texts: dict[str, str],
+                       idents: dict[str, set[str]], counts: dict[str, Counter]) -> list[str]:
+    dead: list[str] = []
+    for path in hdrs:
+        raw = texts.get(path)
+        if raw is None:
+            continue
+        stripped = strip_comments(raw)
+        for match in MACRO.finditer(stripped):
+            name = match.group(1)
+            if name.endswith("_H") or name.endswith("_H_"):
+                continue
+            others = [q for q in corpus if q != path and name in idents.get(q, ())]
+            if others:
+                continue
+            if counts.get(path, Counter())[name] <= 1:
+                dead.append(f"  dead header macro: {name} ({path})")
+    return dead
+
+
+def extract_func_bodies(path: str, texts: dict[str, str]):
+    raw = texts.get(path)
+    if raw is None:
+        return
+    stripped = strip_comments(raw)
+    for match in DEF.finditer(stripped):
+        name = match.group(1)
+        if name in SKIP_DEF:
+            continue
+        line = match.group(0)
+        if not looks_like_def(line, name):
+            continue
+        rest = stripped[match.end():]
+        depth = 1
+        i = 0
+        while i < len(rest) and depth:
+            ch = rest[i]
+            if ch == "(":
+                depth += 1
+            elif ch == ")":
+                depth -= 1
+                if depth == 0:
+                    break
+            elif ch in ";{":
+                break
+            i += 1
+        if i >= len(rest) or rest[i] != ")":
+            continue
+        j = rest.find("{", i)
+        if j < 0 or ";" in rest[i:j]:
+            continue
+        body_start = match.end() + j + 1
+        depth = 1
+        k = body_start
+        while k < len(stripped) and depth:
+            if stripped[k] == "{":
+                depth += 1
+            elif stripped[k] == "}":
+                depth -= 1
+            k += 1
+        body = stripped[body_start:k - 1]
+        norm = re.sub(r"\s+", " ", body).strip()
+        if len(norm) < MIN_CLONE_BODY:
+            continue
+        lineno = stripped[: match.start()].count("\n") + 1
+        digest = hashlib.sha1(norm.encode()).hexdigest()
+        yield name, lineno, digest
+
+
+def scan_clones(src_files: list[str], texts: dict[str, str]) -> list[str]:
+    byhash: dict[str, list[tuple[str, int, str]]] = defaultdict(list)
+    for path in src_files:
+        for name, line, digest in extract_func_bodies(path, texts):
+            byhash[digest].append((path, line, name))
+    dead: list[str] = []
+    for items in sorted(byhash.values(), key=lambda xs: (xs[0][0], xs[0][1])):
+        files = {p for p, _, _ in items}
+        if len(files) < 2:
+            continue
+        first = items[0]
+        for other in items[1:]:
+            if other[0] == first[0]:
+                continue
+            dead.append(
+                "  duplicate function body: "
+                f"{first[2]} ({first[0]}:{first[1]}) identical to "
+                f"{other[2]} ({other[0]}:{other[1]})"
+            )
     return dead
 
 
@@ -137,9 +325,7 @@ def main() -> int:
 
     src_files = expand(src_root, list(SRC_GLOBS))
     hdrs = expand(src_root, ["*.h"])
-    # Owned files are scanned for definitions; the whole src tree is searched
-    # for uses (sqliteInt.h / main.c / vdbe.c hold Register and btree entry
-    # points).
+    owned_hdrs = expand(src_root, list(OWNED_HDR_GLOBS))
     corpus = expand(src_root, ["*.c", "*.h"]) + expand(root, [
         "test/*.c",
         "test/c/*.c",
@@ -149,8 +335,13 @@ def main() -> int:
     corpus = sorted(set(corpus))
     texts, idents, counts = load_tokens(corpus)
 
-    dead = scan_inlines(hdrs, corpus, texts, idents, counts)
+    dead: list[str] = []
+    dead += scan_unused_externs(src_files, corpus, texts, idents, counts)
+    dead += scan_inlines(hdrs, corpus, texts, idents, counts)
     dead += scan_should_be_static(src_files, corpus, texts, idents)
+    dead += scan_unused_prototypes(owned_hdrs, corpus, texts, idents)
+    dead += scan_unused_macros(owned_hdrs, corpus, texts, idents, counts)
+    dead += scan_clones(src_files, texts)
     for line in dead:
         print(line)
     return 1 if dead else 0


### PR DESCRIPTION
## Summary

Follow-up to #2634, branched from current `master`. The existing unused-function / unused-inline / should-be-static checks did not see **copied function bodies** or leftover header prototypes/macros.

### Folds
- One `doltliteVtabMapChunkSourceError` for the identical chunk-source error mappers in log, blame, diff, history, workspace, dbpage, and commit-ancestors (`dolt_diff_t` keeps a thin wrapper that also sets `sourceError`).
- Shared schema-entry equality, table-entry differ, view/trigger record classification, IPK serial type/write, name-index find, PK-range upper bound, and the docs/ignore bound-exec + errmsg helpers.

### Detector
`test/lib/dead_code_scan.py` now covers:
- **B** unused externs (header-inline callers count; embeddable `doltliteServe*` still allowed)
- **C** unused header inlines
- **D** should-be-static
- **E** unused owned-header prototypes
- **F** unused owned-header macros
- **G** identical function bodies across owned `.c` files (normalized, ≥200 chars)

Self-test plants each new failure mode.

## Test plan
- [x] `bash test/dead_code_check.sh` (PASS)
- [x] `bash test/dead_code_check_selftest.sh` (7/7)
- [x] `doltlite_docs.sh` (35/35)
- [x] `doltlite_ignore.sh` (25/25)
- [x] `doltlite_tests.sh` (31/31)
- [x] `doltlite_cherry_pick.sh` (140/140)
- [x] `doltlite_merge.sh` (230/230)