### PR TITLE
Fold leftover cmd copies and catch test-only wrappers

### DIFF
--- a/src/chunk_store.h
+++ b/src/chunk_store.h
@@ -265,10 +265,12 @@ int chunkStoreSerializeRefs(ChunkStore *cs);
 int chunkStoreGetBranchWorkingSet(ChunkStore *cs, const char *zBranch, ProllyHash *pHash);
 int chunkStoreSetBranchWorkingSet(ChunkStore *cs, const char *zBranch, const ProllyHash *pHash);
 
-int chunkStoreAddTag(ChunkStore *cs, const char *zName, const ProllyHash *pCommit);
 int chunkStoreAddTagFull(ChunkStore *cs, const char *zName, const ProllyHash *pCommit,
                          const char *zTagger, const char *zEmail,
                          i64 timestamp, const char *zMessage);
+static inline int chunkStoreAddTag(ChunkStore *cs, const char *zName, const ProllyHash *pCommit){
+  return chunkStoreAddTagFull(cs, zName, pCommit, 0, 0, 0, 0);
+}
 int chunkStoreDeleteTag(ChunkStore *cs, const char *zName);
 int chunkStoreFindTag(ChunkStore *cs, const char *zName, ProllyHash *pCommit);
 

--- a/src/chunk_store_refs_api.c
+++ b/src/chunk_store_refs_api.c
@@ -189,10 +189,6 @@ int chunkStoreFindTag(ChunkStore *cs, const char *zName, ProllyHash *pCommit){
   return SQLITE_OK;
 }
 
-int chunkStoreAddTag(ChunkStore *cs, const char *zName, const ProllyHash *pCommit){
-  return chunkStoreAddTagFull(cs, zName, pCommit, 0, 0, 0, 0);
-}
-
 int chunkStoreAddTagFull(
   ChunkStore *cs,
   const char *zName,

--- a/src/chunk_wal.c
+++ b/src/chunk_wal.c
@@ -1024,10 +1024,6 @@ replay_error:
   return rc;
 }
 
-int csReplayWal(ChunkStore *cs){
-  return csReplayWalSkipping(cs, 0, 0);
-}
-
 /* Ingest records appended after iStart into the live store. The caller
 ** proved the prefix below iStart is the content it already holds. */
 int csReplayWalTail(ChunkStore *cs, i64 iStart){

--- a/src/chunk_wal.h
+++ b/src/chunk_wal.h
@@ -55,8 +55,10 @@ void walStateSetOffset(WalState *w, i64 iOffset);
 void walStateSetDataSize(WalState *w, i64 nData);
 
 struct ChunkStore;
-int csReplayWal(struct ChunkStore *cs);
 int csReplayWalSkipping(struct ChunkStore *cs, i64 iSkipStart, i64 iSkipEnd);
+static inline int csReplayWal(struct ChunkStore *cs){
+  return csReplayWalSkipping(cs, 0, 0);
+}
 int csReplayWalTail(struct ChunkStore *cs, i64 iStart);
 int csTryLoadWalCheckpoint(struct ChunkStore *cs, int *pLoaded,
                            i64 *pSkipStart, i64 *pSkipEnd);

--- a/src/doltlite_cherry_pick.c
+++ b/src/doltlite_cherry_pick.c
@@ -447,33 +447,9 @@ static void doltliteCherryPickFunc(
     db, &pickHash,
     &ourHead, &pickCommit, &parentCommit, &ourCommit
   );
-  if( rc==SQLITE_NOTFOUND ){
-    doltliteCommitClear(&pickCommit);
-    doltliteCommitClear(&parentCommit);
-    doltliteCommitClear(&ourCommit);
-    if( !doltliteCmdSourceResultError(context, cs, &rc) ){
-      sqlite3_result_error(context, "commit not found", -1);
-    }
-    return;
-  }
-  if( rc==SQLITE_EMPTY ){
-    doltliteCommitClear(&pickCommit);
-    sqlite3_result_error(context, "cannot cherry-pick the initial commit", -1);
-    return;
-  }
-  if( rc==SQLITE_DONE ){
-    doltliteCommitClear(&pickCommit);
-    doltliteCommitClear(&parentCommit);
-    sqlite3_result_error(context, "no commits on current branch", -1);
-    return;
-  }
-  if( rc!=SQLITE_OK ){
-    doltliteCommitClear(&pickCommit);
-    doltliteCommitClear(&parentCommit);
-    doltliteCommitClear(&ourCommit);
-    if( !doltliteCmdSourceResultError(context, cs, &rc) ){
-      sqlite3_result_error_code(context, rc);
-    }
+  if( doltliteCmdReportLoadParentedCommitError(
+        context, cs, rc, &pickCommit, &parentCommit, &ourCommit,
+        "cannot cherry-pick the initial commit") ){
     return;
   }
   if( doltliteCommitParentCount(&pickCommit)>1 ){
@@ -503,38 +479,10 @@ static void doltliteCherryPickFunc(
   doltliteCommitClear(&parentCommit);
   doltliteCommitClear(&ourCommit);
 
-  if( rc==SQLITE_BUSY ){
-    sqlite3_free(zApplyErr);
-    if( !doltliteCmdSourceResultError(context, cs, &rc) ){
-      doltliteCmdResultPeerBranchBusy(context, "cherry-pick");
-    }
-    return;
-  }
-  if( rc==SQLITE_DONE ){
-    sqlite3_free(zApplyErr);
-    sqlite3_result_error(context, "no changes were made, nothing to commit", -1);
-    return;
-  }
-  if( rc!=SQLITE_OK ){
-    if( !doltliteCmdSourceResultError(context, cs, &rc) ){
-      if( zApplyErr ){
-        sqlite3_result_error(context, zApplyErr, -1);
-      }else{
-        char *zMsg = sqlite3_mprintf("cherry-pick of %s failed", zRef);
-        sqlite3_result_error(context, zMsg ? zMsg : "cherry-pick failed", -1);
-        sqlite3_free(zMsg);
-      }
-    }
-    sqlite3_free(zApplyErr);
-    return;
-  }
-  sqlite3_free(zApplyErr);
-
-  /* Finish helpers already set the context error; do not overwrite. */
-  if( nConflicts > 0 ) return;
-  if( hexBuf[0] ){
-    sqlite3_result_text(context, hexBuf, -1, SQLITE_TRANSIENT);
-  }
+  doltliteCmdFinishApplyMerged(
+      context, cs, rc, nConflicts, zApplyErr, "cherry-pick", zRef,
+      "no changes were made, nothing to commit",
+      "cherry-pick of %s failed", "cherry-pick failed", hexBuf);
 }
 
 

--- a/src/doltlite_cmd.c
+++ b/src/doltlite_cmd.c
@@ -477,6 +477,16 @@ static int cmdRollbackAutocommitConstraintViolations(
   return SQLITE_OK;
 }
 
+static int cmdNestedRestoreOrError(
+  sqlite3 *db,
+  sqlite3_context *ctx,
+  DoltliteTxnState *pSaved
+){
+  int rc = doltliteRestoreTxnStateOnFailure(db, pSaved, SQLITE_OK);
+  if( rc!=SQLITE_OK ) sqlite3_result_error_code(ctx, rc);
+  return rc;
+}
+
 int doltliteCmdFinishWithConflicts(
   sqlite3 *db,
   sqlite3_context *ctx,
@@ -495,11 +505,8 @@ int doltliteCmdFinishWithConflicts(
     return cmdFinishPlainAfterReport(db, ctx, pSaved,
         cmdReportConflicts(db, ctx, nConflicts, zOp), bSealOnPlain);
   case DOLTLITE_VC_TXN_NESTED_SAVEPOINT:
-    rc = doltliteRestoreTxnStateOnFailure(db, pSaved, SQLITE_OK);
-    if( rc!=SQLITE_OK ){
-      sqlite3_result_error_code(ctx, rc);
-      return rc;
-    }
+    rc = cmdNestedRestoreOrError(db, ctx, pSaved);
+    if( rc!=SQLITE_OK ) return rc;
     {
       char msg[256];
       sqlite3_snprintf(sizeof(msg), msg,
@@ -528,11 +535,8 @@ int doltliteCmdFinishWithConstraintViolations(
     return cmdFinishPlainAfterReport(db, ctx, pSaved,
         cmdReportConstraintViolations(db, ctx, zOp), bSealOnPlain);
   case DOLTLITE_VC_TXN_NESTED_SAVEPOINT:
-    rc = doltliteRestoreTxnStateOnFailure(db, pSaved, SQLITE_OK);
-    if( rc!=SQLITE_OK ){
-      sqlite3_result_error_code(ctx, rc);
-      return rc;
-    }
+    rc = cmdNestedRestoreOrError(db, ctx, pSaved);
+    if( rc!=SQLITE_OK ) return rc;
     if( zNestedMsg ){
       sqlite3_result_error(ctx, zNestedMsg, -1);
     }else{
@@ -595,11 +599,8 @@ int doltliteCmdFinishWithConflictsAndConstraintViolations(
             db, ctx, nConflicts, zOp),
         bSealOnPlain);
   case DOLTLITE_VC_TXN_NESTED_SAVEPOINT:
-    rc = doltliteRestoreTxnStateOnFailure(db, pSaved, SQLITE_OK);
-    if( rc!=SQLITE_OK ){
-      sqlite3_result_error_code(ctx, rc);
-      return rc;
-    }
+    rc = cmdNestedRestoreOrError(db, ctx, pSaved);
+    if( rc!=SQLITE_OK ) return rc;
     if( zNestedMsg ){
       sqlite3_result_error(ctx, zNestedMsg, -1);
     }else{
@@ -647,6 +648,90 @@ int doltliteVtabMapChunkSourceError(
     pVtab->zErrMsg = zErr;
   }
   return pendingRc!=SQLITE_OK ? pendingRc : sourceRc;
+}
+
+int doltliteCmdReportLoadParentedCommitError(
+  sqlite3_context *ctx,
+  ChunkStore *cs,
+  int rc,
+  DoltliteCommit *pTarget,
+  DoltliteCommit *pParent,
+  DoltliteCommit *pOurs,
+  const char *zInitialMsg
+){
+  if( rc==SQLITE_OK ) return 0;
+  if( rc==SQLITE_NOTFOUND ){
+    doltliteCommitClear(pTarget);
+    doltliteCommitClear(pParent);
+    doltliteCommitClear(pOurs);
+    if( !doltliteCmdSourceResultError(ctx, cs, &rc) ){
+      sqlite3_result_error(ctx, "commit not found", -1);
+    }
+    return 1;
+  }
+  if( rc==SQLITE_EMPTY ){
+    doltliteCommitClear(pTarget);
+    sqlite3_result_error(ctx, zInitialMsg, -1);
+    return 1;
+  }
+  if( rc==SQLITE_DONE ){
+    doltliteCommitClear(pTarget);
+    doltliteCommitClear(pParent);
+    sqlite3_result_error(ctx, "no commits on current branch", -1);
+    return 1;
+  }
+  doltliteCommitClear(pTarget);
+  doltliteCommitClear(pParent);
+  doltliteCommitClear(pOurs);
+  if( !doltliteCmdSourceResultError(ctx, cs, &rc) ){
+    sqlite3_result_error_code(ctx, rc);
+  }
+  return 1;
+}
+
+void doltliteCmdFinishApplyMerged(
+  sqlite3_context *ctx,
+  ChunkStore *cs,
+  int rc,
+  int nConflicts,
+  char *zApplyErr,
+  const char *zOp,
+  const char *zRef,
+  const char *zDoneMsg,
+  const char *zFailFmt,
+  const char *zFailFallback,
+  const char *hexBuf
+){
+  if( rc==SQLITE_BUSY ){
+    sqlite3_free(zApplyErr);
+    if( !doltliteCmdSourceResultError(ctx, cs, &rc) ){
+      doltliteCmdResultPeerBranchBusy(ctx, zOp);
+    }
+    return;
+  }
+  if( rc==SQLITE_DONE ){
+    sqlite3_free(zApplyErr);
+    sqlite3_result_error(ctx, zDoneMsg, -1);
+    return;
+  }
+  if( rc!=SQLITE_OK ){
+    if( !doltliteCmdSourceResultError(ctx, cs, &rc) ){
+      if( zApplyErr ){
+        sqlite3_result_error(ctx, zApplyErr, -1);
+      }else{
+        char *zMsg = sqlite3_mprintf(zFailFmt, zRef);
+        sqlite3_result_error(ctx, zMsg ? zMsg : zFailFallback, -1);
+        sqlite3_free(zMsg);
+      }
+    }
+    sqlite3_free(zApplyErr);
+    return;
+  }
+  sqlite3_free(zApplyErr);
+  if( nConflicts > 0 ) return;
+  if( hexBuf && hexBuf[0] ){
+    sqlite3_result_text(ctx, hexBuf, -1, SQLITE_TRANSIENT);
+  }
 }
 
 #endif

--- a/src/doltlite_commit_cmd.c
+++ b/src/doltlite_commit_cmd.c
@@ -13,6 +13,7 @@
 #include "doltlite_name_index.h"
 #include <stddef.h>
 #include "doltlite_ignore.h"
+#include "doltlite_constraint_violations.h"
 
 #include <string.h>
 #include <ctype.h>
@@ -1009,7 +1010,6 @@ static void doltliteCommitFunc(
   }
 
   {
-    extern int doltliteClearAllConstraintViolations(sqlite3*);
     if( doltliteSessionHasConstraintViolations(db) ){
       doltliteClearAllConstraintViolations(db);
     }

--- a/src/doltlite_conflicts.c
+++ b/src/doltlite_conflicts.c
@@ -115,28 +115,19 @@ static int readConflictRow(DlByteReader *r, DoltliteConflictRow *cr){
   return dlReadU32Blob(r, &cr->pTheirVal, &cr->nTheirVal);
 }
 
-static int skipConflictBlob(DlByteReader *r){
-  int n = dlReadU32(r);
-  if( r->err ) return SQLITE_CORRUPT;
-  if( n<0 || (size_t)n > (size_t)(r->end - r->p) ){
-    r->err = 1;
-    return SQLITE_CORRUPT;
-  }
-  r->p += n;
-  return SQLITE_OK;
-}
+
 
 static int skipConflictRow(DlByteReader *r){
   int rc;
-  rc = skipConflictBlob(r);
+  rc = dlSkipU32Blob(r);
   if( rc!=SQLITE_OK ) return rc;
   (void)dlReadI64(r);
   if( r->err ) return SQLITE_CORRUPT;
-  rc = skipConflictBlob(r);
+  rc = dlSkipU32Blob(r);
   if( rc!=SQLITE_OK ) return rc;
-  rc = skipConflictBlob(r);
+  rc = dlSkipU32Blob(r);
   if( rc!=SQLITE_OK ) return rc;
-  return skipConflictBlob(r);
+  return dlSkipU32Blob(r);
 }
 
 static int deserializeAllConflicts(

--- a/src/doltlite_constraint_violations.c
+++ b/src/doltlite_constraint_violations.c
@@ -133,28 +133,19 @@ static int readViolationRow(DlByteReader *rd, ConstraintViolationRow *r){
   return dlReadU32Str(rd, &r->zInfo);
 }
 
-static int skipViolationBlob(DlByteReader *rd){
-  int n = dlReadU32(rd);
-  if( rd->err ) return SQLITE_CORRUPT;
-  if( n<0 || (size_t)n > (size_t)(rd->end - rd->p) ){
-    rd->err = 1;
-    return SQLITE_CORRUPT;
-  }
-  rd->p += n;
-  return SQLITE_OK;
-}
+
 
 static int skipViolationRow(DlByteReader *rd){
   int rc;
   (void)dlReadU8(rd);
   if( rd->err ) return SQLITE_CORRUPT;
-  rc = skipViolationBlob(rd);
+  rc = dlSkipU32Blob(rd);
   if( rc!=SQLITE_OK ) return rc;
   (void)dlReadI64(rd);
   if( rd->err ) return SQLITE_CORRUPT;
-  rc = skipViolationBlob(rd);
+  rc = dlSkipU32Blob(rd);
   if( rc!=SQLITE_OK ) return rc;
-  return skipViolationBlob(rd);
+  return dlSkipU32Blob(rd);
 }
 
 static int deserializeAllViolations(

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -734,6 +734,16 @@ static SQLITE_INLINE int dlReadU32Blob(DlByteReader *r, u8 **pp, int *pn){
   r->p += n;
   return SQLITE_OK;
 }
+static SQLITE_INLINE int dlSkipU32Blob(DlByteReader *r){
+  int n = dlReadU32(r);
+  if( r->err ) return SQLITE_CORRUPT;
+  if( n<0 || (size_t)n > (size_t)(r->end - r->p) ){
+    r->err = 1;
+    return SQLITE_CORRUPT;
+  }
+  r->p += n;
+  return SQLITE_OK;
+}
 static SQLITE_INLINE int dlReadU16Name(DlByteReader *r, char **pz){
   int n = dlReadU16(r);
   *pz = 0;
@@ -960,6 +970,17 @@ int doltliteCmdSourceResultError(
 );
 int doltliteVtabMapChunkSourceError(
   sqlite3_vtab *pVtab, sqlite3 *db, int sourceRc, int mappedRc
+);
+int doltliteCmdReportLoadParentedCommitError(
+  sqlite3_context *ctx, ChunkStore *cs, int rc,
+  DoltliteCommit *pTarget, DoltliteCommit *pParent, DoltliteCommit *pOurs,
+  const char *zInitialMsg
+);
+void doltliteCmdFinishApplyMerged(
+  sqlite3_context *ctx, ChunkStore *cs, int rc, int nConflicts,
+  char *zApplyErr, const char *zOp, const char *zRef,
+  const char *zDoneMsg, const char *zFailFmt, const char *zFailFallback,
+  const char *hexBuf
 );
 
 static SQLITE_INLINE int doltliteVtabSetErrmsgFromDb(

--- a/src/doltlite_merge_cmd.c
+++ b/src/doltlite_merge_cmd.c
@@ -13,6 +13,7 @@
 #include "doltlite_name_index.h"
 #include <stddef.h>
 #include "doltlite_ignore.h"
+#include "doltlite_constraint_violations.h"
 
 #include <string.h>
 #include <ctype.h>
@@ -28,7 +29,6 @@ int mergeAbortInPlace(sqlite3 *db){
   if( rc==SQLITE_OK ) rc = doltliteClearSessionMergeState(db);
   if( rc==SQLITE_OK ) rc = doltliteSetSessionPendingReplayCommit(db, 0);
   if( rc==SQLITE_OK ){
-    extern int doltliteClearAllConstraintViolations(sqlite3*);
     if( doltliteSessionHasConstraintViolations(db) ){
       rc = doltliteClearAllConstraintViolations(db);
     }

--- a/src/doltlite_reset.c
+++ b/src/doltlite_reset.c
@@ -13,6 +13,7 @@
 #include "doltlite_name_index.h"
 #include <stddef.h>
 #include "doltlite_ignore.h"
+#include "doltlite_constraint_violations.h"
 
 #include <string.h>
 #include <ctype.h>
@@ -764,7 +765,6 @@ static void doltliteResetFunc(
     rc = doltliteClearSessionMergeState(db);
 
     if( rc==SQLITE_OK ){
-      extern int doltliteClearAllConstraintViolations(sqlite3*);
       if( doltliteSessionHasConstraintViolations(db) ){
         rc = doltliteClearAllConstraintViolations(db);
       }

--- a/src/doltlite_revert.c
+++ b/src/doltlite_revert.c
@@ -192,33 +192,9 @@ static void doltliteRevertFunc(
     db, &revertHash,
     &ourHead, &revertCommit, &parentCommit, &ourCommit
   );
-  if( rc==SQLITE_NOTFOUND ){
-    doltliteCommitClear(&revertCommit);
-    doltliteCommitClear(&parentCommit);
-    doltliteCommitClear(&ourCommit);
-    if( !doltliteCmdSourceResultError(context, cs, &rc) ){
-      sqlite3_result_error(context, "commit not found", -1);
-    }
-    return;
-  }
-  if( rc==SQLITE_EMPTY ){
-    doltliteCommitClear(&revertCommit);
-    sqlite3_result_error(context, "cannot revert the initial commit", -1);
-    return;
-  }
-  if( rc==SQLITE_DONE ){
-    doltliteCommitClear(&revertCommit);
-    doltliteCommitClear(&parentCommit);
-    sqlite3_result_error(context, "no commits on current branch", -1);
-    return;
-  }
-  if( rc!=SQLITE_OK ){
-    doltliteCommitClear(&revertCommit);
-    doltliteCommitClear(&parentCommit);
-    doltliteCommitClear(&ourCommit);
-    if( !doltliteCmdSourceResultError(context, cs, &rc) ){
-      sqlite3_result_error_code(context, rc);
-    }
+  if( doltliteCmdReportLoadParentedCommitError(
+        context, cs, rc, &revertCommit, &parentCommit, &ourCommit,
+        "cannot revert the initial commit") ){
     return;
   }
 
@@ -260,38 +236,10 @@ static void doltliteRevertFunc(
   doltliteCommitClear(&parentCommit);
   doltliteCommitClear(&ourCommit);
 
-  if( rc==SQLITE_BUSY ){
-    sqlite3_free(zApplyErr);
-    if( !doltliteCmdSourceResultError(context, cs, &rc) ){
-      doltliteCmdResultPeerBranchBusy(context, "revert");
-    }
-    return;
-  }
-  if( rc==SQLITE_DONE ){
-    sqlite3_free(zApplyErr);
-    sqlite3_result_error(context, "nothing to commit", -1);
-    return;
-  }
-  if( rc!=SQLITE_OK ){
-    if( !doltliteCmdSourceResultError(context, cs, &rc) ){
-      if( zApplyErr ){
-        sqlite3_result_error(context, zApplyErr, -1);
-      }else{
-        char *zMsg = sqlite3_mprintf("revert of \"%s\" failed", zRef);
-        sqlite3_result_error(context, zMsg ? zMsg : "revert failed", -1);
-        sqlite3_free(zMsg);
-      }
-    }
-    sqlite3_free(zApplyErr);
-    return;
-  }
-  sqlite3_free(zApplyErr);
-
-  /* Finish helpers already set the context error; do not overwrite. */
-  if( nConflicts > 0 ) return;
-  if( hexBuf[0] ){
-    sqlite3_result_text(context, hexBuf, -1, SQLITE_TRANSIENT);
-  }
+  doltliteCmdFinishApplyMerged(
+      context, cs, rc, nConflicts, zApplyErr, "revert", zRef,
+      "nothing to commit",
+      "revert of \"%s\" failed", "revert failed", hexBuf);
   return;
 
 revert_error:

--- a/src/doltlite_tls.c
+++ b/src/doltlite_tls.c
@@ -201,10 +201,6 @@ fail_net:
   return NULL;
 }
 
-DoltliteConn *doltliteConnOpen(const char *host, int port, int useTls) {
-  return doltliteConnOpenTimeout(host, port, useTls, 0);
-}
-
 int doltliteConnWriteAll(DoltliteConn *c, const void *buf, int nbuf) {
   const unsigned char *p = (const unsigned char *)buf;
   int off = 0;

--- a/src/doltlite_tls.h
+++ b/src/doltlite_tls.h
@@ -9,13 +9,15 @@ extern "C" {
 
 typedef struct DoltliteConn DoltliteConn;
 
-DoltliteConn *doltliteConnOpen(const char *host, int port, int useTls);
 DoltliteConn *doltliteConnOpenTimeout(
   const char *host,
   int port,
   int useTls,
   int timeoutMs
 );
+static inline DoltliteConn *doltliteConnOpen(const char *host, int port, int useTls){
+  return doltliteConnOpenTimeout(host, port, useTls, 0);
+}
 
 #ifndef DOLTLITE_AUTH_CLIENT_ONLY
 typedef struct DoltliteTlsServer DoltliteTlsServer;

--- a/src/sortkey.c
+++ b/src/sortkey.c
@@ -354,16 +354,6 @@ static int sortKeyEncode(const u8 *pRec, int nRec, u8 *pOut, int nMaxFields,
   return pOut ? outPos : (int)outSize;
 }
 
-int sortKeyFromRecord(const u8 *pRec, int nRec, u8 **ppOut, int *pnOut){
-  return sortKeyFromRecordPrefix(pRec, nRec, 0, ppOut, pnOut);
-}
-
-int sortKeyFromRecordPrefix(
-  const u8 *pRec, int nRec, int nKeyField, u8 **ppOut, int *pnOut
-){
-  return sortKeyFromRecordPrefixColl(pRec, nRec, nKeyField, NULL, ppOut, pnOut);
-}
-
 static int sortKeyFromSingleBinaryFieldFast(
   const u8 *pRec, int nRec, int nKeyField, const KeyInfo *pKeyInfo,
   u8 **ppBuf, int *pnAlloc, int *pnOut
@@ -1367,12 +1357,6 @@ int recordFromSortKeyBufferColl(
   rc = recordFromSortKeyBuffer(pNorm, nSortKey, ppBuf, pnAlloc, pnOut);
   if( nNormAlloc ) sqlite3_free(pNorm);
   return rc;
-}
-
-int recordFromSortKey(const u8 *pSortKey, int nSortKey, u8 **ppOut, int *pnOut){
-  int nAlloc = 0;
-  *ppOut = 0;
-  return recordFromSortKeyBuffer(pSortKey, nSortKey, ppOut, &nAlloc, pnOut);
 }
 
 #endif

--- a/src/sortkey.h
+++ b/src/sortkey.h
@@ -32,14 +32,16 @@ static inline int sortKeyByteStartsField(u8 b){
   return 0;
 }
 
-int sortKeyFromRecord(const u8 *pRec, int nRec, u8 **ppOut, int *pnOut);
-
-int sortKeyFromRecordPrefix(const u8 *pRec, int nRec, int nKeyField,
-                            u8 **ppOut, int *pnOut);
-
 int sortKeyFromRecordPrefixColl(const u8 *pRec, int nRec, int nKeyField,
                                  const KeyInfo *pKeyInfo,
                                  u8 **ppOut, int *pnOut);
+static inline int sortKeyFromRecordPrefix(const u8 *pRec, int nRec, int nKeyField,
+                            u8 **ppOut, int *pnOut){
+  return sortKeyFromRecordPrefixColl(pRec, nRec, nKeyField, NULL, ppOut, pnOut);
+}
+static inline int sortKeyFromRecord(const u8 *pRec, int nRec, u8 **ppOut, int *pnOut){
+  return sortKeyFromRecordPrefix(pRec, nRec, 0, ppOut, pnOut);
+}
 int sortKeyFromRecordPrefixCollBuffer(const u8 *pRec, int nRec, int nKeyField,
                                  const KeyInfo *pKeyInfo,
                                  u8 **ppBuf, int *pnAlloc, int *pnOut);
@@ -72,11 +74,15 @@ static inline void sortKeyWriteExactInt64(i64 v, u8 *pOut){
   }
 }
 
-int recordFromSortKey(const u8 *pSortKey, int nSortKey, u8 **ppOut, int *pnOut);
 int recordFromSortKeyBuffer(
   const u8 *pSortKey, int nSortKey,
   u8 **ppBuf, int *pnAlloc, int *pnOut
 );
+static inline int recordFromSortKey(const u8 *pSortKey, int nSortKey, u8 **ppOut, int *pnOut){
+  int nAlloc = 0;
+  *ppOut = 0;
+  return recordFromSortKeyBuffer(pSortKey, nSortKey, ppOut, &nAlloc, pnOut);
+}
 int recordFromSortKeyBufferColl(
   const u8 *pSortKey, int nSortKey, const KeyInfo *pKeyInfo,
   u8 **ppBuf, int *pnAlloc, int *pnOut

--- a/test/dead_code_check.sh
+++ b/test/dead_code_check.sh
@@ -18,6 +18,10 @@
 #   Part F: #define names in owned headers that never appear elsewhere
 #           (include guards skipped).
 #   Part G: identical function bodies copied across owned .c files.
+#   Part H: non-static one-call wrappers whose only extra-file .c mentions are
+#           under test/ (production-dead). doltliteTest* / *ForTest are the
+#           C-test surface and are skipped: those tests link production
+#           libdoltlite, so SQLITE_TEST cannot hide them.
 #
 # Needs the generated headers, so run it after a configure+build (the build
 # dir defaults to ./build, override with DOLTLITE_BUILD_DIR). Point
@@ -75,7 +79,7 @@ else
   done
 fi
 
-echo "== Part B-G: unused externs / inlines / should-be-static / prototypes / macros / clones =="
+echo "== Part B-H: unused externs / inlines / should-be-static / prototypes / macros / clones / test-only wrappers =="
 if ! python3 "$SCRIPT_DIR/lib/dead_code_scan.py" --root "$ROOT" --src-root "$SRC_ROOT"
 then
   fail=1

--- a/test/dead_code_check_selftest.sh
+++ b/test/dead_code_check_selftest.sh
@@ -142,6 +142,18 @@ else
   ok
 fi
 
+# Part H: one-call wrapper only mentioned from test/.
+cat > "$WORK/src/doltlite.c" <<'EOF'
+int dead_code_gate_inner(int x){ return x+1; }
+int dead_code_gate_test_wrapper(int x){
+  return dead_code_gate_inner(x);
+}
+EOF
+mkdir -p "$WORK/test"
+printf 'int dead_code_gate_test_wrapper(int x);\nvoid use(void){ (void)dead_code_gate_test_wrapper(0); }\n' \
+  > "$WORK/test/caller.c"
+expect_scan_hit "test_only_wrapper_is_rejected" "test-only wrapper: dead_code_gate_test_wrapper"
+
 # Part B: unused extern (definition, no caller) on a one-file src tree.
 mkdir -p "$WORK/tiny/src"
 printf 'int dead_code_gate_unused_extern(void){ return 0; }\n' \

--- a/test/lib/dead_code_scan.py
+++ b/test/lib/dead_code_scan.py
@@ -11,6 +11,10 @@ F: #define in an owned header whose identifier never appears elsewhere
    (include guards skipped).
 G: two owned .c files contain functions with identical normalized bodies
    (whitespace collapsed, length >= MIN_CLONE_BODY).
+H: non-static .c function whose body is a single return otherFn(...) and
+   whose only extra-file .c mentions are under test/. doltliteTest* and
+   *ForTest names are the C-test surface (tests link production libdoltlite)
+   and are skipped.
 """
 from __future__ import annotations
 
@@ -57,6 +61,9 @@ ALLOW_EXTERN = {
     "doltliteServeAsync",
     "doltliteServerStop",
 }
+ONE_CALL = re.compile(
+    r"^return\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(.*\)\s*;$"
+)
 SRC_GLOBS = (
     "doltlite.c",
     "doltlite_*.c",
@@ -151,6 +158,92 @@ def iter_defs(path: str, texts: dict[str, str]):
             continue
         lineno = stripped[: match.start()].count("\n") + 1
         yield name, lineno, is_static_def(line), stripped, match
+
+
+def is_test_api_name(name: str) -> bool:
+    return name.startswith("doltliteTest") or name.endswith("ForTest")
+
+
+def is_test_path(path: str, root: str) -> bool:
+    rel = os.path.relpath(path, root)
+    return rel.startswith("test" + os.sep) or rel.startswith("test/")
+
+
+def extract_body(stripped: str, match: re.Match[str]) -> str | None:
+    rest = stripped[match.end():]
+    depth = 1
+    i = 0
+    while i < len(rest) and depth:
+        ch = rest[i]
+        if ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+            if depth == 0:
+                break
+        elif ch in ";{":
+            break
+        i += 1
+    if i >= len(rest) or rest[i] != ")":
+        return None
+    j = rest.find("{", i)
+    if j < 0 or ";" in rest[i:j]:
+        return None
+    body_start = match.end() + j + 1
+    depth = 1
+    k = body_start
+    while k < len(stripped) and depth:
+        if stripped[k] == "{":
+            depth += 1
+        elif stripped[k] == "}":
+            depth -= 1
+        k += 1
+    return stripped[body_start:k - 1]
+
+
+def scan_test_only_wrappers(
+    src_files: list[str],
+    corpus: list[str],
+    root: str,
+    texts: dict[str, str],
+    idents: dict[str, set[str]],
+) -> list[str]:
+    dead: list[str] = []
+    for path in src_files:
+        raw = texts.get(path)
+        if raw is None:
+            continue
+        stripped = strip_comments(raw)
+        for match in DEF.finditer(stripped):
+            name = match.group(1)
+            if name in SKIP_DEF or is_test_api_name(name):
+                continue
+            if name.startswith("sqlite3") or name.startswith("orig_sqlite3"):
+                continue
+            line = match.group(0)
+            if line.lstrip().startswith("static") or not looks_like_def(line, name):
+                continue
+            body = extract_body(stripped, match)
+            if body is None:
+                continue
+            norm = re.sub(r"\s+", " ", body).strip()
+            hit = ONE_CALL.match(norm)
+            if not hit or hit.group(1) == name:
+                continue
+            extra_c = [
+                q for q in corpus
+                if q.endswith(".c") and q != path and name in idents.get(q, ())
+            ]
+            prod = [q for q in extra_c if not is_test_path(q, root)]
+            if prod:
+                continue
+            if Counter(IDENT.findall(stripped))[name] > 1:
+                continue
+            lineno = stripped[: match.start()].count("\n") + 1
+            dead.append(
+                f"  test-only wrapper: {name} ({path}:{lineno}) -> {hit.group(1)}"
+            )
+    return dead
 
 
 def scan_should_be_static(src_files: list[str], corpus: list[str], texts: dict[str, str],
@@ -342,6 +435,7 @@ def main() -> int:
     dead += scan_unused_prototypes(owned_hdrs, corpus, texts, idents)
     dead += scan_unused_macros(owned_hdrs, corpus, texts, idents, counts)
     dead += scan_clones(src_files, texts)
+    dead += scan_test_only_wrappers(src_files, corpus, root, texts, idents)
     for line in dead:
         print(line)
     return 1 if dead else 0


### PR DESCRIPTION
## Summary

Branched from current `master` (not stacked on #2665). Small leftover copies from the dead/duplicate pass, plus a detector for test-only one-call wrappers.

### Folds
- `dlSkipU32Blob` replaces identical skip-blob helpers in conflicts and constraint violations
- `doltliteCmdReportLoadParentedCommitError` / `doltliteCmdFinishApplyMerged` shared by cherry-pick and revert
- `cmdNestedRestoreOrError` for the three nested-savepoint restore tails in `doltlite_cmd.c`
- Drop `extern doltliteClearAllConstraintViolations` in merge/reset/commit; include the existing header
- One-call wrappers that only tests used are now header inlines: `sortKeyFromRecord`, `recordFromSortKey`, `csReplayWal`, `chunkStoreAddTag`, `doltliteConnOpen`

### Detector (Part H)
Flags a non-static `.c` one-call wrapper (`return otherFn(...)`) whose only extra-file `.c` mentions are under `test/`. Skips `doltliteTest*` / `*ForTest`: those C tests link production `libdoltlite`, so wrapping them in `SQLITE_TEST` would break the tests.

Self-test plants a wrapper called only from `test/`.

## Test plan
- [x] `bash test/dead_code_check.sh`
- [x] `bash test/dead_code_check_selftest.sh` (5/5)
- [x] `doltlite_cherry_pick.sh` (140/140)
- [x] `doltlite_merge.sh` (230/230)