### PR TITLE
Land SeekLE/SeekGT prefix seeks on the last match in O(log n)

### DIFF
--- a/src/prolly_btree_cursor.c
+++ b/src/prolly_btree_cursor.c
@@ -144,7 +144,7 @@ static int mergeCompare(BtCursor *pCur, ProllyMutMapEntry *e){
   }
 }
 
-static int mergeScan(BtCursor *pCur, int dir, int *pRes){
+int mergeScan(BtCursor *pCur, int dir, int *pRes){
   assert( pCur!=0 );
   assert( pCur->pMutMap!=0 );
   assert( dir==1 || dir==-1 );

--- a/src/prolly_btree_cursor_count.c
+++ b/src/prolly_btree_cursor_count.c
@@ -187,25 +187,6 @@ int sortKeyFromUnpackedForCount(
   return rc;
 }
 
-/* Exclusive bound after prefix pKey. Drop trailing 0xff or the bound is too high. */
-static int blobPrefixSuccessor(const u8 *pKey, int nKey, u8 **ppOut, int *pnOut){
-  int i;
-  u8 *pOut;
-  for(i=nKey-1; i>=0 && pKey[i]==0xff; i--){}
-  if( i<0 ){
-    *ppOut = 0;
-    *pnOut = 0;
-    return SQLITE_OK;
-  }
-  pOut = sqlite3_malloc(i+1);
-  if( !pOut ) return SQLITE_NOMEM;
-  memcpy(pOut, pKey, i+1);
-  pOut[i]++;
-  *ppOut = pOut;
-  *pnOut = i+1;
-  return SQLITE_OK;
-}
-
 /* Exclusive end after a complete first field. Exact 9-byte numerics prefix
 ** an 18-byte neighbor; a raw successor would count that neighbor in. */
 static int blobFieldSuccessor(const u8 *pKey, int nKey, u8 **ppOut, int *pnOut){
@@ -218,7 +199,7 @@ static int blobFieldSuccessor(const u8 *pKey, int nKey, u8 **ppOut, int *pnOut){
     *pnOut = 10;
     return SQLITE_OK;
   }
-  return blobPrefixSuccessor(pKey, nKey, ppOut, pnOut);
+  return sortKeyPrefixSuccessor(pKey, nKey, ppOut, pnOut);
 }
 
 static int countBlobKeysBefore(

--- a/src/prolly_btree_cursor_seek.c
+++ b/src/prolly_btree_cursor_seek.c
@@ -854,6 +854,151 @@ static int indexMovetoExactTreeHit(
   return SQLITE_OK;
 }
 
+/* Smallest visible entry at or above the raw key, merged across the tree
+** and the pending map; CURSOR_INVALID when there is none. */
+static int seekMergedLowerBound(BtCursor *pCur, const u8 *pKey, int nKey){
+  int rc;
+  int res = 0;
+
+  clearMergeCursorState(pCur);
+  CLEAR_CACHED_PAYLOAD(pCur);
+  rc = prollyCursorSeekBlob(&pCur->pCur, pKey, nKey, &res);
+  if( rc!=SQLITE_OK ) return rc;
+  if( res<0 && prollyCursorIsValid(&pCur->pCur) ){
+    rc = prollyCursorNext(&pCur->pCur);
+    if( rc!=SQLITE_OK ) return rc;
+  }
+  if( pCur->pMutMap && !prollyMutMapIsEmpty(pCur->pMutMap) ){
+    int idx = 0, found = 0;
+    rc = prollyMutMapResolveSortedPos(pCur->pMutMap, pKey, nKey, 0,
+                                      &idx, &found);
+    if( rc!=SQLITE_OK ) return rc;
+    pCur->mmActive = 1;
+    pCur->mmIdx = idx;
+    rc = mergeScan(pCur, 1, &res);
+    if( rc!=SQLITE_OK ) return rc;
+    pCur->eState = res==0 ? CURSOR_VALID : CURSOR_INVALID;
+    /* A backward step from a pending landing re-seeks the tree below it. */
+    pCur->mergeStepDir = 1;
+  }else{
+    pCur->eState = prollyCursorIsValid(&pCur->pCur)
+                 ? CURSOR_VALID : CURSOR_INVALID;
+  }
+  return SQLITE_OK;
+}
+
+static int currentMergedKey(BtCursor *pCur, const u8 **ppKey, int *pnKey){
+  if( pCur->mmActive
+   && (pCur->mergeSrc==MERGE_SRC_MUT || pCur->mergeSrc==MERGE_SRC_BOTH) ){
+    ProllyMutMapEntry *e = 0;
+    int rc = currentMutMapEntry(pCur, &e);
+    if( rc!=SQLITE_OK ) return rc;
+    if( !e ) return SQLITE_NOTFOUND;
+    *ppKey = e->pKey;
+    *pnKey = e->nKey;
+    return SQLITE_OK;
+  }
+  if( !prollyCursorIsValid(&pCur->pCur) ) return SQLITE_NOTFOUND;
+  prollyCursorKey(&pCur->pCur, ppKey, pnKey);
+  return SQLITE_OK;
+}
+
+/* Last visible entry below the raw bound (NULL bound = above everything).
+** pEmpty: no entries at all. pNoneBelow: every entry is at or above the
+** bound; the cursor is left on the first one. */
+static int positionBeforeBound(
+  BtCursor *pCur,
+  const u8 *pBound,
+  int nBound,
+  int *pEmpty,
+  int *pNoneBelow
+){
+  int rc;
+  int res = 0;
+
+  *pEmpty = 0;
+  *pNoneBelow = 0;
+  if( pBound ){
+    rc = seekMergedLowerBound(pCur, pBound, nBound);
+    if( rc!=SQLITE_OK ) return rc;
+    if( pCur->eState==CURSOR_VALID ){
+      rc = prollyBtCursorPrevious(pCur, 0);
+      if( rc==SQLITE_OK ) return SQLITE_OK;
+      if( rc!=SQLITE_DONE ) return rc;
+      *pNoneBelow = 1;
+      rc = prollyBtCursorFirst(pCur, &res);
+      if( rc==SQLITE_OK && res!=0 ) *pEmpty = 1;
+      return rc;
+    }
+  }
+  rc = prollyBtCursorLast(pCur, &res);
+  if( rc==SQLITE_OK && res!=0 ) *pEmpty = 1;
+  return rc;
+}
+
+/* SeekLE/SeekGT prefix seek: land on the last entry whose leading fields
+** equal the seek key, so the caller never walks the matching run. Stock
+** reaches that spot because default_rc<0 makes matches compare below the
+** key inside the b-tree search; here the same position is the predecessor
+** of the prefix's successor. An exact numeric prefix is also a byte prefix
+** of the 18-byte inexact neighbours that sort right after its matches, so
+** when the landing is one of those the bound moves to prefix+0x80, which
+** every neighbour starts with and no field start does. */
+static int indexMovetoPrefixLast(
+  BtCursor *pCur,
+  UnpackedRecord *pIdxKey,
+  const u8 *pSortKey,
+  int nSortKey,
+  int nSeekKeyField,
+  int *pRes
+){
+  u8 *pBound = 0;
+  int nBound = 0;
+  int rc;
+  int pass;
+
+  pIdxKey->eqSeen = 0;
+  *pRes = -1;
+  rc = sortKeyPrefixSuccessor(pSortKey, nSortKey, &pBound, &nBound);
+  if( rc!=SQLITE_OK ) return rc;
+  for(pass=0; pass<2; pass++){
+    const u8 *pKey = 0;
+    int nKey = 0;
+    int empty = 0, noneBelow = 0;
+
+    rc = positionBeforeBound(pCur, pBound, nBound, &empty, &noneBelow);
+    sqlite3_free(pBound);
+    pBound = 0;
+    if( rc!=SQLITE_OK ) return rc;
+    if( empty ){
+      pCur->eState = CURSOR_INVALID;
+      break;
+    }
+    if( noneBelow ){
+      *pRes = 1;
+      break;
+    }
+    rc = currentMergedKey(pCur, &pKey, &nKey);
+    if( rc!=SQLITE_OK ) return rc;
+    if( nKey<nSortKey || memcmp(pKey, pSortKey, nSortKey)!=0 ) break;
+    if( nKey==nSortKey || sortKeyByteStartsField(pKey[nSortKey]) ){
+      pIdxKey->eqSeen = 1;
+      break;
+    }
+    if( pass==1 ) break;
+    pBound = sqlite3_malloc(nSortKey+1);
+    if( !pBound ) return SQLITE_NOMEM;
+    memcpy(pBound, pSortKey, nSortKey);
+    pBound[nSortKey] = 0x80;
+    nBound = nSortKey+1;
+  }
+  /* First/Last/Previous cleared the cached seek key the following
+  ** OP_IdxGT/IdxLT compares against; the buffer itself is untouched. */
+  pCur->nSeekSortKey = nSortKey;
+  pCur->nSeekKeyField = nSeekKeyField;
+  return SQLITE_OK;
+}
+
 int prollyBtCursorIndexMoveto(
   BtCursor *pCur,
   UnpackedRecord *pIdxKey,
@@ -892,6 +1037,11 @@ int prollyBtCursorIndexMoveto(
     rc = indexMovetoCustomCollation(
         pCur, pIdxKey, nSeekKeyField, exactMutMapKey, pRes, &done);
     if( rc!=SQLITE_OK || done ) return rc;
+
+    if( nSeekKeyField>0 && pIdxKey->default_rc<0 ){
+      return indexMovetoPrefixLast(
+          pCur, pIdxKey, pSortKey, nSortKey, nSeekKeyField, pRes);
+    }
 
     rc = indexMovetoExactMutMap(
         pCur, pIdxKey, pSortKey, nSortKey, exactMutMapKey, pRes, &done);

--- a/src/prolly_btree_int.h
+++ b/src/prolly_btree_int.h
@@ -746,6 +746,7 @@ int materializeDeferredMergedSeekBackward(BtCursor *pCur);
 int tableEntryIsTableRoot(Btree*, struct TableEntry*, int*);
 void clearMergeCursorState(BtCursor*);
 int mergeLast(BtCursor *pCur, int *pRes);
+int mergeScan(BtCursor *pCur, int dir, int *pRes);
 static SQLITE_INLINE int prollyCursorCheckInterrupt(BtCursor *pCur){
   sqlite3 *db = pCur && pCur->pBtree ? pCur->pBtree->db : 0;
   if( db && AtomicLoad(&db->u1.isInterrupted) ){

--- a/src/sortkey.c
+++ b/src/sortkey.c
@@ -346,6 +346,24 @@ static int sortKeyEncode(const u8 *pRec, int nRec, u8 *pOut, int nMaxFields,
   return pOut ? outPos : (int)outSize;
 }
 
+int sortKeyPrefixSuccessor(const u8 *pKey, int nKey, u8 **ppOut, int *pnOut){
+  int i;
+  u8 *pOut;
+  for(i=nKey-1; i>=0 && pKey[i]==0xff; i--){}
+  if( i<0 ){
+    *ppOut = 0;
+    *pnOut = 0;
+    return SQLITE_OK;
+  }
+  pOut = sqlite3_malloc(i+1);
+  if( !pOut ) return SQLITE_NOMEM;
+  memcpy(pOut, pKey, i+1);
+  pOut[i]++;
+  *ppOut = pOut;
+  *pnOut = i+1;
+  return SQLITE_OK;
+}
+
 static int sortKeyFromSingleBinaryFieldFast(
   const u8 *pRec, int nRec, int nKeyField, const KeyInfo *pKeyInfo,
   u8 **ppBuf, int *pnAlloc, int *pnOut

--- a/src/sortkey.h
+++ b/src/sortkey.h
@@ -32,6 +32,9 @@ static inline int sortKeyByteStartsField(u8 b){
   return 0;
 }
 
+/* Smallest key above every key that starts with pKey; NULL when none exists. */
+int sortKeyPrefixSuccessor(const u8 *pKey, int nKey, u8 **ppOut, int *pnOut);
+
 int sortKeyFromRecordPrefixColl(const u8 *pRec, int nRec, int nKeyField,
                                  const KeyInfo *pKeyInfo,
                                  u8 **ppOut, int *pnOut);

--- a/src/vdbe.c
+++ b/src/vdbe.c
@@ -5451,20 +5451,11 @@ case OP_SeekGT: {       /* jump0, in3, group, ncycle */
     }
 
 #ifdef DOLTLITE_PROLLY
-    /* Fix for prolly btree prefix-match positioning (issues #179, #180).
-    **
-    ** sqlite3BtreeIndexMoveto() may return res<0 with eqSeen when doing a
-    ** prefix match (search key has fewer fields than the index).  In standard
-    ** SQLite's b-tree, the binary search naturally lands PAST the matching
-    ** range (res>0), so SeekLE calls BtreePrevious to reach the last match.
-    ** In the prolly btree, IndexMoveto lands at the FIRST prefix match
-    ** (res<0), causing SeekLE to stay there — returning the MIN instead of
-    ** MAX for reverse-ordered queries.
-    **
-    ** Fix: when we get res<0 + eqSeen for a SeekLE or SeekGT, advance the
-    ** cursor forward through all prefix-matching entries, then position at
-    ** the first entry PAST the range (res>0).  The existing SeekLE logic
-    ** will then call BtreePrevious to land on the last match. */
+    /* A prefix seek with default_rc<0 must land on the LAST match, since
+    ** SeekLE stays put and SeekGT steps once. The prolly seek does that in
+    ** O(log n) for encodable keys; the unsupported-collation scan path can
+    ** still land on the first match, so finish the walk here. For an
+    ** already-correct landing this costs one step out and one back. */
     if( res<0 && r.eqSeen && (oc==OP_SeekLE || oc==OP_SeekGT) ){
       while(1){
         int nx = sqlite3BtreeNext(pC->uc.pCursor, 0);

--- a/test/doltlite_index_reverse_prefix_seek.sh
+++ b/test/doltlite_index_reverse_prefix_seek.sh
@@ -1,0 +1,135 @@
+#!/bin/bash
+# SeekLE/SeekGT prefix seeks must land on the last matching entry directly, not walk the run.
+DOLTLITE="${1:-${DOLTLITE:-./doltlite}}"
+. "$(dirname "$0")/lib/doltlite_test_common.sh"
+
+echo "=== reverse prefix seeks land on the last match ==="
+echo ""
+
+ROOT=$(mktemp -d /tmp/dl_rev_prefix_XXXXXX)
+trap 'rm -rf "$ROOT"' EXIT
+DB="$ROOT/rp.db"
+
+# Every check compares the indexed plan against the same query forced through a table scan.
+same() {
+  local name="$1" sql="$2" scan="$3"
+  run_test "$name" "SELECT ($sql) IS ($scan);" "1" "$DB"
+}
+
+run_test "seed" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, a INT, b INT, s TEXT, r REAL);
+WITH RECURSIVE c(x) AS (SELECT 1 UNION ALL SELECT x+1 FROM c WHERE x<3000)
+INSERT INTO t(a,b,s,r) SELECT x%7, x, 'k'||(x%13), x/10.0 FROM c;
+INSERT INTO t(a,b,s,r) VALUES(2,NULL,NULL,NULL),(2,NULL,'z',1.5),(9007199254740992,1,'x',1),(9007199254740993,2,'x',1),(9007199254740994,3,'x',1),(9007199254740995,4,'x',1),(-9007199254740993,5,'x',1),(-9007199254740992,6,'x',1);
+CREATE INDEX iab ON t(a,b);
+CREATE INDEX iabd ON t(a,b DESC);
+CREATE INDEX ias ON t(a,s);
+CREATE INDEX iasd ON t(a DESC,s DESC);
+CREATE INDEX iar ON t(a,r);
+CREATE INDEX isb ON t(s,b);
+CREATE INDEX isbn ON t(s COLLATE NOCASE,b);
+SELECT count(*) FROM t;
+" "3008" "$DB"
+
+for a in 0 1 3 6 2 5 9007199254740992 9007199254740993 9007199254740994 9007199254740995 -9007199254740993 -9007199254740992 99; do
+  same "max_b_a_$a" "SELECT max(b) FROM t INDEXED BY iab WHERE a=$a" "SELECT max(b) FROM t NOT INDEXED WHERE a=$a"
+  same "desc_limit_a_$a" "SELECT b FROM t INDEXED BY iab WHERE a=$a ORDER BY b DESC LIMIT 1" "SELECT b FROM t NOT INDEXED WHERE a=$a ORDER BY b DESC LIMIT 1"
+  same "min_b_desc_idx_a_$a" "SELECT min(b) FROM t INDEXED BY iabd WHERE a=$a" "SELECT min(b) FROM t NOT INDEXED WHERE a=$a"
+  same "max_b_desc_idx_a_$a" "SELECT max(b) FROM t INDEXED BY iabd WHERE a=$a" "SELECT max(b) FROM t NOT INDEXED WHERE a=$a"
+  same "max_s_a_$a" "SELECT max(s) FROM t INDEXED BY ias WHERE a=$a" "SELECT max(s) FROM t NOT INDEXED WHERE a=$a"
+  same "min_s_descdesc_a_$a" "SELECT min(s) FROM t INDEXED BY iasd WHERE a=$a" "SELECT min(s) FROM t NOT INDEXED WHERE a=$a"
+  same "max_r_a_$a" "SELECT max(r) FROM t INDEXED BY iar WHERE a=$a" "SELECT max(r) FROM t NOT INDEXED WHERE a=$a"
+  same "gt_prefix_a_$a" "SELECT group_concat(id) FROM (SELECT id FROM t INDEXED BY iab WHERE a>$a ORDER BY a,b,id LIMIT 3)" "SELECT group_concat(id) FROM (SELECT id FROM t NOT INDEXED WHERE a>$a ORDER BY a,b,id LIMIT 3)"
+  same "le_prefix_a_$a" "SELECT group_concat(id) FROM (SELECT id FROM t INDEXED BY iab WHERE a<=$a ORDER BY a DESC,b DESC,id DESC LIMIT 3)" "SELECT group_concat(id) FROM (SELECT id FROM t NOT INDEXED WHERE a<=$a ORDER BY a DESC,b DESC,id DESC LIMIT 3)"
+done
+same "max_b_a_real" "SELECT max(b) FROM t INDEXED BY iab WHERE a=2.0" "SELECT max(b) FROM t NOT INDEXED WHERE a=2.0"
+same "max_b_a_null" "SELECT max(b) FROM t INDEXED BY iab WHERE a IS NULL" "SELECT max(b) FROM t NOT INDEXED WHERE a IS NULL"
+same "two_field_prefix_max" "SELECT max(id) FROM t INDEXED BY iab WHERE a=3 AND b=10" "SELECT max(id) FROM t NOT INDEXED WHERE a=3 AND b=10"
+same "text_prefix_max" "SELECT max(b) FROM t INDEXED BY isb WHERE s='k5'" "SELECT max(b) FROM t NOT INDEXED WHERE s='k5'"
+same "text_prefix_desc_limit" "SELECT b FROM t INDEXED BY isb WHERE s='k12' ORDER BY b DESC LIMIT 1" "SELECT b FROM t NOT INDEXED WHERE s='k12' ORDER BY b DESC LIMIT 1"
+same "nocase_prefix_max" "SELECT max(b) FROM t INDEXED BY isbn WHERE s='K5' COLLATE NOCASE" "SELECT max(b) FROM t NOT INDEXED WHERE s='K5' COLLATE NOCASE"
+same "text_missing_prefix" "SELECT max(b) FROM t INDEXED BY isb WHERE s='nope'" "SELECT max(b) FROM t NOT INDEXED WHERE s='nope'"
+same "text_null_prefix" "SELECT max(b) FROM t INDEXED BY isb WHERE s IS NULL" "SELECT max(b) FROM t NOT INDEXED WHERE s IS NULL"
+same "range_desc_scan" "SELECT group_concat(b) FROM (SELECT b FROM t INDEXED BY iab WHERE a=4 AND b BETWEEN 100 AND 200 ORDER BY b DESC)" "SELECT group_concat(b) FROM (SELECT b FROM t NOT INDEXED WHERE a=4 AND b BETWEEN 100 AND 200 ORDER BY b DESC)"
+
+# Pending map: rows inserted, deleted and moved inside the transaction that runs the seeks.
+run_test "pending_map_matrix" "
+BEGIN;
+INSERT INTO t(a,b,s,r) VALUES(1,999999,'zz',1),(1,-5,'aa',1),(4,999999,'zz',1),(8,1,'p',1),(8,2,'q',1);
+DELETE FROM t WHERE a=3 AND b>2900;
+DELETE FROM t WHERE a=5;
+UPDATE t SET b=b+1000000 WHERE a=6 AND b>2990;
+INSERT INTO t(a,b,s,r) VALUES(9007199254740993,7,'x',1),(9007199254740992,8,'x',1);
+SELECT (SELECT max(b) FROM t INDEXED BY iab WHERE a=1) IS (SELECT max(b) FROM t NOT INDEXED WHERE a=1);
+SELECT (SELECT min(b) FROM t INDEXED BY iabd WHERE a=1) IS (SELECT min(b) FROM t NOT INDEXED WHERE a=1);
+SELECT (SELECT max(b) FROM t INDEXED BY iab WHERE a=3) IS (SELECT max(b) FROM t NOT INDEXED WHERE a=3);
+SELECT (SELECT max(b) FROM t INDEXED BY iab WHERE a=5) IS (SELECT max(b) FROM t NOT INDEXED WHERE a=5);
+SELECT (SELECT max(b) FROM t INDEXED BY iab WHERE a=6) IS (SELECT max(b) FROM t NOT INDEXED WHERE a=6);
+SELECT (SELECT max(b) FROM t INDEXED BY iab WHERE a=8) IS (SELECT max(b) FROM t NOT INDEXED WHERE a=8);
+SELECT (SELECT max(b) FROM t INDEXED BY iab WHERE a=4) IS (SELECT max(b) FROM t NOT INDEXED WHERE a=4);
+SELECT (SELECT max(b) FROM t INDEXED BY iab WHERE a=9007199254740992) IS (SELECT max(b) FROM t NOT INDEXED WHERE a=9007199254740992);
+SELECT (SELECT max(b) FROM t INDEXED BY iab WHERE a=9007199254740993) IS (SELECT max(b) FROM t NOT INDEXED WHERE a=9007199254740993);
+SELECT (SELECT group_concat(id) FROM (SELECT id FROM t INDEXED BY iab WHERE a>5 ORDER BY a,b,id LIMIT 4)) IS (SELECT group_concat(id) FROM (SELECT id FROM t NOT INDEXED WHERE a>5 ORDER BY a,b,id LIMIT 4));
+SELECT (SELECT group_concat(id) FROM (SELECT id FROM t INDEXED BY iab WHERE a<=5 ORDER BY a DESC,b DESC,id DESC LIMIT 4)) IS (SELECT group_concat(id) FROM (SELECT id FROM t NOT INDEXED WHERE a<=5 ORDER BY a DESC,b DESC,id DESC LIMIT 4));
+SELECT (SELECT max(s) FROM t INDEXED BY ias WHERE a=1) IS (SELECT max(s) FROM t NOT INDEXED WHERE a=1);
+ROLLBACK;
+" "1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1" "$DB"
+
+run_test "pending_only_table" "
+BEGIN;
+CREATE TABLE p(a INT, b INT);
+CREATE INDEX pab ON p(a,b);
+INSERT INTO p VALUES(1,1),(1,2),(1,3),(2,1),(9007199254740992,1),(9007199254740993,2);
+SELECT max(b) FROM p INDEXED BY pab WHERE a=1;
+SELECT max(b) FROM p INDEXED BY pab WHERE a=2;
+SELECT max(b) FROM p INDEXED BY pab WHERE a=3;
+SELECT max(b) FROM p INDEXED BY pab WHERE a=9007199254740992;
+SELECT max(b) FROM p INDEXED BY pab WHERE a=9007199254740993;
+DELETE FROM p WHERE a=1 AND b=3;
+SELECT max(b) FROM p INDEXED BY pab WHERE a=1;
+ROLLBACK;
+" "3
+1
+
+1
+2
+2" "$DB"
+
+run_test "clustered_composite_pk_prefix" "
+CREATE TABLE c(a INT, b INT, v TEXT, PRIMARY KEY(a,b));
+WITH RECURSIVE s(x) AS (SELECT 1 UNION ALL SELECT x+1 FROM s WHERE x<2000) INSERT INTO c SELECT x%5, x, 'v' FROM s;
+SELECT (SELECT max(b) FROM c WHERE a=2) IS (SELECT max(b) FROM c NOT INDEXED WHERE a=2);
+SELECT (SELECT b FROM c WHERE a=4 ORDER BY b DESC LIMIT 1) IS (SELECT b FROM c NOT INDEXED WHERE a=4 ORDER BY b DESC LIMIT 1);
+SELECT (SELECT min(b) FROM c WHERE a=0) IS (SELECT min(b) FROM c NOT INDEXED WHERE a=0);
+" "1
+1
+1" "$DB"
+
+# 400k rows sharing one prefix: 20 reverse seeks must not cost a full walk each.
+BIG="$ROOT/big.db"
+run_test "big_seed" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, a INT, b INT);
+WITH RECURSIVE s(x) AS (SELECT 1 UNION ALL SELECT x+1 FROM s WHERE x<400000) INSERT INTO t(a,b) SELECT 1, x FROM s;
+CREATE INDEX iab ON t(a,b);
+SELECT max(b) FROM t WHERE a=1;
+" "400000" "$BIG"
+q=""; for i in $(seq 1 20); do q="$q SELECT max(b) FROM t WHERE a=1;"; done
+secs=$(printf '.timer on\n%s\n' "$q" | "$DOLTLITE" "$BIG" 2>&1 | awk '/Run Time:/{t+=$4} END{printf "%.4f", t}')
+if awk -v s="$secs" 'BEGIN{exit !(s<0.1)}'; then
+  dltest_pass
+else
+  dltest_fail "reverse_prefix_seek_is_log_n" "  20 max(b) seeks over a 400000-row prefix took ${secs}s (limit 0.1s)"
+fi
+
+dltest_finish

--- a/test/lib/doltlite_suite_manifest.sh
+++ b/test/lib/doltlite_suite_manifest.sh
@@ -123,6 +123,7 @@ doltlite_branch_edge.sh
 doltlite_diff_alter.sh
 doltlite_gc_scale.sh
 doltlite_index_prefix.sh
+doltlite_index_reverse_prefix_seek.sh
 doltlite_txn_seek_visibility.sh
 doltlite_txn_seek_prefix_contract.sh
 doltlite_count_numeric_range.sh


### PR DESCRIPTION
Fixes #2668.

`SELECT max(b) FROM t WHERE a=1` / `ORDER BY b DESC LIMIT 1` under an index `(a,b)` walked every entry of the `a=1` group: the prolly `IndexMoveto` landed on the first prefix match and the `vdbe.c` workaround stepped forward through the run. 400k-row group: 22 ms vs 0.04 ms stock.

**Change**
- `prollyBtCursorIndexMoveto` takes a new path for prefix seeks with `default_rc<0`: position at the predecessor of the prefix's successor, merged across tree and pending map (raw lower bound on both, `mergeScan`, one `Previous`). Lands on the last match with `eqSeen`, or on the last entry below the key, or reports "everything is above".
- An exact numeric prefix is also a byte prefix of the 18-byte inexact neighbours (`2^53+1`-style values) that sort right after its matches; when the landing is one of those the bound moves to `prefix+0x80`, which every neighbour starts with and no field start does.
- `blobPrefixSuccessor` moves from the count path into `sortkey.c` as `sortKeyPrefixSuccessor`; `mergeScan` is exported from `prolly_btree_cursor.c`.
- The `vdbe.c` walk is kept as the fallback for the unsupported-collation scan path (comment updated); for a correct landing it costs one step out and one back.

**Result:** `max(b)` on the 400k-row group goes from 22 ms to 0.09 ms locally.

**Tests**
- New `test/doltlite_index_reverse_prefix_seek.sh` (132 checks): indexed plan vs forced table scan for max/min/DESC LIMIT/`>`/`<=` prefix seeks over ASC and DESC second columns, TEXT/REAL/NULL/NOCASE prefixes, missing prefixes, `2^53±k` exact/inexact neighbours, composite clustered PKs, and a pending-map matrix (in-transaction inserts, deletes, moves, pending-only tables). Plus a timing check: 20 reverse seeks over a 400k-row prefix must finish under 0.1 s (0.47 s before, well under after). On master 131/132 pass and only the timing check fails; all pass with the fix.
- Local: 22 seek/index-related shell suites incl. index_prefix, txn_seek_prefix_contract, txn_seek_visibility, nocase_index, count_*, index_row_delta, edge_cases, advanced, feature_deep, savepoint, commit, merge; testfixture over the where*/index*/minmax*/orderby*/skipscan*/collate*/rowvalue*/in*/analyze*/autoindex*/descidx*/unique*/like*/seekscan1 suites (15,892 passing, 0 unexpected); `sql_differential_test.sh` seeds 1–150 vs stock clean; `make lint`; amalgamation compiles. sqllogictest runners aren't built locally, so that gate is left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)