### PR TITLE
Fold leftover copies and catch redundant local externs

### DIFF
--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -3,30 +3,6 @@
 #include "sqliteInt.h"
 #include "doltlite_internal.h"
 
-extern int doltliteLogRegister(sqlite3 *db);
-extern int doltliteCommitAncestorsRegister(sqlite3 *db);
-extern int doltliteStatusRegister(sqlite3 *db);
-extern int doltliteMergeStatusRegister(sqlite3 *db);
-extern int doltliteDiffRegister(sqlite3 *db);
-extern int doltliteSchemasRegister(sqlite3 *db);
-extern int doltliteDiffStatRegister(sqlite3 *db);
-extern int doltliteBranchRegister(sqlite3 *db);
-extern int doltliteConflictsRegister(sqlite3 *db);
-extern int doltliteTagRegister(sqlite3 *db);
-extern int doltliteGcRegister(sqlite3 *db);
-extern int doltliteRegisterWorkspaceTables(sqlite3 *db);
-extern int doltliteAncestorRegister(sqlite3 *db);
-extern int doltliteRegisterBlameTables(sqlite3 *db);
-extern int doltliteSchemaDiffRegister(sqlite3 *db);
-extern int doltlitePatchRegister(sqlite3 *db);
-extern int doltliteRemoteSqlRegister(sqlite3 *db);
-extern int doltliteHashofRegister(sqlite3 *db);
-extern int doltliteConstraintViolationsRegister(sqlite3 *db);
-extern int doltliteVerifyConstraintsRegister(sqlite3 *db);
-extern int doltliteDocsRegister(sqlite3 *db);
-extern int doltliteTestsRegister(sqlite3 *db);
-extern int doltliteIgnoreRegister(sqlite3 *db);
-
 int doltliteRegister(sqlite3 *db){
   int rc;
   if( (rc = doltliteCommitCmdRegister(db))!=SQLITE_OK ) return rc;

--- a/src/doltlite_at.c
+++ b/src/doltlite_at.c
@@ -319,56 +319,13 @@ static void atCursorReset(AtCursor *c){
   c->zCommitRef = 0;
 }
 
-static int atRowMatchesUpper(AtCursor *c){
-  if( !c->pkRange.hasPkHi ) return 1;
-  return doltlitePkRangeMatchesUpper(
-      &c->pkRange, prollyCursorIntKey(&c->common.tblCur));
-}
-
 static int atConnect(sqlite3 *db, void *pAux, int argc,
     const char *const*argv, sqlite3_vtab **ppVtab, char **pzErr){
-  DoltliteVtabCommon *v;
-  const char *zMod = argv[0];
-  size_t nPrefix = strlen("dolt_at_");
-  char *zSchema;
-  int rc;
   (void)pAux;
-
-  v = sqlite3_malloc(sizeof(AtVtab));
-  if( !v ) return SQLITE_NOMEM;
-  memset(v, 0, sizeof(AtVtab));
-  v->db = db;
-
-  if( zMod && strncmp(zMod, "dolt_at_", nPrefix)==0 ){
-    v->zTableName = sqlite3_mprintf("%s", zMod + nPrefix);
-  }else if( argc > 3 ){
-    v->zTableName = sqlite3_mprintf("%s", argv[3]);
-  }else{
-    v->zTableName = sqlite3_mprintf("");
-  }
-  if( !v->zTableName ){
-    doltliteVtabCommonDisconnect(&v->base);
-    return SQLITE_NOMEM;
-  }
-
-  rc = doltliteLoadHistoricalTableColumns(db, v->zTableName,
-                                           &v->cols, pzErr);
-  if( rc==SQLITE_OK ){
-    zSchema = atBuildSchema(&v->cols);
-    if( !zSchema ){
-      rc = SQLITE_NOMEM;
-    }else{
-      rc = sqlite3_declare_vtab(db, zSchema);
-      sqlite3_free(zSchema);
-    }
-  }
-  if( rc!=SQLITE_OK ){
-    doltliteVtabCommonDisconnect(&v->base);
-    return rc;
-  }
-  sqlite3_vtab_config(db, SQLITE_VTAB_INNOCUOUS);
-  *ppVtab = &v->base;
-  return SQLITE_OK;
+  return doltliteVtabConnectHistoricalTable(db, argc, argv,
+                                            "dolt_at_",
+                                            sizeof(AtVtab), atBuildSchema,
+                                            ppVtab, pzErr);
 }
 
 static int atOpen(sqlite3_vtab *pVtab, sqlite3_vtab_cursor **pp){
@@ -569,7 +526,7 @@ static int atFilter(sqlite3_vtab_cursor *cur,
         return rc;
       }
     }
-    if( !prollyCursorIsValid(&c->common.tblCur) || !atRowMatchesUpper(c) ){
+    if( !prollyCursorIsValid(&c->common.tblCur) || !doltlitePkRangeMatchesCursorUpper(&c->pkRange, &c->common.tblCur) ){
       prollyCursorClose(&c->common.tblCur);
       return SQLITE_OK;
     }
@@ -587,7 +544,7 @@ static int atFilter(sqlite3_vtab_cursor *cur,
     prollyCursorClose(&c->common.tblCur);
     return SQLITE_OK;
   }
-  if( seekable && c->pkRange.hasPkHi && !atRowMatchesUpper(c) ){
+  if( seekable && c->pkRange.hasPkHi && !doltlitePkRangeMatchesCursorUpper(&c->pkRange, &c->common.tblCur) ){
     prollyCursorClose(&c->common.tblCur);
     return SQLITE_OK;
   }
@@ -627,7 +584,7 @@ static int atNext(sqlite3_vtab_cursor *cur){
     return SQLITE_OK;
   }
   if( (c->idxNum & AT_IDX_PK_ANY) && c->common.rootIntKey
-   && !atRowMatchesUpper(c) ){
+   && !doltlitePkRangeMatchesCursorUpper(&c->pkRange, &c->common.tblCur) ){
     prollyCursorClose(&c->common.tblCur);
     c->common.tblCurOpen = 0;
     c->common.hasRow = 0;

--- a/src/doltlite_checkout.c
+++ b/src/doltlite_checkout.c
@@ -188,8 +188,6 @@ static int checkoutLoadAndApply(
 
 static int refreshBranchScopedTables(sqlite3 *db){
   int rc;
-  extern int doltliteRegisterWorkspaceTables(sqlite3 *db);
-  extern int doltliteRegisterBlameTables(sqlite3 *db);
 
   rc = doltliteRegisterHistoricalTables(db);
   if( rc!=SQLITE_OK ) return rc;

--- a/src/doltlite_cherry_pick.c
+++ b/src/doltlite_cherry_pick.c
@@ -396,9 +396,7 @@ static void doltliteCherryPickFunc(
     rc = mergeAbortInPlace(db);
     doltliteCmdArgsClear(&args);
     if( rc!=SQLITE_OK ){
-      if( !doltliteCmdSourceResultError(context, cs, &rc) ){
-        sqlite3_result_error_code(context, rc);
-      }
+      doltliteCmdSourceResultErrorOrCode(context, cs, rc);
       return;
     }
     sqlite3_result_int(context, 0);
@@ -421,9 +419,7 @@ static void doltliteCherryPickFunc(
 
   rc = doltliteHasUncommittedChanges(db, &dirty);
   if( rc!=SQLITE_OK ){
-    if( !doltliteCmdSourceResultError(context, cs, &rc) ){
-      sqlite3_result_error_code(context, rc);
-    }
+    doltliteCmdSourceResultErrorOrCode(context, cs, rc);
     return;
   }
   if( dirty ){
@@ -434,13 +430,7 @@ static void doltliteCherryPickFunc(
 
   rc = doltliteResolveRef(db,zRef, &pickHash);
   if( rc!=SQLITE_OK ){
-    if( !doltliteCmdSourceResultError(context, cs, &rc) ){
-      if( rc==SQLITE_NOTFOUND || rc==SQLITE_ERROR ){
-        sqlite3_result_error(context, "invalid commit hash", -1);
-      }else{
-        sqlite3_result_error_code(context, rc);
-      }
-    }
+    doltliteCmdReportInvalidCommitHash(context, cs, rc);
     return;
   }
   rc = doltliteLoadHeadAndParentedCommit(

--- a/src/doltlite_chunk_source.c
+++ b/src/doltlite_chunk_source.c
@@ -12,6 +12,12 @@
 #include "doltlite_remote.h"
 #endif
 
+static int csHasOrigin(ChunkStore *cs){
+  const char *zUrl = 0;
+  return chunkStoreFindRemote(cs, "origin", &zUrl)==SQLITE_OK
+      && zUrl && zUrl[0];
+}
+
 #if DOLTLITE_ENABLE_CHUNK_SOURCE
 
 #define CS_SOURCE_CACHE_BUCKETS 256
@@ -48,16 +54,10 @@ struct DoltliteChunkSourceState {
   char *zErr;
 };
 
-static int csSourceHasOrigin(ChunkStore *cs){
-  const char *zUrl = 0;
-  return chunkStoreFindRemote(cs, "origin", &zUrl)==SQLITE_OK
-      && zUrl && zUrl[0];
-}
-
 static doltlite_chunk_source *csSourceActive(DoltliteChunkSourceState *p){
   if( p->pHostSource ) return p->pHostSource;
   if( p->originEnabled
-   && csSourceHasOrigin((ChunkStore*)p->originSource.pCtx) ){
+   && csHasOrigin((ChunkStore*)p->originSource.pCtx) ){
     return &p->originSource;
   }
   return 0;
@@ -495,7 +495,7 @@ int chunkStoreSourceGet(
   int sourceRc;
   int rc;
   if( !p ){
-    if( csSourceHasOrigin(cs) ) return csSourceSetModeError(cs, pHash);
+    if( csHasOrigin(cs) ) return csSourceSetModeError(cs, pHash);
     return SQLITE_NOTFOUND;
   }
   csSourceClearError(p);
@@ -516,7 +516,7 @@ int chunkStoreSourceGet(
   }
   pSource = csSourceActive(p);
   if( !pSource ){
-    if( csSourceHasOrigin(cs) && !p->originEnabled ){
+    if( csHasOrigin(cs) && !p->originEnabled ){
       return csSourceSetModeError(cs, pHash);
     }
     return SQLITE_NOTFOUND;
@@ -759,7 +759,7 @@ int doltliteOriginSourceEnable(
 
 int chunkStoreOriginSourceEnabled(ChunkStore *cs){
   DoltliteChunkSourceState *p = cs->pChunkSource;
-  return p && p->originEnabled && csSourceHasOrigin(cs);
+  return p && p->originEnabled && csHasOrigin(cs);
 }
 
 static void csSourceDropHost(ChunkStore *cs){
@@ -980,12 +980,6 @@ static int csDisabledEnsureState(ChunkStore *cs){
   return SQLITE_OK;
 }
 
-static int csDisabledHasOrigin(ChunkStore *cs){
-  const char *zUrl = 0;
-  return chunkStoreFindRemote(cs, "origin", &zUrl)==SQLITE_OK
-      && zUrl && zUrl[0];
-}
-
 static int csDisabledSetHashError(
   ChunkStore *cs,
   const ProllyHash *pHash,
@@ -1024,7 +1018,7 @@ int chunkStoreSourceGet(ChunkStore *cs, const ProllyHash *pHash,
                         u8 **ppData, int *pnData){
   *ppData = 0;
   *pnData = 0;
-  if( !csDisabledHasOrigin(cs) ) return SQLITE_NOTFOUND;
+  if( !csHasOrigin(cs) ) return SQLITE_NOTFOUND;
   if( chunkStoreOriginSourceEnabled(cs) ){
     return csDisabledSetHashError(
         cs, pHash, "DoltLite chunk source support is disabled for",
@@ -1080,7 +1074,7 @@ int doltliteOriginSourceEnable(ChunkStore *cs, sqlite3 *db, int *pChanged){
 
 int chunkStoreOriginSourceEnabled(ChunkStore *cs){
   DoltliteChunkSourceState *p = cs->pChunkSource;
-  return p && p->originEnabled && csDisabledHasOrigin(cs);
+  return p && p->originEnabled && csHasOrigin(cs);
 }
 
 void chunkStoreSourceClose(ChunkStore *cs){

--- a/src/doltlite_cmd.c
+++ b/src/doltlite_cmd.c
@@ -633,6 +633,29 @@ int doltliteCmdSourceResultError(
   return 1;
 }
 
+void doltliteCmdSourceResultErrorOrCode(
+  sqlite3_context *ctx,
+  ChunkStore *cs,
+  int rc
+){
+  if( !doltliteCmdSourceResultError(ctx, cs, &rc) ){
+    sqlite3_result_error_code(ctx, rc);
+  }
+}
+
+void doltliteCmdReportInvalidCommitHash(
+  sqlite3_context *ctx,
+  ChunkStore *cs,
+  int rc
+){
+  if( doltliteCmdSourceResultError(ctx, cs, &rc) ) return;
+  if( rc==SQLITE_NOTFOUND || rc==SQLITE_ERROR ){
+    sqlite3_result_error(ctx, "invalid commit hash", -1);
+  }else{
+    sqlite3_result_error_code(ctx, rc);
+  }
+}
+
 int doltliteVtabMapChunkSourceError(
   sqlite3_vtab *pVtab,
   sqlite3 *db,
@@ -683,9 +706,7 @@ int doltliteCmdReportLoadParentedCommitError(
   doltliteCommitClear(pTarget);
   doltliteCommitClear(pParent);
   doltliteCommitClear(pOurs);
-  if( !doltliteCmdSourceResultError(ctx, cs, &rc) ){
-    sqlite3_result_error_code(ctx, rc);
-  }
+  doltliteCmdSourceResultErrorOrCode(ctx, cs, rc);
   return 1;
 }
 

--- a/src/doltlite_gc.c
+++ b/src/doltlite_gc.c
@@ -15,7 +15,7 @@
 #include <unistd.h>
 #endif
 
-extern void csSerializeManifest(const ChunkStore *cs, u8 *aBuf);
+#include "chunk_store_int.h"
 #include "doltlite_internal.h"
 
 typedef struct GcQueue GcQueue;

--- a/src/doltlite_history.c
+++ b/src/doltlite_history.c
@@ -64,12 +64,6 @@ static void htCursorReset(HistCursor *c){
   doltliteCommitQueueClear(&c->queue);
 }
 
-static int htRowMatchesUpper(HistCursor *c){
-  if( !c->pkRange.hasPkHi ) return 1;
-  return doltlitePkRangeMatchesUpper(
-      &c->pkRange, prollyCursorIntKey(&c->common.tblCur));
-}
-
 static int htOpenTableAtCommit(HistCursor *c, sqlite3 *db,
     const char *zTableName, const ProllyHash *pCommitHash){
   ChunkStore *cs = doltliteGetChunkStore(db);
@@ -155,7 +149,7 @@ static int htOpenTableAtCommit(HistCursor *c, sqlite3 *db,
         return rc;
       }
     }
-    if( !prollyCursorIsValid(&c->common.tblCur) || !htRowMatchesUpper(c) ){
+    if( !prollyCursorIsValid(&c->common.tblCur) || !doltlitePkRangeMatchesCursorUpper(&c->pkRange, &c->common.tblCur) ){
       prollyCursorClose(&c->common.tblCur);
       return SQLITE_OK;
     }
@@ -172,7 +166,7 @@ static int htOpenTableAtCommit(HistCursor *c, sqlite3 *db,
     prollyCursorClose(&c->common.tblCur);
     return SQLITE_OK;
   }
-  if( seekable && c->pkRange.hasPkHi && !htRowMatchesUpper(c) ){
+  if( seekable && c->pkRange.hasPkHi && !doltlitePkRangeMatchesCursorUpper(&c->pkRange, &c->common.tblCur) ){
     prollyCursorClose(&c->common.tblCur);
     return SQLITE_OK;
   }
@@ -196,7 +190,7 @@ static int htAdvance(HistCursor *c, sqlite3 *db, const char *zTableName){
         return rc;
       }
       if( prollyCursorIsValid(&c->common.tblCur)
-       && (!c->common.rootIntKey || htRowMatchesUpper(c)) ){
+       && (!c->common.rootIntKey || doltlitePkRangeMatchesCursorUpper(&c->pkRange, &c->common.tblCur)) ){
         return doltliteVtabCommonCaptureRowSide(&c->common, db, zTableName,
                                                 &c->side);
       }

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -968,6 +968,12 @@ void doltliteCmdResultPeerBranchBusy(sqlite3_context *ctx, const char *zOp);
 int doltliteCmdSourceResultError(
   sqlite3_context *ctx, ChunkStore *cs, int *pRc
 );
+void doltliteCmdSourceResultErrorOrCode(
+  sqlite3_context *ctx, ChunkStore *cs, int rc
+);
+void doltliteCmdReportInvalidCommitHash(
+  sqlite3_context *ctx, ChunkStore *cs, int rc
+);
 int doltliteVtabMapChunkSourceError(
   sqlite3_vtab *pVtab, sqlite3 *db, int sourceRc, int mappedRc
 );
@@ -1136,6 +1142,26 @@ int doltliteCherryPickRegister(sqlite3 *db);
 int doltliteRevertRegister(sqlite3 *db);
 int doltliteRebaseRegister(sqlite3 *db);
 int doltliteConfigRegister(sqlite3 *db);
+int doltliteLogRegister(sqlite3 *db);
+int doltliteCommitAncestorsRegister(sqlite3 *db);
+int doltliteStatusRegister(sqlite3 *db);
+int doltliteMergeStatusRegister(sqlite3 *db);
+int doltliteDiffRegister(sqlite3 *db);
+int doltliteSchemasRegister(sqlite3 *db);
+int doltliteDiffStatRegister(sqlite3 *db);
+int doltliteBranchRegister(sqlite3 *db);
+int doltliteConflictsRegister(sqlite3 *db);
+int doltliteTagRegister(sqlite3 *db);
+int doltliteGcRegister(sqlite3 *db);
+int doltliteAncestorRegister(sqlite3 *db);
+int doltliteSchemaDiffRegister(sqlite3 *db);
+int doltlitePatchRegister(sqlite3 *db);
+int doltliteRemoteSqlRegister(sqlite3 *db);
+int doltliteHashofRegister(sqlite3 *db);
+int doltliteConstraintViolationsRegister(sqlite3 *db);
+int doltliteDocsRegister(sqlite3 *db);
+int doltliteTestsRegister(sqlite3 *db);
+int doltliteIgnoreRegister(sqlite3 *db);
 int doltliteMaybeSeedRepo(sqlite3 *db);
 int doltliteSeedStoreIfNeeded(sqlite3*, ChunkStore*, const char*,
                               ProllyHash*, int*);

--- a/src/doltlite_merge.c
+++ b/src/doltlite_merge.c
@@ -8,10 +8,8 @@
 
 static int serializeMergedCatalog(
   sqlite3 *db,
-  const ProllyHash *oursCatHash,
   struct TableEntry *aMerged,
   int nMerged,
-  Pgno iNextTable,
   SchemaEntry *aFallbackSchema,
   int nFallbackSchema,
   ProllyHash *pOutHash
@@ -20,9 +18,6 @@ static int serializeMergedCatalog(
   u8 *buf = 0;
   int nBuf = 0;
   int rc;
-
-  (void)oursCatHash;
-  (void)iNextTable;
 
   rc = doltliteSerializeCatalogEntriesWithFallbackSchema(
       db, aMerged, nMerged, aFallbackSchema, nFallbackSchema, &buf, &nBuf);
@@ -1113,7 +1108,7 @@ int doltliteMergeCatalogs(
       }
       aFallback = aKept;
     }
-    rc = serializeMergedCatalog(db, ours, aMerged, nMerged, iNextMerged,
+    rc = serializeMergedCatalog(db, aMerged, nMerged,
                                 aFallback, nFallback, pMergedHash);
     sqlite3_free(aKept);
   }

--- a/src/doltlite_merge_constraints_notnull.c
+++ b/src/doltlite_merge_constraints_notnull.c
@@ -6,12 +6,6 @@
 ** Use typeof(c)='null': IS NULL is strength-reduced away on NOT NULL
 ** columns, so the obvious query never sees these rows. */
 
-static void freeNames(char **az, int n){
-  int i;
-  for(i=0; i<n; i++) sqlite3_free(az[i]);
-  sqlite3_free(az);
-}
-
 static int loadNotNullColumns(
   sqlite3 *db,
   const char *zTable,
@@ -52,7 +46,7 @@ static int loadNotNullColumns(
   if( rc==SQLITE_OK && stepRc!=SQLITE_DONE ) rc = stepRc;
   rc = finishConstraintStmt(pQ, rc);
   if( rc!=SQLITE_OK ){
-    freeNames(az, n);
+    doltliteFreeNameList(az, n);
     return rc;
   }
   *pazCols = az;
@@ -128,14 +122,14 @@ int doltliteDetectMergeNotNullViolations(
     memset(&pkInfo, 0, sizeof(pkInfo));
     rc = tableHasRowid(db, zTable, &hasRowid);
     if( rc!=SQLITE_OK ){
-      freeNames(azCols, nCols);
+      doltliteFreeNameList(azCols, nCols);
       sqlite3_free(zTable);
       break;
     }
     if( !hasRowid ){
       rc = loadMergePkInfo(db, zTable, &pkInfo);
       if( rc!=SQLITE_OK ){
-        freeNames(azCols, nCols);
+        doltliteFreeNameList(azCols, nCols);
         sqlite3_free(zTable);
         break;
       }
@@ -155,7 +149,7 @@ int doltliteDetectMergeNotNullViolations(
     }
     zQuery = sqlite3_str_finish(pStr);
     if( !zQuery ){
-      freeNames(azCols, nCols);
+      doltliteFreeNameList(azCols, nCols);
       freeMergePkInfo(&pkInfo);
       sqlite3_free(zTable);
       rc = SQLITE_NOMEM;
@@ -164,7 +158,7 @@ int doltliteDetectMergeNotNullViolations(
     rc = sqlite3_prepare_v2(db, zQuery, -1, &pQ, 0);
     sqlite3_free(zQuery);
     if( rc!=SQLITE_OK ){
-      freeNames(azCols, nCols);
+      doltliteFreeNameList(azCols, nCols);
       freeMergePkInfo(&pkInfo);
       sqlite3_free(zTable);
       break;
@@ -242,7 +236,7 @@ int doltliteDetectMergeNotNullViolations(
     }
     if( rc==SQLITE_OK && queryStepRc!=SQLITE_DONE ) rc = queryStepRc;
     rc = finishConstraintStmt(pQ, rc);
-    freeNames(azCols, nCols);
+    doltliteFreeNameList(azCols, nCols);
     freeMergePkInfo(&pkInfo);
     sqlite3_free(zTable);
     if( rc!=SQLITE_OK ) break;

--- a/src/doltlite_merge_constraints_strict.c
+++ b/src/doltlite_merge_constraints_strict.c
@@ -5,12 +5,6 @@
 /* Merge can pair a STRICT schema with a forbidden stored type. NULL
 ** is the NOT NULL detector's; ANY admits everything. */
 
-static void strictFreeNames(char **az, int n){
-  int i;
-  for(i=0; i<n; i++) sqlite3_free(az[i]);
-  sqlite3_free(az);
-}
-
 /* STRICT storage class, or 0 for ANY. */
 static const char *strictAllowedTypeof(const char *zDecl){
   if( sqlite3_stricmp(zDecl, "INT")==0
@@ -103,8 +97,8 @@ static int loadStrictColumns(
   if( rc==SQLITE_OK && stepRc!=SQLITE_DONE ) rc = stepRc;
   rc = finishConstraintStmt(pQ, rc);
   if( rc!=SQLITE_OK ){
-    strictFreeNames(azCols, n);
-    strictFreeNames(azAllowed, n);
+    doltliteFreeNameList(azCols, n);
+    doltliteFreeNameList(azAllowed, n);
     return rc;
   }
   *pazCols = azCols;
@@ -192,16 +186,16 @@ int doltliteDetectMergeStrictViolations(
     memset(&pkInfo, 0, sizeof(pkInfo));
     rc = tableHasRowid(db, zTable, &hasRowid);
     if( rc!=SQLITE_OK ){
-      strictFreeNames(azCols, nCols);
-      strictFreeNames(azAllowed, nCols);
+      doltliteFreeNameList(azCols, nCols);
+      doltliteFreeNameList(azAllowed, nCols);
       sqlite3_free(zTable);
       break;
     }
     if( !hasRowid ){
       rc = loadMergePkInfo(db, zTable, &pkInfo);
       if( rc!=SQLITE_OK ){
-        strictFreeNames(azCols, nCols);
-        strictFreeNames(azAllowed, nCols);
+        doltliteFreeNameList(azCols, nCols);
+        doltliteFreeNameList(azAllowed, nCols);
         sqlite3_free(zTable);
         break;
       }
@@ -223,8 +217,8 @@ int doltliteDetectMergeStrictViolations(
     }
     zQuery = sqlite3_str_finish(pStr);
     if( !zQuery ){
-      strictFreeNames(azCols, nCols);
-      strictFreeNames(azAllowed, nCols);
+      doltliteFreeNameList(azCols, nCols);
+      doltliteFreeNameList(azAllowed, nCols);
       freeMergePkInfo(&pkInfo);
       sqlite3_free(zTable);
       rc = SQLITE_NOMEM;
@@ -233,8 +227,8 @@ int doltliteDetectMergeStrictViolations(
     rc = sqlite3_prepare_v2(db, zQuery, -1, &pQ, 0);
     sqlite3_free(zQuery);
     if( rc!=SQLITE_OK ){
-      strictFreeNames(azCols, nCols);
-      strictFreeNames(azAllowed, nCols);
+      doltliteFreeNameList(azCols, nCols);
+      doltliteFreeNameList(azAllowed, nCols);
       freeMergePkInfo(&pkInfo);
       sqlite3_free(zTable);
       break;
@@ -313,8 +307,8 @@ int doltliteDetectMergeStrictViolations(
 
     if( rc==SQLITE_OK && queryStepRc!=SQLITE_DONE ) rc = queryStepRc;
     rc = finishConstraintStmt(pQ, rc);
-    strictFreeNames(azCols, nCols);
-    strictFreeNames(azAllowed, nCols);
+    doltliteFreeNameList(azCols, nCols);
+    doltliteFreeNameList(azAllowed, nCols);
     freeMergePkInfo(&pkInfo);
     sqlite3_free(zTable);
     if( rc!=SQLITE_OK ) break;

--- a/src/doltlite_revert.c
+++ b/src/doltlite_revert.c
@@ -179,13 +179,7 @@ static void doltliteRevertFunc(
 
   rc = doltliteResolveRef(db,zRef, &revertHash);
   if( rc!=SQLITE_OK ){
-    if( !doltliteCmdSourceResultError(context, cs, &rc) ){
-      if( rc==SQLITE_NOTFOUND || rc==SQLITE_ERROR ){
-        sqlite3_result_error(context, "invalid commit hash", -1);
-      }else{
-        sqlite3_result_error_code(context, rc);
-      }
-    }
+    doltliteCmdReportInvalidCommitHash(context, cs, rc);
     return;
   }
   rc = doltliteLoadHeadAndParentedCommit(

--- a/src/doltlite_verify_constraints.c
+++ b/src/doltlite_verify_constraints.c
@@ -113,12 +113,6 @@ static int collectChangedTables(
   return SQLITE_OK;
 }
 
-static void freeStringList(char **az, int n){
-  int i;
-  for(i=0; i<n; i++) sqlite3_free(az[i]);
-  sqlite3_free(az);
-}
-
 static int hasRecordedViolations(
   sqlite3 *db,
   const char **azTables,
@@ -276,7 +270,7 @@ static void doltVerifyConstraintsFunc(
           int nNew = nInterAlloc ? nInterAlloc*2 : 4;
           char **azNew = sqlite3_realloc(azInter, nNew * (int)sizeof(char*));
           if( !azNew ){
-            freeStringList(azInter, nInter);
+            doltliteFreeNameList(azInter, nInter);
             sqlite3_result_error_nomem(context);
             goto cleanup;
           }
@@ -285,13 +279,13 @@ static void doltVerifyConstraintsFunc(
         }
         azInter[nInter] = sqlite3_mprintf("%s", azArgTables[i]);
         if( !azInter[nInter] ){
-          freeStringList(azInter, nInter);
+          doltliteFreeNameList(azInter, nInter);
           sqlite3_result_error_nomem(context);
           goto cleanup;
         }
         nInter++;
       }
-      freeStringList(azChanged, nChanged);
+      doltliteFreeNameList(azChanged, nChanged);
       azChanged = azInter;
       nChanged = nInter;
     }
@@ -349,7 +343,7 @@ detection_done:
   sqlite3_result_int(context, nViolations>0 ? 1 : 0);
 
 cleanup:
-  freeStringList(azChanged, nChanged);
+  doltliteFreeNameList(azChanged, nChanged);
   sqlite3_free((void*)azArgTables);
   doltliteCmdArgsClear(&args);
 }

--- a/src/doltlite_vtab_util.h
+++ b/src/doltlite_vtab_util.h
@@ -86,6 +86,13 @@ static SQLITE_INLINE int doltliteVtabCommonCaptureRowSide(
   return SQLITE_OK;
 }
 
+static SQLITE_INLINE int doltlitePkRangeMatchesCursorUpper(
+  const DoltlitePkRange *pRange,
+  ProllyCursor *pCur
+){
+  return doltlitePkRangeMatchesUpper(pRange, prollyCursorIntKey(pCur));
+}
+
 static SQLITE_INLINE int doltliteVtabCommonDisconnect(
   sqlite3_vtab *pVtab
 ){

--- a/src/prolly_btree_cursor.c
+++ b/src/prolly_btree_cursor.c
@@ -953,7 +953,7 @@ int sqlite3BtreeProllyIndexRowid(BtCursor *pCur, i64 *pRowid){
   if( unlikely(typeRowid<1 || typeRowid>9 || typeRowid==7) ){
     goto prolly_idx_rowid_corruption;
   }
-  lenRowid = prollySerialTypeLen(typeRowid);
+  lenRowid = (u32)dlSerialTypeLen(typeRowid);
   testcase( (u32)nRec==szHdr+lenRowid );
   if( unlikely((u32)nRec<szHdr+lenRowid) ){
     goto prolly_idx_rowid_corruption;

--- a/src/prolly_btree_int.h
+++ b/src/prolly_btree_int.h
@@ -469,7 +469,6 @@ int mutMapShouldDrain(BtCursor *pCur);
 int prollyBtreeCheckMaxPageCount(Btree *p);
 int cacheCursorPayloadZeroTail(BtCursor *pCur, const u8 *pData,
                                int nData, i64 nZeroTail);
-u32 prollySerialTypeLen(u32 serialType);
 int currentMutMapEntry(BtCursor *pCur, ProllyMutMapEntry **ppEntry);
 void setCursorToMutMapEntryPhys(BtCursor *pCur, int physIdx);
 const char *findTableNumberName(sqlite3 *db, Pgno iTable);

--- a/src/prolly_btree_mutation.c
+++ b/src/prolly_btree_mutation.c
@@ -210,14 +210,6 @@ static int prollyGetVarint32(const u8 *p, u32 *pVal){
   }
 }
 
-u32 prollySerialTypeLen(u32 serialType){
-  static const u8 aLen[] = {0, 1, 2, 3, 4, 6, 8};
-  if( serialType <= 6 ) return aLen[serialType];
-  if( serialType == 7 ) return 8;
-  if( serialType >= 12 ) return (serialType - 12) / 2;
-  return 0;
-}
-
 static int sortKeyFromIntRecordLocal(
   BtCursor *pCur,
   const u8 *pRec,
@@ -255,7 +247,7 @@ static int sortKeyFromIntRecordLocal(
       return SQLITE_NOTFOUND;
     }
     hdrOff += prollyGetVarint32(pRec + hdrOff, &serialType);
-    fieldLen = prollySerialTypeLen(serialType);
+    fieldLen = (u32)dlSerialTypeLen(serialType);
     if( fieldLen > (u32)nRec - dataOff ) return SQLITE_CORRUPT;
     if( serialType==8 ){
       v = 0;

--- a/src/prolly_btree_orig.c
+++ b/src/prolly_btree_orig.c
@@ -322,7 +322,4 @@ int origCursorCursorIsValidNNVt(BtCursor *pCur){
   return origBtreeCursorIsValidNN(pCur->pOrigCursor);
 }
 
-extern int doltliteRegister(sqlite3 *db);
-
-
 #endif /* DOLTLITE_PROLLY */

--- a/src/prolly_btree_txn.c
+++ b/src/prolly_btree_txn.c
@@ -15,9 +15,7 @@ static void btreeTakeCatalogCache(Btree *p, u8 **ppData, int nData,
   }
 }
 
-static int findSavepointTableIndexInArray(
-  SavepointTableEntry*, int, Pgno
-);
+static int findITableIndex(const void *a, int n, int stride, Pgno iTable);
 
 void freeSavepointTables(struct SavepointTableState *pState){
   sqlite3_free(pState->zRebaseOrigBranch);
@@ -314,8 +312,8 @@ static int inheritPendingSnapshots(
   for(i=0; i<pChild->nPendingSnapshot; i++){
     SavepointPendingSnapshot *pSnap = &pChild->aPendingSnapshot[i];
     if( !pSnap->pPending ) continue;
-    if( findSavepointTableIndexInArray(pParent->aTables, pParent->nTables,
-                                       pSnap->iTable) < 0 ){
+    if( findITableIndex(pParent->aTables, pParent->nTables,
+                        (int)sizeof(pParent->aTables[0]), pSnap->iTable) < 0 ){
       prollyMutMapFree(pSnap->pPending);
       sqlite3_free(pSnap->pPending);
       pSnap->pPending = 0;
@@ -395,7 +393,8 @@ int snapshotPendingForFlush(Btree *pBtree, Pgno iTable,
       int rc = ensureSavepointTablesCaptured(pBtree, pState);
       if( rc!=SQLITE_OK ) return rc;
     }
-    j = findSavepointTableIndexInArray(pState->aTables, pState->nTables, iTable);
+    j = findITableIndex(pState->aTables, pState->nTables,
+                        (int)sizeof(pState->aTables[0]), iTable);
     if( j < 0 ) continue;
     if( findPendingSnapshotIndex(pState, iTable) >= 0 ) return SQLITE_OK;
     {
@@ -416,38 +415,19 @@ int snapshotPendingForFlush(Btree *pBtree, Pgno iTable,
   return SQLITE_OK;
 }
 
-static int findTableIndexInArray(
-  struct TableEntry *aTables,
-  int nTables,
+static int findITableIndex(
+  const void *a,
+  int n,
+  int stride,
   Pgno iTable
 ){
+  const unsigned char *p = (const unsigned char*)a;
   int lo = 0;
-  int hi = nTables;
+  int hi = n;
+  if( !a || n<=0 || stride<=0 ) return -1;
   while( lo < hi ){
     int mid = lo + ((hi - lo) / 2);
-    Pgno midTable = aTables[mid].iTable;
-    if( midTable==iTable ){
-      return mid;
-    }
-    if( midTable < iTable ){
-      lo = mid + 1;
-    }else{
-      hi = mid;
-    }
-  }
-  return -1;
-}
-
-static int findSavepointTableIndexInArray(
-  SavepointTableEntry *aTables,
-  int nTables,
-  Pgno iTable
-){
-  int lo = 0;
-  int hi = nTables;
-  while( lo < hi ){
-    int mid = lo + ((hi - lo) / 2);
-    Pgno midTable = aTables[mid].iTable;
+    Pgno midTable = *(const Pgno*)(p + (size_t)mid * (size_t)stride);
     if( midTable==iTable ){
       return mid;
     }
@@ -489,8 +469,9 @@ static int restoreTablesFromSavepoint(
     if( !pMap ){
       continue;
     }
-    iSaved = findSavepointTableIndexInArray(
-        pState->aTables, pState->nTables, aCurrent[k].iTable);
+    iSaved = findITableIndex(
+        pState->aTables, pState->nTables,
+        (int)sizeof(pState->aTables[0]), aCurrent[k].iTable);
     if( iSaved>=0 ){
       pState->aTables[iSaved].pPending = pMap;
     }else{
@@ -568,8 +549,9 @@ static int restoreTablesFromSavepoint(
 
   if( pState->nTables>0 ){
     for(k=0; k<pState->nTables; k++){
-      int idx = findTableIndexInArray(
-          pBtree->cat.a, pBtree->cat.n, pState->aTables[k].iTable);
+      int idx = findITableIndex(
+          pBtree->cat.a, pBtree->cat.n,
+          (int)sizeof(pBtree->cat.a[0]), pState->aTables[k].iTable);
       if( idx < 0 ){
         return SQLITE_CORRUPT;
       }

--- a/src/sortkey.c
+++ b/src/sortkey.c
@@ -28,14 +28,6 @@ static int skGetVarint32(const u8 *p, u32 *pVal){
   }
 }
 
-static u32 serialTypeLen(u32 serialType){
-  static const u8 aLen[] = {0, 1, 2, 3, 4, 6, 8};
-  if( serialType <= 6 ) return aLen[serialType];
-  if( serialType == 7 ) return 8;
-  if( serialType >= 12 ) return (serialType - 12) / 2;
-  return 0;
-}
-
 static u8 serialTypeTag(u32 serialType){
   if( serialType == 0 ) return SORTKEY_NULL;
   if( serialType <= 6 || serialType == 8 || serialType == 9 ){
@@ -307,7 +299,7 @@ static int sortKeyEncode(const u8 *pRec, int nRec, u8 *pOut, int nMaxFields,
     if( nMaxFields > 0 && nField >= nMaxFields ) break;
 
     hdrOff += skGetVarint32(pRec + hdrOff, &serialType);
-    fieldLen = serialTypeLen(serialType);
+    fieldLen = (u32)dlSerialTypeLen(serialType);
 
     if( fieldLen > (u32)nRec - dataOff ) return -1;
     pField = pRec + dataOff;
@@ -377,7 +369,7 @@ static int sortKeyFromSingleBinaryFieldFast(
   hdrOff += skGetVarint32(pRec + hdrOff, &serialType);
   if( nKeyField<=0 && hdrOff<hdrSize ) return SQLITE_NOTFOUND;
 
-  fieldLen = serialTypeLen(serialType);
+  fieldLen = (u32)dlSerialTypeLen(serialType);
   dataOff = hdrSize;
   if( fieldLen > (u32)nRec - dataOff ) return SQLITE_CORRUPT;
 

--- a/test/dead_code_check.sh
+++ b/test/dead_code_check.sh
@@ -17,11 +17,14 @@
 #   Part E: non-static prototypes in owned headers that never appear in any .c.
 #   Part F: #define names in owned headers that never appear elsewhere
 #           (include guards skipped).
-#   Part G: identical function bodies copied across owned .c files.
+#   Part G: identical function bodies copied across owned .c files, or two
+#           differently named functions in the same file.
 #   Part H: non-static one-call wrappers whose only extra-file .c mentions are
 #           under test/ (production-dead). doltliteTest* / *ForTest are the
 #           C-test surface and are skipped: those tests link production
 #           libdoltlite, so SQLITE_TEST cannot hide them.
+#   Part I: file-local extern of an owned function whose prototype already
+#           appears in a header this .c includes.
 #
 # Needs the generated headers, so run it after a configure+build (the build
 # dir defaults to ./build, override with DOLTLITE_BUILD_DIR). Point
@@ -79,7 +82,7 @@ else
   done
 fi
 
-echo "== Part B-H: unused externs / inlines / should-be-static / prototypes / macros / clones / test-only wrappers =="
+echo "== Part B-I: unused externs / inlines / should-be-static / prototypes / macros / clones / test-only wrappers / redundant local externs =="
 if ! python3 "$SCRIPT_DIR/lib/dead_code_scan.py" --root "$ROOT" --src-root "$SRC_ROOT"
 then
   fail=1

--- a/test/dead_code_check_selftest.sh
+++ b/test/dead_code_check_selftest.sh
@@ -142,6 +142,55 @@ else
   ok
 fi
 
+# Part G (same file): identical bodies under two names.
+cat > "$WORK/src/doltlite_samefile.c" <<'EOF'
+static int dead_code_gate_samefile_left(int a, int b, int c){
+  int t;
+  if( a<0 ) a = -a;
+  if( b<0 ) b = -b;
+  if( c<0 ) c = -c;
+  t = a*b + b*c + c*a + a + b + c + 42;
+  if( t<0 ) t = -t;
+  t = t + a*a + b*b + c*c;
+  t = t + (a+1)*(b+1)*(c+1);
+  t = t + (a-1)*(b-1)*(c-1);
+  return t;
+}
+static int dead_code_gate_samefile_right(int a, int b, int c){
+  int t;
+  if( a<0 ) a = -a;
+  if( b<0 ) b = -b;
+  if( c<0 ) c = -c;
+  t = a*b + b*c + c*a + a + b + c + 42;
+  if( t<0 ) t = -t;
+  t = t + a*a + b*b + c*c;
+  t = t + (a+1)*(b+1)*(c+1);
+  t = t + (a-1)*(b-1)*(c-1);
+  return t;
+}
+EOF
+rm -f "$WORK/src/doltlite_clone_a.c" "$WORK/src/doltlite_clone_b.c" "$WORK/src/doltlite.c"
+expect_scan_hit "samefile_duplicate_body_is_rejected" "duplicate function body: dead_code_gate_samefile_left"
+
+# Part I: local extern of a prototype already in an included header.
+cat > "$WORK/src/doltlite_fixture.h" <<'EOF'
+#ifndef DOLTLITE_FIXTURE_H
+#define DOLTLITE_FIXTURE_H
+int dead_code_gate_already_proto(void);
+#endif
+EOF
+cat > "$WORK/src/doltlite.c" <<'EOF'
+#include "doltlite_fixture.h"
+extern int dead_code_gate_already_proto(void);
+int dead_code_gate_already_proto(void){ return 1; }
+EOF
+cat > "$WORK/src/doltlite_other.c" <<'EOF'
+int dead_code_gate_already_proto(void);
+int dead_code_gate_other_use(void){ return dead_code_gate_already_proto(); }
+EOF
+rm -f "$WORK/src/doltlite_samefile.c"
+expect_scan_hit "redundant_local_extern_is_rejected" "redundant local extern: dead_code_gate_already_proto"
+
 # Part H: one-call wrapper only mentioned from test/.
 cat > "$WORK/src/doltlite.c" <<'EOF'
 int dead_code_gate_inner(int x){ return x+1; }

--- a/test/lib/dead_code_scan.py
+++ b/test/lib/dead_code_scan.py
@@ -9,12 +9,14 @@ D: non-static function with no identifier occurrence outside its .c
 E: non-static prototype in an owned header that never appears in any .c.
 F: #define in an owned header whose identifier never appears elsewhere
    (include guards skipped).
-G: two owned .c files contain functions with identical normalized bodies
-   (whitespace collapsed, length >= MIN_CLONE_BODY).
+G: two owned .c functions have identical normalized bodies (whitespace
+   collapsed, length >= MIN_CLONE_BODY), across files or same-file aliases.
 H: non-static .c function whose body is a single return otherFn(...) and
    whose only extra-file .c mentions are under test/. doltliteTest* and
    *ForTest names are the C-test surface (tests link production libdoltlite)
    and are skipped.
+I: file-local extern of an owned function whose prototype already appears
+   in a header this .c includes.
 """
 from __future__ import annotations
 
@@ -64,6 +66,11 @@ ALLOW_EXTERN = {
 ONE_CALL = re.compile(
     r"^return\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(.*\)\s*;$"
 )
+INCLUDE = re.compile(r'^\s*#\s*include\s+"([^"]+)"', re.M)
+LOCAL_EXTERN = re.compile(
+    r"^\s*extern\s+.+?\b([A-Za-z_][A-Za-z0-9_]*)\s*\([^;]*\)\s*;",
+    re.M | re.S,
+)
 SRC_GLOBS = (
     "doltlite.c",
     "doltlite_*.c",
@@ -81,7 +88,7 @@ OWNED_HDR_GLOBS = (
     "sortkey.h",
     "record_codec.h",
 )
-MIN_CLONE_BODY = 200
+MIN_CLONE_BODY = 100
 
 
 def expand(root: str, patterns: list[str]) -> list[str]:
@@ -393,18 +400,79 @@ def scan_clones(src_files: list[str], texts: dict[str, str]) -> list[str]:
             byhash[digest].append((path, line, name))
     dead: list[str] = []
     for items in sorted(byhash.values(), key=lambda xs: (xs[0][0], xs[0][1])):
+        if len(items) < 2:
+            continue
         files = {p for p, _, _ in items}
-        if len(files) < 2:
+        names = {n for _, _, n in items}
+        if len(files) < 2 and len(names) < 2:
             continue
         first = items[0]
         for other in items[1:]:
-            if other[0] == first[0]:
+            if other[0] == first[0] and other[2] == first[2]:
                 continue
             dead.append(
                 "  duplicate function body: "
                 f"{first[2]} ({first[0]}:{first[1]}) identical to "
                 f"{other[2]} ({other[0]}:{other[1]})"
             )
+    return dead
+
+
+def resolve_include(inc: str, from_path: str, src_root: str) -> str | None:
+    cands = [
+        os.path.normpath(os.path.join(os.path.dirname(from_path), inc)),
+        os.path.normpath(os.path.join(src_root, inc)),
+        os.path.normpath(os.path.join(src_root, os.path.basename(inc))),
+    ]
+    for cand in cands:
+        if os.path.isfile(cand):
+            return os.path.abspath(cand)
+    return None
+
+
+def header_has_proto(hpath: str, name: str, texts: dict[str, str]) -> bool:
+    raw = texts.get(hpath)
+    if raw is None:
+        try:
+            raw = open(hpath, errors="replace").read()
+        except OSError:
+            return False
+    proto = re.compile(
+        r"^(?!\s)(?:SQLITE_PRIVATE\s+|SQLITE_API\s+|SQLITE_EXTERN\s+)?"
+        r".+?\b" + re.escape(name) + r"\s*\([^;]*\)\s*;",
+        re.M,
+    )
+    return bool(proto.search(strip_comments(raw)))
+
+
+def scan_redundant_externs(
+    src_files: list[str],
+    src_root: str,
+    texts: dict[str, str],
+) -> list[str]:
+    dead: list[str] = []
+    for path in src_files:
+        raw = texts.get(path)
+        if raw is None:
+            continue
+        stripped = strip_comments(raw)
+        headers = []
+        for match in INCLUDE.finditer(stripped):
+            hpath = resolve_include(match.group(1), path, src_root)
+            if hpath:
+                headers.append(hpath)
+        if not headers:
+            continue
+        for match in LOCAL_EXTERN.finditer(stripped):
+            name = match.group(1)
+            if name in SKIP_DEF or name in ALLOW_EXTERN:
+                continue
+            if name.startswith("sqlite3") or name.startswith("orig_sqlite3"):
+                continue
+            if not any(header_has_proto(h, name, texts) for h in headers):
+                continue
+            lineno = stripped[: match.start()].count("\n") + 1
+            dead.append(f"  redundant local extern: {name} ({path}:{lineno})")
     return dead
 
 
@@ -436,6 +504,7 @@ def main() -> int:
     dead += scan_unused_macros(owned_hdrs, corpus, texts, idents, counts)
     dead += scan_clones(src_files, texts)
     dead += scan_test_only_wrappers(src_files, corpus, root, texts, idents)
+    dead += scan_redundant_externs(src_files, src_root, texts)
     for line in dead:
         print(line)
     return 1 if dead else 0


### PR DESCRIPTION
## Summary

Follow-up to #2665 / #2672. Fold remaining exact copies the previous gates still missed, and teach the dead-code scanner two new cases.

**Shared helpers**
- `serialTypeLen` / `prollySerialTypeLen` → existing `dlSerialTypeLen`
- `freeNames` / `strictFreeNames` / `freeStringList` → `doltliteFreeNameList`
- `atConnect` → `doltliteVtabConnectHistoricalTable` (history already used this)
- `atRowMatchesUpper` / `htRowMatchesUpper` → `doltlitePkRangeMatchesCursorUpper`
- `csSourceHasOrigin` / `csDisabledHasOrigin` → one `csHasOrigin`
- `findTableIndexInArray` / `findSavepointTableIndexInArray` → `findITableIndex`
- cherry-pick / revert resolve-ref and `result_error_code` fallbacks → `doltliteCmdReportInvalidCommitHash` / `doltliteCmdSourceResultErrorOrCode`

**Dead declarations**
- Drop local `extern`s that already have a header prototype (`doltlite.c` register list, checkout workspace/blame, `csSerializeManifest` in gc)
- Delete the unused `extern int doltliteRegister` in `prolly_btree_orig.c`
- Drop unused `oursCatHash` / `iNextTable` args on `serializeMergedCatalog`

**Scanner**
- Part G: same-file aliases, and `MIN_CLONE_BODY` 200 → 100 (vtab BestIndex stubs stay under the line)
- Part I: file-local `extern` of a function whose prototype is already in an included header

Left for a later pass (near-clones, medium risk): conflicts vs constraint-violations framed blobs, notnull vs strict detector loops, docs vs ignore lazy vtabs, `dolt_hashof_table` vs `_index`.

## Test plan

- [x] `bash test/dead_code_check.sh` (Parts A–I)
- [x] `bash test/dead_code_check_selftest.sh` (10/10)
- [x] `bash test/lint_layers.sh`
- [x] `make doltlite`
- [x] `test/doltlite_cherry_pick.sh` (140/140)
- [x] `test/doltlite_revert_dirty.sh` (42/42)
- [x] `test/doltlite_branch_edge.sh` (79/79, includes `dolt_at_*`)

Co-Authored-By: Grok 4.6 <noreply@x.ai>