### PR TITLE
Make header-only helpers static and drop duplicate prototypes

### DIFF
--- a/src/chunk_store.h
+++ b/src/chunk_store.h
@@ -321,6 +321,7 @@ int chunkStoreSourceSet(ChunkStore *cs, sqlite3 *db,
 void chunkStoreSourceCloseWriter(ChunkStore *cs);
 void chunkStoreSourceClose(ChunkStore *cs);
 char *chunkStoreSourceTakeError(ChunkStore *cs, int *pRc);
+int chunkStoreOriginSourceEnabled(ChunkStore *cs);
 
 int chunkStorePut(ChunkStore *cs, const u8 *pData, int nData,
                   ProllyHash *pHash);

--- a/src/chunk_store_int.h
+++ b/src/chunk_store_int.h
@@ -19,14 +19,10 @@ typedef sqlite3_file *CsFileLock;
 #define CS_PENDING_DRAIN_LIMIT (64*1024*1024)
 
 
-int csFileLockHeld(sqlite3_file *pFile);
 int csFileLock(sqlite3_vfs *pVfs, const char *path,
                sqlite3_file **ppFile, char **pzName);
 int csFileLockPromote(sqlite3_file *pFile);
 void csFileUnlock(sqlite3_file *pFile, char **pzName);
-int csFileLockNB(sqlite3_vfs *pVfs, const char *path,
-                 sqlite3_file **ppFile, char **pzName);
-int csReloadFromDisk(ChunkStore *cs);
 int csReloadFromDiskPreservingLocalRefs(ChunkStore *cs);
 int csRestoreOrMergeLocalRefs(ChunkStore *cs, SavedRefsState *pSaved,
                               const ProllyHash *pSavedRefsHash,

--- a/src/chunk_store_lock.c
+++ b/src/chunk_store_lock.c
@@ -8,7 +8,9 @@
 #include <stdlib.h>
 #include <limits.h>
 
-int csFileLockHeld(sqlite3_file *pFile){
+static int csReloadFromDisk(ChunkStore *cs);
+
+static int csFileLockHeld(sqlite3_file *pFile){
   return pFile!=0;
 }
 
@@ -136,7 +138,7 @@ void csFileUnlock(sqlite3_file *pFile, char **pzName){
   }
 }
 
-int csFileLockNB(sqlite3_vfs *pVfs, const char *path,
+static int csFileLockNB(sqlite3_vfs *pVfs, const char *path,
                         sqlite3_file **ppFile, char **pzName){
   return csFileLock(pVfs, path, ppFile, pzName);
 }
@@ -643,7 +645,7 @@ int chunkStoreForceRefresh(ChunkStore *cs){
   return rc;
 }
 
-int csReloadFromDisk(ChunkStore *cs){
+static int csReloadFromDisk(ChunkStore *cs){
   ChunkStore tmp;
   ChunkStoreReloadState saved;
   char *zOldFilename;

--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -2,6 +2,8 @@
 
 #include "sqliteInt.h"
 #include "doltlite_internal.h"
+#include "doltlite_constraint_violations.h"
+#include "doltlite_ignore.h"
 
 int doltliteRegister(sqlite3 *db){
   int rc;

--- a/src/doltlite_add.c
+++ b/src/doltlite_add.c
@@ -10,7 +10,6 @@
 #include "doltlite_commit.h"
 #include "doltlite_record.h"
 #include "doltlite_internal.h"
-#include "doltlite_name_index.h"
 #include <stddef.h>
 #include "doltlite_ignore.h"
 

--- a/src/doltlite_cherry_pick.c
+++ b/src/doltlite_cherry_pick.c
@@ -10,7 +10,6 @@
 #include "doltlite_commit.h"
 #include "doltlite_record.h"
 #include "doltlite_internal.h"
-#include "doltlite_name_index.h"
 #include <stddef.h>
 #include "doltlite_ignore.h"
 

--- a/src/doltlite_chunk_walk.c
+++ b/src/doltlite_chunk_walk.c
@@ -7,7 +7,7 @@
 #include "chunk_store.h"
 #include "chunk_refs.h"
 #include "doltlite_commit.h"
-#include "doltlite_chunk_walk.h"
+#include "prolly_chunk_walk.h"
 
 #include <string.h>
 

--- a/src/doltlite_chunk_walk.h
+++ b/src/doltlite_chunk_walk.h
@@ -1,7 +1,0 @@
-
-#ifndef DOLTLITE_CHUNK_WALK_H
-#define DOLTLITE_CHUNK_WALK_H
-
-#include "prolly_chunk_walk.h"
-
-#endif

--- a/src/doltlite_cmd.c
+++ b/src/doltlite_cmd.c
@@ -7,6 +7,11 @@
 
 #include <string.h>
 
+static void doltliteCmdResultUnknownOption(sqlite3_context *ctx, const char *zOpt);
+static void doltliteCmdResultMissingOptionValue(
+  sqlite3_context *ctx, const char *zOptName
+);
+
 static DoltliteCmdOption *cmdFindLongOption(
   DoltliteCmdOption *aOption,
   int nOption,
@@ -211,7 +216,7 @@ int doltliteCmdRejectDetached(sqlite3_context *ctx){
   return 1;
 }
 
-void doltliteCmdResultUnknownOption(sqlite3_context *ctx, const char *zOpt){
+static void doltliteCmdResultUnknownOption(sqlite3_context *ctx, const char *zOpt){
   char *zErr = sqlite3_mprintf("unknown option `%s`", zOpt ? zOpt : "");
   if( zErr ){
     sqlite3_result_error(ctx, zErr, -1);
@@ -221,7 +226,7 @@ void doltliteCmdResultUnknownOption(sqlite3_context *ctx, const char *zOpt){
   }
 }
 
-void doltliteCmdResultMissingOptionValue(
+static void doltliteCmdResultMissingOptionValue(
   sqlite3_context *ctx,
   const char *zOptName
 ){

--- a/src/doltlite_commit.c
+++ b/src/doltlite_commit.c
@@ -156,7 +156,7 @@ int doltliteCommitCatalogHash(sqlite3 *db, const ProllyHash *pCommit,
   return SQLITE_OK;
 }
 
-int doltliteRefToCatalogHash(sqlite3 *db, const char *zRef,
+static int doltliteRefToCatalogHash(sqlite3 *db, const char *zRef,
                              ProllyHash *pCatHash){
   ProllyHash commitHash;
   int rc = doltliteResolveRef(db, zRef, &commitHash);

--- a/src/doltlite_commit_cmd.c
+++ b/src/doltlite_commit_cmd.c
@@ -10,7 +10,6 @@
 #include "doltlite_commit.h"
 #include "doltlite_record.h"
 #include "doltlite_internal.h"
-#include "doltlite_name_index.h"
 #include <stddef.h>
 #include "doltlite_ignore.h"
 #include "doltlite_constraint_violations.h"

--- a/src/doltlite_config.c
+++ b/src/doltlite_config.c
@@ -10,7 +10,6 @@
 #include "doltlite_commit.h"
 #include "doltlite_record.h"
 #include "doltlite_internal.h"
-#include "doltlite_name_index.h"
 #include <stddef.h>
 #include "doltlite_ignore.h"
 

--- a/src/doltlite_conflicts.c
+++ b/src/doltlite_conflicts.c
@@ -2,6 +2,7 @@
 #ifdef DOLTLITE_PROLLY
 
 #include "doltlite_vtab_util.h"
+#include "doltlite_ancestor.h"
 #include "doltlite_internal.h"
 #include <string.h>
 

--- a/src/doltlite_core.c
+++ b/src/doltlite_core.c
@@ -11,7 +11,7 @@
 #include "doltlite_commit.h"
 #include "doltlite_record.h"
 #include "doltlite_internal.h"
-#include "doltlite_name_index.h"
+#include "doltlite_constraint_violations.h"
 #include <stddef.h>
 #include "doltlite_ignore.h"
 

--- a/src/doltlite_creds.c
+++ b/src/doltlite_creds.c
@@ -67,7 +67,7 @@ void doltliteSha512_224(const unsigned char *in, size_t inlen,
 
 static const char B32_ALPHABET[] = "0123456789abcdefghijklmnopqrstuv";
 
-char *doltliteBase32Encode(const unsigned char *in, size_t inlen) {
+static char *doltliteBase32Encode(const unsigned char *in, size_t inlen) {
   size_t outlen = (inlen * 8 + 4) / 5;
   char *out = (char *)sqlite3_malloc(outlen + 1);
   size_t oi = 0;

--- a/src/doltlite_creds.h
+++ b/src/doltlite_creds.h
@@ -24,8 +24,6 @@ typedef struct DoltliteCreds DoltliteCreds;
 void doltliteSha512_224(const unsigned char *in, size_t inlen,
                         unsigned char out[DOLTLITE_KID_RAW_LEN]);
 
-char *doltliteBase32Encode(const unsigned char *in, size_t inlen);
-
 char *doltliteBase64UrlEncode(const unsigned char *in, size_t inlen);
 int doltliteBase64UrlDecode(const char *in, unsigned char **out, size_t *outlen);
 

--- a/src/doltlite_diff.c
+++ b/src/doltlite_diff.c
@@ -12,7 +12,6 @@
 #include "doltlite_record.h"
 #include "doltlite_internal.h"
 #include "prolly_record.h"
-#include "doltlite_name_index.h"
 #include <stddef.h>
 #include <string.h>
 #include <time.h>

--- a/src/doltlite_diff_stat.c
+++ b/src/doltlite_diff_stat.c
@@ -11,7 +11,6 @@
 #include "doltlite_commit.h"
 #include "doltlite_record.h"
 #include "doltlite_internal.h"
-#include "doltlite_name_index.h"
 #include <stddef.h>
 #include <string.h>
 

--- a/src/doltlite_diff_table.c
+++ b/src/doltlite_diff_table.c
@@ -5,6 +5,7 @@
 #include "prolly_hashset.h"
 #include "prolly_diff.h"
 #include "doltlite_commit.h"
+#include "doltlite_ancestor.h"
 #include "doltlite_internal.h"
 
 #include <assert.h>

--- a/src/doltlite_gc.c
+++ b/src/doltlite_gc.c
@@ -7,7 +7,7 @@
 #include "prolly_node.h"
 #include "chunk_store.h"
 #include "doltlite_commit.h"
-#include "doltlite_chunk_walk.h"
+#include "prolly_chunk_walk.h"
 
 #include <string.h>
 #include <stdio.h>
@@ -1115,7 +1115,7 @@ static void doltliteGcFunc(
 
 /* Compaction targets one store. Mark from cs's own refs and session hashes
 ** sharing cs, so an ATTACH is marked from its own state. */
-int doltliteGcCompactStoreWithPhase(
+static int doltliteGcCompactStoreWithPhase(
   sqlite3 *db,
   ChunkStore *cs,
   const char **pzPhase

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -19,8 +19,6 @@ typedef struct DoltliteTxnState DoltliteTxnState;
 typedef struct DoltlitePkRange DoltlitePkRange;
 typedef struct DoltliteCommitQueue DoltliteCommitQueue;
 
-int chunkStoreOriginSourceEnabled(ChunkStore*);
-
 #define DOLTLITE_RANGE_NONE      0
 #define DOLTLITE_RANGE_TWO_DOT   2
 #define DOLTLITE_RANGE_THREE_DOT 3
@@ -861,7 +859,6 @@ static SQLITE_INLINE int dlReadFramedHeader(DlByteReader *r, u8 m0, u8 m1,
 
 ChunkStore *doltliteGetChunkStore(sqlite3 *db);
 ChunkStore *doltliteBtreeChunkStore(Btree *p);
-int doltliteGcCompactStoreWithPhase(sqlite3 *db, ChunkStore *cs, const char **pzPhase);
 int doltliteGcCompactStore(sqlite3 *db, ChunkStore *cs);
 int doltliteGcCompactDbWithPhase(sqlite3 *db, int iDb, const char **pzPhase);
 int doltliteGcVacuumInto(sqlite3 *db, int iDb, const char *zOut,
@@ -956,10 +953,7 @@ int doltliteCmdParseArgs(
 );
 void doltliteCmdArgsClear(DoltliteCmdArgs *pArgs);
 int doltliteCmdRejectDetached(sqlite3_context *ctx);
-void doltliteCmdResultUnknownOption(sqlite3_context *ctx, const char *zOpt);
-void doltliteCmdResultMissingOptionValue(
-  sqlite3_context *ctx, const char *zOptName
-);
+
 int doltliteCmdParseAuthor(
   sqlite3_context *ctx, const char *zAuthor,
   char **pzName, char **pzEmail
@@ -1117,12 +1111,6 @@ int doltliteCatalogRenameMate(
 );
 
 int mergeAbortInPlace(sqlite3 *db);
-int mergeFastForward(
-  sqlite3 *db, sqlite3_context *context, ChunkStore *cs,
-  const ProllyHash *pOurHead, const ProllyHash *pTheirHead,
-  const ProllyHash *pIgnored,
-  int squash
-);
 int doltliteMergeRef(
   sqlite3 *db,
   sqlite3_context *context,
@@ -1158,10 +1146,8 @@ int doltliteSchemaDiffRegister(sqlite3 *db);
 int doltlitePatchRegister(sqlite3 *db);
 int doltliteRemoteSqlRegister(sqlite3 *db);
 int doltliteHashofRegister(sqlite3 *db);
-int doltliteConstraintViolationsRegister(sqlite3 *db);
 int doltliteDocsRegister(sqlite3 *db);
 int doltliteTestsRegister(sqlite3 *db);
-int doltliteIgnoreRegister(sqlite3 *db);
 int doltliteMaybeSeedRepo(sqlite3 *db);
 int doltliteSeedStoreIfNeeded(sqlite3*, ChunkStore*, const char*,
                               ProllyHash*, int*);
@@ -1195,9 +1181,6 @@ int doltliteDetectMergeStrictViolations(sqlite3 *db, const ProllyHash *pAncCatHa
                                        char **pzErrMsg, int *pnFound,
                                        const char **azTables, int nTables);
 
-int doltliteConstraintViolationBatchBegin(sqlite3 *db);
-int doltliteConstraintViolationBatchEnd(sqlite3 *db, int commit);
-
 int doltliteGetWorkingTableState(sqlite3 *db, const char *zTable,
                                  ProllyHash *pRoot, u8 *pFlags,
                                  ProllyHash *pSchemaHash);
@@ -1208,9 +1191,6 @@ int doltliteRestoreTxnState(sqlite3 *db, DoltliteTxnState *p);
 
 int doltliteResolveRef(sqlite3 *db, const char *zRef, ProllyHash *pCommit);
 int doltliteUserRefNameIsValid(const char *zName);
-int doltliteFindAncestor(sqlite3 *db, const ProllyHash *pCommit1,
-                         const ProllyHash *pCommit2,
-                         ProllyHash *pAncestor);
 
 typedef struct DoltliteCommit DoltliteCommit;
 int doltliteLoadCommit(sqlite3 *db, const ProllyHash *pHash,
@@ -1245,8 +1225,6 @@ int applyMergedCatalogAndCommit(
 
 int doltliteCommitCatalogHash(sqlite3 *db, const ProllyHash *pCommit,
                               ProllyHash *pCatHash);
-int doltliteRefToCatalogHash(sqlite3 *db, const char *zRef,
-                             ProllyHash *pCatHash);
 
 int doltliteRefIsWorking(const char *zRef);
 int doltliteRefIsStaged(const char *zRef);
@@ -1294,19 +1272,6 @@ KeyInfo *doltliteKeyInfoOfIndex(sqlite3 *db, Index *pIdx);
 int doltliteMasterViewTriggerRowsDiffer(sqlite3 *db, const ProllyHash *pOldRoot,
                                         const ProllyHash *pNewRoot, u8 flags,
                                         int *pDiffer);
-struct DoltlitePartialIndex;
-int doltliteIndexMutMapRowDelta(
-  sqlite3 *db,
-  Index *pIdx,
-  ProllyMutMap *pMap,
-  const i16 *aiColumn, int nIdxCol,
-  KeyInfo *pKeyInfo,
-  int iPKey, i64 intKey,
-  const u8 *pTreeKey, int nTreeKey,
-  const u8 *pOldVal, int nOldVal,
-  const u8 *pNewVal, int nNewVal,
-  struct DoltlitePartialIndex *pPart
-);
 int doltliteIndexApplyRowDelta(
   sqlite3 *db,
   ChunkStore *cs,
@@ -1382,7 +1347,6 @@ int doltliteGetSessionTableRoot(sqlite3 *db, Pgno iTable,
                                  ProllyHash *pRoot, u8 *pFlags);
 int doltliteSaveWorkingSet(sqlite3 *db);
 int doltlitePersistWorkingSet(sqlite3 *db);
-int doltliteSaveWorkingSetWithHash(sqlite3 *db, const ProllyHash *pWorkingCatHash);
 int doltlitePersistWorkingSetWithHash(sqlite3 *db, const ProllyHash *pWorkingCatHash);
 void doltliteAdoptRollbackBaseline(sqlite3 *db, const ProllyHash *pCatalogHash);
 int doltliteLoadWorkingSet(sqlite3 *db, const char *zBranch);

--- a/src/doltlite_log.c
+++ b/src/doltlite_log.c
@@ -6,6 +6,7 @@
 #include "prolly_hash.h"
 #include "chunk_store.h"
 
+#include "doltlite_ancestor.h"
 #include "doltlite_internal.h"
 #include <string.h>
 #include <time.h>

--- a/src/doltlite_merge_cmd.c
+++ b/src/doltlite_merge_cmd.c
@@ -13,7 +13,7 @@
 #include "doltlite_commit.h"
 #include "doltlite_record.h"
 #include "doltlite_internal.h"
-#include "doltlite_name_index.h"
+#include "doltlite_ancestor.h"
 #include "record_codec.h"
 #include <stddef.h>
 #include "doltlite_ignore.h"
@@ -649,7 +649,7 @@ int mergeAbortInPlace(sqlite3 *db){
   return SQLITE_OK;
 }
 
-int mergeFastForward(
+static int mergeFastForward(
   sqlite3 *db,
   sqlite3_context *context,
   ChunkStore *cs,

--- a/src/doltlite_merge_constraints.c
+++ b/src/doltlite_merge_constraints.c
@@ -2,7 +2,7 @@
 
 #include "doltlite_merge_constraints_int.h"
 
-int copyCursorRow(
+static int copyCursorRow(
   ProllyCursor *pCur,
   u8 **ppKey, int *pnKey,
   u8 **ppVal, int *pnVal
@@ -34,7 +34,7 @@ int copyCursorRow(
   return SQLITE_OK;
 }
 
-int fetchRowByRowid(
+static int fetchRowByRowid(
   ChunkStore *cs,
   ProllyCache *pCache,
   const ProllyHash *pRoot,
@@ -66,7 +66,7 @@ int fetchRowByRowid(
   return rc;
 }
 
-int fetchRowByBlobKey(
+static int fetchRowByBlobKey(
   ChunkStore *cs,
   ProllyCache *pCache,
   const ProllyHash *pRoot,
@@ -304,7 +304,7 @@ u8 *buildRecordFromStmtCols(
   return pOut;
 }
 
-int recordPrefixEquals(
+static int recordPrefixEquals(
   const u8 *pLeft, int nLeft,
   const u8 *pRight, int nRight,
   int nField
@@ -331,7 +331,7 @@ int recordPrefixEquals(
 
 /* PK-equals-all-columns rows store an empty value; match the sort-key
 ** record instead or callers skip the check as "no such row". */
-int fetchRowByPkRecord(
+static int fetchRowByPkRecord(
   ChunkStore *cs,
   ProllyCache *pCache,
   const ProllyHash *pRoot,

--- a/src/doltlite_merge_constraints_int.h
+++ b/src/doltlite_merge_constraints_int.h
@@ -24,19 +24,6 @@ int loadMergePkInfo(sqlite3 *db, const char *zTable, MergePkInfo *pPk);
 int finishConstraintStmt(sqlite3_stmt *pStmt, int rc);
 void setConstraintError(sqlite3 *db, char **pzErrMsg, int rc);
 
-int copyCursorRow(
-  ProllyCursor *pCur,
-  u8 **ppKey, int *pnKey,
-  u8 **ppVal, int *pnVal
-);
-int fetchRowByRowid(
-  ChunkStore *cs, ProllyCache *pCache, const ProllyHash *pRoot, u8 flags,
-  i64 targetRowid, u8 **ppKey, int *pnKey, u8 **ppVal, int *pnVal
-);
-int fetchRowByBlobKey(
-  ChunkStore *cs, ProllyCache *pCache, const ProllyHash *pRoot, u8 flags,
-  const u8 *pKey, int nKey, u8 **ppKey, int *pnKey, u8 **ppVal, int *pnVal
-);
 int catalogTableChanged(
   struct TableEntry *aAnc, int nAnc,
   struct TableEntry *aCur, int nCur,
@@ -50,15 +37,6 @@ int loadAncestorAndCurrentCatalogs(
 );
 u8 *buildRecordFromStmtCols(
   sqlite3_stmt *pStmt, int iStart, int nField, int *pnOut
-);
-int recordPrefixEquals(
-  const u8 *pLeft, int nLeft, const u8 *pRight, int nRight, int nField
-);
-int fetchRowByPkRecord(
-  ChunkStore *cs, ProllyCache *pCache, const ProllyHash *pRoot, u8 flags,
-  sqlite3 *db, const char *zTable,
-  const u8 *pPkRec, int nPkRec, int nPkField,
-  u8 **ppKey, int *pnKey, u8 **ppVal, int *pnVal
 );
 int fetchAncestorRowByName(
   sqlite3 *db, struct TableEntry *aAnc, int nAnc, const char *zTable,

--- a/src/doltlite_merge_int.h
+++ b/src/doltlite_merge_int.h
@@ -255,8 +255,6 @@ int hasAnySchemaConflict(
   int nConflictTables
 );
 
-int mergeIndexColumnsOverlap(const char *zSqlA, const char *zSqlB);
-
 int mergePreDetectDualIndexOverlap(
   SchemaEntry *aAnc, int nAnc,
   SchemaEntry *aOurs, int nOurs,
@@ -341,10 +339,6 @@ int doltlitePartialIndexMatchesRecord(sqlite3 *db, Index *pIdx,
 int doltlitePartialIndexLoad(sqlite3 *db, Index *pIdx,
                              DoltlitePartialIndex *pOut);
 void doltlitePartialIndexClear(DoltlitePartialIndex *p);
-
-void mergeColDefaultsFree(MergeColDefaults *p);
-int mergeColDefaultsLoad(const char *zSql, const char *zTable,
-                         MergeColDefaults *pOut);
 
 int normalizeSideToMergedLayout(
   sqlite3 *db,

--- a/src/doltlite_merge_pass2.c
+++ b/src/doltlite_merge_pass2.c
@@ -195,7 +195,7 @@ static void mergeIndexNameListFree(MergeIndexNameList *p){
   sqlite3_free(p->az);
 }
 
-int mergeIndexColumnsOverlap(const char *zSqlA, const char *zSqlB){
+static int mergeIndexColumnsOverlap(const char *zSqlA, const char *zSqlB){
   MergeIndexNameList a;
   MergeIndexNameList b;
   int i, j, bOverlap = 0;

--- a/src/doltlite_merge_rows.c
+++ b/src/doltlite_merge_rows.c
@@ -617,7 +617,7 @@ static int indexRowInPartialIndex(
       pPart->colsInit ? &pPart->cols : 0, &pPart->pStmt, pIn);
 }
 
-int doltliteIndexMutMapRowDelta(
+static int doltliteIndexMutMapRowDelta(
   sqlite3 *db,
   Index *pIdx,
   ProllyMutMap *pMap,

--- a/src/doltlite_merge_schema.c
+++ b/src/doltlite_merge_schema.c
@@ -1059,7 +1059,7 @@ int doltliteTableSchemaConflictDetail(
 /* Evaluate declared defaults once. A pre-ADD-COLUMN row omits the
 ** new field; reads materialize the default. Rewriting into a wider
 ** record covers that slot, so leaving NULL would replace the default. */
-void mergeColDefaultsFree(MergeColDefaults *p){
+static void mergeColDefaultsFree(MergeColDefaults *p){
   int i;
   if( p->apOwned ){
     for(i=0; i<p->nCol; i++) sqlite3_free(p->apOwned[i]);
@@ -1069,7 +1069,7 @@ void mergeColDefaultsFree(MergeColDefaults *p){
   memset(p, 0, sizeof(*p));
 }
 
-int mergeColDefaultsLoad(
+static int mergeColDefaultsLoad(
   const char *zSql,
   const char *zTable,
   MergeColDefaults *pOut

--- a/src/doltlite_patch.c
+++ b/src/doltlite_patch.c
@@ -2,6 +2,7 @@
 
 #include "sqliteInt.h"
 #include "doltlite_vtab_util.h"
+#include "doltlite_ancestor.h"
 #include "doltlite_internal.h"
 #include "record_codec.h"
 #include "prolly_cursor.h"

--- a/src/doltlite_rebase.c
+++ b/src/doltlite_rebase.c
@@ -11,7 +11,6 @@
 #include "doltlite_record.h"
 #include "doltlite_internal.h"
 #include <stdio.h>
-#include "doltlite_name_index.h"
 #include <stddef.h>
 #include "doltlite_ignore.h"
 

--- a/src/doltlite_record.c
+++ b/src/doltlite_record.c
@@ -76,7 +76,7 @@ i64 doltliteSyntheticRowidFromSortKey(const u8 *pSortKey, int nSortKey,
   return doltliteRowidHash(pSortKey, nSortKey);
 }
 
-u32 doltliteSerialTypeOf(const DoltliteSerialValue *pVal, u32 *pLen){
+static u32 doltliteSerialTypeOf(const DoltliteSerialValue *pVal, u32 *pLen){
   if( pVal->eType == SQLITE_NULL ){ *pLen = 0; return 0; }
   if( pVal->eType == SQLITE_INTEGER ){
     i64 v = pVal->i;
@@ -102,7 +102,7 @@ u32 doltliteSerialTypeOf(const DoltliteSerialValue *pVal, u32 *pLen){
   return 0;
 }
 
-void doltliteSerialPut(u8 *pOut, const DoltliteSerialValue *pVal, u32 serialType){
+static void doltliteSerialPut(u8 *pOut, const DoltliteSerialValue *pVal, u32 serialType){
   i64 v;
   int nByte, i;
   if( serialType==0 || serialType==8 || serialType==9 ) return;

--- a/src/doltlite_remote.c
+++ b/src/doltlite_remote.c
@@ -10,7 +10,7 @@
 #include "doltlite_internal.h"
 #include "prolly_hashset.h"
 #include "prolly_node.h"
-#include "doltlite_chunk_walk.h"
+#include "prolly_chunk_walk.h"
 #include <string.h>
 #ifndef _WIN32
 #include <errno.h>
@@ -722,7 +722,7 @@ static void localClose(DoltliteRemote *pRemote){
   sqlite3_free(p);
 }
 
-DoltliteRemote *doltliteLocalAsRemote(ChunkStore *pLocal){
+static DoltliteRemote *doltliteLocalAsRemote(ChunkStore *pLocal){
   LocalAsRemote *p = sqlite3_malloc(sizeof(LocalAsRemote));
   if( !p ) return 0;
   memset(p, 0, sizeof(LocalAsRemote));

--- a/src/doltlite_remote.h
+++ b/src/doltlite_remote.h
@@ -72,8 +72,6 @@ DoltliteRemote *doltliteFsRemoteOpen(sqlite3_vfs *pVfs, const char *zPath);
 DoltliteRemote *doltliteRemoteOpenReadOnly(sqlite3_vfs *pVfs,
                                            const char *zUrl);
 
-DoltliteRemote *doltliteLocalAsRemote(ChunkStore *pLocal);
-
 DoltliteRemote *doltliteHttpRemoteOpen(const char *zUrl);
 
 int doltliteHttpParseResponseForTest(const u8 *pRaw, int nRaw, int nHash);

--- a/src/doltlite_reset.c
+++ b/src/doltlite_reset.c
@@ -10,7 +10,6 @@
 #include "doltlite_commit.h"
 #include "doltlite_record.h"
 #include "doltlite_internal.h"
-#include "doltlite_name_index.h"
 #include <stddef.h>
 #include "doltlite_ignore.h"
 #include "doltlite_constraint_violations.h"

--- a/src/doltlite_revert.c
+++ b/src/doltlite_revert.c
@@ -10,7 +10,6 @@
 #include "doltlite_commit.h"
 #include "doltlite_record.h"
 #include "doltlite_internal.h"
-#include "doltlite_name_index.h"
 #include <stddef.h>
 #include "doltlite_ignore.h"
 

--- a/src/doltlite_schema_diff.c
+++ b/src/doltlite_schema_diff.c
@@ -9,7 +9,6 @@
 #include "doltlite_commit.h"
 #include "doltlite_record.h"
 #include "doltlite_internal.h"
-#include "doltlite_name_index.h"
 #include <stddef.h>
 #include <string.h>
 

--- a/src/doltlite_status.c
+++ b/src/doltlite_status.c
@@ -9,7 +9,6 @@
 #include "chunk_store.h"
 #include "doltlite_commit.h"
 #include "doltlite_internal.h"
-#include "doltlite_name_index.h"
 #include <stddef.h>
 #include "doltlite_ignore.h"
 #include "doltlite_record.h"

--- a/src/prolly_btree_int.h
+++ b/src/prolly_btree_int.h
@@ -453,7 +453,6 @@ static inline void btreeFreeCatalogTables(Btree *p){
 
 void invalidateCursors(BtShared *pBt, Pgno iTable, int errCode);
 void invalidateSchema(Btree *pBtree);
-int flushMutMap(BtCursor *pCur);
 void refreshCursorMutMapAliases(Btree *pBtree, BtShared *pBt,
                                         Pgno iTable, ProllyMutMap *pNewMap);
 int getCursorPayload(BtCursor *pCur, const u8 **ppData, int *pnData);
@@ -477,7 +476,6 @@ void cacheCurrentTreePayloadIfIntKey(BtCursor *pCur);
 void cacheCurrentTreeStoredPayloadNonIntKey(BtCursor *pCur);
 int copyZeroTailPayload(ProllyMutMapEntry *e, u32 offset, u32 amt, void *pBuf);
 void btreeMarkWorkingStateChanged(Btree *p, int bLocal);
-int restoreFromCommitted(Btree *p);
 int rollbackNeedsSchemaReset(Btree *pBtree);
 int btreeFillWorkingSetBlob(
   u8 *buf,
@@ -685,7 +683,6 @@ extern const struct BtreeOps origBtreeVtOps;
 extern const struct BtCursorOps prollyCursorOps;
 extern const struct BtCursorOps origCursorVtOps;
 
-int btreeLoadBranchHeadCatalog(ChunkStore*, const char*, ProllyHash*, ProllyHash*);
 typedef struct BtreeBranchState BtreeBranchState;
 struct BtreeBranchState {
   ProllyHash catalog;
@@ -711,10 +708,6 @@ int btreeStoreWorkingSetBlob(ChunkStore*, const char*, const ProllyHash*,
                              const ProllyHash*, const ProllyHash*, u8,
                              const ProllyHash*, const ProllyHash*, const char*,
                              const char*, const ProllyHash*);
-int btreePutRebaseMetadataOnBranch(ChunkStore*, const char*, u8,
-                                   const ProllyHash*, const ProllyHash*,
-                                   const char*, const char*);
-int btreeClearRebaseMetadataOnBranch(ChunkStore*, const char*);
 int btreeReadWorkingCatalog(ChunkStore*, const char*, ProllyHash*, ProllyHash*);
 int btreeWriteWorkingState(ChunkStore*, const char*, const ProllyHash*,
                            const ProllyHash*);
@@ -724,7 +717,6 @@ int btreeRefreshSharedWorkingState(Btree*);
 int btreeReloadBranchWorkingStateInto(Btree*, int, ProllyHash*);
 int doltliteBtreeHydrateDeferred(Btree*);
 int doltliteOriginSourceEnable(ChunkStore*, sqlite3*, int*);
-int chunkStoreOriginSourceEnabled(ChunkStore*);
 int doltliteBtreeRunDeferredWork(sqlite3*);
 void doltliteBtreeRegistrationDone(sqlite3*);
 void btreeStoreCommittedFromCurrent(Btree*, const ProllyHash*);
@@ -733,7 +725,6 @@ int ensureStatementSavepointsCaptured(Btree*);
 int pushSavepoint(Btree*, int);
 void freeSavepointTables(struct SavepointTableState*);
 int snapshotPendingForFlush(Btree*, Pgno, ProllyMutMap**, ProllyMutMap**, int*);
-void btreeDiscardAllSavepoints(Btree*);
 int serializeCatalog(Btree*, u8**, int*);
 int doltliteFlushAndSerializeBtreeCatalog(Btree*, u8**, int*);
 int serializeCatalogForCommit(Btree*, u8**, int*);

--- a/src/prolly_btree_mutation.c
+++ b/src/prolly_btree_mutation.c
@@ -399,7 +399,7 @@ int advanceTreeCursor(BtCursor *pCur, int dir){
   }
 }
 
-int flushMutMap(BtCursor *pCur){
+static int flushMutMap(BtCursor *pCur){
   struct TableEntry *pTE;
   ProllyMutMap *pFlushMap;
   int captured;

--- a/src/prolly_btree_state.c
+++ b/src/prolly_btree_state.c
@@ -108,7 +108,7 @@ int btreeLoadWorkingSetBlob(
   return SQLITE_OK;
 }
 
-int btreeLoadBranchHeadCatalog(
+static int btreeLoadBranchHeadCatalog(
   ChunkStore *cs,
   const char *zBranch,
   ProllyHash *pCatHash,
@@ -311,7 +311,7 @@ int btreeStoreWorkingSetBlob(
   return rc;
 }
 
-int btreePutRebaseMetadataOnBranch(
+static int btreePutRebaseMetadataOnBranch(
   ChunkStore *cs,
   const char *zBranch,
   u8 rebaseFlags,
@@ -350,7 +350,7 @@ int btreePutRebaseMetadataOnBranch(
                                   &cvs);
 }
 
-int btreeClearRebaseMetadataOnBranch(ChunkStore *cs, const char *zBranch){
+static int btreeClearRebaseMetadataOnBranch(ChunkStore *cs, const char *zBranch){
   ProllyHash cat, commit, staged, mergeC, conflicts, cvs;
   char *zIgnoreOrig = 0;
   char *zIgnoreReturn = 0;
@@ -1182,7 +1182,7 @@ int doltliteSeedSessionHashes(
   return rc;
 }
 
-int doltliteSaveWorkingSetWithHash(sqlite3 *db, const ProllyHash *pWorkingCatHash){
+static int doltliteSaveWorkingSetWithHash(sqlite3 *db, const ProllyHash *pWorkingCatHash){
   ChunkStore *cs = doltliteGetChunkStore(db);
   Btree *pBtree;
   u8 *catData = 0;

--- a/src/prolly_btree_txn.c
+++ b/src/prolly_btree_txn.c
@@ -16,6 +16,8 @@ static void btreeTakeCatalogCache(Btree *p, u8 **ppData, int nData,
 }
 
 static int findITableIndex(const void *a, int n, int stride, Pgno iTable);
+static int restoreFromCommitted(Btree *p);
+static void btreeDiscardAllSavepoints(Btree *p);
 
 void freeSavepointTables(struct SavepointTableState *pState){
   sqlite3_free(pState->zRebaseOrigBranch);
@@ -1118,7 +1120,7 @@ int sqlite3BtreeCommit(Btree *p){
   return p->pOps->xCommit(p);
 }
 
-int restoreFromCommitted(Btree *p){
+static int restoreFromCommitted(Btree *p){
   assert( p!=0 && p->pBt!=0 );
   if( prollyHashIsEmpty(&p->committedCatalogHash) ){
     if( p->bCatalogDropped ){
@@ -1472,7 +1474,7 @@ static int persistRolledBackSessionState(Btree *p, BtShared *pBt){
   return chunkStoreCommit(&pBt->store);
 }
 
-void btreeDiscardAllSavepoints(Btree *p){
+static void btreeDiscardAllSavepoints(Btree *p){
   int j;
   for(j=0; j<p->nSavepoint; j++){
     freeSavepointTables(&p->aSavepointTables[j]);

--- a/src/record_codec.h
+++ b/src/record_codec.h
@@ -103,9 +103,6 @@ struct DoltliteSerialValue {
   int n;
 };
 
-u32 doltliteSerialTypeOf(const DoltliteSerialValue *pVal, u32 *pLen);
-void doltliteSerialPut(u8 *pOut, const DoltliteSerialValue *pVal, u32 serialType);
-
 /* Assemble an SQLite-format record (header varints + body) from nField
 ** serial values. Returns a sqlite3_malloc'd buffer of *pnOut bytes, or 0
 ** on OOM or nField<=0. */

--- a/test/dead_code_check.sh
+++ b/test/dead_code_check.sh
@@ -12,9 +12,11 @@
 #   Part C: static inline helpers in headers that never appear outside their
 #           definition (the compiler will not warn; each TU that includes the
 #           header just omits the unused inline).
-#   Part D: non-static functions with no identifier occurrence outside the
-#           defining file. Those should be static so Part A can see them.
-#   Part E: non-static prototypes in owned headers that never appear in any .c.
+#   Part D: non-static functions with no other .c mention. A header prototype
+#           is not a caller. Btree vtable methods stay non-static.
+#   Part E: non-static prototypes in owned headers that never appear in any .c,
+#           or the same prototype in two owned headers (btree-int vs internal
+#           seam copies excepted).
 #   Part F: #define names in owned headers that never appear elsewhere
 #           (include guards skipped).
 #   Part G: identical function bodies copied across owned .c files, or two
@@ -82,7 +84,7 @@ else
   done
 fi
 
-echo "== Part B-I: unused externs / inlines / should-be-static / prototypes / macros / clones / test-only wrappers / redundant local externs =="
+echo "== Part B-I: unused externs / inlines / should-be-static / prototypes / macros / clones / test-only wrappers / redundant local externs / duplicate prototypes =="
 if ! python3 "$SCRIPT_DIR/lib/dead_code_scan.py" --root "$ROOT" --src-root "$SRC_ROOT"
 then
   fail=1

--- a/test/dead_code_check_selftest.sh
+++ b/test/dead_code_check_selftest.sh
@@ -116,6 +116,41 @@ static int dead_code_gate_same_file_caller(int x){
 EOF
 expect_scan_hit "should_be_static_is_rejected" "should be static: dead_code_gate_should_be_static"
 
+# Part D: header prototype is not a caller.
+cat > "$WORK/src/doltlite_fixture.h" <<'EOF'
+#ifndef DOLTLITE_FIXTURE_H
+#define DOLTLITE_FIXTURE_H
+int dead_code_gate_header_only_proto(int x);
+#endif
+EOF
+cat > "$WORK/src/doltlite.c" <<'EOF'
+#include "doltlite_fixture.h"
+int dead_code_gate_header_only_proto(int x){
+  return x;
+}
+static int dead_code_gate_header_only_caller(int x){
+  return dead_code_gate_header_only_proto(x);
+}
+EOF
+expect_scan_hit "header_proto_is_not_a_caller" "should be static: dead_code_gate_header_only_proto"
+
+# Part E: same prototype in two owned headers.
+cat > "$WORK/src/doltlite_fixture.h" <<'EOF'
+#ifndef DOLTLITE_FIXTURE_H
+#define DOLTLITE_FIXTURE_H
+int dead_code_gate_dup_proto(void);
+#endif
+EOF
+cat > "$WORK/src/doltlite_other.h" <<'EOF'
+#ifndef DOLTLITE_OTHER_H
+#define DOLTLITE_OTHER_H
+int dead_code_gate_dup_proto(void);
+#endif
+EOF
+: > "$WORK/src/doltlite.c"
+expect_scan_hit "duplicate_header_prototype_is_rejected" "duplicate header prototype: dead_code_gate_dup_proto"
+rm -f "$WORK/src/doltlite_other.h" "$WORK/src/doltlite_fixture.h"
+
 # Part A: unused static in a real translation unit (compiler-driven).
 cp "$ROOT/src/doltlite_add.c" "$WORK/src/doltlite_add.c"
 printf '\nstatic int dead_code_gate_unused_static(void){ return 0; }\n' \

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -10,7 +10,7 @@
 #include "chunk_store.h"
 #include "chunk_refs.h"
 #include "doltlite_commit.h"
-#include "doltlite_chunk_walk.h"
+#include "prolly_chunk_walk.h"
 #include "doltlite_ancestor.h"
 #include "doltlite_internal.h"
 #include "doltlite_record.h"

--- a/test/lib/dead_code_scan.py
+++ b/test/lib/dead_code_scan.py
@@ -4,8 +4,10 @@
 B: extern function defined in owned .c, never referenced from another .c and
    never called in its defining file (header declaration does not count).
 C: static inline in a header whose identifier never appears elsewhere.
-D: non-static function with no identifier occurrence outside its .c
-   (should be static so Part A can see it).
+D: non-static function with no other .c mention. A header prototype
+   does not count as a caller (should be static so Part A can see it).
+   Btree vtable methods (prollyBtree* / origBtree*) stay non-static:
+   other TUs call them through the ops table, not by name.
 E: non-static prototype in an owned header that never appears in any .c.
 F: #define in an owned header whose identifier never appears elsewhere
    (include guards skipped).
@@ -63,6 +65,13 @@ ALLOW_EXTERN = {
     "doltliteServeAsync",
     "doltliteServerStop",
 }
+VTBL_PREFIXES = (
+    "prollyBtree",
+    "prollyBtCursor",
+    "origBtree",
+    "origCursor",
+)
+SEAM_HDRS = frozenset({"prolly_btree_int.h", "doltlite_internal.h"})
 ONE_CALL = re.compile(
     r"^return\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(.*\)\s*;$"
 )
@@ -253,17 +262,71 @@ def scan_test_only_wrappers(
     return dead
 
 
+def is_vtbl_method(name: str) -> bool:
+    return name.startswith(VTBL_PREFIXES)
+
+
+def header_uses_beyond_proto(hpath: str, name: str, texts: dict[str, str]) -> bool:
+    raw = texts.get(hpath)
+    if raw is None:
+        return False
+    proto = re.compile(
+        r"^(?!\s)(?:SQLITE_PRIVATE\s+|SQLITE_API\s+|SQLITE_EXTERN\s+)?"
+        r".+?\b" + re.escape(name) + r"\s*\([^;]*\)\s*;",
+        re.M,
+    )
+    leftover = proto.sub("", strip_comments(raw))
+    return name in IDENT.findall(leftover)
+
+
 def scan_should_be_static(src_files: list[str], corpus: list[str], texts: dict[str, str],
                           idents: dict[str, set[str]]) -> list[str]:
     dead: list[str] = []
     for path in src_files:
         for name, line, is_static, stripped, match in iter_defs(path, texts):
-            if is_static:
+            if is_static or name in ALLOW_EXTERN or is_vtbl_method(name):
                 continue
-            others = [q for q in corpus if q != path and name in idents.get(q, ())]
-            if others:
+            others_c = [
+                q for q in corpus
+                if q.endswith(".c") and q != path and name in idents.get(q, ())
+            ]
+            if others_c:
+                continue
+            hdrs = [
+                q for q in corpus
+                if q.endswith(".h") and name in idents.get(q, ())
+            ]
+            if any(header_uses_beyond_proto(h, name, texts) for h in hdrs):
                 continue
             dead.append(f"  should be static: {name} ({path}:{line})")
+    return dead
+
+
+def scan_duplicate_prototypes(
+    owned_hdrs: list[str], texts: dict[str, str]
+) -> list[str]:
+    byname: dict[str, list[str]] = defaultdict(list)
+    for path in owned_hdrs:
+        raw = texts.get(path)
+        if raw is None:
+            continue
+        for match in PROTO.finditer(strip_comments(raw)):
+            name = match.group(1)
+            if name in SKIP_DEF or name in ALLOW_EXTERN:
+                continue
+            if name.startswith("sqlite3") or name.startswith("orig_sqlite3"):
+                continue
+            byname[name].append(path)
+    dead: list[str] = []
+    for name, paths in sorted(byname.items()):
+        uniq = sorted(set(paths))
+        if len(uniq) < 2:
+            continue
+        bases = {os.path.basename(p) for p in uniq}
+        if bases == SEAM_HDRS:
+            continue
+        shown = ", ".join(uniq)
+        dead.append(f"  duplicate header prototype: {name} ({shown})")
     return dead
 
 
@@ -501,6 +564,7 @@ def main() -> int:
     dead += scan_inlines(hdrs, corpus, texts, idents, counts)
     dead += scan_should_be_static(src_files, corpus, texts, idents)
     dead += scan_unused_prototypes(owned_hdrs, corpus, texts, idents)
+    dead += scan_duplicate_prototypes(owned_hdrs, texts)
     dead += scan_unused_macros(owned_hdrs, corpus, texts, idents, counts)
     dead += scan_clones(src_files, texts)
     dead += scan_test_only_wrappers(src_files, corpus, root, texts, idents)

--- a/tool/mksqlite3c.tcl
+++ b/tool/mksqlite3c.tcl
@@ -257,7 +257,7 @@ if {$doltlite} {
     prolly_diff.h prolly_encoding.h prolly_hash.h prolly_hashset.h prolly_mutate.h
     prolly_mutmap.h prolly_node.h prolly_record.h prolly_three_way_diff.h
     prolly_three_way_merge.h prolly_xxhash.h prolly_btree_int.h
-    doltlite_ancestor.h doltlite_catalog_types.h doltlite_chunk_walk.h doltlite_commit.h
+    doltlite_ancestor.h doltlite_catalog_types.h doltlite_commit.h
     doltlite_constraint_violations.h doltlite_ignore.h doltlite_internal.h
     doltlite_branch_int.h doltlite_merge_int.h doltlite_merge_constraints_int.h
     doltlite_name_index.h doltlite_parse.h


### PR DESCRIPTION
## Summary

Follow-up to #2675. Header prototypes were fooling Part D (a declaration counted as a caller), so same-file helpers stayed non-static. Duplicate prototypes across owned headers were also invisible.

**Should-be-static**
- Part D now ignores header prototypes. Btree vtable methods (`prollyBtree*` / `origBtree*`) stay non-static: other TUs call them through the ops table, not by name.
- Static same-file helpers whose only extra mention was a prototype (merge constraint fetchers, `mergeFastForward`, gc compact-with-phase, lock helpers, serial encode, etc.) and delete those decls.

**Duplicate prototypes**
- `doltliteFindAncestor` stays in `doltlite_ancestor.h`
- Constraint-violation batch APIs stay in `doltlite_constraint_violations.h`
- `chunkStoreOriginSourceEnabled` moves to `chunk_store.h` (both `internal.h` and `prolly_btree_int.h` already include it)
- Scanner flags the same prototype in two owned headers; the btree-int vs internal seam copies are excepted (TableEntry clash)

**Includes**
- Delete `doltlite_chunk_walk.h` (7-line alias of `prolly_chunk_walk.h`)
- Drop 13 redundant `#include "doltlite_name_index.h"` after `doltlite_internal.h` already pulls it

## Test plan

- [x] `bash test/dead_code_check.sh` (Parts A–I)
- [x] `bash test/dead_code_check_selftest.sh` (12/12)
- [x] `bash test/lint_layers.sh`
- [x] `make doltlite`
- [x] `test/doltlite_cherry_pick.sh` (140/140)
- [x] `test/doltlite_branch_edge.sh` (79/79)

Co-Authored-By: Grok 4.6 <noreply@x.ai>