### PR TITLE
Share leftover near-copies in hashof, lazy vtabs, and CV scan

### DIFF
--- a/src/doltlite_conflicts.c
+++ b/src/doltlite_conflicts.c
@@ -140,6 +140,10 @@ static int skipConflictRowIO(DlByteReader *r, void *pRow){
   return skipConflictRow(r);
 }
 
+static void freeConflictRowIO(void *pRow){
+  freeConflictRow((DoltliteConflictRow*)pRow);
+}
+
 static int deserializeAllConflicts(
   const u8 *data,
   int nData,
@@ -168,7 +172,7 @@ static int deserializeAllConflicts(
     void *aRows = 0;
     rc = dlReadNamedRowTable(&r, &aTables[i].zName, &aTables[i].nConflicts,
                              &aRows, sizeof(DoltliteConflictRow), 0,
-                             readConflictRowIO);
+                             readConflictRowIO, freeConflictRowIO);
     if( rc!=SQLITE_OK ) goto conflicts_cleanup;
     aTables[i].aRows = (DoltliteConflictRow*)aRows;
   }
@@ -291,7 +295,8 @@ static int loadConflictTable(
     rc = dlMatchOrSkipNamedTable(&r, zTableName, pFound,
                                  &pTable->zName, &pTable->nConflicts, &aRows,
                                  sizeof(DoltliteConflictRow), 0,
-                                 readConflictRowIO, skipConflictRowIO);
+                                 readConflictRowIO, skipConflictRowIO,
+                                 freeConflictRowIO);
     if( rc!=SQLITE_OK ) goto conflict_table_cleanup;
     if( aRows ) pTable->aRows = (DoltliteConflictRow*)aRows;
   }

--- a/src/doltlite_conflicts.c
+++ b/src/doltlite_conflicts.c
@@ -131,13 +131,22 @@ static int skipConflictRow(DlByteReader *r){
   return dlSkipU32Blob(r);
 }
 
+static int readConflictRowIO(DlByteReader *r, void *pRow){
+  return readConflictRow(r, (DoltliteConflictRow*)pRow);
+}
+
+static int skipConflictRowIO(DlByteReader *r, void *pRow){
+  (void)pRow;
+  return skipConflictRow(r);
+}
+
 static int deserializeAllConflicts(
   const u8 *data,
   int nData,
   ConflictTableInfo **ppTables, int *pnTables
 ){
   DlByteReader r;
-  int nTables, i, j, rc;
+  int nTables, i, rc;
   ConflictTableInfo *aTables;
 
   *ppTables = 0;
@@ -156,29 +165,12 @@ static int deserializeAllConflicts(
   memset(aTables, 0, nTables ? nTables * (int)sizeof(ConflictTableInfo) : 1);
 
   for(i=0; i<nTables; i++){
-    int nc;
-    rc = dlReadU16Name(&r, &aTables[i].zName);
+    void *aRows = 0;
+    rc = dlReadNamedRowTable(&r, &aTables[i].zName, &aTables[i].nConflicts,
+                             &aRows, sizeof(DoltliteConflictRow), 0,
+                             readConflictRowIO);
     if( rc!=SQLITE_OK ) goto conflicts_cleanup;
-    nc = dlReadU32(&r);
-    if( r.err || nc<0 ){ rc = SQLITE_CORRUPT; goto conflicts_cleanup; }
-    /* nc cannot exceed remaining bytes; malloc64 avoids 32-bit overflow. */
-    if( (sqlite3_uint64)nc > (sqlite3_uint64)(r.end - r.p) ){
-      rc = SQLITE_CORRUPT; goto conflicts_cleanup;
-    }
-    aTables[i].nConflicts = nc;
-    if( nc>0 ){
-      aTables[i].aRows = sqlite3_malloc64(
-          (sqlite3_uint64)nc * sizeof(DoltliteConflictRow));
-      if( !aTables[i].aRows ){ rc = SQLITE_NOMEM; goto conflicts_cleanup; }
-      memset(aTables[i].aRows, 0,
-             (sqlite3_uint64)nc * sizeof(DoltliteConflictRow));
-    }
-
-    for(j=0; j<nc; j++){
-      DoltliteConflictRow *cr = &aTables[i].aRows[j];
-      rc = readConflictRow(&r, cr);
-      if( rc!=SQLITE_OK ) goto conflicts_cleanup;
-    }
+    aTables[i].aRows = (DoltliteConflictRow*)aRows;
   }
 
   if( r.err || r.p != r.end ){ rc = SQLITE_CORRUPT; goto conflicts_cleanup; }
@@ -273,7 +265,7 @@ static int loadConflictTable(
   ProllyHash hash;
   u8 *data = 0; int nData = 0;
   DlByteReader r;
-  int nTables, i, j, rc;
+  int nTables, i, rc;
 
   memset(pTable, 0, sizeof(*pTable));
   *pFound = 0;
@@ -295,44 +287,13 @@ static int loadConflictTable(
   }
 
   for(i=0; i<nTables; i++){
-    char *zName = 0;
-    int nc;
-    int isMatch;
-
-    rc = dlReadU16Name(&r, &zName);
+    void *aRows = 0;
+    rc = dlMatchOrSkipNamedTable(&r, zTableName, pFound,
+                                 &pTable->zName, &pTable->nConflicts, &aRows,
+                                 sizeof(DoltliteConflictRow), 0,
+                                 readConflictRowIO, skipConflictRowIO);
     if( rc!=SQLITE_OK ) goto conflict_table_cleanup;
-    nc = dlReadU32(&r);
-    if( r.err || nc<0 ){
-      sqlite3_free(zName);
-      rc = SQLITE_CORRUPT; goto conflict_table_cleanup;
-    }
-    if( (sqlite3_uint64)nc > (sqlite3_uint64)(r.end - r.p) ){
-      sqlite3_free(zName);
-      rc = SQLITE_CORRUPT; goto conflict_table_cleanup;
-    }
-
-    isMatch = (*pFound==0 && zName && strcmp(zName, zTableName)==0);
-    if( isMatch ){
-      pTable->zName = zName;
-      zName = 0;
-      pTable->nConflicts = nc;
-      if( nc>0 ){
-        pTable->aRows = sqlite3_malloc64((sqlite3_uint64)nc * sizeof(DoltliteConflictRow));
-        if( !pTable->aRows ){ rc = SQLITE_NOMEM; goto conflict_table_cleanup; }
-        memset(pTable->aRows, 0, (sqlite3_uint64)nc * sizeof(DoltliteConflictRow));
-      }
-      for(j=0; j<nc; j++){
-        rc = readConflictRow(&r, &pTable->aRows[j]);
-        if( rc!=SQLITE_OK ) goto conflict_table_cleanup;
-      }
-      *pFound = 1;
-    }else{
-      sqlite3_free(zName);
-      for(j=0; j<nc; j++){
-        rc = skipConflictRow(&r);
-        if( rc!=SQLITE_OK ) goto conflict_table_cleanup;
-      }
-    }
+    if( aRows ) pTable->aRows = (DoltliteConflictRow*)aRows;
   }
 
   if( r.err || r.p != r.end ){ rc = SQLITE_CORRUPT; goto conflict_table_cleanup; }

--- a/src/doltlite_constraint_violations.c
+++ b/src/doltlite_constraint_violations.c
@@ -148,13 +148,22 @@ static int skipViolationRow(DlByteReader *rd){
   return dlSkipU32Blob(rd);
 }
 
+static int readViolationRowIO(DlByteReader *r, void *pRow){
+  return readViolationRow(r, (ConstraintViolationRow*)pRow);
+}
+
+static int skipViolationRowIO(DlByteReader *r, void *pRow){
+  (void)pRow;
+  return skipViolationRow(r);
+}
+
 static int deserializeAllViolations(
   const u8 *data,
   int nData,
   ConstraintViolationTable **ppTables, int *pnTables
 ){
   DlByteReader rd;
-  int nTables, i, j, rc;
+  int nTables, i, rc;
   ConstraintViolationTable *aTables;
 
   *ppTables = 0;
@@ -173,25 +182,12 @@ static int deserializeAllViolations(
   memset(aTables, 0, nTables ? nTables * (int)sizeof(*aTables) : 1);
 
   for(i=0; i<nTables; i++){
-    int nr;
-    rc = dlReadU16Name(&rd, &aTables[i].zName);
+    void *aRows = 0;
+    rc = dlReadNamedRowTable(&rd, &aTables[i].zName, &aTables[i].nRows,
+                             &aRows, sizeof(ConstraintViolationRow), 1,
+                             readViolationRowIO);
     if( rc!=SQLITE_OK ) goto fail;
-    nr = dlReadU32(&rd);
-    if( rd.err || nr<0 ){ rc = SQLITE_CORRUPT; goto fail; }
-    /* nr cannot exceed remaining bytes (1 byte/row min). malloc64 avoids 32-bit overflow. */
-    if( (sqlite3_uint64)nr > (sqlite3_uint64)(rd.end - rd.p) ){
-      rc = SQLITE_CORRUPT; goto fail;
-    }
-    aTables[i].nRows = nr;
-    aTables[i].aRows = sqlite3_malloc64(nr ? (sqlite3_uint64)nr * sizeof(ConstraintViolationRow) : 1);
-    if( !aTables[i].aRows ){ rc = SQLITE_NOMEM; goto fail; }
-    memset(aTables[i].aRows, 0, nr ? (sqlite3_uint64)nr * sizeof(ConstraintViolationRow) : 1);
-
-    for(j=0; j<nr; j++){
-      ConstraintViolationRow *r = &aTables[i].aRows[j];
-      rc = readViolationRow(&rd, r);
-      if( rc!=SQLITE_OK ) goto fail;
-    }
+    aTables[i].aRows = (ConstraintViolationRow*)aRows;
   }
 
   if( rd.err || rd.p != rd.end ){ rc = SQLITE_CORRUPT; goto fail; }
@@ -247,7 +243,7 @@ static int loadViolationTable(
   ProllyHash hash;
   u8 *data = 0; int nData = 0;
   DlByteReader rd;
-  int nTables, i, j, rc;
+  int nTables, i, rc;
 
   memset(pTable, 0, sizeof(*pTable));
   *pFound = 0;
@@ -267,42 +263,13 @@ static int loadViolationTable(
   }
 
   for(i=0; i<nTables; i++){
-    char *zName = 0;
-    int nr;
-    int isMatch;
-
-    rc = dlReadU16Name(&rd, &zName);
+    void *aRows = 0;
+    rc = dlMatchOrSkipNamedTable(&rd, zTableName, pFound,
+                                 &pTable->zName, &pTable->nRows, &aRows,
+                                 sizeof(ConstraintViolationRow), 1,
+                                 readViolationRowIO, skipViolationRowIO);
     if( rc!=SQLITE_OK ) goto fail;
-    nr = dlReadU32(&rd);
-    if( rd.err || nr<0 ){
-      sqlite3_free(zName);
-      rc = SQLITE_CORRUPT; goto fail;
-    }
-    if( (sqlite3_uint64)nr > (sqlite3_uint64)(rd.end - rd.p) ){
-      sqlite3_free(zName);
-      rc = SQLITE_CORRUPT; goto fail;
-    }
-
-    isMatch = (*pFound==0 && zName && strcmp(zName, zTableName)==0);
-    if( isMatch ){
-      pTable->zName = zName;
-      zName = 0;
-      pTable->nRows = nr;
-      pTable->aRows = sqlite3_malloc64(nr ? (sqlite3_uint64)nr * sizeof(ConstraintViolationRow) : 1);
-      if( !pTable->aRows ){ rc = SQLITE_NOMEM; goto fail; }
-      memset(pTable->aRows, 0, nr ? (sqlite3_uint64)nr * sizeof(ConstraintViolationRow) : 1);
-      for(j=0; j<nr; j++){
-        rc = readViolationRow(&rd, &pTable->aRows[j]);
-        if( rc!=SQLITE_OK ) goto fail;
-      }
-      *pFound = 1;
-    }else{
-      sqlite3_free(zName);
-      for(j=0; j<nr; j++){
-        rc = skipViolationRow(&rd);
-        if( rc!=SQLITE_OK ) goto fail;
-      }
-    }
+    if( aRows ) pTable->aRows = (ConstraintViolationRow*)aRows;
   }
 
   if( rd.err || rd.p != rd.end ){ rc = SQLITE_CORRUPT; goto fail; }

--- a/src/doltlite_constraint_violations.c
+++ b/src/doltlite_constraint_violations.c
@@ -157,6 +157,10 @@ static int skipViolationRowIO(DlByteReader *r, void *pRow){
   return skipViolationRow(r);
 }
 
+static void freeViolationRowIO(void *pRow){
+  freeViolationRow((ConstraintViolationRow*)pRow);
+}
+
 static int deserializeAllViolations(
   const u8 *data,
   int nData,
@@ -185,7 +189,7 @@ static int deserializeAllViolations(
     void *aRows = 0;
     rc = dlReadNamedRowTable(&rd, &aTables[i].zName, &aTables[i].nRows,
                              &aRows, sizeof(ConstraintViolationRow), 1,
-                             readViolationRowIO);
+                             readViolationRowIO, freeViolationRowIO);
     if( rc!=SQLITE_OK ) goto fail;
     aTables[i].aRows = (ConstraintViolationRow*)aRows;
   }
@@ -267,7 +271,8 @@ static int loadViolationTable(
     rc = dlMatchOrSkipNamedTable(&rd, zTableName, pFound,
                                  &pTable->zName, &pTable->nRows, &aRows,
                                  sizeof(ConstraintViolationRow), 1,
-                                 readViolationRowIO, skipViolationRowIO);
+                                 readViolationRowIO, skipViolationRowIO,
+                                 freeViolationRowIO);
     if( rc!=SQLITE_OK ) goto fail;
     if( aRows ) pTable->aRows = (ConstraintViolationRow*)aRows;
   }

--- a/src/doltlite_docs.c
+++ b/src/doltlite_docs.c
@@ -240,16 +240,10 @@ static int docsSeedAgent(DocsVtab *p){
 }
 
 static int docsMaterialize(DocsVtab *p){
-  int rc;
-  char *zErr = 0;
-  if( sqlite3FindTable(p->db, "dolt_docs", "main") ) return SQLITE_OK;
-  rc = sqlite3_exec(p->db, zDocsCreate, 0, 0, &zErr);
-  if( rc!=SQLITE_OK ){
-    sqlite3_free(p->base.zErrMsg);
-    p->base.zErrMsg = sqlite3_mprintf("%s", zErr ? zErr : sqlite3_errstr(rc));
-    sqlite3_free(zErr);
-    return rc;
-  }
+  int existed = sqlite3FindTable(p->db, "dolt_docs", "main")!=0;
+  int rc = doltliteLazyCreateTable(&p->base, p->db, "dolt_docs", zDocsCreate);
+  if( rc!=SQLITE_OK ) return rc;
+  if( existed ) return SQLITE_OK;
   return docsSeedAgent(p);
 }
 
@@ -258,65 +252,30 @@ static int docsBegin(sqlite3_vtab *pBase){
 }
 
 static const char *docsInsertSql(sqlite3 *db){
-  switch( sqlite3_vtab_on_conflict(db) ){
-    case SQLITE_REPLACE:
-      return "INSERT OR REPLACE INTO main.dolt_docs(doc_name, doc_text) "
-             "VALUES(?1, ?2)";
-    case SQLITE_IGNORE:
-      return "INSERT OR IGNORE INTO main.dolt_docs(doc_name, doc_text) "
-             "VALUES(?1, ?2)";
-    case SQLITE_FAIL:
-      return "INSERT OR FAIL INTO main.dolt_docs(doc_name, doc_text) "
-             "VALUES(?1, ?2)";
-    case SQLITE_ROLLBACK:
-      return "INSERT OR ROLLBACK INTO main.dolt_docs(doc_name, doc_text) "
-             "VALUES(?1, ?2)";
-    default:
-      return "INSERT INTO main.dolt_docs(doc_name, doc_text) VALUES(?1, ?2)";
-  }
+  return doltliteVtabOnConflictOr(db,
+      "INSERT OR REPLACE INTO main.dolt_docs(doc_name, doc_text) VALUES(?1, ?2)",
+      "INSERT OR IGNORE INTO main.dolt_docs(doc_name, doc_text) VALUES(?1, ?2)",
+      "INSERT OR FAIL INTO main.dolt_docs(doc_name, doc_text) VALUES(?1, ?2)",
+      "INSERT OR ROLLBACK INTO main.dolt_docs(doc_name, doc_text) VALUES(?1, ?2)",
+      "INSERT INTO main.dolt_docs(doc_name, doc_text) VALUES(?1, ?2)");
 }
 
 static const char *docsUpdateSql(sqlite3 *db){
-  switch( sqlite3_vtab_on_conflict(db) ){
-    case SQLITE_REPLACE:
-      return "UPDATE OR REPLACE main.dolt_docs SET doc_name=?1, doc_text=?2 "
-             "WHERE doc_name=?3";
-    case SQLITE_IGNORE:
-      return "UPDATE OR IGNORE main.dolt_docs SET doc_name=?1, doc_text=?2 "
-             "WHERE doc_name=?3";
-    case SQLITE_FAIL:
-      return "UPDATE OR FAIL main.dolt_docs SET doc_name=?1, doc_text=?2 "
-             "WHERE doc_name=?3";
-    case SQLITE_ROLLBACK:
-      return "UPDATE OR ROLLBACK main.dolt_docs SET doc_name=?1, doc_text=?2 "
-             "WHERE doc_name=?3";
-    default:
-      return "UPDATE main.dolt_docs SET doc_name=?1, doc_text=?2 "
-             "WHERE doc_name=?3";
-  }
+  return doltliteVtabOnConflictOr(db,
+      "UPDATE OR REPLACE main.dolt_docs SET doc_name=?1, doc_text=?2 WHERE doc_name=?3",
+      "UPDATE OR IGNORE main.dolt_docs SET doc_name=?1, doc_text=?2 WHERE doc_name=?3",
+      "UPDATE OR FAIL main.dolt_docs SET doc_name=?1, doc_text=?2 WHERE doc_name=?3",
+      "UPDATE OR ROLLBACK main.dolt_docs SET doc_name=?1, doc_text=?2 WHERE doc_name=?3",
+      "UPDATE main.dolt_docs SET doc_name=?1, doc_text=?2 WHERE doc_name=?3");
 }
 
 static int docsUpdate(sqlite3_vtab *pBase, int argc, sqlite3_value **argv,
                       sqlite3_int64 *pRowid){
   DocsVtab *p = (DocsVtab*)pBase;
-  int rc;
-
-  rc = docsMaterialize(p);
-  if( rc!=SQLITE_OK ) return rc;
-
-  if( argc==1 ){
-    return doltliteVtabExecBound(&p->base, p->db,
-        "DELETE FROM main.dolt_docs WHERE doc_name=?1", argv[0], 0, 0);
-  }
-  if( sqlite3_value_type(argv[0])!=SQLITE_NULL ){
-    return doltliteVtabExecBound(&p->base, p->db,
-        docsUpdateSql(p->db), argv[2], argv[3], argv[0]);
-  }
-
-  rc = doltliteVtabExecBound(&p->base, p->db, docsInsertSql(p->db), argv[2], argv[3], 0);
-  if( rc!=SQLITE_OK ) return rc;
-  if( pRowid ) *pRowid = sqlite3_last_insert_rowid(p->db);
-  return SQLITE_OK;
+  return doltliteLazyTwoColUpdate(pBase, p->db, argc, argv, pRowid,
+      (int(*)(void*))docsMaterialize, p,
+      "DELETE FROM main.dolt_docs WHERE doc_name=?1",
+      docsUpdateSql(p->db), docsInsertSql(p->db));
 }
 
 static sqlite3_module doltliteDocsModule = {

--- a/src/doltlite_hashof.c
+++ b/src/doltlite_hashof.c
@@ -822,24 +822,38 @@ static int hashofResolveRefCatalog(
   return 0;
 }
 
-static void doltliteHashofTableFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
+typedef int (*HashofInCatalogFn)(
+  sqlite3 *db, const ProllyHash *pCatHash, const char *zName, char *pHex
+);
+
+static void hashofNamedObjectFunc(
+  sqlite3_context *ctx,
+  int argc,
+  sqlite3_value **argv,
+  const char *zFn,
+  const char *zKind,
+  HashofInCatalogFn xLookup
+){
   sqlite3 *db;
-  const char *zTable;
+  const char *zName;
   ProllyHash catHash;
   char hex[PROLLY_HASH_SIZE*2+1];
+  char zErr[80];
   int rc;
 
   if( argc!=1 && argc!=2 ){
-    sqlite3_result_error(ctx, "dolt_hashof_table() takes 1 or 2 arguments", -1);
+    sqlite3_snprintf(sizeof(zErr), zErr, "%s() takes 1 or 2 arguments", zFn);
+    sqlite3_result_error(ctx, zErr, -1);
     return;
   }
   if( sqlite3_value_type(argv[0])==SQLITE_NULL ){
     sqlite3_result_null(ctx);
     return;
   }
-  zTable = (const char*)sqlite3_value_text(argv[0]);
-  if( !zTable || !*zTable ){
-    sqlite3_result_error(ctx, "dolt_hashof_table: table not found", -1);
+  zName = (const char*)sqlite3_value_text(argv[0]);
+  if( !zName || !*zName ){
+    sqlite3_snprintf(sizeof(zErr), zErr, "%s: %s not found", zFn, zKind);
+    sqlite3_result_error(ctx, zErr, -1);
     return;
   }
   db = sqlite3_context_db_handle(ctx);
@@ -847,23 +861,31 @@ static void doltliteHashofTableFunc(sqlite3_context *ctx, int argc, sqlite3_valu
   if( argc==1 ){
     rc = doltliteFlushCatalogToHash(db, &catHash);
     if( rc!=SQLITE_OK ){
-      sqlite3_result_error(ctx, "dolt_hashof_table: catalog flush failed", -1);
+      sqlite3_snprintf(sizeof(zErr), zErr, "%s: catalog flush failed", zFn);
+      sqlite3_result_error(ctx, zErr, -1);
       return;
     }
   }else{
-    if( hashofResolveRefCatalog(ctx, db, argv[1], "dolt_hashof_table", &catHash) ) return;
+    if( hashofResolveRefCatalog(ctx, db, argv[1], zFn, &catHash) ) return;
   }
 
-  rc = hashofTableInCatalog(db, &catHash, zTable, hex);
+  rc = xLookup(db, &catHash, zName, hex);
   if( rc==SQLITE_NOTFOUND ){
-    sqlite3_result_error(ctx, "dolt_hashof_table: table not found", -1);
+    sqlite3_snprintf(sizeof(zErr), zErr, "%s: %s not found", zFn, zKind);
+    sqlite3_result_error(ctx, zErr, -1);
     return;
   }
   if( rc!=SQLITE_OK ){
-    sqlite3_result_error(ctx, "dolt_hashof_table: table not found in catalog", -1);
+    sqlite3_snprintf(sizeof(zErr), zErr, "%s: %s not found in catalog", zFn, zKind);
+    sqlite3_result_error(ctx, zErr, -1);
     return;
   }
   sqlite3_result_text(ctx, hex, PROLLY_HASH_SIZE*2, SQLITE_TRANSIENT);
+}
+
+static void doltliteHashofTableFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
+  hashofNamedObjectFunc(ctx, argc, argv, "dolt_hashof_table", "table",
+                        hashofTableInCatalog);
 }
 
 static void doltliteHashofDbFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
@@ -897,47 +919,8 @@ static void doltliteHashofDbFunc(sqlite3_context *ctx, int argc, sqlite3_value *
 }
 
 static void doltliteHashofIndexFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
-  sqlite3 *db;
-  const char *zIndex;
-  ProllyHash catHash;
-  char hex[PROLLY_HASH_SIZE*2+1];
-  int rc;
-
-  if( argc!=1 && argc!=2 ){
-    sqlite3_result_error(ctx, "dolt_hashof_index() takes 1 or 2 arguments", -1);
-    return;
-  }
-  if( sqlite3_value_type(argv[0])==SQLITE_NULL ){
-    sqlite3_result_null(ctx);
-    return;
-  }
-  zIndex = (const char*)sqlite3_value_text(argv[0]);
-  if( !zIndex || !*zIndex ){
-    sqlite3_result_error(ctx, "dolt_hashof_index: index not found", -1);
-    return;
-  }
-  db = sqlite3_context_db_handle(ctx);
-
-  if( argc==1 ){
-    rc = doltliteFlushCatalogToHash(db, &catHash);
-    if( rc!=SQLITE_OK ){
-      sqlite3_result_error(ctx, "dolt_hashof_index: catalog flush failed", -1);
-      return;
-    }
-  }else{
-    if( hashofResolveRefCatalog(ctx, db, argv[1], "dolt_hashof_index", &catHash) ) return;
-  }
-
-  rc = hashofIndexInCatalog(db, &catHash, zIndex, hex);
-  if( rc==SQLITE_NOTFOUND ){
-    sqlite3_result_error(ctx, "dolt_hashof_index: index not found", -1);
-    return;
-  }
-  if( rc!=SQLITE_OK ){
-    sqlite3_result_error(ctx, "dolt_hashof_index: index not found in catalog", -1);
-    return;
-  }
-  sqlite3_result_text(ctx, hex, PROLLY_HASH_SIZE*2, SQLITE_TRANSIENT);
+  hashofNamedObjectFunc(ctx, argc, argv, "dolt_hashof_index", "index",
+                        hashofIndexInCatalog);
 }
 
 static void doltliteHashofCatalogFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){

--- a/src/doltlite_ignore.c
+++ b/src/doltlite_ignore.c
@@ -376,17 +376,7 @@ static int ignoreRowid(sqlite3_vtab_cursor *pCursor, sqlite3_int64 *pRowid){
 }
 
 static int ignoreMaterialize(IgnoreVtab *p){
-  char *zErr = 0;
-  int rc;
-  if( sqlite3FindTable(p->db, "dolt_ignore", "main") ) return SQLITE_OK;
-  rc = sqlite3_exec(p->db, zIgnoreCreate, 0, 0, &zErr);
-  if( rc!=SQLITE_OK ){
-    sqlite3_free(p->base.zErrMsg);
-    p->base.zErrMsg = sqlite3_mprintf("%s",
-        zErr ? zErr : sqlite3_errstr(rc));
-    sqlite3_free(zErr);
-  }
-  return rc;
+  return doltliteLazyCreateTable(&p->base, p->db, "dolt_ignore", zIgnoreCreate);
 }
 
 static int ignoreBegin(sqlite3_vtab *pBase){
@@ -396,65 +386,30 @@ static int ignoreBegin(sqlite3_vtab *pBase){
 
 
 static const char *ignoreInsertSql(sqlite3 *db){
-  switch( sqlite3_vtab_on_conflict(db) ){
-    case SQLITE_REPLACE:
-      return "INSERT OR REPLACE INTO main.dolt_ignore(pattern, ignored) "
-             "VALUES(?1, ?2)";
-    case SQLITE_IGNORE:
-      return "INSERT OR IGNORE INTO main.dolt_ignore(pattern, ignored) "
-             "VALUES(?1, ?2)";
-    case SQLITE_FAIL:
-      return "INSERT OR FAIL INTO main.dolt_ignore(pattern, ignored) "
-             "VALUES(?1, ?2)";
-    case SQLITE_ROLLBACK:
-      return "INSERT OR ROLLBACK INTO main.dolt_ignore(pattern, ignored) "
-             "VALUES(?1, ?2)";
-    default:
-      return "INSERT INTO main.dolt_ignore(pattern, ignored) VALUES(?1, ?2)";
-  }
+  return doltliteVtabOnConflictOr(db,
+      "INSERT OR REPLACE INTO main.dolt_ignore(pattern, ignored) VALUES(?1, ?2)",
+      "INSERT OR IGNORE INTO main.dolt_ignore(pattern, ignored) VALUES(?1, ?2)",
+      "INSERT OR FAIL INTO main.dolt_ignore(pattern, ignored) VALUES(?1, ?2)",
+      "INSERT OR ROLLBACK INTO main.dolt_ignore(pattern, ignored) VALUES(?1, ?2)",
+      "INSERT INTO main.dolt_ignore(pattern, ignored) VALUES(?1, ?2)");
 }
 
 static const char *ignoreUpdateSql(sqlite3 *db){
-  switch( sqlite3_vtab_on_conflict(db) ){
-    case SQLITE_REPLACE:
-      return "UPDATE OR REPLACE main.dolt_ignore SET pattern=?1, ignored=?2 "
-             "WHERE pattern=?3";
-    case SQLITE_IGNORE:
-      return "UPDATE OR IGNORE main.dolt_ignore SET pattern=?1, ignored=?2 "
-             "WHERE pattern=?3";
-    case SQLITE_FAIL:
-      return "UPDATE OR FAIL main.dolt_ignore SET pattern=?1, ignored=?2 "
-             "WHERE pattern=?3";
-    case SQLITE_ROLLBACK:
-      return "UPDATE OR ROLLBACK main.dolt_ignore SET pattern=?1, ignored=?2 "
-             "WHERE pattern=?3";
-    default:
-      return "UPDATE main.dolt_ignore SET pattern=?1, ignored=?2 "
-             "WHERE pattern=?3";
-  }
+  return doltliteVtabOnConflictOr(db,
+      "UPDATE OR REPLACE main.dolt_ignore SET pattern=?1, ignored=?2 WHERE pattern=?3",
+      "UPDATE OR IGNORE main.dolt_ignore SET pattern=?1, ignored=?2 WHERE pattern=?3",
+      "UPDATE OR FAIL main.dolt_ignore SET pattern=?1, ignored=?2 WHERE pattern=?3",
+      "UPDATE OR ROLLBACK main.dolt_ignore SET pattern=?1, ignored=?2 WHERE pattern=?3",
+      "UPDATE main.dolt_ignore SET pattern=?1, ignored=?2 WHERE pattern=?3");
 }
 
 static int ignoreUpdate(sqlite3_vtab *pBase, int argc, sqlite3_value **argv,
                         sqlite3_int64 *pRowid){
   IgnoreVtab *p = (IgnoreVtab*)pBase;
-  int rc;
-
-  rc = ignoreMaterialize(p);
-  if( rc!=SQLITE_OK ) return rc;
-
-  if( argc==1 ){
-    return doltliteVtabExecBound(&p->base, p->db,
-        "DELETE FROM main.dolt_ignore WHERE pattern=?1", argv[0], 0, 0);
-  }
-  if( sqlite3_value_type(argv[0])!=SQLITE_NULL ){
-    return doltliteVtabExecBound(&p->base, p->db,
-        ignoreUpdateSql(p->db), argv[2], argv[3], argv[0]);
-  }
-
-  rc = doltliteVtabExecBound(&p->base, p->db, ignoreInsertSql(p->db), argv[2], argv[3], 0);
-  if( rc!=SQLITE_OK ) return rc;
-  if( pRowid ) *pRowid = sqlite3_last_insert_rowid(p->db);
-  return SQLITE_OK;
+  return doltliteLazyTwoColUpdate(pBase, p->db, argc, argv, pRowid,
+      (int(*)(void*))ignoreMaterialize, p,
+      "DELETE FROM main.dolt_ignore WHERE pattern=?1",
+      ignoreUpdateSql(p->db), ignoreInsertSql(p->db));
 }
 
 static sqlite3_module doltliteIgnoreModule = {

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -11,6 +11,7 @@
 #include "doltlite_catalog_types.h"
 #include <time.h>
 #include <limits.h>
+#include <string.h>
 
 typedef struct BtShared BtShared;
 typedef struct ProllyCache ProllyCache;
@@ -857,6 +858,119 @@ static SQLITE_INLINE int dlReadFramedHeader(DlByteReader *r, u8 m0, u8 m1,
   return SQLITE_OK;
 }
 
+typedef int (*DlRowIO)(DlByteReader *r, void *pRow);
+
+static SQLITE_INLINE int dlReadNamedRowTable(
+  DlByteReader *r,
+  char **pzName,
+  int *pnRows,
+  void **ppRows,
+  size_t szRow,
+  int bAllocEmpty,
+  DlRowIO xRead
+){
+  int nr, j, rc;
+  void *aRows = 0;
+
+  *pzName = 0;
+  *pnRows = 0;
+  *ppRows = 0;
+  rc = dlReadU16Name(r, pzName);
+  if( rc!=SQLITE_OK ) return rc;
+  nr = dlReadU32(r);
+  if( r->err || nr<0 ){
+    sqlite3_free(*pzName);
+    *pzName = 0;
+    return SQLITE_CORRUPT;
+  }
+  if( (sqlite3_uint64)nr > (sqlite3_uint64)(r->end - r->p) ){
+    sqlite3_free(*pzName);
+    *pzName = 0;
+    return SQLITE_CORRUPT;
+  }
+  if( nr>0 || bAllocEmpty ){
+    aRows = sqlite3_malloc64(nr ? (sqlite3_uint64)nr * szRow : 1);
+    if( !aRows ){
+      sqlite3_free(*pzName);
+      *pzName = 0;
+      return SQLITE_NOMEM;
+    }
+    memset(aRows, 0, nr ? (sqlite3_uint64)nr * szRow : 1);
+  }
+  for(j=0; j<nr; j++){
+    rc = xRead(r, (char*)aRows + (size_t)j * szRow);
+    if( rc!=SQLITE_OK ){
+      sqlite3_free(aRows);
+      sqlite3_free(*pzName);
+      *pzName = 0;
+      return rc;
+    }
+  }
+  *pnRows = nr;
+  *ppRows = aRows;
+  return SQLITE_OK;
+}
+
+static SQLITE_INLINE int dlMatchOrSkipNamedTable(
+  DlByteReader *r,
+  const char *zWant,
+  int *pFound,
+  char **pzName,
+  int *pnRows,
+  void **ppRows,
+  size_t szRow,
+  int bAllocEmpty,
+  DlRowIO xRead,
+  DlRowIO xSkip
+){
+  char *zName = 0;
+  int nr, j, rc;
+  int isMatch;
+
+  rc = dlReadU16Name(r, &zName);
+  if( rc!=SQLITE_OK ) return rc;
+  nr = dlReadU32(r);
+  if( r->err || nr<0 ){
+    sqlite3_free(zName);
+    return SQLITE_CORRUPT;
+  }
+  if( (sqlite3_uint64)nr > (sqlite3_uint64)(r->end - r->p) ){
+    sqlite3_free(zName);
+    return SQLITE_CORRUPT;
+  }
+  isMatch = (*pFound==0 && zName && strcmp(zName, zWant)==0);
+  if( isMatch ){
+    void *aRows = 0;
+    if( nr>0 || bAllocEmpty ){
+      aRows = sqlite3_malloc64(nr ? (sqlite3_uint64)nr * szRow : 1);
+      if( !aRows ){
+        sqlite3_free(zName);
+        return SQLITE_NOMEM;
+      }
+      memset(aRows, 0, nr ? (sqlite3_uint64)nr * szRow : 1);
+    }
+    for(j=0; j<nr; j++){
+      rc = xRead(r, (char*)aRows + (size_t)j * szRow);
+      if( rc!=SQLITE_OK ){
+        sqlite3_free(aRows);
+        sqlite3_free(zName);
+        return rc;
+      }
+    }
+    *pzName = zName;
+    *pnRows = nr;
+    *ppRows = aRows;
+    *pFound = 1;
+    return SQLITE_OK;
+  }
+  sqlite3_free(zName);
+  for(j=0; j<nr; j++){
+    rc = xSkip(r, 0);
+    if( rc!=SQLITE_OK ) return rc;
+  }
+  return SQLITE_OK;
+}
+
 ChunkStore *doltliteGetChunkStore(sqlite3 *db);
 ChunkStore *doltliteBtreeChunkStore(Btree *p);
 int doltliteGcCompactStore(sqlite3 *db, ChunkStore *cs);
@@ -1010,6 +1124,67 @@ static SQLITE_INLINE int doltliteVtabExecBound(
   sqlite3_step(pStmt);
   rc = sqlite3_finalize(pStmt);
   if( rc!=SQLITE_OK ) return doltliteVtabSetErrmsgFromDb(pVtab, db, rc);
+  return SQLITE_OK;
+}
+
+static SQLITE_INLINE const char *doltliteVtabOnConflictOr(
+  sqlite3 *db,
+  const char *zReplace,
+  const char *zIgnore,
+  const char *zFail,
+  const char *zRollback,
+  const char *zDefault
+){
+  switch( sqlite3_vtab_on_conflict(db) ){
+    case SQLITE_REPLACE: return zReplace;
+    case SQLITE_IGNORE: return zIgnore;
+    case SQLITE_FAIL: return zFail;
+    case SQLITE_ROLLBACK: return zRollback;
+    default: return zDefault;
+  }
+}
+
+static SQLITE_INLINE int doltliteLazyCreateTable(
+  sqlite3_vtab *pBase,
+  sqlite3 *db,
+  const char *zName,
+  const char *zCreate
+){
+  char *zErr = 0;
+  int rc;
+  if( sqlite3FindTable(db, zName, "main") ) return SQLITE_OK;
+  rc = sqlite3_exec(db, zCreate, 0, 0, &zErr);
+  if( rc!=SQLITE_OK ){
+    sqlite3_free(pBase->zErrMsg);
+    pBase->zErrMsg = sqlite3_mprintf("%s", zErr ? zErr : sqlite3_errstr(rc));
+    sqlite3_free(zErr);
+  }
+  return rc;
+}
+
+static SQLITE_INLINE int doltliteLazyTwoColUpdate(
+  sqlite3_vtab *pBase,
+  sqlite3 *db,
+  int argc,
+  sqlite3_value **argv,
+  sqlite3_int64 *pRowid,
+  int (*xMaterialize)(void*),
+  void *pMat,
+  const char *zDeleteSql,
+  const char *zUpdateSql,
+  const char *zInsertSql
+){
+  int rc = xMaterialize(pMat);
+  if( rc!=SQLITE_OK ) return rc;
+  if( argc==1 ){
+    return doltliteVtabExecBound(pBase, db, zDeleteSql, argv[0], 0, 0);
+  }
+  if( sqlite3_value_type(argv[0])!=SQLITE_NULL ){
+    return doltliteVtabExecBound(pBase, db, zUpdateSql, argv[2], argv[3], argv[0]);
+  }
+  rc = doltliteVtabExecBound(pBase, db, zInsertSql, argv[2], argv[3], 0);
+  if( rc!=SQLITE_OK ) return rc;
+  if( pRowid ) *pRowid = sqlite3_last_insert_rowid(db);
   return SQLITE_OK;
 }
 

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -859,6 +859,22 @@ static SQLITE_INLINE int dlReadFramedHeader(DlByteReader *r, u8 m0, u8 m1,
 }
 
 typedef int (*DlRowIO)(DlByteReader *r, void *pRow);
+typedef void (*DlRowFree)(void *pRow);
+
+static SQLITE_INLINE void dlFreeRowArray(
+  void *aRows,
+  int nRows,
+  size_t szRow,
+  DlRowFree xFree
+){
+  int k;
+  if( aRows && xFree ){
+    for(k=0; k<nRows; k++){
+      xFree((char*)aRows + (size_t)k * szRow);
+    }
+  }
+  sqlite3_free(aRows);
+}
 
 static SQLITE_INLINE int dlReadNamedRowTable(
   DlByteReader *r,
@@ -867,7 +883,8 @@ static SQLITE_INLINE int dlReadNamedRowTable(
   void **ppRows,
   size_t szRow,
   int bAllocEmpty,
-  DlRowIO xRead
+  DlRowIO xRead,
+  DlRowFree xFree
 ){
   int nr, j, rc;
   void *aRows = 0;
@@ -900,7 +917,7 @@ static SQLITE_INLINE int dlReadNamedRowTable(
   for(j=0; j<nr; j++){
     rc = xRead(r, (char*)aRows + (size_t)j * szRow);
     if( rc!=SQLITE_OK ){
-      sqlite3_free(aRows);
+      dlFreeRowArray(aRows, j+1, szRow, xFree);
       sqlite3_free(*pzName);
       *pzName = 0;
       return rc;
@@ -921,7 +938,8 @@ static SQLITE_INLINE int dlMatchOrSkipNamedTable(
   size_t szRow,
   int bAllocEmpty,
   DlRowIO xRead,
-  DlRowIO xSkip
+  DlRowIO xSkip,
+  DlRowFree xFree
 ){
   char *zName = 0;
   int nr, j, rc;
@@ -952,7 +970,7 @@ static SQLITE_INLINE int dlMatchOrSkipNamedTable(
     for(j=0; j<nr; j++){
       rc = xRead(r, (char*)aRows + (size_t)j * szRow);
       if( rc!=SQLITE_OK ){
-        sqlite3_free(aRows);
+        dlFreeRowArray(aRows, j+1, szRow, xFree);
         sqlite3_free(zName);
         return rc;
       }

--- a/src/doltlite_merge_constraints.c
+++ b/src/doltlite_merge_constraints.c
@@ -572,5 +572,138 @@ int fetchRowByPkFromTable(
                             ppKey, pnKey, ppVal, pnVal);
 }
 
+int scanMergeColumnFlagViolations(
+  sqlite3 *db,
+  const char *zTable,
+  struct TableEntry *aAnc, int nAnc,
+  char **azCols, char **azExtra, int nCols,
+  u8 cvType,
+  int *pnFound
+){
+  int hasRowid;
+  int nKeyCol;
+  MergePkInfo pkInfo;
+  sqlite3_str *pStr;
+  char *zQuery = 0;
+  sqlite3_stmt *pQ = 0;
+  int i;
+  int rc;
+  int queryStepRc;
+
+  memset(&pkInfo, 0, sizeof(pkInfo));
+  rc = tableHasRowid(db, zTable, &hasRowid);
+  if( rc!=SQLITE_OK ) return rc;
+  if( !hasRowid ){
+    rc = loadMergePkInfo(db, zTable, &pkInfo);
+    if( rc!=SQLITE_OK ) return rc;
+  }
+  nKeyCol = hasRowid ? 1 : pkInfo.nPk;
+
+  pStr = sqlite3_str_new(db);
+  sqlite3_str_appendf(pStr, "SELECT %s",
+                      hasRowid ? "rowid" : pkInfo.zPkCols);
+  for(i=0; i<nCols; i++){
+    if( azExtra ){
+      sqlite3_str_appendf(pStr, ", typeof(\"%w\") NOT IN ('null','%s')",
+                          azCols[i], azExtra[i]);
+    }else{
+      sqlite3_str_appendf(pStr, ", typeof(\"%w\")='null'", azCols[i]);
+    }
+  }
+  sqlite3_str_appendf(pStr, " FROM main.\"%w\" NOT INDEXED WHERE 0", zTable);
+  for(i=0; i<nCols; i++){
+    if( azExtra ){
+      sqlite3_str_appendf(pStr, " OR typeof(\"%w\") NOT IN ('null','%s')",
+                          azCols[i], azExtra[i]);
+    }else{
+      sqlite3_str_appendf(pStr, " OR typeof(\"%w\")='null'", azCols[i]);
+    }
+  }
+  zQuery = sqlite3_str_finish(pStr);
+  if( !zQuery ){
+    freeMergePkInfo(&pkInfo);
+    return SQLITE_NOMEM;
+  }
+  rc = sqlite3_prepare_v2(db, zQuery, -1, &pQ, 0);
+  sqlite3_free(zQuery);
+  if( rc!=SQLITE_OK ){
+    freeMergePkInfo(&pkInfo);
+    return rc;
+  }
+
+  while( (queryStepRc = sqlite3_step(pQ))==SQLITE_ROW ){
+    u8 *pKey = 0; int nKey = 0;
+    u8 *pVal = 0; int nVal = 0;
+    i64 intKey = 0;
+    sqlite3_str *pInfo;
+    char *zInfo;
+    int nNamed = 0;
+    int appendRc;
+
+    if( hasRowid ){
+      intKey = sqlite3_column_int64(pQ, 0);
+      rc = fetchOrphanRow(db, zTable, intKey, &pKey, &nKey, &pVal, &nVal);
+    }else{
+      u8 *pPkRec = 0; int nPkRec = 0;
+      pPkRec = buildRecordFromStmtCols(pQ, 0, pkInfo.nPk, &nPkRec);
+      if( !pPkRec ){ rc = SQLITE_NOMEM; break; }
+      rc = fetchRowByPkFromTable(db, zTable, pPkRec, nPkRec, pkInfo.nPk,
+                                 &pKey, &nKey, &pVal, &nVal);
+      sqlite3_free(pPkRec);
+    }
+    if( rc==SQLITE_NOTFOUND ){ rc = SQLITE_OK; continue; }
+    if( rc!=SQLITE_OK ){
+      sqlite3_free(pKey);
+      sqlite3_free(pVal);
+      break;
+    }
+
+    if( aAnc ){
+      u8 *pAncVal = 0; int nAncVal = 0;
+      int ancRc = hasRowid
+          ? fetchAncestorRowByName(db, aAnc, nAnc, zTable,
+                                   intKey, &pAncVal, &nAncVal)
+          : fetchAncestorRowByKey(db, aAnc, nAnc, zTable,
+                                  pKey, nKey, &pAncVal, &nAncVal);
+      int preExisting = (ancRc==SQLITE_OK)
+          && isRowPreExisting(pVal, nVal, pAncVal, nAncVal);
+      sqlite3_free(pAncVal);
+      if( preExisting ){
+        sqlite3_free(pKey);
+        sqlite3_free(pVal);
+        continue;
+      }
+    }
+
+    pInfo = sqlite3_str_new(db);
+    sqlite3_str_appendall(pInfo, "{\"Columns\": [");
+    for(i=0; i<nCols; i++){
+      if( sqlite3_column_int(pQ, nKeyCol + i) ){
+        sqlite3_str_appendf(pInfo, "%s\"%w\"", nNamed ? ", " : "", azCols[i]);
+        nNamed++;
+      }
+    }
+    sqlite3_str_appendall(pInfo, "]}");
+    zInfo = sqlite3_str_finish(pInfo);
+    if( !zInfo ){
+      sqlite3_free(pKey);
+      sqlite3_free(pVal);
+      rc = SQLITE_NOMEM;
+      break;
+    }
+    appendRc = doltliteAppendConstraintViolation(
+        db, zTable, cvType, intKey, pKey, nKey, pVal, nVal, zInfo);
+    sqlite3_free(zInfo);
+    sqlite3_free(pKey);
+    sqlite3_free(pVal);
+    if( appendRc!=SQLITE_OK ){ rc = appendRc; break; }
+    if( pnFound ) (*pnFound)++;
+  }
+  if( rc==SQLITE_OK && queryStepRc!=SQLITE_DONE ) rc = queryStepRc;
+  rc = finishConstraintStmt(pQ, rc);
+  freeMergePkInfo(&pkInfo);
+  return rc;
+}
+
 
 #endif

--- a/src/doltlite_merge_constraints_int.h
+++ b/src/doltlite_merge_constraints_int.h
@@ -60,5 +60,11 @@ int fetchRowByPkFromTable(
   const u8 *pPkRec, int nPkRec, int nPkField,
   u8 **ppKey, int *pnKey, u8 **ppVal, int *pnVal
 );
+int scanMergeColumnFlagViolations(
+  sqlite3 *db, const char *zTable,
+  struct TableEntry *aAnc, int nAnc,
+  char **azCols, char **azExtra, int nCols,
+  u8 cvType, int *pnFound
+);
 
 #endif /* DOLTLITE_MERGE_CONSTRAINTS_INT_H */

--- a/src/doltlite_merge_constraints_notnull.c
+++ b/src/doltlite_merge_constraints_notnull.c
@@ -91,14 +91,6 @@ int doltliteDetectMergeNotNullViolations(
     char *zTable;
     char **azCols = 0;
     int nCols = 0;
-    int hasRowid;
-    int nKeyCol;
-    MergePkInfo pkInfo;
-    sqlite3_str *pStr;
-    char *zQuery = 0;
-    sqlite3_stmt *pQ = 0;
-    int i;
-    int queryStepRc;
 
     if( !zTableRaw ) continue;
     zTable = sqlite3_mprintf("%s", zTableRaw);
@@ -119,125 +111,10 @@ int doltliteDetectMergeNotNullViolations(
       continue;
     }
 
-    memset(&pkInfo, 0, sizeof(pkInfo));
-    rc = tableHasRowid(db, zTable, &hasRowid);
-    if( rc!=SQLITE_OK ){
-      doltliteFreeNameList(azCols, nCols);
-      sqlite3_free(zTable);
-      break;
-    }
-    if( !hasRowid ){
-      rc = loadMergePkInfo(db, zTable, &pkInfo);
-      if( rc!=SQLITE_OK ){
-        doltliteFreeNameList(azCols, nCols);
-        sqlite3_free(zTable);
-        break;
-      }
-    }
-    nKeyCol = hasRowid ? 1 : pkInfo.nPk;
-
-    /* One row per offender, with a flag per NOT NULL column, as Dolt. */
-    pStr = sqlite3_str_new(db);
-    sqlite3_str_appendf(pStr, "SELECT %s",
-                        hasRowid ? "rowid" : pkInfo.zPkCols);
-    for(i=0; i<nCols; i++){
-      sqlite3_str_appendf(pStr, ", typeof(\"%w\")='null'", azCols[i]);
-    }
-    sqlite3_str_appendf(pStr, " FROM main.\"%w\" NOT INDEXED WHERE 0", zTable);
-    for(i=0; i<nCols; i++){
-      sqlite3_str_appendf(pStr, " OR typeof(\"%w\")='null'", azCols[i]);
-    }
-    zQuery = sqlite3_str_finish(pStr);
-    if( !zQuery ){
-      doltliteFreeNameList(azCols, nCols);
-      freeMergePkInfo(&pkInfo);
-      sqlite3_free(zTable);
-      rc = SQLITE_NOMEM;
-      break;
-    }
-    rc = sqlite3_prepare_v2(db, zQuery, -1, &pQ, 0);
-    sqlite3_free(zQuery);
-    if( rc!=SQLITE_OK ){
-      doltliteFreeNameList(azCols, nCols);
-      freeMergePkInfo(&pkInfo);
-      sqlite3_free(zTable);
-      break;
-    }
-
-    while( (queryStepRc = sqlite3_step(pQ))==SQLITE_ROW ){
-      u8 *pKey = 0; int nKey = 0;
-      u8 *pVal = 0; int nVal = 0;
-      i64 intKey = 0;
-      sqlite3_str *pInfo;
-      char *zInfo;
-      int nNamed = 0;
-      int appendRc;
-
-      if( hasRowid ){
-        intKey = sqlite3_column_int64(pQ, 0);
-        rc = fetchOrphanRow(db, zTable, intKey, &pKey, &nKey, &pVal, &nVal);
-      }else{
-        u8 *pPkRec = 0; int nPkRec = 0;
-        pPkRec = buildRecordFromStmtCols(pQ, 0, pkInfo.nPk, &nPkRec);
-        if( !pPkRec ){ rc = SQLITE_NOMEM; break; }
-        rc = fetchRowByPkFromTable(db, zTable, pPkRec, nPkRec, pkInfo.nPk,
-                                   &pKey, &nKey, &pVal, &nVal);
-        sqlite3_free(pPkRec);
-      }
-      if( rc==SQLITE_NOTFOUND ){ rc = SQLITE_OK; continue; }
-      if( rc!=SQLITE_OK ){
-        sqlite3_free(pKey);
-        sqlite3_free(pVal);
-        break;
-      }
-
-      /* Pre-merge NULL is not this merge's violation. */
-      if( aAnc ){
-        u8 *pAncVal = 0; int nAncVal = 0;
-        int ancRc = hasRowid
-            ? fetchAncestorRowByName(db, aAnc, nAnc, zTable,
-                                     intKey, &pAncVal, &nAncVal)
-            : fetchAncestorRowByKey(db, aAnc, nAnc, zTable,
-                                    pKey, nKey, &pAncVal, &nAncVal);
-        int preExisting = (ancRc==SQLITE_OK)
-            && isRowPreExisting(pVal, nVal, pAncVal, nAncVal);
-        sqlite3_free(pAncVal);
-        if( preExisting ){
-          sqlite3_free(pKey);
-          sqlite3_free(pVal);
-          continue;
-        }
-      }
-
-      pInfo = sqlite3_str_new(db);
-      sqlite3_str_appendall(pInfo, "{\"Columns\": [");
-      for(i=0; i<nCols; i++){
-        if( sqlite3_column_int(pQ, nKeyCol + i) ){
-          sqlite3_str_appendf(pInfo, "%s\"%w\"", nNamed ? ", " : "", azCols[i]);
-          nNamed++;
-        }
-      }
-      sqlite3_str_appendall(pInfo, "]}");
-      zInfo = sqlite3_str_finish(pInfo);
-      if( !zInfo ){
-        sqlite3_free(pKey);
-        sqlite3_free(pVal);
-        rc = SQLITE_NOMEM;
-        break;
-      }
-      appendRc = doltliteAppendConstraintViolation(
-          db, zTable, DOLTLITE_CV_NOT_NULL,
-          intKey, pKey, nKey, pVal, nVal, zInfo);
-      sqlite3_free(zInfo);
-      sqlite3_free(pKey);
-      sqlite3_free(pVal);
-      if( appendRc!=SQLITE_OK ){ rc = appendRc; break; }
-      if( pnFound ) (*pnFound)++;
-    }
-    if( rc==SQLITE_OK && queryStepRc!=SQLITE_DONE ) rc = queryStepRc;
-    rc = finishConstraintStmt(pQ, rc);
+    rc = scanMergeColumnFlagViolations(
+        db, zTable, aAnc, nAnc, azCols, 0, nCols,
+        DOLTLITE_CV_NOT_NULL, pnFound);
     doltliteFreeNameList(azCols, nCols);
-    freeMergePkInfo(&pkInfo);
     sqlite3_free(zTable);
     if( rc!=SQLITE_OK ) break;
   }

--- a/src/doltlite_merge_constraints_strict.c
+++ b/src/doltlite_merge_constraints_strict.c
@@ -145,15 +145,7 @@ int doltliteDetectMergeStrictViolations(
     char **azCols = 0;
     char **azAllowed = 0;
     int nCols = 0;
-    int hasRowid;
-    int nKeyCol;
-    MergePkInfo pkInfo;
-    sqlite3_str *pStr;
-    char *zQuery = 0;
-    sqlite3_stmt *pQ = 0;
-    int i;
     int isStrict;
-    int queryStepRc;
 
     if( !zTableRaw ) continue;
     zTable = sqlite3_mprintf("%s", zTableRaw);
@@ -183,133 +175,11 @@ int doltliteDetectMergeStrictViolations(
       continue;
     }
 
-    memset(&pkInfo, 0, sizeof(pkInfo));
-    rc = tableHasRowid(db, zTable, &hasRowid);
-    if( rc!=SQLITE_OK ){
-      doltliteFreeNameList(azCols, nCols);
-      doltliteFreeNameList(azAllowed, nCols);
-      sqlite3_free(zTable);
-      break;
-    }
-    if( !hasRowid ){
-      rc = loadMergePkInfo(db, zTable, &pkInfo);
-      if( rc!=SQLITE_OK ){
-        doltliteFreeNameList(azCols, nCols);
-        doltliteFreeNameList(azAllowed, nCols);
-        sqlite3_free(zTable);
-        break;
-      }
-    }
-    nKeyCol = hasRowid ? 1 : pkInfo.nPk;
-
-    /* One row per offender, with a flag per typed column. */
-    pStr = sqlite3_str_new(db);
-    sqlite3_str_appendf(pStr, "SELECT %s",
-                        hasRowid ? "rowid" : pkInfo.zPkCols);
-    for(i=0; i<nCols; i++){
-      sqlite3_str_appendf(pStr, ", typeof(\"%w\") NOT IN ('null','%s')",
-                          azCols[i], azAllowed[i]);
-    }
-    sqlite3_str_appendf(pStr, " FROM main.\"%w\" NOT INDEXED WHERE 0", zTable);
-    for(i=0; i<nCols; i++){
-      sqlite3_str_appendf(pStr, " OR typeof(\"%w\") NOT IN ('null','%s')",
-                          azCols[i], azAllowed[i]);
-    }
-    zQuery = sqlite3_str_finish(pStr);
-    if( !zQuery ){
-      doltliteFreeNameList(azCols, nCols);
-      doltliteFreeNameList(azAllowed, nCols);
-      freeMergePkInfo(&pkInfo);
-      sqlite3_free(zTable);
-      rc = SQLITE_NOMEM;
-      break;
-    }
-    rc = sqlite3_prepare_v2(db, zQuery, -1, &pQ, 0);
-    sqlite3_free(zQuery);
-    if( rc!=SQLITE_OK ){
-      doltliteFreeNameList(azCols, nCols);
-      doltliteFreeNameList(azAllowed, nCols);
-      freeMergePkInfo(&pkInfo);
-      sqlite3_free(zTable);
-      break;
-    }
-
-    while( (queryStepRc = sqlite3_step(pQ))==SQLITE_ROW ){
-      u8 *pKey = 0; int nKey = 0;
-      u8 *pVal = 0; int nVal = 0;
-      i64 intKey = 0;
-      sqlite3_str *pInfo;
-      char *zInfo;
-      int nNamed = 0;
-      int appendRc;
-
-      if( hasRowid ){
-        intKey = sqlite3_column_int64(pQ, 0);
-        rc = fetchOrphanRow(db, zTable, intKey, &pKey, &nKey, &pVal, &nVal);
-      }else{
-        u8 *pPkRec = 0; int nPkRec = 0;
-        pPkRec = buildRecordFromStmtCols(pQ, 0, pkInfo.nPk, &nPkRec);
-        if( !pPkRec ){ rc = SQLITE_NOMEM; break; }
-        rc = fetchRowByPkFromTable(db, zTable, pPkRec, nPkRec, pkInfo.nPk,
-                                   &pKey, &nKey, &pVal, &nVal);
-        sqlite3_free(pPkRec);
-      }
-      if( rc==SQLITE_NOTFOUND ){ rc = SQLITE_OK; continue; }
-      if( rc!=SQLITE_OK ){
-        sqlite3_free(pKey);
-        sqlite3_free(pVal);
-        break;
-      }
-
-      /* Pre-merge forbidden type is not this merge's violation. */
-      if( aAnc ){
-        u8 *pAncVal = 0; int nAncVal = 0;
-        int ancRc = hasRowid
-            ? fetchAncestorRowByName(db, aAnc, nAnc, zTable,
-                                     intKey, &pAncVal, &nAncVal)
-            : fetchAncestorRowByKey(db, aAnc, nAnc, zTable,
-                                    pKey, nKey, &pAncVal, &nAncVal);
-        int preExisting = (ancRc==SQLITE_OK)
-            && isRowPreExisting(pVal, nVal, pAncVal, nAncVal);
-        sqlite3_free(pAncVal);
-        if( preExisting ){
-          sqlite3_free(pKey);
-          sqlite3_free(pVal);
-          continue;
-        }
-      }
-
-      pInfo = sqlite3_str_new(db);
-      sqlite3_str_appendall(pInfo, "{\"Columns\": [");
-      for(i=0; i<nCols; i++){
-        if( sqlite3_column_int(pQ, nKeyCol + i) ){
-          sqlite3_str_appendf(pInfo, "%s\"%w\"", nNamed ? ", " : "", azCols[i]);
-          nNamed++;
-        }
-      }
-      sqlite3_str_appendall(pInfo, "]}");
-      zInfo = sqlite3_str_finish(pInfo);
-      if( !zInfo ){
-        sqlite3_free(pKey);
-        sqlite3_free(pVal);
-        rc = SQLITE_NOMEM;
-        break;
-      }
-      appendRc = doltliteAppendConstraintViolation(
-          db, zTable, DOLTLITE_CV_STRICT_TYPE,
-          intKey, pKey, nKey, pVal, nVal, zInfo);
-      sqlite3_free(zInfo);
-      sqlite3_free(pKey);
-      sqlite3_free(pVal);
-      if( appendRc!=SQLITE_OK ){ rc = appendRc; break; }
-      if( pnFound ) (*pnFound)++;
-    }
-
-    if( rc==SQLITE_OK && queryStepRc!=SQLITE_DONE ) rc = queryStepRc;
-    rc = finishConstraintStmt(pQ, rc);
+    rc = scanMergeColumnFlagViolations(
+        db, zTable, aAnc, nAnc, azCols, azAllowed, nCols,
+        DOLTLITE_CV_STRICT_TYPE, pnFound);
     doltliteFreeNameList(azCols, nCols);
     doltliteFreeNameList(azAllowed, nCols);
-    freeMergePkInfo(&pkInfo);
     sqlite3_free(zTable);
     if( rc!=SQLITE_OK ) break;
   }

--- a/src/doltlite_tests.c
+++ b/src/doltlite_tests.c
@@ -100,17 +100,7 @@ static int testsRowid(sqlite3_vtab_cursor *pCursor, sqlite3_int64 *pRowid){
 }
 
 static int testsMaterialize(TestsVtab *p){
-  char *zErr = 0;
-  int rc;
-  if( sqlite3FindTable(p->db, "dolt_tests", "main") ) return SQLITE_OK;
-  rc = sqlite3_exec(p->db, zTestsCreate, 0, 0, &zErr);
-  if( rc!=SQLITE_OK ){
-    sqlite3_free(p->base.zErrMsg);
-    p->base.zErrMsg = sqlite3_mprintf("%s",
-        zErr ? zErr : sqlite3_errstr(rc));
-    sqlite3_free(zErr);
-  }
-  return rc;
+  return doltliteLazyCreateTable(&p->base, p->db, "dolt_tests", zTestsCreate);
 }
 
 static int testsBegin(sqlite3_vtab *pBase){

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -2697,6 +2697,92 @@ static void run_conflicts_blob_corruption(void){
   removeDbFiles(dbpath);
 }
 
+static int build_named_conflict_blob(u8 *buf, int nBuf){
+  static const u8 payload[] = "conflict-blob-payload";
+  DlByteWriter w;
+  int i;
+
+  dlWriterInit(&w, buf, nBuf);
+  dlWriteFramedHeader(&w, 'D', 'L', 'C', 1, 1);
+  dlWriteU16Name(&w, "t", 1);
+  dlWriteU32(&w, 2);
+  for(i=0; i<2; i++){
+    dlWriteU32Blob(&w, payload, (int)sizeof(payload));
+    dlWriteI64(&w, i+1);
+    dlWriteU32Blob(&w, payload, (int)sizeof(payload));
+    dlWriteU32Blob(&w, payload, (int)sizeof(payload));
+    dlWriteU32Blob(&w, payload, (int)sizeof(payload));
+  }
+  if( w.err ) return -1;
+  return (int)(w.p - buf);
+}
+
+static int build_named_violation_blob(u8 *buf, int nBuf){
+  static const u8 payload[] = "violation-blob-payload";
+  DlByteWriter w;
+  int i;
+
+  dlWriterInit(&w, buf, nBuf);
+  dlWriteFramedHeader(&w, 'D', 'C', 'V', 1, 1);
+  dlWriteU16Name(&w, "t", 1);
+  dlWriteU32(&w, 2);
+  for(i=0; i<2; i++){
+    dlWriteU8(&w, 2);
+    dlWriteU32Blob(&w, payload, (int)sizeof(payload));
+    dlWriteI64(&w, i+1);
+    dlWriteU32Blob(&w, payload, (int)sizeof(payload));
+    dlWriteU32Blob(&w, payload, (int)sizeof(payload));
+  }
+  if( w.err ) return -1;
+  return (int)(w.p - buf);
+}
+
+static void check_truncated_deserialize_does_not_leak(
+  const char *zKind,
+  int (*xDeserialize)(const u8*, int),
+  const u8 *blob,
+  int nFull
+){
+  sqlite3_int64 beforeBytes;
+  char zName[96];
+  int n, rc, nBad = 0;
+
+  sqlite3_snprintf(sizeof(zName), zName, "%s_full_blob_ok", zKind);
+  check(zName, nFull>0 && xDeserialize(blob, nFull)==SQLITE_OK);
+
+  (void)xDeserialize((const u8*)"", 0);
+  beforeBytes = sqlite3_memory_used();
+  for(n=0; n<nFull; n++){
+    rc = xDeserialize(blob, n);
+    if( rc!=SQLITE_CORRUPT ){
+      fprintf(stderr, "FAIL: %s prefix %d rc=%d\n", zKind, n, rc);
+      nBad++;
+    }
+  }
+  sqlite3_snprintf(sizeof(zName), zName, "%s_truncated_prefixes_corrupt", zKind);
+  check(zName, nBad==0);
+  sqlite3_snprintf(sizeof(zName), zName, "%s_truncated_prefixes_do_not_leak", zKind);
+  check(zName, sqlite3_memory_used()==beforeBytes);
+}
+
+static void run_conflicts_cv_truncated_deserialize_leak(void){
+  u8 conflictBlob[512];
+  u8 violationBlob[512];
+  int nConflict;
+  int nViolation;
+
+  printf("=== Conflicts/CV Truncated Deserialize Leak Test ===\n\n");
+  nConflict = build_named_conflict_blob(conflictBlob, (int)sizeof(conflictBlob));
+  nViolation = build_named_violation_blob(violationBlob, (int)sizeof(violationBlob));
+  check("conflict_blob_built", nConflict>0);
+  check("violation_blob_built", nViolation>0);
+  check_truncated_deserialize_does_not_leak(
+    "conflicts", doltliteDeserializeConflictsForTest, conflictBlob, nConflict);
+  check_truncated_deserialize_does_not_leak(
+    "constraint_violations", doltliteDeserializeConstraintViolationsForTest,
+    violationBlob, nViolation);
+}
+
 static void run_status_error_propagation(void){
   sqlite3 *db = 0;
   char dbpath[256];
@@ -14167,6 +14253,7 @@ static const RegressionCase aCases[] = {
   { "refs_blob_corruption", "Refs Blob Corruption Test", run_refs_blob_corruption },
   { "refresh_error_propagation", "Refresh Error Propagation Test", run_refresh_error_propagation },
   { "conflicts_blob_corruption", "Conflicts Blob Corruption Test", run_conflicts_blob_corruption },
+  { "conflicts_cv_truncated_deserialize_leak", "Conflicts/CV Truncated Deserialize Leak Test", run_conflicts_cv_truncated_deserialize_leak },
   { "status_error_propagation", "Status Error Propagation Test", run_status_error_propagation },
   { "status_many_table_renames", "Status Many Table Renames Test", run_status_many_table_renames },
   { "refs_commit_merges_concurrent_peer_refs", "Refs Commit Merges Concurrent Peer Refs Test", run_refs_commit_merges_concurrent_peer_refs },


### PR DESCRIPTION
## Summary

Follow-up to #2678. The remaining leftovers were near-copies (same control flow, different names/strings), not byte-identical clones.

- **hashof:** `dolt_hashof_table` / `dolt_hashof_index` share `hashofNamedObjectFunc`. Error text is still `dolt_hashof_table: table not found` / `dolt_hashof_index: index not found`.
- **Lazy vtabs:** `dolt_docs`, `dolt_ignore`, and `dolt_tests` materialize through `doltliteLazyCreateTable`. Docs/ignore two-column write uses `doltliteVtabOnConflictOr` + `doltliteLazyTwoColUpdate`. Docs still seeds `AGENT.md` only on first create.
- **Merge detectors:** NOT NULL and STRICT share `scanMergeColumnFlagViolations` (query, fetch, ancestor skip, `{"Columns":[...]}` JSON).
- **Framed blobs:** conflicts and constraint-violations deserialize/load a named table through `dlReadNamedRowTable` / `dlMatchOrSkipNamedTable`. Row layouts and magics (`DLC` vs `DCV`) are unchanged. Conflict serialize still uses `sqlite3FaultSim(950)`.

## Test plan

- [x] `bash test/dead_code_check.sh`
- [x] `bash test/dead_code_check_selftest.sh` (12/12)
- [x] `bash test/lint_layers.sh`
- [x] `make doltlite`
- [x] cherry-pick 140, docs 35, ignore 25, hashof_refs 23, conflicts 54, conflict_rows 29, merge_status 31
- [x] hashof_table / hashof_index missing-name error strings

Co-Authored-By: Grok 4.6 <noreply@x.ai>