### PR TITLE
Share leftover empty-vtab and merge-index scan copies

### DIFF
--- a/src/doltlite_docs.c
+++ b/src/doltlite_docs.c
@@ -210,12 +210,6 @@ static int docsColumn(sqlite3_vtab_cursor *pCursor,
   return SQLITE_OK;
 }
 
-static int docsRowid(sqlite3_vtab_cursor *pCursor, sqlite3_int64 *pRowid){
-  (void)pCursor;
-  *pRowid = 0;
-  return SQLITE_OK;
-}
-
 static int docsClose(sqlite3_vtab_cursor *pCursor){
   DocsCursor *c = (DocsCursor*)pCursor;
   sqlite3_finalize(c->pStmt);
@@ -281,7 +275,7 @@ static int docsUpdate(sqlite3_vtab *pBase, int argc, sqlite3_value **argv,
 static sqlite3_module doltliteDocsModule = {
   0, 0, docsConnect, docsBestIndex, doltliteVtabDisconnect, 0,
   docsOpen, docsClose, docsFilter, docsNext, docsEof,
-  docsColumn, docsRowid,
+  docsColumn, doltliteVtabZeroRowid,
   docsUpdate, docsBegin, 0, 0, 0, 0, 0, 0, 0, 0, 0
 };
 

--- a/src/doltlite_ignore.c
+++ b/src/doltlite_ignore.c
@@ -335,44 +335,9 @@ static int ignoreConnect(sqlite3 *db, void *pAux, int argc,
   return SQLITE_OK;
 }
 
-static int ignoreBestIndex(sqlite3_vtab *pVtab, sqlite3_index_info *pInfo){
-  (void)pVtab;
-  pInfo->estimatedCost = 10.0;
-  pInfo->estimatedRows = 0;
-  return SQLITE_OK;
-}
-
 static int ignoreOpen(sqlite3_vtab *pVtab, sqlite3_vtab_cursor **ppCursor){
   (void)pVtab;
   return doltliteVtabOpenCursor(ppCursor, sizeof(IgnoreCursor));
-}
-
-static int ignoreFilter(sqlite3_vtab_cursor *pCursor,
-    int idxNum, const char *idxStr, int argc, sqlite3_value **argv){
-  (void)pCursor; (void)idxNum; (void)idxStr; (void)argc; (void)argv;
-  return SQLITE_OK;
-}
-
-static int ignoreNext(sqlite3_vtab_cursor *pCursor){
-  (void)pCursor;
-  return SQLITE_OK;
-}
-
-static int ignoreEof(sqlite3_vtab_cursor *pCursor){
-  (void)pCursor;
-  return 1;
-}
-
-static int ignoreColumn(sqlite3_vtab_cursor *pCursor,
-    sqlite3_context *ctx, int iCol){
-  (void)pCursor; (void)ctx; (void)iCol;
-  return SQLITE_OK;
-}
-
-static int ignoreRowid(sqlite3_vtab_cursor *pCursor, sqlite3_int64 *pRowid){
-  (void)pCursor;
-  *pRowid = 0;
-  return SQLITE_OK;
 }
 
 static int ignoreMaterialize(IgnoreVtab *p){
@@ -413,9 +378,9 @@ static int ignoreUpdate(sqlite3_vtab *pBase, int argc, sqlite3_value **argv,
 }
 
 static sqlite3_module doltliteIgnoreModule = {
-  0, 0, ignoreConnect, ignoreBestIndex, doltliteVtabDisconnect, 0,
-  ignoreOpen, doltliteVtabClose, ignoreFilter, ignoreNext, ignoreEof,
-  ignoreColumn, ignoreRowid,
+  0, 0, ignoreConnect, doltliteVtabBestIndexEmpty, doltliteVtabDisconnect, 0,
+  ignoreOpen, doltliteVtabClose, doltliteVtabEmptyFilter, doltliteVtabEmptyNext,
+  doltliteVtabEofAlways, doltliteVtabEmptyColumn, doltliteVtabZeroRowid,
   ignoreUpdate, ignoreBegin, 0, 0, 0, 0, 0, 0, 0, 0, 0
 };
 

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -555,6 +555,55 @@ static SQLITE_INLINE int doltliteVtabClose(sqlite3_vtab_cursor *pCur){
   return SQLITE_OK;
 }
 
+static SQLITE_INLINE int doltliteVtabBestIndexEmpty(
+  sqlite3_vtab *pVtab,
+  sqlite3_index_info *pInfo
+){
+  (void)pVtab;
+  pInfo->estimatedCost = 10.0;
+  pInfo->estimatedRows = 0;
+  return SQLITE_OK;
+}
+
+static SQLITE_INLINE int doltliteVtabEmptyFilter(
+  sqlite3_vtab_cursor *pCursor,
+  int idxNum,
+  const char *idxStr,
+  int argc,
+  sqlite3_value **argv
+){
+  (void)pCursor; (void)idxNum; (void)idxStr; (void)argc; (void)argv;
+  return SQLITE_OK;
+}
+
+static SQLITE_INLINE int doltliteVtabEmptyNext(sqlite3_vtab_cursor *pCursor){
+  (void)pCursor;
+  return SQLITE_OK;
+}
+
+static SQLITE_INLINE int doltliteVtabEofAlways(sqlite3_vtab_cursor *pCursor){
+  (void)pCursor;
+  return 1;
+}
+
+static SQLITE_INLINE int doltliteVtabEmptyColumn(
+  sqlite3_vtab_cursor *pCursor,
+  sqlite3_context *ctx,
+  int iCol
+){
+  (void)pCursor; (void)ctx; (void)iCol;
+  return SQLITE_OK;
+}
+
+static SQLITE_INLINE int doltliteVtabZeroRowid(
+  sqlite3_vtab_cursor *pCursor,
+  sqlite3_int64 *pRowid
+){
+  (void)pCursor;
+  *pRowid = 0;
+  return SQLITE_OK;
+}
+
 static SQLITE_INLINE int doltliteVtabOpenCursor(
   sqlite3_vtab_cursor **ppCursor,
   int nByte

--- a/src/doltlite_merge_pass2.c
+++ b/src/doltlite_merge_pass2.c
@@ -266,32 +266,8 @@ int mergeIndexColumnGoneFrom(
   const char *zSideTableSql,
   char **pzColumn
 ){
-  MergeIndexColCtx ctx;
-  int rc;
-
-  if( pzColumn ) *pzColumn = 0;
-  if( !zIndexSql || !zAncTableSql || !zSideTableSql ) return 0;
-
-  memset(&ctx, 0, sizeof(ctx));
-  if( parseColumns(zAncTableSql, &ctx.aAnc, &ctx.nAnc)!=SQLITE_OK ) return 0;
-  if( parseColumns(zSideTableSql, &ctx.aSide, &ctx.nSide)!=SQLITE_OK ){
-    freeColumns(ctx.aAnc, ctx.nAnc);
-    return 0;
-  }
-
-  rc = mergeIndexEachColumn(zIndexSql, mergeIndexColSurvives, &ctx);
-  freeColumns(ctx.aAnc, ctx.nAnc);
-  freeColumns(ctx.aSide, ctx.nSide);
-  if( rc!=SQLITE_OK || !ctx.zMissing ){
-    sqlite3_free(ctx.zMissing);
-    return 0;
-  }
-  if( pzColumn ){
-    *pzColumn = ctx.zMissing;
-  }else{
-    sqlite3_free(ctx.zMissing);
-  }
-  return 1;
+  return mergeIndexColumnScan(zIndexSql, zAncTableSql, zSideTableSql,
+                              mergeIndexColSurvives, pzColumn);
 }
 
 

--- a/src/doltlite_rebase.c
+++ b/src/doltlite_rebase.c
@@ -1334,18 +1334,6 @@ static int rebaseDropPlan(sqlite3 *db){
       sqlite3_exec(db, "DROP TABLE IF EXISTS main.dolt_rebase", 0, 0, 0);
 }
 
-static int rebaseClaimActiveEndRetry(
-  sqlite3 *db,
-  const char *zWorkingBranch
-){
-  int rc;
-  db->busyHandler.nBusy = 0;
-  do {
-    rc = rebaseClaimActiveEnd(db, zWorkingBranch);
-  }while( rebaseRetryableRc(rc) && rebaseEndBusyRetry(db) );
-  return rc;
-}
-
 static int rebaseRetryBranchOp(
   sqlite3 *db,
   int (*xOp)(sqlite3*, const char*),
@@ -1407,7 +1395,7 @@ static int rebaseDiscardWorkingBranch(
 ){
   int rc;
 
-  rc = rebaseClaimActiveEndRetry(db, zWorkingBranch);
+  rc = rebaseRetryBranchOp(db, rebaseClaimActiveEnd, zWorkingBranch);
   if( rc!=SQLITE_OK && rc!=SQLITE_DONE ) return rc;
   rc = rebaseRetryDbOp(db, rebaseDropPlan);
   if( rc!=SQLITE_OK ) return rc;
@@ -1717,7 +1705,7 @@ static void doltliteRebaseInteractiveAbort(
   }
 
   /* Names before claim clears session rebase state. */
-  rc = rebaseClaimActiveEndRetry(db, zWorking);
+  rc = rebaseRetryBranchOp(db, rebaseClaimActiveEnd, zWorking);
   if( rc==SQLITE_DONE ){
     sqlite3_free(zReturnBranch);
     sqlite3_free(zWorking);
@@ -1870,7 +1858,7 @@ static void doltliteRebaseInteractiveContinue(
 
   /* Claim before replay so a concurrent --abort loses with "no rebase
   ** in progress" rather than both failing mid-recovery. */
-  rc = rebaseClaimActiveEndRetry(db, zWorking);
+  rc = rebaseRetryBranchOp(db, rebaseClaimActiveEnd, zWorking);
   if( rc==SQLITE_DONE ){
     sqlite3_result_error(context, "no rebase in progress", -1);
     goto abort_err_silent;

--- a/src/doltlite_tests.c
+++ b/src/doltlite_tests.c
@@ -59,44 +59,9 @@ static int testsConnect(sqlite3 *db, void *pAux, int argc,
   return SQLITE_OK;
 }
 
-static int testsBestIndex(sqlite3_vtab *pVtab, sqlite3_index_info *pInfo){
-  (void)pVtab;
-  pInfo->estimatedCost = 10.0;
-  pInfo->estimatedRows = 0;
-  return SQLITE_OK;
-}
-
 static int testsOpen(sqlite3_vtab *pVtab, sqlite3_vtab_cursor **ppCursor){
   (void)pVtab;
   return doltliteVtabOpenCursor(ppCursor, sizeof(TestsCursor));
-}
-
-static int testsFilter(sqlite3_vtab_cursor *pCursor,
-    int idxNum, const char *idxStr, int argc, sqlite3_value **argv){
-  (void)pCursor; (void)idxNum; (void)idxStr; (void)argc; (void)argv;
-  return SQLITE_OK;
-}
-
-static int testsNext(sqlite3_vtab_cursor *pCursor){
-  (void)pCursor;
-  return SQLITE_OK;
-}
-
-static int testsEof(sqlite3_vtab_cursor *pCursor){
-  (void)pCursor;
-  return 1;
-}
-
-static int testsColumn(sqlite3_vtab_cursor *pCursor,
-    sqlite3_context *ctx, int iCol){
-  (void)pCursor; (void)ctx; (void)iCol;
-  return SQLITE_OK;
-}
-
-static int testsRowid(sqlite3_vtab_cursor *pCursor, sqlite3_int64 *pRowid){
-  (void)pCursor;
-  *pRowid = 0;
-  return SQLITE_OK;
 }
 
 static int testsMaterialize(TestsVtab *p){
@@ -139,9 +104,9 @@ static int testsUpdate(sqlite3_vtab *pBase, int argc, sqlite3_value **argv,
 }
 
 static sqlite3_module doltliteTestsModule = {
-  0, 0, testsConnect, testsBestIndex, doltliteVtabDisconnect, 0,
-  testsOpen, doltliteVtabClose, testsFilter, testsNext, testsEof,
-  testsColumn, testsRowid,
+  0, 0, testsConnect, doltliteVtabBestIndexEmpty, doltliteVtabDisconnect, 0,
+  testsOpen, doltliteVtabClose, doltliteVtabEmptyFilter, doltliteVtabEmptyNext,
+  doltliteVtabEofAlways, doltliteVtabEmptyColumn, doltliteVtabZeroRowid,
   testsUpdate, testsBegin, 0, 0, 0, 0, 0, 0, 0, 0, 0
 };
 


### PR DESCRIPTION
## Summary

Follow-up to #2681. Remaining small near-copies, not the larger conflict/CV rewrite or merge-constraint table walks.

- **Merge index scan:** `mergeIndexColumnGoneFrom` calls `mergeIndexColumnScan` with `mergeIndexColSurvives`, matching `mergeIndexColumnRenamedAway`.
- **Lazy vtabs:** `dolt_ignore` and `dolt_tests` use shared empty BestIndex/Filter/Next/Eof/Column/Rowid helpers. `dolt_docs` still scans (synthetic `AGENT.md`) and only shares the zero-rowid helper.
- **Rebase:** claim-end retries go through `rebaseRetryBranchOp` instead of a copy of its busy-retry loop.

On-disk layouts and user-facing error strings are unchanged.

## Test plan

- [x] `bash test/dead_code_check.sh` (Parts A–I)
- [x] `bash test/dead_code_check_selftest.sh` (12/12)
- [x] `bash test/lint_layers.sh`
- [x] `make doltlite`
- [x] `doltlite_ignore.sh` (25/25)
- [x] `doltlite_tests.sh` (31/31)
- [x] `doltlite_docs.sh` (35/35)
- [x] `doltlite_rebase.sh` (65/65)
- [x] `doltlite_merge_index_conflict.sh` (40/40)

Co-Authored-By: Grok 4.6 <noreply@x.ai>