### PR TITLE
Resolve VC table arguments case-insensitively

### DIFF
--- a/src/doltlite_add.c
+++ b/src/doltlite_add.c
@@ -92,7 +92,7 @@ static struct TableEntry *addFindEntryByName(
   int i;
   if( !zName ) return 0;
   for(i=0; i<nEntries; i++){
-    if( aEntries[i].zName && strcmp(aEntries[i].zName, zName)==0 ){
+    if( aEntries[i].zName && sqlite3_stricmp(aEntries[i].zName, zName)==0 ){
       return &aEntries[i];
     }
   }
@@ -292,14 +292,14 @@ int doltliteIndexSchemaRowsDifferForTable(
   for(i=0; i<nA; i++){
     int found = 0;
     if( !aA[i].zType || strcmp(aA[i].zType, "index")!=0
-     || !aA[i].zTblName || strcmp(aA[i].zTblName, zTable)!=0 ){
+     || !aA[i].zTblName || sqlite3_stricmp(aA[i].zTblName, zTable)!=0 ){
       continue;
     }
     for(j=0; j<nB; j++){
       if( aB[j].zType && strcmp(aB[j].zType, "index")==0
-       && aB[j].zTblName && strcmp(aB[j].zTblName, zTable)==0
+       && aB[j].zTblName && sqlite3_stricmp(aB[j].zTblName, zTable)==0
        && aB[j].zName && aA[i].zName
-       && strcmp(aB[j].zName, aA[i].zName)==0
+       && sqlite3_stricmp(aB[j].zName, aA[i].zName)==0
        && ((aB[j].zSql==0)==(aA[i].zSql==0))
        && (aB[j].zSql==0 || strcmp(aB[j].zSql, aA[i].zSql)==0) ){
         found = 1;
@@ -311,7 +311,7 @@ int doltliteIndexSchemaRowsDifferForTable(
   }
   for(j=0; j<nB; j++){
     if( aB[j].zType && strcmp(aB[j].zType, "index")==0
-     && aB[j].zTblName && strcmp(aB[j].zTblName, zTable)==0 ){
+     && aB[j].zTblName && sqlite3_stricmp(aB[j].zTblName, zTable)==0 ){
       nBForTable++;
     }
   }
@@ -325,7 +325,7 @@ int amTableStagedByName(struct TableEntry *aStaged, int nStaged,
   int i;
   if( !zTbl ) return 0;
   for(i=0; i<nStaged; i++){
-    if( aStaged[i].zName && strcmp(aStaged[i].zName, zTbl)==0 ) return 1;
+    if( aStaged[i].zName && sqlite3_stricmp(aStaged[i].zName, zTbl)==0 ) return 1;
   }
   return 0;
 }
@@ -470,7 +470,7 @@ void addRemoveIndexEntriesOfTable(
         break;
       }
     }
-    if( !zParent || strcmp(zParent, zTable)!=0 ){ j++; continue; }
+    if( !zParent || sqlite3_stricmp(zParent, zTable)!=0 ){ j++; continue; }
     sqlite3_free(aStaged[j].zName);
     if( j+1<*pnStaged ){
       memmove(&aStaged[j], &aStaged[j+1],
@@ -497,7 +497,7 @@ int addAppendIndexEntriesOfTable(
      || strcmp(aWorkSchema[i].zType, "index")!=0
      || aWorkSchema[i].iRootpage<=1
      || !aWorkSchema[i].zTblName
-     || strcmp(aWorkSchema[i].zTblName, zTable)!=0 ){
+     || sqlite3_stricmp(aWorkSchema[i].zTblName, zTable)!=0 ){
       continue;
     }
     for(j=0; j<nWorking; j++){
@@ -538,7 +538,7 @@ static int addStageShadowTablesOf(
     if( !aWorkSchema[i].zType
      || strcmp(aWorkSchema[i].zType, "table")!=0
      || !aWorkSchema[i].zName
-     || strcmp(aWorkSchema[i].zName, zTable)==0
+     || sqlite3_stricmp(aWorkSchema[i].zName, zTable)==0
      || !sqlite3IsShadowTableOf(db, pTab, aWorkSchema[i].zName) ){
       continue;
     }
@@ -546,7 +546,7 @@ static int addStageShadowTablesOf(
     if( !pWork ) continue;
     for(k=0; k<*pnStaged; k++){
       if( (*paStaged)[k].zName
-       && strcmp((*paStaged)[k].zName, pWork->zName)==0 ){
+       && sqlite3_stricmp((*paStaged)[k].zName, pWork->zName)==0 ){
         char *zDup = sqlite3_mprintf("%s", pWork->zName);
         if( !zDup ) return SQLITE_NOMEM;
         sqlite3_free((*paStaged)[k].zName);
@@ -604,7 +604,7 @@ static void addRemoveShadowEntriesOfDroppedVtab(
     }
     for(k=0; k<*pnStaged; ){
       if( aStaged[k].zName
-       && strcmp(aStaged[k].zName, aStagedSchema[i].zName)==0 ){
+       && sqlite3_stricmp(aStaged[k].zName, aStagedSchema[i].zName)==0 ){
         sqlite3_free(aStaged[k].zName);
         if( k+1<*pnStaged ){
           memmove(&aStaged[k], &aStaged[k+1],
@@ -708,6 +708,7 @@ int doltliteStageNamedTables(
 
   for(i=0; i<argc; i++){
     const char *zTable = (const char*)sqlite3_value_text(argv[i]);
+    Table *pLive;
     Pgno iTable = 0;
     int j;
     if( !zTable || strcmp(zTable, ".")==0 ) continue;
@@ -716,6 +717,9 @@ int doltliteStageNamedTables(
       if( zPrior && sqlite3_stricmp(zPrior, zTable)==0 ) break;
     }
     if( j<i ) continue;
+
+    pLive = sqlite3FindTable(db, zTable, "main");
+    if( pLive ) zTable = pLive->zName;
 
     if( !bForce ){
       int ignored = 0;
@@ -730,7 +734,6 @@ int doltliteStageNamedTables(
     /* Vtabs have no catalog entry; commit content is the shadow tables. Stage
     ** those and adopt the working master so the vtab schema row travels too. */
     {
-      Table *pLive = sqlite3FindTable(db, zTable, "main");
       if( pLive && IsVirtual(pLive) ){
         int w;
         rc = addStageShadowTablesOf(db, context, &aStaged, &nStaged,
@@ -746,7 +749,7 @@ int doltliteStageNamedTables(
           if( aWorkSchema[w].zType
            && strcmp(aWorkSchema[w].zType, "table")==0
            && aWorkSchema[w].zName
-           && strcmp(aWorkSchema[w].zName, zTable)!=0
+           && sqlite3_stricmp(aWorkSchema[w].zName, zTable)!=0
            && sqlite3IsShadowTableOf(db, pLive, aWorkSchema[w].zName) ){
             ADDNAMED_TOUCH(aWorkSchema[w].zName);
           }
@@ -761,7 +764,7 @@ int doltliteStageNamedTables(
       int found = 0;
       Pgno iDroppedTable = 0;
       for(j=0; j<nStaged; j++){
-        if( aStaged[j].zName && strcmp(aStaged[j].zName, zTable)==0 ){
+        if( aStaged[j].zName && sqlite3_stricmp(aStaged[j].zName, zTable)==0 ){
           iDroppedTable = aStaged[j].iTable;
           found = 1;
           break;
@@ -776,7 +779,7 @@ int doltliteStageNamedTables(
           int removeEntry = 0;
           if( iDroppedTable!=0 && aStaged[j].iTable==iDroppedTable ){
             removeEntry = 1;
-          }else if( aStaged[j].zName && strcmp(aStaged[j].zName, zTable)==0 ){
+          }else if( aStaged[j].zName && sqlite3_stricmp(aStaged[j].zName, zTable)==0 ){
             removeEntry = 1;
           }
           if( removeEntry ){

--- a/src/doltlite_checkout.c
+++ b/src/doltlite_checkout.c
@@ -71,7 +71,7 @@ static int checkoutLoadLiveTableSql(
   *pzSql = 0;
   zQry = sqlite3_mprintf(
       "SELECT sql FROM main.sqlite_master "
-      "WHERE type='table' AND name='%q'",
+      "WHERE type='table' AND name='%q' COLLATE NOCASE",
       zName);
   if( !zQry ) return SQLITE_NOMEM;
   rc = sqlite3_prepare_v2(db, zQry, -1, &pStmt, 0);
@@ -141,7 +141,8 @@ static int checkoutLoadSourceTableSql(
         prollyCursorClose(&cur);
         return rc;
       }
-      if( strcmp(zType, "table")==0 && strcmp(zEntryName, zName)==0 ){
+      if( strcmp(zType, "table")==0
+       && sqlite3_stricmp(zEntryName, zName)==0 ){
         *pFound = 1;
         rc = checkoutSchemaTextField(pVal, nVal, &ri, 4, pzSql);
         sqlite3_free(zType);
@@ -578,7 +579,7 @@ static int checkoutReconcileTableIndexes(
 
   rc = sqlite3_prepare_v2(db,
       "SELECT name, sql FROM sqlite_master"
-      " WHERE type='index' AND tbl_name=?1 AND sql IS NOT NULL",
+      " WHERE type='index' AND tbl_name=?1 COLLATE NOCASE AND sql IS NOT NULL",
       -1, &pStmt, 0);
   if( rc!=SQLITE_OK ) return rc;
   sqlite3_bind_text(pStmt, 1, zTable, -1, SQLITE_STATIC);
@@ -589,8 +590,10 @@ static int checkoutReconcileTableIndexes(
     if( !zName ) continue;
     for(j=0; j<nSourceSchema; j++){
       if( aSourceSchema[j].zType && strcmp(aSourceSchema[j].zType, "index")==0
-       && aSourceSchema[j].zTblName && strcmp(aSourceSchema[j].zTblName, zTable)==0
-       && aSourceSchema[j].zName && strcmp(aSourceSchema[j].zName, zName)==0
+       && aSourceSchema[j].zTblName
+       && sqlite3_stricmp(aSourceSchema[j].zTblName, zTable)==0
+       && aSourceSchema[j].zName
+       && sqlite3_stricmp(aSourceSchema[j].zName, zName)==0
        && aSourceSchema[j].zSql ){
         char *zLiveCanon = doltliteCanonicalizeSchemaSql(zSql ? zSql : "", zName);
         char *zSrcCanon = doltliteCanonicalizeSchemaSql(aSourceSchema[j].zSql, zName);
@@ -631,7 +634,8 @@ static int checkoutReconcileTableIndexes(
     int exists;
     sqlite3_stmt *pChk = 0;
     if( !aSourceSchema[j].zType || strcmp(aSourceSchema[j].zType, "index")!=0 ) continue;
-    if( !aSourceSchema[j].zTblName || strcmp(aSourceSchema[j].zTblName, zTable)!=0 ) continue;
+    if( !aSourceSchema[j].zTblName
+     || sqlite3_stricmp(aSourceSchema[j].zTblName, zTable)!=0 ) continue;
     if( !aSourceSchema[j].zName || !aSourceSchema[j].zSql ) continue;
     rc = sqlite3_prepare_v2(db,
         "SELECT 1 FROM sqlite_master WHERE type='index' AND name=?1",
@@ -670,7 +674,7 @@ static int checkoutReconcileVtabShadowIndexes(
     char *zDup;
     if( !aSourceSchema[i].zName || !aSourceSchema[i].zType
      || strcmp(aSourceSchema[i].zType, "table")!=0
-     || strcmp(aSourceSchema[i].zName, zVtab)==0
+     || sqlite3_stricmp(aSourceSchema[i].zName, zVtab)==0
      || !sqlite3IsShadowTableOf(db, pTab, aSourceSchema[i].zName) ){
       continue;
     }
@@ -704,7 +708,8 @@ static void checkoutAdoptSourceIndexRoots(
   for(j=0; j<nSourceSchema; j++){
     struct TableEntry *pSrcEntry, *pWorkEntry;
     if( !aSourceSchema[j].zType || strcmp(aSourceSchema[j].zType, "index")!=0 ) continue;
-    if( !aSourceSchema[j].zTblName || strcmp(aSourceSchema[j].zTblName, zTable)!=0 ) continue;
+    if( !aSourceSchema[j].zTblName
+     || sqlite3_stricmp(aSourceSchema[j].zTblName, zTable)!=0 ) continue;
     if( !aSourceSchema[j].zName ) continue;
     pSrcEntry = doltliteFindTableByNumber(aSource, nSource,
                                           aSourceSchema[j].iRootpage);
@@ -712,7 +717,7 @@ static void checkoutAdoptSourceIndexRoots(
     for(k=0; k<nWorkSchema; k++){
       if( aWorkSchema[k].zType && strcmp(aWorkSchema[k].zType, "index")==0
        && aWorkSchema[k].zName
-       && strcmp(aWorkSchema[k].zName, aSourceSchema[j].zName)==0 ){
+       && sqlite3_stricmp(aWorkSchema[k].zName, aSourceSchema[j].zName)==0 ){
         break;
       }
     }
@@ -793,7 +798,7 @@ static int checkoutAdoptVtabShadows(
       int srcIdx = -1, workIdx = -1;
       if( !zName || !aList[pass][i].zType
        || strcmp(aList[pass][i].zType, "table")!=0
-       || strcmp(zName, zVtab)==0
+       || sqlite3_stricmp(zName, zVtab)==0
        || !sqlite3IsShadowTableOf(db, pTab, zName) ){
         continue;
       }
@@ -801,12 +806,13 @@ static int checkoutAdoptVtabShadows(
         continue;  /* already handled from the source list */
       }
       for(j=0; j<nSource; j++){
-        if( aSource[j].zName && strcmp(aSource[j].zName, zName)==0 ){
+        if( aSource[j].zName && sqlite3_stricmp(aSource[j].zName, zName)==0 ){
           srcIdx = j; break;
         }
       }
       for(j=0; j<*pnWorking; j++){
-        if( (*paWorking)[j].zName && strcmp((*paWorking)[j].zName, zName)==0 ){
+        if( (*paWorking)[j].zName
+         && sqlite3_stricmp((*paWorking)[j].zName, zName)==0 ){
           workIdx = j; break;
         }
       }
@@ -886,7 +892,7 @@ static int doltliteCheckoutTables(
       int srcIdx = -1;
       if( !zName ) continue;
       for(j=0; j<nSource; j++){
-        if( aSource[j].zName && strcmp(aSource[j].zName, zName)==0 ){
+        if( aSource[j].zName && sqlite3_stricmp(aSource[j].zName, zName)==0 ){
           srcIdx = j;
           break;
         }
@@ -1010,12 +1016,12 @@ static int doltliteCheckoutTables(
     if( !zName ) continue;
 
     for(j=0; j<nSource; j++){
-      if( aSource[j].zName && strcmp(aSource[j].zName, zName)==0 ){
+      if( aSource[j].zName && sqlite3_stricmp(aSource[j].zName, zName)==0 ){
         srcIdx = j; break;
       }
     }
     for(j=0; j<nWorking; j++){
-      if( aWorking[j].zName && strcmp(aWorking[j].zName, zName)==0 ){
+      if( aWorking[j].zName && sqlite3_stricmp(aWorking[j].zName, zName)==0 ){
         workIdx = j; break;
       }
     }
@@ -1048,7 +1054,8 @@ static int doltliteCheckoutTables(
       nWorking--;
     }else{
       rc = checkoutInstallSourceEntry(&aWorking, &nWorking,
-                                      &aSource[srcIdx], zName, workIdx);
+                                      &aSource[srcIdx],
+                                      aSource[srcIdx].zName, workIdx);
       if( rc!=SQLITE_OK ){
         freeSchemaEntries(aSourceSchema, nSourceSchema);
         checkoutSchemaInfoClear(aSchema, nNames);

--- a/src/doltlite_conflicts.c
+++ b/src/doltlite_conflicts.c
@@ -424,7 +424,8 @@ static int deleteConflictRowFromCatalog(
       goto delete_conflict_done;
     }
 
-    isMatch = (!deleted && zName && strcmp(zName, zTableName)==0);
+    isMatch = (!deleted && zName
+               && sqlite3_stricmp(zName, zTableName)==0);
     if( isMatch ){
       u8 *pCountOut = 0;
       int nKeep = 0;
@@ -559,7 +560,8 @@ static int removeConflictTableFromCatalog(
       goto remove_conflict_done;
     }
 
-    isMatch = (*pFound==0 && zName && strcmp(zName, zTableName)==0);
+    isMatch = (*pFound==0 && zName
+               && sqlite3_stricmp(zName, zTableName)==0);
     for(j=0; j<nc; j++){
       rc = skipConflictRow(&r);
       if( rc!=SQLITE_OK ){
@@ -1281,7 +1283,8 @@ static int conflictsResolveTableExists(sqlite3 *db, const char *zTable, int *pEx
 
   *pExists = 0;
   rc = sqlite3_prepare_v2(db,
-      "SELECT 1 FROM main.sqlite_master WHERE type='table' AND name=?1",
+      "SELECT 1 FROM main.sqlite_master "
+      "WHERE type='table' AND name=?1 COLLATE NOCASE",
       -1, &pStmt, 0);
   if( rc!=SQLITE_OK ) return rc;
   rc = sqlite3_bind_text(pStmt, 1, zTable, -1, SQLITE_TRANSIENT);

--- a/src/doltlite_hashof.c
+++ b/src/doltlite_hashof.c
@@ -67,6 +67,7 @@ static int hashofIndexRootByName(
   int found = 0;
   Pgno iRoot = 0;
   char *zSql = 0;
+  char *zCanonicalIndex = 0;
   char *zTable = 0;
 
   if( pzTable ) *pzTable = 0;
@@ -79,7 +80,14 @@ static int hashofIndexRootByName(
     if( sqlite3_stricmp(aSchema[i].zName, zIndex)!=0 ) continue;
     iRoot = aSchema[i].iRootpage;
     zSql = aSchema[i].zSql ? sqlite3_mprintf("%s", aSchema[i].zSql) : 0;
+    zCanonicalIndex = sqlite3_mprintf("%s", aSchema[i].zName);
     zTable = aSchema[i].zTblName ? sqlite3_mprintf("%s", aSchema[i].zTblName) : 0;
+    if( !zCanonicalIndex ){
+      sqlite3_free(zSql);
+      sqlite3_free(zTable);
+      freeSchemaEntries(aSchema, nSchema);
+      return SQLITE_NOMEM;
+    }
     found = 1;
     break;
   }
@@ -89,6 +97,7 @@ static int hashofIndexRootByName(
   rc = doltliteLoadCatalog(db, pCatHash, &aTables, &nTables, 0);
   if( rc!=SQLITE_OK ){
     sqlite3_free(zSql);
+    sqlite3_free(zCanonicalIndex);
     sqlite3_free(zTable);
     return rc;
   }
@@ -104,13 +113,14 @@ static int hashofIndexRootByName(
   }
   doltliteFreeCatalog(aTables, nTables);
   if( zSql ){
-    char *zCanon = doltliteCanonicalizeSchemaSql(zSql, zIndex);
+    char *zCanon = doltliteCanonicalizeSchemaSql(zSql, zCanonicalIndex);
     if( zCanon ){
       prollyHashCompute(zCanon, (int)strlen(zCanon), pSchemaHash);
       sqlite3_free(zCanon);
     }
     sqlite3_free(zSql);
   }
+  sqlite3_free(zCanonicalIndex);
   if( !found ){
     sqlite3_free(zTable);
     return SQLITE_NOTFOUND;

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -956,7 +956,7 @@ static SQLITE_INLINE int dlMatchOrSkipNamedTable(
     sqlite3_free(zName);
     return SQLITE_CORRUPT;
   }
-  isMatch = (*pFound==0 && zName && strcmp(zName, zWant)==0);
+  isMatch = (*pFound==0 && zName && sqlite3_stricmp(zName, zWant)==0);
   if( isMatch ){
     void *aRows = 0;
     if( nr>0 || bAllocEmpty ){

--- a/src/doltlite_schema_diff.c
+++ b/src/doltlite_schema_diff.c
@@ -351,7 +351,7 @@ int loadSchemaEntryFromCatalog(
 
       rc = dlRecordTextField(pVal, nVal, &ri, 1, &zEntryName);
       if( rc!=SQLITE_OK ) goto load_schema_entry_done;
-      if( zEntryName && strcmp(zEntryName, zName)==0 ){
+      if( zEntryName && sqlite3_stricmp(zEntryName, zName)==0 ){
         rc = dlRecordTextField(pVal, nVal, &ri, 0, &zType);
         if( rc==SQLITE_OK ){
           rc = dlRecordTextField(pVal, nVal, &ri, 2, &zTblName);
@@ -410,7 +410,7 @@ void freeSchemaEntries(SchemaEntry *a, int n){
 SchemaEntry *findSchemaEntry(SchemaEntry *a, int n, const char *zName){
   int i;
   for(i=0; i<n; i++){
-    if( a[i].zName && strcmp(a[i].zName, zName)==0 ) return &a[i];
+    if( a[i].zName && sqlite3_stricmp(a[i].zName, zName)==0 ) return &a[i];
   }
   return 0;
 }

--- a/src/prolly_btree_catalog.c
+++ b/src/prolly_btree_catalog.c
@@ -2332,7 +2332,8 @@ int doltliteLoadTableRootByName(
       q += nName+nTbl;
       if( !found
        && nType==5 && memcmp(pType, "table", 5)==0
-       && nName==nWant && memcmp(pName, zTableName, nName)==0 ){
+       && nName==nWant
+       && sqlite3_strnicmp((const char*)pName, zTableName, nName)==0 ){
         found = 1;
         memcpy(&foundRoot, &root, sizeof(foundRoot));
         memcpy(&foundSchemaHash, &schemaHash, sizeof(foundSchemaHash));
@@ -2353,7 +2354,8 @@ int doltliteLoadTableRootByName(
       }
       pName = q;
       q += nLen;
-      if( !found && nLen==nWant && memcmp(pName, zTableName, nLen)==0 ){
+      if( !found && nLen==nWant
+       && sqlite3_strnicmp((const char*)pName, zTableName, nLen)==0 ){
         found = 1;
         memcpy(&foundRoot, &root, sizeof(foundRoot));
         memcpy(&foundSchemaHash, &schemaHash, sizeof(foundSchemaHash));
@@ -2546,7 +2548,7 @@ int doltliteResolveTableName(sqlite3 *db, const char *zTable, Pgno *piTable){
   if( pBtree && pBtree->cat.a ){
     for(i=0; i<pBtree->cat.n; i++){
       if( pBtree->cat.a[i].zName
-       && strcmp(pBtree->cat.a[i].zName, zTable)==0 ){
+       && sqlite3_stricmp(pBtree->cat.a[i].zName, zTable)==0 ){
         *piTable = pBtree->cat.a[i].iTable;
         return SQLITE_OK;
       }
@@ -2556,7 +2558,7 @@ int doltliteResolveTableName(sqlite3 *db, const char *zTable, Pgno *piTable){
   if( !pSchema ) return SQLITE_ERROR;
   for(k=sqliteHashFirst(&pSchema->tblHash); k; k=sqliteHashNext(k)){
     Table *pTab = (Table*)sqliteHashData(k);
-    if( pTab && strcmp(pTab->zName, zTable)==0 ){
+    if( pTab && sqlite3_stricmp(pTab->zName, zTable)==0 ){
       *piTable = pTab->tnum;
       return SQLITE_OK;
     }

--- a/src/prolly_btree_mutation.c
+++ b/src/prolly_btree_mutation.c
@@ -1728,7 +1728,7 @@ int doltliteApplyRawRowMutation(
     pTE = 0;
     for(i=0; i<pBtree->cat.n; i++){
       if( pBtree->cat.a[i].zName
-       && strcmp(pBtree->cat.a[i].zName, zTable)==0 ){
+       && sqlite3_stricmp(pBtree->cat.a[i].zName, zTable)==0 ){
         pTE = &pBtree->cat.a[i];
         break;
       }

--- a/test/doltlite_identifier_case.test
+++ b/test/doltlite_identifier_case.test
@@ -1,0 +1,94 @@
+# 2026-09-07
+#
+# The author disclaims copyright to this source code.  In place of
+# a legal notice, here is a blessing:
+#
+#    May you do good and not evil.
+#    May you find forgiveness for yourself and forgive others.
+#    May you share freely, never taking more than you give.
+#
+#***********************************************************************
+
+set testdir [file dirname $argv0]
+source $testdir/tester.tcl
+
+do_execsql_test doltlite_identifier_case-1.1 {
+  CREATE TABLE Mixed(id INT PRIMARY KEY, v TEXT);
+  INSERT INTO Mixed VALUES(1, 'base');
+  SELECT dolt_add('mixed');
+  SELECT length(dolt_commit('-m', 'base'));
+  UPDATE Mixed SET v='working';
+  SELECT length(dolt_hashof_table('MIXED'));
+  SELECT dolt_hashof_table('MIXED')=dolt_hashof_table('Mixed');
+  SELECT dolt_checkout('mIxEd');
+  SELECT v FROM Mixed;
+  UPDATE Mixed SET v='reset';
+  SELECT dolt_reset('MIXED');
+  CREATE TABLE UntrackedMixed(id INT PRIMARY KEY);
+  SELECT dolt_clean('untrackedmixed');
+  CREATE TABLE UntrackedMixed(id INT PRIMARY KEY);
+  SELECT dolt_verify_constraints('MIXED');
+} {0 40 40 1 0 base 0 0 0}
+
+reset_db
+
+do_execsql_test doltlite_identifier_case-2.1 {
+  CREATE TABLE Mixed(id INT PRIMARY KEY, v INT);
+  CREATE INDEX Mixed_v ON Mixed(v);
+  INSERT INTO Mixed VALUES(1, 10);
+  SELECT length(dolt_commit('-Am', 'base'));
+  SELECT dolt_branch('feature');
+  SELECT dolt_checkout('feature');
+  UPDATE Mixed SET v=20;
+  SELECT length(dolt_commit('-Am', 'feature'));
+  SELECT dolt_checkout('main');
+  UPDATE Mixed SET v=30;
+  SELECT dolt_checkout('feature', 'mIxEd');
+  SELECT v FROM Mixed;
+  SELECT length(dolt_hashof_table('MIXED', 'feature'));
+  SELECT dolt_hashof_table('MIXED', 'feature')=
+         dolt_hashof_table('Mixed', 'feature');
+  SELECT dolt_hashof_index('mIxEd_v')=dolt_hashof_index('Mixed_v');
+} {40 0 0 40 0 0 20 40 1 1}
+
+reset_db
+
+do_execsql_test doltlite_identifier_case-3.1 {
+  CREATE TABLE DropMixed(id INT PRIMARY KEY);
+  SELECT length(dolt_commit('-Am', 'base'));
+  DROP TABLE DropMixed;
+  SELECT dolt_add('dropmixed');
+  SELECT status, staged FROM dolt_status
+   WHERE lower(table_name)='dropmixed';
+} {40 0 deleted 1}
+
+reset_db
+
+do_execsql_test doltlite_identifier_case-4.1 {
+  CREATE TABLE Mixed(id INT PRIMARY KEY, v INT);
+  INSERT INTO Mixed VALUES(1, 10);
+  SELECT length(dolt_commit('-Am', 'base'));
+  SELECT dolt_branch('feature');
+  SELECT dolt_checkout('feature');
+  UPDATE Mixed SET v=20;
+  SELECT length(dolt_commit('-Am', 'feature'));
+  SELECT dolt_checkout('main');
+  UPDATE Mixed SET v=30;
+  SELECT length(dolt_commit('-Am', 'main'));
+} {40 0 0 40 0 40}
+
+do_test doltlite_identifier_case-4.2 {
+  lindex [catchsql {
+    BEGIN;
+    SELECT dolt_merge('feature');
+  }] 0
+} {1}
+
+do_execsql_test doltlite_identifier_case-4.3 {
+  SELECT count(*) FROM dolt_conflicts_Mixed;
+  SELECT dolt_conflicts_resolve('--theirs', 'mIxEd');
+  SELECT v FROM Mixed;
+  ROLLBACK;
+} {1 0 20}
+
+finish_test

--- a/test/regression-buckets/ported.txt
+++ b/test/regression-buckets/ported.txt
@@ -33,6 +33,7 @@ doltlite_data_version
 doltlite_page_size_default
 doltlite_savepoint_release
 doltlite_default_materialization
+doltlite_identifier_case
 doltlite_merge_constraint_prune
 doltlite_merge_ignored
 doltlite_recover_changes


### PR DESCRIPTION
## Summary

- resolve live and historical table names with SQLite's case-insensitive identifier rules
- preserve canonical table/index spelling through checkout and hashing
- apply the same lookup rules to conflict resolution and dropped-table staging
- add regression coverage for working, historical, indexed, dropped, and conflicted tables

The local Dolt v2.2.4 oracle still rejects mixed-case names for these functions, contrary to the issue report, so this is covered as SQLite-consistency behavior rather than new Dolt parity.

## Tests

- `build/testfixture test/doltlite_identifier_case.test`
- `bash test/run_doltlite_tests.sh` — 129 suites passed
- `make lint`
- `bash test/lint_orphaned_suites.sh`
- `bash test/vc_oracle_add_test.sh build/doltlite dolt`
- `bash test/vc_oracle_checkout_test.sh build/doltlite dolt`
- `bash test/vc_oracle_hashof_test.sh build/doltlite dolt`
- `bash test/vc_oracle_conflicts_resolve_test.sh build/doltlite dolt`

Fixes #2685

Co-Authored-By: OpenAI Codex <noreply@openai.com>
