### PR TITLE
Report table renames directly in diff and patch

### DIFF
--- a/src/doltlite_diff.c
+++ b/src/doltlite_diff.c
@@ -241,6 +241,36 @@ static void diffNameIndexFree(DiffNameIndex *pIdx){
   doltliteNameIndexFree(pIdx);
 }
 
+static struct TableEntry *diffFindTableByNameNoCase(
+  struct TableEntry *aCat,
+  int nCat,
+  const char *zName
+){
+  int i;
+  if( !zName ) return 0;
+  for(i=0; i<nCat; i++){
+    if( aCat[i].zName && sqlite3_stricmp(aCat[i].zName,zName)==0 ){
+      return &aCat[i];
+    }
+  }
+  return 0;
+}
+
+static struct TableEntry *diffRenamePartner(
+  struct TableEntry *aOther,
+  int nOther,
+  const struct TableEntry *pRef,
+  struct TableEntry *aRef,
+  int nRef
+){
+  struct TableEntry *p;
+  if( !pRef ) return 0;
+  p = doltliteFindTableByNumber(aOther, nOther, pRef->iTable);
+  if( !p || !p->zName ) return 0;
+  if( diffFindTableByNameNoCase(aRef,nRef,p->zName) ) return 0;
+  return p;
+}
+
 
 
 static void freeBatch(DoltliteDiffCursor *pCur){
@@ -373,7 +403,37 @@ static int diffFilteredTableRoots(
   if( !childFound && !parentFound ) return SQLITE_OK;
 
   if( !childFound || !parentFound ){
+    struct TableEntry *aChild = 0, *aParent = 0;
+    struct TableEntry *e, *p, *pRen;
+    int nChild = 0, nParent = 0;
     u8 dataChange;
+
+    rc = doltliteLoadCatalog(db, pChildCat, &aChild, &nChild, 0);
+    if( rc!=SQLITE_OK ) return rc;
+    rc = doltliteLoadCatalog(db, pParentCat, &aParent, &nParent, 0);
+    if( rc!=SQLITE_OK ){
+      doltliteFreeCatalog(aChild, nChild);
+      return rc;
+    }
+    e = diffFindTableByNameNoCase(aChild,nChild,pCur->zFilterTable);
+    p = diffFindTableByNameNoCase(aParent,nParent,pCur->zFilterTable);
+    if( e && !p ){
+      pRen = diffRenamePartner(aParent,nParent,e,aChild,nChild);
+      if( pRen ){
+        dataChange = prollyHashCompare(&e->root,&pRen->root)!=0;
+        rc = batchAppend(pCur,zHex,e->zName,pCommit,dataChange,1);
+        doltliteFreeCatalog(aChild, nChild);
+        doltliteFreeCatalog(aParent, nParent);
+        return rc;
+      }
+    }else if( p && !e
+           && diffRenamePartner(aChild,nChild,p,aParent,nParent) ){
+      doltliteFreeCatalog(aChild, nChild);
+      doltliteFreeCatalog(aParent, nParent);
+      return SQLITE_OK;
+    }
+    doltliteFreeCatalog(aChild, nChild);
+    doltliteFreeCatalog(aParent, nParent);
     rc = diffRootHasRows(db, childFound ? &childRoot : &parentRoot,
                          &dataChange);
     if( rc!=SQLITE_OK ) return rc;
@@ -517,9 +577,15 @@ static int diffCatalogPair(
     }
     p = addNameIndexFind(&parentIdx, e->zName);
     if( !p ){
-      rc = diffRootHasRows(db, &e->root, &dataChange);
-      if( rc!=SQLITE_OK ) goto diff_done;
-      schemaChange = 1;
+      p = diffRenamePartner(aParent,nParent,e,aChild,nChild);
+      if( p ){
+        dataChange = prollyHashCompare(&e->root,&p->root)!=0;
+        schemaChange = 1;
+      }else{
+        rc = diffRootHasRows(db, &e->root, &dataChange);
+        if( rc!=SQLITE_OK ) goto diff_done;
+        schemaChange = 1;
+      }
     }else{
       dataChange   = (prollyHashCompare(&e->root, &p->root) != 0) ? 1 : 0;
       schemaChange = (prollyHashCompare(&e->schemaHash, &p->schemaHash) != 0) ? 1 : 0;
@@ -538,6 +604,7 @@ static int diffCatalogPair(
     u8 dataChange;
     if( !p->zName ) continue;
     if( addNameIndexFind(&childIdx, p->zName) ) continue;
+    if( diffRenamePartner(aChild,nChild,p,aParent,nParent) ) continue;
     rc = diffRootHasRows(db, &p->root, &dataChange);
     if( rc!=SQLITE_OK ) goto diff_done;
     rc = batchAppend(pCur, zHex, p->zName, pCommit, dataChange, 1);

--- a/src/doltlite_patch.c
+++ b/src/doltlite_patch.c
@@ -849,8 +849,11 @@ static int patchNativeAlter(
   int isCandidate = 0;
   int rc = SQLITE_OK;
   *pzAlter = 0;
-  if( strcmp(pTable->zFromName,pTable->zToName)!=0 ) return SQLITE_OK;
-  if( pFrom->col.nCol==pTo->col.nCol ){
+  if( strcmp(pTable->zFromName,pTable->zToName)!=0 ){
+    isCandidate = 1;
+    zAlter = sqlite3_mprintf("ALTER TABLE \"%w\" RENAME TO \"%w\"",
+                             pTable->zFromName,pTable->zToName);
+  }else if( pFrom->col.nCol==pTo->col.nCol ){
     for(i=0; i<pFrom->col.nCol; i++){
       if( strcmp(pFrom->col.azName[i],pTo->col.azName[i])!=0 ){
         nDiff++;

--- a/test/vc_oracle_diff_test.sh
+++ b/test/vc_oracle_diff_test.sh
@@ -212,6 +212,38 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'modify_u_only');
 " "t,u"
 
+rename_summary_setup="
+CREATE TABLE t(id INT PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 10), (2, 20);
+SELECT dolt_commit('-Am', 'base');
+ALTER TABLE t RENAME TO u;
+SELECT dolt_commit('-Am', 'rename');
+"
+oracle_summary "summary_table_rename" "$rename_summary_setup"
+oracle_summary_filter_name "summary_table_rename_new_name" \
+  "$rename_summary_setup" "u"
+oracle_summary_filter_name "summary_table_rename_old_name" \
+  "$rename_summary_setup" "t"
+
+oracle_summary "summary_table_rename_with_data" "
+CREATE TABLE t(id INT PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 10), (2, 20);
+SELECT dolt_commit('-Am', 'base');
+ALTER TABLE t RENAME TO u;
+UPDATE u SET v=99 WHERE id=1;
+SELECT dolt_commit('-Am', 'rename and edit');
+"
+
+oracle_summary "summary_table_rename_and_reuse_old_name" "
+CREATE TABLE t(id INT PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 10);
+SELECT dolt_commit('-Am', 'base');
+ALTER TABLE t RENAME TO u;
+CREATE TABLE t(id INT PRIMARY KEY, v INT);
+INSERT INTO t VALUES (2, 20);
+SELECT dolt_commit('-Am', 'rename and recreate');
+"
+
 echo "--- per-table: row-level diff ---"
 
 oracle "table_diff_modify_row" "

--- a/test/vc_oracle_patch_test.sh
+++ b/test/vc_oracle_patch_test.sh
@@ -200,6 +200,18 @@ oracle_shape schema_filter_count "$basic_setup" "'HEAD~1','HEAD'" "count(*)" \
 oracle_shape unknown_filter_empty "$basic_setup" "'HEAD~1','HEAD'" "count(*)" \
   "diff_type='unknown'"
 
+native_rename_setup="
+CREATE TABLE t(pk INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1,'one'),(2,'two');
+SELECT dolt_commit('-A','-m','base');
+ALTER TABLE t RENAME TO u;
+SELECT dolt_commit('-A','-m','target');
+"
+oracle_shape table_rename_single_schema_statement "$native_rename_setup" \
+  "'HEAD~1','HEAD'" "count(*)" "diff_type='schema'"
+oracle_shape table_rename_has_no_data_statements "$native_rename_setup" \
+  "'HEAD~1','HEAD'" "count(*)" "diff_type='data'"
+
 oracle_data multi_table_order "
 CREATE TABLE z(pk INTEGER PRIMARY KEY, v TEXT);
 CREATE TABLE a(pk INTEGER PRIMARY KEY, v TEXT);
@@ -433,7 +445,7 @@ else
 fi
 vc_oracle_assert_match apply_literal_round_trip "$actual_fingerprint" "$target_fingerprint"
 
-# Table rename as an executable rebuild, including quoted ids and the index.
+# Table rename as executable ALTER, including quoted ids and the index.
 rename_dir="$TMPROOT/apply_rename"
 mkdir -p "$rename_dir"
 rename_db="$rename_dir/db"
@@ -450,6 +462,9 @@ target_fingerprint=$("$DOLTLITE" "$rename_db" \
   "SELECT group_concat(\"pk col\"||':'||\"value\",',') FROM (SELECT * FROM \"new table\" ORDER BY \"pk col\");" \
   "SELECT group_concat(type||':'||name,',') FROM (SELECT type,name FROM sqlite_master WHERE tbl_name='new table' ORDER BY type,name);")
 "$DOLTLITE" "$rename_db" "SELECT statement FROM dolt_patch('HEAD~1','HEAD');" >"$rename_dir/patch.sql"
+actual_rename=$(grep '^ALTER TABLE ' "$rename_dir/patch.sql" || true)
+vc_oracle_assert_match native_table_rename_sql "$actual_rename" \
+  'ALTER TABLE "odd table" RENAME TO "new table";'
 "$DOLTLITE" "$rename_db" "SELECT dolt_reset('--hard','HEAD~1');" >/dev/null
 if "$DOLTLITE" "$rename_db" <"$rename_dir/patch.sql" 2>"$rename_dir/apply.err"; then
   actual_fingerprint=$("$DOLTLITE" "$rename_db" \


### PR DESCRIPTION
## Summary

- pair renamed tables in `dolt_diff` by stable table identity, including filtered history queries
- emit validated SQLite `ALTER TABLE ... RENAME TO` patches for pure table renames
- cover pure renames, rename-plus-data, old-name reuse, filters, indexes, quoted identifiers, and patch replay against the Dolt oracle

## Tests

- `bash test/vc_oracle_diff_test.sh build/doltlite dolt` — 75 passed
- `bash test/vc_oracle_patch_test.sh build/doltlite dolt` — 88 passed
- `bash test/run_doltlite_tests.sh build/doltlite` — 130 suites passed
- `make -C build lint`

Fixes #2687

Co-Authored-By: OpenAI Codex <noreply@openai.com>
