### PR TITLE
Disambiguate generated version-control columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,6 +367,12 @@ SELECT d.*
   JOIN dolt_log('v1.0..HEAD') AS l ON l.commit_hash = d.to_commit;
 ```
 
+SQLite requires virtual-table column names to be unique. If a generated user
+column in `dolt_diff_<table>`, `dolt_history_<table>`, or
+`dolt_conflicts_<table>` collides case-insensitively with a metadata column,
+the metadata keeps its Dolt name and the user column receives the first
+available numeric suffix (`_1`, `_2`, …).
+
 #### Log and History
 
 ```sql

--- a/src/doltlite_conflicts.c
+++ b/src/doltlite_conflicts.c
@@ -1055,6 +1055,9 @@ struct CfRowCur {
 };
 
 static char *cfrBuildSchema(const DoltliteColInfo *ci){
+  static const char *const azReserved[] = {
+    "from_root_ish", "our_diff_type", "their_diff_type", "dolt_conflict_id"
+  };
   sqlite3_str *pStr = sqlite3_str_new(0);
   char *z;
   if( !pStr ) return 0;
@@ -1062,13 +1065,17 @@ static char *cfrBuildSchema(const DoltliteColInfo *ci){
 
   if( ci->nCol>0 ){
     sqlite3_str_appendall(pStr, ", ");
-    if( doltliteAppendQuotedColumnList(pStr, ci->azName, ci->nCol, "base_", ", ")!=SQLITE_OK ){
+    if( doltliteAppendDisambiguatedColumnList(
+            pStr,ci->azName,ci->nCol,"base_",", ",azReserved,
+            ArraySize(azReserved),-1)!=SQLITE_OK ){
       sqlite3_str_reset(pStr);
       return 0;
     }
 
     sqlite3_str_appendall(pStr, ", ");
-    if( doltliteAppendQuotedColumnList(pStr, ci->azName, ci->nCol, "our_", ", ")!=SQLITE_OK ){
+    if( doltliteAppendDisambiguatedColumnList(
+            pStr,ci->azName,ci->nCol,"our_",", ",azReserved,
+            ArraySize(azReserved),-1)!=SQLITE_OK ){
       sqlite3_str_reset(pStr);
       return 0;
     }
@@ -1077,7 +1084,9 @@ static char *cfrBuildSchema(const DoltliteColInfo *ci){
 
   if( ci->nCol>0 ){
     sqlite3_str_appendall(pStr, ", ");
-    if( doltliteAppendQuotedColumnList(pStr, ci->azName, ci->nCol, "their_", ", ")!=SQLITE_OK ){
+    if( doltliteAppendDisambiguatedColumnList(
+            pStr,ci->azName,ci->nCol,"their_",", ",azReserved,
+            ArraySize(azReserved),-1)!=SQLITE_OK ){
       sqlite3_str_reset(pStr);
       return 0;
     }

--- a/src/doltlite_diff_table.c
+++ b/src/doltlite_diff_table.c
@@ -13,21 +13,27 @@
 #include <time.h>
 
 static char *buildDiffSchema(const DoltliteColInfo *ci){
+  static const char *const azReserved[] = {
+    "to_commit", "to_commit_date", "from_commit", "from_commit_date",
+    "diff_type", "from_ref", "to_ref"
+  };
   sqlite3_str *pStr = sqlite3_str_new(0);
   char *z;
   if( !pStr ) return 0;
 
   sqlite3_str_appendall(pStr, "CREATE TABLE x(");
-  if( doltliteAppendQuotedColumnList(pStr, ci->azName, ci->nCol,
-                                     "to_", ", ")!=SQLITE_OK ){
+  if( doltliteAppendDisambiguatedColumnList(
+          pStr,ci->azName,ci->nCol,"to_",", ",
+          azReserved,ArraySize(azReserved),-1)!=SQLITE_OK ){
     sqlite3_str_reset(pStr);
     return 0;
   }
   sqlite3_str_appendall(pStr, ", to_commit TEXT, to_commit_date TEXT");
   if( ci->nCol>0 ){
     sqlite3_str_appendall(pStr, ", ");
-    if( doltliteAppendQuotedColumnList(pStr, ci->azName, ci->nCol,
-                                       "from_", ", ")!=SQLITE_OK ){
+    if( doltliteAppendDisambiguatedColumnList(
+            pStr,ci->azName,ci->nCol,"from_",", ",
+            azReserved,ArraySize(azReserved),-1)!=SQLITE_OK ){
       sqlite3_str_reset(pStr);
       return 0;
     }

--- a/src/doltlite_history.c
+++ b/src/doltlite_history.c
@@ -8,12 +8,16 @@
 #include <time.h>
 
 static char *htBuildSchema(const DoltliteColInfo *ci){
+  static const char *const azReserved[] = {
+    "commit_hash", "committer", "commit_date", "start_ref"
+  };
   sqlite3_str *pStr = sqlite3_str_new(0);
   char *z;
   if( !pStr ) return 0;
   sqlite3_str_appendall(pStr, "CREATE TABLE x(");
-  if( doltliteAppendIntegerPkColumnList(pStr, ci->azName, ci->nCol,
-                                        ci->iPkCol)!=SQLITE_OK ){
+  if( doltliteAppendDisambiguatedColumnList(
+          pStr,ci->azName,ci->nCol,"",", ",azReserved,
+          ArraySize(azReserved),ci->iPkCol)!=SQLITE_OK ){
     sqlite3_str_reset(pStr);
     return 0;
   }

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -702,6 +702,69 @@ static SQLITE_INLINE int doltliteAppendIntegerPkColumnList(
   return sqlite3_str_errcode(pStr);
 }
 
+static SQLITE_INLINE int doltliteVtabColumnNameUsed(
+  char *const *azName,
+  int nName,
+  int iName,
+  const char *zPrefix,
+  const char *const *azReserved,
+  int nReserved,
+  const char *zCandidate
+){
+  int i;
+  int nPrefix = (int)strlen(zPrefix);
+  if( (int)strlen(zCandidate)>=nPrefix
+   && sqlite3_strnicmp(zCandidate,zPrefix,nPrefix)==0 ){
+    for(i=0; i<nName; i++){
+      if( i!=iName
+       && sqlite3_stricmp(zCandidate+nPrefix,azName[i])==0 ){
+        return 1;
+      }
+    }
+  }
+  for(i=0; i<nReserved; i++){
+    if( sqlite3_stricmp(zCandidate,azReserved[i])==0 ) return 1;
+  }
+  return 0;
+}
+
+static SQLITE_INLINE int doltliteAppendDisambiguatedColumnList(
+  sqlite3_str *pStr,
+  char *const *azName,
+  int nName,
+  const char *zPrefix,
+  const char *zSep,
+  const char *const *azReserved,
+  int nReserved,
+  int iIntegerPk
+){
+  int i;
+  if( !zPrefix ) zPrefix = "";
+  if( !zSep ) zSep = ", ";
+  for(i=0; i<nName; i++){
+    char *zBase = sqlite3_mprintf("%s%s",zPrefix,azName[i]);
+    char *zColumn = zBase;
+    int iSuffix = 1;
+    if( !zBase ) return SQLITE_NOMEM;
+    while( doltliteVtabColumnNameUsed(azName,nName,i,zPrefix,
+                                      azReserved,nReserved,zColumn) ){
+      if( zColumn!=zBase ) sqlite3_free(zColumn);
+      zColumn = sqlite3_mprintf("%s_%d",zBase,iSuffix++);
+      if( !zColumn ){
+        sqlite3_free(zBase);
+        return SQLITE_NOMEM;
+      }
+    }
+    if( i>0 ) sqlite3_str_appendall(pStr,zSep);
+    sqlite3_str_appendf(pStr,"\"%w\"%s",zColumn,
+                        i==iIntegerPk ? " INTEGER" : "");
+    if( zColumn!=zBase ) sqlite3_free(zColumn);
+    sqlite3_free(zBase);
+    if( sqlite3_str_errcode(pStr)!=SQLITE_OK ) return sqlite3_str_errcode(pStr);
+  }
+  return SQLITE_OK;
+}
+
 static SQLITE_INLINE void doltliteFreeStringArray(char **az, int n){
   int i;
   if( !az ) return;

--- a/test/doltlite_vtab_column_collision.test
+++ b/test/doltlite_vtab_column_collision.test
@@ -1,0 +1,103 @@
+# 2026-09-08
+#
+# The author disclaims copyright to this source code.  In place of
+# a legal notice, here is a blessing:
+#
+#    May you do good and not evil.
+#    May you find forgiveness for yourself and forgive others.
+#    May you share freely, never taking more than you give.
+#
+#***********************************************************************
+
+set testdir [file dirname $argv0]
+source $testdir/tester.tcl
+
+do_execsql_test doltlite_vtab_column_collision-1.1 {
+  CREATE TABLE d(
+    id INT PRIMARY KEY,
+    "commit" TEXT,
+    commit_1 TEXT,
+    commit_date TEXT,
+    commit_date_1 TEXT,
+    ref TEXT,
+    ref_1 TEXT
+  );
+  INSERT INTO d VALUES(1, 'c', 'c1', 'd', 'd1', 'r', 'r1');
+  SELECT length(dolt_commit('-Am', 'base'));
+  UPDATE d SET "commit"='working';
+  SELECT group_concat(name, '|') FROM (
+    SELECT name FROM pragma_table_xinfo('dolt_diff_d') ORDER BY cid
+  );
+} {40 {to_id|to_commit_2|to_commit_1|to_commit_date_2|to_commit_date_1|to_ref_2|to_ref_1|to_commit|to_commit_date|from_id|from_commit_2|from_commit_1|from_commit_date_2|from_commit_date_1|from_ref_2|from_ref_1|from_commit|from_commit_date|diff_type|from_ref|to_ref}}
+
+do_execsql_test doltlite_vtab_column_collision-1.2 {
+  SELECT to_commit_2, to_commit_1, to_commit_date_2, to_commit_date_1,
+         to_ref_2, to_ref_1, to_commit, diff_type
+    FROM dolt_diff_d
+   WHERE to_commit='WORKING';
+} {working c1 d d1 r r1 WORKING modified}
+
+reset_db
+
+do_execsql_test doltlite_vtab_column_collision-2.1 {
+  CREATE TABLE h(
+    id INT PRIMARY KEY,
+    commit_hash TEXT,
+    commit_hash_1 TEXT,
+    "Committer" TEXT,
+    "Committer_1" TEXT,
+    commit_date TEXT,
+    commit_date_1 TEXT,
+    start_ref TEXT,
+    start_ref_1 TEXT
+  );
+  INSERT INTO h VALUES(1, 'h', 'h1', 'm', 'm1', 'd', 'd1', 's', 's1');
+  SELECT length(dolt_commit('-Am', 'base'));
+  SELECT group_concat(name, '|') FROM (
+    SELECT name FROM pragma_table_xinfo('dolt_history_h') ORDER BY cid
+  );
+} {40 {id|commit_hash_2|commit_hash_1|Committer_2|Committer_1|commit_date_2|commit_date_1|start_ref_2|start_ref_1|commit_hash|committer|commit_date|start_ref}}
+
+do_execsql_test doltlite_vtab_column_collision-2.2 {
+  SELECT commit_hash_2, commit_hash_1, committer_2, committer_1,
+         commit_date_2, commit_date_1, start_ref_2, start_ref_1,
+         length(commit_hash)
+    FROM dolt_history_h
+   WHERE commit_hash=(SELECT commit_hash FROM dolt_log WHERE message='base');
+} {h h1 m m1 d d1 s s1 40}
+
+reset_db
+
+do_execsql_test doltlite_vtab_column_collision-3.1 {
+  CREATE TABLE c(id INT PRIMARY KEY, diff_type TEXT, diff_type_1 TEXT);
+  INSERT INTO c VALUES(1, 'base', 'keep');
+  SELECT length(dolt_commit('-Am', 'base'));
+  SELECT dolt_checkout('-b', 'feature');
+  UPDATE c SET diff_type='theirs';
+  SELECT length(dolt_commit('-Am', 'theirs'));
+  SELECT dolt_checkout('main');
+  UPDATE c SET diff_type='ours';
+  SELECT length(dolt_commit('-Am', 'ours'));
+} {40 0 40 0 40}
+
+do_test doltlite_vtab_column_collision-3.2 {
+  lindex [catchsql {
+    BEGIN;
+    SELECT dolt_merge('feature');
+  }] 0
+} {1}
+
+do_execsql_test doltlite_vtab_column_collision-3.3 {
+  SELECT group_concat(name, '|') FROM (
+    SELECT name FROM pragma_table_xinfo('dolt_conflicts_c') ORDER BY cid
+  );
+} {{from_root_ish|base_id|base_diff_type|base_diff_type_1|our_id|our_diff_type_2|our_diff_type_1|our_diff_type|their_id|their_diff_type_2|their_diff_type_1|their_diff_type|dolt_conflict_id}}
+
+do_execsql_test doltlite_vtab_column_collision-3.4 {
+  SELECT base_diff_type, our_diff_type_2, our_diff_type,
+         their_diff_type_2, their_diff_type
+    FROM dolt_conflicts_c;
+  ROLLBACK;
+} {base ours modified theirs modified}
+
+finish_test

--- a/test/regression-buckets/ported.txt
+++ b/test/regression-buckets/ported.txt
@@ -35,6 +35,7 @@ doltlite_page_size_default
 doltlite_savepoint_release
 doltlite_default_materialization
 doltlite_identifier_case
+doltlite_vtab_column_collision
 doltlite_merge_constraint_prune
 doltlite_merge_ignored
 doltlite_recover_changes


### PR DESCRIPTION
## Summary

- preserve canonical metadata column names in dolt_diff_<table>, dolt_history_<table>, and dolt_conflicts_<table>
- suffix colliding generated user-data columns with the first available _N name
- cover case-insensitive collisions, hidden metadata columns, existing suffixes, and row values

## Testing

- bash test/run_doltlite_tests.sh build/doltlite (131 suites passed)
- bash test/vc_oracle_diff_test.sh build/doltlite dolt (75 passed)
- bash test/vc_oracle_history_test.sh build/doltlite dolt (31 passed)
- bash test/vc_oracle_conflicts_table_test.sh build/doltlite dolt (13 passed)
- make -C build lint
- bash test/lint_orphaned_suites.sh

Fixes #2695

Co-Authored-By: OpenAI Codex <noreply@openai.com>
