### PR TITLE
Open slash-named branches by database path

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,6 +476,9 @@ Open a branch at connect time via the database path (CLI, C API, or bindings):
 ./doltlite my.db/feature
 ```
 
+The file is the longest existing database-file prefix, so branch names may
+contain `/` (for example, `my.db/feature/parser`).
+
 ```c
 sqlite3_open("my.db@feature", &db);
 ```

--- a/src/main.c
+++ b/src/main.c
@@ -3700,7 +3700,8 @@ static int openDatabase(
       rc = SQLITE_NOMEM_BKPT;
     }
 #ifdef DOLTLITE_PROLLY
-    if( rc!=SQLITE_IOERR_CHUNK_SOURCE )
+    if( rc!=SQLITE_IOERR_CHUNK_SOURCE
+     && !(rc==SQLITE_CANTOPEN && db->errCode==SQLITE_CANTOPEN) )
 #endif
     sqlite3Error(db, rc);
     goto opendb_out;

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -556,8 +556,8 @@ static int doltliteResolveOpenBranchPath(
   char **pzStoreFilename,
   const char **pzBranch
 ){
-  const char *z;
-  const char *zSep = 0;
+  const char *zSep;
+  const char *zEnd;
   int parentExists = 0;
   int rc;
   char *zParent;
@@ -571,51 +571,52 @@ static int doltliteResolveOpenBranchPath(
     return SQLITE_OK;
   }
 
-  for(z=zFilename; *z; z++){
-    if( *z=='/' || *z=='\\' || *z=='@' ) zSep = z;
+  zEnd = zFilename + strlen(zFilename);
+  for(zSep=zEnd; zSep>zFilename; ){
+    zSep--;
+    if( *zSep!='/' && *zSep!='\\' && *zSep!='@' ) continue;
+    if( zSep==zFilename || zSep[1]=='\0' ) continue;
+    nParent = (int)(zSep - zFilename);
+    zParent = sqlite3_mprintf("%.*s", nParent, zFilename);
+    if( !zParent ) return SQLITE_NOMEM;
+    if( !doltliteLooksLikeDbPath(zParent) ){
+      sqlite3_free(zParent);
+      continue;
+    }
+    parentExists = 0;
+    rc = doltliteFileExists(pVfs, zParent, &parentExists);
+    if( rc!=SQLITE_OK ){
+      sqlite3_free(zParent);
+      return rc;
+    }
+    if( !parentExists ){
+      sqlite3_free(zParent);
+      continue;
+    }
+    parentIsFile = 0;
+    rc = doltliteReadableFile(pVfs, zParent, &parentIsFile);
+    if( rc!=SQLITE_OK ){
+      sqlite3_free(zParent);
+      return rc;
+    }
+    if( !parentIsFile ){
+      sqlite3_free(zParent);
+      continue;
+    }
+    parentIsSqlite = 0;
+    rc = origBtreeIsSqliteFile(pVfs, zParent, &parentIsSqlite);
+    if( rc!=SQLITE_OK ){
+      sqlite3_free(zParent);
+      return rc;
+    }
+    if( parentIsSqlite ){
+      sqlite3_free(zParent);
+      return SQLITE_OK;
+    }
+    *pzStoreFilename = zParent;
+    *pzBranch = zSep + 1;
+    break;
   }
-  if( !zSep || zSep==zFilename || zSep[1]=='\0' ) return SQLITE_OK;
-
-  nParent = (int)(zSep - zFilename);
-  zParent = sqlite3_mprintf("%.*s", nParent, zFilename);
-  if( !zParent ) return SQLITE_NOMEM;
-  if( !doltliteLooksLikeDbPath(zParent) ){
-    sqlite3_free(zParent);
-    return SQLITE_OK;
-  }
-
-  rc = doltliteFileExists(pVfs, zParent, &parentExists);
-  if( rc!=SQLITE_OK ){
-    sqlite3_free(zParent);
-    return rc;
-  }
-  if( !parentExists ){
-    sqlite3_free(zParent);
-    return SQLITE_OK;
-  }
-
-  rc = doltliteReadableFile(pVfs, zParent, &parentIsFile);
-  if( rc!=SQLITE_OK ){
-    sqlite3_free(zParent);
-    return rc;
-  }
-  if( !parentIsFile ){
-    sqlite3_free(zParent);
-    return SQLITE_OK;
-  }
-
-  rc = origBtreeIsSqliteFile(pVfs, zParent, &parentIsSqlite);
-  if( rc!=SQLITE_OK ){
-    sqlite3_free(zParent);
-    return rc;
-  }
-  if( parentIsSqlite ){
-    sqlite3_free(zParent);
-    return SQLITE_OK;
-  }
-
-  *pzStoreFilename = zParent;
-  *pzBranch = zSep + 1;
   return SQLITE_OK;
 }
 
@@ -900,11 +901,17 @@ int sqlite3BtreeOpen(
     if( zBranchFromPath && rc!=SQLITE_OK ){
       int openRc;
       rc = btreeApplyChunkSourceError(db, &pBt->store, rc);
-      openRc = rc==SQLITE_NOMEM || rc==SQLITE_IOERR_NOMEM
-             || rc==SQLITE_IOERR_CHUNK_SOURCE ? rc : SQLITE_ERROR;
-      if( openRc==SQLITE_ERROR ){
-        sqlite3ErrorWithMsg(db, SQLITE_ERROR,
-                            "unable to select branch \"%s\"", zDef);
+      if( rc==SQLITE_NOTFOUND ){
+        openRc = SQLITE_CANTOPEN;
+        sqlite3ErrorWithMsg(db, openRc,
+                            "branch or revision \"%s\" not found", zDef);
+      }else{
+        openRc = rc==SQLITE_NOMEM || rc==SQLITE_IOERR_NOMEM
+               || rc==SQLITE_IOERR_CHUNK_SOURCE ? rc : SQLITE_ERROR;
+        if( openRc==SQLITE_ERROR ){
+          sqlite3ErrorWithMsg(db, openRc,
+                              "unable to select branch \"%s\"", zDef);
+        }
       }
       pagerShimDestroy(pBt->pPagerShim);
       prollyCacheFree(&pBt->cache);

--- a/test/detached_head_test.c
+++ b/test/detached_head_test.c
@@ -99,6 +99,8 @@ int main(void){
                                       sizeof(zHash))==SQLITE_OK && strlen(zHash)==40);
   check("insert second row", execSql(db, "INSERT INTO t VALUES(2)")==SQLITE_OK);
   check("commit second row", execSql(db, "SELECT dolt_commit('-A','-m','c2')")==SQLITE_OK);
+  check("create slash branch",
+        execSql(db, "SELECT dolt_branch('feature/x')")==SQLITE_OK);
   check("attached checkout tag rejected",
         sqlite3_exec(db, "SELECT dolt_checkout('v1')", 0, 0, 0)!=SQLITE_OK);
   check("rejected checkout stays attached",
@@ -106,6 +108,38 @@ int main(void){
         && strcmp(zOpen, "main")==0 && sqlite3_db_readonly(db, "main")==0);
   snprintf(zOpen, sizeof(zOpen), "SELECT dolt_checkout('%s')", zHash);
   check("attached checkout hash rejected", sqlite3_exec(db, zOpen, 0, 0, 0)!=SQLITE_OK);
+  sqlite3_close(db);
+  db = 0;
+
+  snprintf(zOpen, sizeof(zOpen), "%s/feature/x", zPath);
+  rc = sqlite3_open(zOpen, &db);
+  check("open slash branch name", rc==SQLITE_OK);
+  if( rc==SQLITE_OK ){
+    check("slash branch active",
+          scalarText(db, "SELECT active_branch()", zOpen, sizeof(zOpen))==SQLITE_OK
+          && strcmp(zOpen, "feature/x")==0);
+  }
+  sqlite3_close(db);
+  db = 0;
+
+  snprintf(zOpen, sizeof(zOpen), "%s@feature/x", zPath);
+  rc = sqlite3_open(zOpen, &db);
+  check("open at slash branch name", rc==SQLITE_OK);
+  sqlite3_close(db);
+  db = 0;
+
+  snprintf(zOpen, sizeof(zOpen), "%s/missing/name", zPath);
+  rc = sqlite3_open(zOpen, &db);
+  check("missing slash branch is cantopen", (rc & 0xff)==SQLITE_CANTOPEN);
+  check("missing slash branch names ref",
+        strstr(sqlite3_errmsg(db), "missing/name")!=0);
+  sqlite3_close(db);
+  db = 0;
+
+  snprintf(zOpen, sizeof(zOpen), "%s/missing", zPath);
+  rc = sqlite3_open(zOpen, &db);
+  check("missing branch is cantopen", (rc & 0xff)==SQLITE_CANTOPEN);
+  check("missing branch names ref", strstr(sqlite3_errmsg(db), "missing")!=0);
   sqlite3_close(db);
   db = 0;
 

--- a/test/doltlite_open_branch.sh
+++ b/test/doltlite_open_branch.sh
@@ -53,6 +53,12 @@ SELECT dolt_checkout('main');
 INSERT INTO t VALUES(2,'main2');
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main2');
+SELECT dolt_branch('feature/x');
+SELECT dolt_checkout('feature/x');
+UPDATE t SET v='slash' WHERE id=1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','slash');
+SELECT dolt_checkout('main');
 SQL
 
 res=$("$DOLTLITE" "$DB" "SELECT active_branch(); SELECT v FROM t WHERE id=1;" | normalize_output)
@@ -64,11 +70,26 @@ check_eq "at_selects_side" $'side\nside' "$res"
 res=$("$DOLTLITE" "$DB/side" "SELECT active_branch(); SELECT v FROM t WHERE id=1;" | normalize_output)
 check_eq "slash_selects_side" $'side\nside' "$res"
 
+res=$("$DOLTLITE" "$DB/feature/x" "SELECT active_branch(); SELECT v FROM t WHERE id=1;" | normalize_output)
+check_eq "slash_selects_nested_branch" $'feature/x\nslash' "$res"
+
+res=$("$DOLTLITE" "$DB@feature/x" "SELECT active_branch(); SELECT v FROM t WHERE id=1;" | normalize_output)
+check_eq "at_selects_nested_branch" $'feature/x\nslash' "$res"
+
 res=$("$DOLTLITE" "$DB" "SELECT active_branch(); SELECT v FROM t WHERE id=1;" | normalize_output)
 check_eq "branch_open_does_not_change_default" $'main\nmain' "$res"
 
 res=$("$DOLTLITE" "$DB@missing" "SELECT active_branch();" 2>&1 | normalize_output || true)
-check_match "missing_branch_errors" "unable to open database|unable to select branch|branch.*not found|SQLITE_NOTFOUND" "$res"
+check_match "missing_branch_errors" 'branch or revision "missing" not found' "$res"
+
+res=$("$DOLTLITE" "$DB/missing/name" "SELECT active_branch();" 2>&1 | normalize_output || true)
+check_match "missing_nested_branch_errors" 'branch or revision "missing/name" not found' "$res"
+
+res=$("$DOLTLITE" "$DB/main/" "SELECT active_branch();" 2>&1 | normalize_output || true)
+check_match "trailing_slash_branch_errors" 'branch or revision "main/" not found' "$res"
+
+res=$("$DOLTLITE" "$DB//main" "SELECT active_branch();" 2>&1 | normalize_output || true)
+check_match "leading_slash_branch_errors" 'branch or revision "/main" not found' "$res"
 
 cat <<'SQL' | "$DOLTLITE" "$DB" >/dev/null 2>&1
 SELECT dolt_branch('-m','side','renamed');
@@ -90,7 +111,7 @@ SELECT dolt_branch('-D','copy');
 SQL
 
 res=$("$DOLTLITE" "$DB@copy" "SELECT active_branch();" 2>&1 | normalize_output || true)
-check_match "deleted_branch_open_errors" "unable to open database|unable to select branch|branch.*not found|SQLITE_NOTFOUND" "$res"
+check_match "deleted_branch_open_errors" 'branch or revision "copy" not found' "$res"
 
 res=$("$DOLTLITE" "$DB/v1" "SELECT IFNULL(active_branch(),'NULL'); SELECT group_concat(id || ':' || v, ',') FROM t;" | normalize_output)
 check_eq "tag_open_is_detached" $'NULL\n1:main' "$res"

--- a/test/vc_oracle_connection_branch_test.sh
+++ b/test/vc_oracle_connection_branch_test.sh
@@ -314,6 +314,18 @@ oracle "default_open_uses_main" "$TMPROOT/default_open_uses_main/dl/db.sqlite" "
 oracle "at_branch_selects_branch" "$TMPROOT/at_branch_selects_branch/dl/db.sqlite@side" "side"
 oracle "slash_branch_selects_branch" "$TMPROOT/slash_branch_selects_branch/dl/db.sqlite/side" "side"
 
+oracle_with_mutation "nested_slash_branch_selects_branch" \
+  "SELECT dolt_branch('feature/x');" \
+  "$TMPROOT/nested_slash_branch_selects_branch/dl/db.sqlite/feature/x" \
+  "feature/x" \
+  "SELECT active_branch() AS value UNION ALL SELECT v FROM t WHERE id=1;"
+
+oracle_with_mutation "at_nested_slash_branch_selects_branch" \
+  "SELECT dolt_branch('feature/x');" \
+  "$TMPROOT/at_nested_slash_branch_selects_branch/dl/db.sqlite@feature/x" \
+  "feature/x" \
+  "SELECT active_branch() AS value UNION ALL SELECT v FROM t WHERE id=1;"
+
 oracle_with_mutation "renamed_branch_open_selects_branch" \
   "SELECT dolt_branch('-m','side','renamed');" \
   "$TMPROOT/renamed_branch_open_selects_branch/dl/db.sqlite@renamed" \


### PR DESCRIPTION
## Summary

- resolve qualified database paths from the longest existing file prefix so branch names may contain slashes
- return SQLITE_CANTOPEN with the missing branch or revision named in the error
- cover slash and @ qualification, malformed separators, the C API, and Dolt oracle parity

## Testing

- bash test/run_doltlite_tests.sh build/doltlite (131 suites passed)
- bash test/run_c_tests.sh build coverage --build (22 passed)
- bash test/vc_oracle_connection_branch_test.sh build/doltlite dolt (33 passed)
- make -C build lint
- clean DOLTLITE_PROLLY=0 sqlite3 build

Fixes #2698

Co-Authored-By: OpenAI Codex <noreply@openai.com>
