### PR TITLE
Close dead-code gate holes on orig adapter and source macros

### DIFF
--- a/src/btree_orig_api.c
+++ b/src/btree_orig_api.c
@@ -182,11 +182,6 @@ int origBtreeCountIndexRange(
 ){
   return orig_sqlite3BtreeCountIndexRange(db, C(pCur), pLower, pUpper, pn);
 }
-int origBtreeClosesWithCursor(void *p, void *pCur){
-
-  (void)p; (void)pCur;
-  return 1;
-}
 void origBtreeTripAllCursors(void *p, int e, int w){
   orig_sqlite3BtreeTripAllCursors(B(p), e, w);
 }
@@ -198,20 +193,6 @@ int origBtreeCursorIsValidNN(void *pCur){
 int origBtreeTransferRow(void *pDest, void *pSrc, i64 iKey){
   return orig_sqlite3BtreeTransferRow(C(pDest), C(pSrc), iKey);
 }
-void origBtreeEnterAll(sqlite3 *db){
-#ifndef SQLITE_OMIT_SHARED_CACHE
-  orig_sqlite3BtreeEnterAll(db);
-#else
-  (void)db;
-#endif
-}
-void origBtreeLeaveAll(sqlite3 *db){
-#if !defined(SQLITE_OMIT_SHARED_CACHE) && SQLITE_THREADSAFE
-  orig_sqlite3BtreeLeaveAll(db);
-#else
-  (void)db;
-#endif
-}
 int origBtreeIsEmpty(void *pCur, int *pRes){
   return orig_sqlite3BtreeIsEmpty(C(pCur), pRes);
 }
@@ -221,11 +202,6 @@ int origBtreeClearTableOfCursor(void *pCur){
 int origBtreeMaxRecordSize(void *pCur){
   return orig_sqlite3BtreeMaxRecordSize(C(pCur));
 }
-void origBtreeCursorHint(void *pCur, unsigned int mask, ...){
-
-  (void)pCur; (void)mask;
-}
-
 int origBtreeCursorSize(void){ return orig_sqlite3BtreeCursorSize(); }
 void origBtreeEnter(void *p){
 #ifndef SQLITE_OMIT_SHARED_CACHE

--- a/src/btree_orig_api.h
+++ b/src/btree_orig_api.h
@@ -79,18 +79,14 @@ int origBtreeCountRange(sqlite3 *db, void *pCur, i64 iLower, i64 iUpper,
                         i64 *pnEntry);
 int origBtreeCountIndexRange(sqlite3 *db, void *pCur, UnpackedRecord *pLower,
                              UnpackedRecord *pUpper, i64 *pnEntry);
-int origBtreeClosesWithCursor(void *p, void *pCur);
 void origBtreeTripAllCursors(void *p, int errCode, int writeOnly);
 void origBtreeCursorPin(void *pCur);
 void origBtreeCursorUnpin(void *pCur);
 int origBtreeCursorIsValidNN(void *pCur);
 int origBtreeTransferRow(void *pDest, void *pSrc, i64 iKey);
-void origBtreeEnterAll(sqlite3 *db);
-void origBtreeLeaveAll(sqlite3 *db);
 int origBtreeIsEmpty(void *pCur, int *pRes);
 int origBtreeClearTableOfCursor(void *pCur);
 int origBtreeMaxRecordSize(void *pCur);
-void origBtreeCursorHint(void *pCur, unsigned int mask, ...);
 
 int origBtreeCursorSize(void);
 int origBtreeCursorIsLastOnSingle(void *pCur);

--- a/src/btree_orig_prefix.h
+++ b/src/btree_orig_prefix.h
@@ -24,7 +24,6 @@
 #define sqlite3BtreeCount orig_sqlite3BtreeCount
 #define sqlite3BtreeCountIndexRange orig_sqlite3BtreeCountIndexRange
 #define sqlite3BtreeCountRange orig_sqlite3BtreeCountRange
-#define sqlite3BtreeCreateIndex orig_sqlite3BtreeCreateIndex
 #define sqlite3BtreeCreateTable orig_sqlite3BtreeCreateTable
 #define sqlite3BtreeCursor orig_sqlite3BtreeCursor
 #define sqlite3BtreeCursorHasHint orig_sqlite3BtreeCursorHasHint
@@ -55,7 +54,6 @@
 #define sqlite3BtreeGetMeta orig_sqlite3BtreeGetMeta
 #define sqlite3BtreeGetPageSize orig_sqlite3BtreeGetPageSize
 #define sqlite3BtreeGetRequestedReserve orig_sqlite3BtreeGetRequestedReserve
-#define sqlite3BtreeGetReserve orig_sqlite3BtreeGetReserve
 #define sqlite3BtreeGetReserveNoMutex orig_sqlite3BtreeGetReserveNoMutex
 #define sqlite3BtreeHoldsAllMutexes orig_sqlite3BtreeHoldsAllMutexes
 #define sqlite3BtreeHoldsMutex orig_sqlite3BtreeHoldsMutex
@@ -86,7 +84,6 @@
 #define sqlite3BtreePayloadChecked orig_sqlite3BtreePayloadChecked
 #define sqlite3BtreePayloadFetch orig_sqlite3BtreePayloadFetch
 #define sqlite3BtreePayloadSize orig_sqlite3BtreePayloadSize
-#define sqlite3BtreePrev orig_sqlite3BtreePrev
 #define sqlite3BtreePrevious orig_sqlite3BtreePrevious
 #define sqlite3BtreePutData orig_sqlite3BtreePutData
 #define sqlite3BtreeRollback orig_sqlite3BtreeRollback
@@ -141,7 +138,6 @@
 #define sqlite3PagerJrnlFile orig_sqlite3PagerJrnlFile
 #define sqlite3PagerLockingMode orig_sqlite3PagerLockingMode
 #define sqlite3PagerLookup orig_sqlite3PagerLookup
-#define sqlite3PagerMalloc orig_sqlite3PagerMalloc
 #define sqlite3PagerMaxPageCount orig_sqlite3PagerMaxPageCount
 #define sqlite3PagerMemUsed orig_sqlite3PagerMemUsed
 #define sqlite3PagerMovepage orig_sqlite3PagerMovepage
@@ -159,7 +155,6 @@
 #define sqlite3PagerRekey orig_sqlite3PagerRekey
 #define sqlite3PagerRollback orig_sqlite3PagerRollback
 #define sqlite3PagerSavepoint orig_sqlite3PagerSavepoint
-#define sqlite3PagerSetBusyhandler orig_sqlite3PagerSetBusyhandler
 #define sqlite3PagerSetBusyHandler orig_sqlite3PagerSetBusyHandler
 #define sqlite3PagerSetCachesize orig_sqlite3PagerSetCachesize
 #define sqlite3PagerSetFlags orig_sqlite3PagerSetFlags
@@ -201,7 +196,6 @@
 #define sqlite3WalCallback orig_sqlite3WalCallback
 #define sqlite3WalCheckpoint orig_sqlite3WalCheckpoint
 #define sqlite3WalClose orig_sqlite3WalClose
-#define sqlite3WalCloseSnapshot orig_sqlite3WalCloseSnapshot
 #ifdef SQLITE_ENABLE_SETLK_TIMEOUT
 #define sqlite3WalDb orig_sqlite3WalDb
 #endif
@@ -216,7 +210,6 @@
 #define sqlite3WalHeapMemory orig_sqlite3WalHeapMemory
 #define sqlite3WalLimit orig_sqlite3WalLimit
 #define sqlite3WalOpen orig_sqlite3WalOpen
-#define sqlite3WalOpenSnapshot orig_sqlite3WalOpenSnapshot
 #define sqlite3WalReadFrame orig_sqlite3WalReadFrame
 #define sqlite3WalSavepoint orig_sqlite3WalSavepoint
 #define sqlite3WalSavepointUndo orig_sqlite3WalSavepointUndo
@@ -254,14 +247,5 @@
 #endif
 #define sqlite3HeaderSizeBtree orig_sqlite3HeaderSizeBtree
 #define sqlite3SectorSize orig_sqlite3SectorSize
-
-#define sqlite3BtreeEnter orig_sqlite3BtreeEnter
-#define sqlite3BtreeEnterAll orig_sqlite3BtreeEnterAll
-#define sqlite3BtreeEnterCursor orig_sqlite3BtreeEnterCursor
-#define sqlite3BtreeHoldsAllMutexes orig_sqlite3BtreeHoldsAllMutexes
-#define sqlite3BtreeHoldsMutex orig_sqlite3BtreeHoldsMutex
-#define sqlite3BtreeLeave orig_sqlite3BtreeLeave
-#define sqlite3BtreeLeaveAll orig_sqlite3BtreeLeaveAll
-#define sqlite3BtreeLeaveCursor orig_sqlite3BtreeLeaveCursor
 
 #endif

--- a/src/doltlite_creds.c
+++ b/src/doltlite_creds.c
@@ -1065,10 +1065,6 @@ int doltliteCredsValidateAuthDir(const char *dir) {
   return rc;
 }
 
-#define JWT_ISSUER_EXPECTED   "dolt-client.dolthub.com"
-#define JWT_SUBJECT_PREFIX_V  "doltClientCredentials/"
-#define JWT_TOKEN_VERSION_V   "2023.01"
-
 int doltliteCredsVerifyBearer(const char *authValue, const char *expectedAudience,
                               const char *authKeysDir, long now, char **kidOut) {
   const char *jwt;
@@ -1106,7 +1102,7 @@ int doltliteCredsVerifyBearer(const char *authValue, const char *expectedAudienc
   ver = jsonFindString(hdr, "dolt_token_version");
   kid = jsonFindString(hdr, "kid");
   if (!alg || strcmp(alg, "EdDSA") != 0) goto done;
-  if (!ver || strcmp(ver, JWT_TOKEN_VERSION_V) != 0) goto done;
+  if (!ver || strcmp(ver, JWT_TOKEN_VERSION) != 0) goto done;
   if (!kid) goto done;
 
   if (doltliteCredsLoadPubKey(authKeysDir, kid, pub) != 0) goto done;
@@ -1122,11 +1118,11 @@ int doltliteCredsVerifyBearer(const char *authValue, const char *expectedAudienc
 
   iss = jsonFindString(claims, "iss");
   sub = jsonFindString(claims, "sub");
-  if (!iss || strcmp(iss, JWT_ISSUER_EXPECTED) != 0) goto done;
+  if (!iss || strcmp(iss, JWT_ISSUER) != 0) goto done;
 
-  expectSub = (char *)sqlite3_malloc(strlen(JWT_SUBJECT_PREFIX_V) + strlen(kid) + 1);
+  expectSub = (char *)sqlite3_malloc(strlen(JWT_SUBJECT_PREFIX) + strlen(kid) + 1);
   if (!expectSub) goto done;
-  strcpy(expectSub, JWT_SUBJECT_PREFIX_V);
+  strcpy(expectSub, JWT_SUBJECT_PREFIX);
   strcat(expectSub, kid);
   if (!sub || strcmp(sub, expectSub) != 0) goto done;
 

--- a/src/prolly_btree_int.h
+++ b/src/prolly_btree_int.h
@@ -61,9 +61,6 @@ int doltliteSerializeCatalogEntriesWithFallbackSchema(
   u8 **ppOut,
   int *pnOut
 );
-#ifndef SQLITE_OMIT_WAL
-int origBtreeCheckpoint(void *p, int eMode, int *pnLog, int *pnCkpt);
-#endif
 
 u32 prollyBtreeGetU32LE(const u8 *p);
 

--- a/src/prolly_mutate.c
+++ b/src/prolly_mutate.c
@@ -9,8 +9,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-#define PROLLY_EST_ENTRIES_PER_LEAF 50
-
 static int parentChildSubtreeCount(
   ChunkStore *pStore,
   ProllyCache *pCache,

--- a/test/dead_code_check.sh
+++ b/test/dead_code_check.sh
@@ -17,8 +17,8 @@
 #   Part E: non-static prototypes in owned headers that never appear in any .c,
 #           or the same prototype in two owned headers (btree-int vs internal
 #           seam copies excepted).
-#   Part F: #define names in owned headers that never appear elsewhere
-#           (include guards skipped).
+#   Part F: #define names in owned headers and owned .c files that never
+#           appear elsewhere (include guards skipped).
 #   Part G: identical function bodies copied across owned .c files, or two
 #           differently named functions in the same file.
 #   Part H: non-static one-call wrappers whose only extra-file .c mentions are
@@ -49,6 +49,7 @@ SRCS=(
   "$SRC_ROOT"/remotesrv_main.c
   "$SRC_ROOT"/pager_shim.c
   "$SRC_ROOT"/sortkey.c
+  "$SRC_ROOT"/btree_orig_api.c
 )
 
 CFLAGS=(
@@ -84,7 +85,7 @@ else
   done
 fi
 
-echo "== Part B-I: unused externs / inlines / should-be-static / prototypes / macros / clones / test-only wrappers / redundant local externs / duplicate prototypes =="
+echo "== Part B-I: unused externs / inlines / should-be-static / prototypes / macros / clones / test-only wrappers / redundant local externs / duplicate prototypes / source macros =="
 if ! python3 "$SCRIPT_DIR/lib/dead_code_scan.py" --root "$ROOT" --src-root "$SRC_ROOT"
 then
   fail=1

--- a/test/dead_code_check_selftest.sh
+++ b/test/dead_code_check_selftest.sh
@@ -73,6 +73,15 @@ EOF
 : > "$WORK/src/doltlite.c"
 expect_scan_hit "header_macro_is_rejected" "dead header macro: DEAD_CODE_GATE_UNUSED_MACRO"
 
+# Part F: unused #define in an owned .c file.
+rm -f "$WORK/src/doltlite_fixture.h"
+cat > "$WORK/src/doltlite.c" <<'EOF'
+#define DEAD_CODE_GATE_UNUSED_SRC_MACRO 1
+static int dead_code_gate_alive(void){ return 0; }
+static int dead_code_gate_caller(void){ return dead_code_gate_alive(); }
+EOF
+expect_scan_hit "source_macro_is_rejected" "dead source macro: DEAD_CODE_GATE_UNUSED_SRC_MACRO"
+
 # Part G: identical function bodies in two owned .c files.
 cat > "$WORK/src/doltlite_clone_a.c" <<'EOF'
 static int dead_code_gate_clone_left(int a, int b, int c){

--- a/test/lib/dead_code_scan.py
+++ b/test/lib/dead_code_scan.py
@@ -9,8 +9,8 @@ D: non-static function with no other .c mention. A header prototype
    Btree vtable methods (prollyBtree* / origBtree*) stay non-static:
    other TUs call them through the ops table, not by name.
 E: non-static prototype in an owned header that never appears in any .c.
-F: #define in an owned header whose identifier never appears elsewhere
-   (include guards skipped).
+F: #define in an owned header or owned .c whose identifier never appears
+   elsewhere (include guards skipped).
 G: two owned .c functions have identical normalized bodies (whitespace
    collapsed, length >= MIN_CLONE_BODY), across files or same-file aliases.
 H: non-static .c function whose body is a single return otherFn(...) and
@@ -88,6 +88,7 @@ SRC_GLOBS = (
     "remotesrv_main.c",
     "pager_shim.c",
     "sortkey.c",
+    "btree_orig_api.c",
 )
 OWNED_HDR_GLOBS = (
     "doltlite*.h",
@@ -96,6 +97,8 @@ OWNED_HDR_GLOBS = (
     "pager_shim.h",
     "sortkey.h",
     "record_codec.h",
+    "btree_orig_api.h",
+    "btree_orig_prefix.h",
 )
 MIN_CLONE_BODY = 100
 
@@ -387,14 +390,15 @@ def scan_unused_prototypes(hdrs: list[str], corpus: list[str], texts: dict[str, 
     return dead
 
 
-def scan_unused_macros(hdrs: list[str], corpus: list[str], texts: dict[str, str],
+def scan_unused_macros(paths: list[str], corpus: list[str], texts: dict[str, str],
                        idents: dict[str, set[str]], counts: dict[str, Counter]) -> list[str]:
     dead: list[str] = []
-    for path in hdrs:
+    for path in paths:
         raw = texts.get(path)
         if raw is None:
             continue
         stripped = strip_comments(raw)
+        kind = "header" if path.endswith(".h") else "source"
         for match in MACRO.finditer(stripped):
             name = match.group(1)
             if name.endswith("_H") or name.endswith("_H_"):
@@ -403,7 +407,7 @@ def scan_unused_macros(hdrs: list[str], corpus: list[str], texts: dict[str, str]
             if others:
                 continue
             if counts.get(path, Counter())[name] <= 1:
-                dead.append(f"  dead header macro: {name} ({path})")
+                dead.append(f"  dead {kind} macro: {name} ({path})")
     return dead
 
 
@@ -565,7 +569,7 @@ def main() -> int:
     dead += scan_should_be_static(src_files, corpus, texts, idents)
     dead += scan_unused_prototypes(owned_hdrs, corpus, texts, idents)
     dead += scan_duplicate_prototypes(owned_hdrs, texts)
-    dead += scan_unused_macros(owned_hdrs, corpus, texts, idents, counts)
+    dead += scan_unused_macros(owned_hdrs + src_files, corpus, texts, idents, counts)
     dead += scan_clones(src_files, texts)
     dead += scan_test_only_wrappers(src_files, corpus, root, texts, idents)
     dead += scan_redundant_externs(src_files, src_root, texts)


### PR DESCRIPTION
## Summary

Follow-up to #2688. The no-dead-code job still could not see the orig btree adapter or `#define`s in owned `.c` files.

**Dead code**
- Unused `origBtreeClosesWithCursor` / `origBtreeEnterAll` / `origBtreeLeaveAll` / `origBtreeCursorHint` (never called; `sqlite3BtreeEnterAll` / `CursorHint` / `ClosesWithCursor` go through `prolly_btree.c` / cursor, not these wrappers)
- Leftover `PROLLY_EST_ENTRIES_PER_LEAF` after streaming-merge became unconditional
- Unused orig-prefix macros (`sqlite3BtreeCreateIndex`, `sqlite3BtreePrev`, `sqlite3BtreeGetReserve`, `sqlite3PagerMalloc`, `sqlite3PagerSetBusyhandler`, `sqlite3WalCloseSnapshot`, `sqlite3WalOpenSnapshot`)
- Duplicated mutex-prefix `#define`s at the bottom of `btree_orig_prefix.h`
- Duplicate `origBtreeCheckpoint` prototype in `prolly_btree_int.h` (already included from `btree_orig_api.h`)
- Duplicate JWT issuer/subject/version macros in bearer verify

**Gate**
- Compile and scan `btree_orig_api.c`
- Own `btree_orig_api.h` and `btree_orig_prefix.h` for unused/duplicate prototypes and macros
- Part F also scans `#define`s in owned `.c` files
- Self-test plants an unused source-file macro (13/13)

Larger near-copies (conflict vs CV framed blobs, merge-constraint table walks) are still structurally similar rather than unused; this pass is the remaining dead symbols plus the holes that hid them.

## Test plan

- [x] `bash test/dead_code_check.sh` (PASS)
- [x] `bash test/dead_code_check_selftest.sh` (13/13)
- [x] `bash test/lint_layers.sh`
- [x] `bash test/lint_orig_btree_adapter.sh`
- [x] `bash test/lint_no_raw_os_fileio.sh`
- [x] `bash test/lint_export_filters.sh`

Co-Authored-By: Grok 4.6 <noreply@x.ai>