### PR TITLE
Guard orig adapter symbols omitted with SQLITE_OMIT_INCRBLOB

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -1020,3 +1020,6 @@ jobs:
 
     - name: Dead-code gate self-test
       run: bash test/dead_code_check_selftest.sh
+
+    - name: OMIT_INCRBLOB orig adapter link
+      run: bash test/omit_incrblob_orig_adapter_test.sh

--- a/src/btree_orig_api.c
+++ b/src/btree_orig_api.c
@@ -80,14 +80,14 @@ int origBtreeConnectionCount(void *p){
 #endif
 }
 void origBtreeEnterCursor(void *pCur){
-#if !defined(SQLITE_OMIT_SHARED_CACHE) && SQLITE_THREADSAFE
+#if !defined(SQLITE_OMIT_SHARED_CACHE) && !defined(SQLITE_OMIT_INCRBLOB)
   orig_sqlite3BtreeEnterCursor(C(pCur));
 #else
   (void)pCur;
 #endif
 }
 void origBtreeLeaveCursor(void *pCur){
-#if !defined(SQLITE_OMIT_SHARED_CACHE) && SQLITE_THREADSAFE
+#if !defined(SQLITE_OMIT_SHARED_CACHE) && !defined(SQLITE_OMIT_INCRBLOB) && SQLITE_THREADSAFE
   orig_sqlite3BtreeLeaveCursor(C(pCur));
 #else
   (void)pCur;
@@ -150,10 +150,10 @@ const void *origBtreePayloadFetch(void *pCur, u32 *pAmt){
 }
 i64 origBtreeIntegerKey(void *pCur){ return orig_sqlite3BtreeIntegerKey(C(pCur)); }
 i64 origBtreeOffset(void *pCur){ return orig_sqlite3BtreeOffset(C(pCur)); }
+#ifndef SQLITE_OMIT_INCRBLOB
 u32 origBtreePayloadChecked(void *pCur, u32 off, u32 amt, void *pBuf){
   return orig_sqlite3BtreePayloadChecked(C(pCur), off, amt, pBuf);
 }
-#ifndef SQLITE_OMIT_INCRBLOB
 int origBtreePutData(void *pCur, u32 off, u32 amt, void *pBuf){
   return orig_sqlite3BtreePutData(C(pCur), off, amt, pBuf);
 }

--- a/src/btree_orig_api.h
+++ b/src/btree_orig_api.h
@@ -69,8 +69,8 @@ int origBtreePayload(void *pCur, u32 offset, u32 amt, void *pBuf);
 const void *origBtreePayloadFetch(void *pCur, u32 *pAmt);
 i64 origBtreeIntegerKey(void *pCur);
 i64 origBtreeOffset(void *pCur);
-u32 origBtreePayloadChecked(void *pCur, u32 offset, u32 amt, void *pBuf);
 #ifndef SQLITE_OMIT_INCRBLOB
+u32 origBtreePayloadChecked(void *pCur, u32 offset, u32 amt, void *pBuf);
 int origBtreePutData(void *pCur, u32 offset, u32 amt, void *pBuf);
 void origBtreeIncrblobCursor(void *pCur);
 #endif

--- a/test/lint_orig_btree_adapter.sh
+++ b/test/lint_orig_btree_adapter.sh
@@ -82,6 +82,54 @@ if "origBtreeOffset" not in api_c or "orig_sqlite3BtreeOffset" not in api_c:
 if "origBtreeCountRange" not in api_c or "orig_sqlite3BtreeCountRange" not in api_c:
     fails.append("origBtreeCountRange must forward orig_sqlite3BtreeCountRange")
 
+# Stock btree compiles these only without SQLITE_OMIT_INCRBLOB. Calling them
+# from the adapter without that guard leaves unresolved orig_sqlite3* symbols.
+INCRBLOB_SYMS = (
+    "orig_sqlite3BtreeEnterCursor",
+    "orig_sqlite3BtreeLeaveCursor",
+    "orig_sqlite3BtreePayloadChecked",
+    "orig_sqlite3BtreePutData",
+    "orig_sqlite3BtreeIncrblobCursor",
+)
+IF_LINE = re.compile(r"^\s*#\s*(if|ifdef|ifndef|else|elif|endif)\b(.*)$")
+stack = []
+for lineno, raw in enumerate(api_c.splitlines(), 1):
+    directive = IF_LINE.match(raw)
+    if directive:
+        kind = directive.group(1)
+        rest = directive.group(2).strip()
+        if kind in ("if", "ifdef", "ifndef"):
+            stack.append((kind, rest, False))
+        elif kind == "elif":
+            if stack:
+                stack[-1] = ("if", rest, False)
+        elif kind == "else":
+            if stack:
+                kind0, rest0, _ = stack[-1]
+                stack[-1] = (kind0, rest0, True)
+        elif kind == "endif" and stack:
+            stack.pop()
+        continue
+    for sym in INCRBLOB_SYMS:
+        if sym not in raw:
+            continue
+        guarded = False
+        for kind, rest, inverted in stack:
+            mentions = "SQLITE_OMIT_INCRBLOB" in rest
+            if not mentions:
+                continue
+            if inverted:
+                continue
+            if kind == "ifndef" and rest == "SQLITE_OMIT_INCRBLOB":
+                guarded = True
+            elif kind in ("if", "elif") and "!defined(SQLITE_OMIT_INCRBLOB)" in rest.replace(" ", ""):
+                guarded = True
+        if not guarded:
+            fails.append(
+                "%s:%d calls %s without SQLITE_OMIT_INCRBLOB"
+                % ("btree_orig_api.c", lineno, sym)
+            )
+
 if fails:
     print("lint_orig_btree_adapter: %d violation(s)" % len(fails), file=sys.stderr)
     for f in fails:

--- a/test/omit_incrblob_orig_adapter_test.sh
+++ b/test/omit_incrblob_orig_adapter_test.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# SQLITE_OMIT_INCRBLOB must not leave unresolved orig_sqlite3Btree* cursor
+# symbols in btree_orig_api.o.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$ROOT"
+BUILD_DIR="${DOLTLITE_BUILD_DIR:-$ROOT/build}"
+CC="${CC:-cc}"
+
+if [ ! -f "$BUILD_DIR/sqlite_cfg.h" ]; then
+  echo "SETUP FAILED: $BUILD_DIR/sqlite_cfg.h missing; configure+build first" >&2
+  exit 2
+fi
+
+OBJ=$(mktemp)
+ERR=$(mktemp)
+trap 'rm -f "$OBJ" "$ERR"' EXIT
+
+CFLAGS=(
+  -DNDEBUG -O1 -g
+  -DSQLITE_ENABLE_MATH_FUNCTIONS -DSQLITE_THREADSAFE=1
+  -DDOLTLITE_PROLLY=1 -DDOLTLITE_VERSION='"dev"'
+  -DSQLITE_ENABLE_FTS5 -DSQLITE_ENABLE_RTREE
+  -D_HAVE_SQLITE_CONFIG_H -DBUILD_sqlite
+  -DSQLITE_OMIT_INCRBLOB -DSQLITE_OMIT_WAL
+  "-I$BUILD_DIR" "-I$ROOT/src" -Iext/rtree -Iext/icu -Iext/fts3 -Iext/session
+  -Iext/misc -Iext/blake3 -Iext/ed25519 -Iext/mbedtls/include
+)
+
+if ! "$CC" "${CFLAGS[@]}" -c -o "$OBJ" src/btree_orig_api.c 2>"$ERR"; then
+  echo "FAIL: btree_orig_api.c did not compile with SQLITE_OMIT_INCRBLOB" >&2
+  sed 's/^/  /' "$ERR" >&2
+  exit 1
+fi
+
+undef=$(nm -u "$OBJ" 2>/dev/null | grep -E 'orig_sqlite3Btree(EnterCursor|LeaveCursor|PayloadChecked)$' || true)
+if [ -n "$undef" ]; then
+  echo "FAIL: SQLITE_OMIT_INCRBLOB left unresolved orig btree symbols:" >&2
+  echo "$undef" | sed 's/^/  /' >&2
+  exit 1
+fi
+
+echo "omit_incrblob_orig_adapter: PASS"


### PR DESCRIPTION
## Summary

Ito flagged this on #2704 as unrelated to that dead-code change: a library built with `-DSQLITE_OMIT_INCRBLOB` (and `-DSQLITE_OMIT_WAL`) cannot link because `btree_orig_api.o` still references stock symbols that are not compiled.

Upstream `btmutex.c` / `btree.c` define `sqlite3BtreeEnterCursor`, `sqlite3BtreeLeaveCursor`, and `sqlite3BtreePayloadChecked` only inside `#ifndef SQLITE_OMIT_INCRBLOB`. The orig adapter called the prefixed versions from shared-cache/threadsafe guards (`EnterCursor`/`LeaveCursor`) or with no guard (`PayloadChecked`).

- Call those `orig_sqlite3*` symbols only when incremental blob I/O is enabled (same as `PutData` / `IncrblobCursor`)
- `lint_orig_btree_adapter.sh` fails if those calls lose the `SQLITE_OMIT_INCRBLOB` guard
- CI compiles `btree_orig_api.c` with `SQLITE_OMIT_INCRBLOB` + `SQLITE_OMIT_WAL` and rejects unresolved `orig_sqlite3BtreeEnterCursor` / `LeaveCursor` / `PayloadChecked`

The default DoltLite build is unchanged.

## Test plan

- [x] `bash test/lint_orig_btree_adapter.sh` passes on the fix
- [x] The same lint fails on `origin/master` (3 unguarded `orig_sqlite3*` calls)
- [x] `bash test/omit_incrblob_orig_adapter_test.sh` passes
- [x] That compile test fails on unfixed `btree_orig_api.c` (undeclared `orig_sqlite3BtreePayloadChecked`)
- [x] `bash test/lint_layers.sh`

Co-Authored-By: Grok 4.6 <noreply@x.ai>