### PR TITLE
Clone AUTOINCREMENT sequence data last

### DIFF
--- a/src/shell.c.in
+++ b/src/shell.c.in
@@ -6149,8 +6149,15 @@ static void tryToCloneSchema(
   const unsigned char *zSql;
   char *zErrMsg = 0;
 
+#ifdef DOLTLITE_PROLLY
+  zQuery = sqlite3_mprintf("SELECT name, sql FROM sqlite_schema"
+                           " WHERE %s"
+                           " ORDER BY name='sqlite_sequence', rowid ASC",
+                           zWhere);
+#else
   zQuery = sqlite3_mprintf("SELECT name, sql FROM sqlite_schema"
                            " WHERE %s ORDER BY rowid ASC", zWhere);
+#endif
   shell_check_oom(zQuery);
   rc = sqlite3_prepare_v2(p->db, zQuery, -1, &pQuery, 0);
   if( rc ){

--- a/src/shell.c.in
+++ b/src/shell.c.in
@@ -6042,6 +6042,14 @@ static void tryToCloneData(
   int cnt = 0;
   const int spinRate = 10000;
 
+#ifdef DOLTLITE_PROLLY
+  /* AUTOINCREMENT clones already inserted sqlite_sequence rows. Replace them
+  ** with the source counters instead of appending duplicates. */
+  if( sqlite3_stricmp(zTable, "sqlite_sequence")==0 ){
+    sqlite3_exec(newDb, "DELETE FROM sqlite_sequence", 0, 0, 0);
+  }
+#endif
+
   zQuery = sqlite3_mprintf("SELECT * FROM \"%w\"", zTable);
   shell_check_oom(zQuery);
   rc = sqlite3_prepare_v2(p->db, zQuery, -1, &pQuery, 0);

--- a/test/doltlite_autoinc_sequence_reset.sh
+++ b/test/doltlite_autoinc_sequence_reset.sh
@@ -128,4 +128,21 @@ INSERT INTO tt(v) VALUES(3);
 SELECT id FROM tt;
 " "1" "$DB"
 
+run_test "seq_clone_copies_without_error" "
+.mode batch
+CREATE TABLE t(id INTEGER PRIMARY KEY AUTOINCREMENT);
+INSERT INTO t VALUES(1),(2);
+UPDATE sqlite_sequence SET seq=100 WHERE name='t';
+.clone $ROOT/clone.db
+.open $ROOT/clone.db
+SELECT max(seq) FROM sqlite_sequence;
+INSERT INTO t DEFAULT VALUES;
+SELECT max(id) FROM t;
+SELECT max(seq) FROM sqlite_sequence;
+" "t... done
+done
+100
+101
+101" ":memory:"
+
 dltest_finish

--- a/test/doltlite_autoinc_sequence_reset.sh
+++ b/test/doltlite_autoinc_sequence_reset.sh
@@ -135,14 +135,48 @@ INSERT INTO t VALUES(1),(2);
 UPDATE sqlite_sequence SET seq=100 WHERE name='t';
 .clone $ROOT/clone.db
 .open $ROOT/clone.db
-SELECT max(seq) FROM sqlite_sequence;
+SELECT name, seq FROM sqlite_sequence ORDER BY name;
+SELECT count(*) FROM sqlite_sequence;
 INSERT INTO t DEFAULT VALUES;
 SELECT max(id) FROM t;
-SELECT max(seq) FROM sqlite_sequence;
+SELECT name, seq FROM sqlite_sequence ORDER BY name;
+SELECT count(*) FROM sqlite_sequence;
 " "t... done
 done
-100
+t|100
+1
 101
-101" ":memory:"
+t|101
+1" ":memory:"
+
+run_test "seq_clone_two_autoinc_tables_one_row_each" "
+.mode batch
+CREATE TABLE a(id INTEGER PRIMARY KEY AUTOINCREMENT);
+CREATE TABLE b(id INTEGER PRIMARY KEY AUTOINCREMENT);
+INSERT INTO a DEFAULT VALUES;
+INSERT INTO b DEFAULT VALUES;
+UPDATE sqlite_sequence SET seq=40 WHERE name='a';
+UPDATE sqlite_sequence SET seq=80 WHERE name='b';
+.clone $ROOT/clone2.db
+.open $ROOT/clone2.db
+SELECT name, seq FROM sqlite_sequence ORDER BY name;
+SELECT count(*) FROM sqlite_sequence;
+INSERT INTO a DEFAULT VALUES;
+INSERT INTO b DEFAULT VALUES;
+SELECT max(id) FROM a;
+SELECT max(id) FROM b;
+SELECT name, seq FROM sqlite_sequence ORDER BY name;
+SELECT count(*) FROM sqlite_sequence;
+" "a... done
+b... done
+done
+a|40
+b|80
+2
+41
+81
+a|41
+b|81
+2" ":memory:"
 
 dltest_finish


### PR DESCRIPTION
## Summary

- copy sqlite_sequence after AUTOINCREMENT tables even when DoltLite catalog order puts it first
- prevent the false missing-table error and preserve raised sequence counters
- add CLI regression covering clone output, copied sequence state, and next allocation

## Testing

- `bash test/doltlite_autoinc_sequence_reset.sh build/doltlite` (14 passed)
- `bash test/run_doltlite_tests.sh build/doltlite` (132 suites passed)
- `make -C build lint`

Fixes #2706

Co-Authored-By: OpenAI Codex <noreply@openai.com>