### PR TITLE
Share the merge-constraint user-table walk

### DIFF
--- a/src/doltlite_merge_constraints.c
+++ b/src/doltlite_merge_constraints.c
@@ -111,7 +111,7 @@ int catalogTableChanged(
 }
 
 
-int cvTableAllowed(
+static int cvTableAllowed(
   const char *zTable,
   const char **azTables,
   int nTables
@@ -125,7 +125,7 @@ int cvTableAllowed(
   return 0;
 }
 
-int loadAncestorAndCurrentCatalogs(
+static int loadAncestorAndCurrentCatalogs(
   sqlite3 *db,
   const ProllyHash *pAncCatHash,
   struct TableEntry **paAnc, int *pnAnc,
@@ -157,6 +157,82 @@ int loadAncestorAndCurrentCatalogs(
     *paAnc = 0;
     *pnAnc = 0;
   }
+  return rc;
+}
+
+int walkMergeUserTables(
+  sqlite3 *db,
+  const ProllyHash *pAncCatHash,
+  char **pzErrMsg,
+  const char **azTables,
+  int nTables,
+  int skipUnchanged,
+  int wantSql,
+  MergeUserTableWalk xWalk,
+  void *pCtx
+){
+  sqlite3_stmt *pTbls = 0;
+  struct TableEntry *aAnc = 0;
+  int nAnc = 0;
+  struct TableEntry *aCur = 0;
+  int nCur = 0;
+  int rc;
+  int stepRc;
+
+  rc = loadAncestorAndCurrentCatalogs(db, pAncCatHash, &aAnc, &nAnc,
+                                      &aCur, &nCur);
+  if( rc!=SQLITE_OK ) return rc;
+
+  rc = sqlite3_prepare_v2(db,
+      wantSql
+        ? "SELECT name, sql FROM main.sqlite_master WHERE type='table' "
+          "AND name NOT LIKE 'sqlite_%' AND name NOT LIKE 'dolt_%'"
+        : "SELECT name FROM main.sqlite_master WHERE type='table' "
+          "AND name NOT LIKE 'sqlite_%' AND name NOT LIKE 'dolt_%'",
+      -1, &pTbls, 0);
+  if( rc!=SQLITE_OK ){
+    doltliteFreeCatalog(aAnc, nAnc);
+    doltliteFreeCatalog(aCur, nCur);
+    return rc;
+  }
+
+  while( (stepRc = sqlite3_step(pTbls))==SQLITE_ROW ){
+    const char *zTableRaw = (const char*)sqlite3_column_text(pTbls, 0);
+    const char *zSqlRaw = wantSql ? (const char*)sqlite3_column_text(pTbls, 1) : 0;
+    char *zTable;
+    char *zSql = 0;
+
+    if( !zTableRaw ) continue;
+    if( wantSql && !zSqlRaw ) continue;
+    zTable = sqlite3_mprintf("%s", zTableRaw);
+    if( !zTable ){ rc = SQLITE_NOMEM; break; }
+    if( wantSql ){
+      zSql = sqlite3_mprintf("%s", zSqlRaw);
+      if( !zSql ){
+        sqlite3_free(zTable);
+        rc = SQLITE_NOMEM;
+        break;
+      }
+    }
+    if( !cvTableAllowed(zTable, azTables, nTables)
+     || (skipUnchanged
+         && !catalogTableChanged(aAnc, nAnc, aCur, nCur, zTable)) ){
+      sqlite3_free(zTable);
+      sqlite3_free(zSql);
+      continue;
+    }
+    rc = xWalk(db, zTable, zSql, aAnc, nAnc, aCur, nCur, pCtx);
+    sqlite3_free(zTable);
+    sqlite3_free(zSql);
+    if( rc!=SQLITE_OK ) break;
+  }
+  if( rc==SQLITE_OK && stepRc!=SQLITE_DONE && stepRc!=SQLITE_ROW ){
+    rc = stepRc;
+  }
+  rc = finishConstraintStmt(pTbls, rc);
+  doltliteFreeCatalog(aAnc, nAnc);
+  doltliteFreeCatalog(aCur, nCur);
+  setConstraintError(db, pzErrMsg, rc);
   return rc;
 }
 

--- a/src/doltlite_merge_constraints_check.c
+++ b/src/doltlite_merge_constraints_check.c
@@ -103,6 +103,147 @@ static int nextCheckClause(
   return 0;
 }
 
+typedef struct CheckWalk CheckWalk;
+struct CheckWalk {
+  char **pzErrMsg;
+  int *pnFound;
+};
+
+static int checkWalkTable(
+  sqlite3 *db,
+  const char *zTable,
+  const char *zSql,
+  struct TableEntry *aAnc, int nAnc,
+  struct TableEntry *aCur, int nCur,
+  void *pCtx
+){
+  CheckWalk *pWalk = (CheckWalk*)pCtx;
+  int offset = 0;
+  int hasRowid = 1;
+  MergePkInfo pkInfo;
+  int rc;
+  (void)aCur; (void)nCur;
+
+  memset(&pkInfo, 0, sizeof(pkInfo));
+  rc = tableHasRowid(db, zTable, &hasRowid);
+  if( rc!=SQLITE_OK ) return rc;
+  if( !hasRowid ){
+    rc = loadMergePkInfo(db, zTable, &pkInfo);
+    if( rc != SQLITE_OK ) return rc;
+  }
+
+  for(;;){
+    char *zExpr = 0;
+    char *zCkName = 0;
+    int clauseRc = nextCheckClause(zSql, &offset, &zExpr, &zCkName);
+    char *zQuery;
+    sqlite3_stmt *pQ = 0;
+    int queryStepRc;
+
+    if( clauseRc <= 0 ){
+      sqlite3_free(zExpr);
+      sqlite3_free(zCkName);
+      if( clauseRc<0 ) rc = -clauseRc;
+      break;
+    }
+
+    if( hasRowid ){
+      zQuery = sqlite3_mprintf(
+          "SELECT rowid FROM main.\"%w\" NOT INDEXED WHERE NOT (%s)",
+          zTable, zExpr);
+    }else{
+      zQuery = sqlite3_mprintf(
+          "SELECT %s FROM main.\"%w\" NOT INDEXED WHERE NOT (%s)",
+          pkInfo.zPkCols, zTable, zExpr);
+    }
+    if( !zQuery ){
+      sqlite3_free(zExpr);
+      sqlite3_free(zCkName);
+      rc = SQLITE_NOMEM;
+      break;
+    }
+    rc = sqlite3_prepare_v2(db, zQuery, -1, &pQ, 0);
+    sqlite3_free(zQuery);
+    if( rc != SQLITE_OK ){
+      setConstraintError(db, pWalk->pzErrMsg, rc);
+      sqlite3_free(zExpr);
+      sqlite3_free(zCkName);
+      break;
+    }
+
+    while( (queryStepRc = sqlite3_step(pQ)) == SQLITE_ROW ){
+      u8 *pKey = 0; int nKey = 0;
+      u8 *pVal = 0; int nVal = 0;
+      char *zInfo;
+      int appendRc;
+      i64 intKey = 0;
+
+      if( hasRowid ){
+        intKey = sqlite3_column_int64(pQ, 0);
+        rc = fetchOrphanRow(db, zTable, intKey, &pKey, &nKey, &pVal, &nVal);
+      }else{
+        u8 *pPkRec = 0; int nPkRec = 0;
+        pPkRec = buildRecordFromStmtCols(pQ, 0, pkInfo.nPk, &nPkRec);
+        if( !pPkRec ){ rc = SQLITE_NOMEM; break; }
+        rc = fetchRowByPkFromTable(db, zTable, pPkRec, nPkRec, pkInfo.nPk,
+                                   &pKey, &nKey, &pVal, &nVal);
+        sqlite3_free(pPkRec);
+      }
+      if( rc == SQLITE_NOTFOUND ){ rc = SQLITE_OK; continue; }
+      if( rc != SQLITE_OK ){
+        sqlite3_free(pKey);
+        sqlite3_free(pVal);
+        break;
+      }
+
+      if( aAnc ){
+        u8 *pAncVal = 0; int nAncVal = 0;
+        int ancRc = hasRowid
+            ? fetchAncestorRowByName(db, aAnc, nAnc, zTable,
+                                     intKey, &pAncVal, &nAncVal)
+            : fetchAncestorRowByKey(db, aAnc, nAnc, zTable,
+                                    pKey, nKey, &pAncVal, &nAncVal);
+        int preExisting = (ancRc==SQLITE_OK)
+            && isRowPreExisting(pVal, nVal, pAncVal, nAncVal);
+        sqlite3_free(pAncVal);
+        if( preExisting ){
+          sqlite3_free(pKey);
+          sqlite3_free(pVal);
+          continue;
+        }
+      }
+
+      zInfo = sqlite3_mprintf(
+          "{\"Name\": \"%w\", \"Expression\": \"%w\"}",
+          zCkName ? zCkName : "", zExpr);
+      if( !zInfo ){
+        sqlite3_free(pKey);
+        sqlite3_free(pVal);
+        rc = SQLITE_NOMEM;
+        break;
+      }
+      appendRc = doltliteAppendConstraintViolation(
+          db, zTable, DOLTLITE_CV_CHECK_CONSTRAINT,
+          intKey, pKey, nKey, pVal, nVal, zInfo);
+      sqlite3_free(zInfo);
+      sqlite3_free(pKey);
+      sqlite3_free(pVal);
+      if( appendRc != SQLITE_OK ){ rc = appendRc; break; }
+      if( pWalk->pnFound ) (*pWalk->pnFound)++;
+    }
+    if( rc==SQLITE_OK && queryStepRc!=SQLITE_DONE ) rc = queryStepRc;
+    setConstraintError(db, pWalk->pzErrMsg, rc);
+    rc = finishConstraintStmt(pQ, rc);
+    setConstraintError(db, pWalk->pzErrMsg, rc);
+    sqlite3_free(zExpr);
+    sqlite3_free(zCkName);
+    if( rc != SQLITE_OK ) break;
+  }
+
+  freeMergePkInfo(&pkInfo);
+  return rc;
+}
+
 int doltliteDetectMergeCheckViolations(
   sqlite3 *db,
   const ProllyHash *pAncCatHash,
@@ -111,195 +252,12 @@ int doltliteDetectMergeCheckViolations(
   const char **azTables,
   int nTables
 ){
-  sqlite3_stmt *pTbls = 0;
-  struct TableEntry *aAnc = 0;
-  int nAnc = 0;
-  struct TableEntry *aCur = 0;
-  int nCur = 0;
-  int rc;
-  int stepRc;
-
+  CheckWalk walk;
   if( pnFound ) *pnFound = 0;
-
-  rc = loadAncestorAndCurrentCatalogs(db, pAncCatHash, &aAnc, &nAnc,
-                                      &aCur, &nCur);
-  if( rc!=SQLITE_OK ) return rc;
-
-  rc = sqlite3_prepare_v2(db,
-      "SELECT name, sql FROM main.sqlite_master WHERE type='table' "
-      "AND name NOT LIKE 'sqlite_%' AND name NOT LIKE 'dolt_%'",
-      -1, &pTbls, 0);
-  if( rc != SQLITE_OK ){
-    doltliteFreeCatalog(aAnc, nAnc);
-    doltliteFreeCatalog(aCur, nCur);
-    return rc;
-  }
-
-  while( (stepRc = sqlite3_step(pTbls)) == SQLITE_ROW ){
-    const char *zTableRaw = (const char*)sqlite3_column_text(pTbls, 0);
-    const char *zSqlRaw   = (const char*)sqlite3_column_text(pTbls, 1);
-    char *zTable;
-    char *zSql;
-    int offset = 0;
-    int hasRowid = 1;
-    MergePkInfo pkInfo;
-
-    if( !zTableRaw || !zSqlRaw ) continue;
-    zTable = sqlite3_mprintf("%s", zTableRaw);
-    zSql   = sqlite3_mprintf("%s", zSqlRaw);
-    if( !zTable || !zSql ){
-      sqlite3_free(zTable);
-      sqlite3_free(zSql);
-      rc = SQLITE_NOMEM;
-      break;
-    }
-    if( !cvTableAllowed(zTable, azTables, nTables) ){
-      sqlite3_free(zTable);
-      sqlite3_free(zSql);
-      continue;
-    }
-    if( !catalogTableChanged(aAnc, nAnc, aCur, nCur, zTable) ){
-      sqlite3_free(zTable);
-      sqlite3_free(zSql);
-      continue;
-    }
-    memset(&pkInfo, 0, sizeof(pkInfo));
-    rc = tableHasRowid(db, zTable, &hasRowid);
-    if( rc!=SQLITE_OK ){
-      sqlite3_free(zTable);
-      sqlite3_free(zSql);
-      break;
-    }
-    if( !hasRowid ){
-      rc = loadMergePkInfo(db, zTable, &pkInfo);
-      if( rc != SQLITE_OK ){
-        sqlite3_free(zTable);
-        sqlite3_free(zSql);
-        break;
-      }
-    }
-
-    for(;;){
-      char *zExpr = 0;
-      char *zCkName = 0;
-      int clauseRc = nextCheckClause(zSql, &offset, &zExpr, &zCkName);
-      char *zQuery;
-      sqlite3_stmt *pQ = 0;
-      int queryStepRc;
-
-      if( clauseRc <= 0 ){
-        sqlite3_free(zExpr);
-        sqlite3_free(zCkName);
-        if( clauseRc<0 ) rc = -clauseRc;
-        break;
-      }
-
-      if( hasRowid ){
-        zQuery = sqlite3_mprintf(
-            "SELECT rowid FROM main.\"%w\" NOT INDEXED WHERE NOT (%s)",
-            zTable, zExpr);
-      }else{
-        zQuery = sqlite3_mprintf(
-            "SELECT %s FROM main.\"%w\" NOT INDEXED WHERE NOT (%s)",
-            pkInfo.zPkCols, zTable, zExpr);
-      }
-      if( !zQuery ){
-        sqlite3_free(zExpr);
-        sqlite3_free(zCkName);
-        rc = SQLITE_NOMEM;
-        break;
-      }
-      rc = sqlite3_prepare_v2(db, zQuery, -1, &pQ, 0);
-      sqlite3_free(zQuery);
-      if( rc != SQLITE_OK ){
-        setConstraintError(db, pzErrMsg, rc);
-        sqlite3_free(zExpr);
-        sqlite3_free(zCkName);
-        break;
-      }
-
-      while( (queryStepRc = sqlite3_step(pQ)) == SQLITE_ROW ){
-        u8 *pKey = 0; int nKey = 0;
-        u8 *pVal = 0; int nVal = 0;
-        char *zInfo;
-        int appendRc;
-        i64 intKey = 0;
-
-        if( hasRowid ){
-          intKey = sqlite3_column_int64(pQ, 0);
-          rc = fetchOrphanRow(db, zTable, intKey, &pKey, &nKey, &pVal, &nVal);
-        }else{
-          u8 *pPkRec = 0; int nPkRec = 0;
-          pPkRec = buildRecordFromStmtCols(pQ, 0, pkInfo.nPk, &nPkRec);
-          if( !pPkRec ){ rc = SQLITE_NOMEM; break; }
-          rc = fetchRowByPkFromTable(db, zTable, pPkRec, nPkRec, pkInfo.nPk,
-                                     &pKey, &nKey, &pVal, &nVal);
-          sqlite3_free(pPkRec);
-        }
-        if( rc == SQLITE_NOTFOUND ){ rc = SQLITE_OK; continue; }
-        if( rc != SQLITE_OK ){
-          sqlite3_free(pKey);
-          sqlite3_free(pVal);
-          break;
-        }
-
-        if( aAnc ){
-          u8 *pAncVal = 0; int nAncVal = 0;
-          int ancRc = hasRowid
-              ? fetchAncestorRowByName(db, aAnc, nAnc, zTable,
-                                       intKey, &pAncVal, &nAncVal)
-              : fetchAncestorRowByKey(db, aAnc, nAnc, zTable,
-                                      pKey, nKey, &pAncVal, &nAncVal);
-          int preExisting = (ancRc==SQLITE_OK)
-              && isRowPreExisting(pVal, nVal, pAncVal, nAncVal);
-          sqlite3_free(pAncVal);
-          if( preExisting ){
-            sqlite3_free(pKey);
-            sqlite3_free(pVal);
-            continue;
-          }
-        }
-
-        zInfo = sqlite3_mprintf(
-            "{\"Name\": \"%w\", \"Expression\": \"%w\"}",
-            zCkName ? zCkName : "", zExpr);
-        if( !zInfo ){
-          sqlite3_free(pKey);
-          sqlite3_free(pVal);
-          rc = SQLITE_NOMEM;
-          break;
-        }
-        appendRc = doltliteAppendConstraintViolation(
-            db, zTable, DOLTLITE_CV_CHECK_CONSTRAINT,
-            intKey, pKey, nKey, pVal, nVal, zInfo);
-        sqlite3_free(zInfo);
-        sqlite3_free(pKey);
-        sqlite3_free(pVal);
-        if( appendRc != SQLITE_OK ){ rc = appendRc; break; }
-        if( pnFound ) (*pnFound)++;
-      }
-      if( rc==SQLITE_OK && queryStepRc!=SQLITE_DONE ) rc = queryStepRc;
-      setConstraintError(db, pzErrMsg, rc);
-      rc = finishConstraintStmt(pQ, rc);
-      setConstraintError(db, pzErrMsg, rc);
-      sqlite3_free(zExpr);
-      sqlite3_free(zCkName);
-      if( rc != SQLITE_OK ) break;
-    }
-
-    sqlite3_free(zTable);
-    sqlite3_free(zSql);
-    freeMergePkInfo(&pkInfo);
-    if( rc != SQLITE_OK ) break;
-  }
-  if( rc == SQLITE_OK && stepRc != SQLITE_DONE && stepRc != SQLITE_ROW ){
-    rc = stepRc;
-  }
-  rc = finishConstraintStmt(pTbls, rc);
-  doltliteFreeCatalog(aAnc, nAnc);
-  doltliteFreeCatalog(aCur, nCur);
-  setConstraintError(db, pzErrMsg, rc);
-  return rc;
+  walk.pzErrMsg = pzErrMsg;
+  walk.pnFound = pnFound;
+  return walkMergeUserTables(db, pAncCatHash, pzErrMsg, azTables, nTables,
+                             1, 1, checkWalkTable, &walk);
 }
 
 

--- a/src/doltlite_merge_constraints_fk.c
+++ b/src/doltlite_merge_constraints_fk.c
@@ -400,6 +400,131 @@ static int detectFkViolationsForSpec(
   return rc;
 }
 
+static int fkWalkTable(
+  sqlite3 *db,
+  const char *zTable,
+  const char *zSql,
+  struct TableEntry *aAnc, int nAnc,
+  struct TableEntry *aCur, int nCur,
+  void *pCtx
+){
+  char *zFkQ = 0;
+  sqlite3_stmt *pFk = 0;
+  int hasRowid = 1;
+  MergePkInfo childPk;
+  int curId = -1;
+  char *zParent = 0;
+  char **azFrom = 0;
+  char **azTo = 0;
+  int nCol = 0;
+  int nAlloc = 0;
+  int childChanged;
+  int fkStepRc;
+  int rc;
+  int *pnFound = (int*)pCtx;
+  (void)zSql;
+
+  childChanged = catalogTableChanged(aAnc, nAnc, aCur, nCur, zTable);
+  memset(&childPk, 0, sizeof(childPk));
+  rc = tableHasRowid(db, zTable, &hasRowid);
+  if( rc!=SQLITE_OK ) return rc;
+  if( !hasRowid ){
+    rc = loadMergePkInfo(db, zTable, &childPk);
+    if( rc != SQLITE_OK ) return rc;
+  }
+
+  zFkQ = sqlite3_mprintf("PRAGMA main.foreign_key_list(%Q)", zTable);
+  if( !zFkQ ){
+    freeMergePkInfo(&childPk);
+    return SQLITE_NOMEM;
+  }
+  rc = sqlite3_prepare_v2(db, zFkQ, -1, &pFk, 0);
+  sqlite3_free(zFkQ);
+  if( rc != SQLITE_OK ){
+    freeMergePkInfo(&childPk);
+    return rc;
+  }
+
+  while( (fkStepRc = sqlite3_step(pFk)) == SQLITE_ROW ){
+    int id = sqlite3_column_int(pFk, 0);
+    const char *zParentRaw = (const char*)sqlite3_column_text(pFk, 2);
+    const char *zFromRaw = (const char*)sqlite3_column_text(pFk, 3);
+    const char *zToRaw = (const char*)sqlite3_column_text(pFk, 4);
+
+    if( curId>=0 && id!=curId ){
+      int parentChanged = catalogTableChanged(aAnc, nAnc, aCur, nCur, zParent);
+      if( childChanged || parentChanged ){
+        struct TableEntry *aCheckAnc = parentChanged ? 0 : aAnc;
+        int nCheckAnc = parentChanged ? 0 : nAnc;
+        rc = backfillParentPk(db, zParent, azTo, nCol);
+        if( rc != SQLITE_OK ) break;
+        rc = detectFkViolationsForSpec(db, aCur, nCur, aCheckAnc, nCheckAnc,
+            zTable, hasRowid, &childPk, zParent, curId,
+            azFrom, azTo, nCol, pnFound);
+      }
+      doltliteFreeStringArray(azFrom, nCol);
+      doltliteFreeStringArray(azTo, nCol);
+      azFrom = 0; azTo = 0; nCol = 0; nAlloc = 0;
+      sqlite3_free(zParent); zParent = 0;
+      if( rc != SQLITE_OK ) break;
+    }
+
+    if( curId != id ){
+      curId = id;
+      zParent = sqlite3_mprintf("%s", zParentRaw ? zParentRaw : "");
+      if( !zParent ){ rc = SQLITE_NOMEM; break; }
+    }
+
+    if( nCol >= nAlloc ){
+      int nNew = nAlloc ? nAlloc*2 : 4;
+      char **azFromNew;
+      char **azToNew;
+      azFromNew = sqlite3_realloc64(azFrom, (sqlite3_int64)nNew * sizeof(char*));
+      if( !azFromNew ){
+        rc = SQLITE_NOMEM;
+        break;
+      }
+      azFrom = azFromNew;
+      azToNew = sqlite3_realloc64(azTo, (sqlite3_int64)nNew * sizeof(char*));
+      if( !azToNew ){
+        rc = SQLITE_NOMEM;
+        break;
+      }
+      azTo = azToNew;
+      nAlloc = nNew;
+    }
+    azFrom[nCol] = sqlite3_mprintf("%s", zFromRaw ? zFromRaw : "");
+    azTo[nCol] = zToRaw ? sqlite3_mprintf("%s", zToRaw) : 0;
+    if( !azFrom[nCol] || (zToRaw && !azTo[nCol]) ){
+      rc = SQLITE_NOMEM;
+      break;
+    }
+    nCol++;
+  }
+
+  if( rc==SQLITE_OK && fkStepRc!=SQLITE_DONE ) rc = fkStepRc;
+  if( rc==SQLITE_OK && curId>=0 ){
+    int parentChanged = catalogTableChanged(aAnc, nAnc, aCur, nCur, zParent);
+    if( childChanged || parentChanged ){
+      struct TableEntry *aCheckAnc = parentChanged ? 0 : aAnc;
+      int nCheckAnc = parentChanged ? 0 : nAnc;
+      rc = backfillParentPk(db, zParent, azTo, nCol);
+      if( rc==SQLITE_OK ){
+        rc = detectFkViolationsForSpec(db, aCur, nCur, aCheckAnc, nCheckAnc,
+            zTable, hasRowid, &childPk, zParent, curId,
+            azFrom, azTo, nCol, pnFound);
+      }
+    }
+  }
+
+  doltliteFreeStringArray(azFrom, nCol);
+  doltliteFreeStringArray(azTo, nCol);
+  sqlite3_free(zParent);
+  rc = finishConstraintStmt(pFk, rc);
+  freeMergePkInfo(&childPk);
+  return rc;
+}
+
 int doltliteDetectMergeFkViolations(
   sqlite3 *db,
   const ProllyHash *pAncCatHash,
@@ -408,174 +533,9 @@ int doltliteDetectMergeFkViolations(
   const char **azTables,
   int nTables
 ){
-  sqlite3_stmt *pTbls = 0;
-  struct TableEntry *aAnc = 0;
-  int nAnc = 0;
-  struct TableEntry *aCur = 0;
-  int nCur = 0;
-  int rc;
-  int nFound = 0;
-  int stepRc;
-
   if( pnFound ) *pnFound = 0;
-
-  rc = loadAncestorAndCurrentCatalogs(db, pAncCatHash, &aAnc, &nAnc,
-                                      &aCur, &nCur);
-  if( rc!=SQLITE_OK ) return rc;
-
-  rc = sqlite3_prepare_v2(db,
-      "SELECT name FROM main.sqlite_master WHERE type='table' "
-      "AND name NOT LIKE 'sqlite_%' AND name NOT LIKE 'dolt_%'",
-      -1, &pTbls, 0);
-  if( rc != SQLITE_OK ){
-    doltliteFreeCatalog(aAnc, nAnc);
-    doltliteFreeCatalog(aCur, nCur);
-    return rc;
-  }
-
-  while( (stepRc = sqlite3_step(pTbls)) == SQLITE_ROW ){
-    const char *zTableRaw = (const char*)sqlite3_column_text(pTbls, 0);
-    char *zTable = 0;
-    char *zFkQ = 0;
-    sqlite3_stmt *pFk = 0;
-    int hasRowid = 1;
-    MergePkInfo childPk;
-    int curId = -1;
-    char *zParent = 0;
-    char **azFrom = 0;
-    char **azTo = 0;
-    int nCol = 0;
-    int nAlloc = 0;
-    int childChanged;
-    int fkStepRc;
-
-    if( !zTableRaw ) continue;
-    zTable = sqlite3_mprintf("%s", zTableRaw);
-    if( !zTable ){ rc = SQLITE_NOMEM; break; }
-    if( !cvTableAllowed(zTable, azTables, nTables) ){
-      sqlite3_free(zTable);
-      continue;
-    }
-    childChanged = catalogTableChanged(aAnc, nAnc, aCur, nCur, zTable);
-    memset(&childPk, 0, sizeof(childPk));
-    rc = tableHasRowid(db, zTable, &hasRowid);
-    if( rc!=SQLITE_OK ){
-      sqlite3_free(zTable);
-      break;
-    }
-    if( !hasRowid ){
-      rc = loadMergePkInfo(db, zTable, &childPk);
-      if( rc != SQLITE_OK ){
-        sqlite3_free(zTable);
-        break;
-      }
-    }
-
-    zFkQ = sqlite3_mprintf("PRAGMA main.foreign_key_list(%Q)", zTable);
-    if( !zFkQ ){
-      freeMergePkInfo(&childPk);
-      sqlite3_free(zTable);
-      rc = SQLITE_NOMEM;
-      break;
-    }
-    rc = sqlite3_prepare_v2(db, zFkQ, -1, &pFk, 0);
-    sqlite3_free(zFkQ);
-    if( rc != SQLITE_OK ){
-      freeMergePkInfo(&childPk);
-      sqlite3_free(zTable);
-      break;
-    }
-
-    while( (fkStepRc = sqlite3_step(pFk)) == SQLITE_ROW ){
-      int id = sqlite3_column_int(pFk, 0);
-      const char *zParentRaw = (const char*)sqlite3_column_text(pFk, 2);
-      const char *zFromRaw = (const char*)sqlite3_column_text(pFk, 3);
-      const char *zToRaw = (const char*)sqlite3_column_text(pFk, 4);
-
-      if( curId>=0 && id!=curId ){
-        int parentChanged = catalogTableChanged(aAnc, nAnc, aCur, nCur, zParent);
-        if( childChanged || parentChanged ){
-          struct TableEntry *aCheckAnc = parentChanged ? 0 : aAnc;
-          int nCheckAnc = parentChanged ? 0 : nAnc;
-          rc = backfillParentPk(db, zParent, azTo, nCol);
-          if( rc != SQLITE_OK ) break;
-          rc = detectFkViolationsForSpec(db, aCur, nCur, aCheckAnc, nCheckAnc,
-              zTable, hasRowid, &childPk, zParent, curId,
-              azFrom, azTo, nCol, &nFound);
-        }
-        doltliteFreeStringArray(azFrom, nCol);
-        doltliteFreeStringArray(azTo, nCol);
-        azFrom = 0; azTo = 0; nCol = 0; nAlloc = 0;
-        sqlite3_free(zParent); zParent = 0;
-        if( rc != SQLITE_OK ) break;
-      }
-
-      if( curId != id ){
-        curId = id;
-        zParent = sqlite3_mprintf("%s", zParentRaw ? zParentRaw : "");
-        if( !zParent ){ rc = SQLITE_NOMEM; break; }
-      }
-
-      if( nCol >= nAlloc ){
-        int nNew = nAlloc ? nAlloc*2 : 4;
-        char **azFromNew;
-        char **azToNew;
-        azFromNew = sqlite3_realloc64(azFrom, (sqlite3_int64)nNew * sizeof(char*));
-        if( !azFromNew ){
-          rc = SQLITE_NOMEM;
-          break;
-        }
-        azFrom = azFromNew;
-        azToNew = sqlite3_realloc64(azTo, (sqlite3_int64)nNew * sizeof(char*));
-        if( !azToNew ){
-          rc = SQLITE_NOMEM;
-          break;
-        }
-        azTo = azToNew;
-        nAlloc = nNew;
-      }
-      azFrom[nCol] = sqlite3_mprintf("%s", zFromRaw ? zFromRaw : "");
-      azTo[nCol] = zToRaw ? sqlite3_mprintf("%s", zToRaw) : 0;
-      if( !azFrom[nCol] || (zToRaw && !azTo[nCol]) ){
-        rc = SQLITE_NOMEM;
-        break;
-      }
-      nCol++;
-    }
-
-    if( rc==SQLITE_OK && fkStepRc!=SQLITE_DONE ) rc = fkStepRc;
-    if( rc==SQLITE_OK && curId>=0 ){
-      int parentChanged = catalogTableChanged(aAnc, nAnc, aCur, nCur, zParent);
-      if( childChanged || parentChanged ){
-        struct TableEntry *aCheckAnc = parentChanged ? 0 : aAnc;
-        int nCheckAnc = parentChanged ? 0 : nAnc;
-        rc = backfillParentPk(db, zParent, azTo, nCol);
-        if( rc==SQLITE_OK ){
-          rc = detectFkViolationsForSpec(db, aCur, nCur, aCheckAnc, nCheckAnc,
-              zTable, hasRowid, &childPk, zParent, curId,
-              azFrom, azTo, nCol, &nFound);
-        }
-      }
-    }
-
-    doltliteFreeStringArray(azFrom, nCol);
-    doltliteFreeStringArray(azTo, nCol);
-    sqlite3_free(zParent);
-    rc = finishConstraintStmt(pFk, rc);
-    freeMergePkInfo(&childPk);
-    sqlite3_free(zTable);
-    if( rc != SQLITE_OK ) break;
-  }
-
-  if( rc == SQLITE_OK && stepRc != SQLITE_DONE && stepRc != SQLITE_ROW ){
-    rc = stepRc;
-  }
-  rc = finishConstraintStmt(pTbls, rc);
-  doltliteFreeCatalog(aAnc, nAnc);
-  doltliteFreeCatalog(aCur, nCur);
-  if( pnFound ) *pnFound = nFound;
-  setConstraintError(db, pzErrMsg, rc);
-  return rc;
+  return walkMergeUserTables(db, pAncCatHash, pzErrMsg, azTables, nTables,
+                             0, 0, fkWalkTable, pnFound);
 }
 
 

--- a/src/doltlite_merge_constraints_int.h
+++ b/src/doltlite_merge_constraints_int.h
@@ -29,11 +29,24 @@ int catalogTableChanged(
   struct TableEntry *aCur, int nCur,
   const char *zTable
 );
-int cvTableAllowed(const char *zTable, const char **azTables, int nTables);
-int loadAncestorAndCurrentCatalogs(
-  sqlite3 *db, const ProllyHash *pAncCatHash,
-  struct TableEntry **paAnc, int *pnAnc,
-  struct TableEntry **paCur, int *pnCur
+typedef int (*MergeUserTableWalk)(
+  sqlite3 *db,
+  const char *zTable,
+  const char *zSql,
+  struct TableEntry *aAnc, int nAnc,
+  struct TableEntry *aCur, int nCur,
+  void *pCtx
+);
+int walkMergeUserTables(
+  sqlite3 *db,
+  const ProllyHash *pAncCatHash,
+  char **pzErrMsg,
+  const char **azTables,
+  int nTables,
+  int skipUnchanged,
+  int wantSql,
+  MergeUserTableWalk xWalk,
+  void *pCtx
 );
 u8 *buildRecordFromStmtCols(
   sqlite3_stmt *pStmt, int iStart, int nField, int *pnOut

--- a/src/doltlite_merge_constraints_notnull.c
+++ b/src/doltlite_merge_constraints_notnull.c
@@ -54,6 +54,28 @@ static int loadNotNullColumns(
   return SQLITE_OK;
 }
 
+static int notNullWalkTable(
+  sqlite3 *db,
+  const char *zTable,
+  const char *zSql,
+  struct TableEntry *aAnc, int nAnc,
+  struct TableEntry *aCur, int nCur,
+  void *pCtx
+){
+  char **azCols = 0;
+  int nCols = 0;
+  int rc;
+  (void)zSql; (void)aCur; (void)nCur;
+  rc = loadNotNullColumns(db, zTable, &azCols, &nCols);
+  if( rc!=SQLITE_OK ) return rc;
+  if( nCols==0 ) return SQLITE_OK;
+  rc = scanMergeColumnFlagViolations(
+      db, zTable, aAnc, nAnc, azCols, 0, nCols,
+      DOLTLITE_CV_NOT_NULL, (int*)pCtx);
+  doltliteFreeNameList(azCols, nCols);
+  return rc;
+}
+
 int doltliteDetectMergeNotNullViolations(
   sqlite3 *db,
   const ProllyHash *pAncCatHash,
@@ -62,70 +84,9 @@ int doltliteDetectMergeNotNullViolations(
   const char **azTables,
   int nTables
 ){
-  sqlite3_stmt *pTbls = 0;
-  struct TableEntry *aAnc = 0;
-  int nAnc = 0;
-  struct TableEntry *aCur = 0;
-  int nCur = 0;
-  int rc;
-  int stepRc;
-
   if( pnFound ) *pnFound = 0;
-
-  rc = loadAncestorAndCurrentCatalogs(db, pAncCatHash, &aAnc, &nAnc,
-                                      &aCur, &nCur);
-  if( rc!=SQLITE_OK ) return rc;
-
-  rc = sqlite3_prepare_v2(db,
-      "SELECT name FROM main.sqlite_master WHERE type='table' "
-      "AND name NOT LIKE 'sqlite_%' AND name NOT LIKE 'dolt_%'",
-      -1, &pTbls, 0);
-  if( rc!=SQLITE_OK ){
-    doltliteFreeCatalog(aAnc, nAnc);
-    doltliteFreeCatalog(aCur, nCur);
-    return rc;
-  }
-
-  while( (stepRc = sqlite3_step(pTbls))==SQLITE_ROW ){
-    const char *zTableRaw = (const char*)sqlite3_column_text(pTbls, 0);
-    char *zTable;
-    char **azCols = 0;
-    int nCols = 0;
-
-    if( !zTableRaw ) continue;
-    zTable = sqlite3_mprintf("%s", zTableRaw);
-    if( !zTable ){ rc = SQLITE_NOMEM; break; }
-    if( !cvTableAllowed(zTable, azTables, nTables)
-     || !catalogTableChanged(aAnc, nAnc, aCur, nCur, zTable) ){
-      sqlite3_free(zTable);
-      continue;
-    }
-
-    rc = loadNotNullColumns(db, zTable, &azCols, &nCols);
-    if( rc!=SQLITE_OK ){
-      sqlite3_free(zTable);
-      break;
-    }
-    if( nCols==0 ){
-      sqlite3_free(zTable);
-      continue;
-    }
-
-    rc = scanMergeColumnFlagViolations(
-        db, zTable, aAnc, nAnc, azCols, 0, nCols,
-        DOLTLITE_CV_NOT_NULL, pnFound);
-    doltliteFreeNameList(azCols, nCols);
-    sqlite3_free(zTable);
-    if( rc!=SQLITE_OK ) break;
-  }
-  if( rc==SQLITE_OK && stepRc!=SQLITE_DONE && stepRc!=SQLITE_ROW ){
-    rc = stepRc;
-  }
-  rc = finishConstraintStmt(pTbls, rc);
-  doltliteFreeCatalog(aAnc, nAnc);
-  doltliteFreeCatalog(aCur, nCur);
-  setConstraintError(db, pzErrMsg, rc);
-  return rc;
+  return walkMergeUserTables(db, pAncCatHash, pzErrMsg, azTables, nTables,
+                             1, 0, notNullWalkTable, pnFound);
 }
 
 #endif

--- a/src/doltlite_merge_constraints_strict.c
+++ b/src/doltlite_merge_constraints_strict.c
@@ -107,6 +107,34 @@ static int loadStrictColumns(
   return SQLITE_OK;
 }
 
+static int strictWalkTable(
+  sqlite3 *db,
+  const char *zTable,
+  const char *zSql,
+  struct TableEntry *aAnc, int nAnc,
+  struct TableEntry *aCur, int nCur,
+  void *pCtx
+){
+  char **azCols = 0;
+  char **azAllowed = 0;
+  int nCols = 0;
+  int isStrict;
+  int rc;
+  (void)zSql; (void)aCur; (void)nCur;
+  rc = tableIsStrict(db, zTable, &isStrict);
+  if( rc!=SQLITE_OK ) return rc;
+  if( !isStrict ) return SQLITE_OK;
+  rc = loadStrictColumns(db, zTable, &azCols, &azAllowed, &nCols);
+  if( rc!=SQLITE_OK ) return rc;
+  if( nCols==0 ) return SQLITE_OK;
+  rc = scanMergeColumnFlagViolations(
+      db, zTable, aAnc, nAnc, azCols, azAllowed, nCols,
+      DOLTLITE_CV_STRICT_TYPE, (int*)pCtx);
+  doltliteFreeNameList(azCols, nCols);
+  doltliteFreeNameList(azAllowed, nCols);
+  return rc;
+}
+
 int doltliteDetectMergeStrictViolations(
   sqlite3 *db,
   const ProllyHash *pAncCatHash,
@@ -115,82 +143,9 @@ int doltliteDetectMergeStrictViolations(
   const char **azTables,
   int nTables
 ){
-  sqlite3_stmt *pTbls = 0;
-  struct TableEntry *aAnc = 0;
-  int nAnc = 0;
-  struct TableEntry *aCur = 0;
-  int nCur = 0;
-  int rc;
-  int stepRc;
-
   if( pnFound ) *pnFound = 0;
-
-  rc = loadAncestorAndCurrentCatalogs(db, pAncCatHash, &aAnc, &nAnc,
-                                      &aCur, &nCur);
-  if( rc!=SQLITE_OK ) return rc;
-
-  rc = sqlite3_prepare_v2(db,
-      "SELECT name FROM main.sqlite_master WHERE type='table' "
-      "AND name NOT LIKE 'sqlite_%' AND name NOT LIKE 'dolt_%'",
-      -1, &pTbls, 0);
-  if( rc!=SQLITE_OK ){
-    doltliteFreeCatalog(aAnc, nAnc);
-    doltliteFreeCatalog(aCur, nCur);
-    return rc;
-  }
-
-  while( (stepRc = sqlite3_step(pTbls))==SQLITE_ROW ){
-    const char *zTableRaw = (const char*)sqlite3_column_text(pTbls, 0);
-    char *zTable;
-    char **azCols = 0;
-    char **azAllowed = 0;
-    int nCols = 0;
-    int isStrict;
-
-    if( !zTableRaw ) continue;
-    zTable = sqlite3_mprintf("%s", zTableRaw);
-    if( !zTable ){ rc = SQLITE_NOMEM; break; }
-    if( !cvTableAllowed(zTable, azTables, nTables)
-     || !catalogTableChanged(aAnc, nAnc, aCur, nCur, zTable) ){
-      sqlite3_free(zTable);
-      continue;
-    }
-    rc = tableIsStrict(db, zTable, &isStrict);
-    if( rc!=SQLITE_OK ){
-      sqlite3_free(zTable);
-      break;
-    }
-    if( !isStrict ){
-      sqlite3_free(zTable);
-      continue;
-    }
-
-    rc = loadStrictColumns(db, zTable, &azCols, &azAllowed, &nCols);
-    if( rc!=SQLITE_OK ){
-      sqlite3_free(zTable);
-      break;
-    }
-    if( nCols==0 ){
-      sqlite3_free(zTable);
-      continue;
-    }
-
-    rc = scanMergeColumnFlagViolations(
-        db, zTable, aAnc, nAnc, azCols, azAllowed, nCols,
-        DOLTLITE_CV_STRICT_TYPE, pnFound);
-    doltliteFreeNameList(azCols, nCols);
-    doltliteFreeNameList(azAllowed, nCols);
-    sqlite3_free(zTable);
-    if( rc!=SQLITE_OK ) break;
-  }
-  if( rc==SQLITE_OK && stepRc!=SQLITE_DONE && stepRc!=SQLITE_ROW ){
-    rc = stepRc;
-  }
-  rc = finishConstraintStmt(pTbls, rc);
-  doltliteFreeCatalog(aAnc, nAnc);
-  doltliteFreeCatalog(aCur, nCur);
-  setConstraintError(db, pzErrMsg, rc);
-  return rc;
+  return walkMergeUserTables(db, pAncCatHash, pzErrMsg, azTables, nTables,
+                             1, 0, strictWalkTable, pnFound);
 }
 
 #endif

--- a/src/doltlite_merge_constraints_unique.c
+++ b/src/doltlite_merge_constraints_unique.c
@@ -735,6 +735,108 @@ without_rowid_done:
   return rc;
 }
 
+static int uniqueWalkTable(
+  sqlite3 *db,
+  const char *zTable,
+  const char *zSql,
+  struct TableEntry *aAnc, int nAnc,
+  struct TableEntry *aCur, int nCur,
+  void *pCtx
+){
+  sqlite3_stmt *pIdxList = 0;
+  char *zIdxQ;
+  int hasRowid = 1;
+  MergePkInfo pkInfo;
+  int indexStepRc;
+  int rc;
+  int *pnFound = (int*)pCtx;
+  (void)zSql; (void)aAnc; (void)nAnc;
+
+  memset(&pkInfo, 0, sizeof(pkInfo));
+  rc = tableHasRowid(db, zTable, &hasRowid);
+  if( rc!=SQLITE_OK ) return rc;
+  if( !hasRowid ){
+    rc = loadMergePkInfo(db, zTable, &pkInfo);
+    if( rc != SQLITE_OK ) return rc;
+  }
+
+  zIdxQ = sqlite3_mprintf("PRAGMA main.index_list(%Q)", zTable);
+  if( !zIdxQ ){
+    freeMergePkInfo(&pkInfo);
+    return SQLITE_NOMEM;
+  }
+  rc = sqlite3_prepare_v2(db, zIdxQ, -1, &pIdxList, 0);
+  sqlite3_free(zIdxQ);
+  if( rc != SQLITE_OK ){
+    freeMergePkInfo(&pkInfo);
+    return rc;
+  }
+
+  while( (indexStepRc = sqlite3_step(pIdxList)) == SQLITE_ROW ){
+    int unique = sqlite3_column_int(pIdxList, 2);
+    const char *zIdxRaw;
+    const char *zOrigin;
+    char *zIdx;
+    Index *pIdx;
+    sqlite3_str *pColList;
+    char *zColList;
+    int i;
+    int supported = 1;
+
+    if( !unique ) continue;
+    zIdxRaw = (const char*)sqlite3_column_text(pIdxList, 1);
+    if( !zIdxRaw ) continue;
+
+    zOrigin = (const char*)sqlite3_column_text(pIdxList, 3);
+    if( zOrigin && strcmp(zOrigin, "pk")==0 ) continue;
+
+    zIdx = sqlite3_mprintf("%s", zIdxRaw);
+    if( !zIdx ){
+      rc = SQLITE_NOMEM;
+      break;
+    }
+    pIdx = sqlite3FindIndex(db, zIdx, "main");
+    if( !pIdx ){
+      sqlite3_free(zIdx);
+      rc = SQLITE_CORRUPT;
+      break;
+    }
+
+    pColList = sqlite3_str_new(0);
+    for(i=0; i<pIdx->nKeyCol; i++){
+      int cno = pIdx->aiColumn[i];
+      if( i>0 ) sqlite3_str_appendall(pColList, ", ");
+      if( cno>=0 && cno<pIdx->pTable->nCol ){
+        sqlite3_str_appendf(
+            pColList, "\"%w\"", pIdx->pTable->aCol[cno].zCnName);
+      }else{
+        supported = 0;
+        sqlite3_str_appendall(pColList, "null");
+      }
+    }
+    zColList = sqlite3_str_finish(pColList);
+    if( !zColList ) rc = SQLITE_NOMEM;
+    if( supported && zColList && *zColList ){
+      if( hasRowid ){
+        rc = detectUniqueViolationsForIndex(
+            db, zTable, pIdx, zColList, pnFound);
+      }else{
+        rc = detectUniqueViolationsForIndexWithoutRowid(
+            db, doltliteFindTableByName(aCur, nCur, zTable),
+            zTable, pIdx, zColList, &pkInfo, pnFound);
+      }
+    }
+    sqlite3_free(zColList);
+    sqlite3_free(zIdx);
+    if( rc != SQLITE_OK ) break;
+  }
+
+  if( rc==SQLITE_OK && indexStepRc!=SQLITE_DONE ) rc = indexStepRc;
+  rc = finishConstraintStmt(pIdxList, rc);
+  freeMergePkInfo(&pkInfo);
+  return rc;
+}
+
 int doltliteDetectMergeUniqueViolations(
   sqlite3 *db,
   const ProllyHash *pAncCatHash,
@@ -743,149 +845,9 @@ int doltliteDetectMergeUniqueViolations(
   const char **azTables,
   int nTables
 ){
-  sqlite3_stmt *pTbls = 0;
-  struct TableEntry *aAnc = 0;
-  int nAnc = 0;
-  struct TableEntry *aCur = 0;
-  int nCur = 0;
-  int rc;
-
   if( pnFound ) *pnFound = 0;
-
-  rc = loadAncestorAndCurrentCatalogs(db, pAncCatHash, &aAnc, &nAnc,
-                                      &aCur, &nCur);
-  if( rc!=SQLITE_OK ) return rc;
-
-  rc = sqlite3_prepare_v2(db,
-      "SELECT name FROM main.sqlite_master WHERE type='table' "
-      "AND name NOT LIKE 'sqlite_%' AND name NOT LIKE 'dolt_%'",
-      -1, &pTbls, 0);
-  if( rc != SQLITE_OK ){
-    doltliteFreeCatalog(aAnc, nAnc);
-    doltliteFreeCatalog(aCur, nCur);
-    return rc;
-  }
-
-  while( (rc = sqlite3_step(pTbls)) == SQLITE_ROW ){
-    const char *zTableRaw = (const char*)sqlite3_column_text(pTbls, 0);
-    char *zTable;
-    sqlite3_stmt *pIdxList = 0;
-    char *zIdxQ;
-    int hasRowid = 1;
-    MergePkInfo pkInfo;
-    int indexStepRc;
-
-    if( !zTableRaw ) continue;
-    zTable = sqlite3_mprintf("%s", zTableRaw);
-    if( !zTable ){ rc = SQLITE_NOMEM; break; }
-    if( !cvTableAllowed(zTable, azTables, nTables) ){
-      sqlite3_free(zTable);
-      continue;
-    }
-    if( !catalogTableChanged(aAnc, nAnc, aCur, nCur, zTable) ){
-      sqlite3_free(zTable);
-      continue;
-    }
-    memset(&pkInfo, 0, sizeof(pkInfo));
-    rc = tableHasRowid(db, zTable, &hasRowid);
-    if( rc!=SQLITE_OK ){
-      sqlite3_free(zTable);
-      break;
-    }
-    if( !hasRowid ){
-      rc = loadMergePkInfo(db, zTable, &pkInfo);
-      if( rc != SQLITE_OK ){
-        sqlite3_free(zTable);
-        break;
-      }
-    }
-
-    zIdxQ = sqlite3_mprintf("PRAGMA main.index_list(%Q)", zTable);
-    if( !zIdxQ ){
-      freeMergePkInfo(&pkInfo);
-      sqlite3_free(zTable);
-      rc = SQLITE_NOMEM;
-      break;
-    }
-    rc = sqlite3_prepare_v2(db, zIdxQ, -1, &pIdxList, 0);
-    sqlite3_free(zIdxQ);
-    if( rc != SQLITE_OK ){
-      freeMergePkInfo(&pkInfo);
-      sqlite3_free(zTable);
-      break;
-    }
-
-    while( (indexStepRc = sqlite3_step(pIdxList)) == SQLITE_ROW ){
-      int unique = sqlite3_column_int(pIdxList, 2);
-      const char *zIdxRaw;
-      const char *zOrigin;
-      char *zIdx;
-      Index *pIdx;
-      sqlite3_str *pColList;
-      char *zColList;
-      int i;
-      int supported = 1;
-
-      if( !unique ) continue;
-      zIdxRaw = (const char*)sqlite3_column_text(pIdxList, 1);
-      if( !zIdxRaw ) continue;
-
-      zOrigin = (const char*)sqlite3_column_text(pIdxList, 3);
-      if( zOrigin && strcmp(zOrigin, "pk")==0 ) continue;
-
-      zIdx = sqlite3_mprintf("%s", zIdxRaw);
-      if( !zIdx ){
-        rc = SQLITE_NOMEM;
-        break;
-      }
-      pIdx = sqlite3FindIndex(db, zIdx, "main");
-      if( !pIdx ){
-        sqlite3_free(zIdx);
-        rc = SQLITE_CORRUPT;
-        break;
-      }
-
-      pColList = sqlite3_str_new(0);
-      for(i=0; i<pIdx->nKeyCol; i++){
-        int cno = pIdx->aiColumn[i];
-        if( i>0 ) sqlite3_str_appendall(pColList, ", ");
-        if( cno>=0 && cno<pIdx->pTable->nCol ){
-          sqlite3_str_appendf(
-              pColList, "\"%w\"", pIdx->pTable->aCol[cno].zCnName);
-        }else{
-          supported = 0;
-          sqlite3_str_appendall(pColList, "null");
-        }
-      }
-      zColList = sqlite3_str_finish(pColList);
-      if( !zColList ) rc = SQLITE_NOMEM;
-      if( supported && zColList && *zColList ){
-        if( hasRowid ){
-          rc = detectUniqueViolationsForIndex(
-              db, zTable, pIdx, zColList, pnFound);
-        }else{
-          rc = detectUniqueViolationsForIndexWithoutRowid(
-              db, doltliteFindTableByName(aCur, nCur, zTable),
-              zTable, pIdx, zColList, &pkInfo, pnFound);
-        }
-      }
-      sqlite3_free(zColList);
-      sqlite3_free(zIdx);
-      if( rc != SQLITE_OK ) break;
-    }
-
-    if( rc==SQLITE_OK && indexStepRc!=SQLITE_DONE ) rc = indexStepRc;
-    rc = finishConstraintStmt(pIdxList, rc);
-    freeMergePkInfo(&pkInfo);
-    sqlite3_free(zTable);
-    if( rc != SQLITE_OK ) break;
-  }
-  if( rc == SQLITE_DONE ) rc = SQLITE_OK;
-  rc = finishConstraintStmt(pTbls, rc);
-  doltliteFreeCatalog(aAnc, nAnc);
-  doltliteFreeCatalog(aCur, nCur);
-  setConstraintError(db, pzErrMsg, rc);
-  return rc;
+  return walkMergeUserTables(db, pAncCatHash, pzErrMsg, azTables, nTables,
+                             1, 0, uniqueWalkTable, pnFound);
 }
 
 


### PR DESCRIPTION
## Summary

The five merge constraint detectors (NOT NULL, STRICT, CHECK, unique, FK) each copied the same catalog load, `sqlite_master` user-table scan, `dolt_`/`sqlite_` skip, and allowed-table filter.

`walkMergeUserTables` owns that loop. Callers supply the per-table body.

- NOT NULL / STRICT / CHECK / unique still skip unchanged tables
- FK does not: a parent-side change can violate an unchanged child
- CHECK still selects `sql` so it can parse CHECK clauses

`cvTableAllowed` and `loadAncestorAndCurrentCatalogs` are now file-local. Net −115 lines.

## Test plan

- [x] `bash test/dead_code_check.sh`
- [x] `bash test/lint_layers.sh`
- [x] `bash test/lint_orig_btree_adapter.sh`
- [x] `DOLTLITE=build/doltlite bash test/doltlite_merge.sh` (230/230)
- [x] `bash test/doltlite_merge_ignore_corners.sh build/doltlite` (3/3)

Co-Authored-By: Grok 4.6 <noreply@x.ai>