### PR TITLE
Derive .import separators from the display mode like sqlite3

### DIFF
--- a/src/shell.c.in
+++ b/src/shell.c.in
@@ -8580,20 +8580,22 @@ static int dotCmdImport(ShellState *p){
   seenInterrupt = 0;
   open_db(p, 0);
   if( sCtx.cColSep==0 ){
-    /* doltlite: .import always defaults to RFC-4180 CSV (comma) regardless
-    ** of the current display mode. Upstream sqlite couples .import's
-    ** separator to the display mode, which surprises users in batch mode
-    ** (default `list` mode -> `|`) who run `.import foo.csv t` and end up
-    ** with one ANY-typed column named after the whole header line.
-    ** Use --colsep/--ascii/--csv to override. */
-    sCtx.cColSep = ',';
+    if( p->mode.spec.zColumnSep && p->mode.spec.zColumnSep[0]!=0 ){
+      sCtx.cColSep = p->mode.spec.zColumnSep[0];
+    }else{
+      sCtx.cColSep = ',';
+    }
   }
   if( (sCtx.cColSep & 0x80)!=0 ){
     eputz("Error: .import column separator must be ASCII\n");
     return 1;
   }
   if( sCtx.cRowSep==0 ){
-    sCtx.cRowSep = '\n';
+    if( p->mode.spec.zRowSep && p->mode.spec.zRowSep[0]!=0 ){
+      sCtx.cRowSep = p->mode.spec.zRowSep[0];
+    }else{
+      sCtx.cRowSep = '\n';
+    }
   }
   if( sCtx.cRowSep=='\r' && xRead!=ascii_read_one_field ){
     sCtx.cRowSep = '\n';

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -5666,26 +5666,7 @@ filefmt filefmt-2.2.2 class=intentional  # SQLite page-header/format bytes; CTLD
 
 # shell bucket — upstream shell*.test driven through the doltlite CLI (the
 # regression jobs alias sqlite3 -> doltlite for this bucket only).
-# .import ignores the display mode's separators (issue 2711, to match
-# sqlite3): the -list / .mode ascii import cases split on ',' instead of the
-# mode separator, and the mode's non-ASCII separator is never seen.
 shell2 shell2-1.4.9 class=engine-gap issue=2706  # .clone errors on sqlite_sequence; clone content is right
-shell2 shell2-1.4.11 class=engine-gap issue=2711  # .import ignores the display mode's 0xFF separator
-shell5 shell5-1.4.4 class=engine-gap issue=2711  # .import comma split; '|' rows read as one column
-shell5 shell5-1.4.5 class=engine-gap issue=2711  # .import comma split
-shell5 shell5-1.4.6 class=engine-gap issue=2711  # .import comma split
-shell5 shell5-1.4.8.1 class=engine-gap issue=2711  # .import comma split
-shell5 shell5-1.4.8.2 class=engine-gap issue=2711  # cascade of 1.4.8.1
-shell5 shell5-1.4.9.1 class=engine-gap issue=2711  # .import comma split
-shell5 shell5-1.4.9.2 class=engine-gap issue=2711  # cascade of 1.4.9.1
-shell5 shell5-1.4.10.1 class=engine-gap issue=2711  # .import comma split
-shell5 shell5-1.4.10.2 class=engine-gap issue=2711  # cascade of 1.4.10.1
-shell5 shell5-1.4.11 class=engine-gap issue=2711  # .import comma split (BOM case)
-shell5 shell5-1.4.12 class=engine-gap issue=2711  # .import comma split (BOM + quoted field)
-shell5 shell5-1.5.1 class=engine-gap issue=2711  # .import comma split (long field)
-shell5 shell5-3.1 class=engine-gap issue=2711  # .mode ascii import still splits on ','
-shell5 shell5-3.2 class=engine-gap issue=2711  # cascade of 3.1
-shell5 shell5-7.1 class=engine-gap issue=2711  # .import comma split into a table with a computed column
 # The CLI leaves DEFENSIVE off (issue 2712, to match sqlite3); stock rejects
 # the sqlite_master write in the dump.
 shell9 shell9-1.2.2 class=engine-gap issue=2712  # .read of a dump that writes sqlite_master succeeds

--- a/test/known_testfixture_exception_ratchet.txt
+++ b/test/known_testfixture_exception_ratchet.txt
@@ -6,8 +6,8 @@
 # Counts are per gate -- one divergent assertion, or one expected crash.
 # Lowering a number is the point. Raising one is a deliberate act that belongs
 # in a PR description.
-gates 4578
+gates 4562
 intentional 3241
 unsupported 1307
 harness 11
-engine-gap 19
+engine-gap 3

--- a/test/oracle_import_test.sh
+++ b/test/oracle_import_test.sh
@@ -20,7 +20,7 @@ oracle_import() {
   printf '%s' "$csv" > "$dir/data.csv"
 
   local dl_out
-  dl_out=$(printf '.import %s t\n.headers off\n.mode csv\nSELECT * FROM t;\n' "$dir/data.csv" \
+  dl_out=$(printf '.mode csv\n.import %s t\n.headers off\nSELECT * FROM t;\n' "$dir/data.csv" \
            | "$DOLTLITE" "$dir/dl/db" 2>"$dir/dl.err" \
            | normalize)
 
@@ -53,7 +53,7 @@ assert_dl_columns() {
   printf '%s' "$csv" > "$dir/data.csv"
 
   local actual
-  actual=$(printf '.import %s t\nSELECT count(*) FROM pragma_table_info(%s);\n' \
+  actual=$(printf '.mode csv\n.import %s t\nSELECT count(*) FROM pragma_table_info(%s);\n' \
                   "$dir/data.csv" "'t'" \
            | "$DOLTLITE" "$dir/dl/db" 2>"$dir/dl.err" \
            | tr -d '\r')


### PR DESCRIPTION
Fixes #2711.

The shell forced a comma default for `.import` regardless of the display mode (`src/shell.c.in`, the "doltlite: .import always defaults to RFC-4180 CSV" block). Restored upstream's derivation: the mode's column/row separators unless `--csv`, `--ascii`, `--colsep`/`--rowsep` say otherwise. The `.import` command is now byte-identical to upstream 3.54.

**Behaviour, doltlite vs a pure upstream 3.54 CLI built from the merge commit** (identical on all four):
- `list` mode `.import d.csv t` → one column (`a,b,c`)
- `.mode csv` then `.import d.csv t` → three columns
- `.mode ascii -colsep "\377"` then `.import` → `Error: .import column separator must be ASCII`
- `-list` with `1|2` → two columns

**Tests.** The 16 shell2/shell5 pins that recorded the override now pass and are retired; shell bucket 396 passing / 5 known. Ratchet: gates 4578 → 4562, engine-gap 19 → 3. `test/oracle_import_test.sh` (sanitizers job) selects `.mode csv` before importing, as the same import is written for sqlite3; it passes 7/7 against both this CLI and the upstream build. The #383 case it guarded (header parsed as one column) is now the documented sqlite3 behaviour for list mode; with `.mode csv` it parses as before. `make lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
