### PR TITLE
Share framed conflict and constraint-violation I/O

### DIFF
--- a/doltlite.mk
+++ b/doltlite.mk
@@ -58,7 +58,7 @@ PROLLY_OBJS = \
               prolly_btree.o prolly_btree_catalog.o prolly_btree_cursor.o prolly_btree_cursor_seek.o prolly_btree_cursor_payload.o prolly_btree_cursor_count.o prolly_btree_mutation.o \
               prolly_btree_orig.o prolly_btree_state.o prolly_btree_txn.o pager_shim.o sortkey.o \
               doltlite_chunk_source.o doltlite.o doltlite_core.o doltlite_cmd.o doltlite_add.o doltlite_clean.o doltlite_commit_cmd.o doltlite_reset.o doltlite_merge_cmd.o doltlite_cherry_pick.o doltlite_revert.o doltlite_rebase.o doltlite_config.o doltlite_commit.o doltlite_ref.o doltlite_log.o doltlite_commit_ancestors.o doltlite_status.o doltlite_merge_status.o \
-              doltlite_diff.o doltlite_diff_table.o doltlite_workspace.o doltlite_branch.o doltlite_branches.o doltlite_checkout.o doltlite_tag.o doltlite_ancestor.o doltlite_merge.o doltlite_merge_pass1.o doltlite_merge_pass2.o doltlite_merge_predetect.o doltlite_merge_rebuild.o doltlite_merge_rows.o doltlite_merge_schema.o doltlite_conflicts.o \
+              doltlite_diff.o doltlite_diff_table.o doltlite_workspace.o doltlite_branch.o doltlite_branches.o doltlite_checkout.o doltlite_tag.o doltlite_ancestor.o doltlite_merge.o doltlite_merge_pass1.o doltlite_merge_pass2.o doltlite_merge_predetect.o doltlite_merge_rebuild.o doltlite_merge_rows.o doltlite_merge_schema.o doltlite_conflicts.o doltlite_framed.o \
               doltlite_gc.o doltlite_chunk_walk.o doltlite_history.o doltlite_at.o doltlite_blame.o doltlite_schema_diff.o doltlite_patch.o doltlite_schemas.o doltlite_diff_stat.o doltlite_record.o \
               doltlite_ignore.o doltlite_docs.o doltlite_tests.o doltlite_hashof.o \
               doltlite_constraint_violations.o doltlite_verify_constraints.o \

--- a/main.mk
+++ b/main.mk
@@ -1550,6 +1550,9 @@ doltlite_ancestor.o:	$(TOP)/src/doltlite_ancestor.c $(DEPS_OBJ_COMMON)
 doltlite_conflicts.o:	$(TOP)/src/doltlite_conflicts.c $(DEPS_OBJ_COMMON)
 	$(T.cc.sqlite) -c $(TOP)/src/doltlite_conflicts.c
 
+doltlite_framed.o:	$(TOP)/src/doltlite_framed.c $(DEPS_OBJ_COMMON)
+	$(T.cc.sqlite) -c $(TOP)/src/doltlite_framed.c
+
 doltlite_gc.o:	$(TOP)/src/doltlite_gc.c $(DEPS_OBJ_COMMON)
 	$(T.cc.sqlite) -c $(TOP)/src/doltlite_gc.c
 

--- a/src/doltlite_conflicts.c
+++ b/src/doltlite_conflicts.c
@@ -10,8 +10,6 @@ typedef DoltliteConflictTable ConflictTableInfo;
 
 static void freeConflictTable(ConflictTableInfo *pTable);
 static void freeConflictTables(ConflictTableInfo *aTables, int nTables);
-static sqlite3_int64 cfrConflictRowid(const DoltliteConflictRow *cr);
-
 void doltliteConflictRowFree(DoltliteConflictRow *pRow){
   if( !pRow ) return;
   sqlite3_free(pRow->pKey);
@@ -26,82 +24,57 @@ static void freeConflictRow(DoltliteConflictRow *pRow){
   memset(pRow, 0, sizeof(*pRow));
 }
 
+static sqlite3_int64 cfrConflictRowid(const DoltliteConflictRow *cr){
+  u64 h = DOLTLITE_FNV1A_OFFSET;
+  h = doltliteFnv1aBytes(h, cr->pKey, cr->nKey);
+  h = doltliteFnv1aSep(h);
+  h = doltliteFnv1aI64(h, cr->intKey);
+  h = doltliteFnv1aSep(h);
+  h = doltliteFnv1aBytes(h, cr->pBaseVal, cr->nBaseVal);
+  h = doltliteFnv1aSep(h);
+  h = doltliteFnv1aBytes(h, cr->pOurVal, cr->nOurVal);
+  h = doltliteFnv1aSep(h);
+  h = doltliteFnv1aBytes(h, cr->pTheirVal, cr->nTheirVal);
+  return (sqlite3_int64)(h & 0x7fffffffffffffffULL);
+}
+
 #define DOLTLITE_CONFLICTS_MAGIC0 'D'
 #define DOLTLITE_CONFLICTS_MAGIC1 'L'
 #define DOLTLITE_CONFLICTS_MAGIC2 'C'
 #define DOLTLITE_CONFLICTS_VERSION 1
 
-int doltliteSerializeConflicts(
-  ChunkStore *cs,
-  DoltliteConflictTable *aTables, int nTables,
-  ProllyHash *pHash
-){
-  sqlite3_int64 sz = 4 + 2;
-  int i, j, rc;
-  u8 *buf;
-  DlByteWriter w;
-
-  if( nTables<0 || nTables>0xffff ) return SQLITE_TOOBIG;
-  if( nTables>0 && !aTables ) return SQLITE_CORRUPT;
-  for(i=0; i<nTables; i++){
-    size_t nName = aTables[i].zName ? strlen(aTables[i].zName) : 0;
-    int nl;
-    if( nName>0xffff || aTables[i].nConflicts<0 ) return SQLITE_TOOBIG;
-    if( aTables[i].nConflicts>0 && !aTables[i].aRows ) return SQLITE_CORRUPT;
-    nl = (int)nName;
-    rc = dlAddSize(&sz, 2 + nl + 4);
-    if( rc!=SQLITE_OK ) return rc;
-    for(j=0; j<aTables[i].nConflicts; j++){
-      DoltliteConflictRow *cr = &aTables[i].aRows[j];
-      if( cr->nKey<0 || cr->nBaseVal<0 || cr->nOurVal<0
-       || cr->nTheirVal<0
-      ){
-        return SQLITE_CORRUPT;
-      }
-      if( (cr->nKey>0 && !cr->pKey)
-       || (cr->nBaseVal>0 && !cr->pBaseVal)
-       || (cr->nOurVal>0 && !cr->pOurVal)
-       || (cr->nTheirVal>0 && !cr->pTheirVal)
-      ){
-        return SQLITE_CORRUPT;
-      }
-      rc = dlAddSize(&sz, 24);
-      if( rc==SQLITE_OK ) rc = dlAddSize(&sz, cr->nKey);
-      if( rc==SQLITE_OK ) rc = dlAddSize(&sz, cr->nBaseVal);
-      if( rc==SQLITE_OK ) rc = dlAddSize(&sz, cr->nOurVal);
-      if( rc==SQLITE_OK ) rc = dlAddSize(&sz, cr->nTheirVal);
-      if( rc!=SQLITE_OK ) return rc;
-    }
-  }
-
-  buf = sqlite3_malloc64((sqlite3_uint64)sz);
-  if( !buf ) return SQLITE_NOMEM;
-  dlWriterInit(&w, buf, (int)sz);
-
-  dlWriteFramedHeader(&w, DOLTLITE_CONFLICTS_MAGIC0, DOLTLITE_CONFLICTS_MAGIC1,
-                      DOLTLITE_CONFLICTS_MAGIC2, DOLTLITE_CONFLICTS_VERSION, nTables);
-  for(i=0; i<nTables; i++){
-    int nl = aTables[i].zName ? (int)strlen(aTables[i].zName) : 0;
-    dlWriteU16Name(&w, aTables[i].zName, nl);
-    dlWriteU32(&w, aTables[i].nConflicts);
-    for(j=0; j<aTables[i].nConflicts; j++){
-      DoltliteConflictRow *cr = &aTables[i].aRows[j];
-      dlWriteU32Blob(&w, cr->pKey, cr->nKey);
-      dlWriteI64(&w, cr->intKey);
-      dlWriteU32Blob(&w, cr->pBaseVal, cr->nBaseVal);
-      dlWriteU32Blob(&w, cr->pOurVal, cr->nOurVal);
-      dlWriteU32Blob(&w, cr->pTheirVal, cr->nTheirVal);
-    }
-  }
-
-  if( w.err || w.p!=w.end ){
-    sqlite3_free(buf);
+static int measureConflictRow(const void *pRow, sqlite3_int64 *pSz){
+  const DoltliteConflictRow *cr = (const DoltliteConflictRow*)pRow;
+  int rc;
+  if( cr->nKey<0 || cr->nBaseVal<0 || cr->nOurVal<0 || cr->nTheirVal<0 ){
     return SQLITE_CORRUPT;
   }
-  rc = sqlite3FaultSim(950) ? SQLITE_IOERR
-                            : chunkStorePut(cs, buf, (int)sz, pHash);
-  sqlite3_free(buf);
+  if( (cr->nKey>0 && !cr->pKey)
+   || (cr->nBaseVal>0 && !cr->pBaseVal)
+   || (cr->nOurVal>0 && !cr->pOurVal)
+   || (cr->nTheirVal>0 && !cr->pTheirVal)
+  ){
+    return SQLITE_CORRUPT;
+  }
+  rc = dlAddSize(pSz, 24);
+  if( rc==SQLITE_OK ) rc = dlAddSize(pSz, cr->nKey);
+  if( rc==SQLITE_OK ) rc = dlAddSize(pSz, cr->nBaseVal);
+  if( rc==SQLITE_OK ) rc = dlAddSize(pSz, cr->nOurVal);
+  if( rc==SQLITE_OK ) rc = dlAddSize(pSz, cr->nTheirVal);
   return rc;
+}
+
+static void writeConflictRow(DlByteWriter *w, const void *pRow){
+  const DoltliteConflictRow *cr = (const DoltliteConflictRow*)pRow;
+  dlWriteU32Blob(w, cr->pKey, cr->nKey);
+  dlWriteI64(w, cr->intKey);
+  dlWriteU32Blob(w, cr->pBaseVal, cr->nBaseVal);
+  dlWriteU32Blob(w, cr->pOurVal, cr->nOurVal);
+  dlWriteU32Blob(w, cr->pTheirVal, cr->nTheirVal);
+}
+
+static i64 conflictRowidIO(const void *pRow){
+  return cfrConflictRowid((const DoltliteConflictRow*)pRow);
 }
 
 static int readConflictRow(DlByteReader *r, DoltliteConflictRow *cr){
@@ -144,48 +117,40 @@ static void freeConflictRowIO(void *pRow){
   freeConflictRow((DoltliteConflictRow*)pRow);
 }
 
+static void freeConflictTablesVoid(void *aTables, int nTables){
+  freeConflictTables((ConflictTableInfo*)aTables, nTables);
+}
+
+static const DlFramedCodec *conflictCodec(void){
+  static const DlFramedCodec codec = {
+    DOLTLITE_CONFLICTS_MAGIC0, DOLTLITE_CONFLICTS_MAGIC1,
+    DOLTLITE_CONFLICTS_MAGIC2, DOLTLITE_CONFLICTS_VERSION,
+    sizeof(DoltliteConflictRow),
+    0, 1, 950,
+    readConflictRowIO, skipConflictRowIO, freeConflictRowIO,
+    measureConflictRow, writeConflictRow, conflictRowidIO
+  };
+  return &codec;
+}
+
+int doltliteSerializeConflicts(
+  ChunkStore *cs,
+  DoltliteConflictTable *aTables, int nTables,
+  ProllyHash *pHash
+){
+  return dlFramedSerialize(cs, pHash, conflictCodec(), nTables,
+      DL_FRAMED_TABLE(DoltliteConflictTable, zName, nConflicts, aRows),
+      aTables);
+}
+
 static int deserializeAllConflicts(
   const u8 *data,
   int nData,
   ConflictTableInfo **ppTables, int *pnTables
 ){
-  DlByteReader r;
-  int nTables, i, rc;
-  ConflictTableInfo *aTables;
-
-  *ppTables = 0;
-  *pnTables = 0;
-  if( !data || nData<(4+2) ) return SQLITE_CORRUPT;
-
-  dlReaderInit(&r, data, nData);
-  if( dlReadFramedHeader(&r, DOLTLITE_CONFLICTS_MAGIC0, DOLTLITE_CONFLICTS_MAGIC1,
-                         DOLTLITE_CONFLICTS_MAGIC2, DOLTLITE_CONFLICTS_VERSION,
-                         &nTables)!=SQLITE_OK ){
-    return SQLITE_CORRUPT;
-  }
-
-  aTables = sqlite3_malloc(nTables ? nTables * (int)sizeof(ConflictTableInfo) : 1);
-  if( !aTables ) return SQLITE_NOMEM;
-  memset(aTables, 0, nTables ? nTables * (int)sizeof(ConflictTableInfo) : 1);
-
-  for(i=0; i<nTables; i++){
-    void *aRows = 0;
-    rc = dlReadNamedRowTable(&r, &aTables[i].zName, &aTables[i].nConflicts,
-                             &aRows, sizeof(DoltliteConflictRow), 0,
-                             readConflictRowIO, freeConflictRowIO);
-    if( rc!=SQLITE_OK ) goto conflicts_cleanup;
-    aTables[i].aRows = (DoltliteConflictRow*)aRows;
-  }
-
-  if( r.err || r.p != r.end ){ rc = SQLITE_CORRUPT; goto conflicts_cleanup; }
-
-  *ppTables = aTables;
-  *pnTables = nTables;
-  return SQLITE_OK;
-
-conflicts_cleanup:
-  freeConflictTables(aTables, nTables);
-  return rc;
+  return dlFramedDeserialize(data, nData, conflictCodec(),
+      DL_FRAMED_TABLE(ConflictTableInfo, zName, nConflicts, aRows),
+      (void**)ppTables, pnTables, freeConflictTablesVoid);
 }
 
 int doltliteDeserializeConflictsForTest(const u8 *data, int nData){
@@ -268,8 +233,8 @@ static int loadConflictTable(
 ){
   ProllyHash hash;
   u8 *data = 0; int nData = 0;
-  DlByteReader r;
-  int nTables, i, rc;
+  void *aRows = 0;
+  int rc;
 
   memset(pTable, 0, sizeof(*pTable));
   *pFound = 0;
@@ -280,36 +245,15 @@ static int loadConflictTable(
 
   rc = chunkStoreGet(cs, &hash, &data, &nData);
   if( rc!=SQLITE_OK ) return rc;
-  if( nData<(4+2) ){ sqlite3_free(data); return SQLITE_CORRUPT; }
-
-  dlReaderInit(&r, data, nData);
-  if( dlReadFramedHeader(&r, DOLTLITE_CONFLICTS_MAGIC0, DOLTLITE_CONFLICTS_MAGIC1,
-                         DOLTLITE_CONFLICTS_MAGIC2, DOLTLITE_CONFLICTS_VERSION,
-                         &nTables)!=SQLITE_OK ){
-    sqlite3_free(data);
-    return SQLITE_CORRUPT;
-  }
-
-  for(i=0; i<nTables; i++){
-    void *aRows = 0;
-    rc = dlMatchOrSkipNamedTable(&r, zTableName, pFound,
-                                 &pTable->zName, &pTable->nConflicts, &aRows,
-                                 sizeof(DoltliteConflictRow), 0,
-                                 readConflictRowIO, skipConflictRowIO,
-                                 freeConflictRowIO);
-    if( rc!=SQLITE_OK ) goto conflict_table_cleanup;
-    if( aRows ) pTable->aRows = (DoltliteConflictRow*)aRows;
-  }
-
-  if( r.err || r.p != r.end ){ rc = SQLITE_CORRUPT; goto conflict_table_cleanup; }
-
+  rc = dlFramedLoadNamed(data, nData, conflictCodec(), zTableName,
+                         &pTable->zName, &pTable->nConflicts, &aRows, pFound);
   sqlite3_free(data);
+  pTable->aRows = (DoltliteConflictRow*)aRows;
+  if( rc!=SQLITE_OK ){
+    freeConflictTable(pTable);
+    return rc;
+  }
   return SQLITE_OK;
-
-conflict_table_cleanup:
-  freeConflictTable(pTable);
-  sqlite3_free(data);
-  return rc;
 }
 
 static void freeConflictTable(ConflictTableInfo *pTable){
@@ -374,131 +318,23 @@ static int deleteConflictRowFromCatalog(
   ProllyHash hash;
   u8 *data = 0;
   u8 *out = 0;
-  int nData = 0;
-  DlByteReader r;
-  DlByteWriter w;
-  int nTables, nOutTables = 0;
-  int i, j, rc = SQLITE_OK;
+  int nData = 0, nOut = 0, nOutTables = 0;
   int deleted = 0;
+  int rc;
+
   rc = doltliteGetSessionConflictsCatalog(db, &hash);
   if( rc!=SQLITE_OK ) return rc;
   if( prollyHashIsEmpty(&hash) ) return SQLITE_OK;
 
   rc = chunkStoreGet(cs, &hash, &data, &nData);
   if( rc!=SQLITE_OK ) return rc;
-  if( nData<(4+2) ){ sqlite3_free(data); return SQLITE_CORRUPT; }
-
-  out = sqlite3_malloc(nData);
-  if( !out ){ sqlite3_free(data); return SQLITE_NOMEM; }
-
-  dlReaderInit(&r, data, nData);
-  if( dlReadFramedHeader(&r, DOLTLITE_CONFLICTS_MAGIC0, DOLTLITE_CONFLICTS_MAGIC1,
-                         DOLTLITE_CONFLICTS_MAGIC2, DOLTLITE_CONFLICTS_VERSION,
-                         &nTables)!=SQLITE_OK ){
-    rc = SQLITE_CORRUPT;
-    goto delete_conflict_done;
-  }
-
-  dlWriterInit(&w, out, nData);
-  dlWriteFramedHeader(&w, DOLTLITE_CONFLICTS_MAGIC0, DOLTLITE_CONFLICTS_MAGIC1,
-                      DOLTLITE_CONFLICTS_MAGIC2, DOLTLITE_CONFLICTS_VERSION, 0);
-
-  for(i=0; i<nTables; i++){
-    const u8 *pTableStart = r.p;
-    u8 *pOutTableStart = w.p;
-    char *zName = 0;
-    int nc;
-    int isMatch;
-
-    rc = dlReadU16Name(&r, &zName);
-    if( rc!=SQLITE_OK ) goto delete_conflict_done;
-    nc = dlReadU32(&r);
-    if( r.err || nc<0 ){
-      sqlite3_free(zName);
-      rc = SQLITE_CORRUPT;
-      goto delete_conflict_done;
-    }
-    if( (sqlite3_uint64)nc > (sqlite3_uint64)(r.end - r.p) ){
-      sqlite3_free(zName);
-      rc = SQLITE_CORRUPT;
-      goto delete_conflict_done;
-    }
-
-    isMatch = (!deleted && zName
-               && sqlite3_stricmp(zName, zTableName)==0);
-    if( isMatch ){
-      u8 *pCountOut = 0;
-      int nKeep = 0;
-      int nl = (int)strlen(zName);
-
-      dlWriteU16Name(&w, zName, nl);
-      pCountOut = w.p;
-      dlWriteU32(&w, 0);
-      for(j=0; j<nc; j++){
-        DoltliteConflictRow cr;
-        memset(&cr, 0, sizeof(cr));
-        rc = readConflictRow(&r, &cr);
-        if( rc!=SQLITE_OK ){
-          freeConflictRow(&cr);
-          sqlite3_free(zName);
-          goto delete_conflict_done;
-        }
-        if( !deleted && cfrConflictRowid(&cr) == deleteRowid ){
-          deleted = 1;
-        }else{
-          dlWriteU32Blob(&w, cr.pKey, cr.nKey);
-          dlWriteI64(&w, cr.intKey);
-          dlWriteU32Blob(&w, cr.pBaseVal, cr.nBaseVal);
-          dlWriteU32Blob(&w, cr.pOurVal, cr.nOurVal);
-          dlWriteU32Blob(&w, cr.pTheirVal, cr.nTheirVal);
-          nKeep++;
-        }
-        freeConflictRow(&cr);
-      }
-      if( nKeep==0 ){
-        w.p = pOutTableStart;
-      }else{
-        DlByteWriter cw;
-        dlWriterInit(&cw, pCountOut, 4);
-        dlWriteU32(&cw, nKeep);
-        assert( !cw.err );
-        nOutTables++;
-      }
-    }else{
-      for(j=0; j<nc; j++){
-        rc = skipConflictRow(&r);
-        if( rc!=SQLITE_OK ){
-          sqlite3_free(zName);
-          goto delete_conflict_done;
-        }
-      }
-      assert( !isMatch );
-      {
-        int nCopy = (int)(r.p - pTableStart);
-        dlWriteBytes(&w, pTableStart, nCopy);
-        nOutTables++;
-      }
-    }
-    sqlite3_free(zName);
-  }
-
-  if( r.err || r.p != r.end || w.err ){
-    rc = SQLITE_CORRUPT;
-    goto delete_conflict_done;
-  }
-  if( deleted ){
-    DlByteWriter hw;
-    dlWriterInit(&hw, out, 6);
-    dlWriteFramedHeader(&hw, DOLTLITE_CONFLICTS_MAGIC0, DOLTLITE_CONFLICTS_MAGIC1,
-                        DOLTLITE_CONFLICTS_MAGIC2, DOLTLITE_CONFLICTS_VERSION,
-                        nOutTables);
-    assert( !hw.err );
-    rc = storeConflictBytes(db, cs, out, (int)(w.p - out), nOutTables);
-  }
-
-delete_conflict_done:
-  sqlite3_free(out);
+  rc = dlFramedDeleteRow(data, nData, conflictCodec(), zTableName, deleteRowid,
+                         &out, &nOut, &nOutTables, &deleted);
   sqlite3_free(data);
+  if( rc==SQLITE_OK && deleted ){
+    rc = storeConflictBytes(db, cs, out, nOut, nOutTables);
+  }
+  sqlite3_free(out);
   return rc;
 }
 
@@ -511,11 +347,9 @@ static int removeConflictTableFromCatalog(
   ProllyHash hash;
   u8 *data = 0;
   u8 *out = 0;
-  int nData = 0;
-  DlByteReader r;
-  DlByteWriter w;
-  int nTables, nOutTables = 0;
-  int i, j, rc = SQLITE_OK;
+  int nData = 0, nOut = 0, nOutTables = 0;
+  int rc;
+
   *pFound = 0;
   rc = doltliteGetSessionConflictsCatalog(db, &hash);
   if( rc!=SQLITE_OK ) return rc;
@@ -523,79 +357,13 @@ static int removeConflictTableFromCatalog(
 
   rc = chunkStoreGet(cs, &hash, &data, &nData);
   if( rc!=SQLITE_OK ) return rc;
-  if( nData<(4+2) ){ sqlite3_free(data); return SQLITE_CORRUPT; }
-
-  out = sqlite3_malloc(nData);
-  if( !out ){ sqlite3_free(data); return SQLITE_NOMEM; }
-
-  dlReaderInit(&r, data, nData);
-  if( dlReadFramedHeader(&r, DOLTLITE_CONFLICTS_MAGIC0, DOLTLITE_CONFLICTS_MAGIC1,
-                         DOLTLITE_CONFLICTS_MAGIC2, DOLTLITE_CONFLICTS_VERSION,
-                         &nTables)!=SQLITE_OK ){
-    rc = SQLITE_CORRUPT;
-    goto remove_conflict_done;
-  }
-
-  dlWriterInit(&w, out, nData);
-  dlWriteFramedHeader(&w, DOLTLITE_CONFLICTS_MAGIC0, DOLTLITE_CONFLICTS_MAGIC1,
-                      DOLTLITE_CONFLICTS_MAGIC2, DOLTLITE_CONFLICTS_VERSION, 0);
-
-  for(i=0; i<nTables; i++){
-    const u8 *pTableStart = r.p;
-    char *zName = 0;
-    int nc;
-    int isMatch;
-
-    rc = dlReadU16Name(&r, &zName);
-    if( rc!=SQLITE_OK ) goto remove_conflict_done;
-    nc = dlReadU32(&r);
-    if( r.err || nc<0 ){
-      sqlite3_free(zName);
-      rc = SQLITE_CORRUPT;
-      goto remove_conflict_done;
-    }
-    if( (sqlite3_uint64)nc > (sqlite3_uint64)(r.end - r.p) ){
-      sqlite3_free(zName);
-      rc = SQLITE_CORRUPT;
-      goto remove_conflict_done;
-    }
-
-    isMatch = (*pFound==0 && zName
-               && sqlite3_stricmp(zName, zTableName)==0);
-    for(j=0; j<nc; j++){
-      rc = skipConflictRow(&r);
-      if( rc!=SQLITE_OK ){
-        sqlite3_free(zName);
-        goto remove_conflict_done;
-      }
-    }
-    if( isMatch ){
-      *pFound = 1;
-    }else{
-      int nCopy = (int)(r.p - pTableStart);
-      dlWriteBytes(&w, pTableStart, nCopy);
-      nOutTables++;
-    }
-    sqlite3_free(zName);
-  }
-
-  if( r.err || r.p != r.end || w.err ){
-    rc = SQLITE_CORRUPT;
-    goto remove_conflict_done;
-  }
-  if( *pFound ){
-    DlByteWriter hw;
-    dlWriterInit(&hw, out, 6);
-    dlWriteFramedHeader(&hw, DOLTLITE_CONFLICTS_MAGIC0, DOLTLITE_CONFLICTS_MAGIC1,
-                        DOLTLITE_CONFLICTS_MAGIC2, DOLTLITE_CONFLICTS_VERSION,
-                        nOutTables);
-    assert( !hw.err );
-    rc = storeConflictBytes(db, cs, out, (int)(w.p - out), nOutTables);
-  }
-
-remove_conflict_done:
-  sqlite3_free(out);
+  rc = dlFramedDropTable(data, nData, conflictCodec(), zTableName,
+                         &out, &nOut, &nOutTables, pFound);
   sqlite3_free(data);
+  if( rc==SQLITE_OK && *pFound ){
+    rc = storeConflictBytes(db, cs, out, nOut, nOutTables);
+  }
+  sqlite3_free(out);
   return rc;
 }
 
@@ -1160,20 +928,6 @@ static const char *cfrDiffType(const u8 *pBase, int nBase,
   int baseHas = (pBase && nBase>0);
   int sideHas = (pSide && nSide>0);
   return doltliteDiffTypeNameFromPresence(baseHas, sideHas);
-}
-
-static sqlite3_int64 cfrConflictRowid(const DoltliteConflictRow *cr){
-  u64 h = DOLTLITE_FNV1A_OFFSET;
-  h = doltliteFnv1aBytes(h, cr->pKey, cr->nKey);
-  h = doltliteFnv1aSep(h);
-  h = doltliteFnv1aI64(h, cr->intKey);
-  h = doltliteFnv1aSep(h);
-  h = doltliteFnv1aBytes(h, cr->pBaseVal, cr->nBaseVal);
-  h = doltliteFnv1aSep(h);
-  h = doltliteFnv1aBytes(h, cr->pOurVal, cr->nOurVal);
-  h = doltliteFnv1aSep(h);
-  h = doltliteFnv1aBytes(h, cr->pTheirVal, cr->nTheirVal);
-  return (sqlite3_int64)(h & 0x7fffffffffffffffULL);
 }
 
 static int cfrColumn(sqlite3_vtab_cursor *cur, sqlite3_context *ctx, int col){

--- a/src/doltlite_constraint_violations.c
+++ b/src/doltlite_constraint_violations.c
@@ -8,7 +8,6 @@
 #include <string.h>
 
 static void freeViolationTable(ConstraintViolationTable *pTable);
-static sqlite3_int64 cvrViolationRowid(const ConstraintViolationRow *r);
 
 static void freeViolationRow(ConstraintViolationRow *r){
   if( !r ) return;
@@ -16,6 +15,21 @@ static void freeViolationRow(ConstraintViolationRow *r){
   sqlite3_free(r->pVal);
   sqlite3_free(r->zInfo);
   memset(r, 0, sizeof(*r));
+}
+
+static sqlite3_int64 cvrViolationRowid(const ConstraintViolationRow *r){
+  u64 h = DOLTLITE_FNV1A_OFFSET;
+  h = doltliteFnv1aBytes(h, r->pKey, r->nKey);
+  h = doltliteFnv1aSep(h);
+  h = doltliteFnv1aI64(h, r->intKey);
+  h = doltliteFnv1aSep(h);
+  h = doltliteFnv1aBytes(h, r->pVal, r->nVal);
+  h = doltliteFnv1aSep(h);
+  h ^= (u64)r->violationType;
+  h *= DOLTLITE_FNV1A_PRIME;
+  h = doltliteFnv1aSep(h);
+  h = doltliteFnv1aStr(h, r->zInfo);
+  return (sqlite3_int64)(h & 0x7fffffffffffffffULL);
 }
 
 static void freeViolationTables(ConstraintViolationTable *a, int n){
@@ -56,70 +70,32 @@ static ConstraintViolationTable *findOrCreateViolationTable(
 #define DCV_MAGIC2 'V'
 #define DCV_VERSION 1
 
-static int serializeViolations(
-  ChunkStore *cs,
-  ConstraintViolationTable *aTables, int nTables,
-  ProllyHash *pHash
-){
-  sqlite3_int64 sz = 4 + 2;
-  int i, j, rc;
-  u8 *buf;
-  DlByteWriter w;
-
-  if( nTables<0 || nTables>0xffff ) return SQLITE_TOOBIG;
-  if( nTables>0 && !aTables ) return SQLITE_CORRUPT;
-  for(i=0; i<nTables; i++){
-    size_t nName = aTables[i].zName ? strlen(aTables[i].zName) : 0;
-    int nl;
-    if( nName>0xffff || aTables[i].nRows<0 ) return SQLITE_TOOBIG;
-    if( aTables[i].nRows>0 && !aTables[i].aRows ) return SQLITE_CORRUPT;
-    nl = (int)nName;
-    rc = dlAddSize(&sz, 2 + nl + 4);
-    if( rc!=SQLITE_OK ) return rc;
-    for(j=0; j<aTables[i].nRows; j++){
-      ConstraintViolationRow *r = &aTables[i].aRows[j];
-      size_t nInfo = r->zInfo ? strlen(r->zInfo) : 0;
-      if( r->nKey<0 || r->nVal<0 ) return SQLITE_CORRUPT;
-      if( (r->nKey>0 && !r->pKey) || (r->nVal>0 && !r->pVal) ){
-        return SQLITE_CORRUPT;
-      }
-      if( nInfo>INT_MAX ) return SQLITE_TOOBIG;
-      rc = dlAddSize(&sz, 21);
-      if( rc==SQLITE_OK ) rc = dlAddSize(&sz, r->nKey);
-      if( rc==SQLITE_OK ) rc = dlAddSize(&sz, r->nVal);
-      if( rc==SQLITE_OK ) rc = dlAddSize(&sz, (sqlite3_int64)nInfo);
-      if( rc!=SQLITE_OK ) return rc;
-    }
-  }
-
-  buf = sqlite3_malloc64((sqlite3_uint64)sz);
-  if( !buf ) return SQLITE_NOMEM;
-  dlWriterInit(&w, buf, (int)sz);
-
-  dlWriteFramedHeader(&w, DCV_MAGIC0, DCV_MAGIC1, DCV_MAGIC2, DCV_VERSION, nTables);
-
-  for(i=0; i<nTables; i++){
-    int nl = aTables[i].zName ? (int)strlen(aTables[i].zName) : 0;
-    dlWriteU16Name(&w, aTables[i].zName, nl);
-    dlWriteU32(&w, aTables[i].nRows);
-    for(j=0; j<aTables[i].nRows; j++){
-      ConstraintViolationRow *r = &aTables[i].aRows[j];
-      int ni = r->zInfo ? (int)strlen(r->zInfo) : 0;
-      dlWriteU8(&w, (u8)r->violationType);
-      dlWriteU32Blob(&w, r->pKey, r->nKey);
-      dlWriteI64(&w, r->intKey);
-      dlWriteU32Blob(&w, r->pVal, r->nVal);
-      dlWriteU32Blob(&w, (const u8*)r->zInfo, ni);
-    }
-  }
-
-  if( w.err || w.p!=w.end ){
-    sqlite3_free(buf);
-    return SQLITE_CORRUPT;
-  }
-  rc = chunkStorePut(cs, buf, (int)sz, pHash);
-  sqlite3_free(buf);
+static int measureViolationRow(const void *pRow, sqlite3_int64 *pSz){
+  const ConstraintViolationRow *r = (const ConstraintViolationRow*)pRow;
+  size_t nInfo = r->zInfo ? strlen(r->zInfo) : 0;
+  int rc;
+  if( r->nKey<0 || r->nVal<0 ) return SQLITE_CORRUPT;
+  if( (r->nKey>0 && !r->pKey) || (r->nVal>0 && !r->pVal) ) return SQLITE_CORRUPT;
+  if( nInfo>INT_MAX ) return SQLITE_TOOBIG;
+  rc = dlAddSize(pSz, 21);
+  if( rc==SQLITE_OK ) rc = dlAddSize(pSz, r->nKey);
+  if( rc==SQLITE_OK ) rc = dlAddSize(pSz, r->nVal);
+  if( rc==SQLITE_OK ) rc = dlAddSize(pSz, (sqlite3_int64)nInfo);
   return rc;
+}
+
+static void writeViolationRow(DlByteWriter *w, const void *pRow){
+  const ConstraintViolationRow *r = (const ConstraintViolationRow*)pRow;
+  int ni = r->zInfo ? (int)strlen(r->zInfo) : 0;
+  dlWriteU8(w, (u8)r->violationType);
+  dlWriteU32Blob(w, r->pKey, r->nKey);
+  dlWriteI64(w, r->intKey);
+  dlWriteU32Blob(w, r->pVal, r->nVal);
+  dlWriteU32Blob(w, (const u8*)r->zInfo, ni);
+}
+
+static i64 violationRowidIO(const void *pRow){
+  return cvrViolationRowid((const ConstraintViolationRow*)pRow);
 }
 
 static int readViolationRow(DlByteReader *rd, ConstraintViolationRow *r){
@@ -161,48 +137,39 @@ static void freeViolationRowIO(void *pRow){
   freeViolationRow((ConstraintViolationRow*)pRow);
 }
 
+static void freeViolationTablesVoid(void *aTables, int nTables){
+  freeViolationTables((ConstraintViolationTable*)aTables, nTables);
+}
+
+static const DlFramedCodec *violationCodec(void){
+  static const DlFramedCodec codec = {
+    DCV_MAGIC0, DCV_MAGIC1, DCV_MAGIC2, DCV_VERSION,
+    sizeof(ConstraintViolationRow),
+    1, 0, 0,
+    readViolationRowIO, skipViolationRowIO, freeViolationRowIO,
+    measureViolationRow, writeViolationRow, violationRowidIO
+  };
+  return &codec;
+}
+
+static int serializeViolations(
+  ChunkStore *cs,
+  ConstraintViolationTable *aTables, int nTables,
+  ProllyHash *pHash
+){
+  return dlFramedSerialize(cs, pHash, violationCodec(), nTables,
+      DL_FRAMED_TABLE(ConstraintViolationTable, zName, nRows, aRows),
+      aTables);
+}
+
 static int deserializeAllViolations(
   const u8 *data,
   int nData,
   ConstraintViolationTable **ppTables, int *pnTables
 ){
-  DlByteReader rd;
-  int nTables, i, rc;
-  ConstraintViolationTable *aTables;
-
-  *ppTables = 0;
-  *pnTables = 0;
-
-  if( !data || nData<(4+2) ) return SQLITE_CORRUPT;
-
-  dlReaderInit(&rd, data, nData);
-  if( dlReadFramedHeader(&rd, DCV_MAGIC0, DCV_MAGIC1, DCV_MAGIC2, DCV_VERSION,
-                         &nTables)!=SQLITE_OK ){
-    return SQLITE_CORRUPT;
-  }
-
-  aTables = sqlite3_malloc(nTables ? nTables * (int)sizeof(*aTables) : 1);
-  if( !aTables ) return SQLITE_NOMEM;
-  memset(aTables, 0, nTables ? nTables * (int)sizeof(*aTables) : 1);
-
-  for(i=0; i<nTables; i++){
-    void *aRows = 0;
-    rc = dlReadNamedRowTable(&rd, &aTables[i].zName, &aTables[i].nRows,
-                             &aRows, sizeof(ConstraintViolationRow), 1,
-                             readViolationRowIO, freeViolationRowIO);
-    if( rc!=SQLITE_OK ) goto fail;
-    aTables[i].aRows = (ConstraintViolationRow*)aRows;
-  }
-
-  if( rd.err || rd.p != rd.end ){ rc = SQLITE_CORRUPT; goto fail; }
-
-  *ppTables = aTables;
-  *pnTables = nTables;
-  return SQLITE_OK;
-
-fail:
-  freeViolationTables(aTables, nTables);
-  return rc;
+  return dlFramedDeserialize(data, nData, violationCodec(),
+      DL_FRAMED_TABLE(ConstraintViolationTable, zName, nRows, aRows),
+      (void**)ppTables, pnTables, freeViolationTablesVoid);
 }
 
 int doltliteDeserializeConstraintViolationsForTest(const u8 *data, int nData){
@@ -246,8 +213,8 @@ static int loadViolationTable(
 ){
   ProllyHash hash;
   u8 *data = 0; int nData = 0;
-  DlByteReader rd;
-  int nTables, i, rc;
+  void *aRows = 0;
+  int rc;
 
   memset(pTable, 0, sizeof(*pTable));
   *pFound = 0;
@@ -257,35 +224,15 @@ static int loadViolationTable(
 
   rc = chunkStoreGet(cs, &hash, &data, &nData);
   if( rc!=SQLITE_OK ) return rc;
-  if( nData<(4+2) ){ sqlite3_free(data); return SQLITE_CORRUPT; }
-
-  dlReaderInit(&rd, data, nData);
-  if( dlReadFramedHeader(&rd, DCV_MAGIC0, DCV_MAGIC1, DCV_MAGIC2, DCV_VERSION,
-                         &nTables)!=SQLITE_OK ){
-    sqlite3_free(data);
-    return SQLITE_CORRUPT;
-  }
-
-  for(i=0; i<nTables; i++){
-    void *aRows = 0;
-    rc = dlMatchOrSkipNamedTable(&rd, zTableName, pFound,
-                                 &pTable->zName, &pTable->nRows, &aRows,
-                                 sizeof(ConstraintViolationRow), 1,
-                                 readViolationRowIO, skipViolationRowIO,
-                                 freeViolationRowIO);
-    if( rc!=SQLITE_OK ) goto fail;
-    if( aRows ) pTable->aRows = (ConstraintViolationRow*)aRows;
-  }
-
-  if( rd.err || rd.p != rd.end ){ rc = SQLITE_CORRUPT; goto fail; }
-
+  rc = dlFramedLoadNamed(data, nData, violationCodec(), zTableName,
+                         &pTable->zName, &pTable->nRows, &aRows, pFound);
   sqlite3_free(data);
+  pTable->aRows = (ConstraintViolationRow*)aRows;
+  if( rc!=SQLITE_OK ){
+    freeViolationTable(pTable);
+    return rc;
+  }
   return SQLITE_OK;
-
-fail:
-  freeViolationTable(pTable);
-  sqlite3_free(data);
-  return rc;
 }
 
 static void freeViolationTable(ConstraintViolationTable *pTable){
@@ -352,128 +299,22 @@ static int deleteViolationRowFromCatalog(
   ProllyHash hash;
   u8 *data = 0;
   u8 *out = 0;
-  int nData = 0;
-  DlByteReader rd;
-  DlByteWriter w;
-  int nTables, nOutTables = 0;
-  int i, j, rc = SQLITE_OK;
+  int nData = 0, nOut = 0, nOutTables = 0;
   int deleted = 0;
+  int rc;
 
   doltliteGetSessionConstraintViolationsCatalog(db, &hash);
   if( prollyHashIsEmpty(&hash) ) return SQLITE_OK;
 
   rc = chunkStoreGet(cs, &hash, &data, &nData);
   if( rc!=SQLITE_OK ) return rc;
-  if( nData<(4+2) ){ sqlite3_free(data); return SQLITE_CORRUPT; }
-
-  out = sqlite3_malloc(nData);
-  if( !out ){ sqlite3_free(data); return SQLITE_NOMEM; }
-
-  dlReaderInit(&rd, data, nData);
-  if( dlReadFramedHeader(&rd, DCV_MAGIC0, DCV_MAGIC1, DCV_MAGIC2, DCV_VERSION,
-                         &nTables)!=SQLITE_OK ){
-    rc = SQLITE_CORRUPT;
-    goto delete_violation_done;
-  }
-
-  dlWriterInit(&w, out, nData);
-  dlWriteFramedHeader(&w, DCV_MAGIC0, DCV_MAGIC1, DCV_MAGIC2, DCV_VERSION, 0);
-
-  for(i=0; i<nTables; i++){
-    const u8 *pTableStart = rd.p;
-    u8 *pOutTableStart = w.p;
-    char *zName = 0;
-    int nr;
-    int isMatch;
-
-    rc = dlReadU16Name(&rd, &zName);
-    if( rc!=SQLITE_OK ) goto delete_violation_done;
-    nr = dlReadU32(&rd);
-    if( rd.err || nr<0 ){
-      sqlite3_free(zName);
-      rc = SQLITE_CORRUPT;
-      goto delete_violation_done;
-    }
-    if( (sqlite3_uint64)nr > (sqlite3_uint64)(rd.end - rd.p) ){
-      sqlite3_free(zName);
-      rc = SQLITE_CORRUPT;
-      goto delete_violation_done;
-    }
-
-    isMatch = (!deleted && zName && strcmp(zName, zTableName)==0);
-    if( isMatch ){
-      u8 *pCountOut = 0;
-      int nKeep = 0;
-      int nl = (int)strlen(zName);
-
-      dlWriteU16Name(&w, zName, nl);
-      pCountOut = w.p;
-      dlWriteU32(&w, 0);
-      for(j=0; j<nr; j++){
-        ConstraintViolationRow vr;
-        memset(&vr, 0, sizeof(vr));
-        rc = readViolationRow(&rd, &vr);
-        if( rc!=SQLITE_OK ){
-          freeViolationRow(&vr);
-          sqlite3_free(zName);
-          goto delete_violation_done;
-        }
-        if( !deleted && cvrViolationRowid(&vr) == deleteRowid ){
-          deleted = 1;
-        }else{
-          int ni = vr.zInfo ? (int)strlen(vr.zInfo) : 0;
-          dlWriteU8(&w, (u8)vr.violationType);
-          dlWriteU32Blob(&w, vr.pKey, vr.nKey);
-          dlWriteI64(&w, vr.intKey);
-          dlWriteU32Blob(&w, vr.pVal, vr.nVal);
-          dlWriteU32Blob(&w, (const u8*)vr.zInfo, ni);
-          nKeep++;
-        }
-        freeViolationRow(&vr);
-      }
-      if( nKeep==0 ){
-        w.p = pOutTableStart;
-      }else{
-        DlByteWriter cw;
-        dlWriterInit(&cw, pCountOut, 4);
-        dlWriteU32(&cw, nKeep);
-        assert( !cw.err );
-        nOutTables++;
-      }
-    }else{
-      for(j=0; j<nr; j++){
-        rc = skipViolationRow(&rd);
-        if( rc!=SQLITE_OK ){
-          sqlite3_free(zName);
-          goto delete_violation_done;
-        }
-      }
-      assert( !isMatch );
-      {
-        int nCopy = (int)(rd.p - pTableStart);
-        dlWriteBytes(&w, pTableStart, nCopy);
-        nOutTables++;
-      }
-    }
-    sqlite3_free(zName);
-  }
-
-  if( rd.err || rd.p != rd.end || w.err ){
-    rc = SQLITE_CORRUPT;
-    goto delete_violation_done;
-  }
-  if( deleted ){
-    DlByteWriter hw;
-    dlWriterInit(&hw, out, 6);
-    dlWriteFramedHeader(&hw, DCV_MAGIC0, DCV_MAGIC1, DCV_MAGIC2, DCV_VERSION,
-                        nOutTables);
-    assert( !hw.err );
-    rc = storeViolationBytes(db, cs, out, (int)(w.p - out), nOutTables);
-  }
-
-delete_violation_done:
-  sqlite3_free(out);
+  rc = dlFramedDeleteRow(data, nData, violationCodec(), zTableName, deleteRowid,
+                         &out, &nOut, &nOutTables, &deleted);
   sqlite3_free(data);
+  if( rc==SQLITE_OK && deleted ){
+    rc = storeViolationBytes(db, cs, out, nOut, nOutTables);
+  }
+  sqlite3_free(out);
   return rc;
 }
 
@@ -856,21 +697,6 @@ static int cvrColumn(sqlite3_vtab_cursor *cur, sqlite3_context *ctx, int col){
     sqlite3_result_null(ctx);
   }
   return SQLITE_OK;
-}
-
-static sqlite3_int64 cvrViolationRowid(const ConstraintViolationRow *r){
-  u64 h = DOLTLITE_FNV1A_OFFSET;
-  h = doltliteFnv1aBytes(h, r->pKey, r->nKey);
-  h = doltliteFnv1aSep(h);
-  h = doltliteFnv1aI64(h, r->intKey);
-  h = doltliteFnv1aSep(h);
-  h = doltliteFnv1aBytes(h, r->pVal, r->nVal);
-  h = doltliteFnv1aSep(h);
-  h ^= (u64)r->violationType;
-  h *= DOLTLITE_FNV1A_PRIME;
-  h = doltliteFnv1aSep(h);
-  h = doltliteFnv1aStr(h, r->zInfo);
-  return (sqlite3_int64)(h & 0x7fffffffffffffffULL);
 }
 
 static int cvrRowid(sqlite3_vtab_cursor *cur, sqlite3_int64 *r){

--- a/src/doltlite_framed.c
+++ b/src/doltlite_framed.c
@@ -1,0 +1,446 @@
+#ifdef DOLTLITE_PROLLY
+
+#include "doltlite_internal.h"
+
+#include <string.h>
+
+static char **framedNameSlot(void *pTab, size_t offName){
+  return (char**)((char*)pTab + offName);
+}
+
+static int *framedNRowsSlot(void *pTab, size_t offNRows){
+  return (int*)((char*)pTab + offNRows);
+}
+
+static void **framedARowsSlot(void *pTab, size_t offARows){
+  return (void**)((char*)pTab + offARows);
+}
+
+static const char *framedNameAt(
+  const void *aTables, size_t szTable, size_t offName, int i
+){
+  return *(char * const *)((const char*)aTables + (size_t)i * szTable + offName);
+}
+
+static int framedNRowsAt(
+  const void *aTables, size_t szTable, size_t offNRows, int i
+){
+  return *(const int*)((const char*)aTables + (size_t)i * szTable + offNRows);
+}
+
+static const void *framedARowsAt(
+  const void *aTables, size_t szTable, size_t offARows, int i
+){
+  return *(void * const *)((const char*)aTables + (size_t)i * szTable + offARows);
+}
+
+static const void *framedRowAt(const void *aRows, size_t szRow, int j){
+  return (const char*)aRows + (size_t)j * szRow;
+}
+
+static int framedNameEq(
+  const DlFramedCodec *pCodec, const char *zHave, const char *zWant
+){
+  if( !zHave || !zWant ) return 0;
+  return pCodec->bNameNocase
+      ? sqlite3_stricmp(zHave, zWant)==0
+      : strcmp(zHave, zWant)==0;
+}
+
+int dlFramedSerialize(
+  ChunkStore *cs,
+  ProllyHash *pHash,
+  const DlFramedCodec *pCodec,
+  int nTables,
+  size_t szTable,
+  size_t offName,
+  size_t offNRows,
+  size_t offARows,
+  const void *aTables
+){
+  sqlite3_int64 sz = 4 + 2;
+  int i, j, rc;
+  u8 *buf;
+  DlByteWriter w;
+
+  if( nTables<0 || nTables>0xffff ) return SQLITE_TOOBIG;
+  if( nTables>0 && !aTables ) return SQLITE_CORRUPT;
+  for(i=0; i<nTables; i++){
+    const char *zName = framedNameAt(aTables, szTable, offName, i);
+    int nRows = framedNRowsAt(aTables, szTable, offNRows, i);
+    const void *aRows = framedARowsAt(aTables, szTable, offARows, i);
+    size_t nName = zName ? strlen(zName) : 0;
+    int nl;
+    if( nName>0xffff || nRows<0 ) return SQLITE_TOOBIG;
+    if( nRows>0 && !aRows ) return SQLITE_CORRUPT;
+    nl = (int)nName;
+    rc = dlAddSize(&sz, 2 + nl + 4);
+    if( rc!=SQLITE_OK ) return rc;
+    for(j=0; j<nRows; j++){
+      rc = pCodec->xMeasureRow(framedRowAt(aRows, pCodec->szRow, j), &sz);
+      if( rc!=SQLITE_OK ) return rc;
+    }
+  }
+
+  buf = sqlite3_malloc64((sqlite3_uint64)sz);
+  if( !buf ) return SQLITE_NOMEM;
+  dlWriterInit(&w, buf, (int)sz);
+
+  dlWriteFramedHeader(&w, pCodec->m0, pCodec->m1, pCodec->m2, pCodec->ver, nTables);
+  for(i=0; i<nTables; i++){
+    const char *zName = framedNameAt(aTables, szTable, offName, i);
+    int nRows = framedNRowsAt(aTables, szTable, offNRows, i);
+    const void *aRows = framedARowsAt(aTables, szTable, offARows, i);
+    int nl = zName ? (int)strlen(zName) : 0;
+    dlWriteU16Name(&w, zName, nl);
+    dlWriteU32(&w, nRows);
+    for(j=0; j<nRows; j++){
+      pCodec->xWriteRow(&w, framedRowAt(aRows, pCodec->szRow, j));
+    }
+  }
+
+  if( w.err || w.p!=w.end ){
+    sqlite3_free(buf);
+    return SQLITE_CORRUPT;
+  }
+  rc = (pCodec->iPutFaultSim && sqlite3FaultSim(pCodec->iPutFaultSim))
+      ? SQLITE_IOERR
+      : chunkStorePut(cs, buf, (int)sz, pHash);
+  sqlite3_free(buf);
+  return rc;
+}
+
+int dlFramedDeserialize(
+  const u8 *data, int nData,
+  const DlFramedCodec *pCodec,
+  size_t szTable,
+  size_t offName,
+  size_t offNRows,
+  size_t offARows,
+  void **ppTables, int *pnTables,
+  void (*xFreeTables)(void *aTables, int nTables)
+){
+  DlByteReader r;
+  int nTables, i, rc;
+  void *aTables;
+
+  *ppTables = 0;
+  *pnTables = 0;
+  if( !data || nData<(4+2) ) return SQLITE_CORRUPT;
+
+  dlReaderInit(&r, data, nData);
+  if( dlReadFramedHeader(&r, pCodec->m0, pCodec->m1, pCodec->m2, pCodec->ver,
+                         &nTables)!=SQLITE_OK ){
+    return SQLITE_CORRUPT;
+  }
+
+  aTables = sqlite3_malloc(nTables ? nTables * (int)szTable : 1);
+  if( !aTables ) return SQLITE_NOMEM;
+  memset(aTables, 0, nTables ? nTables * (int)szTable : 1);
+
+  for(i=0; i<nTables; i++){
+    void *pTab = (char*)aTables + (size_t)i * szTable;
+    void *aRows = 0;
+    rc = dlReadNamedRowTable(&r, framedNameSlot(pTab, offName),
+                             framedNRowsSlot(pTab, offNRows),
+                             &aRows, pCodec->szRow, pCodec->bAllocEmpty,
+                             pCodec->xRead, pCodec->xFree);
+    if( rc!=SQLITE_OK ){
+      xFreeTables(aTables, nTables);
+      return rc;
+    }
+    *framedARowsSlot(pTab, offARows) = aRows;
+  }
+
+  if( r.err || r.p != r.end ){
+    xFreeTables(aTables, nTables);
+    return SQLITE_CORRUPT;
+  }
+
+  *ppTables = aTables;
+  *pnTables = nTables;
+  return SQLITE_OK;
+}
+
+int dlFramedLoadNamed(
+  const u8 *data, int nData,
+  const DlFramedCodec *pCodec,
+  const char *zTableName,
+  char **pzName, int *pnRows, void **ppRows, int *pFound
+){
+  DlByteReader r;
+  int nTables, i, rc;
+
+  *pzName = 0;
+  *pnRows = 0;
+  *ppRows = 0;
+  *pFound = 0;
+  if( !data || nData<(4+2) ) return SQLITE_CORRUPT;
+
+  dlReaderInit(&r, data, nData);
+  if( dlReadFramedHeader(&r, pCodec->m0, pCodec->m1, pCodec->m2, pCodec->ver,
+                         &nTables)!=SQLITE_OK ){
+    return SQLITE_CORRUPT;
+  }
+
+  for(i=0; i<nTables; i++){
+    void *aRows = 0;
+    rc = dlMatchOrSkipNamedTable(&r, zTableName, pFound,
+                                 pzName, pnRows, &aRows,
+                                 pCodec->szRow, pCodec->bAllocEmpty,
+                                 pCodec->xRead, pCodec->xSkip, pCodec->xFree);
+    if( rc!=SQLITE_OK ) return rc;
+    if( aRows ) *ppRows = aRows;
+  }
+
+  if( r.err || r.p != r.end ) return SQLITE_CORRUPT;
+  return SQLITE_OK;
+}
+
+static int framedRewriteOpen(
+  const u8 *data, int nData,
+  const DlFramedCodec *pCodec,
+  u8 **ppOut,
+  DlByteReader *pR,
+  DlByteWriter *pW,
+  int *pnTables
+){
+  if( !data || nData<(4+2) ) return SQLITE_CORRUPT;
+  *ppOut = sqlite3_malloc(nData);
+  if( !*ppOut ) return SQLITE_NOMEM;
+  dlReaderInit(pR, data, nData);
+  if( dlReadFramedHeader(pR, pCodec->m0, pCodec->m1, pCodec->m2, pCodec->ver,
+                         pnTables)!=SQLITE_OK ){
+    sqlite3_free(*ppOut);
+    *ppOut = 0;
+    return SQLITE_CORRUPT;
+  }
+  dlWriterInit(pW, *ppOut, nData);
+  dlWriteFramedHeader(pW, pCodec->m0, pCodec->m1, pCodec->m2, pCodec->ver, 0);
+  return SQLITE_OK;
+}
+
+static int framedRewriteFinish(
+  const u8 *data, int nData,
+  const DlFramedCodec *pCodec,
+  DlByteReader *pR,
+  DlByteWriter *pW,
+  u8 *out,
+  int nOutTables,
+  int bChanged,
+  u8 **ppOut, int *pnOut, int *pnOutTables
+){
+  (void)data; (void)nData;
+  if( pR->err || pR->p != pR->end || pW->err ){
+    sqlite3_free(out);
+    return SQLITE_CORRUPT;
+  }
+  if( !bChanged ){
+    sqlite3_free(out);
+    *ppOut = 0;
+    *pnOut = 0;
+    *pnOutTables = 0;
+    return SQLITE_OK;
+  }
+  {
+    DlByteWriter hw;
+    dlWriterInit(&hw, out, 6);
+    dlWriteFramedHeader(&hw, pCodec->m0, pCodec->m1, pCodec->m2, pCodec->ver,
+                        nOutTables);
+    if( hw.err ){
+      sqlite3_free(out);
+      return SQLITE_CORRUPT;
+    }
+  }
+  *ppOut = out;
+  *pnOut = (int)(pW->p - out);
+  *pnOutTables = nOutTables;
+  return SQLITE_OK;
+}
+
+int dlFramedDeleteRow(
+  const u8 *data, int nData,
+  const DlFramedCodec *pCodec,
+  const char *zTableName,
+  i64 deleteRowid,
+  u8 **ppOut, int *pnOut, int *pnOutTables, int *pDeleted
+){
+  u8 *out = 0;
+  DlByteReader r;
+  DlByteWriter w;
+  int nTables, nOutTables = 0;
+  int i, j, rc;
+  int deleted = 0;
+  void *pRow = 0;
+
+  *ppOut = 0;
+  *pnOut = 0;
+  *pnOutTables = 0;
+  *pDeleted = 0;
+
+  rc = framedRewriteOpen(data, nData, pCodec, &out, &r, &w, &nTables);
+  if( rc!=SQLITE_OK ) return rc;
+
+  pRow = sqlite3_malloc64(pCodec->szRow ? (sqlite3_uint64)pCodec->szRow : 1);
+  if( !pRow ){
+    sqlite3_free(out);
+    return SQLITE_NOMEM;
+  }
+
+  for(i=0; i<nTables; i++){
+    const u8 *pTableStart = r.p;
+    u8 *pOutTableStart = w.p;
+    char *zName = 0;
+    int nr;
+    int isMatch;
+
+    rc = dlReadU16Name(&r, &zName);
+    if( rc!=SQLITE_OK ) goto delete_done;
+    nr = dlReadU32(&r);
+    if( r.err || nr<0 ){
+      sqlite3_free(zName);
+      rc = SQLITE_CORRUPT;
+      goto delete_done;
+    }
+    if( (sqlite3_uint64)nr > (sqlite3_uint64)(r.end - r.p) ){
+      sqlite3_free(zName);
+      rc = SQLITE_CORRUPT;
+      goto delete_done;
+    }
+
+    isMatch = (!deleted && framedNameEq(pCodec, zName, zTableName));
+    if( isMatch ){
+      u8 *pCountOut = 0;
+      int nKeep = 0;
+      int nl = (int)strlen(zName);
+
+      dlWriteU16Name(&w, zName, nl);
+      pCountOut = w.p;
+      dlWriteU32(&w, 0);
+      for(j=0; j<nr; j++){
+        memset(pRow, 0, pCodec->szRow);
+        rc = pCodec->xRead(&r, pRow);
+        if( rc!=SQLITE_OK ){
+          pCodec->xFree(pRow);
+          sqlite3_free(zName);
+          goto delete_done;
+        }
+        if( !deleted && pCodec->xRowid(pRow)==deleteRowid ){
+          deleted = 1;
+        }else{
+          pCodec->xWriteRow(&w, pRow);
+          nKeep++;
+        }
+        pCodec->xFree(pRow);
+      }
+      if( nKeep==0 ){
+        w.p = pOutTableStart;
+      }else{
+        DlByteWriter cw;
+        dlWriterInit(&cw, pCountOut, 4);
+        dlWriteU32(&cw, nKeep);
+        if( cw.err ){
+          sqlite3_free(zName);
+          rc = SQLITE_CORRUPT;
+          goto delete_done;
+        }
+        nOutTables++;
+      }
+    }else{
+      for(j=0; j<nr; j++){
+        rc = pCodec->xSkip(&r, 0);
+        if( rc!=SQLITE_OK ){
+          sqlite3_free(zName);
+          goto delete_done;
+        }
+      }
+      {
+        int nCopy = (int)(r.p - pTableStart);
+        dlWriteBytes(&w, pTableStart, nCopy);
+        nOutTables++;
+      }
+    }
+    sqlite3_free(zName);
+  }
+
+  sqlite3_free(pRow);
+  pRow = 0;
+  *pDeleted = deleted;
+  return framedRewriteFinish(data, nData, pCodec, &r, &w, out, nOutTables,
+                             deleted, ppOut, pnOut, pnOutTables);
+
+delete_done:
+  sqlite3_free(pRow);
+  sqlite3_free(out);
+  return rc;
+}
+
+int dlFramedDropTable(
+  const u8 *data, int nData,
+  const DlFramedCodec *pCodec,
+  const char *zTableName,
+  u8 **ppOut, int *pnOut, int *pnOutTables, int *pFound
+){
+  u8 *out = 0;
+  DlByteReader r;
+  DlByteWriter w;
+  int nTables, nOutTables = 0;
+  int i, j, rc;
+  int found = 0;
+
+  *ppOut = 0;
+  *pnOut = 0;
+  *pnOutTables = 0;
+  *pFound = 0;
+
+  rc = framedRewriteOpen(data, nData, pCodec, &out, &r, &w, &nTables);
+  if( rc!=SQLITE_OK ) return rc;
+
+  for(i=0; i<nTables; i++){
+    const u8 *pTableStart = r.p;
+    char *zName = 0;
+    int nr;
+    int isMatch;
+
+    rc = dlReadU16Name(&r, &zName);
+    if( rc!=SQLITE_OK ) goto drop_done;
+    nr = dlReadU32(&r);
+    if( r.err || nr<0 ){
+      sqlite3_free(zName);
+      rc = SQLITE_CORRUPT;
+      goto drop_done;
+    }
+    if( (sqlite3_uint64)nr > (sqlite3_uint64)(r.end - r.p) ){
+      sqlite3_free(zName);
+      rc = SQLITE_CORRUPT;
+      goto drop_done;
+    }
+
+    isMatch = (!found && framedNameEq(pCodec, zName, zTableName));
+    for(j=0; j<nr; j++){
+      rc = pCodec->xSkip(&r, 0);
+      if( rc!=SQLITE_OK ){
+        sqlite3_free(zName);
+        goto drop_done;
+      }
+    }
+    if( isMatch ){
+      found = 1;
+    }else{
+      int nCopy = (int)(r.p - pTableStart);
+      dlWriteBytes(&w, pTableStart, nCopy);
+      nOutTables++;
+    }
+    sqlite3_free(zName);
+  }
+
+  *pFound = found;
+  return framedRewriteFinish(data, nData, pCodec, &r, &w, out, nOutTables,
+                             found, ppOut, pnOut, pnOutTables);
+
+drop_done:
+  sqlite3_free(out);
+  return rc;
+}
+
+#endif

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -1101,6 +1101,65 @@ static SQLITE_INLINE int dlMatchOrSkipNamedTable(
   return SQLITE_OK;
 }
 
+typedef struct DlFramedCodec DlFramedCodec;
+struct DlFramedCodec {
+  u8 m0, m1, m2, ver;
+  size_t szRow;
+  int bAllocEmpty;
+  int bNameNocase;
+  int iPutFaultSim;
+  DlRowIO xRead;
+  DlRowIO xSkip;
+  DlRowFree xFree;
+  int (*xMeasureRow)(const void *pRow, sqlite3_int64 *pSz);
+  void (*xWriteRow)(DlByteWriter *w, const void *pRow);
+  i64 (*xRowid)(const void *pRow);
+};
+
+#define DL_FRAMED_TABLE(type, nameF, nRowsF, aRowsF) \
+  sizeof(type), offsetof(type, nameF), offsetof(type, nRowsF), offsetof(type, aRowsF)
+
+int dlFramedSerialize(
+  ChunkStore *cs,
+  ProllyHash *pHash,
+  const DlFramedCodec *pCodec,
+  int nTables,
+  size_t szTable,
+  size_t offName,
+  size_t offNRows,
+  size_t offARows,
+  const void *aTables
+);
+int dlFramedDeserialize(
+  const u8 *data, int nData,
+  const DlFramedCodec *pCodec,
+  size_t szTable,
+  size_t offName,
+  size_t offNRows,
+  size_t offARows,
+  void **ppTables, int *pnTables,
+  void (*xFreeTables)(void *aTables, int nTables)
+);
+int dlFramedLoadNamed(
+  const u8 *data, int nData,
+  const DlFramedCodec *pCodec,
+  const char *zTableName,
+  char **pzName, int *pnRows, void **ppRows, int *pFound
+);
+int dlFramedDeleteRow(
+  const u8 *data, int nData,
+  const DlFramedCodec *pCodec,
+  const char *zTableName,
+  i64 deleteRowid,
+  u8 **ppOut, int *pnOut, int *pnOutTables, int *pDeleted
+);
+int dlFramedDropTable(
+  const u8 *data, int nData,
+  const DlFramedCodec *pCodec,
+  const char *zTableName,
+  u8 **ppOut, int *pnOut, int *pnOutTables, int *pFound
+);
+
 ChunkStore *doltliteGetChunkStore(sqlite3 *db);
 ChunkStore *doltliteBtreeChunkStore(Btree *p);
 int doltliteGcCompactStore(sqlite3 *db, ChunkStore *cs);

--- a/tool/mksqlite3c.tcl
+++ b/tool/mksqlite3c.tcl
@@ -844,7 +844,7 @@ proc emit_doltlite_engine_block {} {
     doltlite_commit_ancestors.c doltlite_status.c doltlite_merge_status.c doltlite_diff.c doltlite_diff_table.c
     doltlite_workspace.c
     doltlite_branch.c doltlite_branches.c doltlite_checkout.c doltlite_tag.c doltlite_ancestor.c doltlite_merge.c doltlite_merge_pass1.c doltlite_merge_pass2.c doltlite_merge_predetect.c doltlite_merge_rebuild.c doltlite_merge_rows.c doltlite_merge_schema.c
-    doltlite_conflicts.c doltlite_gc.c doltlite_chunk_walk.c
+    doltlite_framed.c doltlite_conflicts.c doltlite_gc.c doltlite_chunk_walk.c
     doltlite_history.c doltlite_at.c doltlite_blame.c doltlite_schema_diff.c doltlite_patch.c
     doltlite_schemas.c doltlite_diff_stat.c doltlite_record.c doltlite_ignore.c
     doltlite_docs.c


### PR DESCRIPTION
## Summary

Conflicts (`DLC/1`) and constraint violations (`DCV/1`) both persist a named-table framed blob: 6-byte header, then per-table name + row count + typed rows. Serialize, deserialize-all, load-one, rewrite-delete, and drop-table were copied between `doltlite_conflicts.c` and `doltlite_constraint_violations.c`.

This pulls that pipeline into `dlFramed*` with a row codec for:

- magic / version
- row size and empty-table allocation
- case-sensitive vs `NOCASE` name match on rewrite
- `sqlite3FaultSim` on conflict put
- row measure / read / write / skip / free / rowid

Callers keep their row layout and session/txn store helpers. Conflict rewrite still matches names with `sqlite3_stricmp` and injects IOERR 950; CV rewrite stays `strcmp` and still allocates an empty row array (`bAllocEmpty=1`).

Second of the remaining near-clone cleanups after the merge-constraint table walk (#2713).

## Test plan

- [x] `doltlite_regression_test_c conflicts_cv_truncated_deserialize_leak` (8/8)
- [x] `DOLTLITE=build/doltlite bash test/doltlite_conflict_rows.sh` (29/29)
- [x] `DOLTLITE=build/doltlite bash test/doltlite_merge_status.sh` (31/31)
- [x] `DOLTLITE=build/doltlite bash test/doltlite_merge.sh` (230/230)
- [x] `bash test/dead_code_check.sh`