### PR TITLE
Honor correlated dolt_log revisions in joins

### DIFF
--- a/src/doltlite_log.c
+++ b/src/doltlite_log.c
@@ -646,6 +646,10 @@ static int doltliteLogBestIndex(sqlite3_vtab *pVtab, sqlite3_index_info *pInfo){
 
   for(i=0; i<pInfo->nConstraint; i++){
     const struct sqlite3_index_constraint *pC = &pInfo->aConstraint[i];
+    if( pC->iColumn == 5 && pC->op == SQLITE_INDEX_CONSTRAINT_EQ
+     && !pC->usable ){
+      return SQLITE_CONSTRAINT;
+    }
     if( !pC->usable ) continue;
     if( pC->op != SQLITE_INDEX_CONSTRAINT_EQ ) continue;
     if( pC->iColumn == 0 && iHashEq < 0

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -5666,7 +5666,6 @@ filefmt filefmt-2.2.2 class=intentional  # SQLite page-header/format bytes; CTLD
 
 # shell bucket — upstream shell*.test driven through the doltlite CLI (the
 # regression jobs alias sqlite3 -> doltlite for this bucket only).
-shell2 shell2-1.4.9 class=engine-gap issue=2706  # .clone errors on sqlite_sequence; clone content is right
 # The CLI leaves DEFENSIVE off (issue 2712, to match sqlite3); stock rejects
 # the sqlite_master write in the dump.
 shell9 shell9-1.2.2 class=engine-gap issue=2712  # .read of a dump that writes sqlite_master succeeds

--- a/test/known_testfixture_exception_ratchet.txt
+++ b/test/known_testfixture_exception_ratchet.txt
@@ -6,8 +6,8 @@
 # Counts are per gate -- one divergent assertion, or one expected crash.
 # Lowering a number is the point. Raising one is a deliberate act that belongs
 # in a PR description.
-gates 4562
+gates 4561
 intentional 3241
 unsupported 1307
 harness 11
-engine-gap 3
+engine-gap 2

--- a/test/vc_oracle_read_table_joins_test.sh
+++ b/test/vc_oracle_read_table_joins_test.sh
@@ -104,6 +104,14 @@ SELECT dolt_merge('feat', '-m', 'merge_feat');
 SELECT dolt_tag('v2');
 "
 
+CORRELATED_LOG="
+$BRANCHY
+CREATE TABLE requested(id INT PRIMARY KEY, label TEXT, commit_hash TEXT NOT NULL);
+INSERT INTO requested
+  SELECT CASE name WHEN 'feat' THEN 1 ELSE 2 END, name, hash
+  FROM dolt_branches WHERE name IN ('feat', 'side');
+"
+
 echo "--- dolt_log x dolt_commit_ancestors ---"
 
 oracle "log_parent_messages_linear" "$LINEAR" \
@@ -151,6 +159,81 @@ oracle "log_ancestors_cte_tip_parents" "$BRANCHY" \
  FROM tip
  JOIN dolt_commit_ancestors a ON a.commit_hash = tip.hash
  JOIN dolt_log p ON p.commit_hash = a.parent_hash;"
+
+echo "--- correlated dolt_log revisions ---"
+
+run_pair "log_correlated_revision_three_way_join" "$CORRELATED_LOG" \
+"SELECT CONCAT('R|', r.label, '|', count(*))
+ FROM requested r
+ JOIN dolt_commit_ancestors a
+   ON a.commit_hash COLLATE BINARY = r.commit_hash COLLATE BINARY
+  AND a.parent_index = 0
+ JOIN dolt_log(a.commit_hash) c
+   ON c.commit_hash COLLATE BINARY = r.commit_hash COLLATE BINARY
+ GROUP BY r.label;" \
+"SELECT CONCAT('R|', r.label, '|', count(*))
+ FROM requested r
+ JOIN dolt_commit_ancestors a
+   ON a.commit_hash = r.commit_hash AND a.parent_index = 0
+ JOIN dolt_log c ON c.commit_hash = r.commit_hash
+ GROUP BY r.label;"
+
+run_pair "log_correlated_revision_from_branch" "$BRANCHY" \
+"SELECT CONCAT('R|', b.name, '|', c.message)
+ FROM dolt_branches b
+ JOIN dolt_log(b.hash) c ON c.commit_hash = b.hash
+ WHERE b.name IN ('feat', 'side');" \
+"SELECT CONCAT('R|', b.name, '|', c.message)
+ FROM dolt_branches b
+ JOIN dolt_log c ON c.commit_hash = b.hash
+ WHERE b.name IN ('feat', 'side');"
+
+run_pair "log_correlated_parent_revision" "$CORRELATED_LOG" \
+"SELECT CONCAT('R|', r.label, '|', p.message)
+ FROM requested r
+ JOIN dolt_commit_ancestors a
+   ON a.commit_hash = r.commit_hash AND a.parent_index = 0
+ JOIN dolt_log(a.parent_hash) p ON p.commit_hash = a.parent_hash;" \
+"SELECT CONCAT('R|', r.label, '|', p.message)
+ FROM requested r
+ JOIN dolt_commit_ancestors a
+   ON a.commit_hash = r.commit_hash AND a.parent_index = 0
+ JOIN dolt_log p ON p.commit_hash = a.parent_hash;"
+
+run_pair "log_correlated_revision_through_cte" "$CORRELATED_LOG" \
+"WITH parents AS (
+   SELECT r.label, a.parent_hash
+   FROM requested r
+   JOIN dolt_commit_ancestors a
+     ON a.commit_hash = r.commit_hash AND a.parent_index = 0)
+ SELECT CONCAT('R|', parents.label, '|', p.message)
+ FROM parents
+ JOIN dolt_log(parents.parent_hash) p
+   ON p.commit_hash = parents.parent_hash;" \
+"WITH parents AS (
+   SELECT r.label, a.parent_hash
+   FROM requested r
+   JOIN dolt_commit_ancestors a
+     ON a.commit_hash = r.commit_hash AND a.parent_index = 0)
+ SELECT CONCAT('R|', parents.label, '|', p.message)
+ FROM parents
+ JOIN dolt_log p ON p.commit_hash = parents.parent_hash;"
+
+run_pair "log_correlated_revision_cross_join_control" "$CORRELATED_LOG" \
+"SELECT CONCAT('R|', r.label, '|', c.message)
+ FROM requested r
+ CROSS JOIN dolt_commit_ancestors a
+ CROSS JOIN dolt_log(a.commit_hash) c
+ WHERE a.commit_hash = r.commit_hash
+   AND a.parent_index = 0
+   AND c.commit_hash = r.commit_hash;" \
+"SELECT CONCAT('R|', r.label, '|', c.message)
+ FROM requested r
+ CROSS JOIN dolt_commit_ancestors a
+ CROSS JOIN dolt_log c
+ WHERE a.commit_hash = r.commit_hash
+   AND a.parent_index = 0
+   AND c.commit_hash = r.commit_hash;"
 
 echo "--- dolt_log x dolt_diff ---"
 


### PR DESCRIPTION
## Summary

- reject join plans that evaluate `dolt_log` before its correlated revision is available
- add fail-before oracle coverage for the reported three-table join
- cover branch, parent, CTE, and forced `CROSS JOIN` correlation shapes

## Root cause

The joins oracle covered output-column joins but no hidden table-function arguments. `dolt_log` silently accepted an unusable revision constraint, allowing SQLite to order it before the table supplying that argument.

## Testing

- `bash test/vc_oracle_read_table_joins_test.sh build/doltlite dolt` (70 passed)
- `bash test/vc_oracle_diff_tvf_test.sh build/doltlite dolt` (37 passed)
- `bash test/run_doltlite_tests.sh build/doltlite` (132 suites passed)
- `make -C build lint`

Fixes #2718

Co-Authored-By: OpenAI Codex <noreply@openai.com>