### PR TITLE
Open lazy clones at a requested revision

### DIFF
--- a/README.md
+++ b/README.md
@@ -678,6 +678,8 @@ SELECT dolt_push('origin', 'v1.0');       -- push one tag
 SELECT dolt_push('origin', '--tags');     -- push all tags
 SELECT dolt_clone('file:///path/to/source.doltlite');
 SELECT dolt_clone('--lazy', 'file:///path/to/source.doltlite');
+SELECT dolt_clone('--lazy', '--revision', 'release~1',
+                  'file:///path/to/source.doltlite');
 SELECT dolt_fetch('origin', 'main');
 SELECT dolt_pull('origin', 'main');   -- fetch, then fast-forward or merge
 SELECT * FROM dolt_remotes;
@@ -700,6 +702,9 @@ fast-forward pull remain refs-only while the connection is origin-enabled. A
 divergent lazy pull is refused until the store is fully materialized.
 Opening without `lazy_origin=1` leaves cached chunks available, but an
 uncached miss fails with a hash-named error instead of contacting `origin`.
+The optional `--revision` value resolves a branch, tag, commit hash, or
+ancestor expression once during the lazy clone. A branch selects its working
+set; every other revision opens a read-only detached snapshot at that commit.
 
 `dolt_pull` fetches the named remote branch, then integrates it into the
 current local branch. It fast-forwards when the current tip is an ancestor of

--- a/src/doltlite_ref.c
+++ b/src/doltlite_ref.c
@@ -33,10 +33,15 @@ static int doltliteOpenRevisionBase(
   u8 *pIsBranch
 ){
   DoltliteCommit commit;
+  const char *zBranch = zRef;
   int rc;
 
   *pIsBranch = 0;
-  rc = chunkStoreFindBranch(cs, zRef, pCommit);
+  if( strcmp(zRef, "HEAD")==0 || strcmp(zRef, "head")==0 ){
+    zBranch = chunkStoreGetDefaultBranch(cs);
+    if( !zBranch ) return SQLITE_NOTFOUND;
+  }
+  rc = chunkStoreFindBranch(cs, zBranch, pCommit);
   if( rc==SQLITE_OK && !prollyHashIsEmpty(pCommit) ){
     *pIsBranch = 1;
   }else{
@@ -132,7 +137,7 @@ int doltliteResolveOpenRevision(
     }else{
       rc = doltliteOpenRevisionParent(cs, pCommit, n-1);
     }
-    if( rc!=SQLITE_OK ) return SQLITE_NOTFOUND;
+    if( rc!=SQLITE_OK ) return rc;
   }
 
   memset(&commit, 0, sizeof(commit));

--- a/src/doltlite_remote_sql.c
+++ b/src/doltlite_remote_sql.c
@@ -186,6 +186,59 @@ static int remoteSqlResetSessionToCommit(
   return rc;
 }
 
+static int remoteSqlSelectLazyRevision(
+  sqlite3 *db,
+  Btree *pBtree,
+  ChunkStore *cs,
+  const char *zRevision
+){
+  ProllyHash commitHash;
+  ProllyHash catalogHash;
+  u8 isBranch = 0;
+  int rc;
+
+  memset(&commitHash, 0, sizeof(commitHash));
+  memset(&catalogHash, 0, sizeof(catalogHash));
+  rc = doltliteResolveOpenRevision(
+      cs, zRevision, &commitHash, &catalogHash, &isBranch);
+  if( rc!=SQLITE_OK ) return rc;
+
+  if( isBranch ){
+    const char *zBranch = zRevision;
+    if( strcmp(zRevision, "HEAD")==0 || strcmp(zRevision, "head")==0 ){
+      zBranch = chunkStoreGetDefaultBranch(cs);
+      if( !zBranch ) return SQLITE_NOTFOUND;
+    }
+    rc = doltliteSetSessionBranch(db, zBranch);
+    if( rc!=SQLITE_OK ) return rc;
+    pBtree->headCommit = commitHash;
+    pBtree->isDetached = 0;
+    pBtree->bDeferredOpen = 1;
+    return SQLITE_OK;
+  }
+
+  rc = doltliteSwitchCatalog(db, &catalogHash);
+  if( rc!=SQLITE_OK ) return rc;
+  pBtree->headCommit = commitHash;
+  memset(&pBtree->vc, 0, sizeof(pBtree->vc));
+  pBtree->vc.stagedCatalog = catalogHash;
+  pBtree->isRebasing = 0;
+  memset(&pBtree->preRebaseWorkingCat, 0,
+         sizeof(pBtree->preRebaseWorkingCat));
+  memset(&pBtree->rebaseOntoCommit, 0,
+         sizeof(pBtree->rebaseOntoCommit));
+  sqlite3_free(pBtree->zRebaseOrigBranch);
+  pBtree->zRebaseOrigBranch = 0;
+  sqlite3_free(pBtree->zRebaseReturnBranch);
+  pBtree->zRebaseReturnBranch = 0;
+  pBtree->isDetached = 1;
+  pBtree->bDeferredOpen = 0;
+  pBtree->bCatalogDropped = 0;
+  btreeStoreCommittedFromCurrent(pBtree, &catalogHash);
+  btreeMarkWorkingStateChanged(pBtree, 0);
+  return SQLITE_OK;
+}
+
 static void doltRemoteFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   sqlite3 *db = sqlite3_context_db_handle(ctx);
   ChunkStore *cs = doltliteGetChunkStore(db);
@@ -713,9 +766,11 @@ static void doltCloneFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   DoltliteRemote *pRemote = 0;
   DoltliteCmdArgs args;
   DoltliteCmdOption aOption[] = {
-    { "lazy", 0, DOLTLITE_CMD_OPTION_FLAG, 0, 0 }
+    { "lazy", 0, DOLTLITE_CMD_OPTION_FLAG, 0, 0 },
+    { "revision", 0, DOLTLITE_CMD_OPTION_VALUE, 0, 0 }
   };
   const char *zUrl;
+  const char *zRevision = 0;
   DoltliteTxnState savedState;
   int bLazy = 0;
   int dirty = 0;
@@ -723,11 +778,13 @@ static void doltCloneFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
 
   if( !cs ){ doltliteVcResultError(ctx, db, "no database"); return; }
   if( argc<1 ){
-    doltliteVcResultError(ctx, db, "usage: dolt_clone(['--lazy'], url)");
+    doltliteVcResultError(ctx, db,
+      "usage: dolt_clone(['--lazy'] ['--revision' rev], url)");
     return;
   }
 
   aOption[0].pSeen = &bLazy;
+  aOption[1].pzValue = &zRevision;
   rc = doltliteCmdParseArgs(ctx, argc, argv, aOption, ArraySize(aOption),
                             0, &args);
   if( rc!=SQLITE_OK ){
@@ -742,6 +799,11 @@ static void doltCloneFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   if( args.nPositional>1 ){
     doltliteCmdArgsClear(&args);
     doltliteVcResultError(ctx, db, "too many arguments");
+    return;
+  }
+  if( zRevision && !bLazy ){
+    doltliteCmdArgsClear(&args);
+    doltliteVcResultError(ctx, db, "--revision requires --lazy");
     return;
   }
   zUrl = args.azPositional[0];
@@ -843,8 +905,12 @@ static void doltCloneFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
       return;
     }
     pBtree->bDeferredOpen = 1;
-    rc = doltliteBtreePrepareBackupBranch(
-        pBtree, cs, &zPreparedBranch, 0);
+    if( zRevision ){
+      rc = remoteSqlSelectLazyRevision(db, pBtree, cs, zRevision);
+    }else{
+      rc = doltliteBtreePrepareBackupBranch(
+          pBtree, cs, &zPreparedBranch, 0);
+    }
     if( rc==SQLITE_OK && zPreparedBranch ){
       doltliteBtreeInstallBackupBranch(pBtree, zPreparedBranch);
       zPreparedBranch = 0;

--- a/test/remote_test.sh
+++ b/test/remote_test.sh
@@ -984,6 +984,65 @@ SELECT dolt_branch('feature');
 .quit
 ENDSQL
 
+"$DB" "$TMPDIR/lazy_revision_origin.db" <<'ENDSQL' > /dev/null
+CREATE TABLE base_t(id INTEGER PRIMARY KEY);
+INSERT INTO base_t VALUES(1),(2);
+SELECT dolt_commit('-Am','revision base');
+CREATE TABLE main_t(id INTEGER PRIMARY KEY);
+INSERT INTO main_t VALUES(1),(2),(3);
+SELECT dolt_commit('-Am','revision main');
+SELECT dolt_tag('base-tag','HEAD~1');
+SELECT dolt_checkout('-b','feature');
+CREATE TABLE feature_t(id INTEGER PRIMARY KEY);
+INSERT INTO feature_t VALUES(1),(2),(3),(4);
+SELECT dolt_commit('-Am','revision feature');
+SELECT dolt_checkout('main');
+.quit
+ENDSQL
+
+lazy_revision_base=$("$DB" "$TMPDIR/lazy_revision_origin.db" \
+  "SELECT dolt_hashof('HEAD~1');")
+lazy_revision_tables="SELECT group_concat(name, ',') FROM (SELECT name FROM sqlite_master WHERE type='table' ORDER BY name);"
+
+result=$("$DB" "file:lazy_revision_branch?mode=memory&lazy_origin=1" \
+  "SELECT dolt_clone('--lazy','--revision','feature','$R/lazy_revision_origin.db'); SELECT active_branch(); $lazy_revision_tables SELECT count(*) FROM feature_t;")
+check "lazy clone opens a non-default branch working set" "0
+feature
+base_t,feature_t,main_t
+4" "$result"
+
+result=$("$DB" "file:lazy_revision_commit?mode=memory&lazy_origin=1" \
+  "SELECT dolt_clone('--lazy','--revision','$lazy_revision_base','$R/lazy_revision_origin.db'); SELECT IFNULL(active_branch(),'NULL'); SELECT dolt_hashof('HEAD'); $lazy_revision_tables SELECT count(*) FROM base_t;")
+check "lazy clone opens a detached commit" "0
+NULL
+$lazy_revision_base
+base_t
+2" "$result"
+
+result=$("$DB" "file:lazy_revision_tag?mode=memory&lazy_origin=1" \
+  "SELECT dolt_clone('--lazy','--revision','base-tag','$R/lazy_revision_origin.db'); SELECT IFNULL(active_branch(),'NULL'); SELECT dolt_hashof('HEAD'); $lazy_revision_tables SELECT count(*) FROM base_t;")
+check "lazy clone opens a detached tag" "0
+NULL
+$lazy_revision_base
+base_t
+2" "$result"
+
+result=$("$DB" "file:lazy_revision_ancestor?mode=memory&lazy_origin=1" \
+  "SELECT dolt_clone('--lazy','--revision','HEAD~1','$R/lazy_revision_origin.db'); SELECT IFNULL(active_branch(),'NULL'); SELECT dolt_hashof('HEAD'); $lazy_revision_tables SELECT count(*) FROM base_t;")
+check "lazy clone opens a detached ancestor" "0
+NULL
+$lazy_revision_base
+base_t
+2" "$result"
+
+result=$("$DB" "file:lazy_revision_write?mode=memory&lazy_origin=1" \
+  "SELECT dolt_clone('--lazy','--revision','base-tag','$R/lazy_revision_origin.db'); INSERT INTO base_t VALUES(3);" 2>&1)
+check_match "lazy detached revision rejects writes" "readonly|read-only" "$result"
+
+result=$("$DB" "file:lazy_revision_requires_lazy?mode=memory&lazy_origin=1" \
+  "SELECT dolt_clone('--revision','main','$R/lazy_revision_origin.db');" 2>&1)
+check_match "clone revision requires lazy mode" "revision requires --lazy" "$result"
+
 lazy_parity_sql="
 SELECT count(*) || '|' || sum(id) || '|' || sum(length(payload)) FROM lazy_rows;
 SELECT count(*) || '|' || max(message='lazy update') FROM dolt_log;


### PR DESCRIPTION
## Summary

- add optional `--revision <rev>` handling to `dolt_clone(--lazy, ...)`
- resolve branches to their writable working sets
- pin tags, commit hashes, and ancestor expressions to detached read-only snapshots
- fault commit, catalog, schema, and table chunks from the configured `origin` while resolving and reading the snapshot
- preserve existing default-branch behavior when `--revision` is omitted

This gives read-serving consumers a resolve-once snapshot without `dolt_checkout` or working-set mutation:

```sql
SELECT dolt_clone(
  "--lazy", "--revision", "HEAD~1",
  "https://remote/owner/repo"
);
```

The selected revision is connection-local. It remains pinned for that connection's lifetime, but it does not replace the repository's persisted default branch. A later unqualified open therefore uses the default branch; a new connection that needs the historical snapshot selects the revision again. This is intentional and makes no file-format or persistent-selector change.

If origin access fails while resolving or reading a revision, the operation preserves `SQLITE_IOERR_CHUNK_SOURCE` and the requested chunk hash. Failures before remote refs can be fetched use the ordinary remote open/fetch diagnostic because no chunk hash has been requested yet.

## Validation

- `test/remote_test.sh`: 176 passed, 0 failed
- `test/doltlite_at.sh`: 61 passed, 0 failed
- `chunk_source_test`: 313 passed, 0 failed
- `make lint`: passed
- amalgamation enabled and chunk-source-disabled probes: passed
- native DoltLite suites: 132 passed, 0 failed

Also tested read-only against the dev doltliteremoteapi repository `ericrichardson/doltlite-dev-testing` using `file:<key>?mode=memory&cache=shared&lazy_origin=1`:

- non-default branch `raise-eng-salaries` opened as that active branch
- raw commit `74cd1d...` opened detached at the exact hash
- `HEAD~1` opened detached at the expected parent
- schema enumeration and row reads matched each selected revision

Co-Authored-By: OpenAI Codex <noreply@openai.com>
