### PR TITLE
Return the detector's message from dolt_verify_constraints

### DIFF
--- a/src/doltlite_verify_constraints.c
+++ b/src/doltlite_verify_constraints.c
@@ -174,6 +174,7 @@ static void doltVerifyConstraintsFunc(
   int i;
   int rc;
   int nViolations = 0;
+  char *zDetectErr = 0;
   ProllyHash headCat;
   ProllyHash emptyCat;
   DoltliteCommit headCommit;
@@ -315,13 +316,17 @@ static void doltVerifyConstraintsFunc(
   }
 
   rc = doltliteDetectConstraintViolationsFiltered(
-      db, pDetectAnc, azScan, nScan, !bOutputOnly, &nViolations, 0);
+      db, pDetectAnc, azScan, nScan, !bOutputOnly, &nViolations, &zDetectErr);
   if( !bOutputOnly ){
     int erc = doltliteConstraintViolationBatchEnd(db, rc==SQLITE_OK);
     if( rc==SQLITE_OK ) rc = erc;
   }
   if( rc!=SQLITE_OK ){
-    sqlite3_result_error_code(context, rc);
+    if( zDetectErr ){
+      sqlite3_result_error(context, zDetectErr, -1);
+    }else{
+      sqlite3_result_error_code(context, rc);
+    }
     goto cleanup;
   }
 
@@ -349,6 +354,7 @@ detection_done:
   sqlite3_result_int(context, nViolations>0 ? 1 : 0);
 
 cleanup:
+  sqlite3_free(zDetectErr);
   doltliteFreeNameList(azChanged, nChanged);
   sqlite3_free((void*)azArgTables);
   doltliteCmdArgsClear(&args);

--- a/test/doltlite_merge.sh
+++ b/test/doltlite_merge.sh
@@ -1126,17 +1126,17 @@ run_test "verify_recorded_orphan_survives_failed_checks" \
 
 # A row that makes CHECK evaluation itself fail: the detector's message
 # must reach the caller, not a bare error code.
-DB64=/tmp/test_merge64_$$.db; rm -f "$DB64"
-$DOLTLITE "$DB64" > /dev/null 2>&1 <<'SQL'
+DB65=/tmp/test_merge65_$$.db; rm -f "$DB65"
+$DOLTLITE "$DB65" > /dev/null 2>&1 <<'SQL'
 CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT CHECK(json_extract(v,'$.ok')));
 PRAGMA ignore_check_constraints=ON;
 INSERT INTO t VALUES(1,'not-json');
 PRAGMA ignore_check_constraints=OFF;
 SQL
 run_test_match "verify_constraints_all_reports_detector_error" \
-  "SELECT dolt_verify_constraints('--all');" "malformed JSON" "$DB64"
+  "SELECT dolt_verify_constraints('--all');" "malformed JSON" "$DB65"
 run_test_match "verify_constraints_default_reports_detector_error" \
-  "SELECT dolt_verify_constraints();" "malformed JSON" "$DB64"
+  "SELECT dolt_verify_constraints();" "malformed JSON" "$DB65"
 
-rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8" "$DB8B" "$DB9" "$DB10" "$DB11" "$DB11D" "$DB11E" "$DB11F" "$DB12" "$DB13" "$DB14" "$DB15" "$DB16" "$DB17" "$DB18" "$DB19" "$DB20" "$DB20B" "$DB21" "$DB22" "$DB23" "$DB24" "$DB25" "$DB40" "$DB41" "$DB42" "$DB43" "$DB44" "$DB45" "$DB46" "$DB47" "$DB48" "$DB49" "$DB50" "$DB51" "$DB52" "$DB53" "$DB54" "$DB55" "$DB56" "$DB57" "$DB58" "$DB59" "$DB60" "$DB61" "$DB62" "$DB63" "$DB64" "$DB66" "$DB64"
+rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8" "$DB8B" "$DB9" "$DB10" "$DB11" "$DB11D" "$DB11E" "$DB11F" "$DB12" "$DB13" "$DB14" "$DB15" "$DB16" "$DB17" "$DB18" "$DB19" "$DB20" "$DB20B" "$DB21" "$DB22" "$DB23" "$DB24" "$DB25" "$DB40" "$DB41" "$DB42" "$DB43" "$DB44" "$DB45" "$DB46" "$DB47" "$DB48" "$DB49" "$DB50" "$DB51" "$DB52" "$DB53" "$DB54" "$DB55" "$DB56" "$DB57" "$DB58" "$DB59" "$DB60" "$DB61" "$DB62" "$DB63" "$DB64" "$DB66" "$DB65"
 dltest_finish

--- a/test/doltlite_merge.sh
+++ b/test/doltlite_merge.sh
@@ -1124,5 +1124,19 @@ run_test_match "verify_failed_default_scope_keeps_recorded_orphan" \
 run_test "verify_recorded_orphan_survives_failed_checks" \
   "SELECT count(*) FROM dolt_constraint_violations_child;" "1" "$DB66"
 
-rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8" "$DB8B" "$DB9" "$DB10" "$DB11" "$DB11D" "$DB11E" "$DB11F" "$DB12" "$DB13" "$DB14" "$DB15" "$DB16" "$DB17" "$DB18" "$DB19" "$DB20" "$DB20B" "$DB21" "$DB22" "$DB23" "$DB24" "$DB25" "$DB40" "$DB41" "$DB42" "$DB43" "$DB44" "$DB45" "$DB46" "$DB47" "$DB48" "$DB49" "$DB50" "$DB51" "$DB52" "$DB53" "$DB54" "$DB55" "$DB56" "$DB57" "$DB58" "$DB59" "$DB60" "$DB61" "$DB62" "$DB63" "$DB64" "$DB66"
+# A row that makes CHECK evaluation itself fail: the detector's message
+# must reach the caller, not a bare error code.
+DB64=/tmp/test_merge64_$$.db; rm -f "$DB64"
+$DOLTLITE "$DB64" > /dev/null 2>&1 <<'SQL'
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT CHECK(json_extract(v,'$.ok')));
+PRAGMA ignore_check_constraints=ON;
+INSERT INTO t VALUES(1,'not-json');
+PRAGMA ignore_check_constraints=OFF;
+SQL
+run_test_match "verify_constraints_all_reports_detector_error" \
+  "SELECT dolt_verify_constraints('--all');" "malformed JSON" "$DB64"
+run_test_match "verify_constraints_default_reports_detector_error" \
+  "SELECT dolt_verify_constraints();" "malformed JSON" "$DB64"
+
+rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8" "$DB8B" "$DB9" "$DB10" "$DB11" "$DB11D" "$DB11E" "$DB11F" "$DB12" "$DB13" "$DB14" "$DB15" "$DB16" "$DB17" "$DB18" "$DB19" "$DB20" "$DB20B" "$DB21" "$DB22" "$DB23" "$DB24" "$DB25" "$DB40" "$DB41" "$DB42" "$DB43" "$DB44" "$DB45" "$DB46" "$DB47" "$DB48" "$DB49" "$DB50" "$DB51" "$DB52" "$DB53" "$DB54" "$DB55" "$DB56" "$DB57" "$DB58" "$DB59" "$DB60" "$DB61" "$DB62" "$DB63" "$DB64" "$DB66" "$DB64"
 dltest_finish


### PR DESCRIPTION
Fixes #2717.

`dolt_verify_constraints` passed a null error slot to `doltliteDetectConstraintViolationsFiltered` and reported failures with `sqlite3_result_error_code()`, so an expression failure inside a CHECK came back as a bare `SQL logic error`. It now passes the slot and returns the detector's text, the way `dolt_cherry_pick` already does; the code path is unchanged otherwise.

```
CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT CHECK(json_extract(v,'$.ok')));
PRAGMA ignore_check_constraints=ON; INSERT INTO t VALUES(1,'not-json'); PRAGMA ignore_check_constraints=OFF;
SELECT dolt_verify_constraints('--all');
-- before: Error: SQL logic error
-- after:  Error: malformed JSON
```

**Tests.** Two cases in `test/doltlite_merge.sh` (`--all` and default scope) expect `malformed JSON`; against the pre-fix CLI the same statement prints `SQL logic error`. Suite 232/232, `make lint`, amalgamation CLI compiles.

**Not in this PR.** The rebase replay path (`doltlite_rebase.c`, `doltliteDetectConstraintViolationsFiltered(..., 0)`) also drops the detector text and returns only the code; it needs its own look since that function returns an int to a caller that formats its own message. Filed as #2727 with a repro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

