### PR TITLE
Share the serial-type record field decoder

### DIFF
--- a/src/doltlite_merge_constraints_unique.c
+++ b/src/doltlite_merge_constraints_unique.c
@@ -139,12 +139,6 @@ int doltlitePartialIndexWhereSql(sqlite3 *db, Index *pIdx, char **pzWhere){
   return finishConstraintStmt(pStmt, rc);
 }
 
-static int uniqueValueFromRecord(
-  const u8 *pRecord, int nRecord,
-  const DoltliteRecordInfo *pInfo, int iField,
-  DoltliteSerialValue *pValue
-);
-
 int doltlitePartialIndexMatchesRecord(
   sqlite3 *db,
   Index *pIdx,
@@ -195,7 +189,7 @@ int doltlitePartialIndexMatchesRecord(
       rc = sqlite3_bind_null(pStmt, i+1);
       continue;
     }
-    rc = uniqueValueFromRecord(pRec, nRec, &info, iField, &v);
+    rc = doltliteSerialValueFromField(pRec, nRec, &info, iField, &v);
     if( rc!=SQLITE_OK ) break;
     if( v.eType==SQLITE_NULL ){
       rc = sqlite3_bind_null(pStmt, i+1);
@@ -248,48 +242,6 @@ struct UniqueIndexEntry {
   UnpackedRecord *pUnpacked;
 };
 
-static int uniqueValueFromRecord(
-  const u8 *pRecord,
-  int nRecord,
-  const DoltliteRecordInfo *pInfo,
-  int iField,
-  DoltliteSerialValue *pValue
-){
-  int st;
-  int off;
-  int n;
-
-  memset(pValue, 0, sizeof(*pValue));
-  if( iField<0 || iField>=pInfo->nField ) return SQLITE_CORRUPT;
-  st = pInfo->aType[iField];
-  off = pInfo->aOffset[iField];
-  n = dlSerialTypeLen((u64)st);
-  if( n<0 || off<0 || off>nRecord-n ) return SQLITE_CORRUPT;
-  if( st==0 ){
-    pValue->eType = SQLITE_NULL;
-  }else if( st==8 || st==9 || (st>=1 && st<=6) ){
-    pValue->eType = SQLITE_INTEGER;
-    pValue->i = st==8 ? 0 : st==9 ? 1 : dlReadIntBytes(pRecord + off, n);
-  }else if( st==7 ){
-    u64 bits = 0;
-    int i;
-    pValue->eType = SQLITE_FLOAT;
-    for(i=0; i<8; i++) bits = (bits<<8) | pRecord[off+i];
-    memcpy(&pValue->r, &bits, 8);
-  }else if( st>=13 && (st&1)==1 ){
-    pValue->eType = SQLITE_TEXT;
-    pValue->p = pRecord + off;
-    pValue->n = n;
-  }else if( st>=12 && (st&1)==0 ){
-    pValue->eType = SQLITE_BLOB;
-    pValue->p = pRecord + off;
-    pValue->n = n;
-  }else{
-    return SQLITE_CORRUPT;
-  }
-  return SQLITE_OK;
-}
-
 static int uniqueRecordFromTableRow(
   const u8 *pRecord,
   int nRecord,
@@ -320,7 +272,7 @@ static int uniqueRecordFromTableRow(
       break;
     }
     iRecord = pCols->aColToRec[iColumn];
-    rc = uniqueValueFromRecord(
+    rc = doltliteSerialValueFromField(
         pRecord, nRecord, pInfo, iRecord, &aValue[i]);
     if( rc!=SQLITE_OK ) break;
     if( pHasNull && aValue[i].eType==SQLITE_NULL ) *pHasNull = 1;

--- a/src/doltlite_merge_rows.c
+++ b/src/doltlite_merge_rows.c
@@ -62,44 +62,6 @@ static int indexColumnIsExpr(const i16 *aiColumn, int nIdxCol){
   return 0;
 }
 
-static int serialValueFromRecordField(
-  const u8 *pRec, int nRec,
-  const DoltliteRecordInfo *pInfo,
-  int iField,
-  DoltliteSerialValue *pValue
-){
-  int st, off, n;
-  memset(pValue, 0, sizeof(*pValue));
-  if( iField<0 || iField>=pInfo->nField ) return SQLITE_CORRUPT;
-  st = pInfo->aType[iField];
-  off = pInfo->aOffset[iField];
-  n = dlSerialTypeLen((u64)st);
-  if( n<0 || off<0 || off>nRec-n ) return SQLITE_CORRUPT;
-  if( st==0 ){
-    pValue->eType = SQLITE_NULL;
-  }else if( st==8 || st==9 || (st>=1 && st<=6) ){
-    pValue->eType = SQLITE_INTEGER;
-    pValue->i = st==8 ? 0 : st==9 ? 1 : dlReadIntBytes(pRec + off, n);
-  }else if( st==7 ){
-    u64 bits = 0;
-    int i;
-    pValue->eType = SQLITE_FLOAT;
-    for(i=0; i<8; i++) bits = (bits<<8) | pRec[off+i];
-    memcpy(&pValue->r, &bits, 8);
-  }else if( st>=13 && (st&1)==1 ){
-    pValue->eType = SQLITE_TEXT;
-    pValue->p = pRec + off;
-    pValue->n = n;
-  }else if( st>=12 && (st&1)==0 ){
-    pValue->eType = SQLITE_BLOB;
-    pValue->p = pRec + off;
-    pValue->n = n;
-  }else{
-    return SQLITE_CORRUPT;
-  }
-  return SQLITE_OK;
-}
-
 static int bindIndexExprRow(
   sqlite3_stmt *pStmt,
   Table *pTab,
@@ -114,7 +76,7 @@ static int bindIndexExprRow(
       rc = sqlite3_bind_int64(pStmt, i+1, intKey);
     }else if( i<info.nField ){
       DoltliteSerialValue v;
-      rc = serialValueFromRecordField(pRec, nRec, &info, i, &v);
+      rc = doltliteSerialValueFromField(pRec, nRec, &info, i, &v);
       if( rc!=SQLITE_OK ) return rc;
       if( v.eType==SQLITE_NULL ){
         rc = sqlite3_bind_null(pStmt, i+1);
@@ -346,7 +308,7 @@ static int doltliteBuildIndexEntryWithExpr(
         aMem[nOut].eType = SQLITE_INTEGER;
         aMem[nOut].i = intKey;
       }else{
-        rc = serialValueFromRecordField(pRec, nRec, &info, col, &aMem[nOut]);
+        rc = doltliteSerialValueFromField(pRec, nRec, &info, col, &aMem[nOut]);
         if( rc!=SQLITE_OK ) goto expr_fail;
       }
       nOut++;

--- a/src/doltlite_patch.c
+++ b/src/doltlite_patch.c
@@ -939,7 +939,8 @@ static void patchGetValue(
   PatchValue *pOut
 ){
   DoltliteRecordInfo ri;
-  int iField, st, off, n;
+  DoltliteSerialValue v;
+  int iField;
   memset(pOut, 0, sizeof(*pOut));
   pOut->eType = SQLITE_NULL;
   if( iCol==pSchema->col.iPkCol && iCol>=0 ){
@@ -950,37 +951,12 @@ static void patchGetValue(
   if( !pRec || nRec<=0 ) return;
   doltliteParseRecord(pRec, nRec, &ri);
   iField = pSchema->col.aColToRec ? pSchema->col.aColToRec[iCol] : iCol;
-  if( iField<0 || iField>=ri.nField ) return;
-  st = ri.aType[iField];
-  off = ri.aOffset[iField];
-  if( st==0 ) return;
-  if( st==8 || st==9 ){
-    pOut->eType = SQLITE_INTEGER; pOut->i = st==9; return;
-  }
-  if( st>=1 && st<=6 ){
-    n = dlSerialTypeLen((u64)st);
-    if( off>=0 && off<=nRec-n ){
-      pOut->eType = SQLITE_INTEGER;
-      pOut->i = dlReadIntBytes(pRec+off, n);
-    }
-    return;
-  }
-  if( st==7 && off>=0 && off<=nRec-8 ){
-    u64 bits = 0;
-    int i;
-    for(i=0; i<8; i++) bits = (bits<<8) | pRec[off+i];
-    pOut->eType = SQLITE_FLOAT;
-    memcpy(&pOut->r, &bits, 8);
-    return;
-  }
-  if( st>=12 ){
-    n = dlSerialTypeLen((u64)st);
-    if( off>=0 && off<=nRec-n ){
-      pOut->eType = (st&1) ? SQLITE_TEXT : SQLITE_BLOB;
-      pOut->p = pRec+off;
-      pOut->n = n;
-    }
-  }
+  if( doltliteSerialValueFromField(pRec, nRec, &ri, iField, &v)!=SQLITE_OK ) return;
+  pOut->eType = v.eType;
+  pOut->i = v.i;
+  pOut->r = v.r;
+  pOut->p = (const u8*)v.p;
+  pOut->n = v.n;
 }
 
 static void patchAppendHex(sqlite3_str *pStr, const u8 *p, int n){

--- a/src/doltlite_record.c
+++ b/src/doltlite_record.c
@@ -555,78 +555,15 @@ void doltliteParseRecord(const u8 *pData, int nData, DoltliteRecordInfo *pInfo){
   (void)doltliteParseRecordStrict(pData, nData, pInfo);
 }
 
-typedef struct DoltliteDecodedField DoltliteDecodedField;
-struct DoltliteDecodedField {
-  int eType;
-  i64 i;
-  double r;
-  const u8 *p;
-  int n;
-};
-
-static void doltliteDecodeField(
-  const u8 *pData, int nData,
-  int st, int off,
-  DoltliteDecodedField *pOut
-){
-  memset(pOut, 0, sizeof(*pOut));
-  pOut->eType = SQLITE_NULL;
-
-  if( st==0 ) return;
-  if( st==8 ){
-    pOut->eType = SQLITE_INTEGER;
-    pOut->i = 0;
-    return;
-  }
-  if( st==9 ){
-    pOut->eType = SQLITE_INTEGER;
-    pOut->i = 1;
-    return;
-  }
-  if( st>=1 && st<=6 ){
-    int nB = dlSerialTypeLen((u64)st);
-    if( off>=0 && off<=nData-nB ){
-      pOut->eType = SQLITE_INTEGER;
-      pOut->i = dlReadIntBytes(pData + off, nB);
-    }
-    return;
-  }
-  if( st==7 ){
-    if( off>=0 && off<=nData-8 ){
-      const u8 *q = pData + off;
-      u64 bits = 0;
-      int i;
-      for(i=0; i<8; i++) bits = (bits<<8) | q[i];
-      pOut->eType = SQLITE_FLOAT;
-      memcpy(&pOut->r, &bits, 8);
-    }
-    return;
-  }
-  if( st>=13 && (st&1)==1 ){
-    int len = (st-13)/2;
-    if( off>=0 && off<=nData-len ){
-      pOut->eType = SQLITE_TEXT;
-      pOut->p = pData + off;
-      pOut->n = len;
-    }
-    return;
-  }
-  if( st>=12 && (st&1)==0 ){
-    int len = (st-12)/2;
-    if( off>=0 && off<=nData-len ){
-      pOut->eType = SQLITE_BLOB;
-      pOut->p = pData + off;
-      pOut->n = len;
-    }
-  }
-}
-
 void doltliteResultField(
   sqlite3_context *ctx, const u8 *pData, int nData,
   int st, int off
 ){
-  DoltliteDecodedField f;
-  doltliteDecodeField(pData, nData, st, off, &f);
+  DoltliteSerialValue f;
+  if( doltliteSerialValueFromPayload(pData, nData, st, off, &f)!=SQLITE_OK ){
+    sqlite3_result_null(ctx);
+    return;
+  }
   switch( f.eType ){
     case SQLITE_INTEGER:
       sqlite3_result_int64(ctx, f.i);

--- a/src/record_codec.h
+++ b/src/record_codec.h
@@ -103,6 +103,50 @@ struct DoltliteSerialValue {
   int n;
 };
 
+static inline int doltliteSerialValueFromPayload(
+  const u8 *pRec, int nRec, int st, int off, DoltliteSerialValue *pValue
+){
+  int n;
+  memset(pValue, 0, sizeof(*pValue));
+  n = dlSerialTypeLen((u64)st);
+  if( n<0 || off<0 || off>nRec-n ) return SQLITE_CORRUPT;
+  if( st==0 ){
+    pValue->eType = SQLITE_NULL;
+  }else if( st==8 || st==9 || (st>=1 && st<=6) ){
+    pValue->eType = SQLITE_INTEGER;
+    pValue->i = st==8 ? 0 : st==9 ? 1 : dlReadIntBytes(pRec + off, n);
+  }else if( st==7 ){
+    u64 bits = 0;
+    int i;
+    pValue->eType = SQLITE_FLOAT;
+    for(i=0; i<8; i++) bits = (bits<<8) | pRec[off+i];
+    memcpy(&pValue->r, &bits, 8);
+  }else if( st>=13 && (st&1)==1 ){
+    pValue->eType = SQLITE_TEXT;
+    pValue->p = pRec + off;
+    pValue->n = n;
+  }else if( st>=12 && (st&1)==0 ){
+    pValue->eType = SQLITE_BLOB;
+    pValue->p = pRec + off;
+    pValue->n = n;
+  }else{
+    return SQLITE_CORRUPT;
+  }
+  return SQLITE_OK;
+}
+
+static inline int doltliteSerialValueFromField(
+  const u8 *pRec, int nRec,
+  const DoltliteRecordInfo *pInfo,
+  int iField,
+  DoltliteSerialValue *pValue
+){
+  memset(pValue, 0, sizeof(*pValue));
+  if( iField<0 || iField>=pInfo->nField ) return SQLITE_CORRUPT;
+  return doltliteSerialValueFromPayload(
+      pRec, nRec, pInfo->aType[iField], pInfo->aOffset[iField], pValue);
+}
+
 /* Assemble an SQLite-format record (header varints + body) from nField
 ** serial values. Returns a sqlite3_malloc'd buffer of *pnOut bytes, or 0
 ** on OOM or nField<=0. */


### PR DESCRIPTION
## Summary

`uniqueValueFromRecord` and `serialValueFromRecordField` were the same serial-type decode (`NULL` / int / float / text / blob, `dlReadIntBytes`, float-bits). `doltliteDecodeField` and `patchGetValue` were the same cases as a void/lenient helper.

Those now go through `doltliteSerialValueFromPayload` / `doltliteSerialValueFromField` in `record_codec.h`. Unique WITHOUT ROWID collection, merge index-expr bind, `dolt_patch` value rendering, and `doltliteResultField` all share it.

Fifth of the remaining near-clone cleanups after the merge-constraint table walk (#2713), framed conflict/CV I/O (#2719), unique-index internals (#2721), and merge row seeks (#2723).

## Test plan

- [x] `DOLTLITE=build/doltlite bash test/doltlite_merge.sh` (230/230)
- [x] `DOLTLITE=build/doltlite bash test/doltlite_diff_alter.sh` (30/30)
- [x] `bash test/dead_code_check.sh`