### PR TITLE
Preserve rebase constraint detector errors

### DIFF
--- a/src/doltlite_rebase.c
+++ b/src/doltlite_rebase.c
@@ -967,7 +967,8 @@ static int rebaseApplyPlanRowCatalog(
   sqlite3 *db,
   const RebasePlanRow *pRow,
   const ProllyHash *pCurCat,
-  ProllyHash *pMergedCat
+  ProllyHash *pMergedCat,
+  char **pzErr
 ){
   DoltliteCommit parentC, replayC;
   int nConflicts = 0;
@@ -1008,7 +1009,7 @@ static int rebaseApplyPlanRowCatalog(
   }
   if( rc==SQLITE_OK && nConflicts==0 ){
     rc = doltliteDetectConstraintViolationsFiltered(
-        db, &parentC.catalogHash, 0, 0, 1, &nViolations, 0);
+        db, &parentC.catalogHash, 0, 0, 1, &nViolations, pzErr);
   }
   doltliteCommitClear(&parentC);
   doltliteCommitClear(&replayC);
@@ -1061,7 +1062,8 @@ static int rebaseReplayPlanGroup(
   int iStart,
   ProllyHash *pCurCat,
   ProllyHash *pCurHead,
-  int *piNext
+  int *piNext,
+  char **pzErr
 ){
   char *combinedMsg = 0;
   ProllyHash startCat;
@@ -1069,7 +1071,8 @@ static int rebaseReplayPlanGroup(
   int j;
 
   startCat = *pCurCat;
-  rc = rebaseApplyPlanRowCatalog(db, &aPlan[iStart], pCurCat, pCurCat);
+  rc = rebaseApplyPlanRowCatalog(
+      db, &aPlan[iStart], pCurCat, pCurCat, pzErr);
   if( rc!=SQLITE_OK ) return rc;
 
   combinedMsg = sqlite3_mprintf("%s",
@@ -1086,7 +1089,7 @@ static int rebaseReplayPlanGroup(
       continue;
     }
 
-    rc = rebaseApplyPlanRowCatalog(db, &aPlan[j], pCurCat, pCurCat);
+    rc = rebaseApplyPlanRowCatalog(db, &aPlan[j], pCurCat, pCurCat, pzErr);
     if( rc!=SQLITE_OK ){
       sqlite3_free(combinedMsg);
       return rc;
@@ -1786,6 +1789,7 @@ static void doltliteRebaseInteractiveContinue(
   ProllyHash preRebaseCat;
   RebaseFinalizeRefsCtx refsCtx;
   char *zPlanErr = 0;
+  char *zReplayErr = 0;
 
   memset(&curCat, 0, sizeof(curCat));
   memset(&curHead, 0, sizeof(curHead));
@@ -1894,7 +1898,8 @@ static void doltliteRebaseInteractiveContinue(
     while( i < nPlan && strcmp(aPlan[i].zAction, "drop")==0 ) i++;
     if( i >= nPlan ) break;
 
-    rc = rebaseReplayPlanGroup(db, aPlan, nPlan, i, &curCat, &curHead, &j);
+    rc = rebaseReplayPlanGroup(
+        db, aPlan, nPlan, i, &curCat, &curHead, &j, &zReplayErr);
     if( rc==SQLITE_CONSTRAINT ) goto abort_err_conflict;
     if( rc==SQLITE_BUSY ) goto abort_err_cas;
     if( rc!=SQLITE_OK ) goto abort_err;
@@ -1951,6 +1956,7 @@ static void doltliteRebaseInteractiveContinue(
   if( rc!=SQLITE_OK ) goto abort_err;
 
   rebaseFreePlan(aPlan, nPlan);
+  sqlite3_free(zReplayErr);
   {
     char *zMsg = sqlite3_mprintf(
       "Successfully rebased and updated refs/heads/%s", zOrigBranch);
@@ -1964,6 +1970,7 @@ static void doltliteRebaseInteractiveContinue(
 
 abort_err_conflict:
   rebaseFreePlan(aPlan, nPlan);
+  sqlite3_free(zReplayErr);
   recoveryRc = rebaseAbortConflictedContinue(
       db, zOrigBranch, zReturnBranch, zWorking);
   if( doltliteVcTxnMode(db)==DOLTLITE_VC_TXN_AUTOCOMMIT_LIKE ){
@@ -1985,6 +1992,7 @@ abort_err_cas:
       db, aPlan, nPlan, &preRebaseCat, &expectedOrigHead,
       zOrigBranch, zReturnBranch);
   rebaseFreePlan(aPlan, nPlan);
+  sqlite3_free(zReplayErr);
   if( recoveryRc!=SQLITE_OK ){
     sqlite3_free(zOrigBranch);
     sqlite3_free(zReturnBranch);
@@ -2017,6 +2025,7 @@ abort_err:
     sqlite3_free(zOrigBranch);
     sqlite3_free(zReturnBranch);
     sqlite3_free(zWorking);
+    sqlite3_free(zReplayErr);
     if( (stateRc==SQLITE_OK && !rebaseActive) || rc==SQLITE_NOTFOUND ){
       sqlite3_result_error(context, "no rebase in progress", -1);
     }else{
@@ -2036,7 +2045,18 @@ abort_err:
   sqlite3_free(zReturnBranch);
   sqlite3_free(zWorking);
   if( recoveryRc!=SQLITE_OK ){
+    sqlite3_free(zReplayErr);
     rebaseResultRecoveryFailure(context, recoveryRc);
+  }else if( zReplayErr ){
+    char *zMsg = sqlite3_mprintf(
+      "rebase failed — %s — branch restored to pre-rebase state", zReplayErr);
+    sqlite3_free(zReplayErr);
+    if( zMsg ){
+      sqlite3_result_error(context, zMsg, -1);
+      sqlite3_free(zMsg);
+    }else{
+      sqlite3_result_error_nomem(context);
+    }
   }else{
     sqlite3_result_error(context,
       "rebase failed — branch restored to pre-rebase state", -1);
@@ -2045,6 +2065,7 @@ abort_err:
 
 abort_err_silent:
   rebaseFreePlan(aPlan, nPlan);
+  sqlite3_free(zReplayErr);
   sqlite3_free(zOrigBranch);
   sqlite3_free(zReturnBranch);
   sqlite3_free(zWorking);

--- a/test/doltlite_rebase.sh
+++ b/test/doltlite_rebase.sh
@@ -807,7 +807,28 @@ Successfully rebased and updated refs/heads/feat
 main_add_2,base" \
   "$DBE3"
 
-rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB5_SHORT" "$DB6" "$DB7" "$DB8" "$DB9" "$DBE" "$DBE2" "$DBE3"
+DB10=/tmp/test_rebase_detector_error_$$.db; rm -f "$DB10"
+cat <<'SQL' | "$DOLTLITE" "$DB10" >/dev/null 2>&1
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT CHECK(json_extract(v,'$.ok')));
+INSERT INTO t VALUES(0,'{"ok":1}');
+SELECT dolt_commit('-Am','base');
+SELECT dolt_checkout('-b','feat');
+PRAGMA ignore_check_constraints=ON;
+INSERT INTO t VALUES(1,'not-json');
+PRAGMA ignore_check_constraints=OFF;
+SELECT dolt_commit('-am','bad row');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES(2,'{"ok":2}');
+SELECT dolt_commit('-am','main moves');
+SELECT dolt_checkout('feat');
+SQL
+run_test_match "interactive_rebase_reports_detector_error" \
+  "SELECT dolt_rebase('-i','main');
+   SELECT dolt_rebase('--continue');" \
+  "rebase failed — malformed JSON — branch restored to pre-rebase state" \
+  "$DB10/feat"
+
+rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB5_SHORT" "$DB6" "$DB7" "$DB8" "$DB9" "$DB10" "$DBE" "$DBE2" "$DBE3"
 echo ""
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"
 if [ $FAIL -gt 0 ]; then echo -e "$ERRORS"; exit 1; fi


### PR DESCRIPTION
## Summary

- carry constraint-detector errors through interactive rebase replay
- include the detector cause alongside the successful branch-restoration message
- cover malformed CHECK evaluation during `dolt_rebase('--continue')`

## Testing

- `bash test/doltlite_rebase.sh build/doltlite` (66 passed)
- `bash test/vc_oracle_rebase_test.sh build/doltlite dolt` (56 passed)
- `bash test/run_doltlite_tests.sh build/doltlite` (132 suites passed)
- `make -C build lint`

Fixes #2727

Co-Authored-By: OpenAI Codex <noreply@openai.com>
