### PR TITLE
Write dolt_verify_constraints findings in one step

### DIFF
--- a/src/doltlite_constraint_violations.c
+++ b/src/doltlite_constraint_violations.c
@@ -360,6 +360,7 @@ struct ConstraintViolationBatch {
   ConstraintViolationTable *aTables;
   int nTables;
   int nAppended;   /* 0 when nothing was added, matching the non-batch path */
+  int nDropped;    /* tables removed by BatchDropTables; also a write */
 };
 
 int doltliteConstraintViolationBatchBegin(sqlite3 *db){
@@ -382,7 +383,7 @@ int doltliteConstraintViolationBatchEnd(sqlite3 *db, int commit){
   int rc = SQLITE_OK;
   if( !pBatch ) return SQLITE_OK;
   doltliteSetCvBatch(db, 0);
-  if( commit && pBatch->nAppended>0 ){
+  if( commit && (pBatch->nAppended>0 || pBatch->nDropped>0) ){
     ChunkStore *cs = doltliteGetChunkStore(db);
     rc = cs ? storeUpdatedViolations(db, cs, pBatch->aTables, pBatch->nTables)
             : SQLITE_ERROR;
@@ -390,6 +391,45 @@ int doltliteConstraintViolationBatchEnd(sqlite3 *db, int commit){
   freeViolationTables(pBatch->aTables, pBatch->nTables);
   sqlite3_free(pBatch);
   return rc;
+}
+
+int doltliteConstraintViolationBatchActive(sqlite3 *db){
+  return doltliteGetCvBatch(db)!=0;
+}
+
+/* Drop tables from the open batch's copy of the catalog; nNames==0 drops
+** every table. Nothing reaches the store until BatchEnd commits, so a
+** detector error between the drop and the end leaves the recorded
+** findings exactly as they were, and no other session ever sees the
+** cleared state without the new findings beside it. */
+int doltliteConstraintViolationBatchDropTables(
+  sqlite3 *db,
+  const char *const *azTables,
+  int nNames
+){
+  ConstraintViolationBatch *pBatch = (ConstraintViolationBatch*)doltliteGetCvBatch(db);
+  int nKept = 0;
+  int i, j;
+  if( !pBatch ) return SQLITE_MISUSE;
+  for(i=0; i<pBatch->nTables; i++){
+    int drop = nNames==0;
+    for(j=0; !drop && j<nNames; j++){
+      if( pBatch->aTables[i].zName && azTables[j]
+       && sqlite3_stricmp(pBatch->aTables[i].zName, azTables[j])==0 ){
+        drop = 1;
+      }
+    }
+    if( drop ){
+      freeViolationTable(&pBatch->aTables[i]);
+      memset(&pBatch->aTables[i], 0, sizeof(pBatch->aTables[i]));
+      pBatch->nDropped++;
+    }else{
+      if( nKept!=i ) pBatch->aTables[nKept] = pBatch->aTables[i];
+      nKept++;
+    }
+  }
+  pBatch->nTables = nKept;
+  return SQLITE_OK;
 }
 
 int doltliteAppendConstraintViolation(
@@ -425,47 +465,6 @@ int doltliteAppendConstraintViolation(
     rc = storeUpdatedViolations(db, cs, aTables, nTables);
   }
   freeViolationTables(aTables, nTables);
-  return rc;
-}
-
-/* Drop recorded violations only for named tables. Wholesale clear would
-** let a scoped re-check hide other tables from the commit gate. */
-int doltliteClearConstraintViolationsForTables(
-  sqlite3 *db,
-  const char *const *azTables,
-  int nNames
-){
-  ChunkStore *cs = doltliteGetChunkStore(db);
-  ConstraintViolationTable *aTables = 0;
-  int nTables = 0;
-  int nKept = 0;
-  int i, j;
-  int rc;
-
-  if( !cs || nNames<=0 ) return SQLITE_OK;
-  rc = loadAllViolations(db, cs, &aTables, &nTables);
-  if( rc!=SQLITE_OK ) return rc;
-
-  for(i=0; i<nTables; i++){
-    int drop = 0;
-    for(j=0; j<nNames; j++){
-      if( aTables[i].zName && azTables[j]
-       && sqlite3_stricmp(aTables[i].zName, azTables[j])==0 ){
-        drop = 1;
-        break;
-      }
-    }
-    if( drop ){
-      /* Free contents only; the array is one block released at the end. */
-      freeViolationTable(&aTables[i]);
-      memset(&aTables[i], 0, sizeof(aTables[i]));
-    }else{
-      if( nKept!=i ) aTables[nKept] = aTables[i];
-      nKept++;
-    }
-  }
-  rc = storeUpdatedViolations(db, cs, aTables, nKept);
-  freeViolationTables(aTables, nKept);
   return rc;
 }
 

--- a/src/doltlite_constraint_violations.h
+++ b/src/doltlite_constraint_violations.h
@@ -26,9 +26,6 @@ struct ConstraintViolationTable {
   ConstraintViolationRow *aRows;
 };
 
-int doltliteClearConstraintViolationsForTables(
-  sqlite3 *db, const char *const *azTables, int nNames
-);
 
 int doltliteAppendConstraintViolation(
   sqlite3 *db,
@@ -45,6 +42,12 @@ int doltliteClearAllConstraintViolations(sqlite3 *db);
 /* Begin loads; appends accumulate; End persists if commit!=0. Not nestable. */
 int doltliteConstraintViolationBatchBegin(sqlite3 *db);
 int doltliteConstraintViolationBatchEnd(sqlite3 *db, int commit);
+int doltliteConstraintViolationBatchActive(sqlite3 *db);
+int doltliteConstraintViolationBatchDropTables(
+  sqlite3 *db,
+  const char *const *azTables,
+  int nNames
+);
 
 int doltliteConstraintViolationsRegister(sqlite3 *db);
 

--- a/src/doltlite_core.c
+++ b/src/doltlite_core.c
@@ -895,6 +895,7 @@ int doltliteDetectConstraintViolationsFiltered(
   int rc;
   sqlite3_stmt *pStmt = 0;
   int needsDetection = 0;
+  int bOwnBatch = 1;
 
   if( pzErr ) *pzErr = 0;
 
@@ -933,7 +934,11 @@ int doltliteDetectConstraintViolationsFiltered(
     return SQLITE_OK;
   }
 
-  rc = doltliteConstraintViolationBatchBegin(db);
+  /* A caller that already opened a batch (dolt_verify_constraints, which
+  ** drops the tables it re-scans into it first) commits or discards it
+  ** itself, so the clear and the new findings land in one write. */
+  bOwnBatch = !doltliteConstraintViolationBatchActive(db);
+  rc = bOwnBatch ? doltliteConstraintViolationBatchBegin(db) : SQLITE_OK;
   if( rc==SQLITE_OK ){
     rc = doltliteDetectMergeFkViolations(db, pAncCatHash,
                                          &zDetectErrMsg, &nViolations,
@@ -959,7 +964,7 @@ int doltliteDetectConstraintViolationsFiltered(
                                             &zDetectErrMsg, &nStrict,
                                             azTables, nTables);
   }
-  {
+  if( bOwnBatch ){
     int erc = doltliteConstraintViolationBatchEnd(
         db, rc==SQLITE_OK && bPersist);
     if( rc==SQLITE_OK ) rc = erc;

--- a/src/doltlite_verify_constraints.c
+++ b/src/doltlite_verify_constraints.c
@@ -296,17 +296,19 @@ static void doltVerifyConstraintsFunc(
     nScan = nChanged;
   }
 
-  /* Clear findings only for tables about to be re-checked. Default verify
-  ** scans tables that differ from HEAD; wholesale clear would drop others the
-  ** commit gate still reads. Empty scan set is --all with no names. */
+  /* Drop only the tables about to be re-checked (default verify scans those
+  ** that differ from HEAD; an empty scan set is --all with no names) and
+  ** re-detect inside one batch, so the store is written once, on success.
+  ** A detector error discards the batch and the recorded findings stay as
+  ** they were; other sessions never see the cleared set alone. */
   if( !bOutputOnly ){
-    if( nScan>0 ){
-      rc = doltliteClearConstraintViolationsForTables(
+    rc = doltliteConstraintViolationBatchBegin(db);
+    if( rc==SQLITE_OK ){
+      rc = doltliteConstraintViolationBatchDropTables(
           db, (const char *const *)azScan, nScan);
-    }else{
-      rc = doltliteClearAllConstraintViolations(db);
     }
     if( rc!=SQLITE_OK ){
+      doltliteConstraintViolationBatchEnd(db, 0);
       sqlite3_result_error_code(context, rc);
       goto cleanup;
     }
@@ -314,6 +316,10 @@ static void doltVerifyConstraintsFunc(
 
   rc = doltliteDetectConstraintViolationsFiltered(
       db, pDetectAnc, azScan, nScan, !bOutputOnly, &nViolations, 0);
+  if( !bOutputOnly ){
+    int erc = doltliteConstraintViolationBatchEnd(db, rc==SQLITE_OK);
+    if( rc==SQLITE_OK ) rc = erc;
+  }
   if( rc!=SQLITE_OK ){
     sqlite3_result_error_code(context, rc);
     goto cleanup;

--- a/test/doltlite_merge.sh
+++ b/test/doltlite_merge.sh
@@ -1097,5 +1097,32 @@ run_test "cherry_pick_partial_index_null_rows" \
 run_test "cherry_pick_partial_index_verify_constraints" \
   "SELECT dolt_verify_constraints();" "0" "$DB63"
 
-rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8" "$DB8B" "$DB9" "$DB10" "$DB11" "$DB11D" "$DB11E" "$DB11F" "$DB12" "$DB13" "$DB14" "$DB15" "$DB16" "$DB17" "$DB18" "$DB19" "$DB20" "$DB20B" "$DB21" "$DB22" "$DB23" "$DB24" "$DB25" "$DB40" "$DB41" "$DB42" "$DB43" "$DB44" "$DB45" "$DB46" "$DB47" "$DB48" "$DB49" "$DB50" "$DB51" "$DB52" "$DB53" "$DB54" "$DB55" "$DB56" "$DB57" "$DB58" "$DB59" "$DB60" "$DB61" "$DB62" "$DB63" "$DB64"
+# A verify that errors partway must leave earlier findings in place: the
+# clear used to persist before the detectors ran and nothing put it back.
+DB66=/tmp/test_merge66_$$.db; rm -f "$DB66"
+$DOLTLITE "$DB66" > /dev/null 2>&1 <<'SQL'
+PRAGMA foreign_keys=OFF;
+CREATE TABLE parent(id INTEGER PRIMARY KEY);
+CREATE TABLE child(id INTEGER PRIMARY KEY, pid INT REFERENCES parent(id));
+INSERT INTO child VALUES(1, 99);
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT CHECK(json_extract(v,'$.ok')));
+INSERT INTO t VALUES(1,'{"ok":1}');
+SELECT dolt_commit('-Am','base');
+SELECT dolt_verify_constraints('--all');
+PRAGMA ignore_check_constraints=ON;
+INSERT INTO t VALUES(2,'not-json');
+PRAGMA ignore_check_constraints=OFF;
+SQL
+run_test "verify_recorded_orphan_before_failed_check" \
+  "SELECT count(*) FROM dolt_constraint_violations_child;" "1" "$DB66"
+run_test_match "verify_failed_check_keeps_recorded_orphan" \
+  "SELECT dolt_verify_constraints('--all');
+   SELECT count(*) FROM dolt_constraint_violations_child;" "^1\$" "$DB66"
+run_test_match "verify_failed_default_scope_keeps_recorded_orphan" \
+  "SELECT dolt_verify_constraints();
+   SELECT count(*) FROM dolt_constraint_violations_child;" "^1\$" "$DB66"
+run_test "verify_recorded_orphan_survives_failed_checks" \
+  "SELECT count(*) FROM dolt_constraint_violations_child;" "1" "$DB66"
+
+rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8" "$DB8B" "$DB9" "$DB10" "$DB11" "$DB11D" "$DB11E" "$DB11F" "$DB12" "$DB13" "$DB14" "$DB15" "$DB16" "$DB17" "$DB18" "$DB19" "$DB20" "$DB20B" "$DB21" "$DB22" "$DB23" "$DB24" "$DB25" "$DB40" "$DB41" "$DB42" "$DB43" "$DB44" "$DB45" "$DB46" "$DB47" "$DB48" "$DB49" "$DB50" "$DB51" "$DB52" "$DB53" "$DB54" "$DB55" "$DB56" "$DB57" "$DB58" "$DB59" "$DB60" "$DB61" "$DB62" "$DB63" "$DB64" "$DB66"
 dltest_finish


### PR DESCRIPTION
Fixes #2728.

`dolt_verify_constraints` cleared the recorded findings for the tables it was about to scan and persisted that clear immediately; the detectors' batch was only stored on success. Two consequences: a detector error (a CHECK whose expression fails on a row, e.g. `json_extract` on `not-json`) left the catalog with fewer findings than before the call, and between the clear and the final store every other session saw the cleared set, so a concurrent `dolt_commit` could pass its violation gate (Ito's finding on the first cut of this PR).

**Fix.** The clear becomes part of the detector batch. `dolt_verify_constraints` opens the batch, drops the scanned tables from the batch's in-memory copy of the catalog (`doltliteConstraintViolationBatchDropTables`), runs the detectors (which now reuse a caller-owned batch instead of opening their own), and commits or discards the batch once. The store is written exactly once, on success: a failure leaves the recorded findings untouched, and no session can observe the cleared set without the new findings beside it. Output-only mode is unchanged. The standalone per-table clear helper lost its only caller and is removed (dead-code gate passes).

```
-- child(1) -> parent 99 recorded by a first verify; then a not-json row in t
SELECT dolt_verify_constraints('--all');              -- error
SELECT count(*) FROM dolt_constraint_violations_child; -- before: 0    after: 1
SELECT dolt_commit('-am','x');                          -- still refused: violations recorded
```

**Tests.** Three cases in `test/doltlite_merge.sh` (`--all`, default scope, fresh-session readback) assert the orphan stays recorded; before the fix the same readback printed 0. Suite 234/234, `make lint`, `test/dead_code_check.sh`.

**Note.** Based on master, so the detector call still passes a null message slot; #2725 (the message fix) touches the same lines and whichever lands second gets a small rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
