### PR TITLE
Rebuild virtual indexes after cherry-pick

### DIFF
--- a/src/doltlite_cherry_pick.c
+++ b/src/doltlite_cherry_pick.c
@@ -183,11 +183,14 @@ int applyMergedCatalogAndCommit(
 
   {
     char **azReindex = 0;
+    char **azRebuild = 0;
     int nReindex = 0;
+    int nRebuild = 0;
     rc = doltliteMergeCatalogs(db, ancCatHash, ourCatHash, theirCatHash,
                                 &mergedCatHash, pnConflicts, &zMergeErr, 0, 0,
                                 bPreferOurMaster, 0,
-                                &azReindex, &nReindex, 0, 0);
+                                &azReindex, &nReindex,
+                                &azRebuild, &nRebuild);
     if( rc!=SQLITE_OK ){
       if( pzApplyErr && zMergeErr ){
         *pzApplyErr = zMergeErr;
@@ -196,6 +199,7 @@ int applyMergedCatalogAndCommit(
       sqlite3_free(zMergeErr);
       doltliteTxnStateClear(&savedState);
       doltliteFreeNameList(azReindex, nReindex);
+      doltliteFreeNameList(azRebuild, nRebuild);
       return rc;
     }
     sqlite3_free(zMergeErr);
@@ -203,6 +207,7 @@ int applyMergedCatalogAndCommit(
     rc = doltliteRefreshAndConfirmHead(db, cs, ourHead);
     if( rc!=SQLITE_OK ){
       doltliteFreeNameList(azReindex, nReindex);
+      doltliteFreeNameList(azRebuild, nRebuild);
       return doltliteRestoreTxnStateOnFailure(db, &savedState, rc);
     }
     graphLocked = 1;
@@ -214,7 +219,11 @@ int applyMergedCatalogAndCommit(
     if( rc==SQLITE_OK && nReindex>0 ){
       rc = doltliteReindexNamedIndexes(db, azReindex, nReindex);
     }
+    if( rc==SQLITE_OK && nRebuild>0 ){
+      rc = doltliteRebuildVirtualTables(db, azRebuild, nRebuild);
+    }
     doltliteFreeNameList(azReindex, nReindex);
+    doltliteFreeNameList(azRebuild, nRebuild);
     if( rc!=SQLITE_OK ) goto apply_rollback;
   }
 

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -1808,6 +1808,7 @@ int doltliteMergeCatalogs(sqlite3 *db,
     char ***pazReindex, int *pnReindex,
     char ***pazRebuildVtabs, int *pnRebuildVtabs);
 void doltliteFreeNameList(char **az, int n);
+int doltliteRebuildVirtualTables(sqlite3 *db, char **azRebuild, int nRebuild);
 int doltliteIndexSchemaRowsDifferForTable(SchemaEntry *aA, int nA,
     SchemaEntry *aB, int nB, const char *zTable);
 int doltliteDisjoinCatalogEntries(sqlite3 *db,

--- a/src/doltlite_merge_cmd.c
+++ b/src/doltlite_merge_cmd.c
@@ -849,6 +849,34 @@ static int mergeRefLoadCatalogs(
   return SQLITE_OK;
 }
 
+int doltliteRebuildVirtualTables(
+  sqlite3 *db,
+  char **azRebuild,
+  int nRebuild
+){
+  int i;
+  int rc = SQLITE_OK;
+  (void)sqlite3_exec(db, "SELECT 1 FROM sqlite_master LIMIT 1", 0, 0, 0);
+  for(i=0; i<nRebuild && rc==SQLITE_OK; i++){
+    const char *zOwner = azRebuild[i];
+    Table *pTab = sqlite3FindTable(db, zOwner, "main");
+    char *zSql;
+    if( pTab && IsVirtual(pTab) && pTab->u.vtab.nArg>0
+     && sqlite3_stricmp(pTab->u.vtab.azArg[0], "vec1")!=0 ){
+      zSql = sqlite3_mprintf(
+          "INSERT INTO \"%w\"(\"%w\") VALUES('rebuild')", zOwner, zOwner);
+    }else{
+      zSql = sqlite3_mprintf(
+          "INSERT INTO \"%w\"(cmd, arg) VALUES('rebuild',"
+          " (SELECT val FROM \"%w_model\" WHERE id=1))", zOwner, zOwner);
+    }
+    if( !zSql ) return SQLITE_NOMEM;
+    rc = sqlite3_exec(db, zSql, 0, 0, 0);
+    sqlite3_free(zSql);
+  }
+  return rc;
+}
+
 static int mergeRefInstallMergedCatalog(
   sqlite3 *db,
   const ProllyHash *pAncCat,
@@ -898,30 +926,8 @@ static int mergeRefInstallMergedCatalog(
   /* Rebuild derived vtab shadows from merged %_base while the catalog
   ** is live. Populated only on otherwise conflict-free merges. */
   if( *pnRebuildVtabs>0 && nMergeConflicts==0 ){
-    int ri;
-    /* Reload schema so FindTable sees the just-switched catalog. */
-    (void)sqlite3_exec(db, "SELECT 1 FROM sqlite_master LIMIT 1", 0, 0, 0);
-    for(ri=0; ri<*pnRebuildVtabs && rc==SQLITE_OK; ri++){
-      const char *zOwner = (*pazRebuildVtabs)[ri];
-      Table *pTab = sqlite3FindTable(db, zOwner, "main");
-      char *zSql;
-      /* vec1 takes the stored model; fts names itself in a hidden column. */
-      if( pTab && IsVirtual(pTab) && pTab->u.vtab.nArg>0
-       && sqlite3_stricmp(pTab->u.vtab.azArg[0], "vec1")!=0 ){
-        zSql = sqlite3_mprintf(
-            "INSERT INTO \"%w\"(\"%w\") VALUES('rebuild')", zOwner, zOwner);
-      }else{
-        zSql = sqlite3_mprintf(
-            "INSERT INTO \"%w\"(cmd, arg) VALUES('rebuild',"
-            " (SELECT val FROM \"%w_model\" WHERE id=1))", zOwner, zOwner);
-      }
-      if( !zSql ){
-        rc = SQLITE_NOMEM;
-        break;
-      }
-      rc = sqlite3_exec(db, zSql, 0, 0, 0);
-      sqlite3_free(zSql);
-    }
+    rc = doltliteRebuildVirtualTables(
+        db, *pazRebuildVtabs, *pnRebuildVtabs);
   }
   doltliteFreeNameList(*pazRebuildVtabs, *pnRebuildVtabs);
   *pazRebuildVtabs = 0;

--- a/test/doltlite_vtab_vc_matrix.sh
+++ b/test/doltlite_vtab_vc_matrix.sh
@@ -288,6 +288,30 @@ check "merge_clean_shadow_search" "610229,900212" \
 check "merge_clean_shadow_integrity" "" \
   "$(run_sql "INSERT INTO docs(docs) VALUES('integrity-check');" "$DB")"
 
+scenario "cherry-pick rebuilds converged fts5 metadata"
+newdb
+run_sql "CREATE VIRTUAL TABLE docs USING fts5(body);
+INSERT INTO docs(rowid,body) VALUES(1,'base doc');
+SELECT dolt_commit('-Am','base');
+SELECT dolt_checkout('-b','source');
+INSERT INTO docs(rowid,body) VALUES(10,'source one doc');
+INSERT INTO docs(rowid,body) VALUES(11,'source two doc');
+SELECT dolt_commit('-Am','source');
+SELECT dolt_checkout('main');
+DELETE FROM docs WHERE rowid=1;
+INSERT INTO docs(rowid,body) VALUES(20,'target one doc');
+INSERT INTO docs(rowid,body) VALUES(21,'target two doc');
+INSERT INTO docs(rowid,body) VALUES(22,'target three doc');
+INSERT INTO docs(docs) VALUES('rebuild');
+SELECT dolt_commit('-Am','target');
+SELECT dolt_cherry_pick('source');" "$DB" > /dev/null
+check "cherry_pick_fts5_content" "5" \
+  "$(run_sql "SELECT count(*) FROM docs;" "$DB")"
+check "cherry_pick_fts5_search" "5" \
+  "$(run_sql "SELECT count(*) FROM docs WHERE docs MATCH 'doc';" "$DB")"
+check "cherry_pick_fts5_integrity" "" \
+  "$(run_sql "INSERT INTO docs(docs) VALUES('integrity-check');" "$DB")"
+
 scenario "merge adopts a branch-added vtab of every flavor"
 newdb
 run_sql "CREATE TABLE plain(k INTEGER PRIMARY KEY, v TEXT); INSERT INTO plain VALUES(1,'p');


### PR DESCRIPTION
## Summary

- rebuild derived virtual-table shadows after cherry-pick, revert, and rebase apply merges
- share the established branch-merge rebuild path
- add the five-row FTS5 regression reduced from stateful seed 1788904631

## What happened

The failure surfaced after pull, but the preceding cherry-pick created it. Both sides independently had three FTS documents, so their global count records compared equal. Row-level shadow merging kept that count while combining five content rows. Ordinary merge already schedules a rebuild for this case; the shared cherry-pick/revert/rebase apply path discarded that schedule.

## Validation

- `bash ../test/doltlite_vtab_vc_matrix.sh ./doltlite` (54 passed)
- `git diff --check`

Fixes #2731

Co-Authored-By: Codex <noreply@openai.com>
