### PR TITLE
Check Markdown links in CI when docs change

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       docs_only: ${{ steps.files.outputs.docs_only }}
+      docs_changed: ${{ steps.files.outputs.docs_changed }}
     steps:
       - id: files
         uses: actions/github-script@v7
@@ -23,6 +24,7 @@ jobs:
             const pull = context.payload.pull_request;
             if (!pull) {
               core.setOutput('docs_only', 'false');
+              core.setOutput('docs_changed', 'true');
               return;
             }
             const files = await github.paginate(
@@ -38,6 +40,20 @@ jobs:
               'docs_only',
               String(files.length > 0 && files.every(file => file.filename.endsWith('.md')))
             );
+            core.setOutput(
+              'docs_changed',
+              String(files.some(file => file.filename.endsWith('.md')))
+            );
+
+  doc_links:
+    name: Doc links
+    needs: classify
+    if: needs.classify.outputs.docs_changed == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - run: bash test/doc_links_test.sh
 
   build:
     name: Build all binaries
@@ -77,13 +93,14 @@ jobs:
 
   gate:
     name: CI Gate
-    needs: [classify, build, build_test, test_suite, sanitizers, smoke, benchmark]
+    needs: [classify, doc_links, build, build_test, test_suite, sanitizers, smoke, benchmark]
     if: always()
     runs-on: ubuntu-latest
     steps:
       - env:
           DOCS_ONLY: ${{ needs.classify.outputs.docs_only }}
           CLASSIFY: ${{ needs.classify.result }}
+          DOC_LINKS: ${{ needs.doc_links.result }}
           BUILD: ${{ needs.build.result }}
           BUILD_TEST: ${{ needs.build_test.result }}
           TEST_SUITE: ${{ needs.test_suite.result }}
@@ -92,6 +109,7 @@ jobs:
           BENCHMARK: ${{ needs.benchmark.result }}
         run: |
           test "$CLASSIFY" = success
+          case "$DOC_LINKS" in success|skipped) ;; *) exit 1 ;; esac
           if [ "$DOCS_ONLY" = true ]; then
             exit 0
           fi

--- a/doc/doltlite/testing.md
+++ b/doc/doltlite/testing.md
@@ -27,7 +27,8 @@ bash ../test/run_sqllogictest.sh \
 
 CI wiring, coverage floors, and full bucket lists are in
 [`.github/workflows/test.yml`](../../.github/workflows/test.yml) and
-[AGENTS.md](../../AGENTS.md). Contract suites
+[AGENTS.md](../../AGENTS.md). `test/doc_links_test.sh` checks relative links and anchors in tracked
+Markdown; PR CI runs it whenever a `.md` file changes. Contract suites
 (`sqlite_compatibility_contract_test.sh`, `concurrency_contract_test.sh`,
 `storage_format_contract_test.sh`) gate [SQLite compatibility](sqlite-compatibility.md),
 [concurrency](concurrency.md), and [storage format](storage-format.md).

--- a/test/doc_links_test.sh
+++ b/test/doc_links_test.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Every relative link and same-file anchor in a tracked Markdown file must
+# resolve. External URLs are not fetched. Skipped: upstream doc/*.md and
+# autosetup/, and packaging/ READMEs whose links are package-relative.
+
+set -u
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+git ls-files -z -- '*.md' ':!doc/*.md' ':!ext/**' ':!autosetup/**' ':!packaging/**' | python3 -c '
+import os, re, sys
+
+def slug(h):
+    h = re.sub(r"[`*_]", "", h.strip().lower())
+    h = re.sub(r"[^\w\s-]", "", h)
+    return re.sub(r"\s", "-", h)
+
+bad = 0
+for path in filter(None, sys.stdin.read().split("\0")):
+    text = open(path, encoding="utf-8").read()
+    body = re.sub(r"```.*?```", "", text, flags=re.S)
+    anchors = {slug(m.group(1)) for m in re.finditer(r"^#+\s+(.+?)\s*#*$", body, re.M)}
+    for m in re.finditer(r"\]\(([^)\s]+)\)", body):
+        target = m.group(1)
+        if re.match(r"[a-z][a-z0-9+.-]*:", target):
+            continue
+        file, _, anchor = target.partition("#")
+        if file:
+            if not os.path.exists(os.path.join(os.path.dirname(path), file)):
+                print(f"{path}: missing file {target}"); bad += 1
+        elif anchor and anchor not in anchors:
+            print(f"{path}: missing anchor {target}"); bad += 1
+sys.exit(1 if bad else 0)
+'


### PR DESCRIPTION
Adds `test/doc_links_test.sh`: every relative file link and same-file `#anchor` in tracked Markdown must resolve. Skips upstream `doc/*.md`, `autosetup/`, and `packaging/` READMEs (their links are package-relative, e.g. npm's `./LICENSE.md`).

PR CI gets a `doc_links` job that runs when any `.md` file is in the PR, and the CI Gate requires it. Verified locally: clean on master, fails with file and anchor messages when a broken link is injected. This PR touches Markdown, so the job runs here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)