### PR TITLE
Document the doltlite shell and open options (doc/doltlite/cli.md)

### DIFF
--- a/doc/doltlite/README.md
+++ b/doc/doltlite/README.md
@@ -6,6 +6,7 @@ of the version-control features; these pages hold the detail.
 ## Build and embed
 
 - [building.md](building.md) — macOS, Linux, Windows, WebAssembly builds and flags
+- [cli.md](cli.md) — the `doltlite` shell: what differs from `sqlite3`, URI parameters, environment variables
 - [embedding.md](embedding.md) — C API surface, exported symbols, C / Python / Go quickstarts
 - [using-existing-sqlite-bindings.md](using-existing-sqlite-bindings.md) — pointing rusqlite, go-sqlite3, Dart, .NET and FFI bindings at libdoltlite
 

--- a/doc/doltlite/cli.md
+++ b/doc/doltlite/cli.md
@@ -1,0 +1,56 @@
+# The `doltlite` shell and open options
+
+`doltlite` is the SQLite shell. Every dot-command, flag, and output mode is
+upstream's. This page lists what differs and the open-time options that
+select an engine, branch, or access mode.
+
+## Opening a database
+
+```
+doltlite my.db                 # DoltLite format if new; stock SQLite files open as stock
+doltlite my.db@feature         # branch (also my.db/feature); see refs.md
+doltlite my.db/v1.0            # tag or ancestor: read-only snapshot
+doltlite :memory:
+doltlite 'file:my.db?doltlite_engine=sqlite'
+doltlite 'file:my.db?immutable=1'
+doltlite 'file:clone.db?lazy_origin=1'
+```
+
+| URI parameter | Effect |
+|---|---|
+| `doltlite_engine=sqlite` | Create the file as a stock SQLite database. Ignored once the file has content, so it never reinterprets an existing database. |
+| `immutable=1` | Read-only, as in SQLite. `dolt_*` writes fail with `attempt to write a readonly database`. |
+| `lazy_origin=1` | On a lazy clone, fetch missing chunks from `origin` on demand. Without it an uncached chunk is an error. |
+
+The same strings work in `sqlite3_open_v2()` and every binding. Engine
+selection is by file header: a stock file always opens on SQLite's B-tree
+engine, and `dolt_*` functions there fail with `dolt version-control features
+are not available on stock SQLite databases`. `SELECT doltlite_engine()`
+returns `prolly` or `orig`.
+
+## What differs from the SQLite shell
+
+| Surface | DoltLite |
+|---|---|
+| Prompt | `doltlite> ` |
+| `-version` | `DoltLite v0.50.7 (SQLite 3.54.0, 64-bit)` |
+| `.schema`, `.dump` | Objects in catalog order (sorted by name), with the canonical `CREATE` text rather than the text you typed |
+| `.dump --preserve-rowids` | Omits the read-only rowid alias on tables with a non-integer primary key, so the output restores |
+| `.backup`, `.restore` | Work within one format. A DoltLite source writes a DoltLite copy, a stock source a stock copy. Mixing them is refused: `cannot backup between a legacy SQLite database and a doltlite database`. |
+| `.open path@branch` | Selects a branch, like the command line |
+| Committer identity | `dolt_config('user.name', ...)` is per connection. With nothing set, commits record `doltlite` and an empty email. |
+
+Views and triggers over `dolt_*` virtual tables work with the shell's default
+`trusted_schema=0`.
+
+## Environment variables
+
+| Variable | Used by |
+|---|---|
+| `DOLTLITE_CA_FILE` | HTTPS remotes: a private CA bundle |
+| `DOLTLITE_HTTP_TIMEOUT_MS` | HTTP remote requests (default 30000) |
+| `DOLTLITE_CREDS_DIR` | Credential store location (default `~/.doltlite/creds`) |
+| `DOLTLITE_CREDS_KID` | Which stored credential to present |
+| `SQLITE_HISTORY`, `NO_COLOR`, `VISUAL` | Upstream shell behaviour, unchanged |
+
+Remote credentials are covered in [auth.md](auth.md).


### PR DESCRIPTION
Phase 2 of the doc plan. One page for the `doltlite` shell: open forms and URI parameters (`doltlite_engine`, `immutable`, `lazy_origin`), the short list of behaviours that differ from upstream `sqlite3` (prompt, `-version`, `.schema`/`.dump` order and canonical text, same-format-only `.backup`/`.restore`, `.open path@branch`, default committer), and the environment variables the engine reads. Test-build-only knobs are left out.

Checked against `build/doltlite`; the error strings quoted are the ones it prints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)