### PR TITLE
Document the in-database agent guide (doc/doltlite/agents.md)

### DIFF
--- a/doc/doltlite/README.md
+++ b/doc/doltlite/README.md
@@ -20,6 +20,8 @@ of the version-control features; these pages hold the detail.
 
 - [refs.md](refs.md) — revision syntax: branches, tags, hashes, `HEAD~N`, `WORKING`, `STAGED`, ranges, `db@branch` opens, name rules
 
+- [agents.md](agents.md) — the in-database `AGENT.md` guide and the rules an AI agent should know
+
 ## Remotes
 
 - [remotes.md](remotes.md) — push, fetch, pull, clone, lazy clones, filesystem and HTTP URLs

--- a/doc/doltlite/agents.md
+++ b/doc/doltlite/agents.md
@@ -1,0 +1,49 @@
+# DoltLite for AI agents
+
+Every DoltLite database carries its own operations guide. Before generating
+SQL against an unfamiliar database, read it:
+
+```sql
+SELECT doc_text FROM dolt_docs WHERE doc_name = 'AGENT.md';
+```
+
+A fresh database serves DoltLite's default text: the commit loop, branches,
+remotes, diffs, conflict handling inside `BEGIN`, and the SQLite differences
+that matter. It is an ordinary versioned row. A project replaces it with its
+own conventions and the replacement commits, branches, and merges with the
+data:
+
+```sql
+REPLACE INTO dolt_docs VALUES ('AGENT.md', '# Project rules ...');
+SELECT dolt_commit('-A', '-m', 'agent guide');
+```
+
+Deleting the row sticks; DoltLite does not resurrect the default.
+
+## Rules the default guide leans on
+
+- Version control is SQL functions and tables: `SELECT dolt_commit(...)`,
+  never `CALL`. See [dolt-differences.md](dolt-differences.md).
+- `dolt_commit` ends the enclosing SQL transaction, so call it last. A merge
+  that conflicts in autocommit mode is rolled back; run merges inside
+  `BEGIN` to inspect and resolve. See [transactions.md](transactions.md).
+- Every revision spelling, including `HEAD~1`, `WORKING`, and `a..b`, is in
+  [refs.md](refs.md).
+- Each connection has its own branch, and a branch's uncommitted work is
+  shared by every connection on it. Open `db@branch` to start on a branch.
+- Statements that would write fail under `PRAGMA query_only`, which is the
+  simplest way to give an agent read-only access.
+
+## Discovering the surface
+
+```sql
+SELECT name FROM pragma_function_list WHERE name LIKE 'dolt_%' ORDER BY 1;
+SELECT name FROM pragma_module_list  WHERE name LIKE 'dolt_%' ORDER BY 1;
+SELECT dolt_version(), doltlite_engine();
+```
+
+`doltlite_engine()` returns `prolly` on a DoltLite database and `orig` on a
+stock SQLite file, where the `dolt_*` surface is absent.
+
+The repository's own guidance for agents working on the DoltLite source is
+[AGENTS.md](../../AGENTS.md) at the repo root; this page is about databases.


### PR DESCRIPTION
Phase 2 of the doc plan. A short page for people pointing AI agents at DoltLite databases: read the `AGENT.md` row from `dolt_docs` first, replace it with project conventions (it is a versioned row), the handful of rules the default guide depends on (functions not procedures, `dolt_commit` ends the transaction, merges inside `BEGIN`, per-branch working sets, `query_only` for read-only agents), and how to enumerate the `dolt_*` surface from `pragma_function_list` / `pragma_module_list`.

Deliberately does not duplicate the guide text itself; the row in the database is the source of truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)