### PR TITLE
Disable the Google Chrome apt source on CI runners

### DIFF
--- a/.github/scripts/install-apt-deps.sh
+++ b/.github/scripts/install-apt-deps.sh
@@ -5,7 +5,7 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 for path in /etc/apt/sources.list.d/*.list /etc/apt/sources.list.d/*.sources; do
   [ -e "$path" ] || continue
-  if grep -qiE 'packages[.]microsoft[.]com|azure-cli' "$path"; then
+  if grep -qiE 'packages[.]microsoft[.]com|azure-cli|dl[.]google[.]com' "$path"; then
     sudo mv "$path" "$path.disabled"
   fi
 done


### PR DESCRIPTION
Every Linux build job on #2746 failed twice in `Install Linux build dependencies`:

```
E: Failed to fetch https://dl.google.com/linux/chrome-stable/deb/dists/stable/main/binary-amd64/Packages.gz  Hash Sum mismatch
apt-get failed after 2 attempts (exit 100)
```

The runner image (`ubuntu24/20260907.300`) ships that source; we install nothing from it. `install-apt-deps.sh` already disables the Microsoft and azure-cli sources for the same reason, so this adds `dl.google.com` to that pattern. This PR's own run is the test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)