### PR TITLE
Phase 3: feature docs for every version-control surface

### DIFF
--- a/doc/doltlite/README.md
+++ b/doc/doltlite/README.md
@@ -20,8 +20,8 @@ of the version-control features; these pages hold the detail.
 
 ## Version control
 
-Every `dolt_*` function and table, one page per feature. Revision spellings
-shared by all of them are in [refs.md](refs.md).
+Every `dolt_*` function and table, one page per feature. Revision syntax and
+the forms each surface accepts are in [refs.md](refs.md).
 
 - [dolt_commit.md](dolt_commit.md) — `dolt_add`, `dolt_commit`, `dolt_status`, `dolt_config`
 - [dolt_reset.md](dolt_reset.md) — `dolt_reset`, `dolt_clean`

--- a/doc/doltlite/README.md
+++ b/doc/doltlite/README.md
@@ -20,6 +20,30 @@ of the version-control features; these pages hold the detail.
 
 ## Version control
 
+Every `dolt_*` function and table, one page per feature. Revision spellings
+shared by all of them are in [refs.md](refs.md).
+
+- [dolt_commit.md](dolt_commit.md) — `dolt_add`, `dolt_commit`, `dolt_status`, `dolt_config`
+- [dolt_reset.md](dolt_reset.md) — `dolt_reset`, `dolt_clean`
+- [dolt_branch.md](dolt_branch.md) — `dolt_branch`, `dolt_checkout`, `active_branch`, `dolt_branches`, `dolt_remote_branches`, `dolt_default_branch`, `dolt_connect_branch`
+- [dolt_merge.md](dolt_merge.md) — `dolt_merge`, `dolt_merge_status`, `dolt_merge_base`, `dolt_conflicts`, `dolt_conflicts_<table>`, `dolt_schema_conflicts`, `dolt_conflicts_resolve`
+- [dolt_diff.md](dolt_diff.md) — `dolt_diff`, `dolt_diff_<table>`, `dolt_diff_stat`, `dolt_diff_summary`, `dolt_schema_diff`, `dolt_patch`
+- [dolt_log.md](dolt_log.md) — `dolt_log`, `dolt_history_<table>`, `dolt_at_<table>`, `dolt_blame_<table>`, `dolt_commit_ancestors`
+- [dolt_remote.md](dolt_remote.md) — `dolt_remote`, `dolt_push`, `dolt_fetch`, `dolt_pull`, `dolt_clone`, `dolt_remotes`
+- [dolt_rebase.md](dolt_rebase.md) — `dolt_rebase` and the plan table
+- [dolt_cherry_pick.md](dolt_cherry_pick.md) — `dolt_cherry_pick`, `dolt_revert`
+- [dolt_tag.md](dolt_tag.md) — `dolt_tag`, `dolt_tags`
+- [dolt_hashof.md](dolt_hashof.md) — `dolt_hashof`, `dolt_hashof_table`, `dolt_hashof_index`, `dolt_hashof_db`, `dolt_hashof_catalog`
+- [dolt_gc.md](dolt_gc.md) — `dolt_gc`, `VACUUM`
+- [dolt_constraint_violations.md](dolt_constraint_violations.md) — `dolt_constraint_violations`, `dolt_constraint_violations_<table>`, `dolt_verify_constraints`
+- [dolt_workspace.md](dolt_workspace.md) — `dolt_workspace_<table>`
+- [dolt_ignore.md](dolt_ignore.md) — `dolt_ignore`, `dolt_docs`, `dolt_tests`, `dolt_test_run`
+- [dolt_schemas.md](dolt_schemas.md) — `dolt_schemas` and the versioned catalog
+- [dolt_creds.md](dolt_creds.md) — `dolt_creds_new`, `dolt_creds`
+- [dolt_version.md](dolt_version.md) — `dolt_version`, `doltlite_engine`
+
+## Cross-cutting
+
 - [transactions.md](transactions.md) — what `ROLLBACK` undoes, conflicts inside vs outside `BEGIN`, busy outcomes, refusals
 - [refs.md](refs.md) — revision syntax: branches, tags, hashes, `HEAD~N`, `WORKING`, `STAGED`, ranges, `db@branch` opens, name rules
 - [dolt-differences.md](dolt-differences.md) — what is deliberately different from Dolt, and what is missing on purpose

--- a/doc/doltlite/dolt_branch.md
+++ b/doc/doltlite/dolt_branch.md
@@ -9,7 +9,7 @@ Branches and the connection's position on them. Dolt:
 
 ```sql
 SELECT dolt_branch('feature');                 -- from HEAD
-SELECT dolt_branch('feature', 'v1.0');         -- from any revision
+SELECT dolt_branch('feature', 'v1.0');         -- from a commit revision
 SELECT dolt_branch('-m', 'old', 'new');        -- rename
 SELECT dolt_branch('-c', 'src', 'copy');       -- copy
 SELECT dolt_branch('-d', 'feature');           -- delete if merged
@@ -25,11 +25,11 @@ SELECT * FROM dolt_branches;
 
 | Option | Meaning |
 |---|---|
-| `name [, rev]` | Create `name` at `rev` (default `HEAD`) |
+| `name [, rev]` | Create `name` at a commit revision (default `HEAD`) |
 | `-m`, `--move old new` | Rename |
 | `-c`, `--copy old new` | Copy |
 | `-d`, `--delete name` | Delete. Refused for the current branch, the default branch, or an unmerged branch. |
-| `-D name` | Delete even if unmerged |
+| `-D name` | Delete even if unmerged; the current and default branches remain protected |
 | `-f`, `--force` | With `name rev`: move an existing branch to `rev` |
 
 Returns `0`. Branch and tag changes are durable immediately, even inside

--- a/doc/doltlite/dolt_branch.md
+++ b/doc/doltlite/dolt_branch.md
@@ -1,0 +1,83 @@
+# dolt_branch, dolt_checkout, dolt_branches
+
+Branches and the connection's position on them. Dolt:
+[dolt_branch](https://docs.dolthub.com/sql-reference/version-control/dolt-sql-procedures#dolt_branch),
+[dolt_checkout](https://docs.dolthub.com/sql-reference/version-control/dolt-sql-procedures#dolt_checkout),
+[dolt_branches](https://docs.dolthub.com/sql-reference/version-control/dolt-system-tables#dolt_branches).
+
+## Synopsis
+
+```sql
+SELECT dolt_branch('feature');                 -- from HEAD
+SELECT dolt_branch('feature', 'v1.0');         -- from any revision
+SELECT dolt_branch('-m', 'old', 'new');        -- rename
+SELECT dolt_branch('-c', 'src', 'copy');       -- copy
+SELECT dolt_branch('-d', 'feature');           -- delete if merged
+SELECT dolt_branch('-D', 'feature');           -- delete regardless
+SELECT dolt_checkout('feature');
+SELECT dolt_checkout('-b', 'feature2', 'main');
+SELECT dolt_checkout('users');                 -- restore one table from HEAD
+SELECT active_branch();
+SELECT * FROM dolt_branches;
+```
+
+## dolt_branch
+
+| Option | Meaning |
+|---|---|
+| `name [, rev]` | Create `name` at `rev` (default `HEAD`) |
+| `-m`, `--move old new` | Rename |
+| `-c`, `--copy old new` | Copy |
+| `-d`, `--delete name` | Delete. Refused for the current branch, the default branch, or an unmerged branch. |
+| `-D name` | Delete even if unmerged |
+| `-f`, `--force` | With `name rev`: move an existing branch to `rev` |
+
+Returns `0`. Branch and tag changes are durable immediately, even inside
+`BEGIN`. Name rules are in [refs.md](refs.md).
+
+| Error | Cause |
+|---|---|
+| `branch already exists` | create or rename onto an existing name |
+| `cannot delete the current branch` | `-d` on the checked-out branch |
+| `cannot delete the default branch; call dolt_default_branch(<other>) first` | `-d` on the default branch |
+| `branch is not fully merged` | `-d` where `-D` is needed |
+| `invalid branch name` | see the name rules |
+
+## dolt_checkout
+
+| Form | Effect |
+|---|---|
+| `branch` | Switch this connection to `branch` and load its working set. A name that exists only as `remotes/origin/<name>` creates the local branch. |
+| `-b name [, rev]` | Create and switch. `rev` may come first or last. |
+| `table` | Discard working changes to one table, back to `HEAD` |
+
+Every branch has its own working set, so switching never carries or refuses
+uncommitted work. Checking out a tag or commit is refused:
+`dolt does not support a detached head state ...`; open the database by
+path instead (`db/v1.0`). Other errors: `branch name required`,
+`no such branch or table: <x>`, `start point not found`.
+
+## Other functions
+
+| Function | Meaning |
+|---|---|
+| `active_branch()` | Current branch, or `NULL` on a detached open |
+| `dolt_default_branch()` | The branch a bare open lands on. `dolt_default_branch(name)` changes it; `branch '<x>' not found` otherwise. |
+| `dolt_connect_branch(name)` | The primitive behind `db@branch`: switch to an existing local branch, with none of `dolt_checkout`'s create-from-remote or `-b` behaviour |
+
+## dolt_branches
+
+| Column | Meaning |
+|---|---|
+| `name`, `hash` | branch and its tip |
+| `latest_committer`, `latest_committer_email`, `latest_commit_date`, `latest_commit_message` | tip commit metadata |
+| `remote`, `branch` | upstream tracking, when set |
+| `dirty` | `1` when the branch's working set has uncommitted changes |
+
+`dolt_remote_branches` lists `remotes/<remote>/<branch>` rows with the same
+tip columns.
+
+## See also
+
+[refs.md](refs.md), [concurrency.md](concurrency.md),
+`test/vc_oracle_branch_test.sh`, `test/vc_oracle_checkout_test.sh`.

--- a/doc/doltlite/dolt_cherry_pick.md
+++ b/doc/doltlite/dolt_cherry_pick.md
@@ -1,0 +1,56 @@
+# dolt_cherry_pick and dolt_revert
+
+Apply one commit's changes, or their inverse, as a new commit on the current
+branch. Dolt:
+[dolt_cherry_pick](https://docs.dolthub.com/sql-reference/version-control/dolt-sql-procedures#dolt_cherry-pick),
+[dolt_revert](https://docs.dolthub.com/sql-reference/version-control/dolt-sql-procedures#dolt_revert).
+
+## Synopsis
+
+```sql
+SELECT dolt_cherry_pick('0123abcd...');
+SELECT dolt_cherry_pick(dolt_hashof('feature'));
+SELECT dolt_cherry_pick('--abort');
+SELECT dolt_revert('HEAD');
+SELECT dolt_revert('0123abcd...');
+```
+
+## dolt_cherry_pick
+
+| Argument | Meaning |
+|---|---|
+| `commit` | One commit [revision](refs.md). Its parent-to-commit diff is applied as a three-way merge. |
+| `--abort` | Drop an in-progress conflicted cherry-pick |
+
+Returns the new commit hash, keeping the original message. Conflicts behave
+as in [dolt_merge.md](dolt_merge.md): rolled back in autocommit, inspectable
+inside `BEGIN`. A completed cherry-pick ends the enclosing SQL transaction.
+
+| Error | Cause |
+|---|---|
+| `usage: dolt_cherry_pick('commit_hash')` | no argument |
+| `invalid commit hash` | does not resolve |
+| `cherry-picking a merge commit is not supported` | two-parent commit |
+| `cherry-picking multiple commits is not supported yet.` | more than one commit |
+| `cannot cherry-pick with uncommitted changes` | dirty working set |
+| `no cherry-pick in progress` | `--abort` with nothing to abort |
+
+## dolt_revert
+
+`dolt_revert(commit)` commits the inverse of `commit` onto `HEAD` with the
+message `Revert "<original message>"` and returns the new hash. One commit at
+a time; the initial commit cannot be reverted. Conflicts behave like a merge.
+
+| Error | Cause |
+|---|---|
+| `Your local changes would be overwritten by revert.` (with a hint to commit first) | dirty working set |
+| `invalid commit hash` | does not resolve |
+
+## Differences from Dolt
+
+Dolt accepts several commits per call and revert ranges; DoltLite takes one.
+
+## See also
+
+`test/vc_oracle_revert_cherrypick_test.sh`,
+`test/vc_oracle_cherry_pick_abort_test.sh`.

--- a/doc/doltlite/dolt_commit.md
+++ b/doc/doltlite/dolt_commit.md
@@ -1,0 +1,85 @@
+# dolt_commit, dolt_add, dolt_status, dolt_config
+
+The commit loop: stage tables, commit them, see what is pending. Dolt
+equivalents: [dolt_add](https://docs.dolthub.com/sql-reference/version-control/dolt-sql-procedures#dolt_add),
+[dolt_commit](https://docs.dolthub.com/sql-reference/version-control/dolt-sql-procedures#dolt_commit),
+[dolt_status](https://docs.dolthub.com/sql-reference/version-control/dolt-system-tables#dolt_status).
+
+## Synopsis
+
+```sql
+SELECT dolt_add('users', 'orders');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'message');
+SELECT dolt_commit('-am', 'message');           -- -a and -m combine
+SELECT dolt_commit('-A', '-m', 'message', '--author', 'Ann <ann@example.com>');
+SELECT * FROM dolt_status;
+SELECT dolt_config('user.name', 'Ann');
+```
+
+## dolt_add
+
+| Argument | Meaning |
+|---|---|
+| `table`, ... | Stage the named tables. Unknown name: `table not found: <name>` |
+| `-A`, `--all` | Stage every changed table not matched by `dolt_ignore` |
+| `-f`, `--force` | Stage a table even though `dolt_ignore` matches it |
+
+Returns `0`. No arguments: `dolt_add requires table name or '-A'`.
+
+## dolt_commit
+
+| Option | Meaning |
+|---|---|
+| `-m`, `--message` | Commit message. Required unless `--amend`. |
+| `-a`, `--all` | Stage every modified or deleted tracked table first. Does not add new tables. |
+| `-A` | Stage everything, new tables included |
+| `--author 'Name <email>'` | Override the committer for this commit |
+| `--date` | Commit timestamp, ISO 8601 (`2020-01-02T03:04:05Z`) |
+| `--amend` | Replace the HEAD commit with staged changes and, if given, a new message |
+| `--allow-empty` | Create a commit even when nothing is staged |
+| `--skip-empty` | Return `0` instead of erroring when nothing is staged |
+| `-f`, `--force` | Commit despite rows in `dolt_constraint_violations` |
+
+Returns the new commit hash. Inside `BEGIN`, a successful commit also ends
+the SQL transaction; see [transactions.md](transactions.md).
+
+| Error | Cause |
+|---|---|
+| `dolt_commit requires a message: SELECT dolt_commit('-m', 'msg')` | no `-m`, or empty message |
+| `nothing to commit, working tree clean (use dolt_add to stage changes)` | nothing staged and no `-a`/`-A` |
+| `Author not formatted correctly. Use 'Name <author@example.com>' format` | bad `--author` |
+| `cannot commit: unresolved merge conflicts. Use dolt_conflicts_resolve() first.` | see [dolt_merge.md](dolt_merge.md) |
+| `cannot commit: unresolved entries in dolt_constraint_violations ...` | see [dolt_constraint_violations.md](dolt_constraint_violations.md) |
+| `cannot --amend: HEAD has no parent (initial commit)` | amend on the first commit |
+| `unknown option \`--x\``, `no value for option \`message'` | option parsing |
+
+## dolt_status
+
+| Column | Values |
+|---|---|
+| `table_name` | table, or `dolt_ignore` / `dolt_docs` / `dolt_tests` once they exist |
+| `staged` | `1` staged, `0` working |
+| `status` | `new table`, `modified`, `deleted` |
+
+A table that is both staged and further modified appears twice. Tables
+matched by `dolt_ignore` are hidden. An index change shows as a modification
+of its table.
+
+## dolt_config
+
+`dolt_config(key)` reads, `dolt_config(key, value)` sets. Keys: `user.name`,
+`user.email`. Per connection, not persisted. Without them, commits record
+committer `doltlite` with an empty email. Anything else:
+`unknown config key (valid: user.name, user.email)`.
+
+## Differences from Dolt
+
+Functions instead of procedures; `-A` stages new tables where Dolt's `-A`
+does the same. `@@dolt_transaction_commit` has no counterpart: a commit is
+always durable when it returns.
+
+## See also
+
+[dolt_reset.md](dolt_reset.md), [dolt_workspace.md](dolt_workspace.md) for
+row-level staging, `test/vc_oracle_commit_test.sh`.

--- a/doc/doltlite/dolt_constraint_violations.md
+++ b/doc/doltlite/dolt_constraint_violations.md
@@ -1,7 +1,7 @@
 # Constraint violations and dolt_verify_constraints
 
-Rows that break a foreign key, unique index, or check constraint after a
-merge, and the re-scan that finds them. Dolt:
+Rows that break a foreign key, unique index, check, `NOT NULL`, or strict-type
+constraint after a merge, and the re-scan that finds them. Dolt:
 [dolt_constraint_violations](https://docs.dolthub.com/sql-reference/version-control/dolt-system-tables#dolt_constraint_violations),
 [dolt_verify_constraints](https://docs.dolthub.com/sql-reference/version-control/dolt-sql-procedures#dolt_verify_constraints).
 
@@ -33,10 +33,10 @@ back.` Inside `BEGIN` they persist and block `dolt_commit` until resolved.
 | `dolt_constraint_violations_<table>` | `violation_type`, primary-key columns, remaining columns, `violation_info` (JSON) |
 
 The per-table vtable exists only while that table has recorded violations.
-`violation_type` is `foreign key`, `unique index`, or `check constraint`.
-Foreign-key and check violators stay in the base table; unique-index losers
-(the highest rowid) are moved out of the table into the violations vtable.
-Resolve by fixing the data and `DELETE`-ing the violation row.
+`violation_type` is `foreign key`, `unique index`, `check constraint`, `not
+null`, or `strict type`. Violating rows stay in the base table; every member of
+a unique-index collision is recorded. Resolve by fixing the data and
+`DELETE`-ing the violation row.
 
 ## dolt_verify_constraints
 

--- a/doc/doltlite/dolt_constraint_violations.md
+++ b/doc/doltlite/dolt_constraint_violations.md
@@ -1,0 +1,65 @@
+# Constraint violations and dolt_verify_constraints
+
+Rows that break a foreign key, unique index, or check constraint after a
+merge, and the re-scan that finds them. Dolt:
+[dolt_constraint_violations](https://docs.dolthub.com/sql-reference/version-control/dolt-system-tables#dolt_constraint_violations),
+[dolt_verify_constraints](https://docs.dolthub.com/sql-reference/version-control/dolt-sql-procedures#dolt_verify_constraints).
+
+## Synopsis
+
+```sql
+SELECT * FROM dolt_constraint_violations;
+SELECT violation_type, pk, violation_info FROM dolt_constraint_violations_child;
+DELETE FROM dolt_constraint_violations_child WHERE pk = 2;   -- mark resolved
+SELECT dolt_verify_constraints();                -- tables changed since HEAD
+SELECT dolt_verify_constraints('--all');         -- every table
+SELECT dolt_verify_constraints('--output-only', 'child');
+```
+
+## Where they come from
+
+Merges apply cell by cell and do not run referential actions inline, so a
+merged working set can hold rows no single side could have inserted. Those
+land in `dolt_constraint_violations_<table>`. A merge that produces
+violations in autocommit mode is rolled back: `Committing this transaction
+resulted in a working set with constraint violations, transaction rolled
+back.` Inside `BEGIN` they persist and block `dolt_commit` until resolved.
+
+## Tables
+
+| Table | Columns |
+|---|---|
+| `dolt_constraint_violations` | `table`, `num_violations` |
+| `dolt_constraint_violations_<table>` | `violation_type`, primary-key columns, remaining columns, `violation_info` (JSON) |
+
+The per-table vtable exists only while that table has recorded violations.
+`violation_type` is `foreign key`, `unique index`, or `check constraint`.
+Foreign-key and check violators stay in the base table; unique-index losers
+(the highest rowid) are moved out of the table into the violations vtable.
+Resolve by fixing the data and `DELETE`-ing the violation row.
+
+## dolt_verify_constraints
+
+| Option | Meaning |
+|---|---|
+| none | Scan tables changed since `HEAD` and record violations |
+| `-a`, `--all` | Scan every table |
+| `--output-only` | Record nothing; only report |
+| `table`, ... | Restrict the scan |
+
+Returns `1` if violations were found, `0` otherwise. Each call rewrites the
+findings for the scanned tables. Unknown table: `table not found: <x>`.
+
+## Committing
+
+`dolt_commit` refuses with `cannot commit: unresolved entries in
+dolt_constraint_violations. Resolve them (DELETE from the per-table vtable)
+then retry, or pass --force to commit anyway.` `--force` commits with the
+violations still recorded. Unlike conflicts, violations do persist to disk
+and follow the branch.
+
+## See also
+
+[dolt_merge.md](dolt_merge.md), [transactions.md](transactions.md),
+`test/vc_oracle_constraint_violations_test.sh`,
+`test/vc_oracle_verify_constraints_test.sh`.

--- a/doc/doltlite/dolt_constraint_violations.md
+++ b/doc/doltlite/dolt_constraint_violations.md
@@ -34,9 +34,10 @@ back.` Inside `BEGIN` they persist and block `dolt_commit` until resolved.
 
 The per-table vtable exists only while that table has recorded violations.
 `violation_type` is `foreign key`, `unique index`, `check constraint`, `not
-null`, or `strict type`. Violating rows stay in the base table; every member of
-a unique-index collision is recorded. Resolve by fixing the data and
-`DELETE`-ing the violation row.
+null`, or `strict type`. Foreign-key, check, not-null, and strict-type
+violators stay in the base table. A unique-index collision records every
+member, and the higher-rowid row is moved out of the table into the violations
+vtable. Resolve by fixing the data and `DELETE`-ing the violation row.
 
 ## dolt_verify_constraints
 

--- a/doc/doltlite/dolt_creds.md
+++ b/doc/doltlite/dolt_creds.md
@@ -1,0 +1,43 @@
+# dolt_creds and dolt_creds_new
+
+Credentials for authenticated HTTP remotes: an Ed25519 key pair stored
+locally, whose public half a server or DoltHub authorizes.
+
+## Synopsis
+
+```sql
+SELECT dolt_creds_new();
+SELECT dolt_creds('list');
+SELECT dolt_creds('export', '<credential-id>');                 -- public JWK
+SELECT dolt_creds('export', '<credential-id>', '/srv/authorized-keys');
+SELECT dolt_creds('rm', '<credential-id>');
+```
+
+## Behaviour
+
+`dolt_creds_new()` creates a credential in the store, returns its id, and
+prints the DoltHub URL for registering the public key. `dolt_creds()` with no
+arguments reports the state: `no credentials; run SELECT dolt_creds_new()`
+until one exists.
+
+| Action | Effect |
+|---|---|
+| `'list'` | Every stored credential id |
+| `'export', id` | The public key as a JWK |
+| `'export', id, dir` | Write the public JWK into `dir`, the form `doltlite-remotesrv --auth-keys` reads. The private seed never leaves the store. |
+| `'rm', id` | Delete |
+
+Unknown id: `no such credential`. Anything else prints the usage line.
+
+| Setting | Default |
+|---|---|
+| `DOLTLITE_CREDS_DIR` | `~/.doltlite/creds` |
+| `DOLTLITE_CREDS_KID` | the only credential, or the one named |
+
+Remote calls pick up the credential automatically and sign a JWT per request;
+the server rejects private credential files placed in `--auth-keys`.
+
+## See also
+
+[auth.md](auth.md) for the token format and server checks,
+[remotesrv.md](remotesrv.md), [dolt_remote.md](dolt_remote.md).

--- a/doc/doltlite/dolt_creds.md
+++ b/doc/doltlite/dolt_creds.md
@@ -15,8 +15,8 @@ SELECT dolt_creds('rm', '<credential-id>');
 
 ## Behaviour
 
-`dolt_creds_new()` creates a credential in the store, returns its id, and
-prints the DoltHub URL for registering the public key. `dolt_creds()` with no
+`dolt_creds_new()` creates a credential and returns one multiline message with
+its id, public key, and DoltHub registration URL. `dolt_creds()` with no
 arguments reports the state: `no credentials; run SELECT dolt_creds_new()`
 until one exists.
 

--- a/doc/doltlite/dolt_diff.md
+++ b/doc/doltlite/dolt_diff.md
@@ -1,0 +1,67 @@
+# Diffs
+
+What changed between two points in history, at table, row, schema, or
+SQL-statement granularity. Dolt:
+[dolt_diff](https://docs.dolthub.com/sql-reference/version-control/dolt-system-tables#dolt_diff),
+[dolt_diff_stat](https://docs.dolthub.com/sql-reference/version-control/dolt-sql-functions#dolt_diff_stat),
+[dolt_patch](https://docs.dolthub.com/sql-reference/version-control/dolt-sql-functions#dolt_patch).
+
+## Synopsis
+
+```sql
+SELECT * FROM dolt_diff WHERE table_name = 'users';        -- commits that touched a table
+SELECT * FROM dolt_diff_users;                              -- every row change in history
+SELECT * FROM dolt_diff_users WHERE to_commit = 'WORKING';  -- uncommitted
+SELECT * FROM dolt_diff_users('v1.0', 'HEAD');              -- between two revisions
+SELECT * FROM dolt_diff_users('main...feature');
+SELECT * FROM dolt_diff_stat('v1.0', 'HEAD');
+SELECT * FROM dolt_diff_summary('v1.0', 'HEAD', 'users');
+SELECT * FROM dolt_schema_diff('v1.0..HEAD');
+SELECT statement FROM dolt_patch('HEAD', 'WORKING') ORDER BY statement_order;
+```
+
+Revision spellings and which surfaces take ranges: [refs.md](refs.md).
+
+## Surfaces
+
+| Surface | Arguments | Columns |
+|---|---|---|
+| `dolt_diff` | none | `commit_hash`, `committer`, `email`, `date`, `message`, `data_change`, `schema_change`, `table_name` |
+| `dolt_diff_<table>` | none; or `(from, to)`; or `(range)` | `to_<col>...`, `to_commit`, `to_commit_date`, `from_<col>...`, `from_commit`, `from_commit_date`, `diff_type` |
+| `dolt_diff_stat` | `(from, to [, table])` | `table_name`, `rows_unmodified`, `rows_added`, `rows_deleted`, `rows_modified`, `cells_added`, `cells_deleted`, `cells_modified`, `old_row_count`, `new_row_count`, `old_cell_count`, `new_cell_count` |
+| `dolt_diff_summary` | `(from, to [, table])` | `from_table_name`, `to_table_name`, `diff_type`, `data_change`, `schema_change` |
+| `dolt_schema_diff` | `(from, to [, table])` or `(range [, table])` | `from_table_name`, `to_table_name`, `from_create_statement`, `to_create_statement` |
+| `dolt_patch` | `(from, to [, table])` or `(range [, table])` | `statement_order`, `from_commit_hash`, `to_commit_hash`, `table_name`, `diff_type`, `statement` |
+
+`diff_type` is `added`, `modified`, or `removed` for rows; `added`,
+`dropped`, `modified`, or `renamed` for tables in `dolt_diff_summary`;
+`schema` or `data` in `dolt_patch`.
+
+## Behaviour
+
+- `dolt_diff_<table>` with no arguments walks the current branch's history.
+  `to_commit = 'WORKING'` rows cover staged and working edits together.
+- The two-argument form is a snapshot comparison and works even if the table
+  exists at only one endpoint. A single revision is an error:
+  `dolt_diff_<table> requires a '..' or '...' revision range`.
+- `dolt_diff_stat` and `dolt_diff_summary` take no range form:
+  `dolt_diff_stat requires from_ref and to_ref`.
+- `dolt_patch` emits ordered, executable SQLite: `schema` statements first,
+  then `data`. When `ALTER TABLE` cannot express a change it emits a rebuild.
+- `dolt_schema_diff` covers tables, views, indexes, and triggers.
+- A user column that collides case-insensitively with a metadata column is
+  renamed with a numeric suffix (`_1`, `_2`, ...).
+
+Unknown table: `table not found: <x>` (stat, summary) or `dolt_patch: table
+'<x>' does not exist`.
+
+## Differences from Dolt
+
+`dolt_diff_<table>(from, to)` replaces Dolt's `dolt_commit_diff_<table>`.
+Column names may differ; row semantics match.
+
+## See also
+
+[dolt_log.md](dolt_log.md) for `dolt_history_<table>`,
+`test/vc_oracle_diff_test.sh`, `test/vc_oracle_diff_tvf_test.sh`,
+`test/vc_oracle_patch_test.sh`.

--- a/doc/doltlite/dolt_gc.md
+++ b/doc/doltlite/dolt_gc.md
@@ -1,0 +1,42 @@
+# dolt_gc
+
+Reclaim chunks no branch, tag, commit, or working set can reach. Dolt:
+[dolt_gc](https://docs.dolthub.com/sql-reference/version-control/dolt-sql-procedures#dolt_gc).
+
+## Synopsis
+
+```sql
+SELECT dolt_gc();
+-- 12 chunks removed, 45 chunks kept
+VACUUM;                            -- same thing
+VACUUM INTO '/path/compact.db';    -- compacted copy, source untouched
+```
+
+## Behaviour
+
+Stop-the-world mark and sweep over every ref, commit, catalog, working set,
+and prolly node, then a rewrite of the file holding only live chunks. Safe to
+run at any time and idempotent. Deleted history becomes unreachable when its
+last ref goes (`dolt_branch('-D')`, `dolt_tag('-d')`, `dolt_reset('--hard')`),
+so space returns on the next `dolt_gc`. Nothing runs automatically: commit
+cost grows with the WAL since the last collection, and collecting is the
+user's call.
+
+`VACUUM` on a DoltLite database runs the same collection; `PRAGMA
+wal_checkpoint` does too. `VACUUM INTO` writes a compacted DoltLite-format
+copy; `:memory:` as the destination is refused. On an in-memory database the
+result is `0 chunks removed, 0 chunks kept (in-memory)`.
+
+| Error | Cause |
+|---|---|
+| `gc requires exclusive access`, `database is locked by another connection` | a peer holds a write transaction; retry after it commits |
+| `cannot VACUUM from within a transaction` | as in SQLite |
+| `attempt to write a readonly database` | `query_only` or `immutable=1` |
+
+An open reader in another process finishes safely while GC runs; readers
+never see a half-rewritten file.
+
+## See also
+
+[concurrency.md](concurrency.md), [storage-format.md](storage-format.md),
+`test/doltlite_vacuum.sh`.

--- a/doc/doltlite/dolt_gc.md
+++ b/doc/doltlite/dolt_gc.md
@@ -18,9 +18,9 @@ Stop-the-world mark and sweep over every ref, commit, catalog, working set,
 and prolly node, then a rewrite of the file holding only live chunks. Safe to
 run at any time and idempotent. Deleted history becomes unreachable when its
 last ref goes (`dolt_branch('-D')`, `dolt_tag('-d')`, `dolt_reset('--hard')`),
-so space returns on the next `dolt_gc`. Nothing runs automatically: commit
-cost grows with the WAL since the last collection, and collecting is the
-user's call.
+so space returns on the next `dolt_gc`. Collection is manual: unreachable
+chunks occupy space until then. Automatic chunk-WAL checkpoints are separate
+from GC.
 
 `VACUUM` on a DoltLite database runs the same collection; `PRAGMA
 wal_checkpoint` does too. `VACUUM INTO` writes a compacted DoltLite-format

--- a/doc/doltlite/dolt_hashof.md
+++ b/doc/doltlite/dolt_hashof.md
@@ -1,0 +1,51 @@
+# Content hashes: dolt_hashof and friends
+
+Forty-character hashes of commits, tables, indexes, and the whole catalog.
+Dolt: [dolt_hashof](https://docs.dolthub.com/sql-reference/version-control/dolt-sql-functions#dolt_hashof),
+[dolt_hashof_table](https://docs.dolthub.com/sql-reference/version-control/dolt-sql-functions#dolt_hashof_table),
+[dolt_hashof_db](https://docs.dolthub.com/sql-reference/version-control/dolt-sql-functions#dolt_hashof_db).
+
+## Synopsis
+
+```sql
+SELECT dolt_hashof('HEAD');                     -- commit hash
+SELECT dolt_hashof('main~2');
+SELECT dolt_hashof_table('users');              -- includes working edits
+SELECT dolt_hashof_table('users', 'v1.0');
+SELECT dolt_hashof_index('users_by_email');
+SELECT dolt_hashof_db();                        -- whole catalog, WORKING
+SELECT dolt_hashof_db('HEAD');
+SELECT dolt_hashof_catalog();
+```
+
+| Function | Argument | Hashes |
+|---|---|---|
+| `dolt_hashof(rev)` | one commit [revision](refs.md); required | the commit |
+| `dolt_hashof_table(table [, rev])` | default `WORKING` | the table's rows plus every index on it |
+| `dolt_hashof_index(index [, rev])` | default `WORKING` | one index |
+| `dolt_hashof_db([rev])` | default `WORKING` | every table root and the catalog membership |
+| `dolt_hashof_catalog([rev])` | default `WORKING` | the stored catalog chunk itself |
+
+All accept `WORKING` and `STAGED` except `dolt_hashof`, which needs a commit.
+
+## Behaviour
+
+`_table`, `_index`, and `_db` are history-independent: the same set of rows
+hashes the same on any branch, in any insert order. `REINDEX` changes no hash
+on a healthy database; a hash that moves across `REINDEX` means the stored
+index did not match its rows. `_catalog` is the raw catalog chunk and is
+layout-sensitive; use `_db` for content identity.
+
+An index belongs to its table: a changed index moves `dolt_hashof_table` and
+shows in `dolt_status` as a modification of the table.
+
+| Error | Cause |
+|---|---|
+| `dolt_hashof: invalid ref spec` | unknown name, short hash, empty string, or `WORKING` |
+| `dolt_hashof: invalid ancestor spec` | bad `~`/`^` suffix |
+| `dolt_hashof() takes exactly one argument` | arity |
+
+## See also
+
+[refs.md](refs.md), `test/vc_oracle_hashof_test.sh`,
+`test/vc_oracle_hashof_errors_test.sh`.

--- a/doc/doltlite/dolt_ignore.md
+++ b/doc/doltlite/dolt_ignore.md
@@ -1,0 +1,73 @@
+# Versioned system tables: dolt_ignore, dolt_docs, dolt_tests
+
+Three tables that live in the repository and version with it. Each is served
+empty before it exists; the first write creates the real table, which then
+commits, diffs, branches, and merges like any other. Dolt:
+[dolt_ignore](https://docs.dolthub.com/sql-reference/version-control/dolt-system-tables#dolt_ignore),
+[dolt_docs](https://docs.dolthub.com/sql-reference/version-control/dolt-system-tables#dolt_docs),
+[dolt_tests](https://docs.dolthub.com/sql-reference/version-control/dolt-system-tables#dolt_tests).
+
+## dolt_ignore
+
+`dolt_ignore(pattern TEXT NOT NULL, ignored TINYINT NOT NULL, PRIMARY KEY(pattern))`
+
+```sql
+INSERT INTO dolt_ignore VALUES ('tmp_*', 1);
+INSERT INTO dolt_ignore VALUES ('tmp_keep', 0);     -- exception
+```
+
+Matching tables are skipped by `dolt_add('-A')` and `dolt_commit('-A')`,
+hidden from `dolt_status`, and left in the working set. `*` or `%` match any
+run, `?` one character. The most specific matching pattern wins; two patterns
+of equal specificity that disagree error with `the table <t> matches
+conflicting patterns in dolt_ignore`. `dolt_add('-f', table)` stages an
+ignored table anyway.
+
+## dolt_docs
+
+`dolt_docs(doc_name TEXT NOT NULL, doc_text TEXT NOT NULL, PRIMARY KEY(doc_name))`
+
+```sql
+SELECT * FROM dolt_docs;                              -- AGENT.md on a fresh database
+REPLACE INTO dolt_docs VALUES ('README.md', '# my project');
+```
+
+A fresh database serves one default row, `AGENT.md`, DoltLite's guide for
+AI agents (see [agents.md](agents.md)). It is stored on first write like any
+other row, so deleting it sticks. `doc_name` is unique: a second `INSERT` of
+the same name fails; use `REPLACE`.
+
+## dolt_tests and dolt_test_run
+
+`dolt_tests(test_name, test_group, test_query, assertion_type,
+assertion_comparator, assertion_value)`
+
+```sql
+INSERT INTO dolt_tests VALUES
+  ('user count', 'users', 'SELECT * FROM users', 'expected_rows', '==', '10');
+SELECT * FROM dolt_test_run();          -- every test
+SELECT * FROM dolt_test_run('users');   -- one group, or one test name
+```
+
+| Column | Values |
+|---|---|
+| `assertion_type` | `expected_rows`, `expected_columns`, `expected_single_value` (enforced by a CHECK constraint) |
+| `assertion_comparator` | `==`, `!=`, `<`, `>`, `<=`, `>=` |
+| `assertion_value` | compared as integer, float, text, or NULL as appropriate |
+
+`dolt_test_run` returns `test_name`, `test_group_name`, `query`, `status`
+(`PASS`/`FAIL`), `message`. Queries run read-only: a write fails with
+`Cannot execute write queries`, a `PRAGMA` with `Cannot execute PRAGMA
+queries`, and only one statement is allowed. An unknown group or name:
+`could not find tests for argument: <x>`.
+
+## Differences from Dolt
+
+`dolt_docs` rows are stored, including the default; Dolt resurrects its
+defaults on read. The tables appear in `.tables` once they exist. The default
+`AGENT.md` text is DoltLite's own.
+
+## See also
+
+`test/vc_oracle_ignore_test.sh`, `test/vc_oracle_docs_test.sh`,
+`test/vc_oracle_tests_test.sh`.

--- a/doc/doltlite/dolt_ignore.md
+++ b/doc/doltlite/dolt_ignore.md
@@ -1,8 +1,9 @@
 # Versioned system tables: dolt_ignore, dolt_docs, dolt_tests
 
-Three tables that live in the repository and version with it. Each is served
-empty before it exists; the first write creates the real table, which then
-commits, diffs, branches, and merges like any other. Dolt:
+Three tables that live in the repository and version with it. `dolt_ignore`
+and `dolt_tests` start empty; `dolt_docs` starts with `AGENT.md`. The first
+write creates the real table, which then commits, diffs, branches, and merges
+like any other. Dolt:
 [dolt_ignore](https://docs.dolthub.com/sql-reference/version-control/dolt-system-tables#dolt_ignore),
 [dolt_docs](https://docs.dolthub.com/sql-reference/version-control/dolt-system-tables#dolt_docs),
 [dolt_tests](https://docs.dolthub.com/sql-reference/version-control/dolt-system-tables#dolt_tests).

--- a/doc/doltlite/dolt_log.md
+++ b/doc/doltlite/dolt_log.md
@@ -41,7 +41,7 @@ SELECT * FROM dolt_commit_ancestors WHERE commit_hash = dolt_hashof('HEAD');
   that last set each live row's values. Schema-only changes do not move blame.
   The table needs a primary key: `dolt_blame_<t>: table has no primary key`.
 - `dolt_commit_ancestors` has one row per parent; a merge commit has
-  `parent_index` 0 and 1.
+  `parent_index` 0 and 1, and a root has one row with a NULL parent.
 
 | Error | Cause |
 |---|---|
@@ -51,8 +51,9 @@ SELECT * FROM dolt_commit_ancestors WHERE commit_hash = dolt_hashof('HEAD');
 
 ## Differences from Dolt
 
-`dolt_log` doubles as Dolt's `dolt_commits`; there is no separate flat
-table. Column names are the DoltLite set above.
+`dolt_log` walks selected ancestry; `dolt_commit_ancestors` exposes the graph
+across refs. There is no separate flat `dolt_commits` table. Column names are
+the DoltLite set above.
 
 ## See also
 

--- a/doc/doltlite/dolt_log.md
+++ b/doc/doltlite/dolt_log.md
@@ -1,0 +1,61 @@
+# History: dolt_log, dolt_history, dolt_at, dolt_blame
+
+Commit history, and every table's past. Dolt:
+[dolt_log](https://docs.dolthub.com/sql-reference/version-control/dolt-system-tables#dolt_log),
+[dolt_history_<table>](https://docs.dolthub.com/sql-reference/version-control/dolt-system-tables#dolt_history_tablename),
+[dolt_blame_<table>](https://docs.dolthub.com/sql-reference/version-control/dolt-system-tables#dolt_blame_tablename).
+
+## Synopsis
+
+```sql
+SELECT * FROM dolt_log;                         -- current branch
+SELECT * FROM dolt_log('feature');
+SELECT * FROM dolt_log('main..feature');        -- on feature, not on main
+SELECT * FROM dolt_history_users WHERE id = 42;
+SELECT * FROM dolt_history_users('v1.0');
+SELECT * FROM dolt_at_users('HEAD~3');          -- the table as it was
+SELECT * FROM dolt_blame_users;
+SELECT * FROM dolt_commit_ancestors WHERE commit_hash = dolt_hashof('HEAD');
+```
+
+## Surfaces
+
+| Surface | Argument | Columns |
+|---|---|---|
+| `dolt_log` | none, one commit revision, or a range | `commit_hash`, `committer`, `email`, `date`, `message` |
+| `dolt_history_<table>` | none or one commit revision | user columns, `commit_hash`, `committer`, `commit_date` |
+| `dolt_at_<table>` | one revision, `WORKING`/`STAGED` allowed | user columns |
+| `dolt_blame_<table>` | none | primary-key columns, `commit`, `commit_date`, `committer`, `email`, `message` |
+| `dolt_commit_ancestors` | none | `commit_hash`, `parent_hash`, `parent_index` |
+
+## Behaviour
+
+- `dolt_log` walks from the given revision to the root, newest first. Ranges
+  follow git: `a..b` is reachable from `b` not `a`; `a...b` is either side but
+  not both. One argument only.
+- `dolt_history_<table>` yields one row per version of each row in the
+  ancestry of its starting point. Filter by `commit_hash` for one snapshot.
+- `dolt_at_<table>` is a plain read of one snapshot; join it against the live
+  table to compare.
+- `dolt_blame_<table>` walks first parents from `HEAD` and reports the commit
+  that last set each live row's values. Schema-only changes do not move blame.
+  The table needs a primary key: `dolt_blame_<t>: table has no primary key`.
+- `dolt_commit_ancestors` has one row per parent; a merge commit has
+  `parent_index` 0 and 1.
+
+| Error | Cause |
+|---|---|
+| `invalid dolt_log revision: <x>` | unknown revision, `WORKING`, or a malformed range |
+| `ref not found: <x>` | `dolt_history_<t>` / `dolt_at_<t>` given an unknown revision |
+| `no such table: dolt_at_<x>` | no such user table |
+
+## Differences from Dolt
+
+`dolt_log` doubles as Dolt's `dolt_commits`; there is no separate flat
+table. Column names are the DoltLite set above.
+
+## See also
+
+[refs.md](refs.md), [dolt_diff.md](dolt_diff.md),
+`test/vc_oracle_log_test.sh`, `test/vc_oracle_history_test.sh`,
+`test/vc_oracle_blame_test.sh`, `test/vc_oracle_at_test.sh`.

--- a/doc/doltlite/dolt_merge.md
+++ b/doc/doltlite/dolt_merge.md
@@ -24,14 +24,15 @@ SELECT dolt_merge_base('main', 'feature');
 
 | Option | Meaning |
 |---|---|
-| `branch` | Any [revision](refs.md) to merge in |
+| `branch` | One commit [revision](refs.md) to merge in |
 | `--no-ff` | Always create a merge commit, even when fast-forward is possible |
-| `--squash` | Apply and stage the changes without committing; `dolt_commit` then makes a one-parent commit |
-| `--no-commit` | Merge and stage, leave `is_merging = 1`; `dolt_commit` then makes the two-parent commit |
+| `--squash` | Fast-forward: stage without moving `HEAD`. Three-way: make a one-parent commit; add `--no-commit` to only stage. |
+| `--no-commit` | Three-way: stage and leave `is_merging = 1`, or `0` with `--squash`. A possible fast-forward still advances `HEAD`. |
 | `-m`, `--message` | Message for the merge commit (default `Merge branch 'x' into y`) |
 | `--abort` | Drop an in-progress merge and restore the pre-merge working set |
 
-Returns the new tip hash. A fast-forward returns the merged branch's tip.
+Committed merges return the new tip hash. A fast-forward returns the merged
+branch's tip; an uncommitted three-way merge returns `0`.
 `--squash` and `--no-ff` together: `flags '--squash' and '--no-ff' cannot
 be used together`. Other errors: `usage: dolt_merge('branch')`,
 `merge source not found`, `no merge in progress`.
@@ -66,7 +67,8 @@ auto-resolved: abort, align the schemas on one side, merge again.
 A merge that cannot produce a correct result fails instead of guessing: a
 table whose primary key changed on either side, or a derived index (a
 virtual-table shadow) the engine cannot rebuild from merged content.
-Constraint violations do not block the merge; see
+Inside a plain `BEGIN`, constraint violations are recorded and preserved for
+inspection; autocommit rolls the merge back. See
 [dolt_constraint_violations.md](dolt_constraint_violations.md).
 
 ## dolt_merge_base

--- a/doc/doltlite/dolt_merge.md
+++ b/doc/doltlite/dolt_merge.md
@@ -1,0 +1,87 @@
+# dolt_merge and conflicts
+
+Three-way, row-level merge into the current branch. Dolt:
+[dolt_merge](https://docs.dolthub.com/sql-reference/version-control/dolt-sql-procedures#dolt_merge),
+[dolt_conflicts](https://docs.dolthub.com/sql-reference/version-control/dolt-system-tables#dolt_conflicts),
+[dolt_conflicts_resolve](https://docs.dolthub.com/sql-reference/version-control/dolt-sql-procedures#dolt_conflicts_resolve).
+
+## Synopsis
+
+```sql
+SELECT dolt_merge('feature');
+SELECT dolt_merge('--no-ff', '-m', 'Merge feature', 'feature');
+SELECT dolt_merge('--squash', 'feature');
+SELECT dolt_merge('--no-commit', 'feature');
+SELECT dolt_merge('--abort');
+SELECT * FROM dolt_merge_status;
+SELECT * FROM dolt_conflicts;
+SELECT * FROM dolt_conflicts_users;
+SELECT dolt_conflicts_resolve('--theirs', 'users');
+SELECT dolt_merge_base('main', 'feature');
+```
+
+## dolt_merge
+
+| Option | Meaning |
+|---|---|
+| `branch` | Any [revision](refs.md) to merge in |
+| `--no-ff` | Always create a merge commit, even when fast-forward is possible |
+| `--squash` | Apply and stage the changes without committing; `dolt_commit` then makes a one-parent commit |
+| `--no-commit` | Merge and stage, leave `is_merging = 1`; `dolt_commit` then makes the two-parent commit |
+| `-m`, `--message` | Message for the merge commit (default `Merge branch 'x' into y`) |
+| `--abort` | Drop an in-progress merge and restore the pre-merge working set |
+
+Returns the new tip hash. A fast-forward returns the merged branch's tip.
+`--squash` and `--no-ff` together: `flags '--squash' and '--no-ff' cannot
+be used together`. Other errors: `usage: dolt_merge('branch')`,
+`merge source not found`, `no merge in progress`.
+
+Non-conflicting edits to different rows, or the same row on one side only,
+merge. Both sides editing the same row differently is a conflict.
+
+## Conflicts
+
+A conflicting merge does not persist. In autocommit it is rolled back with
+`cannot merge: conflicts detected, autocommit transaction rolled back ...`.
+Inside `BEGIN` the error is `Merge has N conflict(s). Resolve and then
+commit with dolt_commit.` and the transaction stays open with:
+
+| Table | Columns |
+|---|---|
+| `dolt_conflicts` | `table`, `num_conflicts` |
+| `dolt_conflicts_<table>` | `from_root_ish`, `base_<col>...`, `our_<col>...`, `our_diff_type`, `their_<col>...`, `their_diff_type`, `dolt_conflict_id` |
+| `dolt_schema_conflicts` | `table_name`, `base_schema`, `our_schema`, `their_schema`, `description` |
+| `dolt_merge_status` | `is_merging`, `source`, `source_commit`, `target`, `unmerged_tables` (one row, `0` and NULLs when idle) |
+
+Resolve with `dolt_conflicts_resolve('--ours' | '--theirs', table, ...)`, or
+`DELETE FROM dolt_conflicts_<table> WHERE dolt_conflict_id = ...` to keep the
+working value (only `DELETE` is supported on conflict tables). Then
+`dolt_commit` records the merge commit. `COMMIT` with conflicts left fails
+with `constraint failed`; `dolt_commit` with `cannot commit: unresolved merge
+conflicts. Use dolt_conflicts_resolve() first.` Schema conflicts cannot be
+auto-resolved: abort, align the schemas on one side, merge again.
+
+## Refusals
+
+A merge that cannot produce a correct result fails instead of guessing: a
+table whose primary key changed on either side, or a derived index (a
+virtual-table shadow) the engine cannot rebuild from merged content.
+Constraint violations do not block the merge; see
+[dolt_constraint_violations.md](dolt_constraint_violations.md).
+
+## dolt_merge_base
+
+`dolt_merge_base(a, b)` returns the common ancestor's hash. Exactly two
+commit revisions; `WORKING`/`STAGED` are rejected with `could not resolve
+second argument to a commit`.
+
+## Differences from Dolt
+
+Conflicts are never committable (Dolt allows it behind
+`@@dolt_allow_commit_conflicts`). A completed merge ends the enclosing SQL
+transaction like `dolt_commit`.
+
+## See also
+
+[transactions.md](transactions.md), [dolt_cherry_pick.md](dolt_cherry_pick.md),
+`test/vc_oracle_merge_test.sh`, `test/vc_oracle_conflicts_test.sh`.

--- a/doc/doltlite/dolt_rebase.md
+++ b/doc/doltlite/dolt_rebase.md
@@ -1,0 +1,62 @@
+# dolt_rebase
+
+Replay the current branch's commits onto another branch. Dolt:
+[dolt_rebase](https://docs.dolthub.com/sql-reference/version-control/dolt-sql-procedures#dolt_rebase).
+
+## Synopsis
+
+```sql
+SELECT dolt_rebase('main');
+SELECT dolt_rebase('-i', 'main');
+UPDATE dolt_rebase SET action = 'squash' WHERE commit_message = 'fixup';
+SELECT dolt_rebase('--continue');
+SELECT dolt_rebase('--abort');
+```
+
+## Options
+
+| Option | Meaning |
+|---|---|
+| `upstream` | Non-interactive: replay every commit not on `upstream` and move the branch |
+| `-i`, `--interactive upstream` | Start a rebase and populate the `dolt_rebase` plan table; nothing is replayed until `--continue` |
+| `--continue` | Apply the plan |
+| `--abort` | Discard the plan and return to the original branch |
+
+Returns `Successfully rebased and updated refs/heads/<branch>`, or `0` when
+there is nothing to replay. A completed rebase ends the enclosing SQL
+transaction like `dolt_commit`.
+
+## The plan table
+
+`dolt_rebase(rebase_order REAL PRIMARY KEY, action TEXT, commit_hash TEXT,
+commit_message TEXT)` exists only during an interactive rebase. Edit it with
+ordinary SQL: `action` is `pick`, `drop`, `reword`, `squash`, or `fixup`;
+change `commit_message` to reword, `rebase_order` to reorder. The first
+non-drop action must be `pick` or `reword`. While the plan is open the
+connection sits on a working branch named `dolt_rebase_<branch>`.
+
+## Behaviour
+
+The rebase is atomic: a conflict or error restores the original branch and
+reports `conflict rebasing "<message>"; rebase aborted, branch restored to
+pre-rebase state`. The working set must be clean to start.
+
+| Error | Cause |
+|---|---|
+| `usage: dolt_rebase('upstream_branch')` | no arguments |
+| `cannot start a rebase with uncommitted changes` | dirty working set |
+| `rebase already in progress; use --continue or --abort` | second `-i` |
+| `no rebase in progress` | `--continue`/`--abort` with no plan |
+| `first non-drop action must be pick or reword` | invalid plan |
+| `rebase aborted due to changes in the source branch` | upstream moved during the rebase |
+
+## Differences from Dolt
+
+None intended. The 63-byte branch-name limit for interactive rebase
+(`current branch name exceeds the 63-byte persisted-state limit`) is a
+DoltLite storage limit.
+
+## See also
+
+[dolt_merge.md](dolt_merge.md), [dolt_cherry_pick.md](dolt_cherry_pick.md),
+`test/vc_oracle_rebase_test.sh`.

--- a/doc/doltlite/dolt_rebase.md
+++ b/doc/doltlite/dolt_rebase.md
@@ -37,9 +37,9 @@ connection sits on a working branch named `dolt_rebase_<branch>`.
 
 ## Behaviour
 
-The rebase is atomic: a conflict or error restores the original branch and
-reports `conflict rebasing "<message>"; rebase aborted, branch restored to
-pre-rebase state`. The working set must be clean to start.
+Replay failures restore the original branch and report that the rebase was
+aborted. Plan-validation errors leave an interactive rebase open so the plan
+can be fixed and `--continue` retried. The working set must be clean to start.
 
 | Error | Cause |
 |---|---|
@@ -48,7 +48,7 @@ pre-rebase state`. The working set must be clean to start.
 | `rebase already in progress; use --continue or --abort` | second `-i` |
 | `no rebase in progress` | `--continue`/`--abort` with no plan |
 | `first non-drop action must be pick or reword` | invalid plan |
-| `rebase aborted due to changes in the source branch` | upstream moved during the rebase |
+| `rebase aborted due to changes in branch <name>` | the original/current branch moved during the rebase |
 
 ## Differences from Dolt
 

--- a/doc/doltlite/dolt_rebase.md
+++ b/doc/doltlite/dolt_rebase.md
@@ -48,7 +48,8 @@ can be fixed and `--continue` retried. The working set must be clean to start.
 | `rebase already in progress; use --continue or --abort` | second `-i` |
 | `no rebase in progress` | `--continue`/`--abort` with no plan |
 | `first non-drop action must be pick or reword` | invalid plan |
-| `rebase aborted due to changes in branch <name>` | the original/current branch moved during the rebase |
+| `rebase aborted due to changes in branch <name>` | the current branch moved during the rebase |
+| `rebase aborted due to changes in the source branch` | the upstream moved during the rebase |
 
 ## Differences from Dolt
 

--- a/doc/doltlite/dolt_remote.md
+++ b/doc/doltlite/dolt_remote.md
@@ -1,0 +1,78 @@
+# Remotes: dolt_remote, dolt_push, dolt_fetch, dolt_pull, dolt_clone
+
+Sync commits and refs between databases over the filesystem or HTTP. Dolt:
+[dolt_remote](https://docs.dolthub.com/sql-reference/version-control/dolt-sql-procedures#dolt_remote),
+[dolt_push](https://docs.dolthub.com/sql-reference/version-control/dolt-sql-procedures#dolt_push),
+[dolt_clone](https://docs.dolthub.com/sql-reference/version-control/dolt-sql-procedures#dolt_clone).
+
+## Synopsis
+
+```sql
+SELECT dolt_remote('add', 'origin', 'file:///data/remote.db');
+SELECT dolt_remote('add', 'origin', 'http://host:8080/mydb.db');
+SELECT dolt_remote('remove', 'origin');
+SELECT dolt_push('origin', 'main');
+SELECT dolt_push('origin', 'main', '--force');
+SELECT dolt_push('origin', 'v1.0');              -- one tag
+SELECT dolt_push('origin', '--tags');
+SELECT dolt_fetch('origin');                     -- all branches
+SELECT dolt_fetch('origin', 'main');
+SELECT dolt_pull('origin', 'main');
+SELECT dolt_clone('http://host:8080/mydb.db');   -- into an empty database
+SELECT dolt_clone('--lazy', '--revision', 'v1.0', 'file:///data/src.db');
+SELECT * FROM dolt_remotes;
+SELECT * FROM dolt_remote_branches;
+```
+
+## Functions
+
+| Function | Arguments | Notes |
+|---|---|---|
+| `dolt_remote` | `'add', name, url` or `'remove', name` | `file://` or `http(s)://...` URL naming the database file |
+| `dolt_push` | `remote, branch [, '--force']` or `remote, tag` or `remote, '--tags'` | Non-fast-forward is refused without `--force` |
+| `dolt_fetch` | `remote [, branch]` | Updates `remotes/<remote>/<branch>` tracking refs and tags |
+| `dolt_pull` | `remote, branch` | Fetch, then fast-forward or three-way merge into the current branch |
+| `dolt_clone` | `['--lazy'] ['--revision', rev] url` | Only into an empty database; records `origin` |
+
+All return `0` on success. `dolt_pull` behaves like [dolt_merge](dolt_merge.md)
+when it cannot fast-forward, conflicts included.
+
+| Error | Cause |
+|---|---|
+| `usage: dolt_remote(action, name [, url])`, `url required for add`, `remote already exists`, `unknown action: use 'add' or 'remove'` | `dolt_remote` arguments |
+| `remote not found` | unknown remote name |
+| `push failed: branch or tag not found` | local ref does not exist |
+| `not a fast-forward of the remote branch (use force to overwrite)` | remote moved; add `--force` |
+| `fetch failed: branch not found on remote` | `dolt_fetch`/`dolt_pull` of a missing branch |
+| `database is not empty — clone into a fresh database` | `dolt_clone` into a database with tables or commits |
+| `clone failed` | source unreachable or not a DoltLite database |
+| `DoltLite remotes are disabled in this build` | built with `DOLTLITE_ENABLE_REMOTES=0` |
+
+## Behaviour
+
+- Remotes carry commits, tags, and branch refs. Working sets never travel:
+  cloned branches start clean, and a push is refused while the **target**
+  database's branch has uncommitted changes.
+- A lazy clone installs refs without copying chunks and fetches them on
+  demand from `origin`. Reopen it with `?lazy_origin=1` to keep that
+  behaviour in a new process; `--revision` picks the branch to check out, or a
+  read-only snapshot for a tag or commit. A divergent pull on a lazy clone is
+  refused until the store is fully materialized.
+- Fetch and pull install remote tags whose commits were fetched, replacing a
+  same-named local tag when the remote value differs.
+- Pushes to an HTTP remote are validated under the server's lock, so a stale
+  push is rejected rather than overwriting a peer's ref.
+
+## Tables
+
+| Table | Columns |
+|---|---|
+| `dolt_remotes` | `name`, `url`, `fetch_specs`, `params` |
+| `dolt_remote_branches` | `name` (`remotes/origin/main`), `hash`, `latest_committer`, `latest_committer_email`, `latest_commit_date`, `latest_commit_message` |
+
+## See also
+
+[remotes.md](remotes.md) for URL forms and lazy clones,
+[remotesrv.md](remotesrv.md) for serving, [dolt_creds.md](dolt_creds.md) for
+authentication, `test/vc_oracle_remotes_test.sh`,
+`test/vc_oracle_fetch_pull_convergence_test.sh`.

--- a/doc/doltlite/dolt_reset.md
+++ b/doc/doltlite/dolt_reset.md
@@ -9,7 +9,8 @@ Undo staging or working changes on the current branch. Dolt:
 ```sql
 SELECT dolt_reset();                    -- unstage everything
 SELECT dolt_reset('users');             -- unstage one table
-SELECT dolt_reset('--soft');            -- same as no arguments
+SELECT dolt_reset('--soft');            -- no-op; keep staged changes
+SELECT dolt_reset('--soft', 'HEAD~1');  -- move HEAD, keep staged and working
 SELECT dolt_reset('--hard');            -- discard staged and working changes
 SELECT dolt_reset('--hard', 'HEAD~1');  -- also move the branch to a commit
 SELECT dolt_clean('--dry-run');
@@ -21,10 +22,12 @@ SELECT dolt_clean();
 
 | Form | Effect |
 |---|---|
-| no arguments, `--soft` | Unstage all tables; working changes stay |
+| no arguments | Unstage all tables; working changes stay |
 | `table`, ... | Unstage those tables |
+| `--soft` | Make no changes |
+| `--soft`, `rev` | Move the branch to a commit; staged and working changes stay |
 | `--hard` | Working set and staging back to `HEAD` |
-| `--hard`, `rev` | Move the branch to `rev` (any [revision](refs.md)), then reset hard |
+| `--hard`, `rev` | Move the branch to one commit [revision](refs.md), then reset hard |
 
 Returns `0`. `--hard` is not undone by `ROLLBACK`; see
 [transactions.md](transactions.md).

--- a/doc/doltlite/dolt_reset.md
+++ b/doc/doltlite/dolt_reset.md
@@ -1,0 +1,58 @@
+# dolt_reset and dolt_clean
+
+Undo staging or working changes on the current branch. Dolt:
+[dolt_reset](https://docs.dolthub.com/sql-reference/version-control/dolt-sql-procedures#dolt_reset),
+[dolt_clean](https://docs.dolthub.com/sql-reference/version-control/dolt-sql-procedures#dolt_clean).
+
+## Synopsis
+
+```sql
+SELECT dolt_reset();                    -- unstage everything
+SELECT dolt_reset('users');             -- unstage one table
+SELECT dolt_reset('--soft');            -- same as no arguments
+SELECT dolt_reset('--hard');            -- discard staged and working changes
+SELECT dolt_reset('--hard', 'HEAD~1');  -- also move the branch to a commit
+SELECT dolt_clean('--dry-run');
+SELECT dolt_clean('tmp_table');
+SELECT dolt_clean();
+```
+
+## dolt_reset
+
+| Form | Effect |
+|---|---|
+| no arguments, `--soft` | Unstage all tables; working changes stay |
+| `table`, ... | Unstage those tables |
+| `--hard` | Working set and staging back to `HEAD` |
+| `--hard`, `rev` | Move the branch to `rev` (any [revision](refs.md)), then reset hard |
+
+Returns `0`. `--hard` is not undone by `ROLLBACK`; see
+[transactions.md](transactions.md).
+
+| Error | Cause |
+|---|---|
+| `--hard and --soft are mutually exclusive options.` | both flags |
+| `commit not found` | `rev` does not resolve |
+| `table paths cannot be combined with --hard / --soft or a target ref` | mixing forms |
+| `reset conflict: another connection moved this branch. Please retry your transaction.` | peer advanced the branch during the reset |
+
+## dolt_clean
+
+Drops untracked tables: those with status `new table` that have never been
+committed.
+
+| Argument | Meaning |
+|---|---|
+| none | Drop every untracked table |
+| `table`, ... | Drop only those; an unknown name errors with `failed to clean; table not found: '<name>'` |
+| `--dry-run` | Do nothing and return `0`; use `dolt_status` to see what would go |
+
+## Differences from Dolt
+
+`dolt_reset('--hard')` inside `BEGIN` takes effect immediately rather than
+with the transaction.
+
+## See also
+
+[dolt_commit.md](dolt_commit.md), [dolt_workspace.md](dolt_workspace.md),
+`test/vc_oracle_reset_test.sh`, `test/vc_oracle_clean_test.sh`.

--- a/doc/doltlite/dolt_schemas.md
+++ b/doc/doltlite/dolt_schemas.md
@@ -1,0 +1,49 @@
+# dolt_schemas and the versioned catalog
+
+Views and triggers are part of the branch, and `sqlite_schema` is a
+projection of the versioned catalog. Dolt:
+[dolt_schemas](https://docs.dolthub.com/sql-reference/version-control/dolt-system-tables#dolt_schemas).
+
+## Synopsis
+
+```sql
+CREATE VIEW active_users AS SELECT * FROM users WHERE active = 1;
+CREATE TRIGGER audit AFTER UPDATE ON users BEGIN INSERT INTO log VALUES (new.id); END;
+SELECT dolt_commit('-Am', 'view and trigger');
+SELECT type, name, fragment FROM dolt_schemas;
+SELECT * FROM dolt_schema_diff('v1.0', 'HEAD');
+```
+
+## dolt_schemas
+
+| Column | Meaning |
+|---|---|
+| `type` | `view` or `trigger` |
+| `name` | object name |
+| `fragment` | the `CREATE` statement |
+| `extra`, `sql_mode` | present for Dolt shape compatibility; empty |
+
+Tables and indexes are not listed here; `sqlite_schema` has everything.
+
+## Behaviour
+
+- Schema objects switch with `dolt_checkout`, diff with
+  `dolt_schema_diff` and `dolt_patch`, and merge. Two branches adding
+  different views merge cleanly; the same name with different text is a
+  schema conflict.
+- After a schema commit, `sqlite_schema.sql` holds the canonical `CREATE`
+  text (normalized whitespace and quoting) in catalog order, not what you
+  typed. `.schema` and `.dump` print that text. `CHECK` constraint error
+  messages use the canonical form.
+- `sqlite_schema` cannot be written, even under `PRAGMA writable_schema`.
+- `ANALYZE` output in `sqlite_stat1` is an ordinary versioned table.
+
+## Differences from Dolt
+
+`dolt_schemas` covers views and triggers only; Dolt also stores events and
+procedures, which SQLite lacks.
+
+## See also
+
+[dolt_diff.md](dolt_diff.md), [sqlite-compatibility.md](sqlite-compatibility.md),
+`test/vc_oracle_schemas_test.sh`, `test/vc_oracle_triggers_test.sh`.

--- a/doc/doltlite/dolt_tag.md
+++ b/doc/doltlite/dolt_tag.md
@@ -8,7 +8,7 @@ Named, immutable pointers to commits. Dolt:
 
 ```sql
 SELECT dolt_tag('v1.0');                                   -- HEAD
-SELECT dolt_tag('v1.0', 'HEAD~2');                          -- any revision
+SELECT dolt_tag('v1.0', 'HEAD~2');                          -- commit revision
 SELECT dolt_tag('v1.0', 'main', '-m', 'release', '--author', 'Ann <ann@example.com>');
 SELECT dolt_tag('-d', 'v1.0');
 SELECT * FROM dolt_tags;
@@ -18,7 +18,7 @@ SELECT * FROM dolt_tags;
 
 | Option | Meaning |
 |---|---|
-| `name [, rev]` | Create `name` at `rev` (default `HEAD`) |
+| `name [, rev]` | Create `name` at a commit revision (default `HEAD`) |
 | `-m`, `--message` | Tag message |
 | `--author 'Name <email>'` | Tagger; default is the connection's `dolt_config` identity |
 | `-d`, `--delete name` | Delete |

--- a/doc/doltlite/dolt_tag.md
+++ b/doc/doltlite/dolt_tag.md
@@ -1,0 +1,44 @@
+# dolt_tag and dolt_tags
+
+Named, immutable pointers to commits. Dolt:
+[dolt_tag](https://docs.dolthub.com/sql-reference/version-control/dolt-sql-procedures#dolt_tag),
+[dolt_tags](https://docs.dolthub.com/sql-reference/version-control/dolt-system-tables#dolt_tags).
+
+## Synopsis
+
+```sql
+SELECT dolt_tag('v1.0');                                   -- HEAD
+SELECT dolt_tag('v1.0', 'HEAD~2');                          -- any revision
+SELECT dolt_tag('v1.0', 'main', '-m', 'release', '--author', 'Ann <ann@example.com>');
+SELECT dolt_tag('-d', 'v1.0');
+SELECT * FROM dolt_tags;
+```
+
+## Options
+
+| Option | Meaning |
+|---|---|
+| `name [, rev]` | Create `name` at `rev` (default `HEAD`) |
+| `-m`, `--message` | Tag message |
+| `--author 'Name <email>'` | Tagger; default is the connection's `dolt_config` identity |
+| `-d`, `--delete name` | Delete |
+
+Returns `0`. Tags are durable immediately, even inside `BEGIN`, and are pushed
+with `dolt_push(remote, tag)` or `dolt_push(remote, '--tags')`. Name rules are
+in [refs.md](refs.md).
+
+| Error | Cause |
+|---|---|
+| `tag name required` | no arguments |
+| `tag already exists` | duplicate name; delete first |
+| `tag not found` | `-d` of an unknown tag |
+| `invalid tag name` | name rule violation |
+
+## dolt_tags
+
+`tag_name`, `tag_hash`, `tagger`, `email`, `date`, `message`.
+
+## See also
+
+[dolt_branch.md](dolt_branch.md), [dolt_remote.md](dolt_remote.md),
+`test/vc_oracle_tags_test.sh`, `test/vc_oracle_remote_tags_test.sh`.

--- a/doc/doltlite/dolt_version.md
+++ b/doc/doltlite/dolt_version.md
@@ -1,0 +1,22 @@
+# dolt_version and doltlite_engine
+
+```sql
+SELECT dolt_version();      -- v0.50.7
+SELECT doltlite_engine();   -- prolly
+SELECT sqlite_version();    -- 3.54.0
+```
+
+| Function | Returns |
+|---|---|
+| `dolt_version()` | The DoltLite release, from `git describe` at build time. No arguments. |
+| `doltlite_engine()` | `prolly` on a DoltLite-format main database, `orig` when the main database is a stock SQLite file |
+| `sqlite_version()` | The bundled SQLite version, unchanged |
+
+`doltlite_engine()` is the test to run before calling any `dolt_*` function:
+on a stock file they fail with `dolt version-control features are not
+available on stock SQLite databases`. The shell's `-version` prints all of
+this on one line.
+
+## See also
+
+[cli.md](cli.md), [sqlite-files.md](sqlite-files.md).

--- a/doc/doltlite/dolt_version.md
+++ b/doc/doltlite/dolt_version.md
@@ -1,7 +1,7 @@
 # dolt_version and doltlite_engine
 
 ```sql
-SELECT dolt_version();      -- v0.50.7
+SELECT dolt_version();      -- build version from git describe
 SELECT doltlite_engine();   -- prolly
 SELECT sqlite_version();    -- 3.54.0
 ```
@@ -12,10 +12,10 @@ SELECT sqlite_version();    -- 3.54.0
 | `doltlite_engine()` | `prolly` on a DoltLite-format main database, `orig` when the main database is a stock SQLite file |
 | `sqlite_version()` | The bundled SQLite version, unchanged |
 
-`doltlite_engine()` is the test to run before calling any `dolt_*` function:
-on a stock file they fail with `dolt version-control features are not
-available on stock SQLite databases`. The shell's `-version` prints all of
-this on one line.
+Use `doltlite_engine()` before storage-backed `dolt_*` operations. On a stock
+file they fail with `dolt version-control features are not available on stock
+SQLite databases`; `dolt_version()` remains available. Shell `-version` prints
+the DoltLite version, SQLite version, and process bitness, but not the engine.
 
 ## See also
 

--- a/doc/doltlite/dolt_workspace.md
+++ b/doc/doltlite/dolt_workspace.md
@@ -1,0 +1,41 @@
+# dolt_workspace_<table>
+
+Row-level view of a table's uncommitted changes, with a `staged` switch per
+row. Dolt: [dolt_workspace_<table>](https://docs.dolthub.com/sql-reference/version-control/dolt-system-tables#dolt_workspace_tablename).
+
+## Synopsis
+
+```sql
+SELECT id, staged, diff_type, to_id, to_rating, from_rating
+  FROM dolt_workspace_ratings;
+
+UPDATE dolt_workspace_ratings SET staged = 1 WHERE to_confidence > from_confidence;
+UPDATE dolt_workspace_ratings SET staged = 0 WHERE id = 3;
+DELETE FROM dolt_workspace_ratings WHERE staged = 0;   -- discard unstaged edits
+SELECT dolt_commit('-m', 'accept the good ones');
+```
+
+## Columns
+
+| Column | Meaning |
+|---|---|
+| `id` | Row ordinal within the workspace, starting at 1. Not the table's key. |
+| `staged` | `1` if this row change is staged |
+| `diff_type` | `added`, `modified`, `removed` |
+| `to_<col>...` | Working or staged values; NULL for `removed` |
+| `from_<col>...` | `HEAD` values; NULL for `added` |
+
+## Behaviour
+
+- `UPDATE ... SET staged = 1 | 0` stages or unstages individual row changes.
+  `dolt_add` stages the whole table; this is the finer tool.
+- `DELETE` discards unstaged row changes, returning those rows to `HEAD`.
+  Staged rows must be unstaged first: `cannot delete staged rows from
+  workspace`.
+- Writes to any other column are ignored. Edit the table itself.
+- Works for tables with any primary key shape, including none.
+
+## See also
+
+[dolt_commit.md](dolt_commit.md), [dolt_diff.md](dolt_diff.md),
+`test/vc_oracle_workspace_test.sh`.

--- a/doc/doltlite/refs.md
+++ b/doc/doltlite/refs.md
@@ -42,7 +42,7 @@ Both sides are required and a range may hold one operator, so `..main` and
 | `dolt_schema_diff`, `dolt_patch` | `(from, to)` or `(range)` |
 | `dolt_diff_stat`, `dolt_diff_summary` | `(from, to)` only |
 | `dolt_history_<table>(rev)`, `dolt_at_<table>(rev)` | one revision |
-| `dolt_branch(name, rev)`, `dolt_checkout('-b', name, rev)`, `dolt_tag(name, rev)`, `dolt_reset('--hard', rev)` | one revision as start point |
+| `dolt_branch(name, rev)`, `dolt_checkout('-b', name, rev)`, `dolt_tag(name, rev)`, `dolt_reset('--hard' \| '--soft', rev)` | one commit revision as start point |
 
 `dolt_checkout(tag)` and `dolt_checkout(hash)` are refused, as in Dolt: the
 error suggests `dolt_checkout(rev, '-b', name)`. To read a commit without a


### PR DESCRIPTION
Phase 3 of the doc plan in one PR: eighteen pages under `doc/doltlite/`, one per feature, named after the anchor SQL symbol (`dolt_merge.md` covers merge, merge_status, merge_base, conflicts, conflict tables, conflicts_resolve). The index maps every `dolt_*` symbol to its page.

Each page follows the same skeleton: purpose with the Dolt link, synopsis, options table, returns, error text, transaction/concurrency behaviour, divergences from Dolt, see-also with the pinning oracle suite.

Sources: the `DoltliteCmdOption` tables in `src/doltlite_*.c` for every flag (so `--skip-empty`, `--date`, `-D`, `-c`, `--no-commit`, `dolt_add -f`, `dolt_clean --dry-run` and the previously undocumented `dolt_default_branch`, `dolt_connect_branch`, `dolt_schema_conflicts`, `dolt_commit_ancestors`, `dolt_remote_branches`, `dolt_hashof_catalog` are covered); `pragma_table_info` on a live database for every column list; and seven probe sessions against `build/doltlite` for behaviours and the exact error strings quoted.

Docs only, so the build jobs skip. The doc link checker passes on the tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)