### PR TITLE
Scope historical schema discovery to literal refs

### DIFF
--- a/src/build.c
+++ b/src/build.c
@@ -503,6 +503,10 @@ Table *sqlite3LocateTableItem(
   SrcItem *p
 ){
   const char *zDb;
+#if defined(DOLTLITE_PROLLY) && !defined(SQLITE_OMIT_VIRTUALTABLE)
+  ExprList *pSavedHistoricalArgs;
+  Table *pTab;
+#endif
   if( p->fg.fixedSchema ){
     int iDb = sqlite3SchemaToIndex(pParse->db, p->u4.pSchema);
     assert( iDb>=0 && iDb<pParse->db->nDb );
@@ -511,7 +515,16 @@ Table *sqlite3LocateTableItem(
     assert( !p->fg.isSubquery );
     zDb = p->u4.zDatabase;
   }
+#if defined(DOLTLITE_PROLLY) && !defined(SQLITE_OMIT_VIRTUALTABLE)
+  pSavedHistoricalArgs = pParse->db->pDoltliteHistoricalArgs;
+  pParse->db->pDoltliteHistoricalArgs =
+      p->fg.isTabFunc ? p->u1.pFuncArg : 0;
+  pTab = sqlite3LocateTable(pParse, flags, p->zName, zDb);
+  pParse->db->pDoltliteHistoricalArgs = pSavedHistoricalArgs;
+  return pTab;
+#else
   return sqlite3LocateTable(pParse, flags, p->zName, zDb);
+#endif
 }
 
 /*

--- a/src/doltlite_at.c
+++ b/src/doltlite_at.c
@@ -3,6 +3,7 @@
 
 #include "doltlite_vtab_util.h"
 #include "doltlite_commit.h"
+#include "doltlite_ancestor.h"
 #include "doltlite_internal.h"
 
 #include <string.h>
@@ -201,17 +202,197 @@ int doltliteSideColsLoad(
   return SQLITE_OK;
 }
 
+static const char *atHistoricalLiteralArg(sqlite3 *db, int iArg){
+  ExprList *pArgs = db->pDoltliteHistoricalArgs;
+  Expr *pExpr;
+  if( !pArgs || iArg<0 || iArg>=pArgs->nExpr ) return 0;
+  pExpr = pArgs->a[iArg].pExpr;
+  return pExpr && pExpr->op==TK_STRING ? pExpr->u.zToken : 0;
+}
+
+static int atResolveSchemaRef(
+  sqlite3 *db,
+  const char *zRef,
+  int branchEffective,
+  int allowWorkspace,
+  ProllyHash *pCommit,
+  ProllyHash *pCatalog
+){
+  ChunkStore *cs = doltliteGetChunkStore(db);
+  DoltliteCommit commit;
+  int rc;
+
+  memset(&commit, 0, sizeof(commit));
+  memset(pCommit, 0, sizeof(*pCommit));
+  memset(pCatalog, 0, sizeof(*pCatalog));
+  if( allowWorkspace
+   && (doltliteRefIsWorking(zRef) || doltliteRefIsStaged(zRef)) ){
+    rc = doltliteResolveCatalogHashForRef(db, zRef, pCatalog);
+    if( rc==SQLITE_OK ) doltliteGetSessionHead(db, pCommit);
+    return rc;
+  }
+
+  rc = doltliteResolveRef(db, zRef, pCommit);
+  if( rc==SQLITE_OK ) rc = doltliteLoadCommit(db, pCommit, &commit);
+  if( rc==SQLITE_OK ) *pCatalog = commit.catalogHash;
+  doltliteCommitClear(&commit);
+  if( rc==SQLITE_OK && branchEffective && cs ){
+    ProllyHash branchCommit;
+    if( chunkStoreFindBranch(cs, zRef, &branchCommit)==SQLITE_OK
+     && !prollyHashIsEmpty(&branchCommit) ){
+      ProllyHash effective;
+      rc = doltliteResolveBranchEffectiveCatalog(
+          cs, zRef, &branchCommit, pCatalog, &effective);
+      if( rc==SQLITE_OK ) *pCatalog = effective;
+    }
+  }
+  return rc;
+}
+
+static int atResolveLiteralScope(
+  sqlite3 *db,
+  const char *zModule,
+  ProllyHash *aCommit,
+  ProllyHash *aCatalog,
+  int *pnRef,
+  int *pScoped,
+  char **pzErr
+){
+  ChunkStore *cs = doltliteGetChunkStore(db);
+  ExprList *pArgs = db->pDoltliteHistoricalArgs;
+  const char *azRef[2] = {0, 0};
+  char *zLeft = 0;
+  char *zRight = 0;
+  int branchEffective = 0;
+  int allowWorkspace = 0;
+  int nRef = 0;
+  int rangeType = DOLTLITE_RANGE_NONE;
+  int primary;
+  int i;
+  int rc = SQLITE_OK;
+
+  *pnRef = 0;
+  *pScoped = 0;
+  if( !pArgs || !zModule ) return SQLITE_OK;
+  if( sqlite3_strnicmp(zModule, "dolt_at_", 8)==0 ){
+    if( pArgs->nExpr!=1 ) return SQLITE_OK;
+    azRef[0] = atHistoricalLiteralArg(db, 0);
+    branchEffective = 1;
+    allowWorkspace = 1;
+    nRef = azRef[0] ? 1 : 0;
+  }else if( sqlite3_strnicmp(zModule, "dolt_history_", 13)==0 ){
+    if( pArgs->nExpr!=1 ) return SQLITE_OK;
+    azRef[0] = atHistoricalLiteralArg(db, 0);
+    nRef = azRef[0] ? 1 : 0;
+  }else if( sqlite3_strnicmp(zModule, "dolt_diff_", 10)==0 ){
+    allowWorkspace = 1;
+    if( pArgs->nExpr==2 ){
+      azRef[0] = atHistoricalLiteralArg(db, 1);
+      azRef[1] = atHistoricalLiteralArg(db, 0);
+      nRef = azRef[0] && azRef[1] ? 2 : 0;
+    }else if( pArgs->nExpr==1 ){
+      const char *zSpec = atHistoricalLiteralArg(db, 0);
+      if( zSpec ){
+        rc = doltliteSplitRevisionRange(
+            zSpec, &zLeft, &zRight, &rangeType);
+        if( rc==SQLITE_OK ){
+          azRef[0] = zRight;
+          azRef[1] = zLeft;
+          nRef = 2;
+        }else if( rc==SQLITE_NOMEM ){
+          goto done;
+        }else{
+          rc = SQLITE_OK;
+        }
+      }
+    }
+  }
+  if( nRef==0 ) goto done;
+
+  for(i=0; i<nRef; i++){
+    rc = atResolveSchemaRef(db, azRef[i], branchEffective, allowWorkspace,
+                            &aCommit[i], &aCatalog[i]);
+    if( rc!=SQLITE_OK ) goto resolve_failed;
+  }
+  if( rangeType==DOLTLITE_RANGE_THREE_DOT ){
+    DoltliteCommit ancestorCommit;
+    ProllyHash ancestor;
+    memset(&ancestorCommit, 0, sizeof(ancestorCommit));
+    rc = doltliteFindAncestor(db, &aCommit[1], &aCommit[0], &ancestor);
+    if( rc==SQLITE_OK ){
+      rc = doltliteLoadCommit(db, &ancestor, &ancestorCommit);
+    }
+    if( rc==SQLITE_OK ){
+      aCommit[1] = ancestor;
+      aCatalog[1] = ancestorCommit.catalogHash;
+    }
+    doltliteCommitClear(&ancestorCommit);
+    if( rc!=SQLITE_OK ) goto resolve_failed;
+  }
+  *pnRef = nRef;
+  *pScoped = 1;
+  goto done;
+
+resolve_failed:
+  primary = rc & 0xff;
+  if( atTakeChunkSourceError(cs, pzErr, &rc) ) goto done;
+  if( primary==SQLITE_ERROR || primary==SQLITE_NOTFOUND ) rc = SQLITE_OK;
+
+done:
+  sqlite3_free(zLeft);
+  sqlite3_free(zRight);
+  return rc;
+}
+
+static int atLoadSchemaColumns(
+  sqlite3 *db,
+  ChunkStore *cs,
+  ProllyCache *pCache,
+  const ProllyHash *pCatalog,
+  const char *zTableName,
+  DoltliteColInfo *pCols
+){
+  SchemaEntry entry;
+  int found = 0;
+  sqlite3 *tmp = 0;
+  int rc;
+
+  memset(&entry, 0, sizeof(entry));
+  if( prollyHashIsEmpty(pCatalog) ) return SQLITE_OK;
+  rc = loadSchemaEntryFromCatalog(db, cs, pCache, pCatalog,
+                                  zTableName, &entry, &found);
+  if( rc==SQLITE_OK && found && entry.zSql ){
+    rc = sqlite3_open(":memory:", &tmp);
+    if( rc==SQLITE_OK ) rc = sqlite3_exec(tmp, entry.zSql, 0, 0, 0);
+    if( rc==SQLITE_OK ) rc = doltliteGetColumnNames(tmp, zTableName, pCols);
+    if( rc==SQLITE_OK && pCols->nCol<=0 ){
+      doltliteFreeColInfo(pCols);
+      rc = SQLITE_NOTFOUND;
+    }
+  }
+  if( tmp ) sqlite3_close(tmp);
+  clearSchemaEntry(&entry);
+  return rc;
+}
+
 int doltliteLoadHistoricalTableColumns(
   sqlite3 *db,
+  const char *zModule,
   const char *zTableName,
   DoltliteColInfo *pCols,
   char **pzErr
 ){
   ChunkStore *cs = doltliteGetChunkStore(db);
   ProllyCache *pCache = doltliteGetCache(db);
-  int has, rc;
+  ProllyHash aCommit[2];
+  ProllyHash aCatalog[2];
   DoltliteCommitQueue q;
   ProllyHash cur;
+  int nRef = 0;
+  int scoped = 0;
+  int has;
+  int i;
+  int rc;
 
   memset(pCols, 0, sizeof(*pCols));
   pCols->iPkCol = -1;
@@ -222,36 +403,42 @@ int doltliteLoadHistoricalTableColumns(
     doltliteFreeColInfo(pCols);
   }
 
+  memset(aCommit, 0, sizeof(aCommit));
+  memset(aCatalog, 0, sizeof(aCatalog));
+  rc = atResolveLiteralScope(db, zModule, aCommit, aCatalog,
+                             &nRef, &scoped, pzErr);
+  for(i=0; rc==SQLITE_OK && i<nRef && pCols->nCol<=0; i++){
+    rc = atLoadSchemaColumns(
+        db, cs, pCache, &aCatalog[i], zTableName, pCols);
+    if( rc==SQLITE_NOTFOUND ){
+      if( !atTakeChunkSourceError(cs, pzErr, &rc) ) rc = SQLITE_OK;
+    }else if( rc!=SQLITE_OK ){
+      atTakeChunkSourceError(cs, pzErr, &rc);
+    }
+  }
+  if( rc!=SQLITE_OK || pCols->nCol>0 ) return rc;
+
   memset(&q, 0, sizeof(q));
   memset(&cur, 0, sizeof(cur));
   rc = doltliteCommitQueueInit(&q, &cur);
-  if( rc==SQLITE_OK ) rc = atEnqueueReachableRoots(db, &q);
+  if( scoped ){
+    for(i=0; i<nRef && rc==SQLITE_OK; i++){
+      rc = doltliteCommitQueueEnqueue(&q, &aCommit[i]);
+    }
+  }else if( rc==SQLITE_OK ){
+    rc = atEnqueueReachableRoots(db, &q);
+  }
   while( rc==SQLITE_OK && pCols->nCol<=0 ){
     DoltliteCommit commit;
-    SchemaEntry entry;
-    int found = 0;
-    sqlite3 *tmp = 0;
     memset(&commit, 0, sizeof(commit));
-    memset(&entry, 0, sizeof(entry));
     rc = doltliteCommitQueueNext(&q, &cur, &has);
     if( rc!=SQLITE_OK || !has ) break;
     rc = doltliteLoadCommit(db, &cur, &commit);
     if( rc==SQLITE_OK ) rc = doltliteCommitQueueEnqueueParents(&q, &commit);
     if( rc==SQLITE_OK ){
-      rc = loadSchemaEntryFromCatalog(db, cs, pCache, &commit.catalogHash,
-                                      zTableName, &entry, &found);
+      rc = atLoadSchemaColumns(
+          db, cs, pCache, &commit.catalogHash, zTableName, pCols);
     }
-    if( rc==SQLITE_OK && found && entry.zSql ){
-      rc = sqlite3_open(":memory:", &tmp);
-      if( rc==SQLITE_OK ) rc = sqlite3_exec(tmp, entry.zSql, 0, 0, 0);
-      if( rc==SQLITE_OK ) rc = doltliteGetColumnNames(tmp, zTableName, pCols);
-      if( rc==SQLITE_OK && pCols->nCol<=0 ){
-        doltliteFreeColInfo(pCols);
-        rc = SQLITE_NOTFOUND;
-      }
-    }
-    if( tmp ) sqlite3_close(tmp);
-    clearSchemaEntry(&entry);
     doltliteCommitClear(&commit);
     if( rc==SQLITE_NOTFOUND ){
       if( !atTakeChunkSourceError(cs, pzErr, &rc) ) rc = SQLITE_OK;
@@ -261,9 +448,7 @@ int doltliteLoadHistoricalTableColumns(
   }
   doltliteCommitQueueClear(&q);
 
-  if( rc==SQLITE_OK && pCols->nCol<=0 ){
-    return SQLITE_NOTFOUND;
-  }
+  if( rc==SQLITE_OK && pCols->nCol<=0 ) return SQLITE_NOTFOUND;
   return rc;
 }
 

--- a/src/doltlite_vtab_util.h
+++ b/src/doltlite_vtab_util.h
@@ -119,7 +119,7 @@ static SQLITE_INLINE int doltliteVtabCommonRowid(
 }
 
 /* Allocates nByte (>= sizeof(DoltliteVtabCommon)); caller fills trailing fields. */
-int doltliteLoadHistoricalTableColumns(sqlite3*, const char*,
+int doltliteLoadHistoricalTableColumns(sqlite3*, const char*, const char*,
                                        DoltliteColInfo*, char**);
 
 static SQLITE_INLINE int doltliteVtabConnectTable(
@@ -153,7 +153,7 @@ static SQLITE_INLINE int doltliteVtabConnectTable(
   }
 
   if( historical ){
-    rc = doltliteLoadHistoricalTableColumns(db, v->zTableName,
+    rc = doltliteLoadHistoricalTableColumns(db, zMod, v->zTableName,
                                              &v->cols, pzErr);
     if( rc==SQLITE_NOTFOUND && (!pzErr || !*pzErr) ){
       if( pzErr ) *pzErr = sqlite3_mprintf("no such table: %s", zMod);

--- a/src/sqliteInt.h
+++ b/src/sqliteInt.h
@@ -1814,6 +1814,9 @@ struct sqlite3 {
   VtabCtx *pVtabCtx;            /* Context for active vtab connect/create */
   VTable **aVTrans;             /* Virtual tables with open transactions */
   VTable *pDisconnect;          /* Disconnect these in next sqlite3_prepare() */
+#ifdef DOLTLITE_PROLLY
+  ExprList *pDoltliteHistoricalArgs;
+#endif
 #endif
   Hash aFunc;                   /* Hash table of connection functions */
   Hash aCollSeq;                /* All collating sequences */

--- a/test/chunk_source_test.c
+++ b/test/chunk_source_test.c
@@ -2404,9 +2404,11 @@ static void testDeferredRegistrationScope(const char *zPrefix){
   sqlite3 *lazyDb = 0;
   SourceCtx source;
   doltlite_chunk_source api;
+  ProllyHash noiseHash;
   unsigned char *pRefs = 0;
   int nRefs = 0;
   sqlite3_int64 nRow = 0;
+  char *zNoiseHash = 0;
   char zSource[192];
   char zLazy[192];
   char zSql[192];
@@ -2415,6 +2417,7 @@ static void testDeferredRegistrationScope(const char *zPrefix){
   int i;
 
   memset(&source, 0, sizeof(source));
+  memset(&noiseHash, 0, sizeof(noiseHash));
   snprintf(zSource, sizeof(zSource), "%s_registration_source.db", zPrefix);
   snprintf(zLazy, sizeof(zLazy), "%s_registration_lazy.db", zPrefix);
   removeStore(zSource);
@@ -2424,6 +2427,11 @@ static void testDeferredRegistrationScope(const char *zPrefix){
       "CREATE TABLE main_only(id INTEGER PRIMARY KEY, v INTEGER);"
       "INSERT INTO main_only VALUES(1,1);"
       "SELECT dolt_commit('-A','-m','main');"
+      "SELECT dolt_checkout('-b','noise');"
+      "CREATE TABLE noise_only(id INTEGER PRIMARY KEY, v INTEGER);"
+      "INSERT INTO noise_only VALUES(1,1);"
+      "SELECT dolt_commit('-A','-m','noise');"
+      "SELECT dolt_checkout('main');"
       "SELECT dolt_checkout('-b','deep');"
       "CREATE TABLE history_only(id INTEGER PRIMARY KEY, v INTEGER);"
       "INSERT INTO history_only VALUES(1,0);"
@@ -2435,6 +2443,10 @@ static void testDeferredRegistrationScope(const char *zPrefix){
       "SELECT dolt_commit('-am','deep %d')", i, i);
     rc = execSql(sourceDb, zSql);
   }
+  if( rc==SQLITE_OK ){
+    rc = queryText(sourceDb, "SELECT dolt_hashof('noise')", &zNoiseHash);
+  }
+  if( rc==SQLITE_OK ) rc = doltliteHexToHash(zNoiseHash, &noiseHash);
   if( rc==SQLITE_OK ) rc = execSql(sourceDb, "SELECT dolt_checkout('main')");
   check("build deep non-current registration history", rc==SQLITE_OK);
   if( rc!=SQLITE_OK ) goto registration_done;
@@ -2458,15 +2470,57 @@ static void testDeferredRegistrationScope(const char *zPrefix){
   rc = queryInt64(lazyDb, "SELECT 1", &nRow);
   check("trivial query does not fault non-current history",
         rc==SQLITE_OK && nRow==1 && source.nRequest<=nStartupRequest+1);
+
+  sourceResetCounters(&source);
+  source.mode = SOURCE_ONE_NOTFOUND;
+  memcpy(source.faultHash, noiseHash.data, PROLLY_HASH_SIZE);
+  rc = queryInt64(lazyDb,
+      "SELECT count(*) FROM dolt_at_history_only('deep')", &nRow);
+  check("literal dolt_at schema lookup stays on its ref",
+        rc==SQLITE_OK && nRow==1 && !source.faultIssued);
+
+  sourceResetCounters(&source);
+  memcpy(source.faultHash, noiseHash.data, PROLLY_HASH_SIZE);
+  rc = queryInt64(lazyDb,
+      "SELECT count(*) FROM dolt_diff_history_only('main','deep')", &nRow);
+  check("literal dolt_diff schema lookup stays on its refs",
+        rc==SQLITE_OK && nRow==1 && !source.faultIssued);
+
+  doltliteHistoricalModulesReset(lazyDb);
+  sourceResetCounters(&source);
+  memcpy(source.faultHash, noiseHash.data, PROLLY_HASH_SIZE);
+  rc = queryInt64(lazyDb,
+      "SELECT count(*) FROM dolt_diff_history_only('main..deep')", &nRow);
+  check("literal dolt_diff range schema lookup stays on its refs",
+        rc==SQLITE_OK && nRow==1 && !source.faultIssued);
+
+  doltliteHistoricalModulesReset(lazyDb);
+  sourceResetCounters(&source);
+  memcpy(source.faultHash, noiseHash.data, PROLLY_HASH_SIZE);
+  rc = queryInt64(lazyDb,
+      "SELECT count(*) FROM dolt_diff_history_only('main...deep')", &nRow);
+  check("literal dolt_diff merge-base schema lookup stays on its refs",
+        rc==SQLITE_OK && nRow==1 && !source.faultIssued);
+
+  sourceResetCounters(&source);
+  memcpy(source.faultHash, noiseHash.data, PROLLY_HASH_SIZE);
   rc = queryInt64(lazyDb,
       "SELECT count(*) FROM dolt_history_history_only('deep')", &nRow);
-  check("historical-only module registers on demand",
-        rc==SQLITE_OK && nRow==13 && source.nRequest>nStartupRequest);
+  check("literal dolt_history schema lookup stays on its ref",
+        rc==SQLITE_OK && nRow==13 && !source.faultIssued);
+
+  source.mode = SOURCE_NORMAL;
+  rc = queryInt64(lazyDb,
+      "WITH ref(v) AS (VALUES('noise')) "
+      "SELECT count(*) FROM ref, dolt_at_noise_only(ref.v)", &nRow);
+  check("expression historical lookup keeps reachable-ref fallback",
+        rc==SQLITE_OK && nRow==1);
 
 registration_done:
   if( lazyDb ) sqlite3_close(lazyDb);
   sourceClose(&source);
   if( sourceDb ) sqlite3_close(sourceDb);
+  sqlite3_free(zNoiseHash);
   sqlite3_free(pRefs);
   removeStore(zSource);
   removeStore(zLazy);

--- a/test/vc_perf_ceiling.sh
+++ b/test/vc_perf_ceiling.sh
@@ -21,6 +21,8 @@ RUNS=${VC_PERF_RUNS:-3}
 TABLES=${VC_PERF_TABLES:-800}
 ROWS_PER_TABLE=${VC_PERF_ROWS_PER_TABLE:-125}
 BRANCHES=${VC_PERF_BRANCHES:-300}
+HISTORY_BRANCHES=${VC_PERF_HISTORY_BRANCHES:-200}
+HISTORY_DEPTH=${VC_PERF_HISTORY_DEPTH:-200}
 CHECKOUT_TABLES=${VC_PERF_CHECKOUT_TABLES:-400}
 CHECKOUT_ROWS_PER_TABLE=${VC_PERF_CHECKOUT_ROWS_PER_TABLE:-250}
 MERGE_ROWS=${VC_PERF_MERGE_ROWS:-100000}
@@ -126,6 +128,34 @@ make_branch_db() {
   run_sql_file "$db" "$TMPDIR/branches.sql" "$bin"
 }
 
+make_history_db() {
+  local db="$1"
+  local bin="$2"
+  local sql="$TMPDIR/history.sql"
+  {
+    echo "CREATE TABLE anchor(id INTEGER PRIMARY KEY, v INTEGER);"
+    echo "INSERT INTO anchor VALUES(1,0);"
+    echo "SELECT dolt_commit('-A','-m','base');"
+    for ((i=1; i<=HISTORY_BRANCHES; i++)); do
+      printf -v branch "noise_%04d" "$i"
+      echo "SELECT dolt_checkout('-b','$branch');"
+      echo "UPDATE anchor SET v=$i;"
+      echo "SELECT dolt_commit('-am','noise $i');"
+      echo "SELECT dolt_checkout('main');"
+    done
+    echo "SELECT dolt_checkout('-b','zz_history');"
+    echo "CREATE TABLE history_only(id INTEGER PRIMARY KEY, v INTEGER);"
+    echo "INSERT INTO history_only VALUES(1,0);"
+    echo "SELECT dolt_commit('-A','-m','history 0');"
+    for ((i=1; i<=HISTORY_DEPTH; i++)); do
+      echo "UPDATE history_only SET v=$i;"
+      echo "SELECT dolt_commit('-am','history $i');"
+    done
+    echo "SELECT dolt_checkout('main');"
+  } > "$sql"
+  run_sql_file "$db" "$sql" "$bin"
+}
+
 make_merge_data_db() {
   local db="$1"
   local bin="$2"
@@ -195,6 +225,7 @@ prepare_fixtures() {
   run_sql_file "$dest/many_schema.db" "$TMPDIR/dirty_schema.sql" "$bin"
 
   make_branch_db "$dest/branches.db" "$bin"
+  make_history_db "$dest/history.db" "$bin"
 
   make_many_tables_db "$dest/checkout.db" "$CHECKOUT_TABLES" "$CHECKOUT_ROWS_PER_TABLE" "$bin"
   run_sql "$dest/checkout.db" "SELECT dolt_branch('feat');" "$bin"
@@ -390,6 +421,12 @@ bench_sql "branch_list_many_branches" "branches.db" \
   "SELECT count(*) FROM dolt_branches;" 35
 bench_sql "branch_create_delete" "branches.db" \
   "SELECT dolt_branch('tmp_perf'); SELECT dolt_branch('-D','tmp_perf');" 40
+bench_sql "at_literal_deep_history" "history.db" \
+  "SELECT count(*) FROM dolt_at_history_only('zz_history');" 100
+bench_sql "diff_literal_deep_history" "history.db" \
+  "SELECT count(*) FROM dolt_diff_history_only('main','zz_history');" 120
+bench_sql "history_literal_deep_history" "history.db" \
+  "SELECT count(*) FROM dolt_history_history_only('zz_history');" 150
 bench_sql "checkout_branch_clean" "checkout.db" \
   "SELECT dolt_checkout('feat'); SELECT dolt_checkout('main');" 150
 bench_sql "merge_data_no_conflicts" "merge_data.db" \
@@ -436,7 +473,8 @@ tables, and schema-dirty cases update 1 row plus add a column in 20 tables.
 Branch tests use $BRANCHES branches, checkout uses a clean $CHECKOUT_TABLES-table
 branch switch over $((CHECKOUT_TABLES * CHECKOUT_ROWS_PER_TABLE)) rows, and merge
 tests use $MERGE_ROWS-row tables with $MERGE_CHANGE_ROWS changed or conflicting
-rows per side.
+rows per side. Historical queries use $HISTORY_BRANCHES unrelated branches and
+a $HISTORY_DEPTH-commit target history.
 
 IO probe: ${IO_PROBE_NOTE} (reference ${VC_PERF_IO_REF_US}us);
 ceilings scaled by ${IO_SCALE}x.


### PR DESCRIPTION
## Summary

- scope `dolt_at`, `dolt_diff`, and `dolt_history` schema discovery to literal refs
- support two-ref, `..`, and `...` diff forms while preserving expression fallback
- add deterministic chunk-source coverage and deep-history performance workloads

Follow-up to #2732.

## Performance proof

The regression makes an unrelated branch tip unavailable and requires literal historical queries on another ref to succeed without fetching it. This deterministically catches the old global traversal without relying on timing. The existing paired PR benchmark now also measures all three operations across 200 unrelated branches and a 200-commit history.

## Validation

- `chunk_source_test`: 324 passed, 0 failed
- `test/run_doltlite_tests.sh`: 132 suites passed, 0 failed
- C coverage suites: 22 passed, 0 failed
- default-size VC performance workload: passed
- `make lint`
- clean `DOLTLITE_PROLLY=0` SQLite build

Co-Authored-By: OpenAI Codex <noreply@openai.com>
