### PR TITLE
Feature the detective demo at the top of the docs index

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ the proud product of
 
 [DoltLite is Beta](https://www.dolthub.com/blog/2026-08-31-doltlite-beta/).
 Documentation beyond this README lives in [doc/doltlite](doc/doltlite/README.md).
+New here? Start with [the detective demo](doc/doltlite/demo.md): a whodunit
+that is secretly the tutorial, every SQL block runnable as written.
 
 ## Install
 

--- a/doc/doltlite/README.md
+++ b/doc/doltlite/README.md
@@ -3,6 +3,12 @@
 Flat list. The [README](../../README.md) covers install, bindings, and a tour
 of the version-control features; these pages hold the detail.
 
+## Start here
+
+- [demo.md](demo.md) — **The DoltHub Break Room Incident**: a whodunit that is
+  secretly the tutorial. Every SQL block runs as written against
+  `./doltlite case.db`, and a test keeps the story honest.
+
 ## Build and embed
 
 - [building.md](building.md) — macOS, Linux, Windows, WebAssembly builds and flags
@@ -64,4 +70,3 @@ the forms each surface accepts are in [refs.md](refs.md).
 
 - [performance.md](performance.md) — benchmarks and asserted complexity properties
 - [testing.md](testing.md) — test layers, oracles, and allowlists
-- [demo.md](demo.md) — a narrative walkthrough of the version-control features


### PR DESCRIPTION
Moves `demo.md` out of the Project list into its own "Start here" section at the top of `doc/doltlite/README.md`, with a hook that says what it is: a whodunit that is secretly the tutorial, every block runnable, pinned by its own test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)