### PR TITLE
Add bindings.md; shrink the README bindings table

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,22 +64,22 @@ Download `doltlite-tools-win-x64-<ver>.zip` from
 
 ## Bindings
 
-Language-specific wrappers around `libdoltlite`. Each one exposes the bundled
-SQLite version's public `sqlite3_*` API surface plus the Dolt version-control
-functions, subject to the [storage-engine exceptions](#sqlite-compatibility).
+Language-specific wrappers around `libdoltlite`, each exposing the bundled
+SQLite API plus the Dolt version-control functions. Platforms, gotchas, and
+per-language notes: [bindings.md](doc/doltlite/bindings.md).
 
-| Language | Distribution | Source |
-|---|---|---|
-| Python | `pip install doltlite` | [dolthub/doltlite-python](https://github.com/dolthub/doltlite-python) |
-| Ruby | `gem install doltlite` | [dolthub/doltlite-ruby](https://github.com/dolthub/doltlite-ruby) |
-| Node.js / Bun | `npm install @dolthub/doltlite` | [dolthub/doltlite-node](https://github.com/dolthub/doltlite-node) |
-| PHP | `composer require dolthub/doltlite-php` | this repo ([`packaging/composer`](packaging/composer)), distributed via [dolthub/doltlite-php](https://github.com/dolthub/doltlite-php) |
-| .NET | `dotnet add package DoltHub.Doltlite` | this repo ([`packaging/nuget`](packaging/nuget)); works under Microsoft.Data.Sqlite.Core, EF Core, Dapper |
-| Rust | `cargo add doltlite` | this repo ([`packaging/rust`](packaging/rust)); engine vendored, or run the full default build and point `rusqlite` at it with `SQLITE3_LIB_DIR` |
-| Go | `go get github.com/dolthub/doltlite-driver` | this repo ([`packaging/go`](packaging/go)), distributed via [dolthub/doltlite-driver](https://github.com/dolthub/doltlite-driver); `database/sql` driver, engine vendored |
-| Browser / WASM | `npm install @dolthub/doltlite-wasm` | this repo ([`packaging/npm`](packaging/npm), built from [`ext/wasm`](ext/wasm)) |
-| Swift (iOS / macOS) | SwiftPM: `https://github.com/dolthub/doltlite-swift` | [dolthub/doltlite-swift](https://github.com/dolthub/doltlite-swift) (XCFramework built by [`packaging/swift`](packaging/swift)) |
-| Android | Gradle: `com.dolthub:doltlite-android` | [dolthub/doltlite-android](https://github.com/dolthub/doltlite-android) (AAR + JNA) |
+| Language | Distribution |
+|---|---|
+| Python | `pip install doltlite` |
+| Ruby | `gem install doltlite` |
+| Node.js / Bun | `npm install @dolthub/doltlite` |
+| Browser / WASM | `npm install @dolthub/doltlite-wasm` |
+| PHP | `composer require dolthub/doltlite-php` |
+| .NET | `dotnet add package DoltHub.Doltlite` |
+| Rust | `cargo add doltlite` |
+| Go | `go get github.com/dolthub/doltlite-driver` |
+| Swift (iOS / macOS) | SwiftPM: `https://github.com/dolthub/doltlite-swift` |
+| Android | Gradle: `com.dolthub:doltlite-android` |
 
 ## Building
 

--- a/doc/doltlite/README.md
+++ b/doc/doltlite/README.md
@@ -14,6 +14,7 @@ of the version-control features; these pages hold the detail.
 - [building.md](building.md) — macOS, Linux, Windows, WebAssembly builds and flags
 - [cli.md](cli.md) — the `doltlite` shell: what differs from `sqlite3`, URI parameters, environment variables
 - [embedding.md](embedding.md) — C API surface, exported symbols, C / Python / Go quickstarts
+- [bindings.md](bindings.md) — every language package: what it bundles, platforms, and gotchas
 - [using-existing-sqlite-bindings.md](using-existing-sqlite-bindings.md) — pointing rusqlite, go-sqlite3, Dart, .NET and FFI bindings at libdoltlite
 
 ## Behaviour contracts

--- a/doc/doltlite/bindings.md
+++ b/doc/doltlite/bindings.md
@@ -1,0 +1,112 @@
+# Language bindings
+
+Every binding wraps the same `libdoltlite`: the bundled SQLite's `sqlite3_*`
+API plus the `dolt_*` functions and tables, subject to the
+[storage-engine exceptions](sqlite-compatibility.md). Each section says what
+the package bundles, which platforms it covers, and what tends to go wrong.
+
+| Language | Install | Bundled engine | Source |
+|---|---|---|---|
+| Python | `pip install doltlite` | Linux x86_64/arm64, macOS arm64 | [doltlite-python](https://github.com/dolthub/doltlite-python) |
+| Ruby | `gem install doltlite` | Linux x86_64/arm64, macOS arm64/x86_64 | [doltlite-ruby](https://github.com/dolthub/doltlite-ruby) |
+| Node.js / Bun | `npm install @dolthub/doltlite` | Linux x64/arm64, macOS x64/arm64, Windows x64 | [doltlite-node](https://github.com/dolthub/doltlite-node) |
+| Browser / WASM | `npm install @dolthub/doltlite-wasm` | any wasm runtime | [`packaging/npm`](../../packaging/npm) |
+| PHP | `composer require dolthub/doltlite-php` | Linux x86_64/arm64, macOS arm64 | [`packaging/composer`](../../packaging/composer) |
+| .NET | `dotnet add package DoltHub.Doltlite` | linux-x64, linux-arm64, osx-arm64, win-x64 | [`packaging/nuget`](../../packaging/nuget) |
+| Rust | `cargo add doltlite` | compiled from source; Linux, macOS | [`packaging/rust`](../../packaging/rust) |
+| Go | `go get github.com/dolthub/doltlite-driver` | compiled from source; Linux, macOS | [`packaging/go`](../../packaging/go) |
+| Swift | SwiftPM `https://github.com/dolthub/doltlite-swift` | iOS 14+, macOS 11+, Catalyst 14+ | [doltlite-swift](https://github.com/dolthub/doltlite-swift) |
+| Android | Gradle `com.dolthub:doltlite-android` | arm64-v8a, armeabi-v7a, x86_64, x86 | [doltlite-android](https://github.com/dolthub/doltlite-android) |
+
+Any language with a C FFI can load `libdoltlite` directly; see
+[using-existing-sqlite-bindings.md](using-existing-sqlite-bindings.md) for
+pointing an existing SQLite binding at it.
+
+## Python
+
+Rides on the stdlib `sqlite3` module by loading `libdoltlite` in place of
+the system SQLite before `_sqlite3` initializes. That only works when the
+interpreter links SQLite as a shared library: distro or system Python,
+Homebrew, pyenv, and conda do. python-build-standalone interpreters, the
+default for `uv python install`, mise, and Rye, statically link SQLite and
+fail with `DoltliteLoadError`; point `uv venv --python` at a supported
+interpreter instead. On macOS the bootstrap re-executes the interpreter with
+an `install_name_tool` shim, so Xcode Command Line Tools are needed. Intel
+Mac wheels are not shipped; build locally and set `DOLTLITE_LIB`.
+
+## Ruby
+
+Precompiled gems bundle the engine; the plain gem falls back to a
+system-installed `libdoltlite`. `db.commit` in the README examples is a Dolt
+commit, not a SQL `COMMIT`.
+
+## Node.js and Bun
+
+A drop-in for `node:sqlite` (`DatabaseSync`, `StatementSync`) with `dolt_*`
+methods added, plus `binPath()` for the bundled `doltlite` CLI. Prebuilt
+binaries cover Linux, macOS, and Windows x64; elsewhere it builds from source
+with `node-gyp`, which needs Python 3 and a C++ toolchain. For the browser use
+the wasm package below.
+
+## Browser and WASM
+
+Upstream SQLite's wasm build on the DoltLite engine, same JavaScript API.
+Persistent storage needs OPFS and cross-origin isolation headers; remotes work
+over HTTP through the host's XHR or worker thread. Details: [wasm.md](wasm.md).
+
+## PHP
+
+A `Doltlite3` class shaped like `SQLite3`, over PHP's `ffi` extension (PHP 8.1+,
+`ffi.enable` permitting). Differences from `SQLite3`: errors always throw
+`Doltlite\Exception`; `openBlob`, `createFunction`, `createAggregate`,
+`createCollation`, and `setAuthorizer` are not implemented.
+
+Windows is not supported. Composer will install the package there because
+its metadata has no platform restriction, but releases do not reliably
+include `libdoltlite.dll` and the package is not tested on Windows, so the
+first `new Doltlite3(...)` fails inside `FFI::cdef()` with a loader error.
+`DOLTLITE_PHP_LIB=/path/to/libdoltlite.<ext>` overrides library resolution
+on any platform; on Windows that is an untested escape hatch, not support.
+
+## .NET
+
+Works under `Microsoft.Data.Sqlite`, EF Core, and Dapper through
+SQLitePCLRaw: call `Doltlite.Init()` once before the first connection, then
+version control is plain SQL on the same connection. Bundles linux-x64,
+linux-arm64, osx-arm64, and win-x64; set `DOLTLITE_NET_LIB` to a library you
+built for anything else. .NET 6.0 or later.
+
+## Rust
+
+The crate vendors the amalgamation and compiles it in `build.rs`, so the
+first build takes a few minutes and needs a C compiler and zlib. Linux and
+macOS are covered by CI; Windows is not, because the build links the
+platform's zlib, which MSVC toolchains lack. Remotes, TLS included, are
+compiled in. To use `rusqlite` instead, point `libsqlite3-sys` at a full
+DoltLite build (`make`, not `make doltlite-lib`) with `SQLITE3_LIB_DIR` and
+`SQLITE3_INCLUDE_DIR`.
+
+## Go
+
+A `database/sql` driver with the engine vendored via cgo; needs a C compiler
+and zlib, Linux and macOS only for the same zlib reason as Rust. Safe across
+goroutines through `*sql.DB`; transactions begin as `BEGIN IMMEDIATE` so lock
+contention surfaces at `Begin`, with a five-second default wait. This is
+`doltlite-driver`; `dolthub/doltlite-go` is the pure-Go sync protocol library,
+and `dolthub/driver` embeds Dolt itself if you want MySQL dialect without cgo.
+
+## Swift
+
+An XCFramework for iOS 14+, macOS 11+, and Mac Catalyst 14+, exposing the full
+C API. Dolt cannot run on iOS; this is the way to ship versioned SQL there.
+
+## Android
+
+Android's framework SQLite cannot be swapped, so the AAR vendors one
+`libdoltlite.so` per ABI (arm64-v8a, armeabi-v7a, x86_64, x86) and reaches
+it through JNA.
+
+## See also
+
+[embedding.md](embedding.md) for the C API, [cli.md](cli.md) for `db@branch`
+open syntax that every binding accepts as the database path.

--- a/packaging/composer/README.md
+++ b/packaging/composer/README.md
@@ -20,6 +20,11 @@ classes so existing code ports by search-and-replace.
 - Linux (x86_64/arm64) or macOS (arm64). The package bundles a
   prebuilt `libdoltlite` per platform; `DOLTLITE_PHP_LIB=/path/to/lib`
   overrides resolution for anything else.
+- Windows is not supported. Composer will install the package there, but
+  releases do not reliably include `libdoltlite.dll` and nothing is tested on
+  Windows, so the first `new Doltlite3(...)` fails inside `FFI::cdef()` with a
+  loader error. `DOLTLITE_PHP_LIB` pointing at a DLL you built yourself is an
+  untested escape hatch, not support.
 
 ## Install
 


### PR DESCRIPTION
`doc/doltlite/bindings.md`: a summary table (install, bundled engine platforms, source) and a section per language with the requirements and traps gathered from each package's README: which Pythons can and cannot load the engine, the macOS shim, Node's prebuilt-vs-`node-gyp` path, PHP's `SQLite3` differences, .NET's `Doltlite.Init()`, the zlib reason Rust and Go lack Windows, `doltlite-driver` vs `doltlite-go` vs `dolthub/driver`, Swift and Android platforms.

README: the Bindings table drops to Language and Distribution with a link to the page.

Fixes #2585: `packaging/composer/README.md` and `bindings.md` state that Windows is unsupported, that Composer will still install the package there, that releases do not reliably include `libdoltlite.dll`, and that `DOLTLITE_PHP_LIB` is an untested escape hatch rather than support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)