### PR TITLE
Free the VACUUM INTO filename after its file handle closes

### DIFF
--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -116,7 +116,7 @@ jobs:
       run: |
         cd build
         for s in doltlite_branch doltlite_default_branch doltlite_tag \
-                 doltlite_gc remote_test; do
+                 doltlite_gc doltlite_vacuum remote_test; do
           echo "=== $s ==="
           bash ../test/$s.sh ./doltlite || exit 1
         done
@@ -182,7 +182,7 @@ jobs:
       run: |
         cd build
         for s in doltlite_branch doltlite_default_branch doltlite_tag \
-                 doltlite_gc remote_test; do
+                 doltlite_gc doltlite_vacuum remote_test; do
           echo "=== $s ==="
           bash ../test/$s.sh ./doltlite || exit 1
         done

--- a/src/doltlite_gc.c
+++ b/src/doltlite_gc.c
@@ -1214,8 +1214,8 @@ int doltliteGcVacuumInto(
     rc = gcWriteCompactedTo(cs, &marked, zPath, 0, &bTargetNonEmpty,
                             &pOutFile, &finalSize,
                             &aNewIndex, &nNewIndex, &nNewData);
-    sqlite3_free(zPath);
     if( bTargetNonEmpty ){
+      sqlite3_free(zPath);
       prollyHashSetFree(&marked);
       chunkStoreUnlock(cs);
       *pzPhase = "output file already exists";
@@ -1225,10 +1225,13 @@ int doltliteGcVacuumInto(
   prollyHashSetFree(&marked);
   chunkStoreUnlock(cs);
   if( rc!=SQLITE_OK ){
+    sqlite3_free(zPath);
     *pzPhase = "vacuum into write failed";
     return rc;
   }
+  /* The VFS keeps the open name until xClose; free it after. */
   sqlite3OsCloseFree(pOutFile);
+  sqlite3_free(zPath);
   sqlite3_free(aNewIndex);
   return SQLITE_OK;
 }

--- a/test/doltlite_gc.sh
+++ b/test/doltlite_gc.sh
@@ -348,7 +348,9 @@ db_rm "$DB"
 # VACUUM INTO renames the copy over its output path, so closing the handle
 # logs through the output filename; that name must outlive the handle
 # (a use-after-free under ASAN otherwise).
-DB=/tmp/test_gc_vacuum_into_$$.db; db_rm "$DB"; COPY=/tmp/test_gc_vacuum_into_copy_$$.db; db_rm "$COPY"
+# The copy path is relative to the cwd: a /tmp path is not a valid VFS path
+# for the Windows build.
+DB=/tmp/test_gc_vacuum_into_$$.db; db_rm "$DB"; COPY=test_gc_vacuum_into_copy_$$.db; db_rm "$COPY"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'a'),(2,'b');
 SELECT dolt_commit('-A','-m','seed');" | $DOLTLITE "$DB" > /dev/null 2>&1

--- a/test/doltlite_gc.sh
+++ b/test/doltlite_gc.sh
@@ -345,16 +345,16 @@ run_test_match "gc_mark_failure_names_missing_chunk" \
 
 db_rm "$DB"
 
-# VACUUM INTO after gc in one session: the output filename must outlive the
-# handle it was opened with (a use-after-free under ASAN otherwise).
+# VACUUM INTO renames the copy over its output path, so closing the handle
+# logs through the output filename; that name must outlive the handle
+# (a use-after-free under ASAN otherwise).
 DB=/tmp/test_gc_vacuum_into_$$.db; db_rm "$DB"; COPY=/tmp/test_gc_vacuum_into_copy_$$.db; db_rm "$COPY"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'a'),(2,'b');
 SELECT dolt_commit('-A','-m','seed');" | $DOLTLITE "$DB" > /dev/null 2>&1
-run_test "gc_then_vacuum_into_same_session" \
-  "SELECT dolt_gc() IS NOT NULL; VACUUM; VACUUM INTO '$COPY'; SELECT count(*) FROM t;" \
-  "1
-2" "$DB"
+run_test "vacuum_into_name_outlives_handle" \
+  "VACUUM INTO '$COPY'; SELECT count(*) FROM t;" \
+  "2" "$DB"
 run_test "gc_vacuum_into_copy_readable" "SELECT count(*) FROM t;" "2" "$COPY"
 db_rm "$DB"; db_rm "$COPY"
 

--- a/test/doltlite_gc.sh
+++ b/test/doltlite_gc.sh
@@ -345,4 +345,17 @@ run_test_match "gc_mark_failure_names_missing_chunk" \
 
 db_rm "$DB"
 
+# VACUUM INTO after gc in one session: the output filename must outlive the
+# handle it was opened with (a use-after-free under ASAN otherwise).
+DB=/tmp/test_gc_vacuum_into_$$.db; db_rm "$DB"; COPY=/tmp/test_gc_vacuum_into_copy_$$.db; db_rm "$COPY"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'a'),(2,'b');
+SELECT dolt_commit('-A','-m','seed');" | $DOLTLITE "$DB" > /dev/null 2>&1
+run_test "gc_then_vacuum_into_same_session" \
+  "SELECT dolt_gc() IS NOT NULL; VACUUM; VACUUM INTO '$COPY'; SELECT count(*) FROM t;" \
+  "1
+2" "$DB"
+run_test "gc_vacuum_into_copy_readable" "SELECT count(*) FROM t;" "2" "$COPY"
+db_rm "$DB"; db_rm "$COPY"
+
 dltest_finish


### PR DESCRIPTION
Found by the docs-validation examples runner (#2758) under CI's ASAN/UBSAN oracle job, then reproduced locally with CI's sanitizer flags.

`doltliteGcVacuumInto` freed the double-NUL output filename as soon as `gcWriteCompactedTo` returned, but the unix VFS holds that pointer until `xClose`, and `unixClose` → `verifyDbFile` → `sqlite3_log` reads it:

```
ERROR: AddressSanitizer: heap-use-after-free
  READ of size 3 in strlen ← sqlite3_str_vappendf ← sqlite3_log ← verifyDbFile ← unixClose
      ← sqlite3OsCloseFree ← doltliteGcVacuumInto doltlite_gc.c:1231
  freed by sqlite3_free ← doltliteGcVacuumInto doltlite_gc.c:1217
  allocated by chunkStoreDupFilenameDoubleNul ← doltliteGcVacuumInto doltlite_gc.c:1211
```

Fix: free the name after `sqlite3OsCloseFree`, and on the two error returns that previously skipped the free. The sibling sites (`doltlite_gc.c` compaction temp name, `pager_shim.c` backup temp name) already free after close.

Test: `vacuum_into_name_outlives_handle` in `test/doltlite_gc.sh`, which the sanitizer job runs: a plain `VACUUM INTO` on a two-row table. On the pre-fix ASAN binary it aborts with the report above; with the fix the suite is 60/60, and 60/60 on the plain build. Plain `VACUUM INTO` is enough because the copy is renamed over the output path, so `unixClose` always logs `file renamed while open` through the freed name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)