### PR TITLE
Run every shell suite under ASan/UBSan; consolidate sanitizer jobs

### DIFF
--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -13,16 +13,17 @@ jobs:
       matrix:
         include:
           - suite: oracles
-          - suite: oracles-refs-workspace
-            bucket: refs-workspace
-          - suite: oracles-diff-history-data
-            bucket: diff-history-data
-          - suite: oracles-remotes-recovery
-            bucket: remotes-recovery
+          # The three small Dolt-oracle buckets share one runner; the merge
+          # bucket alone is as long as the three together.
+          - suite: oracles-vc
+            bucket: refs-workspace diff-history-data remotes-recovery
           - suite: oracles-merge
             bucket: merge-replay-schema
-          - suite: native
-          - suite: c-regression
+          # The DoltLite shell suites (sanitizer manifest set) split in two.
+          - suite: native-1
+            shard: 1/2
+          - suite: native-2
+            shard: 2/2
 
     steps:
     - uses: actions/checkout@v4
@@ -78,53 +79,34 @@ jobs:
       if: matrix.bucket
       run: |
         cd build
-        while IFS= read -r oracle; do
-          [ -z "$oracle" ] && continue
-          echo "--- $oracle ---"
-          bash "../test/$oracle" ./doltlite dolt || exit 1
-        done < "../test/oracle-buckets/${{ matrix.bucket }}.txt"
+        for bucket in ${{ matrix.bucket }}; do
+          while IFS= read -r oracle; do
+            [ -z "$oracle" ] && continue
+            echo "--- $oracle ---"
+            bash "../test/$oracle" ./doltlite dolt || exit 1
+          done < "../test/oracle-buckets/$bucket.txt"
+        done
       timeout-minutes: 25
 
     - name: Correctness regression tests
-      if: matrix.suite == 'native'
+      if: matrix.suite == 'native-1'
       run: cd build && bash ../test/correctness_test.sh ./doltlite
 
-    # Version-control virtual tables decode stored values and rebuild rows
-    # through the prolly record codec — exactly where signed-int / value
-    # decode UB lives (the left-shift-of-negative this PR fixes surfaced
-    # here). The oracle suites above are stock-SQL semantics and the C
-    # corpus is C-API level; neither exercises these SQL vtab read paths.
-    - name: VC virtual-table read suites
-      if: matrix.suite == 'native'
+    # Every DoltLite shell suite the coverage job runs, under ASan/UBSan,
+    # minus the ones that need artifacts this tarball lacks. The set is the
+    # manifest's sanitizer set, sharded across the two native jobs so neither
+    # exceeds the budget; a new suite is covered here by default.
+    - name: DoltLite shell suites (ASan/UBSan)
+      if: matrix.shard
       run: |
-        cd build
-        for s in doltlite_at doltlite_history doltlite_diff doltlite_diff_table \
-                 doltlite_diff_table_range \
-                 doltlite_schema_diff doltlite_workspace doltlite_conflicts \
-                 doltlite_conflict_rows doltlite_comparison doltlite_merge; do
-          echo "=== $s ==="
-          bash ../test/$s.sh ./doltlite || exit 1
-        done
-
-    # Ref-mutation, GC, and remote clone/pull paths deserialize the refs blob
-    # and rewrite refs/chunks — memory-management code (the refs int-overflow
-    # and the cursor-pin / merge-cleanup fixes lived here) that the oracle and
-    # read-vtab suites above never exercise under ASan. Kept to fast,
-    # self-contained suites (no server, no external Dolt) to stay in budget.
-    - name: VC ref-mutation + remote suites
-      if: matrix.suite == 'native'
-      run: |
-        cd build
-        for s in doltlite_branch doltlite_default_branch doltlite_tag \
-                 doltlite_gc doltlite_vacuum remote_test; do
-          echo "=== $s ==="
-          bash ../test/$s.sh ./doltlite || exit 1
-        done
+        DOLTLITE_BUILD_DIR="$PWD/build" DOLTLITE_SUITE_SET=sanitizer \
+          DOLTLITE_SUITE_SHARD=${{ matrix.shard }} bash test/run_doltlite_tests.sh
+      timeout-minutes: 20
 
     # The C regression corpus (~310k checks) under ASan/UBSan with leak
     # detection — where the #1325/#1328 use-after-frees and leaks lived.
     - name: C regression corpus (ASan/UBSan)
-      if: matrix.suite == 'c-regression'
+      if: matrix.suite == 'native-2'
       run: cd build && ./doltlite_regression_test_c all
 
   # Same ASan/UBSan coverage as the Linux job above, but on macOS/arm64 to

--- a/test/lib/doltlite_suite_manifest.sh
+++ b/test/lib/doltlite_suite_manifest.sh
@@ -158,6 +158,19 @@ doltlite_coverage_suites() {
   done < <(doltlite_all_suites)
 }
 
+# Everything the coverage set runs except suites that need artifacts the
+# sanitizer build tarball does not carry (build guard, stock parity) or that
+# the sanitizer job runs on its own (the C regression corpus).
+doltlite_sanitizer_suites() {
+  local excluded
+  excluded="$(printf '%s\n' build_artifacts_guard_test.sh doltlite_parity.sh doltlite_regression_test_c.sh)"
+  while IFS= read -r suite; do
+    if ! grep -Fqx "$suite" <<<"$excluded"; then
+      echo "$suite"
+    fi
+  done < <(doltlite_coverage_suites)
+}
+
 doltlite_windows_suites() {
   cat <<'EOF'
 build_artifacts_guard_test.sh

--- a/test/run_doltlite_tests.sh
+++ b/test/run_doltlite_tests.sh
@@ -25,12 +25,29 @@ case "${DOLTLITE_SUITE_SET:-all}" in
   all) suite_manifest=doltlite_all_suites ;;
   coverage) suite_manifest=doltlite_coverage_suites ;;
   timing) suite_manifest=doltlite_timing_suites ;;
+  sanitizer) suite_manifest=doltlite_sanitizer_suites ;;
   *)
     echo "ERROR: unknown DOLTLITE_SUITE_SET: $DOLTLITE_SUITE_SET"
     exit 1
     ;;
 esac
 while IFS= read -r line; do TESTS+=("$line"); done < <("$suite_manifest")
+
+# DOLTLITE_SUITE_SHARD=k/n keeps every n-th suite starting at k (1-based), so
+# a slow build can split one set across parallel jobs without a second list.
+if [ -n "${DOLTLITE_SUITE_SHARD:-}" ]; then
+  shard_k="${DOLTLITE_SUITE_SHARD%/*}"; shard_n="${DOLTLITE_SUITE_SHARD#*/}"
+  if ! [ "$shard_k" -ge 1 ] 2>/dev/null || ! [ "$shard_k" -le "$shard_n" ] 2>/dev/null; then
+    echo "ERROR: DOLTLITE_SUITE_SHARD must be k/n with 1 <= k <= n: $DOLTLITE_SUITE_SHARD"
+    exit 1
+  fi
+  SHARDED=()
+  for i in "${!TESTS[@]}"; do
+    if [ $(( i % shard_n )) -eq $(( shard_k - 1 )) ]; then SHARDED+=("${TESTS[$i]}"); fi
+  done
+  TESTS=("${SHARDED[@]}")
+  echo "Shard $DOLTLITE_SUITE_SHARD: ${#TESTS[@]} suites"
+fi
 
 total_pass=0
 total_fail=0


### PR DESCRIPTION
Follow-up to #2761. The native sanitizer job ran 16 hand-listed shell suites; `doltlite_vacuum` was not one of them, which is how a use-after-free on every `VACUUM INTO` stayed invisible.

**Coverage.** `test/lib/doltlite_suite_manifest.sh` gains `doltlite_sanitizer_suites`: the coverage set minus `build_artifacts_guard_test.sh` and `doltlite_parity.sh` (need artifacts the sanitizer tarball lacks) and `doltlite_regression_test_c.sh` (the job runs the C corpus itself). `test/run_doltlite_tests.sh` accepts `DOLTLITE_SUITE_SET=sanitizer` and `DOLTLITE_SUITE_SHARD=k/n`. The sanitizer job runs the set in two shards, so a new suite is covered under ASan by default instead of by remembering to add it to a YAML list.

**Consolidation.** Nine sanitizer jobs become seven:

| Before | After |
|---|---|
| oracles-refs-workspace (3.2 min), oracles-diff-history-data (2.1), oracles-remotes-recovery (2.2) | `oracles-vc`, one job over the three bucket files |
| native (2.3, 16 suites), c-regression (0.5) | `native-1` (61 suites + correctness), `native-2` (60 suites + C corpus) |
| oracles, oracles-merge, macos, tsan | unchanged |

Local timing under the ASan build with both shards running concurrently: shard 1/2 259 s (61/61 pass), shard 2/2 236 s (60/60 pass), no sanitizer reports. Full set serially was 7.1 min, so each CI job should land around 5 minutes. The macOS job keeps its hand lists (no Dolt, no shard) and is unchanged here.

The only required check on master is `CI Gate`, and nothing references the removed job names. This touches the same lines as #2761's `doltlite_vacuum` addition; merge that first and I will rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)