### PR TITLE
Split dolt_ignore.md into dolt_ignore, dolt_docs, and dolt_tests pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ SELECT * FROM dolt_status;
 UPDATE dolt_workspace_ratings SET staged = 1 WHERE to_confidence > from_confidence;
 ```
 
-**Ignore, docs, tests** — [dolt_ignore.md](doc/doltlite/dolt_ignore.md)
+**Ignore, docs, tests** — [dolt_ignore.md](doc/doltlite/dolt_ignore.md), [dolt_docs.md](doc/doltlite/dolt_docs.md), [dolt_tests.md](doc/doltlite/dolt_tests.md)
 
 ```sql
 INSERT INTO dolt_ignore VALUES ('tmp_*', 1);

--- a/doc/doltlite/README.md
+++ b/doc/doltlite/README.md
@@ -44,7 +44,9 @@ the forms each surface accepts are in [refs.md](refs.md).
 - [dolt_gc.md](dolt_gc.md) — `dolt_gc`, `VACUUM`
 - [dolt_constraint_violations.md](dolt_constraint_violations.md) — `dolt_constraint_violations`, `dolt_constraint_violations_<table>`, `dolt_verify_constraints`
 - [dolt_workspace.md](dolt_workspace.md) — `dolt_workspace_<table>`
-- [dolt_ignore.md](dolt_ignore.md) — `dolt_ignore`, `dolt_docs`, `dolt_tests`, `dolt_test_run`
+- [dolt_ignore.md](dolt_ignore.md) — `dolt_ignore`
+- [dolt_docs.md](dolt_docs.md) — `dolt_docs`
+- [dolt_tests.md](dolt_tests.md) — `dolt_tests`, `dolt_test_run`
 - [dolt_schemas.md](dolt_schemas.md) — `dolt_schemas` and the versioned catalog
 - [dolt_creds.md](dolt_creds.md) — `dolt_creds_new`, `dolt_creds`
 - [dolt_version.md](dolt_version.md) — `dolt_version`, `doltlite_engine`

--- a/doc/doltlite/dolt_docs.md
+++ b/doc/doltlite/dolt_docs.md
@@ -1,0 +1,42 @@
+# dolt_docs
+
+Versioned documents keyed by name: a README, a license, or the `AGENT.md`
+guide every fresh database carries. Dolt:
+[dolt_docs](https://docs.dolthub.com/sql-reference/version-control/dolt-system-tables#dolt_docs).
+
+## Synopsis
+
+```sql
+SELECT doc_name FROM dolt_docs;                       -- AGENT.md on a fresh database
+INSERT INTO dolt_docs VALUES ('README.md', '# my project');
+REPLACE INTO dolt_docs VALUES ('README.md', '# updated');
+SELECT doc_text FROM dolt_docs WHERE doc_name = 'AGENT.md';
+SELECT dolt_commit('-A', '-m', 'update docs');
+```
+
+## Schema
+
+`dolt_docs(doc_name TEXT NOT NULL, doc_text TEXT NOT NULL, PRIMARY KEY(doc_name))`
+
+Served before it exists; the first write creates the real table, which then
+commits, diffs, branches, and merges like any other.
+
+## Behaviour
+
+- A fresh database serves one row, `AGENT.md`, DoltLite's operations guide
+  for AI agents. See [agents.md](agents.md) for the text and how to use it.
+- The default row is stored on first write like any other row, so deleting
+  or replacing it sticks and shows in diffs.
+- `doc_name` is the primary key: a second `INSERT` of the same name fails
+  with `UNIQUE constraint failed: dolt_docs.doc_name`; use `REPLACE`.
+
+## Differences from Dolt
+
+Dolt synthesizes its default docs on every read and resurrects them when
+deleted; DoltLite stores them. The default `AGENT.md` text is DoltLite's own,
+and the table appears in `.tables` once it exists.
+
+## See also
+
+[agents.md](agents.md), [dolt_ignore.md](dolt_ignore.md),
+[dolt_tests.md](dolt_tests.md), `test/vc_oracle_docs_test.sh`.

--- a/doc/doltlite/dolt_ignore.md
+++ b/doc/doltlite/dolt_ignore.md
@@ -1,74 +1,40 @@
-# Versioned system tables: dolt_ignore, dolt_docs, dolt_tests
+# dolt_ignore
 
-Three tables that live in the repository and version with it. `dolt_ignore`
-and `dolt_tests` start empty; `dolt_docs` starts with `AGENT.md`. The first
-write creates the real table, which then commits, diffs, branches, and merges
-like any other. Dolt:
-[dolt_ignore](https://docs.dolthub.com/sql-reference/version-control/dolt-system-tables#dolt_ignore),
-[dolt_docs](https://docs.dolthub.com/sql-reference/version-control/dolt-system-tables#dolt_docs),
-[dolt_tests](https://docs.dolthub.com/sql-reference/version-control/dolt-system-tables#dolt_tests).
+Patterns for tables that `dolt_add('-A')` and `dolt_commit('-A')` should
+skip. Dolt: [dolt_ignore](https://docs.dolthub.com/sql-reference/version-control/dolt-system-tables#dolt_ignore).
 
-## dolt_ignore
+## Synopsis
+
+```sql
+SELECT * FROM dolt_ignore;                          -- empty on a fresh database
+INSERT INTO dolt_ignore VALUES ('tmp_*', 1);
+INSERT INTO dolt_ignore VALUES ('tmp_keep', 0);     -- exception
+SELECT dolt_add('-f', 'tmp_table');                 -- stage an ignored table anyway
+```
+
+## Schema
 
 `dolt_ignore(pattern TEXT NOT NULL, ignored TINYINT NOT NULL, PRIMARY KEY(pattern))`
 
-```sql
-INSERT INTO dolt_ignore VALUES ('tmp_*', 1);
-INSERT INTO dolt_ignore VALUES ('tmp_keep', 0);     -- exception
-```
+The table is served empty before it exists; the first write creates it, and
+from then on it commits, diffs, branches, and merges like any other table.
 
-Matching tables are skipped by `dolt_add('-A')` and `dolt_commit('-A')`,
-hidden from `dolt_status`, and left in the working set. `*` or `%` match any
-run, `?` one character. The most specific matching pattern wins; two patterns
-of equal specificity that disagree error with `the table <t> matches
-conflicting patterns in dolt_ignore`. `dolt_add('-f', table)` stages an
-ignored table anyway.
+## Behaviour
 
-## dolt_docs
-
-`dolt_docs(doc_name TEXT NOT NULL, doc_text TEXT NOT NULL, PRIMARY KEY(doc_name))`
-
-```sql
-SELECT * FROM dolt_docs;                              -- AGENT.md on a fresh database
-REPLACE INTO dolt_docs VALUES ('README.md', '# my project');
-```
-
-A fresh database serves one default row, `AGENT.md`, DoltLite's guide for
-AI agents (see [agents.md](agents.md)). It is stored on first write like any
-other row, so deleting it sticks. `doc_name` is unique: a second `INSERT` of
-the same name fails; use `REPLACE`.
-
-## dolt_tests and dolt_test_run
-
-`dolt_tests(test_name, test_group, test_query, assertion_type,
-assertion_comparator, assertion_value)`
-
-```sql
-INSERT INTO dolt_tests VALUES
-  ('user count', 'users', 'SELECT * FROM users', 'expected_rows', '==', '10');
-SELECT * FROM dolt_test_run();          -- every test
-SELECT * FROM dolt_test_run('users');   -- one group, or one test name
-```
-
-| Column | Values |
-|---|---|
-| `assertion_type` | `expected_rows`, `expected_columns`, `expected_single_value` (enforced by a CHECK constraint) |
-| `assertion_comparator` | `==`, `!=`, `<`, `>`, `<=`, `>=` |
-| `assertion_value` | compared as integer, float, text, or NULL as appropriate |
-
-`dolt_test_run` returns `test_name`, `test_group_name`, `query`, `status`
-(`PASS`/`FAIL`), `message`. Queries run read-only: a write fails with
-`Cannot execute write queries`, a `PRAGMA` with `Cannot execute PRAGMA
-queries`, and only one statement is allowed. An unknown group or name:
-`could not find tests for argument: <x>`.
+- `*` or `%` match any run of characters, `?` exactly one.
+- A matching table is skipped by `dolt_add('-A')`, hidden from `dolt_status`,
+  and left in the working set untouched.
+- The most specific matching pattern wins, so `tmp_keep` with `ignored = 0`
+  overrides `tmp_*`. Two patterns of equal specificity that disagree error
+  with `the table <t> matches conflicting patterns in dolt_ignore`.
+- Naming an ignored table in `dolt_add` does not stage it; only
+  `dolt_add('-f', table)` does.
 
 ## Differences from Dolt
 
-`dolt_docs` rows are stored, including the default; Dolt resurrects its
-defaults on read. The tables appear in `.tables` once they exist. The default
-`AGENT.md` text is DoltLite's own.
+None intended. The table shows in `.tables` once it exists.
 
 ## See also
 
-`test/vc_oracle_ignore_test.sh`, `test/vc_oracle_docs_test.sh`,
-`test/vc_oracle_tests_test.sh`.
+[dolt_commit.md](dolt_commit.md), [dolt_docs.md](dolt_docs.md),
+[dolt_tests.md](dolt_tests.md), `test/vc_oracle_ignore_test.sh`.

--- a/doc/doltlite/dolt_tests.md
+++ b/doc/doltlite/dolt_tests.md
@@ -1,0 +1,55 @@
+# dolt_tests and dolt_test_run
+
+SQL assertions stored in the database and versioned with it. Dolt:
+[dolt_tests](https://docs.dolthub.com/sql-reference/version-control/dolt-system-tables#dolt_tests),
+[dolt_test_run](https://docs.dolthub.com/sql-reference/version-control/dolt-sql-procedures#dolt_test_run).
+
+## Synopsis
+
+```sql
+INSERT INTO dolt_tests VALUES
+  ('user count', 'users', 'SELECT * FROM users', 'expected_rows', '==', '3');
+INSERT INTO dolt_tests VALUES
+  ('has email', 'users', 'SELECT count(*) FROM users WHERE email IS NULL', 'expected_single_value', '==', '0');
+SELECT * FROM dolt_test_run();              -- every test
+SELECT * FROM dolt_test_run('users');       -- one group
+SELECT * FROM dolt_test_run('user count');  -- one test
+SELECT dolt_commit('-A', '-m', 'add tests');
+```
+
+## Schema
+
+`dolt_tests(test_name, test_group, test_query, assertion_type,
+assertion_comparator, assertion_value)`
+
+| Column | Values |
+|---|---|
+| `assertion_type` | `expected_rows`, `expected_columns`, `expected_single_value`; anything else fails a `CHECK` constraint |
+| `assertion_comparator` | `==`, `!=`, `<`, `>`, `<=`, `>=` |
+| `assertion_value` | compared as integer, float, text, or NULL as the query result dictates |
+
+Served empty before it exists; the first write creates the real table.
+
+## dolt_test_run
+
+Returns `test_name`, `test_group_name`, `query`, `status` (`PASS` or `FAIL`),
+`message`. With no argument or `'*'` it runs everything; otherwise the
+argument names a group or a single test.
+
+Queries run read-only and one statement at a time: a write fails with
+`Cannot execute write queries`, a `PRAGMA` with `Cannot execute PRAGMA
+queries`, and `expected_single_value` requires exactly one cell.
+
+| Error | Cause |
+|---|---|
+| `could not find tests for argument: <x>` | no group or test by that name |
+| `dolt_test_run requires literal arguments` | argument is not a literal |
+
+## Differences from Dolt
+
+None intended.
+
+## See also
+
+[dolt_ignore.md](dolt_ignore.md), [dolt_docs.md](dolt_docs.md),
+`test/vc_oracle_tests_test.sh`.


### PR DESCRIPTION
The combined "versioned system tables" page becomes three, matching the one-page-per-feature rule: `dolt_ignore.md`, `dolt_docs.md`, and `dolt_tests.md` (which keeps `dolt_test_run`). Index and README cheat-sheet links updated. Each page's examples run under the doc examples test; link and error-string checks pass.

One correction while splitting: the old text implied naming an ignored table in `dolt_add` stages it. It does not; only `dolt_add('-f', table)` does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)