### PR TITLE
Prevent orphaned indexes in merged catalogs

### DIFF
--- a/src/prolly_btree_catalog.c
+++ b/src/prolly_btree_catalog.c
@@ -1367,8 +1367,21 @@ static int doltliteSerializeCatalogEntriesForBtreeImpl(
     return rc;
   }
   filterSchemaCatalogRows(aRows, &nRows, aTables, nTables);
-  /* Constructed arrays: drop index rows whose parent table is gone. */
-  if( aTables!=pBtree->cat.a ){
+  if( !bForeignDomain ){
+    rc = appendMissingSchemaCatalogRows(db, btreeSchemaName(pBtree),
+                                        &aRows, &nRows, aMeta, nMeta,
+                                        aTables, nTables);
+  }
+  if( rc==SQLITE_OK ){
+    rc = appendFallbackSchemaCatalogRows(&aRows, &nRows, aTables, nTables,
+                                         aFallbackSchema, nFallbackSchema);
+  }
+  if( rc!=SQLITE_OK ){
+    freeCatalogEntryMeta(aMeta, nMeta);
+    return rc;
+  }
+  /* Drop index rows whose parent table is gone. */
+  {
     int nOut = 0;
     for(i=0; i<nRows; i++){
       int keep = 1;
@@ -1379,12 +1392,6 @@ static int doltliteSerializeCatalogEntriesForBtreeImpl(
           if( aRows[j].zType && strcmp(aRows[j].zType, "table")==0
            && aRows[j].zName
            && strcmp(aRows[j].zName, aRows[i].zTblName)==0 ){
-            keep = 1;
-          }
-        }
-        for(j=0; j<nTables && !keep; j++){
-          if( aTables[j].zName
-           && strcmp(aTables[j].zName, aRows[i].zTblName)==0 ){
             keep = 1;
           }
         }
@@ -1404,20 +1411,6 @@ static int doltliteSerializeCatalogEntriesForBtreeImpl(
       }
     }
     nRows = nOut;
-  }
-  /* Live numbers belong to this connection; skip on a foreign-domain catalog. */
-  if( !bForeignDomain ){
-    rc = appendMissingSchemaCatalogRows(db, btreeSchemaName(pBtree),
-                                        &aRows, &nRows, aMeta, nMeta,
-                                        aTables, nTables);
-  }
-  if( rc==SQLITE_OK ){
-    rc = appendFallbackSchemaCatalogRows(&aRows, &nRows, aTables, nTables,
-                                         aFallbackSchema, nFallbackSchema);
-  }
-  if( rc!=SQLITE_OK ){
-    freeCatalogEntryMeta(aMeta, nMeta);
-    return rc;
   }
   if( nRows>0 ){
     ProllyMutMap mm;


### PR DESCRIPTION
## Summary

- filter orphaned index rows after live and fallback schema rows are assembled
- require a surviving schema table row instead of treating conflict-only physical catalog entries as visible parents
- prevent delete-vs-modify merges with rootpage churn from producing a malformed schema

## Validation

- reproduced seed 1789021470 step 10957 against the captured nightly database
- verified the merge now reports the expected conflict instead of `database disk image is malformed`
- `bash test/doltlite_schema_merge.sh build/doltlite` (399 passed)
- `make lint`

Fixes #2769

Co-Authored-By: OpenAI Codex <noreply@openai.com>