### PR TITLE
Confirm nightly VC performance regressions

### DIFF
--- a/.github/workflows/nightly-performance.yml
+++ b/.github/workflows/nightly-performance.yml
@@ -185,15 +185,23 @@ jobs:
         set +e
         (
           cd build-nightly
-          VC_PERF_RESULTS_OUTPUT="$results/vc.tsv" \
-            VC_PERF_SAMPLES_OUTPUT="$results/vc-samples.tsv" \
-            bash ../test/vc_perf_ceiling.sh ./doltlite
-        ) > "$results/vc.md" 2> "$results/vc.stderr"
+          VC_PERF_GATE_MODE=none python3 ../test/benchmark_retry.py \
+            --suite vc \
+            --results-dir "$results" \
+            --max-attempts 3 \
+            --individual-ratio 1.0 \
+            --aggregate-ratio 1000 \
+            --min-delta-us 0 \
+            --individual-min-delta-us 0 \
+            --fail-confirmed \
+            -- bash ../test/vc_perf_ceiling.sh ./doltlite
+        ) > "$results/vc.retry.log" 2> "$results/vc.stderr"
         bench_rc=$?
         set -e
         finished_at=$(date +%s)
         echo "$bench_rc" > "$results/vc.status"
         echo "$((finished_at - started_at))" > "$results/vc.duration"
+        cat "$results/vc.retry.log"
         cat "$results/vc.md"
         cat "$results/vc.stderr" >&2
         echo "bench_rc=$bench_rc" >> "$GITHUB_OUTPUT"

--- a/test/benchmark_retry.py
+++ b/test/benchmark_retry.py
@@ -120,6 +120,7 @@ def run_with_retries(
     individual_min_delta_us,
     command_runner=subprocess.run,
     producer_id=None,
+    fail_confirmed=False,
 ):
     results_dir = pathlib.Path(results_dir)
     attempts_dir = results_dir / "attempts"
@@ -296,8 +297,7 @@ def run_with_retries(
             )
             continue
 
-        # A valid measurement is always published. The aggregate report job
-        # enforces the gate after this third consecutive regression.
+        # A valid measurement is always published before enforcement.
         try:
             promote_attempt(
                 attempt_dir,
@@ -320,16 +320,14 @@ def run_with_retries(
             ),
             flush=True,
         )
-        return 0
+        return 1 if fail_confirmed else 0
 
     raise AssertionError("retry loop did not return")
 
 
 def main(argv=None):
     parser = argparse.ArgumentParser(
-        description=(
-            "Retry a paired benchmark only when its performance gate fails"
-        )
+        description="Retry a benchmark only when its performance gate fails"
     )
     parser.add_argument("--suite", required=True)
     parser.add_argument("--results-dir", required=True)
@@ -338,6 +336,7 @@ def main(argv=None):
     parser.add_argument("--aggregate-ratio", type=float, default=1.15)
     parser.add_argument("--min-delta-us", type=int, default=5000)
     parser.add_argument("--individual-min-delta-us", type=int, default=5000)
+    parser.add_argument("--fail-confirmed", action="store_true")
     parser.add_argument("command", nargs=argparse.REMAINDER)
     args = parser.parse_args(argv)
 
@@ -358,6 +357,7 @@ def main(argv=None):
         args.aggregate_ratio,
         args.min_delta_us,
         args.individual_min_delta_us,
+        fail_confirmed=args.fail_confirmed,
     )
 
 

--- a/test/benchmark_retry_test.py
+++ b/test/benchmark_retry_test.py
@@ -55,7 +55,7 @@ class FakeRunner:
 
 
 class BenchmarkRetryTest(unittest.TestCase):
-    def run_retry(self, directory, outcomes):
+    def run_retry(self, directory, outcomes, fail_confirmed=False):
         runner = FakeRunner(outcomes)
         rc = benchmark_retry.run_with_retries(
             "int",
@@ -68,6 +68,7 @@ class BenchmarkRetryTest(unittest.TestCase):
             5000,
             runner,
             PRODUCER_ID,
+            fail_confirmed,
         )
         return rc, runner
 
@@ -135,6 +136,16 @@ class BenchmarkRetryTest(unittest.TestCase):
             f"# producer_id\t{PRODUCER_ID}\n"
             "reads\tpoint\t100000\t150000\n",
         )
+
+    def test_confirmed_failure_can_fail_caller(self):
+        with tempfile.TemporaryDirectory() as directory:
+            rc, runner = self.run_retry(
+                directory,
+                [(100_000, 130_000)] * 3,
+                fail_confirmed=True,
+            )
+        self.assertEqual(rc, 1)
+        self.assertEqual(runner.calls, 3)
 
     def test_rotating_individual_failures_stop_without_confirmation(self):
         steady = ("reads", "steady", 1_000_000, 1_000_000)

--- a/test/vc_perf_ceiling.sh
+++ b/test/vc_perf_ceiling.sh
@@ -16,6 +16,11 @@ if [ -n "$VC_PERF_BASELINE" ] && [ ! -x "$VC_PERF_BASELINE" ]; then
 fi
 VC_PERF_BASELINE_LABEL="${VC_PERF_BASELINE_LABEL:-PR base}"
 VC_PERF_CANDIDATE_LABEL="${VC_PERF_CANDIDATE_LABEL:-PR candidate}"
+VC_PERF_GATE_MODE="${VC_PERF_GATE_MODE:-enforce}"
+case "$VC_PERF_GATE_MODE" in
+  enforce|none) ;;
+  *) echo "unknown VC_PERF_GATE_MODE: $VC_PERF_GATE_MODE" >&2; exit 2 ;;
+esac
 
 RUNS=${VC_PERF_RUNS:-3}
 TABLES=${VC_PERF_TABLES:-800}
@@ -485,7 +490,8 @@ $(printf "%b" "$rows")
 EOF
 fi
 
-if [ -z "$VC_PERF_BASELINE" ] && [ "$failures" -ne 0 ]; then
+if [ -z "$VC_PERF_BASELINE" ] && [ "$VC_PERF_GATE_MODE" = "enforce" ] \
+    && [ "$failures" -ne 0 ]; then
   echo "$failures version-control benchmark(s) exceeded their ceiling." >&2
   exit 1
 fi


### PR DESCRIPTION
## Summary

- run the nightly VC ceiling suite through the existing exact-gate retry framework
- collect up to three independent 101-sample attempts when a ceiling is exceeded
- fail only when the same benchmark exceeds its ceiling in all three attempts
- retain the direct one-attempt gate behavior outside the nightly retry wrapper

## Why

The #2770 run had 54-60% MAD in the two failed merge benchmarks and an 800us fsync probe versus 114us in the preceding healthy run. Successful merges were affected while rollback-only conflict merges stayed stable, indicating transient runner I/O rather than an engine regression.

## Validation

- `python3 test/benchmark_retry_test.py` (10 passed)
- `python3 test/benchmark_compare_test.py` (24 passed)
- `python3 test/nightly_performance_report_test.py` (9 passed)
- reduced-size end-to-end VC ceiling smoke test
- `make lint`

Fixes #2770

Co-Authored-By: OpenAI Codex <noreply@openai.com>