### PR TITLE
Publish manual Go driver dev snapshots

### DIFF
--- a/.github/workflows/go-driver-dev.yml
+++ b/.github/workflows/go-driver-dev.yml
@@ -1,0 +1,103 @@
+name: Publish Go Driver Dev
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    if: github.repository == 'dolthub/doltlite'
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    concurrency:
+      group: doltlite-driver-publish
+      cancel-in-progress: false
+    env:
+      GH_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN }}
+    steps:
+    - name: Check release bot token
+      run: |
+        if [ -z "${GH_TOKEN}" ]; then
+          echo "RELEASE_BOT_TOKEN is required to push dev builds to doltlite-driver"
+          exit 1
+        fi
+        gh auth status
+        gh auth setup-git
+
+    - uses: actions/checkout@v4
+      with:
+        ref: master
+        fetch-depth: 0
+
+    - name: Resolve source revision
+      run: echo "SOURCE_SHA=$(git rev-parse HEAD)" >> "$GITHUB_ENV"
+
+    - name: Install dependencies
+      run: bash .github/scripts/install-apt-deps.sh build-essential zlib1g-dev tcl
+
+    - uses: actions/setup-go@v5
+      with:
+        go-version: '1.23'
+        cache: false
+
+    - name: Configure git identity
+      run: |
+        git config --global user.name "DoltHub Release Bot"
+        git config --global user.email "releases@dolthub.com"
+
+    - name: Build and test the driver
+      run: |
+        mkdir -p build && cd build
+        ../configure
+        make -j2 sqlite3.c sqlite3.h
+        cd ..
+        bash packaging/go/test-package.sh build
+
+    - name: Publish the dev snapshot
+      run: |
+        set -euo pipefail
+        stage="$(mktemp -d)"
+        trap 'rm -rf "$stage"' EXIT
+
+        bash packaging/go/assemble.sh "dev-${SOURCE_SHA}" "$stage/pkg" build
+        rm -f "$stage/pkg/.version"
+        printf '%s\n' "$SOURCE_SHA" > "$stage/pkg/DOLTLITE_SOURCE_REVISION"
+
+        gh repo clone dolthub/doltlite-driver "$stage/doltlite-driver"
+        cd "$stage/doltlite-driver"
+        if git ls-remote --exit-code --heads origin dev >/dev/null 2>&1; then
+          git fetch origin dev
+          git switch --create dev --track origin/dev
+        else
+          git switch --create dev origin/main
+        fi
+
+        git fetch origin main
+        if ! git merge-base --is-ancestor origin/main HEAD; then
+          git merge --strategy=ours origin/main \
+            -m "Merge doltlite-driver releases into dev"
+        fi
+
+        find . -mindepth 1 -maxdepth 1 -not -name .git -exec rm -rf {} +
+        cp -R "$stage/pkg/." .
+        git add -A
+        if ! git diff --cached --quiet; then
+          git commit -m "doltlite dev ${SOURCE_SHA}"
+        fi
+        git push origin dev
+
+        driver_sha="$(git rev-parse HEAD)"
+        cd "$stage"
+        driver_version="$(GOPROXY=direct go list -m -f '{{.Version}}' \
+          "github.com/dolthub/doltlite-driver@${driver_sha}")"
+        {
+          echo "### DoltLite Go driver dev snapshot"
+          echo
+          echo "- DoltLite source: \`${SOURCE_SHA}\`"
+          echo "- Driver commit: \`${driver_sha}\`"
+          echo "- Go version: \`${driver_version}\`"
+          echo
+          echo "\`go get github.com/dolthub/doltlite-driver@dev\`"
+        } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -821,6 +821,9 @@ jobs:
     if: github.event_name != 'workflow_dispatch'
     needs: release
     runs-on: ubuntu-latest
+    concurrency:
+      group: doltlite-driver-publish
+      cancel-in-progress: false
     env:
       GH_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN }}
       VERSION: ${{ github.ref_name }}
@@ -877,6 +880,16 @@ jobs:
         fi
         git tag "${VERSION}"
         git push origin "${VERSION}"
+
+        if git ls-remote --exit-code --heads origin dev >/dev/null 2>&1; then
+          git fetch origin dev
+          git switch --create dev --track origin/dev
+          if ! git merge-base --is-ancestor main HEAD; then
+            git merge --strategy=ours main \
+              -m "Merge doltlite-driver ${VERSION} into dev"
+            git push origin dev
+          fi
+        fi
 
   # ── Publish the .NET NuGet package ───────────────────────
   # nuget.org takes uploaded artifacts, so there is no split repo: assemble

--- a/packaging/go/README.md
+++ b/packaging/go/README.md
@@ -14,6 +14,17 @@ go get github.com/dolthub/doltlite-driver
 Requires cgo (`CGO_ENABLED=1`, the default when a C compiler is present) and
 zlib. The first build compiles the engine and is then cached.
 
+Development snapshots built from DoltLite's `master` branch are available on
+the driver's `dev` branch:
+
+```sh
+go get github.com/dolthub/doltlite-driver@dev
+```
+
+Go records an immutable pseudo-version in `go.mod`. Run the command again to
+advance to a newer snapshot, and commit the resulting `go.mod` and `go.sum`
+changes before deploying.
+
 ## Use
 
 ```go

--- a/packaging/go/assemble.sh
+++ b/packaging/go/assemble.sh
@@ -17,6 +17,13 @@ VERSION="${1:?usage: assemble.sh <version> <out_dir> <build_dir>}"
 OUT_DIR="${2:?usage: assemble.sh <version> <out_dir> <build_dir>}"
 BUILD_DIR="${3:?usage: assemble.sh <version> <out_dir> <build_dir>}"
 
+case "$VERSION" in
+  *[!A-Za-z0-9._+-]*)
+    echo "ERROR: version contains unsupported characters: $VERSION" >&2
+    exit 1
+    ;;
+esac
+
 PKG_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT="$(cd "$PKG_DIR/../.." && pwd)"
 
@@ -31,14 +38,19 @@ rm -rf "$OUT_DIR"
 mkdir -p "$OUT_DIR"
 
 cp "$PKG_DIR/doltlite.go" "$OUT_DIR/doltlite.go"
+sed "s/@DOLTLITE_VERSION@/$VERSION/g" \
+  "$PKG_DIR/doltlite_build.go.in" > "$OUT_DIR/doltlite_build.go"
 cp "$PKG_DIR/go.mod"      "$OUT_DIR/go.mod"
 cp "$PKG_DIR/README.md"   "$OUT_DIR/README.md"
 cp "$ROOT/LICENSE.md"     "$OUT_DIR/LICENSE.md"
-cp "$BUILD_DIR/sqlite3.c" "$OUT_DIR/doltlite.c"
+sed "s/# define DOLTLITE_VERSION \"doltlite-amalgamation\"/# define DOLTLITE_VERSION \"$VERSION\"/" \
+  "$BUILD_DIR/sqlite3.c" > "$OUT_DIR/doltlite.c"
 cp "$BUILD_DIR/sqlite3.h" "$OUT_DIR/doltlite.h"
 
-# Go modules take their version from the repository tag, not from go.mod, so
-# there is nothing to stamp -- record it for the pushing side instead.
+grep -Fq "# define DOLTLITE_VERSION \"$VERSION\"" "$OUT_DIR/doltlite.c"
+
+# Go modules take their version from the repository tag, not from go.mod.
+# Record it for the pushing side as well as in the compiled build metadata.
 echo "$VERSION" > "$OUT_DIR/.version"
 
 echo "Staged doltlite-driver $VERSION in $OUT_DIR:"

--- a/packaging/go/doltlite_build.go.in
+++ b/packaging/go/doltlite_build.go.in
@@ -1,0 +1,4 @@
+package doltlite
+
+// BuildVersion identifies the DoltLite source bundled into this module.
+const BuildVersion = "@DOLTLITE_VERSION@"

--- a/packaging/go/smoke-test/main.go
+++ b/packaging/go/smoke-test/main.go
@@ -45,10 +45,14 @@ func main() {
 	defer cleanup()
 
 	check("engine version reports", doltlite.Version() != "", true)
+	check("build version reports", doltlite.BuildVersion != "", true)
 
 	db, err := sql.Open("doltlite", dbPath)
 	must(err)
 	defer db.Close()
+	var buildVersion string
+	must(db.QueryRow(`SELECT dolt_version()`).Scan(&buildVersion))
+	check("engine version is stamped", buildVersion, doltlite.BuildVersion)
 
 	_, err = db.Exec(`CREATE TABLE t(pk INTEGER PRIMARY KEY, s TEXT, f REAL, b BLOB)`)
 	must(err)


### PR DESCRIPTION
## Summary

- add a manually dispatched workflow that builds and smoke-tests the tip of DoltLite `master`
- publish the assembled module to `dolthub/doltlite-driver` on its `dev` branch for consumption through `go get github.com/dolthub/doltlite-driver@dev`
- stamp the generated Go package and `dolt_version()` with the embedded DoltLite revision
- serialize dev and release publication, and retain stable release commits in the dev branch ancestry

## Why

Development deployments need a remotely consumable driver built from current DoltLite without waiting for a release. The workflow is manual-only, while Go records each selected dev snapshot as an immutable pseudo-version in downstream `go.mod` files.

## Validation

- clean configure and DoltLite amalgamation build from current `master`
- `bash packaging/go/test-package.sh build`
- `actionlint` on the dev and release workflows
- shell syntax and `git diff --check`

Co-Authored-By: OpenAI Codex <noreply@openai.com>