### PR TITLE
Generate SQL differential seeds in one process

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -285,7 +285,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install dependencies
-      run: bash .github/scripts/install-apt-deps.sh zlib1g-dev
+      run: bash .github/scripts/install-apt-deps.sh zlib1g-dev llvm
 
     - name: Download instrumented build
       uses: actions/download-artifact@v4
@@ -296,7 +296,10 @@ jobs:
       run: |
         tar -xzf coverage-build.tar.gz
         mkdir -p "$RUNNER_TEMP/coverage-profiles"
-        echo "LLVM_PROFILE_FILE=$RUNNER_TEMP/coverage-profiles/%8m.profraw" >> "$GITHUB_ENV"
+        # %p dumps one file per process. %8m flock-merges on every exit; this
+        # job starts ~5000 instrumented processes and that merge was the
+        # 15-minute timeout tail. A later step folds the raw dumps to one file.
+        echo "LLVM_PROFILE_FILE=$RUNNER_TEMP/coverage-profiles/%p.profraw" >> "$GITHUB_ENV"
 
     - name: Randomized SQL differential sweep (vs stock SQLite)
       run: |
@@ -305,6 +308,21 @@ jobs:
           ./doltlite ./sqlite3-stock \
           ${{ matrix.first }} ${{ matrix.last }}
       timeout-minutes: 15
+
+    - name: Merge per-process coverage profiles
+      if: always()
+      run: |
+        set -euo pipefail
+        dir="$RUNNER_TEMP/coverage-profiles"
+        list=$(mktemp)
+        find "$dir" -type f -name '*.profraw' | LC_ALL=C sort > "$list"
+        if [ ! -s "$list" ]; then
+          echo "no profraw files to merge"
+          exit 0
+        fi
+        echo "merging $(wc -l < "$list") profraw files"
+        llvm-profdata merge -sparse -f "$list" -o "$dir/sql-differential.profdata"
+        xargs rm -f < "$list"
 
     - name: Upload SQL differential coverage profiles
       if: always()

--- a/test/source_coverage_report.sh
+++ b/test/source_coverage_report.sh
@@ -56,9 +56,10 @@ find "$REPO_ROOT/src" -maxdepth 1 -type f \
      -o -name 'btree_orig_api.c' \) \
   | LC_ALL=C sort > "$SOURCE_LIST"
 
-find "$PROFILE_DIR" -type f -name '*.profraw' | LC_ALL=C sort > "$PROFILE_LIST"
+find "$PROFILE_DIR" -type f \( -name '*.profraw' -o -name '*.profdata' \) \
+  | LC_ALL=C sort > "$PROFILE_LIST"
 if [ ! -s "$PROFILE_LIST" ]; then
-  echo "ERROR: no LLVM raw profiles found under $PROFILE_DIR"
+  echo "ERROR: no LLVM profraw/profdata files found under $PROFILE_DIR"
   exit 1
 fi
 

--- a/test/sql_differential_fuzzer.py
+++ b/test/sql_differential_fuzzer.py
@@ -513,19 +513,23 @@ class Gen:
         return "\n".join(self.out)
 
 
-def main():
-    if len(sys.argv) < 2:
-        sys.stderr.write("usage: %s SEED [--include-<group>]... [--all]\n"
-                         "groups: %s\n" % (sys.argv[0], " ".join(GROUPS)))
-        return 2
-    seed = int(sys.argv[1])
-    flags = sys.argv[2:]
+def parse_groups(flags):
     if "--all" in flags:
         groups = list(GROUPS)
     else:
         groups = [g for g in GROUPS if ("--include-%s" % g) in flags]
     unknown = [f for f in flags
                if f != "--all" and f[len("--include-"):] not in GROUPS]
+    return groups, unknown
+
+
+def main():
+    if len(sys.argv) < 2:
+        sys.stderr.write("usage: %s SEED [--include-<group>]... [--all]\n"
+                         "groups: %s\n" % (sys.argv[0], " ".join(GROUPS)))
+        return 2
+    seed = int(sys.argv[1])
+    groups, unknown = parse_groups(sys.argv[2:])
     if unknown:
         sys.stderr.write("unknown flag(s): %s\n" % " ".join(unknown))
         return 2

--- a/test/sql_differential_sweep.py
+++ b/test/sql_differential_sweep.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Run generated SQL through doltlite and stock SQLite.
+
+Usage: sql_differential_sweep.py DOLTLITE SQLITE FIRST LAST [--include-<group>]... [--all]
+"""
+
+import difflib
+import importlib.util
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+
+PROGRESS_EVERY = 250
+
+MODULE_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                           "sql_differential_fuzzer.py")
+SPEC = importlib.util.spec_from_file_location("sql_differential_fuzzer",
+                                              MODULE_PATH)
+fuzz = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(fuzz)
+
+
+def unlink_db(path):
+    for suffix in ("", "-lock", "-wal", "-shm", "-journal"):
+        try:
+            os.remove(path + suffix)
+        except OSError:
+            pass
+
+
+def run_engine(binary, db, sql):
+    proc = subprocess.run(
+        [binary, db],
+        input=sql.encode(),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    return proc.returncode, proc.stdout
+
+
+def maybe_progress(done, total, seed, t0):
+    if done != 1 and done != total and done % PROGRESS_EVERY != 0:
+        return
+    elapsed = time.monotonic() - t0
+    rate = done / elapsed if elapsed > 0 else 0.0
+    sys.stdout.write("  ... %d/%d (seed %d)  %.1fs  %.1f/s\n" % (
+        done, total, seed, elapsed, rate))
+    sys.stdout.flush()
+
+
+def save_failing(sql, seed):
+    dest = os.environ.get("DOLTLITE_DIFF_SAVE_DIR")
+    if not dest:
+        return
+    try:
+        path = os.path.join(dest, "seed_%d.sql" % seed)
+        with open(path, "w") as fh:
+            fh.write(sql)
+            if not sql.endswith("\n"):
+                fh.write("\n")
+    except OSError:
+        pass
+
+
+def show_diff(out_dl, out_sq):
+    left = out_dl.decode("utf-8", "replace").splitlines()
+    right = out_sq.decode("utf-8", "replace").splitlines()
+    diff = difflib.unified_diff(left, right, lineterm="")
+    for i, line in enumerate(diff):
+        if i >= 20:
+            break
+        sys.stdout.write("    %s\n" % line)
+
+
+def sweep(doltlite, sqlite3, first, last, groups):
+    total = last - first + 1
+    work = tempfile.mkdtemp()
+    dl_db = os.path.join(work, "dl.db")
+    sq_db = os.path.join(work, "sq.db")
+    pass_n = 0
+    fail_n = 0
+    errored = 0
+    failed_seeds = []
+    t0 = time.monotonic()
+    try:
+        for i, seed in enumerate(range(first, last + 1), 1):
+            try:
+                sql = fuzz.Gen(seed, groups).run()
+            except Exception as exc:
+                sys.stdout.write("  ERROR: generator failed for seed %d\n" % seed)
+                sys.stdout.write("    %s\n" % exc)
+                fail_n += 1
+                failed_seeds.append(seed)
+                maybe_progress(i, total, seed, t0)
+                continue
+
+            unlink_db(dl_db)
+            unlink_db(sq_db)
+            rc_dl, out_dl = run_engine(doltlite, dl_db, sql)
+            rc_sq, out_sq = run_engine(sqlite3, sq_db, sql)
+
+            if rc_dl == rc_sq and out_dl == out_sq:
+                pass_n += 1
+                if b"Error" in out_dl or b"error" in out_dl:
+                    errored += 1
+                maybe_progress(i, total, seed, t0)
+                continue
+
+            fail_n += 1
+            failed_seeds.append(seed)
+            save_failing(sql, seed)
+            if fail_n <= 5:
+                sys.stdout.write(
+                    "  FAIL: seed %d (doltlite rc=%d, stock rc=%d)\n" % (
+                        seed, rc_dl, rc_sq))
+                show_diff(out_dl, out_sq)
+            elif fail_n == 6:
+                sys.stdout.write(
+                    "  ... further diffs omitted; every failing seed is listed below and\n"
+                    "      its script saved to the artifact directory\n")
+            maybe_progress(i, total, seed, t0)
+    finally:
+        shutil.rmtree(work, ignore_errors=True)
+
+    sys.stdout.write("\n")
+    sys.stdout.write("Results: %d passed, %d failed out of %d seeds\n" % (
+        pass_n, fail_n, pass_n + fail_n))
+    if errored:
+        sys.stdout.write(
+            "          (%d of the passing seeds had a statement both engines\n"
+            "           rejected, and they agreed on the rejection)\n" % errored)
+    if fail_n:
+        flags = []
+        if set(groups) == set(fuzz.GROUPS):
+            flags = ["--all"]
+        else:
+            flags = ["--include-%s" % g for g in groups]
+        sys.stdout.write("Failing seeds:%s\n" % "".join(" %d" % s for s in failed_seeds))
+        sys.stdout.write("Reproduce with: python3 test/sql_differential_fuzzer.py <seed>%s\n" %
+                         ("".join(" %s" % f for f in flags)))
+        sys.stdout.flush()
+        return 1
+    sys.stdout.flush()
+    return 0
+
+
+def main():
+    if len(sys.argv) < 5:
+        sys.stderr.write(
+            "usage: %s DOLTLITE SQLITE FIRST LAST [--include-<group>]... [--all]\n"
+            "groups: %s\n" % (sys.argv[0], " ".join(fuzz.GROUPS)))
+        return 2
+    doltlite, sqlite3 = sys.argv[1], sys.argv[2]
+    try:
+        first = int(sys.argv[3])
+        last = int(sys.argv[4])
+    except ValueError:
+        sys.stderr.write("seeds must be integers\n")
+        return 2
+    if last < first:
+        sys.stderr.write("last seed is before first seed\n")
+        return 2
+    groups, unknown = fuzz.parse_groups(sys.argv[5:])
+    if unknown:
+        sys.stderr.write("unknown flag(s): %s\n" % " ".join(unknown))
+        return 2
+    for binary in (doltlite, sqlite3):
+        if not os.path.isfile(binary) or not os.access(binary, os.X_OK):
+            sys.stderr.write("ERROR: not executable: %s\n" % binary)
+            return 1
+    return sweep(doltlite, sqlite3, first, last, groups)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/sql_differential_sweep_test.py
+++ b/test/sql_differential_sweep_test.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+
+import importlib.util
+import os
+import pathlib
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+HERE = pathlib.Path(__file__).resolve().parent
+FUZZER = HERE / "sql_differential_fuzzer.py"
+SWEEP = HERE / "sql_differential_sweep.py"
+
+SPEC = importlib.util.spec_from_file_location("sql_differential_fuzzer", FUZZER)
+fuzz = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(fuzz)
+
+
+def write_stub(path, body):
+    path.write_text("#!%s\n%s" % (sys.executable, body))
+    path.chmod(0o755)
+
+
+class ParseGroupsTest(unittest.TestCase):
+    def test_default_flags(self):
+        groups, unknown = fuzz.parse_groups(
+            ["--include-large-ints", "--include-desc"])
+        self.assertEqual(groups, ["large-ints", "desc"])
+        self.assertEqual(unknown, [])
+
+    def test_all(self):
+        groups, unknown = fuzz.parse_groups(["--all"])
+        self.assertEqual(groups, fuzz.GROUPS)
+        self.assertEqual(unknown, [])
+
+    def test_unknown(self):
+        groups, unknown = fuzz.parse_groups(["--include-nope"])
+        self.assertEqual(groups, [])
+        self.assertEqual(unknown, ["--include-nope"])
+
+
+class GeneratorParityTest(unittest.TestCase):
+    def test_cli_matches_inprocess(self):
+        groups = ["large-ints", "desc"]
+        sql = fuzz.Gen(7, groups).run()
+        out = subprocess.check_output(
+            [sys.executable, str(FUZZER), "7",
+             "--include-large-ints", "--include-desc"],
+            text=True)
+        self.assertEqual(out, sql + "\n")
+
+
+class SweepHarnessTest(unittest.TestCase):
+    def run_sweep(self, first, last, dl, sq, extra_env=None, flags=None):
+        env = os.environ.copy()
+        if extra_env:
+            env.update(extra_env)
+        cmd = [sys.executable, "-u", str(SWEEP), str(dl), str(sq),
+               str(first), str(last)]
+        if flags:
+            cmd.extend(flags)
+        return subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                              text=True, env=env)
+
+    def test_agreeing_stubs_pass_with_progress(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = pathlib.Path(tmp)
+            stub = tmp / "engine"
+            write_stub(stub, "import sys\nsys.stdin.read()\nsys.stdout.write('ok\\n')\n")
+            proc = self.run_sweep(1, 3, stub, stub)
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            self.assertIn("Results: 3 passed, 0 failed out of 3 seeds", proc.stdout)
+            self.assertIn("... 1/3 (seed 1)", proc.stdout)
+            self.assertIn("... 3/3 (seed 3)", proc.stdout)
+
+    def test_divergence_saves_script(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = pathlib.Path(tmp)
+            dl = tmp / "dl"
+            sq = tmp / "sq"
+            write_stub(dl, "import sys\nsys.stdin.read()\nsys.stdout.write('dl\\n')\n")
+            write_stub(sq, "import sys\nsys.stdin.read()\nsys.stdout.write('sq\\n')\n")
+            save = tmp / "save"
+            save.mkdir()
+            proc = self.run_sweep(4, 4, dl, sq, extra_env={
+                "DOLTLITE_DIFF_SAVE_DIR": str(save),
+            })
+            self.assertEqual(proc.returncode, 1, proc.stderr)
+            self.assertIn("FAIL: seed 4", proc.stdout)
+            self.assertIn("Failing seeds: 4", proc.stdout)
+            saved = save / "seed_4.sql"
+            self.assertTrue(saved.is_file())
+            self.assertIn("CREATE TABLE", saved.read_text())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/sql_differential_test.sh
+++ b/test/sql_differential_test.sh
@@ -29,6 +29,7 @@ LAST="${4:-${DOLTLITE_DIFF_LAST_SEED:-200}}"
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 GEN="$SCRIPT_DIR/sql_differential_fuzzer.py"
+SWEEP="$SCRIPT_DIR/sql_differential_sweep.py"
 
 for bin in "$DOLTLITE" "$SQLITE3"; do
   if [ ! -x "$bin" ]; then
@@ -36,8 +37,8 @@ for bin in "$DOLTLITE" "$SQLITE3"; do
     exit 1
   fi
 done
-if [ ! -f "$GEN" ]; then
-  echo "ERROR: missing generator: $GEN"
+if [ ! -f "$GEN" ] || [ ! -f "$SWEEP" ]; then
+  echo "ERROR: missing generator or sweep runner"
   exit 1
 fi
 
@@ -71,76 +72,11 @@ else
   done
 fi
 
-WORK="$(mktemp -d)"
-trap 'rm -rf "$WORK"' EXIT
-
 echo "=== SQL differential sweep: seeds $FIRST..$LAST ==="
 echo "    doltlite: $DOLTLITE"
 echo "    stock:    $SQLITE3"
 [ -n "$GENFLAGS" ] && echo "    groups:  $GENFLAGS"
 echo ""
 
-pass=0
-fail=0
-errored=0
-failed_seeds=""
-
-# -f %.0f, not a bare seq: BSD seq renders a seed this size as 4.82399e+09 and
-# the generator cannot parse that. The nightly draws seeds up to 9e9, so a
-# window it picks would fail on every seed on a Mac and pass on the runner.
-for seed in $(seq -f %.0f "$FIRST" "$LAST"); do
-  sql="$WORK/case.sql"
-  if ! python3 "$GEN" "$seed" $GENFLAGS > "$sql" 2>"$WORK/gen.err"; then
-    echo "  ERROR: generator failed for seed $seed"
-    cat "$WORK/gen.err"
-    fail=$((fail + 1))
-    continue
-  fi
-
-  rm -f "$WORK/dl.db" "$WORK/dl.db-lock" "$WORK/dl.db-wal" "$WORK/sq.db"
-  out_dl=$("$DOLTLITE" "$WORK/dl.db" < "$sql" 2>&1)
-  rc_dl=$?
-  out_sq=$("$SQLITE3" "$WORK/sq.db" < "$sql" 2>&1)
-  rc_sq=$?
-
-  if [ "$rc_dl" -eq "$rc_sq" ] && [ "$out_dl" = "$out_sq" ]; then
-    pass=$((pass + 1))
-    # Some workloads conflict on purpose: INSERT OR ROLLBACK, or a CHECK
-    # violation from the constraints group. Both engines rejecting a statement
-    # and agreeing on how is the comparison working, not the script breaking,
-    # so count those rather than leave a nonzero exit looking accidental.
-    case "$out_dl" in
-      *Error*|*error*) errored=$((errored + 1)) ;;
-    esac
-    continue
-  fi
-
-  fail=$((fail + 1))
-  failed_seeds="$failed_seeds $seed"
-  # Every failing seed keeps its script, so a long sweep does not end up with
-  # more failures than reproducers. Only the first few print a diff, because
-  # that is about keeping the log readable.
-  if [ -n "${DOLTLITE_DIFF_SAVE_DIR:-}" ]; then
-    cp "$sql" "$DOLTLITE_DIFF_SAVE_DIR/seed_$seed.sql" 2>/dev/null || true
-  fi
-  if [ "$fail" -le 5 ]; then
-    echo "  FAIL: seed $seed (doltlite rc=$rc_dl, stock rc=$rc_sq)"
-    diff <(printf '%s\n' "$out_dl") <(printf '%s\n' "$out_sq") \
-      | head -20 | sed 's/^/    /'
-  elif [ "$fail" -eq 6 ]; then
-    echo "  ... further diffs omitted; every failing seed is listed below and"
-    echo "      its script saved to the artifact directory"
-  fi
-done
-
-echo ""
-echo "Results: $pass passed, $fail failed out of $((pass + fail)) seeds"
-if [ "$errored" -gt 0 ]; then
-  echo "          ($errored of the passing seeds had a statement both engines"
-  echo "           rejected, and they agreed on the rejection)"
-fi
-if [ "$fail" -gt 0 ]; then
-  echo "Failing seeds:$failed_seeds"
-  echo "Reproduce with: python3 test/sql_differential_fuzzer.py <seed>$GENFLAGS"
-  exit 1
-fi
+python3 "$SCRIPT_DIR/sql_differential_sweep_test.py" -q || exit 1
+python3 -u "$SWEEP" "$DOLTLITE" "$SQLITE3" "$FIRST" "$LAST" $GENFLAGS


### PR DESCRIPTION
## Summary
- generate each shard's SQL in one Python process instead of execing the fuzzer once per seed
- print progress every 250 seeds (and after the first) so a 15-minute timeout names how far the sweep got
- dump LLVM coverage per-pid (`%p.profraw`) and merge to one `.profdata` before upload, instead of `%8m` flock-merge on every instrumented exit

The PR `sql-differential-1-5000` / `5001-10000` jobs are a serial loop: 5,000 seeds × (Python + doltlite + sqlite3). Quiet runners finish in ~4 minutes; loaded ones hit the 15-minute step. There is no hung seed — the same window has finished all 5,000 in 13.4 minutes, both shards time out, and reruns pass. The script printed nothing until `Results:`, so a timeout looked like a hang.

Locally the in-process generator runs ~74 seeds/s (~1.1 min for 5,000) against a non-coverage build, versus ~3.5 min with one Python exec per seed. The 15-minute cap stays.

Nightly `sql_differential_test.sh` (100k seeds, `--all`) picks this up automatically.

## Validation
- `python3 test/sql_differential_sweep_test.py -q` (generator/CLI parity, stub pass and fail paths)
- `bash test/lint_orphaned_suites.sh`
- `bash test/sql_differential_test.sh ./build/doltlite ./build-stockref/sqlite3 1 500` — 500 passed, progress at 1/250/500
- same harness on seeds `10000001..10000005` (nightly-sized integers)

Co-Authored-By: Grok 4.6 <noreply@x.ai>