### PR TITLE
Reject failed SQL oracle executions

### DIFF
--- a/main.mk
+++ b/main.mk
@@ -313,6 +313,7 @@ lint:
 	@bash $(TOP)/test/check_testfixture_exception_inventory.sh
 	@bash $(TOP)/test/check_testfixture_exception_inventory_test.sh
 	@bash $(TOP)/test/dolt_oracle_upgrade_test.sh
+	@bash $(TOP)/test/sql_oracle_harness_test.sh
 
 ########################################################################
 ########################################################################

--- a/test/lib/sql_oracle_common.sh
+++ b/test/lib/sql_oracle_common.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+sql_oracle_check_binaries() {
+  local script_dir="$1" var bin resolved output
+  for var in DOLTLITE SQLITE3; do
+    bin="${!var}"
+    if ! resolved=$(command -v "$bin") || [ ! -x "$resolved" ]; then
+      echo "ERROR: not executable: $bin" >&2
+      return 1
+    fi
+    printf -v "$var" '%s' "$resolved"
+    bin="$resolved"
+    if ! output=$("$bin" :memory: "SELECT 'sql-oracle-ready',6*7;" 2>&1); then
+      echo "ERROR: $bin failed the SQL execution probe: $output" >&2
+      return 1
+    fi
+    if [ "$output" != "sql-oracle-ready|42" ]; then
+      echo "ERROR: $bin returned unexpected SQL probe output: $output" >&2
+      return 1
+    fi
+  done
+  bash "$script_dir/assert_stock_reference.sh" "$SQLITE3" "$DOLTLITE"
+}
+
+normalize_oracle_output() {
+  LC_ALL=C sed -E \
+    -e 's/^Error near line [0-9]+: /ERROR: /' \
+    -e 's/^Runtime error near line [0-9]+: /ERROR: /' \
+    -e 's/ \([0-9]+\)$//'
+}
+
+oracle() {
+  oracle_with_flags "$1" "$2" ""
+}
+
+oracle_error() {
+  oracle_with_flags "$1" "$2" "" "${3:?expected error text required}"
+}
+
+oracle_with_flags() {
+  local name="$1" sql="$2" flag="$3" expected_error="${4-}"
+  local dl="$SQL_ORACLE_TMP/dl_${name}.db" sq="$SQL_ORACLE_TMP/sq_${name}.db"
+  local out_dl out_sq norm_dl norm_sq rc_dl=0 rc_sq=0 expected_rc=0
+  if [ -n "$expected_error" ]; then expected_rc=1; fi
+  rm -f "$dl" "$sq"
+  out_dl=$(printf '%s\n' "$sql" | "$DOLTLITE" ${flag:+"$flag"} "$dl" 2>&1) || rc_dl=$?
+  out_sq=$(printf '%s\n' "$sql" | "$SQLITE3" ${flag:+"$flag"} "$sq" 2>&1) || rc_sq=$?
+  norm_dl=$(printf '%s\n' "$out_dl" | normalize_oracle_output)
+  norm_sq=$(printf '%s\n' "$out_sq" | normalize_oracle_output)
+  if [ "$rc_dl" -eq "$expected_rc" ] && [ "$rc_sq" -eq "$expected_rc" ] \
+     && [ "$norm_dl" = "$norm_sq" ] \
+     && { [ "$expected_rc" -eq 0 ] || [[ "$norm_sq" == *"$expected_error"* ]]; }; then
+    pass=$((pass+1))
+  else
+    fail=$((fail+1))
+    echo "  FAIL: $name"
+    echo "    expected rc: $expected_rc${expected_error:+ ($expected_error)}"
+    echo "    doltlite rc: $rc_dl"
+    echo "    doltlite: $(printf '%s\n' "$out_dl" | head -3)"
+    echo "    sqlite3 rc:  $rc_sq"
+    echo "    sqlite3:  $(printf '%s\n' "$out_sq" | head -3)"
+  fi
+}
+
+oracle_unsafe() {
+  oracle_with_flags "$1" "$2" "--unsafe-testing"
+}

--- a/test/sql_oracle_harness_test.sh
+++ b/test/sql_oracle_harness_test.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ORACLE="${1:-$SCRIPT_DIR/sql_oracle_test.sh}"
+SQL_ORACLE_TMP=$(mktemp -d)
+trap 'rm -rf "$SQL_ORACLE_TMP"' EXIT
+source "$SCRIPT_DIR/lib/sql_oracle_common.sh"
+
+DOLTLITE="$SQL_ORACLE_TMP/candidate"
+SQLITE3="$SQL_ORACLE_TMP/reference"
+cat > "$DOLTLITE" <<'EOF'
+#!/usr/bin/env bash
+cat >/dev/null
+if [ "${expect_unsafe:-0}" = 1 ] && [ "$1" != --unsafe-testing ]; then
+  exit 99
+fi
+case "$0" in
+  */candidate) printf '%s' "$candidate_output"; exit "$candidate_rc" ;;
+  */reference) printf '%s' "$reference_output"; exit "$reference_rc" ;;
+esac
+EOF
+cp "$DOLTLITE" "$SQLITE3"
+chmod +x "$DOLTLITE" "$SQLITE3"
+
+check_case() {
+  local name="$1" want_fail="$2" kind="$3" error="${4-}"
+  local pass=0 fail=0
+  if [ "$kind" = error ]; then
+    oracle_error "$name" "SELECT 42;" "$error" > "$SQL_ORACLE_TMP/case.log"
+  elif [ "$kind" = unsafe ]; then
+    oracle_unsafe "$name" "SELECT 42;" > "$SQL_ORACLE_TMP/case.log"
+  else
+    oracle "$name" "SELECT 42;" > "$SQL_ORACLE_TMP/case.log"
+  fi
+  if [ "$fail" -ne "$want_fail" ] || [ "$pass" -ne "$((1-want_fail))" ]; then
+    echo "FAIL: $name (pass=$pass fail=$fail)"
+    cat "$SQL_ORACLE_TMP/case.log"
+    exit 1
+  fi
+}
+
+export candidate_rc=0 reference_rc=0 candidate_output=42 reference_output=42
+check_case successful_query 0 success
+export candidate_output= reference_output=
+check_case successful_empty_output 0 success
+export candidate_rc=1 reference_rc=1
+check_case matching_silent_failures 1 success
+export candidate_output='shared error' reference_output='shared error'
+check_case matching_unexpected_errors 1 success
+check_case matching_expected_error 0 error 'shared error'
+check_case wrong_expected_error 1 error 'different error'
+export candidate_rc=0 reference_rc=0
+check_case expected_error_did_not_fail 1 error 'shared error'
+export candidate_rc=1 reference_rc=0
+check_case candidate_only_failure 1 success
+export candidate_rc=0 reference_rc=1
+check_case reference_only_failure 1 success
+export candidate_rc=0 reference_rc=0 candidate_output=41 reference_output=42
+check_case different_rows 1 success
+export candidate_rc=134 reference_rc=134
+check_case matching_crashes 1 success
+export candidate_output='shared error' reference_output='shared error'
+check_case crashing_expected_error 1 error 'shared error'
+export candidate_rc=127 reference_rc=127
+check_case matching_launch_errors 1 error 'shared error'
+export candidate_rc=1 reference_rc=1 candidate_output= reference_output=
+check_case empty_expected_error 1 error 'shared error'
+export candidate_output=$'Error near line 3: UNIQUE constraint failed: t.x (19)\n1'
+export reference_output=$'Runtime error near line 7: UNIQUE constraint failed: t.x (19)\n1'
+check_case normalized_expected_error 0 error 'UNIQUE constraint failed: t.x'
+export candidate_rc=0 reference_rc=0 candidate_output=42 reference_output=42 expect_unsafe=1
+check_case unsafe_flag_preserved 0 unsafe
+unset expect_unsafe
+
+expect_startup_failure() {
+  local name="$1" candidate="$2" reference="$3"
+  if bash "$ORACLE" "$candidate" "$reference" > "$SQL_ORACLE_TMP/startup.log" 2>&1; then
+    echo "FAIL: oracle accepted $name"
+    tail -5 "$SQL_ORACLE_TMP/startup.log"
+    exit 1
+  fi
+}
+
+cat > "$SQL_ORACLE_TMP/fails" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+cat > "$SQL_ORACLE_TMP/empty" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+cat > "$SQL_ORACLE_TMP/pretends" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' 'sql-oracle-ready|42'
+EOF
+chmod +x "$SQL_ORACLE_TMP/fails" "$SQL_ORACLE_TMP/empty" "$SQL_ORACLE_TMP/pretends"
+expect_startup_failure silent_failure "$SQL_ORACLE_TMP/fails" "$SQL_ORACLE_TMP/fails"
+expect_startup_failure empty_success "$SQL_ORACLE_TMP/empty" "$SQL_ORACLE_TMP/empty"
+expect_startup_failure missing_executable "$SQL_ORACLE_TMP/missing" "$SQL_ORACLE_TMP/missing"
+expect_startup_failure no_stock_database "$SQL_ORACLE_TMP/pretends" "$SQL_ORACLE_TMP/pretends"
+
+echo "SQL oracle harness: 20 checks passed"

--- a/test/sql_oracle_test.sh
+++ b/test/sql_oracle_test.sh
@@ -1,49 +1,15 @@
 #!/bin/bash
 
+set -uo pipefail
+
 DOLTLITE="${1:-./doltlite}"
 SQLITE3="${2:-./sqlite3}"
-TMPDIR=$(mktemp -d)
-trap "rm -rf $TMPDIR" EXIT
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/lib/sql_oracle_common.sh"
+if ! sql_oracle_check_binaries "$SCRIPT_DIR"; then exit 1; fi
+SQL_ORACLE_TMP=$(mktemp -d) || exit 1
+trap 'rm -rf "$SQL_ORACLE_TMP"' EXIT
 pass=0; fail=0
-
-normalize_oracle_output() {
-  LC_ALL=C sed -E \
-    -e 's/^Error near line [0-9]+: /ERROR: /' \
-    -e 's/^Runtime error near line [0-9]+: /ERROR: /' \
-    -e 's/ \([0-9]+\)$//'
-}
-
-oracle() {
-  local name="$1" sql="$2"
-  oracle_with_flags "$name" "$sql" ""
-}
-
-oracle_with_flags() {
-  local name="$1" sql="$2" flags="$3"
-  local dl="$TMPDIR/dl_${name}.db" sq="$TMPDIR/sq_${name}.db"
-  local out_dl out_sq norm_dl norm_sq rc_dl rc_sq
-  rm -f "$dl" "$sq"
-  out_dl=$(echo "$sql" | "$DOLTLITE" $flags "$dl" 2>&1)
-  rc_dl=$?
-  out_sq=$(echo "$sql" | "$SQLITE3" $flags "$sq" 2>&1)
-  rc_sq=$?
-  norm_dl=$(printf '%s\n' "$out_dl" | normalize_oracle_output)
-  norm_sq=$(printf '%s\n' "$out_sq" | normalize_oracle_output)
-  if [ "$rc_dl" -eq "$rc_sq" ] && [ "$norm_dl" = "$norm_sq" ]; then
-    pass=$((pass+1))
-  else
-    fail=$((fail+1))
-    echo "  FAIL: $name"
-    echo "    doltlite rc: $rc_dl"
-    echo "    doltlite: $(echo "$out_dl" | head -3)"
-    echo "    sqlite3 rc:  $rc_sq"
-    echo "    sqlite3:  $(echo "$out_sq" | head -3)"
-  fi
-}
-
-oracle_unsafe() {
-  oracle_with_flags "$1" "$2" "--unsafe-testing"
-}
 
 echo "=== Index Oracle Tests ==="
 echo ""
@@ -3556,12 +3522,12 @@ SELECT first || ' ' || last as full_name FROM t WHERE last = 'Doe' ORDER BY firs
 echo ""
 echo "--- Category 56: Subquery patterns ---"
 
-oracle "cat56_all_any" "
+oracle_error "cat56_all_any" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, val INT);
 CREATE INDEX idx ON t(val);
 INSERT INTO t VALUES(1,10),(2,20),(3,30),(4,40),(5,50);
 SELECT id FROM t WHERE val > ALL(SELECT val FROM t WHERE id <= 2) ORDER BY id;
-"
+" 'near "ALL": syntax error'
 
 oracle "cat56_subquery_having" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, grp TEXT, val INT);
@@ -4818,13 +4784,13 @@ SELECT sum(val) FROM t;
 SELECT min(val), max(val) FROM t;
 "
 
-oracle "cat88_insert_abort" "
+oracle_error "cat88_insert_abort" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, val INT UNIQUE);
 INSERT INTO t VALUES(1, 10),(2, 20);
 INSERT OR ABORT INTO t VALUES(3, 10);
 SELECT * FROM t ORDER BY id;
 SELECT count(*) FROM t;
-"
+" 'UNIQUE constraint failed: t.val'
 
 oracle "cat88_insert_sorted_explicit_rowid" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT);
@@ -5074,11 +5040,11 @@ GROUP BY category HAVING total / cnt > 100 ORDER BY category;
 echo ""
 echo "--- Category 95: Complex INSERT patterns ---"
 
-oracle "cat95_insert_returning_agg" "
+oracle_error "cat95_insert_returning_agg" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, val INT);
 CREATE INDEX idx ON t(val);
 INSERT INTO t VALUES(1,10),(2,20),(3,30) RETURNING sum(val) OVER () as total;
-"
+" 'misuse of window function sum()'
 
 oracle "cat95_insert_from_cte" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, val INT, rank_val INT);
@@ -5963,16 +5929,16 @@ SELECT count(b.k), count(*) FROM a LEFT JOIN b USING(k);
 echo ""
 echo "--- Category 121: Defensively-walled internal paths ---"
 
-oracle "cat121_drop_sqlite_master_rejected" "
+oracle_error "cat121_drop_sqlite_master_rejected" "
 CREATE TABLE t(x INT);
 DROP TABLE sqlite_master;
-"
+" 'table sqlite_master may not be dropped'
 
-oracle "cat121_drop_sqlite_master_writable_schema_rejected" "
+oracle_error "cat121_drop_sqlite_master_writable_schema_rejected" "
 PRAGMA writable_schema = 1;
 CREATE TABLE t(x INT);
 DROP TABLE sqlite_master;
-"
+" 'table sqlite_master may not be dropped'
 
 oracle_unsafe "cat121_writable_schema_delete_master" "
 CREATE TABLE keep(x INT);


### PR DESCRIPTION
Running the SQL oracle with `/usr/bin/false` for both executables previously exited successfully and reported 569 passes. The harness now checks that both executables return a known SQL result and uses the existing stock-reference checker to validate the reference's file format and SQLite version.

Positive cases require successful execution from both engines. The five intentional SQL-error cases explicitly require exit status 1, the expected error text, and matching normalized output. Shared crashes, silent failures, and unexpected errors cannot count as passes. All 569 cases remain enabled.

Add 20 harness self-checks for success, empty successful output, matching failures, crashes, mismatched rows, expected errors, shell flags, and unusable executables. The self-test runs under `make lint`.

Validation:
- Before: the original false/false command reported 569 passes; the new self-test fails against the unfixed harness.
- After: false/false fails at startup, and using DoltLite as its own stock reference is rejected.
- Real DoltLite versus verified stock SQLite: 569 passed, 0 failed.
- All 20 harness self-checks, lint, shell syntax, and orphaned-suite checks pass.

Fixes #2780

Co-Authored-By: OpenAI Codex <noreply@openai.com>
