### PR TITLE
Batch lazy diff frontier chunk fetches

### DIFF
--- a/src/prolly_diff.c
+++ b/src/prolly_diff.c
@@ -6,6 +6,15 @@
 
 #include <string.h>
 
+#define DIFF_PREFETCH_MAX_PAIRS 256
+#define DIFF_PREFETCH_BATCH_HASHES 256
+
+typedef struct DiffPrefetchPair DiffPrefetchPair;
+struct DiffPrefetchPair {
+  ProllyHash oldHash;
+  ProllyHash newHash;
+};
+
 int prollyFetchNode(ChunkStore *pStore, const ProllyHash *pHash,
                     ProllyNode *pNode, u8 **ppData){
   u8 *pData = 0;
@@ -707,6 +716,126 @@ static void diffIterPopFrame(ProllyDiffIter *pIter){
   memset(pF, 0, sizeof(*pF));
 }
 
+static int diffIterPrefetchPairs(
+  ProllyDiffIter *pIter,
+  const DiffPrefetchPair *aInitial,
+  int nInitial
+){
+  DiffPrefetchPair aPair[DIFF_PREFETCH_MAX_PAIRS];
+  ProllyHash aHash[DIFF_PREFETCH_BATCH_HASHES];
+  int iLevel = 0;
+  int nPair = nInitial;
+  int rc = SQLITE_OK;
+
+  if( !pIter->pStore->pChunkSource || nInitial==0 ) return SQLITE_OK;
+  memcpy(aPair, aInitial, (size_t)nInitial * sizeof(DiffPrefetchPair));
+
+  while( iLevel<nPair ){
+    int iLevelEnd = nPair;
+    int iBatch = iLevel;
+    int k;
+
+    while( iBatch<iLevelEnd ){
+      int nBatchPair = iLevelEnd - iBatch;
+      int nHash;
+      if( nBatchPair>DIFF_PREFETCH_BATCH_HASHES/2 ){
+        nBatchPair = DIFF_PREFETCH_BATCH_HASHES/2;
+      }
+      for(k=0; k<nBatchPair; k++){
+        aHash[k*2] = aPair[iBatch+k].oldHash;
+        aHash[k*2+1] = aPair[iBatch+k].newHash;
+      }
+      nHash = nBatchPair * 2;
+      rc = chunkStoreSourcePrefetchMany(pIter->pStore, aHash, nHash);
+      if( rc!=SQLITE_OK ) return rc;
+      iBatch += nBatchPair;
+    }
+
+    if( pIter->shapeMismatch ) break;
+    for(k=iLevel; k<iLevelEnd && nPair<DIFF_PREFETCH_MAX_PAIRS; k++){
+      ProllyNode oldNode, newNode;
+      u8 *pOldData = 0;
+      u8 *pNewData = 0;
+      int i = 0;
+      int j = 0;
+
+      rc = prollyFetchNode(pIter->pStore, &aPair[k].oldHash,
+                           &oldNode, &pOldData);
+      if( rc!=SQLITE_OK ) return rc;
+      rc = prollyFetchNode(pIter->pStore, &aPair[k].newHash,
+                           &newNode, &pNewData);
+      if( rc!=SQLITE_OK ){
+        sqlite3_free(pOldData);
+        return rc;
+      }
+      if( oldNode.level>0 && newNode.level>0
+       && oldNode.level==newNode.level ){
+        while( i<(int)oldNode.nItems
+            && j<(int)newNode.nItems
+            && nPair<DIFF_PREFETCH_MAX_PAIRS ){
+          DiffPrefetchPair *pPair = &aPair[nPair];
+          prollyNodeChildHash(&oldNode, i, &pPair->oldHash);
+          prollyNodeChildHash(&newNode, j, &pPair->newHash);
+          if( prollyHashCompare(&pPair->oldHash, &pPair->newHash)==0 ){
+            i++;
+            j++;
+            continue;
+          }
+          if( diffNodeKeyCmp(&oldNode, i, &newNode, j,
+                             pIter->flags)!=0 ){
+            break;
+          }
+          nPair++;
+          i++;
+          j++;
+        }
+      }
+      sqlite3_free(pOldData);
+      sqlite3_free(pNewData);
+    }
+    iLevel = iLevelEnd;
+  }
+
+  return SQLITE_OK;
+}
+
+static int diffIterPrefetchFrame(
+  ProllyDiffIter *pIter,
+  DiffIterFrame *pF
+){
+  DiffPrefetchPair aPair[DIFF_PREFETCH_MAX_PAIRS];
+  int i = pF->i;
+  int j = pF->j;
+  int nPair = 0;
+
+  if( !pIter->pStore->pChunkSource ) return SQLITE_OK;
+  if( i<pF->iPrefetched && j<pF->jPrefetched ) return SQLITE_OK;
+
+  while( i<(int)pF->oldNode.nItems
+      && j<(int)pF->newNode.nItems
+      && nPair<DIFF_PREFETCH_MAX_PAIRS ){
+    DiffPrefetchPair *pPair = &aPair[nPair];
+    prollyNodeChildHash(&pF->oldNode, i, &pPair->oldHash);
+    prollyNodeChildHash(&pF->newNode, j, &pPair->newHash);
+    if( prollyHashCompare(&pPair->oldHash, &pPair->newHash)==0 ){
+      i++;
+      j++;
+      continue;
+    }
+    if( diffNodeKeyCmp(&pF->oldNode, i, &pF->newNode, j,
+                       pIter->flags)!=0 ){
+      break;
+    }
+    nPair++;
+    i++;
+    j++;
+  }
+
+  pF->iPrefetched = i;
+  pF->jPrefetched = j;
+  return diffIterPrefetchPairs(pIter, aPair, nPair);
+}
+
 /* Expand one differing subtree pair: identical hashes vanish, same-level
 ** internal pairs suspend as a frame, everything else (leaves, mixed
 ** levels, one empty side) becomes a cursor range. */
@@ -787,6 +916,8 @@ static int diffIterAdvanceFrame(ProllyDiffIter *pIter){
     cmp = diffNodeKeyCmp(&pF->oldNode, pF->i, &pF->newNode, pF->j,
                          pIter->flags);
     if( cmp==0 ){
+      rc = diffIterPrefetchFrame(pIter, pF);
+      if( rc!=SQLITE_OK ) return rc;
       pF->i++;
       pF->j++;
       return diffIterDescendPair(pIter, &oldChild, &newChild);
@@ -847,6 +978,25 @@ int prollyDiffIterOpen(
   pIter->newFlags = newFlags;
   pIter->shapeMismatch =
       ((oldFlags ^ newFlags) & PROLLY_NODE_INTKEY)!=0;
+
+  if( pStore->pChunkSource
+   && prollyHashCompare(pOldRoot, pNewRoot)!=0 ){
+    if( !prollyHashIsEmpty(pOldRoot) && !prollyHashIsEmpty(pNewRoot) ){
+      DiffPrefetchPair rootPair;
+      rootPair.oldHash = *pOldRoot;
+      rootPair.newHash = *pNewRoot;
+      rc = diffIterPrefetchPairs(pIter, &rootPair, 1);
+    }else{
+      ProllyHash rootHash = prollyHashIsEmpty(pOldRoot)
+                          ? *pNewRoot : *pOldRoot;
+      rc = chunkStoreSourcePrefetchMany(pStore, &rootHash, 1);
+    }
+    if( rc!=SQLITE_OK ){
+      pIter->eof = 1;
+      pIter->rc = rc;
+      return rc;
+    }
+  }
 
   if( pIter->shapeMismatch ){
     rc = diffIterActivateRange(pIter, pOldRoot, pNewRoot, 0, 0);

--- a/src/prolly_diff.h
+++ b/src/prolly_diff.h
@@ -60,6 +60,8 @@ struct DiffIterFrame {
   u8 *pNewData;
   int i;
   int j;
+  int iPrefetched;
+  int jPrefetched;
 };
 
 typedef struct ProllyDiffIter ProllyDiffIter;

--- a/test/chunk_source_test.c
+++ b/test/chunk_source_test.c
@@ -36,6 +36,7 @@ struct SourceCtx {
   int nGet;
   int nGetMany;
   int nManyHash;
+  int nMaxManyHash;
   int nRequest;
   int nReturned;
   int faultIssued;
@@ -276,6 +277,15 @@ static int buildSource(const char *zPath, sqlite3 **ppDb){
   if( rc==SQLITE_OK ){
     rc = execSql(db, "SELECT dolt_commit('-A','-m','base fixture')");
   }
+  if( rc==SQLITE_OK ) rc = execSql(db, "SELECT dolt_branch('sparse')");
+  if( rc==SQLITE_OK ) rc = execSql(db, "SELECT dolt_checkout('sparse')");
+  if( rc==SQLITE_OK ){
+    rc = execSql(db,
+      "UPDATE items SET payload=substr('sparse-'||payload,1,700) "
+      "WHERE id%97=0;"
+      "SELECT dolt_commit('-am','sparse changes')");
+  }
+  if( rc==SQLITE_OK ) rc = execSql(db, "SELECT dolt_checkout('main')");
   if( rc==SQLITE_OK ) rc = execSql(db, "SELECT dolt_branch('feature')");
   if( rc==SQLITE_OK ) rc = execSql(db, "SELECT dolt_checkout('feature')");
   if( rc==SQLITE_OK ){
@@ -337,6 +347,7 @@ static void sourceResetCounters(SourceCtx *p){
   p->nGet = 0;
   p->nGetMany = 0;
   p->nManyHash = 0;
+  p->nMaxManyHash = 0;
   p->nRequest = 0;
   p->nReturned = 0;
   p->faultIssued = 0;
@@ -428,6 +439,7 @@ static int sourceGetMany(
   int rc = DOLTLITE_SOURCE_OK;
   p->nGetMany++;
   p->nManyHash += nHash;
+  if( nHash>p->nMaxManyHash ) p->nMaxManyHash = nHash;
   for(i=0; i<nHash; i++){
     apBytes[i] = 0;
     anBytes[i] = 0;
@@ -977,6 +989,44 @@ static void testReadOnlyCacheAndBatching(
 
 readonly_done:
   if( b ) sqlite3_close(b);
+}
+
+static void testDiffFrontierBatching(
+  const char *zPath,
+  SourceCtx *pCtx,
+  doltlite_chunk_source *pApi,
+  const unsigned char *pRefs,
+  int nRefs
+){
+  sqlite3 *db = 0;
+  sqlite3_int64 nModified = 0;
+  int rc;
+
+  check("create diff-frontier refs-only store",
+        createLazyFile(zPath, pRefs, nRefs)==SQLITE_OK);
+  rc = openDb(zPath, SQLITE_OPEN_READONLY, &db);
+  check("open diff-frontier refs-only store", rc==SQLITE_OK);
+  if( rc!=SQLITE_OK ) goto diff_batch_done;
+  pCtx->mode = SOURCE_NORMAL;
+  rc = doltlite_set_chunk_source(db, "main", pApi);
+  check("register diff-frontier source", rc==SQLITE_OK);
+  if( rc!=SQLITE_OK ) goto diff_batch_done;
+
+  sourceResetCounters(pCtx);
+  rc = queryInt64(db,
+      "SELECT rows_modified FROM "
+      "dolt_diff_stat('sparse~1','sparse','items')", &nModified);
+  check("lazy sparse diff succeeds", rc==SQLITE_OK && nModified==24);
+  check("sparse diff uses batch source reads", pCtx->nGetMany>0);
+  check("sparse diff batches a frontier",
+        pCtx->nMaxManyHash>2 && pCtx->nManyHash>pCtx->nGetMany);
+  check("sparse diff bounds frontier round trips", pCtx->nGetMany<=2);
+
+diff_batch_done:
+  if( db ){
+    (void)doltlite_set_chunk_source(db, "main", 0);
+    sqlite3_close(db);
+  }
 }
 
 static void testFailedRegistrationDetaches(
@@ -2539,6 +2589,7 @@ int main(void){
   char zSource[192];
   char zWrite[192];
   char zReadOnly[192];
+  char zDiffBatch[192];
   char zDetach[192];
   char zWorkingSetMiss[192];
   char zOtherWorkingSetMiss[192];
@@ -2565,6 +2616,7 @@ int main(void){
   snprintf(zSource, sizeof(zSource), "%s_source.db", zPrefix);
   snprintf(zWrite, sizeof(zWrite), "%s_write.db", zPrefix);
   snprintf(zReadOnly, sizeof(zReadOnly), "%s_readonly.db", zPrefix);
+  snprintf(zDiffBatch, sizeof(zDiffBatch), "%s_diff_batch.db", zPrefix);
   snprintf(zDetach, sizeof(zDetach), "%s_detach.db", zPrefix);
   snprintf(zWorkingSetMiss, sizeof(zWorkingSetMiss),
            "%s_working_set_miss.db", zPrefix);
@@ -2616,6 +2668,8 @@ int main(void){
   source.mode = SOURCE_NORMAL;
   testReadOnlyCacheAndBatching(
       zReadOnly, sourceDb, &source, &api, pNewRefs, nNewRefs);
+  testDiffFrontierBatching(
+      zDiffBatch, &source, &api, pNewRefs, nNewRefs);
   testFailedRegistrationDetaches(
       zDetach, &source, &api, pNewRefs, nNewRefs);
   testWorkingSetNotFound(
@@ -2656,6 +2710,7 @@ test_done:
   removeStore(zSource);
   removeStore(zWrite);
   removeStore(zReadOnly);
+  removeStore(zDiffBatch);
   removeStore(zDetach);
   removeStore(zWorkingSetMiss);
   removeStore(zOtherWorkingSetMiss);


### PR DESCRIPTION
## Summary

- prefetch bounded breadth-first frontiers of differing prolly nodes through the generic chunk-source batch interface
- skip identical subtrees and retain range fallback when chunk boundaries diverge
- leave ordinary stores without a chunk source on the existing local-read path
- add a sparse-diff regression test that verifies bounded multi-hash source reads

## Performance

On the persisted lazy-origin fixture, a distant diff dropped from 285 one-hash requests and about 69 seconds to 12 requests and about 12 seconds. The primary diff frontiers were fetched in batches of 96 and 180 hashes.

## Testing

- make lint
- chunk_source_test: 331 passed
- doltlite_diff.sh: 50 passed
- doltlite_diff_table.sh: 95 passed
- vc_oracle_diff_stat_test.sh: 117 passed
- vc_oracle_diff_test.sh: 75 passed
- run_doltlite_tests.sh: 132 suites passed