### PR TITLE
Reject empty and failed stock SQL oracle runs

### DIFF
--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -57,6 +57,7 @@ jobs:
       if: matrix.suite == 'oracles'
       run: |
         cd build
+        bash ../test/assert_stock_reference.sh ./sqlite3 ./doltlite || exit 1
         bash ../test/sql_oracle_test.sh ./doltlite ./sqlite3 || exit 1
         bash ../test/oracle_import_test.sh ./doltlite dolt || exit 1
         for f in ../test/oracle_*_test.sh; do
@@ -136,6 +137,7 @@ jobs:
     - name: SQL oracle tests (vs stock SQLite)
       run: |
         cd build
+        bash ../test/assert_stock_reference.sh ./sqlite3 ./doltlite || exit 1
         bash ../test/sql_oracle_test.sh ./doltlite ./sqlite3 || exit 1
         for f in ../test/oracle_*_test.sh; do
           [ "$(basename "$f")" = "oracle_import_test.sh" ] && continue

--- a/main.mk
+++ b/main.mk
@@ -314,6 +314,7 @@ lint:
 	@bash $(TOP)/test/check_testfixture_exception_inventory_test.sh
 	@bash $(TOP)/test/dolt_oracle_upgrade_test.sh
 	@bash $(TOP)/test/sql_oracle_harness_test.sh
+	@bash $(TOP)/test/stock_oracle_harness_test.sh
 
 ########################################################################
 ########################################################################

--- a/test/lib/sql_oracle_common.sh
+++ b/test/lib/sql_oracle_common.sh
@@ -19,6 +19,15 @@ sql_oracle_check_binaries() {
       return 1
     fi
   done
+  if [ "$DOLTLITE" -ef "$SQLITE3" ]; then
+    echo "ERROR: candidate and reference are the same executable" >&2
+    return 1
+  fi
+  if ! output=$("$DOLTLITE" :memory: "SELECT doltlite_engine();" 2>&1) \
+     || [ "$output" != "prolly" ]; then
+    echo "ERROR: $DOLTLITE is not a DoltLite prolly engine: $output" >&2
+    return 1
+  fi
   bash "$script_dir/assert_stock_reference.sh" "$SQLITE3" "$DOLTLITE"
 }
 

--- a/test/lib/stock_oracle_common.sh
+++ b/test/lib/stock_oracle_common.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+source "$(dirname "${BASH_SOURCE[0]}")/sql_oracle_common.sh"
+
+stock_oracle_init() {
+  nonempty=0
+  sql_oracle_check_binaries "$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+}
+
+stock_oracle_assert() {
+  local name="$1" dl_out="$2" sq_out="$3" dl_rc="$4" sq_rc="$5"
+  local expected_error="${6-}" expect_empty="${7:-0}" expected_rc=0
+  if [ -n "$expected_error" ]; then expected_rc=1; fi
+  if [ "$dl_rc" -eq "$expected_rc" ] && [ "$sq_rc" -eq "$expected_rc" ] \
+     && [ "$dl_out" = "$sq_out" ] \
+     && { [ "$expect_empty" -eq 1 ] && [ -z "$sq_out" ] \
+          || { [ "$expect_empty" -eq 0 ] && [ -n "$sq_out" ]; }; } \
+     && { [ "$expected_rc" -eq 0 ] || [[ "$sq_out" == *"$expected_error"* ]]; }; then
+    pass=$((pass+1))
+    if [ -n "$sq_out" ]; then nonempty=$((nonempty+1)); fi
+  else
+    fail=$((fail+1))
+    FAILED_NAMES="$FAILED_NAMES $name"
+    echo "  FAIL: $name"
+    echo "    expected rc: $expected_rc${expected_error:+ ($expected_error)}; empty: $expect_empty"
+    echo "    doltlite rc: $dl_rc"
+    printf '%s\n' "$dl_out" | sed 's/^/      /'
+    echo "    sqlite3 rc: $sq_rc"
+    printf '%s\n' "$sq_out" | sed 's/^/      /'
+  fi
+}
+
+oracle_error() {
+  oracle "$1" "$3" "${2:?expected error text required}"
+}
+
+oracle_empty() {
+  oracle "$1" "$2" "" 1
+}
+
+stock_oracle_finish() {
+  if [ "$pass" -eq 0 ] || [ "$nonempty" -eq 0 ]; then
+    fail=$((fail+1))
+    FAILED_NAMES="$FAILED_NAMES suite_floor"
+    echo "  FAIL: suite needs passing comparisons and non-empty compared output"
+  fi
+  echo ""
+  echo "=== Results: $pass passed, $fail failed ==="
+  if [ "$fail" -gt 0 ]; then
+    echo "Failed:$FAILED_NAMES"
+    return 1
+  fi
+}

--- a/test/oracle_attach_test.sh
+++ b/test/oracle_attach_test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -u
+set -uo pipefail
 
 DOLTLITE="${1:-./doltlite}"
 SQLITE3="${2:-./sqlite3}"
@@ -8,6 +8,8 @@ TMPROOT=$(mktemp -d)
 trap "rm -rf $TMPROOT" EXIT
 pass=0; fail=0
 FAILED_NAMES=""
+source "$(dirname "$0")/lib/stock_oracle_common.sh"
+stock_oracle_init || exit 1
 
 normalize() {
   tr -d '\r' \
@@ -22,21 +24,14 @@ oracle() {
   local dir="$TMPROOT/$name"
   mkdir -p "$dir/dl" "$dir/sq"
 
+  local dl_rc=0 sq_rc=0
   local dl_out
-  dl_out=$(printf '%s\n' "$sql" | "$DOLTLITE" "$dir/dl/db" 2>&1 | normalize)
+  dl_out=$(printf '%s\n' "$sql" | "$DOLTLITE" "$dir/dl/db" 2>&1 | normalize) || dl_rc=$?
 
   local sq_out
-  sq_out=$(printf '%s\n' "$sql" | "$SQLITE3" "$dir/sq/db" 2>&1 | normalize)
+  sq_out=$(printf '%s\n' "$sql" | "$SQLITE3" "$dir/sq/db" 2>&1 | normalize) || sq_rc=$?
 
-  if [ "$dl_out" = "$sq_out" ]; then
-    pass=$((pass+1))
-  else
-    fail=$((fail+1))
-    FAILED_NAMES="$FAILED_NAMES $name"
-    echo "  FAIL: $name"
-    echo "    doltlite:"; echo "$dl_out" | sed 's/^/      /'
-    echo "    sqlite3:";  echo "$sq_out" | sed 's/^/      /'
-  fi
+  stock_oracle_assert "$name" "$dl_out" "$sq_out" "$dl_rc" "$sq_rc" "${3-}" "${4:-0}"
 }
 
 echo "=== Oracle Tests: ATTACH + cross-engine ==="
@@ -66,7 +61,7 @@ CREATE TABLE aux.v(id INT PRIMARY KEY);
 SELECT name FROM aux.sqlite_master WHERE type='table' ORDER BY name;
 "
 
-oracle "detach_nonexistent_fails" "
+oracle_error "detach_nonexistent_fails" "no such database: nosuch" "
 DETACH DATABASE nosuch;
 "
 
@@ -215,7 +210,7 @@ SELECT count(*) FROM aux.u;
 
 echo "--- cross-engine triggers ---"
 
-oracle "trigger_references_aux_rejected" "
+oracle_error "trigger_references_aux_rejected" "qualified table names are not allowed" "
 CREATE TABLE t(id INT PRIMARY KEY, v INT);
 ATTACH DATABASE ':memory:' AS aux;
 CREATE TABLE aux.log(id INT PRIMARY KEY, v INT);
@@ -276,10 +271,4 @@ SELECT t.v, u.v FROM t JOIN aux.u u USING (id) WHERE t.id = 25;
 "
 
 
-echo ""
-echo "=== Results: $pass passed, $fail failed ==="
-if [ "$fail" -gt 0 ]; then
-  echo "Failed:$FAILED_NAMES"
-  exit 1
-fi
-exit 0
+stock_oracle_finish

--- a/test/oracle_dot_commands_test.sh
+++ b/test/oracle_dot_commands_test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -u
+set -uo pipefail
 
 DOLTLITE="${1:-./doltlite}"
 SQLITE3="${2:-./sqlite3}"
@@ -8,6 +8,8 @@ TMPROOT=$(mktemp -d)
 trap "rm -rf $TMPROOT" EXIT
 pass=0; fail=0
 FAILED_NAMES=""
+source "$(dirname "$0")/lib/stock_oracle_common.sh"
+stock_oracle_init || exit 1
 
 normalize() {
   tr -d '\r' \
@@ -23,26 +25,18 @@ oracle() {
   mkdir -p "$dir"
 
   mkdir -p "$dir/dl" "$dir/sq"
+  local dl_rc=0 sq_rc=0
   local dl_out
   dl_out=$(printf '%s\n%s\n' "$setup" "$cmd" \
            | "$DOLTLITE" "$dir/dl/db" 2>"$dir/dl.err" \
-           | normalize)
+           | normalize) || dl_rc=$?
 
   local sq_out
   sq_out=$(printf '%s\n%s\n' "$setup" "$cmd" \
            | "$SQLITE3" "$dir/sq/db" 2>"$dir/sq.err" \
-           | normalize)
+           | normalize) || sq_rc=$?
 
-  if [ "$dl_out" = "$sq_out" ]; then
-    pass=$((pass+1))
-  else
-    fail=$((fail+1))
-    FAILED_NAMES="$FAILED_NAMES $name"
-    echo "  FAIL: $name"
-    echo "    cmd: $cmd"
-    echo "    doltlite:"; echo "$dl_out" | sed 's/^/      /'
-    echo "    sqlite3:";  echo "$sq_out" | sed 's/^/      /'
-  fi
+  stock_oracle_assert "$name" "$dl_out" "$sq_out" "$dl_rc" "$sq_rc" "" "${4:-0}"
 }
 
 # sqlite_master order differs (canonical vs creation); compare sorted.
@@ -50,23 +44,15 @@ oracle_sorted() {
   local name="$1" setup="$2" cmd="$3"
   local dir="$TMPROOT/$name"
   mkdir -p "$dir/dl" "$dir/sq"
+  local dl_rc=0 sq_rc=0
   local dl_out sq_out
   dl_out=$(printf '%s\n%s\n' "$setup" "$cmd" \
            | "$DOLTLITE" "$dir/dl/db" 2>"$dir/dl.err" \
-           | normalize | sort)
+           | normalize | sort) || dl_rc=$?
   sq_out=$(printf '%s\n%s\n' "$setup" "$cmd" \
            | "$SQLITE3" "$dir/sq/db" 2>"$dir/sq.err" \
-           | normalize | sort)
-  if [ "$dl_out" = "$sq_out" ]; then
-    pass=$((pass+1))
-  else
-    fail=$((fail+1))
-    FAILED_NAMES="$FAILED_NAMES $name"
-    echo "  FAIL: $name"
-    echo "    cmd: $cmd"
-    echo "    doltlite:"; echo "$dl_out" | sed 's/^/      /'
-    echo "    sqlite3:";  echo "$sq_out" | sed 's/^/      /'
-  fi
+           | normalize | sort) || sq_rc=$?
+  stock_oracle_assert "$name" "$dl_out" "$sq_out" "$dl_rc" "$sq_rc" "" "${4:-0}"
 }
 
 oracle_dbinfo() {
@@ -78,28 +64,23 @@ oracle_dbinfo() {
   # a non-INTEGER PRIMARY KEY; .indexes still lists the in-memory PK.
   local filter='grep -Ev "^(file change counter|database page count|schema cookie|autovacuum top root|data version|number of indexes:)"'
 
+  local dl_rc=0 sq_rc=0
   local dl_out
   dl_out=$(printf '%s\n.dbinfo\n' "$setup" \
            | "$DOLTLITE" "$dir/dl/db" 2>"$dir/dl.err" \
            | eval "$filter" \
-           | normalize)
+           | normalize) || dl_rc=$?
 
   local sq_out
   sq_out=$(printf '%s\n.dbinfo\n' "$setup" \
            | "$SQLITE3" "$dir/sq/db" 2>"$dir/sq.err" \
            | eval "$filter" \
-           | normalize)
+           | normalize) || sq_rc=$?
 
-  if [ "$dl_out" = "$sq_out" ]; then
-    pass=$((pass+1))
-  else
-    fail=$((fail+1))
-    FAILED_NAMES="$FAILED_NAMES $name"
-    echo "  FAIL: $name"
-    echo "    doltlite:"; echo "$dl_out" | sed 's/^/      /'
-    echo "    sqlite3:";  echo "$sq_out" | sed 's/^/      /'
-  fi
+  stock_oracle_assert "$name" "$dl_out" "$sq_out" "$dl_rc" "$sq_rc" "" "${4:-0}"
 }
+
+oracle_empty() { oracle "$@" 1; }
 
 SEED_EMPTY=""
 
@@ -158,8 +139,8 @@ INSERT INTO t VALUES(1,NULL,NULL);
 INSERT INTO t VALUES(2,'with ''apostrophe''',NULL);
 INSERT INTO t VALUES(3,'ok',x'deadbeef');"
 
-SEED_QUOTED_NAME='CREATE TABLE "my-table"(id INT, "col name" TEXT);
-INSERT INTO "my-table" VALUES(1,''hi'');'
+SEED_QUOTED_NAME="CREATE TABLE \"my-table\"(id INT, \"col name\" TEXT);
+INSERT INTO \"my-table\" VALUES(1,'hi');"
 
 SEED_MIXED_CASE="CREATE TABLE Users(id INT);
 CREATE TABLE USERS_LOG(id INT);
@@ -170,23 +151,23 @@ echo ""
 
 echo "--- .tables ---"
 
-oracle "tables_empty" "$SEED_EMPTY" ".tables"
+oracle_empty "tables_empty" "$SEED_EMPTY" ".tables"
 oracle "tables_one"   "$SEED_ONE_TABLE" ".tables"
 oracle "tables_many"  "$SEED_MANY_TABLES" ".tables"
 oracle "tables_pattern_prefix" "$SEED_MANY_TABLES" ".tables user%"
 oracle "tables_pattern_suffix" "$SEED_MANY_TABLES" ".tables %s"
 oracle "tables_pattern_contains" "$SEED_MANY_TABLES" ".tables %post%"
-oracle "tables_pattern_nomatch"  "$SEED_MANY_TABLES" ".tables nomatch%"
+oracle_empty "tables_pattern_nomatch"  "$SEED_MANY_TABLES" ".tables nomatch%"
 oracle "tables_with_view"        "$SEED_WITH_VIEW" ".tables"
 
 echo "--- .schema ---"
 
-oracle "schema_empty"           "$SEED_EMPTY" ".schema"
+oracle_empty "schema_empty"           "$SEED_EMPTY" ".schema"
 oracle "schema_one_table"       "$SEED_ONE_TABLE" ".schema"
 oracle_sorted "schema_many_tables"     "$SEED_MANY_TABLES" ".schema"
 oracle "schema_single_table"    "$SEED_MANY_TABLES" ".schema users"
 oracle_sorted "schema_pattern"         "$SEED_MANY_TABLES" ".schema us%"
-oracle "schema_nomatch"         "$SEED_MANY_TABLES" ".schema nomatch"
+oracle_empty "schema_nomatch"         "$SEED_MANY_TABLES" ".schema nomatch"
 oracle_sorted "schema_with_index"      "$SEED_WITH_INDEX" ".schema"
 oracle "schema_with_view"       "$SEED_WITH_VIEW" ".schema"
 oracle "schema_view_only"       "$SEED_WITH_VIEW" ".schema high"
@@ -195,11 +176,11 @@ oracle "schema_indent_flag"     "$SEED_ONE_TABLE" ".schema --indent"
 
 echo "--- .indexes ---"
 
-oracle "indexes_empty"            "$SEED_EMPTY" ".indexes"
-oracle "indexes_none"             "$SEED_ONE_TABLE" ".indexes"
+oracle_empty "indexes_empty"            "$SEED_EMPTY" ".indexes"
+oracle_empty "indexes_none"             "$SEED_ONE_TABLE" ".indexes"
 oracle "indexes_with_index"       "$SEED_WITH_INDEX" ".indexes"
 oracle "indexes_specific_table"   "$SEED_WITH_INDEX" ".indexes t"
-oracle "indexes_nomatch_table"    "$SEED_WITH_INDEX" ".indexes nomatch"
+oracle_empty "indexes_nomatch_table"    "$SEED_WITH_INDEX" ".indexes nomatch"
 
 echo "--- .databases ---"
 
@@ -256,9 +237,4 @@ oracle "dump_quoted_name"      "$SEED_QUOTED_NAME" ".dump"
 oracle_sorted "tables_mixed_case"     "$SEED_MIXED_CASE" ".tables"
 oracle_sorted "schema_mixed_case"     "$SEED_MIXED_CASE" ".schema"
 
-echo ""
-echo "=== Results: $pass passed, $fail failed ==="
-if [ $fail -gt 0 ]; then
-  echo "Failed:$FAILED_NAMES"
-  exit 1
-fi
+stock_oracle_finish

--- a/test/oracle_foreign_keys_test.sh
+++ b/test/oracle_foreign_keys_test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -u
+set -uo pipefail
 
 DOLTLITE="${1:-./doltlite}"
 SQLITE3="${2:-./sqlite3}"
@@ -8,6 +8,8 @@ TMPROOT=$(mktemp -d)
 trap "rm -rf $TMPROOT" EXIT
 pass=0; fail=0
 FAILED_NAMES=""
+source "$(dirname "$0")/lib/stock_oracle_common.sh"
+stock_oracle_init || exit 1
 
 normalize() {
   tr -d '\r' \
@@ -22,21 +24,14 @@ oracle() {
   local dir="$TMPROOT/$name"
   mkdir -p "$dir/dl" "$dir/sq"
 
+  local dl_rc=0 sq_rc=0
   local dl_out
-  dl_out=$(printf '%s\n' "$sql" | "$DOLTLITE" "$dir/dl/db" 2>&1 | normalize)
+  dl_out=$(printf '%s\n' "$sql" | "$DOLTLITE" "$dir/dl/db" 2>&1 | normalize) || dl_rc=$?
 
   local sq_out
-  sq_out=$(printf '%s\n' "$sql" | "$SQLITE3" "$dir/sq/db" 2>&1 | normalize)
+  sq_out=$(printf '%s\n' "$sql" | "$SQLITE3" "$dir/sq/db" 2>&1 | normalize) || sq_rc=$?
 
-  if [ "$dl_out" = "$sq_out" ]; then
-    pass=$((pass+1))
-  else
-    fail=$((fail+1))
-    FAILED_NAMES="$FAILED_NAMES $name"
-    echo "  FAIL: $name"
-    echo "    doltlite:"; echo "$dl_out" | sed 's/^/      /'
-    echo "    sqlite3:";  echo "$sq_out" | sed 's/^/      /'
-  fi
+  stock_oracle_assert "$name" "$dl_out" "$sq_out" "$dl_rc" "$sq_rc" "${3-}" "${4:-0}"
 }
 
 echo "=== Oracle Tests: foreign keys (single branch) ==="
@@ -53,7 +48,7 @@ INSERT INTO child VALUES(10, 1);
 SELECT c.id, c.pid, p.name FROM child c JOIN parent p ON c.pid = p.id;
 "
 
-oracle "insert_child_no_parent" "
+oracle_error "insert_child_no_parent" "FOREIGN KEY constraint failed" "
 PRAGMA foreign_keys = ON;
 CREATE TABLE parent(id INT PRIMARY KEY, name TEXT);
 CREATE TABLE child(id INT PRIMARY KEY, pid INT REFERENCES parent(id));
@@ -72,7 +67,7 @@ INSERT INTO child VALUES(11, 1);
 SELECT id, pid FROM child ORDER BY id;
 "
 
-oracle "update_child_to_invalid_parent" "
+oracle_error "update_child_to_invalid_parent" "FOREIGN KEY constraint failed" "
 PRAGMA foreign_keys = ON;
 CREATE TABLE parent(id INT PRIMARY KEY);
 CREATE TABLE child(id INT PRIMARY KEY, pid INT REFERENCES parent(id));
@@ -82,7 +77,7 @@ UPDATE child SET pid = 99 WHERE id = 10;
 SELECT id, pid FROM child;
 "
 
-oracle "delete_parent_with_child_rejected" "
+oracle_error "delete_parent_with_child_rejected" "FOREIGN KEY constraint failed" "
 PRAGMA foreign_keys = ON;
 CREATE TABLE parent(id INT PRIMARY KEY);
 CREATE TABLE child(id INT PRIMARY KEY, pid INT REFERENCES parent(id));
@@ -93,7 +88,7 @@ SELECT id FROM parent;
 SELECT id, pid FROM child;
 "
 
-oracle "delete_parent_restrict" "
+oracle_error "delete_parent_restrict" "FOREIGN KEY constraint failed" "
 PRAGMA foreign_keys = ON;
 CREATE TABLE parent(id INT PRIMARY KEY);
 CREATE TABLE child(id INT PRIMARY KEY,
@@ -186,7 +181,7 @@ SELECT id FROM parent ORDER BY id;
 SELECT id, pid FROM child ORDER BY id;
 "
 
-oracle "delete_set_default_violates" "
+oracle_error "delete_set_default_violates" "FOREIGN KEY constraint failed" "
 PRAGMA foreign_keys = ON;
 CREATE TABLE parent(id INT PRIMARY KEY);
 CREATE TABLE child(
@@ -256,7 +251,7 @@ INSERT INTO tree VALUES(4, 2);
 SELECT id, parent_id FROM tree ORDER BY id;
 "
 
-oracle "self_ref_insert_before_parent_fails" "
+oracle_error "self_ref_insert_before_parent_fails" "FOREIGN KEY constraint failed" "
 PRAGMA foreign_keys = ON;
 CREATE TABLE tree(
   id INT PRIMARY KEY,
@@ -266,7 +261,7 @@ INSERT INTO tree VALUES(2, 1);
 SELECT count(*) FROM tree;
 "
 
-oracle "self_ref_cascade_delete" "
+oracle_empty "self_ref_cascade_delete" "
 PRAGMA foreign_keys = ON;
 CREATE TABLE tree(
   id INT PRIMARY KEY,
@@ -298,7 +293,7 @@ INSERT INTO c VALUES(11, 'eu', 2);
 SELECT id, region, code FROM c ORDER BY id;
 "
 
-oracle "composite_fk_insert_missing_half_fails" "
+oracle_error "composite_fk_insert_missing_half_fails" "FOREIGN KEY constraint failed" "
 PRAGMA foreign_keys = ON;
 CREATE TABLE p(
   region TEXT,
@@ -352,7 +347,7 @@ COMMIT;
 SELECT id, pid FROM child;
 "
 
-oracle "deferred_fk_unresolved_commit_fails" "
+oracle_error "deferred_fk_unresolved_commit_fails" "FOREIGN KEY constraint failed" "
 PRAGMA foreign_keys = ON;
 CREATE TABLE parent(id INT PRIMARY KEY);
 CREATE TABLE child(
@@ -367,10 +362,10 @@ SELECT id, pid FROM child;
 
 oracle "defer_fks_pragma_ok_when_resolved" "
 PRAGMA foreign_keys = ON;
-PRAGMA defer_foreign_keys = ON;
 CREATE TABLE parent(id INT PRIMARY KEY);
 CREATE TABLE child(id INT PRIMARY KEY, pid INT REFERENCES parent(id));
 BEGIN;
+PRAGMA defer_foreign_keys = ON;
 INSERT INTO child VALUES(10, 1);
 INSERT INTO parent VALUES(1);
 COMMIT;
@@ -379,7 +374,7 @@ SELECT id, pid FROM child;
 
 echo "--- transaction interactions ---"
 
-oracle "immediate_violation_aborts_statement" "
+oracle_error "immediate_violation_aborts_statement" "FOREIGN KEY constraint failed" "
 PRAGMA foreign_keys = ON;
 CREATE TABLE parent(id INT PRIMARY KEY);
 CREATE TABLE child(id INT PRIMARY KEY, pid INT REFERENCES parent(id));
@@ -407,7 +402,7 @@ SELECT id, pid FROM child ORDER BY id;
 
 echo "--- NO ACTION vs RESTRICT ---"
 
-oracle "no_action_deferred_to_end_of_statement" "
+oracle_error "no_action_deferred_to_end_of_statement" "FOREIGN KEY constraint failed" "
 PRAGMA foreign_keys = ON;
 CREATE TABLE parent(id INT PRIMARY KEY);
 CREATE TABLE child(
@@ -422,7 +417,7 @@ SELECT id FROM parent ORDER BY id;
 SELECT id, pid FROM child ORDER BY id;
 "
 
-oracle "restrict_rejects_midstatement_violation" "
+oracle_error "restrict_rejects_midstatement_violation" "FOREIGN KEY constraint failed" "
 PRAGMA foreign_keys = ON;
 CREATE TABLE parent(id INT PRIMARY KEY);
 CREATE TABLE child(
@@ -555,7 +550,7 @@ SELECT count(*) FROM child;
 SELECT id, msg FROM log ORDER BY id;
 "
 
-oracle "trigger_abort_prevents_cascade" "
+oracle_error "trigger_abort_prevents_cascade" "no" "
 PRAGMA foreign_keys = ON;
 CREATE TABLE parent(id INT PRIMARY KEY);
 CREATE TABLE child(id INT PRIMARY KEY,
@@ -672,10 +667,4 @@ SELECT count(*) FROM child;
 "
 
 
-echo ""
-echo "=== Results: $pass passed, $fail failed ==="
-if [ "$fail" -gt 0 ]; then
-  echo "Failed:$FAILED_NAMES"
-  exit 1
-fi
-exit 0
+stock_oracle_finish

--- a/test/oracle_fts5_test.sh
+++ b/test/oracle_fts5_test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -u
+set -uo pipefail
 
 DOLTLITE="${1:-./doltlite}"
 SQLITE3="${2:-./sqlite3}"
@@ -8,32 +8,27 @@ TMPROOT=$(mktemp -d)
 trap "rm -rf $TMPROOT" EXIT
 pass=0; fail=0
 FAILED_NAMES=""
+source "$(dirname "$0")/lib/stock_oracle_common.sh"
+stock_oracle_init || exit 1
 
 oracle() {
   local name="$1" sql="$2"
   local dir="$TMPROOT/$name"
   mkdir -p "$dir/dl" "$dir/sq"
 
+  local dl_rc=0 sq_rc=0
   local dl_out
-  dl_out=$(printf '%s\n' "$sql" | "$DOLTLITE" "$dir/dl/db" 2>&1 | tr -d '\r')
+  dl_out=$(printf '%s\n' "$sql" | "$DOLTLITE" "$dir/dl/db" 2>&1 | tr -d '\r') || dl_rc=$?
   local sq_out
-  sq_out=$(printf '%s\n' "$sql" | "$SQLITE3" "$dir/sq/db" 2>&1 | tr -d '\r')
+  sq_out=$(printf '%s\n' "$sql" | "$SQLITE3" "$dir/sq/db" 2>&1 | tr -d '\r') || sq_rc=$?
 
-  if [ "$dl_out" = "$sq_out" ]; then
-    pass=$((pass+1))
-  else
-    fail=$((fail+1))
-    FAILED_NAMES="$FAILED_NAMES $name"
-    echo "  FAIL: $name"
-    echo "    doltlite:"; echo "$dl_out" | sed 's/^/      /'
-    echo "    sqlite3:";  echo "$sq_out" | sed 's/^/      /'
-  fi
+  stock_oracle_assert "$name" "$dl_out" "$sq_out" "$dl_rc" "$sq_rc" "${3-}" "${4:-0}"
 }
 
 make_inserts() {
-  local n="$1"
+  local n="$1" first="${2:-1}"
   local i
-  for i in $(seq 1 "$n"); do
+  for i in $(seq "$first" "$((first+n-1))"); do
     echo "INSERT INTO chunks(rowid, content) VALUES($i, 'x');"
   done
 }
@@ -66,7 +61,7 @@ echo "--- FTS5 mixed scenarios ---"
 oracle "fts5_insert_match_interleave" "$SETUP
 $(make_inserts 15)
 SELECT count(*) FROM chunks WHERE chunks MATCH 'x';
-$(make_inserts 15)
+$(make_inserts 15 16)
 SELECT count(*) FROM chunks WHERE chunks MATCH 'x';"
 
 oracle "fts5_rebuild_after_16" "$SETUP
@@ -79,9 +74,4 @@ $(make_inserts 16)
 DELETE FROM chunks WHERE rowid=8;
 SELECT count(*) FROM chunks;"
 
-echo ""
-echo "=== Results: $pass passed, $fail failed ==="
-if [ $fail -gt 0 ]; then
-  echo "Failed:$FAILED_NAMES"
-  exit 1
-fi
+stock_oracle_finish

--- a/test/oracle_generated_columns_test.sh
+++ b/test/oracle_generated_columns_test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -u
+set -uo pipefail
 
 DOLTLITE="${1:-./doltlite}"
 SQLITE3="${2:-./sqlite3}"
@@ -8,6 +8,8 @@ TMPROOT=$(mktemp -d)
 trap "rm -rf $TMPROOT" EXIT
 pass=0; fail=0
 FAILED_NAMES=""
+source "$(dirname "$0")/lib/stock_oracle_common.sh"
+stock_oracle_init || exit 1
 
 normalize() {
   tr -d '\r' \
@@ -22,21 +24,14 @@ oracle() {
   local dir="$TMPROOT/$name"
   mkdir -p "$dir/dl" "$dir/sq"
 
+  local dl_rc=0 sq_rc=0
   local dl_out
-  dl_out=$(printf '%s\n' "$sql" | "$DOLTLITE" "$dir/dl/db" 2>&1 | normalize)
+  dl_out=$(printf '%s\n' "$sql" | "$DOLTLITE" "$dir/dl/db" 2>&1 | normalize) || dl_rc=$?
 
   local sq_out
-  sq_out=$(printf '%s\n' "$sql" | "$SQLITE3" "$dir/sq/db" 2>&1 | normalize)
+  sq_out=$(printf '%s\n' "$sql" | "$SQLITE3" "$dir/sq/db" 2>&1 | normalize) || sq_rc=$?
 
-  if [ "$dl_out" = "$sq_out" ]; then
-    pass=$((pass+1))
-  else
-    fail=$((fail+1))
-    FAILED_NAMES="$FAILED_NAMES $name"
-    echo "  FAIL: $name"
-    echo "    doltlite:"; echo "$dl_out" | sed 's/^/      /'
-    echo "    sqlite3:";  echo "$sq_out" | sed 's/^/      /'
-  fi
+  stock_oracle_assert "$name" "$dl_out" "$sq_out" "$dl_rc" "$sq_rc" "${3-}" "${4:-0}"
 }
 
 echo "=== Oracle Tests: generated columns ==="
@@ -179,7 +174,7 @@ SELECT id, a, b, prod FROM t;
 
 echo "--- illegal specification ---"
 
-oracle "insert_into_generated_fails" "
+oracle_error "insert_into_generated_fails" "cannot INSERT into generated column" "
 CREATE TABLE t(
   id INT PRIMARY KEY,
   a INT,
@@ -191,7 +186,7 @@ SELECT id, a, b FROM t;
 
 echo "--- constraints ---"
 
-oracle "check_on_generated_violates" "
+oracle_error "check_on_generated_violates" "CHECK constraint failed: doubled < 100" "
 CREATE TABLE t(
   id INT PRIMARY KEY,
   a INT,
@@ -212,7 +207,7 @@ INSERT INTO t(id, a) VALUES(1, 10), (2, 20), (3, 49);
 SELECT id, doubled FROM t ORDER BY id;
 "
 
-oracle "unique_on_stored_generated" "
+oracle_error "unique_on_stored_generated" "UNIQUE constraint failed: t.lower_name" "
 CREATE TABLE t(
   id INT PRIMARY KEY,
   name TEXT,
@@ -223,7 +218,7 @@ INSERT INTO t(id, name) VALUES(2, 'alice');
 SELECT id, name, lower_name FROM t ORDER BY id;
 "
 
-oracle "unique_index_on_virtual_generated" "
+oracle_error "unique_index_on_virtual_generated" "UNIQUE constraint failed: t.lower_name" "
 CREATE TABLE t(
   id INT PRIMARY KEY,
   name TEXT,
@@ -296,7 +291,7 @@ SELECT id, doubled, plus_one FROM t;
 
 echo "--- ALTER TABLE ADD ---"
 
-oracle "alter_add_stored_rejected" "
+oracle_error "alter_add_stored_rejected" "cannot add a STORED column" "
 CREATE TABLE t(id INT PRIMARY KEY, a INT);
 INSERT INTO t(id, a) VALUES(1, 5);
 ALTER TABLE t ADD COLUMN doubled INT GENERATED ALWAYS AS (a * 2) STORED;
@@ -473,7 +468,7 @@ SELECT id, a, sq FROM t ORDER BY id;
 
 echo "--- illegal self-reference ---"
 
-oracle "self_reference_rejected" "
+oracle_error "self_reference_rejected" "generated column loop" "
 CREATE TABLE t(
   id INT PRIMARY KEY,
   a INT GENERATED ALWAYS AS (a + 1) STORED
@@ -492,10 +487,4 @@ SELECT id, a, doubled FROM t;
 "
 
 
-echo ""
-echo "=== Results: $pass passed, $fail failed ==="
-if [ "$fail" -gt 0 ]; then
-  echo "Failed:$FAILED_NAMES"
-  exit 1
-fi
-exit 0
+stock_oracle_finish

--- a/test/oracle_large_blobs_test.sh
+++ b/test/oracle_large_blobs_test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -u
+set -uo pipefail
 
 DOLTLITE="${1:-./doltlite}"
 SQLITE3="${2:-./sqlite3}"
@@ -8,6 +8,8 @@ TMPROOT=$(mktemp -d)
 trap "rm -rf $TMPROOT" EXIT
 pass=0; fail=0
 FAILED_NAMES=""
+source "$(dirname "$0")/lib/stock_oracle_common.sh"
+stock_oracle_init || exit 1
 
 normalize() {
   tr -d '\r' \
@@ -22,21 +24,14 @@ oracle() {
   local dir="$TMPROOT/$name"
   mkdir -p "$dir/dl" "$dir/sq"
 
+  local dl_rc=0 sq_rc=0
   local dl_out
-  dl_out=$(printf '%s\n' "$sql" | "$DOLTLITE" "$dir/dl/db" 2>&1 | normalize)
+  dl_out=$(printf '%s\n' "$sql" | "$DOLTLITE" "$dir/dl/db" 2>&1 | normalize) || dl_rc=$?
 
   local sq_out
-  sq_out=$(printf '%s\n' "$sql" | "$SQLITE3" "$dir/sq/db" 2>&1 | normalize)
+  sq_out=$(printf '%s\n' "$sql" | "$SQLITE3" "$dir/sq/db" 2>&1 | normalize) || sq_rc=$?
 
-  if [ "$dl_out" = "$sq_out" ]; then
-    pass=$((pass+1))
-  else
-    fail=$((fail+1))
-    FAILED_NAMES="$FAILED_NAMES $name"
-    echo "  FAIL: $name"
-    echo "    doltlite:"; echo "$dl_out" | sed 's/^/      /'
-    echo "    sqlite3:";  echo "$sq_out" | sed 's/^/      /'
-  fi
+  stock_oracle_assert "$name" "$dl_out" "$sq_out" "$dl_rc" "$sq_rc" "${3-}" "${4:-0}"
 }
 
 echo "=== Oracle Tests: large BLOB / TEXT ==="
@@ -242,10 +237,4 @@ SELECT a.id, length(a.b), c.id, length(c.b) FROM a JOIN c ON a.id = c.aid ORDER 
 "
 
 
-echo ""
-echo "=== Results: $pass passed, $fail failed ==="
-if [ "$fail" -gt 0 ]; then
-  echo "Failed:$FAILED_NAMES"
-  exit 1
-fi
-exit 0
+stock_oracle_finish

--- a/test/oracle_savepoints_test.sh
+++ b/test/oracle_savepoints_test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -u
+set -uo pipefail
 
 DOLTLITE="${1:-./doltlite}"
 SQLITE3="${2:-./sqlite3}"
@@ -8,6 +8,8 @@ TMPROOT=$(mktemp -d)
 trap "rm -rf $TMPROOT" EXIT
 pass=0; fail=0
 FAILED_NAMES=""
+source "$(dirname "$0")/lib/stock_oracle_common.sh"
+stock_oracle_init || exit 1
 
 normalize() {
   tr -d '\r' \
@@ -22,21 +24,14 @@ oracle() {
   local dir="$TMPROOT/$name"
   mkdir -p "$dir/dl" "$dir/sq"
 
+  local dl_rc=0 sq_rc=0
   local dl_out
-  dl_out=$(printf '%s\n' "$sql" | "$DOLTLITE" "$dir/dl/db" 2>&1 | normalize)
+  dl_out=$(printf '%s\n' "$sql" | "$DOLTLITE" "$dir/dl/db" 2>&1 | normalize) || dl_rc=$?
 
   local sq_out
-  sq_out=$(printf '%s\n' "$sql" | "$SQLITE3" "$dir/sq/db" 2>&1 | normalize)
+  sq_out=$(printf '%s\n' "$sql" | "$SQLITE3" "$dir/sq/db" 2>&1 | normalize) || sq_rc=$?
 
-  if [ "$dl_out" = "$sq_out" ]; then
-    pass=$((pass+1))
-  else
-    fail=$((fail+1))
-    FAILED_NAMES="$FAILED_NAMES $name"
-    echo "  FAIL: $name"
-    echo "    doltlite:"; echo "$dl_out" | sed 's/^/      /'
-    echo "    sqlite3:";  echo "$sq_out" | sed 's/^/      /'
-  fi
+  stock_oracle_assert "$name" "$dl_out" "$sq_out" "$dl_rc" "$sq_rc" "${3-}" "${4:-0}"
 }
 
 echo "=== Oracle Tests: savepoints + rollbacks ==="
@@ -189,7 +184,7 @@ RELEASE SAVEPOINT s1;
 SELECT id, v FROM t ORDER BY id;
 "
 
-oracle "nested_rollback_outer_discards_inner" "
+oracle_empty "nested_rollback_outer_discards_inner" "
 CREATE TABLE t(id INT PRIMARY KEY, v INT);
 SAVEPOINT s1;
 INSERT INTO t VALUES(1, 10);
@@ -508,7 +503,7 @@ SELECT 't', id, v FROM t ORDER BY id;
 SELECT 'log', id, v FROM log ORDER BY id;
 "
 
-oracle "trigger_raise_rollback_through_savepoint" "
+oracle_error "trigger_raise_rollback_through_savepoint" "no neg" "
 CREATE TABLE t(id INT PRIMARY KEY, v INT);
 CREATE TRIGGER no_neg BEFORE INSERT ON t WHEN new.v < 0 BEGIN
   SELECT RAISE(ROLLBACK, 'no neg');
@@ -608,9 +603,4 @@ ROLLBACK;
 SELECT id, v FROM t ORDER BY id;
 "
 
-echo ""
-echo "=== Results: $pass passed, $fail failed ==="
-if [ $fail -gt 0 ]; then
-  echo "Failed:$FAILED_NAMES"
-  exit 1
-fi
+stock_oracle_finish

--- a/test/oracle_temp_tables_test.sh
+++ b/test/oracle_temp_tables_test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -u
+set -uo pipefail
 
 DOLTLITE="${1:-./doltlite}"
 SQLITE3="${2:-./sqlite3}"
@@ -8,6 +8,8 @@ TMPROOT=$(mktemp -d)
 trap "rm -rf $TMPROOT" EXIT
 pass=0; fail=0
 FAILED_NAMES=""
+source "$(dirname "$0")/lib/stock_oracle_common.sh"
+stock_oracle_init || exit 1
 
 normalize() {
   tr -d '\r' \
@@ -22,21 +24,14 @@ oracle() {
   local dir="$TMPROOT/$name"
   mkdir -p "$dir/dl" "$dir/sq"
 
+  local dl_rc=0 sq_rc=0
   local dl_out
-  dl_out=$(printf '%s\n' "$sql" | "$DOLTLITE" "$dir/dl/db" 2>&1 | normalize)
+  dl_out=$(printf '%s\n' "$sql" | "$DOLTLITE" "$dir/dl/db" 2>&1 | normalize) || dl_rc=$?
 
   local sq_out
-  sq_out=$(printf '%s\n' "$sql" | "$SQLITE3" "$dir/sq/db" 2>&1 | normalize)
+  sq_out=$(printf '%s\n' "$sql" | "$SQLITE3" "$dir/sq/db" 2>&1 | normalize) || sq_rc=$?
 
-  if [ "$dl_out" = "$sq_out" ]; then
-    pass=$((pass+1))
-  else
-    fail=$((fail+1))
-    FAILED_NAMES="$FAILED_NAMES $name"
-    echo "  FAIL: $name"
-    echo "    doltlite:"; echo "$dl_out" | sed 's/^/      /'
-    echo "    sqlite3:";  echo "$sq_out" | sed 's/^/      /'
-  fi
+  stock_oracle_assert "$name" "$dl_out" "$sq_out" "$dl_rc" "$sq_rc" "${3-}" "${4:-0}"
 }
 
 echo "=== Oracle Tests: CREATE TEMP TABLE / TRIGGER ==="
@@ -211,7 +206,7 @@ INSERT INTO t VALUES(1, 'a'),(2, 'b'),(3, 'a'),(4, 'c');
 SELECT id FROM t WHERE tag = 'a' ORDER BY id;
 "
 
-oracle "temp_table_unique_index_rejects_dup" "
+oracle_error "temp_table_unique_index_rejects_dup" "UNIQUE constraint failed: t.u" "
 CREATE TEMP TABLE t(id INT PRIMARY KEY, u INT);
 CREATE UNIQUE INDEX idx_u ON t(u);
 INSERT INTO t VALUES(1, 100);
@@ -221,14 +216,14 @@ SELECT id, u FROM t ORDER BY id;
 
 echo "--- TEMP constraints ---"
 
-oracle "temp_check_constraint" "
+oracle_error "temp_check_constraint" "CHECK constraint failed: v > 0" "
 CREATE TEMP TABLE t(id INT PRIMARY KEY, v INT CHECK (v > 0));
 INSERT INTO t VALUES(1, 10);
 INSERT INTO t VALUES(2, -1);
 SELECT id, v FROM t ORDER BY id;
 "
 
-oracle "temp_not_null_constraint" "
+oracle_error "temp_not_null_constraint" "NOT NULL constraint failed: t.v" "
 CREATE TEMP TABLE t(id INT PRIMARY KEY, v TEXT NOT NULL);
 INSERT INTO t VALUES(1, NULL);
 SELECT count(*) FROM t;
@@ -261,10 +256,4 @@ SELECT v FROM t WHERE id = 25;
 "
 
 
-echo ""
-echo "=== Results: $pass passed, $fail failed ==="
-if [ "$fail" -gt 0 ]; then
-  echo "Failed:$FAILED_NAMES"
-  exit 1
-fi
-exit 0
+stock_oracle_finish

--- a/test/oracle_triggers_test.sh
+++ b/test/oracle_triggers_test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -u
+set -uo pipefail
 
 DOLTLITE="${1:-./doltlite}"
 SQLITE3="${2:-./sqlite3}"
@@ -8,6 +8,8 @@ TMPROOT=$(mktemp -d)
 trap "rm -rf $TMPROOT" EXIT
 pass=0; fail=0
 FAILED_NAMES=""
+source "$(dirname "$0")/lib/stock_oracle_common.sh"
+stock_oracle_init || exit 1
 
 normalize() {
   tr -d '\r' \
@@ -19,21 +21,14 @@ oracle() {
   local dir="$TMPROOT/$name"
   mkdir -p "$dir/dl" "$dir/sq"
 
+  local dl_rc=0 sq_rc=0
   local dl_out
-  dl_out=$(printf '%s\n' "$sql" | "$DOLTLITE" "$dir/dl/db" 2>&1 | normalize)
+  dl_out=$(printf '%s\n' "$sql" | "$DOLTLITE" "$dir/dl/db" 2>&1 | normalize) || dl_rc=$?
 
   local sq_out
-  sq_out=$(printf '%s\n' "$sql" | "$SQLITE3" "$dir/sq/db" 2>&1 | normalize)
+  sq_out=$(printf '%s\n' "$sql" | "$SQLITE3" "$dir/sq/db" 2>&1 | normalize) || sq_rc=$?
 
-  if [ "$dl_out" = "$sq_out" ]; then
-    pass=$((pass+1))
-  else
-    fail=$((fail+1))
-    FAILED_NAMES="$FAILED_NAMES $name"
-    echo "  FAIL: $name"
-    echo "    doltlite:"; echo "$dl_out" | sed 's/^/      /'
-    echo "    sqlite3:";  echo "$sq_out" | sed 's/^/      /'
-  fi
+  stock_oracle_assert "$name" "$dl_out" "$sq_out" "$dl_rc" "$sq_rc" "${3-}" "${4:-0}"
 }
 
 echo "=== Oracle Tests: SQL triggers ==="
@@ -166,7 +161,7 @@ SELECT n FROM counter;
 
 echo "--- RAISE actions ---"
 
-oracle "raise_abort_reverts_statement" "
+oracle_error "raise_abort_reverts_statement" "negative not allowed" "
 CREATE TABLE t(id INT PRIMARY KEY, v INT);
 INSERT INTO t VALUES(1,10);
 CREATE TRIGGER guard BEFORE INSERT ON t WHEN new.v < 0 BEGIN
@@ -189,7 +184,7 @@ INSERT INTO t VALUES(3, 30);
 SELECT id, v FROM t ORDER BY id;
 "
 
-oracle "raise_fail_on_second_row" "
+oracle_error "raise_fail_on_second_row" "no neg" "
 CREATE TABLE src(id INT, v INT);
 INSERT INTO src VALUES(1,10),(2,-1),(3,30);
 CREATE TABLE t(id INT PRIMARY KEY, v INT);
@@ -200,7 +195,7 @@ INSERT OR FAIL INTO t SELECT id, v FROM src ORDER BY id;
 SELECT id, v FROM t ORDER BY id;
 "
 
-oracle "raise_rollback_reverts_transaction" "
+oracle_error "raise_rollback_reverts_transaction" "negatives forbidden" "
 CREATE TABLE t(id INT PRIMARY KEY, v INT);
 CREATE TRIGGER no_neg BEFORE INSERT ON t WHEN new.v < 0 BEGIN
   SELECT RAISE(ROLLBACK, 'negatives forbidden');
@@ -378,9 +373,4 @@ SELECT remaining FROM log ORDER BY remaining;
 SELECT id FROM t ORDER BY id;
 "
 
-echo ""
-echo "=== Results: $pass passed, $fail failed ==="
-if [ $fail -gt 0 ]; then
-  echo "Failed:$FAILED_NAMES"
-  exit 1
-fi
+stock_oracle_finish

--- a/test/oracle_upsert_test.sh
+++ b/test/oracle_upsert_test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -u
+set -uo pipefail
 
 DOLTLITE="${1:-./doltlite}"
 SQLITE3="${2:-./sqlite3}"
@@ -8,6 +8,8 @@ TMPROOT=$(mktemp -d)
 trap "rm -rf $TMPROOT" EXIT
 pass=0; fail=0
 FAILED_NAMES=""
+source "$(dirname "$0")/lib/stock_oracle_common.sh"
+stock_oracle_init || exit 1
 
 normalize() {
   tr -d '\r' \
@@ -22,21 +24,14 @@ oracle() {
   local dir="$TMPROOT/$name"
   mkdir -p "$dir/dl" "$dir/sq"
 
+  local dl_rc=0 sq_rc=0
   local dl_out
-  dl_out=$(printf '%s\n' "$sql" | "$DOLTLITE" "$dir/dl/db" 2>&1 | normalize)
+  dl_out=$(printf '%s\n' "$sql" | "$DOLTLITE" "$dir/dl/db" 2>&1 | normalize) || dl_rc=$?
 
   local sq_out
-  sq_out=$(printf '%s\n' "$sql" | "$SQLITE3" "$dir/sq/db" 2>&1 | normalize)
+  sq_out=$(printf '%s\n' "$sql" | "$SQLITE3" "$dir/sq/db" 2>&1 | normalize) || sq_rc=$?
 
-  if [ "$dl_out" = "$sq_out" ]; then
-    pass=$((pass+1))
-  else
-    fail=$((fail+1))
-    FAILED_NAMES="$FAILED_NAMES $name"
-    echo "  FAIL: $name"
-    echo "    doltlite:"; echo "$dl_out" | sed 's/^/      /'
-    echo "    sqlite3:";  echo "$sq_out" | sed 's/^/      /'
-  fi
+  stock_oracle_assert "$name" "$dl_out" "$sq_out" "$dl_rc" "$sq_rc" "${3-}" "${4:-0}"
 }
 
 echo "=== Oracle Tests: UPSERT / INSERT OR <action> ==="
@@ -44,14 +39,14 @@ echo ""
 
 echo "--- INSERT OR ABORT ---"
 
-oracle "insert_or_abort_rejects_dup_pk" "
+oracle_error "insert_or_abort_rejects_dup_pk" "UNIQUE constraint failed: t.id" "
 CREATE TABLE t(id INT PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1, 'a');
 INSERT INTO t VALUES(1, 'b');
 SELECT id, v FROM t;
 "
 
-oracle "insert_or_abort_multirow_rollback" "
+oracle_error "insert_or_abort_multirow_rollback" "UNIQUE constraint failed: t.id" "
 CREATE TABLE t(id INT PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1, 'a');
 INSERT INTO t VALUES(2, 'b'), (1, 'c');
@@ -112,7 +107,7 @@ SELECT count(*) FROM child;
 
 echo "--- INSERT OR FAIL ---"
 
-oracle "insert_or_fail_preserves_prior_rows" "
+oracle_error "insert_or_fail_preserves_prior_rows" "UNIQUE constraint failed: t.id" "
 CREATE TABLE t(id INT PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1, 'a');
 INSERT OR FAIL INTO t VALUES(2, 'b'), (1, 'dup'), (3, 'c');
@@ -121,7 +116,7 @@ SELECT id, v FROM t ORDER BY id;
 
 echo "--- INSERT OR ROLLBACK ---"
 
-oracle "insert_or_rollback_aborts_txn" "
+oracle_error "insert_or_rollback_aborts_txn" "UNIQUE constraint failed: t.id" "
 CREATE TABLE t(id INT PRIMARY KEY, v TEXT);
 BEGIN;
 INSERT INTO t VALUES(1, 'a');
@@ -222,7 +217,7 @@ INSERT INTO t VALUES(1, 'b') ON CONFLICT(id) DO UPDATE SET id = 99;
 SELECT id, v FROM t ORDER BY id;
 "
 
-oracle "do_update_modifies_target_column_collision" "
+oracle_error "do_update_modifies_target_column_collision" "UNIQUE constraint failed: t.id" "
 CREATE TABLE t(id INT PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1, 'a');
 INSERT INTO t VALUES(2, 'b');
@@ -363,10 +358,4 @@ SELECT id, v FROM t;
 "
 
 
-echo ""
-echo "=== Results: $pass passed, $fail failed ==="
-if [ "$fail" -gt 0 ]; then
-  echo "Failed:$FAILED_NAMES"
-  exit 1
-fi
-exit 0
+stock_oracle_finish

--- a/test/oracle_without_rowid_test.sh
+++ b/test/oracle_without_rowid_test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -u
+set -uo pipefail
 
 DOLTLITE="${1:-./doltlite}"
 SQLITE3="${2:-./sqlite3}"
@@ -8,6 +8,8 @@ TMPROOT=$(mktemp -d)
 trap "rm -rf $TMPROOT" EXIT
 pass=0; fail=0
 FAILED_NAMES=""
+source "$(dirname "$0")/lib/stock_oracle_common.sh"
+stock_oracle_init || exit 1
 
 normalize() {
   tr -d '\r' \
@@ -22,21 +24,14 @@ oracle() {
   local dir="$TMPROOT/$name"
   mkdir -p "$dir/dl" "$dir/sq"
 
+  local dl_rc=0 sq_rc=0
   local dl_out
-  dl_out=$(printf '%s\n' "$sql" | "$DOLTLITE" "$dir/dl/db" 2>&1 | normalize)
+  dl_out=$(printf '%s\n' "$sql" | "$DOLTLITE" "$dir/dl/db" 2>&1 | normalize) || dl_rc=$?
 
   local sq_out
-  sq_out=$(printf '%s\n' "$sql" | "$SQLITE3" "$dir/sq/db" 2>&1 | normalize)
+  sq_out=$(printf '%s\n' "$sql" | "$SQLITE3" "$dir/sq/db" 2>&1 | normalize) || sq_rc=$?
 
-  if [ "$dl_out" = "$sq_out" ]; then
-    pass=$((pass+1))
-  else
-    fail=$((fail+1))
-    FAILED_NAMES="$FAILED_NAMES $name"
-    echo "  FAIL: $name"
-    echo "    doltlite:"; echo "$dl_out" | sed 's/^/      /'
-    echo "    sqlite3:";  echo "$sq_out" | sed 's/^/      /'
-  fi
+  stock_oracle_assert "$name" "$dl_out" "$sq_out" "$dl_rc" "$sq_rc" "${3-}" "${4:-0}"
 }
 
 echo "=== Oracle Tests: WITHOUT ROWID ==="
@@ -70,13 +65,13 @@ SELECT id, v FROM t;
 
 echo "--- rowid column absence ---"
 
-oracle "select_rowid_rejected" "
+oracle_error "select_rowid_rejected" "no such column: rowid" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT) WITHOUT ROWID;
 INSERT INTO t VALUES(1, 10);
 SELECT rowid FROM t;
 "
 
-oracle "select_oid_rejected" "
+oracle_error "select_oid_rejected" "no such column: oid" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT) WITHOUT ROWID;
 INSERT INTO t VALUES(1, 10);
 SELECT oid FROM t;
@@ -90,26 +85,26 @@ SELECT * FROM t ORDER BY id;
 
 echo "--- integer PK semantics ---"
 
-oracle "int_pk_without_rowid_no_autoalloc" "
+oracle_error "int_pk_without_rowid_no_autoalloc" "NOT NULL constraint failed: t.id" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT) WITHOUT ROWID;
 INSERT INTO t(v) VALUES('a');
 SELECT id, v FROM t;
 "
 
-oracle "autoincrement_rejected" "
+oracle_error "autoincrement_rejected" "AUTOINCREMENT not allowed on WITHOUT ROWID tables" "
 CREATE TABLE t(id INTEGER PRIMARY KEY AUTOINCREMENT, v TEXT) WITHOUT ROWID;
 SELECT 1;
 "
 
 echo "--- PK implies NOT NULL ---"
 
-oracle "text_pk_null_rejected" "
+oracle_error "text_pk_null_rejected" "NOT NULL constraint failed: t.k" "
 CREATE TABLE t(k TEXT PRIMARY KEY, v INT) WITHOUT ROWID;
 INSERT INTO t VALUES(NULL, 1);
 SELECT count(*) FROM t;
 "
 
-oracle "composite_pk_null_half_rejected" "
+oracle_error "composite_pk_null_half_rejected" "NOT NULL constraint failed: t.b" "
 CREATE TABLE t(a INT, b INT, v INT, PRIMARY KEY(a, b)) WITHOUT ROWID;
 INSERT INTO t VALUES(1, NULL, 10);
 SELECT count(*) FROM t;
@@ -137,7 +132,7 @@ INSERT INTO t VALUES(1,1,11),(1,2,12),(2,1,21),(2,2,22),(3,1,31);
 SELECT a, b, v FROM t WHERE a = 2 ORDER BY b;
 "
 
-oracle "composite_pk_dup_rejected" "
+oracle_error "composite_pk_dup_rejected" "UNIQUE constraint failed: t.a, t.b" "
 CREATE TABLE t(a INT, b INT, v TEXT, PRIMARY KEY(a, b)) WITHOUT ROWID;
 INSERT INTO t VALUES(1, 1, 'a');
 INSERT INTO t VALUES(1, 1, 'b');
@@ -146,14 +141,14 @@ SELECT a, b, v FROM t;
 
 echo "--- PK collation ---"
 
-oracle "text_pk_nocase" "
+oracle_error "text_pk_nocase" "UNIQUE constraint failed: t.k" "
 CREATE TABLE t(k TEXT PRIMARY KEY COLLATE NOCASE, v INT) WITHOUT ROWID;
 INSERT INTO t VALUES('Alice', 1);
 INSERT INTO t VALUES('alice', 2);
 SELECT k, v FROM t ORDER BY k;
 "
 
-oracle "text_pk_rtrim" "
+oracle_error "text_pk_rtrim" "UNIQUE constraint failed: t.k" "
 CREATE TABLE t(k TEXT PRIMARY KEY COLLATE RTRIM, v INT) WITHOUT ROWID;
 INSERT INTO t VALUES('abc', 1);
 INSERT INTO t VALUES('abc ', 2);
@@ -176,7 +171,7 @@ UPDATE t SET a = 10 WHERE a = 1 AND b = 1;
 SELECT a, b, v FROM t ORDER BY a, b;
 "
 
-oracle "update_pk_to_existing_collides" "
+oracle_error "update_pk_to_existing_collides" "UNIQUE constraint failed: t.k" "
 CREATE TABLE t(k INT PRIMARY KEY, v TEXT) WITHOUT ROWID;
 INSERT INTO t VALUES(1, 'a'),(2, 'b');
 UPDATE t SET k = 2 WHERE k = 1;
@@ -223,7 +218,7 @@ INSERT INTO t VALUES(1, 'a', 10),(2, 'b', 20),(3, 'a', 30);
 SELECT k, v FROM t WHERE tag = 'a' ORDER BY k;
 "
 
-oracle "unique_secondary_index_on_without_rowid" "
+oracle_error "unique_secondary_index_on_without_rowid" "UNIQUE constraint failed: t.u" "
 CREATE TABLE t(k INT PRIMARY KEY, u INT, v INT) WITHOUT ROWID;
 CREATE UNIQUE INDEX idx_u ON t(u);
 INSERT INTO t VALUES(1, 100, 'a');
@@ -388,10 +383,4 @@ SELECT count(*) FROM t WHERE a = 1;
 "
 
 
-echo ""
-echo "=== Results: $pass passed, $fail failed ==="
-if [ "$fail" -gt 0 ]; then
-  echo "Failed:$FAILED_NAMES"
-  exit 1
-fi
-exit 0
+stock_oracle_finish

--- a/test/sql_oracle_harness_test.sh
+++ b/test/sql_oracle_harness_test.sh
@@ -93,12 +93,17 @@ exit 0
 EOF
 cat > "$SQL_ORACLE_TMP/pretends" <<'EOF'
 #!/usr/bin/env bash
-printf '%s\n' 'sql-oracle-ready|42'
+if [ "${2-}" = 'SELECT doltlite_engine();' ]; then
+  echo prolly
+else
+  echo 'sql-oracle-ready|42'
+fi
 EOF
 chmod +x "$SQL_ORACLE_TMP/fails" "$SQL_ORACLE_TMP/empty" "$SQL_ORACLE_TMP/pretends"
 expect_startup_failure silent_failure "$SQL_ORACLE_TMP/fails" "$SQL_ORACLE_TMP/fails"
 expect_startup_failure empty_success "$SQL_ORACLE_TMP/empty" "$SQL_ORACLE_TMP/empty"
 expect_startup_failure missing_executable "$SQL_ORACLE_TMP/missing" "$SQL_ORACLE_TMP/missing"
-expect_startup_failure no_stock_database "$SQL_ORACLE_TMP/pretends" "$SQL_ORACLE_TMP/pretends"
+cp "$SQL_ORACLE_TMP/pretends" "$SQL_ORACLE_TMP/pretend_reference"
+expect_startup_failure no_stock_database "$SQL_ORACLE_TMP/pretends" "$SQL_ORACLE_TMP/pretend_reference"
 
 echo "SQL oracle harness: 20 checks passed"

--- a/test/stock_oracle_harness_test.sh
+++ b/test/stock_oracle_harness_test.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SUITE_DIR="${1:-$SCRIPT_DIR}"
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+source "$SCRIPT_DIR/lib/stock_oracle_common.sh"
+checks=0
+
+check_comparison() {
+  local name="$1" want_fail="$2"
+  shift 2
+  local pass=0 fail=0 nonempty=0 FAILED_NAMES=""
+  stock_oracle_assert "$name" "$@" > "$WORK/comparison.log"
+  if [ "$fail" -ne "$want_fail" ] || [ "$pass" -ne "$((1-want_fail))" ]; then
+    cat "$WORK/comparison.log"
+    echo "FAIL: $name (pass=$pass fail=$fail)"
+    exit 1
+  fi
+  checks=$((checks+1))
+}
+
+check_comparison matching_rows 0 42 42 0 0
+check_comparison different_rows 1 41 42 0 0
+check_comparison empty_rows 1 '' '' 0 0
+check_comparison expected_empty 0 '' '' 0 0 '' 1
+check_comparison unexpected_rows 1 42 42 0 0 '' 1
+check_comparison silent_failures 1 '' '' 1 1
+check_comparison failed_empty 1 '' '' 1 1 '' 1
+check_comparison matching_errors 1 'SQL error' 'SQL error' 1 1
+check_comparison expected_error 0 'SQL error' 'SQL error' 1 1 'SQL error'
+check_comparison wrong_error 1 'SQL error' 'SQL error' 1 1 'other error'
+check_comparison missing_error 1 'SQL error' 'SQL error' 0 0 'SQL error'
+check_comparison candidate_failure 1 42 42 1 0
+check_comparison reference_failure 1 42 42 0 1
+check_comparison matching_crashes 1 'SQL error' 'SQL error' 134 134 'SQL error'
+check_comparison launch_failures 1 'SQL error' 'SQL error' 127 127 'SQL error'
+
+check_floor() {
+  local name="$1" pass="$2" fail="$3" nonempty="$4" expected="$5"
+  local FAILED_NAMES="" rc=0
+  stock_oracle_finish > "$WORK/floor.log" || rc=$?
+  if [ "$rc" -ne "$expected" ]; then
+    cat "$WORK/floor.log"
+    echo "FAIL: $name"
+    exit 1
+  fi
+  checks=$((checks+1))
+}
+check_floor no_cases 0 0 0 1
+check_floor only_empty_cases 5 0 0 1
+check_floor failed_case 5 1 5 1
+check_floor passing_suite 5 0 5 0
+
+for suite in attach dot_commands foreign_keys fts5 generated_columns large_blobs \
+             savepoints temp_tables triggers upsert without_rowid; do
+  for engine in /usr/bin/true /usr/bin/false "$WORK/missing"; do
+    if bash "$SUITE_DIR/oracle_${suite}_test.sh" "$engine" "$engine" \
+        > "$WORK/startup.log" 2>&1; then
+      echo "FAIL: $suite accepted $engine"
+      tail -5 "$WORK/startup.log"
+      exit 1
+    fi
+    checks=$((checks+1))
+  done
+done
+
+cat > "$WORK/engine" <<'ENGINE'
+#!/usr/bin/env bash
+if [ "$#" -eq 2 ]; then
+  case "$2" in
+    "SELECT 'sql-oracle-ready',6*7;") echo 'sql-oracle-ready|42'; exit 0 ;;
+    'SELECT sqlite_version();') echo '3.54.0'; exit 0 ;;
+    'CREATE TABLE x(y); INSERT INTO x VALUES(1);')
+      printf 'SQLite format 3\000' > "$1"; exit 0 ;;
+  esac
+fi
+cat >/dev/null
+printf '%s' "$oracle_test_output"
+exit "$oracle_test_rc"
+ENGINE
+chmod +x "$WORK/engine"
+for suite in upsert dot_commands fts5; do
+  for scenario in empty failure crash; do
+    export oracle_test_output='' oracle_test_rc=0
+    if [ "$scenario" = failure ]; then
+      export oracle_test_output='unexpected engine error' oracle_test_rc=1
+    elif [ "$scenario" = crash ]; then
+      export oracle_test_output='unexpected engine error' oracle_test_rc=134
+    fi
+    if bash "$SUITE_DIR/oracle_${suite}_test.sh" "$WORK/engine" "$WORK/engine" \
+        > "$WORK/runtime.log" 2>&1; then
+      echo "FAIL: $suite accepted runtime $scenario"
+      tail -5 "$WORK/runtime.log"
+      exit 1
+    fi
+    if ! grep -q 'FAIL:' "$WORK/runtime.log"; then
+      cat "$WORK/runtime.log"
+      echo "FAIL: $suite did not reach comparisons"
+      exit 1
+    fi
+    checks=$((checks+1))
+  done
+done
+
+echo "Stock oracle harness: $checks checks passed"

--- a/test/stock_oracle_harness_test.sh
+++ b/test/stock_oracle_harness_test.sh
@@ -73,6 +73,9 @@ if [ "$#" -eq 2 ]; then
   case "$2" in
     "SELECT 'sql-oracle-ready',6*7;") echo 'sql-oracle-ready|42'; exit 0 ;;
     'SELECT sqlite_version();') echo '3.54.0'; exit 0 ;;
+    'SELECT doltlite_engine();')
+      printf '%s\n' "${oracle_test_engine:-prolly}"
+      exit "${oracle_test_engine_rc:-0}" ;;
     'CREATE TABLE x(y); INSERT INTO x VALUES(1);')
       printf 'SQLite format 3\000' > "$1"; exit 0 ;;
   esac
@@ -82,6 +85,35 @@ printf '%s' "$oracle_test_output"
 exit "$oracle_test_rc"
 ENGINE
 chmod +x "$WORK/engine"
+cp "$WORK/engine" "$WORK/candidate"
+cp "$WORK/engine" "$WORK/reference"
+ln -s "$WORK/candidate" "$WORK/symlink"
+ln "$WORK/candidate" "$WORK/hardlink"
+
+check_binaries() {
+  local name="$1" DOLTLITE="$2" SQLITE3="$3" expected="${4-}" rc=0
+  sql_oracle_check_binaries "$SCRIPT_DIR" > "$WORK/binaries.log" 2>&1 || rc=$?
+  if { [ -z "$expected" ] && [ "$rc" -ne 0 ]; } \
+     || { [ -n "$expected" ] && { [ "$rc" -eq 0 ] \
+         || ! grep -Fq "$expected" "$WORK/binaries.log"; }; }; then
+    cat "$WORK/binaries.log"
+    echo "FAIL: $name (rc=$rc)"
+    exit 1
+  fi
+  checks=$((checks+1))
+}
+check_binaries distinct_engines "$WORK/candidate" "$WORK/reference"
+check_binaries same_file "$WORK/candidate" "$WORK/candidate" 'same executable'
+check_binaries relative_alias "$WORK/candidate" "$WORK/./candidate" 'same executable'
+check_binaries symlink_alias "$WORK/candidate" "$WORK/symlink" 'same executable'
+check_binaries hardlink_alias "$WORK/candidate" "$WORK/hardlink" 'same executable'
+export oracle_test_engine=sqlite
+check_binaries copied_stock "$WORK/candidate" "$WORK/reference" 'not a DoltLite'
+export oracle_test_engine='no such function: doltlite_engine' oracle_test_engine_rc=1
+check_binaries missing_engine_function "$WORK/candidate" "$WORK/reference" 'not a DoltLite'
+export oracle_test_engine=prolly
+check_binaries failed_engine_probe "$WORK/candidate" "$WORK/reference" 'not a DoltLite'
+unset oracle_test_engine oracle_test_engine_rc
 for suite in upsert dot_commands fts5; do
   for scenario in empty failure crash; do
     export oracle_test_output='' oracle_test_rc=0
@@ -90,7 +122,7 @@ for suite in upsert dot_commands fts5; do
     elif [ "$scenario" = crash ]; then
       export oracle_test_output='unexpected engine error' oracle_test_rc=134
     fi
-    if bash "$SUITE_DIR/oracle_${suite}_test.sh" "$WORK/engine" "$WORK/engine" \
+    if bash "$SUITE_DIR/oracle_${suite}_test.sh" "$WORK/candidate" "$WORK/reference" \
         > "$WORK/runtime.log" 2>&1; then
       echo "FAIL: $suite accepted runtime $scenario"
       tail -5 "$WORK/runtime.log"


### PR DESCRIPTION
All eleven stock-SQL oracle suites could report success with `/usr/bin/true` as both engines, and identical engine failures could pass as matching output. They now share executable SQL probes, stock-reference validation, exit-status checks, and a requirement for passing comparisons with non-empty output. Expected SQL errors and empty results are explicit per test.

Startup also rejects candidate/reference paths that identify the same executable, including symlinks and hardlinks, and requires the candidate to report the DoltLite prolly engine. Separate copies of stock SQLite therefore cannot pass as candidate-versus-reference comparisons.

The stronger checks exposed three setup mistakes, now corrected: quoted-name fixtures lost SQL string quotes, deferred foreign keys were enabled before setup transactions cleared the setting, and interleaved FTS inserts reused rowids. Both sanitizer oracle jobs explicitly validate their stock SQLite reference.

Validation:
- Before: all 11 suites passed with `/usr/bin/true`; the harness self-test fails against the original suites. Ito's same-stock-binary case also reproduced as 35/35 passing UPSERT checks before the provenance fix.
- After: all 376 stock-suite comparisons and 569 SQL oracle cases pass against real stock SQLite.
- All 12 suites reject identical, symlinked, hardlinked, and copied stock candidates.
- All 69 stock-harness and 20 SQL-harness checks pass, including identity/provenance, runtime failures, expected errors/empty results, and suite floors.
- Lint, orphaned-suite checks, shell syntax, workflow YAML parsing, and `git diff --check` pass.

Fixes #2790

Co-Authored-By: OpenAI Codex <noreply@openai.com>
