### PR TITLE
Guard remaining SQLite-core edits with DOLTLITE_PROLLY

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,7 +69,10 @@ make DOLTLITE_PROLLY=0 sqlite3   # stock SQLite, for oracle/perf comparison
   change or you validate a stale engine. A repo-root `./doltlite` or `./sqlite3`
   built over the prolly `.o` files is DoltLite-in-disguise; to get *real* stock
   SQLite for comparison, build with `DOLTLITE_PROLLY=0` in a clean directory.
-- `make lint` runs the layering and raw-file-I/O guards over `src/`.
+- `make lint` runs the layering and raw-file-I/O guards over `src/`, and
+  checks that SQLite-core files above `btree.h` still match
+  `.sqlite-upstream-base` after `#ifdef DOLTLITE_PROLLY` branches are
+  stripped.
 
 ## Source layout
 

--- a/main.mk
+++ b/main.mk
@@ -309,7 +309,9 @@ lint:
 	@bash $(TOP)/test/lint_no_raw_os_fileio.sh $(TOP)/src
 	@bash $(TOP)/test/lint_export_filters.sh $(TOP)/src
 	@bash $(TOP)/test/lint_orig_btree_adapter.sh $(TOP)/src
+	@bash $(TOP)/test/lint_prolly_guards.sh $(TOP)/src
 	@bash $(TOP)/test/lint_layers_selftest.sh
+	@bash $(TOP)/test/lint_prolly_guards_selftest.sh
 	@bash $(TOP)/test/check_testfixture_exception_inventory.sh
 	@bash $(TOP)/test/check_testfixture_exception_inventory_test.sh
 	@bash $(TOP)/test/dolt_oracle_upgrade_test.sh

--- a/src/alter.c
+++ b/src/alter.c
@@ -511,7 +511,6 @@ void sqlite3AlterFinishAddColumn(Parse *pParse, Token *pColDef){
         zTab, zDb
       );
     }
-
 #ifdef DOLTLITE_PROLLY
     if( pDflt && (pCol->colFlags & COLFLAG_GENERATED)==0 ){
       FuncDef *pFunc = sqlite3FindFunction(

--- a/src/build.c
+++ b/src/build.c
@@ -1112,8 +1112,7 @@ int sqlite3WritableSchema(sqlite3 *db){
 ** unqualified name for a new schema object (table, index, view or
 ** trigger). All names are legal except those that begin with the string
 ** "sqlite_" (in upper, lower or mixed case). This portion of the namespace
-** is reserved for internal use. DoltLite also reserves "dolt_" except
-** CREATE TABLE of dolt_ignore, dolt_docs, dolt_tests, and dolt_rebase.
+** is reserved for internal use.
 **
 ** When parsing the sqlite_schema table, this routine also checks to
 ** make sure the "type", "name", and "tbl_name" columns are consistent
@@ -1347,11 +1346,13 @@ void sqlite3StartTable(
   }
   pParse->sNameToken = *pName;
   if( zName==0 ) return;
+#ifdef DOLTLITE_PROLLY
   /* The reserved shadow-name check resolves the owning virtual table
   ** through the schema, so the schema must be loaded before it runs. */
   if( !IN_SPECIAL_PARSE && SQLITE_OK!=sqlite3ReadSchema(pParse) ){
     goto begin_table_error;
   }
+#endif
   if( sqlite3CheckObjectName(pParse, zName, isView?"view":"table", zName) ){
     goto begin_table_error;
   }
@@ -2874,10 +2875,27 @@ void sqlite3EndTable(
   assert( (p->tabFlags & TF_HasPrimaryKey)!=0
        || (p->iPKey<0 && sqlite3PrimaryKeyIndex(p)==0) );
 
+#ifndef DOLTLITE_PROLLY
+  /* Special processing for WITHOUT ROWID Tables */
+  if( tabOpts & TF_WithoutRowid ){
+    if( (p->tabFlags & TF_Autoincrement) ){
+      sqlite3ErrorMsg(pParse,
+          "AUTOINCREMENT not allowed on WITHOUT ROWID tables");
+      return;
+    }
+    if( (p->tabFlags & TF_HasPrimaryKey)==0 ){
+      sqlite3ErrorMsg(pParse, "PRIMARY KEY missing on table %s", p->zName);
+      return;
+    }
+    p->tabFlags |= TF_WithoutRowid | TF_NoVisibleRowid;
+    convertToWithoutRowidTable(pParse, p);
+  }
+  iDb = sqlite3SchemaToIndex(db, p->pSchema);
+  assert( iDb>=0 && iDb<=db->nDb );
+#else
   iDb = sqlite3SchemaToIndex(db, p->pSchema);
   assert( iDb>=0 && iDb<=db->nDb );
 
-#ifdef DOLTLITE_PROLLY
   /* Cluster non-INTEGER PRIMARY KEY tables as WITHOUT ROWID so the
   ** storage key is the user PK (merge identity). convertToWithoutRowidTable
   ** runs later, after the dolt_* schema guards, so PK-implied NOT NULL
@@ -2903,15 +2921,10 @@ void sqlite3EndTable(
   }
 #endif
 
-  /* Doltlite: dolt_ignore is a user-created system table whose
-  ** schema is load-bearing — dolt_add / dolt_status run
-  ** `SELECT pattern, ignored FROM dolt_ignore` and would silently
-  ** ignore all patterns if the columns don't match. Enforce the
-  ** exact shape at CREATE TIME so the failure mode is a clear parse
-  ** error instead of silent mis-configuration. Skipped during
-  ** schema replay (db->init.busy): a previously-validated on-disk
-  ** schema is assumed correct. */
 #ifdef DOLTLITE_PROLLY
+  /* dolt_ignore is a user-created system table whose schema is
+  ** load-bearing. Enforce the exact shape at CREATE TIME. Skipped
+  ** during schema replay (db->init.busy). */
   if( !db->init.busy
    && !db->init.imposterTable
    && iDb!=1
@@ -3077,7 +3090,6 @@ void sqlite3EndTable(
     }
   }
 #endif
-
 #ifdef DOLTLITE_PROLLY
   if( tabOpts & TF_WithoutRowid ){
     if( (p->tabFlags & TF_Autoincrement) ){
@@ -3093,23 +3105,7 @@ void sqlite3EndTable(
     if( bUserWithoutRowid ) p->tabFlags |= TF_NoVisibleRowid;
     convertToWithoutRowidTable(pParse, p);
   }
-#else
-  /* Special processing for WITHOUT ROWID Tables */
-  if( tabOpts & TF_WithoutRowid ){
-    if( (p->tabFlags & TF_Autoincrement) ){
-      sqlite3ErrorMsg(pParse,
-          "AUTOINCREMENT not allowed on WITHOUT ROWID tables");
-      return;
-    }
-    if( (p->tabFlags & TF_HasPrimaryKey)==0 ){
-      sqlite3ErrorMsg(pParse, "PRIMARY KEY missing on table %s", p->zName);
-      return;
-    }
-    p->tabFlags |= TF_WithoutRowid | TF_NoVisibleRowid;
-    convertToWithoutRowidTable(pParse, p);
-  }
 #endif
-
 #ifndef SQLITE_OMIT_CHECK
   /* Resolve names in all CHECK constraint expressions.
   */
@@ -4810,11 +4806,13 @@ void sqlite3CreateIndex(
       assert( sqlite3SchemaMutexHeld(db, 0, pIndex->pSchema) );
       if( pTblName!=0 ){
         pIndex->tnum = db->init.newTnum;
-        if( sqlite3IndexHasDuplicateRootPage(pIndex)
 #ifdef DOLTLITE_PROLLY
+        if( sqlite3IndexHasDuplicateRootPage(pIndex)
          || (HasRowid(pIndex->pTable) && pIndex->tnum==pIndex->pTable->tnum)
-#endif
         ){
+#else
+        if( sqlite3IndexHasDuplicateRootPage(pIndex) ){
+#endif
           sqlite3ErrorMsg(pParse, "invalid rootpage");
           pParse->rc = SQLITE_CORRUPT_BKPT;
           goto exit_create_index;

--- a/src/delete.c
+++ b/src/delete.c
@@ -277,7 +277,6 @@ Expr *sqlite3LimitWhere(
 }
 #endif /* defined(SQLITE_ENABLE_UPDATE_DELETE_LIMIT) */
        /*      && !defined(SQLITE_OMIT_SUBQUERY) */
-
 #ifdef DOLTLITE_PROLLY
 static int doltliteExprContainsOr(const Expr *pExpr){
   if( pExpr==0 ) return 0;
@@ -552,18 +551,14 @@ void sqlite3DeleteFrom(
       sqlite3VdbeAddOp1(v, OP_FinishSeek, iTabCur);
     }
  
-    /* Keep track of the number of rows to be deleted.
-    **
-    ** For the one-pass paths the row is deleted inline here in the WHERE loop,
-    ** so count it here. For the two-pass path (ONEPASS_OFF) the WHERE loop only
-    ** collects keys: under DoltLite's OR handling the same row is visited once
-    ** per OR term (bComplex is forced for any OR WHERE — see
-    ** doltliteExprContainsOr above — so the inline ONEPASS_MULTI delete that
-    ** stock SQLite uses, which removes a row before the next term re-finds it,
-    ** is unavailable). Counting here would count duplicates; the actual delete
-    ** loop iterates the de-duplicated keys (OP_RowSetRead / the ephemeral
-    ** index), so for ONEPASS_OFF we count there instead. */
+    /* Keep track of the number of rows to be deleted */
+#ifdef DOLTLITE_PROLLY
+    /* ONEPASS_OFF collects keys only. DoltLite forces bComplex for OR WHERE,
+    ** so the same row can be visited once per term; count in the de-dup loop. */
     if( memCnt && eOnePass!=ONEPASS_OFF ){
+#else
+    if( memCnt ){
+#endif
       sqlite3VdbeAddOp2(v, OP_AddImm, memCnt, 1);
     }
  
@@ -654,15 +649,13 @@ void sqlite3DeleteFrom(
       addrLoop = sqlite3VdbeAddOp3(v, OP_RowSetRead, iRowSet, 0, iKey);
       VdbeCoverage(v);
       assert( nKey==1 );
-    }
-
-    /* Count the row here for the two-pass path: this loop iterates the
-    ** de-duplicated keys collected above, so each row is counted exactly once
-    ** (the WHERE-loop count was suppressed for ONEPASS_OFF). */
+    } 
+ 
+#ifdef DOLTLITE_PROLLY
     if( memCnt && eOnePass==ONEPASS_OFF ){
       sqlite3VdbeAddOp2(v, OP_AddImm, memCnt, 1);
     }
-
+#endif
     /* Delete the row */
 #ifndef SQLITE_OMIT_VIRTUALTABLE
     if( IsVirtual(pTab) ){

--- a/src/insert.c
+++ b/src/insert.c
@@ -422,24 +422,31 @@ static int rowidTableUsesSharedSeq(Parse *pParse, int iDb, Table *pTab){
       && (db->mDbFlags & DBFLAG_Vacuum)==0;
 }
 #endif
-
 static int autoIncBegin(
   Parse *pParse,      /* Parsing context */
   int iDb,            /* Index of the database holding pTab */
   Table *pTab         /* The table we are writing to */
 ){
   int memId = 0;      /* Register holding maximum rowid */
+#ifdef DOLTLITE_PROLLY
   int bSeqOnly = 0;
+#endif
   assert( pParse->db->aDb[iDb].pSchema!=0 );
 #if defined(DOLTLITE_PROLLY) && !defined(SQLITE_TEST)
   if( (pTab->tabFlags & TF_Autoincrement)==0 ){
     bSeqOnly = rowidTableUsesSharedSeq(pParse, iDb, pTab);
   }
 #endif
+#ifdef DOLTLITE_PROLLY
   if( bSeqOnly
    || ((pTab->tabFlags & TF_Autoincrement)!=0
        && (pParse->db->mDbFlags & DBFLAG_Vacuum)==0)
   ){
+#else
+  if( (pTab->tabFlags & TF_Autoincrement)!=0
+   && (pParse->db->mDbFlags & DBFLAG_Vacuum)==0
+  ){
+#endif
     Parse *pToplevel = sqlite3ParseToplevel(pParse);
     AutoincInfo *pInfo;
     Table *pSeqTab = pParse->db->aDb[iDb].pSchema->pSeqTab;
@@ -447,12 +454,20 @@ static int autoIncBegin(
     /* Verify that the sqlite_sequence table exists and is an ordinary
     ** rowid table with exactly two columns.
     ** Ticket d8dc2b3a58cd5dc2918a1d4acb 2018-05-23 */
+#ifdef DOLTLITE_PROLLY
     if( !bSeqOnly
      && (pSeqTab==0
          || !HasRowid(pSeqTab)
          || NEVER(IsVirtual(pSeqTab))
          || pSeqTab->nCol!=2)
     ){
+#else
+    if( pSeqTab==0
+     || !HasRowid(pSeqTab)
+     || NEVER(IsVirtual(pSeqTab))
+     || pSeqTab->nCol!=2
+    ){
+#endif
       pParse->nErr++;
       pParse->rc = SQLITE_CORRUPT_SEQUENCE;
       return 0;
@@ -632,7 +647,6 @@ static SQLITE_NOINLINE void autoIncrementEnd(Parse *pParse){
 void sqlite3AutoincrementEnd(Parse *pParse){
   if( pParse->usesAinc ) autoIncrementEnd(pParse);
 }
-
 #if defined(DOLTLITE_PROLLY) && !defined(SQLITE_TEST)
 /* Schema index when pTab is a prolly-backed sqlite_sequence whose rows a
 ** top-level statement is writing directly, else -1. */

--- a/src/main.c
+++ b/src/main.c
@@ -53,7 +53,7 @@ int SQLITE_EXTRA_AUTOEXT(sqlite3*);
 #if defined(DOLTLITE_PROLLY) && defined(SQLITE_ENABLE_DBPAGE_VTAB)
 int doltliteDbpageRegister(sqlite3*);
 #endif
-#if DOLTLITE_VEC1
+#if defined(DOLTLITE_PROLLY) && DOLTLITE_VEC1
 int sqlite3Vec1Init(sqlite3*);
 #endif
 /*
@@ -92,8 +92,7 @@ static int (*const sqlite3BuiltinExtensions[])(sqlite3*) = {
 #ifdef SQLITE_ENABLE_BYTECODE_VTAB
   sqlite3VdbeBytecodeVtabInit,
 #endif
-#if DOLTLITE_VEC1
-  /* doltlite ships the vec1 vector-search extension built in. */
+#if defined(DOLTLITE_PROLLY) && DOLTLITE_VEC1
   sqlite3Vec1Init,
 #endif
 #ifdef SQLITE_EXTRA_AUTOEXT
@@ -1139,7 +1138,6 @@ static int nocaseCollatingFunc(
   }
   return r;
 }
-
 #ifdef DOLTLITE_PROLLY
 int sqlite3DoltliteIsBuiltinCollation(const CollSeq *p){
   if( !p || !p->zName ) return 0;
@@ -2942,7 +2940,6 @@ static int createCollation(
   int enc2;
  
   assert( sqlite3_mutex_held(db->mutex) );
-
 #ifdef DOLTLITE_PROLLY
   if( sqlite3StrICmp(zName, "BINARY")==0
    || sqlite3StrICmp(zName, "NOCASE")==0

--- a/src/pragma.c
+++ b/src/pragma.c
@@ -1383,11 +1383,11 @@ void sqlite3Pragma(
       ** WITHOUT ROWID table named zRight, and if there is, show the
       ** structure of the PRIMARY KEY index for that table. */
       pTab = sqlite3LocateTable(pParse, LOCATE_NOERR, zRight, zDb);
-      if( pTab && !HasRowid(pTab)
 #ifdef DOLTLITE_PROLLY
-       && !IsDoltClusteredPk(pTab)
+      if( pTab && !HasRowid(pTab) && !IsDoltClusteredPk(pTab) ){
+#else
+      if( pTab && !HasRowid(pTab) ){
 #endif
-      ){
         pIdx = sqlite3PrimaryKeyIndex(pTab);
       }
     }

--- a/src/select.c
+++ b/src/select.c
@@ -5547,6 +5547,7 @@ static Table *isSimpleCount(Select *p, AggInfo *pAggInfo){
   return pTab;
 }
 
+#ifdef DOLTLITE_PROLLY
 static int exprIsRowidOfTable(Expr *pExpr, Table *pTab){
   while( pExpr && (pExpr->op==TK_UPLUS || pExpr->op==TK_COLLATE) ){
     pExpr = pExpr->pLeft;
@@ -5771,7 +5772,7 @@ static Index *isSimpleIndexRangeCount(
   *ppTab = pTab;
   return pIdx;
 }
-
+#endif
 /*
 ** If the source-list item passed as an argument was augmented with an
 ** INDEXED BY clause, then try to locate the specified index. If there
@@ -7128,7 +7129,6 @@ static int aggregateArgCanBeNull(const Expr *pExpr){
   return sqlite3ExprCanBeNull(pExpr);
 }
 #endif
-
 /*
 ** Generate code that will update the accumulator memory cells for an
 ** aggregate based on the current cursor position.
@@ -9129,6 +9129,7 @@ int sqlite3Select(
     else {
       /* Aggregate functions without GROUP BY. tag-select-0820 */
       Table *pTab;
+#ifdef DOLTLITE_PROLLY
       Expr *pRangeLow = 0;
       Expr *pRangeHigh = 0;
       Index *pRangeIdx = 0;
@@ -9192,7 +9193,9 @@ int sqlite3Select(
               pTab->zName
           );
         }
-      }else if( (pTab = isSimpleCount(p, pAggInfo))!=0 ){
+      }else
+#endif
+      if( (pTab = isSimpleCount(p, pAggInfo))!=0 ){
         /* tag-select-0821
         **
         ** If isSimpleCount() returns a pointer to a Table structure, then

--- a/src/vdbe.c
+++ b/src/vdbe.c
@@ -111,18 +111,22 @@ static void updateMaxBlobsize(Mem *p){
 ** This macro evaluates to true if either the update hook or the preupdate
 ** hook are enabled for database connect DB.
 */
+#ifdef DOLTLITE_PROLLY
 #ifdef SQLITE_ENABLE_PREUPDATE_HOOK
 # define HAS_UPDATE_HOOK_CB(DB) ((DB)->xPreUpdateCallback||(DB)->xUpdateCallback)
 #else
 # define HAS_UPDATE_HOOK_CB(DB) ((DB)->xUpdateCallback)
 #endif
-#ifdef DOLTLITE_PROLLY
   /* Internal DML must not fire hooks. Do not clear xPreUpdateCallback:
   ** the session module stores its object list in pPreUpdateArg. */
 # define HAS_UPDATE_HOOK(DB) \
     (HAS_UPDATE_HOOK_CB(DB) && ((DB)->mDbFlags & DBFLAG_InternalDml)==0)
 #else
-# define HAS_UPDATE_HOOK(DB) HAS_UPDATE_HOOK_CB(DB)
+#ifdef SQLITE_ENABLE_PREUPDATE_HOOK
+# define HAS_UPDATE_HOOK(DB) ((DB)->xPreUpdateCallback||(DB)->xUpdateCallback)
+#else
+# define HAS_UPDATE_HOOK(DB) ((DB)->xUpdateCallback)
+#endif
 #endif
 
 /*
@@ -1696,6 +1700,7 @@ case OP_Move: {
     assert( pIn1<=&aMem[(p->nMem+1 - p->nCursor)] );
     assert( memIsValid(pIn1) );
     memAboutToChange(p, pOut);
+#ifdef DOLTLITE_PROLLY
     if( (pIn1->flags & MEM_Ephem)!=0
      && (pIn1->flags & (MEM_Str|MEM_Blob))!=0
      && (pIn1->flags & MEM_Zero)==0
@@ -1721,6 +1726,9 @@ case OP_Move: {
       sqlite3VdbeMemMove(pOut, pIn1);
       Deephemeralize(pOut);
     }
+#else
+    sqlite3VdbeMemMove(pOut, pIn1);
+#endif
 #ifdef SQLITE_DEBUG
     pIn1->pScopyFrom = 0;
     { int i;
@@ -1731,6 +1739,9 @@ case OP_Move: {
         }
       }
     }
+#endif
+#ifndef DOLTLITE_PROLLY
+    Deephemeralize(pOut);
 #endif
     REGISTER_TRACE(p2++, pOut);
     pIn1++;
@@ -3153,10 +3164,12 @@ op_column_restart:
       pC->payloadSize = sqlite3BtreePayloadSize(pCrsr);
       pC->aRow = sqlite3BtreePayloadFetch(pCrsr, &pC->szRow);
 #endif
+#ifdef DOLTLITE_PROLLY
       if( pC->aRow==0 ){
         if( db->mallocFailed ) goto no_mem;
         goto op_column_corrupt;
       }
+#endif
       assert( pC->szRow<=pC->payloadSize );
 #ifndef DOLTLITE_PROLLY
       assert( pC->szRow<=65536 );  /* Maximum page size is 64KiB */
@@ -4017,6 +4030,7 @@ case OP_Count: {         /* out2 */
   goto check_for_interrupt;
 }
 
+#ifdef DOLTLITE_PROLLY
 /* Opcode: CountRange P1 P2 P3 * *
 ** Synopsis: r[P2]=count_range(r[P3]..r[P3+1])
 **
@@ -4061,7 +4075,7 @@ case OP_CountRange: {    /* out2 */
   goto check_for_interrupt;
 }
 
-#if defined(DOLTLITE_PROLLY) && !defined(SQLITE_TEST)
+#if !defined(SQLITE_TEST)
 /* Opcode: DoltliteSeqMax P1 P2 P3 * *
 ** Synopsis: r[P1]=max(r[P1], chunkStoreGetSequenceValue(r[P2]))
 **
@@ -4268,7 +4282,7 @@ case OP_CountIndexRange: {    /* out2 */
   pOut->u.i = nEntry;
   goto check_for_interrupt;
 }
-
+#endif
 /* Opcode: Savepoint P1 * * P4 *
 **
 ** Open, release or rollback the savepoint named by parameter P4, depending
@@ -4602,11 +4616,11 @@ case OP_Transaction: {
 
     if( p->usesStmtJournal
      && pOp->p2
-     && (db->autoCommit==0 || db->nVdbeRead>1
-#if defined(DOLTLITE_PROLLY)
-         || p->hasVUpdate
+#ifdef DOLTLITE_PROLLY
+     && (db->autoCommit==0 || db->nVdbeRead>1 || p->hasVUpdate)
+#else
+     && (db->autoCommit==0 || db->nVdbeRead>1)
 #endif
-        )
     ){
       assert( sqlite3BtreeTxnState(pBt)==SQLITE_TXN_WRITE );
       if( p->iStatement==0 ){
@@ -4614,11 +4628,16 @@ case OP_Transaction: {
         db->nStatement++;
         p->iStatement = db->nSavepoint + db->nStatement;
       }
+#ifdef DOLTLITE_PROLLY
       if( db->nVtabSavepoint==0 ){
         rc = sqlite3VtabSavepoint(db, SAVEPOINT_BEGIN, p->iStatement-1);
       }else{
         rc = SQLITE_OK;
       }
+#else
+
+      rc = sqlite3VtabSavepoint(db, SAVEPOINT_BEGIN, p->iStatement-1);
+#endif
       if( rc==SQLITE_OK ){
         rc = sqlite3BtreeBeginStmt(pBt, p->iStatement);
       }
@@ -4973,6 +4992,7 @@ case OP_OpenDup: {           /* ncycle */
   pOrig->noReuse = 1;
   rc = sqlite3BtreeCursor(pCx->ub.pBtx, pCx->pgnoRoot, BTREE_WRCSR,
                           pCx->pKeyInfo, pCx->uc.pCursor);
+#ifdef DOLTLITE_PROLLY
   /* Stock SQLite asserts this open cannot fail: a second cursor on an
   ** already-open btree needs no allocation. doltlite's cursor open DOES
   ** allocate (catalog entry + prolly cursor state), so under OOM it can
@@ -4980,6 +5000,12 @@ case OP_OpenDup: {           /* ncycle */
   ** cursor (left zeroed by sqlite3BtreeCursorZero), which a later
   ** OP_NewRowid/OP_Last would dereference via the prolly cursor ops. */
   if( rc ) goto abort_due_to_error;
+#else
+  /* The sqlite3BtreeCursor() routine can only fail for the first cursor
+  ** opened for a database.  Since there is already an open cursor when this
+  ** opcode is run, the sqlite3BtreeCursor() cannot fail */
+  assert( rc==SQLITE_OK );
+#endif
   break;
 }
 
@@ -5330,7 +5356,9 @@ case OP_SeekGT: {       /* jump0, in3, group, ncycle */
 
   pC->deferredMoveto = 0;
   pC->cacheStatus = CACHE_STALE;
+#ifdef DOLTLITE_PROLLY
   pC->idxRowidCacheValid = 0;
+#endif
   if( pC->isTable ){
     u16 flags3, newType;
     /* The OPFLAG_SEEKEQ/BTREE_SEEK_EQ flag is only set on index cursors */
@@ -5449,7 +5477,6 @@ case OP_SeekGT: {       /* jump0, in3, group, ncycle */
       assert( res!=0 );
       goto seek_not_found;
     }
-
 #ifdef DOLTLITE_PROLLY
     /* A prefix seek with default_rc<0 must land on the LAST match, since
     ** SeekLE stays put and SeekGT steps once. The prolly seek does that in
@@ -5717,7 +5744,9 @@ case OP_SeekScan: {          /* ncycle */
     }
     nStep--;
     pC->cacheStatus = CACHE_STALE;
+#ifdef DOLTLITE_PROLLY
     pC->idxRowidCacheValid = 0;
+#endif
     rc = sqlite3BtreeNext(pC->uc.pCursor, 0);
     if( rc ){
       if( rc==SQLITE_DONE ){
@@ -5952,7 +5981,9 @@ case OP_Found: {        /* jump, in3, ncycle */
   pC->nullRow = 1-alreadyExists;
   pC->deferredMoveto = 0;
   pC->cacheStatus = CACHE_STALE;
+#ifdef DOLTLITE_PROLLY
   pC->idxRowidCacheValid = 0;
+#endif
   if( pOp->opcode==OP_Found ){
     VdbeBranchTaken(alreadyExists!=0,2);
     if( alreadyExists ) goto jump_to_p2;
@@ -6545,13 +6576,11 @@ case OP_Delete: {
   /* Invoke the update-hook if required. */
   if( opflags & OPFLAG_NCHANGE ){
     p->nChange++;
-    if( db->xUpdateCallback && ALWAYS(pTab!=0)
 #ifdef DOLTLITE_PROLLY
-     && VisibleRowid(pTab)
+    if( db->xUpdateCallback && ALWAYS(pTab!=0) && VisibleRowid(pTab) ){
 #else
-     && HasRowid(pTab)
+    if( db->xUpdateCallback && ALWAYS(pTab!=0) && HasRowid(pTab) ){
 #endif
-    ){
 #ifdef DOLTLITE_PROLLY
       db->xUpdateCallback(db->pUpdateArg, SQLITE_DELETE, zDb, pTab->zName,
           HasRowid(pTab) ? pC->movetoTarget : iHookRowid);
@@ -6705,7 +6734,7 @@ case OP_RowData: {
   break;
 }
 
-/* Opcode: Rowid P1 P2 P3 * *
+/* Opcode: Rowid P1 P2 * * *
 ** Synopsis: r[P2]=PX rowid of P1
 **
 ** Store in register P2 an integer which is the key of the table entry that
@@ -6714,11 +6743,6 @@ case OP_RowData: {
 ** P1 can be either an ordinary table or a virtual table.  There used to
 ** be a separate OP_VRowid opcode for use with virtual tables, but this
 ** one opcode now works for both table types.
-**
-** If P3 is non-zero, P1 is used only for KeyInfo and r[P2] is the SQL
-** rowid of the index record in r[P3]. Clustered PRIMARY KEY RETURNING
-** and NEW.rowid use that form because the PK cursor is still a null row
-** after OP_IdxInsert.
 */
 case OP_Rowid: {                 /* out2, ncycle */
   VdbeCursor *pC;
@@ -6808,7 +6832,9 @@ case OP_NullRow: {
   }
   pC->nullRow = 1;
   pC->cacheStatus = CACHE_STALE;
+#ifdef DOLTLITE_PROLLY
   pC->idxRowidCacheValid = 0;
+#endif
   if( pC->eCurType==CURTYPE_BTREE ){
     assert( pC->uc.pCursor!=0 );
     sqlite3BtreeClearCursor(pC->uc.pCursor);
@@ -6868,7 +6894,9 @@ case OP_Last: {              /* jump0, ncycle */
   pC->nullRow = (u8)res;
   pC->deferredMoveto = 0;
   pC->cacheStatus = CACHE_STALE;
+#ifdef DOLTLITE_PROLLY
   pC->idxRowidCacheValid = 0;
+#endif
   if( rc ) goto abort_due_to_error;
   if( pOp->p2>0 ){
     VdbeBranchTaken(res!=0,2);
@@ -6986,7 +7014,9 @@ case OP_Rewind: {        /* jump0, ncycle */
     rc = sqlite3BtreeFirst(pCrsr, &res);
     pC->deferredMoveto = 0;
     pC->cacheStatus = CACHE_STALE;
+#ifdef DOLTLITE_PROLLY
     pC->idxRowidCacheValid = 0;
+#endif
   }
   if( rc ) goto abort_due_to_error;
   pC->nullRow = (u8)res;
@@ -7117,7 +7147,9 @@ case OP_Next:          /* jump, ncycle */
 
 next_tail:
   pC->cacheStatus = CACHE_STALE;
+#ifdef DOLTLITE_PROLLY
   pC->idxRowidCacheValid = 0;
+#endif
   VdbeBranchTaken(rc==SQLITE_OK,2);
   if( rc==SQLITE_OK ){
     pC->nullRow = 0;
@@ -7188,12 +7220,14 @@ case OP_IdxInsert: {        /* in2 */
       x.aMem = 0;
       x.nMem = 0;
     }
-  }else
-#endif
-  {
+  }else{
     x.aMem = aMem + pOp->p3;
     x.nMem = (u16)pOp->p4.i;
   }
+#else
+  x.aMem = aMem + pOp->p3;
+  x.nMem = (u16)pOp->p4.i;
+#endif
   rc = sqlite3BtreeInsert(pC->uc.pCursor, &x,
        (pOp->p5 & (OPFLAG_APPEND|OPFLAG_SAVEPOSITION|OPFLAG_PREFORMAT)),
       ((pOp->p5 & OPFLAG_USESEEKRESULT) ? pC->seekResult : 0)
@@ -7304,7 +7338,9 @@ case OP_IdxDelete: {
         goto abort_due_to_error;
       }
       pC->cacheStatus = CACHE_STALE;
+#ifdef DOLTLITE_PROLLY
       pC->idxRowidCacheValid = 0;
+#endif
       pC->seekResult = 0;
       break;
     }
@@ -7320,7 +7356,9 @@ case OP_IdxDelete: {
   if( rc ) goto abort_due_to_error;
   assert( pC->deferredMoveto==0 );
   pC->cacheStatus = CACHE_STALE;
+#ifdef DOLTLITE_PROLLY
   pC->idxRowidCacheValid = 0;
+#endif
   pC->seekResult = 0;
   break;
 }
@@ -7379,23 +7417,26 @@ case OP_IdxRowid: {           /* out2, ncycle */
 
   if( !pC->nullRow ){
     rowid = 0;  /* Not needed.  Only used to silence a warning. */
+#ifdef DOLTLITE_PROLLY
     if( pC->idxRowidCacheValid ){
       rowid = pC->idxRowidCache;
     }else{
-#if defined(DOLTLITE_PROLLY)
       rc = sqlite3BtreeProllyIndexRowid(pC->uc.pCursor, &rowid);
       if( rc==SQLITE_NOTFOUND ){
         rc = sqlite3VdbeIdxRowid(db, pC->uc.pCursor, &rowid);
       }
-#else
-      rc = sqlite3VdbeIdxRowid(db, pC->uc.pCursor, &rowid);
-#endif
       if( rc!=SQLITE_OK ){
         goto abort_due_to_error;
       }
       pC->idxRowidCache = rowid;
       pC->idxRowidCacheValid = 1;
     }
+#else
+    rc = sqlite3VdbeIdxRowid(db, pC->uc.pCursor, &rowid);
+    if( rc!=SQLITE_OK ){
+      goto abort_due_to_error;
+    }
+#endif
     if( pOp->opcode==OP_DeferredSeek ){
       assert( pOp->p3>=0 && pOp->p3<p->nCursor );
       pTabCur = p->apCsr[pOp->p3];
@@ -8773,7 +8814,6 @@ case OP_JournalMode: {    /* out2 */
   if( eNew==PAGER_JOURNALMODE_QUERY ) eNew = eOld;
   assert( sqlite3BtreeHoldsMutex(pBt) );
   if( !sqlite3PagerOkToChangeJournalMode(pPager) ) eNew = eOld;
-
 #ifdef DOLTLITE_PROLLY
   if( eNew!=eOld && sqlite3BtreeIsDoltliteFormat(pBt) ){
     /* doltlite keeps data in a content-addressed chunk store with no
@@ -9056,10 +9096,10 @@ case OP_VCreate: {
       assert( resetSchemaOnFault==0 || resetSchemaOnFault==pOp->p1+1 );
       resetSchemaOnFault = pOp->p1+1;
     }
-#endif
     if( rc && db->mallocFailed ){
       rc = SQLITE_NOMEM_BKPT;
     }
+#endif
 #if defined(DOLTLITE_PROLLY) && defined(SQLITE_TEST)
     /* The generic constructor message only replaces the tokenizer error
     ** when allocating that error failed; the OOM harness expects NOMEM. */

--- a/src/vdbeInt.h
+++ b/src/vdbeInt.h
@@ -108,8 +108,10 @@ struct VdbeCursor {
   /* seekResult does not distinguish between "no seeks have ever occurred
   ** on this cursor" and "the most recent seek was an exact match".
   ** For CURTYPE_PSEUDO, seekResult is the register holding the record */
+#ifdef DOLTLITE_PROLLY
   u8 idxRowidCacheValid;  /* True if idxRowidCache is valid */
   i64 idxRowidCache;      /* Rowid decoded from the current index entry */
+#endif
 
   /* When a new VdbeCursor is allocated, only the fields above are zeroed.
   ** The fields that follow are uninitialized, and must be individually

--- a/src/vdbeaux.c
+++ b/src/vdbeaux.c
@@ -3897,7 +3897,9 @@ int SQLITE_NOINLINE sqlite3VdbeHandleMovedCursor(VdbeCursor *p){
   assert( sqlite3BtreeCursorHasMoved(p->uc.pCursor) );
   rc = sqlite3BtreeCursorRestore(p->uc.pCursor, &isDifferentRow);
   p->cacheStatus = CACHE_STALE;
+#ifdef DOLTLITE_PROLLY
   p->idxRowidCacheValid = 0;
+#endif
   if( isDifferentRow ) p->nullRow = 1;
   return rc;
 }

--- a/src/where.c
+++ b/src/where.c
@@ -4684,7 +4684,6 @@ int sqlite3DoltliteVtabConstraintIsCorrelated(
   return pTerm->prereqRight!=0;
 }
 #endif
-
 /*
 ** Return true if ORDER BY clause may be handled as DISTINCT.
 */
@@ -7943,13 +7942,16 @@ void sqlite3WhereEnd(WhereInfo *pWInfo){
           }
         }else if( pOp->opcode==OP_Rowid ){
 #ifdef DOLTLITE_PROLLY
-          if( HasRowid(pTab) || IsPrimaryKeyIndex(pIdx) )
-#endif
-          {
+          if( HasRowid(pTab) || IsPrimaryKeyIndex(pIdx) ){
             pOp->p1 = pLevel->iIdxCur;
             pOp->opcode = OP_IdxRowid;
             OpcodeRewriteTrace(db, k, pOp);
           }
+#else
+          pOp->p1 = pLevel->iIdxCur;
+          pOp->opcode = OP_IdxRowid;
+          OpcodeRewriteTrace(db, k, pOp);
+#endif
         }else if( pOp->opcode==OP_IfNullRow ){
           pOp->p1 = pLevel->iIdxCur;
           OpcodeRewriteTrace(db, k, pOp);

--- a/test/lib/strip_doltlite_prolly.py
+++ b/test/lib/strip_doltlite_prolly.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Drop DOLTLITE_PROLLY branches the way unifdef -UDOLTLITE_PROLLY does.
+
+Other #if directives are left in the text. Used by lint_prolly_guards.sh so
+a DOLTLITE_PROLLY=0 compile of SQLite-core files stays stock.
+"""
+
+import re
+import sys
+
+DIR_RE = re.compile(
+    r"^([ \t]*#[ \t]*)(ifdef|ifndef|if|elif|else|endif)\b(.*)$"
+)
+
+
+def _eval_if(expr):
+    e = expr.strip()
+    if "//" in e:
+        e = e.split("//", 1)[0].strip()
+    e = re.sub(r"/\*.*?\*/", " ", e)
+    e = re.sub(r"\s+", " ", e).strip()
+    if "DOLTLITE_PROLLY" not in e:
+        return None
+    e = re.sub(r"defined\s*\(\s*DOLTLITE_PROLLY\s*\)", "0", e)
+    e = re.sub(r"\bDOLTLITE_PROLLY\b", "0", e)
+    while True:
+        n = e
+        n = re.sub(r"!\s*0", "1", n)
+        n = re.sub(r"!\s*1", "0", n)
+        n = re.sub(r"\(\s*0\s*\)", "0", n)
+        n = re.sub(r"\(\s*1\s*\)", "1", n)
+        if n == e:
+            break
+        e = n
+    e = e.strip()
+    if e == "0":
+        return False
+    if e == "1":
+        return True
+    if re.match(r"0\s*&&", e):
+        return False
+    if re.match(r"1\s*\|\|", e):
+        return True
+    return None
+
+
+def _eval_dir(kind, rest):
+    rest = rest.strip()
+    if kind == "ifdef":
+        name = rest.split()[0] if rest else ""
+        if name == "DOLTLITE_PROLLY":
+            return False
+        return None
+    if kind == "ifndef":
+        name = rest.split()[0] if rest else ""
+        if name == "DOLTLITE_PROLLY":
+            return True
+        return None
+    if kind in ("if", "elif"):
+        return _eval_if(rest)
+    return None
+
+
+def strip(text):
+    out = []
+    # keep: emit lines. resolved: this frame ate its #if/#else/#endif.
+    stack = []
+
+    def parent_keep():
+        return all(fr[0] for fr in stack)
+
+    for line in text.splitlines(True):
+        raw = line[:-1] if line.endswith("\n") else line
+        m = DIR_RE.match(raw)
+        if not m:
+            if parent_keep():
+                out.append(line)
+            continue
+        kind = m.group(2)
+        rest = m.group(3)
+        if kind in ("if", "ifdef", "ifndef"):
+            val = _eval_dir(kind, rest)
+            if not parent_keep():
+                stack.append((False, True))
+                continue
+            if val is None:
+                stack.append((True, False))
+                out.append(line)
+            else:
+                stack.append((val, True))
+            continue
+        if kind == "elif":
+            if not stack:
+                if parent_keep():
+                    out.append(line)
+                continue
+            keep, resolved = stack[-1]
+            if not resolved:
+                out.append(line)
+                continue
+            if keep:
+                stack[-1] = (False, True)
+            else:
+                val = _eval_dir("elif", rest)
+                if val is None:
+                    stack[-1] = (True, False)
+                    out.append(line)
+                else:
+                    stack[-1] = (val, True)
+            continue
+        if kind == "else":
+            if not stack:
+                if parent_keep():
+                    out.append(line)
+                continue
+            keep, resolved = stack[-1]
+            if not resolved:
+                out.append(line)
+                continue
+            above = all(fr[0] for fr in stack[:-1])
+            stack[-1] = (above and not keep, True)
+            continue
+        if kind == "endif":
+            if not stack:
+                if parent_keep():
+                    out.append(line)
+                continue
+            _keep, resolved = stack.pop()
+            if not resolved and parent_keep():
+                out.append(line)
+            continue
+        if parent_keep():
+            out.append(line)
+    return "".join(out)
+
+
+def main(argv):
+    if len(argv) == 1 or argv[1] == "-":
+        sys.stdout.write(strip(sys.stdin.read()))
+        return 0
+    for path in argv[1:]:
+        with open(path) as fh:
+            sys.stdout.write(strip(fh.read()))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/test/lint_prolly_guards.sh
+++ b/test/lint_prolly_guards.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# SQLite-core files above btree.h must match .sqlite-upstream-base after
+# DOLTLITE_PROLLY branches are stripped. Otherwise DOLTLITE_PROLLY=0 is
+# not stock and the vs-stock oracles compare the engine to itself.
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/.." && pwd)"
+SRC="${1:-$REPO/src}"
+STRIP="$HERE/lib/strip_doltlite_prolly.py"
+BASE_FILE="$REPO/.sqlite-upstream-base"
+
+# Still differ from upstream after stripping. Shrink this list; do not grow it.
+skip_file() {
+  case "$1" in
+    test*.c|tclsqlite*)
+      return 0 ;;
+    backup.c|btmutex.c|btree.c|btree.h|dbstat.c|func.c|memdb.c|os.c|os_kv.c|os_unix.c|os_win.c|pcache.c|sqlite.h.in|sqliteInt.h|vacuum.c|vdbeaux.c|vdbeblob.c|vdbesort.c|vtab.c|wherecode.c)
+      return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+if [ ! -f "$STRIP" ]; then
+  echo "lint_prolly_guards: missing $STRIP" >&2
+  exit 2
+fi
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "lint_prolly_guards: python3 is required" >&2
+  exit 2
+fi
+if [ ! -f "$BASE_FILE" ]; then
+  echo "lint_prolly_guards: missing $BASE_FILE" >&2
+  exit 2
+fi
+
+SHA=$(tr -d '[:space:]' < "$BASE_FILE")
+if [ -z "$SHA" ]; then
+  echo "lint_prolly_guards: $BASE_FILE is empty" >&2
+  exit 2
+fi
+
+cd "$REPO"
+if ! git cat-file -e "$SHA:src/vdbe.c" 2>/dev/null; then
+  echo "lint_prolly_guards: fetching $SHA for the upstream originals"
+  git fetch --depth=1 origin "$SHA" || git fetch origin "$SHA"
+  if ! git cat-file -e "$SHA:src/vdbe.c" 2>/dev/null; then
+    echo "lint_prolly_guards: cannot read $SHA:src/vdbe.c" >&2
+    echo "  that SHA is .sqlite-upstream-base; fetch it or fix the file" >&2
+    exit 2
+  fi
+fi
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+mkdir -p "$WORK/up"
+git archive "$SHA" src | tar -x -C "$WORK/up"
+
+FAIL=0
+CHECKED=0
+SKIPPED=0
+
+shopt -s nullglob
+for path in "$SRC"/*.c "$SRC"/*.h; do
+  [ -f "$path" ] || continue
+  base=$(basename "$path")
+  if skip_file "$base"; then
+    SKIPPED=$((SKIPPED + 1))
+    continue
+  fi
+  up="$WORK/up/src/$base"
+  [ -f "$up" ] || continue
+  CHECKED=$((CHECKED + 1))
+  python3 "$STRIP" "$path" > "$WORK/head"
+  if ! diff -q "$up" "$WORK/head" >/dev/null; then
+    echo "LINT: src/$base differs from $SHA after stripping DOLTLITE_PROLLY"
+    echo "      wrap the edit in #ifdef DOLTLITE_PROLLY, or if this is an"
+    echo "      upstream merge, update .sqlite-upstream-base"
+    diff -u "$up" "$WORK/head" | head -40 | sed 's/^/      /'
+    FAIL=$((FAIL + 1))
+  fi
+done
+
+if [ "$CHECKED" -eq 0 ]; then
+  echo "lint_prolly_guards: checked no files" >&2
+  exit 2
+fi
+
+if [ "$FAIL" -ne 0 ]; then
+  echo "lint_prolly_guards: $FAIL file(s) drifted from stock SQLite ($CHECKED checked, $SKIPPED still-open)"
+  exit 1
+fi
+echo "lint_prolly_guards: $CHECKED file(s) match $SHA after stripping DOLTLITE_PROLLY"
+exit 0

--- a/test/lint_prolly_guards_selftest.sh
+++ b/test/lint_prolly_guards_selftest.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# Structural plus behavioural checks for lint_prolly_guards.sh.
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/.." && pwd)"
+LINT="$HERE/lint_prolly_guards.sh"
+STRIP="$HERE/lib/strip_doltlite_prolly.py"
+
+PASS=0
+FAIL=0
+ERRORS=""
+ok() { PASS=$((PASS + 1)); }
+bad() { FAIL=$((FAIL + 1)); ERRORS="$ERRORS\nFAIL: $1\n  $2"; }
+
+echo "=== lint_prolly_guards self-test ==="
+
+skip_body=$(sed -n '/^skip_file()/,/^}/p' "$LINT")
+if echo "$skip_body" | grep -q 'btree.c'; then
+  ok
+else
+  bad "skip_list_mentions_btree" "skip_file() should still exclude btree.c (storage seam)"
+fi
+for f in btree.c vdbeaux.c wherecode.c sqliteInt.h; do
+  if [ -f "$REPO/src/$f" ]; then
+    ok
+  else
+    bad "skip_target_exists:$f" "skip_file lists $f but src/$f is gone; drop it from the skip list"
+  fi
+done
+
+python3 - "$STRIP" <<'PY' || exit 2
+import importlib.util, sys
+spec = importlib.util.spec_from_file_location("strip", sys.argv[1])
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+cases = [
+    ("plain", "int x;\n", "int x;\n"),
+    ("ifdef_drop",
+     "#ifdef DOLTLITE_PROLLY\nfoo();\n#endif\nint x;\n",
+     "int x;\n"),
+    ("ifndef_keep",
+     "#ifndef DOLTLITE_PROLLY\nbar();\n#endif\n",
+     "bar();\n"),
+    ("if_defined_drop",
+     "#if defined(DOLTLITE_PROLLY)\nfoo();\n#else\nbar();\n#endif\n",
+     "bar();\n"),
+    ("and_short_circuit",
+     "#if defined(DOLTLITE_PROLLY) && !defined(SQLITE_TEST)\nfoo();\n#endif\nint x;\n",
+     "int x;\n"),
+    ("passthrough_other",
+     "#ifdef SQLITE_DEBUG\nfoo();\n#endif\n",
+     "#ifdef SQLITE_DEBUG\nfoo();\n#endif\n"),
+    ("nested_in_drop",
+     "#ifdef DOLTLITE_PROLLY\n#ifdef SQLITE_DEBUG\nfoo();\n#endif\nbar();\n#endif\nint x;\n",
+     "int x;\n"),
+]
+fail = 0
+for name, src, want in cases:
+    got = mod.strip(src)
+    if got != want:
+        fail += 1
+        print("FAIL strip:%s" % name)
+        print("  got:  %r" % got)
+        print("  want: %r" % want)
+if fail:
+    sys.exit(1)
+print("stripper unit tests passed")
+PY
+ok
+
+if command -v unifdef >/dev/null 2>&1; then
+  py=$(python3 "$STRIP" "$REPO/src/vdbe.c")
+  uni=$(unifdef -UDOLTLITE_PROLLY "$REPO/src/vdbe.c" || true)
+  if [ "$py" = "$uni" ]; then
+    ok
+  else
+    bad "matches_unifdef_vdbe" "python stripper disagrees with unifdef -UDOLTLITE_PROLLY on src/vdbe.c"
+  fi
+else
+  ok
+fi
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+cp "$REPO/src/expr.c" "$WORK/expr.c"
+
+out=$(bash "$LINT" "$WORK" 2>&1)
+rc=$?
+if [ "$rc" -eq 0 ] && echo "$out" | grep -q "match"; then
+  ok
+else
+  bad "subset_src_passes" "expected a clean pass on unmodified expr.c, got rc=$rc
+$out"
+fi
+
+printf '\nint leaked_unguarded;\n' >> "$WORK/expr.c"
+out=$(bash "$LINT" "$WORK" 2>&1)
+rc=$?
+if [ "$rc" -ne 0 ] && echo "$out" | grep -q "src/expr.c"; then
+  ok
+else
+  bad "unguarded_edit_is_rejected" "expected a src/expr.c violation, got rc=$rc
+$out"
+fi
+
+cp "$REPO/src/expr.c" "$WORK/expr.c"
+printf '#ifdef DOLTLITE_PROLLY\nint leaked_guarded;\n#endif\n' >> "$WORK/expr.c"
+out=$(bash "$LINT" "$WORK" 2>&1)
+rc=$?
+if [ "$rc" -eq 0 ]; then
+  ok
+else
+  bad "guarded_edit_is_allowed" "expected a pass for an #ifdef DOLTLITE_PROLLY addition, got rc=$rc
+$out"
+fi
+
+echo
+echo "Results: $PASS passed, $FAIL failed out of $((PASS + FAIL)) tests"
+if [ "$FAIL" -gt 0 ]; then
+  echo -e "$ERRORS"
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary
Wrap the remaining unguarded edits above the `btree.h` seam in `#ifdef DOLTLITE_PROLLY` so `make DOLTLITE_PROLLY=0 sqlite3` is stock SQLite.

Issue #2802 measured 574 changed lines after `unifdef -UDOLTLITE_PROLLY` against the merged upstream (`2fed9802b0`). The stock oracle is built from this tree, so a bug in those paths (the `count(*)` range fast path especially) cannot be caught by `sql_oracle_test.sh`.

Guarded:
- `select.c` / `vdbe.c`: `OP_CountRange` / `OP_CountIndexRange` and the planner that emits them
- `vdbe.c`: ephemeral `OP_Move` fast-copy, `OP_Column` `aRow==0`, `nVtabSavepoint`, `OP_OpenDup` OOM, `idxRowidCache`
- `delete.c`: `changes()` counting on `ONEPASS_OFF`
- `insert.c`: `bSeqOnly` AUTOINCREMENT path
- `build.c`: schema load before CREATE TABLE, `dolt_*` name reservation comment
- `main.c`: `DOLTLITE_VEC1` auto-extension (now also requires `DOLTLITE_PROLLY`)

`unifdef -UDOLTLITE_PROLLY` on `vdbe.c`, `select.c`, `build.c`, `where.c`, `pragma.c`, `alter.c`, `insert.c`, `delete.c`, `main.c`, `expr.c` now matches upstream.

`make lint` now runs `test/lint_prolly_guards.sh`: 84 SQLite-core files must still match `.sqlite-upstream-base` after `DOLTLITE_PROLLY` branches are stripped. Files that still differ (btree, VFS, `wherecode.c`, …) are skipped — shrink that list, don't grow it. An unguarded edit to a checked file fails the lint with a diff.

## Validation
- `unifdef -UDOLTLITE_PROLLY` vs `2fed9802b0`: 0 remaining `diff -w` lines on the files in #2802
- `make doltlite` and `make DOLTLITE_PROLLY=0 sqlite3` both compile
- `bash test/lint_prolly_guards.sh` — 84 files match
- `bash test/lint_prolly_guards_selftest.sh` — 10 passed
- `SELECT count(*) FROM t WHERE id BETWEEN 10 AND 20` still uses the range plan (`SEARCH t USING INTEGER PRIMARY KEY (rowid>? AND rowid<?)`)
- OR-delete `changes()` still reports 2, not 4

Fixes #2802

Co-Authored-By: Grok 4.6 <noreply@x.ai>