### PR TITLE
Reduce redundant CI builds, profile merges, and compression

### DIFF
--- a/.github/scripts/ci-build-failure-test.py
+++ b/.github/scripts/ci-build-failure-test.py
@@ -1,0 +1,84 @@
+import os
+from pathlib import Path
+import re
+import subprocess
+import tempfile
+
+
+workflow = (Path(__file__).resolve().parents[1] / "workflows/ci-build.yml").read_text()
+cases = (
+    ("checked", "Build Linux-only test binaries", "ubuntu"),
+    ("checked", "Build standalone Unix test probes", "ubuntu"),
+    ("checked", "Build standalone Unix test probes", "macos"),
+    ("tsan-build", "Build", "ubuntu"),
+)
+stub = """#!/usr/bin/env bash
+set -eu
+printf '%s\\n' "${0##*/} $*" >> "$COMMAND_LOG"
+if [ "$(wc -l < "$COMMAND_LOG")" -eq "$FAIL_AT" ]; then
+  echo 'injected compiler failure' >&2
+  exit 42
+fi
+if [ "$EMIT_WARNING" = 1 ]; then echo 'warning: injected compiler warning'; fi
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = -o ]; then touch "$2"; break; fi
+  shift
+done
+"""
+
+
+def run(script, fail_at, warning, errexit):
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        (root / "build").mkdir()
+        (root / "examples/go").mkdir(parents=True)
+        (root / "bin").mkdir()
+        for command in ("make", "cc", "gcc", "clang", "go"):
+            path = root / "bin" / command
+            path.write_text(stub)
+            path.chmod(0o755)
+        path = root / "step.sh"
+        path.write_text(script + '\nprintf packaged > "$PACKAGE_MARKER"\n')
+        env = dict(os.environ, PATH=f"{root / 'bin'}:{os.environ['PATH']}",
+                   COMMAND_LOG=str(root / "commands"), FAIL_AT=str(fail_at),
+                   EMIT_WARNING=str(warning), PACKAGE_MARKER=str(root / "package"),
+                   CFLAGS="-O2", TSAN_CFLAGS="-O1 -fsanitize=thread",
+                   TSAN_LDFLAGS="-fsanitize=thread")
+        result = subprocess.run(
+            ["bash", *(["-e"] if errexit else []), str(path)],
+            cwd=root, env=env, capture_output=True, text=True, timeout=30,
+        )
+        commands = (root / "commands").read_text().splitlines()
+        log = (root / "build/build.log").read_text()
+        return result, commands, log, (root / "package").exists()
+
+
+checks = 0
+for job, step, platform in cases:
+    job_match = re.search(rf"^  {re.escape(job)}:\n(.*?)(?=^  \S|\Z)",
+                          workflow, re.M | re.S)
+    assert job_match, job
+    step_match = re.search(
+        rf"^    - name: {re.escape(step)}\n.*?^      run: \|\n((?:        [^\n]*\n|\n)+)",
+        job_match[1], re.M | re.S,
+    )
+    assert step_match, (job, step)
+    script = "".join(line[8:] if line.startswith("        ") else line
+                     for line in step_match[1].splitlines(keepends=True))
+    script = script.replace("${{ matrix.platform }}", platform)
+    for errexit in (False, True):
+        result, commands, log, packaged = run(script, 0, 0, errexit)
+        assert result.returncode == 0 and packaged, (step, result.stderr)
+        checks += 1
+        for fail_at in range(1, len(commands) + 1):
+            result, executed, log, packaged = run(script, fail_at, 0, errexit)
+            assert result.returncode == 42 and not packaged, (step, fail_at, result)
+            assert executed == commands[:fail_at], (step, fail_at, executed)
+            assert "injected compiler failure" in log, (step, fail_at, log)
+            checks += 1
+        result, _, log, packaged = run(script, 0, 1, errexit)
+        assert result.returncode != 0 and not packaged, (step, result)
+        assert "warning: injected compiler warning" in log, step
+        checks += 1
+
+print(f"CI build failure propagation: {checks} checks passed")

--- a/.github/scripts/ci-optimization-test.sh
+++ b/.github/scripts/ci-optimization-test.sh
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 script_dir="$(cd "$(dirname "$0")" && pwd)"
+python3 "$script_dir/ci-build-failure-test.py"
 work=$(mktemp -d)
 trap 'rm -rf "$work"' EXIT
 mkdir -p "$work/payload/nested" "$work/profiles with spaces" "$work/bin"

--- a/.github/scripts/ci-optimization-test.sh
+++ b/.github/scripts/ci-optimization-test.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+mkdir -p "$work/payload/nested" "$work/profiles with spaces" "$work/bin"
+printf 'test data\n' > "$work/payload/nested/file"
+chmod 755 "$work/payload/nested/file"
+ln -s nested/file "$work/payload/link"
+tar -czf "$work/original.tar.gz" -C "$work" payload
+bash "$script_dir/package-ci-build.sh" "$work/fast.tar.gz" -C "$work" payload
+diff <(tar -tvf "$work/original.tar.gz") <(tar -tvf "$work/fast.tar.gz")
+mkdir "$work/original" "$work/fast"
+tar -xzf "$work/original.tar.gz" -C "$work/original"
+tar -xzf "$work/fast.tar.gz" -C "$work/fast"
+diff -r "$work/original" "$work/fast"
+[ -x "$work/fast/payload/nested/file" ]
+[ "$(readlink "$work/fast/payload/link")" = nested/file ]
+if bash "$script_dir/package-ci-build.sh" "$work/missing.tar.gz" \
+    -C "$work" missing > "$work/package.log" 2>&1; then
+  echo 'FAIL: packaging accepted a missing input'
+  exit 1
+fi
+
+cat > "$work/bin/llvm-profdata" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+[ "$1" = merge ] && [ "$2" = -sparse ] && [ "$3" = -f ] && [ "$5" = -o ]
+cp "$4" "$PROFILE_LIST_COPY"
+if [ "${FAIL_MERGE:-0}" = 1 ]; then exit 1; fi
+printf 'merged\n' > "$6"
+STUB
+chmod +x "$work/bin/llvm-profdata"
+export PATH="$work/bin:$PATH" PROFILE_LIST_COPY="$work/input-list"
+profiles="$work/profiles with spaces"
+bash "$script_dir/merge-coverage-profiles.sh" "$profiles"
+[ ! -e "$PROFILE_LIST_COPY" ]
+printf raw > "$profiles/2.profraw"
+printf raw > "$profiles/1.profraw"
+printf keep > "$profiles/keep.txt"
+if FAIL_MERGE=1 bash "$script_dir/merge-coverage-profiles.sh" "$profiles"; then
+  echo 'FAIL: merger accepted a failed llvm-profdata invocation'
+  exit 1
+fi
+[ -f "$profiles/1.profraw" ] && [ -f "$profiles/2.profraw" ]
+bash "$script_dir/merge-coverage-profiles.sh" "$profiles" sql-differential
+printf '%s\n' "$profiles/1.profraw" "$profiles/2.profraw" > "$work/expected-list"
+cmp "$work/expected-list" "$PROFILE_LIST_COPY"
+[ -s "$profiles/sql-differential.profdata" ]
+[ ! -e "$profiles/1.profraw" ] && [ ! -e "$profiles/2.profraw" ]
+[ -f "$profiles/keep.txt" ]
+printf raw > "$profiles/3.profraw"
+bash "$script_dir/merge-coverage-profiles.sh" "$profiles"
+[ -s "$profiles/coverage.profdata" ] && [ ! -e "$profiles/3.profraw" ]
+echo 'CI packaging and profile merge checks passed'

--- a/.github/scripts/merge-coverage-profiles.sh
+++ b/.github/scripts/merge-coverage-profiles.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+dir="${1:?Usage: merge-coverage-profiles.sh <profile-dir> [output-name]}"
+name="${2:-coverage}"
+list=$(mktemp)
+trap 'rm -f "$list"' EXIT
+find "$dir" -type f -name '*.profraw' | LC_ALL=C sort > "$list"
+if [ ! -s "$list" ]; then
+  echo "no profraw files to merge"
+  exit 0
+fi
+echo "merging $(wc -l < "$list") profraw files"
+llvm-profdata merge -sparse -f "$list" -o "$dir/$name.profdata"
+while IFS= read -r profile; do
+  printf '%s\0' "$profile"
+done < "$list" | xargs -0 rm -f

--- a/.github/scripts/package-ci-build.sh
+++ b/.github/scripts/package-ci-build.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+archive="${1:?Usage: package-ci-build.sh <archive.tar.gz> <tar arguments...>}"
+shift
+tar -cf - "$@" | gzip -1 > "$archive"

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -112,11 +112,13 @@ jobs:
         set -o pipefail
         {
           make DOLTLITE_PROLLY_CHECK=1 doltlite-c-tests-build
+          cc $CFLAGS -Wno-comment -I. -I../src \
+            -c sqlite3.c -o ci-amalgamation.o
           cc $CFLAGS -Wno-comment -DDOLTLITE_PROLLY=1 -I. -I../src \
-            -o threadtest4 ../test/threadtest4.c sqlite3.c \
+            -o threadtest4 ../test/threadtest4.c ci-amalgamation.o \
             -ldl -lpthread -lm -lz
           cc $CFLAGS -Wno-comment -I. -I../src \
-            -o threadtest5 ../test/threadtest5.c sqlite3.c \
+            -o threadtest5 ../test/threadtest5.c ci-amalgamation.o \
             -ldl -lpthread -lm -lz
           gcc $CFLAGS -o quickstart \
             ../examples/quickstart.c -I. libdoltlite.a -lpthread -lz -lm
@@ -233,12 +235,15 @@ jobs:
             -I../src -I../ext/blake3 -DDOLTLITE_PROLLY=1 \
             -lm -o blake3_kat
           probe_libs=(-lz -lpthread -lm)
+          probe_amalgamation=sqlite3.c
           if [ "${{ matrix.platform }}" = "ubuntu" ]; then
             probe_libs+=(-ldl)
+            probe_amalgamation=ci-amalgamation.o
           fi
           cc $CFLAGS -Wno-comment -I. \
-            ../test/amalgamation_http_probe.c sqlite3.c \
+            ../test/amalgamation_http_probe.c "$probe_amalgamation" \
             "${probe_libs[@]}" -o amalgamation_http_probe
+          rm -f ci-amalgamation.o
         } 2>&1 | tee -a build.log
         if grep -E "warning:" build.log; then
           echo "::error::compiler warnings in standalone probes"
@@ -295,18 +300,19 @@ jobs:
 
     - name: Package checked build
       if: matrix.platform != 'windows'
-      run: tar -czf checked-build-${{ matrix.platform }}.tar.gz build
+      run: bash .github/scripts/package-ci-build.sh checked-build-${{ matrix.platform }}.tar.gz build
 
     - name: Package checked Windows build
       if: matrix.platform == 'windows'
       shell: msys2 {0}
-      run: tar -czf checked-build-windows.tar.gz build
+      run: bash .github/scripts/package-ci-build.sh checked-build-windows.tar.gz build
 
     - name: Upload checked build
       uses: actions/upload-artifact@v4
       with:
         name: checked-build-${{ matrix.platform }}
         path: checked-build-${{ matrix.platform }}.tar.gz
+        compression-level: 0
         retention-days: 1
 
   sqllogictest-build:
@@ -366,13 +372,14 @@ jobs:
           -lpthread -lm -lz -lodbc
 
     - name: Package
-      run: tar -czf sqllogictest-build.tar.gz build/sqllogictest
+      run: bash .github/scripts/package-ci-build.sh sqllogictest-build.tar.gz build/sqllogictest
 
     - name: Upload
       uses: actions/upload-artifact@v4
       with:
         name: sqllogictest-build
         path: sqllogictest-build.tar.gz
+        compression-level: 0
         retention-days: 1
 
   coverage-build:
@@ -411,7 +418,6 @@ jobs:
           make -j2 DOLTLITE_PROLLY_CHECK=1 \
             doltlite doltlite-remotesrv doltlite-lib testfixture \
             doltlite-c-tests-build doltlite-regression-test-c-build
-          make DOLTLITE_PROLLY=0 sqlite3
           blake_objects=(blake3.o blake3_portable.o blake3_dispatch.o)
           for object in blake3_sse2.o blake3_sse41.o blake3_avx2.o blake3_avx512.o blake3_neon.o; do
             [ ! -f "$object" ] || blake_objects+=("$object")
@@ -428,7 +434,7 @@ jobs:
         find . -type f -name '*.profraw' -delete
 
     - name: Build the stock reference
-      run: bash test/build_stock_reference.sh build-stockref build-coverage/doltlite
+      run: bash test/build_stock_reference.sh --shell-only build-stockref build-coverage/doltlite
 
     - name: Package
       run: |
@@ -449,13 +455,14 @@ jobs:
         bash test/assert_stock_reference.sh \
           coverage-artifact/build-coverage/sqlite3-stock \
           coverage-artifact/build-coverage/doltlite
-        tar -C coverage-artifact -czf coverage-build.tar.gz build-coverage
+        bash .github/scripts/package-ci-build.sh coverage-build.tar.gz -C coverage-artifact build-coverage
 
     - name: Upload
       uses: actions/upload-artifact@v4
       with:
         name: coverage-build
         path: coverage-build.tar.gz
+        compression-level: 0
         retention-days: 1
 
   benchmark-build:
@@ -519,7 +526,7 @@ jobs:
         mv benchmark-base/build benchmark-baseline
         git rev-parse HEAD > benchmark-candidate-sha
         git -C benchmark-base rev-parse HEAD > benchmark-baseline-sha
-        tar -czf benchmark-build.tar.gz \
+        bash .github/scripts/package-ci-build.sh benchmark-build.tar.gz \
           build benchmark-baseline \
           benchmark-candidate-sha benchmark-baseline-sha
 
@@ -528,6 +535,7 @@ jobs:
       with:
         name: benchmark-build
         path: benchmark-build.tar.gz
+        compression-level: 0
         retention-days: 1
 
   asan-ubsan-build:
@@ -596,13 +604,14 @@ jobs:
         fi
 
     - name: Package
-      run: tar -czf asan-ubsan-${{ matrix.platform }}.tar.gz build
+      run: bash .github/scripts/package-ci-build.sh asan-ubsan-${{ matrix.platform }}.tar.gz build
 
     - name: Upload
       uses: actions/upload-artifact@v4
       with:
         name: asan-ubsan-${{ matrix.platform }}
         path: asan-ubsan-${{ matrix.platform }}.tar.gz
+        compression-level: 0
         retention-days: 1
 
   tsan-build:
@@ -634,12 +643,15 @@ jobs:
         {
           make CC=clang CFLAGS="$TSAN_CFLAGS" LDFLAGS="$TSAN_LDFLAGS" \
             sqlite3.c sqlite3.h
+          clang $TSAN_CFLAGS -I. -I../src \
+            -c sqlite3.c -o ci-amalgamation.o
           clang $TSAN_CFLAGS -DDOLTLITE_PROLLY=1 -I. -I../src \
-            -o threadtest4 ../test/threadtest4.c sqlite3.c \
+            -o threadtest4 ../test/threadtest4.c ci-amalgamation.o \
             $TSAN_LDFLAGS -ldl -lpthread -lm -lz
           clang $TSAN_CFLAGS -I. -I../src \
-            -o threadtest5 ../test/threadtest5.c sqlite3.c \
+            -o threadtest5 ../test/threadtest5.c ci-amalgamation.o \
             $TSAN_LDFLAGS -ldl -lpthread -lm -lz
+          rm -f ci-amalgamation.o
           make CC=clang CFLAGS="$TSAN_CFLAGS" LDFLAGS="$TSAN_LDFLAGS" \
             doltlite doltlite-remotesrv vc_concurrency_test \
             vc_ref_mutation_stress_test
@@ -650,13 +662,14 @@ jobs:
         fi
 
     - name: Package
-      run: tar -czf tsan-build.tar.gz build
+      run: bash .github/scripts/package-ci-build.sh tsan-build.tar.gz build
 
     - name: Upload
       uses: actions/upload-artifact@v4
       with:
         name: tsan-build
         path: tsan-build.tar.gz
+        compression-level: 0
         retention-days: 1
 
   crash-build:
@@ -699,13 +712,14 @@ jobs:
         fi
 
     - name: Package
-      run: tar -czf crash-build.tar.gz build-crash
+      run: bash .github/scripts/package-ci-build.sh crash-build.tar.gz build-crash
 
     - name: Upload
       uses: actions/upload-artifact@v4
       with:
         name: crash-build
         path: crash-build.tar.gz
+        compression-level: 0
         retention-days: 1
 
   fuzz-build:
@@ -758,13 +772,14 @@ jobs:
         fi
 
     - name: Package
-      run: tar -czf fuzz-build.tar.gz build-fuzz
+      run: bash .github/scripts/package-ci-build.sh fuzz-build.tar.gz build-fuzz
 
     - name: Upload
       uses: actions/upload-artifact@v4
       with:
         name: fuzz-build
         path: fuzz-build.tar.gz
+        compression-level: 0
         retention-days: 1
 
   wasm-build:
@@ -843,7 +858,7 @@ jobs:
 
     - name: Package
       run: |
-        tar -czf ci-wasm-build.tar.gz \
+        bash .github/scripts/package-ci-build.sh ci-wasm-build.tar.gz \
           build/doltlite \
           build/doltlite-remotesrv \
           ext/wasm/jswasm \
@@ -854,6 +869,7 @@ jobs:
       with:
         name: ci-wasm-build
         path: ci-wasm-build.tar.gz
+        compression-level: 0
         retention-days: 1
 
   compat-build:
@@ -885,13 +901,14 @@ jobs:
           bash test/doltlite_compat_test.sh --build-only
 
     - name: Package
-      run: tar -czf compat-build.tar.gz .compat-cache
+      run: bash .github/scripts/package-ci-build.sh compat-build.tar.gz .compat-cache
 
     - name: Upload
       uses: actions/upload-artifact@v4
       with:
         name: compat-build
         path: compat-build.tar.gz
+        compression-level: 0
         retention-days: 1
 
   development-builds:
@@ -978,7 +995,7 @@ jobs:
           build-assert/doltlite_regression_test_c \
           > build-assert/development-build.sha256
         echo "$GITHUB_SHA" > build-assert/development-build.commit
-        tar -czf development-build.tar.gz \
+        bash .github/scripts/package-ci-build.sh development-build.tar.gz \
           build-assert/catalog_serialize_determinism_test \
           build-assert/doltlite_regression_test_c \
           build-assert/development-build.sha256 \
@@ -989,6 +1006,7 @@ jobs:
       with:
         name: development-build
         path: development-build.tar.gz
+        compression-level: 0
         retention-days: 1
 
   no-dead-code:

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -108,8 +108,8 @@ jobs:
     - name: Build Linux-only test binaries
       if: matrix.platform == 'ubuntu'
       run: |
+        set -eo pipefail
         cd build
-        set -o pipefail
         {
           make DOLTLITE_PROLLY_CHECK=1 doltlite-c-tests-build
           cc $CFLAGS -Wno-comment -I. -I../src \
@@ -200,8 +200,8 @@ jobs:
     - name: Build standalone Unix test probes
       if: matrix.platform != 'windows'
       run: |
+        set -eo pipefail
         cd build
-        set -o pipefail
         {
           cc $CFLAGS -Wall \
             -I../src -I../ext/ed25519 \
@@ -638,8 +638,8 @@ jobs:
 
     - name: Build
       run: |
+        set -eo pipefail
         cd build
-        set -o pipefail
         {
           make CC=clang CFLAGS="$TSAN_CFLAGS" LDFLAGS="$TSAN_LDFLAGS" \
             sqlite3.c sqlite3.h

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -207,7 +207,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        bash .github/scripts/install-apt-deps.sh build-essential zlib1g-dev
+        bash .github/scripts/install-apt-deps.sh build-essential zlib1g-dev llvm
 
     - name: Download instrumented build
       uses: actions/download-artifact@v4
@@ -218,7 +218,7 @@ jobs:
       run: |
         tar -xzf coverage-build.tar.gz
         mkdir -p "$RUNNER_TEMP/coverage-profiles"
-        echo "LLVM_PROFILE_FILE=$RUNNER_TEMP/coverage-profiles/%8m.profraw" >> "$GITHUB_ENV"
+        echo "LLVM_PROFILE_FILE=$RUNNER_TEMP/coverage-profiles/%p.profraw" >> "$GITHUB_ENV"
 
     - name: Install Dolt
       run: bash .github/scripts/install-dolt-oracle.sh
@@ -258,6 +258,10 @@ jobs:
           bash "$f" ./doltlite ./sqlite3-stock || exit 1
         done
       timeout-minutes: 10
+
+    - name: Merge per-process coverage profiles
+      if: always()
+      run: bash .github/scripts/merge-coverage-profiles.sh "$RUNNER_TEMP/coverage-profiles"
 
     - name: Upload oracle coverage profiles
       if: always()
@@ -311,18 +315,7 @@ jobs:
 
     - name: Merge per-process coverage profiles
       if: always()
-      run: |
-        set -euo pipefail
-        dir="$RUNNER_TEMP/coverage-profiles"
-        list=$(mktemp)
-        find "$dir" -type f -name '*.profraw' | LC_ALL=C sort > "$list"
-        if [ ! -s "$list" ]; then
-          echo "no profraw files to merge"
-          exit 0
-        fi
-        echo "merging $(wc -l < "$list") profraw files"
-        llvm-profdata merge -sparse -f "$list" -o "$dir/sql-differential.profdata"
-        xargs rm -f < "$list"
+      run: bash .github/scripts/merge-coverage-profiles.sh "$RUNNER_TEMP/coverage-profiles" sql-differential
 
     - name: Upload SQL differential coverage profiles
       if: always()
@@ -462,7 +455,7 @@ jobs:
     - name: Install dependencies
       run: |
         bash .github/scripts/install-apt-deps.sh \
-          build-essential clang zlib1g-dev
+          build-essential clang zlib1g-dev llvm
 
     - name: Download instrumented build
       uses: actions/download-artifact@v4
@@ -473,7 +466,11 @@ jobs:
       run: |
         tar -xzf coverage-build.tar.gz
         mkdir -p "$RUNNER_TEMP/coverage-profiles"
-        echo "LLVM_PROFILE_FILE=$RUNNER_TEMP/coverage-profiles/%8m.profraw" >> "$GITHUB_ENV"
+        profile_pattern=%8m.profraw
+        if [ "${{ matrix.suite }}" = "shell" ]; then
+          profile_pattern=%p.profraw
+        fi
+        echo "LLVM_PROFILE_FILE=$RUNNER_TEMP/coverage-profiles/$profile_pattern" >> "$GITHUB_ENV"
 
     - name: Deterministic shell tests
       if: matrix.suite == 'shell'
@@ -495,6 +492,10 @@ jobs:
     - name: Deterministic C tests
       if: matrix.suite == 'c'
       run: bash test/run_c_tests.sh build-coverage coverage
+
+    - name: Merge per-process coverage profiles
+      if: always() && matrix.suite == 'shell'
+      run: bash .github/scripts/merge-coverage-profiles.sh "$RUNNER_TEMP/coverage-profiles"
 
     - name: Upload native coverage profiles
       if: always()

--- a/main.mk
+++ b/main.mk
@@ -315,6 +315,7 @@ lint:
 	@bash $(TOP)/test/dolt_oracle_upgrade_test.sh
 	@bash $(TOP)/test/sql_oracle_harness_test.sh
 	@bash $(TOP)/test/stock_oracle_harness_test.sh
+	@bash $(TOP)/.github/scripts/ci-optimization-test.sh
 
 ########################################################################
 ########################################################################

--- a/test/build_stock_reference.sh
+++ b/test/build_stock_reference.sh
@@ -12,20 +12,27 @@
 # storage, which made every comparison against it pass by construction.
 #
 # A directory that has never built doltlite cannot get this wrong, so that is
-# where the reference is built. It costs one amalgamation and one compile.
+# where the reference is built.
 #
 # Note this is only for the reference. A build directory's own `sqlite3` is
 # expected to be doltlite-flavoured -- the inherited shell tests run it -- so
 # this never touches one.
 #
-# Usage: build_stock_reference.sh <build-dir> [engine-binary]
+# Usage: build_stock_reference.sh [--shell-only] <build-dir> [engine-binary]
 #
 # Leaves <build-dir>/sqlite3 and <build-dir>/sqlite3.o, the latter for callers
 # that link a benchmark harness against stock instead of driving the shell.
+# --shell-only omits sqlite3.o.
 
 set -euo pipefail
 
-DIR="${1:?Usage: build_stock_reference.sh <build-dir> [engine-binary]}"
+TARGETS=(sqlite3 sqlite3.o)
+if [ "${1-}" = "--shell-only" ]; then
+  TARGETS=(sqlite3)
+  shift
+fi
+
+DIR="${1:?Usage: build_stock_reference.sh [--shell-only] <build-dir> [engine-binary]}"
 ENGINE="${2-}"
 
 # Resolved before the cd below, or a relative path stops meaning what it did.
@@ -53,7 +60,7 @@ cd "$DIR"
   exit 1
 }
 
-make DOLTLITE_PROLLY=0 sqlite3 sqlite3.o >build.log 2>&1 || {
+make DOLTLITE_PROLLY=0 "${TARGETS[@]}" >build.log 2>&1 || {
   echo "ERROR: building the stock reference failed in $DIR"
   tail -30 build.log
   exit 1


### PR DESCRIPTION
CI recompiles unused or identical amalgamations, merges coverage on thousands of process exits, and compresses build archives twice. This change reduces that work within the existing jobs:

- Remove the unused coverage `sqlite3` build and add `--shell-only` to the stock-reference helper. Existing callers still receive `sqlite3.o` for benchmark linking.
- Share an amalgamation object among the checked Linux thread tests and HTTP probe; share a separate TSan object between its thread tests.
- Write oracle and native-shell profiles per process and merge before upload, using the same helper as SQL differential coverage.
- Use fast gzip for CI build archives and disable upload-artifact compression for those compressed files.
- Explicitly enable fail-fast handling in the shared-object build steps, preserving GitHub's existing `bash -e` behavior when the scripts run under plain Bash too.

Test commands, compiler configurations, job matrices, runners, and timeout budgets are preserved. No buckets are split.

Validation:
- Clean default and shell-only stock builds pass reference assertions and generate identical amalgamation/header files. Only the default mode produces `sqlite3.o`, which links and runs the benchmark timer.
- All 569 SQL oracle cases pass using the shell-only reference.
- The three checked amalgamation preprocessing configurations match; all checked drivers link, both threadtest4 modes and threadtest5 pass, and the HTTP remote probe passes. TSan drivers link against their separate shared object; both threadtest4 modes and threadtest5 also pass under TSan.
- Real LLVM pooled and per-process runs produce identical complete coverage exports. Helper tests cover empty input, failed merges preserving raw profiles, and paths with spaces.
- Archive contents, metadata, executable modes, and symlinks match. A local sample compressed in 1.62s versus 2.33s, growing from 18.23 MB to 20.15 MB; CI will establish runner-level savings.
- Failure injection against the actual workflow blocks passes 64 checks covering success, every build-command failure, log retention, and warning rejection under plain Bash and `bash -e`. The plain-Bash reproduction fails before the explicit flags; all 32 `bash -e` control checks already pass before the change.
- Lint, shell syntax, YAML parsing, orphaned-suite checks, and unchanged job-matrix/timeout checks pass.

Co-Authored-By: OpenAI Codex <noreply@openai.com>

