### PR TITLE
Map unique-index columns from the index table during merge

### DIFF
--- a/src/doltlite_merge_constraints_unique.c
+++ b/src/doltlite_merge_constraints_unique.c
@@ -242,17 +242,21 @@ struct UniqueIndexEntry {
   UnpackedRecord *pUnpacked;
 };
 
+/* Record slots come from the index's own table, never from column info read
+** back over the connection: mid-merge that read still returns the pre-merge
+** catalog, so a column the merged schema adds looks absent and an index over
+** it cannot be mapped. */
 static int uniqueRecordFromTableRow(
   const u8 *pRecord,
   int nRecord,
   const DoltliteRecordInfo *pInfo,
-  const DoltliteColInfo *pCols,
   Index *pIdx,
   int nField,
   u8 **ppOut,
   int *pnOut,
   int *pHasNull
 ){
+  Table *pTab = pIdx->pTable;
   DoltliteSerialValue *aValue;
   int i;
   int rc = SQLITE_OK;
@@ -267,11 +271,13 @@ static int uniqueRecordFromTableRow(
   for(i=0; i<nField; i++){
     int iColumn = pIdx->aiColumn[i];
     int iRecord;
-    if( iColumn<0 || iColumn>=pCols->nCol ){
-      rc = SQLITE_NOTFOUND;
+    if( iColumn<0 || iColumn>=pTab->nCol ){
+      rc = SQLITE_CORRUPT;
       break;
     }
-    iRecord = pCols->aColToRec[iColumn];
+    iRecord = HasRowid(pTab)
+        ? sqlite3TableColumnToStorage(pTab, iColumn)
+        : sqlite3TableColumnToIndex(sqlite3PrimaryKeyIndex(pTab), iColumn);
     rc = doltliteSerialValueFromField(
         pRecord, nRecord, pInfo, iRecord, &aValue[i]);
     if( rc!=SQLITE_OK ) break;
@@ -595,12 +601,12 @@ static int detectUniqueViolationsForIndexWithoutRowid(
     }
     if( rc==SQLITE_OK ){
       rc = uniqueRecordFromTableRow(
-          pRecord, nRecord, &info, &cols, pIdx, pIdx->nKeyCol,
+          pRecord, nRecord, &info, pIdx, pIdx->nKeyCol,
           &entry.pKey, &entry.nKey, &hasNull);
     }
     if( rc==SQLITE_OK && !hasNull ){
       rc = uniqueRecordFromTableRow(
-          pRecord, nRecord, &info, &cols, pPkIdx, pPkIdx->nKeyCol,
+          pRecord, nRecord, &info, pPkIdx, pPkIdx->nKeyCol,
           &entry.pPk, &entry.nPk, 0);
     }
     sqlite3_free(pOwnedRecord);

--- a/test/doltlite_merge_generated.test
+++ b/test/doltlite_merge_generated.test
@@ -170,6 +170,56 @@ foreach indexed {0 1} {
   } {1 1 1 2 2 2 5 7 3 7 8 15}
 }
 
+foreach {shape key vals1 vals2} {
+  clustered {id INT PRIMARY KEY} {1,1,2} {2,1,2}
+  textpk {id TEXT PRIMARY KEY} {'a',1,2} {'b',1,2}
+} {
+  reset_db
+  execsql "CREATE TABLE t($key, x INT, y INT)"
+  execsql "INSERT INTO t(id,x,y) VALUES($vals1)"
+  execsql {
+    SELECT dolt_commit('-Am','base');
+    SELECT dolt_branch('feature');
+  }
+  execsql "CREATE TABLE t2($key, x INT, y INT, z INT AS(x+y) STORED UNIQUE)"
+  execsql {
+    INSERT INTO t2(id,x,y) SELECT id,x,y FROM t;
+    DROP TABLE t;
+    ALTER TABLE t2 RENAME TO t;
+    SELECT dolt_commit('-Am','left adds unique stored column');
+    SELECT dolt_checkout('feature');
+  }
+  execsql "INSERT INTO t(id,x,y) VALUES($vals2)"
+  execsql {
+    SELECT dolt_commit('-Am','right inserts colliding row');
+    SELECT dolt_checkout('main');
+  }
+  set name "doltlite_merge_generated-cvunique-$shape"
+  set before [execsql {SELECT dolt_hashof_table('t')}]
+
+  # The recomputed value collides on a clustered key, where the unique
+  # detector cannot read the merged column list back over the connection.
+  # It must report a constraint violation, not an internal result code.
+  do_test $name.1 {
+    set res [catchsql {SELECT dolt_merge('feature')}]
+    list [lindex $res 0] \
+         [string match {*constraint violation*} [lindex $res 1]]
+  } {1 1}
+  do_test $name.2 {
+    expr {$before eq [execsql {SELECT dolt_hashof_table('t')}]}
+  } {1}
+
+  # The refusal has to be durable: reopening must not surface the row the
+  # merge rejected, and the unique index must still hold.
+  db close
+  sqlite3 db test.db
+  do_test $name.3 {
+    list [execsql {SELECT count(*) FROM t}] \
+         [expr {$before eq [execsql {SELECT dolt_hashof_table('t')}]}] \
+         [execsql {PRAGMA integrity_check}]
+  } {1 1 ok}
+}
+
 foreach kind {unique evaluation} {
   reset_db
   if {$kind eq "unique"} {


### PR DESCRIPTION
Found by the Ito QA run on #2808, which correctly called it pre-existing rather than caused by that PR. I confirmed that by reproducing it on master at `c3c4ea0a8e`, before #2808 landed.

## The bug

One branch adds a STORED generated column with `UNIQUE`; the other inserts a row whose recomputed value collides. On a **clustered** primary key (`INT PRIMARY KEY`, `TEXT PRIMARY KEY` — `INTEGER PRIMARY KEY` was always fine) the merge fails with `unknown operation`. The immediate view looks correct and the table hash is unchanged, so the refusal appears to have worked. Reopening the database tells a different story:

```
-- before the fix, after reopen
ROWS_REOPEN|1|3
ROWS_REOPEN|2|3          <-- the row the merge rejected
PRAGMA integrity_check → non-unique entry in index sqlite_autoindex_t_2
```

The rejected row is durable and the unique index it violates is left inconsistent.

## Root cause

`uniqueRecordFromTableRow` resolved declared columns to record slots through `DoltliteColInfo` from `doltliteGetColumnNames`, which runs `PRAGMA main.table_xinfo` over the connection. Mid-merge that pragma answers from the persisted catalog, which still holds the pre-merge shape, while `pIdx->pTable` is the merged schema:

```
DBG2 zTable=t idxTab=t nCol=3 cols=id,x,y, | idxTab nCol=4:id,x,y,z,
DBG idx=sqlite_autoindex_t_2 i=0 iColumn=3 nCol=3 nField=1
```

So `aiColumn[0]==3` failed the `iColumn>=pCols->nCol` bounds test and the walk returned `SQLITE_NOTFOUND`. That is this file's sentinel for "no violation" (`doltlite_merge_constraints_unique.c:33`), so the collision went undetected, and the code escaped to the caller through `sqlite3_result_error_code` as `unknown operation`. Because the merge then failed outside the constraint-violation path, `doltliteRestoreTxnStateOnFailure` restored the in-memory view but left the persisted working set behind — hence a clean-looking failure that reopens dirty.

Not a dangling `Index`: an ASAN build reports nothing, and the table pointer is valid.

## The fix

Take record slots from the index's own table — `sqlite3TableColumnToStorage` for rowid tables, `sqlite3TableColumnToIndex(sqlite3PrimaryKeyIndex(pTab), …)` for clustered — the same mapping `mergeGeneratedPrepare` already uses, so the index and the columns can never come from different schema generations. The `pCols` parameter is dropped. A genuine out-of-range column now returns `SQLITE_CORRUPT`, so it can never be read as an absence of violations.

All three key shapes now refuse properly, with no row after reopen and `integrity_check` clean:

```
Error: Committing this transaction resulted in a working set with constraint violations, transaction rolled back.
ROWS_REOPEN|1|3
ok
```

## Evidence

Fail-before / pass-after on `test/doltlite_merge_generated.test`, which grows from 81 to 87 assertions:

| build | result |
| --- | --- |
| without the fix | 4 unexpected failures (`-cvunique-clustered.1/.3`, `-cvunique-textpk.1/.3`) |
| with the fix | 87 passing, 0 divergences |

The new cases assert the error names a constraint violation rather than an internal code, that the hash is unchanged, and — the part the original report missed — that after closing and reopening, the row count, the hash, and `PRAGMA integrity_check` all still hold.

Also green: 132 DoltLite shell suites; `doltlite_merge_generated` + `doltlite_merge_ignored` + `doltlite_merge_constraint_prune` in testfixture (4784 tests); the constraint-violation, verify-constraints, merge, merge-generated, pk-shapes and conflicts oracle suites against Dolt 2.3.1; `make lint`.

A plain `UNIQUE` column with no generated column always rolled back correctly, which is what isolates this to the generated-column path on clustered keys.

## Not fixed here

Any unexpected result code out of `mergeRefDetectConstraintViolations` still reaches `merge_fail`, where the in-memory view is restored but the persisted working set is not — that window is why the row appeared only after reopen.

I could not find a second way to land an error in it. A generated expression that raises, an unresolvable foreign-key parent column, a CHECK violation on a generated column, and the plain UNIQUE control all roll back correctly, hash unchanged after reopen and integrity intact, because they fail before the merged rows are persisted. So this is hardening rather than a live defect, and reaching it now would take fault injection. Noted for a future look at merge-failure atomicity, not filed as a bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
