### PR TITLE
Fail three shell suites when the engine cannot commit

### DIFF
--- a/test/doltlite_checkpoint_threshold_env.sh
+++ b/test/doltlite_checkpoint_threshold_env.sh
@@ -6,7 +6,7 @@ set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/lib/doltlite_test_common.sh"
-DOLTLITE="${1:-./doltlite}"
+DOLTLITE="${1:-$DOLTLITE}"
 
 if ! command -v python3 >/dev/null 2>&1; then
   echo "SKIP: python3 required to read checkpoint stamps"
@@ -25,8 +25,8 @@ with open(path, "rb") as f:
     f.seek(0, 2)
     n = f.tell()
     if n < 169:
-        print(0)
-        raise SystemExit
+        sys.stderr.write("file too short for a checkpoint stamp: %d bytes\n" % n)
+        raise SystemExit(2)
     f.seek(n - 169)
     rec = f.read(169)
 print(struct.unpack_from("<I", rec, 1 + 8)[0])
@@ -36,12 +36,23 @@ print(struct.unpack_from("<I", rec, 1 + 8)[0])
 echo "=== WAL checkpoint threshold env is test-only ==="
 
 export DOLTLITE_WAL_CHECKPOINT_THRESHOLD=1
-"$DOLTLITE" "$DB" \
+if ! dltest_require "cli_commit" "$DB" \
   "CREATE TABLE t(id INTEGER PRIMARY KEY, b BLOB);
    INSERT INTO t VALUES(1, randomblob(8192));
-   SELECT dolt_commit('-A','-m','env-threshold');" >/dev/null
-magic="$(checkpoint_magic "$DB")"
-if [ "$magic" = "0" ]; then
+   SELECT dolt_commit('-A','-m','env-threshold');"; then
+  dltest_finish
+fi
+if [ ! -f "$DB" ]; then
+  dltest_fail "cli_commit" "  expected a database file after commit"
+  dltest_finish
+fi
+run_test "cli_commit_log" "SELECT count(*) FROM dolt_log;" "2" "$DB"
+magic=$(checkpoint_magic "$DB")
+crc=$?
+if [ "$crc" -ne 0 ]; then
+  dltest_fail "cli_ignores_checkpoint_threshold_env" \
+    "  could not read checkpoint stamp (rc=$crc)"
+elif [ "$magic" = "0" ]; then
   dltest_pass
 else
   dltest_fail "cli_ignores_checkpoint_threshold_env" \

--- a/test/doltlite_merge_nocase_reindex.sh
+++ b/test/doltlite_merge_nocase_reindex.sh
@@ -8,7 +8,7 @@ echo ""
 DB=/tmp/test_merge_nocase_$$.db
 rm -f "$DB"
 
-cat <<'EOF' | $DOLTLITE "$DB" > /dev/null 2>&1
+NOCASE_SETUP="
 CREATE TABLE t(
   id INTEGER PRIMARY KEY,
   name TEXT COLLATE NOCASE,
@@ -28,52 +28,64 @@ SELECT dolt_checkout('main');
 UPDATE t SET score = 11 WHERE id = 1;
 INSERT INTO t VALUES (5, 'EPSILON', 50);
 SELECT dolt_commit('-Am', 'main_side');
-SELECT dolt_merge('feat');
-EOF
+"
 
-run_test "nocase_merge_row_count" \
-  "SELECT count(*) FROM t;" "5" "$DB"
-run_test "nocase_merge_scores" \
-  "SELECT group_concat(id || ':' || score, ',') FROM (SELECT id, score FROM t ORDER BY id);" \
-  "1:11,2:21,3:30,4:40,5:50" "$DB"
+if dltest_require "nocase_setup" "$DB" "$NOCASE_SETUP"; then
+  if [ ! -f "$DB" ]; then
+    dltest_fail "nocase_setup" "  expected a database file after setup"
+  else
+  run_test_match "nocase_merge" "SELECT dolt_merge('feat');" "^[0-9a-f]{40}$" "$DB"
+  run_test "nocase_merge_log" "SELECT count(*) FROM dolt_log;" "5" "$DB"
 
-run_test "nocase_merge_idx_seek_alpha" \
-  "SELECT id || ':' || score FROM t INDEXED BY idx_name WHERE name = 'alpha';" \
-  "1:11" "$DB"
-run_test "nocase_merge_idx_seek_delta" \
-  "SELECT id || ':' || score FROM t INDEXED BY idx_name WHERE name = 'DELTA';" \
-  "4:40" "$DB"
-run_test "nocase_merge_idx_order" \
-  "SELECT group_concat(id, ',') FROM (SELECT id FROM t INDEXED BY idx_name WHERE name >= 'a' ORDER BY name, id);" \
-  "1,2,4,5,3" "$DB"
+  run_test "nocase_merge_row_count" \
+    "SELECT count(*) FROM t;" "5" "$DB"
+  run_test "nocase_merge_scores" \
+    "SELECT group_concat(id || ':' || score, ',') FROM (SELECT id, score FROM t ORDER BY id);" \
+    "1:11,2:21,3:30,4:40,5:50" "$DB"
 
-PRE_REINDEX=$(echo "SELECT group_concat(id || ':' || name || ':' || score, ',') FROM (SELECT id, name, score FROM t INDEXED BY idx_name WHERE name >= 'a' ORDER BY name, id);" | $DOLTLITE "$DB" 2>/dev/null | tail -1)
+  run_test "nocase_merge_idx_seek_alpha" \
+    "SELECT id || ':' || score FROM t INDEXED BY idx_name WHERE name = 'alpha';" \
+    "1:11" "$DB"
+  run_test "nocase_merge_idx_seek_delta" \
+    "SELECT id || ':' || score FROM t INDEXED BY idx_name WHERE name = 'DELTA';" \
+    "4:40" "$DB"
+  run_test "nocase_merge_idx_order" \
+    "SELECT group_concat(id, ',') FROM (SELECT id FROM t INDEXED BY idx_name WHERE name >= 'a' ORDER BY name, id);" \
+    "1,2,4,5,3" "$DB"
 
-echo "REINDEX idx_name;" | $DOLTLITE "$DB" > /dev/null 2>&1
-POST_REINDEX=$(echo "SELECT group_concat(id || ':' || name || ':' || score, ',') FROM (SELECT id, name, score FROM t INDEXED BY idx_name WHERE name >= 'a' ORDER BY name, id);" | $DOLTLITE "$DB" 2>/dev/null | tail -1)
+  PRE_REINDEX=$(echo "SELECT group_concat(id || ':' || name || ':' || score, ',') FROM (SELECT id, name, score FROM t INDEXED BY idx_name WHERE name >= 'a' ORDER BY name, id);" | $DOLTLITE "$DB" 2>/dev/null | tail -1)
 
-if [ -n "$PRE_REINDEX" ] && [ "$PRE_REINDEX" = "$POST_REINDEX" ]; then
-  PASS=$((PASS+1))
-else
-  FAIL=$((FAIL+1))
-  ERRORS="$ERRORS\nFAIL: nocase_merge_reindex_idempotent\n  pre:  $PRE_REINDEX\n  post: $POST_REINDEX"
+  if dltest_require "nocase_reindex" "$DB" "REINDEX idx_name;"; then
+    POST_REINDEX=$(echo "SELECT group_concat(id || ':' || name || ':' || score, ',') FROM (SELECT id, name, score FROM t INDEXED BY idx_name WHERE name >= 'a' ORDER BY name, id);" | $DOLTLITE "$DB" 2>/dev/null | tail -1)
+
+    if [ -n "$PRE_REINDEX" ] && [ "$PRE_REINDEX" = "$POST_REINDEX" ]; then
+      dltest_pass
+    else
+      dltest_fail "nocase_merge_reindex_idempotent" \
+        "  pre:  $PRE_REINDEX\n  post: $POST_REINDEX"
+    fi
+
+    if dltest_require "nocase_fresh_index" "$DB" \
+      "DROP INDEX idx_name; CREATE INDEX idx_name ON t(name COLLATE NOCASE);"; then
+      FRESH=$(echo "SELECT group_concat(id || ':' || name || ':' || score, ',') FROM (SELECT id, name, score FROM t INDEXED BY idx_name WHERE name >= 'a' ORDER BY name, id);" | $DOLTLITE "$DB" 2>/dev/null | tail -1)
+
+      if [ -n "$POST_REINDEX" ] && [ "$POST_REINDEX" = "$FRESH" ]; then
+        dltest_pass
+      else
+        dltest_fail "nocase_merge_matches_fresh_index" \
+          "  reindex: $POST_REINDEX\n  fresh:   $FRESH"
+      fi
+    fi
+  fi
+
+  run_test_lastline "nocase_merge_integrity" "PRAGMA integrity_check;" "ok" "$DB"
+  fi
 fi
-
-echo "DROP INDEX idx_name; CREATE INDEX idx_name ON t(name COLLATE NOCASE);" | $DOLTLITE "$DB" > /dev/null 2>&1
-FRESH=$(echo "SELECT group_concat(id || ':' || name || ':' || score, ',') FROM (SELECT id, name, score FROM t INDEXED BY idx_name WHERE name >= 'a' ORDER BY name, id);" | $DOLTLITE "$DB" 2>/dev/null | tail -1)
-
-if [ -n "$POST_REINDEX" ] && [ "$POST_REINDEX" = "$FRESH" ]; then
-  PASS=$((PASS+1))
-else
-  FAIL=$((FAIL+1))
-  ERRORS="$ERRORS\nFAIL: nocase_merge_matches_fresh_index\n  reindex: $POST_REINDEX\n  fresh:   $FRESH"
-fi
-
-run_test_lastline "nocase_merge_integrity" "PRAGMA integrity_check;" "ok" "$DB"
+rm -f "$DB"
 
 DB2=/tmp/test_merge_nocase_desc_$$.db
 rm -f "$DB2"
-cat <<'EOF' | $DOLTLITE "$DB2" > /dev/null 2>&1
+DESC_SETUP="
 CREATE TABLE t(id INTEGER PRIMARY KEY, name TEXT COLLATE NOCASE, v INT);
 CREATE INDEX idx_nd ON t(name COLLATE NOCASE DESC, v);
 INSERT INTO t VALUES (1, 'a', 1), (2, 'B', 2);
@@ -84,22 +96,29 @@ SELECT dolt_commit('-Am', 'feat');
 SELECT dolt_checkout('main');
 INSERT INTO t VALUES (4, 'D', 4);
 SELECT dolt_commit('-Am', 'main');
-SELECT dolt_merge('feat');
-EOF
+"
 
-run_test "nocase_desc_merge_count" "SELECT count(*) FROM t;" "4" "$DB2"
-run_test "nocase_desc_idx_seek" \
-  "SELECT id FROM t INDEXED BY idx_nd WHERE name = 'b';" "2" "$DB2"
-PRE2=$(echo "SELECT group_concat(id, ',') FROM (SELECT id FROM t INDEXED BY idx_nd WHERE name >= 'a' ORDER BY name DESC, v, id);" | $DOLTLITE "$DB2" 2>/dev/null | tail -1)
-echo "REINDEX idx_nd;" | $DOLTLITE "$DB2" > /dev/null 2>&1
-POST2=$(echo "SELECT group_concat(id, ',') FROM (SELECT id FROM t INDEXED BY idx_nd WHERE name >= 'a' ORDER BY name DESC, v, id);" | $DOLTLITE "$DB2" 2>/dev/null | tail -1)
-if [ -n "$PRE2" ] && [ "$PRE2" = "$POST2" ]; then
-  PASS=$((PASS+1))
-else
-  FAIL=$((FAIL+1))
-  ERRORS="$ERRORS\nFAIL: nocase_desc_reindex_idempotent\n  pre:  $PRE2\n  post: $POST2"
+if dltest_require "nocase_desc_setup" "$DB2" "$DESC_SETUP"; then
+  if [ ! -f "$DB2" ]; then
+    dltest_fail "nocase_desc_setup" "  expected a database file after setup"
+  else
+  run_test_match "nocase_desc_merge" "SELECT dolt_merge('feat');" "^[0-9a-f]{40}$" "$DB2"
+  run_test "nocase_desc_merge_log" "SELECT count(*) FROM dolt_log;" "5" "$DB2"
+  run_test "nocase_desc_merge_count" "SELECT count(*) FROM t;" "4" "$DB2"
+  run_test "nocase_desc_idx_seek" \
+    "SELECT id FROM t INDEXED BY idx_nd WHERE name = 'b';" "2" "$DB2"
+  PRE2=$(echo "SELECT group_concat(id, ',') FROM (SELECT id FROM t INDEXED BY idx_nd WHERE name >= 'a' ORDER BY name DESC, v, id);" | $DOLTLITE "$DB2" 2>/dev/null | tail -1)
+  if dltest_require "nocase_desc_reindex" "$DB2" "REINDEX idx_nd;"; then
+    POST2=$(echo "SELECT group_concat(id, ',') FROM (SELECT id FROM t INDEXED BY idx_nd WHERE name >= 'a' ORDER BY name DESC, v, id);" | $DOLTLITE "$DB2" 2>/dev/null | tail -1)
+    if [ -n "$PRE2" ] && [ "$PRE2" = "$POST2" ]; then
+      dltest_pass
+    else
+      dltest_fail "nocase_desc_reindex_idempotent" \
+        "  pre:  $PRE2\n  post: $POST2"
+    fi
+  fi
+  fi
 fi
 rm -f "$DB2"
-rm -f "$DB"
 
 dltest_finish

--- a/test/doltlite_rollback_durability.sh
+++ b/test/doltlite_rollback_durability.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
-DOLTLITE="${1:-./doltlite}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/doltlite_test_common.sh"
+DOLTLITE="${1:-$DOLTLITE}"
 TMP=$(mktemp -d)
 trap "rm -rf $TMP" EXIT
-PASS=0; FAIL=0; ERRORS=""
 
 file_size() {
   case "$(uname -s)" in
@@ -16,20 +17,26 @@ stable_rollback() {
   local name="$1" setup="$2" txn="$3"
   local db="$TMP/${name}.db"
   rm -f "$db"
-  if [ -n "$setup" ]; then
-    printf '%s\n' "$setup" | "$DOLTLITE" "$db" >/dev/null 2>&1
+  if ! dltest_require "${name}_setup" "$db" "$setup"; then
+    return
   fi
+  if [ ! -f "$db" ]; then
+    dltest_fail "$name" "  expected a database file after setup"
+    return
+  fi
+  run_test "${name}_log" "SELECT count(*) FROM dolt_log;" "2" "$db"
   local size_before sha_before size_after sha_after
   size_before=$(file_size "$db")
   sha_before=$(file_sha "$db")
-  printf '%s\n' "$txn" | "$DOLTLITE" "$db" >/dev/null 2>&1
+  if ! dltest_require "${name}_txn" "$db" "$txn"; then
+    return
+  fi
   size_after=$(file_size "$db")
   sha_after=$(file_sha "$db")
   if [ "$size_before" = "$size_after" ] && [ "$sha_before" = "$sha_after" ]; then
-    PASS=$((PASS+1))
+    dltest_pass
   else
-    FAIL=$((FAIL+1))
-    ERRORS="$ERRORS\nFAIL: $name\n  expected: file unchanged (size=$size_before sha=${sha_before:0:8})\n  got:      size=$size_after sha=${sha_after:0:8} (delta=$((size_after-size_before)))"
+    dltest_fail "$name" "  expected: file unchanged (size=$size_before sha=${sha_before:0:8})\n  got:      size=$size_after sha=${sha_after:0:8} (delta=$((size_after-size_before)))"
   fi
 }
 
@@ -83,6 +90,4 @@ stable_rollback "many_inserts_rollback" \
 stable_rollback "rollback_after_select_only_inside_txn" \
   "$SEED_T" "BEGIN; SELECT count(*) FROM t; ROLLBACK;"
 
-echo ""
-echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"
-if [ $FAIL -gt 0 ]; then echo -e "$ERRORS"; exit 1; fi
+dltest_finish

--- a/test/lib/doltlite_test_common.sh
+++ b/test/lib/doltlite_test_common.sh
@@ -18,6 +18,28 @@ dltest_run_sql() {
   fi
 }
 
+# -bail so a missing dolt_* function is a non-zero status, not a continued script.
+dltest_engine() {
+  local db="$1"
+  local sql="$2"
+  printf '%s\n' "$sql" | perl -e "alarm($DLTEST_TIMEOUT);exec @ARGV" \
+    "$DOLTLITE" -bail "$db" 2>&1
+}
+
+dltest_require() {
+  local name="$1"
+  local db="$2"
+  local sql="$3"
+  local out rc
+  out=$(dltest_engine "$db" "$sql")
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    dltest_fail "$name" "  engine rc=$rc\n  $out"
+    return 1
+  fi
+  return 0
+}
+
 dltest_pass() {
   PASS=$((PASS+1))
 }


### PR DESCRIPTION
## Summary
`doltlite_rollback_durability.sh`, `doltlite_checkpoint_threshold_env.sh`, and `doltlite_merge_nocase_reindex.sh` passed against `/usr/bin/true` and stock sqlite3: setup rc was ignored, missing files compared as empty, a short file counted as checkpoint magic 0, and a linear apply of both sides' INSERTs produced the post-merge rows.

- Run setup/txn SQL with `-bail` and fail on non-zero status (`dltest_require` in `doltlite_test_common.sh`).
- Require the database file to exist after setup, and `SELECT count(*) FROM dolt_log` to show a real history.
- Refuse a checkpoint stamp read on a file shorter than the WAL footer.
- Assert `dolt_merge` returned a hash and `dolt_log` has five commits (init + two sides + merge, plus the implicit first commit).

## Validation
Fail-before:
- `bash test/doltlite_rollback_durability.sh /usr/bin/true` → 14 failed (no db file)
- `bash test/doltlite_rollback_durability.sh sqlite3-stock` → engine rc=1, no such function: dolt_commit
- `bash test/doltlite_checkpoint_threshold_env.sh /usr/bin/true` → no db file
- `bash test/doltlite_checkpoint_threshold_env.sh sqlite3-stock` → no such function: dolt_commit
- `DOLTLITE=/usr/bin/true bash test/doltlite_merge_nocase_reindex.sh` → no db file
- `DOLTLITE=sqlite3-stock bash test/doltlite_merge_nocase_reindex.sh` → no such function: dolt_commit

Pass-after (`build/doltlite`): rollback 28/28, checkpoint 2/2, merge_nocase 15/15.

Fixes #2791

Co-Authored-By: Grok 4.6 <noreply@x.ai>