### PR TITLE
Cancel CI for PRs that conflict after master advances

### DIFF
--- a/.github/scripts/cancel-conflicted-pr-runs.js
+++ b/.github/scripts/cancel-conflicted-pr-runs.js
@@ -1,0 +1,72 @@
+module.exports = async function cancelConflictedPrRuns({
+  github, context, core,
+  sleep = ms => new Promise(resolve => setTimeout(resolve, ms)),
+}) {
+  const repo = context.repo;
+  const runsByPull = new Map();
+  for (const status of ['queued', 'in_progress', 'pending', 'waiting', 'requested']) {
+    const runs = await github.paginate(github.rest.actions.listWorkflowRuns, {
+      ...repo, workflow_id: 'pr-ci.yml', event: 'pull_request', status, per_page: 100,
+    });
+    for (const run of runs) {
+      if (run.event !== 'pull_request' || run.status === 'completed') continue;
+      for (const pull of run.pull_requests || []) {
+        if (pull.base.ref !== 'master') continue;
+        if (!runsByPull.has(pull.number)) runsByPull.set(pull.number, new Map());
+        runsByPull.get(pull.number).set(run.id, run);
+      }
+    }
+  }
+
+  async function getPull(number) {
+    try {
+      return (await github.rest.pulls.get({...repo, pull_number: number})).data;
+    } catch (error) {
+      if (error.status !== 404) throw error;
+      return null;
+    }
+  }
+
+  function current(pull) {
+    return pull && pull.state === 'open' && !pull.merged &&
+      pull.base.ref === 'master' && pull.base.sha === context.sha;
+  }
+
+  let pending = [...runsByPull.keys()];
+  let cancelled = 0;
+  const cancelledRuns = new Set();
+  for (let attempt = 0; attempt < 6 && pending.length; attempt++) {
+    const retry = [];
+    for (const number of pending) {
+      const pull = await getPull(number);
+      if (!current(pull)) continue;
+      if (pull.mergeable == null) {
+        retry.push(number);
+        continue;
+      }
+      if (pull.mergeable !== false) continue;
+      for (const run of runsByPull.get(number).values()) {
+        if (run.head_sha !== pull.head.sha || cancelledRuns.has(run.id)) continue;
+        const confirmed = await getPull(number);
+        if (!current(confirmed) || confirmed.head.sha !== pull.head.sha ||
+            confirmed.mergeable !== false) break;
+        try {
+          await github.rest.actions.cancelWorkflowRun({...repo, run_id: run.id});
+          cancelledRuns.add(run.id);
+          cancelled++;
+          core.info(`Cancelled CI run ${run.id}: PR #${number} conflicts with master ${context.sha}`);
+        } catch (error) {
+          if (error.status !== 409) throw error;
+          core.info(`CI run ${run.id} is no longer cancellable`);
+        }
+      }
+    }
+    pending = retry;
+    if (pending.length && attempt < 5) await sleep(5000);
+  }
+  for (const number of pending) {
+    core.info(`PR #${number} mergeability remains unknown; leaving CI running`);
+  }
+  core.info(`Cancelled ${cancelled} conflicted PR CI run(s)`);
+  return cancelled;
+};

--- a/.github/scripts/cancel-conflicted-pr-runs.test.js
+++ b/.github/scripts/cancel-conflicted-pr-runs.test.js
@@ -1,0 +1,169 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const cancel = require('./cancel-conflicted-pr-runs.js');
+
+const repo = {owner: 'dolthub', repo: 'doltlite'};
+const statuses = ['queued', 'in_progress', 'pending', 'waiting', 'requested'];
+const pull = (overrides = {}) => ({
+  state: 'open', merged: false, mergeable: false,
+  base: {ref: 'master', sha: 'master-tip'}, head: {sha: 'pr-tip'},
+  ...overrides,
+});
+const run = (overrides = {}) => ({
+  id: 100, event: 'pull_request', status: 'queued', head_sha: 'pr-tip',
+  pull_requests: [{number: 42, base: {ref: 'master'}}],
+  ...overrides,
+});
+const apiError = status => Object.assign(new Error(`HTTP ${status}`), {status});
+
+function fixture({runs = [run()], pulls = [pull()], cancelError} = {}) {
+  const listed = [], fetched = [], cancelled = [], sleeps = [], logs = [];
+  const github = {rest: {
+    actions: {
+      listWorkflowRuns() {},
+      async cancelWorkflowRun(args) {
+        assert.deepEqual(args, {...repo, run_id: args.run_id});
+        cancelled.push(args.run_id);
+        if (cancelError) throw cancelError;
+      },
+    },
+    pulls: {async get(args) {
+      assert.deepEqual(args, {...repo, pull_number: args.pull_number});
+      const index = fetched.length;
+      fetched.push(args.pull_number);
+      const value = typeof pulls === 'function' ? pulls(args.pull_number, index) :
+        pulls[Math.min(index, pulls.length - 1)];
+      if (value instanceof Error) throw value;
+      return {data: value};
+    }},
+  }};
+  github.paginate = async (method, args) => {
+    assert.equal(method, github.rest.actions.listWorkflowRuns);
+    assert.deepEqual(args, {...repo, workflow_id: 'pr-ci.yml',
+      event: 'pull_request', status: args.status, per_page: 100});
+    listed.push(args.status);
+    return typeof runs === 'function' ? runs(args.status) :
+      runs.filter(item => item.status === args.status);
+  };
+  return {
+    listed, fetched, cancelled, sleeps, logs,
+    execute: () => cancel({github, context: {repo, sha: 'master-tip'},
+      core: {info: message => logs.push(message)},
+      sleep: async ms => sleeps.push(ms)}),
+  };
+}
+
+for (const status of statuses) {
+  test(`cancels ${status} CI for a confirmed conflict`, async () => {
+    const f = fixture({runs: [run({status})]});
+    assert.equal(await f.execute(), 1);
+    assert.deepEqual(f.cancelled, [100]);
+    assert.deepEqual(f.fetched, [42, 42]);
+    assert.deepEqual(f.listed, statuses);
+  });
+}
+
+test('retries unknown mergeability before cancelling', async () => {
+  const f = fixture({pulls: [pull({mergeable: null}), pull(), pull()]});
+  assert.equal(await f.execute(), 1);
+  assert.deepEqual(f.sleeps, [5000]);
+  assert.deepEqual(f.cancelled, [100]);
+});
+
+test('leaves CI running when mergeability stays unknown', async () => {
+  const f = fixture({pulls: [pull({mergeable: null})]});
+  assert.equal(await f.execute(), 0);
+  assert.equal(f.fetched.length, 6);
+  assert.deepEqual(f.sleeps, Array(5).fill(5000));
+  assert.deepEqual(f.cancelled, []);
+  assert.ok(f.logs.some(message => message.includes('mergeability remains unknown')));
+});
+
+const changes = {
+  'mergeable PR': {mergeable: true},
+  'closed PR': {state: 'closed'},
+  'merged PR': {merged: true},
+  'different base branch': {base: {ref: 'release', sha: 'master-tip'}},
+  'new master tip': {base: {ref: 'master', sha: 'new-master-tip'}},
+};
+for (const [name, change] of Object.entries(changes)) {
+  test(`leaves ${name} alone`, async () => {
+    const f = fixture({pulls: [pull(change)]});
+    assert.equal(await f.execute(), 0);
+    assert.deepEqual(f.cancelled, []);
+  });
+}
+
+for (const [name, change] of Object.entries({...changes,
+  'updated PR head': {head: {sha: 'new-pr-tip'}},
+  'unknown mergeability': {mergeable: null},
+})) {
+  test(`rechecks ${name} immediately before cancellation`, async () => {
+    const f = fixture({pulls: [pull(), pull(change)]});
+    assert.equal(await f.execute(), 0);
+    assert.deepEqual(f.fetched, [42, 42]);
+    assert.deepEqual(f.cancelled, []);
+  });
+}
+
+test('does not cancel a run for an older PR head', async () => {
+  const f = fixture({runs: [run({head_sha: 'old-pr-tip'})]});
+  assert.equal(await f.execute(), 0);
+  assert.deepEqual(f.cancelled, []);
+});
+
+test('ignores unrelated events, completed runs, and other PR bases', async () => {
+  const f = fixture({runs: () => [
+    run({event: 'workflow_dispatch'}), run({status: 'completed'}),
+    run({pull_requests: []}), run({pull_requests: undefined}),
+    run({pull_requests: [{number: 42, base: {ref: 'release'}}]}),
+  ]});
+  assert.equal(await f.execute(), 0);
+  assert.deepEqual(f.fetched, []);
+  assert.deepEqual(f.cancelled, []);
+});
+
+test('deduplicates runs that change status during enumeration', async () => {
+  const f = fixture({runs: status => [run({status})]});
+  assert.equal(await f.execute(), 1);
+  assert.deepEqual(f.cancelled, [100]);
+});
+
+test('cancels all matching runs across pages and leaves a healthy PR running', async () => {
+  const runs = Array.from({length: 105}, (_, id) => run({id}));
+  runs.push(run({id: 200, pull_requests: [{number: 43, base: {ref: 'master'}}]}));
+  const f = fixture({runs, pulls: number => pull({mergeable: number === 43})});
+  assert.equal(await f.execute(), 105);
+  assert.deepEqual(f.cancelled, Array.from({length: 105}, (_, id) => id));
+});
+
+test('rechecks the PR between cancellations', async () => {
+  const f = fixture({runs: [run(), run({id: 101})],
+    pulls: [pull(), pull(), pull({mergeable: true})]});
+  assert.equal(await f.execute(), 1);
+  assert.deepEqual(f.cancelled, [100]);
+});
+
+test('tolerates a run finishing before cancellation', async () => {
+  const f = fixture({cancelError: apiError(409)});
+  assert.equal(await f.execute(), 0);
+  assert.ok(f.logs.some(message => message.includes('no longer cancellable')));
+});
+
+for (const pulls of [[apiError(404)], [pull(), apiError(404)]]) {
+  test('tolerates a PR disappearing during inspection', async () => {
+    const f = fixture({pulls});
+    assert.equal(await f.execute(), 0);
+    assert.deepEqual(f.cancelled, []);
+  });
+}
+
+test('surfaces cancellation API errors', async () => {
+  const error = apiError(403);
+  await assert.rejects(fixture({cancelError: error}).execute(), error);
+});
+
+test('surfaces pull request API errors', async () => {
+  const error = apiError(500);
+  await assert.rejects(fixture({pulls: [error]}).execute(), error);
+});

--- a/.github/workflows/cancel-conflicted-ci.yml
+++ b/.github/workflows/cancel-conflicted-ci.yml
@@ -1,0 +1,42 @@
+name: Cancel conflicted PR CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    paths:
+      - .github/workflows/cancel-conflicted-ci.yml
+      - .github/scripts/cancel-conflicted-pr-runs.js
+      - .github/scripts/cancel-conflicted-pr-runs.test.js
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cancel-conflicted-ci-${{ github.event_name == 'push' && 'master' || github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - run: node --test .github/scripts/cancel-conflicted-pr-runs.test.js
+
+  cancel:
+    if: github.event_name == 'push'
+    needs: test
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      pull-requests: read
+      actions: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const cancel = require('./.github/scripts/cancel-conflicted-pr-runs.js');
+            await cancel({github, context, core});

--- a/.github/workflows/cancel-conflicted-ci.yml
+++ b/.github/workflows/cancel-conflicted-ci.yml
@@ -3,17 +3,12 @@ name: Cancel conflicted PR CI
 on:
   push:
     branches: [master]
-  pull_request:
-    paths:
-      - .github/workflows/cancel-conflicted-ci.yml
-      - .github/scripts/cancel-conflicted-pr-runs.js
-      - .github/scripts/cancel-conflicted-pr-runs.test.js
 
 permissions:
   contents: read
 
 concurrency:
-  group: cancel-conflicted-ci-${{ github.event_name == 'push' && 'master' || github.event.pull_request.number }}
+  group: cancel-conflicted-ci-master
   cancel-in-progress: true
 
 jobs:
@@ -25,7 +20,6 @@ jobs:
       - run: node --test .github/scripts/cancel-conflicted-pr-runs.test.js
 
   cancel:
-    if: github.event_name == 'push'
     needs: test
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -1021,5 +1021,8 @@ jobs:
     - name: Dead-code gate self-test
       run: bash test/dead_code_check_selftest.sh
 
+    - name: Conflict cancellation tests
+      run: node --test .github/scripts/cancel-conflicted-pr-runs.test.js
+
     - name: OMIT_INCRBLOB orig adapter link
       run: bash test/omit_incrblob_orig_adapter_test.sh


### PR DESCRIPTION
When a master push makes an open PR conflict, its queued and running CI currently continues consuming runners. Add an Ubuntu workflow that checks active PR CI runs after each master push and cancels runs whose current PR head has a confirmed conflict with that master tip. Cancellation covers the entire CI run, including macOS and Windows jobs.

Unknown mergeability is retried for up to 25 seconds. The script rechecks the PR head, base, open state, and conflict immediately before each cancellation. Mergeable PRs, older PR-head runs, manual runs, and unrelated workflows are left alone. A push resolving the conflict starts normal PR CI again.

Validation: 29 Node tests cover active run states, mergeability retries, concurrent PR/base changes, pagination results, duplicate runs, and API races/errors. actionlint passes for all workflows. The cancellation workflow triggers only on master pushes, so it creates no PR checks or skipped PR jobs. Its tests run as a step in the existing no-dead-code CI job for PRs, and before cancellation on master.

Co-Authored-By: OpenAI Codex <noreply@openai.com>

