### PR TITLE
Reduce macOS CI runner time

### DIFF
--- a/.github/actions/asan-build/action.yml
+++ b/.github/actions/asan-build/action.yml
@@ -35,10 +35,14 @@ runs:
     shell: bash -e {0}
   - name: Build
     run: |
+      set -eo pipefail
       cd build
-      set -o pipefail
+      make_jobs=()
+      if [ "${{ inputs.platform }}" = "macos" ]; then
+        make_jobs=(-j"$(sysctl -n hw.logicalcpu)")
+      fi
       {
-        make CFLAGS="$ASAN_CFLAGS" LDFLAGS="$ASAN_LDFLAGS" \
+        make "${make_jobs[@]}" CFLAGS="$ASAN_CFLAGS" LDFLAGS="$ASAN_LDFLAGS" \
           doltlite libdoltlite.a
         make DOLTLITE_PROLLY=0 sqlite3
         cc $ASAN_CFLAGS -I. -I../src \

--- a/.github/actions/checked-probes/action.yml
+++ b/.github/actions/checked-probes/action.yml
@@ -104,7 +104,13 @@ runs:
       set -eo pipefail
       cd build
       {
-        cc $CFLAGS -Wall \
+        ci_compile() { "$@"; }
+        ci_compile_wait() { :; }
+        if [ "${{ inputs.platform }}" = "macos" ]; then
+          source ../.github/scripts/parallel-compile.sh
+          ci_compile_init "$(sysctl -n hw.logicalcpu)"
+        fi
+        ci_compile cc $CFLAGS -Wall \
           -I../src -I../ext/ed25519 \
           ../test/doltlite_creds_kat.c ../test/sqlite3_alloc_stub.c \
           ../src/doltlite_creds.c \
@@ -113,7 +119,7 @@ runs:
           ../ext/ed25519/keypair.c ../ext/ed25519/sign.c \
           ../ext/ed25519/verify.c ../ext/ed25519/add_scalar.c \
           -o creds_kat
-        cc $CFLAGS -Wall \
+        ci_compile cc $CFLAGS -Wall \
           -I../src -I../ext/ed25519 \
           ../test/creds_verify_kat.c ../test/sqlite3_alloc_stub.c \
           ../src/doltlite_creds.c \
@@ -122,7 +128,7 @@ runs:
           ../ext/ed25519/keypair.c ../ext/ed25519/sign.c \
           ../ext/ed25519/verify.c ../ext/ed25519/add_scalar.c \
           -o creds_verify_kat
-        cc $CFLAGS -I../src -I../ext/mbedtls/include \
+        ci_compile cc $CFLAGS -I../src -I../ext/mbedtls/include \
           ../test/doltlite_tls_test_main.c ../test/sqlite3_alloc_stub.c \
           ../src/doltlite_tls.c \
           ../ext/mbedtls/library/*.c \
@@ -131,7 +137,7 @@ runs:
         for object in blake3_sse2.o blake3_sse41.o blake3_avx2.o blake3_avx512.o blake3_neon.o; do
           [ ! -f "$object" ] || blake_objects+=("$object")
         done
-        cc $CFLAGS ../test/blake3_kat.c \
+        ci_compile cc $CFLAGS ../test/blake3_kat.c \
           prolly_hash.o "${blake_objects[@]}" \
           -I../src -I../ext/blake3 -DDOLTLITE_PROLLY=1 \
           -lm -o blake3_kat
@@ -141,9 +147,10 @@ runs:
           probe_libs+=(-ldl)
           probe_amalgamation=ci-amalgamation.o
         fi
-        cc $CFLAGS -Wno-comment -I. \
+        ci_compile cc $CFLAGS -Wno-comment -I. \
           ../test/amalgamation_http_probe.c "$probe_amalgamation" \
           "${probe_libs[@]}" -o amalgamation_http_probe
+        ci_compile_wait
         rm -f ci-amalgamation.o
       } 2>&1 | tee -a build.log
       if grep -E "warning:" build.log; then

--- a/.github/scripts/ci-build-failure-test.py
+++ b/.github/scripts/ci-build-failure-test.py
@@ -2,6 +2,7 @@ import os
 from pathlib import Path
 import re
 import subprocess
+import shutil
 import tempfile
 import textwrap
 
@@ -12,6 +13,8 @@ cases = (
     ("actions/checked-probes/action.yml", None, "Build standalone Unix test probes", "ubuntu"),
     ("actions/checked-probes/action.yml", None, "Build standalone Unix test probes", "macos"),
     ("workflows/ci-build.yml", "tsan-build", "Build", "ubuntu"),
+    ("actions/asan-build/action.yml", None, "Build", "ubuntu"),
+    ("actions/asan-build/action.yml", None, "Build", "macos"),
 )
 stub = """#!/usr/bin/env bash
 set -eu
@@ -34,6 +37,10 @@ def run(script, fail_at, warning, errexit):
         (root / "build").mkdir()
         (root / "examples/go").mkdir(parents=True)
         (root / "bin").mkdir()
+        (root / ".github/scripts").mkdir(parents=True)
+        shutil.copy(github_dir / "scripts/parallel-compile.sh", root / ".github/scripts")
+        (root / "bin/sysctl").write_text("#!/bin/sh\necho 1\n")
+        (root / "bin/sysctl").chmod(0o755)
         for command in ("make", "cc", "gcc", "clang", "go"):
             path = root / "bin" / command
             path.write_text(stub)
@@ -44,7 +51,9 @@ def run(script, fail_at, warning, errexit):
                    COMMAND_LOG=str(root / "commands"), FAIL_AT=str(fail_at),
                    EMIT_WARNING=str(warning), PACKAGE_MARKER=str(root / "package"),
                    CFLAGS="-O2", TSAN_CFLAGS="-O1 -fsanitize=thread",
-                   TSAN_LDFLAGS="-fsanitize=thread")
+                   TSAN_LDFLAGS="-fsanitize=thread",
+                   ASAN_CFLAGS="-O1 -fsanitize=address,undefined",
+                   ASAN_LDFLAGS="-fsanitize=address,undefined")
         result = subprocess.run(
             ["bash", *(["-e"] if errexit else []), str(path)],
             cwd=root, env=env, capture_output=True, text=True, timeout=30,

--- a/.github/scripts/ci-optimization-test.sh
+++ b/.github/scripts/ci-optimization-test.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 
 script_dir="$(cd "$(dirname "$0")" && pwd)"
 python3 "$script_dir/ci-build-failure-test.py"
+python3 "$script_dir/parallel-compile-test.py"
+python3 "$script_dir/macos-build-jobs-test.py"
 work=$(mktemp -d)
 trap 'rm -rf "$work"' EXIT
 mkdir -p "$work/payload/nested" "$work/profiles with spaces" "$work/bin"

--- a/.github/scripts/macos-build-jobs-test.py
+++ b/.github/scripts/macos-build-jobs-test.py
@@ -1,0 +1,53 @@
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+
+repo = Path(__file__).resolve().parents[2]
+with tempfile.TemporaryDirectory() as tmp:
+    root = Path(tmp)
+    (root / 'test/lib').mkdir(parents=True)
+    (root / 'build').mkdir()
+    (root / 'bin').mkdir()
+    shutil.copy(repo / 'test/run_doltlite_regression_case.sh', root / 'test')
+    (root / 'test/lib/build_artifacts.sh').write_text(
+        'dl_check_archive_flags() { printf "archive-check\\n" >> "$LOG"; }\n')
+    for name in ('make', 'cc'):
+        path = root / 'bin' / name
+        path.write_text('''#!/bin/bash
+printf '%s' "${0##*/}" >> "$LOG"
+printf ' <%s>' "$@" >> "$LOG"
+printf '\\n' >> "$LOG"
+if [ "${0##*/}" = make ] && [ "${FAIL_MAKE:-0}" = 1 ]; then exit 42; fi
+''')
+        path.chmod(0o755)
+    runner = root / 'build/doltlite_regression_test_c'
+    runner.write_text('#!/bin/bash\nprintf "run <%s>\\n" "$*" >> "$LOG"\n')
+    runner.chmod(0o755)
+    env = dict(os.environ, PATH=f'{root / "bin"}:{os.environ["PATH"]}',
+               LOG=str(root / 'log'), CFLAGS='-O2 -g -Werror',
+               DOLTLITE_BUILD_DIR=str(root / 'build'), CC='cc')
+    env.pop('DOLTLITE_REGRESSION_PREBUILT', None)
+    env.pop('DOLTLITE_REGRESSION_JOBS', None)
+    for jobs in ('', '2'):
+        (root / 'log').write_text('')
+        result = subprocess.run(['bash', str(root / 'test/run_doltlite_regression_case.sh'), 'all'],
+                                env=dict(env, DOLTLITE_REGRESSION_JOBS=jobs), capture_output=True)
+        assert result.returncode == 0, result
+        lines = (root / 'log').read_text().splitlines()
+        expected = 'make' + (' <-j2>' if jobs else '')
+        expected += f' <-C> <{root / "build"}> <libdoltlite.a>'
+        assert lines[0] == expected and lines[1] == 'archive-check', lines
+        assert lines[2].startswith('cc <-O2> <-g> <-Werror>') and lines[3] == 'run <all>', lines
+    for jobs in ('0', '-1', 'unbounded', '2 extra'):
+        (root / 'log').write_text('')
+        result = subprocess.run(['bash', str(root / 'test/run_doltlite_regression_case.sh')],
+                                env=dict(env, DOLTLITE_REGRESSION_JOBS=jobs), capture_output=True)
+        assert result.returncode != 0 and not (root / 'log').read_text(), result
+    (root / 'log').write_text('')
+    result = subprocess.run(['bash', str(root / 'test/run_doltlite_regression_case.sh')],
+                            env=dict(env, DOLTLITE_REGRESSION_JOBS='2', FAIL_MAKE='1'), capture_output=True)
+    assert result.returncode == 42 and len((root / 'log').read_text().splitlines()) == 1, result
+
+print('Regression build parallelism: 7 configuration/failure checks passed')

--- a/.github/scripts/macos-package-cache-key.sh
+++ b/.github/scripts/macos-package-cache-key.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+{
+  sw_vers
+  shasum -a 256 "$(xcrun --find clang)"
+  xcrun --show-sdk-path
+  xcrun --show-sdk-version
+  cc --version
+  go version
+  go env CC CGO_CFLAGS CGO_CPPFLAGS CGO_CXXFLAGS CGO_LDFLAGS GOOS GOARCH
+  rustc -vV
+  cargo --version
+  ccache --version
+  printf '%s\n' "${ImageOS:-}" "${ImageVersion:-}" \
+    "${CC:-}" "${CXX:-}" "${CFLAGS:-}" "${CPPFLAGS:-}" \
+    "${CXXFLAGS:-}" "${LDFLAGS:-}" "${RUSTFLAGS:-}"
+} | shasum -a 256 | cut -d ' ' -f 1

--- a/.github/scripts/parallel-compile-test.py
+++ b/.github/scripts/parallel-compile-test.py
@@ -1,0 +1,60 @@
+import json
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+
+helper = Path(__file__).with_name('parallel-compile.sh').resolve()
+worker = '''import json, os, sys, time
+number = int(sys.argv[1])
+def event(kind):
+    with open(os.environ['EVENT_LOG'], 'a') as log:
+        log.write(json.dumps([kind, number]) + '\\n')
+event('start')
+open('started-' + str(number), 'w').close()
+if number < int(os.environ['WORKER_JOBS']):
+    deadline = time.monotonic() + 10
+    while sum(name.startswith('started-') for name in os.listdir('.')) < int(os.environ['WORKER_JOBS']):
+        if time.monotonic() > deadline:
+            raise RuntimeError('compiler workers did not start concurrently')
+        time.sleep(0.01)
+time.sleep(0.05)
+print('compiler output', number)
+event('finish')
+sys.exit(42 if number == int(os.environ['FAIL_TASK']) else 0)
+'''
+
+for jobs in (1, 2, 3):
+    for failed in (-1, 0, 1, 4):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / 'worker.py').write_text(worker)
+            script = '''set -euo pipefail
+source "$HELPER"
+ci_compile_init "$JOBS"
+for i in 0 1 2 3 4; do ci_compile python3 worker.py "$i"; done
+ci_compile_wait
+printf packaged > package
+'''
+            result = subprocess.run(['bash'], input=script, text=True, cwd=root,
+                                    env=dict(os.environ, HELPER=str(helper), JOBS=str(jobs),
+                                             EVENT_LOG=str(root / 'events'), FAIL_TASK=str(failed), WORKER_JOBS=str(jobs)),
+                                    capture_output=True, timeout=30)
+            assert result.returncode == (0 if failed == -1 else 42), result
+            assert (root / 'package').exists() == (failed == -1), result
+            active = set()
+            finished = set()
+            peak = 0
+            for kind, number in map(json.loads, (root / 'events').read_text().splitlines()):
+                if kind == 'start':
+                    active.add(number)
+                    peak = max(peak, len(active))
+                else:
+                    active.remove(number)
+                    finished.add(number)
+                    assert f'compiler output {number}' in result.stdout, result
+            assert not active and peak <= jobs, (active, peak, result)
+            if failed == -1:
+                assert finished == set(range(5)) and peak == jobs, (finished, peak)
+
+print('Parallel compiler scheduling: 12 bounded concurrency/failure checks passed')

--- a/.github/scripts/parallel-compile.sh
+++ b/.github/scripts/parallel-compile.sh
@@ -1,0 +1,58 @@
+ci_compile_init() {
+  ci_compile_jobs="$1"
+  [[ "$ci_compile_jobs" =~ ^[1-9][0-9]*$ ]] || return 1
+  ci_compile_tmp=$(mktemp -d)
+  ci_compile_pids=()
+  ci_compile_index=0
+  trap 'ci_compile_cleanup "$?"' EXIT
+}
+
+ci_compile_reap() {
+  local rc i
+  while :; do
+    for i in "${!ci_compile_pids[@]}"; do
+      if ! kill -0 "${ci_compile_pids[$i]}" 2>/dev/null; then
+        rc=0
+        wait "${ci_compile_pids[$i]}" || rc=$?
+        cat "$ci_compile_tmp/$i.log" || rc=$?
+        unset 'ci_compile_pids[i]'
+        return "$rc"
+      fi
+    done
+    sleep 0.05
+  done
+}
+
+ci_compile_wait() {
+  local rc=0 status
+  while [ "${#ci_compile_pids[@]}" -gt 0 ]; do
+    if ci_compile_reap; then :; else
+      status=$?
+      if [ "$rc" -eq 0 ]; then rc=$status; fi
+    fi
+  done
+  return "$rc"
+}
+
+ci_compile_cleanup() {
+  local rc="$1" status
+  if ci_compile_wait; then :; else
+    status=$?
+    if [ "$rc" -eq 0 ]; then rc=$status; fi
+  fi
+  rm -rf "$ci_compile_tmp"
+  exit "$rc"
+}
+
+ci_compile() {
+  if [ "$ci_compile_jobs" -eq 1 ]; then
+    "$@"
+    return
+  fi
+  "$@" > "$ci_compile_tmp/$ci_compile_index.log" 2>&1 &
+  ci_compile_pids[$ci_compile_index]=$!
+  ci_compile_index=$((ci_compile_index+1))
+  if [ "${#ci_compile_pids[@]}" -ge "$ci_compile_jobs" ]; then
+    ci_compile_reap
+  fi
+}

--- a/.github/workflows/platform-test.yml
+++ b/.github/workflows/platform-test.yml
@@ -123,11 +123,42 @@ jobs:
         go-version: '1.23'
         cache: false
 
+    - name: Set up macOS package caches
+      if: matrix.platform == 'macos'
+      id: package-cache
+      run: |
+        brew install ccache
+        cache_key=$(bash .github/scripts/macos-package-cache-key.sh)
+        echo "key=$cache_key" >> "$GITHUB_OUTPUT"
+        echo "go-build=$(go env GOCACHE)" >> "$GITHUB_OUTPUT"
+        echo "go-mod=$(go env GOMODCACHE)" >> "$GITHUB_OUTPUT"
+
+    - name: Restore macOS package caches
+      if: matrix.platform == 'macos'
+      uses: actions/cache@v4
+      with:
+        path: |
+          ${{ steps.package-cache.outputs.go-build }}
+          ${{ steps.package-cache.outputs.go-mod }}
+          ~/.cargo/registry
+          ~/.cargo/git
+          ${{ runner.temp }}/doltlite-package-target
+          ${{ runner.temp }}/doltlite-ccache
+        key: macos-packages-v1-${{ runner.arch }}-${{ steps.package-cache.outputs.key }}-${{ hashFiles('packaging/go/**', 'packaging/rust/**', 'build/sqlite3.c', 'build/sqlite3.h') }}
+        restore-keys: |
+          macos-packages-v1-${{ runner.arch }}-${{ steps.package-cache.outputs.key }}-
+
     - name: Smoke test the doltlite-driver module
       if: matrix.platform != 'windows'
       shell: bash
       run: |
         chmod +x packaging/go/assemble.sh packaging/go/test-package.sh
+        if [ "${{ matrix.platform }}" = "macos" ]; then
+          export DOLTLITE_PACKAGE_WORK_ROOT="$RUNNER_TEMP/doltlite-packages"
+          export CCACHE_DIR="$RUNNER_TEMP/doltlite-ccache"
+          export CCACHE_MAXSIZE=128M CCACHE_COMPILERCHECK=content
+          export CC="ccache ${CC:-$(go env CC)}"
+        fi
         bash packaging/go/test-package.sh build
       timeout-minutes: 20
 
@@ -136,7 +167,17 @@ jobs:
       shell: bash
       run: |
         chmod +x packaging/rust/assemble.sh packaging/rust/test-package.sh
+        if [ "${{ matrix.platform }}" = "macos" ]; then
+          export DOLTLITE_PACKAGE_WORK_ROOT="$RUNNER_TEMP/doltlite-packages"
+          export CCACHE_DIR="$RUNNER_TEMP/doltlite-ccache"
+          export CCACHE_MAXSIZE=128M CCACHE_COMPILERCHECK=content
+          export CC="ccache ${CC:-cc}"
+          export DOLTLITE_PACKAGE_TARGET_DIR="$RUNNER_TEMP/doltlite-package-target"
+        fi
         bash packaging/rust/test-package.sh build
+        if [ "${{ matrix.platform }}" = "macos" ]; then
+          bash packaging/rust/test-cache.sh
+        fi
       timeout-minutes: 25
 
     # The step above runs on whatever stable the runner ships, which cannot
@@ -195,7 +236,9 @@ jobs:
 
     - name: Doltlite feature tests
       if: matrix.platform == 'macos'
-      run: cd build && bash ../test/run_doltlite_tests.sh
+      run: |
+        cd build
+        DOLTLITE_REGRESSION_JOBS=$(sysctl -n hw.logicalcpu) bash ../test/run_doltlite_tests.sh
       timeout-minutes: 20
 
     - name: Doltlite timing and scale tests

--- a/packaging/go/test-package.sh
+++ b/packaging/go/test-package.sh
@@ -15,8 +15,15 @@ BUILD_DIR="$(cd "${1:-$ROOT/build}" && pwd)"
 
 command -v go >/dev/null || { echo "ERROR: go is required" >&2; exit 1; }
 
-STAGE="$(mktemp -d)"
-CONSUMER="$(mktemp -d)"
+if [ -n "${DOLTLITE_PACKAGE_WORK_ROOT:-}" ]; then
+  mkdir -p "$DOLTLITE_PACKAGE_WORK_ROOT/go"
+  STAGE="$DOLTLITE_PACKAGE_WORK_ROOT/go/stage"
+  CONSUMER="$DOLTLITE_PACKAGE_WORK_ROOT/go/consumer"
+  mkdir "$STAGE" "$CONSUMER"
+else
+  STAGE="$(mktemp -d)"
+  CONSUMER="$(mktemp -d)"
+fi
 trap 'chmod -R u+w "$STAGE" "$CONSUMER" 2>/dev/null; rm -rf "$STAGE" "$CONSUMER"' EXIT
 
 bash "$PKG_DIR/assemble.sh" "0.0.0" "$STAGE/pkg" "$BUILD_DIR"

--- a/packaging/rust/refresh-package.sh
+++ b/packaging/rust/refresh-package.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Cargo normalizes archive mtimes; refresh them before reusing a target directory.
+find "${1:?package directory required}" -type f -exec touch {} +

--- a/packaging/rust/test-cache.sh
+++ b/packaging/rust/test-cache.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+pkg_dir=$(cd "$(dirname "$0")" && pwd)
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+mkdir -p "$work/pkg/src" "$work/pkg/vendor"
+cat > "$work/pkg/Cargo.toml" <<'TOML'
+[package]
+name = "doltlite-cache-fixture"
+version = "0.0.0"
+edition = "2021"
+TOML
+cat > "$work/pkg/build.rs" <<'RS'
+fn main() {
+    println!("cargo:rerun-if-changed=vendor/value");
+    let value = std::fs::read_to_string("vendor/value").unwrap();
+    println!("cargo:rustc-env=FIXTURE_VALUE={}", value.trim());
+}
+RS
+cat > "$work/pkg/src/main.rs" <<'RS'
+fn main() { println!("{}", env!("FIXTURE_VALUE")); }
+RS
+export CARGO_TARGET_DIR="$work/target"
+for value in first second; do
+  printf '%s\n' "$value" > "$work/pkg/vendor/value"
+  find "$work/pkg" -type f -exec touch -t 200001010000 {} +
+  bash "$pkg_dir/refresh-package.sh" "$work/pkg"
+  output=$(cargo run --manifest-path "$work/pkg/Cargo.toml" --offline --release --quiet)
+  [ "$output" = "$value" ] || {
+    echo "FAIL: reused '$output' after changing packaged source to '$value'" >&2
+    exit 1
+  }
+done
+printf '%s\n' 'invalid Rust source' > "$work/pkg/src/main.rs"
+find "$work/pkg" -type f -exec touch -t 200001010000 {} +
+bash "$pkg_dir/refresh-package.sh" "$work/pkg"
+if cargo run --manifest-path "$work/pkg/Cargo.toml" --offline --release --quiet > "$work/output" 2>&1; then
+  echo 'FAIL: reused cached binary after introducing a compile error' >&2
+  exit 1
+fi
+echo 'Cargo package cache invalidation tests passed'

--- a/packaging/rust/test-package.sh
+++ b/packaging/rust/test-package.sh
@@ -16,8 +16,15 @@ BUILD_DIR="$(cd "${1:-$ROOT/build}" && pwd)"
 
 command -v cargo >/dev/null || { echo "ERROR: cargo is required" >&2; exit 1; }
 
-STAGE="$(mktemp -d)"
-CONSUMER="$(mktemp -d)"
+if [ -n "${DOLTLITE_PACKAGE_WORK_ROOT:-}" ]; then
+  mkdir -p "$DOLTLITE_PACKAGE_WORK_ROOT/rust"
+  STAGE="$DOLTLITE_PACKAGE_WORK_ROOT/rust/stage"
+  CONSUMER="$DOLTLITE_PACKAGE_WORK_ROOT/rust/consumer"
+  mkdir "$STAGE" "$CONSUMER"
+else
+  STAGE="$(mktemp -d)"
+  CONSUMER="$(mktemp -d)"
+fi
 trap 'rm -rf "$STAGE" "$CONSUMER"' EXIT
 
 bash "$PKG_DIR/assemble.sh" "0.0.0" "$STAGE/pkg" "$BUILD_DIR"
@@ -42,4 +49,8 @@ sed -i.bak "s|^doltlite = .*|doltlite = { path = \"$EXTRACTED\" }|" \
   "$CONSUMER/Cargo.toml"
 rm -f "$CONSUMER/Cargo.toml.bak"
 cd "$CONSUMER"
+if [ -n "${DOLTLITE_PACKAGE_TARGET_DIR:-}" ]; then
+  bash "$PKG_DIR/refresh-package.sh" "$EXTRACTED"
+  export CARGO_TARGET_DIR="$DOLTLITE_PACKAGE_TARGET_DIR"
+fi
 DOLTLITE_EXPECT_VERSION="v0.0.0" cargo run --release --quiet

--- a/test/lib/sql_oracle_common.sh
+++ b/test/lib/sql_oracle_common.sh
@@ -54,6 +54,11 @@ oracle_with_flags() {
   rm -f "$dl" "$sq"
   out_dl=$(printf '%s\n' "$sql" | "$DOLTLITE" ${flag:+"$flag"} "$dl" 2>&1) || rc_dl=$?
   out_sq=$(printf '%s\n' "$sql" | "$SQLITE3" ${flag:+"$flag"} "$sq" 2>&1) || rc_sq=$?
+  if [ "$expected_rc" -eq 0 ] && [ "$rc_dl" -eq 0 ] && [ "$rc_sq" -eq 0 ] \
+     && [ "$out_dl" = "$out_sq" ]; then
+    pass=$((pass+1))
+    return
+  fi
   norm_dl=$(printf '%s\n' "$out_dl" | normalize_oracle_output)
   norm_sq=$(printf '%s\n' "$out_sq" | normalize_oracle_output)
   if [ "$rc_dl" -eq "$expected_rc" ] && [ "$rc_sq" -eq "$expected_rc" ] \

--- a/test/run_doltlite_regression_case.sh
+++ b/test/run_doltlite_regression_case.sh
@@ -18,7 +18,12 @@ esac
 
 if [ "${DOLTLITE_REGRESSION_PREBUILT:-0}" != "1" ]; then
   source "$script_dir/lib/build_artifacts.sh"
-  make -C "$build_dir" libdoltlite.a
+  make_args=(-C "$build_dir" libdoltlite.a)
+  if [ -n "${DOLTLITE_REGRESSION_JOBS:-}" ]; then
+    [[ "$DOLTLITE_REGRESSION_JOBS" =~ ^[1-9][0-9]*$ ]] || exit 1
+    make_args=(-j"$DOLTLITE_REGRESSION_JOBS" "${make_args[@]}")
+  fi
+  make "${make_args[@]}"
   dl_check_archive_flags "$build_dir/libdoltlite.a" "${CFLAGS:-"-g"}"
   "${CC:-cc}" ${CFLAGS:-"-g"} -I"$build_dir" -I"$repo_root/src" \
     -o "$build_dir/doltlite_regression_test_c" \

--- a/test/sql_oracle_harness_test.sh
+++ b/test/sql_oracle_harness_test.sh
@@ -24,8 +24,11 @@ EOF
 cp "$DOLTLITE" "$SQLITE3"
 chmod +x "$DOLTLITE" "$SQLITE3"
 
+checks=0
+
 check_case() {
   local name="$1" want_fail="$2" kind="$3" error="${4-}"
+  checks=$((checks+1))
   local pass=0 fail=0
   if [ "$kind" = error ]; then
     oracle_error "$name" "SELECT 42;" "$error" > "$SQL_ORACLE_TMP/case.log"
@@ -74,8 +77,27 @@ export candidate_rc=0 reference_rc=0 candidate_output=42 reference_output=42 exp
 check_case unsafe_flag_preserved 0 unsafe
 unset expect_unsafe
 
+sed() {
+  printf 'normalized\n' >> "$SQL_ORACLE_TMP/normalizations"
+  command sed "$@"
+}
+export candidate_output=$'first\nsecond (19)\n\n' reference_output=$'first\nsecond (19)\n'
+check_case identical_multiline_output 0 success
+[ ! -e "$SQL_ORACLE_TMP/normalizations" ]
+export candidate_output=$'first (19)\nsecond' reference_output=$'first\nsecond'
+check_case normalized_success 0 success
+[ "$(wc -l < "$SQL_ORACLE_TMP/normalizations")" -eq 2 ]
+export reference_output=$'first\nthird'
+check_case different_multiline_output 1 success
+export candidate_rc=1 reference_rc=1
+export candidate_output='Error near line 2: shared error (19)'
+export reference_output="$candidate_output"
+check_case identical_errors_still_normalized 0 error 'ERROR: shared error'
+unset -f sed
+
 expect_startup_failure() {
   local name="$1" candidate="$2" reference="$3"
+  checks=$((checks+1))
   if bash "$ORACLE" "$candidate" "$reference" > "$SQL_ORACLE_TMP/startup.log" 2>&1; then
     echo "FAIL: oracle accepted $name"
     tail -5 "$SQL_ORACLE_TMP/startup.log"
@@ -106,4 +128,4 @@ expect_startup_failure missing_executable "$SQL_ORACLE_TMP/missing" "$SQL_ORACLE
 cp "$SQL_ORACLE_TMP/pretends" "$SQL_ORACLE_TMP/pretend_reference"
 expect_startup_failure no_stock_database "$SQL_ORACLE_TMP/pretends" "$SQL_ORACLE_TMP/pretend_reference"
 
-echo "SQL oracle harness: 20 checks passed"
+echo "SQL oracle harness: $checks checks passed"


### PR DESCRIPTION
macOS CI spends runner time on serial compilation and repeated package builds. This change reduces that work within the existing jobs and preserves compiler configurations, test cases, timeouts, and bucket membership.

- Parallelize the native regression archive rebuild and sanitizer object build on macOS using the runner's CPU count.
- Compile independent macOS probes with bounded concurrency, collecting every log and propagating every failure. Linux probe compilation stays serial.
- Cache Go/Rust compilation and dependencies with stable disposable staging paths, native compiler caching, and keys covering source inputs, architecture, compiler, SDK, and toolchains. Packages and consumer dependencies are still assembled/resolved afresh.
- Refresh extracted Rust package timestamps before reusing Cargo artifacts. Cargo's normalized archive timestamps otherwise let changed native source reuse a stale build; a real-Cargo regression reproduces that failure without the fix.
- Bypass SQL-oracle normalization only when both executions succeed and their raw output is identical; preserve the existing handling of mismatches and expected errors.

Validation: clean native and sanitizer builds; all 311,222 C regression assertions in both configurations; every existing macOS sanitizer test step; all standalone probe wrappers; 84 compiler failure/warning checks, 12 concurrency checks, 7 regression-build checks, 24 oracle-harness checks, Cargo cache invalidation tests, packaging/profile checks, orphan guard, and actionlint. Serial/parallel builds emitted identical compiler arguments. Warm Go and Rust caches rejected changed C source and compiler flags.

Local measurements: native archive compilation took 55.8s serial versus 24.5s with two workers. Go package tests took 39.7s cold versus 0.8s warm; Rust took 35.0s cold versus 2.8s warm. These exclude GitHub cache transfer/setup costs; net CI savings still need measurement.

Co-Authored-By: OpenAI Codex <noreply@openai.com>
