### PR TITLE
Keep HEAD message when amending without -m

### DIFF
--- a/doc/doltlite/dolt_commit.md
+++ b/doc/doltlite/dolt_commit.md
@@ -47,7 +47,7 @@ the SQL transaction; see [transactions.md](transactions.md).
 
 | Error | Cause |
 |---|---|
-| `dolt_commit requires a message: SELECT dolt_commit('-m', 'msg')` | no `-m`, or empty message |
+| `dolt_commit requires a message: SELECT dolt_commit('-m', 'msg')` | no `-m` unless `--amend`, or empty message |
 | `nothing to commit, working tree clean (use dolt_add to stage changes)` | nothing staged and no `-a`/`-A` |
 | `Author not formatted correctly. Use 'Name <author@example.com>' format` | bad `--author` |
 | `cannot commit: unresolved merge conflicts. Use dolt_conflicts_resolve() first.` | see [dolt_merge.md](dolt_merge.md) |

--- a/src/doltlite_commit_cmd.c
+++ b/src/doltlite_commit_cmd.c
@@ -539,6 +539,7 @@ static int doltliteCommitCreateObject(
   ProllyHash aExtraParents[DOLTLITE_MAX_PARENTS];
   int nExtraParents = 0;
   char *zParsedName = 0, *zParsedEmail = 0;
+  char *zAmendMessage = 0;
   const char *zMessage;
   const char *zAuthor;
   int rc;
@@ -595,8 +596,14 @@ static int doltliteCommitCreateObject(
       }
     }
     if( !zMessage || !*zMessage ){
-      zMessage = sqlite3_mprintf("%s",
+      zAmendMessage = sqlite3_mprintf("%s",
           headCommit.zMessage ? headCommit.zMessage : "");
+      if( !zAmendMessage ){
+        doltliteCommitClear(&headCommit);
+        sqlite3_result_error_code(context, SQLITE_NOMEM);
+        return SQLITE_NOMEM;
+      }
+      zMessage = zAmendMessage;
     }
     doltliteCommitClear(&headCommit);
   }
@@ -624,13 +631,24 @@ static int doltliteCommitCreateObject(
   if( zAuthor ){
     rc = doltliteCmdParseAuthor(context, zAuthor,
                                 &zParsedName, &zParsedEmail);
-    if( rc!=SQLITE_OK ) return rc;
+    if( rc!=SQLITE_OK ){
+      sqlite3_free(zAmendMessage);
+      return rc;
+    }
   }
 
   {
     const char *p = zMessage;
+    if( !p ){
+      sqlite3_free(zAmendMessage);
+      sqlite3_free(zParsedName);
+      sqlite3_free(zParsedEmail);
+      sqlite3_result_error_code(context, SQLITE_NOMEM);
+      return SQLITE_NOMEM;
+    }
     while( *p==' ' || *p=='\t' || *p=='\n' || *p=='\r' ) p++;
     if( *p==0 ){
+      sqlite3_free(zAmendMessage);
       sqlite3_free(zParsedName);
       sqlite3_free(zParsedEmail);
       sqlite3_result_error(context,
@@ -642,6 +660,7 @@ static int doltliteCommitCreateObject(
   rc = doltliteCreateAndStoreCommitWithTime(db, &parentHash, pCatalogHash,
       zMessage, zParsedName, zParsedEmail, aExtraParents, nExtraParents,
       opts->zDate!=0, opts->explicitTimestamp, pCommitHashOut);
+  sqlite3_free(zAmendMessage);
   sqlite3_free(zParsedName);
   sqlite3_free(zParsedEmail);
   if( rc!=SQLITE_OK ){
@@ -846,7 +865,7 @@ static void doltliteCommitFunc(
     }
   }
 
-  if( !zMessage || zMessage[0]==0 ){
+  if( (!zMessage || zMessage[0]==0) && !amend ){
     sqlite3_result_error(context,
       "dolt_commit requires a message: SELECT dolt_commit('-m', 'msg')", -1);
     return;

--- a/test/doltlite_commit.sh
+++ b/test/doltlite_commit.sh
@@ -660,7 +660,66 @@ SELECT dolt_add('tokens');
 SELECT dolt_commit('-m','tokens');" \
   "[0-9a-f]{40}$" "$DB24"
 
-rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8" "$DB9" "$DB10" "$DB11" "$DB12" "$DB13" "$DB14" "$DB15" "$DB16" "$DB17" "$DB18" "$DB19" "$DB20" "$DB21" "$DB22" "$DB23" "$DB24"
+DB25=/tmp/test_dolt_commit_amend_nomsg_$$.db; rm -f "$DB25"
+
+run_test_match "amend_setup" \
+  "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'a');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c1');" \
+  "^[0-9a-f]{40}$" "$DB25"
+
+run_test_match "amend_without_message" \
+  "INSERT INTO t VALUES(2,'b');
+SELECT dolt_add('t');
+SELECT dolt_commit('--amend');" \
+  "^[0-9a-f]{40}$" "$DB25"
+
+run_test "amend_without_message_keeps_head" \
+  "SELECT message FROM dolt_log LIMIT 1;" \
+  "c1" "$DB25"
+
+run_test "amend_without_message_has_row" \
+  "SELECT count(*) FROM dolt_at_t('HEAD');" \
+  "2" "$DB25"
+
+run_test "amend_without_message_log_count" \
+  "SELECT count(*) FROM dolt_log;" \
+  "2" "$DB25"
+
+run_test_match "amend_author_without_message" \
+  "INSERT INTO t VALUES(3,'c');
+SELECT dolt_add('t');
+SELECT dolt_commit('--amend', '--author', 'Pat <pat@example.com>');" \
+  "^[0-9a-f]{40}$" "$DB25"
+
+run_test "amend_author_without_message_keeps_head" \
+  "SELECT message FROM dolt_log LIMIT 1;" \
+  "c1" "$DB25"
+
+run_test "amend_author_without_message_sets_author" \
+  "SELECT committer FROM dolt_log LIMIT 1;" \
+  "Pat" "$DB25"
+
+run_test "amend_author_without_message_sets_email" \
+  "SELECT email FROM dolt_log LIMIT 1;" \
+  "pat@example.com" "$DB25"
+
+run_test_match "amend_date_without_message" \
+  "INSERT INTO t VALUES(4,'d');
+SELECT dolt_add('t');
+SELECT dolt_commit('--amend', '--date', '2020-06-15T12:00:00Z');" \
+  "^[0-9a-f]{40}$" "$DB25"
+
+run_test "amend_date_without_message_keeps_head" \
+  "SELECT message FROM dolt_log LIMIT 1;" \
+  "c1" "$DB25"
+
+run_test "amend_date_without_message_sets_date" \
+  "SELECT substr(date,1,10) FROM dolt_log LIMIT 1;" \
+  "2020-06-15" "$DB25"
+
+rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8" "$DB9" "$DB10" "$DB11" "$DB12" "$DB13" "$DB14" "$DB15" "$DB16" "$DB17" "$DB18" "$DB19" "$DB20" "$DB21" "$DB22" "$DB23" "$DB24" "$DB25"
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"

--- a/test/vc_oracle_commit_test.sh
+++ b/test/vc_oracle_commit_test.sh
@@ -312,6 +312,36 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('--amend', '-m', 'amended with row 2');
 "
 
+oracle "commit_amend_keeps_head_message" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1, 'a');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+INSERT INTO t VALUES (2, 'b');
+SELECT dolt_add('t');
+SELECT dolt_commit('--amend');
+"
+
+oracle "commit_amend_author_without_message" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1, 'a');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+INSERT INTO t VALUES (2, 'b');
+SELECT dolt_add('t');
+SELECT dolt_commit('--amend', '--author', 'Pat <pat@example.com>');
+"
+
+oracle "commit_amend_date_without_message" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1, 'a');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+INSERT INTO t VALUES (2, 'b');
+SELECT dolt_add('t');
+SELECT dolt_commit('--amend', '--date', '2020-06-15T12:00:00Z');
+"
+
 # Amending a merge must keep every parent; dropping them makes a later merge of the same branch replay.
 oracle "commit_amend_merge_commit" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);


### PR DESCRIPTION
## Summary
`dolt_commit('--amend')` without `-m` was refused with `dolt_commit requires a message` before the amend path could copy HEAD's message. Dolt 2.3.1 and `doc/doltlite/dolt_commit.md` keep that message and fold staged changes into HEAD. The same refusal hit `--amend --author` and `--amend --date` without `-m`.

- Gate the empty-message check on `!amend`.
- Keep the HEAD-message fallback, and free the copied string on every path including OOM.
- Native tests cover amend / `--author` / `--date` without `-m` (HEAD message, HEAD row count, author, date).
- Commit oracle cases `commit_amend_keeps_head_message`, `commit_amend_author_without_message`, `commit_amend_date_without_message`.

## Validation
Fail-before (`build/doltlite` on master): `SELECT dolt_commit('--amend')` → `dolt_commit requires a message`; native suite 110 passed / 4 failed.

Pass-after (`build/doltlite`): `test/doltlite_commit.sh` 116/116; `test/vc_oracle_commit_test.sh` 83/83 vs Dolt 2.3.1.

`dolt_commit()` without `--amend` still requires `-m`.

Fixes #2792

Co-Authored-By: Grok 4.6 <noreply@x.ai>