### PR TITLE
Reduce CI scheduler, harness and benchmark overhead

### DIFF
--- a/.github/scripts/benchmark-build-test.py
+++ b/.github/scripts/benchmark-build-test.py
@@ -1,0 +1,105 @@
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import tarfile
+import tempfile
+import textwrap
+
+
+scripts = Path(__file__).resolve().parent
+workflow = (scripts.parent / "workflows/ci-build.yml").read_text().split("  benchmark-build:\n", 1)[1].split("\n  asan-ubsan-build:", 1)[0]
+
+
+def step(name):
+    match = re.search(rf"    - name: {re.escape(name)}\n.*?      run: \|\n((?:        [^\n]*\n|\n)+)", workflow, re.S)
+    assert match, name
+    return textwrap.dedent(match[1])
+
+
+stub = r'''#!/usr/bin/env bash
+set -eu
+name="${0##*/}"
+printf '%s %s\n' "$name" "$*" >> "$COMMAND_LOG"
+if [ "${FAIL_COMMAND:-}" = "$name" ]; then echo 'injected failure' >&2; exit 42; fi
+if [ "${WARN_COMMAND:-}" = "$name" ]; then echo 'warning: injected warning' >&2; fi
+case "$name" in
+  configure) ;;
+  make) printf '#!/bin/sh\necho candidate\n' > doltlite; chmod +x doltlite ;;
+  cc) printf '#!/bin/sh\necho timer\n' > bench_timer_doltlite; chmod +x bench_timer_doltlite ;;
+esac
+'''
+
+
+def main():
+    checks = 0
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        (root / "bin").mkdir()
+        (root / "source").mkdir()
+        for name in ("make", "cc"):
+            path = root / "bin" / name
+            path.write_text(stub)
+            path.chmod(0o755)
+        (root / "bin/find").write_text("#!/bin/sh\nexit 0\n")
+        (root / "bin/find").chmod(0o755)
+        (root / "source/configure").write_text(stub)
+        (root / "source/configure").chmod(0o755)
+        log = root / "commands"
+        env = dict(os.environ, PATH=f"{root / 'bin'}:{os.environ['PATH']}", COMMAND_LOG=str(log))
+        for fail, warning in (("", ""), ("configure", ""), ("make", ""), ("cc", ""), ("", "make"), ("", "cc")):
+            log.unlink(missing_ok=True)
+            result = subprocess.run(["bash", str(scripts / "build-optimized-benchmark.sh"), str(root / "source")],
+                                    env=dict(env, FAIL_COMMAND=fail, WARN_COMMAND=warning), capture_output=True, text=True)
+            assert result.returncode == (42 if fail else 1 if warning else 0), result
+            commands = log.read_text().splitlines()
+            expected = ["configure ", "make -j2 doltlite doltlite-lib", "cc -O2 -Werror -I. -I../src -o bench_timer_doltlite ../test/sysbench_timer.c libdoltlite.a -lpthread -lz -lm"]
+            if fail:
+                expected = expected[:["configure", "make", "cc"].index(fail) + 1]
+            assert commands == expected, commands
+            if warning:
+                assert "warning: injected warning" in (root / "source/build/build.log").read_text()
+            checks += 1
+        shutil.copytree(root / "source/build", root / "benchmark-baseline")
+        valid_log = "make -j2 doltlite doltlite-lib\n"
+        base = root / "benchmark-baseline"
+        for bad in ("", "warning", "log", "binary", "permission"):
+            (base / "build.log").write_text(valid_log)
+            (base / "doltlite").write_text("#!/bin/sh\nexit 0\n")
+            (base / "doltlite").chmod(0o755)
+            if bad == "warning":
+                (base / "build.log").write_text("warning: cached compiler warning\n")
+            elif bad == "log":
+                (base / "build.log").unlink()
+            elif bad == "binary":
+                (base / "doltlite").unlink()
+            elif bad == "permission":
+                (base / "doltlite").chmod(0o644)
+            result = subprocess.run(["bash", "-e", "-c", step("Validate base build")], cwd=root, capture_output=True)
+            assert (result.returncode == 0) == (bad == ""), (bad, result)
+            checks += 1
+        (base / "doltlite").chmod(0o755)
+        shutil.copytree(root / "source/build", root / "build")
+        (root / ".github/scripts").mkdir(parents=True)
+        shutil.copy(scripts / "package-ci-build.sh", root / ".github/scripts")
+        (root / "bin/git").write_text("#!/bin/sh\nprintf '%040d\\n' 1\n")
+        (root / "bin/git").chmod(0o755)
+        (root / "build/unused.o").write_bytes(b"unused" * 1000)
+        subprocess.run(["bash", "-e", "-c", step("Package")], cwd=root, env=env, check=True)
+        with tarfile.open(root / "benchmark-build.tar.gz") as archive:
+            expected = {"build/doltlite", "build/bench_timer_doltlite", "benchmark-baseline/doltlite",
+                        "benchmark-baseline/bench_timer_doltlite", "benchmark-candidate-sha", "benchmark-baseline-sha"}
+            assert set(archive.getnames()) == expected
+            for entry in archive:
+                assert archive.extractfile(entry).read() == (root / entry.name).read_bytes()
+                assert entry.mode == (root / entry.name).stat().st_mode & 0o777
+            archive.extractall(root / "consumer", filter="data")
+        for path in sorted(expected - {"benchmark-candidate-sha", "benchmark-baseline-sha"}):
+            subprocess.run([str(root / "consumer" / path)], check=True, capture_output=True)
+        checks += 1
+    print(f"Benchmark builds, cached validation and runtime archive: {checks} checks passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/benchmark-cache-key-test.py
+++ b/.github/scripts/benchmark-cache-key-test.py
@@ -1,0 +1,83 @@
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+
+
+scripts = Path(__file__).resolve().parent
+stub = '''#!/usr/bin/env bash
+set -eu
+name="${0##*/}"
+if [ "${KEY_TOOL_FAIL:-}" = "$name" ]; then exit 42; fi
+case "$name" in
+  cc|clang) echo "compiler $*" ;;
+  make) echo make-4 ;;
+  dpkg-query) echo "zlib=1.2.13"; echo "tcl=8.6" ;;
+  uname) echo x86_64 ;;
+esac
+'''
+
+
+def main():
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        (root / "bin").mkdir()
+        (root / "scripts").mkdir()
+        source = root / "base"
+        source.mkdir()
+        for name in ("cc", "clang", "as", "ld", "make", "dpkg-query", "uname"):
+            path = root / "bin" / name
+            path.write_text(stub)
+            path.chmod(0o755)
+        for name in ("benchmark-cache-key.sh", "build-optimized-benchmark.sh"):
+            shutil.copy(scripts / name, root / "scripts")
+        subprocess.run(["git", "init", "-q", str(source)], check=True)
+        (source / "source.c").write_text("first\n")
+        subprocess.run(["git", "-C", str(source), "add", "source.c"], check=True)
+        commit = ["git", "-C", str(source), "-c", "user.name=CI Test", "-c", "user.email=ci@example.com", "commit", "-qm"]
+        subprocess.run([*commit, "first"], check=True)
+        env = dict(os.environ, PATH=f"{root / 'bin'}:{os.environ['PATH']}")
+
+        def key(extra=None):
+            result = subprocess.run(["bash", str(root / "scripts/benchmark-cache-key.sh"), str(source)],
+                                    env=dict(env, **(extra or {})), text=True, capture_output=True)
+            return result
+
+        baseline = key()
+        assert baseline.returncode == 0 and len(baseline.stdout.strip()) == 64, baseline
+        assert key().stdout == baseline.stdout
+        checks = 1
+        for rel in ("bin/cc", "bin/as", "bin/ld", "bin/make", "bin/dpkg-query", "bin/uname",
+                    "scripts/build-optimized-benchmark.sh", "scripts/benchmark-cache-key.sh"):
+            path = root / rel
+            original = path.read_text()
+            path.write_text(original.replace("make-4", "make-5").replace("zlib=1.2.13", "zlib=1.3").replace("x86_64", "aarch64") + "\n# changed\n")
+            changed = key()
+            assert changed.returncode == 0 and changed.stdout != baseline.stdout, (rel, changed)
+            path.write_text(original)
+            assert key().stdout == baseline.stdout, rel
+            checks += 1
+        for name, value in (("CFLAGS", "-O0"), ("CPPFLAGS", "-DTEST=1"), ("LDFLAGS", "-static"),
+                            ("MAKEFLAGS", "-e"), ("CC", "clang"), ("ImageVersion", "next"), ("LIBRARY_PATH", "/different")):
+            changed = key({name: value})
+            assert changed.returncode == 0 and changed.stdout != baseline.stdout, (name, changed)
+            checks += 1
+        clang_key = key({"CC": "clang"}).stdout
+        with (root / "bin/clang").open("a") as stream:
+            stream.write("\n# changed compiler\n")
+        assert key({"CC": "clang"}).stdout != clang_key
+        checks += 1
+        (source / "source.c").write_text("second\n")
+        subprocess.run(["git", "-C", str(source), "add", "source.c"], check=True)
+        subprocess.run([*commit, "second"], check=True)
+        assert key().stdout != baseline.stdout
+        checks += 1
+        for tool in ("cc", "make", "dpkg-query", "uname"):
+            assert key({"KEY_TOOL_FAIL": tool}).returncode != 0, tool
+            checks += 1
+    print(f"Benchmark cache identity: {checks} invalidation and failure checks passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/benchmark-cache-key.sh
+++ b/.github/scripts/benchmark-cache-key.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source_dir="${1:?Usage: benchmark-cache-key.sh <base-source-directory>}"
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+read -r -a compiler <<< "${CC:-cc}"
+{
+  git -C "$source_dir" rev-parse HEAD
+  sha256sum "$script_dir/build-optimized-benchmark.sh" "$script_dir/benchmark-cache-key.sh"
+  uname -m
+  printf '%s\n' "${ImageOS:-}" "${ImageVersion:-}"
+  cc --version
+  cc -dumpmachine
+  "${compiler[@]}" --version
+  for tool in "${compiler[@]}"; do
+    if tool_path=$(command -v "$tool"); then
+      sha256sum "$tool_path"
+    fi
+  done
+  sha256sum "$(command -v cc)" "$(command -v as)" "$(command -v ld)"
+  make --version
+  dpkg-query -W -f='${binary:Package}=${Version}\n' | LC_ALL=C sort
+  env | LC_ALL=C sort | grep -E '^(CC|CXX|CPP|CFLAGS|CPPFLAGS|LDFLAGS|LIBS|AR|ARFLAGS|AS|LD|NM|RANLIB|MAKEFLAGS|CPATH|C_INCLUDE_PATH|LIBRARY_PATH|PKG_CONFIG_PATH|TCL_CONFIG)=' || [ "$?" -eq 1 ]
+} | sha256sum | cut -d ' ' -f1

--- a/.github/scripts/build-optimized-benchmark.sh
+++ b/.github/scripts/build-optimized-benchmark.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source_dir="${1:?Usage: build-optimized-benchmark.sh <source-directory>}"
+mkdir -p "$source_dir/build"
+cd "$source_dir/build"
+TCL_CONFIG=$(find /usr/lib -name tclConfig.sh -print -quit 2>/dev/null)
+if [ -n "$TCL_CONFIG" ]; then
+  ../configure --with-tcl="$(dirname "$TCL_CONFIG")"
+else
+  ../configure
+fi
+{
+  make -j2 doltlite doltlite-lib
+  cc -O2 -Werror -I. -I../src \
+    -o bench_timer_doltlite ../test/sysbench_timer.c \
+    libdoltlite.a -lpthread -lz -lm
+} 2>&1 | tee build.log
+if grep -E 'warning:' build.log; then
+  echo '::error::compiler warnings in optimized build'
+  exit 1
+fi

--- a/.github/scripts/ci-optimization-test.sh
+++ b/.github/scripts/ci-optimization-test.sh
@@ -6,6 +6,10 @@ script_dir="$(cd "$(dirname "$0")" && pwd)"
 python3 "$script_dir/ci-build-failure-test.py"
 python3 "$script_dir/parallel-compile-test.py"
 python3 "$script_dir/macos-build-jobs-test.py"
+python3 "$script_dir/benchmark-build-test.py"
+python3 "$script_dir/benchmark-cache-key-test.py"
+python3 "$script_dir/../../test/sqllogictest_gate_test.py"
+python3 "$script_dir/../../test/sysbench_harness_test.py"
 work=$(mktemp -d)
 trap 'rm -rf "$work"' EXIT
 mkdir -p "$work/payload/nested" "$work/profiles with spaces" "$work/bin"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -141,10 +141,7 @@ jobs:
     - name: Download paired build metadata
       uses: actions/download-artifact@v4
       with:
-        name: benchmark-build
-
-    - name: Extract paired build metadata
-      run: tar -xzf benchmark-build.tar.gz
+        name: benchmark-build-metadata
 
     - name: Test relative comparison policy
       run: |

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -199,49 +199,48 @@ jobs:
         bash .github/scripts/install-apt-deps.sh \
           build-essential tcl-dev zlib1g-dev
 
-    - name: Configure
+    - name: Identify base build cache
+      id: base-key
       run: |
-        TCL_CONFIG=$(find /usr/lib -name tclConfig.sh -print -quit 2>/dev/null)
-        for source in . benchmark-base; do
-          mkdir -p "$source/build"
-          if [ -n "$TCL_CONFIG" ]; then
-            (cd "$source/build" && ../configure --with-tcl=$(dirname "$TCL_CONFIG"))
-          else
-            (cd "$source/build" && ../configure)
-          fi
-        done
+        key=$(bash .github/scripts/benchmark-cache-key.sh benchmark-base)
+        echo "key=$key" >> "$GITHUB_OUTPUT"
 
-    - name: Build
+    - name: Restore base build
+      id: base-cache
+      uses: actions/cache@v4
+      with:
+        path: benchmark-baseline
+        key: benchmark-base-v1-${{ runner.os }}-${{ runner.arch }}-${{ steps.base-key.outputs.key }}
+
+    - name: Build candidate
+      run: bash .github/scripts/build-optimized-benchmark.sh .
+
+    - name: Build base
+      if: steps.base-cache.outputs.cache-hit != 'true'
       run: |
-        set -o pipefail
-        {
-          (
-            cd build
-            make -j2 doltlite doltlite-lib
-            cc -O2 -Werror -I. -I../src \
-              -o bench_timer_doltlite ../test/sysbench_timer.c \
-              libdoltlite.a -lpthread -lz -lm
-          )
-          (
-            cd benchmark-base/build
-            make -j2 doltlite doltlite-lib
-            cc -O2 -Werror -I. -I../src \
-              -o bench_timer_doltlite ../test/sysbench_timer.c \
-              libdoltlite.a -lpthread -lz -lm
-          )
-        } 2>&1 | tee build.log
-        if grep -E "warning:" build.log; then
-          echo "::error::compiler warnings in optimized build"
+        rm -rf benchmark-baseline
+        bash .github/scripts/build-optimized-benchmark.sh benchmark-base
+        mkdir benchmark-baseline
+        cp benchmark-base/build/doltlite benchmark-base/build/bench_timer_doltlite \
+          benchmark-base/build/build.log benchmark-baseline/
+
+    - name: Validate base build
+      run: |
+        test -x benchmark-baseline/doltlite
+        test -x benchmark-baseline/bench_timer_doltlite
+        test -s benchmark-baseline/build.log
+        if grep -E "warning:" benchmark-baseline/build.log; then
+          echo "::error::compiler warnings in optimized base build"
           exit 1
         fi
 
     - name: Package
       run: |
-        mv benchmark-base/build benchmark-baseline
         git rev-parse HEAD > benchmark-candidate-sha
         git -C benchmark-base rev-parse HEAD > benchmark-baseline-sha
         bash .github/scripts/package-ci-build.sh benchmark-build.tar.gz \
-          build benchmark-baseline \
+          build/doltlite build/bench_timer_doltlite \
+          benchmark-baseline/doltlite benchmark-baseline/bench_timer_doltlite \
           benchmark-candidate-sha benchmark-baseline-sha
 
     - name: Upload
@@ -250,6 +249,15 @@ jobs:
         name: benchmark-build
         path: benchmark-build.tar.gz
         compression-level: 0
+        retention-days: 1
+
+    - name: Upload build metadata
+      uses: actions/upload-artifact@v4
+      with:
+        name: benchmark-build-metadata
+        path: |
+          benchmark-candidate-sha
+          benchmark-baseline-sha
         retention-days: 1
 
   asan-ubsan-build:
@@ -589,7 +597,7 @@ jobs:
     - name: Install dependencies
       run: |
         bash .github/scripts/install-apt-deps.sh \
-          build-essential tcl-dev zlib1g-dev
+          build-essential tcl-dev libsqlite3-tcl zlib1g-dev
 
     - name: Configure
       run: |
@@ -605,8 +613,7 @@ jobs:
     - name: Compile development configurations
       run: |
         cd build
-        make DOLTLITE_PROLLY=1 testfixture
-        ./testfixture ../test/testrunner.tcl \
+        tclsh ../test/testrunner.tcl \
           --buildonly --jobs 4 \
           --config ${{ matrix.configuration }} mdevtest
 

--- a/test/lib/sysbench_benchmark.sh
+++ b/test/lib/sysbench_benchmark.sh
@@ -19,12 +19,7 @@ BENCH_SAMPLES_FILE="$TMPDIR/bench_samples.tsv"
 printf 'section\ttest\trun\tbaseline_us\tcandidate_us\n' \
   > "$BENCH_SAMPLES_FILE"
 
-fmt_us() {
-  python3 - "$1" <<'PYEOF'
-import sys
-print(f"{int(sys.argv[1]):,}")
-PYEOF
-}
+BENCH_REPORT_SCRIPT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/sysbench_report.py"
 
 run_bench() {
   local id="$1"
@@ -93,17 +88,6 @@ bench_runs_summary() {
   fi
 }
 
-median_us() {
-  python3 - "$@" <<'PYEOF'
-import sys
-vals = sorted(int(v) for v in sys.argv[1:] if int(v) >= 0)
-if not vals:
-    print(-1)
-else:
-    print(vals[len(vals)//2])
-PYEOF
-}
-
 run_bench_pair_stable() {
   local section="$1"
   local test_name="$2"
@@ -111,8 +95,6 @@ run_bench_pair_stable() {
   local baseline_db="$4"
   local candidate_db="$5"
   local runs i baseline_sample candidate_sample
-  local baseline_samples=()
-  local candidate_samples=()
   runs=$(bench_runs_for_test "$test_name")
 
   for ((i=1; i<=runs; i++)); do
@@ -131,16 +113,12 @@ run_bench_pair_stable() {
         baseline "$BENCH_BASELINE_KIND" "$BENCH_BASELINE_BINARY" \
         "$BENCH_BASELINE_TIMER" "$sql_file" "$baseline_db")
     fi
-    baseline_samples+=("$baseline_sample")
-    candidate_samples+=("$candidate_sample")
     printf '%s\t%s\t%d\t%s\t%s\n' \
       "$section" "$test_name" "$i" "$baseline_sample" "$candidate_sample" \
       >> "$BENCH_SAMPLES_FILE"
+    printf '%s\t%s\t%d\t%s\t%s\n' \
+      "$section" "$test_name" "$i" "$baseline_sample" "$candidate_sample"
   done
-
-  printf '%s\t%s\n' \
-    "$(median_us "${baseline_samples[@]}")" \
-    "$(median_us "${candidate_samples[@]}")"
 }
 
 run_section() {
@@ -148,43 +126,21 @@ run_section() {
   local tests="$2"
   local baseline_db="$3"
   local candidate_db="$4"
-  local ratio_sum=0
-  local ratio_count=0
-  local avg_ratio="--"
-  local t pair baseline candidate baseline_display candidate_display ratio
+  local t pair
+  local BENCH_SECTION_SAMPLES_FILE="$TMPDIR/bench_section_samples.tsv"
+  : > "$BENCH_SECTION_SAMPLES_FILE"
 
   echo "| Test | $BENCH_BASELINE_LABEL (us) | $BENCH_CANDIDATE_LABEL (us) | Multiplier |"
   echo "|------|------------:|--------------:|-----------:|"
   for t in $tests; do
     pair=$(run_bench_pair_stable \
       "$section" "$t" "$TMPDIR/$t.sql" "$baseline_db" "$candidate_db")
-    IFS=$'\t' read -r baseline candidate <<< "$pair"
-    baseline_display="$baseline"
-    candidate_display="$candidate"
-    if [ "$baseline" -eq -1 ] 2>/dev/null; then baseline_display="crash"; fi
-    if [ "$candidate" -eq -1 ] 2>/dev/null; then candidate_display="crash"; fi
-    if [ "$baseline" -ge 0 ] 2>/dev/null; then
-      baseline_display=$(fmt_us "$baseline")
+    if [ -n "$pair" ]; then
+      printf '%s\n' "$pair" >> "$BENCH_SECTION_SAMPLES_FILE"
     fi
-    if [ "$candidate" -ge 0 ] 2>/dev/null; then
-      candidate_display=$(fmt_us "$candidate")
-    fi
-    if [ "$baseline" -gt 0 ] 2>/dev/null \
-        && [ "$candidate" -ge 0 ] 2>/dev/null; then
-      ratio=$(python3 -c "print(f'{$candidate/$baseline:.2f}')")
-      ratio_sum=$(python3 -c "print($ratio_sum + ($candidate/$baseline))")
-      ratio_count=$((ratio_count + 1))
-    else
-      ratio="--"
-    fi
-    printf '%s\t%s\t%s\t%s\n' \
-      "$section" "$t" "$baseline" "$candidate" >> "$BENCH_RESULTS_FILE"
-    echo "| $t | $baseline_display | $candidate_display | ${ratio} |"
   done
-  if [ "$ratio_count" -gt 0 ]; then
-    avg_ratio=$(python3 -c "print(f'{($ratio_sum/$ratio_count):.2f}')")
-  fi
-  echo "| Average |  |  | ${avg_ratio} |"
+  python3 "$BENCH_REPORT_SCRIPT" section \
+    "$BENCH_SECTION_SAMPLES_FILE" "$section" "$tests" "$BENCH_RESULTS_FILE"
 }
 
 benchmark_autocommit_note() {
@@ -203,64 +159,11 @@ benchmark_gate_note() {
 }
 
 check_ceiling() {
-  local section="$1"
-  local tests="$2"
-  local max="$3"
-  local failed=0
-  local t line baseline candidate over ratio
-  for t in $tests; do
-    line=$(awk -F '\t' -v section="$section" -v test="$t" \
-      '$1==section && $2==test {print $3 "\t" $4; exit}' \
-      "$BENCH_RESULTS_FILE")
-    baseline="${line%%$'\t'*}"
-    candidate="${line#*$'\t'}"
-    if ! [ "$baseline" -gt 0 ] 2>/dev/null \
-        || ! [ "$candidate" -ge 0 ] 2>/dev/null; then
-      echo "FAIL: $section/$t did not produce valid timings" >&2
-      failed=1
-      continue
-    fi
-    over=$(python3 -c "r=$candidate/$baseline; print(1 if r>$max else 0)")
-    if [ "$over" = "1" ]; then
-      ratio=$(python3 -c "print(f'{$candidate/$baseline:.2f}')")
-      echo "FAIL: $section/$t = ${ratio}x (ceiling: ${max}x)" >&2
-      failed=1
-    fi
-  done
-  return "$failed"
+  python3 "$BENCH_REPORT_SCRIPT" ceiling "$BENCH_RESULTS_FILE" "$1" "$2" "$3"
 }
 
 check_average_ceiling() {
-  local section="$1"
-  local tests="$2"
-  local max="$3"
-  local ratio
-  ratio=$(python3 - "$BENCH_RESULTS_FILE" "$section" "$tests" <<'PYEOF'
-import sys
-path, section, tests = sys.argv[1], sys.argv[2], sys.argv[3].split()
-wanted = set(tests)
-ratios = []
-with open(path) as f:
-    for line in f:
-        cols = line.rstrip("\n").split("\t")
-        if len(cols) < 4 or cols[0] != section or cols[1] not in wanted:
-            continue
-        baseline, candidate = int(cols[2]), int(cols[3])
-        if baseline > 0 and candidate >= 0:
-            ratios.append(candidate / baseline)
-if len(ratios) == len(wanted):
-    print(f"{sum(ratios) / len(ratios):.2f}")
-PYEOF
-)
-  if [ -z "$ratio" ]; then
-    echo "FAIL: $section average is missing valid timings" >&2
-    return 1
-  fi
-  if python3 -c "r=$ratio; raise SystemExit(0 if r>$max else 1)"; then
-    echo "FAIL: $section average = ${ratio}x (ceiling: ${max}x)" >&2
-    return 1
-  fi
-  return 0
+  python3 "$BENCH_REPORT_SCRIPT" average "$BENCH_RESULTS_FILE" "$1" "$2" "$3"
 }
 
 benchmark_copy_results() {

--- a/test/lib/sysbench_report.py
+++ b/test/lib/sysbench_report.py
@@ -1,0 +1,81 @@
+import sys
+from collections import defaultdict
+
+
+def median(values):
+    valid = sorted(int(value) for value in values if int(value) >= 0)
+    return valid[len(valid) // 2] if valid else -1
+
+
+def section_report(path, section, tests, results):
+    samples = defaultdict(lambda: ([], []))
+    with open(path) as stream:
+        for line in stream:
+            _, test, _, baseline, candidate = line.rstrip("\n").split("\t")
+            samples[test][0].append(baseline)
+            samples[test][1].append(candidate)
+    ratio_sum = 0
+    ratio_count = 0
+    with open(results, "a") as stream:
+        for test in tests.split():
+            baseline, candidate = (median(values) for values in samples[test])
+            baseline_display = f"{baseline:,}" if baseline >= 0 else "crash"
+            candidate_display = f"{candidate:,}" if candidate >= 0 else "crash"
+            ratio = "--"
+            if baseline > 0 and candidate >= 0:
+                ratio = f"{candidate / baseline:.2f}"
+                ratio_sum += candidate / baseline
+                ratio_count += 1
+            stream.write(f"{section}\t{test}\t{baseline}\t{candidate}\n")
+            print(f"| {test} | {baseline_display} | {candidate_display} | {ratio} |")
+    average = f"{ratio_sum / ratio_count:.2f}" if ratio_count else "--"
+    print(f"| Average |  |  | {average} |")
+    return 0
+
+
+def ceiling(path, section, tests, maximum):
+    rows = {}
+    with open(path) as stream:
+        for line in stream:
+            cols = line.rstrip("\n").split("\t")
+            if len(cols) >= 4 and cols[0] == section:
+                rows.setdefault(cols[1], cols[2:4])
+    failed = 0
+    for test in tests.split():
+        try:
+            baseline, candidate = map(int, rows.get(test, ("", "")))
+        except ValueError:
+            baseline = candidate = -1
+        if baseline <= 0 or candidate < 0:
+            print(f"FAIL: {section}/{test} did not produce valid timings", file=sys.stderr)
+            failed = 1
+        elif candidate / baseline > float(maximum):
+            print(f"FAIL: {section}/{test} = {candidate / baseline:.2f}x (ceiling: {maximum}x)", file=sys.stderr)
+            failed = 1
+    return failed
+
+
+def average_ceiling(path, section, tests, maximum):
+    wanted = set(tests.split())
+    ratios = []
+    with open(path) as stream:
+        for line in stream:
+            cols = line.rstrip("\n").split("\t")
+            if len(cols) < 4 or cols[0] != section or cols[1] not in wanted:
+                continue
+            baseline, candidate = int(cols[2]), int(cols[3])
+            if baseline > 0 and candidate >= 0:
+                ratios.append(candidate / baseline)
+    if len(ratios) != len(wanted):
+        print(f"FAIL: {section} average is missing valid timings", file=sys.stderr)
+        return 1
+    ratio = f"{sum(ratios) / len(ratios):.2f}"
+    if float(ratio) > float(maximum):
+        print(f"FAIL: {section} average = {ratio}x (ceiling: {maximum}x)", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    commands = {"section": section_report, "ceiling": ceiling, "average": average_ceiling}
+    sys.exit(commands[sys.argv[1]](*sys.argv[2:]))

--- a/test/run_sqllogictest.sh
+++ b/test/run_sqllogictest.sh
@@ -10,26 +10,6 @@ DIVERGENCE_FILE="${4:-$SCRIPT_DIR/known_sqllogictest_divergences.txt}"
 
 PER_FILE_TIMEOUT=300
 
-expected_for() {
-  local rel="$1"
-  [ -f "$DIVERGENCE_FILE" ] || return 0
-  awk -v f="$rel" '
-    { sub(/#.*/, ""); gsub(/^[ \t]+|[ \t]+$/, "")
-      if ($0 == "") next
-      if ($1 == f) print $2 }
-  ' "$DIVERGENCE_FILE"
-}
-
-listed_files() {
-  [ -f "$DIVERGENCE_FILE" ] || return 0
-  awk '{ sub(/#.*/, ""); gsub(/^[ \t]+|[ \t]+$/, ""); if ($0=="") next; print $1 }' "$DIVERGENCE_FILE" | sort -u
-}
-
-tokens() {
-  timeout "$PER_FILE_TIMEOUT" "$1" --verify "$2" 2>&1 \
-    | grep -oE '!DIVERGE [0-9]+' | awk '{print $2}' | LC_ALL=C sort -u
-}
-
 mapfile -t TEST_FILES < <(find "$TESTDIR" -name '*.test' -type f | sort)
 if [ ${#TEST_FILES[@]} -eq 0 ]; then
   echo "ERROR: No .test files found under $TESTDIR"
@@ -44,88 +24,6 @@ echo "Test files:      ${#TEST_FILES[@]}"
 echo "Divergence list: $DIVERGENCE_FILE ($(grep -cvE '^[[:space:]]*(#|$)' "$DIVERGENCE_FILE" 2>/dev/null || echo 0) entries)"
 echo ""
 
-n_files=0
-n_div_files=0
-total_div=0
-total_unexpected=0
-total_fixed=0
-total_crash=0
-unexpected_lines=""
-fixed_lines=""
-crash_lines=""
-
-seen_file_list=""
-
-for f in "${TEST_FILES[@]}"; do
-  rel="${f#"$TESTDIR"/}"
-  n_files=$((n_files + 1))
-  seen_file_list="$seen_file_list$rel"$'\n'
-
-  dl_out=$(timeout "$PER_FILE_TIMEOUT" "$DOLTLITE_RUNNER" --verify "$f" 2>&1) && dl_rc=0 || dl_rc=$?
-  if [ "$dl_rc" -eq 124 ] || ! echo "$dl_out" | grep -q 'errors out of'; then
-    echo "CRASH/TIMEOUT: $rel (doltlite rc=$dl_rc)"
-    total_crash=$((total_crash + 1))
-    crash_lines="$crash_lines"$'\n'"  $rel (rc=$dl_rc)"
-    continue
-  fi
-  dl=$(echo "$dl_out" | grep -oE '!DIVERGE [0-9]+' | awk '{print $2}' | LC_ALL=C sort -u)
-  st=$(tokens "$STOCK_RUNNER" "$f")
-
-  divg=$(comm -23 <(printf '%s\n' "$dl" | grep -v '^$') <(printf '%s\n' "$st" | grep -v '^$'))
-  exp=$(expected_for "$rel" | LC_ALL=C sort -u)
-
-  [ -z "$divg" ] && [ -z "$exp" ] && continue
-
-  unexpected=$(comm -23 <(printf '%s\n' "$divg" | grep -v '^$') <(printf '%s\n' "$exp" | grep -v '^$'))
-  fixed=$(comm -13 <(printf '%s\n' "$divg" | grep -v '^$') <(printf '%s\n' "$exp" | grep -v '^$'))
-
-  n_div=$(printf '%s\n' "$divg" | grep -c .)
-  n_unexp=$(printf '%s\n' "$unexpected" | grep -c .)
-  n_fix=$(printf '%s\n' "$fixed" | grep -c .)
-  total_div=$((total_div + n_div))
-  [ "$n_div" -gt 0 ] && n_div_files=$((n_div_files + 1))
-
-  if [ "$n_unexp" -eq 0 ] && [ "$n_fix" -eq 0 ]; then
-    [ "$n_div" -gt 0 ] && echo "OK: $rel ($n_div known divergences)"
-  else
-    if [ "$n_unexp" -gt 0 ]; then
-      echo "FAIL: $rel — unexpected divergences (not in list):"
-      printf '%s\n' "$unexpected" | grep . | sed 's/^/    line /'
-      total_unexpected=$((total_unexpected + n_unexp))
-      while IFS= read -r ln; do [ -n "$ln" ] && unexpected_lines="$unexpected_lines"$'\n'"  $rel $ln"; done <<< "$unexpected"
-    fi
-    if [ "$n_fix" -gt 0 ]; then
-      echo "FIXED: $rel — listed entries that no longer diverge (remove from list):"
-      printf '%s\n' "$fixed" | grep . | sed 's/^/    line /'
-      total_fixed=$((total_fixed + n_fix))
-      while IFS= read -r ln; do [ -n "$ln" ] && fixed_lines="$fixed_lines"$'\n'"  $rel $ln"; done <<< "$fixed"
-    fi
-  fi
-done
-
-while IFS= read -r lf; do
-  [ -z "$lf" ] && continue
-  if ! printf '%s' "$seen_file_list" | grep -Fxq -- "$lf"; then
-    echo "STALE: $lf is in the divergence list but not present in the corpus"
-    n=$(expected_for "$lf" | grep -c .)
-    total_fixed=$((total_fixed + n))
-    fixed_lines="$fixed_lines"$'\n'"  $lf (file missing, $n entries)"
-  fi
-done < <(listed_files)
-
-echo ""
-echo "============================================"
-echo "  files:                  $n_files"
-echo "  files with divergences: $n_div_files"
-echo "  known divergences:      $total_div"
-if [ "$total_unexpected" -gt 0 ] || [ "$total_crash" -gt 0 ] || [ "$total_fixed" -gt 0 ]; then
-  [ "$total_unexpected" -gt 0 ] && { echo "  UNEXPECTED divergences:  $total_unexpected$unexpected_lines"; }
-  [ "$total_crash" -gt 0 ]      && { echo "  crashes/timeouts:        $total_crash$crash_lines"; }
-  [ "$total_fixed" -gt 0 ]      && { echo "  list entries to remove:  $total_fixed$fixed_lines"; }
-  echo "============================================"
-  echo "::error::sqllogictest divergence gate failed (unexpected=$total_unexpected, crashes=$total_crash, to-remove=$total_fixed)"
-  exit 1
-fi
-echo "============================================"
-echo "OK: all doltlite divergences are accounted for in the allow-list."
-exit 0
+exec python3 "$SCRIPT_DIR/sqllogictest_gate.py" \
+  "$DOLTLITE_RUNNER" "$STOCK_RUNNER" "$TESTDIR" "$DIVERGENCE_FILE" \
+  "$PER_FILE_TIMEOUT" "${TEST_FILES[@]}"

--- a/test/sqllogictest_gate.py
+++ b/test/sqllogictest_gate.py
@@ -1,0 +1,91 @@
+import re
+import subprocess
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+
+def run(runner, path, timeout):
+    try:
+        result = subprocess.run(["timeout", timeout, runner, "--verify", path],
+                                stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    except OSError as error:
+        return str(error).encode(), 127 if isinstance(error, FileNotFoundError) else 126
+    rc = result.returncode
+    return result.stdout, rc if rc >= 0 else 128 - rc
+
+
+def tokens(output):
+    return set(re.findall(rb"!DIVERGE ([0-9]+)", output))
+
+
+def main():
+    doltlite, stock, directory, manifest, timeout, *files = sys.argv[1:]
+    expected = defaultdict(list)
+    if Path(manifest).is_file():
+        for line in Path(manifest).read_bytes().splitlines():
+            cols = line.split(b"#", 1)[0].split()
+            if cols:
+                expected[cols[0].decode()].append(cols[1] if len(cols) > 1 else b"")
+    n_div_files = total_div = 0
+    unexpected_lines, fixed_lines, crash_lines = [], [], []
+    total_fixed = 0
+    seen = set()
+    for path in files:
+        rel = path.removeprefix(directory + "/")
+        seen.add(rel)
+        output, rc = run(doltlite, path, timeout)
+        if rc == 124 or b"errors out of" not in output:
+            print(f"CRASH/TIMEOUT: {rel} (doltlite rc={rc})")
+            crash_lines.append(f"  {rel} (rc={rc})")
+            continue
+        stock_output, _ = run(stock, path, timeout)
+        divergences = tokens(output) - tokens(stock_output)
+        exp = set(expected[rel]) - {b""}
+        unexpected, fixed = divergences - exp, exp - divergences
+        total_div += len(divergences)
+        n_div_files += bool(divergences)
+        if not unexpected and not fixed:
+            if divergences:
+                print(f"OK: {rel} ({len(divergences)} known divergences)")
+            continue
+        if unexpected:
+            print(f"FAIL: {rel} — unexpected divergences (not in list):")
+            for line in sorted(unexpected):
+                number = line.decode()
+                print(f"    line {number}")
+                unexpected_lines.append(f"  {rel} {number}")
+        if fixed:
+            print(f"FIXED: {rel} — listed entries that no longer diverge (remove from list):")
+            for line in sorted(fixed):
+                number = line.decode()
+                print(f"    line {number}")
+                fixed_lines.append(f"  {rel} {number}")
+            total_fixed += len(fixed)
+    for rel in sorted(expected.keys() - seen):
+        print(f"STALE: {rel} is in the divergence list but not present in the corpus")
+        count = sum(bool(line) for line in expected[rel])
+        total_fixed += count
+        fixed_lines.append(f"  {rel} (file missing, {count} entries)")
+    print("\n============================================")
+    print(f"  files:                  {len(files)}")
+    print(f"  files with divergences: {n_div_files}")
+    print(f"  known divergences:      {total_div}")
+    if unexpected_lines or crash_lines or total_fixed:
+        if unexpected_lines:
+            print(f"  UNEXPECTED divergences:  {len(unexpected_lines)}\n" + "\n".join(unexpected_lines))
+        if crash_lines:
+            print(f"  crashes/timeouts:        {len(crash_lines)}\n" + "\n".join(crash_lines))
+        if total_fixed:
+            print(f"  list entries to remove:  {total_fixed}\n" + "\n".join(fixed_lines))
+        print("============================================")
+        print(f"::error::sqllogictest divergence gate failed (unexpected={len(unexpected_lines)}, crashes={len(crash_lines)}, to-remove={total_fixed})")
+        return 1
+    print("============================================")
+    print("OK: all doltlite divergences are accounted for in the allow-list.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.stdout.reconfigure(line_buffering=True)
+    sys.exit(main())

--- a/test/sqllogictest_gate_test.py
+++ b/test/sqllogictest_gate_test.py
@@ -1,0 +1,90 @@
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+
+
+script = Path(__file__).with_name("sqllogictest_gate.py")
+runner = '''#!/usr/bin/env python3
+import json, os, pathlib, sys
+_, limit, binary, verify, path = sys.argv
+assert limit == '300' and verify == '--verify'
+with open(os.environ['CALLS'], 'a') as stream:
+    stream.write(f'{binary} {pathlib.Path(path).name}\\n')
+output, rc = json.loads(pathlib.Path(path).read_text())[binary]
+print(output, file=sys.stderr)
+sys.exit(rc)
+'''
+cases = [
+    ("pass", "", ("0 errors out of 2 tests", 0), ("0 errors out of 2 tests", 0), 0, []),
+    ("stock-only", "", ("0 errors out of 2 tests", 0), ("!DIVERGE 7", 1), 0, []),
+    ("known", "case.test 7\ncase.test 7 # duplicate\n", ("!DIVERGE 7\n1 errors out of 2 tests", 1), ("", 0), 0,
+     ["OK: case.test (1 known divergences)"]),
+    ("unexpected", "", ("!DIVERGE 2 !DIVERGE 10 !DIVERGE 2\n2 errors out of 3 tests", 1), ("", 0), 1,
+     ["    line 10\n    line 2", "unexpected=2, crashes=0, to-remove=0"]),
+    ("fixed", "case.test 7\n", ("0 errors out of 2 tests", 0), ("", 0), 1,
+     ["FIXED: case.test", "unexpected=0, crashes=0, to-remove=1"]),
+    ("mixed", "case.test 7\ncase.test 8\n", ("!DIVERGE 7 !DIVERGE 9\n2 errors out of 2 tests", 1), ("", 0), 1,
+     ["    line 9", "    line 8", "unexpected=1, crashes=0, to-remove=1"]),
+    ("timeout", "case.test 7\n", ("!DIVERGE 7\n1 errors out of 2 tests", 124), ("", 0), 1,
+     ["CRASH/TIMEOUT: case.test (doltlite rc=124)", "unexpected=0, crashes=1, to-remove=0"]),
+    ("crash", "", ("segmentation fault", 139), ("", 0), 1,
+     ["CRASH/TIMEOUT: case.test (doltlite rc=139)"]),
+    ("missing-summary", "", ("!DIVERGE 1", 0), ("", 0), 1,
+     ["CRASH/TIMEOUT: case.test (doltlite rc=0)"]),
+    ("stock-timeout", "", ("!DIVERGE 1\n1 errors out of 2 tests", 1), ("!DIVERGE 1", 124), 0, []),
+    ("stale", "missing.test 4\nmissing.test 4\nmissing.test 8\n", ("0 errors out of 2 tests", 0), ("", 0), 1,
+     ["missing.test (file missing, 3 entries)", "to-remove=3"]),
+    ("comments", "  # comment\n\tcase.test\t7 # reason\n\n", ("!DIVERGE 7\n1 errors out of 2 tests", 1), ("", 0), 0, []),
+    ("leading-zero", "case.test 07\n", ("!DIVERGE 7\n1 errors out of 2 tests", 1), ("", 0), 1,
+     ["    line 7", "    line 07", "unexpected=1, crashes=0, to-remove=1"]),
+    ("missing-manifest", None, ("0 errors out of 2 tests", 0), ("", 0), 0, []),
+]
+
+
+def main():
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        (root / "timeout").write_text(runner)
+        (root / "timeout").chmod(0o755)
+        corpus = root / "corpus with spaces"
+        corpus.mkdir()
+        path = corpus / "case.test"
+        manifest, calls = root / "manifest", root / "calls"
+        env = dict(os.environ, PATH=f"{root}:{os.environ['PATH']}", CALLS=str(calls))
+        for name, expected, dl, st, rc, needles in cases:
+            path.write_text(json.dumps({"doltlite": dl, "stock": st}))
+            manifest.unlink(missing_ok=True)
+            calls.unlink(missing_ok=True)
+            if expected is not None:
+                manifest.write_text(expected)
+            result = subprocess.run([sys.executable, str(script), "doltlite", "stock",
+                                     str(corpus), str(manifest), "300", str(path)],
+                                    env=env, capture_output=True, text=True, timeout=10)
+            assert result.returncode == rc, (name, result)
+            for needle in needles:
+                assert needle in result.stdout, (name, needle, result.stdout)
+            wanted = ["doltlite case.test"]
+            if dl[1] != 124 and "errors out of" in dl[0]:
+                wanted.append("stock case.test")
+            assert calls.read_text().splitlines() == wanted, name
+        second = corpus / "second.test"
+        third = corpus / "third.test"
+        path.write_text(json.dumps({"doltlite": ("!DIVERGE 3\n1 errors out of 2 tests", 1), "stock": ("", 0)}))
+        second.write_text(json.dumps({"doltlite": ("!DIVERGE 5\n1 errors out of 2 tests", 1), "stock": ("", 0)}))
+        third.write_text(json.dumps({"doltlite": ("crashed", 139), "stock": ("", 0)}))
+        manifest.write_text("case.test 3\nsecond.test 7\nmissing.test 8\nmissing.test 8\n")
+        result = subprocess.run([sys.executable, str(script), "doltlite", "stock",
+                                 str(corpus), str(manifest), "300", str(path), str(second), str(third)],
+                                env=env, capture_output=True, text=True, timeout=10)
+        assert result.returncode == 1, result
+        for needle in ("files:                  3", "files with divergences: 2",
+                       "known divergences:      2", "unexpected=1, crashes=1, to-remove=3"):
+            assert needle in result.stdout, result.stdout
+    print(f"SQLLogicTest gate: {len(cases) + 1} classification and invocation checks passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/sysbench_harness_test.py
+++ b/test/sysbench_harness_test.py
@@ -1,0 +1,91 @@
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+
+
+helper = Path(__file__).resolve().parent / "lib/sysbench_benchmark.sh"
+script = r'''
+set -eu
+TMPDIR="$WORK"
+SQLITE3=sqlite DOLTLITE=doltlite BENCH_TIMER_SQLITE=timer BENCH_TIMER_DOLTLITE=timer
+BENCH_RUNS=4 BENCH_AC_WRITE_RUNS=3
+source "$HELPER"
+run_bench() {
+  local count=0 id="$1" test="${5##*/}"
+  test="${test%.sql}"
+  if [ -e "$TMPDIR/$id-$test.count" ]; then read -r count < "$TMPDIR/$id-$test.count"; fi
+  count=$((count+1))
+  echo "$count" > "$TMPDIR/$id-$test.count"
+  printf '%s %s %s %s\n' "$id" "$test" "$count" "$6" >> "$TMPDIR/calls"
+  case "$test/$id" in
+    even/baseline) set -- 1000 4000 3000 2000 ;;
+    even/candidate) set -- 8000 2000 4000 6000 ;;
+    invalid/baseline) set -- -1 10 -2 30 ;;
+    invalid/candidate) set -- -1 -1 -1 -1 ;;
+    zero/baseline) set -- 0 0 0 0 ;;
+    zero/candidate) set -- 10 20 30 40 ;;
+    rounded_ac/baseline) set -- 200 200 200 ;;
+    rounded_ac/candidate) set -- 301 301 301 ;;
+  esac
+  shift $((count-1))
+  echo "$1"
+}
+run_section mem 'even invalid zero' :memory: :memory:
+run_section ac 'rounded_ac' baseline.db candidate.db
+check_ceiling mem 'even invalid zero absent' 2 || echo 'individual failed'
+check_ceiling ac rounded_ac 1.50 || echo 'rounding individual failed'
+check_average_ceiling ac rounded_ac 1.50 || echo 'rounding average failed'
+check_average_ceiling ac rounded_ac 1.49 || echo 'average failed'
+check_average_ceiling mem 'even invalid zero absent' 2 || echo 'missing average failed'
+'''
+expected_report = '''| Test | SQLite (us) | DoltLite (us) | Multiplier |
+|------|------------:|--------------:|-----------:|
+| even | 3,000 | 6,000 | 2.00 |
+| invalid | 30 | crash | -- |
+| zero | 0 | 30 | -- |
+| Average |  |  | 2.00 |
+| Test | SQLite (us) | DoltLite (us) | Multiplier |
+|------|------------:|--------------:|-----------:|
+| rounded_ac | 200 | 301 | 1.50 |
+| Average |  |  | 1.50 |
+individual failed
+rounding individual failed
+average failed
+missing average failed
+'''
+expected_errors = '''FAIL: mem/invalid did not produce valid timings
+FAIL: mem/zero did not produce valid timings
+FAIL: mem/absent did not produce valid timings
+FAIL: ac/rounded_ac = 1.50x (ceiling: 1.50x)
+FAIL: ac average = 1.50x (ceiling: 1.49x)
+FAIL: mem average is missing valid timings
+'''
+
+
+def main():
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        result = subprocess.run(["bash", "-c", script], text=True, capture_output=True,
+                                env=dict(os.environ, WORK=tmp, HELPER=str(helper)), timeout=30)
+        assert result.returncode == 0, result
+        assert result.stdout == expected_report, result.stdout
+        assert result.stderr == expected_errors, result.stderr
+        assert (root / "bench_results.tsv").read_text() == (
+            "mem\teven\t3000\t6000\nmem\tinvalid\t30\t-1\nmem\tzero\t0\t30\nac\trounded_ac\t200\t301\n")
+        calls = []
+        for test, count in (("even", 4), ("invalid", 4), ("zero", 4), ("rounded_ac", 3)):
+            for i in range(1, count + 1):
+                for side in (("baseline", "candidate") if i % 2 else ("candidate", "baseline")):
+                    db = f"{side}.db" if test.endswith("_ac") else ":memory:"
+                    calls.append(f"{side} {test} {i} {db}")
+        assert (root / "calls").read_text().splitlines() == calls
+        samples = (root / "bench_samples.tsv").read_text().splitlines()
+        assert len(samples) == 16 and samples[0] == "section\ttest\trun\tbaseline_us\tcandidate_us"
+        assert samples[1:5] == [f"mem\teven\t{i}\t{b}\t{c}" for i, b, c in
+                                 ((1, 1000, 8000), (2, 4000, 2000), (3, 3000, 4000), (4, 2000, 6000))]
+    print("Sysbench harness: medians, reports, samples, pairing and ceiling checks passed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
CI repeatedly builds the development scheduler and PR-base benchmark binaries, starts short-lived parsers for each test/result, and transfers benchmark files that consumers never use. This removes that overhead within the existing job buckets.

- Run the development build scheduler with `tclsh` and the packaged SQLite Tcl extension, preserving all four All-O0 and six All-Debug configurations.
- Classify SQLLogicTest output in one Python process and load the divergence manifest once. Preserve runner order, per-file timeouts, and unexpected/fixed/stale divergence and crash handling.
- Batch benchmark medians, formatting, ratios and ceiling calculations by section. Preserve paired invocation order, sample counts, invalid timing handling, rounding, thresholds and report/TSV contents.
- Package only the four benchmark executables and two SHA files. Give the report job a separate metadata artifact while retaining its provenance checks.
- Cache validated PR-base benchmark executables by resolved base SHA, build recipe, compiler/linker identities, dependencies, flags, architecture and runner image. Build the candidate every time, rebuild the base on a cache miss, and check the saved compiler log on cache hits.

Validation:

- Ubuntu scheduler dry runs produced identical build scripts and commands for all ten development configurations.
- 54 old/new SQLLogicTest comparisons matched output, exit status and runner calls exactly; 15 permanent classification/aggregation checks pass.
- All four benchmark suites produced identical reports, results, samples and 754 timer calls each with deterministic timers at the unchanged 5/9 sample counts. Separate checks cover even medians, invalid/zero samples, missing timings, pairing and threshold rounding.
- A clean Ubuntu optimized build passed all four suites with real executables (69 small-data measurements each). Archive checks preserve executable bytes/permissions; 22 cache identity/failure checks and 12 build failure/warning/archive checks pass.
- Existing CI optimization, comparison/retry/report policy tests, orphan-suite guard and actionlint pass. Full corpus and performance gates run in CI.

Local measurements: benchmark suite Python startups fell from 421 to 7 (including SQL generation), saving roughly 10–11 seconds per suite with database execution stubbed out. The Ubuntu sample archive shrank from 111.5 MB to 37.0 MB, and the report now downloads only two SHA files. These are local measurements; net GitHub runner savings, including cache transfer costs, remain to be measured.

Co-Authored-By: OpenAI Codex <noreply@openai.com>
