### PR TITLE
Fix interactive rebase commit message semantics

### DIFF
--- a/doc/doltlite/dolt_rebase.md
+++ b/doc/doltlite/dolt_rebase.md
@@ -30,9 +30,12 @@ transaction like `dolt_commit`.
 ## The plan table
 
 `dolt_rebase(rebase_order REAL PRIMARY KEY, action TEXT, commit_hash TEXT,
-commit_message TEXT)` exists only during an interactive rebase. Edit it with
-ordinary SQL: `action` is `pick`, `drop`, `reword`, `squash`, or `fixup`;
-change `commit_message` to reword, `rebase_order` to reorder. The first
+commit_message TEXT NOT NULL)` exists only during an interactive rebase.
+Edit it with ordinary SQL: `action` is `pick`, `drop`, `reword`, `squash`, or `fixup`;
+set `action` to `reword` and change `commit_message` to edit a message,
+or change `rebase_order` to reorder. `pick` and `squash` use the original
+commit messages; `fixup` keeps the preceding message. An empty reword
+message also keeps the original message. NULL messages are rejected. The first
 non-drop action must be `pick` or `reword`. While the plan is open the
 connection sits on a working branch named `dolt_rebase_<branch>`.
 

--- a/src/doltlite_rebase.c
+++ b/src/doltlite_rebase.c
@@ -709,7 +709,7 @@ static int doltliteValidateRebasePlanTable(sqlite3 *db, char **pzErr){
       "rebase_order REAL PRIMARY KEY, "
       "action TEXT, "
       "commit_hash TEXT, "
-      "commit_message TEXT)");
+      "commit_message TEXT NOT NULL)");
   }
   return SQLITE_CONSTRAINT;
 }
@@ -748,6 +748,10 @@ static int rebaseReadPlan(sqlite3 *db, RebasePlanRow **paPlan, int *pnPlan){
     RebasePlanRow *r;
     const char *zHex;
 
+    if( sqlite3_column_type(pStmt, 3)==SQLITE_NULL ){
+      rc = SQLITE_CONSTRAINT_NOTNULL;
+      goto fail;
+    }
     if( nPlan >= nAlloc ){
       int nNew = nAlloc ? nAlloc*2 : 16;
       RebasePlanRow *tmp = sqlite3_realloc(aPlan, nNew*(int)sizeof(RebasePlanRow));
@@ -857,7 +861,7 @@ static int rebaseWritePlanRows(
     "  rebase_order REAL PRIMARY KEY,"
     "  action TEXT,"
     "  commit_hash TEXT,"
-    "  commit_message TEXT"
+    "  commit_message TEXT NOT NULL"
     ")", 0, 0, 0);
   if( rc!=SQLITE_OK ) return rc;
 
@@ -931,7 +935,7 @@ static int rebaseCreateAndPopulatePlanTable(
     "  rebase_order REAL PRIMARY KEY,"
     "  action TEXT,"
     "  commit_hash TEXT,"
-    "  commit_message TEXT"
+    "  commit_message TEXT NOT NULL"
     ")", 0, 0, 0);
   if( rc!=SQLITE_OK ) return rc;
 
@@ -968,6 +972,7 @@ static int rebaseApplyPlanRowCatalog(
   const RebasePlanRow *pRow,
   const ProllyHash *pCurCat,
   ProllyHash *pMergedCat,
+  char **pzMessage,
   char **pzErr
 ){
   DoltliteCommit parentC, replayC;
@@ -975,6 +980,7 @@ static int rebaseApplyPlanRowCatalog(
   int nViolations = 0;
   int rc;
 
+  *pzMessage = 0;
   memset(&parentC, 0, sizeof(parentC));
   memset(&replayC, 0, sizeof(replayC));
 
@@ -1011,11 +1017,20 @@ static int rebaseApplyPlanRowCatalog(
     rc = doltliteDetectConstraintViolationsFiltered(
         db, &parentC.catalogHash, 0, 0, 1, &nViolations, pzErr);
   }
+  if( rc==SQLITE_OK && (nConflicts>0 || nViolations>0) ){
+    rc = SQLITE_CONSTRAINT;
+  }
+  if( rc==SQLITE_OK ){
+    const char *zMessage = replayC.zMessage;
+    if( strcmp(pRow->zAction, "reword")==0 && pRow->zCommitMessage[0] ){
+      zMessage = pRow->zCommitMessage;
+    }
+    *pzMessage = sqlite3_mprintf("%s", zMessage ? zMessage : "");
+    if( !*pzMessage ) rc = SQLITE_NOMEM;
+  }
   doltliteCommitClear(&parentC);
   doltliteCommitClear(&replayC);
-  if( rc!=SQLITE_OK ) return rc;
-  if( nConflicts>0 || nViolations>0 ) return SQLITE_CONSTRAINT;
-  return SQLITE_OK;
+  return rc;
 }
 
 static void (*rebaseBeforeAdvanceHook)(void) = 0;
@@ -1072,36 +1087,34 @@ static int rebaseReplayPlanGroup(
 
   startCat = *pCurCat;
   rc = rebaseApplyPlanRowCatalog(
-      db, &aPlan[iStart], pCurCat, pCurCat, pzErr);
+      db, &aPlan[iStart], pCurCat, pCurCat, &combinedMsg, pzErr);
   if( rc!=SQLITE_OK ) return rc;
-
-  combinedMsg = sqlite3_mprintf("%s",
-      aPlan[iStart].zCommitMessage ? aPlan[iStart].zCommitMessage : "");
-  if( !combinedMsg ) return SQLITE_NOMEM;
 
   j = iStart + 1;
   while( j < nPlan
       && (strcmp(aPlan[j].zAction, "squash")==0
        || strcmp(aPlan[j].zAction, "fixup")==0
        || strcmp(aPlan[j].zAction, "drop")==0) ){
+    char *zMessage = 0;
     if( strcmp(aPlan[j].zAction, "drop")==0 ){
       j++;
       continue;
     }
 
-    rc = rebaseApplyPlanRowCatalog(db, &aPlan[j], pCurCat, pCurCat, pzErr);
+    rc = rebaseApplyPlanRowCatalog(
+        db, &aPlan[j], pCurCat, pCurCat, &zMessage, pzErr);
     if( rc!=SQLITE_OK ){
       sqlite3_free(combinedMsg);
       return rc;
     }
 
     if( strcmp(aPlan[j].zAction, "squash")==0 ){
-      char *zNew = sqlite3_mprintf("%s\n\n%s", combinedMsg,
-                                   aPlan[j].zCommitMessage ? aPlan[j].zCommitMessage : "");
+      char *zNew = sqlite3_mprintf("%s\n\n%s", combinedMsg, zMessage);
       sqlite3_free(combinedMsg);
       combinedMsg = zNew;
-      if( !combinedMsg ) return SQLITE_NOMEM;
     }
+    sqlite3_free(zMessage);
+    if( !combinedMsg ) return SQLITE_NOMEM;
     j++;
   }
 
@@ -1826,6 +1839,11 @@ static void doltliteRebaseInteractiveContinue(
   }
 
   rc = rebaseReadPlan(db, &aPlan, &nPlan);
+  if( rc==SQLITE_CONSTRAINT_NOTNULL ){
+    sqlite3_result_error(context,
+      "dolt_rebase.commit_message must not be NULL", -1);
+    goto abort_err_silent;
+  }
   if( rc!=SQLITE_OK ) goto abort_err;
 
   /* Unknown plan verbs (typos in dolt_rebase.action) are not silent picks.

--- a/test/doltlite_rebase_messages.test
+++ b/test/doltlite_rebase_messages.test
@@ -1,0 +1,112 @@
+set testdir [file dirname $argv0]
+source $testdir/tester.tcl
+
+proc rebase_message_setup {} {
+  reset_db
+  execsql {
+    CREATE TABLE t(id INTEGER PRIMARY KEY);
+    INSERT INTO t VALUES(0);
+    SELECT dolt_commit('-Am', 'init');
+    SELECT dolt_checkout('-b', 'feat');
+    INSERT INTO t VALUES(1);
+    SELECT dolt_commit('-am', 'f1');
+    INSERT INTO t VALUES(2);
+    SELECT dolt_commit('-am', 'f2');
+    INSERT INTO t VALUES(3);
+    SELECT dolt_commit('-am', 'f3');
+    SELECT dolt_checkout('main');
+    INSERT INTO t VALUES(10);
+    SELECT dolt_commit('-am', 'main');
+    SELECT dolt_checkout('feat');
+    SELECT dolt_rebase('-i', 'main');
+  }
+}
+
+foreach {name plan expected} {
+  pick {
+    UPDATE dolt_rebase SET commit_message = 'ignored';
+  } {f3 f2 f1 main init}
+  squash {
+    UPDATE dolt_rebase SET commit_message = 'ignored';
+    UPDATE dolt_rebase SET action = 'squash' WHERE rebase_order = 2;
+  } {f3 {f1
+
+f2} main init}
+  reword_squash_fixup {
+    UPDATE dolt_rebase SET commit_message = 'ignored';
+    UPDATE dolt_rebase SET action = 'reword', commit_message = 'rewritten'
+      WHERE rebase_order = 1;
+    UPDATE dolt_rebase SET action = 'squash' WHERE rebase_order = 2;
+    UPDATE dolt_rebase SET action = 'fixup' WHERE rebase_order = 3;
+  } {{rewritten
+
+f2} main init}
+  empty {
+    UPDATE dolt_rebase SET commit_message = '';
+    UPDATE dolt_rebase SET action = 'reword' WHERE rebase_order = 1;
+  } {f3 f2 f1 main init}
+} {
+  rebase_message_setup
+  do_test rebase-messages-$name {
+    execsql $plan
+    execsql {SELECT dolt_rebase('--continue')}
+    execsql {SELECT message FROM dolt_log WHERE message NOT LIKE 'Initialize%'}
+  } $expected
+  do_execsql_test rebase-messages-$name-rows {
+    SELECT id FROM t ORDER BY id;
+  } {0 1 2 3 10}
+}
+
+rebase_message_setup
+do_test rebase-messages-hash {
+  set first [db one {SELECT commit_hash FROM dolt_rebase WHERE rebase_order=1}]
+  set third [db one {SELECT commit_hash FROM dolt_rebase WHERE rebase_order=3}]
+  db eval {UPDATE dolt_rebase SET commit_hash=$third WHERE rebase_order=1}
+  db eval {UPDATE dolt_rebase SET commit_hash=$first WHERE rebase_order=3}
+  execsql {SELECT dolt_rebase('--continue')}
+  execsql {SELECT message FROM dolt_log WHERE message NOT LIKE 'Initialize%'}
+} {f1 f2 f3 main init}
+
+rebase_message_setup
+do_catchsql_test rebase-messages-null-update {
+  UPDATE dolt_rebase SET commit_message = CASE rebase_order
+    WHEN 2 THEN NULL ELSE 'changed' END;
+} {1 {NOT NULL constraint failed: dolt_rebase.commit_message}}
+do_execsql_test rebase-messages-null-update-atomic {
+  SELECT commit_message FROM dolt_rebase ORDER BY rebase_order;
+} {f1 f2 f3}
+do_catchsql_test rebase-messages-null-insert {
+  INSERT INTO dolt_rebase SELECT 4, 'pick', commit_hash, NULL
+    FROM dolt_rebase WHERE rebase_order=1;
+} {1 {NOT NULL constraint failed: dolt_rebase.commit_message}}
+do_test rebase-messages-null-continue {
+  execsql {SELECT dolt_rebase('--continue')}
+  execsql {SELECT message FROM dolt_log WHERE message NOT LIKE 'Initialize%'}
+} {f3 f2 f1 main init}
+
+rebase_message_setup
+execsql {
+  CREATE TEMP TABLE saved_plan AS SELECT * FROM dolt_rebase;
+  DROP TABLE dolt_rebase;
+  CREATE TABLE dolt_rebase(rebase_order REAL PRIMARY KEY,
+    action TEXT, commit_hash TEXT, commit_message TEXT);
+  INSERT INTO dolt_rebase SELECT * FROM saved_plan;
+  DROP TABLE saved_plan;
+  UPDATE dolt_rebase SET commit_message=NULL WHERE rebase_order=2;
+}
+do_catchsql_test rebase-messages-legacy-null {
+  SELECT dolt_rebase('--continue');
+} {1 {dolt_rebase.commit_message must not be NULL}}
+do_execsql_test rebase-messages-legacy-plan-retained {
+  SELECT count(*) FROM dolt_rebase;
+  SELECT count(*) FROM dolt_branches WHERE name='dolt_rebase_feat';
+} {3 1}
+do_test rebase-messages-legacy-repair {
+  execsql {
+    UPDATE dolt_rebase SET commit_message='ignored' WHERE rebase_order=2;
+    SELECT dolt_rebase('--continue');
+  }
+  execsql {SELECT message FROM dolt_log WHERE message NOT LIKE 'Initialize%'}
+} {f3 f2 f1 main init}
+
+finish_test

--- a/test/regression-buckets/ported.txt
+++ b/test/regression-buckets/ported.txt
@@ -46,3 +46,4 @@ doltlite_recover_changes
 doltlite_gc_stop_world
 doltlite_reload_uncommitted_recent
 doltlite_recover_cacheflush_oom
+doltlite_rebase_messages

--- a/test/vc_oracle_rebase_test.sh
+++ b/test/vc_oracle_rebase_test.sh
@@ -690,6 +690,32 @@ UPDATE dolt_rebase SET action = 'fixup' WHERE commit_message = 'f3';
 SELECT dolt_rebase('--continue');
 " "SELECT CONCAT('LOG|', message) FROM dolt_log;"
 
+for action in pick reword squash fixup; do
+  oracle "interactive_${action}_edited_plan_message" "
+$INTERACTIVE_SETUP
+SELECT dolt_rebase('-i', 'main');
+UPDATE dolt_rebase SET commit_message = 'ignored';
+UPDATE dolt_rebase SET action = '$action', commit_message = 'edited'
+  WHERE rebase_order = 2;
+SELECT dolt_rebase('--continue');
+" "SELECT CONCAT('LOG|', REPLACE(message, CHAR(10), ' | ')) FROM dolt_log;"
+done
+
+oracle "interactive_empty_reword_message" "
+$INTERACTIVE_SETUP
+SELECT dolt_rebase('-i', 'main');
+UPDATE dolt_rebase SET action = 'reword', commit_message = ''
+  WHERE rebase_order = 1;
+SELECT dolt_rebase('--continue');
+" "SELECT CONCAT('LOG|', message) FROM dolt_log;"
+
+oracle_error_reopen "interactive_null_message_update" "
+$INTERACTIVE_SETUP
+SELECT dolt_rebase('-i', 'main');
+UPDATE dolt_rebase SET commit_message = NULL WHERE rebase_order = 1;
+" "SELECT dolt_checkout('dolt_rebase_feat');
+SELECT CONCAT('LOG|', commit_message) FROM dolt_rebase ORDER BY rebase_order;"
+
 LONG_INTERACTIVE_SETUP="
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
 INSERT INTO t VALUES (1, 1);


### PR DESCRIPTION
Interactive rebase treated edits to any plan row's `commit_message` as a reword and converted NULL messages to empty strings. Replay now uses the referenced commit's message for `pick` and `squash`; `fixup` retains the preceding message, and only a nonempty `reword` overrides it.

New plan tables reject NULL messages on INSERT/UPDATE. Older nullable plans remain readable, but NULL messages fail validation before replay and leave the plan available for repair and retry. Empty reword messages retain the original message, matching Dolt 2.3.1 rather than the issue's suggested empty-string rejection. The documentation now describes these rules.

Validation: the new testfixture regression had 12 failures before the fix and passes all 17 checks afterward, with no memory leaks. It covers action-specific messages, edited commit hashes, atomic NULL rejection, and repair of older nullable plans. All 62 Dolt rebase oracle cases pass, including six new comparisons against Dolt 2.3.1. The full native runner passes all 132 suites; `make lint` and the orphan-suite guard pass.

Fixes #2796

Co-Authored-By: OpenAI Codex <noreply@openai.com>
