### PR TITLE
Accept --author on dolt_revert

### DIFF
--- a/doc/doltlite/dolt_cherry_pick.md
+++ b/doc/doltlite/dolt_cherry_pick.md
@@ -10,6 +10,7 @@ branch. Dolt:
 ```sql
 SELECT dolt_cherry_pick('0123abcd...');
 SELECT dolt_revert('HEAD');
+SELECT dolt_revert('HEAD', '--author', 'Ann <ann@example.com>');
 BEGIN;
 SELECT dolt_cherry_pick(dolt_hashof('feature'));   -- error: conflicts, inspect dolt_conflicts
 SELECT dolt_cherry_pick('--abort');
@@ -42,10 +43,16 @@ inside `BEGIN`. A completed cherry-pick ends the enclosing SQL transaction.
 message `Revert "<original message>"` and returns the new hash. One commit at
 a time; the initial commit cannot be reverted. Conflicts behave like a merge.
 
+| Argument | Meaning |
+|---|---|
+| `commit` | One commit [revision](refs.md) to invert onto `HEAD` |
+| `--author 'Name <email>'` | Override the committer for the revert commit |
+
 | Error | Cause |
 |---|---|
 | `Your local changes would be overwritten by revert.` (with a hint to commit first) | dirty working set |
 | `invalid commit hash` | does not resolve |
+| `Author not formatted correctly. Use 'Name <author@example.com>' format` | bad `--author` |
 
 ## Differences from Dolt
 

--- a/src/doltlite_cherry_pick.c
+++ b/src/doltlite_cherry_pick.c
@@ -139,6 +139,8 @@ int applyMergedCatalogAndCommit(
   const ProllyHash *ourHead,
   const ProllyHash *pCommitOurCatHash,
   const char *zMessage,
+  const char *zAuthorName,
+  const char *zAuthorEmail,
   int bPreferOurMaster,
   int bRejectUnchanged,
   int *pnConflicts,
@@ -326,7 +328,7 @@ int applyMergedCatalogAndCommit(
   }
 
   rc = doltliteCreateAndStoreCommit(db, ourHead, &commitCatHash,
-      zMessage, NULL, NULL, NULL, 0, &commitHash);
+      zMessage, zAuthorName, zAuthorEmail, NULL, 0, &commitHash);
   if( rc!=SQLITE_OK ) goto apply_rollback;
 
   rc = doltliteCompareAndAdvanceBranch(
@@ -469,7 +471,7 @@ static void doltliteCherryPickFunc(
 
     rc = applyMergedCatalogAndCommit(db, context,
         &parentCommit.catalogHash, &ourCommit.catalogHash,
-        &pickCommit.catalogHash, &ourHead, 0, zMsg, 0, 1, &nConflicts, 0,
+        &pickCommit.catalogHash, &ourHead, 0, zMsg, 0, 0, 0, 1, &nConflicts, 0,
         &zApplyErr, hexBuf);
   }
 

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -1621,6 +1621,8 @@ int applyMergedCatalogAndCommit(
   const ProllyHash *ourHead,
   const ProllyHash *pCommitOurCatHash,
   const char *zMessage,
+  const char *zAuthorName,
+  const char *zAuthorEmail,
   int bPreferOurMaster,
   int bRejectUnchanged,
   int *pnConflicts,

--- a/src/doltlite_rebase.c
+++ b/src/doltlite_rebase.c
@@ -493,7 +493,7 @@ static int doltliteRebaseLinearReplay(
         &replayCommit.catalogHash,
         &curHead, 0,
         replayCommit.zMessage ? replayCommit.zMessage : "",
-        0, 1, &nConflicts, &nViolations, &zApplyErr, hexBuf);
+        0, 0, 0, 1, &nConflicts, &nViolations, &zApplyErr, hexBuf);
 
     doltliteCommitClear(&replayCommit);
     doltliteCommitClear(&parentCommit);

--- a/src/doltlite_revert.c
+++ b/src/doltlite_revert.c
@@ -135,6 +135,12 @@ static void doltliteRevertFunc(
   sqlite3 *db = sqlite3_context_db_handle(context);
   ChunkStore *cs = doltliteGetChunkStore(db);
   const char *zRef;
+  const char *zAuthor = 0;
+  char *zParsedName = 0, *zParsedEmail = 0;
+  DoltliteCmdArgs args;
+  DoltliteCmdOption aOption[] = {
+    { "author", 0, DOLTLITE_CMD_OPTION_VALUE, 0, &zAuthor }
+  };
   ProllyHash revertHash, ourHead;
   ProllyHash liveOurCatalog;
   DoltliteCommit revertCommit, parentCommit, ourCommit;
@@ -154,30 +160,42 @@ static void doltliteRevertFunc(
     sqlite3_result_int(context, 0);
     return;
   }
-  if( argc>1 ){
-    char *zErr = sqlite3_mprintf("branch not found: %s",
-        (const char*)sqlite3_value_text(argv[1]));
-    if( zErr ){
-      sqlite3_result_error(context, zErr, -1);
-      sqlite3_free(zErr);
-    }else{
-      sqlite3_result_error_nomem(context);
-    }
-    return;
-  }
 
-  if( sqlite3_value_type(argv[0])==SQLITE_NULL ){
-    sqlite3_result_error(context, "invalid commit hash", -1);
+  rc = doltliteCmdParseArgs(context, argc, argv, aOption, ArraySize(aOption),
+                            0, &args);
+  if( rc!=SQLITE_OK ) return;
+  if( args.nPositional!=1 ){
+    int nPos = args.nPositional;
+    doltliteCmdArgsClear(&args);
+    sqlite3_result_error(context,
+      nPos>1
+        ? "reverting multiple commits is not supported yet."
+        : "nothing specified to revert",
+      -1);
     return;
   }
-  zRef = (const char*)sqlite3_value_text(argv[0]);
-  if( !zRef ){
-    sqlite3_result_error_nomem(context);
-    return;
+  zRef = args.azPositional[0];
+  if( zAuthor ){
+    rc = doltliteCmdParseAuthor(context, zAuthor, &zParsedName, &zParsedEmail);
+    if( rc!=SQLITE_OK ){
+      doltliteCmdArgsClear(&args);
+      return;
+    }
+    if( !zParsedEmail || zParsedEmail[0]==0 ){
+      sqlite3_free(zParsedName);
+      sqlite3_free(zParsedEmail);
+      doltliteCmdArgsClear(&args);
+      sqlite3_result_error(context,
+        "Aborting commit due to empty author email. Is your config set?", -1);
+      return;
+    }
   }
+  doltliteCmdArgsClear(&args);
 
   rc = doltliteResolveRef(db,zRef, &revertHash);
   if( rc!=SQLITE_OK ){
+    sqlite3_free(zParsedName);
+    sqlite3_free(zParsedEmail);
     doltliteCmdReportInvalidCommitHash(context, cs, rc);
     return;
   }
@@ -188,6 +206,8 @@ static void doltliteRevertFunc(
   if( doltliteCmdReportLoadParentedCommitError(
         context, cs, rc, &revertCommit, &parentCommit, &ourCommit,
         "cannot revert the initial commit") ){
+    sqlite3_free(zParsedName);
+    sqlite3_free(zParsedEmail);
     return;
   }
 
@@ -201,6 +221,8 @@ static void doltliteRevertFunc(
       doltliteCommitClear(&revertCommit);
       doltliteCommitClear(&parentCommit);
       doltliteCommitClear(&ourCommit);
+      sqlite3_free(zParsedName);
+      sqlite3_free(zParsedEmail);
       sqlite3_result_error(context,
         "Your local changes would be overwritten by revert.\n"
         "hint: Please commit your changes before you revert.", -1);
@@ -221,13 +243,16 @@ static void doltliteRevertFunc(
 
     rc = applyMergedCatalogAndCommit(db, context,
         &revertCommit.catalogHash, &liveOurCatalog,
-        &parentCommit.catalogHash, &ourHead, pCommitOurs, msg, 1, 1,
+        &parentCommit.catalogHash, &ourHead, pCommitOurs, msg,
+        zParsedName, zParsedEmail, 1, 1,
         &nConflicts, 0, &zApplyErr, hexBuf);
   }
 
   doltliteCommitClear(&revertCommit);
   doltliteCommitClear(&parentCommit);
   doltliteCommitClear(&ourCommit);
+  sqlite3_free(zParsedName);
+  sqlite3_free(zParsedEmail);
 
   doltliteCmdFinishApplyMerged(
       context, cs, rc, nConflicts, zApplyErr, "revert", zRef,
@@ -239,6 +264,8 @@ revert_error:
   doltliteCommitClear(&revertCommit);
   doltliteCommitClear(&parentCommit);
   doltliteCommitClear(&ourCommit);
+  sqlite3_free(zParsedName);
+  sqlite3_free(zParsedEmail);
   if( !doltliteCmdSourceResultError(context, cs, &rc) ){
     char *zMsg = sqlite3_mprintf("revert of \"%s\" failed", zRef);
     sqlite3_result_error(context, zMsg ? zMsg : "revert failed", -1);

--- a/test/doltlite_cherry_pick.sh
+++ b/test/doltlite_cherry_pick.sh
@@ -312,6 +312,46 @@ run_test_match "rv_err_badhash" "SELECT dolt_revert('bad');" "invalid" "$DB"
 run_test_match "rv_err_initial" \
   "SELECT dolt_revert((SELECT commit_hash FROM dolt_log WHERE message='Initialize data repository'));" \
   "initial commit" "$DB"
+run_test_match "rv_author_bad" \
+  "SELECT dolt_revert('HEAD','--author','not-an-author');" \
+  "Author not formatted correctly" "$DB"
+run_test_match "rv_author_empty_email" \
+  "SELECT dolt_revert('HEAD','--author','Ann <>');" \
+  "empty author email" "$DB"
+
+rm -f "$DB"
+
+DB=/tmp/test_rv_author_$$.db; rm -f "$DB"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'a');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c1');
+INSERT INTO t VALUES(2,'b');
+SELECT dolt_commit('-am','c2');" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+run_test_match "rv_author_hash" \
+  "SELECT dolt_revert('HEAD','--author','Ann <ann@x.com>');" \
+  "^[0-9a-f]{40}$" "$DB"
+run_test "rv_author_committer" "SELECT committer FROM dolt_log LIMIT 1;" "Ann" "$DB"
+run_test "rv_author_email" "SELECT email FROM dolt_log LIMIT 1;" "ann@x.com" "$DB"
+run_test "rv_author_message" "SELECT message FROM dolt_log LIMIT 1;" "Revert \"c2\"" "$DB"
+run_test "rv_author_count" "SELECT count(*) FROM t;" "1" "$DB"
+
+rm -f "$DB"
+
+DB=/tmp/test_rv_author_first_$$.db; rm -f "$DB"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'a');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c1');
+INSERT INTO t VALUES(2,'b');
+SELECT dolt_commit('-am','c2');" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+run_test_match "rv_author_first_hash" \
+  "SELECT dolt_revert('--author','Ann <ann@x.com>','HEAD');" \
+  "^[0-9a-f]{40}$" "$DB"
+run_test "rv_author_first_committer" "SELECT committer FROM dolt_log LIMIT 1;" "Ann" "$DB"
+run_test "rv_author_first_count" "SELECT count(*) FROM t;" "1" "$DB"
 
 rm -f "$DB"
 

--- a/test/vc_oracle_revert_test.sh
+++ b/test/vc_oracle_revert_test.sh
@@ -178,6 +178,24 @@ SELECT CONCAT('L|', message) FROM dolt_log
   WHERE message IN ('schema', 'add row') OR message LIKE 'Revert%';
 "
 
+oracle_state "revert_author_override" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1, 'a');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+INSERT INTO t VALUES(2, 'b');
+SELECT dolt_commit('-am', 'c2');
+SELECT dolt_revert('HEAD', '--author', 'Ann <ann@x.com>');
+" "
+SELECT 'L|' || committer || '|' || coalesce(email, '') || '|' || message
+  FROM dolt_log LIMIT 1;
+SELECT 'C|' || count(*) FROM t;
+" "
+SELECT CONCAT('L|', committer, '|', coalesce(email, ''), '|', message)
+  FROM dolt_log LIMIT 1;
+SELECT CONCAT('C|', count(*)) FROM t;
+"
+
 echo ""
 echo "======================================="
 echo "Results: $pass passed, $fail failed"


### PR DESCRIPTION
## Summary
`dolt_revert` treated any second argument as a missing branch, so `SELECT dolt_revert('HEAD','--author','Ann <ann@x.com>')` failed with `branch not found: --author`. Dolt 2.3.1 accepts `--author` and records that identity on the revert commit.

- Parse flags with `doltliteCmdParseArgs` and an `author` string option.
- Pass name/email through `applyMergedCatalogAndCommit` into the revert commit.
- Document `--author` on revert in `doc/doltlite/dolt_cherry_pick.md`.

## Validation
Fail-before (`build/doltlite` on master): `SELECT dolt_revert('HEAD','--author','Ann <ann@x.com>')` → `branch not found: --author`; log still `doltlite||c2` / 2 rows.

Pass-after:
- Issue repro: `Ann|ann@x.com|Revert "c2"` / 1 row
- `DOLTLITE=build/doltlite bash test/doltlite_cherry_pick.sh` → 150/150
- `DOLTLITE=build/doltlite bash test/doltlite_revert_dirty.sh` → 42/42
- `bash test/vc_oracle_revert_test.sh build/doltlite dolt` → 7/7 vs Dolt 2.3.1
- `bash test/oracle_doc_examples_test.sh build/doltlite ignored dolt_cherry_pick.md` → PASS

`dolt_revert()` with no arguments still returns `0`.

Fixes #2799

Co-Authored-By: Grok 4.6 <noreply@x.ai>