### PR TITLE
Match the dolt_diff table_name filter exactly

### DIFF
--- a/src/doltlite_diff.c
+++ b/src/doltlite_diff.c
@@ -370,8 +370,8 @@ static int diffFilteredTableRoots(
   if( !pCur->zFilterTable ) return SQLITE_OK;
   if( strcmp(pCur->zFilterTable, "dolt_schemas")==0 ) return SQLITE_NOTFOUND;
 
-  rc = doltliteLoadTableRootByName(db, pChildCat, pCur->zFilterTable,
-                                   &childRoot, 0, &childSchema);
+  rc = doltliteLoadTableRootByNameExact(db, pChildCat, pCur->zFilterTable,
+                                       &childRoot, 0, &childSchema);
   if( rc==SQLITE_NOTFOUND ){
     rc = doltliteVtabMapChunkSourceError(pCur->base.pVtab, db, rc, SQLITE_OK);
     if( rc!=SQLITE_OK ) return rc;
@@ -385,8 +385,8 @@ static int diffFilteredTableRoots(
     memset(&childSchema, 0, sizeof(childSchema));
   }
 
-  rc = doltliteLoadTableRootByName(db, pParentCat, pCur->zFilterTable,
-                                   &parentRoot, 0, &parentSchema);
+  rc = doltliteLoadTableRootByNameExact(db, pParentCat, pCur->zFilterTable,
+                                       &parentRoot, 0, &parentSchema);
   if( rc==SQLITE_NOTFOUND ){
     rc = doltliteVtabMapChunkSourceError(pCur->base.pVtab, db, rc, SQLITE_OK);
     if( rc!=SQLITE_OK ) return rc;
@@ -415,8 +415,8 @@ static int diffFilteredTableRoots(
       doltliteFreeCatalog(aChild, nChild);
       return rc;
     }
-    e = diffFindTableByNameNoCase(aChild,nChild,pCur->zFilterTable);
-    p = diffFindTableByNameNoCase(aParent,nParent,pCur->zFilterTable);
+    e = doltliteFindTableByName(aChild,nChild,pCur->zFilterTable);
+    p = doltliteFindTableByName(aParent,nParent,pCur->zFilterTable);
     if( e && !p ){
       pRen = diffRenamePartner(aParent,nParent,e,aChild,nChild);
       if( pRen ){

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -835,6 +835,15 @@ int doltliteLoadTableRootByName(
   ProllyHash *pSchemaHash
 );
 
+int doltliteLoadTableRootByNameExact(
+  sqlite3 *db,
+  const ProllyHash *pCatHash,
+  const char *zTableName,
+  ProllyHash *pRoot,
+  u8 *pFlags,
+  ProllyHash *pSchemaHash
+);
+
 int doltliteLoadTableRootById(
   sqlite3 *db,
   const ProllyHash *pCatHash,

--- a/src/prolly_btree_catalog.c
+++ b/src/prolly_btree_catalog.c
@@ -2246,10 +2246,11 @@ int doltliteLoadCatalog(sqlite3 *db, const ProllyHash *catHash,
   return SQLITE_OK;
 }
 
-int doltliteLoadTableRootByName(
+static int catalogLoadTableRootByName(
   sqlite3 *db,
   const ProllyHash *pCatHash,
   const char *zTableName,
+  int bExact,
   ProllyHash *pRoot,
   u8 *pFlags,
   ProllyHash *pSchemaHash
@@ -2326,7 +2327,8 @@ int doltliteLoadTableRootByName(
       if( !found
        && nType==5 && memcmp(pType, "table", 5)==0
        && nName==nWant
-       && sqlite3_strnicmp((const char*)pName, zTableName, nName)==0 ){
+       && (bExact ? memcmp(pName, zTableName, (size_t)nName)==0
+                  : sqlite3_strnicmp((const char*)pName, zTableName, nName)==0) ){
         found = 1;
         memcpy(&foundRoot, &root, sizeof(foundRoot));
         memcpy(&foundSchemaHash, &schemaHash, sizeof(foundSchemaHash));
@@ -2348,7 +2350,8 @@ int doltliteLoadTableRootByName(
       pName = q;
       q += nLen;
       if( !found && nLen==nWant
-       && sqlite3_strnicmp((const char*)pName, zTableName, nLen)==0 ){
+       && (bExact ? memcmp(pName, zTableName, (size_t)nLen)==0
+                  : sqlite3_strnicmp((const char*)pName, zTableName, nLen)==0) ){
         found = 1;
         memcpy(&foundRoot, &root, sizeof(foundRoot));
         memcpy(&foundSchemaHash, &schemaHash, sizeof(foundSchemaHash));
@@ -2367,6 +2370,33 @@ int doltliteLoadTableRootByName(
   if( pFlags ) *pFlags = foundFlags;
   if( pSchemaHash ) memcpy(pSchemaHash, &foundSchemaHash, sizeof(*pSchemaHash));
   return SQLITE_OK;
+}
+
+/* Table-name arguments resolve case-insensitively, matching Dolt. */
+int doltliteLoadTableRootByName(
+  sqlite3 *db,
+  const ProllyHash *pCatHash,
+  const char *zTableName,
+  ProllyHash *pRoot,
+  u8 *pFlags,
+  ProllyHash *pSchemaHash
+){
+  return catalogLoadTableRootByName(db, pCatHash, zTableName, 0,
+                                    pRoot, pFlags, pSchemaHash);
+}
+
+/* For a filter on a table_name column, where the comparison the caller wrote
+** is an ordinary BINARY one and a case variant must not match. */
+int doltliteLoadTableRootByNameExact(
+  sqlite3 *db,
+  const ProllyHash *pCatHash,
+  const char *zTableName,
+  ProllyHash *pRoot,
+  u8 *pFlags,
+  ProllyHash *pSchemaHash
+){
+  return catalogLoadTableRootByName(db, pCatHash, zTableName, 1,
+                                    pRoot, pFlags, pSchemaHash);
 }
 
 int doltliteLoadTableRootById(

--- a/test/doltlite_diff.sh
+++ b/test/doltlite_diff.sh
@@ -298,6 +298,41 @@ run_test "status_table_added_does_not_list_untouched_view" \
   "SELECT group_concat(table_name||'|'||staged||'|'||status) FROM dolt_status;" \
   "later|0|new table" "$DB19"
 
-rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8" "$DB9" "$DB10" "$DB11" "$DB12" "$DB13" "$DB14" "$DB15" "$DB16" "$DB17" "$DB18" "$DB19"
+# table_name is an ordinary TEXT column, so a filter on it compares like any
+# other BINARY comparison and a case variant must not match. Table-name
+# *arguments* stay case-insensitive, matching Dolt, but report the catalog's
+# spelling rather than echoing what the caller typed.
+DB20=/tmp/test_diff_case_$$.db; rm -f "$DB20"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'a');
+SELECT dolt_commit('-Am','init');
+INSERT INTO t VALUES(2,'b');" | $DOLTLITE "$DB20" > /dev/null 2>&1
+
+run_test "diff_filter_exact_case_matches" \
+  "SELECT count(*) FROM dolt_diff WHERE table_name='t';" \
+  "2" "$DB20"
+run_test "diff_filter_wrong_case_matches_nothing" \
+  "SELECT count(*) FROM dolt_diff WHERE table_name='T';" \
+  "0" "$DB20"
+run_test "diff_filter_in_list_does_not_double" \
+  "SELECT count(*) FROM dolt_diff WHERE table_name IN ('T','t');" \
+  "2" "$DB20"
+run_test "diff_filter_never_invents_a_table" \
+  "SELECT count(*) FROM dolt_diff WHERE table_name NOT IN (SELECT name FROM sqlite_master WHERE type='table');" \
+  "0" "$DB20"
+# Dolt is inconsistent across these three and DoltLite matches it surface by
+# surface: dolt_diff_stat echoes the caller's spelling, while dolt_patch and
+# dolt_diff_summary report the catalog's. Verified against Dolt 2.3.3.
+run_test "diff_stat_arg_case_insensitive_echoes_caller" \
+  "SELECT table_name FROM dolt_diff_stat('HEAD','WORKING','T');" \
+  "T" "$DB20"
+run_test "diff_summary_arg_is_canonical" \
+  "SELECT to_table_name FROM dolt_diff_summary('HEAD','WORKING','T');" \
+  "t" "$DB20"
+run_test "patch_arg_is_canonical" \
+  "SELECT DISTINCT table_name FROM dolt_patch('HEAD','WORKING','T');" \
+  "t" "$DB20"
+
+rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8" "$DB9" "$DB10" "$DB11" "$DB12" "$DB13" "$DB14" "$DB15" "$DB16" "$DB17" "$DB18" "$DB19" "$DB20"
 
 dltest_finish


### PR DESCRIPTION
Fixes #2795.

The `dolt_diff` vtab resolved a `table_name` filter case-insensitively and then emitted the filter string as the row's `table_name`. The constraint is not omitted, so SQLite re-checks it, and the fabricated value always satisfied the very predicate that produced it.

```sql
SELECT table_name FROM dolt_diff;                              -- t, t
SELECT table_name FROM dolt_diff WHERE table_name='T';         -- T, T   (no such table)
SELECT count(*) FROM dolt_diff WHERE table_name IN ('T','t');  -- 4, not 2
```

The `IN` list doubles because SQLite loops the values, each iteration matches the same table, and each relabels it to that iteration's spelling.

`table_name` is an ordinary TEXT column, so a filter on it should compare like any other BINARY comparison, and `dolt_status` already behaves that way. The filter now resolves exactly, through a new `doltliteLoadTableRootByNameExact` and the existing case-sensitive catalog finder, so a case variant matches nothing and the emitted name is the one the catalog holds.

| query | before | after |
| --- | --- | --- |
| `WHERE table_name='t'` | 2 rows | 2 rows |
| `WHERE table_name='T'` | 2 rows labelled `T` | 0 rows |
| `IN ('T','t')` | 4 rows | 2 rows |
| rows naming a table not in the catalog | 2 | 0 |

## Table-name arguments are unchanged

Arguments stay case-insensitive, matching Dolt. I went further than the issue here, and then backed it out.

The issue also called out `dolt_diff_stat(...,'T')` echoing the caller's spelling as part of the same inconsistency. I canonicalized it, which broke the existing `filter_table_case_insensitive_stat` oracle case. Checking Dolt 2.3.3 directly settled it:

| filter passed | Dolt `dolt_diff_stat` | Dolt `dolt_patch` | Dolt `dolt_diff_summary` |
| --- | --- | --- | --- |
| `mixed` | `mixed` | `MiXeD` | `MiXeD` |
| `MiXeD` | `MiXeD` | `MiXeD` | `MiXeD` |
| `MIXED` | `MIXED` | `MiXeD` | `MiXeD` |

So `dolt_diff_stat` echoes while `dolt_patch` and `dolt_diff_summary` report the catalog's spelling. That is not self-consistent, but Dolt is the reference for these surfaces and DoltLite already matched it on all three. The echo is therefore not a bug, and I reverted that part rather than diverge. Worth noting on the issue when it closes.

## Evidence

Seven cases added to `test/doltlite_diff.sh`, covering exact match, wrong case, the `IN` list, that no row names a table absent from `sqlite_master`, and the per-surface argument rules above.

| build | result |
| --- | --- |
| without the fix | 3 of the new cases fail |
| with the fix | 57 passing in that suite |

Also green: 132 shell suites, all 35 gated C tests, `make lint`, and the whole diff family against Dolt 2.3.1 — diff 75, diff_stat 117, diff TVF 37, patch 90, multi-PK 30, schema_diff 67.

🤖 Generated with [Claude Code](https://claude.com/claude-code)