### PR TITLE
Keep interactive rebase plans after invalid commit hashes

### DIFF
--- a/doc/doltlite/dolt_rebase.md
+++ b/doc/doltlite/dolt_rebase.md
@@ -49,6 +49,7 @@ can be fixed and `--continue` retried. The working set must be clean to start.
 | `rebase already in progress; use --continue or --abort` | second `-i` |
 | `no rebase in progress` | `--continue`/`--abort` with no plan |
 | `first non-drop action must be pick or reword` | invalid plan |
+| `invalid commit hash: <hash>` | a plan hash does not resolve to a commit; repair the plan and retry |
 | `rebase aborted due to changes in branch <name>` | the current branch moved during the rebase |
 | `rebase aborted due to changes in the source branch` | the upstream moved during the rebase |
 

--- a/src/doltlite_rebase.c
+++ b/src/doltlite_rebase.c
@@ -1860,6 +1860,30 @@ static void doltliteRebaseInteractiveContinue(
     goto abort_err_silent;
   }
 
+  for(i=0; i<nPlan; i++){
+    DoltliteCommit commit;
+    memset(&commit, 0, sizeof(commit));
+    rc = doltliteLoadCommit(db, &aPlan[i].commitHash, &commit);
+    doltliteCommitClear(&commit);
+    if( rc!=SQLITE_OK ){
+      if( rc==SQLITE_NOTFOUND || rc==SQLITE_CORRUPT ){
+        char zHex[PROLLY_HASH_SIZE*2+1];
+        char *zMsg;
+        doltliteHashToHex(&aPlan[i].commitHash, zHex);
+        zMsg = sqlite3_mprintf("invalid commit hash: %s", zHex);
+        if( zMsg ){
+          sqlite3_result_error(context, zMsg, -1);
+          sqlite3_free(zMsg);
+        }else{
+          sqlite3_result_error_nomem(context);
+        }
+      }else{
+        sqlite3_result_error_code(context, rc);
+      }
+      goto abort_err_silent;
+    }
+  }
+
   /* Claim before replay so a concurrent --abort loses with "no rebase
   ** in progress" rather than both failing mid-recovery. */
   rc = rebaseRetryBranchOp(db, rebaseClaimActiveEnd, zWorking);

--- a/test/doltlite_rebase_plan_hash.test
+++ b/test/doltlite_rebase_plan_hash.test
@@ -1,0 +1,88 @@
+set testdir [file dirname $argv0]
+source $testdir/tester.tcl
+
+proc rebase_hash_setup {} {
+  reset_db
+  execsql {
+    CREATE TABLE t(id INTEGER PRIMARY KEY);
+    INSERT INTO t VALUES(0);
+    SELECT dolt_commit('-Am', 'init');
+    SELECT dolt_checkout('-b', 'feat');
+    INSERT INTO t VALUES(1);
+    SELECT dolt_commit('-am', 'f1');
+    INSERT INTO t VALUES(2);
+    SELECT dolt_commit('-am', 'f2');
+    SELECT dolt_checkout('main');
+    INSERT INTO t VALUES(10);
+    SELECT dolt_commit('-am', 'main');
+    SELECT dolt_checkout('feat');
+    SELECT dolt_rebase('-i', 'main');
+  }
+}
+
+foreach badhash {
+  0000000000000000000000000000000000000000
+  ffffffffffffffffffffffffffffffffffffffff
+  catalog
+} {
+  foreach {action messages rows} {
+    pick {f2 f1 main init} {0 1 2 10}
+    reword {f2 f1 main init} {0 1 2 10}
+    squash {{f1
+
+f2} main init} {0 1 2 10}
+    fixup {f1 main init} {0 1 2 10}
+    drop {f1 main init} {0 1 10}
+  } {
+    rebase_hash_setup
+    set invalid $badhash
+    if {$badhash eq "catalog"} {
+      set invalid [db one {SELECT dolt_hashof_catalog('main')}]
+    }
+    set feature [db one {SELECT dolt_hashof('feat')}]
+    set working [db one {SELECT dolt_hashof('HEAD')}]
+    set valid [db one {SELECT commit_hash FROM dolt_rebase WHERE rebase_order=2}]
+    db eval {
+      UPDATE dolt_rebase SET action=$action, commit_hash=$invalid
+        WHERE rebase_order=2;
+    }
+    set name rebase-plan-hash-$action-[string index $badhash 0]
+    do_catchsql_test $name-error {
+      SELECT dolt_rebase('--continue');
+    } [list 1 "invalid commit hash: $invalid"]
+    do_test $name-intact {
+      list [db one {SELECT active_branch()}] \
+           [db one {SELECT count(*) FROM dolt_rebase}] \
+           [expr {$feature eq [db one {SELECT dolt_hashof('feat')}]}] \
+           [expr {$working eq [db one {SELECT dolt_hashof('HEAD')}]}] \
+           [execsql {SELECT id FROM t ORDER BY id}]
+    } {dolt_rebase_feat 2 1 1 {0 10}}
+    do_test $name-repair {
+      db eval {UPDATE dolt_rebase SET commit_hash=$valid WHERE rebase_order=2}
+      execsql {SELECT dolt_rebase('--continue')}
+      execsql {SELECT message FROM dolt_log WHERE message NOT LIKE 'Initialize%'}
+    } $messages
+    do_execsql_test $name-rows {
+      SELECT id FROM t ORDER BY id;
+    } $rows
+  }
+}
+
+rebase_hash_setup
+set feature [db one {SELECT dolt_hashof('feat')}]
+execsql {
+  UPDATE dolt_rebase SET commit_hash='0000000000000000000000000000000000000000'
+    WHERE rebase_order=2;
+}
+do_catchsql_test rebase-plan-hash-abort-error {
+  SELECT dolt_rebase('--continue');
+} {1 {invalid commit hash: 0000000000000000000000000000000000000000}}
+do_test rebase-plan-hash-abort {
+  execsql {SELECT dolt_rebase('--abort')}
+  list [db one {SELECT active_branch()}] \
+       [expr {$feature eq [db one {SELECT dolt_hashof('HEAD')}]}] \
+       [db one {SELECT count(*) FROM dolt_branches WHERE name='dolt_rebase_feat'}] \
+       [execsql {SELECT id FROM t ORDER BY id}]
+} {feat 1 0 {0 1 2}}
+
+finish_test

--- a/test/regression-buckets/ported.txt
+++ b/test/regression-buckets/ported.txt
@@ -42,6 +42,7 @@ doltlite_vtab_column_collision
 doltlite_merge_constraint_prune
 doltlite_merge_generated
 doltlite_merge_ignored
+doltlite_rebase_plan_hash
 doltlite_recover_changes
 doltlite_gc_stop_world
 doltlite_reload_uncommitted_recent

--- a/test/vc_oracle_rebase_test.sh
+++ b/test/vc_oracle_rebase_test.sh
@@ -957,6 +957,29 @@ SELECT CONCAT('LOG|P|', count(*)) FROM dolt_branches WHERE name='dolt_rebase_fea
 SELECT CONCAT('LOG|T|', count(*)) FROM t;
 "
 
+for action in pick reword squash fixup drop; do
+  oracle_error_reopen "interactive_invalid_${action}_hash_repair" "
+$INTERACTIVE_SETUP
+SELECT dolt_rebase('-i', 'main');
+UPDATE dolt_rebase SET action='$action',
+  commit_hash=SUBSTR('0000000000000000000000000000000000000000',
+                     1, LENGTH(dolt_hashof('HEAD')))
+  WHERE rebase_order=2;
+SELECT dolt_rebase('--continue');
+" "
+SELECT dolt_checkout('dolt_rebase_feat');
+SELECT CONCAT('LOG|B|', active_branch());
+SELECT CONCAT('LOG|P|', count(*)) FROM dolt_rebase;
+SELECT CONCAT('LOG|BEFORE|', id) FROM t ORDER BY id;
+UPDATE dolt_rebase SET commit_hash=(
+  SELECT commit_hash FROM dolt_log('feat') WHERE message='f2'
+) WHERE rebase_order=2;
+SELECT dolt_rebase('--continue');
+SELECT CONCAT('LOG|M|', REPLACE(message, CHAR(10), ' | ')) FROM dolt_log;
+SELECT CONCAT('LOG|AFTER|', id) FROM t ORDER BY id;
+"
+done
+
 echo "--- rebase dissolves merge commits in range ---"
 
 MERGE_DISSOLVE_SETUP="


### PR DESCRIPTION
An unresolvable hash in an interactive rebase plan could cause `--continue` to claim the rebase, replay earlier rows, delete the plan, and abort. It now loads every planned commit before claiming the rebase, including rows marked `drop`, matching Dolt's plan validation.

Missing hashes and hashes referring to non-commit chunks report `invalid commit hash: <hash>`. The plan, working branch and branch heads remain intact so the user can repair and retry or abort. Other commit-loading errors retain their SQLite error codes and also leave the plan open.

Validation: the new regression reproduces the failure before the fix and passes all 63 checks afterward, with no memory leaks. It covers zero/nonzero missing hashes, catalog hashes, every action, unchanged heads and rows, repair/retry, and abort. All 61 Dolt rebase oracle cases pass, including five new cases that reopen and repair the plan against Dolt 2.3.1. All 132 native suites, `make lint`, and the orphan-suite guard pass.

Fixes #2797

Co-Authored-By: OpenAI Codex <noreply@openai.com>
