### PR TITLE
Document clustered PK index_xinfo and pin it in the pragma matrix

### DIFF
--- a/doc/doltlite/pragmas.md
+++ b/doc/doltlite/pragmas.md
@@ -38,7 +38,7 @@ versioned table like any other.
 | `integrity_check`, `quick_check` | Run SQLite's row and index checks, then walk the chunk graph of the named tables and of every branch, tag, and working set. Missing or corrupt chunks count as errors. |
 | `table_info`, `table_xinfo` | Non-integer primary key columns report `notnull=1`, because clustered keys are `NOT NULL`. |
 | `table_list` | A table with a non-integer primary key reports `wr=1`; it is stored like a `WITHOUT ROWID` table. |
-| `index_xinfo` | The automatic index of a non-integer primary key returns no rows: the key is the table, not a separate index. |
+| `index_xinfo` | The automatic index of a non-integer primary key lists every table column. Secondary indexes trail the PK columns as non-key entries instead of `rowid`. |
 | `writable_schema` | Accepted, but `sqlite_master` still refuses writes. The catalog is a projection, not a table. |
 | `schema_version` | Increments on every schema change. Assigning a value is ignored. |
 | `data_version` | Changes when another connection commits, as in SQLite. |

--- a/test/oracle_pragma_matrix_test.sh
+++ b/test/oracle_pragma_matrix_test.sh
@@ -51,9 +51,12 @@ else bad "pragmas.md names unknown pragmas" "$(echo "$extra" | tr '\n' ' ')"; fi
 SCHEMA="CREATE TABLE p(id INTEGER PRIMARY KEY, name TEXT NOT NULL, n INT CHECK(n>0));
 CREATE TABLE c(id INTEGER PRIMARY KEY AUTOINCREMENT, pid INT REFERENCES p(id), v TEXT);
 CREATE INDEX c_pid ON c(pid);
+CREATE TABLE npk(a INT, b TEXT, c REAL, PRIMARY KEY(a,b));
+CREATE INDEX npk_c ON npk(c);
 CREATE VIEW v AS SELECT * FROM p;
 INSERT INTO p VALUES(1,'a',1),(2,'b',2);
-INSERT INTO c(pid,v) VALUES(1,'x'),(2,'y');"
+INSERT INTO c(pid,v) VALUES(1,'x'),(2,'y');
+INSERT INTO npk VALUES(1,'a',1.5),(2,'b',2.5);"
 
 # Read, write, read again. Pragmas with no write form just read.
 stmts_for() {
@@ -118,10 +121,10 @@ stmts_for() {
     synchronous)        echo "PRAGMA synchronous; PRAGMA synchronous=OFF; PRAGMA synchronous;" ;;
     integrity_check)    echo "PRAGMA integrity_check; PRAGMA integrity_check(p);" ;;
     quick_check)        echo "PRAGMA quick_check;" ;;
-    table_info)         echo "PRAGMA table_info(p); PRAGMA table_info(c);" ;;
-    table_xinfo)        echo "PRAGMA table_xinfo(p);" ;;
-    table_list)         echo "SELECT schema, name, type, ncol, wr, strict FROM pragma_table_list WHERE name IN ('p','c') ORDER BY name;" ;;
-    index_xinfo)        echo "PRAGMA index_xinfo(c_pid);" ;;
+    table_info)         echo "PRAGMA table_info(p); PRAGMA table_info(c); PRAGMA table_info(npk);" ;;
+    table_xinfo)        echo "PRAGMA table_xinfo(p); PRAGMA table_xinfo(npk);" ;;
+    table_list)         echo "SELECT schema, name, type, ncol, wr, strict FROM pragma_table_list WHERE name IN ('p','c','npk') ORDER BY name;" ;;
+    index_xinfo)        echo "PRAGMA index_xinfo(c_pid); PRAGMA index_xinfo(sqlite_autoindex_npk_1); PRAGMA index_xinfo(npk_c);" ;;
     writable_schema)    echo "PRAGMA writable_schema; PRAGMA writable_schema=1; PRAGMA writable_schema;" ;;
     schema_version)     echo "PRAGMA schema_version=500; PRAGMA schema_version;" ;;
     data_store_directory|lock_proxy_file) echo "SELECT 'platform';" ;;
@@ -152,6 +155,35 @@ for prag in $same_list; do
   if [ "$st_dl" = 99 ] || [ "$st_sq" = 99 ]; then bad "same_$prag" "doltlite: $dl  stock: $sq"
   elif [ "$dl" = "$sq" ] && [ "$st_dl" = "$st_sq" ]; then ok "same_$prag"
   else bad "same_$prag" "doltlite(rc=$st_dl): $dl  stock(rc=$st_sq): $sq"; fi
+done
+
+# Same intent, DoltLite mechanics: clustered non-integer PK rows in pragmas.md.
+adapted_asserted=""
+expect_adapted() {  # expect_adapted <name> <sql> <expected-output-joined-by-|>
+  local got st
+  adapted_asserted="$adapted_asserted $1"
+  run_on "$DOLTLITE" "$TMPDIR/dl.db" "$2" "$TMPDIR/dl.out"; st=$?
+  got=$(tr '\n' '|' <"$TMPDIR/dl.out")
+  if [ "$st" = 0 ] && [ "$got" = "$3" ]; then ok "adapted_$1"
+  else bad "adapted_$1" "got $got (rc=$st) expected $3 (rc=0)"; fi
+}
+expect_adapted table_info \
+  "PRAGMA table_info(npk);" \
+  "0|a|INT|1||1|1|b|TEXT|1||2|2|c|REAL|0||0|"
+expect_adapted table_xinfo \
+  "PRAGMA table_xinfo(npk);" \
+  "0|a|INT|1||1|0|1|b|TEXT|1||2|0|2|c|REAL|0||0|0|"
+expect_adapted table_list \
+  "SELECT wr FROM pragma_table_list WHERE name='npk';" \
+  "1|"
+expect_adapted index_xinfo \
+  "PRAGMA index_xinfo(sqlite_autoindex_npk_1); PRAGMA index_xinfo(npk_c);" \
+  "0|0|a|0|BINARY|1|1|1|b|0|BINARY|1|2|2|c|0|BINARY|0|0|2|c|0|BINARY|1|1|0|a|0|BINARY|0|2|1|b|0|BINARY|0|"
+for need in table_info table_xinfo table_list index_xinfo; do
+  case " $adapted_asserted " in
+    *" $need "*) ;;
+    *) bad "adapted_$need" "clustered-PK row in pragmas.md has no assertion" ;;
+  esac
 done
 
 # Accepted and inert: DoltLite reads back the documented value and exits 0.


### PR DESCRIPTION
## Summary
`doc/doltlite/pragmas.md` said the automatic index of a non-integer primary key returns no rows. That is false: DoltLite clusters those tables like `WITHOUT ROWID`, so `index_xinfo` lists every table column, and secondary indexes trail the PK columns as non-key entries instead of `rowid`. The pragma matrix schema only had `INTEGER PRIMARY KEY` tables, so those adapted rows were never checked.

- Reword the `index_xinfo` row.
- Add composite-PK table `npk` plus `npk_c` to the matrix schema.
- Assert `table_info` / `table_xinfo` `notnull=1`, `table_list wr=1`, autoindex xinfo, and secondary PK trailers.

## Validation
Fail-before: `PRAGMA index_xinfo(sqlite_autoindex_t_1)` on `PRIMARY KEY(a,b)` returned three rows (`a`, `b`, `c`); the doc claimed none. The matrix never created such a table.

Pass-after: `bash test/oracle_pragma_matrix_test.sh build/doltlite build-stockref/sqlite3` → 64/64, including `adapted_table_info`, `adapted_table_xinfo`, `adapted_table_list`, `adapted_index_xinfo`.

Fixes #2804

Co-Authored-By: Grok 4.6 <noreply@x.ai>