### PR TITLE
Resolve conflicts for every named table

### DIFF
--- a/doc/doltlite/dolt_merge.md
+++ b/doc/doltlite/dolt_merge.md
@@ -60,7 +60,9 @@ commit with dolt_commit.` and the transaction stays open with:
 
 Resolve with `dolt_conflicts_resolve('--ours' | '--theirs', table, ...)`, or
 `DELETE FROM dolt_conflicts_<table> WHERE dolt_conflict_id = ...` to keep the
-working value (only `DELETE` is supported on conflict tables). Then
+working value (only `DELETE` is supported on conflict tables). One call can
+resolve several named tables; a missing table name rejects the call before
+any table is resolved. Existing tables without conflicts are ignored. Then
 `dolt_commit` records the merge commit. `COMMIT` with conflicts left fails
 with `constraint failed`; `dolt_commit` with `cannot commit: unresolved merge
 conflicts. Use dolt_conflicts_resolve() first.` Schema conflicts cannot be

--- a/doc/doltlite/transactions.md
+++ b/doc/doltlite/transactions.md
@@ -36,7 +36,7 @@ differently in the two modes:
 
 While conflicts remain, `dolt_commit` fails with `cannot commit: unresolved
 merge conflicts` and `COMMIT` fails with `constraint failed`. Resolve with
-`dolt_conflicts_resolve('--ours' | '--theirs', table)` or by editing
+`dolt_conflicts_resolve('--ours' | '--theirs', table, ...)` or by editing
 `dolt_conflicts_<table>`, then `dolt_commit` records the merge commit.
 Nothing conflicted is ever written to disk, so no other connection can see
 or inherit a half-finished merge. Dolt can commit a conflicted working set;

--- a/src/doltlite_conflicts.c
+++ b/src/doltlite_conflicts.c
@@ -1071,103 +1071,93 @@ static int conflictsResolveSealSuccessfulTopSavepoint(sqlite3 *db){
   return SQLITE_OK;
 }
 
-static void conflictsResolveFinishNoConflictTable(
-  sqlite3_context *ctx,
-  sqlite3 *db,
-  const char *zTable
-){
-  int tableExists = 0;
-  int rc;
-
-  rc = conflictsResolveTableExists(db, zTable, &tableExists);
-  if( rc!=SQLITE_OK ){
-    sqlite3_result_error_code(ctx, rc);
-    return;
-  }
-  if( tableExists ){
-    rc = conflictsResolveSealSuccessfulTopSavepoint(db);
-    if( rc!=SQLITE_OK ){
-      sqlite3_result_error_code(ctx, rc);
-      return;
-    }
-    sqlite3_result_int(ctx, 0);
-    return;
-  }
-  sqlite3_result_error(ctx, "table not found", -1);
-}
-
 static void conflictsResolveParsedFunc(
   sqlite3_context *ctx,
   int useOurs,
-  const char *zTable
+  int nTables,
+  const char **azTables
 ){
   sqlite3 *db = sqlite3_context_db_handle(ctx);
   ChunkStore *cs = doltliteGetChunkStore(db);
   ConflictTableInfo table;
   int found = 0;
-  int j, rc;
+  int needsSeal = 0;
+  int i, j, rc;
 
   if(!cs){ sqlite3_result_error(ctx,"no database",-1); return; }
 
-  rc = loadConflictTable(db, cs, zTable, &table, &found);
-  if( rc!=SQLITE_OK ){
-    sqlite3_result_error_code(ctx, rc);
-    return;
-  }
-  if( found && table.nConflicts==0 ){
-    freeConflictTable(&table);
-    sqlite3_result_error(ctx,
-      "Unable to automatically resolve schema conflicts since data changes "
-      "may not have been fully merged yet. Abort this merge, align the "
-      "schemas on one side, then rerun the merge.", -1);
-    return;
-  }
-  freeConflictTable(&table);
-  found = 0;
-
-  if( useOurs ){
-    rc = removeConflictTableFromCatalog(db, cs, zTable, &found);
+  for(i=0; i<nTables; i++){
+    int tableExists = 0;
+    rc = loadConflictTable(db, cs, azTables[i], &table, &found);
     if( rc!=SQLITE_OK ){
       sqlite3_result_error_code(ctx, rc);
       return;
     }
-    if( found ){
-      sqlite3_result_int(ctx, 0);
-    }else{
-      conflictsResolveFinishNoConflictTable(ctx, db, zTable);
-    }
-
-  }else{
-    rc = loadConflictTable(db, cs, zTable, &table, &found);
-    if( rc!=SQLITE_OK ){
-      sqlite3_result_error_code(ctx, rc);
-      return;
-    }
-
-    if( found ){
-      for(j=0; j<table.nConflicts; j++){
-        DoltliteConflictRow *cr = &table.aRows[j];
-        rc = doltliteApplyRawRowMutation(db, zTable,
-                                         cr->pKey, cr->nKey, cr->intKey,
-                                         cr->pTheirVal, cr->nTheirVal);
-        if( rc!=SQLITE_OK ){
-          freeConflictTable(&table);
-          sqlite3_result_error(ctx, "failed to apply theirs value", -1);
-          return;
-        }
-      }
+    if( found && table.nConflicts==0 ){
       freeConflictTable(&table);
-      rc = removeConflictTableFromCatalog(db, cs, zTable, &found);
+      sqlite3_result_error(ctx,
+        "Unable to automatically resolve schema conflicts since data changes "
+        "may not have been fully merged yet. Abort this merge, align the "
+        "schemas on one side, then rerun the merge.", -1);
+      return;
+    }
+    freeConflictTable(&table);
+    rc = conflictsResolveTableExists(db, azTables[i], &tableExists);
+    if( rc!=SQLITE_OK ){
+      sqlite3_result_error_code(ctx, rc);
+      return;
+    }
+    if( !tableExists ){
+      sqlite3_result_error(ctx, "table not found", -1);
+      return;
+    }
+  }
+
+  for(i=0; i<nTables; i++){
+    if( useOurs ){
+      rc = removeConflictTableFromCatalog(db, cs, azTables[i], &found);
       if( rc!=SQLITE_OK ){
         sqlite3_result_error_code(ctx, rc);
         return;
       }
-      sqlite3_result_int(ctx, 0);
     }else{
-      conflictsResolveFinishNoConflictTable(ctx, db, zTable);
+      rc = loadConflictTable(db, cs, azTables[i], &table, &found);
+      if( rc!=SQLITE_OK ){
+        sqlite3_result_error_code(ctx, rc);
+        return;
+      }
+      if( found ){
+        for(j=0; j<table.nConflicts; j++){
+          DoltliteConflictRow *cr = &table.aRows[j];
+          rc = doltliteApplyRawRowMutation(db, azTables[i],
+                                           cr->pKey, cr->nKey, cr->intKey,
+                                           cr->pTheirVal, cr->nTheirVal);
+          if( rc!=SQLITE_OK ){
+            freeConflictTable(&table);
+            sqlite3_result_error(ctx, "failed to apply theirs value", -1);
+            return;
+          }
+        }
+        freeConflictTable(&table);
+        rc = removeConflictTableFromCatalog(db, cs, azTables[i], &found);
+        if( rc!=SQLITE_OK ){
+          sqlite3_result_error_code(ctx, rc);
+          return;
+        }
+      }else{
+        freeConflictTable(&table);
+      }
     }
-
+    if( !found ) needsSeal = 1;
   }
+  if( needsSeal ){
+    rc = conflictsResolveSealSuccessfulTopSavepoint(db);
+    if( rc!=SQLITE_OK ){
+      sqlite3_result_error_code(ctx, rc);
+      return;
+    }
+  }
+  sqlite3_result_int(ctx, 0);
 }
 
 static void conflictsResolveFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
@@ -1183,13 +1173,13 @@ static void conflictsResolveFunc(sqlite3_context *ctx, int argc, sqlite3_value *
   rc = doltliteCmdParseArgs(ctx, argc, argv, aOption, ArraySize(aOption),
                             0, &args);
   if( rc!=SQLITE_OK ) return;
-  if( useOurs + useTheirs!=1 || args.nPositional!=1 ){
+  if( useOurs + useTheirs!=1 || args.nPositional<1 ){
     doltliteCmdArgsClear(&args);
     sqlite3_result_error(ctx,
-      "usage: dolt_conflicts_resolve('--ours'|'--theirs','table')", -1);
+      "usage: dolt_conflicts_resolve('--ours'|'--theirs','table',...)", -1);
     return;
   }
-  conflictsResolveParsedFunc(ctx, useOurs, args.azPositional[0]);
+  conflictsResolveParsedFunc(ctx, useOurs, args.nPositional, args.azPositional);
   doltliteCmdArgsClear(&args);
 }
 

--- a/test/doltlite_conflicts_multi.test
+++ b/test/doltlite_conflicts_multi.test
@@ -1,0 +1,103 @@
+set testdir [file dirname $argv0]
+source $testdir/tester.tcl
+
+proc conflicts_multi_setup {} {
+  reset_db
+  execsql {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+    CREATE TABLE u(id TEXT PRIMARY KEY, v TEXT);
+    CREATE TABLE w(id INTEGER PRIMARY KEY, v TEXT);
+    CREATE TABLE clean(id INTEGER PRIMARY KEY);
+    INSERT INTO t VALUES(1,'base');
+    INSERT INTO u VALUES('key','base');
+    INSERT INTO w VALUES(1,'base');
+    INSERT INTO clean VALUES(1);
+    SELECT dolt_commit('-Am','base');
+    SELECT dolt_checkout('-b','side');
+    UPDATE t SET v='side';
+    UPDATE u SET v='side';
+    UPDATE w SET v='side';
+    SELECT dolt_commit('-am','side');
+    SELECT dolt_checkout('main');
+    UPDATE t SET v='main';
+    UPDATE u SET v='main';
+    UPDATE w SET v='main';
+    SELECT dolt_commit('-am','main');
+    BEGIN;
+  }
+  set result [catchsql {SELECT dolt_merge('side')}]
+  if {[lindex $result 0] != 1 || [db one {SELECT count(*) FROM dolt_conflicts}] != 3} {
+    error "expected three merge conflicts: $result"
+  }
+}
+
+foreach {mode value} {ours main theirs side} {
+  set i 0
+  foreach tables { {'t','u'} {'u','t'} {'t','t','u'} {'clean','t','u'} {'t','u','clean'} } {
+    incr i
+    conflicts_multi_setup
+    execsql {SAVEPOINT before_resolve}
+    do_test conflicts-multi-$mode-$i-resolve {
+      execsql "SELECT dolt_conflicts_resolve('--$mode',$tables)"
+    } {0}
+    do_execsql_test conflicts-multi-$mode-$i-selected {
+      SELECT v FROM t;
+      SELECT v FROM u;
+      SELECT v FROM w;
+      SELECT "table" FROM dolt_conflicts;
+    } [list $value $value main w]
+    do_execsql_test conflicts-multi-$mode-$i-rollback {
+      ROLLBACK TO before_resolve;
+      SELECT v FROM t;
+      SELECT v FROM u;
+      SELECT v FROM w;
+      SELECT count(*) FROM dolt_conflicts;
+    } {main main main 3}
+    do_test conflicts-multi-$mode-$i-commit {
+      execsql "SELECT dolt_conflicts_resolve('--$mode',$tables,'w')"
+      execsql {SELECT dolt_commit('-Am','resolved')}
+      execsql {SELECT count(*) FROM dolt_conflicts; SELECT v FROM t; SELECT v FROM u; SELECT v FROM w}
+    } [list 0 $value $value $value]
+  }
+  set i 0
+  foreach tables { {'missing','t','u'} {'t','missing','u'} {'t','u','missing'} } {
+    incr i
+    conflicts_multi_setup
+    do_test conflicts-multi-$mode-missing-$i-error {
+      catchsql "SELECT dolt_conflicts_resolve('--$mode',$tables)"
+    } {1 {table not found}}
+    do_execsql_test conflicts-multi-$mode-missing-$i-intact {
+      SELECT count(*) FROM dolt_conflicts;
+      SELECT v FROM t;
+      SELECT v FROM u;
+      SELECT v FROM w;
+    } {3 main main main}
+    do_test conflicts-multi-$mode-missing-$i-repair {
+      execsql "SELECT dolt_conflicts_resolve('--$mode','t','u','w')"
+      execsql {SELECT count(*) FROM dolt_conflicts; SELECT v FROM t; SELECT v FROM u; SELECT v FROM w}
+    } [list 0 $value $value $value]
+  }
+}
+
+reset_db
+execsql {CREATE TABLE t(id INTEGER PRIMARY KEY); CREATE TABLE u(id INTEGER PRIMARY KEY)}
+do_execsql_test conflicts-multi-clean-savepoint {
+  SAVEPOINT s;
+  SELECT dolt_conflicts_resolve('--ours','t','u');
+} {0}
+do_catchsql_test conflicts-multi-clean-savepoint-sealed {
+  ROLLBACK TO s;
+} {1 {no such savepoint: s}}
+
+do_execsql_test conflicts-multi-clean-invalid-savepoint {
+  SAVEPOINT s;
+} {}
+do_catchsql_test conflicts-multi-clean-invalid {
+  SELECT dolt_conflicts_resolve('--ours','t','missing');
+} {1 {table not found}}
+do_execsql_test conflicts-multi-clean-invalid-rollback {
+  ROLLBACK TO s;
+  RELEASE s;
+} {}
+
+finish_test

--- a/test/regression-buckets/ported.txt
+++ b/test/regression-buckets/ported.txt
@@ -43,6 +43,7 @@ doltlite_merge_constraint_prune
 doltlite_merge_generated
 doltlite_merge_ignored
 doltlite_rebase_plan_hash
+doltlite_conflicts_multi
 doltlite_recover_changes
 doltlite_gc_stop_world
 doltlite_reload_uncommitted_recent

--- a/test/vc_oracle_conflicts_resolve_test.sh
+++ b/test/vc_oracle_conflicts_resolve_test.sh
@@ -139,6 +139,56 @@ SELECT dolt_merge('feature');
 SELECT CONCAT('R|t|', id, '|', v) FROM t ORDER BY id;
 SELECT CONCAT('R|u_conflicts|', num_conflicts) FROM dolt_conflicts WHERE \`table\`='u';"
 
+MULTI_CONFLICT_SETUP="
+CREATE TABLE t(id INT PRIMARY KEY, v INT);
+CREATE TABLE u(id INT PRIMARY KEY, v INT);
+CREATE TABLE clean(id INT PRIMARY KEY);
+INSERT INTO t VALUES(1, 10);
+INSERT INTO u VALUES(1, 100);
+SELECT dolt_commit('-Am', 'base');
+SELECT dolt_checkout('-b', 'feature');
+UPDATE t SET v=20;
+UPDATE u SET v=200;
+SELECT dolt_commit('-am', 'feature');
+SELECT dolt_checkout('main');
+UPDATE t SET v=30;
+UPDATE u SET v=300;
+SELECT dolt_commit('-am', 'main');
+SELECT dolt_merge('feature');
+"
+
+for mode in ours theirs; do
+  i=0
+  for tables in "'t','u'" "'u','t'" "'t','t','u'" "'clean','t','u'" "'t','u','clean'"; do
+    i=$((i+1))
+    oracle "resolve_${mode}_multiple_$i" "$MULTI_CONFLICT_SETUP" "
+SELECT dolt_conflicts_resolve('--$mode', $tables);
+SELECT CONCAT('R|conflicts|', count(*)) FROM dolt_conflicts;
+SELECT CONCAT('R|t|', v) FROM t;
+SELECT CONCAT('R|u|', v) FROM u;
+"
+  done
+  i=0
+  for tables in "'missing','t','u'" "'t','missing','u'" "'t','u','missing'"; do
+    i=$((i+1))
+    oracle "resolve_${mode}_missing_multiple_$i" "$MULTI_CONFLICT_SETUP" "
+SELECT dolt_conflicts_resolve('--$mode', $tables);
+SELECT CONCAT('R|conflicts|', count(*)) FROM dolt_conflicts;
+SELECT CONCAT('R|t|', v) FROM t;
+SELECT CONCAT('R|u|', v) FROM u;
+"
+  done
+  oracle "resolve_${mode}_multiple_savepoint" "$MULTI_CONFLICT_SETUP" "
+SAVEPOINT both_tables;
+SELECT dolt_conflicts_resolve('--$mode', 't', 'u');
+SELECT CONCAT('R|resolved|', count(*)) FROM dolt_conflicts;
+ROLLBACK TO both_tables;
+SELECT CONCAT('R|restored|', count(*)) FROM dolt_conflicts;
+SELECT CONCAT('R|t|', v) FROM t;
+SELECT CONCAT('R|u|', v) FROM u;
+"
+done
+
 echo "--- resolve then commit ---"
 
 oracle "resolve_and_commit" \
@@ -177,7 +227,7 @@ oracle_error "resolve_missing_table" \
 SELECT dolt_conflicts_resolve('--ours', 'nope');
 "
 
-oracle_error "resolve_extra_positional_arg" \
+oracle_error "resolve_missing_second_table" \
   "$CONFLICT_SETUP
 SELECT dolt_conflicts_resolve('--ours', 't', 'extra');
 "


### PR DESCRIPTION
`dolt_conflicts_resolve('--theirs','t','u')` currently rejects the table list and leaves both tables conflicted. Accept multiple table names for both resolution modes and validate the complete list before changing rows or conflicts, so a missing table leaves every table untouched.

Reuse the existing resolution logic for each table. Regression and Dolt oracle coverage exercise table ordering, duplicate names, clean tables, missing names at every position, and savepoint rollback. The regression suite also checks that untargeted conflicts remain intact and that resolving all tables permits a merge commit. Update the documented signature.

Validation:
- Regression fails on the original engine; all 64 checks pass with the fix.
- Conflict-resolution Dolt oracle: 46 cases pass.
- Native DoltLite suites: 132 pass.
- `make -C build lint`, orphaned-suite guard, and `git diff --check` pass.

Fixes #2798

Co-Authored-By: OpenAI Codex <noreply@openai.com>
