### PR TITLE
Fix conflicted CI cancellation with stale PR base metadata

### DIFF
--- a/.github/scripts/cancel-conflicted-pr-runs.js
+++ b/.github/scripts/cancel-conflicted-pr-runs.js
@@ -3,6 +3,14 @@ module.exports = async function cancelConflictedPrRuns({
   sleep = ms => new Promise(resolve => setTimeout(resolve, ms)),
 }) {
   const repo = context.repo;
+  async function currentMaster() {
+    const {data} = await github.rest.git.getRef({...repo, ref: 'heads/master'});
+    if (data.object.sha === context.sha) return true;
+    core.info(`Master advanced beyond ${context.sha}; leaving CI to the newer push workflow`);
+    return false;
+  }
+
+  if (!await currentMaster()) return 0;
   const runsByPull = new Map();
   for (const status of ['queued', 'in_progress', 'pending', 'waiting', 'requested']) {
     const runs = await github.paginate(github.rest.actions.listWorkflowRuns, {
@@ -29,7 +37,7 @@ module.exports = async function cancelConflictedPrRuns({
 
   function current(pull) {
     return pull && pull.state === 'open' && !pull.merged &&
-      pull.base.ref === 'master' && pull.base.sha === context.sha;
+      pull.base.ref === 'master';
   }
 
   let pending = [...runsByPull.keys()];
@@ -50,6 +58,7 @@ module.exports = async function cancelConflictedPrRuns({
         const confirmed = await getPull(number);
         if (!current(confirmed) || confirmed.head.sha !== pull.head.sha ||
             confirmed.mergeable !== false) break;
+        if (!await currentMaster()) return cancelled;
         try {
           await github.rest.actions.cancelWorkflowRun({...repo, run_id: run.id});
           cancelledRuns.add(run.id);

--- a/.github/scripts/cancel-conflicted-pr-runs.test.js
+++ b/.github/scripts/cancel-conflicted-pr-runs.test.js
@@ -16,9 +16,17 @@ const run = (overrides = {}) => ({
 });
 const apiError = status => Object.assign(new Error(`HTTP ${status}`), {status});
 
-function fixture({runs = [run()], pulls = [pull()], cancelError} = {}) {
+function fixture({runs = [run()], pulls = [pull()], masterTips = ['master-tip'], cancelError} = {}) {
   const listed = [], fetched = [], cancelled = [], sleeps = [], logs = [];
+  const refs = [];
   const github = {rest: {
+    git: {async getRef(args) {
+      assert.deepEqual(args, {...repo, ref: 'heads/master'});
+      const value = masterTips[Math.min(refs.length, masterTips.length - 1)];
+      refs.push(args.ref);
+      if (value instanceof Error) throw value;
+      return {data: {object: {sha: value}}};
+    }},
     actions: {
       listWorkflowRuns() {},
       async cancelWorkflowRun(args) {
@@ -84,7 +92,6 @@ const changes = {
   'closed PR': {state: 'closed'},
   'merged PR': {merged: true},
   'different base branch': {base: {ref: 'release', sha: 'master-tip'}},
-  'new master tip': {base: {ref: 'master', sha: 'new-master-tip'}},
 };
 for (const [name, change] of Object.entries(changes)) {
   test(`leaves ${name} alone`, async () => {
@@ -166,4 +173,42 @@ test('surfaces cancellation API errors', async () => {
 test('surfaces pull request API errors', async () => {
   const error = apiError(500);
   await assert.rejects(fixture({pulls: [error]}).execute(), error);
+});
+
+test('cancels a conflicted PR whose base SHA still names an older master commit', async () => {
+  const f = fixture({pulls: [pull({base: {ref: 'master', sha: 'old-master-tip'}})]});
+  assert.equal(await f.execute(), 1);
+  assert.deepEqual(f.cancelled, [100]);
+});
+
+test('allows stale PR base metadata on the confirmation read', async () => {
+  const f = fixture({pulls: [pull(), pull({base: {ref: 'master', sha: 'old-master-tip'}})]});
+  assert.equal(await f.execute(), 1);
+  assert.deepEqual(f.cancelled, [100]);
+});
+
+test('leaves new master tip alone', async () => {
+  const f = fixture({masterTips: ['new-master-tip']});
+  assert.equal(await f.execute(), 0);
+  assert.deepEqual(f.cancelled, []);
+  assert.deepEqual(f.listed, []);
+});
+
+test('rechecks new master tip immediately before cancellation', async () => {
+  const f = fixture({masterTips: ['master-tip', 'new-master-tip']});
+  assert.equal(await f.execute(), 0);
+  assert.deepEqual(f.fetched, [42, 42]);
+  assert.deepEqual(f.cancelled, []);
+});
+
+test('stops when master advances between cancellations', async () => {
+  const f = fixture({runs: [run(), run({id: 101})],
+    masterTips: ['master-tip', 'master-tip', 'new-master-tip']});
+  assert.equal(await f.execute(), 1);
+  assert.deepEqual(f.cancelled, [100]);
+});
+
+test('surfaces master ref API errors', async () => {
+  const error = apiError(500);
+  await assert.rejects(fixture({masterTips: [error]}).execute(), error);
 });


### PR DESCRIPTION
The conflict canceller ran after master advanced but skipped #2827 because GitHub's PR response still reported its previous base SHA. It compared that stale `pull.base.sha` with the triggering push SHA and treated the PR as belonging to another master tip.

Check the actual `heads/master` ref instead, both before scanning runs and immediately before cancellation. Continue checking that the PR is open, targets master, still conflicts, and has the same head as the CI run. Stop if master advances during the scan.

Validation: two regressions reproducing stale PR base metadata fail before the fix. All 33 tests pass afterward, including master advancing before or between cancellations and the existing unrelated-PR guards. `git diff --check` passes.

Co-Authored-By: OpenAI Codex <noreply@openai.com>
