### PR TITLE
Rebuild main.o when DOLTLITE_VEC1 changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ build-*/
 *.dSYM/
 
 # Amalgamation / lemon / build scratch
+.doltlite-feature-flags
+.doltlite-feature-flags.tmp
 tsrc/
 /Makefile
 /sqlite3.c

--- a/doc/doltlite/building.md
+++ b/doc/doltlite/building.md
@@ -35,8 +35,10 @@ bash test/build_stock_reference.sh build-stock build/doltlite
 ```
 
 Vec1 is built into native DoltLite by default. Use `make DOLTLITE_VEC1=0` to
-omit it. Compile the DoltLite amalgamation with `-DDOLTLITE_VEC1=1` to include
-vec1; otherwise it can be built and loaded as an extension.
+omit it. Changing `DOLTLITE_VEC1`, `DOLTLITE_ENABLE_REMOTES`, or
+`DOLTLITE_ENABLE_CHUNK_SOURCE` rebuilds `main.o`; a clean is not required.
+Compile the DoltLite amalgamation with `-DDOLTLITE_VEC1=1` to include vec1;
+otherwise it can be built and loaded as an extension.
 
 ## WebAssembly (`ext/wasm`)
 

--- a/doltlite.mk
+++ b/doltlite.mk
@@ -163,3 +163,17 @@ ifeq ($(DOLTLITE_PROLLY),1)
     -DSQLITE_ENABLE_STMTVTAB \
     -DSQLITE_ENABLE_UNKNOWN_SQL_FUNCTION
 endif
+
+# VEC1=1 compiles sqlite3Vec1Init into main.o; VEC1=0 drops vec1.o from the
+# link. Without a flags stamp make reuses main.o and the link fails. Remove
+# the objects when flags change: macOS /usr/bin/make is GNU 3.81 and only
+# compares timestamps to one second.
+DOLTLITE_FEATURE_STAMP = .doltlite-feature-flags
+DOLTLITE_FEATURE_STAMP_TEXT = PROLLY=$(DOLTLITE_PROLLY) VEC1=$(DOLTLITE_VEC1) REMOTES=$(DOLTLITE_ENABLE_REMOTES) CHUNK_SOURCE=$(DOLTLITE_ENABLE_CHUNK_SOURCE) PROLLY_CHECK=$(DOLTLITE_PROLLY_CHECK)
+_doltlite_feature_stamp_n := $(shell printf '%s\n' "$(DOLTLITE_FEATURE_STAMP_TEXT)" > $(DOLTLITE_FEATURE_STAMP).tmp && if cmp -s $(DOLTLITE_FEATURE_STAMP).tmp $(DOLTLITE_FEATURE_STAMP) 2>/dev/null; then rm -f $(DOLTLITE_FEATURE_STAMP).tmp; else mv $(DOLTLITE_FEATURE_STAMP).tmp $(DOLTLITE_FEATURE_STAMP) && rm -f main.o sqlite3.o; fi)
+main.o sqlite3.o: $(DOLTLITE_FEATURE_STAMP)
+
+clean-doltlite-feature-stamp:
+	rm -f $(DOLTLITE_FEATURE_STAMP) $(DOLTLITE_FEATURE_STAMP).tmp
+tidy: clean-doltlite-feature-stamp
+clean: clean-doltlite-feature-stamp

--- a/test/feature_flags_stamp_test.sh
+++ b/test/feature_flags_stamp_test.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# VEC1=1 then VEC1=0 must rebuild main.o. Otherwise the object still
+# references sqlite3Vec1Init after vec1.o is dropped from the link.
+set -euo pipefail
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+tmp="$(mktemp -d "${TMPDIR:-/tmp}/doltlite-feature-stamp.XXXXXX")"
+trap 'rm -rf "$tmp"' EXIT
+cd "$tmp"
+
+cat > main.c <<'EOF'
+#if defined(DOLTLITE_PROLLY) && DOLTLITE_VEC1
+int sqlite3Vec1Init(void);
+static int (*const sqlite3BuiltinExtensions[])(void) = { sqlite3Vec1Init };
+#endif
+int main(void) { return 0; }
+EOF
+cat > vec1.c <<'EOF'
+int sqlite3Vec1Init(void) { return 0; }
+EOF
+
+cat > Makefile <<EOF
+TOP := $REPO
+CC ?= cc
+CFLAGS :=
+LIBOBJS0 = main.o
+include \$(TOP)/doltlite.mk
+
+main.o: main.c
+	\$(CC) -c main.c -o main.o \$(OPT_FEATURE_FLAGS)
+vec1.o: vec1.c
+	\$(CC) -c vec1.c -o vec1.o
+app: main.o \$(if \$(filter 1,\$(DOLTLITE_VEC1)),vec1.o)
+	\$(CC) -o app main.o \$(if \$(filter 1,\$(DOLTLITE_VEC1)),vec1.o)
+EOF
+
+make DOLTLITE_PROLLY=1 DOLTLITE_VEC1=1 app
+if ! ./app; then
+  echo "FAIL: VEC1=1 app did not run" >&2
+  exit 1
+fi
+if ! grep -q 'VEC1=1' .doltlite-feature-flags; then
+  echo "FAIL: stamp missing VEC1=1: $(cat .doltlite-feature-flags)" >&2
+  exit 1
+fi
+
+qrc=0
+make DOLTLITE_PROLLY=1 DOLTLITE_VEC1=0 -q main.o || qrc=$?
+if [ "$qrc" -eq 0 ]; then
+  echo "FAIL: VEC1=0 left main.o up to date" >&2
+  exit 1
+fi
+if [ "$qrc" -ne 1 ]; then
+  echo "FAIL: make -q VEC1=0 main.o rc=$qrc" >&2
+  exit 1
+fi
+
+make DOLTLITE_PROLLY=1 DOLTLITE_VEC1=0 app
+if ! ./app; then
+  echo "FAIL: VEC1=0 app did not run" >&2
+  exit 1
+fi
+if ! grep -q 'VEC1=0' .doltlite-feature-flags; then
+  echo "FAIL: stamp missing VEC1=0: $(cat .doltlite-feature-flags)" >&2
+  exit 1
+fi
+if command -v nm >/dev/null 2>&1 && nm main.o 2>/dev/null | grep -q 'U .*sqlite3Vec1Init'; then
+  echo "FAIL: VEC1=0 main.o still references sqlite3Vec1Init" >&2
+  nm main.o | grep vec1 >&2 || true
+  exit 1
+fi
+
+qrc=0
+make DOLTLITE_PROLLY=1 DOLTLITE_VEC1=0 -q main.o || qrc=$?
+if [ "$qrc" -ne 0 ]; then
+  echo "FAIL: second VEC1=0 make rebuilt main.o rc=$qrc" >&2
+  exit 1
+fi
+
+echo "feature flags stamp: PASS"

--- a/test/lib/doltlite_suite_manifest.sh
+++ b/test/lib/doltlite_suite_manifest.sh
@@ -3,6 +3,7 @@
 doltlite_all_suites() {
   cat <<'EOF'
 build_artifacts_guard_test.sh
+feature_flags_stamp_test.sh
 install_sh_layout_test.sh
 homebrew_formula_test.sh
 sqlite_compatibility_contract_test.sh


### PR DESCRIPTION
## Summary
`make DOLTLITE_VEC1=0 doltlite` in a `build/` compiled with `DOLTLITE_VEC1=1` dropped `vec1.o` from the link but reused `main.o`, which still referenced `sqlite3Vec1Init`. A clean rebuild worked. Found by Ito on #2806.

Stamp `DOLTLITE_VEC1` / `DOLTLITE_PROLLY` / remotes / chunk-source in `.doltlite-feature-flags` and remove `main.o` (and `sqlite3.o`) when the stamp changes. Touching the stamp alone is not enough: macOS `/usr/bin/make` is GNU 3.81 and only compares mtimes to one second.

## Validation
Fail-before: `nm build/main.o` had `U _sqlite3Vec1Init`; `make DOLTLITE_VEC1=0 -q main.o` rc=0; `make DOLTLITE_VEC1=0 doltlite` failed with `undefined reference to sqlite3Vec1Init`.

Pass-after:
- Isolated `bash test/feature_flags_stamp_test.sh` → PASS
- `make DOLTLITE_VEC1=0 doltlite` rebuilt only `main.c` and linked; `nm main.o` has no vec1 refs; `./doltlite :memory: 'SELECT doltlite_engine();'` → `prolly`
- `make DOLTLITE_VEC1=1 doltlite` restored vec1

Fixes #2809

Co-Authored-By: Grok 4.6 <noreply@x.ai>