### PR TITLE
Skip retry metadata when reading nightly result TSV

### DIFF
--- a/test/nightly_performance_report.py
+++ b/test/nightly_performance_report.py
@@ -82,6 +82,20 @@ def read_results(path):
     except OSError as exc:
         raise ValueError(f"unable to read results: {path}") from exc
     for line_number, line in enumerate(rows, 1):
+        if line.startswith("# "):
+            if results:
+                raise ValueError(
+                    f"{path}:{line_number}: metadata follows results"
+                )
+            columns = line[2:].split("\t", 1)
+            if len(columns) != 2 or columns[0] not in (
+                "suite",
+                "producer_id",
+            ):
+                raise ValueError(
+                    f"{path}:{line_number}: invalid result metadata"
+                )
+            continue
         columns = line.split("\t")
         if len(columns) != 4:
             raise ValueError(

--- a/test/nightly_performance_report_test.py
+++ b/test/nightly_performance_report_test.py
@@ -270,6 +270,36 @@ class NightlyPerformanceReportTest(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, "workload mismatch"):
                 nightly_report.load_suite(directory, "int")
 
+    def test_reads_retry_promoted_vc_results(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            directory = pathlib.Path(temporary)
+            self.write_suite(directory, "vc")
+            path = directory / "vc.tsv"
+            path.write_text(
+                "# suite\tvc\n"
+                "# producer_id\tabc123\n"
+                + path.read_text(encoding="utf-8"),
+                encoding="utf-8",
+            )
+            suite = nightly_report.load_suite(directory, "vc")
+        self.assertEqual(len(suite.results), 1)
+        self.assertEqual(suite.results[0].test, "status_clean")
+        self.assertEqual(suite.results[0].baseline_us, 200000)
+        self.assertEqual(suite.results[0].candidate_us, 100000)
+
+    def test_rejects_metadata_after_vc_results(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            directory = pathlib.Path(temporary)
+            self.write_suite(directory, "vc")
+            path = directory / "vc.tsv"
+            path.write_text(
+                path.read_text(encoding="utf-8")
+                + "# producer_id\tabc123\n",
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(ValueError, "metadata follows results"):
+                nightly_report.load_suite(directory, "vc")
+
     def test_rejects_noncontiguous_sample_runs(self):
         with tempfile.TemporaryDirectory() as temporary:
             directory = pathlib.Path(temporary)


### PR DESCRIPTION
## Summary
Nightly #2833 is a reporter parse error, not a performance regression. The version-control job passed its absolute ceiling; the report job then failed on `nightly-results/vc.tsv:1: expected four tab-separated columns`.

`benchmark_retry.py` prepends `# suite` / `# producer_id` when promoting `vc.tsv`. `benchmark_compare.py` already skips those lines. The nightly reporter did not, so line 1 (`# suite\tvc`) looked like a two-column data row.

Skip the same metadata in `read_results`.

## Validation
Fail-before: `test_reads_retry_promoted_vc_results` → `vc.tsv:1: expected four tab-separated columns` (same as the nightly issue).

Pass-after: `python3 test/nightly_performance_report_test.py` → 11/11.

Fixes #2833

Co-Authored-By: Grok 4.6 <noreply@x.ai>