### PR TITLE
Detect NOT NULL violations in generated merge values

### DIFF
--- a/doc/doltlite/dolt_constraint_violations.md
+++ b/doc/doltlite/dolt_constraint_violations.md
@@ -25,6 +25,10 @@ violations in autocommit mode is rolled back: `Committing this transaction
 resulted in a working set with constraint violations, transaction rolled
 back.` Inside `BEGIN` they persist and block `dolt_commit` until resolved.
 
+`NOT NULL` checks include stored and virtual generated columns. The checks
+use their computed values: valid non-NULL results still merge, and nullable
+generated columns may produce NULL.
+
 ## Tables
 
 | Table | Columns |

--- a/src/doltlite_merge_constraints_notnull.c
+++ b/src/doltlite_merge_constraints_notnull.c
@@ -23,7 +23,8 @@ static int loadNotNullColumns(
   *pazCols = 0;
   *pnCols = 0;
   zSql = sqlite3_mprintf(
-      "SELECT name FROM pragma_table_info(%Q) WHERE \"notnull\"=1", zTable);
+      "SELECT name FROM pragma_table_xinfo(%Q) "
+      "WHERE \"notnull\"=1 AND hidden!=1", zTable);
   if( !zSql ) return SQLITE_NOMEM;
   rc = sqlite3_prepare_v2(db, zSql, -1, &pQ, 0);
   sqlite3_free(zSql);

--- a/src/doltlite_merge_generated.c
+++ b/src/doltlite_merge_generated.c
@@ -133,12 +133,9 @@ static int mergeGeneratedPrepare(
 #endif
 }
 
-/* A record taken wholesale from their side was written against their schema.
-** Relayout into the merged layout leaves a generated column the merged schema
-** adds holding its filled default rather than its expression value, so the
-** stored value is recomputed before it reaches rows or indexes. Returns their
-** record untouched, and *ppOwned zeroed, when the table stores none. */
-int mergeGeneratedTheirRow(
+/* Relayout can fill a newly added generated column with its default instead
+** of its expression value. Recompute before updating rows or indexes. */
+int mergeGeneratedSideRow(
   sqlite3 *db, Table *pTab, sqlite3_stmt **ppStmt, i64 intKey,
   const u8 **ppVal, int *pnVal, u8 **ppOwned
 ){

--- a/src/doltlite_merge_int.h
+++ b/src/doltlite_merge_int.h
@@ -144,7 +144,7 @@ int mergeGeneratedRecord(
   sqlite3 *db, Table *pTab, sqlite3_stmt **ppStmt, i64 intKey,
   u8 **ppRecord, int *pnRecord
 );
-int mergeGeneratedTheirRow(
+int mergeGeneratedSideRow(
   sqlite3 *db, Table *pTab, sqlite3_stmt **ppStmt, i64 intKey,
   const u8 **ppVal, int *pnVal, u8 **ppOwned
 );

--- a/src/doltlite_merge_rows.c
+++ b/src/doltlite_merge_rows.c
@@ -1027,20 +1027,44 @@ static int rowMergeCallback(void *pCtx, const ThreeWayChange *pChange){
 
   switch( pChange->type ){
     case THREE_WAY_LEFT_ADD:
-    case THREE_WAY_LEFT_MODIFY:
-    case THREE_WAY_LEFT_DELETE:
+    case THREE_WAY_LEFT_MODIFY: {
+      const u8 *pOurs = pChange->pOurVal;
+      int nOurs = pChange->nOurVal;
+      u8 *pOwned;
+      int ix;
 
+      if( !ctx->pGeneratedTable ) break;
+      rc = mergeGeneratedSideRow(ctx->db, ctx->pGeneratedTable,
+          &ctx->pGeneratedStmt, pChange->intKey, &pOurs, &nOurs, &pOwned);
+      if( rc!=SQLITE_OK ) return rc;
+      if( nOurs!=pChange->nOurVal
+       || memcmp(pOurs, pChange->pOurVal, nOurs)!=0 ){
+        rc = prollyMutMapInsert(ctx->pEdits,
+            pChange->pKey, pChange->nKey, pChange->intKey, pOurs, nOurs);
+        for(ix=0; ix<ctx->nIndexes && rc==SQLITE_OK; ix++){
+          MergeIndexInfo *mi = &ctx->aIndexes[ix];
+          rc = doltliteIndexMutMapRowDelta(
+              ctx->db, mi->pIdx, mi->pEdits, mi->aiColumn, mi->nColumn,
+              mi->pKeyInfo, mi->iPKey, pChange->intKey,
+              pChange->pKey, pChange->nKey,
+              pChange->pOurVal, pChange->nOurVal, pOurs, nOurs, &mi->part);
+        }
+      }
+      sqlite3_free(pOwned);
+      break;
+    }
+
+    case THREE_WAY_LEFT_DELETE:
       break;
 
     case THREE_WAY_RIGHT_ADD: {
-
       const u8 *pTheirs;
       int nTheirs;
       u8 *pOwned;
 
       pTheirs = pChange->pTheirVal;
       nTheirs = pChange->nTheirVal;
-      rc = mergeGeneratedTheirRow(ctx->db, ctx->pGeneratedTable,
+      rc = mergeGeneratedSideRow(ctx->db, ctx->pGeneratedTable,
           &ctx->pGeneratedStmt, pChange->intKey, &pTheirs, &nTheirs, &pOwned);
       if( rc!=SQLITE_OK ) return rc;
       rc = prollyMutMapInsert(ctx->pEdits,
@@ -1063,14 +1087,13 @@ static int rowMergeCallback(void *pCtx, const ThreeWayChange *pChange){
     }
 
     case THREE_WAY_RIGHT_MODIFY: {
-
       const u8 *pTheirs;
       int nTheirs;
       u8 *pOwned;
 
       pTheirs = pChange->pTheirVal;
       nTheirs = pChange->nTheirVal;
-      rc = mergeGeneratedTheirRow(ctx->db, ctx->pGeneratedTable,
+      rc = mergeGeneratedSideRow(ctx->db, ctx->pGeneratedTable,
           &ctx->pGeneratedStmt, pChange->intKey, &pTheirs, &nTheirs, &pOwned);
       if( rc!=SQLITE_OK ) return rc;
       rc = prollyMutMapInsert(ctx->pEdits,
@@ -1093,7 +1116,6 @@ static int rowMergeCallback(void *pCtx, const ThreeWayChange *pChange){
     }
 
     case THREE_WAY_RIGHT_DELETE:
-
       rc = prollyMutMapDelete(ctx->pEdits,
           pChange->pKey, pChange->nKey, pChange->intKey);
       if( rc==SQLITE_OK && ctx->nIndexes>0
@@ -1111,7 +1133,6 @@ static int rowMergeCallback(void *pCtx, const ThreeWayChange *pChange){
       break;
 
     case THREE_WAY_CONVERGENT:
-
       break;
 
     case THREE_WAY_CONFLICT_MM: {

--- a/test/doltlite_merge_generated_notnull.test
+++ b/test/doltlite_merge_generated_notnull.test
@@ -1,0 +1,120 @@
+set testdir [file dirname $argv0]
+source $testdir/tester.tcl
+
+proc generated_notnull_setup {key storage operation outcome direction} {
+  reset_db
+  set constraint [expr {$outcome eq "nullable" ? "" : "NOT NULL"}]
+  set generated "z INT AS(nullif(x+y,100)) $storage $constraint"
+  set schema "id $key PRIMARY KEY, x INT, y INT"
+  if {$operation eq "cell"} {append schema ", $generated"}
+  execsql "CREATE TABLE t($schema)"
+  execsql {
+    INSERT INTO t(id,x,y) VALUES(1,1,2);
+    SELECT dolt_commit('-Am','base');
+    SELECT dolt_branch('feature');
+  }
+  if {$operation eq "cell"} {
+    execsql {UPDATE t SET x=50}
+  } else {
+    execsql "CREATE TABLE t2($schema, $generated)"
+    execsql {
+      INSERT INTO t2(id,x,y) SELECT id,x,y FROM t;
+      DROP TABLE t;
+      ALTER TABLE t2 RENAME TO t;
+    }
+  }
+  execsql {
+    CREATE INDEX iz ON t(z);
+    SELECT dolt_commit('-Am','main');
+    SELECT dolt_checkout('feature');
+  }
+  set y [expr {$outcome eq "valid" ? 5 : 50}]
+  if {$operation eq "insert"} {
+    execsql "INSERT INTO t(id,x,y) VALUES(2,50,$y)"
+  } elseif {$operation eq "update"} {
+    execsql "UPDATE t SET x=50,y=$y"
+  } else {
+    execsql "UPDATE t SET y=$y"
+  }
+  execsql {SELECT dolt_commit('-Am','feature')}
+  if {$direction eq "forward"} {
+    execsql {SELECT dolt_checkout('main')}
+    return feature
+  }
+  return main
+}
+
+foreach key {INTEGER INT} {
+  foreach storage {STORED VIRTUAL} {
+    foreach operation {insert update cell} {
+      foreach direction {forward reverse} {
+        set prefix generated-notnull-$key-$storage-$operation-$direction
+        foreach txn {autocommit explicit} {
+          set target [generated_notnull_setup $key $storage $operation invalid $direction]
+          set before [execsql {SELECT dolt_hashof('HEAD'); SELECT dolt_hashof_table('t')}]
+          if {$txn eq "explicit"} {execsql {BEGIN}}
+          set name $prefix-$txn
+          do_test $name-merge {
+            set result [catchsql "SELECT dolt_merge('$target')"]
+            list [lindex $result 0] [string match {*constraint violations*} [lindex $result 1]]
+          } {1 1}
+          if {$txn eq "explicit"} {
+            set id [expr {$operation eq "insert" ? 2 : 1}]
+            do_execsql_test $name-violation {
+              SELECT violation_type,id,json_extract(violation_info,'$.Columns[0]')
+                FROM dolt_constraint_violations_t;
+              SELECT count(*) FROM t WHERE typeof(z)='null';
+            } [list {not null} $id z 1]
+            do_test $name-commit-blocked {
+              set result [catchsql {SELECT dolt_commit('-Am','invalid')}]
+              list [lindex $result 0] [string match {*dolt_constraint_violations*} [lindex $result 1]]
+            } {1 1}
+            do_execsql_test $name-verify {
+              DELETE FROM dolt_constraint_violations_t;
+              SELECT dolt_verify_constraints('--all');
+              SELECT count(*) FROM dolt_constraint_violations_t;
+            } {1 1}
+            do_execsql_test $name-repair {
+              UPDATE t SET x=40 WHERE typeof(z)='null';
+              SELECT dolt_verify_constraints('--all');
+              SELECT count(*) FROM dolt_constraint_violations;
+              PRAGMA integrity_check;
+            } {0 0 ok}
+            do_test $name-commit {
+              execsql {SELECT length(dolt_commit('-Am','resolved'))}
+            } {40}
+          } else {
+            do_test $name-restored {
+              list [expr {$before eq [execsql {
+                SELECT dolt_hashof('HEAD'); SELECT dolt_hashof_table('t')
+              }]}] [execsql {SELECT count(*) FROM dolt_constraint_violations; PRAGMA integrity_check}]
+            } {1 {0 ok}}
+            db close
+            sqlite3 db [expr {$direction eq "forward" ? "test.db" : "test.db/feature"}]
+            do_test $name-reopen {
+              list [expr {$before eq [execsql {
+                SELECT dolt_hashof('HEAD'); SELECT dolt_hashof_table('t')
+              }]}] [execsql {PRAGMA integrity_check}]
+            } {1 ok}
+          }
+        }
+        foreach outcome {valid nullable} {
+          set target [generated_notnull_setup $key $storage $operation $outcome $direction]
+          set name $prefix-$outcome
+          do_test $name-merge {
+            execsql "SELECT length(dolt_merge('$target'))"
+          } {40}
+          do_execsql_test $name-clean {
+            SELECT count(*) FROM dolt_constraint_violations;
+            SELECT quote(z) FROM t ORDER BY id DESC LIMIT 1;
+            SELECT quote(z) FROM t INDEXED BY iz ORDER BY id DESC LIMIT 1;
+            PRAGMA integrity_check;
+          } [list 0 [expr {$outcome eq "valid" ? 55 : "NULL"}] \
+                    [expr {$outcome eq "valid" ? 55 : "NULL"}] ok]
+        }
+      }
+    }
+  }
+}
+
+finish_test

--- a/test/regression-buckets/ported.txt
+++ b/test/regression-buckets/ported.txt
@@ -41,6 +41,7 @@ doltlite_historical_affinity
 doltlite_vtab_column_collision
 doltlite_merge_constraint_prune
 doltlite_merge_generated
+doltlite_merge_generated_notnull
 doltlite_merge_schema_errors
 doltlite_merge_ignored
 doltlite_rebase_plan_hash


### PR DESCRIPTION
A merge could commit NULL into a NOT NULL generated column without recording a violation. The detector enumerated `pragma_table_info`, which omits generated columns. Use `pragma_table_xinfo` to include stored and virtual generated columns while continuing to exclude hidden virtual-table columns.

Also recompute stored generated values for rows retained from the destination branch, updating their index entries when the record changes. Without this, reversing the merge could leave an otherwise valid new row with an uncomputed NULL. Detection stays value-driven: valid generated values and nullable NULLs still merge successfully.

Regression coverage exercises both primary-key representations and merge directions, inserts, updates, cell merges, stored and virtual generated columns, indexes, autocommit rollback and reopen, violation metadata, blocked commits, verification, and repair.

Validation:
- Reproduced the failure before the fix; all 313 new regression checks pass afterward.
- Existing generated-column regression: 87 checks pass.
- Dolt oracle suites: 12 generated-merge cases and 11 constraint-violation cases pass.
- Native DoltLite suites: all 133 pass.
- Lint, orphaned-suite guard, and `git diff --check` pass.

Fixes #2812

Co-Authored-By: OpenAI Codex <noreply@openai.com>
