### PR TITLE
Make macOS caches effective and reduce repeated CI setup

### DIFF
--- a/.github/actions/asan-build/action.yml
+++ b/.github/actions/asan-build/action.yml
@@ -68,6 +68,9 @@ runs:
     if: inputs.platform == 'macos'
     shell: bash
     run: bash .github/scripts/check-compiler-cache.sh
+  - name: Save compiler cache
+    if: inputs.platform == 'macos'
+    uses: ./.github/actions/save-macos-build-cache
   - name: Package
     run: |
       bash .github/scripts/package-ci-build.sh asan-ubsan-${{ inputs.platform }}.tar.gz \

--- a/.github/actions/asan-build/action.yml
+++ b/.github/actions/asan-build/action.yml
@@ -29,6 +29,7 @@ runs:
       mkdir -p build
       cd build
       if [ "${{ inputs.platform }}" = "macos" ]; then
+        source ../.github/scripts/use-macos-compiler-cache.sh
         export PATH="$(brew --prefix tcl-tk)/bin:$PATH"
         ../configure
       else
@@ -46,6 +47,7 @@ runs:
       cd build
       make_jobs=(-j2)
       if [ "${{ inputs.platform }}" = "macos" ]; then
+        source ../.github/scripts/use-macos-compiler-cache.sh
         make_jobs=(-j"$(sysctl -n hw.logicalcpu)")
       fi
       {
@@ -62,6 +64,10 @@ runs:
         exit 1
       fi
     shell: bash -e {0}
+  - name: Verify compiler cache
+    if: inputs.platform == 'macos'
+    shell: bash
+    run: bash .github/scripts/check-compiler-cache.sh
   - name: Package
     run: |
       bash .github/scripts/package-ci-build.sh asan-ubsan-${{ inputs.platform }}.tar.gz \

--- a/.github/actions/checked-build/action.yml
+++ b/.github/actions/checked-build/action.yml
@@ -47,6 +47,7 @@ runs:
       mkdir -p build
       cd build
       if [ "${{ inputs.platform }}" = "macos" ]; then
+        source ../.github/scripts/use-macos-compiler-cache.sh
         export PATH="$(brew --prefix tcl-tk)/bin:$PATH"
         ../configure
       else
@@ -72,6 +73,7 @@ runs:
       set -o pipefail
       make_jobs=2
       if [ "${{ inputs.platform }}" = "macos" ]; then
+        source ../.github/scripts/use-macos-compiler-cache.sh
         make_jobs=$(sysctl -n hw.logicalcpu)
       fi
       {
@@ -92,3 +94,7 @@ runs:
       fi
       DOLTLITE_LINT_JOBS="$make_jobs" make lint
     shell: bash -e {0}
+  - name: Verify compiler cache
+    if: inputs.platform == 'macos'
+    shell: bash
+    run: bash .github/scripts/check-compiler-cache.sh

--- a/.github/actions/checked-probes/action.yml
+++ b/.github/actions/checked-probes/action.yml
@@ -190,3 +190,6 @@ runs:
       path: checked-headers.tar.gz
       compression-level: 0
       retention-days: 1
+  - name: Save compiler cache
+    if: inputs.platform == 'macos'
+    uses: ./.github/actions/save-macos-build-cache

--- a/.github/actions/checked-probes/action.yml
+++ b/.github/actions/checked-probes/action.yml
@@ -104,54 +104,10 @@ runs:
       set -eo pipefail
       cd build
       {
-        ci_compile() { "$@"; }
-        ci_compile_wait() { :; }
         if [ "${{ inputs.platform }}" = "macos" ]; then
-          source ../.github/scripts/parallel-compile.sh
-          ci_compile_init "$(sysctl -n hw.logicalcpu)"
+          source ../.github/scripts/use-macos-compiler-cache.sh
         fi
-        ci_compile cc $CFLAGS -Wall \
-          -I../src -I../ext/ed25519 \
-          ../test/doltlite_creds_kat.c ../test/sqlite3_alloc_stub.c \
-          ../src/doltlite_creds.c \
-          ../ext/ed25519/fe.c ../ext/ed25519/ge.c \
-          ../ext/ed25519/sc.c ../ext/ed25519/sha512.c \
-          ../ext/ed25519/keypair.c ../ext/ed25519/sign.c \
-          ../ext/ed25519/verify.c ../ext/ed25519/add_scalar.c \
-          -o creds_kat
-        ci_compile cc $CFLAGS -Wall \
-          -I../src -I../ext/ed25519 \
-          ../test/creds_verify_kat.c ../test/sqlite3_alloc_stub.c \
-          ../src/doltlite_creds.c \
-          ../ext/ed25519/fe.c ../ext/ed25519/ge.c \
-          ../ext/ed25519/sc.c ../ext/ed25519/sha512.c \
-          ../ext/ed25519/keypair.c ../ext/ed25519/sign.c \
-          ../ext/ed25519/verify.c ../ext/ed25519/add_scalar.c \
-          -o creds_verify_kat
-        ci_compile cc $CFLAGS -I../src -I../ext/mbedtls/include \
-          ../test/doltlite_tls_test_main.c ../test/sqlite3_alloc_stub.c \
-          ../src/doltlite_tls.c \
-          ../ext/mbedtls/library/*.c \
-          -o tls_test
-        blake_objects=(blake3.o blake3_portable.o blake3_dispatch.o)
-        for object in blake3_sse2.o blake3_sse41.o blake3_avx2.o blake3_avx512.o blake3_neon.o; do
-          [ ! -f "$object" ] || blake_objects+=("$object")
-        done
-        ci_compile cc $CFLAGS ../test/blake3_kat.c \
-          prolly_hash.o "${blake_objects[@]}" \
-          -I../src -I../ext/blake3 -DDOLTLITE_PROLLY=1 \
-          -lm -o blake3_kat
-        probe_libs=(-lz -lpthread -lm)
-        probe_amalgamation=sqlite3.c
-        if [ "${{ inputs.platform }}" = "ubuntu" ]; then
-          probe_libs+=(-ldl)
-          probe_amalgamation=ci-amalgamation.o
-        fi
-        ci_compile cc $CFLAGS -Wno-comment -I. \
-          ../test/amalgamation_http_probe.c "$probe_amalgamation" \
-          "${probe_libs[@]}" -o amalgamation_http_probe
-        ci_compile_wait
-        rm -f ci-amalgamation.o
+        bash ../.github/scripts/build-standalone-probes.sh "${{ inputs.platform }}"
       } 2>&1 | tee -a build.log
       if grep -E "warning:" build.log; then
         echo "::error::compiler warnings in standalone probes"
@@ -218,5 +174,19 @@ runs:
     with:
       name: checked-build-${{ inputs.platform }}
       path: checked-build-${{ inputs.platform }}.tar.gz
+      compression-level: 0
+      retention-days: 1
+  - name: Package generated headers
+    if: inputs.platform == 'ubuntu'
+    shell: bash
+    run: |
+      bash .github/scripts/package-ci-build.sh checked-headers.tar.gz \
+        build/sqlite3.h build/sqlite_cfg.h build/parse.h build/opcodes.h
+  - name: Upload generated headers
+    if: inputs.platform == 'ubuntu'
+    uses: actions/upload-artifact@v4
+    with:
+      name: checked-headers
+      path: checked-headers.tar.gz
       compression-level: 0
       retention-days: 1

--- a/.github/actions/macos-build-cache/action.yml
+++ b/.github/actions/macos-build-cache/action.yml
@@ -32,15 +32,18 @@ runs:
         echo "CCACHE_DIR=$RUNNER_TEMP/doltlite-${{ inputs.configuration }}-ccache"
         echo "CCACHE_MAXSIZE=256M"
         echo "CCACHE_COMPILERCHECK=content"
+        echo "DOLTLITE_COMPILER_CACHE_KEY=macos-build-v1-${{ runner.arch }}-$key-${{ github.sha }}"
       } >> "$GITHUB_ENV"
   - name: Restore compiler cache
     id: cache
-    uses: actions/cache@v4
+    uses: actions/cache/restore@v4
     with:
-      path: ${{ runner.temp }}/doltlite-${{ inputs.configuration }}-ccache
-      key: macos-build-v1-${{ runner.arch }}-${{ steps.identity.outputs.key }}-${{ github.sha }}
+      path: ${{ env.CCACHE_DIR }}
+      key: ${{ env.DOLTLITE_COMPILER_CACHE_KEY }}
       restore-keys: |
         macos-build-v1-${{ runner.arch }}-${{ steps.identity.outputs.key }}-
   - name: Reset compiler statistics
     shell: bash
-    run: ccache --zero-stats
+    run: |
+      ccache --zero-stats
+      echo "DOLTLITE_COMPILER_CACHE_HIT=${{ steps.cache.outputs.cache-hit }}" >> "$GITHUB_ENV"

--- a/.github/actions/macos-build-cache/action.yml
+++ b/.github/actions/macos-build-cache/action.yml
@@ -28,7 +28,6 @@ runs:
       brew install ccache
       key=$(bash .github/scripts/macos-build-cache-key.sh)
       echo "key=$key" >> "$GITHUB_OUTPUT"
-      echo "$(brew --prefix ccache)/libexec" >> "$GITHUB_PATH"
       {
         echo "CCACHE_DIR=$RUNNER_TEMP/doltlite-${{ inputs.configuration }}-ccache"
         echo "CCACHE_MAXSIZE=256M"
@@ -42,3 +41,6 @@ runs:
       key: macos-build-v1-${{ runner.arch }}-${{ steps.identity.outputs.key }}-${{ github.sha }}
       restore-keys: |
         macos-build-v1-${{ runner.arch }}-${{ steps.identity.outputs.key }}-
+  - name: Reset compiler statistics
+    shell: bash
+    run: ccache --zero-stats

--- a/.github/actions/save-macos-build-cache/action.yml
+++ b/.github/actions/save-macos-build-cache/action.yml
@@ -1,0 +1,11 @@
+name: Save macOS compiler cache
+description: Save the active compiler cache before leaving its build context.
+runs:
+  using: composite
+  steps:
+  - name: Save compiler cache
+    if: env.DOLTLITE_COMPILER_CACHE_HIT != 'true'
+    uses: actions/cache/save@v4
+    with:
+      path: ${{ env.CCACHE_DIR }}
+      key: ${{ env.DOLTLITE_COMPILER_CACHE_KEY }}

--- a/.github/actions/sqllogictest-cache/action.yml
+++ b/.github/actions/sqllogictest-cache/action.yml
@@ -1,0 +1,24 @@
+name: SQLLogicTest reference cache
+description: Reuse the pinned SQLLogicTest sources and stock runner.
+runs:
+  using: composite
+  steps:
+  - name: Identify reference
+    id: identity
+    shell: bash
+    run: |
+      key=$(bash .github/scripts/sqllogictest-cache-key.sh)
+      echo "key=$key" >> "$GITHUB_OUTPUT"
+  - name: Restore reference
+    id: cache
+    uses: actions/cache@v4
+    with:
+      path: .sqllogictest-cache
+      key: sqllogictest-reference-v1-${{ runner.os }}-${{ runner.arch }}-${{ steps.identity.outputs.key }}
+  - name: Build reference
+    if: steps.cache.outputs.cache-hit != 'true'
+    shell: bash
+    run: bash .github/scripts/sqllogictest-reference.sh build .sqllogictest-cache
+  - name: Validate reference
+    shell: bash
+    run: bash .github/scripts/sqllogictest-reference.sh validate .sqllogictest-cache

--- a/.github/scripts/build-standalone-probes.sh
+++ b/.github/scripts/build-standalone-probes.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+platform="${1:?platform required}"
+source ../.github/scripts/parallel-compile.sh
+case "$platform" in
+  macos) ci_compile_init "${DOLTLITE_PROBE_JOBS:-$(sysctl -n hw.logicalcpu)}" ;;
+  ubuntu) ci_compile_init "${DOLTLITE_PROBE_JOBS:-2}" ;;
+  *) exit 1 ;;
+esac
+mkdir -p ci-probe-objects
+creds_objects=()
+for source in ../test/sqlite3_alloc_stub.c ../src/doltlite_creds.c \
+              ../ext/ed25519/{fe,ge,sc,sha512,keypair,sign,verify,add_scalar}.c; do
+  object="ci-probe-objects/creds-${source##*/}.o"
+  ci_compile cc $CFLAGS -Wall -I../src -I../ext/ed25519 -c "$source" -o "$object"
+  creds_objects+=("$object")
+done
+for name in doltlite_creds_kat creds_verify_kat; do
+  ci_compile cc $CFLAGS -Wall -I../src -I../ext/ed25519 \
+    -c "../test/$name.c" -o "ci-probe-objects/$name.o"
+done
+tls_objects=()
+for source in ../test/doltlite_tls_test_main.c ../test/sqlite3_alloc_stub.c \
+              ../src/doltlite_tls.c ../ext/mbedtls/library/*.c; do
+  object="ci-probe-objects/tls-${source##*/}.o"
+  ci_compile cc $CFLAGS -I../src -I../ext/mbedtls/include -c "$source" -o "$object"
+  tls_objects+=("$object")
+done
+ci_compile cc $CFLAGS -I../src -I../ext/blake3 -DDOLTLITE_PROLLY=1 \
+  -c ../test/blake3_kat.c -o ci-probe-objects/blake3_kat.o
+ci_compile cc $CFLAGS -Wno-comment -I. \
+  -c ../test/amalgamation_http_probe.c -o ci-probe-objects/amalgamation_http_probe.o
+probe_libs=(-lz -lpthread -lm)
+probe_amalgamation=ci-amalgamation.o
+if [ "$platform" = ubuntu ]; then
+  probe_libs+=(-ldl)
+else
+  probe_amalgamation=ci-probe-objects/amalgamation.o
+  ci_compile cc $CFLAGS -Wno-comment -I. -c sqlite3.c -o "$probe_amalgamation"
+fi
+ci_compile_wait
+ci_compile cc $CFLAGS -Wall ci-probe-objects/doltlite_creds_kat.o "${creds_objects[@]}" -o creds_kat
+ci_compile cc $CFLAGS -Wall ci-probe-objects/creds_verify_kat.o "${creds_objects[@]}" -o creds_verify_kat
+ci_compile cc $CFLAGS "${tls_objects[@]}" -o tls_test
+blake_objects=(blake3.o blake3_portable.o blake3_dispatch.o)
+for object in blake3_sse2.o blake3_sse41.o blake3_avx2.o blake3_avx512.o blake3_neon.o; do
+  [ ! -f "$object" ] || blake_objects+=("$object")
+done
+ci_compile cc $CFLAGS ci-probe-objects/blake3_kat.o prolly_hash.o "${blake_objects[@]}" -lm -o blake3_kat
+ci_compile cc $CFLAGS -Wno-comment ci-probe-objects/amalgamation_http_probe.o "$probe_amalgamation" \
+  "${probe_libs[@]}" -o amalgamation_http_probe
+ci_compile_wait
+rm -rf ci-probe-objects
+rm -f ci-amalgamation.o

--- a/.github/scripts/check-compiler-cache.sh
+++ b/.github/scripts/check-compiler-cache.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ccache --show-stats --verbose
+ccache --print-stats | awk '
+  $1 == "cache_miss" || $1 == "direct_cache_hit" || $1 == "preprocessed_cache_hit" { calls += $2 }
+  $1 == "files_in_cache" { files = $2 }
+  END { exit calls == 0 || files == 0 }
+'
+test -d "${CCACHE_DIR:?}"

--- a/.github/scripts/ci-artifact-tests.sh
+++ b/.github/scripts/ci-artifact-tests.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+mkdir -p "$work/payload/nested" "$work/profiles with spaces" "$work/bin"
+printf 'test data\n' > "$work/payload/nested/file"
+chmod 755 "$work/payload/nested/file"
+ln -s nested/file "$work/payload/link"
+tar -czf "$work/original.tar.gz" -C "$work" payload
+bash "$script_dir/package-ci-build.sh" "$work/fast.tar.gz" -C "$work" payload
+diff <(tar -tvf "$work/original.tar.gz") <(tar -tvf "$work/fast.tar.gz")
+mkdir "$work/original" "$work/fast"
+tar -xzf "$work/original.tar.gz" -C "$work/original"
+tar -xzf "$work/fast.tar.gz" -C "$work/fast"
+diff -r "$work/original" "$work/fast"
+[ -x "$work/fast/payload/nested/file" ]
+[ "$(readlink "$work/fast/payload/link")" = nested/file ]
+if bash "$script_dir/package-ci-build.sh" "$work/missing.tar.gz" \
+    -C "$work" missing > "$work/package.log" 2>&1; then
+  echo 'FAIL: packaging accepted a missing input'
+  exit 1
+fi
+
+cat > "$work/bin/llvm-profdata" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+[ "$1" = merge ] && [ "$2" = -sparse ] && [ "$3" = -f ] && [ "$5" = -o ]
+cp "$4" "$PROFILE_LIST_COPY"
+if [ "${FAIL_MERGE:-0}" = 1 ]; then exit 1; fi
+printf 'merged\n' > "$6"
+STUB
+chmod +x "$work/bin/llvm-profdata"
+export PATH="$work/bin:$PATH" PROFILE_LIST_COPY="$work/input-list"
+profiles="$work/profiles with spaces"
+bash "$script_dir/merge-coverage-profiles.sh" "$profiles"
+[ ! -e "$PROFILE_LIST_COPY" ]
+printf raw > "$profiles/2.profraw"
+printf raw > "$profiles/1.profraw"
+printf keep > "$profiles/keep.txt"
+if FAIL_MERGE=1 bash "$script_dir/merge-coverage-profiles.sh" "$profiles"; then
+  echo 'FAIL: merger accepted a failed llvm-profdata invocation'
+  exit 1
+fi
+[ -f "$profiles/1.profraw" ] && [ -f "$profiles/2.profraw" ]
+bash "$script_dir/merge-coverage-profiles.sh" "$profiles" sql-differential
+printf '%s\n' "$profiles/1.profraw" "$profiles/2.profraw" > "$work/expected-list"
+cmp "$work/expected-list" "$PROFILE_LIST_COPY"
+[ -s "$profiles/sql-differential.profdata" ]
+[ ! -e "$profiles/1.profraw" ] && [ ! -e "$profiles/2.profraw" ]
+[ -f "$profiles/keep.txt" ]
+printf raw > "$profiles/3.profraw"
+bash "$script_dir/merge-coverage-profiles.sh" "$profiles"
+[ -s "$profiles/coverage.profdata" ] && [ ! -e "$profiles/3.profraw" ]
+echo 'CI packaging and profile merge checks passed'

--- a/.github/scripts/ci-build-failure-test.py
+++ b/.github/scripts/ci-build-failure-test.py
@@ -41,7 +41,13 @@ def run(script, fail_at, warning, errexit):
         (root / "examples/go").mkdir(parents=True)
         (root / "bin").mkdir()
         (root / ".github/scripts").mkdir(parents=True)
-        shutil.copy(github_dir / "scripts/parallel-compile.sh", root / ".github/scripts")
+        for name in ('parallel-compile.sh', 'build-standalone-probes.sh', 'use-macos-compiler-cache.sh'):
+            shutil.copy(github_dir / 'scripts' / name, root / '.github/scripts')
+        (root / 'ccache/libexec').mkdir(parents=True)
+        for name in ('cc', 'c++'):
+            (root / 'ccache/libexec' / name).symlink_to(root / 'bin/cc')
+        (root / 'bin/brew').write_text(f'#!/bin/bash\necho "{root}/ccache"\n')
+        (root / 'bin/brew').chmod(0o755)
         (root / "tclConfig.sh").write_text('TCL_INCLUDE_SPEC="-I/fake/tcl"\n')
         (root / "bin/find").write_text(f'#!/bin/sh\necho "{root}/tclConfig.sh"\n')
         (root / "bin/find").chmod(0o755)
@@ -54,7 +60,7 @@ def run(script, fail_at, warning, errexit):
         path = root / "step.sh"
         path.write_text(script + '\nprintf packaged > "$PACKAGE_MARKER"\n')
         env = dict(os.environ, PATH=f"{root / 'bin'}:{os.environ['PATH']}",
-                   COMMAND_LOG=str(root / "commands"), FAIL_AT=str(fail_at),
+                   DOLTLITE_PROBE_JOBS="1", COMMAND_LOG=str(root / "commands"), FAIL_AT=str(fail_at),
                    EMIT_WARNING=str(warning), PACKAGE_MARKER=str(root / "package"),
                    CFLAGS="-O2", TSAN_CFLAGS="-O1 -fsanitize=thread",
                    TSAN_LDFLAGS="-fsanitize=thread",

--- a/.github/scripts/ci-cache-and-packages-test.py
+++ b/.github/scripts/ci-cache-and-packages-test.py
@@ -121,6 +121,12 @@ def checked_build():
         root = Path(tmp)
         for directory in ('bin', 'build', 'test'):
             (root / directory).mkdir()
+        (root / '.github/scripts').mkdir(parents=True)
+        shutil.copy(scripts / 'use-macos-compiler-cache.sh', root / '.github/scripts')
+        (root / 'ccache/libexec').mkdir(parents=True)
+        for name in ('cc', 'c++'):
+            write_executable(root / 'ccache/libexec' / name, '#!/bin/bash\nexit 0\n')
+        write_executable(root / 'bin/brew', f'#!/bin/bash\necho "{root}/ccache"\n')
         write_executable(root / 'bin/sysctl', '#!/bin/sh\necho 6\n')
         write_executable(root / 'bin/make', r'''#!/bin/bash
 set -eu
@@ -205,7 +211,8 @@ def cache_producers():
     for text in (producer, platform):
         assert 'uses: ./.github/actions/macos-package-cache' in text
         assert 'bash .github/scripts/macos-package-tests.sh build' in text
-        assert 'export PATH="$(brew --prefix ccache)/libexec:$PATH"' in text
+        assert 'source .github/scripts/use-macos-compiler-cache.sh' in text
+        assert 'bash ../.github/scripts/check-compiler-cache.sh' in text
     action = (github / 'actions/macos-package-cache/action.yml').read_text()
     assert 'echo "CCACHE_DIR=$RUNNER_TEMP/doltlite-ccache"' in action
     assert '${{ runner.temp }}/doltlite-ccache' in action

--- a/.github/scripts/ci-followup-test.py
+++ b/.github/scripts/ci-followup-test.py
@@ -96,7 +96,16 @@ for event in ['start', 'end']:
         f.seek(0)
         json.dump(data, f)
         f.truncate()
-    if event == 'start': time.sleep(0.08)
+    if event == 'start':
+        deadline = time.monotonic() + 10
+        while True:
+            with state.open() as f:
+                fcntl.flock(f, fcntl.LOCK_SH)
+                ready = len(json.load(f)['start']) >= int(os.environ['WORKERS'])
+            if ready: break
+            assert time.monotonic() < deadline, 'workers did not overlap'
+            time.sleep(0.01)
+        time.sleep(0.03)
 print(name)
 sys.exit(42 if os.environ.get('FAIL') == name else 0)
 ''')
@@ -113,7 +122,7 @@ sys.exit(42 if os.environ.get('FAIL') == name else 0)
             command = ['bash', str(scripts / 'ci-optimization-test.sh')] if standalone else [
                 'bash', str(root / 'test/run_lint_selftests.sh'), *extras]
             result = run(command, cwd=root, env=dict(os.environ, STATE=str(state), FAIL=fail,
-                                                    DOLTLITE_LINT_JOBS=str(jobs)))
+                                                    DOLTLITE_LINT_JOBS=str(jobs), WORKERS=str(jobs)))
             data = json.loads(state.read_text())
             assert result.returncode == (42 if fail else 0), result
             assert data['active'] == 0 and sorted(data['start']) == sorted(data['end']), data

--- a/.github/scripts/ci-followup-test.py
+++ b/.github/scripts/ci-followup-test.py
@@ -1,0 +1,252 @@
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import tarfile
+import tempfile
+import textwrap
+
+repo = Path(__file__).resolve().parents[2]
+checks = 0
+
+
+def executable(path, body):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body)
+    path.chmod(0o755)
+
+
+def run(args, **kwargs):
+    return subprocess.run(args, capture_output=True, text=True, timeout=30, **kwargs)
+
+
+def step(path, name, indent='  '):
+    match = re.search(rf'^{indent}- name: {re.escape(name)}\n.*?^{indent}  run: \|\n'
+                      rf'((?:{indent}    [^\n]*\n|\n)+)', path.read_text(), re.M | re.S)
+    assert match, name
+    return textwrap.dedent(match[1])
+
+
+def compiler_cache():
+    global checks
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        (root / '.github/scripts').mkdir(parents=True)
+        shutil.copy(repo / '.github/scripts/use-macos-compiler-cache.sh', root / '.github/scripts')
+        for name in ('cc', 'c++'):
+            executable(root / 'ccache/libexec' / name, '#!/bin/bash\nexit 0\n')
+        executable(root / 'bin/brew', f'#!/bin/bash\necho "{root}/$2"\n')
+        executable(root / 'configure', '#!/bin/bash\nprintf "%s\\n" "${CC:-}" > "$SEEN"\n')
+        env = dict(os.environ, PATH=f'{root}/bin:{os.environ["PATH"]}', SEEN=str(root / 'seen'))
+        env.pop('CC', None)
+        for action, name in [('checked-build', 'Configure Unix build'), ('asan-build', 'Configure')]:
+            command = step(repo / f'.github/actions/{action}/action.yml', name)
+            command = command.replace('${{ inputs.platform }}', 'macos')
+            result = run(['bash', '-e', '-c', command], cwd=root, env=env)
+            assert result.returncode == 0, result
+            assert (root / 'seen').read_text().strip() == str(root / 'ccache/libexec/cc')
+            checks += 1
+        executable(root / 'bin/ccache', '''#!/bin/bash
+[ "${FAIL_STATS:-0}" = 0 ] || exit 42
+if [ "$1" = --print-stats ]; then
+  printf 'cache_miss\t%s\ndirect_cache_hit\t%s\nfiles_in_cache\t%s\n' "$MISSES" "$HITS" "$FILES"
+fi
+''')
+        cache = root / 'cache'
+        cache.mkdir()
+        env.update(CCACHE_DIR=str(cache))
+        for misses, hits, files, failure, expected in [(1, 0, 2, 0, True), (0, 1, 2, 0, True),
+                (0, 0, 2, 0, False), (1, 0, 0, 0, False), (1, 0, 2, 1, False)]:
+            result = run(['bash', str(repo / '.github/scripts/check-compiler-cache.sh')],
+                         env=dict(env, MISSES=str(misses), HITS=str(hits), FILES=str(files),
+                                  FAIL_STATS=str(failure)))
+            assert (result.returncode == 0) == expected, result
+            checks += 1
+
+
+def workers():
+    global checks
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        scripts = root / '.github/scripts'
+        scripts.mkdir(parents=True)
+        (root / 'test').mkdir()
+        for name in ('parallel-compile.sh', 'ci-selftests.sh', 'ci-optimization-test.sh'):
+            shutil.copy(repo / '.github/scripts' / name, scripts)
+        shutil.copy(repo / 'test/run_lint_selftests.sh', root / 'test')
+        manifest = (scripts / 'ci-selftests.sh').read_text()
+        names = [str((Path('.github/scripts') / name)) for name in
+                 re.findall(r'ci_compile (?:python3|bash) "\$script_dir/([^"]+)"', manifest)]
+        extras = ['test/lint_layers_selftest.sh', 'test/stock_oracle_harness_test.sh']
+        worker = root / 'worker.py'
+        worker.write_text('''import fcntl, json, os, sys, time
+from pathlib import Path
+name = sys.argv[1]
+state = Path(os.environ['STATE'])
+for event in ['start', 'end']:
+    with state.open('r+') as f:
+        fcntl.flock(f, fcntl.LOCK_EX)
+        data = json.load(f)
+        data[event].append(name)
+        data['active'] += 1 if event == 'start' else -1
+        data['max'] = max(data['max'], data['active'])
+        f.seek(0)
+        json.dump(data, f)
+        f.truncate()
+    if event == 'start': time.sleep(0.08)
+print(name)
+sys.exit(42 if os.environ.get('FAIL') == name else 0)
+''')
+        for name in names + extras:
+            if name.endswith('.py'):
+                body = f'import runpy, sys\nsys.argv = [{str(worker)!r}, {name!r}]\nrunpy.run_path({str(worker)!r}, run_name="__main__")\n'
+            else:
+                body = f'#!/bin/bash\nexec python3 "{worker}" "{name}"\n'
+            executable(root / name, body)
+        for standalone, jobs, fail in [(False, 3, ''), (False, 1, ''), (True, 3, '')] + [
+                (False, 3, name) for name in [extras[0], extras[1], names[0], names[-1]]]:
+            state = root / 'state.json'
+            state.write_text(json.dumps(dict(start=[], end=[], active=0, max=0)))
+            command = ['bash', str(scripts / 'ci-optimization-test.sh')] if standalone else [
+                'bash', str(root / 'test/run_lint_selftests.sh'), *extras]
+            result = run(command, cwd=root, env=dict(os.environ, STATE=str(state), FAIL=fail,
+                                                    DOLTLITE_LINT_JOBS=str(jobs)))
+            data = json.loads(state.read_text())
+            assert result.returncode == (42 if fail else 0), result
+            assert data['active'] == 0 and sorted(data['start']) == sorted(data['end']), data
+            assert 1 <= data['max'] <= jobs, data
+            assert sorted(result.stdout.splitlines()) == sorted(data['end']), result
+            if not fail:
+                assert sorted(data['end']) == sorted(names + ([] if standalone else extras)), data
+                assert data['max'] == jobs, data
+            checks += 1
+
+
+def header_archive():
+    global checks
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        (root / '.github/scripts').mkdir(parents=True)
+        shutil.copy(repo / '.github/scripts/package-ci-build.sh', root / '.github/scripts')
+        (root / 'build').mkdir()
+        headers = ['sqlite3.h', 'sqlite_cfg.h', 'parse.h', 'opcodes.h']
+        for name in headers + ['doltlite', 'unused.o']:
+            (root / 'build' / name).write_text(name)
+        command = step(repo / '.github/actions/checked-probes/action.yml', 'Package generated headers')
+        result = run(['bash', '-e', '-c', command], cwd=root)
+        assert result.returncode == 0, result
+        with tarfile.open(root / 'checked-headers.tar.gz') as archive:
+            assert sorted(archive.getnames()) == sorted('build/' + h for h in headers)
+            for member in archive:
+                assert archive.extractfile(member).read() == Path(member.name).name.encode()
+        checks += 1
+        for header in headers:
+            (root / 'build' / header).unlink()
+            assert run(['bash', '-e', '-c', command], cwd=root).returncode != 0
+            (root / 'build' / header).write_text(header)
+            checks += 1
+        workflow = (repo / '.github/workflows/ci-build.yml').read_text().split('  no-dead-code:')[1]
+        assert 'name: checked-headers\n' in workflow and 'tar -xzf checked-headers.tar.gz' in workflow
+        checks += 1
+
+
+def reference_cache():
+    global checks
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        for name in ('.github/scripts/sqllogictest-cache-key.sh', '.github/scripts/sqllogictest-reference.sh',
+                     'test/patch_sqllogictest.pl'):
+            (root / name).parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy(repo / name, root / name)
+        for name in ('gcc', 'as', 'ld', 'fossil', 'perl', 'dpkg-query'):
+            executable(root / 'bin' / name, '''#!/bin/bash
+[ "${FAIL_TOOL:-}" != "${0##*/}" ] || exit 42
+echo "${0##*/} ${TOOL_VERSION:-1}"
+''')
+        executable(root / 'bin/sha256sum', '''#!/usr/bin/env python3
+import hashlib, pathlib, sys
+if len(sys.argv) == 1:
+    print(hashlib.sha256(sys.stdin.buffer.read()).hexdigest() + '  -')
+else:
+    for name in sys.argv[1:]:
+        print(hashlib.sha256(pathlib.Path(name).read_bytes()).hexdigest() + '  ' + name)
+''')
+        env = dict(os.environ, PATH=f'{root}/bin:{os.environ["PATH"]}')
+        command = ['bash', str(root / '.github/scripts/sqllogictest-cache-key.sh')]
+        baseline = run(command, env=env)
+        assert baseline.returncode == 0 and len(baseline.stdout.strip()) == 64, baseline
+        assert run(command, env=env).stdout == baseline.stdout
+        checks += 1
+        for name, value in [('TOOL_VERSION', 'next'), ('ImageVersion', 'next'), ('CPATH', '/other')]:
+            changed = run(command, env=dict(env, **{name: value}))
+            assert changed.returncode == 0 and changed.stdout != baseline.stdout, changed
+            checks += 1
+        for name in ('gcc', 'ld', 'fossil', 'perl', 'dpkg-query'):
+            assert run(command, env=dict(env, FAIL_TOOL=name)).returncode != 0
+            checks += 1
+        for name in ('test/patch_sqllogictest.pl', '.github/scripts/sqllogictest-reference.sh', 'bin/gcc'):
+            file = root / name
+            original = file.read_text()
+            file.write_text(original + '\n# changed\n')
+            changed = run(command, env=env)
+            assert changed.returncode == 0 and changed.stdout != baseline.stdout, changed
+            file.write_text(original)
+            checks += 1
+        identity = step(repo / '.github/actions/sqllogictest-cache/action.yml', 'Identify reference')
+        output = root / 'output'
+        result = run(['bash', '-e', '-c', identity], cwd=root,
+                     env=dict(env, FAIL_TOOL='gcc', GITHUB_OUTPUT=str(output)))
+        assert result.returncode != 0 and not output.exists(), result
+        checks += 1
+
+
+def reference_validation():
+    global checks
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        cache = root / 'cache'
+        (cache / 'tree/src').mkdir(parents=True)
+        (cache / 'tree/test').mkdir()
+        names = ['sqllogictest.c', 'slt_odbc3.c', 'sqlite3.c', 'sqlite3.h', 'md5.o', 'sqlite3.o']
+        for name in names:
+            (cache / 'tree/src' / name).write_text(name)
+        (cache / 'tree/test/a.test').write_text('query I\nSELECT 1\n')
+        revision = re.search(r'^revision=(.*)$', (repo / '.github/scripts/sqllogictest-reference.sh').read_text(), re.M)[1]
+        (cache / 'revision').write_text(revision + '\n')
+        executable(cache / 'tree/src/sqllogictest-stock', '''#!/bin/bash
+[ "$1" = --verify ] || exit 42
+[ "${FAIL_RUNNER:-0}" = 0 ] || exit 42
+printf '%s errors out of 4 tests in smoke.test - 0 skipped.\\n' "${ERRORS:-0}" >&2
+''')
+        (cache / 'MANIFEST').write_text(''.join(
+            hashlib.sha256(p.read_bytes()).hexdigest() + '  ' + str(p.relative_to(cache)) + '\n'
+            for p in (cache / 'tree').rglob('*') if p.is_file()))
+        command = ['bash', str(repo / '.github/scripts/sqllogictest-reference.sh'), 'validate', str(cache)]
+        assert run(command).returncode == 0
+        checks += 1
+        for env in [dict(os.environ, FAIL_RUNNER='1'), dict(os.environ, ERRORS='1')]:
+            assert run(command, env=env).returncode != 0
+            checks += 1
+        for name in names:
+            file = cache / 'tree/src' / name
+            file.unlink()
+            assert run(command).returncode != 0
+            file.write_text(name)
+            checks += 1
+        (cache / 'tree/test/a.test').write_text('changed corpus\n')
+        assert run(command).returncode != 0
+        checks += 1
+        (cache / 'revision').write_text('wrong\n')
+        assert run(command).returncode != 0
+        checks += 1
+
+
+compiler_cache()
+workers()
+header_archive()
+reference_cache()
+reference_validation()
+print(f'Compiler cache wiring, shared workers, header payloads and SQLLogicTest cache: {checks} checks passed')

--- a/.github/scripts/ci-followup-test.py
+++ b/.github/scripts/ci-followup-test.py
@@ -67,6 +67,46 @@ fi
             checks += 1
 
 
+def cache_lifecycle():
+    global checks
+    action = repo / '.github/actions/macos-build-cache/action.yml'
+    restore = action.read_text()
+    save = (repo / '.github/actions/save-macos-build-cache/action.yml').read_text()
+    assert 'uses: actions/cache/restore@v4' in restore
+    assert 'uses: actions/cache/save@v4' in save
+    assert 'path: ${{ env.CCACHE_DIR }}' in restore and 'path: ${{ env.CCACHE_DIR }}' in save
+    assert 'key: ${{ env.DOLTLITE_COMPILER_CACHE_KEY }}' in restore and 'key: ${{ env.DOLTLITE_COMPILER_CACHE_KEY }}' in save
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        executable(root / 'bin/brew', '#!/bin/bash\nexit 0\n')
+        executable(root / 'bin/ccache', '#!/bin/bash\nexit 0\n')
+        executable(root / '.github/scripts/macos-build-cache-key.sh', '#!/bin/bash\necho "$CACHE_BUILD_CONFIGURATION-key"\n')
+        env = dict(os.environ, PATH=f'{root}/bin:{os.environ["PATH"]}', RUNNER_TEMP=str(root),
+                   GITHUB_ENV=str(root / 'env'), GITHUB_OUTPUT=str(root / 'outputs'))
+        saved = []
+        for configuration in ('checked', 'asan'):
+            command = step(action, 'Identify compiler cache')
+            for name, value in [('inputs.configuration', configuration), ('runner.arch', 'ARM64'), ('github.sha', 'revision')]:
+                command = command.replace('${{ ' + name + ' }}', value)
+            result = run(['bash', '-e', '-c', command], cwd=root,
+                         env=dict(env, CACHE_BUILD_CONFIGURATION=configuration))
+            assert result.returncode == 0, result
+            env.update(line.split('=', 1) for line in (root / 'env').read_text().splitlines())
+            assert env['CCACHE_DIR'] == str(root / f'doltlite-{configuration}-ccache')
+            assert env['DOLTLITE_COMPILER_CACHE_KEY'] == f'macos-build-v1-ARM64-{configuration}-key-revision'
+            Path(env['CCACHE_DIR']).mkdir()
+            (Path(env['CCACHE_DIR']) / 'compiler-output').write_text(configuration)
+            saved.append((env['DOLTLITE_COMPILER_CACHE_KEY'], env['CCACHE_DIR']))
+            checks += 1
+        assert saved[0][0] != saved[1][0] and saved[0][1] != saved[1][1]
+    probes = (repo / '.github/actions/checked-probes/action.yml').read_text()
+    assert probes.index('build-standalone-probes.sh') < probes.index('uses: ./.github/actions/save-macos-build-cache')
+    seed = (repo / '.github/workflows/seed-ci-caches.yml').read_text()
+    assert seed.count('uses: ./.github/actions/save-macos-build-cache') == 2
+    assert seed.index('uses: ./.github/actions/save-macos-build-cache') < seed.index('id: asan-cache')
+    checks += 1
+
+
 def workers():
     global checks
     with tempfile.TemporaryDirectory() as tmp:
@@ -254,6 +294,7 @@ printf '%s errors out of 4 tests in smoke.test - 0 skipped.\\n' "${ERRORS:-0}" >
 
 
 compiler_cache()
+cache_lifecycle()
 workers()
 header_archive()
 reference_cache()

--- a/.github/scripts/ci-next-optimizations-test.py
+++ b/.github/scripts/ci-next-optimizations-test.py
@@ -29,6 +29,8 @@ def lint_workers():
         (root / '.github/scripts').mkdir(parents=True)
         shutil.copy(repo / 'test/run_lint_selftests.sh', root / 'test')
         shutil.copy(scripts / 'parallel-compile.sh', root / '.github/scripts')
+        (root / '.github/scripts/ci-selftests.sh').write_text(
+            'ci_selftests() { ci_compile bash \"$root/.github/scripts/ci-optimization-test.sh\"; }\n')
         recipe = run(['make', '-f', 'main.mk', '-n', 'lint', f'TOP={repo}'], cwd=repo)
         assert recipe.returncode == 0, recipe
         commands = [shlex.split(line.replace(str(repo), str(root)))

--- a/.github/scripts/ci-optimization-test.sh
+++ b/.github/scripts/ci-optimization-test.sh
@@ -1,66 +1,9 @@
 #!/usr/bin/env bash
-
 set -euo pipefail
 
 script_dir="$(cd "$(dirname "$0")" && pwd)"
-python3 "$script_dir/ci-build-failure-test.py"
-python3 "$script_dir/parallel-compile-test.py"
-python3 "$script_dir/macos-build-jobs-test.py"
-python3 "$script_dir/ci-cache-and-packages-test.py"
-python3 "$script_dir/ci-next-optimizations-test.py"
-python3 "$script_dir/benchmark-build-test.py"
-python3 "$script_dir/benchmark-cache-key-test.py"
-python3 "$script_dir/../../test/sqllogictest_gate_test.py"
-python3 "$script_dir/../../test/sysbench_harness_test.py"
-work=$(mktemp -d)
-trap 'rm -rf "$work"' EXIT
-mkdir -p "$work/payload/nested" "$work/profiles with spaces" "$work/bin"
-printf 'test data\n' > "$work/payload/nested/file"
-chmod 755 "$work/payload/nested/file"
-ln -s nested/file "$work/payload/link"
-tar -czf "$work/original.tar.gz" -C "$work" payload
-bash "$script_dir/package-ci-build.sh" "$work/fast.tar.gz" -C "$work" payload
-diff <(tar -tvf "$work/original.tar.gz") <(tar -tvf "$work/fast.tar.gz")
-mkdir "$work/original" "$work/fast"
-tar -xzf "$work/original.tar.gz" -C "$work/original"
-tar -xzf "$work/fast.tar.gz" -C "$work/fast"
-diff -r "$work/original" "$work/fast"
-[ -x "$work/fast/payload/nested/file" ]
-[ "$(readlink "$work/fast/payload/link")" = nested/file ]
-if bash "$script_dir/package-ci-build.sh" "$work/missing.tar.gz" \
-    -C "$work" missing > "$work/package.log" 2>&1; then
-  echo 'FAIL: packaging accepted a missing input'
-  exit 1
-fi
-
-cat > "$work/bin/llvm-profdata" <<'STUB'
-#!/usr/bin/env bash
-set -euo pipefail
-[ "$1" = merge ] && [ "$2" = -sparse ] && [ "$3" = -f ] && [ "$5" = -o ]
-cp "$4" "$PROFILE_LIST_COPY"
-if [ "${FAIL_MERGE:-0}" = 1 ]; then exit 1; fi
-printf 'merged\n' > "$6"
-STUB
-chmod +x "$work/bin/llvm-profdata"
-export PATH="$work/bin:$PATH" PROFILE_LIST_COPY="$work/input-list"
-profiles="$work/profiles with spaces"
-bash "$script_dir/merge-coverage-profiles.sh" "$profiles"
-[ ! -e "$PROFILE_LIST_COPY" ]
-printf raw > "$profiles/2.profraw"
-printf raw > "$profiles/1.profraw"
-printf keep > "$profiles/keep.txt"
-if FAIL_MERGE=1 bash "$script_dir/merge-coverage-profiles.sh" "$profiles"; then
-  echo 'FAIL: merger accepted a failed llvm-profdata invocation'
-  exit 1
-fi
-[ -f "$profiles/1.profraw" ] && [ -f "$profiles/2.profraw" ]
-bash "$script_dir/merge-coverage-profiles.sh" "$profiles" sql-differential
-printf '%s\n' "$profiles/1.profraw" "$profiles/2.profraw" > "$work/expected-list"
-cmp "$work/expected-list" "$PROFILE_LIST_COPY"
-[ -s "$profiles/sql-differential.profdata" ]
-[ ! -e "$profiles/1.profraw" ] && [ ! -e "$profiles/2.profraw" ]
-[ -f "$profiles/keep.txt" ]
-printf raw > "$profiles/3.profraw"
-bash "$script_dir/merge-coverage-profiles.sh" "$profiles"
-[ -s "$profiles/coverage.profdata" ] && [ ! -e "$profiles/3.profraw" ]
-echo 'CI packaging and profile merge checks passed'
+source "$script_dir/parallel-compile.sh"
+source "$script_dir/ci-selftests.sh"
+ci_compile_init "${DOLTLITE_LINT_JOBS:-1}"
+ci_selftests
+ci_compile_wait

--- a/.github/scripts/ci-selftests.sh
+++ b/.github/scripts/ci-selftests.sh
@@ -1,0 +1,15 @@
+ci_selftests() {
+  local script_dir
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  ci_compile python3 "$script_dir/ci-build-failure-test.py"
+  ci_compile python3 "$script_dir/parallel-compile-test.py"
+  ci_compile python3 "$script_dir/macos-build-jobs-test.py"
+  ci_compile python3 "$script_dir/ci-cache-and-packages-test.py"
+  ci_compile python3 "$script_dir/ci-next-optimizations-test.py"
+  ci_compile python3 "$script_dir/ci-followup-test.py"
+  ci_compile python3 "$script_dir/benchmark-build-test.py"
+  ci_compile python3 "$script_dir/benchmark-cache-key-test.py"
+  ci_compile python3 "$script_dir/../../test/sqllogictest_gate_test.py"
+  ci_compile python3 "$script_dir/../../test/sysbench_harness_test.py"
+  ci_compile bash "$script_dir/ci-artifact-tests.sh"
+}

--- a/.github/scripts/sqllogictest-cache-key.sh
+++ b/.github/scripts/sqllogictest-cache-key.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$root"
+{
+  sha256sum .github/scripts/sqllogictest-reference.sh .github/scripts/sqllogictest-cache-key.sh \
+    test/patch_sqllogictest.pl "$(command -v gcc)" "$(command -v as)" "$(command -v ld)"
+  gcc --version
+  gcc -dumpmachine
+  ld --version
+  fossil version
+  perl -V
+  dpkg-query -W gcc libc6-dev binutils unixodbc-dev libodbc2 libodbcinst2
+  printf '%s\n' "${ImageOS:-}" "${ImageVersion:-}" \
+    "${CPATH:-}" "${C_INCLUDE_PATH:-}" "${LIBRARY_PATH:-}" "${GCC_EXEC_PREFIX:-}"
+} | sha256sum | cut -d ' ' -f 1

--- a/.github/scripts/sqllogictest-reference.sh
+++ b/.github/scripts/sqllogictest-reference.sh
@@ -31,6 +31,7 @@ case "$mode" in
     )
     printf '%s\n' "$revision" > "$cache/revision"
     (cd "$cache" && find tree -type f -exec shasum -a 256 {} + > MANIFEST)
+    exit 0
     ;;
   validate) ;;
   *) exit 1 ;;

--- a/.github/scripts/sqllogictest-reference.sh
+++ b/.github/scripts/sqllogictest-reference.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+mode="${1:?build or validate required}"
+cache="${2:?cache directory required}"
+root="$(cd "$(dirname "$0")/../.." && pwd)"
+revision=db57eba95d7c412bb413da5480c8be24109a8faf
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+case "$mode" in
+  build)
+    fossil clone https://www.sqlite.org/sqllogictest/ "$work/source.fossil"
+    mkdir -p "$cache"
+    cache="$(cd "$cache" && pwd)"
+    mkdir "$cache/tree"
+    (
+      cd "$cache/tree"
+      fossil open "$work/source.fossil" "$revision"
+      fossil close
+      perl "$root/test/patch_sqllogictest.pl" < src/sqllogictest.c > src/sqllogictest.c.patched
+      mv src/sqllogictest.c.patched src/sqllogictest.c
+      grep -q 'SQLINTEGER indicator' src/slt_odbc3.c
+      perl -pi -e 's/SQLINTEGER indicator/SQLLEN indicator/g' src/slt_odbc3.c
+      cd src
+      gcc -Werror -g -O2 -DSQLITE_NO_SYNC=1 -DSQLITE_THREADSAFE=0 \
+        -DSQLITE_OMIT_LOAD_EXTENSION -c md5.c
+      gcc -Werror -g -O2 -DSQLITE_NO_SYNC=1 -DSQLITE_THREADSAFE=0 \
+        -DSQLITE_OMIT_LOAD_EXTENSION -c sqlite3.c
+      gcc -Werror -g -O2 -o sqllogictest-stock \
+        sqllogictest.c md5.o sqlite3.o -lpthread -lm -lodbc
+    )
+    printf '%s\n' "$revision" > "$cache/revision"
+    (cd "$cache" && find tree -type f -exec shasum -a 256 {} + > MANIFEST)
+    ;;
+  validate) ;;
+  *) exit 1 ;;
+esac
+test "$(cat "$cache/revision")" = "$revision"
+(cd "$cache" && shasum -a 256 -c MANIFEST > /dev/null)
+for name in sqllogictest.c slt_odbc3.c sqlite3.c sqlite3.h md5.o sqlite3.o; do
+  test -s "$cache/tree/src/$name"
+done
+test -n "$(find "$cache/tree/test" -type f -name '*.test' -print -quit)"
+cat > "$work/smoke.test" <<'SQL'
+statement ok
+CREATE TABLE cache_smoke(v INTEGER)
+
+statement ok
+INSERT INTO cache_smoke VALUES(42)
+
+query I
+SELECT v FROM cache_smoke
+----
+42
+
+statement error
+SELECT dolt_version()
+SQL
+"$cache/tree/src/sqllogictest-stock" --verify "$work/smoke.test" 2>&1 | tee "$work/smoke.log"
+grep -Eq '^0 errors out of 4 tests .* - 0 skipped\.$' "$work/smoke.log"

--- a/.github/scripts/use-macos-compiler-cache.sh
+++ b/.github/scripts/use-macos-compiler-cache.sh
@@ -1,0 +1,4 @@
+export PATH="$(brew --prefix ccache)/libexec:$PATH"
+export CC="$(command -v cc)"
+export CXX="$(command -v c++)"
+[[ "$CC" == */ccache/libexec/cc ]]

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -54,27 +54,13 @@ jobs:
         fi
         make DOLTLITE_PROLLY=1 DOLTLITE_PROLLY_CHECK=1 sqlite3.c sqlite3.h
 
+    - name: Restore SQLLogicTest reference
+      uses: ./.github/actions/sqllogictest-cache
+
     - name: Build sqllogictest runners
       run: |
-        fossil clone https://www.sqlite.org/sqllogictest/ /tmp/sqllogictest.fossil
-        mkdir -p build/sqllogictest
-        cd build/sqllogictest
-        fossil open /tmp/sqllogictest.fossil db57eba95d7c412bb413da5480c8be24109a8faf
-        perl ../../test/patch_sqllogictest.pl \
-          < src/sqllogictest.c > src/sqllogictest.c.patched
-        mv src/sqllogictest.c.patched src/sqllogictest.c
-        # unixODBC declares SQLGetData's indicator as SQLLEN*. The pinned
-        # upstream source still uses the 32-bit SQLINTEGER typedef.
-        grep -q 'SQLINTEGER indicator' src/slt_odbc3.c
-        perl -pi -e 's/SQLINTEGER indicator/SQLLEN indicator/g' \
-          src/slt_odbc3.c
-        cd src
-        gcc -Werror -g -O2 -DSQLITE_NO_SYNC=1 -DSQLITE_THREADSAFE=0 \
-          -DSQLITE_OMIT_LOAD_EXTENSION -c md5.c
-        gcc -Werror -g -O2 -DSQLITE_NO_SYNC=1 -DSQLITE_THREADSAFE=0 \
-          -DSQLITE_OMIT_LOAD_EXTENSION -c sqlite3.c
-        gcc -Werror -g -O2 -o sqllogictest-stock \
-          sqllogictest.c md5.o sqlite3.o -lpthread -lm -lodbc
+        cp -R .sqllogictest-cache/tree build/sqllogictest
+        cd build/sqllogictest/src
         cp ../../sqlite3.c sqlite3.c
         cp ../../sqlite3.h sqlite3.h
         gcc -Werror -Wno-comment -g -O2 \
@@ -699,13 +685,13 @@ jobs:
       run: |
         bash .github/scripts/install-apt-deps.sh build-essential zlib1g-dev
 
-    - name: Download checked build
+    - name: Download generated headers
       uses: actions/download-artifact@v4
       with:
-        name: checked-build-ubuntu
+        name: checked-headers
 
-    - name: Extract checked build
-      run: tar -xzf checked-build-ubuntu.tar.gz
+    - name: Extract generated headers
+      run: tar -xzf checked-headers.tar.gz
 
     - name: Dead-code gate
       run: bash test/dead_code_check.sh

--- a/.github/workflows/platform-test.yml
+++ b/.github/workflows/platform-test.yml
@@ -205,9 +205,11 @@ jobs:
     - name: Doltlite feature tests
       if: matrix.platform == 'macos'
       run: |
-        export PATH="$(brew --prefix ccache)/libexec:$PATH"
+        source .github/scripts/use-macos-compiler-cache.sh
+        ccache --zero-stats
         cd build
         DOLTLITE_REGRESSION_JOBS=$(sysctl -n hw.logicalcpu) bash ../test/run_doltlite_tests.sh
+        bash ../.github/scripts/check-compiler-cache.sh
       timeout-minutes: 20
 
     - name: Doltlite timing and scale tests

--- a/.github/workflows/seed-ci-caches.yml
+++ b/.github/workflows/seed-ci-caches.yml
@@ -60,6 +60,9 @@ jobs:
           exit 1
         fi
     - uses: ./.github/actions/compatibility-cache
+    - name: Install SQLLogicTest dependencies
+      run: bash .github/scripts/install-apt-deps.sh fossil unixodbc-dev
+    - uses: ./.github/actions/sqllogictest-cache
 
   macos:
     if: >-
@@ -96,10 +99,12 @@ jobs:
     - name: Warm native compiler cache
       if: steps.package-cache.outputs.cache-hit != 'true'
       run: |
-        export PATH="$(brew --prefix ccache)/libexec:$PATH"
+        source .github/scripts/use-macos-compiler-cache.sh
+        ccache --zero-stats
         cd build
         ../configure
         make -j"$(sysctl -n hw.logicalcpu)" libdoltlite.a
+        bash ../.github/scripts/check-compiler-cache.sh
 
     - uses: ./.github/actions/macos-build-cache
       id: checked-cache
@@ -113,8 +118,10 @@ jobs:
         mkdir build
         cd build
         export PATH="$(brew --prefix tcl-tk)/bin:$PATH"
+        source ../.github/scripts/use-macos-compiler-cache.sh
         ../configure
         make -j"$(sysctl -n hw.logicalcpu)" DOLTLITE_PROLLY_CHECK=1 libdoltlite.a
+        bash ../.github/scripts/check-compiler-cache.sh
     - uses: ./.github/actions/macos-build-cache
       id: asan-cache
       with:
@@ -128,7 +135,9 @@ jobs:
         mkdir build
         cd build
         export PATH="$(brew --prefix tcl-tk)/bin:$PATH"
+        source ../.github/scripts/use-macos-compiler-cache.sh
         ../configure
         make -j"$(sysctl -n hw.logicalcpu)" \
           CFLAGS="-O1 -g -Werror -Wno-deprecated-declarations -fsanitize=address,undefined -fno-omit-frame-pointer -fno-sanitize-recover=all" \
           LDFLAGS="-fsanitize=address,undefined" libdoltlite.a
+        bash ../.github/scripts/check-compiler-cache.sh

--- a/.github/workflows/seed-ci-caches.yml
+++ b/.github/workflows/seed-ci-caches.yml
@@ -122,6 +122,7 @@ jobs:
         ../configure
         make -j"$(sysctl -n hw.logicalcpu)" DOLTLITE_PROLLY_CHECK=1 libdoltlite.a
         bash ../.github/scripts/check-compiler-cache.sh
+    - uses: ./.github/actions/save-macos-build-cache
     - uses: ./.github/actions/macos-build-cache
       id: asan-cache
       with:
@@ -141,3 +142,4 @@ jobs:
           CFLAGS="-O1 -g -Werror -Wno-deprecated-declarations -fsanitize=address,undefined -fno-omit-frame-pointer -fno-sanitize-recover=all" \
           LDFLAGS="-fsanitize=address,undefined" libdoltlite.a
         bash ../.github/scripts/check-compiler-cache.sh
+    - uses: ./.github/actions/save-macos-build-cache

--- a/main.mk
+++ b/main.mk
@@ -316,7 +316,7 @@ lint:
 	@bash $(TOP)/test/dolt_oracle_upgrade_test.sh
 	@bash $(TOP)/test/sql_oracle_harness_test.sh
 	@bash $(TOP)/test/run_lint_selftests.sh test/lint_layers_selftest.sh \
-	  test/stock_oracle_harness_test.sh .github/scripts/ci-optimization-test.sh
+	  test/stock_oracle_harness_test.sh
 
 ########################################################################
 ########################################################################

--- a/test/run_lint_selftests.sh
+++ b/test/run_lint_selftests.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 root="$(cd "$(dirname "$0")/.." && pwd)"
 source "$root/.github/scripts/parallel-compile.sh"
+source "$root/.github/scripts/ci-selftests.sh"
 if [ "$#" -eq 0 ]; then
   echo 'Usage: run_lint_selftests.sh suite ...' >&2
   exit 1
@@ -11,4 +12,5 @@ ci_compile_init "${DOLTLITE_LINT_JOBS:-1}"
 for script in "$@"; do
   ci_compile bash "$root/$script"
 done
+ci_selftests
 ci_compile_wait


### PR DESCRIPTION
The macOS compiler caches were not being saved, while CI continued rebuilding fixed SQLLogicTest inputs and transferring a complete checked build to a job that only needs generated headers. This implements the next five execution optimizations:

- Select the macOS ccache compiler wrappers explicitly during configuration and compilation, and save each cache explicitly while its configuration is active instead of deferring the save to nested post-job cleanup. Reset statistics before builds and require actual cacheable calls and stored entries afterward, including the existing native regression build and cache warmer.
- Compile standalone Unix probes into individual objects, reuse identical inputs, and retain the existing link inputs and flags. Use bounded compiler workers on both macOS and Ubuntu.
- Cache the pinned SQLLogicTest checkout and stock runner, keyed by the patch/build scripts, compiler, dependencies, and environment. Validate the revision, file checksums, and stock smoke test. Compile the current DoltLite runner separately on every run. Seed references through the existing Ubuntu producer, after benchmark cache identity has been calculated.
- Publish a generated-header artifact for the existing dead-code job. It still compiles current source and runs every guard, without downloading the library and executable payload.
- Run the existing lint and CI self-tests through one bounded worker pool, preserving standalone invocation, complete worker output, and failure propagation without nested worker pools.

All existing job buckets, compiler flags, test selection, timeouts, benchmark samples, and ratio gates are retained.

Validation: full lint and orphan guards pass; the compiler-wiring regression fails on master and passes with this change. The CI harness passes 190 compiler failure/warning checks and 47 new cache, worker, manifest, and payload checks. Fresh macOS checked and ASan builds pass; warm builds record 323/324 and 324/324 cache hits respectively. Standalone probe tests pass on macOS and Linux, with 127/127 warm macOS probe compilations cached. Linux dead-code and OMIT_INCRBLOB guards pass using only the 227 KiB header artifact. The real cached SQLLogicTest reference and newly built candidate pass all 622 corpus files with zero divergences. Workflow actionlint and composite YAML parsing pass.

Hosted validation on the current head: both macOS build jobs pass and explicitly save their compiler caches; the SQLLogicTest build and header-only dead-code job also pass. Remaining CI suites are running. Cross-run cache reuse and net runner savings still need measurement.

Co-Authored-By: OpenAI Codex <noreply@openai.com>
