### PR TITLE
Give cache seeding time to finish, and a voice when it does not

### DIFF
--- a/.github/scripts/ci-cache-and-packages-test.py
+++ b/.github/scripts/ci-cache-and-packages-test.py
@@ -203,10 +203,19 @@ def cache_producers():
     for text in (producer, consumer):
         assert 'path: benchmark-baseline\n' in text
         assert 'key: benchmark-base-v1-${{ runner.os }}-${{ runner.arch }}-${{ steps.base-key.outputs.key }}\n' in text
-    assert 'restore-keys:' not in producer.split('  macos:')[0]
-    assert producer.count("github.ref == format('refs/heads/{0}', github.event.repository.default_branch)") == 2
-    assert "github.event_name != 'push'" in producer.split('  macos:')[1]
-    assert producer.count('cancel-in-progress: false') == 2
+    # An exact key only: a base build from another revision must never stand in.
+    assert 'restore-keys:' not in producer
+    # Every job that warms a cache is pinned to the default branch and queues
+    # rather than cancels, whatever the caches are split across.
+    parts = re.split(r'^  ([A-Za-z0-9_-]+):[ \t]*$', producer.split('\njobs:\n')[1], flags=re.M)
+    seeding = {name: body for name, body in zip(parts[1::2], parts[2::2])
+               if name != 'watchdog'}
+    assert len(seeding) >= 4, sorted(seeding)
+    for name, body in seeding.items():
+        assert "github.ref == format('refs/heads/{0}', github.event.repository.default_branch)" in body, name
+        assert 'cancel-in-progress: false' in body, name
+        if name.startswith('macos'):
+            assert "github.event_name != 'push'" in body, name
     platform = (github / 'workflows/platform-test.yml').read_text()
     for text in (producer, platform):
         assert 'uses: ./.github/actions/macos-package-cache' in text
@@ -218,7 +227,7 @@ def cache_producers():
     assert '${{ runner.temp }}/doltlite-ccache' in action
     assert "'src/**'" in action and "'build/sqlite3.c'" in action
     assert 'CCACHE_COMPILERCHECK=content' in action
-    return 10
+    return 9 + len(seeding)
 
 
 if __name__ == '__main__':

--- a/.github/scripts/ci-next-optimizations-test.py
+++ b/.github/scripts/ci-next-optimizations-test.py
@@ -250,12 +250,19 @@ def wiring():
     seed = (repo / '.github/workflows/seed-ci-caches.yml').read_text()
     assert 'uses: ./.github/actions/compatibility-cache' in seed
     assert 'uses: ./.github/actions/compatibility-cache' in (repo / '.github/workflows/ci-build.yml').read_text()
-    mac = seed.split('  macos:\n')[1]
-    assert "github.event_name != 'push'" in mac
+    # The macOS caches may be split across jobs; what matters is that every
+    # macOS seed job skips pushes and that the pair warms both configurations.
+    parts = re.split(r'^  ([A-Za-z0-9_-]+):[ \t]*$', seed.split('\njobs:\n')[1], flags=re.M)
+    macs = {name: body for name, body in zip(parts[1::2], parts[2::2])
+            if 'runs-on: macos-latest' in body}
+    assert macs, 'no macOS seed job'
+    for name, body in macs.items():
+        assert "github.event_name != 'push'" in body, name
+    mac = ''.join(macs.values())
     assert mac.count('uses: ./.github/actions/macos-build-cache') == 2
     for name in ('checked-build', 'asan-build'):
         assert 'uses: ./.github/actions/macos-build-cache' in (repo / f'.github/actions/{name}/action.yml').read_text()
-    assert seed.count('runs-on: macos-latest') == 1
+    assert seed.count('runs-on: macos-latest') == len(macs)
     mac_build = (repo / '.github/workflows/macos-build.yml').read_text()
     warning = re.search(r'warning-flags: (.*)', mac_build)[1]
     flags = re.search(r'ASAN_CFLAGS: (.*)\n        (.*)', mac_build)

--- a/.github/scripts/ci-selftests.sh
+++ b/.github/scripts/ci-selftests.sh
@@ -7,6 +7,7 @@ ci_selftests() {
   ci_compile python3 "$script_dir/ci-cache-and-packages-test.py"
   ci_compile python3 "$script_dir/ci-next-optimizations-test.py"
   ci_compile python3 "$script_dir/ci-followup-test.py"
+  ci_compile python3 "$script_dir/seed-cache-workflow-test.py"
   ci_compile python3 "$script_dir/benchmark-build-test.py"
   ci_compile python3 "$script_dir/benchmark-cache-key-test.py"
   ci_compile python3 "$script_dir/../../test/sqllogictest_gate_test.py"

--- a/.github/scripts/seed-cache-workflow-test.py
+++ b/.github/scripts/seed-cache-workflow-test.py
@@ -1,0 +1,138 @@
+# Two invariants about workflows that nothing watches.
+#
+# A seeded cache is only seeded when it is cold, so a seed job that is given
+# less time than the work it warms passes every run that finds a warm cache and
+# times out on exactly the runs that matter. Nothing downstream fails: PR CI
+# just quietly rebuilds from scratch forever. So each seed job must carry at
+# least the budget CI already gives the same work.
+#
+# And a scheduled workflow that fails reports nothing by itself. Every
+# scheduled workflow therefore has to cut an issue somehow.
+
+import re
+from pathlib import Path
+
+repo = Path(__file__).resolve().parents[2]
+workflows = repo / '.github/workflows'
+checks = 0
+
+
+def jobs(name):
+    """Map job id -> (body, timeout-minutes or None) for one workflow."""
+    text = (workflows / name).read_text()
+    start = re.search(r'^jobs:[ \t]*$', text, re.M)
+    assert start, f'{name}: no jobs block'
+    parts = re.split(r'^  ([A-Za-z0-9_-]+):[ \t]*$', text[start.end():], flags=re.M)
+    found = {}
+    for job, body in zip(parts[1::2], parts[2::2]):
+        limit = re.search(r'^    timeout-minutes:[ \t]*(\d+)[ \t]*$', body, re.M)
+        found[job] = (body, int(limit[1]) if limit else None)
+    assert found, f'{name}: parsed no jobs'
+    return found
+
+
+# Work a seed job warms -> the CI job that already budgets for it. A seed job
+# that warms several caches serially needs the sum, counted per occurrence.
+REFERENCE = {
+    'uses: ./.github/actions/compatibility-cache': ('ci-build.yml', 'compat-build'),
+    'uses: ./.github/actions/sqllogictest-cache': ('ci-build.yml', 'sqllogictest-build'),
+    'build-optimized-benchmark.sh': ('ci-build.yml', 'benchmark-build'),
+    'macos-package-tests.sh': ('platform-test.yml', 'build-and-test'),
+    'uses: ./.github/actions/macos-build-cache': ('macos-build.yml', 'checked'),
+}
+
+
+def seed_budgets():
+    global checks
+    seed = jobs('seed-ci-caches.yml')
+    budgeted = 0
+    for job, (body, limit) in seed.items():
+        needed = 0
+        for marker, (workflow, reference) in REFERENCE.items():
+            count = body.count(marker)
+            if not count:
+                continue
+            budget = jobs(workflow)[reference][1]
+            assert budget, f'{workflow}:{reference} has no timeout to compare against'
+            needed += budget * count
+        if not needed:
+            continue
+        assert limit, f'seed job {job} warms a cache but sets no timeout-minutes'
+        assert limit >= needed, (
+            f'seed job {job} has {limit} minutes for work CI budgets {needed} '
+            f'minutes for; it will time out whenever the cache is actually cold')
+        budgeted += 1
+        checks += 1
+    assert budgeted >= 2, f'expected several seed jobs to warm caches, found {budgeted}'
+    # The mapping is only worth anything if every marker still appears.
+    for marker, (workflow, reference) in REFERENCE.items():
+        assert any(marker in body for body, _ in seed.values()), \
+            f'no seed job warms {marker}; drop it from REFERENCE or restore the seeding'
+        assert reference in jobs(workflow), f'{workflow} no longer defines {reference}'
+        checks += 1
+
+
+# Cuts issues with `gh issue create` rather than the shared action.
+REPORTS_DIRECTLY = {'sqlite-upstream-drift.yml'}
+# Ratchet: scheduled workflows that still report nothing when they fail. Empty
+# this set, never add to it.
+KNOWN_SILENT = {'dolt-oracle-upgrade.yml'}
+
+
+def scheduled_workflows_report():
+    global checks
+    scheduled = 0
+    for path in sorted(workflows.glob('*.yml')):
+        text = path.read_text()
+        if not re.search(r'^  schedule:[ \t]*$', text, re.M):
+            continue
+        scheduled += 1
+        if path.name in KNOWN_SILENT:
+            assert 'report-failure-issue' not in text, \
+                f'{path.name} reports failures now; remove it from KNOWN_SILENT'
+            continue
+        reporter = ('report-failure-issue' in text or
+                    (path.name in REPORTS_DIRECTLY and 'gh issue create' in text))
+        assert reporter, (
+            f'{path.name} runs on a schedule but reports nothing when it fails')
+        checks += 1
+    assert scheduled >= 6, f'expected the scheduled workflows, found {scheduled}'
+
+
+# A watchdog only fires while the run survives; a whole-run cancellation kills
+# it too. The weekly heartbeat is the outside observer, so it has to know about
+# every scheduled workflow that is otherwise silent.
+def heartbeat_covers_seeding():
+    global checks
+    text = (workflows / 'nightly-heartbeat.yml').read_text()
+    audited = re.search(r'^        for wf in ([^;]+); do', text, re.M)
+    assert audited, 'nightly-heartbeat no longer lists the workflows it audits'
+    assert 'seed-ci-caches' in audited[1].split(), \
+        'nightly-heartbeat does not audit seed-ci-caches, so a cancelled seed run is silent'
+    checks += 1
+
+
+def watchdog_arms_on_every_bad_end():
+    global checks
+    seed = jobs('seed-ci-caches.yml')
+    assert 'watchdog' in seed, 'seed-ci-caches has no watchdog job'
+    body, _ = seed['watchdog']
+    assert re.search(r'^    if:.*failure\(\).*cancelled\(\)', body, re.M), \
+        'the seed watchdog must arm on failure() and cancelled()'
+    assert 'issues: write' in body, 'the seed watchdog cannot open an issue'
+    assert 'uses: ./.github/actions/report-failure-issue' in body
+    needed = re.search(r'^    needs:[ \t]*\[([^\]]*)\]', body, re.M)
+    assert needed, 'the seed watchdog does not declare what it watches'
+    watched = {name.strip() for name in needed[1].split(',')}
+    working = {job for job, (text, _) in seed.items()
+               if job != 'watchdog' and any(m in text for m in REFERENCE)}
+    assert working <= watched, \
+        f'seed jobs not watched by the watchdog: {sorted(working - watched)}'
+    checks += 1
+
+
+seed_budgets()
+scheduled_workflows_report()
+heartbeat_covers_seeding()
+watchdog_arms_on_every_bad_end()
+print(f'Seed cache budgets and scheduled-workflow reporting: {checks} checks passed')

--- a/.github/workflows/nightly-heartbeat.yml
+++ b/.github/workflows/nightly-heartbeat.yml
@@ -1,12 +1,16 @@
-# The nightlies are silent when green and cut issues when they fail — but a
-# run that is cancelled whole, or never scheduled at all, produces nothing.
-# GitHub cancels every job in a cancelled run, per-run watchdogs included, so
-# absence cannot be detected from inside the run. This weekly job looks at
-# the record from outside: each of the last seven nights must show a
+# The scheduled workflows are silent when green and cut issues when they fail
+# — but a run that is cancelled whole, or never scheduled at all, produces
+# nothing. GitHub cancels every job in a cancelled run, per-run watchdogs
+# included, so absence cannot be detected from inside the run. This weekly job
+# looks at the record from outside: each of the last seven days must show a
 # scheduled run that reached a conclusion (success, or failure — failures
-# report themselves) for every nightly workflow, and each workflow must
+# report themselves) for every audited workflow, and each workflow must
 # still be active (a repo without pushes for 60 days gets its schedules
 # disabled by GitHub). Silent when the record is complete.
+#
+# Cache seeding is audited alongside the nightlies: it reports its own
+# failures, but a seed run that never happens leaves the caches cold and
+# nothing else notices.
 name: Nightly Heartbeat
 
 on:
@@ -34,7 +38,7 @@ jobs:
         BODY="$RUNNER_TEMP/heartbeat-body.md"
         : > "$BODY"
         SINCE=$(date -u -d '8 days ago' +%Y-%m-%d)
-        for wf in nightly-fuzz nightly-stress nightly-scale nightly-performance; do
+        for wf in nightly-fuzz nightly-stress nightly-scale nightly-performance seed-ci-caches; do
           state=$(gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/${wf}.yml" --jq .state)
           if [ "$state" != "active" ]; then
             echo "- \`$wf\` is **$state** — its schedule is not running at all." >> "$BODY"
@@ -54,8 +58,8 @@ jobs:
         done
         if [ -s "$BODY" ]; then
           {
-            echo "The nightly record for the last seven nights has holes. A missing or"
-            echo "cancelled night reports nothing on its own — that is why this check exists."
+            echo "The scheduled-run record for the last seven days has holes. A missing"
+            echo "or cancelled run reports nothing on its own — that is why this check exists."
             echo ""
             cat "$BODY"
           } > "$RUNNER_TEMP/heartbeat-issue.md"
@@ -63,7 +67,7 @@ jobs:
           echo "HEARTBEAT_GAPS=1" >> "$GITHUB_ENV"
           cat "$RUNNER_TEMP/heartbeat-issue.md"
         else
-          echo "All four nightlies ran to a conclusion every night. Silent."
+          echo "Every audited workflow ran to a conclusion every day. Silent."
         fi
 
     - name: Report the gaps

--- a/.github/workflows/seed-ci-caches.yml
+++ b/.github/workflows/seed-ci-caches.yml
@@ -1,3 +1,10 @@
+# Warms the caches PR CI restores, so a cold cache costs a scheduled run
+# rather than every pull request. Each cache is warmed by its own job: the
+# work is independent, and one slow cache must not eat the budget of the
+# others. A job is given at least the time CI already budgets for the same
+# work, because a seed job only does that work when the cache is cold --- a
+# budget that fits a warm run passes every time and times out on exactly the
+# runs that matter.
 name: Seed CI caches
 
 on:
@@ -14,7 +21,7 @@ jobs:
   benchmark:
     if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     concurrency:
       group: seed-benchmark-cache
       cancel-in-progress: false
@@ -59,22 +66,51 @@ jobs:
           echo "::error::compiler warnings in optimized base build"
           exit 1
         fi
+
+  compatibility:
+    if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    concurrency:
+      group: seed-compatibility-cache
+      cancel-in-progress: false
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.repository.default_branch }}
+        fetch-depth: 0
+    - name: Install dependencies
+      run: |
+        bash .github/scripts/install-apt-deps.sh \
+          build-essential tcl-dev zlib1g-dev
     - uses: ./.github/actions/compatibility-cache
+
+  sqllogictest:
+    if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    concurrency:
+      group: seed-sqllogictest-cache
+      cancel-in-progress: false
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.repository.default_branch }}
     - name: Install SQLLogicTest dependencies
-      run: bash .github/scripts/install-apt-deps.sh fossil unixodbc-dev
+      run: |
+        bash .github/scripts/install-apt-deps.sh \
+          build-essential fossil unixodbc-dev
     - uses: ./.github/actions/sqllogictest-cache
 
-  macos:
+  macos-packages:
     if: >-
       github.event_name != 'push' &&
       github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
     runs-on: macos-latest
-    timeout-minutes: 15
+    timeout-minutes: 35
     concurrency:
-      group: seed-macos-cache
+      group: seed-macos-package-cache
       cancel-in-progress: false
-    env:
-      CFLAGS: -O2 -g -Werror
     steps:
     - uses: actions/checkout@v4
       with:
@@ -106,6 +142,23 @@ jobs:
         make -j"$(sysctl -n hw.logicalcpu)" libdoltlite.a
         bash ../.github/scripts/check-compiler-cache.sh
 
+  macos-builds:
+    if: >-
+      github.event_name != 'push' &&
+      github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+    runs-on: macos-latest
+    timeout-minutes: 50
+    concurrency:
+      group: seed-macos-build-cache
+      cancel-in-progress: false
+    env:
+      CFLAGS: -O2 -g -Werror
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.repository.default_branch }}
+    - name: Install build dependencies
+      run: brew install tcl-tk
     - uses: ./.github/actions/macos-build-cache
       id: checked-cache
       with:
@@ -143,3 +196,45 @@ jobs:
           LDFLAGS="-fsanitize=address,undefined" libdoltlite.a
         bash ../.github/scripts/check-compiler-cache.sh
     - uses: ./.github/actions/save-macos-build-cache
+
+  # Seeding is invisible when it breaks: the caches simply stay cold and PR CI
+  # gets slower. Nothing downstream turns red, so the run has to report itself.
+  # A whole-run cancellation kills this job too, which is what the weekly
+  # nightly-heartbeat audit catches from outside.
+  watchdog:
+    needs: [benchmark, compatibility, sqllogictest, macos-packages, macos-builds]
+    if: failure() || cancelled()
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      issues: write
+    steps:
+    - uses: actions/checkout@v4
+    - name: Describe the incident
+      run: |
+        {
+          echo "A scheduled CI cache seeding run did not finish."
+          echo ""
+          echo "Every cache below is restored by PR CI and rebuilt from scratch"
+          echo "when it is missing. A seed run that fails or times out leaves the"
+          echo "cold cache in place, and the only symptom is that pull requests"
+          echo "get slower, which nothing else reports."
+          echo ""
+          echo "| Cache | Result |"
+          echo "| --- | --- |"
+          echo "| benchmark base build | ${{ needs.benchmark.result }} |"
+          echo "| compatibility references | ${{ needs.compatibility.result }} |"
+          echo "| SQLLogicTest reference | ${{ needs.sqllogictest.result }} |"
+          echo "| macOS package caches | ${{ needs.macos-packages.result }} |"
+          echo "| macOS compiler caches | ${{ needs.macos-builds.result }} |"
+          echo ""
+          echo "A job that timed out is budgeted for less than the work it warms;"
+          echo "compare it against the CI job that builds the same thing."
+        } > "$RUNNER_TEMP/seed-watchdog-body.md"
+    - uses: ./.github/actions/report-failure-issue
+      with:
+        label: seed-ci-caches
+        title: "CI cache seeding did not finish"
+        body-file: ${{ runner.temp }}/seed-watchdog-body.md
+        token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Follow-up to #2843, from reviewing it.

## The defect

`seed-ci-caches.yml` budgeted less time than the work it warms.

| Seed job | Budget | CI budget for the same work |
| --- | --- | --- |
| `benchmark` (3 Ubuntu caches) | 15 min | 15 + 20 + 10 |
| `macos` (packages + 2 builds) | 15 min | 25 + 20 + 20 |

The failure mode is invisible by construction. A seed job only does real work
when the cache is cold, so every run that found a warm cache finished in
minutes and passed. The run *after* a cache-invalidating change — the only run
that seeds anything — blew the timeout. Nothing downstream turns red when
seeding fails; PR CI just rebuilds from scratch forever.

It compounded because this workflow, alone among the scheduled ones, had no
failure reporter. Nightly fuzz, stress, scale, performance, heartbeat and
inventory-liveness all cut an issue. A seed failure notified nobody.

## The fix

- One job per cache (`benchmark`, `compatibility`, `sqllogictest`,
  `macos-packages`, `macos-builds`), so one slow cache cannot eat another's
  budget, each carrying at least the budget CI already gives that work.
- A `watchdog` job on `failure() || cancelled()` using the existing
  `report-failure-issue` action, with `issues: write` scoped to that job.
- `seed-ci-caches` enrolled in `nightly-heartbeat`, since a whole-run
  cancellation kills the watchdog too — the same reasoning the heartbeat
  already documents for the nightlies.

Splitting macOS costs a duplicated `brew`/`configure` (~5 min at the 10x rate)
and buys failure isolation plus a budget that maps 1:1 to an established CI
number. Ubuntu splits for free and now runs its three caches in parallel.

## Why this cannot come back

`seed-cache-workflow-test.py` (wired into `make lint`) holds two invariants:

1. a seed job budgets at least the **sum** of the CI budgets for the work it
   warms, counted per occurrence;
2. every workflow with a `schedule:` trigger reports its own failures.

It derives the reference budgets by parsing the CI workflows rather than
repeating them, so it stays true as those budgets change.

Fail-before, on the pre-fix tree:

```
seed job benchmark has 15 minutes for work CI budgets 45 minutes for;
it will time out whenever the cache is actually cold
```

and for the other four cases: watchdog removed, heartbeat enrollment dropped,
a scheduled workflow losing its reporter, and a budget cut back to 15.

## One thing this surfaced but does not fix

`dolt-oracle-upgrade.yml` is scheduled daily and also reports nothing on
failure — same bug class, different workflow. It sits in a `KNOWN_SILENT`
ratchet set with a "empty this, never add to it" note rather than a quiet
exemption. Filing separately rather than bundling it here.

## Existing checks

Two assertions in `ci-cache-and-packages-test.py` and
`ci-next-optimizations-test.py` hardcoded the seed job count (`== 2`). Rather
than bump the numbers, they now assert the property per job — every seeding
job is pinned to the default branch, queues rather than cancels, and every
macOS job skips pushes — and name the job that broke it. Verified each still
bites by removing the guard from one job at a time.

`make lint` is green: 20 new checks, 380+ existing CI-wiring checks unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)