### PR TITLE
Bump Homebrew formula to 0.50.10

### DIFF
--- a/packaging/homebrew/doltlite.rb
+++ b/packaging/homebrew/doltlite.rb
@@ -6,8 +6,8 @@
 class Doltlite < Formula
   desc "SQLite fork with Git-style version control via prolly trees"
   homepage "https://github.com/dolthub/doltlite"
-  url "https://github.com/dolthub/doltlite/releases/download/v0.50.9/doltlite-autoconf-0.50.9.tar.gz"
-  sha256 "8295fc600d229b4fa5effbdec91a6e027d16dbf58323fdd0c31de3971162556a"
+  url "https://github.com/dolthub/doltlite/releases/download/v0.50.10/doltlite-autoconf-0.50.10.tar.gz"
+  sha256 "54530766cf57dd33c046998872db76a3bdf09e673fd629b87ef5b7fde1854f7c"
   # Composite, and both halves are real: the DoltLite extensions are
   # Apache-2.0, the SQLite code they are built on is public domain. Stating
   # only the first would misdescribe the tarball this formula builds.


### PR DESCRIPTION
Points the formula at the v0.50.10 release tarball. Opened by the release workflow.