### PR TITLE
Report a Dolt oracle upgrade that never finished

### DIFF
--- a/.github/scripts/seed-cache-workflow-test.py
+++ b/.github/scripts/seed-cache-workflow-test.py
@@ -76,7 +76,7 @@ def seed_budgets():
 REPORTS_DIRECTLY = {'sqlite-upstream-drift.yml'}
 # Ratchet: scheduled workflows that still report nothing when they fail. Empty
 # this set, never add to it.
-KNOWN_SILENT = {'dolt-oracle-upgrade.yml'}
+KNOWN_SILENT = set()
 
 
 def scheduled_workflows_report():
@@ -99,17 +99,28 @@ def scheduled_workflows_report():
     assert scheduled >= 6, f'expected the scheduled workflows, found {scheduled}'
 
 
-# A watchdog only fires while the run survives; a whole-run cancellation kills
-# it too. The weekly heartbeat is the outside observer, so it has to know about
-# every scheduled workflow that is otherwise silent.
-def heartbeat_covers_seeding():
+# A watchdog only fires while its own run survives; a whole-run cancellation
+# kills it along with everything else. So a watchdog is only half the story:
+# the weekly heartbeat has to audit that workflow from outside as well.
+def heartbeat_covers_every_watchdog():
     global checks
     text = (workflows / 'nightly-heartbeat.yml').read_text()
-    audited = re.search(r'^        for wf in ([^;]+); do', text, re.M)
-    assert audited, 'nightly-heartbeat no longer lists the workflows it audits'
-    assert 'seed-ci-caches' in audited[1].split(), \
-        'nightly-heartbeat does not audit seed-ci-caches, so a cancelled seed run is silent'
-    checks += 1
+    listed = re.search(r'^        for wf in ([^;]+); do', text, re.M)
+    assert listed, 'nightly-heartbeat no longer lists the workflows it audits'
+    audited = set(listed[1].split())
+    covered = 0
+    for path in sorted(workflows.glob('*.yml')):
+        body = path.read_text()
+        if not re.search(r'^  schedule:[ \t]*$', body, re.M):
+            continue
+        if not re.search(r'^  watchdog:[ \t]*$', body, re.M):
+            continue
+        assert path.stem in audited, (
+            f'{path.name} has a watchdog but nightly-heartbeat does not audit it; '
+            f'a whole-run cancellation would kill the watchdog and report nothing')
+        covered += 1
+        checks += 1
+    assert covered >= 5, f'expected the watchdog workflows, found {covered}'
 
 
 def watchdog_arms_on_every_bad_end():
@@ -133,6 +144,6 @@ def watchdog_arms_on_every_bad_end():
 
 seed_budgets()
 scheduled_workflows_report()
-heartbeat_covers_seeding()
+heartbeat_covers_every_watchdog()
 watchdog_arms_on_every_bad_end()
 print(f'Seed cache budgets and scheduled-workflow reporting: {checks} checks passed')

--- a/.github/workflows/dolt-oracle-upgrade.yml
+++ b/.github/workflows/dolt-oracle-upgrade.yml
@@ -37,3 +37,40 @@ jobs:
 
     - name: Reconcile Dolt oracle upgrades
       run: bash .github/scripts/upgrade-dolt-oracle.sh
+
+  # A successful run's product is a pull request, so a failed run leaves
+  # nothing behind and an absent PR is indistinguishable from "Dolt had no new
+  # release today". The pin then stops tracking Dolt with nothing saying so.
+  # A whole-run cancellation kills this job too, which is what the weekly
+  # nightly-heartbeat audit catches from outside.
+  watchdog:
+    needs: upgrade
+    if: failure() || cancelled()
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      issues: write
+    steps:
+    - uses: actions/checkout@v4
+    - name: Describe the incident
+      run: |
+        {
+          echo "The scheduled Dolt oracle upgrade run did not finish."
+          echo ""
+          echo "This job reconciles \`.dolt-oracle-version\` against the latest"
+          echo "Dolt release and opens the upgrade pull request. When it fails"
+          echo "there is no pull request whose absence anyone would notice, so"
+          echo "the oracle silently stops tracking Dolt."
+          echo ""
+          echo "Currently pinned: \`$(tr -d '[:space:]' < .dolt-oracle-version)\`"
+          echo ""
+          echo "The upgrade script is \`set -euo pipefail\` throughout, so the"
+          echo "step log names the failing command."
+        } > "$RUNNER_TEMP/dolt-oracle-watchdog-body.md"
+    - uses: ./.github/actions/report-failure-issue
+      with:
+        label: dolt-oracle-upgrade
+        title: "Dolt oracle upgrade did not finish"
+        body-file: ${{ runner.temp }}/dolt-oracle-watchdog-body.md
+        token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nightly-heartbeat.yml
+++ b/.github/workflows/nightly-heartbeat.yml
@@ -38,7 +38,7 @@ jobs:
         BODY="$RUNNER_TEMP/heartbeat-body.md"
         : > "$BODY"
         SINCE=$(date -u -d '8 days ago' +%Y-%m-%d)
-        for wf in nightly-fuzz nightly-stress nightly-scale nightly-performance seed-ci-caches; do
+        for wf in nightly-fuzz nightly-stress nightly-scale nightly-performance seed-ci-caches dolt-oracle-upgrade; do
           state=$(gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/${wf}.yml" --jq .state)
           if [ "$state" != "active" ]; then
             echo "- \`$wf\` is **$state** — its schedule is not running at all." >> "$BODY"


### PR DESCRIPTION
Closes #2845.

## The gap

`dolt-oracle-upgrade.yml` ran daily on a schedule and reported nothing when
it failed. It was the last scheduled workflow without a reporter — the four
nightlies, `inventory-issue-liveness` and (as of #2844) `seed-ci-caches` all
cut an issue via `report-failure-issue`, and `sqlite-upstream-drift` calls
`gh issue create` directly.

A successful run's product is a pull request, so a failed run leaves nothing
behind, and an absent PR is indistinguishable from "Dolt had no new release
today". The oracle pin could stop tracking Dolt for an arbitrary stretch with
nothing saying so.

I checked this was worth a watchdog rather than a script fix first:
`upgrade-dolt-oracle.sh` is `set -euo pipefail` throughout and exits non-zero
on an unparseable version or a failed `gh` call, so failures were already
reaching the job. Only the reporting was missing.

## The fix

- The same `watchdog` job the nightlies use (`failure() || cancelled()`,
  `issues: write` scoped to that job, `GITHUB_TOKEN` rather than the release
  bot token). The body names the currently pinned version and points at the
  step log.
- Enrollment in the weekly `nightly-heartbeat` audit, because a whole-run
  cancellation takes a watchdog with it.

## A rule that was waiting to be written down

Mapping watchdogs against the heartbeat's audit list showed the workflows
carrying a `watchdog:` job were *already exactly* the workflows the heartbeat
audits. So the lint #2844 added — which named `seed-ci-caches` specifically —
now states the general property instead:

> a watchdog only fires while its own run survives, so any workflow carrying
> one must also be audited from outside.

Adding a watchdog anywhere now *requires* the heartbeat enrollment, rather
than depending on someone remembering it. That is strictly stronger than the
assertion it replaces and it covers `seed-ci-caches` as a case rather than by
name.

`KNOWN_SILENT` is now empty, as intended when it was introduced.

## Fail-before

| Regression | Diagnostic |
| --- | --- |
| watchdog removed | `dolt-oracle-upgrade.yml runs on a schedule but reports nothing when it fails` |
| watchdog present, unaudited | `...has a watchdog but nightly-heartbeat does not audit it; a whole-run cancellation would kill the watchdog and report nothing` |
| `seed-ci-caches` dropped from the audit | same message, for `seed-ci-caches.yml` |
| ratchet entry left behind after the fix | `...reports failures now; remove it from KNOWN_SILENT` |

That last one is why the ratchet is safe to keep: a stale entry fails rather
than quietly exempting a workflow that no longer needs exempting.

`make lint` is green; the test goes 20 → 26 checks, and the other CI-wiring
suites (57 and 52 checks) are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)