### PR TITLE
Cache All-Debug compiler objects and start long builds first

### DIFF
--- a/.github/actions/development-debug-build/action.yml
+++ b/.github/actions/development-debug-build/action.yml
@@ -1,0 +1,75 @@
+name: Development All-Debug build
+description: Build every All-Debug target with cached compiler objects.
+runs:
+  using: composite
+  steps:
+  - name: Install dependencies
+    shell: bash
+    run: |
+      bash .github/scripts/install-apt-deps.sh \
+        build-essential tcl-dev libsqlite3-tcl zlib1g-dev ccache
+
+  - name: Identify compiler cache
+    id: identity
+    shell: bash
+    run: |
+      key=$({
+        sha256sum "$(readlink -f /usr/bin/cc)"
+        cc --version
+        ccache --version
+        dpkg-query -W -f='${Package} ${Version}\n' \
+          libc6-dev linux-libc-dev tcl-dev libsqlite3-tcl zlib1g-dev
+        printf '%s\n' "${ImageOS:-}" "${ImageVersion:-}"
+      } | sha256sum | cut -d ' ' -f 1)
+      echo "key=development-debug-v1-${{ runner.arch }}-$key" >> "$GITHUB_OUTPUT"
+
+  - name: Verify build scheduling
+    shell: bash
+    run: python3 .github/scripts/development-debug-test.py --scheduler --compiler
+
+  - name: Restore compiler cache
+    id: cache
+    uses: actions/cache/restore@v4
+    with:
+      path: ${{ runner.temp }}/development-debug-ccache
+      key: ${{ steps.identity.outputs.key }}-${{ github.sha }}
+      restore-keys: |
+        ${{ steps.identity.outputs.key }}-
+
+  - name: Compile development configurations
+    shell: bash
+    env:
+      CCACHE_DIR: ${{ runner.temp }}/development-debug-ccache
+      CCACHE_MAXSIZE: 512M
+      CCACHE_COMPILERCHECK: content
+      DOLTLITE_SPLIT_TEST_COMPILE: '1'
+      CC: ccache cc
+      CFLAGS: -O2 -g -Werror
+    run: |
+      ccache --zero-stats
+      mkdir -p build
+      cd build
+      TCL_CONFIG=$(find /usr/lib -name tclConfig.sh -print -quit 2>/dev/null)
+      if [ -n "$TCL_CONFIG" ]; then
+        ../configure --with-tcl=$(dirname "$TCL_CONFIG")
+      else
+        ../configure
+      fi
+      tclsh ../test/testrunner.tcl --buildonly --jobs 4 --config All-Debug mdevtest
+      bash ../.github/scripts/check-compiler-cache.sh
+
+  - name: Report development build timings
+    if: always()
+    shell: bash
+    run: |
+      if [ -f build/testrunner.db ]; then
+        python3 .github/scripts/development-build-timings.py build/testrunner.db \
+          | tee -a "$GITHUB_STEP_SUMMARY"
+      fi
+
+  - name: Save compiler cache
+    if: steps.cache.outputs.cache-hit != 'true'
+    uses: actions/cache/save@v4
+    with:
+      path: ${{ runner.temp }}/development-debug-ccache
+      key: ${{ steps.identity.outputs.key }}-${{ github.sha }}

--- a/.github/actions/development-debug-build/action.yml
+++ b/.github/actions/development-debug-build/action.yml
@@ -17,6 +17,8 @@ runs:
     id: identity
     shell: bash
     run: |
+      cc --version
+      lscpu | grep -E '^(CPU\(s\)|Model name|Thread\(s\) per core|Core\(s\) per socket):'
       key=$({
         sha256sum "$(readlink -f /usr/bin/cc)"
         cc --version
@@ -79,3 +81,13 @@ runs:
     with:
       path: ${{ runner.temp }}/development-debug-ccache
       key: ${{ steps.identity.outputs.key }}-${{ github.sha }}
+
+  - name: Upload build timings and commands
+    if: always() && steps.build.outcome != 'skipped'
+    uses: actions/upload-artifact@v4
+    with:
+      name: development-debug-logs
+      path: |
+        build/testrunner.db
+        build/testrunner.log
+      retention-days: 1

--- a/.github/actions/development-debug-build/action.yml
+++ b/.github/actions/development-debug-build/action.yml
@@ -1,5 +1,9 @@
 name: Development All-Debug build
 description: Build every All-Debug target with cached compiler objects.
+inputs:
+  seed:
+    description: Only populate a missing compiler cache.
+    default: 'false'
 runs:
   using: composite
   steps:
@@ -37,6 +41,8 @@ runs:
         ${{ steps.identity.outputs.key }}-
 
   - name: Compile development configurations
+    id: build
+    if: inputs.seed != 'true' || steps.cache.outputs.cache-matched-key == ''
     shell: bash
     env:
       CCACHE_DIR: ${{ runner.temp }}/development-debug-ccache
@@ -68,7 +74,7 @@ runs:
       fi
 
   - name: Save compiler cache
-    if: steps.cache.outputs.cache-hit != 'true'
+    if: steps.build.outcome == 'success' && steps.cache.outputs.cache-hit != 'true'
     uses: actions/cache/save@v4
     with:
       path: ${{ runner.temp }}/development-debug-ccache

--- a/.github/scripts/ci-selftests.sh
+++ b/.github/scripts/ci-selftests.sh
@@ -7,6 +7,7 @@ ci_selftests() {
   ci_compile python3 "$script_dir/ci-cache-and-packages-test.py"
   ci_compile python3 "$script_dir/ci-next-optimizations-test.py"
   ci_compile python3 "$script_dir/ci-followup-test.py"
+  ci_compile python3 "$script_dir/development-debug-test.py"
   ci_compile python3 "$script_dir/seed-cache-workflow-test.py"
   ci_compile python3 "$script_dir/benchmark-build-test.py"
   ci_compile python3 "$script_dir/benchmark-cache-key-test.py"

--- a/.github/scripts/development-build-timings.py
+++ b/.github/scripts/development-build-timings.py
@@ -1,0 +1,17 @@
+import sqlite3
+import sys
+
+with sqlite3.connect(sys.argv[1]) as db:
+    rows = db.execute('''
+        SELECT displayname, state, starttime, endtime FROM jobs
+        WHERE displaytype='bld' ORDER BY starttime
+    ''').fetchall()
+if not rows:
+    sys.exit('No development build timings recorded')
+start = min((row[2] for row in rows if row[2] is not None), default=0)
+print('| Target | State | Start | Duration |')
+print('| --- | --- | ---: | ---: |')
+for name, state, begin, end in rows:
+    offset = f'{(begin-start)/1000:.1f}s' if begin is not None else '—'
+    duration = f'{(end-begin)/1000:.1f}s' if begin is not None and end is not None else '—'
+    print(f'| {name} | {state} | {offset} | {duration} |')

--- a/.github/scripts/development-debug-test.py
+++ b/.github/scripts/development-debug-test.py
@@ -100,7 +100,12 @@ check("DOLTLITE_SPLIT_TEST_COMPILE: '1'" in action and 'CC: ccache cc' in action
 check('check-compiler-cache.sh' in action, 'cache health check missing')
 check('actions/cache/save@v4' in action and 'actions/cache/restore@v4' in action,
       'compiler cache must be restored and saved explicitly')
+check("default: 'false'" in action and "if: inputs.seed != 'true' ||" in action,
+      'PR builds must still compile on a cache hit')
+check("steps.cache.outputs.cache-matched-key == ''" in action,
+      'seeding must not rebuild an already populated compiler cache')
 seed = (repo / '.github/workflows/seed-ci-caches.yml').read_text()
+check("seed: 'true'" in seed, 'seeding must opt into skipping populated caches')
 check('needs: [benchmark, compatibility, sqllogictest, development-debug,' in seed,
       'cache seeding failure is not watched')
 

--- a/.github/scripts/development-debug-test.py
+++ b/.github/scripts/development-debug-test.py
@@ -1,0 +1,166 @@
+import json
+import os
+from pathlib import Path
+import subprocess
+import sqlite3
+import sys
+import tempfile
+
+repo = Path(__file__).resolve().parents[2]
+checks = 0
+
+
+def check(condition, message):
+    global checks
+    assert condition, message
+    checks += 1
+
+
+with tempfile.TemporaryDirectory(prefix='development build ') as temp:
+    root = Path(temp)
+    compiler = root / 'compiler.py'
+    compiler.write_text('''
+import json, os, pathlib, sys
+args = sys.argv[1:]
+with open('commands.jsonl', 'a') as f:
+    f.write(json.dumps(args) + '\\n')
+if os.environ.get('FAIL_ARGUMENT') in args:
+    print('injected compiler failure', file=sys.stderr)
+    sys.exit(23)
+if os.environ.get('FAIL_LINK') and '-c' not in args:
+    print('injected linker failure', file=sys.stderr)
+    sys.exit(24)
+if '-c' in args:
+    print('compiler diagnostic', file=sys.stderr)
+pathlib.Path(args[args.index('-o') + 1]).write_text('output')
+''')
+
+    def run(extra_env=None, extra_flags=()):
+        (root / 'commands.jsonl').unlink(missing_ok=True)
+        (root / 'testfixture').unlink(missing_ok=True)
+        result = subprocess.run([
+            sys.executable, str(repo / 'tool/compile-test.py'),
+            '--cc', sys.executable, str(compiler), '-g', '-I.',
+            '--cflags', '-DSQLITE_TEST=1', '-DVERSION="test version"', *extra_flags,
+            '--sources', 'one dir/same.c', 'two dir/same.c', 'libengine.a',
+            '--ldflags', '-ltcl', '-lm', '--output', 'testfixture',
+        ], cwd=root, env=dict(os.environ, **(extra_env or {})),
+           capture_output=True, text=True)
+        calls = [json.loads(line) for line in (root / 'commands.jsonl').read_text().splitlines()]
+        return result, calls
+
+    result, calls = run()
+    check(result.returncode == 0, result.stderr)
+    check(len(calls) == 3, 'two compilations and one link are required')
+    check(result.stderr.count('compiler diagnostic') == 2, 'compiler diagnostics lost')
+    check((root / 'testfixture').is_file(), 'output missing')
+    objects = []
+    for index, source in enumerate(('one dir/same.c', 'two dir/same.c')):
+        args = calls[index]
+        check(args[args.index('-c') + 1] == source, 'source argument changed')
+        check('-DSQLITE_TEST=1' in args and '-DVERSION="test version"' in args,
+              'test flags or quoting changed')
+        check('-ltcl' not in args and 'libengine.a' not in args, 'link inputs reached compiler')
+        obj = args[args.index('-o') + 1]
+        check((root / obj).is_file(), 'object missing')
+        objects.append(obj)
+    check(objects[0] != objects[1], 'same-named sources overwrite one another')
+    link = calls[-1]
+    check(link[link.index('-o') + 2:] == objects + ['libengine.a', '-ltcl', '-lm'],
+          'link order changed')
+    check('-DSQLITE_TEST=1' in link, 'link flags changed')
+
+    for flag in ('-fsanitize=address', '-fsanitize=undefined'):
+        result, calls = run(extra_flags=(flag,))
+        check(result.returncode == 0, result.stderr)
+        check(all(flag in args for args in calls), 'sanitizer flag lost during compile or link')
+
+    for source in ('one dir/same.c', 'two dir/same.c'):
+        result, calls = run({'FAIL_ARGUMENT': source})
+        check(result.returncode == 23, 'compiler failure hidden')
+        check('injected compiler failure' in result.stderr, 'compiler failure diagnostic lost')
+        check(all('-c' in args for args in calls), 'linked after a failed compilation')
+        check(not (root / 'testfixture').exists(), 'failed build created a binary')
+
+    result, calls = run({'FAIL_LINK': '1'})
+    check(result.returncode == 24, 'linker failure hidden')
+    check('injected linker failure' in result.stderr, 'linker failure diagnostic lost')
+    check(not (root / 'testfixture').exists(), 'failed link created a binary')
+
+workflow = (repo / '.github/workflows/ci-build.yml').read_text()
+job = workflow.split('  development-builds:\n', 1)[1].split('  assert-build:\n', 1)[0]
+check("if: matrix.configuration == 'All-Debug'" in job, 'All-Debug must use the cached build')
+check(job.count("if: matrix.configuration != 'All-Debug'") == 3,
+      'All-O0 must retain its install, configure and compile steps')
+action = (repo / '.github/actions/development-debug-build/action.yml').read_text()
+check('--buildonly --jobs 4 --config All-Debug mdevtest' in action,
+      'development targets or worker limit changed')
+check("DOLTLITE_SPLIT_TEST_COMPILE: '1'" in action and 'CC: ccache cc' in action,
+      'compilations do not reach the cache')
+check('check-compiler-cache.sh' in action, 'cache health check missing')
+check('actions/cache/save@v4' in action and 'actions/cache/restore@v4' in action,
+      'compiler cache must be restored and saved explicitly')
+seed = (repo / '.github/workflows/seed-ci-caches.yml').read_text()
+check('needs: [benchmark, compatibility, sqllogictest, development-debug,' in seed,
+      'cache seeding failure is not watched')
+
+if '--scheduler' in sys.argv:
+    for configuration, expected in (
+            ('All-Debug', ['fuzzcheck-asan', 'fuzzcheck-ubsan', 'testfixture',
+                           'fuzzcheck', 'sessionfuzz', 'sqlite3']),
+            ('All-O0', ['testfixture', 'fuzzcheck', 'sessionfuzz', 'sqlite3'])):
+        for workers in (1, 4):
+            with tempfile.TemporaryDirectory() as temp:
+                result = subprocess.run([
+                    'tclsh', str(repo / 'test/testrunner.tcl'), '--dryrun', '--buildonly',
+                    '--jobs', str(workers), '--config', configuration, 'mdevtest',
+                ], cwd=temp, text=True, capture_output=True)
+                check(result.returncode == 0, result.stdout + result.stderr)
+                log = (Path(temp) / 'testrunner.log').read_text()
+                targets = [line.split('bash make.sh ', 1)[1].split()[0]
+                           for line in log.splitlines() if 'bash make.sh ' in line]
+                check(targets == expected, f'wrong build order or target set: {targets}')
+                with sqlite3.connect(Path(temp) / 'testrunner.db') as db:
+                    rows = db.execute('SELECT jobid, displayname, depid, cmd FROM jobs').fetchall()
+                fixture = next(row for row in rows if '(testfixture)' in row[1])
+                shell = next(row for row in rows if '(sqlite3)' in row[1])
+                check(str(shell[2]) == str(fixture[0]), 'shell prerequisite lost')
+                check('cp sqlite3 ' in shell[3], 'shell copy to fixture directory lost')
+
+if '--compiler' in sys.argv:
+    with tempfile.TemporaryDirectory(prefix='development-cache-') as temp:
+        root = Path(temp)
+        env = dict(os.environ, CCACHE_DIR=str(root / 'cache'), CCACHE_COMPILERCHECK='content')
+        (root / 'value.h').write_text('#define VALUE 4\n')
+        (root / 'value.c').write_text('#include "value.h"\nint value(void){return VALUE+EXTRA;}\n')
+        (root / 'main.c').write_text(
+            '#include <stdio.h>\nint value(void);\n'
+            'int main(void){printf("%d %s\\n", value(), VERSION);return 0;}\n')
+
+        def compile_probe(expected, extra=1, version='first'):
+            result = subprocess.run([
+                sys.executable, str(repo / 'tool/compile-test.py'),
+                '--cc', 'ccache', 'cc', '-g', '-O0',
+                '--cflags', f'-DEXTRA={extra}', f'-DVERSION="{version}"',
+                '--sources', 'main.c', 'value.c', '--ldflags', '-lm', '--output', 'probe',
+            ], cwd=root, env=env, capture_output=True, text=True)
+            check(result.returncode == 0, result.stderr)
+            result = subprocess.run([str(root / 'probe')], capture_output=True, text=True, check=True)
+            check(result.stdout.strip() == expected, 'cached program has stale inputs: ' + result.stdout)
+
+        compile_probe('5 first')
+        subprocess.run(['ccache', '--zero-stats'], env=env, check=True, capture_output=True)
+        compile_probe('5 first')
+        result = subprocess.run(['ccache', '--print-stats'], env=env, check=True,
+                                capture_output=True, text=True)
+        stats = dict(line.split() for line in result.stdout.splitlines())
+        hits = int(stats.get('direct_cache_hit', 0)) + int(stats.get('preprocessed_cache_hit', 0))
+        check(hits == 2, f'warm compilation did not reuse both objects: {stats}')
+        (root / 'value.h').write_text('#define VALUE 8\n')
+        compile_probe('9 first')
+        compile_probe('11 first', extra=3)
+        compile_probe('11 second', extra=3, version='second')
+        (root / 'value.c').write_text('#include "value.h"\nint value(void){return VALUE+EXTRA+100;}\n')
+        compile_probe('111 second', extra=3, version='second')
+
+print(f'Development build caching: {checks} checks passed')

--- a/.github/scripts/seed-cache-workflow-test.py
+++ b/.github/scripts/seed-cache-workflow-test.py
@@ -34,6 +34,7 @@ def jobs(name):
 # Work a seed job warms -> the CI job that already budgets for it. A seed job
 # that warms several caches serially needs the sum, counted per occurrence.
 REFERENCE = {
+    'uses: ./.github/actions/development-debug-build': ('ci-build.yml', 'development-builds'),
     'uses: ./.github/actions/compatibility-cache': ('ci-build.yml', 'compat-build'),
     'uses: ./.github/actions/sqllogictest-cache': ('ci-build.yml', 'sqllogictest-build'),
     'build-optimized-benchmark.sh': ('ci-build.yml', 'benchmark-build'),

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -585,12 +585,17 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    - uses: ./.github/actions/development-debug-build
+      if: matrix.configuration == 'All-Debug'
+
     - name: Install dependencies
+      if: matrix.configuration != 'All-Debug'
       run: |
         bash .github/scripts/install-apt-deps.sh \
           build-essential tcl-dev libsqlite3-tcl zlib1g-dev
 
     - name: Configure
+      if: matrix.configuration != 'All-Debug'
       run: |
         mkdir -p build
         cd build
@@ -602,6 +607,7 @@ jobs:
         fi
 
     - name: Compile development configurations
+      if: matrix.configuration != 'All-Debug'
       run: |
         cd build
         tclsh ../test/testrunner.tcl \

--- a/.github/workflows/seed-ci-caches.yml
+++ b/.github/workflows/seed-ci-caches.yml
@@ -102,6 +102,21 @@ jobs:
           build-essential fossil unixodbc-dev
     - uses: ./.github/actions/sqllogictest-cache
 
+  development-debug:
+    if: >-
+      github.event_name != 'push' &&
+      github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    concurrency:
+      group: seed-development-debug-cache
+      cancel-in-progress: false
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.repository.default_branch }}
+    - uses: ./.github/actions/development-debug-build
+
   macos-packages:
     if: >-
       github.event_name != 'push' &&
@@ -202,7 +217,7 @@ jobs:
   # A whole-run cancellation kills this job too, which is what the weekly
   # nightly-heartbeat audit catches from outside.
   watchdog:
-    needs: [benchmark, compatibility, sqllogictest, macos-packages, macos-builds]
+    needs: [benchmark, compatibility, sqllogictest, development-debug, macos-packages, macos-builds]
     if: failure() || cancelled()
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -226,6 +241,7 @@ jobs:
           echo "| benchmark base build | ${{ needs.benchmark.result }} |"
           echo "| compatibility references | ${{ needs.compatibility.result }} |"
           echo "| SQLLogicTest reference | ${{ needs.sqllogictest.result }} |"
+          echo "| All-Debug compiler cache | ${{ needs.development-debug.result }} |"
           echo "| macOS package caches | ${{ needs.macos-packages.result }} |"
           echo "| macOS compiler caches | ${{ needs.macos-builds.result }} |"
           echo ""

--- a/.github/workflows/seed-ci-caches.yml
+++ b/.github/workflows/seed-ci-caches.yml
@@ -116,6 +116,8 @@ jobs:
       with:
         ref: ${{ github.event.repository.default_branch }}
     - uses: ./.github/actions/development-debug-build
+      with:
+        seed: 'true'
 
   macos-packages:
     if: >-

--- a/main.mk
+++ b/main.mk
@@ -2290,11 +2290,17 @@ TESTFIXTURE_SRC1 = sqlite3.c
 TESTFIXTURE_SRC = $(TESTSRC) tclsqlite-ex.c
 TESTFIXTURE_SRC += $(TESTFIXTURE_SRC$(USE_AMALGAMATION))
 
-testfixture$(T.exe):	$(T.tcl.env.sh) has_tclsh85 $(TESTFIXTURE_SRC)
-	$(T.link.tcl) -DSQLITE_NO_SYNC=1 $(TESTFIXTURE_FLAGS) \
-		-o $@ $(TESTFIXTURE_SRC) \
-		$$TCL_LIB_SPEC $$TCL_INCLUDE_SPEC $$TCL_LIBS \
-		$(LDFLAGS.libsqlite3)
+T.testlink = $(T.link) $(1) -o $@ $(2) $(3)
+ifeq ($(DOLTLITE_SPLIT_TEST_COMPILE),1)
+  TEST_COMPILE_DEP = $(TOP)/tool/compile-test.py
+  T.testlink = python3 $(TOP)/tool/compile-test.py --cc $(T.link) \
+    --cflags $(1) --sources $(2) --ldflags $(3) --output $@
+endif
+
+testfixture$(T.exe):	$(T.tcl.env.sh) has_tclsh85 $(TESTFIXTURE_SRC) $(TEST_COMPILE_DEP)
+	$(T.tcl.env.source); \
+		$(call T.testlink,-DSQLITE_NO_SYNC=1 $(TESTFIXTURE_FLAGS) $$TCL_INCLUDE_SPEC,\
+		$(TESTFIXTURE_SRC),$$TCL_LIB_SPEC $$TCL_LIBS $(LDFLAGS.libsqlite3))
 
 coretestprogs:	testfixture$(B.exe) sqlite3$(B.exe)
 
@@ -2654,12 +2660,10 @@ sqlite3-shell-static.flags.0 =
 # runtime performance hit, which is fine for use in the shell but is
 # not appropriate for the canonical library build.
 #
-sqlite3$(T.exe):	shell.c sqlite3.c
-	$(T.link) -o $@ \
-		shell.c sqlite3.c \
-		$(sqlite3-shell-static.flags.$(STATIC_CLI_SHELL)) \
-		$(CFLAGS.readline) $(SHELL_OPT) $(CFLAGS.icu) \
-		$(LDFLAGS.libsqlite3) $(LDFLAGS.readline)
+sqlite3$(T.exe):	shell.c sqlite3.c $(TEST_COMPILE_DEP)
+	$(call T.testlink,$(sqlite3-shell-static.flags.$(STATIC_CLI_SHELL)) \
+		$(CFLAGS.readline) $(SHELL_OPT) $(CFLAGS.icu),shell.c sqlite3.c,\
+		$(LDFLAGS.libsqlite3) $(LDFLAGS.readline))
 #
 # Build sqlite3$(T.exe) by default except in wasi-sdk builds.  Yes, the
 # semantics of 0 and 1 are confusingly swapped here.
@@ -3125,23 +3129,23 @@ fuzzershell$(T.exe):	$(TOP)/tool/fuzzershell.c sqlite3.c sqlite3.h
 fuzzy: fuzzershell$(T.exe)
 xbin: fuzzershell$(T.exe)
 
-fuzzcheck$(T.exe):	$(FUZZCHECK_SRC) $(FUZZCHECK_DEP)
-	$(T.link) -o $@ $(FUZZCHECK_OPT) $(FUZZCHECK_SRC) $(LDFLAGS.libsqlite3)
+fuzzcheck$(T.exe):	$(FUZZCHECK_SRC) $(FUZZCHECK_DEP) $(TEST_COMPILE_DEP)
+	$(call T.testlink,$(FUZZCHECK_OPT),$(FUZZCHECK_SRC),$(LDFLAGS.libsqlite3))
 fuzzy: fuzzcheck$(T.exe)
 xbin: fuzzcheck$(T.exe)
 
 # -fsanitize=... flags for fuzzcheck-asan.
 CFLAGS.fuzzcheck-asan.fsanitize ?= -fsanitize=address
 
-fuzzcheck-asan$(T.exe):	$(FUZZCHECK_SRC) $(FUZZCHECK_DEP)
-	$(T.link) -o $@ $(CFLAGS.fuzzcheck-asan.fsanitize) $(FUZZCHECK_OPT) $(FUZZCHECK_SRC) \
-		$(LDFLAGS.libsqlite3)
+fuzzcheck-asan$(T.exe):	$(FUZZCHECK_SRC) $(FUZZCHECK_DEP) $(TEST_COMPILE_DEP)
+	$(call T.testlink,$(CFLAGS.fuzzcheck-asan.fsanitize) $(FUZZCHECK_OPT),\
+		$(FUZZCHECK_SRC),$(LDFLAGS.libsqlite3))
 fuzzy: fuzzcheck-asan$(T.exe)
 xbin: fuzzcheck-asan$(T.exe)
 
-fuzzcheck-ubsan$(T.exe):	$(FUZZCHECK_SRC) $(FUZZCHECK_DEP)
-	$(T.link) -o $@ -fsanitize=undefined $(FUZZCHECK_OPT) $(FUZZCHECK_SRC) \
-		$(LDFLAGS.libsqlite3)
+fuzzcheck-ubsan$(T.exe):	$(FUZZCHECK_SRC) $(FUZZCHECK_DEP) $(TEST_COMPILE_DEP)
+	$(call T.testlink,-fsanitize=undefined $(FUZZCHECK_OPT),\
+		$(FUZZCHECK_SRC),$(LDFLAGS.libsqlite3))
 fuzzy: fuzzcheck-ubsan$(T.exe)
 xbin: fuzzcheck-ubsan$(T.exe)
 
@@ -3151,8 +3155,8 @@ ossshell$(T.exe):	$(TOP)/test/ossfuzz.c $(TOP)/test/ossshell.c sqlite3.c sqlite3
 fuzzy: ossshell$(T.exe)
 xbin: ossshell$(T.exe)
 
-sessionfuzz$(T.exe):	$(TOP)/test/sessionfuzz.c sqlite3.c sqlite3.h
-	$(T.link) -o $@ $(TOP)/test/sessionfuzz.c $(LDFLAGS.libsqlite3)
+sessionfuzz$(T.exe):	$(TOP)/test/sessionfuzz.c sqlite3.c sqlite3.h $(TEST_COMPILE_DEP)
+	$(call T.testlink,,$(TOP)/test/sessionfuzz.c,$(LDFLAGS.libsqlite3))
 fuzzy: sessionfuzz$(T.exe)
 
 dbfuzz$(T.exe):	$(TOP)/test/dbfuzz.c sqlite3.c sqlite3.h
@@ -3348,6 +3352,7 @@ tidy:
 	rm -f *.o *.obj *.c *.da *.bb *.bbg gmon.* *.rws sqlite3$(T.exe) doltlite$(T.exe)
 	rm -f fts5.h keywordhash.h opcodes.h sqlite3.h sqlite3ext.h sqlite3session.h
 	rm -rf .libs .deps tsrc .target_source
+	rm -rf .test-objects
 	rm -f lemon$(B.exe) sqlite*.tar.gz
 	rm -f mkkeywordhash$(B.exe) mksourceid$(B.exe)
 	rm -f parse.* fts5parse.*

--- a/test/testrunner.tcl
+++ b/test/testrunner.tcl
@@ -1173,7 +1173,14 @@ proc r_get_next_job {iJob} {
       }
     }
 
-    if {($iJob%2)} {
+    if {$TRG(buildonly)} {
+      append orderby {ORDER BY
+        CASE
+          WHEN displayname GLOB '* (fuzzcheck-*san)' THEN 0
+          WHEN displayname GLOB '* (testfixture)' THEN 1
+          ELSE 2
+        END, jobid}
+    } elseif {($iJob%2)} {
       append orderby "ORDER BY priority ASC"
     } else {
       append orderby "ORDER BY priority DESC"

--- a/tool/compile-test.py
+++ b/tool/compile-test.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import subprocess
+import sys
+
+
+def build(argv):
+    groups = {name: [] for name in ('--cc', '--cflags', '--sources', '--ldflags', '--output')}
+    group = None
+    for arg in argv:
+        if arg in groups:
+            group = arg
+        elif group is None:
+            raise ValueError(f'unexpected argument: {arg}')
+        else:
+            groups[group].append(arg)
+    if not groups['--cc'] or not groups['--sources'] or len(groups['--output']) != 1:
+        raise ValueError('compiler, sources and one output are required')
+
+    output = groups['--output'][0]
+    directory = Path('.test-objects') / Path(output).name
+    directory.mkdir(parents=True, exist_ok=True)
+    command = groups['--cc'] + groups['--cflags']
+    objects = []
+    for index, source in enumerate(groups['--sources']):
+        if not source.endswith('.c'):
+            objects.append(source)
+            continue
+        obj = str(directory / f'{index}.o')
+        subprocess.run(command + ['-c', source, '-o', obj], check=True)
+        objects.append(obj)
+    subprocess.run(command + ['-o', output] + objects + groups['--ldflags'], check=True)
+
+
+if __name__ == '__main__':
+    try:
+        build(sys.argv[1:])
+    except subprocess.CalledProcessError as error:
+        sys.exit(error.returncode if error.returncode > 0 else 128 - error.returncode)
+    except (ValueError, OSError) as error:
+        sys.exit(str(error))


### PR DESCRIPTION
All-Debug spent 6m56s of its last 7m27s job compiling six executables without a compiler cache. The build-only scheduler could start sessionfuzz while the longer ASan build waited for a worker.

Compile each target's C sources into cacheable objects before linking, enabled only by the All-Debug CI action. Preserve source order at link time, compiler flags, version stamps, all six targets, the four-worker limit, and the existing CI matrix. Start sanitizer builds and testfixture (the shell's prerequisite) first in build-only mode, and report per-target timings. All-O0 retains its existing workflow steps.

Restore and explicitly save a configuration-specific ccache, with health checks. Warm the same action from master on scheduled/manual cache-seeding runs, skipping the build when a compatible compiler cache is already present. The existing budget and failure-reporting guards cover the new seed job. No source, header, flag, or version inputs are ignored to obtain cache hits; engine amalgamation changes still require recompilation.

Validation:
- Full lint and CI self-tests pass, including the existing 190 compiler failure checks. Actionlint and composite-action YAML parsing pass.
- 69 new checks cover compiler/linker failure propagation, diagnostics, same-named source files, link ordering, sanitizer flags, target selection, prerequisite preservation, cold/warm cache reuse, and source/header/flag/version invalidation.
- A real macOS ASan build passes. Same-path rebuild: 12.36s uncached versus 0.59s warm, with 20/20 object cache hits. This is a local target measurement, not a prediction for the full hosted job.
- A one-case ASan corpus smoke passes with both build paths. An optional full fuzzdata8 smoke reaches the same existing cursor assertion with both the original combined compile/link command and the split command.
- All six Linux builds pass and preserve their global symbol sets. On the same four-CPU ARM64 container: master 371.83s, candidate cold 367.08s, candidate warm 16.28s with 319/319 cache hits. The cold difference is small; unchanged-input cache reuse is the measured gain. With only the version stamp changed, the run took 361.00s despite 312/319 cache hits: seven misses include the expensive engine objects, and the CLI correctly reports the new version. This does not establish a large speedup for normal follow-up commits. The CLI reports the expected engine and version.
- The optional historical-affinity runtime suite reaches the same existing unixOpen assertion in both baseline and candidate All-Debug fixtures.
- Initial hosted All-Debug and All-O0 jobs pass, and the compiler cache is saved. Hosted All-Debug cold compilation took 12m19s versus 6m56s in the earlier run, so hosted runner savings are not yet established. Compiler/CPU details and build-command artifacts are now recorded; the final-head run is queued for its first runner and will test cross-revision reuse.
- A merge-tree check against #2847 succeeds without conflicts.

Co-Authored-By: OpenAI Codex <noreply@openai.com>
