### PR TITLE
Refuse --amend during merge, cherry-pick, and rebase

### DIFF
--- a/doc/doltlite/dolt_commit.md
+++ b/doc/doltlite/dolt_commit.md
@@ -53,6 +53,9 @@ the SQL transaction; see [transactions.md](transactions.md).
 | `cannot commit: unresolved merge conflicts. Use dolt_conflicts_resolve() first.` | see [dolt_merge.md](dolt_merge.md) |
 | `cannot commit: unresolved entries in dolt_constraint_violations ...` | see [dolt_constraint_violations.md](dolt_constraint_violations.md) |
 | `cannot --amend: HEAD has no parent (initial commit)` | amend on the first commit |
+| `you are in the middle of a merge -- cannot amend` | `--amend` while a merge is in progress |
+| `you are in the middle of a cherry-pick -- cannot amend` | `--amend` while a cherry-pick or revert is in progress |
+| `you are in the middle of a rebase -- cannot amend` | `--amend` while a rebase is in progress |
 | `unknown option`, `no value for option` | option parsing; the message names the option |
 
 ## dolt_status

--- a/src/doltlite_commit_cmd.c
+++ b/src/doltlite_commit_cmd.c
@@ -845,6 +845,28 @@ static void doltliteCommitFunc(
   skipEmpty = opts.skipEmpty;
   force = opts.force;
 
+  if( amend ){
+    u8 isMerging = 0;
+    u8 isRebasing = 0;
+    doltliteGetSessionMergeState(db, &isMerging, 0, 0);
+    if( isMerging ){
+      sqlite3_result_error(context,
+        "you are in the middle of a merge -- cannot amend", -1);
+      return;
+    }
+    doltliteGetSessionRebaseState(db, &isRebasing, 0, 0, 0, 0);
+    if( isRebasing ){
+      sqlite3_result_error(context,
+        "you are in the middle of a rebase -- cannot amend", -1);
+      return;
+    }
+    if( doltliteSessionHasPendingReplayCommit(db) ){
+      sqlite3_result_error(context,
+        "you are in the middle of a cherry-pick -- cannot amend", -1);
+      return;
+    }
+  }
+
   if( !force && doltliteSessionHasConstraintViolations(db) ){
     sqlite3_result_error(context,
       "cannot commit: unresolved entries in dolt_constraint_violations. "

--- a/test/doltlite_cherry_pick.sh
+++ b/test/doltlite_cherry_pick.sh
@@ -738,6 +738,12 @@ run_test "cp_conflict_not_a_merge" \
 Error near line 5: unresolved conflicts — resolve them or roll back first
 Error near line 6: no merge in progress" \
   "$DB"
+run_test_match "cp_amend_during_conflict_refused" \
+  "BEGIN;
+   SELECT dolt_cherry_pick('feat');
+   SELECT dolt_commit('--amend','-m','oops');
+   ROLLBACK;" \
+  "you are in the middle of a cherry-pick -- cannot amend" "$DB"
 rm -f "$DB"
 
 DB=/tmp/test_cp_abort_$$.db; rm -f "$DB"

--- a/test/doltlite_commit.sh
+++ b/test/doltlite_commit.sh
@@ -719,7 +719,42 @@ run_test "amend_date_without_message_sets_date" \
   "SELECT substr(date,1,10) FROM dolt_log LIMIT 1;" \
   "2020-06-15" "$DB25"
 
-rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8" "$DB9" "$DB10" "$DB11" "$DB12" "$DB13" "$DB14" "$DB15" "$DB16" "$DB17" "$DB18" "$DB19" "$DB20" "$DB21" "$DB22" "$DB23" "$DB24" "$DB25"
+rm -f "$DB25"
+
+DB26=/tmp/test_dolt_commit_amend_merge_$$.db; rm -f "$DB26"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'a');
+SELECT dolt_commit('-Am','c1');
+SELECT dolt_branch('side');
+INSERT INTO t VALUES(2,'main');
+SELECT dolt_commit('-am','main');
+SELECT dolt_checkout('side');
+INSERT INTO t VALUES(3,'side');
+SELECT dolt_commit('-am','side');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('--no-commit','--no-ff','side');" | $DOLTLITE "$DB26" > /dev/null 2>&1
+
+run_test_match "amend_during_merge_refused" \
+  "SELECT dolt_commit('--amend','-m','oops');" \
+  "you are in the middle of a merge -- cannot amend" "$DB26"
+
+run_test "amend_during_merge_keeps_tip" \
+  "SELECT message FROM dolt_log LIMIT 1;" \
+  "main" "$DB26"
+
+run_test "amend_during_merge_still_merging" \
+  "SELECT is_merging FROM dolt_merge_status;" \
+  "1" "$DB26"
+
+run_test_match "amend_during_merge_then_finish" \
+  "SELECT dolt_commit('-m','merged');" \
+  "^[0-9a-f]{40}$" "$DB26"
+
+run_test "amend_during_merge_then_finish_msg" \
+  "SELECT message FROM dolt_log LIMIT 1;" \
+  "merged" "$DB26"
+
+rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8" "$DB9" "$DB10" "$DB11" "$DB12" "$DB13" "$DB14" "$DB15" "$DB16" "$DB17" "$DB18" "$DB19" "$DB20" "$DB21" "$DB22" "$DB23" "$DB24" "$DB25" "$DB26"
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"

--- a/test/doltlite_rebase.sh
+++ b/test/doltlite_rebase.sh
@@ -118,6 +118,15 @@ SQL
 
 DB3=/tmp/test_rebase_dirty_$$.db
 seed_dirty_main "$DB3"
+run_test_match "amend_during_rebase_refused" \
+  "SELECT dolt_checkout('feat');
+   SELECT dolt_rebase('-i','main');
+   SELECT dolt_commit('--amend','-m','oops');
+   SELECT dolt_rebase('--abort');" \
+  "you are in the middle of a rebase -- cannot amend" \
+  "$DB3"
+
+seed_dirty_main "$DB3"
 run_test "interactive_rebase_keeps_other_branch_uncommitted_work" \
   "SELECT dolt_checkout('feat');
    SELECT dolt_rebase('-i','main');

--- a/test/vc_oracle_commit_test.sh
+++ b/test/vc_oracle_commit_test.sh
@@ -343,6 +343,24 @@ SELECT dolt_commit('--amend', '--date', '2020-06-15T12:00:00Z');
 "
 
 # Amending a merge must keep every parent; dropping them makes a later merge of the same branch replay.
+oracle_error "commit_amend_during_merge" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'a');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c1');
+SELECT dolt_branch('side');
+INSERT INTO t VALUES(2,'main');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','main');
+SELECT dolt_checkout('side');
+INSERT INTO t VALUES(3,'side');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','side');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('--no-commit','--no-ff','side');
+SELECT dolt_commit('--amend','-m','oops');
+"
+
 oracle "commit_amend_merge_commit" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
 INSERT INTO t VALUES (1, 10);


### PR DESCRIPTION
## Summary
`dolt_commit('--amend')` during a `--no-commit` merge rewrote HEAD's parent and dropped the pre-merge tip from the branch lineage. Dolt 2.3.1 refuses with `you are in the middle of a merge -- cannot amend`.

Refuse `--amend` while a merge, rebase, or pending cherry-pick/revert is in progress. Amending an already-completed merge commit is unchanged (`commit_amend_merge_commit`).

## Validation
Fail-before: issue SQL succeeded; log tip was `oops` / `side` / `c1`.

Pass-after:
- Issue repro: `you are in the middle of a merge -- cannot amend`; tip still `main`; `is_merging=1`
- `bash test/doltlite_commit.sh build/doltlite` → 121/121
- `DOLTLITE=build/doltlite bash test/doltlite_cherry_pick.sh` → 151/151
- `bash test/doltlite_rebase.sh build/doltlite` → 67/67
- `bash test/vc_oracle_commit_test.sh build/doltlite dolt` → 84/84 vs Dolt 2.3.1
- `bash test/oracle_doc_examples_test.sh build/doltlite ignored dolt_commit.md` → PASS

Fixes #2855

Co-Authored-By: Grok 4.6 <noreply@x.ai>