### PR TITLE
Keep dolt_clean scoped to main when TEMP tables shadow names

### DIFF
--- a/doc/doltlite/dolt_reset.md
+++ b/doc/doltlite/dolt_reset.md
@@ -44,9 +44,6 @@ Returns `0`. `--hard` is not undone by `ROLLBACK`; see
 Drops untracked tables: those with status `new table` that have never been
 committed.
 
-Cleanup targets the main database. A TEMP table with the same name is preserved,
-including its rows.
-
 | Argument | Meaning |
 |---|---|
 | none | Drop every untracked table |

--- a/doc/doltlite/dolt_reset.md
+++ b/doc/doltlite/dolt_reset.md
@@ -44,6 +44,9 @@ Returns `0`. `--hard` is not undone by `ROLLBACK`; see
 Drops untracked tables: those with status `new table` that have never been
 committed.
 
+Cleanup targets the main database. A TEMP table with the same name is preserved,
+including its rows.
+
 | Argument | Meaning |
 |---|---|
 | none | Drop every untracked table |

--- a/src/doltlite_clean.c
+++ b/src/doltlite_clean.c
@@ -140,7 +140,7 @@ static int cleanDropTables(sqlite3 *db, const CleanNames *pNames){
     rc = sqlite3_db_config(db, SQLITE_DBCONFIG_ENABLE_FKEY, 0, &ignored);
   }
   for(i=pNames->n-1; rc==SQLITE_OK && i>=0; i--){
-    char *zSql = sqlite3_mprintf("DROP TABLE \"%w\"", pNames->az[i]);
+    char *zSql = sqlite3_mprintf("DROP TABLE main.\"%w\"", pNames->az[i]);
     if( !zSql ){
       rc = SQLITE_NOMEM;
       break;

--- a/test/doltlite_clean.sh
+++ b/test/doltlite_clean.sh
@@ -86,5 +86,25 @@ run_test "clean_named_overrides_ignore" "SELECT dolt_clean('ig_named');" "0" "$D
 run_test "clean_named_drops_ignored_target" "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='ig_named';" "0" "$DB8"
 run_test "clean_named_keeps_other_untracked" "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='other';" "1" "$DB8"
 
+for mode in named all; do
+  DB9=/tmp/test_clean_temp_shadow_${mode}_$$.db; rm -f "$DB9"
+  args=""
+  if [ "$mode" = named ]; then args="'T'"; fi
+  run_test "clean_temp_shadow_$mode" \
+    "CREATE TABLE main.t(id INTEGER PRIMARY KEY);
+     INSERT INTO main.t VALUES(1);
+     CREATE TEMP TABLE t(id INTEGER PRIMARY KEY);
+     INSERT INTO temp.t VALUES(99);
+     SELECT dolt_clean($args);
+     SELECT count(*) FROM main.sqlite_master WHERE name='t';
+     SELECT id FROM temp.t;" \
+    "0
+0
+99" "$DB9"
+  run_test "clean_temp_shadow_${mode}_reopen" \
+    "SELECT count(*) FROM main.sqlite_master WHERE name='t';" "0" "$DB9"
+  rm -f "$DB9"
+done
+
 rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8"
 dltest_finish

--- a/test/doltlite_clean_temp_shadow.test
+++ b/test/doltlite_clean_temp_shadow.test
@@ -1,0 +1,52 @@
+set testdir [file dirname $argv0]
+source $testdir/tester.tcl
+
+foreach kind {table virtual} {
+  if {$kind eq "virtual"} {
+    ifcapable !fts5 {continue}
+  }
+  foreach mode {named all} {
+    reset_db
+    execsql {
+      CREATE TABLE keep(id INTEGER PRIMARY KEY,v TEXT);
+      INSERT INTO keep VALUES(1,'tracked');
+      SELECT dolt_commit('-Am','base');
+    }
+    if {$kind eq "table"} {
+      execsql {CREATE TABLE "clean""target"(id INTEGER PRIMARY KEY,v TEXT)}
+    } else {
+      execsql {CREATE VIRTUAL TABLE "clean""target" USING fts5(v)}
+    }
+    execsql {
+      INSERT INTO main."clean""target"(v) VALUES('untracked');
+      CREATE TEMP TABLE "clean""target"(id INTEGER PRIMARY KEY,v TEXT);
+      INSERT INTO temp."clean""target" VALUES(99,'temporary');
+    }
+    set name clean-temp-shadow-$kind-$mode
+    do_execsql_test $name-dry-run {
+      SELECT dolt_clean('--dry-run');
+      SELECT v FROM main."clean""target";
+      SELECT id,v FROM temp."clean""target";
+    } {0 untracked 99 temporary}
+    set args {}
+    if {$mode eq "named"} {set args {'CLEAN"TARGET'}}
+    do_execsql_test $name-clean "SELECT dolt_clean($args)" {0}
+    do_execsql_test $name-main-removed {
+      SELECT count(*) FROM main.sqlite_master WHERE name GLOB 'clean"target*';
+      SELECT v FROM main.keep;
+    } {0 tracked}
+    do_execsql_test $name-temp-preserved {
+      SELECT id,v FROM temp."clean""target";
+    } {99 temporary}
+    db close
+    sqlite3 db test.db
+    do_execsql_test $name-reopen {
+      SELECT count(*) FROM main.sqlite_master WHERE name GLOB 'clean"target*';
+      SELECT v FROM main.keep;
+      SELECT count(*) FROM dolt_status;
+      PRAGMA integrity_check;
+    } {0 tracked 0 ok}
+  }
+}
+
+finish_test

--- a/test/regression-buckets/ported.txt
+++ b/test/regression-buckets/ported.txt
@@ -41,6 +41,7 @@ doltlite_historical_affinity
 doltlite_vtab_column_collision
 doltlite_merge_constraint_prune
 doltlite_constraint_temp_shadow
+doltlite_clean_temp_shadow
 doltlite_merge_generated
 doltlite_merge_generated_notnull
 doltlite_merge_schema_errors


### PR DESCRIPTION
When `main.t` and `temp.t` both existed, `dolt_clean('t')` selected the main table but issued an unqualified DROP TABLE. It deleted the TEMP table and its rows, left the untracked main table intact, and returned success.

Qualify the generated drop with `main`. Add CLI and testfixture coverage for named and all-table cleanup, quoted/case-insensitive names, ordinary and FTS5 tables, dry runs, TEMP-row preservation, tracked-table preservation, and removal after reopening. Register the new regression suite.

Validation:
- Fail-before/pass-after: four CLI checks and twelve testfixture checks failed on the unfixed engine. After the fix, all 51 clean CLI tests and all 21 testfixture checks pass.
- All 135 native suites pass across two shards.
- All 11 clean oracle cases pass against Dolt.
- Rebuilt CLI and testfixture; full lint passes.

Fixes #2851

Co-Authored-By: OpenAI Codex <noreply@openai.com>
