### PR TITLE
Reset cursor iterator state when a pending map is cleared in place

### DIFF
--- a/src/prolly_btree_mutation.c
+++ b/src/prolly_btree_mutation.c
@@ -432,6 +432,9 @@ static int flushMutMap(BtCursor *pCur){
     pCur->flushSeekEdits = 0;
   }else{
     prollyMutMapClear((ProllyMutMap*)pTE->pPending);
+    /* Clearing in place leaves every cursor's mmIdx past nEntries. */
+    refreshCursorMutMapAliases(pCur->pBtree, pCur->pBt, pCur->pgnoRoot,
+                               (ProllyMutMap*)pTE->pPending);
   }
 
   return SQLITE_OK;
@@ -471,6 +474,7 @@ int flushPendingForTable(
   if( pTE->pPending==pMap ){
     if( clearInPlace ){
       prollyMutMapClear(pMap);
+      refreshCursorMutMapAliases(pBtree, pBt, pTE->iTable, pMap);
     }else{
       prollyMutMapFree(pMap);
       sqlite3_free(pMap);

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -13790,6 +13790,56 @@ static void run_count_flush_keeps_scan(void){
   removeDbFiles(dbpath);
 }
 
+/* A pending map that drains mid-build must not leave cursors pointing past
+** nEntries; PROLLY_MUTMAP_PENDING_FLUSH_LIMIT is 65536, so the index build
+** has to cross it. */
+static void run_index_build_flush_resets_cursor(void){
+  sqlite3 *db = 0;
+  sqlite3_stmt *stmt = 0;
+  char dbpath[256];
+  char seen[128];
+  int rc;
+
+  printf("=== Index Build Flush Resets Cursor Test ===\n\n");
+  make_dbpath(dbpath, sizeof(dbpath), "test_index_build_flush_resets_cursor");
+  removeDbFiles(dbpath);
+
+  check("open_db_for_index_build_flush", open_db(dbpath, &db)==SQLITE_OK);
+  check("setup_rows_for_index_build_flush", execSql(db,
+    "CREATE TABLE t(id INTEGER PRIMARY KEY, a INT, b INT);"
+    "WITH RECURSIVE s(x) AS (SELECT 1 UNION ALL SELECT x+1 FROM s WHERE x<70000)"
+    "  INSERT INTO t(a,b) SELECT 1, x FROM s;")==SQLITE_OK);
+  check("index_build_crosses_flush_limit", execSql(db,
+    "CREATE INDEX iab ON t(a,b);")==SQLITE_OK);
+
+  rc = sqlite3_prepare_v2(db,
+    "SELECT (SELECT max(b) FROM t INDEXED BY iab WHERE a=1)"
+    "    || '|' || (SELECT max(b) FROM t NOT INDEXED WHERE a=1)"
+    "    || '|' || (SELECT count(*) FROM t INDEXED BY iab WHERE a=1);",
+    -1, &stmt, 0);
+  check("prepare_index_build_flush_probe", rc==SQLITE_OK);
+  if( stmt ){
+    rc = collect_stepped_text(stmt, seen, (int)sizeof(seen));
+    check("index_build_flush_probe_done", rc==SQLITE_DONE);
+    check("index_build_flush_index_matches_scan",
+          strcmp(seen, "70000|70000|70000")==0);
+  }
+  sqlite3_finalize(stmt);
+  stmt = 0;
+
+  rc = sqlite3_prepare_v2(db, "PRAGMA integrity_check;", -1, &stmt, 0);
+  check("prepare_index_build_flush_integrity", rc==SQLITE_OK);
+  if( stmt ){
+    rc = collect_stepped_text(stmt, seen, (int)sizeof(seen));
+    check("index_build_flush_integrity_done", rc==SQLITE_DONE);
+    check("index_build_flush_integrity_ok", strcmp(seen, "ok")==0);
+  }
+  sqlite3_finalize(stmt);
+
+  sqlite3_close(db);
+  removeDbFiles(dbpath);
+}
+
 static void run_negzero_sortkey_eq(void){
   static const u8 posZero[] = {
     0x02, 0x07,
@@ -14432,6 +14482,7 @@ static const RegressionCase aCases[] = {
   { "blob_restore_mutmap_keeps_scan", "Blob Restore MutMap Keeps Scan Test", run_blob_restore_mutmap_keeps_scan },
   { "intpk_scan_delete_keeps_scan", "INT PK Scan Delete Keeps Scan Test", run_intpk_scan_delete_keeps_scan },
   { "count_flush_keeps_scan", "Count Flush Keeps Scan Test", run_count_flush_keeps_scan },
+  { "index_build_flush_resets_cursor", "Index Build Flush Resets Cursor Test", run_index_build_flush_resets_cursor },
   { "negzero_sortkey_eq", "Negzero Sortkey Eq Test", run_negzero_sortkey_eq },
   { "reset_database_current_branch", "Reset Database Current Branch Test", run_reset_database_current_branch },
   { "clustered_pk_update_hook", "Clustered PK Update Hook Test", run_clustered_pk_update_hook },


### PR DESCRIPTION
Fixes #2864.

`flushMutMap` and `flushPendingForTable` clear the pending mutmap in place and leave every cursor over that table holding an `mmIdx` that is now past `nEntries`. The third clear-in-place site, `prollyBtCursorCount` in `src/prolly_btree_cursor_count.c:318-321`, already calls `refreshCursorMutMapAliases` right after its clear; these two did not.

It only bites through `currentMutMapEntry` (`src/prolly_btree_mutation.c:323-335`), which is the one `mmIdx` reader that trusts the cached index. Its physical-index path checks both bounds, and every `mmIdx` read in `src/prolly_btree_cursor.c` checks both bounds; the ordered path checks only `>= 0`.

`CREATE INDEX` crosses `PROLLY_MUTMAP_PENDING_FLUSH_LIMIT` (65536) on a table of roughly 70k rows, drains mid-build, and then reads entry 65534 of a map that now holds none.

```
prollyMutMapEntryAt(mm=..., idx=65534) at prolly_mutmap.c:984
currentMutMapEntry(pCur=...) at prolly_btree_mutation.c:333
prollyBtCursorInsert(...) at prolly_btree_mutation.c:923
sqlite3BtreeInsert(...) at prolly_btree_mutation.c:1190
sqlite3VdbeExec(...) at vdbe.c:7231
```

**Release-build impact is a missed optimisation, not wrong data.** `freeEntryData` zeroes `pKey` and `nKey` as it frees, so the stale entry reads back empty and the payload-reuse comparison in `prollyBtCursorInsert` is skipped rather than answered wrongly. The index built by a release binary verifies correct, and ASan is clean. The defect is a real broken invariant that aborts every assert build, and the entry it lands on is arbitrary rather than guaranteed-cleared, so it is worth closing rather than documenting.

I left the `refreshCursorMutMapAliases` call at `src/prolly_btree_mutation.c:1121` alone. It is not redundant: `flushMutMap` returns early when the map is already empty, and that call still resets state on that path.

**Fail-before / pass-after:** new `index_build_flush_resets_cursor` case in the assert-enabled C regression binary, which is the artifact `build-test.yml` runs as `build-assert/doltlite_regression_test_c all`.

```
before:  Assertion failed: (idx>=0 && idx<mm->nEntries), function prollyMutMapEntryAt,
         file prolly_mutmap.c, line 984.
after:   Results: 9 passed, 0 failed out of 9 tests
```

The case also checks the index against a table scan and runs `integrity_check`, so it still carries weight on a build without asserts.

**Validation**

| Gate | Result |
|---|---|
| `build-assert/doltlite_regression_test_c all` | 311231 passed, 0 failed |
| `test/run_c_tests.sh` | rc=0, all passed, 0 not built, 0 stale |
| `test/run_doltlite_tests.sh` | 135 passed, 0 failed |
| same battery on the pre-fix binary (control) | 135 passed, 0 failed |
| original repro at 70k / 100k / 400k rows | index built, `integrity_check` ok |

An earlier battery run showed two failures (`merge_index_replaced_not_duplicated_objects`, `many_branches_count`). Both were contention from my own concurrently running batteries: they pass standalone on the fixed binary, the serialized rerun is clean, and one later "failure" was two `make` processes colliding in the same build directory. The table above is the serialized run.

Performance is unchanged. Five interleaved runs of a 400k-row bulk insert plus two index builds: identical minimum of 0.540s on both binaries, means within noise. The refresh walks the table's cursor list once per drain, so once every 65536 pending entries.

SQLLogicTest needs the dedicated runner binaries and has no local build tree here, so it runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
