### PR TITLE
Fail DoltLite suites that are not a prolly engine

### DIFF
--- a/test/doltlite_dbpage.sh
+++ b/test/doltlite_dbpage.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 
-DOLTLITE="${1:-./doltlite}"
+DOLTLITE="${1:-${DOLTLITE:-./doltlite}}"
 PASS=0; FAIL=0; ERRORS=""
+if ! bash "$(dirname "$0")/lib/assert_doltlite_engine.sh" "$DOLTLITE"; then
+  exit 1
+fi
 
 run_test() {
   local n="$1" s="$2" e="$3" d="$4"

--- a/test/engine_floor_test.sh
+++ b/test/engine_floor_test.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Stock sqlite3 must not satisfy DoltLite suites or sql-differential.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+STOCK="${2:-${SQLITE3:-$SCRIPT_DIR/../build-stockref/sqlite3}}"
+ENG="${1:-${DOLTLITE:-$SCRIPT_DIR/../build/doltlite}}"
+
+if [ ! -x "$STOCK" ]; then
+  echo "ERROR: stock reference not executable: $STOCK"
+  exit 1
+fi
+
+echo "=== engine floor ==="
+
+if bash "$SCRIPT_DIR/lib/assert_doltlite_engine.sh" "$STOCK" >/tmp/floor-stock.out 2>&1; then
+  echo "FAIL: assert_doltlite_engine.sh accepted stock sqlite3"
+  cat /tmp/floor-stock.out
+  exit 1
+fi
+echo "PASS: stock sqlite3 rejected as engine"
+
+if [ -x "$ENG" ]; then
+  if ! bash "$SCRIPT_DIR/lib/assert_doltlite_engine.sh" "$ENG"; then
+    echo "FAIL: assert_doltlite_engine.sh rejected $ENG"
+    exit 1
+  fi
+  echo "PASS: $ENG accepted as engine"
+fi
+
+if DOLTLITE="$STOCK" bash -c '. "'"$SCRIPT_DIR"'/lib/doltlite_test_common.sh"' \
+     >/tmp/floor-common.out 2>&1; then
+  echo "FAIL: common.sh accepted stock sqlite3"
+  cat /tmp/floor-common.out
+  exit 1
+fi
+echo "PASS: common.sh rejects stock sqlite3"
+
+if bash "$SCRIPT_DIR/sql_differential_test.sh" "$STOCK" "$STOCK" 1 1 \
+     >/tmp/floor-diff.out 2>&1; then
+  echo "FAIL: sql-differential stock vs stock passed"
+  cat /tmp/floor-diff.out
+  exit 1
+fi
+if ! grep -q "SQLite database header\|same file" /tmp/floor-diff.out; then
+  echo "FAIL: sql-differential stock vs stock failed for the wrong reason"
+  cat /tmp/floor-diff.out
+  exit 1
+fi
+echo "PASS: sql-differential stock vs stock rejected"
+
+echo "engine floor: PASS"

--- a/test/engine_floor_test.sh
+++ b/test/engine_floor_test.sh
@@ -36,6 +36,18 @@ if DOLTLITE="$STOCK" bash -c '. "'"$SCRIPT_DIR"'/lib/doltlite_test_common.sh"' \
 fi
 echo "PASS: common.sh rejects stock sqlite3"
 
+if [ -x "$ENG" ]; then
+  if ! DOLTLITE="$ENG" bash -c 'set -u
+    . "'"$SCRIPT_DIR"'/lib/doltlite_test_common.sh"
+    run_test_match "nounset_no_bail" "SELECT 1;" "." ":memory:"
+    [ "$FAIL" -eq 0 ]
+  '; then
+    echo "FAIL: common.sh run_test_match broke under set -u"
+    exit 1
+  fi
+  echo "PASS: common.sh run_test_match under set -u"
+fi
+
 if bash "$SCRIPT_DIR/sql_differential_test.sh" "$STOCK" "$STOCK" 1 1 \
      >/tmp/floor-diff.out 2>&1; then
   echo "FAIL: sql-differential stock vs stock passed"

--- a/test/engine_floor_test.sh
+++ b/test/engine_floor_test.sh
@@ -3,22 +3,15 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-STOCK="${2:-${SQLITE3:-$SCRIPT_DIR/../build-stockref/sqlite3}}"
 ENG="${1:-${DOLTLITE:-$SCRIPT_DIR/../build/doltlite}}"
-
-if [ ! -x "$STOCK" ]; then
-  echo "ERROR: stock reference not executable: $STOCK"
-  exit 1
+STOCK="${2:-${SQLITE3:-}}"
+if [ -z "$STOCK" ] || [ ! -x "$STOCK" ]; then
+  for c in "$SCRIPT_DIR/../build-stockref/sqlite3" ./sqlite3-stock; do
+    if [ -x "$c" ]; then STOCK="$c"; break; fi
+  done
 fi
 
 echo "=== engine floor ==="
-
-if bash "$SCRIPT_DIR/lib/assert_doltlite_engine.sh" "$STOCK" >/tmp/floor-stock.out 2>&1; then
-  echo "FAIL: assert_doltlite_engine.sh accepted stock sqlite3"
-  cat /tmp/floor-stock.out
-  exit 1
-fi
-echo "PASS: stock sqlite3 rejected as engine"
 
 if [ -x "$ENG" ]; then
   if ! bash "$SCRIPT_DIR/lib/assert_doltlite_engine.sh" "$ENG"; then
@@ -26,17 +19,6 @@ if [ -x "$ENG" ]; then
     exit 1
   fi
   echo "PASS: $ENG accepted as engine"
-fi
-
-if DOLTLITE="$STOCK" bash -c '. "'"$SCRIPT_DIR"'/lib/doltlite_test_common.sh"' \
-     >/tmp/floor-common.out 2>&1; then
-  echo "FAIL: common.sh accepted stock sqlite3"
-  cat /tmp/floor-common.out
-  exit 1
-fi
-echo "PASS: common.sh rejects stock sqlite3"
-
-if [ -x "$ENG" ]; then
   if ! DOLTLITE="$ENG" bash -c 'set -u
     . "'"$SCRIPT_DIR"'/lib/doltlite_test_common.sh"
     run_test_match "nounset_no_bail" "SELECT 1;" "." ":memory:"
@@ -46,7 +28,30 @@ if [ -x "$ENG" ]; then
     exit 1
   fi
   echo "PASS: common.sh run_test_match under set -u"
+else
+  echo "SKIP: no DoltLite engine at $ENG"
 fi
+
+if [ ! -x "$STOCK" ]; then
+  echo "SKIP: no stock sqlite3 for rejection tests"
+  echo "engine floor: PASS"
+  exit 0
+fi
+
+if bash "$SCRIPT_DIR/lib/assert_doltlite_engine.sh" "$STOCK" >/tmp/floor-stock.out 2>&1; then
+  echo "FAIL: assert_doltlite_engine.sh accepted stock sqlite3"
+  cat /tmp/floor-stock.out
+  exit 1
+fi
+echo "PASS: stock sqlite3 rejected as engine"
+
+if DOLTLITE="$STOCK" bash -c '. "'"$SCRIPT_DIR"'/lib/doltlite_test_common.sh"' \
+     >/tmp/floor-common.out 2>&1; then
+  echo "FAIL: common.sh accepted stock sqlite3"
+  cat /tmp/floor-common.out
+  exit 1
+fi
+echo "PASS: common.sh rejects stock sqlite3"
 
 if bash "$SCRIPT_DIR/sql_differential_test.sh" "$STOCK" "$STOCK" 1 1 \
      >/tmp/floor-diff.out 2>&1; then

--- a/test/engine_floor_test.sh
+++ b/test/engine_floor_test.sh
@@ -28,6 +28,22 @@ if [ -x "$ENG" ]; then
     exit 1
   fi
   echo "PASS: common.sh run_test_match under set -u"
+
+  fake="$(mktemp "${TMPDIR:-/tmp}/dltest-fake.XXXXXX")"
+  printf '%s\n' '#!/bin/sh' 'echo 1' 'exit 7' >"$fake"
+  chmod +x "$fake"
+  if DLTEST_SKIP_ENGINE_FLOOR=1 DOLTLITE="$fake" bash -c '
+    . "'"$SCRIPT_DIR"'/lib/doltlite_test_common.sh"
+    run_test "nonzero_exit" "SELECT 1;" "1" ":memory:"
+    [ "$FAIL" -gt 0 ]
+  '; then
+    echo "PASS: run_test rejects matching output with rc!=0"
+  else
+    echo "FAIL: run_test passed when the engine exited 7"
+    rm -f "$fake"
+    exit 1
+  fi
+  rm -f "$fake"
 else
   echo "SKIP: no DoltLite engine at $ENG"
 fi

--- a/test/homebrew_formula_test.sh
+++ b/test/homebrew_formula_test.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # The in-repo Homebrew formula must not pin a pre-freeze tarball, and
 # bump-formula.sh must rewrite url/sha256 the way the release job does.
+DLTEST_SKIP_ENGINE_FLOOR=1
 . "$(dirname "$0")/lib/doltlite_test_common.sh"
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"

--- a/test/lib/assert_doltlite_engine.sh
+++ b/test/lib/assert_doltlite_engine.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+#
+# Assert that a binary is a DoltLite prolly engine: it writes a DoltLite
+# image, not an SQLite header, and doltlite_engine() is prolly.
+#
+# Usage: assert_doltlite_engine.sh <engine>
+
+set -uo pipefail
+
+ENG="${1:?Usage: assert_doltlite_engine.sh <engine>}"
+
+if [ ! -x "$ENG" ]; then
+  echo "ERROR: not executable: $ENG"
+  exit 1
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+if ! "$ENG" "$WORK/eng.db" "CREATE TABLE x(y); INSERT INTO x VALUES(1);" \
+     >/dev/null 2>&1; then
+  echo "ERROR: $ENG could not create a database, so it cannot be the engine"
+  exit 1
+fi
+
+if [ ! -s "$WORK/eng.db" ]; then
+  echo "ERROR: $ENG wrote no database file, so it cannot be the engine"
+  exit 1
+fi
+
+header="$(head -c 15 "$WORK/eng.db" 2>/dev/null)"
+if [ "$header" = "SQLite format 3" ]; then
+  echo "ERROR: $ENG writes an SQLite database header."
+  echo "       Suites that only check SELECT count(*) / PRAGMA integrity_check"
+  echo "       go green on stock sqlite3. Build the engine with DOLTLITE_PROLLY=1."
+  echo "       header bytes: $(head -c 15 "$WORK/eng.db" | od -An -c | tr -s ' ')"
+  exit 1
+fi
+
+got="$("$ENG" "$WORK/eng.db" "SELECT doltlite_engine();" 2>/dev/null | tail -1)"
+if [ "$got" != "prolly" ]; then
+  echo "ERROR: $ENG doltlite_engine() is '${got:-empty}', want prolly"
+  exit 1
+fi
+
+echo "OK: $ENG is a DoltLite prolly engine"

--- a/test/lib/doltlite_suite_manifest.sh
+++ b/test/lib/doltlite_suite_manifest.sh
@@ -3,6 +3,7 @@
 doltlite_all_suites() {
   cat <<'EOF'
 build_artifacts_guard_test.sh
+engine_floor_test.sh
 feature_flags_stamp_test.sh
 install_sh_layout_test.sh
 homebrew_formula_test.sh

--- a/test/lib/doltlite_test_common.sh
+++ b/test/lib/doltlite_test_common.sh
@@ -64,22 +64,32 @@ dltest_fail() {
   ERRORS="$ERRORS\nFAIL: $name\n$msg"
 }
 
+dltest_expected_error() {
+  case "$1" in
+    Error*|*"Error near"*|*"Parse error"*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 run_test() {
   local name="$1"
   local sql="$2"
   local expected="$3"
   local db="$4"
   local result rc bail=""
-  case "$expected" in
-    Error*|*"Error near"*) ;;
-    *) bail=bail ;;
-  esac
+  if ! dltest_expected_error "$expected"; then
+    bail=bail
+  fi
   result=$(dltest_run_sql "$sql" "$db" $bail)
   rc=$?
-  if [ "$result" = "$expected" ]; then
+  if [ -n "$bail" ]; then
+    if [ "$result" = "$expected" ] && [ "$rc" -eq 0 ]; then
+      dltest_pass
+    else
+      dltest_fail "$name" "  engine rc=$rc\n  expected: $expected\n  got:      $result"
+    fi
+  elif [ "$result" = "$expected" ]; then
     dltest_pass
-  elif [ -n "$bail" ] && [ "$rc" -ne 0 ]; then
-    dltest_fail "$name" "  engine rc=$rc\n  expected: $expected\n  got:      $result"
   else
     dltest_fail "$name" "  expected: $expected\n  got:      $result"
   fi

--- a/test/lib/doltlite_test_common.sh
+++ b/test/lib/doltlite_test_common.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-DOLTLITE="${DOLTLITE:-./doltlite}"
+DOLTLITE="${1:-${DOLTLITE:-./doltlite}}"
 PASS="${PASS:-0}"
 FAIL="${FAIL:-0}"
 ERRORS="${ERRORS:-}"
@@ -11,10 +11,14 @@ DLTEST_MATCH_FLAGS="${DLTEST_MATCH_FLAGS:-}"
 dltest_run_sql() {
   local sql="$1"
   local db="$2"
+  local extra=()
+  [ "${3:-}" = "bail" ] && extra=(-bail)
   if [ "$DLTEST_STRIP_CR" = "1" ]; then
-    echo "$sql" | perl -e "alarm($DLTEST_TIMEOUT);exec @ARGV" "$DOLTLITE" "$db" 2>&1 | tr -d '\r'
+    echo "$sql" | perl -e "alarm($DLTEST_TIMEOUT);exec @ARGV" \
+      "$DOLTLITE" "${extra[@]}" "$db" 2>&1 | tr -d '\r'
   else
-    echo "$sql" | perl -e "alarm($DLTEST_TIMEOUT);exec @ARGV" "$DOLTLITE" "$db" 2>&1
+    echo "$sql" | perl -e "alarm($DLTEST_TIMEOUT);exec @ARGV" \
+      "$DOLTLITE" "${extra[@]}" "$db" 2>&1
   fi
 }
 
@@ -56,8 +60,17 @@ run_test() {
   local sql="$2"
   local expected="$3"
   local db="$4"
-  local result
-  result=$(dltest_run_sql "$sql" "$db")
+  local result rc bail=""
+  case "$expected" in
+    Error*|*"Error near"*) ;;
+    *) bail=bail ;;
+  esac
+  result=$(dltest_run_sql "$sql" "$db" $bail)
+  rc=$?
+  if [ -n "$bail" ] && [ "$rc" -ne 0 ]; then
+    dltest_fail "$name" "  engine rc=$rc\n  expected: $expected\n  got:      $result"
+    return
+  fi
   if [ "$result" = "$expected" ]; then
     dltest_pass
   else
@@ -101,3 +114,11 @@ dltest_finish() {
     exit 1
   fi
 }
+
+if [ "${DLTEST_SKIP_ENGINE_FLOOR:-0}" != "1" ]; then
+  _dltest_floor="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/assert_doltlite_engine.sh"
+  if ! bash "$_dltest_floor" "$DOLTLITE"; then
+    exit 1
+  fi
+  unset _dltest_floor
+fi

--- a/test/lib/doltlite_test_common.sh
+++ b/test/lib/doltlite_test_common.sh
@@ -11,14 +11,23 @@ DLTEST_MATCH_FLAGS="${DLTEST_MATCH_FLAGS:-}"
 dltest_run_sql() {
   local sql="$1"
   local db="$2"
-  local extra=()
-  [ "${3:-}" = "bail" ] && extra=(-bail)
-  if [ "$DLTEST_STRIP_CR" = "1" ]; then
-    echo "$sql" | perl -e "alarm($DLTEST_TIMEOUT);exec @ARGV" \
-      "$DOLTLITE" "${extra[@]}" "$db" 2>&1 | tr -d '\r'
+  # macOS /bin/bash 3.2 + set -u treats empty "${arr[@]}" as unbound.
+  if [ "${3:-}" = "bail" ]; then
+    if [ "$DLTEST_STRIP_CR" = "1" ]; then
+      echo "$sql" | perl -e "alarm($DLTEST_TIMEOUT);exec @ARGV" \
+        "$DOLTLITE" -bail "$db" 2>&1 | tr -d '\r'
+    else
+      echo "$sql" | perl -e "alarm($DLTEST_TIMEOUT);exec @ARGV" \
+        "$DOLTLITE" -bail "$db" 2>&1
+    fi
   else
-    echo "$sql" | perl -e "alarm($DLTEST_TIMEOUT);exec @ARGV" \
-      "$DOLTLITE" "${extra[@]}" "$db" 2>&1
+    if [ "$DLTEST_STRIP_CR" = "1" ]; then
+      echo "$sql" | perl -e "alarm($DLTEST_TIMEOUT);exec @ARGV" \
+        "$DOLTLITE" "$db" 2>&1 | tr -d '\r'
+    else
+      echo "$sql" | perl -e "alarm($DLTEST_TIMEOUT);exec @ARGV" \
+        "$DOLTLITE" "$db" 2>&1
+    fi
   fi
 }
 

--- a/test/lib/doltlite_test_common.sh
+++ b/test/lib/doltlite_test_common.sh
@@ -76,12 +76,10 @@ run_test() {
   esac
   result=$(dltest_run_sql "$sql" "$db" $bail)
   rc=$?
-  if [ -n "$bail" ] && [ "$rc" -ne 0 ]; then
-    dltest_fail "$name" "  engine rc=$rc\n  expected: $expected\n  got:      $result"
-    return
-  fi
   if [ "$result" = "$expected" ]; then
     dltest_pass
+  elif [ -n "$bail" ] && [ "$rc" -ne 0 ]; then
+    dltest_fail "$name" "  engine rc=$rc\n  expected: $expected\n  got:      $result"
   else
     dltest_fail "$name" "  expected: $expected\n  got:      $result"
   fi

--- a/test/sql_differential_test.sh
+++ b/test/sql_differential_test.sh
@@ -50,6 +50,15 @@ fi
 if ! bash "$SCRIPT_DIR/assert_stock_reference.sh" "$SQLITE3" "$DOLTLITE"; then
   exit 1
 fi
+if ! bash "$SCRIPT_DIR/lib/assert_doltlite_engine.sh" "$DOLTLITE"; then
+  exit 1
+fi
+if python3 -c 'import os,sys; sys.exit(0 if os.path.samefile(sys.argv[1], sys.argv[2]) else 1)' \
+     "$DOLTLITE" "$SQLITE3" 2>/dev/null; then
+  echo "ERROR: candidate and reference are the same file: $DOLTLITE"
+  echo "       sql-differential would compare stock sqlite3 with itself and pass."
+  exit 1
+fi
 
 # Not named GROUPS: bash keeps that as the caller's group-id array and silently
 # ignores assignments to it.


### PR DESCRIPTION
## Summary
`run_test` ignored `\$1` and engine rc, so `SELECT count(*)` after a discarded `dolt_commit` matched stock SQLite. `sql_differential_test.sh` only asserted that the *reference* writes an SQLite header, so stock vs stock was green.

- `DOLTLITE=\"\${1:-\${DOLTLITE:-./doltlite}}\"`
- Probe a DoltLite image + `doltlite_engine()='prolly'` when sourcing `doltlite_test_common.sh` (`DLTEST_SKIP_ENGINE_FLOOR=1` for Homebrew formula tests)
- `run_test` uses `-bail` and fails on `rc != 0` unless the expected output is an error
- sql-differential requires the candidate is a prolly engine and not the same file as the reference
- Same floor in `doltlite_dbpage.sh`

## Validation
Fail-before:
- `DOLTLITE=build-stockref/sqlite3 bash test/doltlite_index_prefix.sh` → 32/32
- `bash test/sql_differential_test.sh build-stockref/sqlite3 build-stockref/sqlite3 1 1` → 1/1

Pass-after:
- Those two now exit 1 (`writes an SQLite database header` / same file)
- `bash test/engine_floor_test.sh build/doltlite build-stockref/sqlite3` → PASS
- `DOLTLITE=build/doltlite bash test/doltlite_index_prefix.sh` → 32/32
- `DOLTLITE=build/doltlite bash test/doltlite_count_numeric_range.sh` → 7/7
- `bash test/doltlite_dbpage.sh build/doltlite` → 14/14
- `DOLTLITE=build/doltlite bash test/doltlite_cherry_pick.sh` → 151/151
- `bash test/sql_differential_test.sh build/doltlite build-stockref/sqlite3 1 1` → 1/1
- `bash test/homebrew_formula_test.sh` → 12/12
- `bash test/lint_orphaned_suites.sh` → OK

Fixes #2857

Co-Authored-By: Grok 4.6 <noreply@x.ai>