### PR TITLE
Fix historical primary-key filters after schema changes

### DIFF
--- a/src/doltlite_at.c
+++ b/src/doltlite_at.c
@@ -50,6 +50,7 @@ struct AtCursor {
   DoltliteSideCols side;
   char *zCommitRef;
   int idxNum;
+  int pkSeekable;
   DoltlitePkRange pkRange;
 };
 
@@ -631,7 +632,6 @@ static int atFilter(sqlite3_vtab_cursor *cur,
   ProllyHash tableRoot; u8 flags=0;
   ProllyHash schemaHash;
   int rc, res;
-  int seekable;
   (void)idxStr;
 
   memset(&schemaHash, 0, sizeof(schemaHash));
@@ -704,10 +704,11 @@ static int atFilter(sqlite3_vtab_cursor *cur,
   prollyCursorInit(&c->common.tblCur, cs, pCache, &tableRoot, flags);
   c->common.rootIntKey = (flags & PROLLY_NODE_INTKEY) != 0;
 
-  seekable = c->common.rootIntKey
-          && (idxNum & AT_IDX_PK_ANY) != 0;
+  c->pkSeekable = c->common.rootIntKey
+              && (idxNum & AT_IDX_PK_ANY) != 0
+              && doltliteSideColsMatchIntPk(&c->side, &v->cols);
 
-  if( seekable && (idxNum & AT_IDX_PK_EQ) && c->pkRange.hasPkLo ){
+  if( c->pkSeekable && (idxNum & AT_IDX_PK_EQ) && c->pkRange.hasPkLo ){
     rc = prollyCursorSeekInt(&c->common.tblCur, c->pkRange.pkLo, &res);
     if( rc!=SQLITE_OK ){
       prollyCursorClose(&c->common.tblCur);
@@ -722,7 +723,7 @@ static int atFilter(sqlite3_vtab_cursor *cur,
                                             &c->side);
   }
 
-  if( seekable && c->pkRange.hasPkLo ){
+  if( c->pkSeekable && c->pkRange.hasPkLo ){
     i64 startKey = c->pkRange.pkLo;
     if( c->pkRange.pkLoStrict ) startKey++;
     rc = prollyCursorSeekInt(&c->common.tblCur, startKey, &res);
@@ -755,7 +756,7 @@ static int atFilter(sqlite3_vtab_cursor *cur,
     prollyCursorClose(&c->common.tblCur);
     return SQLITE_OK;
   }
-  if( seekable && c->pkRange.hasPkHi && !doltlitePkRangeMatchesCursorUpper(&c->pkRange, &c->common.tblCur) ){
+  if( c->pkSeekable && c->pkRange.hasPkHi && !doltlitePkRangeMatchesCursorUpper(&c->pkRange, &c->common.tblCur) ){
     prollyCursorClose(&c->common.tblCur);
     return SQLITE_OK;
   }
@@ -773,9 +774,8 @@ static int atNext(sqlite3_vtab_cursor *cur){
     c->common.hasRow = 0;
     return SQLITE_OK;
   }
-  /* EQ probe only positions intkey roots; mismatched shapes must keep stepping. */
   if( (c->idxNum & AT_IDX_PK_EQ) && c->pkRange.hasPkLo
-   && c->common.rootIntKey ){
+   && c->pkSeekable ){
     prollyCursorClose(&c->common.tblCur);
     c->common.tblCurOpen = 0;
     c->common.hasRow = 0;
@@ -794,7 +794,7 @@ static int atNext(sqlite3_vtab_cursor *cur){
     c->common.hasRow = 0;
     return SQLITE_OK;
   }
-  if( (c->idxNum & AT_IDX_PK_ANY) && c->common.rootIntKey
+  if( c->pkSeekable
    && !doltlitePkRangeMatchesCursorUpper(&c->pkRange, &c->common.tblCur) ){
     prollyCursorClose(&c->common.tblCur);
     c->common.tblCurOpen = 0;

--- a/src/doltlite_history.c
+++ b/src/doltlite_history.c
@@ -54,6 +54,7 @@ struct HistCursor {
   char *zCommitter;
   i64 commitDate;
   int idxNum;
+  int pkSeekable;
   DoltlitePkRange pkRange;
   int singleCommit;
 };
@@ -70,13 +71,13 @@ static void htCursorReset(HistCursor *c){
 
 static int htOpenTableAtCommit(HistCursor *c, sqlite3 *db,
     const char *zTableName, const ProllyHash *pCommitHash){
+  DoltliteVtabCommon *v = (DoltliteVtabCommon*)c->common.base.pVtab;
   ChunkStore *cs = doltliteGetChunkStore(db);
   ProllyCache *pCache = doltliteGetCache(db);
   DoltliteCommit commit;
   ProllyHash tableRoot; u8 flags = 0;
   ProllyHash schemaHash;
   int rc, res;
-  int seekable;
 
   memset(&schemaHash, 0, sizeof(schemaHash));
   memset(&commit, 0, sizeof(commit));
@@ -103,7 +104,6 @@ static int htOpenTableAtCommit(HistCursor *c, sqlite3 *db,
   rc = doltliteLoadTableRootByName(db, &commit.catalogHash, zTableName,
                                    &tableRoot, &flags, &schemaHash);
   if( rc==SQLITE_OK ){
-    DoltliteVtabCommon *v = (DoltliteVtabCommon*)c->common.base.pVtab;
     rc = doltliteSideColsLoad(db, &commit.catalogHash, &schemaHash,
                               zTableName, &v->cols,
                               !prollyHashIsEmpty(&tableRoot), &c->side);
@@ -121,10 +121,11 @@ static int htOpenTableAtCommit(HistCursor *c, sqlite3 *db,
   prollyCursorInit(&c->common.tblCur, cs, pCache, &tableRoot, flags);
   c->common.rootIntKey = (flags & PROLLY_NODE_INTKEY) != 0;
 
-  seekable = c->common.rootIntKey
-          && (c->idxNum & HIST_IDX_PK_ANY) != 0;
+  c->pkSeekable = c->common.rootIntKey
+              && (c->idxNum & HIST_IDX_PK_ANY) != 0
+              && doltliteSideColsMatchIntPk(&c->side, &v->cols);
 
-  if( seekable && (c->idxNum & HIST_IDX_PK_EQ) && c->pkRange.hasPkLo ){
+  if( c->pkSeekable && (c->idxNum & HIST_IDX_PK_EQ) && c->pkRange.hasPkLo ){
     rc = prollyCursorSeekInt(&c->common.tblCur, c->pkRange.pkLo, &res);
     if( rc!=SQLITE_OK ){
       prollyCursorClose(&c->common.tblCur);
@@ -138,7 +139,7 @@ static int htOpenTableAtCommit(HistCursor *c, sqlite3 *db,
     return SQLITE_OK;
   }
 
-  if( seekable && c->pkRange.hasPkLo ){
+  if( c->pkSeekable && c->pkRange.hasPkLo ){
     i64 startKey = c->pkRange.pkLo;
     if( c->pkRange.pkLoStrict ) startKey++;
     rc = prollyCursorSeekInt(&c->common.tblCur, startKey, &res);
@@ -170,7 +171,7 @@ static int htOpenTableAtCommit(HistCursor *c, sqlite3 *db,
     prollyCursorClose(&c->common.tblCur);
     return SQLITE_OK;
   }
-  if( seekable && c->pkRange.hasPkHi && !doltlitePkRangeMatchesCursorUpper(&c->pkRange, &c->common.tblCur) ){
+  if( c->pkSeekable && c->pkRange.hasPkHi && !doltlitePkRangeMatchesCursorUpper(&c->pkRange, &c->common.tblCur) ){
     prollyCursorClose(&c->common.tblCur);
     return SQLITE_OK;
   }
@@ -183,7 +184,7 @@ static int htAdvance(HistCursor *c, sqlite3 *db, const char *zTableName){
 
   if( c->common.tblCurOpen ){
     if( (c->idxNum & HIST_IDX_PK_EQ) && c->pkRange.hasPkLo
-     && c->common.rootIntKey ){
+     && c->pkSeekable ){
       prollyCursorClose(&c->common.tblCur);
       c->common.tblCurOpen = 0;
     }else{
@@ -194,7 +195,7 @@ static int htAdvance(HistCursor *c, sqlite3 *db, const char *zTableName){
         return rc;
       }
       if( prollyCursorIsValid(&c->common.tblCur)
-       && (!c->common.rootIntKey || doltlitePkRangeMatchesCursorUpper(&c->pkRange, &c->common.tblCur)) ){
+       && (!c->pkSeekable || doltlitePkRangeMatchesCursorUpper(&c->pkRange, &c->common.tblCur)) ){
         return doltliteVtabCommonCaptureRowSide(&c->common, db, zTableName,
                                                 &c->side);
       }

--- a/src/doltlite_vtab_util.h
+++ b/src/doltlite_vtab_util.h
@@ -86,6 +86,16 @@ static SQLITE_INLINE int doltliteVtabCommonCaptureRowSide(
   return SQLITE_OK;
 }
 
+static SQLITE_INLINE int doltliteSideColsMatchIntPk(
+  const DoltliteSideCols *pSide,
+  const DoltliteColInfo *pDeclared
+){
+  int iPk = pDeclared->iPkCol;
+  return iPk>=0 && (!pSide->valid
+      || (pSide->ci.iPkCol>=0
+          && pSide->aDeclToSide[iPk]==pSide->ci.iPkCol));
+}
+
 static SQLITE_INLINE int doltlitePkRangeMatchesCursorUpper(
   const DoltlitePkRange *pRange,
   ProllyCursor *pCur

--- a/test/doltlite_historical_pk_mapping.test
+++ b/test/doltlite_historical_pk_mapping.test
@@ -1,0 +1,77 @@
+set testdir [file dirname $argv0]
+source $testdir/tester.tcl
+
+foreach {layout schema rows} {
+  changed {oldkey INTEGER PRIMARY KEY, id INT}
+    {(-100,42),(1,99),(2,42),(100,7)}
+  changed_reordered {id INT, oldkey INTEGER PRIMARY KEY}
+    {(-100,42),(1,99),(2,42),(100,7)}
+  same_reordered {id INTEGER PRIMARY KEY, oldkey INT}
+    {(-100,42),(1,99),(100,7)}
+  clustered {oldkey INT, id INT, PRIMARY KEY(oldkey,id)}
+    {(-100,42),(1,99),(2,42),(100,7)}
+  keyless {oldkey INT, id INT}
+    {(-100,42),(1,99),(2,42),(100,7)}
+} {
+  reset_db
+  execsql "CREATE TABLE t($schema);
+           INSERT INTO t(oldkey,id) VALUES $rows;"
+  execsql {
+    SELECT dolt_commit('-Am','old');
+    SELECT dolt_tag('old');
+    DROP TABLE t;
+    CREATE TABLE t(oldkey INT, id INTEGER PRIMARY KEY);
+    INSERT INTO t VALUES(10,42),(11,99),(12,7);
+    SELECT dolt_commit('-Am','new');
+  }
+  foreach phase {live reopen} {
+    if {$phase eq "reopen"} {
+      db close
+      sqlite3 db test.db
+    }
+    foreach {surface source} {
+      snapshot_old {dolt_at_t('old')}
+      snapshot_current {dolt_at_t('HEAD')}
+      history {dolt_history_t}
+      history_old {dolt_history_t('old')}
+      history_commit {dolt_history_t WHERE commit_hash=dolt_hashof('old')}
+    } {
+      set base "SELECT oldkey,id FROM $source"
+      foreach {predicate where} {
+        eq {id=42}
+        eq_first {id=7}
+        ge {id>=42}
+        gt {id>7}
+        le {id<=42}
+        lt {id<99}
+        bounded {id>7 AND id<=42}
+        in {id IN (7,42)}
+      } {
+        set expected [execsql "SELECT oldkey,id FROM ($base LIMIT -1)
+                               WHERE $where ORDER BY oldkey,id"]
+        set joiner WHERE
+        if {$surface eq "history_commit"} {set joiner AND}
+        do_execsql_test historical-pk-$layout-$phase-$surface-$predicate \
+            "$base $joiner $where ORDER BY oldkey,id" $expected
+      }
+    }
+  }
+}
+
+reset_db
+do_execsql_test historical-pk-missing-setup {
+  CREATE TABLE t(oldkey INTEGER PRIMARY KEY);
+  INSERT INTO t VALUES(1),(2);
+  SELECT length(dolt_commit('-Am','old'));
+  DROP TABLE t;
+  CREATE TABLE t(oldkey INT, id INTEGER PRIMARY KEY);
+  INSERT INTO t VALUES(1,42);
+  SELECT length(dolt_commit('-Am','new'));
+} {40 40}
+do_execsql_test historical-pk-missing {
+  SELECT oldkey,id FROM dolt_at_t('HEAD~1') WHERE id IS NULL ORDER BY oldkey;
+  SELECT count(*) FROM dolt_at_t('HEAD~1') WHERE id=42;
+  SELECT oldkey,id FROM dolt_history_t WHERE id=42;
+} {1 {} 2 {} 0 1 42}
+
+finish_test

--- a/test/doltlite_history.sh
+++ b/test/doltlite_history.sh
@@ -384,4 +384,29 @@ run_test "hist_namemap_old_commit" \
 
 rm -f "$DBH"
 
+DB=/tmp/test_hist_pk_mapping_$$.db; rm -f "$DB"
+echo "CREATE TABLE t(oldkey INTEGER PRIMARY KEY, id INT);
+INSERT INTO t VALUES(-100,42),(1,99),(2,42),(100,7);
+SELECT dolt_commit('-Am','old');
+DROP TABLE t;
+CREATE TABLE t(oldkey INT, id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES(10,42),(11,99),(12,7);
+SELECT dolt_commit('-Am','new');" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+run_test "snapshot_changed_pk_eq" \
+  "SELECT oldkey,id FROM dolt_at_t('HEAD~1') WHERE id=42 ORDER BY oldkey;" \
+  "-100|42
+2|42" "$DB"
+run_test "snapshot_changed_pk_range" \
+  "SELECT oldkey,id FROM dolt_at_t('HEAD~1') WHERE id<=42 ORDER BY oldkey;" \
+  "-100|42
+2|42
+100|7" "$DB"
+run_test "history_changed_pk_eq" \
+  "SELECT count(*) FROM dolt_history_t WHERE id=42;" "3" "$DB"
+run_test "history_changed_pk_range" \
+  "SELECT count(*) FROM dolt_history_t WHERE id>7 AND id<=42;" "3" "$DB"
+
+rm -f "$DB"
+
 dltest_finish

--- a/test/regression-buckets/ported.txt
+++ b/test/regression-buckets/ported.txt
@@ -38,6 +38,7 @@ doltlite_default_materialization
 doltlite_identifier_case
 doltlite_patch_rowid_alias
 doltlite_historical_affinity
+doltlite_historical_pk_mapping
 doltlite_vtab_column_collision
 doltlite_merge_constraint_prune
 doltlite_constraint_temp_shadow


### PR DESCRIPTION
After a table's integer primary key moved from one column to another, filters on `dolt_at_*` and `dolt_history_*` could silently lose historical rows. The readers sought using the old table's unrelated key and could stop scanning before reaching matching rows.

Require the declared primary key to map to the historical schema's rowid alias before seeking or applying early termination. Otherwise scan that snapshot and let SQLite filter the rendered values. Preserve seeks when the primary key is unchanged, including when columns have been reordered.

Validation:
- New regression suite: 176 failures before the fix; all 403 checks pass afterward. Covers equality, ranges, IN, commit filters, reopening, reordered columns, clustered keys, keyless tables, and missing columns.
- Four added CLI checks fail on the unfixed engine and pass with the fix.
- All 135 native suites pass across two shards.
- Existing historical affinity and key-shape regressions: 122 and 22 checks pass.
- Dolt snapshot and history oracles: 30 and 31 cases pass.
- Rebuilt CLI and testfixture; full lint passes.

Fixes #2852

Co-Authored-By: OpenAI Codex <noreply@openai.com>
